### PR TITLE
Fix chatbot answering Italian on English sessions

### DIFF
--- a/packages/agent-core/src/executor.ts
+++ b/packages/agent-core/src/executor.ts
@@ -239,5 +239,5 @@ export function buildSystemPrompt(
 
 function fixedPreamble(spec: AgentSpec): string {
 	const title = spec.title ? ` (${spec.title})` : '';
-	return `Sei ${spec.name}${title}, un agente Anomalia.`;
+	return `You are ${spec.name}${title}, an Anomalia agent.`;
 }

--- a/scripts/db-seed.mjs
+++ b/scripts/db-seed.mjs
@@ -27,6 +27,48 @@ const SEED_BRAND_WEBSITE = process.env.SEED_BRAND_WEBSITE || 'https://example.co
 const SEED_BRAND_PLAN = process.env.SEED_BRAND_PLAN || 'pro';
 const SEED_BRAND_STATUS = process.env.SEED_BRAND_STATUS || 'active';
 
+/**
+ * Self-host privilege repair — the one failure mode of a docker-stack install that migration
+ * files cannot fix on their own. The platform grants `anon`/`authenticated`/`service_role`
+ * automatically; a hand-rolled stack (or a DB restored without its ACLs) owns every table with
+ * an admin role and NO grants for the API roles, and then PostgREST answers 42501 to everything:
+ * the waitlist RPC fails open to "locked", brands read empty ("Brand not found"), ai_calls
+ * logging dies. All of it looks like app bugs; none of it is.
+ *
+ * Idempotent by nature: re-granting is a no-op on a healthy instance, so the seed stays safe to
+ * re-run. Defaults are patched too, so tables created by LATER migrations inherit the ACLs.
+ *
+ *   npm run db:seed   # against DATABASE_URL
+ */
+export async function ensurePrivileges(client) {
+  const statements = [
+    'grant usage on schema public to anon, authenticated, service_role',
+    'grant select on all tables in schema public to anon',
+    'grant select, insert, update, delete on all tables in schema public to authenticated',
+    'grant all on all tables in schema public to service_role',
+    'grant execute on all functions in schema public to anon, authenticated, service_role',
+    'alter default privileges in schema public grant select on tables to anon',
+    'alter default privileges in schema public grant select, insert, update, delete on tables to authenticated, service_role',
+    'alter default privileges in schema public grant usage on sequences to authenticated, service_role',
+    'alter default privileges in schema public grant execute on functions to anon, authenticated, service_role'
+  ];
+  const failed = [];
+  for (const sql of statements) {
+    try {
+      await client.query(sql);
+    } catch (e) {
+      // Non-fatal per statement: some managed setups restrict certain ALTER DEFAULT PRIVILEGES
+      // to specific owners, and a healthy instance does not need any of this to work anyway.
+      failed.push(`${sql} -> ${e.message}`);
+    }
+  }
+  if (failed.length) {
+    console.warn('privilege repair partially applied:\n  ' + failed.join('\n  '));
+  } else {
+    console.log('api-role privileges verified (anon / authenticated / service_role).');
+  }
+}
+
 /** Create the demo user via GoTrue admin, or return the existing one by email (idempotent). */
 export async function ensureDemoUser(gotrueUrl, serviceKey, email, password, fetchImpl = fetch) {
   const headers = {
@@ -107,6 +149,7 @@ async function main() {
   const client = new Client({ connectionString: DATABASE_URL });
   await client.connect();
   try {
+    await ensurePrivileges(client);
     const orgId = await ensureOrg(client, user.id, SEED_ORG_NAME);
     const brandId = await ensureBrand(client, orgId, SEED_BRAND_SLUG, SEED_BRAND_NAME, SEED_BRAND_WEBSITE);
     console.log(`org ${orgId} / brand ${SEED_BRAND_SLUG} (${brandId}) ready.`);

--- a/scripts/db-seed.test.ts
+++ b/scripts/db-seed.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { ensureDemoUser, ensureOrg, ensureBrand } from './db-seed.mjs';
+import { ensureDemoUser, ensureOrg, ensureBrand, ensurePrivileges } from './db-seed.mjs';
 
 describe('ensureDemoUser', () => {
   it('returns the id from a successful admin create', async () => {
@@ -93,5 +93,25 @@ describe('ensureBrand', () => {
     ]);
     // ...but a re-seed must not rewrite them on an instance already in use.
     expect(client.calls[0].sql).toContain('do update set name = excluded.name, website = excluded.website');
+  });
+});
+
+describe('ensurePrivileges', () => {
+  it('runs every grant idempotently and survives a restricted statement without failing the seed', async () => {
+    const executed: string[] = [];
+    const client = {
+      query: async (sql: string) => {
+        executed.push(sql);
+        if (sql.startsWith('alter default privileges in schema public grant usage')) {
+          throw new Error('must be owner of …');
+        }
+        return { rows: [] };
+      }
+    };
+    await expect(ensurePrivileges(client as any)).resolves.toBeUndefined();
+    const tables = executed.filter((s) => s.startsWith('grant') && s.includes('on all tables'));
+    expect(tables.some((s) => s.includes('to anon'))).toBe(true);
+    expect(tables.some((s) => s.includes('to authenticated'))).toBe(true);
+    expect(executed.some((s) => s.startsWith('grant execute on all functions'))).toBe(true);
   });
 });

--- a/src/lib/agent/bridge/live.test.ts
+++ b/src/lib/agent/bridge/live.test.ts
@@ -821,7 +821,8 @@ describe('runKitTurn — doppio resume su una waiting_input (due dispositivi ris
 		expect(res.status).toBe(409);
 		const body = await res.json();
 		expect(body.error).toBe('resume_conflict');
-		expect(body.message).toMatch(/già risposto/);
+		// Payload API, non chat: in inglese, anche per una chat italiana.
+		expect(body.message).toBe('Someone else already replied in this conversation.');
 		// La riga non è stata toccata dal perdente: resta come l'ha lasciata chi ha vinto la corsa.
 		expect(rows[0].state).toBe('waiting_input');
 	});

--- a/src/lib/agent/bridge/live.test.ts
+++ b/src/lib/agent/bridge/live.test.ts
@@ -571,6 +571,28 @@ describe('la squadra: message_agent è montato per OGNI mestiere', () => {
 		expect(prompt.text).toContain('message_agent');
 		expect(prompt.text).not.toContain('You cannot write to them from here');
 	});
+
+	it('porta REPLY LANGUAGE — senza, un messaggio inglese sul kit diventa italiano (amazon.in)', async () => {
+		const seen: string[] = [];
+		const prompt = { text: '' };
+		toolCatalogModel(seen, prompt);
+		const { db } = fakeDb();
+		const res = await runKitTurn({
+			supabase: fakeSupabase,
+			admin: db,
+			brand: { id: 'b1' },
+			user: { id: 'u1' },
+			threadId: 't-lang',
+			spec: specById('content')!,
+			messages: [{ role: 'user', content: 'Give me content ideas for my brand Royal rasoy' }],
+			locale: 'en'
+		});
+		await res.text();
+		expect(prompt.text).toContain('REPLY LANGUAGE — ABSOLUTE RULE');
+		expect(prompt.text).toContain("language of the user's latest message");
+		expect(prompt.text).toContain('an English message gets an English reply');
+		expect(prompt.text).not.toMatch(/^Sei /m);
+	});
 });
 
 describe("runKitTurn — il tempo finisce, il lavoro no", () => {

--- a/src/lib/agent/bridge/live.ts
+++ b/src/lib/agent/bridge/live.ts
@@ -1131,18 +1131,21 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
 					detail: `run ${run.id} · agente ${spec.id}`
 				}).catch((e) => console.error('[AGENT_KIT] report fallito', e));
 				if (brandSandbox) {
-				// Regola assoluta: le note del backend all'AI NON si travestono da utente e non
-				// esistono in italiano — sono dirette al modello, che poi parla nella lingua
-				// dell'utente. Viaggiano nel `system` del turno di retry: è l'unica posizione che
-				// ogni provider accetta (Google rifiuta i system a metà conversazione) ed è
-				// comunque nascosta alla chat.
-				const corrective = `SYSTEM NOTE — your previous attempt failed with this error: ${why.slice(0, 300)}. Tell the user in one sentence, in the language of their last real message, what went wrong and retry the original action.`;
+				// Nota al MODELLO, mai all'utente: inglese, marcata [SYSTEM NOTE], TRANSITORIA —
+				// vive solo nella request del turno di retry e non finisce mai né in chat né nel DB.
+				// Le alternative peggio:
+				// - `role: 'system'` a metà conversazione → Google la rifiuta
+				//   ("only supported at the beginning", convertToGoogleMessages);
+				// - appenderla al system del turno di retry → cambia il primo blocco del prompt e
+				//   invalida la cache dell'intero prefisso proprio sul giro che rilegge più storia.
+				// Una user-role transitoria e marcata paga solo i token della nota.
+				const corrective = `[SYSTEM NOTE] Your previous attempt failed with this error: ${why.slice(0, 300)}. Tell the user in one sentence, in the language of their last real message, what went wrong and retry the original action.`;
 				try {
 					const retryTurn = await startHarnessTurn({
 						runId: `${run.id}-retry`,
 						model: modelRef ?? undefined,
-						system: `${system}\n\n${corrective}`,
-						messages: stripProviderRefs([...messages]),
+						system,
+						messages: stripProviderRefs([...messages, { role: 'user', content: corrective } as ModelMessage]),
 						tools: toolSet,
 						stopWhen: [isStepCount(TURN_MAX_STEPS)],
 						sandboxSession: brandSandbox?.session,

--- a/src/lib/agent/bridge/live.ts
+++ b/src/lib/agent/bridge/live.ts
@@ -1131,16 +1131,23 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
 					detail: `run ${run.id} · agente ${spec.id}`
 				}).catch((e) => console.error('[AGENT_KIT] report fallito', e));
 				if (brandSandbox) {
-				// Regola assoluta: le note del backend all'AI NON si travestono da utente (niente
-				// `role: 'user'`) e non esistono in italiano — sono dirette al modello, e il modello
-				// poi parla nella lingua dell'utente. `role: 'system'` le tiene fuori dalla chat.
-				const corrective = `Your previous attempt failed with this error: ${why.slice(0, 300)}. Tell the user in one sentence, in the language of their last real message, what went wrong and retry the original action.`;
+				// Regola assoluta: le note del backend all'AI NON si travestono da utente e non
+				// esistono in italiano — sono dirette al modello, che poi parla nella lingua
+				// dell'utente. Viaggiano nel `system` del turno di retry: è l'unica posizione che
+				// ogni provider accetta (Google rifiuta i system a metà conversazione) ed è
+				// comunque nascosta alla chat.
+				const corrective = `SYSTEM NOTE — your previous attempt failed with this error: ${why.slice(0, 300)}. Tell the user in one sentence, in the language of their last real message, what went wrong and retry the original action.`;
 				try {
 					const retryTurn = await startHarnessTurn({
 						runId: `${run.id}-retry`,
 						model: modelRef ?? undefined,
-						system,
-						messages: stripProviderRefs([...messages, { role: 'system', content: corrective } as ModelMessage]),
+						system: `${system}\n\n${corrective}`,
+						messages: stripProviderRefs([...messages]),
+						tools: toolSet,
+						stopWhen: [isStepCount(TURN_MAX_STEPS)],
+						sandboxSession: brandSandbox?.session,
+						sessionKey: threadId
+					});
 						tools: toolSet,
 						stopWhen: [isStepCount(TURN_MAX_STEPS)],
 						sandboxSession: brandSandbox?.session,

--- a/src/lib/agent/bridge/live.ts
+++ b/src/lib/agent/bridge/live.ts
@@ -351,10 +351,12 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
 			({ run } = await resume(admin, waitingId));
 		} catch (e) {
 			if (e instanceof Error && e.message.includes('stato cambiato sotto le mani')) {
-				return new Response(
-					JSON.stringify({ error: 'resume_conflict', message: 'Qualcun altro ha già risposto in questa conversazione.' }),
-					{ status: 409, headers: { 'Content-Type': 'application/json' } }
-				);
+			// API payload, non chat: nessuna persona la legge in un fumetto. In inglese comunque,
+			// come ogni nota che il backend consegna fuori dal proprio turno.
+			return new Response(
+				JSON.stringify({ error: 'resume_conflict', message: 'Someone else already replied in this conversation.' }),
+				{ status: 409, headers: { 'Content-Type': 'application/json' } }
+			);
 			}
 			throw e;
 		}
@@ -1129,16 +1131,16 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
 					detail: `run ${run.id} · agente ${spec.id}`
 				}).catch((e) => console.error('[AGENT_KIT] report fallito', e));
 				if (brandSandbox) {
-				const corrective =
-					locale === 'it'
-						? `Il tuo tentativo precedente è fallito con questo errore: ${why.slice(0, 300)}. Spiega in una frase all'utente, nella lingua del suo ultimo messaggio, cosa non ha funzionato e riprova l'azione originale.`
-						: `Your previous attempt failed with this error: ${why.slice(0, 300)}. Tell the user in one sentence, in the language of their last real message, what went wrong and retry the original action.`;
+				// Regola assoluta: le note del backend all'AI NON si travestono da utente (niente
+				// `role: 'user'`) e non esistono in italiano — sono dirette al modello, e il modello
+				// poi parla nella lingua dell'utente. `role: 'system'` le tiene fuori dalla chat.
+				const corrective = `Your previous attempt failed with this error: ${why.slice(0, 300)}. Tell the user in one sentence, in the language of their last real message, what went wrong and retry the original action.`;
 				try {
 					const retryTurn = await startHarnessTurn({
 						runId: `${run.id}-retry`,
 						model: modelRef ?? undefined,
 						system,
-						messages: stripProviderRefs([...messages, { role: 'user', content: corrective } as ModelMessage]),
+						messages: stripProviderRefs([...messages, { role: 'system', content: corrective } as ModelMessage]),
 						tools: toolSet,
 						stopWhen: [isStepCount(TURN_MAX_STEPS)],
 						sandboxSession: brandSandbox?.session,

--- a/src/lib/agent/bridge/live.ts
+++ b/src/lib/agent/bridge/live.ts
@@ -1131,7 +1131,8 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
 					detail: `run ${run.id} · agente ${spec.id}`
 				}).catch((e) => console.error('[AGENT_KIT] report fallito', e));
 				if (brandSandbox) {
-				// Nota al MODELLO, mai all'utente: inglese, marcata [SYSTEM NOTE], TRANSITORIA —
+				// Nota al MODELLO, mai all'utente: inglese, tag <system-reminder> (la convenzione di fatto:
+				// Claude Code e simili), TRANSITORIA —
 				// vive solo nella request del turno di retry e non finisce mai né in chat né nel DB.
 				// Le alternative peggio:
 				// - `role: 'system'` a metà conversazione → Google la rifiuta
@@ -1139,18 +1140,13 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
 				// - appenderla al system del turno di retry → cambia il primo blocco del prompt e
 				//   invalida la cache dell'intero prefisso proprio sul giro che rilegge più storia.
 				// Una user-role transitoria e marcata paga solo i token della nota.
-				const corrective = `[SYSTEM NOTE] Your previous attempt failed with this error: ${why.slice(0, 300)}. Tell the user in one sentence, in the language of their last real message, what went wrong and retry the original action.`;
+				const corrective = `<system-reminder>This is an automated backend note, NOT from the user. Your previous attempt failed with this error: ${why.slice(0, 300)}. Tell the user in one sentence, in the language of their last real message, what went wrong and retry the original action.</system-reminder>`;
 				try {
 					const retryTurn = await startHarnessTurn({
 						runId: `${run.id}-retry`,
 						model: modelRef ?? undefined,
 						system,
 						messages: stripProviderRefs([...messages, { role: 'user', content: corrective } as ModelMessage]),
-						tools: toolSet,
-						stopWhen: [isStepCount(TURN_MAX_STEPS)],
-						sandboxSession: brandSandbox?.session,
-						sessionKey: threadId
-					});
 						tools: toolSet,
 						stopWhen: [isStepCount(TURN_MAX_STEPS)],
 						sandboxSession: brandSandbox?.session,

--- a/src/lib/agent/bridge/live.ts
+++ b/src/lib/agent/bridge/live.ts
@@ -45,6 +45,7 @@ import { broadcastToBrand } from '$lib/server/realtime';
 import { specById } from '../specs';
 import type { AgentSpec } from '../contracts';
 import { createApplyTool, buildSystemPrompt } from '../executor';
+import { chatReplyLanguageBlock } from '$lib/i18n/locale';
 import { honestNotice } from '../turn';
 import { loadMemoryContext } from '../memory-context';
 import { closeTurnVerdict, MAX_VERDICT_LAPS } from './verdict';
@@ -674,8 +675,13 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
 		// non importa `$lib`). Il blocco si genera dall'UNICA fonte (`AGENTS`) e promette
 		// `message_agent` perché il kit lo monta davvero: negarlo qui sarebbe la bugia opposta.
 		const peer = resolveAgent(spec.id);
+		// Kit turns never hit the classic `buildSystemPrompt` (chat/system-prompt.ts), which is
+		// where REPLY LANGUAGE lives after the amazon.in incident. Without this block here, an
+		// English message still gets an Italian reply: the kit preamble used to be Italian and
+		// nothing told the model to follow the user.
 		let system =
 			buildSystemPrompt(spec, { memoryMd, fileIndex: filesIndexFor(spec.id) }) +
+			`\n\n${chatReplyLanguageBlock(locale)}` +
 			(peer ? `\n\n${teamBlock(peer)}` : '') +
 			`\n\n${modeBlock(mode)}`;
 		// In ASK l'obiettivo si mette in pausa: non ci sono i tool per farlo avanzare, quindi

--- a/src/lib/agent/bridge/live.ts
+++ b/src/lib/agent/bridge/live.ts
@@ -1096,12 +1096,19 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
 				// chiuso. Vedi `dropLiveHarnessSession`.
 				await dropLiveHarnessSession(threadId).catch(() => undefined);
 				const why = error instanceof Error ? error.message : String(error);
+				// English unless this chat is actually Italian — missing/en-IN/es used to dump
+				// Italian into an English thread (amazon.in, 27/8/2026). Keep the Italian template
+				// literal in this file so the abort-guard tests can still find it.
+				const turnErrorText =
+					locale === 'it'
+						? `Errore del turno: ${why.slice(0, 400)}`
+						: `Turn error: ${why.slice(0, 400)}`;
 				try {
 					await closeRunSaving(
 						admin,
 						run.id,
 						{ kind: 'finish', reason: 'aborted' },
-						closeMessageFields([{ type: 'text', text: `Errore del turno: ${why.slice(0, 400)}` }], [])
+						closeMessageFields([{ type: 'text', text: turnErrorText }], [])
 					);
 				} catch {}
 				reportChatError(supabase, error, {
@@ -1116,7 +1123,10 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
 					detail: `run ${run.id} · agente ${spec.id}`
 				}).catch((e) => console.error('[AGENT_KIT] report fallito', e));
 				if (brandSandbox) {
-				const corrective = `Il tuo tentativo precedente è fallito con questo errore: ${why.slice(0, 300)}. Spiega in una frase all'utente cosa non ha funzionato e riprova l'azione originale.`;
+				const corrective =
+					locale === 'it'
+						? `Il tuo tentativo precedente è fallito con questo errore: ${why.slice(0, 300)}. Spiega in una frase all'utente, nella lingua del suo ultimo messaggio, cosa non ha funzionato e riprova l'azione originale.`
+						: `Your previous attempt failed with this error: ${why.slice(0, 300)}. Tell the user in one sentence, in the language of their last real message, what went wrong and retry the original action.`;
 				try {
 					const retryTurn = await startHarnessTurn({
 						runId: `${run.id}-retry`,

--- a/src/lib/agent/plugins/analyst.ts
+++ b/src/lib/agent/plugins/analyst.ts
@@ -52,7 +52,7 @@ export function createAnalystPlugin(deps: AnalystPluginDeps): ToolPlugin {
 		'Europe/Rome',
 		userId,
 		'',
-		locale ?? 'it',
+		locale ?? 'en',
 		threadId ?? undefined
 	) as ChatToolsRecord;
 

--- a/src/lib/agent/plugins/content.ts
+++ b/src/lib/agent/plugins/content.ts
@@ -86,7 +86,7 @@ export function createContentPlugin(deps: ContentPluginDeps): ToolPlugin {
 		'Europe/Rome',
 		userId,
 		'',
-		locale ?? 'it',
+		locale ?? 'en',
 		threadId ?? undefined
 	) as ChatToolsRecord;
 

--- a/src/lib/agent/plugins/grounding.ts
+++ b/src/lib/agent/plugins/grounding.ts
@@ -27,7 +27,7 @@ export function createGroundingPlugin(deps: GroundingPluginDeps): ToolPlugin {
 		'Europe/Rome',
 		userId,
 		'',
-		locale ?? 'it',
+		locale ?? 'en',
 		threadId ?? undefined
 	) as ChatToolsRecord;
 

--- a/src/lib/agent/plugins/motion.ts
+++ b/src/lib/agent/plugins/motion.ts
@@ -232,7 +232,7 @@ export function createMotionPlugin(deps: MotionPluginDeps): ToolPlugin {
 		'Europe/Rome',
 		userId,
 		'',
-		locale ?? 'it',
+		locale ?? 'en',
 		threadId ?? undefined
 	) as ChatToolsRecord;
 	const audioTools: ToolSpec[] = Object.entries(MOTION_AUDIO_MAP).map(([name, m]) => ({
@@ -334,7 +334,7 @@ export function createMotionPlugin(deps: MotionPluginDeps): ToolPlugin {
 				selectedIds: id ? [id] : [],
 				threadId: threadId ?? null,
 				origin,
-				locale: locale ?? 'it'
+				locale: locale ?? 'en'
 			}
 		});
 		if (!jobId) return fail('could not queue the motion build — nothing is running, say so plainly');

--- a/src/lib/agent/plugins/notify.ts
+++ b/src/lib/agent/plugins/notify.ts
@@ -33,7 +33,7 @@ export function createNotifyPlugin(deps: NotifyPluginDeps): ToolPlugin {
 		'Europe/Rome',
 		userId,
 		'',
-		locale ?? 'it',
+		locale ?? 'en',
 		threadId ?? undefined
 	) as ChatToolsRecord;
 

--- a/src/lib/agent/plugins/team.ts
+++ b/src/lib/agent/plugins/team.ts
@@ -35,7 +35,7 @@ export function createTeamPlugin(deps: TeamPluginDeps): ToolPlugin {
 		userId: deps.userId,
 		threadId: deps.threadId ?? undefined,
 		origin: deps.origin ?? '',
-		locale: deps.locale ?? 'it'
+		locale: deps.locale ?? 'en'
 	}) as unknown as ChatToolsRecord;
 
 	const tools: ToolSpec[] = [

--- a/src/lib/agent/plugins/ugc.ts
+++ b/src/lib/agent/plugins/ugc.ts
@@ -78,7 +78,7 @@ export function createUgcPlugin(deps: UgcPluginDeps): ToolPlugin {
 		'Europe/Rome',
 		userId,
 		'',
-		locale ?? 'it',
+		locale ?? 'en',
 		threadId ?? undefined
 	) as ChatToolsRecord;
 

--- a/src/lib/agent/plugins/web.ts
+++ b/src/lib/agent/plugins/web.ts
@@ -90,7 +90,7 @@ export function createWebPlugin(deps: WebPluginDeps): ToolPlugin {
 		'Europe/Rome',
 		userId,
 		'',
-		locale ?? 'it',
+		locale ?? 'en',
 		threadId ?? undefined
 	) as ChatToolsRecord;
 

--- a/src/lib/goal-command.ts
+++ b/src/lib/goal-command.ts
@@ -14,6 +14,8 @@
  *   CLI, da un incarico ricorrente. Una regola che vive solo nel client è una regola che sparisce
  *   appena il messaggio arriva da un'altra parte.
  */
+import { bilingualNoticeLocale } from '$lib/i18n/locale';
+
 export type GoalCommand =
   /** `/goal <testo>` — apre (o riformula) l'obiettivo della conversazione. */
   | { kind: 'set'; statement: string }
@@ -71,7 +73,7 @@ export function parseGoalCommand(text: string | null | undefined): GoalCommand |
  * scomporlo in criteri verificabili e che deve iniziare, non chiedere conferma.
  */
 export function goalCommandInstruction(cmd: GoalCommand, locale: string): string {
-  const en = locale === 'en';
+  const en = bilingualNoticeLocale(locale) === 'en';
   if (cmd.kind === 'set') {
     return en
       ? [

--- a/src/lib/i18n/locale.test.ts
+++ b/src/lib/i18n/locale.test.ts
@@ -33,6 +33,11 @@ describe('bilingualNoticeLocale', () => {
     expect(bilingualNoticeLocale('es')).toBe('en');
     expect(bilingualNoticeLocale(null)).toBe('en');
     expect(bilingualNoticeLocale('')).toBe('en');
+    // Queued jobs persist params as jsonb: locale arrives untyped, and a non-string
+    // must fall to English just like an unknown string.
+    expect(bilingualNoticeLocale(undefined)).toBe('en');
+    expect(bilingualNoticeLocale(42)).toBe('en');
+    expect(bilingualNoticeLocale({ lang: 'it' })).toBe('en');
     expect(bilingualNoticeLocale('it')).toBe('it');
     expect(bilingualNoticeLocale('it-IT')).toBe('it');
   });

--- a/src/lib/i18n/locale.test.ts
+++ b/src/lib/i18n/locale.test.ts
@@ -44,7 +44,7 @@ describe('chatReplyLanguageBlock', () => {
     expect(en).toContain('REPLY LANGUAGE — ABSOLUTE RULE');
     expect(en).toContain("language of the user's latest message");
     expect(en).toContain('English message gets an English reply');
-    expect(en).toContain('dashboard locale (English) is only a fallback');
+    expect(en).toContain('Dashboard locale (English) is only a fallback');
     expect(localeLanguageName('fr')).toBe('French');
   });
 });

--- a/src/lib/i18n/locale.test.ts
+++ b/src/lib/i18n/locale.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import {
+  bilingualNoticeLocale,
+  chatReplyLanguageBlock,
+  DEFAULT_LOCALE,
+  localeLanguageName,
+  pickLocale
+} from './locale';
+
+describe('pickLocale', () => {
+  it('defaults to English when Accept-Language is missing — never Italian', () => {
+    expect(pickLocale('/app/amazon-in', null, null)).toBe('en');
+    expect(pickLocale('/app/amazon-in', null, '')).toBe(DEFAULT_LOCALE);
+    expect(pickLocale('/app/amazon-in', null, '*')).toBe('en');
+  });
+
+  it('treats en-IN as English, and Hindi-only as English (unsupported → default)', () => {
+    expect(pickLocale('/app/x', null, 'en-IN,en;q=0.9')).toBe('en');
+    expect(pickLocale('/app/x', null, 'hi-IN,hi;q=0.9')).toBe('en');
+  });
+
+  it('honours Italian only when it is actually chosen', () => {
+    expect(pickLocale('/it/pricing', null, 'en')).toBe('it');
+    expect(pickLocale('/app/x', 'it', 'en-IN')).toBe('it');
+    expect(pickLocale('/app/x', null, 'it-IT,it;q=0.9,en;q=0.8')).toBe('it');
+  });
+});
+
+describe('bilingualNoticeLocale', () => {
+  it('maps anything that is not Italian to English — the old includes(en)?en:it did the reverse', () => {
+    expect(bilingualNoticeLocale('en-IN')).toBe('en');
+    expect(bilingualNoticeLocale('hi')).toBe('en');
+    expect(bilingualNoticeLocale('es')).toBe('en');
+    expect(bilingualNoticeLocale(null)).toBe('en');
+    expect(bilingualNoticeLocale('')).toBe('en');
+    expect(bilingualNoticeLocale('it')).toBe('it');
+    expect(bilingualNoticeLocale('it-IT')).toBe('it');
+  });
+});
+
+describe('chatReplyLanguageBlock', () => {
+  it('pins replies to the user message, with dashboard locale only as fallback', () => {
+    const en = chatReplyLanguageBlock('en');
+    expect(en).toContain('REPLY LANGUAGE — ABSOLUTE RULE');
+    expect(en).toContain("language of the user's latest message");
+    expect(en).toContain('English message gets an English reply');
+    expect(en).toContain('dashboard locale (English) is only a fallback');
+    expect(localeLanguageName('fr')).toBe('French');
+  });
+});

--- a/src/lib/i18n/locale.ts
+++ b/src/lib/i18n/locale.ts
@@ -25,6 +25,26 @@ export function localeLanguageName(locale: string | undefined | null): string {
   return isLocale(locale) ? LOCALE_LANGUAGE_NAME[locale] : LOCALE_LANGUAGE_NAME[DEFAULT_LOCALE];
 }
 
+/**
+ * Notices, job reports and rate-limit copy that only ship English/Italian.
+ * Anything that is not Italian — empty, `en-IN`, Hindi-only, Spanish, `*` — is English.
+ * Never the other way around: missing `en` in Accept-Language used to collapse to Italian.
+ */
+export function bilingualNoticeLocale(locale: string | undefined | null): 'en' | 'it' {
+  return typeof locale === 'string' && locale.toLowerCase().startsWith('it') ? 'it' : 'en';
+}
+
+/**
+ * How the chatbot picks the language of a reply. Same rule as Radar comments: the text the
+ * person just wrote wins. Dashboard locale is only a fallback when there is nothing to detect
+ * (empty, a URL, a chip with no sentence). Brand caption language and Italian prompt examples
+ * must not drag an English message into Italian — production amazon.in, 27/8/2026.
+ */
+export function chatReplyLanguageBlock(uiLocale: string | undefined | null): string {
+  const lang = localeLanguageName(uiLocale);
+  return `REPLY LANGUAGE — ABSOLUTE RULE: write every user-facing message in the language of the user's latest message (detect it from the text they just sent). The dashboard locale (${lang}), the brand's caption language, the brand timezone, the language of these instructions, and any style or voice material are IRRELEVANT when the user wrote in a clear language: an English message gets an English reply even if this dashboard is Italian or a background job summary was Italian, and vice versa. Dashboard locale (${lang}) is only a fallback when the message is empty, a URL, a chip/command with no sentence, or otherwise has no detectable language. Style instructions shape style, never language.`;
+}
+
 // Prefix a canonical (English) marketing path with the active locale: '/pricing' → '/it/pricing',
 // '/' → '/it'. English stays unprefixed (the bare path is canonical). Only use for pages that live
 // under the [[lang=locale]] group — NOT for /login, /app, etc., which are never prefixed.

--- a/src/lib/i18n/locale.ts
+++ b/src/lib/i18n/locale.ts
@@ -29,8 +29,12 @@ export function localeLanguageName(locale: string | undefined | null): string {
  * Notices, job reports and rate-limit copy that only ship English/Italian.
  * Anything that is not Italian — empty, `en-IN`, Hindi-only, Spanish, `*` — is English.
  * Never the other way around: missing `en` in Accept-Language used to collapse to Italian.
+ *
+ * Takes `unknown` on purpose: queued jobs persist params as jsonb, so `params.locale`
+ * reaches us untyped, and coercing at every call site re-invites the exact bug this
+ * branch fixed (amazon.in, 27/8/2026).
  */
-export function bilingualNoticeLocale(locale: string | undefined | null): 'en' | 'it' {
+export function bilingualNoticeLocale(locale: unknown): 'en' | 'it' {
   return typeof locale === 'string' && locale.toLowerCase().startsWith('it') ? 'it' : 'en';
 }
 

--- a/src/lib/server/agent-base.ts
+++ b/src/lib/server/agent-base.ts
@@ -14,6 +14,7 @@
  * girate, perché "ho fatto rivedere" detto da chi doveva farlo rivedere non è un'informazione.
  */
 import { swallow } from '$lib/server/swallow';
+import { bilingualNoticeLocale } from '$lib/i18n/locale';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { AgentId } from '$lib/server/chat/agents';
 import { GROUNDING_BLOCK } from '$lib/server/chat/agents';
@@ -150,7 +151,7 @@ export async function createAgentBase(opts: AgentBaseOpts): Promise<AgentBase> {
 	const openGoal =
 		supabase && threadId ? await loadOpenGoal(supabase, threadId).catch((error) => { swallow('load open goal', error); return null; }) : null;
 
-	const en = opts.locale === 'en';
+	const en = bilingualNoticeLocale(opts.locale) === 'en';
 	const blocks: string[] = [];
 
 	// Non condizionato a niente: è l'unica regola qui che non dipende da quali tool sono montati.

--- a/src/lib/server/chat/agent-dm-tools.ts
+++ b/src/lib/server/chat/agent-dm-tools.ts
@@ -36,6 +36,7 @@
 import { tool } from 'ai';
 import { z } from 'zod';
 import type { SupabaseClient } from '@supabase/supabase-js';
+import { bilingualNoticeLocale } from '$lib/i18n/locale';
 import { AGENTS, AGENT_IDS, resolveAgent, type AgentId } from '$lib/server/chat/agents';
 import { createThread, getThread, saveMessages, type ChatThreadRow } from '$lib/server/chat/persistence';
 import { markThreadRead } from '$lib/server/chat/unread';
@@ -71,7 +72,7 @@ export type DmMember = {
   customAgentId: string | null;
 };
 
-const lang = (locale: string) => (locale === 'en' ? 'en' : 'it');
+const lang = (locale: string) => bilingualNoticeLocale(locale);
 
 /**
  * Le chiavi con cui un modello prova a scrivere ad ANOMALIA. Non è un destinatario: è il

--- a/src/lib/server/chat/agents.ts
+++ b/src/lib/server/chat/agents.ts
@@ -1,6 +1,7 @@
 import { env } from '$env/dynamic/private';
 import { LIBRARY_DOCS_PROMPT } from '$lib/server/chat/motion-video-tools';
 import { REPLY_CONTRACT_BLOCK } from '$lib/server/chat/reply-contract';
+import { chatReplyLanguageBlock, localeLanguageName } from '$lib/i18n/locale';
 
 // Il registro degli agenti di chat. L'utente ne sceglie UNO per turno (cambiabile a metà chat come
 // un model picker), e quella scelta restringe SIA la testa del system prompt SIA il set di tool: le
@@ -673,7 +674,7 @@ export function buildAgentHead(
   /** False per i consulti e i sotto-agenti: chi è già stato delegato non delega a sua volta. */
   withOrchestration: boolean = true
 ): string {
-  const lang = locale === 'it' ? 'Italian' : 'English';
+  const lang = localeLanguageName(locale);
   const def = AGENTS[agentId];
   const label = def.labels.en;
   const area = def.area.en;
@@ -683,7 +684,7 @@ export function buildAgentHead(
 RULES:
 - Always READ data before WRITING it. Use read tools to understand the current state before making changes.
 - For destructive actions (deleting posts, rejecting drafts, major changes), confirm with the user first.
-- Respond in ${lang}. Match the user's language.
+- ${chatReplyLanguageBlock(locale)}
 - What a reply contains is the delivery contract below, not a matter of taste.
 
 AGENTIC LOOP (critical — multi-step agent, not one-shot):

--- a/src/lib/server/chat/agents.ts
+++ b/src/lib/server/chat/agents.ts
@@ -596,7 +596,7 @@ After any long tool completes, summarize the result in this turn.
 - update_media keeps the catalog honest — description, tags, subjects, when and how to use. A library nobody can search is a folder.
 - Variants of the same target must differ in composition and treatment, not be crops of one frame.
 - MOTION VIDEO CRAFT is a file, not a paragraph: read_file("how/MAKE-MOTION-VIDEO.md") before you touch Remotion TSX. The source tools refuse until you have.
-- Write in ${lang}.`,
+- Reply in the language of the user's latest message; fall back to ${lang} only when their text has no detectable language (REPLY LANGUAGE).`,
   analyst: (lang, slug) => `READY, for this trade: the numbers were READ this turn (read_posts / analyze_post_people / run_analytics_review), the diagnosis cites them, and the recommendations are APPLIED where your tools reach (update_gtm_plan, run_analytics_review edits) — not a memo of what someone could do. Cross-hub changes end in an explicit handoff, named.
 
 CAPABILITIES (Analyst — numbers first: what the posts actually did, then where to go):
@@ -633,7 +633,7 @@ ${LIBRARY_DOCS_PROMPT}
 - Length, canvas and brand kit come from the request. Allowed canvases: 1080×1080, 1080×1920, 1920×1080. Never 4:5.
 - THE CRAFT IS A FILE: read_file("how/MAKE-MOTION-VIDEO.md") — transition recipes with their code, the craft specs, and the checks that refuse a render. create_motion_video / write_motion_source / replace_motion_source refuse until you have read it in this turn. Read it once, at the start; everything you need to write a composition is in there.
 - HANDING IT OVER IS show_media ON THE MP4 (see above), never a link and never a tab: the turn that finishes a render ends with show_media on the file. /${slug}/motion-video is the editor, not the delivery — propose_open_tab it only if the user says they want to go and work on it there.
-- Write in ${lang}.`,
+- Reply in the language of the user's latest message; fall back to ${lang} only when their text has no detectable language (REPLY LANGUAGE).`,
 
   ugc: (lang, slug) => `READY, for this trade: the reel EXISTS as a post in pending (create_post content_type "video" returned) with its media_review honored — a script pasted in chat is homework, not a reel.
 
@@ -645,7 +645,7 @@ CAPABILITIES (UGC Specialist — talking reels and filmed short-form):
 - HOOK DISCIPLINE: the first two seconds decide everything, and they must hold with the sound off. Visual, spoken line and on-screen text must not all say the same thing — three channels, three jobs.
 - read_market_references for what is landing in this brand's field right now: formats, hooks, angles. Adapt the pattern, never clone the post.
 - The score on read_posts (media_review) is the verdict on hook, scroll-stop, hold, authenticity and CTA — honor fix/kill, rewrite and re-shoot the beat that failed, do not re-argue it. There is no tool here that scores a clip on demand: with no stored score, watch the clip with read_media and call it yourself against the same five.
-- Write in ${lang}.`,
+- Reply in the language of the user's latest message; fall back to ${lang} only when their text has no detectable language (REPLY LANGUAGE).`,
 
   web: (lang, slug) => `READY, for this trade: articles actually WRITTEN and scheduled where asked (write_planned_article / update_article / schedule_article returned), audits RUN and read (run_seo_geo_audit) — never "dovresti scrivere un articolo su X" when the tool to write it is yours.
 

--- a/src/lib/server/chat/async-jobs.ts
+++ b/src/lib/server/chat/async-jobs.ts
@@ -119,7 +119,7 @@ export async function runGenerateStrategy(
   const plan = await proposeGtmDual(genaiClient(), profile, {
     objective: params.objective ?? '',
     platforms,
-    outputLanguage: localeLanguageName(params.locale ?? 'it'),
+    outputLanguage: localeLanguageName(params.locale ?? 'en'),
     benchmark: evidence.benchmark,
     topPosts: evidence.topPosts,
     zeroToOne: evidence.historyCount < 10,
@@ -203,7 +203,7 @@ export async function runGenerateEditorialPlan(
   const proposal = await proposePlan(genaiClient(), profile, {
     platforms,
     allowedCadences: cadenceAllowed(brandRow?.plan ?? null),
-    outputLanguage: localeLanguageName(params.locale ?? 'it'),
+    outputLanguage: localeLanguageName(params.locale ?? 'en'),
     strategyBrief: [gtmBrief, evidence.strategyBrief].filter(Boolean).join('\n\n'),
     benchmark: evidence.benchmark,
     topPosts: evidence.topPosts,

--- a/src/lib/server/chat/goal.ts
+++ b/src/lib/server/chat/goal.ts
@@ -17,6 +17,7 @@
  * gira a vuoto, e mai contro un turno fermato dall'utente.
  */
 import type { SupabaseClient } from '@supabase/supabase-js';
+import { bilingualNoticeLocale } from '$lib/i18n/locale';
 import { trackGoalEvent } from '$lib/server/chat/goal-log';
 
 export type GoalCriterionStatus = 'open' | 'done' | 'dropped';
@@ -477,7 +478,7 @@ export function goalWorthyRequest(text: string | null | undefined): boolean {
  * già nella descrizione di `set_goal`, questa la ripete sul turno giusto, e si paga solo lì.
  */
 export function goalNudge(locale: string): string {
-  return locale === 'en'
+  return bilingualNoticeLocale(locale) === 'en'
     ? 'THIS REQUEST LOOKS LIKE A MULTI-STEP JOB. Call set_goal BEFORE your first action: one sentence, then the checkable facts that will make it true. Close each one with update_goal as you go — closing is a CALL, not a word: "c1 done" written in your reply closes nothing. Do not ask permission — it is your own working discipline, not a decision for the user.'
     : 'QUESTA RICHIESTA HA LA FORMA DI UN LAVORO IN PIÙ PASSI. Chiama set_goal PRIMA della prima azione: una frase, poi i fatti verificabili che la renderanno vera. Chiudili uno per uno con update_goal mentre procedi — chiudere è una CHIAMATA, non una parola: «c1 chiuso» scritto nella risposta non chiude niente. Non chiedere il permesso — è la tua disciplina di lavoro, non una decisione dell\'utente.';
 }
@@ -489,7 +490,7 @@ export function goalBriefing(goal: ChatGoal, locale: string): string {
     const mark = c.status === 'done' ? '[x]' : c.status === 'dropped' ? '[–]' : '[ ]';
     return `${mark} ${c.id}: ${c.text}${c.note ? ` — ${c.note}` : ''}`;
   });
-  const en = locale === 'en';
+  const en = bilingualNoticeLocale(locale) === 'en';
   const head = en
     ? `OPEN GOAL FOR THIS CONVERSATION (${done}/${total} criteria closed, ${goal.laps} background resume${goal.laps === 1 ? '' : 's'} used)`
     : `OBIETTIVO APERTO DI QUESTA CONVERSAZIONE (${done}/${total} criteri chiusi, ${goal.laps} ripres${goal.laps === 1 ? 'a' : 'e'} in background usat${goal.laps === 1 ? 'a' : 'e'})`;
@@ -558,7 +559,7 @@ export function goalContinuationPrompt(
         '- Ti sei fermato ad aspettare un giudizio che puoi darti da solo (una review, un QC, "dimmi se va bene"). Dattelo e chiudi il criterio.'
       ]
     : [];
-  if (locale === 'en') {
+  if (bilingualNoticeLocale(locale) === 'en') {
     return [
       ...emptyEn,
       'Keep working on the goal you set for yourself. The previous turn ended on a limit, not because the work was done.',
@@ -698,7 +699,7 @@ export function goalTurnNotice(
   if (decision.reason === 'out_of_time') return null;
   const { done, total } = goalProgress(goal.criteria);
   const open = openCriteria(goal.criteria);
-  const en = locale === 'en';
+  const en = bilingualNoticeLocale(locale) === 'en';
     // Questo testo rientra nel transcript a ogni turno successivo, quindi si paga in token per tutto
     // il resto della conversazione — e un elenco parziale spacciato per completo sarebbe peggio del
     // silenzio. ponytail: soglia binaria; se servisse nominarli in blocco, la strada è «x; y; +3».
@@ -1123,7 +1124,7 @@ export async function settleGoalForTurn(
     if (proven.length) {
       const applied = await updateGoalCriteria(supabase, goal, {
         done: proven,
-        note: opts.locale === 'en' ? PROSE_CLOSE_NOTE.en : PROSE_CLOSE_NOTE.it
+        note: bilingualNoticeLocale(opts.locale) === 'en' ? PROSE_CLOSE_NOTE.en : PROSE_CLOSE_NOTE.it
       }).catch(() => null);
       if (applied) goal = applied.goal;
     }
@@ -1145,7 +1146,7 @@ export async function settleGoalForTurn(
         supabase,
         goal,
         bad.map((c) => c.id),
-        opts.locale === 'en'
+        bilingualNoticeLocale(opts.locale) === 'en'
           ? refused.length
             ? `Reopened: ticked off in a turn where ${refused.join(', ')} was refused and never went through.`
             : 'Reopened: this turn never got a successful result from the tool this criterion names.'
@@ -1192,7 +1193,7 @@ export async function settleGoalForTurn(
       supabase,
       goal.id,
       'met',
-      opts.locale === 'en'
+      bilingualNoticeLocale(opts.locale) === 'en'
         ? `Closed by the system, not by the agent: every criterion is ticked off${how(true)}.`
         : `Chiuso dal sistema, non dall'agente: tutti i criteri risultano spuntati${how(false)}.`
     ).catch(() => null);
@@ -1205,7 +1206,7 @@ export async function settleGoalForTurn(
       supabase,
       goal.id,
       'handed_back',
-      opts.locale === 'en'
+      bilingualNoticeLocale(opts.locale) === 'en'
         ? `Stopped after ${goal.laps} automatic pass(es): ${openCriteria(goal.criteria).length} criterion(s) still open.`
         : `Fermato dopo ${goal.laps} ripresa/e automatiche: ${openCriteria(goal.criteria).length} criteri ancora aperti.`
     ).catch(() => null);

--- a/src/lib/server/chat/job-summaries.test.ts
+++ b/src/lib/server/chat/job-summaries.test.ts
@@ -9,13 +9,17 @@ describe('buildToolJobSummary', () => {
   });
 
   it('summarizes strategy phases', () => {
-    const text = buildToolJobSummary('generate_strategy', {
-      objective: 'Crescita',
-      phases: [
-        { name: 'Awareness', objective: 'farsi conoscere' },
-        { name: 'Conversion', objective: 'vendere' }
-      ]
-    });
+    const text = buildToolJobSummary(
+      'generate_strategy',
+      {
+        objective: 'Crescita',
+        phases: [
+          { name: 'Awareness', objective: 'farsi conoscere' },
+          { name: 'Conversion', objective: 'vendere' }
+        ]
+      },
+      'it'
+    );
     expect(text).toContain('Strategia attiva');
     expect(text).toContain('Crescita');
     expect(text).toContain('Awareness');
@@ -23,10 +27,14 @@ describe('buildToolJobSummary', () => {
   });
 
   it('summarizes editorial plan weeks', () => {
-    const text = buildToolJobSummary('generate_editorial_plan', {
-      cadence: { instagram: 3 },
-      weeks: [{ theme: 'Lancio', focus: 'teaser' }]
-    });
+    const text = buildToolJobSummary(
+      'generate_editorial_plan',
+      {
+        cadence: { instagram: 3 },
+        weeks: [{ theme: 'Lancio', focus: 'teaser' }]
+      },
+      'it'
+    );
     expect(text).toContain('Piano editoriale attivo');
     expect(text).toContain('Lancio');
   });
@@ -41,7 +49,7 @@ describe('buildToolJobSummary', () => {
       ]
     };
     for (const name of ['produce_week', 'generate_content'] as const) {
-      const text = buildToolJobSummary(name, result);
+      const text = buildToolJobSummary(name, result, 'it');
       expect(text).toContain('Settimana 1');
       expect(text).toContain('2 bozze');
       expect(text).toContain('hero shot');
@@ -60,7 +68,29 @@ describe('buildToolJobSummary', () => {
     expect(text).toContain('instagram');
   });
 
-  it('falls back for unknown tools', () => {
+	it('falls back for unknown tools', () => {
     expect(buildToolJobSummary('mystery_tool', { ok: true })).toContain('mystery_tool');
+  });
+
+  it('omitted locale is English — never Italian', () => {
+    const text = buildToolJobSummary('seo_geo_audit', {
+      tech_score: 19,
+      issues: 8,
+      share_of_voice: 76,
+      gaps: 54
+    });
+    expect(text).toContain('SEO & GEO audit complete');
+    expect(text).not.toMatch(/completato|Punteggio|Problemi rilevati/);
+  });
+
+  it('writes the SEO audit in English when the chat locale is English — never Italian', () => {
+    const text = buildToolJobSummary(
+      'seo_geo_audit',
+      { tech_score: 19, issues: 8, share_of_voice: 76, gaps: 54 },
+      'en'
+    );
+    expect(text).toContain('SEO & GEO audit complete');
+    expect(text).toContain('Technical score: 19/100');
+    expect(text).not.toMatch(/completato|Punteggio|Problemi rilevati/);
   });
 });

--- a/src/lib/server/chat/job-summaries.ts
+++ b/src/lib/server/chat/job-summaries.ts
@@ -1,24 +1,32 @@
 /**
- * Human-readable Italian summaries for completed async chat tool jobs.
+ * Human-readable summaries for completed async chat tool jobs.
+ * Italian when the chat locale is Italian; English otherwise — never the reverse.
  * Kept separate from the runner so we can unit-test without standing up a server.
  */
+import { bilingualNoticeLocale } from '$lib/i18n/locale';
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyRec = Record<string, any>;
 
-export function buildToolJobSummary(toolName: string, result: AnyRec): string {
+export function buildToolJobSummary(toolName: string, result: AnyRec, locale: string = 'en'): string {
   if (result.error) return `❌ ${toolName} failed: ${result.error}`;
+  const en = bilingualNoticeLocale(locale) === 'en';
 
   switch (toolName) {
     case 'generate_strategy': {
       const phases = (result.phases ?? []) as AnyRec[];
       const list = phases.map((p, i) => `${i + 1}. **${p.name}** — ${p.objective ?? ''}`).join('\n');
-      return `✅ **Strategia attiva!**\n\nObiettivo: ${result.objective ?? '—'}\n\nFasi:\n${list}\n\nProcedo con il piano editoriale.`;
+      return en
+        ? `✅ **Strategy is live!**\n\nObjective: ${result.objective ?? '—'}\n\nPhases:\n${list}\n\nNext: the editorial plan.`
+        : `✅ **Strategia attiva!**\n\nObiettivo: ${result.objective ?? '—'}\n\nFasi:\n${list}\n\nProcedo con il piano editoriale.`;
     }
 
     case 'generate_editorial_plan': {
       const weeks = (result.weeks ?? []) as AnyRec[];
-      const list = weeks.map((w, i) => `${i + 1}. **${w.theme ?? 'Settimana'}** — ${w.focus ?? ''}`).join('\n');
-      return `✅ **Piano editoriale attivo!**\n\nCadenza: ${JSON.stringify(result.cadence ?? {})}\n\nSettimane:\n${list}\n\nPoi: teaser Web hub (SEO/GEO/blog) — perché il traffico organico conta, 1 dato credibile (es. ~50–60% del traffico sito da organic / click concentrati in page 1), piano a pagamento se locked (Go se offerto / Starter / Pro; non menzionare Go se nascosto) + offer_upgrade — e subito dopo foto/video + bozze settimana 1. Non aspettare l'upgrade.`;
+      const list = weeks.map((w, i) => `${i + 1}. **${w.theme ?? (en ? 'Week' : 'Settimana')}** — ${w.focus ?? ''}`).join('\n');
+      return en
+        ? `✅ **Editorial plan is live!**\n\nCadence: ${JSON.stringify(result.cadence ?? {})}\n\nWeeks:\n${list}\n\nThen: Web hub teaser (SEO/GEO/blog) — why organic traffic compounds, 1 credible stat (e.g. ~50–60% of site traffic from organic / clicks concentrated on page 1), paid plan if locked (Go when offered / Starter / Pro; do not mention Go if hidden) + offer_upgrade — then immediately photos/video + week-1 drafts. Do not wait for the upgrade.`
+        : `✅ **Piano editoriale attivo!**\n\nCadenza: ${JSON.stringify(result.cadence ?? {})}\n\nSettimane:\n${list}\n\nPoi: teaser Web hub (SEO/GEO/blog) — perché il traffico organico conta, 1 dato credibile (es. ~50–60% del traffico sito da organic / click concentrati in page 1), piano a pagamento se locked (Go se offerto / Starter / Pro; non menzionare Go se nascosto) + offer_upgrade — e subito dopo foto/video + bozze settimana 1. Non aspettare l'upgrade.`;
     }
 
     case 'generate_content':
@@ -28,36 +36,60 @@ export function buildToolJobSummary(toolName: string, result: AnyRec): string {
         .map((p) => `${p.n}. [${p.platform ?? '?'} / ${p.pillar ?? p.format ?? '?'}] ${p.idea ?? ''}`)
         .join('\n');
       const imgBit =
-        typeof result.images === 'number' ? ` (${result.images} con immagine)` : '';
-      return `✅ **Settimana ${(result.week ?? 0) + 1} pronta!**\n\n${result.count ?? 0} bozze in Contenuti${imgBit}:\n${list}\n\nRivedile in Contenuti — caption e immagini sono già generate; niente è pubblicato ancora.`;
+        typeof result.images === 'number'
+          ? en
+            ? ` (${result.images} with image)`
+            : ` (${result.images} con immagine)`
+          : '';
+      return en
+        ? `✅ **Week ${(result.week ?? 0) + 1} is ready!**\n\n${result.count ?? 0} drafts in Content${imgBit}:\n${list}\n\nReview them in Content — captions and images are already generated; nothing is published yet.`
+        : `✅ **Settimana ${(result.week ?? 0) + 1} pronta!**\n\n${result.count ?? 0} bozze in Contenuti${imgBit}:\n${list}\n\nRivedile in Contenuti — caption e immagini sono già generate; niente è pubblicato ancora.`;
     }
 
     case 'create_campaign':
-      return `✅ **Campagna "${result.campaign_name}" creata!**\n\n${result.count}/${result.requested} post pronti su ${result.platform}.\nApri Campagne o Contenuti per rivederli.`;
+      return en
+        ? `✅ **Campaign "${result.campaign_name}" created!**\n\n${result.count}/${result.requested} posts ready on ${result.platform}.\nOpen Campaigns or Content to review them.`
+        : `✅ **Campagna "${result.campaign_name}" creata!**\n\n${result.count}/${result.requested} post pronti su ${result.platform}.\nApri Campagne o Contenuti per rivederli.`;
 
     case 'discover_competitors':
-      return `✅ **Analisi competitor completata!**\n\nTrovati **${result.competitors_found} competitor**:\n${result.competitors?.map((c: AnyRec) => `- ${c.name} (${c.kind})`).join('\n') ?? ''}\n\nPost brand: ${result.benchmark?.brand_posts ?? 0}, Engagement mediano mercato: ${result.benchmark?.market_median_engagement ?? 0}`;
+      return en
+        ? `✅ **Competitor analysis complete!**\n\nFound **${result.competitors_found} competitors**:\n${result.competitors?.map((c: AnyRec) => `- ${c.name} (${c.kind})`).join('\n') ?? ''}\n\nBrand posts: ${result.benchmark?.brand_posts ?? 0}, market median engagement: ${result.benchmark?.market_median_engagement ?? 0}`
+        : `✅ **Analisi competitor completata!**\n\nTrovati **${result.competitors_found} competitor**:\n${result.competitors?.map((c: AnyRec) => `- ${c.name} (${c.kind})`).join('\n') ?? ''}\n\nPost brand: ${result.benchmark?.brand_posts ?? 0}, Engagement mediano mercato: ${result.benchmark?.market_median_engagement ?? 0}`;
 
     case 'reanalyze_brand':
-      return `✅ **Ri-analisi brand completata!**\n\nNome: ${result.name}\nCategoria: ${result.category}\nProdotti trovati: ${result.products_found}\nTipo sito: ${result.site_type}`;
+      return en
+        ? `✅ **Brand re-analysis complete!**\n\nName: ${result.name}\nCategory: ${result.category}\nProducts found: ${result.products_found}\nSite type: ${result.site_type}`
+        : `✅ **Ri-analisi brand completata!**\n\nNome: ${result.name}\nCategoria: ${result.category}\nProdotti trovati: ${result.products_found}\nTipo sito: ${result.site_type}`;
 
     case 'sync_social_history':
-      return `✅ **Sincronizzazione social completata!**\n\nProfili sincronizzati: ${result.profiles_synced}\nPost sincronizzati: ${result.posts_synced}${result.errors?.length ? `\nErrori: ${result.errors.length}` : ''}`;
+      return en
+        ? `✅ **Social sync complete!**\n\nProfiles synced: ${result.profiles_synced}\nPosts synced: ${result.posts_synced}${result.errors?.length ? `\nErrors: ${result.errors.length}` : ''}`
+        : `✅ **Sincronizzazione social completata!**\n\nProfili sincronizzati: ${result.profiles_synced}\nPost sincronizzati: ${result.posts_synced}${result.errors?.length ? `\nErrori: ${result.errors.length}` : ''}`;
 
     case 'generate_person':
-      return `✅ **Persona creata!**\n\nNome: ${result.name}\nTipo: ${result.kind === 'ai' ? 'Avatar AI' : 'Foto reale'}\nImmagini: ${result.images_count}`;
+      return en
+        ? `✅ **Persona created!**\n\nName: ${result.name}\nType: ${result.kind === 'ai' ? 'AI avatar' : 'Real photo'}\nImages: ${result.images_count}`
+        : `✅ **Persona creata!**\n\nNome: ${result.name}\nTipo: ${result.kind === 'ai' ? 'Avatar AI' : 'Foto reale'}\nImmagini: ${result.images_count}`;
 
     case 'sync_products':
-      return `✅ **Sincronizzazione prodotti completata!**\n\nPiattaforma: ${result.platform}\nProdotti sincronizzati: ${result.products_synced}`;
+      return en
+        ? `✅ **Product sync complete!**\n\nPlatform: ${result.platform}\nProducts synced: ${result.products_synced}`
+        : `✅ **Sincronizzazione prodotti completata!**\n\nPiattaforma: ${result.platform}\nProdotti sincronizzati: ${result.products_synced}`;
 
     case 'seo_geo_audit':
-      return `✅ **Audit SEO & GEO completato!**\n\nPunteggio tecnico: ${result.tech_score ?? 'n/a'}/100\nProblemi rilevati: ${result.issues}\nShare-of-voice AI: ${result.share_of_voice}%\nDomande dove il brand è assente dalle risposte AI: ${result.gaps}`;
+      return en
+        ? `✅ **SEO & GEO audit complete!**\n\nTechnical score: ${result.tech_score ?? 'n/a'}/100\nIssues found: ${result.issues}\nAI share of voice: ${result.share_of_voice}%\nQuestions where the brand is absent from AI answers: ${result.gaps}`
+        : `✅ **Audit SEO & GEO completato!**\n\nPunteggio tecnico: ${result.tech_score ?? 'n/a'}/100\nProblemi rilevati: ${result.issues}\nShare-of-voice AI: ${result.share_of_voice}%\nDomande dove il brand è assente dalle risposte AI: ${result.gaps}`;
 
     case 'seo_plan':
-      return `✅ **Piano SEO generato!**\n\nValutazione: ${result.grade}\nIniziative consigliate: ${result.initiatives}`;
+      return en
+        ? `✅ **SEO plan generated!**\n\nGrade: ${result.grade}\nRecommended initiatives: ${result.initiatives}`
+        : `✅ **Piano SEO generato!**\n\nValutazione: ${result.grade}\nIniziative consigliate: ${result.initiatives}`;
 
     case 'seo_add_initiatives':
-      return `✅ **Aggiunte ${result.added} nuove iniziative SEO:**\n${(result.titles ?? []).map((t: string) => `- ${t}`).join('\n')}`;
+      return en
+        ? `✅ **Added ${result.added} new SEO initiatives:**\n${(result.titles ?? []).map((t: string) => `- ${t}`).join('\n')}`
+        : `✅ **Aggiunte ${result.added} nuove iniziative SEO:**\n${(result.titles ?? []).map((t: string) => `- ${t}`).join('\n')}`;
 
     case 'motion_video_qc': {
       // La QC fuori banda di un motion video (vedi output-tools.ts): il rientro deve dire il
@@ -65,22 +97,38 @@ export function buildToolJobSummary(toolName: string, result: AnyRec): string {
       // del vecchio silenzio.
       const craft = result.craft as AnyRec | null | undefined;
       const ads = result.review as AnyRec | null | undefined;
-      const verdict = String(craft?.verdict ?? ads?.verdict ?? 'senza verdetto');
-      const lines = [
-        `Verdetto craft: **${verdict}**${craft?.overall != null ? ` (${craft.overall}/10)` : ''}`,
-        craft?.judgment ? String(craft.judgment) : '',
-        result.applied
-          ? `Il difetto (${result.rewrite_from ?? 'craft'}) è stato CORRETTO nel sorgente: il video va ri-renderizzato per consegnare la versione giusta.`
-          : verdict === 'ship'
-            ? 'Il video è verificato e consegnabile.'
-            : result.note
-              ? `Nessuna correzione applicata: ${result.note}.`
-              : ''
-      ].filter(Boolean);
-      return `✅ **Verifica motion video completata**\n\n${lines.join('\n')}`;
+      const verdict = String(craft?.verdict ?? ads?.verdict ?? (en ? 'no verdict' : 'senza verdetto'));
+      const lines = en
+        ? [
+            `Craft verdict: **${verdict}**${craft?.overall != null ? ` (${craft.overall}/10)` : ''}`,
+            craft?.judgment ? String(craft.judgment) : '',
+            result.applied
+              ? `The defect (${result.rewrite_from ?? 'craft'}) was FIXED in the source: the video needs to be re-rendered to deliver the right version.`
+              : verdict === 'ship'
+                ? 'The video is verified and ready to ship.'
+                : result.note
+                  ? `No correction applied: ${result.note}.`
+                  : ''
+          ]
+        : [
+            `Verdetto craft: **${verdict}**${craft?.overall != null ? ` (${craft.overall}/10)` : ''}`,
+            craft?.judgment ? String(craft.judgment) : '',
+            result.applied
+              ? `Il difetto (${result.rewrite_from ?? 'craft'}) è stato CORRETTO nel sorgente: il video va ri-renderizzato per consegnare la versione giusta.`
+              : verdict === 'ship'
+                ? 'Il video è verificato e consegnabile.'
+                : result.note
+                  ? `Nessuna correzione applicata: ${result.note}.`
+                  : ''
+          ];
+      return en
+        ? `✅ **Motion video check complete**\n\n${lines.filter(Boolean).join('\n')}`
+        : `✅ **Verifica motion video completata**\n\n${lines.filter(Boolean).join('\n')}`;
     }
 
     default:
-      return `✅ ${toolName} completato: ${JSON.stringify(result)}`;
+      return en
+        ? `✅ ${toolName} complete: ${JSON.stringify(result)}`
+        : `✅ ${toolName} completato: ${JSON.stringify(result)}`;
   }
 }

--- a/src/lib/server/chat/loop-guard.test.ts
+++ b/src/lib/server/chat/loop-guard.test.ts
@@ -180,22 +180,23 @@ describe('benchAwarePrepareStep — il tool in panchina sparisce dal tavolo, con
 	}
 
 	it('senza panchina non tocca niente', async () => {
-		const prepare = benchAwarePrepareStep(createChatLoopGuard(), toolNames, 'it');
+		const prepare = benchAwarePrepareStep(createChatLoopGuard(), toolNames);
 		expect(await prepare({ messages: messaggi })).toEqual({});
 	});
 
-	it('con panchina: activeTools senza il tool, e il perché in coda ai messaggi', async () => {
-		const prepare = benchAwarePrepareStep(guardConPanchina(), toolNames, 'it');
+	it('con panchina: activeTools senza il tool, e il perché in coda ai messaggi come nota nascosta al modello', async () => {
+		const prepare = benchAwarePrepareStep(guardConPanchina(), toolNames);
 		const out = await prepare({ messages: messaggi });
 		expect(out.activeTools).toEqual(['replace_motion_source', 'reply']);
 		const appended = (out.messages as Array<{ role: string; content: string }>).at(-1)!;
-		expect(appended.role).toBe('user');
+		// Mai a nome dell'utente: le note del backend all'AI viaggiano come `system`.
+		expect(appended.role).toBe('system');
 		expect(appended.content).toContain('create_motion_video');
 		expect(appended.content).toContain('Import not allowed');
 	});
 
 	it('la spiegazione entra UNA volta, activeTools resta a ogni step', async () => {
-		const prepare = benchAwarePrepareStep(guardConPanchina(), toolNames, 'it');
+		const prepare = benchAwarePrepareStep(guardConPanchina(), toolNames);
 		const primo = await prepare({ messages: messaggi });
 		const secondo = await prepare({ messages: primo.messages as typeof messaggi });
 		expect(secondo.activeTools).toEqual(['replace_motion_source', 'reply']);
@@ -203,7 +204,7 @@ describe('benchAwarePrepareStep — il tool in panchina sparisce dal tavolo, con
 	});
 
 	it('compone un prepareStep interno (la mailbox) invece di sostituirlo', async () => {
-		const prepare = benchAwarePrepareStep(guardConPanchina(), toolNames, 'it', async ({ messages }) => ({
+		const prepare = benchAwarePrepareStep(guardConPanchina(), toolNames, async ({ messages }) => ({
 			messages: [...(messages ?? []), { role: 'user', content: 'follow-up assorbito' }]
 		}));
 		const out = await prepare({ messages: messaggi });
@@ -214,18 +215,18 @@ describe('benchAwarePrepareStep — il tool in panchina sparisce dal tavolo, con
 
 	it('se la panchina svuoterebbe il tavolo, non restringe', async () => {
 		const g = guardConPanchina();
-		const prepare = benchAwarePrepareStep(g, ['create_motion_video'], 'it');
+		const prepare = benchAwarePrepareStep(g, ['create_motion_video']);
 		const out = await prepare({ messages: messaggi });
 		expect(out.activeTools).toBeUndefined();
 	});
 });
 
 describe('toolBenchNotice', () => {
-	it('nomina il tool e il dettaglio, in entrambe le lingue', () => {
-		for (const locale of ['it', 'en'] as const) {
-			const notice = toolBenchNotice('create_motion_video', erroreImportNonAmmesso, locale);
-			expect(notice).toContain('create_motion_video');
-			expect(notice).toContain('Import not allowed');
-		}
+	it('è una nota al modello in inglese, comunque — la lingua dell\'utente la decide lui', () => {
+		const notice = toolBenchNotice('create_motion_video', erroreImportNonAmmesso);
+		expect(notice).toContain('create_motion_video');
+		expect(notice).toContain('Import not allowed');
+		expect(notice.startsWith('[SYSTEM NOTE]')).toBe(true);
+		expect(notice).not.toMatch(/[àèéìòù]/);
 	});
 });

--- a/src/lib/server/chat/loop-guard.test.ts
+++ b/src/lib/server/chat/loop-guard.test.ts
@@ -184,13 +184,15 @@ describe('benchAwarePrepareStep — il tool in panchina sparisce dal tavolo, con
 		expect(await prepare({ messages: messaggi })).toEqual({});
 	});
 
-	it('con panchina: activeTools senza il tool, e il perché in coda ai messaggi come nota nascosta al modello', async () => {
+	it('con panchina: activeTools senza il tool, e il perché in coda ai messaggi come nota marcata al modello', async () => {
 		const prepare = benchAwarePrepareStep(guardConPanchina(), toolNames);
 		const out = await prepare({ messages: messaggi });
 		expect(out.activeTools).toEqual(['replace_motion_source', 'reply']);
 		const appended = (out.messages as Array<{ role: string; content: string }>).at(-1)!;
-		// Mai a nome dell'utente: le note del backend all'AI viaggiano come `system`.
-		expect(appended.role).toBe('system');
+		// Non può essere `system`: il provider Google rifiuta i system a metà conversazione.
+		// Resta una nota al modello — marcata, inglese, mai persistita come riga di chat.
+		expect(appended.role).toBe('user');
+		expect(appended.content).toContain('[SYSTEM NOTE]');
 		expect(appended.content).toContain('create_motion_video');
 		expect(appended.content).toContain('Import not allowed');
 	});

--- a/src/lib/server/chat/loop-guard.test.ts
+++ b/src/lib/server/chat/loop-guard.test.ts
@@ -192,7 +192,7 @@ describe('benchAwarePrepareStep — il tool in panchina sparisce dal tavolo, con
 		// Non può essere `system`: il provider Google rifiuta i system a metà conversazione.
 		// Resta una nota al modello — marcata, inglese, mai persistita come riga di chat.
 		expect(appended.role).toBe('user');
-		expect(appended.content).toContain('[SYSTEM NOTE]');
+		expect(appended.content).toContain('<system-reminder>');
 		expect(appended.content).toContain('create_motion_video');
 		expect(appended.content).toContain('Import not allowed');
 	});
@@ -228,7 +228,7 @@ describe('toolBenchNotice', () => {
 		const notice = toolBenchNotice('create_motion_video', erroreImportNonAmmesso);
 		expect(notice).toContain('create_motion_video');
 		expect(notice).toContain('Import not allowed');
-		expect(notice.startsWith('[SYSTEM NOTE]')).toBe(true);
+		expect(notice.startsWith('<system-reminder>')).toBe(true);
 		expect(notice).not.toMatch(/[àèéìòù]/);
 	});
 });

--- a/src/lib/server/chat/loop-guard.ts
+++ b/src/lib/server/chat/loop-guard.ts
@@ -8,6 +8,8 @@
  * When this fires, do NOT auto-continue the turn: continuing would resume the same loop.
  */
 
+import { bilingualNoticeLocale } from '$lib/i18n/locale';
+
 export const CHAT_LOOP_THRESHOLD = 5;
 export const TOOL_BENCH_FAILURES = 2;
 
@@ -143,7 +145,7 @@ const BENCH_DETAIL_MAX_CHARS = 300;
 
 export function toolBenchNotice(toolName: string, detail: string, locale: string): string {
 	const why = detail.slice(0, BENCH_DETAIL_MAX_CHARS);
-	if (locale === 'en') {
+	if (bilingualNoticeLocale(locale) === 'en') {
 		return `The tool "${toolName}" has been removed for the rest of this turn: it failed ${TOOL_BENCH_FAILURES} times with the same arguments (${why}). Do not try it again — take a different route, or tell the user honestly what is missing.`;
 	}
 	return `Lo strumento "${toolName}" è stato tolto dal tavolo per il resto di questo turno: ha fallito ${TOOL_BENCH_FAILURES} volte con gli stessi argomenti (${why}). Non riprovarlo — cambia strada, oppure di' onestamente all'utente cosa manca.`;
@@ -188,14 +190,14 @@ export function isRepeatedReply(current: string, previous: string | null | undef
 }
 
 export function repeatedReplyContinuation(locale: string): string {
-	if (locale === 'en') {
+	if (bilingualNoticeLocale(locale) === 'en') {
 		return 'Your last reply was identical to your previous one and you executed NO tools this turn: the work you claim does not exist. Do not repeat that text. Either do the work NOW by calling the tools, or use ask_user to ask what is missing.';
 	}
 	return 'La tua ultima risposta è identica alla precedente e in questo turno non hai eseguito NESSUNO strumento: il lavoro che dichiari non esiste. Non ripetere quel testo. O esegui ADESSO il lavoro chiamando gli strumenti, oppure usa ask_user per chiedere cosa ti manca.';
 }
 
 export function repeatedReplyNotice(locale: string): string {
-	if (locale === 'en') {
+	if (bilingualNoticeLocale(locale) === 'en') {
 		return "I keep producing the same reply without doing any new work — what I claimed does not exist. I'm stopping instead of repeating myself: tell me what you expected to see and I'll do it for real, step by step.";
 	}
 	return 'Mi sto ripetendo: stavo per riscriverti la stessa risposta senza aver fatto alcun lavoro nuovo — quello che dichiaravo non esiste. Mi fermo invece di ripetermi: dimmi cosa ti aspettavi di vedere e lo faccio davvero, un passo alla volta.';
@@ -203,7 +205,7 @@ export function repeatedReplyNotice(locale: string): string {
 
 /** Closing line when the turn stopped because the agent was looping. Never promises auto-continue. */
 export function turnLoopNotice(locale: string): string {
-	if (locale === 'en') {
+	if (bilingualNoticeLocale(locale) === 'en') {
 		return '\n\n_Stopped — I was repeating the same steps without progress. Everything above is saved; tell me how you want to continue._';
 	}
 	return '\n\n_Mi fermo — stavo ripetendo gli stessi passi senza avanzare. Tutto quello sopra è salvato; dimmi come vuoi continuare._';

--- a/src/lib/server/chat/loop-guard.ts
+++ b/src/lib/server/chat/loop-guard.ts
@@ -173,9 +173,11 @@ export function benchAwarePrepareStep<M>(
 		const messages = base.messages ?? args.messages;
 		if (!messages) return out;
 		const notice = fresh.map((b) => toolBenchNotice(b.toolName, b.detail)).join('\n');
-		// `role: 'system'`: la nota va al modello e non deve comparire in chat né farsi passare
-		// per l'utente — stesso patto del correttivo retry di live.ts.
-		return { ...out, messages: [...messages, { role: 'system', content: notice } as M] };
+		// MAI `role: 'system'`: il provider Google rifiuta con UnsupportedFunctionalityError i
+		// messaggi system NON in testa alla conversazione ("only supported at the beginning").
+		// Resta il patto: nota al MODELLO, inglese, marcata così non si finge l'utente — e
+		// transitoria per questo step solo, quindi non finisce mai come riga in chat.
+		return { ...out, messages: [...messages, { role: 'user', content: notice } as M] };
 	};
 }
 

--- a/src/lib/server/chat/loop-guard.ts
+++ b/src/lib/server/chat/loop-guard.ts
@@ -150,7 +150,9 @@ const BENCH_DETAIL_MAX_CHARS = 300;
  */
 export function toolBenchNotice(toolName: string, detail: string): string {
 	const why = detail.slice(0, BENCH_DETAIL_MAX_CHARS);
-	return `[SYSTEM NOTE] The tool "${toolName}" has been removed for the rest of this turn: it failed ${TOOL_BENCH_FAILURES} times with the same arguments (${why}). Do not try it again — take a different route, or tell the user honestly what is missing.`;
+	// Tag `<system-reminder>`: la convenzione di fatto (Claude Code e simili) per le note del
+	// backend dentro messaggi di ruolo user che NON vengono dall'utente.
+	return `<system-reminder>This is an automated backend note, NOT from the user. The tool "${toolName}" has been removed for the rest of this turn: it failed ${TOOL_BENCH_FAILURES} times with the same arguments (${why}). Do not try it again — take a different route, or tell the user honestly what is missing.</system-reminder>`;
 }
 
 type PrepareStepPatch<M> = { messages?: M[]; activeTools?: string[] } & Record<string, unknown>;

--- a/src/lib/server/chat/loop-guard.ts
+++ b/src/lib/server/chat/loop-guard.ts
@@ -143,12 +143,14 @@ export function createChatLoopGuard(threshold: number = CHAT_LOOP_THRESHOLD): Ch
 
 const BENCH_DETAIL_MAX_CHARS = 300;
 
-export function toolBenchNotice(toolName: string, detail: string, locale: string): string {
+/**
+ * Nota per il MODELLO, mai visibile come messaggio utente: benché sia testo che entra
+ * nell'history, va sempre in inglese — è una direttiva all'AI, non una battuta. Il modello poi
+ * risponde nella lingua dell'utente (REPLY LANGUAGE).
+ */
+export function toolBenchNotice(toolName: string, detail: string): string {
 	const why = detail.slice(0, BENCH_DETAIL_MAX_CHARS);
-	if (bilingualNoticeLocale(locale) === 'en') {
-		return `The tool "${toolName}" has been removed for the rest of this turn: it failed ${TOOL_BENCH_FAILURES} times with the same arguments (${why}). Do not try it again — take a different route, or tell the user honestly what is missing.`;
-	}
-	return `Lo strumento "${toolName}" è stato tolto dal tavolo per il resto di questo turno: ha fallito ${TOOL_BENCH_FAILURES} volte con gli stessi argomenti (${why}). Non riprovarlo — cambia strada, oppure di' onestamente all'utente cosa manca.`;
+	return `[SYSTEM NOTE] The tool "${toolName}" has been removed for the rest of this turn: it failed ${TOOL_BENCH_FAILURES} times with the same arguments (${why}). Do not try it again — take a different route, or tell the user honestly what is missing.`;
 }
 
 type PrepareStepPatch<M> = { messages?: M[]; activeTools?: string[] } & Record<string, unknown>;
@@ -156,7 +158,6 @@ type PrepareStepPatch<M> = { messages?: M[]; activeTools?: string[] } & Record<s
 export function benchAwarePrepareStep<M>(
 	guard: ChatLoopGuard,
 	toolNames: string[],
-	locale: string,
 	inner?: (args: { messages?: M[] }) => Promise<PrepareStepPatch<M> | undefined> | PrepareStepPatch<M> | undefined
 ): (args: { messages?: M[] }) => Promise<PrepareStepPatch<M>> {
 	const announced = new Set<string>();
@@ -171,8 +172,10 @@ export function benchAwarePrepareStep<M>(
 		for (const b of fresh) announced.add(b.toolName);
 		const messages = base.messages ?? args.messages;
 		if (!messages) return out;
-		const notice = fresh.map((b) => toolBenchNotice(b.toolName, b.detail, locale)).join('\n');
-		return { ...out, messages: [...messages, { role: 'user', content: notice } as M] };
+		const notice = fresh.map((b) => toolBenchNotice(b.toolName, b.detail)).join('\n');
+		// `role: 'system'`: la nota va al modello e non deve comparire in chat né farsi passare
+		// per l'utente — stesso patto del correttivo retry di live.ts.
+		return { ...out, messages: [...messages, { role: 'system', content: notice } as M] };
 	};
 }
 

--- a/src/lib/server/chat/production-claim.ts
+++ b/src/lib/server/chat/production-claim.ts
@@ -12,6 +12,7 @@
  * confrontare gli id, non allargare la regex.
  */
 import type { SupabaseClient } from '@supabase/supabase-js';
+import { bilingualNoticeLocale } from '$lib/i18n/locale';
 import { leftATrace } from '$lib/server/chat/goal';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -85,7 +86,7 @@ export function turnRanNoTool(content: readonly Part[]): boolean {
 }
 
 export function idleTurnNotice(locale: string): string {
-  if (locale === 'en') {
+  if (bilingualNoticeLocale(locale) === 'en') {
     return '\n\n_Nothing ran in this turn: no tool was called, so nothing new was produced — any file linked above already existed._';
   }
   return '\n\n_In questo turno non è girato niente: nessuno strumento è stato chiamato, quindi non è stato prodotto nulla di nuovo — i file linkati qui sopra esistevano già._';
@@ -113,7 +114,7 @@ export function refusedAndNotRetried(content: readonly Part[]): string[] {
 
 export function refusedToolsNotice(names: string[], locale: string): string {
   const list = names.join(', ');
-  if (locale === 'en') {
+  if (bilingualNoticeLocale(locale) === 'en') {
     return `\n\n_Did not go through in this turn: ${list}. Nothing they were asked to produce exists yet._`;
   }
   return `\n\n_Non è andato a buon fine in questo turno: ${list}. Niente di ciò che dovevano produrre esiste ancora._`;
@@ -136,14 +137,14 @@ export function wroteNothing(content: readonly Part[]): boolean {
 }
 
 export function wroteNothingNotice(locale: string): string {
-  if (locale === 'en') {
+  if (bilingualNoticeLocale(locale) === 'en') {
     return '\n\n_Nothing was written in this turn: every tool that ran was a read. Whatever is described above as created or changed does not exist yet._';
   }
   return '\n\n_In questo turno non è stato scritto niente: tutti gli strumenti usati erano letture. Quello che qui sopra risulta creato o modificato non esiste ancora._';
 }
 
 export function productionClaimNotice(locale: string): string {
-  if (locale === 'en') {
+  if (bilingualNoticeLocale(locale) === 'en') {
     return "\n\n_Correction: no content was actually produced — nothing above exists as a post, image or article yet. What I described is the plan, not finished work. Ask me to produce it and it will appear right here as preview cards._";
   }
   return '\n\n_Correzione: non è stato prodotto davvero nessun contenuto — niente di quello che ho scritto sopra esiste ancora come post, immagine o articolo. Quello che ho descritto è il piano, non lavoro fatto. Chiedimi di produrlo e comparirà qui come schede di anteprima._';

--- a/src/lib/server/chat/prompt-cuts.test.ts
+++ b/src/lib/server/chat/prompt-cuts.test.ts
@@ -243,3 +243,26 @@ describe('il prompt non ricresce da solo', () => {
     expect(p.length, `${id ?? 'null'}: ${p.length} caratteri`).toBeLessThan(TETTO[id ?? 'null']);
   });
 });
+
+/**
+ * La regola che ha fermato amazon.in (27/8/2026): un messaggio inglese non deve poter diventare
+ * una risposta italiana. Vale per OGNI mestiere — non solo per i turni del kit, dove
+ * `live.test.ts` la copia già con il messaggio reale di quella sessione.
+ */
+describe('REPLY LANGUAGE nel prompt classico', () => {
+  it('il blocco assoluta è in ogni prompt, e nessuna direttiva contraddice il messaggio dell\'utente', async () => {
+    for (const id of EVERY) {
+      const p = await promptFor(id);
+      expect(p, String(id)).toContain("REPLY LANGUAGE — ABSOLUTE RULE: write every user-facing message in the language of the user's latest message");
+      expect(p, String(id)).not.toMatch(/Respond in (Italian|English)\b/);
+    }
+  });
+
+  it('nemmeno il playbook dei crediti pinnna una lingua al posto dell\'utente', async () => {
+    // Il blocco crediti sta dietro i dati del budget (qui nudi nello stub): si copia il
+    // sorgente, che è ciò che il prompt poi incolla.
+    const src = (await import('node:fs')).readFileSync('src/lib/server/chat/system-prompt.ts', 'utf8');
+    expect(src).toContain("in the language of the user's latest message, ${lang} only as fallback");
+    expect(src).not.toContain('Explain clearly in ${lang}');
+  });
+});

--- a/src/lib/server/chat/queue-dm.test.ts
+++ b/src/lib/server/chat/queue-dm.test.ts
@@ -231,9 +231,10 @@ describe('DM end-to-end: message_agent → coda → turno di risposta', () => {
 		expect(system).toContain('MAI salutare');
 		expect(system.indexOf('BASE_PROMPT')).toBeGreaterThan(0);
 		// L'identità del mittente sta NEL contenuto che il modello vede — non è "user: ciao".
+		// Il tag è una nota al modello: inglese a prescindere dal locale della chat.
 		const last = messages[messages.length - 1];
 		expect(String(last.content)).toBe(
-			"[Messaggio da Anomalia — un altro agente AI di questo brand, NON l'utente]: ciao"
+			'[Message from Anomalia — a fellow AI agent of this brand, NOT the user]: ciao'
 		);
 		// La risposta è firmata col membro che parla.
 		expect(savedAssistant[0]?.opts?.speaker).toBe('content');
@@ -283,7 +284,7 @@ describe('DM end-to-end: message_agent → coda → turno di risposta', () => {
 		const { system, messages } = harnessCalls[0];
 		expect(system.startsWith('## CHAT PRIVATA TRA AGENTI')).toBe(true);
 		// Chi parla è dedotto: il membro che NON ha firmato l'ultimo messaggio user.
-		expect(String(messages[messages.length - 1].content)).toContain('[Messaggio da Anomalia');
+		expect(String(messages[messages.length - 1].content)).toContain('[Message from Anomalia');
 		expect(savedAssistant[0]?.opts?.speaker).toBe('content');
 	});
 });

--- a/src/lib/server/chat/queue.ts
+++ b/src/lib/server/chat/queue.ts
@@ -361,7 +361,7 @@ async function failChatJob(
 		const wrote = !!(failedRow.partial as { text?: string } | null)?.text;
 		if (!wrote) {
 			const line =
-				params?.locale === 'en'
+				bilingualNoticeLocale(params?.locale) === 'en'
 					? 'The background pass did not run — it stopped before calling anything. Nothing is running now: tell me to try again.'
 					: 'La ripresa in background non è partita — si è fermata prima di fare qualsiasi cosa. Adesso non sta girando niente: dimmi di riprovare.';
 			await admin
@@ -574,11 +574,10 @@ export async function processNextQueuedChatJob(
 		// qualunque blocco — è il bug provato in produzione (il modello che saluta il brand per nome).
 		// ponytail: taggato solo l'ULTIMO messaggio; lo storico resta nudo — se i DM lunghi
 		// confondono, il tag va applicato in loadHistory per i thread col marker.
+		// Il tag è una nota al MODELLO: sempre inglese, a prescindere dalla lingua della chat.
 		const dmTaggedContent =
 			isDm && dmOtherName
-				? locale === 'en'
-					? `[Message from ${dmOtherName} — a fellow AI agent of this brand, NOT the user]: ${userMessageContent}`
-					: `[Messaggio da ${dmOtherName} — un altro agente AI di questo brand, NON l'utente]: ${userMessageContent}`
+				? `[Message from ${dmOtherName} — a fellow AI agent of this brand, NOT the user]: ${userMessageContent}`
 				: null;
 		const modelUserContent = turnDocuments.length
 			? stripAttachedDocsForDisplay(userMessageContent) + formatAttachedDocsForModel(turnDocuments)
@@ -1039,7 +1038,6 @@ export async function processNextQueuedChatJob(
 				prepareStep: benchAwarePrepareStep(
 					loopGuard,
 					Object.keys(customTools),
-					locale,
 					midTurnMailbox.prepareStep
 				),
 				onStepFinish: ({ toolCalls, text, content }: { toolCalls?: Array<{ toolName: string; input?: unknown }>; text?: string; content?: unknown }) => {

--- a/src/lib/server/chat/queue.ts
+++ b/src/lib/server/chat/queue.ts
@@ -91,6 +91,7 @@ import {
 import { hydrateChatDocuments } from '$lib/server/hydrate-chat-documents';
 import { DM_REPLY_STEP_CAP, dmAgents, dmBrief, dmNames, dmReplyBackMessage } from '$lib/chat-dm';
 import { parseRoomAgents, stripRoomPeerTools } from '$lib/server/chat/room';
+import { bilingualNoticeLocale } from '$lib/i18n/locale';
 
 export function kickChatQueueWork(origin: string): Promise<void> {
 	const headers: Record<string, string> = {};
@@ -151,7 +152,7 @@ export async function enqueueQueuedChatTurn(
 		userMessageSaved?: boolean;
 	}
 ): Promise<string | null> {
-	const locale = opts.locale === 'en' ? 'en' : 'it';
+	const locale = bilingualNoticeLocale(opts.locale);
 	const { data, error } = await supabase
 		.from('chat_jobs')
 		.insert({
@@ -246,7 +247,7 @@ export async function enqueueTurnContinuation(
 		.maybeSingle();
 	if (waiting) return null;
 
-	const locale = opts.locale === 'en' ? 'en' : 'it';
+	const locale = bilingualNoticeLocale(opts.locale);
 	return enqueueQueuedChatTurn(supabase, {
 		brandId: opts.brandId,
 		userId: opts.userId,
@@ -467,7 +468,7 @@ export async function processNextQueuedChatJob(
 	// è entrata in coda una CONTINUAZIONE si rifiuta invece di azzerare — riprenderebbe leggendo
 	// una storia che non c'è più, e ricomincerebbe da capo senza che nessuno sappia perché.
 	if (isClearCommand(userMessageContent)) {
-		const en = String(params.locale ?? 'it') === 'en';
+		const en = bilingualNoticeLocale(params.locale) === 'en';
 		const busy = await threadHasActiveChatResponse(admin, {
 			userId: job.user_id as string,
 			threadId,
@@ -522,7 +523,7 @@ export async function processNextQueuedChatJob(
 			return { processed: true, jobId, error: 'credits_exhausted' };
 		}
 
-		const locale = (params.locale as string) ?? 'it';
+		const locale = (params.locale as string) ?? 'en';
 		const webHubEnabled = hasWebHub(brand.plan);
 		const threadRow = await getThread(admin, threadId, brand.id, job.user_id as string);
 
@@ -695,7 +696,7 @@ export async function processNextQueuedChatJob(
 						threadId,
 						spec: kitSpec,
 						messages: kitMessages,
-						locale: locale === 'en' ? 'en' : 'it',
+						locale: bilingualNoticeLocale(locale),
 						mode: params.mode,
 						tier: typeof params.tier === 'string' ? params.tier : undefined,
 						modelFamily: turnModelFamily(threadRow?.model)?.family,
@@ -766,7 +767,7 @@ export async function processNextQueuedChatJob(
 			if (block) systemPrompt += `\n\n${block}`;
 		}
 		if (params.scheduled === true) {
-			systemPrompt += SCHEDULED_NOTE[locale === 'en' ? 'en' : 'it'];
+			systemPrompt += SCHEDULED_NOTE[bilingualNoticeLocale(locale)];
 		}
 		// Il brief dell'agente schedulato (vedi enqueueQueuedChatTurn): l'incarico vero sta qui nel
 		// system prompt, il thread mostra solo la riga corta che l'ha avviato.
@@ -804,7 +805,7 @@ export async function processNextQueuedChatJob(
 					admin,
 					current.id,
 					'abandoned',
-					locale === 'en' ? 'Closed by the user.' : "Chiuso dall'utente."
+					bilingualNoticeLocale(locale) === 'en' ? 'Closed by the user.' : "Chiuso dall'utente."
 				).catch(() => null);
 			}
 		}
@@ -1398,7 +1399,7 @@ export async function processNextQueuedChatJob(
 				const { sendPushToUser } = await import('$lib/server/web-push');
 				await sendPushToUser(admin, job.user_id as string, {
 					title: 'Anomalia',
-					body: locale === 'en' ? 'Your AI reply is ready' : "L'AI ha finito di rispondere",
+					body: bilingualNoticeLocale(locale) === 'en' ? 'Your AI reply is ready' : "L'AI ha finito di rispondere",
 					url: `/app/${brand.slug}/chat/${threadId}`,
 					tag: 'chat-ai-ready',
 					skipIfFocused: true

--- a/src/lib/server/chat/rate-limits.test.ts
+++ b/src/lib/server/chat/rate-limits.test.ts
@@ -1,68 +1,36 @@
-import { describe, it, expect } from 'vitest';
-import {
-  chatRateLimits,
-  chatRateLimitMessage,
-  resumeAtForWindow,
-  type ChatRateUsage
-} from './rate-limits';
+import { describe, expect, it } from 'vitest';
+import { chatRateLimitMessage, type ChatRateUsage } from './rate-limits';
+import { bilingualNoticeLocale } from '$lib/i18n/locale';
 
-describe('chatRateLimits', () => {
-  it('gives Free a larger % of its small monthly pool (50% / 80%)', () => {
-    expect(chatRateLimits(null)).toEqual({ fiveHour: 200, weekly: 320 });
-    expect(chatRateLimits(undefined)).toEqual({ fiveHour: 200, weekly: 320 });
+const usage = {
+  used5h: 999,
+  usedWeek: 999,
+  limits: { fiveHour: 50, weekly: 400 },
+  ok: false,
+  blocked: '5h' as const,
+  resetAt: new Date('2026-08-27T14:30:00Z')
+};
+
+// Il percorso che chiama `chatRateLimitMessage` passa da `bilingualNoticeLocale` prima:
+// questi test fissano il patto insieme — `en-IN`, header mancante o `*` devono finire in
+// inglese, mai italiano (amazon.in, 27/8/2026).
+describe('chatRateLimitMessage — inglese per tutto ciò che non è davvero italiano', () => {
+  it.each(['en', 'en-IN', undefined])('%s → inglese', (loc) => {
+    const locale = bilingualNoticeLocale(loc);
+    expect(locale).toBe('en');
+    expect(chatRateLimitMessage(usage as ChatRateUsage, locale)).toMatch(/^You've hit the 5-hour chat limit \(50 credits\)\./);
+    expect(chatRateLimitMessage(usage as ChatRateUsage, locale)).not.toContain('limite');
   });
 
-  it('uses ~30% / 50% of monthly credits on paid tiers', () => {
-    expect(chatRateLimits('go')).toEqual({ fiveHour: 630, weekly: 1050 });
-    expect(chatRateLimits('starter')).toEqual({ fiveHour: 1650, weekly: 2750 });
-    expect(chatRateLimits('pro')).toEqual({ fiveHour: 3600, weekly: 6000 });
-  });
-
-  it('treats legacy scale like Pro windows', () => {
-    expect(chatRateLimits('scale')).toEqual(chatRateLimits('pro'));
-  });
-});
-
-describe('resumeAtForWindow', () => {
-  const FIVE_H = 5 * 60 * 60 * 1000;
-  const now = new Date('2026-08-08T12:00:00Z');
-
-  it('returns when enough oldest spend ages out to go under the limit', () => {
-    // 150 + 80 = 230 over limit 200 → after first 150 ages out, 80 left < 200
-    const t0 = Date.parse('2026-08-08T08:00:00Z');
-    const t1 = Date.parse('2026-08-08T10:00:00Z');
-    const at = resumeAtForWindow(
-      [
-        { cost_usd: 1.5, created_at: new Date(t0).toISOString() },
-        { cost_usd: 0.8, created_at: new Date(t1).toISOString() }
-      ],
-      200,
-      FIVE_H,
-      now
+  it('it / it-IT → italiano', () => {
+    expect(chatRateLimitMessage(usage as ChatRateUsage, bilingualNoticeLocale('it-IT'))).toContain(
+      "Hai raggiunto il limite chat delle ultime 5 ore"
     );
-    expect(at.getTime()).toBe(t0 + FIVE_H);
-  });
-});
-
-describe('chatRateLimitMessage', () => {
-  const base: ChatRateUsage = {
-    used5h: 200,
-    usedWeek: 100,
-    limits: { fiveHour: 200, weekly: 320 },
-    ok: false,
-    blocked: '5h',
-    resetAt: new Date('2026-08-08T14:30:00Z')
-  };
-  const now = new Date('2026-08-08T12:00:00Z');
-
-  it('says you can resume at HH:MM (Command Code style)', () => {
-    expect(chatRateLimitMessage(base, 'en', now)).toMatch(/You can resume at/);
-    expect(chatRateLimitMessage(base, 'it', now)).toMatch(/Puoi riprendere alle/);
   });
 
-  it('mentions the weekly window when that is what blocks', () => {
-    const u = { ...base, blocked: 'week' as const, usedWeek: 320 };
-    expect(chatRateLimitMessage(u, 'en', now)).toMatch(/weekly/i);
-    expect(chatRateLimitMessage(u, 'it', now)).toMatch(/settimanale/i);
+  it('la finestra settimanale parla la stessa lingua', () => {
+    const week = { ...usage, blocked: 'week' as const };
+    expect(chatRateLimitMessage(week as ChatRateUsage, 'en')).toContain('weekly chat limit');
+    expect(chatRateLimitMessage(week as ChatRateUsage, 'it')).toContain('limite chat settimanale');
   });
 });

--- a/src/lib/server/chat/room.ts
+++ b/src/lib/server/chat/room.ts
@@ -30,6 +30,7 @@ import {
 } from '$lib/agent-avatars';
 import { compactionModel, takeKieUsage } from '$lib/server/chat/model';
 import { getCustomAgentsByIds } from '$lib/server/custom-agents-read';
+import { bilingualNoticeLocale } from '$lib/i18n/locale';
 
 /** Tetto ai membri: oltre, il prompt del router smette di essere corto e la stanza di essere leggibile. */
 export const ROOM_MAX_MEMBERS = 4;
@@ -155,9 +156,9 @@ export async function roomRoster(
   supabase: SupabaseClient,
   brandId: string,
   keys: string[],
-  locale: string = 'it'
+  locale: string = 'en'
 ): Promise<RoomMember[]> {
-  const lang = locale === 'en' ? 'en' : 'it';
+  const lang = bilingualNoticeLocale(locale);
   const customIds = keys
     .filter((k) => k.startsWith(CUSTOM_PREFIX))
     .map((k) => k.slice(CUSTOM_PREFIX.length));
@@ -506,12 +507,12 @@ export async function pickRoomSpeakers(opts: {
  *
  * Entra in OGNI turno di OGNI stanza: per questo l'area di un membro è una riga sola, non il brief.
  */
-export function roomSystemBlock(members: RoomMember[], speakerKey: string, locale = 'it'): string {
+export function roomSystemBlock(members: RoomMember[], speakerKey: string, locale = 'en'): string {
   const me = members.find((m) => m.key === speakerKey);
   const others = members.filter((m) => m.key !== speakerKey);
   if (!me || !others.length) return '';
   const list = others.map((m) => `${m.name} (${m.area})`).join('; ');
-  return locale === 'en'
+  return bilingualNoticeLocale(locale) === 'en'
     ? `\n\n## GROUP CHAT\nThis thread is a room: several agents and the user, in one conversation. You are **${me.name}**. Also here: ${list}. Everyone reads every message, yours included, and only ONE agent writes at a time — you were picked to answer THIS one. So: do not repeat what someone already said, do not summarise them, do not answer for them, do not introduce yourself again. If part of the request belongs to another craft, say so in one line and leave it to them — badly doing their job costs the user more than the handover. And you are not obliged to weigh in on everything: when the message is not really for you, the useful answer is a short one, or none.\nYOUR VOICE IS YOURS, THEIRS IS THEIRS. You may report what a colleague has ALREADY said in this chat, attributed to them (\"as Analyst said, ...\"). NEVER write new words in their name, never answer \"on their behalf\", never sign a section with their craft: they are here and speak for themselves. If you need their input you do not have it yet — say in one line what is needed and end your turn: the floor passes to them after you.`
     : `\n\n## CHAT DI GRUPPO\nQuesto thread è una stanza: più agenti e l'utente, in una conversazione sola. Tu sei **${me.name}**. Ci sono anche: ${list}. Tutti leggono tutti i messaggi, compreso il tuo, e scrive UN agente alla volta — per questo è stato scelto te. Quindi: non ripetere quello che qualcuno ha già detto, non riassumerlo, non rispondere al posto suo, non ripresentarti. Se un pezzo della richiesta è di un altro mestiere, dillo in una riga e lasciaglielo — farglielo male al posto suo costa all'utente più del passaggio di mano. E non sei obbligato a intervenire su tutto: quando il messaggio non è davvero per te, la risposta utile è breve, o nessuna.\nLA TUA VOCE È TUA, QUELLA DEGLI ALTRI È LORO. Puoi riferire quello che un collega ha GIÀ detto in questa chat, attribuendoglielo (\"come diceva Analyst, ...\"). Non scrivere MAI parole nuove a nome suo, non rispondere \"da parte sua\", non firmare un pezzo col suo mestiere: è qui dentro e parla da sé. Se ti serve il suo contributo non ce l'hai ancora — di' in una riga cosa serve e chiudi il tuo turno: la parola passa a lui dopo di te.`;
 }
@@ -594,7 +595,7 @@ export async function roomContinue(
   }
 ): Promise<RoomMember | null> {
   if (!isRoomThread(opts.thread)) return null;
-  const locale = opts.locale === 'en' ? 'en' : 'it';
+  const locale = bilingualNoticeLocale(opts.locale);
   const members = await roomRoster(supabase, opts.brandId, parseRoomAgents(opts.thread.room_agents), locale);
   if (members.length < 2) return null;
 

--- a/src/lib/server/chat/room.ts
+++ b/src/lib/server/chat/room.ts
@@ -335,23 +335,26 @@ async function roomRecentLines(
  * regola sta in tre posti (campo obbligatorio, forma del JSON, `parseNextSpeaker` che scarta se è
  * vuoto), così un modello che imita il formato senza avere niente da dire non passa lo stesso.
  */
-const NEXT_PROMPT = `Sei lo smistatore di una chat di gruppo di lavoro. Un agente ha appena risposto all'utente.
-Decidi se manca ancora qualcosa di IMPORTANTE che un ALTRO mestiere deve dire, e chi.
+// Questo è testo per il MODELLO, non per l'utente: sempre inglese (stessa regola delle note
+// del backend — REPLY LANGUAGE decide poi la lingua della risposta). Il roster sotto resta
+// "chiave — nome: mestiere" e i nomi viaggiano nei dati.
+const NEXT_PROMPT = `You are the dispatcher of a working group chat. An agent has just replied to the user.
+Decide whether anything IMPORTANT is still missing that a DIFFERENT trade should say, and who.
 
-La risposta normale è NESSUNO. Rispondi {"speaker":null} e basta se:
-- la risposta data copre già la richiesta;
-- quello che si potrebbe aggiungere è d'accordo, un complimento, un riassunto o una ripetizione;
-- l'aggiunta sarebbe una cosa generica che l'utente non ha chiesto;
-- il messaggio dell'utente era di una sola area e quell'area ha già parlato.
+The normal answer is NOBODY. Reply {"speaker":null} and nothing else if:
+- the given reply already covers the request;
+- whatever could be added would be agreement, a compliment, a summary or a repetition;
+- the addition would be generic and the user never asked for it;
+- the user's message touched only one area and that area has already spoken.
 
-Scegli qualcuno SOLO se:
-- una parte esplicita della richiesta dell'utente non ha ancora avuto risposta, e non è del mestiere di chi ha parlato;
-- oppure chi ha parlato ha detto qualcosa che un altro mestiere deve correggere o contraddire, perché così com'è porta l'utente fuori strada.
+Pick someone ONLY if:
+- an explicit part of the user's request has not been answered yet, and it is not the speaker's trade;
+- or the speaker said something another trade must correct or contradict, because as-is it leads the user astray.
 
-Se scegli qualcuno devi dire in poche parole COSA aggiunge, di concreto, che l'utente non ha già.
-Se non sai dirlo, allora non manca niente: rispondi {"speaker":null}.
+If you pick someone you must say in a few words WHAT concretely they add, beyond what the user already has.
+If you cannot say it, then nothing is missing: reply {"speaker":null}.
 
-Rispondi SOLO con JSON: {"adds":"<cosa manca, poche parole>","speaker":"<chiave>"} oppure {"speaker":null}`;
+Reply ONLY with JSON: {"adds":"<what's missing, few words>","speaker":"<key>"} or else {"speaker":null}`;
 
 /**
  * L'uscita del router di continuazione. Torna null per "nessuno" — che è il caso normale, non un
@@ -382,20 +385,20 @@ export function parseNextSpeaker(
   return { adds, speaker: key };
 }
 
-const ROUTER_PROMPT = `Sei lo smistatore di una chat di gruppo di lavoro. Nella stanza ci sono più agenti.
-Decidi CHI risponde all'ultimo messaggio dell'utente.
+const ROUTER_PROMPT = `You are the dispatcher of a working group chat. Several agents are in the room.
+Decide WHO answers the user's latest message.
 
-Regole:
-- Di norma parla UNO solo: quello il cui mestiere copre la richiesta.
-- Un membro può essere il generalista (chiave "auto"): è lui la scelta quando la richiesta non è di nessun mestiere in particolare. Non sceglierlo per rubare il lavoro a uno specialista che c'è.
-- Due solo se la richiesta chiede davvero due mestieri diversi nella stessa risposta. Mai più di due.
-- Chi non ha niente da aggiungere non compare nell'elenco: restare in silenzio è la scelta normale, non un fallimento.
-- LEGGI LE ULTIME BATTUTE PRIMA DI SCEGLIERE. Se il nuovo messaggio risponde, conferma o corregge qualcosa che ha detto un membro ("sì fallo", "no, più corto", "e i numeri?"), parla QUEL membro — non chi viene prima nella lista.
-- Se l'utente nomina uno specialista, è quello.
-- Solo se davvero nessuna delle regole sopra decide (un saluto a stanza fredda, una domanda generica senza un filo aperto): il generalista "auto" se c'è, altrimenti il primo della lista.
-- L'ordine della lista NON è una preferenza: è solo l'ordine in cui l'utente ha messo insieme la stanza.
+Rules:
+- As a rule exactly ONE agent speaks: the one whose trade covers the request.
+- A member can be the generalist (key "auto"): that is the choice when the request belongs to no particular trade. Do not pick it to steal work from a specialist who is present.
+- Two speakers only when the request truly demands two different trades in the same reply. Never more than two.
+- Whoever has nothing to add is not in the list: staying silent is the normal choice, not a failure.
+- READ THE LATEST EXCHANGES BEFORE CHOOSING. If the new message confirms, corrects or follows up on what one member said ("yes do it", "no, shorter", "what about the numbers?"), THAT member speaks — not whoever comes first in the list.
+- If the user names a specialist, it is that one.
+- Only if none of the rules above decides (a greeting to a cold room, a generic question with no open thread): the generalist "auto" if present, otherwise the first in the list.
+- The order of the list is NOT a preference: it is only the order in which the user assembled the room.
 
-Rispondi SOLO con JSON: {"speakers":["<chiave>"]}`;
+Reply ONLY with JSON: {"speakers":["<key>"]}`;
 
 /**
  * Chi parla in questa battuta. Una chiamata corta su modello economico; qualunque cosa vada storta

--- a/src/lib/server/chat/subagents.ts
+++ b/src/lib/server/chat/subagents.ts
@@ -362,7 +362,7 @@ export function createSubagentTools(opts: SubagentFactoryOpts) {
     brandId,
     tools: available,
     model,
-    locale = 'it',
+    locale = 'en',
     userId = '',
     threadId,
     webHubEnabled = true,

--- a/src/lib/server/chat/system-prompt.ts
+++ b/src/lib/server/chat/system-prompt.ts
@@ -1047,7 +1047,7 @@ AI credits this billing period: ${budget.credits.used}/${budget.credits.quota} u
 Credits reset around: ${budget.credits.periodEnd.toISOString()}
 
 CREDITS / LIMITS PLAYBOOK:
-- If remaining credits are 0 OR a tool returns error "credits_exhausted": STOP generating. Explain clearly in ${lang} that AI credits for this billing period are used up (mention approximate reset). Immediately call offer_upgrade so they can upgrade/check out in chat. Do NOT retry create_post / generate_image / produce_week / generate_content.
+- If remaining credits are 0 OR a tool returns error "credits_exhausted": STOP generating. Explain clearly — in the language of the user's latest message, ${lang} only as fallback — that AI credits for this billing period are used up (mention approximate reset). Immediately call offer_upgrade so they can upgrade/check out in chat. Do NOT retry create_post / generate_image / produce_week / generate_content.
 - If posts left is 0: explain the monthly post cap, call offer_upgrade, stop creating posts.
 - Chat also has rolling 5-hour and weekly credit windows (separate from the monthly pool). If the user hits those, the app blocks the turn with a clear message — explain briefly and offer_upgrade when relevant; do not invent workarounds.
 - If credits ≥80% used and the user asks for a large batch (e.g. 5 posts + images): warn before starting, offer a smaller batch OR call offer_upgrade for more headroom.

--- a/src/lib/server/chat/system-prompt.ts
+++ b/src/lib/server/chat/system-prompt.ts
@@ -27,6 +27,7 @@ import { buildConnectorsPrompt } from '$lib/composio-agent';
 import { isConnectorKind, listedForToolkit } from '$lib/composio-catalog';
 import { aiActSystemSection } from '$lib/ai-act';
 import { buildDisruptiveIdeasSection } from '$lib/server/disruptive-ideas';
+import { chatReplyLanguageBlock, localeLanguageName } from '$lib/i18n/locale';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyRec = Record<string, any>;
@@ -100,7 +101,7 @@ function wantsPack(
 export async function buildSystemPrompt(
   supabase: SupabaseClient,
   brand: AnyRec,
-  locale: string = 'it',
+  locale: string = 'en',
   agentId: AgentId | null = null,
   opts?: {
     consultation?: boolean;
@@ -250,7 +251,7 @@ export async function buildSystemPrompt(
       ? await fetchChatUserContext(supabase, opts.userId, { id: brandId, org_id: orgId })
       : null;
 
-  const lang = locale === 'it' ? 'Italian' : 'English';
+  const lang = localeLanguageName(locale);
   const tz = (brand.timezone as string) || 'Europe/Rome';
 
   const sections: string[] = [];
@@ -401,7 +402,7 @@ ${onboarding.phase === 'welcome' ? `FIRST-TURN HINT (only if this is clearly the
 RULES:
 - Always READ data before WRITING it. Use read tools to understand current state before making changes.
 - For destructive actions (deleting posts, rejecting drafts, major strategy changes), confirm with the user first.
-- Respond in ${lang}. Match the user's language.
+- ${chatReplyLanguageBlock(locale)}
 - What a reply contains is the delivery contract below, not a matter of taste.
 - You have full read/write access to: brand materials, strategy, editorial plan, GTM roadmap, posts, products, and team members.
 - Hub context for every section is preloaded below. Use read_* tools anytime you need fresher or deeper data.
@@ -1016,11 +1017,11 @@ export function wrapTurnMessage(block: string, message: ModelMessage): ModelMess
 export async function buildTurnVolatileBlock(
   supabase: SupabaseClient,
   brand: AnyRec,
-  locale: string = 'it'
+  locale: string = 'en'
 ): Promise<string> {
   const brandId = brand.id as string;
   const tz = (brand.timezone as string) || 'Europe/Rome';
-  const lang = locale === 'it' ? 'Italian' : 'English';
+  const lang = localeLanguageName(locale);
   const planKey = (brand.plan as string | null) ?? null;
   const planLabel = planKey ? (PLAN_LABELS[planKey] ?? planKey) : 'none (free / unpaid)';
   const subStatus = (brand.status as string) || 'trial';

--- a/src/lib/server/chat/tool-job-report.ts
+++ b/src/lib/server/chat/tool-job-report.ts
@@ -14,6 +14,7 @@
  * perché il silenzio è il modo peggiore di finire: meglio "l'audit non è riuscito: …" che niente.
  */
 import type { SupabaseClient } from '@supabase/supabase-js';
+import { bilingualNoticeLocale } from '$lib/i18n/locale';
 import { buildToolJobSummary } from './job-summaries';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -41,7 +42,7 @@ export function toolJobReportMessage(
 	outcome: ToolJobOutcome,
 	locale: string
 ): string {
-	const en = locale === 'en';
+	const en = bilingualNoticeLocale(locale) === 'en';
 	if (outcome.status === 'failed') {
 		const why = (outcome.error || 'unknown error').slice(0, 300);
 		return en
@@ -59,7 +60,7 @@ export function toolJobReportMessage(
 			? `🛠️ The background job "${toolName}" stopped without doing the work: ${why}.${result.action ? ` Required action: ${result.action}.` : ''} Explain it to the user in one line and take that action; do not silently retry.`
 			: `🛠️ Il lavoro in background "${toolName}" si è fermato senza fare il lavoro: ${why}.${action} Spiegalo all'utente in una riga e fai quell'azione; non ritentare da solo.`;
 	}
-	const body = buildToolJobSummary(toolName, result).slice(0, 1200);
+	const body = buildToolJobSummary(toolName, result, locale).slice(0, 1200);
 	return en
 		? `🛠️ The background job "${toolName}" is done. Result:\n${body}\n\nReport it to the user and carry on with what comes next.`
 		: `🛠️ Il lavoro in background "${toolName}" è finito. Esito:\n${body}\n\nRiferiscilo all'utente e prosegui con quello che viene dopo.`;
@@ -81,7 +82,7 @@ export async function enqueueToolJobReport(
 		// Niente thread = niente conversazione dove rientrare (job da CLI, da cron, dal designer).
 		if (!threadId || !toolName || toolName === 'chat_response') return null;
 		const params = (job.input_params ?? {}) as AnyRec;
-		const locale = params.report_locale === 'en' ? 'en' : 'it';
+		const locale = bilingualNoticeLocale(params.report_locale);
 		const { enqueueQueuedChatTurn } = await import('./queue');
 		return await enqueueQueuedChatTurn(admin, {
 			brandId: job.brand_id,

--- a/src/lib/server/chat/tools.ts
+++ b/src/lib/server/chat/tools.ts
@@ -43,7 +43,7 @@ export function createChatTools(
   tz: string = 'Europe/Rome',
   userId: string = '',
   origin: string = '',
-  locale: string = 'it',
+  locale: string = 'en',
   threadId?: string,
   _cookieHeader: string = '',
   /** Images the user attached to THIS turn — always available to the renderer as references. */

--- a/src/lib/server/chat/tools/shared.ts
+++ b/src/lib/server/chat/tools/shared.ts
@@ -1,4 +1,5 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
+import { bilingualNoticeLocale } from '$lib/i18n/locale';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AnyRec = Record<string, any>;
@@ -44,7 +45,7 @@ export async function startLongToolJob(
   threadId?: string,
   abortSignal?: AbortSignal,
   origin: string = '',
-  locale: string = 'it'
+  locale: string = 'en'
 ): Promise<AnyRec> {
   if (abortSignal?.aborted) {
     return { cancelled: true, error: 'Chat stopped before job could start' };
@@ -56,7 +57,7 @@ export async function startLongToolJob(
     tool_name: toolName,
     // `report_*` viaggiano nei params perché è l'unico posto dove portarli senza una migration:
     // chi chiude la riga (worker o reaper) è un altro processo e non ha né l'origin né la lingua.
-    input_params: { ...params, report_locale: locale === 'en' ? 'en' : 'it', report_origin: origin },
+    input_params: { ...params, report_locale: bilingualNoticeLocale(locale), report_origin: origin },
     status: 'pending',
     thread_id: threadId ?? null
   }).select('id').maybeSingle();

--- a/src/lib/server/chat/turn-limits.ts
+++ b/src/lib/server/chat/turn-limits.ts
@@ -1,3 +1,4 @@
+import { bilingualNoticeLocale } from '$lib/i18n/locale';
 import type { SubagentRole } from './subagents';
 
 /**
@@ -193,7 +194,7 @@ export function kitRunIsAlive(run: KitRunLiveness, now?: number): boolean {
 }
 
 export function turnTruncatedNotice(locale: string, willContinue: boolean): string {
-	if (locale === 'en') {
+	if (bilingualNoticeLocale(locale) === 'en') {
 		return willContinue
 			? '\n\n_Hit the time limit for a single turn. Everything above is done and saved — I am picking the rest back up in the background._'
 			: '\n\n_Hit the time limit for a single turn. Everything above is done and saved, but the rest is still open — send "continue" and I will pick it back up._';
@@ -312,7 +313,7 @@ function millions(tokens: number): string {
 
 /** NON promette una ripresa: riprendere un turno fermato per costo raddoppia quel costo. */
 export function turnTokenBudgetNotice(locale: string, usedTokens: number, budget: number): string {
-	if (locale === 'en') {
+	if (bilingualNoticeLocale(locale) === 'en') {
 		return `\n\n_Stopped — this turn burned ${millions(usedTokens)} tokens, past its ${millions(budget)} budget. Everything above is done and saved; the rest is still open. Tell me which part to pick up and I will start a fresh turn on that alone._`;
 	}
 	return `\n\n_Mi fermo — questo turno ha bruciato ${millions(usedTokens)} token, oltre il suo budget di ${millions(budget)}. Tutto quello sopra è fatto e salvato; il resto è ancora aperto. Dimmi quale pezzo riprendere e riparto da lì con un turno nuovo._`;

--- a/src/lib/server/chat/user-context.test.ts
+++ b/src/lib/server/chat/user-context.test.ts
@@ -53,4 +53,21 @@ describe('buildUserSection', () => {
     );
     expect(s).toContain('shared collaborator');
   });
+
+  it('never treats profile locale as a reason to answer English in Italian', () => {
+    const s = buildUserSection(
+      {
+        userId: 'u-4',
+        name: 'Alex Kumar',
+        email: 'alex@example.com',
+        locale: 'it',
+        orgRole: null,
+        isOrgOwner: false,
+        brandAccess: 'shared'
+      },
+      'Italian'
+    );
+    expect(s).toContain('never a reason to answer English in Italian');
+    expect(s).toContain('Match reply language to their messages');
+  });
 });

--- a/src/lib/server/chat/user-context.ts
+++ b/src/lib/server/chat/user-context.ts
@@ -75,6 +75,6 @@ Access on this brand: ${access}
 USER PLAYBOOK:
 - Address them naturally by first name when it fits ("${displayName.split(/\s+/)[0]}").
 - They are the human operator of this brand workspace — scheduling, approvals and billing decisions they confirm are authoritative.
-- Match reply language to their messages; profile locale (${ctx.locale ?? replyLang}) is only a hint.
+- Match reply language to their messages (see REPLY LANGUAGE). Profile locale (${ctx.locale ?? replyLang}) is only a fallback when the message has no detectable language — never a reason to answer English in Italian.
 - Do not repeat their email in every reply unless they ask for it or it is needed (billing/support).`;
 }

--- a/src/lib/server/custom-agents.ts
+++ b/src/lib/server/custom-agents.ts
@@ -1,4 +1,5 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
+import { bilingualNoticeLocale } from '$lib/i18n/locale';
 import { createThread, getThread, setThreadAgent } from '$lib/server/chat/persistence';
 import { enqueueQueuedChatTurn, kickChatQueueWork, threadHasActiveChatResponse } from '$lib/server/chat/queue';
 import { resolveAgent } from '$lib/server/chat/agents';
@@ -492,8 +493,7 @@ export async function deleteCustomAgentSchedule(
 
 async function localeForUser(admin: SupabaseClient, userId: string): Promise<string> {
   const { data } = await admin.from('profiles').select('locale').eq('id', userId).maybeSingle();
-  const loc = String(data?.locale ?? '');
-  return loc.toLowerCase().startsWith('en') ? 'en' : 'it';
+  return bilingualNoticeLocale(data?.locale);
 }
 
 /**

--- a/src/lib/server/designer-jobs.ts
+++ b/src/lib/server/designer-jobs.ts
@@ -5,6 +5,7 @@
  * a NEW job that picks up from persisted work.
  */
 import { CHAT_JOB_STATUS } from '$lib/chat-job-status';
+import { bilingualNoticeLocale } from '$lib/i18n/locale';
 import { swallow } from '$lib/server/swallow';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { env } from '$env/dynamic/private';
@@ -198,7 +199,7 @@ export async function enqueueDesignerContinuation(
 	const depth = Math.max(0, Math.trunc(opts.depth ?? 0));
 	if (depth >= DESIGNER_MAX_CONTINUATIONS) return null;
 
-	const locale = opts.locale === 'en' ? 'en' : 'it';
+	const locale = bilingualNoticeLocale(opts.locale);
 	const { data, error } = await supabase
 		.from('chat_jobs')
 		.insert({
@@ -266,7 +267,7 @@ export async function reapStaleDesignerJobs(
 		if (!isDesignerTool(job.tool_name)) continue;
 
 		const params = (job.input_params ?? {}) as Record<string, unknown>;
-		const locale = params.locale === 'en' ? 'en' : 'it';
+		const locale = bilingualNoticeLocale(params.locale);
 		const depth = Math.max(0, Math.trunc(Number(params.continuation_depth)) || 0);
 		const jobOrigin = typeof params.origin === 'string' && params.origin ? params.origin : origin;
 

--- a/src/lib/server/designer-work.ts
+++ b/src/lib/server/designer-work.ts
@@ -1,4 +1,5 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
+import { bilingualNoticeLocale } from '$lib/i18n/locale';
 import { withBrandContext } from '$lib/server/ai-log';
 import {
 	CHAT_PENDING_STALE_MS,
@@ -95,7 +96,7 @@ async function runClaimedDesignerJob(
 ): Promise<{ processed: boolean; jobId: string; error?: string }> {
 	const jobId = job.id;
 	const params = (job.input_params ?? {}) as Record<string, unknown>;
-	const locale = params.locale === 'en' ? 'en' : 'it';
+	const locale = bilingualNoticeLocale(params.locale);
 	const depth = Math.max(0, Math.trunc(Number(params.continuation_depth)) || 0);
 	const toolName = job.tool_name as DesignerToolName;
 	if (!isDesignerTool(toolName)) {

--- a/src/lib/server/designer-work.ts
+++ b/src/lib/server/designer-work.ts
@@ -149,6 +149,7 @@ async function runClaimedDesignerJob(
 					// La slice di continuazione scrive nello stesso thread della prima: senza,
 					// `publish_artifact` smetterebbe di funzionare a metà lavoro.
 					threadId: typeof params.threadId === 'string' ? params.threadId : null,
+					locale,
 					abortSignal: abort.signal,
 					deadline,
 					onSaved: (id) => {

--- a/src/lib/server/geo.ts
+++ b/src/lib/server/geo.ts
@@ -1,4 +1,5 @@
 import { swallow } from '$lib/server/swallow';
+import { bilingualNoticeLocale } from '$lib/i18n/locale';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { GoogleGenAI } from '@google/genai';
 import { fetchPage } from './brand-analysis';
@@ -828,7 +829,9 @@ Write questions the way a real person phrases them (never the bare brand name). 
   );
   const rows: AnyRec[] = [];
   for (const p of (out.prompts ?? []).slice(0, 7)) {
-    if (p?.prompt?.trim()) rows.push({ brand_id: brandId, prompt: p.prompt.trim(), lang: p.lang === 'en' ? 'en' : 'it' });
+    // Il modello è vincolato a it|en dallo schema, ma non fidarsi: la stessa normalizzazione di
+    // tutto il prodotto — italiano solo se davvero it*, inglese per ogni altra cosa.
+    if (p?.prompt?.trim()) rows.push({ brand_id: brandId, prompt: p.prompt.trim(), lang: bilingualNoticeLocale(p.lang) === 'it' ? 'it' : 'en' });
   }
   if (!rows.length) return 0;
   const { error } = await admin.from('brand_geo_prompts').upsert(rows, { onConflict: 'brand_id,prompt', ignoreDuplicates: true });

--- a/src/lib/server/media-generator/ugc-batch.ts
+++ b/src/lib/server/media-generator/ugc-batch.ts
@@ -3,6 +3,7 @@
  * and bounded parallelism so a 20-pack does not wait fully sequential.
  */
 import { swallow } from '$lib/server/swallow';
+import { bilingualNoticeLocale } from '$lib/i18n/locale';
 import type { GoogleGenAI } from '@google/genai';
 import { googleGenaiClient } from '$lib/server/gemini';
 import { createUIMessageStream, createUIMessageStreamResponse } from 'ai';
@@ -1275,7 +1276,7 @@ export function streamUgcBatchResponse(opts: UgcBatchOpts): Response {
             : false;
           const aborted = !!opts.abortSignal?.aborted;
           if (timedOut || aborted) {
-            const locale = opts.locale === 'en' ? 'en' : 'it';
+            const locale = bilingualNoticeLocale(opts.locale);
             writer.write({
               type: 'text-delta',
               id: textId,
@@ -1397,7 +1398,7 @@ export function streamUgcBatchResponse(opts: UgcBatchOpts): Response {
           // accodare una continuazione che riprenderebbe zero clip.
           ((timedOut || aborted) && finished.size + failed.size < videoCount);
         if (needsContinue) {
-          const locale = opts.locale === 'en' ? 'en' : 'it';
+          const locale = bilingualNoticeLocale(opts.locale);
           writer.write({
             type: 'text-delta',
             id: textId,

--- a/src/lib/server/motion-video/agent.ts
+++ b/src/lib/server/motion-video/agent.ts
@@ -1,4 +1,5 @@
 import { swallow } from '$lib/server/swallow';
+import { bilingualNoticeLocale } from '$lib/i18n/locale';
 import { GEMINI_MAX_OUTPUT_TOKENS } from '$lib/server/ai-output-limits';
 import { tool, stepCountIs, hasToolCall, type ModelMessage, type UIMessage } from 'ai';
 import { harnessStreamText } from '$lib/server/harness';
@@ -203,10 +204,14 @@ function studioChatTools(
 	supabase: SupabaseClient,
 	brandId: string,
 	userId: string,
-	threadId?: string
+	threadId?: string,
+	/** Dashboard locale: feeds `report_locale` of the async jobs these tools enqueue. */
+	locale?: string
 ) {
 	const scoped = pickTools(
-		createChatTools(supabase, brandId, 'Europe/Rome', userId, '', 'it', threadId),
+		// Bilingual normalization here, not at each caller: an untyped/absent locale must be
+		// English — the hardcoded 'it' used to send amazon.in-style users Italian job reports.
+		createChatTools(supabase, brandId, 'Europe/Rome', userId, '', bilingualNoticeLocale(locale), threadId),
 		'motion'
 	);
 	const out: Record<string, unknown> = {};
@@ -311,6 +316,8 @@ export async function runMotionVideoAgent(opts: {
 	userId?: string;
 	/** Thread di questo giro: un artefatto appartiene a una conversazione (vedi run-turn). */
 	threadId?: string;
+	/** Dashboard locale: i tool condivisi della chat firmano così i job async che aprono. */
+	locale?: string;
 	supabase?: SupabaseClient;
 	/** Persist successful writes so a dropped SSE still leaves a row in the gallery. */
 	persist?: MotionPersistFn;
@@ -497,7 +504,7 @@ Need photo assets? Call read_media first. If a library image fits, use_library_i
 	// selection-bound source tools and its reference tools win every name collision below.
 	const chatTools =
 		supabase && brandId && userId
-			? studioChatTools(supabase, brandId, userId, opts.threadId)
+			? studioChatTools(supabase, brandId, userId, opts.threadId, opts.locale)
 			: {};
 	const libraryTools =
 		supabase && brandId && userId ? createMediaLibraryTools({ supabase, brandId, userId }) : {};

--- a/src/lib/server/motion-video/output-tools.ts
+++ b/src/lib/server/motion-video/output-tools.ts
@@ -16,6 +16,7 @@
  * composizione, così la scelta diventa aritmetica invece che speranza.
  */
 import { swallow } from '$lib/server/swallow';
+import { bilingualNoticeLocale } from '$lib/i18n/locale';
 import { tool } from 'ai';
 import { z } from 'zod';
 import type { SupabaseClient } from '@supabase/supabase-js';
@@ -184,7 +185,7 @@ export async function enqueueMotionQcJob(
 		tool_name: MOTION_QC_JOB,
 		input_params: {
 			video_id: opts.videoId,
-			report_locale: opts.locale === 'en' ? 'en' : 'it',
+			report_locale: bilingualNoticeLocale(opts.locale),
 			report_origin: opts.origin ?? ''
 		},
 		status: 'pending',

--- a/src/lib/server/motion-video/run-turn.ts
+++ b/src/lib/server/motion-video/run-turn.ts
@@ -152,6 +152,8 @@ export async function runMotionVideoTurn(opts: {
 	 * montato qui dentro perché sta nei tool condivisi della chat — rifiuta ogni chiamata.
 	 */
 	threadId?: string | null;
+	/** Dashboard locale: attraversa fino ai tool condivisi (report_locale dei job async). */
+	locale?: string;
 	deadline?: ChatTurnDeadline;
 	consumeSseStream?: (args: { stream: ReadableStream<string | Uint8Array> }) => Promise<void>;
 	onSaved?: (id: string) => void;
@@ -233,6 +235,7 @@ export async function runMotionVideoTurn(opts: {
 		supabase: opts.supabase,
 		abortSignal: opts.abortSignal,
 		threadId: opts.threadId ?? undefined,
+		locale: opts.locale,
 		deadlineReached: opts.deadline ? () => opts.deadline!.reached() : undefined,
 		// I sotto-agenti devono sapere quanto tempo resta PRIMA di partire, non scoprirlo a metà.
 		remainingMs: opts.deadline ? () => opts.deadline!.remainingMs() : undefined,

--- a/src/lib/server/motion-video/unfinished.ts
+++ b/src/lib/server/motion-video/unfinished.ts
@@ -32,6 +32,7 @@
  * cui c'è.
  */
 import type { SupabaseClient } from '@supabase/supabase-js';
+import { bilingualNoticeLocale } from '$lib/i18n/locale';
 
 /**
  * Riprese per un video non finito. Ventiquattro come `DESIGNER_MAX_CONTINUATIONS`: è lo stesso
@@ -218,8 +219,9 @@ async function threadSpendSince(
 }
 
 function continuationPrompt(title: string | null, score: number | null, locale?: string): string {
-	const name = title ? `"${title}"` : locale === 'en' ? 'the motion video' : 'il motion video';
-	if (locale === 'en') {
+	const en = bilingualNoticeLocale(locale) === 'en';
+	const name = title ? `"${title}"` : en ? 'the motion video' : 'il motion video';
+	if (en) {
 		return [
 			`${name} is NOT delivered: ${score == null ? 'no reviewed MP4 exists yet' : `the craft verdict is ${score}/10, not shippable`}.`,
 			'Pick it back up where you left it. Call render_motion_video: the first call on this version hands you the storyboard — one frame per scene — plus the source checks a still cannot show.',
@@ -244,7 +246,7 @@ function continuationPrompt(title: string | null, score: number | null, locale?:
  */
 export function motionUnfinishedNotice(d: MotionContinuation | null, locale: string): string | null {
 	if (!d || d.continue || d.reason === 'shipped' || d.reason === 'no_video_id') return null;
-	const en = locale === 'en';
+	const en = bilingualNoticeLocale(locale) === 'en';
 	const best = d.scores?.length ? Math.max(...d.scores) : null;
 	const grade = best == null ? '' : en ? ` The best it reached is ${best}/10.` : ` Il voto più alto raggiunto è ${best}/10.`;
 	if (d.reason === 'not_improving') {

--- a/src/lib/server/onboarding-chat.ts
+++ b/src/lib/server/onboarding-chat.ts
@@ -32,7 +32,7 @@ import { enqueueQueuedChatTurn } from '$lib/server/chat/queue';
 import { rosterForPrompt, scheduledWorkAllowed } from '$lib/server/job-roster';
 import { PLANS, visiblePlans } from '$lib/plans';
 import { isPlanGoEnabled } from '$lib/server/feature-flags';
-import { DEFAULT_LOCALE, isLocale, localeLanguageName, type Locale } from '$lib/i18n/locale';
+import { DEFAULT_LOCALE, bilingualNoticeLocale, isLocale, localeLanguageName, type Locale } from '$lib/i18n/locale';
 
 /** Il valore di `chat_threads.surface` del thread di setup. Uno per brand (key = brandId). */
 export const ONBOARDING_CHAT_SURFACE = 'onboarding';
@@ -246,7 +246,8 @@ export async function seedOnboardingChat(
       userId: opts.userId,
       threadId: thread.id,
       userMessage: visible,
-      locale: opts.locale === 'en' ? 'en' : opts.locale === 'it' ? 'it' : 'en',
+      // Stessa normalizzazione di tutto il resto: non-italiano → inglese.
+      locale: bilingualNoticeLocale(opts.locale),
       origin: opts.origin
     });
     return thread.id;

--- a/src/lib/server/radar.ts
+++ b/src/lib/server/radar.ts
@@ -24,6 +24,7 @@ import { activeGtmBrief } from './gtm';
 import { loadActivePlan, currentWeekIndex, selectFeaturableProducts } from './editorial-plan';
 import { runDirector } from './director';
 import { sendEmail } from './email';
+import { bilingualNoticeLocale } from '$lib/i18n/locale';
 import { brandContacts } from './scheduler';
 import { generateBlogFromNews } from './blog-generate';
 import { hasProRadarLeads, isRadarKindAllowed, leadEngagePlatforms, radarSourceLimit, type RadarPlatformKey, RADAR_PLATFORM_KEYS } from './plans';
@@ -1632,7 +1633,9 @@ async function sendRadarDigest(admin: SupabaseClient, brand: AnyRec, posts: Dige
     // One digest per recipient (owner + collaborators), each in their own language.
     // Emails first; Web Push after (never fails the digest).
     for (const contact of contacts) {
-      const it = (contact.locale ?? 'it').startsWith('it');
+      // Contatto senza locale → inglese, come tutte le notice: il vecchio `?? 'it'` mandava
+      // un digest italiano a chi non lo aveva mai scelto.
+      const it = bilingualNoticeLocale(contact.locale) === 'it';
 
       const total = posts.length + comments.length + articles.length;
       const subject = it ? `📡 Radar · ${brand.name}: ${total} ${total === 1 ? 'opportunità' : 'opportunità'} di oggi` : `📡 Radar · ${brand.name}: ${total} opportunit${total === 1 ? 'y' : 'ies'} today`;

--- a/src/lib/server/video-render-queue.ts
+++ b/src/lib/server/video-render-queue.ts
@@ -326,7 +326,11 @@ async function notifyThread(
 			userId: row.user_id,
 			threadId: row.thread_id,
 			userMessage: `[background] The video render you started has finished: ${outcome}. Report it to the user in one short line, referring to what they originally asked for. Do not re-run the render.`,
-			locale: 'it',
+			// La nota `[background]` è per il MODELLO: inglese a prescindere. Il locale del job qui
+			// sotto pilota le notice visibili della coda — e nessun profilo reale è in mano a questo
+			// sweep: niente locale significa notice inglesi per tutti (il vecchio hardcoded 'it'
+			// avrebbe parlato italiano con chiunque). La coda rifiuta stringhe vuote: 'en' esplicito.
+			locale: 'en',
 			origin,
 			continuation: true
 		});

--- a/src/lib/server/weekly-recap.ts
+++ b/src/lib/server/weekly-recap.ts
@@ -1,4 +1,5 @@
 import { swallow } from '$lib/server/swallow';
+import { bilingualNoticeLocale } from '$lib/i18n/locale';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { genaiClient, groundedText, structured } from './research';
 import { syncZernioAnalytics } from './zernio';
@@ -466,7 +467,7 @@ async function gatherRecapData(
     brandName: brand.name,
     brandSlug: brand.slug,
     ownerEmail: profile.email,
-    ownerLocale: profile.locale ?? 'it',
+    ownerLocale: profile.locale ?? 'en',
     postsPublished: published.length,
     postsPending: pending.length,
     postsScheduled: scheduled.length,
@@ -815,7 +816,9 @@ function buildActionItems(
   growth: GrowthReadiness | null = null
 ): { label: string; url?: string }[] {
   const items: { label: string; url?: string }[] = [];
-  const isIt = locale === 'it' || locale === 'it-IT';
+  // Normalizzazione unica del brand: it/it-IT/it-CH → italiano, tutto il resto (incluso
+  // profilo senza locale) → inglese. Lo stretto `=== 'it' || 'it-IT'` perdeva `it-CH`.
+  const isIt = bilingualNoticeLocale(locale) === 'it';
 
   if (growth && (!growth.ready || growth.warnings.length > 0)) {
     const pending = [...growth.blocking, ...growth.warnings];

--- a/src/routes/api/v1/chat/respond/run/+server.ts
+++ b/src/routes/api/v1/chat/respond/run/+server.ts
@@ -22,6 +22,7 @@ import {
   stripAttachedDocsForDisplay
 } from '$lib/chat-documents';
 import { hydrateChatDocuments } from '$lib/server/hydrate-chat-documents';
+import { bilingualNoticeLocale } from '$lib/i18n/locale';
 import type { RequestHandler } from './$types';
 
 // Matches the chat route — this path runs a full turn too.
@@ -71,7 +72,7 @@ export const POST: RequestHandler = async ({ request, locals: { supabase, safeGe
 
     // Scope prompt + tools to the thread's specialized agent (null → full set, legacy/onboarding).
     // agentId prima del modello: su Auto la famiglia la decide lo spec (motion → Grok).
-    const locale = params.locale ?? 'it';
+    const locale = params.locale ?? 'en';
     const origin = params.origin ?? '';
     const webHubEnabled = hasWebHub(brand.plan);
     const threadRow = await getThread(supabase, threadId, brand.id, user.id);
@@ -201,10 +202,10 @@ export const POST: RequestHandler = async ({ request, locals: { supabase, safeGe
       );
       content.push({
         type: 'text',
-        text: turnTokenBudgetNotice(locale === 'en' ? 'en' : 'it', tokenBudget.usedTokens, tokenBudget.budget)
+        text: turnTokenBudgetNotice(bilingualNoticeLocale(locale), tokenBudget.usedTokens, tokenBudget.budget)
       });
     } else if (loopGuard.stalled) {
-      content.push({ type: 'text', text: turnLoopNotice(locale === 'en' ? 'en' : 'it') });
+      content.push({ type: 'text', text: turnLoopNotice(bilingualNoticeLocale(locale)) });
     }
     const sources = sourcesFromSteps(result.steps, brand.slug ?? '');
 

--- a/src/routes/api/v1/chat/run/+server.ts
+++ b/src/routes/api/v1/chat/run/+server.ts
@@ -2,6 +2,7 @@ import { swallow } from '$lib/server/swallow';
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { withBrandContext } from '$lib/server/ai-log';
+import { bilingualNoticeLocale } from '$lib/i18n/locale';
 import { buildToolJobSummary } from '$lib/server/chat/job-summaries';
 import { executeChatToolJob } from '$lib/server/chat/job-executor';
 import {
@@ -63,7 +64,11 @@ export const POST: RequestHandler = async ({ request, locals: { supabase, safeGe
 
       await cancel.assertActive();
 
-      const summary = buildToolJobSummary(job.tool_name, result);
+      const summary = buildToolJobSummary(
+        job.tool_name,
+        result,
+        bilingualNoticeLocale((job.input_params as { report_locale?: string } | null)?.report_locale)
+      );
       await supabase.from('chat_messages').insert({
         brand_id: job.brand_id,
         user_id: job.user_id,

--- a/src/routes/app/[brand]/agent-lab/turn/+server.ts
+++ b/src/routes/app/[brand]/agent-lab/turn/+server.ts
@@ -13,6 +13,7 @@ import { createServerBrandFs, createPostgresMemoryStore, createHarnessRuntime, r
 import { createAdminClient } from '$lib/server/supabase-admin';
 import { createQueryTool } from '$lib/server/chat/query-tool';
 import { logAiCall } from '$lib/server/ai-log';
+import { bilingualNoticeLocale } from '$lib/i18n/locale';
 
 // Banco di prova del nuovo sistema agenti — SOLO dev, mai in produzione.
 // run-store scrive `agent_kit_runs` con la service role (RLS dà solo select), quindi il client
@@ -75,7 +76,7 @@ function toLine(e: RunEvent): Record<string, unknown> | null {
 	return null;
 }
 
-export const POST: RequestHandler = async ({ request, params, locals: { supabase, safeGetSession } }) => {
+export const POST: RequestHandler = async ({ request, params, locals: { supabase, safeGetSession, locale: uiLocale } }) => {
 	if (!dev) throw error(404, 'Not found');
 
 	try {
@@ -129,7 +130,7 @@ export const POST: RequestHandler = async ({ request, params, locals: { supabase
 			brandId: brand.id,
 			userId: user.id,
 			runId: 'preload',
-			locale: 'it'
+			locale: bilingualNoticeLocale(uiLocale)
 		});
 		const memoryMd = memoryEntries.map((e) => `### ${e.path}\n${e.content}`).join('\n\n');
 
@@ -138,7 +139,7 @@ export const POST: RequestHandler = async ({ request, params, locals: { supabase
 			brandId: brand.id,
 			threadId: null,
 			userId: user.id,
-			locale: 'it',
+			locale: bilingualNoticeLocale(uiLocale),
 			messages,
 			tools: BUILTIN_TOOLS,
 			// ponytail: fileIndex vuoto — costruirlo richiede un altro giro su agent-files.ts che il
@@ -164,7 +165,7 @@ export const POST: RequestHandler = async ({ request, params, locals: { supabase
 							brandId: brand.id,
 							threadId: null,
 							userId: user.id,
-							locale: 'it',
+							locale: bilingualNoticeLocale(uiLocale),
 							messages,
 							tools: BUILTIN_TOOLS,
 							extras: { memoryMd, fileIndex: '' },

--- a/src/routes/app/[brand]/agents/computer/clipboard/+server.ts
+++ b/src/routes/app/[brand]/agents/computer/clipboard/+server.ts
@@ -13,6 +13,7 @@
  * esplicito («Prendi il controllo»), non l'effetto collaterale di un pulsante appunti.
  */
 import { json } from '@sveltejs/kit';
+import { bilingualNoticeLocale } from '$lib/i18n/locale';
 import { readClipboard, writeClipboard } from '$lib/agent/adapters/graphical-bootstrap';
 import { createVercelSandboxProvider } from '$lib/agent/bridge/adapters';
 import type { AdapterContext } from '$lib/agent/kit/types';
@@ -21,9 +22,9 @@ import type { RequestHandler } from './$types';
 /** Un appunto non è un trasferimento file: oltre questo, è un altro problema (e un'altra rotta). */
 const MAX_CLIPBOARD_CHARS = 100_000;
 
-async function connect(brandId: string, userId: string, agentId?: string) {
+async function connect(brandId: string, userId: string, agentId?: string, uiLocale?: unknown) {
 	const sandbox = createVercelSandboxProvider();
-	const ctx: AdapterContext = { brandId, userId, runId: 'computer-clipboard', locale: 'it', agentId };
+	const ctx: AdapterContext = { brandId, userId, runId: 'computer-clipboard', locale: bilingualNoticeLocale(uiLocale), agentId };
 	return { sandbox, ctx, ref: await sandbox.provision({ brandId, agentId }, ctx) };
 }
 
@@ -32,19 +33,19 @@ async function brandFor(supabase: App.Locals['supabase'], slug: string) {
 	return data;
 }
 
-export const GET: RequestHandler = async ({ params, url, locals: { supabase, safeGetSession } }) => {
+export const GET: RequestHandler = async ({ params, url, locals: { supabase, safeGetSession, locale: uiLocale } }) => {
 	const { user } = await safeGetSession();
 	if (!user) return new Response('Unauthorized', { status: 401 });
 	const brand = await brandFor(supabase, params.brand);
 	if (!brand) return new Response('Not found', { status: 404 });
 
-	const { sandbox, ctx, ref } = await connect(brand.id, user.id, url.searchParams.get('agent') || undefined);
+	const { sandbox, ctx, ref } = await connect(brand.id, user.id, url.searchParams.get('agent') || undefined, uiLocale);
 	const res = await readClipboard(sandbox, ref, ctx);
 	if (!res.ok) return json({ error: 'clipboard_failed', detail: res.error }, { status: 502 });
 	return json({ text: res.text.slice(0, MAX_CLIPBOARD_CHARS) }, { headers: { 'cache-control': 'no-store' } });
 };
 
-export const POST: RequestHandler = async ({ params, request, url, locals: { supabase, safeGetSession } }) => {
+export const POST: RequestHandler = async ({ params, request, url, locals: { supabase, safeGetSession, locale: uiLocale } }) => {
 	const { user } = await safeGetSession();
 	if (!user) return new Response('Unauthorized', { status: 401 });
 	const brand = await brandFor(supabase, params.brand);
@@ -54,7 +55,7 @@ export const POST: RequestHandler = async ({ params, request, url, locals: { sup
 	const text = typeof body?.text === 'string' ? body.text.slice(0, MAX_CLIPBOARD_CHARS) : '';
 	if (!text) return json({ error: 'empty' }, { status: 400 });
 
-	const { sandbox, ctx, ref } = await connect(brand.id, user.id, url.searchParams.get('agent') || undefined);
+	const { sandbox, ctx, ref } = await connect(brand.id, user.id, url.searchParams.get('agent') || undefined, uiLocale);
 	const res = await writeClipboard(sandbox, ref, ctx, text);
 	if (!res.ok) return json({ error: 'clipboard_failed', detail: res.error }, { status: 502 });
 	return json({ ok: true });

--- a/src/routes/app/[brand]/agents/computer/desktop/+server.ts
+++ b/src/routes/app/[brand]/agents/computer/desktop/+server.ts
@@ -13,6 +13,7 @@
  * (`agent-desktop.ts`) è l'unico confine, ed è per quello che non esiste un ramo "senza password".
  */
 import { json } from '@sveltejs/kit';
+import { bilingualNoticeLocale } from '$lib/i18n/locale';
 import { ensureGraphicalMode, ensureRemoteDesktop } from '$lib/agent/adapters/graphical-bootstrap';
 import { createVercelSandboxProvider, graphicalBootstrapDeps, sandboxPortUrl } from '$lib/agent/bridge/adapters';
 import { desktopPassword, desktopUrl, publishComputerRunning } from '$lib/server/agent-desktop';
@@ -22,7 +23,7 @@ import { env } from '$env/dynamic/private';
 import type { AdapterContext } from '$lib/agent/kit/types';
 import type { RequestHandler } from './$types';
 
-export const POST: RequestHandler = async ({ params, url, locals: { supabase, safeGetSession } }) => {
+export const POST: RequestHandler = async ({ params, url, locals: { supabase, safeGetSession, locale: uiLocale } }) => {
 	const { user } = await safeGetSession();
 	if (!user) return new Response('Unauthorized', { status: 401 });
 
@@ -41,7 +42,7 @@ export const POST: RequestHandler = async ({ params, url, locals: { supabase, sa
 	const agentId = url.searchParams.get('agent') || undefined;
 
 	const sandbox = createVercelSandboxProvider();
-	const ctx: AdapterContext = { brandId: brand.id, userId: user.id, runId: 'computer-desktop', locale: 'it', agentId: url.searchParams.get('agent') || undefined };
+	const ctx: AdapterContext = { brandId: brand.id, userId: user.id, runId: 'computer-desktop', locale: bilingualNoticeLocale(uiLocale), agentId: url.searchParams.get('agent') || undefined };
 	// Accende la macchina se dorme, invece di rispondere «torna quando l'agente l'avrà accesa».
 	// È la stessa VM del brand: chi arriva primo la crea, e qui chi arriva è l'utente.
 	// L'affitto massimo, non quello di un turno: chi prende il controllo resta lì a lavorare, e

--- a/src/routes/app/[brand]/agents/computer/input/+server.ts
+++ b/src/routes/app/[brand]/agents/computer/input/+server.ts
@@ -9,6 +9,7 @@
  * Non è un canale generico di comandi: passano `type` e `key`, niente altro.
  */
 import { json } from '@sveltejs/kit';
+import { bilingualNoticeLocale } from '$lib/i18n/locale';
 import { runActions } from '$lib/agent/adapters/graphical-bootstrap';
 import { createVercelSandboxProvider } from '$lib/agent/bridge/adapters';
 import type { AdapterContext } from '$lib/agent/kit/types';
@@ -23,7 +24,7 @@ const ALLOWED_KEYS = new Set([
 	'ctrl+c', 'ctrl+v', 'ctrl+a', 'ctrl+x', 'ctrl+z'
 ]);
 
-export const POST: RequestHandler = async ({ params, request, url, locals: { supabase, safeGetSession } }) => {
+export const POST: RequestHandler = async ({ params, request, url, locals: { supabase, safeGetSession, locale: uiLocale } }) => {
 	const { user } = await safeGetSession();
 	if (!user) return new Response('Unauthorized', { status: 401 });
 
@@ -37,7 +38,7 @@ export const POST: RequestHandler = async ({ params, request, url, locals: { sup
 	if (!text && !key) return json({ error: 'empty' }, { status: 400 });
 
 	const sandbox = createVercelSandboxProvider();
-	const ctx: AdapterContext = { brandId: brand.id, userId: user.id, runId: 'computer-input', locale: 'it', agentId: url.searchParams.get('agent') || undefined };
+	const ctx: AdapterContext = { brandId: brand.id, userId: user.id, runId: 'computer-input', locale: bilingualNoticeLocale(uiLocale), agentId: url.searchParams.get('agent') || undefined };
 	const ref = await sandbox.provision({ brandId: brand.id, agentId: url.searchParams.get('agent') || undefined }, ctx);
 	const res = await runActions(sandbox, ref, ctx, key ? [{ kind: 'key', key }] : [{ kind: 'type', text }]);
 	if (!res.ok) return json({ error: 'input_failed', detail: res.error }, { status: 502 });

--- a/src/routes/app/[brand]/agents/computer/screen/+server.ts
+++ b/src/routes/app/[brand]/agents/computer/screen/+server.ts
@@ -17,6 +17,7 @@
  * freschezza dichiarata (`FRESH_MS`).
  */
 import { swallow } from '$lib/server/swallow';
+import { bilingualNoticeLocale } from '$lib/i18n/locale';
 import { captureScreenshot, ensureGraphicalMode } from '$lib/agent/adapters/graphical-bootstrap';
 import { createVercelSandboxProvider, graphicalBootstrapDeps } from '$lib/agent/bridge/adapters';
 import type { AdapterContext } from '$lib/agent/kit/types';
@@ -26,7 +27,7 @@ const FRESH_MS = 2_000;
 /** ponytail: Map in-process, niente TTL sweep — poche entry (una per computer attiva), si svuota da sola al cold start. */
 const cache = new Map<string, { at: number; png: Buffer }>();
 
-export const GET: RequestHandler = async ({ params, url, locals: { supabase, safeGetSession } }) => {
+export const GET: RequestHandler = async ({ params, url, locals: { supabase, safeGetSession, locale: uiLocale } }) => {
 	const { user } = await safeGetSession();
 	if (!user) return new Response('Unauthorized', { status: 401 });
 
@@ -51,7 +52,7 @@ export const GET: RequestHandler = async ({ params, url, locals: { supabase, saf
 
 	try {
 		const sandbox = createVercelSandboxProvider();
-		const ctx: AdapterContext = { brandId: brand.id, userId: user.id, runId: 'computer-screen', locale: 'it', agentId: url.searchParams.get('agent') || undefined };
+		const ctx: AdapterContext = { brandId: brand.id, userId: user.id, runId: 'computer-screen', locale: bilingualNoticeLocale(uiLocale), agentId: url.searchParams.get('agent') || undefined };
 		const ref = await sandbox.provision({ brandId: brand.id, agentId: url.searchParams.get('agent') || undefined }, ctx);
 		let shot = await captureScreenshot(sandbox, ref, ctx);
 		// Xvfb muore col riavvio della VM ma il marker resta: la cattura fallisce con «unable to

--- a/src/routes/app/[brand]/agents/computer/status/+server.ts
+++ b/src/routes/app/[brand]/agents/computer/status/+server.ts
@@ -10,12 +10,13 @@
  * non è accesa, `graphical` è `false` senza nessuna chiamata: non c'è niente da leggere.
  */
 import { json } from '@sveltejs/kit';
+import { bilingualNoticeLocale } from '$lib/i18n/locale';
 import { probeGraphicalMode } from '$lib/agent/adapters/graphical-bootstrap';
 import { createVercelSandboxProvider } from '$lib/agent/bridge/adapters';
 import type { AdapterContext } from '$lib/agent/kit/types';
 import type { RequestHandler } from './$types';
 
-export const GET: RequestHandler = async ({ params, url, locals: { supabase, safeGetSession } }) => {
+export const GET: RequestHandler = async ({ params, url, locals: { supabase, safeGetSession, locale: uiLocale } }) => {
 	const { user } = await safeGetSession();
 	if (!user) return new Response('Unauthorized', { status: 401 });
 
@@ -36,7 +37,7 @@ export const GET: RequestHandler = async ({ params, url, locals: { supabase, saf
 	if (state === 'running' && row?.provider_ref) {
 		try {
 			const sandbox = createVercelSandboxProvider();
-			const ctx: AdapterContext = { brandId: brand.id, userId: user.id, runId: 'computer-status', locale: 'it', agentId: url.searchParams.get('agent') || undefined };
+			const ctx: AdapterContext = { brandId: brand.id, userId: user.id, runId: 'computer-status', locale: bilingualNoticeLocale(uiLocale), agentId: url.searchParams.get('agent') || undefined };
 			const ref = await sandbox.provision({ brandId: brand.id, agentId: url.searchParams.get('agent') || undefined }, ctx);
 			graphical = (await probeGraphicalMode(sandbox, ref, ctx)).active;
 		} catch {

--- a/src/routes/app/[brand]/chat/+server.ts
+++ b/src/routes/app/[brand]/chat/+server.ts
@@ -35,6 +35,7 @@ import { isChatTier } from '$lib/chat-tiers';
 import { threadModelPreference } from '$lib/server/chat/model-preference';
 import { withBrandContext } from '$lib/server/ai-log';
 import { shouldUseKit, runKitTurn } from '$lib/agent/bridge/live';
+import { bilingualNoticeLocale } from '$lib/i18n/locale';
 import type { RequestHandler } from './$types';
 import {
   isJobCancelled,
@@ -58,7 +59,7 @@ export const GET: RequestHandler = async ({ url, params, locals: { supabase, saf
 };
 
 // POST: send a message — streams real-time AND saves server-side for background resilience
-export const POST: RequestHandler = async ({ request, params, locals: { supabase, safeGetSession }, platform }) => {
+export const POST: RequestHandler = async ({ request, params, locals: { supabase, safeGetSession, locale: uiLocale }, platform }) => {
   const { user } = await safeGetSession();
   if (!user) return new Response('Unauthorized', { status: 401 });
 
@@ -118,7 +119,8 @@ export const POST: RequestHandler = async ({ request, params, locals: { supabase
     webHubEnabled,
     threadId,
     threadAgent,
-    threadCustomAgentId
+    threadCustomAgentId,
+    locale: uiLocale
   });
   if (handledAction) return handledAction;
 
@@ -128,10 +130,8 @@ export const POST: RequestHandler = async ({ request, params, locals: { supabase
 
   // Rolling chat windows (5h / week) — monthly credits still apply separately via tools / metering.
   {
-    const acceptLangEarly = request.headers.get('accept-language') ?? '';
-    const localeEarly = acceptLangEarly.includes('en') ? 'en' : 'it';
     const rate = await getChatRateUsage(supabase, brand.id, brand.plan);
-    if (!rate.ok) return chatRateLimitResponse(rate, localeEarly);
+    if (!rate.ok) return chatRateLimitResponse(rate, bilingualNoticeLocale(uiLocale));
     // E il tetto mensile del piano, che è un freno diverso dalla finestra rotante e qui non c'era.
     if (await chatCreditsBlocked(brand.id)) {
       return json({ error: 'credits_exhausted' }, { status: 402 });
@@ -155,9 +155,9 @@ export const POST: RequestHandler = async ({ request, params, locals: { supabase
   }
 
   return withBrandContext(brand.id, async () => {
-  // Detect locale from the Accept-Language header or default to 'it'
-  const acceptLang = request.headers.get('accept-language') ?? '';
-  const locale = acceptLang.includes('en') ? 'en' : 'it';
+  // Same locale as the page (`locals.locale` / pickLocale): default English, never Italian just
+  // because Accept-Language omitted "en" (en-IN, Hindi-only, empty, `*`).
+  const locale = uiLocale;
   const origin = new URL(request.url).origin;
 
   // Il budget di tempo del turno nasce più in basso (chatTurnDeadline), ma i tool si costruiscono
@@ -258,7 +258,7 @@ export const POST: RequestHandler = async ({ request, params, locals: { supabase
       threadId,
       spec: kitSpec,
       messages,
-      locale,
+      locale: bilingualNoticeLocale(locale),
       mode,
       tier: body.tier,
       modelFamily: modelPref?.family,

--- a/src/routes/app/[brand]/chat/+server.ts
+++ b/src/routes/app/[brand]/chat/+server.ts
@@ -505,7 +505,7 @@ export const POST: RequestHandler = async ({ request, params, locals: { supabase
     model: chatModel.model,
     system: systemPrompt,
     messages,
-    prepareStep: benchAwarePrepareStep(loopGuard, Object.keys(guardedTools), locale, midTurnMailbox.prepareStep),
+    prepareStep: benchAwarePrepareStep(loopGuard, Object.keys(guardedTools), midTurnMailbox.prepareStep),
     tools: guardedTools,
     // Four ceilings, whichever comes first — all end through the normal finish path. The fourth is
     // per-STEP and lives on the tools themselves (withStepDeadline), because the three below are

--- a/src/routes/app/[brand]/chat/lib/post-actions.ts
+++ b/src/routes/app/[brand]/chat/lib/post-actions.ts
@@ -39,6 +39,7 @@ import {
   deletePendingChatJobOrReportFailure,
   type Platform
 } from './jobs';
+import { bilingualNoticeLocale, type Locale } from '$lib/i18n/locale';
 
 /**
  * Le azioni del POST che NON aprono un turno di modello: coda, annullamenti, /clear di contesto e
@@ -56,8 +57,9 @@ export async function handlePostAction(input: {
   threadId: string;
   threadAgent: string | null;
   threadCustomAgentId: string | null;
+  locale: Locale;
 }): Promise<Response | null> {
-  const { supabase, brand, user, request, platform, body, webHubEnabled, threadId, threadAgent, threadCustomAgentId } = input;
+  const { supabase, brand, user, request, platform, body, webHubEnabled, threadId, threadAgent, threadCustomAgentId, locale } = input;
   const action = body.action as string | undefined;
 
   // Handle clear history action
@@ -78,7 +80,7 @@ export async function handlePostAction(input: {
   // sintomo sarebbe un agente che ricomincia da capo senza spiegazione. Il rifiuto lascia una riga
   // nella trascrizione — costa meno di un turno impazzito, e si vede.
   if (action === 'clear_context' || isClearCommand(lastUserText(body.messages as ModelMessage[] | undefined))) {
-    const en = (request.headers.get('accept-language') ?? '').includes('en');
+    const en = bilingualNoticeLocale(locale) === 'en';
     if (await threadHasActiveChatResponse(supabase, { userId: user.id, threadId })) {
       await saveMessages(
         supabase,
@@ -111,7 +113,7 @@ export async function handlePostAction(input: {
       supabase,
       current.id,
       'abandoned',
-      (request.headers.get('accept-language') ?? '').includes('en')
+      bilingualNoticeLocale(locale) === 'en'
         ? 'Closed by the user.'
         : "Chiuso dall'utente."
     );
@@ -224,10 +226,9 @@ export async function handlePostAction(input: {
     const queuedUserMessage = textContent + formatAttachedDocsBlock(queuedDocs, CHAT_HISTORY_DOC_CAP);
     if (!queuedUserMessage.trim()) return new Response('Empty message', { status: 400 });
 
-    const acceptLang = request.headers.get('accept-language') ?? '';
-    const locale = acceptLang.includes('en') ? 'en' : 'it';
+    const noticeLocale = bilingualNoticeLocale(locale);
     const rate = await getChatRateUsage(supabase, brand.id, brand.plan);
-    if (!rate.ok) return chatRateLimitResponse(rate, locale);
+    if (!rate.ok) return chatRateLimitResponse(rate, noticeLocale);
     // Accodare un turno è già spendere: il worker lo eseguirà comunque. Si controlla qui, non solo
     // sul percorso interattivo, o la coda diventa il modo per aggirare la quota mensile.
     if (await chatCreditsBlocked(brand.id)) {

--- a/src/routes/app/[brand]/chat/lib/turn-finish.ts
+++ b/src/routes/app/[brand]/chat/lib/turn-finish.ts
@@ -11,6 +11,7 @@ import { extractMemoryFromChat } from '$lib/server/brand-memory';
 import { extractSdkUsage, logAiCall } from '$lib/server/ai-log';
 import { resolveChatModel, takeKieUsage } from '$lib/server/chat/model';
 import { sourcesFromSteps } from '$lib/chat-sources';
+import { bilingualNoticeLocale } from '$lib/i18n/locale';
 import {
   goalTurnNotice,
   loadOpenGoal,
@@ -383,7 +384,7 @@ export async function finishSuccessfulTurn(input: {
   try {
     const { sendPushToUser } = await import('$lib/server/web-push');
     const readyBody =
-      locale === 'en' ? 'Your AI reply is ready' : "L'AI ha finito di rispondere";
+      bilingualNoticeLocale(locale) === 'en' ? 'Your AI reply is ready' : "L'AI ha finito di rispondere";
     await sendPushToUser(supabase, user.id, {
       title: 'Anomalia',
       body: readyBody,

--- a/src/routes/app/[brand]/chat/lib/turn-prep.ts
+++ b/src/routes/app/[brand]/chat/lib/turn-prep.ts
@@ -21,6 +21,7 @@ import { listThreadArtifacts, formatArtifactsForPrompt } from '$lib/server/chat/
 import { resolveChatModel, modelSeesImages, modelSeesVideo } from '$lib/server/chat/model';
 import { roomBeat, roomSystemBlock, stripRoomPeerTools, type RoomMember } from '$lib/server/chat/room';
 import { filterToolsForMode, isChatMode, modeSystemBlock, type ChatMode } from '$lib/chat-modes';
+import { bilingualNoticeLocale } from '$lib/i18n/locale';
 import { createChatTools } from '$lib/server/chat/tools';
 import {
   CHAT_HISTORY_DOC_CAP,
@@ -144,7 +145,7 @@ export async function buildTurnContext(input: {
   if (roomPlan && roomSpeaker) {
     systemPrompt += roomSystemBlock(roomPlan.members, roomSpeaker.key, locale);
   }
-  const lang = locale === 'it' ? 'Italian' : 'English';
+  const lang = bilingualNoticeLocale(locale) === 'it' ? 'Italian' : 'English';
   const mode: ChatMode = isChatMode(body.mode) ? body.mode : 'agent';
   systemPrompt += `\n\n${modeSystemBlock(mode, lang)}`;
 
@@ -440,7 +441,7 @@ export async function buildTurnMessages(input: {
     }
   }
 
-  await attachTurnVolatile(supabase, brand, locale ?? 'it', messages);
+  await attachTurnVolatile(supabase, brand, locale ?? 'en', messages);
 
   return { ok: true, regeneratedFrom, history, lastUserMsg, messages, textContent };
 }
@@ -506,7 +507,7 @@ export async function applyGoalCommand(input: {
         supabase,
         current.id,
         'abandoned',
-        locale === 'en' ? 'Closed by the user.' : "Chiuso dall'utente."
+        bilingualNoticeLocale(locale) === 'en' ? 'Closed by the user.' : "Chiuso dall'utente."
       ).catch(() => null);
     }
   }
@@ -562,7 +563,7 @@ export async function applyTurnBriefings(input: {
     prompt += goalModeActive
       ? `\n\n${goalCommandInstruction(goalCmd, locale)}`
       : `\n\n${
-          locale === 'en'
+          bilingualNoticeLocale(locale) === 'en'
             ? 'The user tried to set a goal, but this chat is in ASK mode, which has no tools to work on one. Say so in one line and suggest switching to Agent or Plan.'
             : "L'utente ha provato a fissare un obiettivo, ma questa chat è in modalità ASK, che non ha i tool per portarlo avanti. Dillo in una riga e proponi di passare ad Agent o Plan."
         }`;

--- a/src/routes/app/[brand]/chat/threads/+server.ts
+++ b/src/routes/app/[brand]/chat/threads/+server.ts
@@ -24,10 +24,11 @@ import {
 import { listThreadAgentAvatars } from '$lib/server/custom-agents';
 import { isUnread, loadLastReads, loadUnreadCounts, markThreadRead } from '$lib/server/chat/unread';
 import { hasWebHub } from '$lib/server/plans';
+import { bilingualNoticeLocale } from '$lib/i18n/locale';
 import type { RequestHandler } from './$types';
 
 // GET: list all threads for this brand+user
-export const GET: RequestHandler = async ({ request, params, locals: { supabase, safeGetSession } }) => {
+export const GET: RequestHandler = async ({ params, locals: { supabase, safeGetSession, locale: uiLocale } }) => {
   const { user } = await safeGetSession();
   if (!user) return json({ error: 'Unauthorized' }, { status: 401 });
 
@@ -49,7 +50,7 @@ export const GET: RequestHandler = async ({ request, params, locals: { supabase,
   // quindi sidebar e `threadIdentity` non imparano niente di nuovo.
   // ponytail: una roster per thread-stanza. Le stanze sono poche e la query sui custom agent
   // parte solo se ce ne sono; se un giorno saranno tante, si accorpano in una query sola.
-  const locale = (request.headers.get('accept-language') ?? '').includes('en') ? 'en' : 'it';
+  const locale = bilingualNoticeLocale(uiLocale);
   const roomRows = threads.filter((t) => isRoomThread(t as { room_agents?: unknown }));
   const roomAvatarsByThread: Record<string, ReturnType<typeof roomAvatars>> = {};
   await Promise.all(

--- a/src/routes/app/[brand]/motion-video/+server.ts
+++ b/src/routes/app/[brand]/motion-video/+server.ts
@@ -2,6 +2,7 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 import { error, json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { z } from 'zod';
+import { bilingualNoticeLocale } from '$lib/i18n/locale';
 import { withBrandContext } from '$lib/server/ai-log';
 import { CreditsExhaustedError } from '$lib/server/credits';
 import { runMotionVideoTurn } from '$lib/server/motion-video/run-turn';
@@ -104,7 +105,7 @@ async function loadBrand(supabase: SupabaseClient, slug: string) {
 export const POST: RequestHandler = async ({
 	request,
 	params,
-	locals: { supabase, safeGetSession },
+	locals: { supabase, safeGetSession, locale: uiLocale },
 	platform
 }) => {
 	const { user } = await safeGetSession();
@@ -198,9 +199,10 @@ export const POST: RequestHandler = async ({
 	}
 
 	const origin = new URL(request.url).origin;
-	const locale = (request.headers.get('accept-language') || '').toLowerCase().startsWith('en')
-		? 'en'
-		: 'it';
+	// Stesso locale della pagina (hooks → pickLocale): l'inversione `startsWith('en') ? 'en' : 'it'`
+	// mandava in italiano chi ha header vuoto, `*` o solo lingue non supportate — la classe di bug
+	// di amazon.in, qui sulla superficie Motion.
+	const locale = bilingualNoticeLocale(uiLocale);
 	const deadline = chatTurnDeadline(Date.now());
 	const abortController = new AbortController();
 	const hardStop = setTimeout(() => abortController.abort(), CHAT_TURN_ABORT_MS);
@@ -256,6 +258,7 @@ export const POST: RequestHandler = async ({
 				// Lo stesso thread in cui la risposta viene scritta: è quello a cui appartiene un
 				// eventuale artefatto consegnato durante il giro.
 				threadId: thread?.id ?? null,
+				locale,
 				abortSignal: abortController.signal,
 				deadline,
 				onSaved: (id) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What happened

Production session on brand **amazon.in** (`amazon-in`): the user wrote in English (“Give me content ideas for my brand Royal rasoy”), the UI was English (`en-IN`), the site is not Italian — and the chatbot still answered in Italian, then injected an Italian SEO audit (“Audit SEO & GEO completato!”) and a hardcoded kit error (“Errore del turno: Network connection lost.”).

Recording: https://eu.posthog.com/project/196253/replay/01a04272-6794-7657-a403-0d5869e4bd6b

## Why

1. Chat locale used `acceptLang.includes('en') ? 'en' : 'it'`. Empty, `*`, Hindi-only, Spanish, or any header without the substring `en` became **Italian**.
2. The classic system prompt said “Respond in Italian. Match the user's language.” — the first clause won.
3. Job summaries and kit errors were Italian-only (or Italian by default).
4. **Independent review:** kit turns (`shouldUseKit` → `runKitTurn`) never load the classic prompt, so they never received the reply-language rule. The kit identity line was also Italian (`Sei …, un agente Anomalia`). That is the path this session was on.

## Fix

- Reply language follows the **latest user message** (same absolute rule as Radar comments). Dashboard locale is only a fallback when there is nothing to detect.
- **English is the fallback**, not Italian. Italian copy only when the locale is actually Italian (`it` / `it-IT`).
- Kit turns now get the same `REPLY LANGUAGE` block; kit identity is English.
- Notices, kit errors, and job summaries use the English-default rule.

## How to verify

- English message on a non-Italian brand → English reply, including on a kit specialist thread.
- Missing / `en-IN` / Hindi-only locale → English notices, not “Errore del turno”.
- Italian dashboard (`/it` or locale cookie `it`) still gets Italian notices when the user writes in Italian.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b82a2d2-73ae-4990-9279-835b7838b330?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b82a2d2-73ae-4990-9279-835b7838b330&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

