### PR TITLE
Hide marketing pages on self-host with HIDE_MARKETING

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## 2026-08-27
 
+### Self-host: nascondere il sito di marketing, partire dall'app
+
+Non c'era. `TENANT_BRAND_ID` salta lo switcher dei brand, `BILLING_PROVIDER=open`
+toglie i crediti, ma `/` restava la landing di anomalia.so — pricing, pitch,
+waitlist e tutto. Chi installa per sé non ha un sito commerciale da mostrare.
+
+`HIDE_MARKETING=1` (anche `true` / `yes`) reindirizza il gruppo
+`[[lang=locale]]` e `/start` a `/app`. Login, auth, API, admin e i blog dei
+brand restano. Non è nella guida: si accende dall'env, si rilegge a ogni
+richiesta, il hosted product senza la variabile non cambia. Un bounce OAuth
+sul Site URL con `?code=` passa ancora da `/auth/callback` prima del
+redirect, altrimenti il code si perde. Lo sitemap smette di elencare le
+pagine che ormai 303-ano.
+
+L'healthcheck di compose picchiava `/`: busybox wget tratta un 303 come
+errore, quindi accendere la flag avrebbe lasciato l'app forever-unhealthy.
+Ora picchia `/robots.txt`, che è sempre 200.
+
 ### Il secondo messaggio di un thread si vedeva rifiutare OGNI tool
 
 `startHarnessTurn` cuoce il ToolSet una volta per `sessionKey` (il thread) e

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,10 @@ brand restano. Non è nella guida: si accende dall'env, si rilegge a ogni
 richiesta, il hosted product senza la variabile non cambia. Un bounce OAuth
 sul Site URL con `?code=` passa ancora da `/auth/callback` prima del
 redirect, altrimenti il code si perde. Lo sitemap smette di elencare le
-pagine che ormai 303-ano.
+pagine che ormai 303-ano e, se manca la service-role key (CI, self-host
+minimale), esce con la sola parte statica invece di un 500 permanente;
+in produzione una query fallita resta comunque un errore — il crawler
+mantieni l'ultima copia buona invece di vedere mezzo sitemap svanire.
 
 L'healthcheck di compose picchiava `/`: busybox wget tratta un 303 come
 errore, quindi accendere la flag avrebbe lasciato l'app forever-unhealthy.

--- a/infra/compose/docker-compose.yml
+++ b/infra/compose/docker-compose.yml
@@ -311,7 +311,9 @@ services:
       kong:
         condition: service_healthy
     healthcheck:
-      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://127.0.0.1:3000/']
+      # Not `/`: HIDE_MARKETING 303s the homepage to /app, and busybox wget treats
+      # 3xx as a failed spider. robots.txt is always 200 and does not need a session.
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://127.0.0.1:3000/robots.txt']
       timeout: 5s
       interval: 10s
       retries: 5
@@ -331,6 +333,8 @@ services:
       APP_SECRET: ${APP_SECRET:-}
       GEMINI_API_KEY: ${GEMINI_API_KEY:-}
       CRON_SECRET: ${CRON_SECRET:-}
+      # Undocumented: HIDE_MARKETING=1 serves the app at `/` instead of the marketing site.
+      HIDE_MARKETING: ${HIDE_MARKETING:-}
 
   cron:
     container_name: anomalia-cron

--- a/scripts/self-host-compose.test.ts
+++ b/scripts/self-host-compose.test.ts
@@ -57,6 +57,18 @@ describe('.env.example', () => {
 	});
 });
 
+describe('healthcheck dell’app', () => {
+	/**
+	 * wget --spider di busybox considera 3xx un errore. La homepage, con HIDE_MARKETING=1,
+	 * risponde 303 verso /app: un healthcheck su `/` farebbe restare l'app forever-unhealthy
+	 * nel momento in cui si accende la flag. robots.txt è sempre 200, senza sessione.
+	 */
+	it('non picchia la homepage: HIDE_MARKETING la reindirizza', () => {
+		expect(COMPOSE).toMatch(/127\.0\.0\.1:3000\/robots\.txt/);
+		expect(COMPOSE).not.toMatch(/127\.0\.0\.1:3000\/'/);
+	});
+});
+
 describe('le migration ricostruiscono ciò che il codice scrive', () => {
 	/**
 	 * Trovato installando: su un database appena migrato ogni riga di `ai_calls` veniva rifiutata

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,5 +1,5 @@
 import {sequence} from '@sveltejs/kit/hooks';
-import { json, text } from '@sveltejs/kit';
+import { json, redirect, text } from '@sveltejs/kit';
 import * as Sentry from '@sentry/sveltekit';
 import { createServerClient, type CookieOptions } from '@supabase/ssr';
 import { PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY } from '$env/static/public';
@@ -9,6 +9,7 @@ import { withBrandContext } from '$lib/server/ai-log';
 import { createAdminClient } from '$lib/server/supabase-admin';
 import { captureReferralCookie } from '$lib/server/referrals';
 import { isCsrfForbidden } from '$lib/server/csrf';
+import { marketingShellTarget } from '$lib/server/marketing-shell';
 
 type CookieToSet = { name: string; value: string; options: CookieOptions };
 
@@ -121,6 +122,23 @@ export const handle: Handle = sequence(csrf, Sentry.sentryHandle(), async ({ eve
   // brand blogs stay clean; their Powered-by badge already links to anomalia.so/?ref=….
   if (!isBlogRoute) {
     captureReferralCookie(event.cookies, event.url.searchParams.get('ref'));
+  }
+
+  // Self-host: HIDE_MARKETING=1 manda il pitch (homepage, pricing, /start, …) in /app.
+  // Prima di reindirizzare, lo stesso safety net della load della homepage: un bounce
+  // OAuth/magic-link sul Site URL con ?code= non deve finire in /app e perdere il code.
+  const marketingDest = marketingShellTarget(event.route.id);
+  if (marketingDest) {
+    if (event.url.searchParams.has('code') || event.url.searchParams.has('error_description')) {
+      throw redirect(303, `/auth/callback${event.url.search}`);
+    }
+    // /it → /app terrebbe la lingua solo su QUESTA richiesta (il prefisso sta nel path).
+    // La cookie è ciò che /app leggerà al giro dopo, stessa forma del language toggle.
+    const loc = event.locals.locale;
+    if (loc && loc !== 'en' && !event.cookies.get('locale')) {
+      event.cookies.set('locale', loc, { path: '/', maxAge: 31536000, sameSite: 'lax' });
+    }
+    throw redirect(303, marketingDest);
   }
 
   const doResolve = () =>

--- a/src/lib/server/marketing-shell.test.ts
+++ b/src/lib/server/marketing-shell.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const fake: Record<string, string | undefined> = {};
+vi.mock('$env/dynamic/private', () => ({ env: fake }));
+
+const { hideMarketing, isMarketingRoute, marketingShellTarget } = await import('./marketing-shell');
+
+afterEach(() => {
+	delete fake.HIDE_MARKETING;
+});
+
+describe('hideMarketing', () => {
+	it('spento di default: il hosted product non cambia', () => {
+		expect(hideMarketing()).toBe(false);
+	});
+
+	it('stringa vuota o spazi valgono come non impostata', () => {
+		fake.HIDE_MARKETING = '   ';
+		expect(hideMarketing()).toBe(false);
+	});
+
+	it('1 / true / yes, qualunque casing', () => {
+		for (const v of ['1', 'true', 'TRUE', 'yes', 'Yes']) {
+			fake.HIDE_MARKETING = v;
+			expect(hideMarketing(), v).toBe(true);
+		}
+	});
+
+	it('0 / false / garbage non accendono niente', () => {
+		for (const v of ['0', 'false', 'no', 'on', 'hide']) {
+			fake.HIDE_MARKETING = v;
+			expect(hideMarketing(), v).toBe(false);
+		}
+	});
+});
+
+describe('isMarketingRoute', () => {
+	it('homepage, pricing e il resto del gruppo locale', () => {
+		expect(isMarketingRoute('/[[lang=locale]]')).toBe(true);
+		expect(isMarketingRoute('/[[lang=locale]]/pricing')).toBe(true);
+		expect(isMarketingRoute('/[[lang=locale]]/docs/api')).toBe(true);
+		expect(isMarketingRoute('/[[lang=locale]]/waitlist')).toBe(true);
+		expect(isMarketingRoute('/[[lang=locale]]/tools/geo-audit')).toBe(true);
+	});
+
+	it('/start è il funnel della landing: senza landing non c’è', () => {
+		expect(isMarketingRoute('/start')).toBe(true);
+		expect(isMarketingRoute('/start/')).toBe(true);
+	});
+
+	it('app, auth, API, blog, admin, asset restano', () => {
+		for (const id of [
+			'/app',
+			'/app/[brand]/chat/[thread]',
+			'/login',
+			'/auth/callback',
+			'/oauth/authorize',
+			'/cli/callback',
+			'/api/status',
+			'/api/v1/autopilot/tick',
+			'/approve/[token]',
+			'/admin/videos',
+			'/blog/[site]',
+			'/blog-preview/[id]',
+			'/_site',
+			'/_site/[slug]',
+			'/robots.txt',
+			'/sitemap.xml',
+			'/status',
+			'/l/[code]'
+		]) {
+			expect(isMarketingRoute(id), id).toBe(false);
+		}
+	});
+
+	it('senza route.id non si indovina: un 404 resta un 404', () => {
+		expect(isMarketingRoute(null)).toBe(false);
+		expect(isMarketingRoute(undefined)).toBe(false);
+		expect(isMarketingRoute('')).toBe(false);
+	});
+});
+
+describe('marketingShellTarget', () => {
+	it('flag spenta: nessuna rotta si muove, nemmeno la homepage', () => {
+		expect(marketingShellTarget('/[[lang=locale]]')).toBeNull();
+		expect(marketingShellTarget('/[[lang=locale]]/pricing')).toBeNull();
+		expect(marketingShellTarget('/start')).toBeNull();
+	});
+
+	it('flag accesa: il pitch va in /app, il resto no', () => {
+		fake.HIDE_MARKETING = '1';
+		expect(marketingShellTarget('/[[lang=locale]]')).toBe('/app');
+		expect(marketingShellTarget('/[[lang=locale]]/pricing')).toBe('/app');
+		expect(marketingShellTarget('/start')).toBe('/app');
+		expect(marketingShellTarget('/app')).toBeNull();
+		expect(marketingShellTarget('/login')).toBeNull();
+		expect(marketingShellTarget('/_site')).toBeNull();
+		expect(marketingShellTarget('/blog/[site]')).toBeNull();
+	});
+});
+
+describe('il redirect vive in un posto solo', () => {
+	it('hooks.server.ts usa marketingShellTarget, non un pathname indovinato', async () => {
+		const { readFileSync } = await import('node:fs');
+		const src = readFileSync('src/hooks.server.ts', 'utf8');
+		expect(src).toContain("from '$lib/server/marketing-shell'");
+		expect(src).toContain('marketingShellTarget(event.route.id)');
+		// Il pathname su un blog custom-domain è `/` — giudicarlo come marketing
+		// manderebbe il sito del brand in /app. Deve restare route.id.
+		expect(src).not.toMatch(/isMarketingRoute\(event\.url\.pathname\)/);
+	});
+});

--- a/src/lib/server/marketing-shell.ts
+++ b/src/lib/server/marketing-shell.ts
@@ -1,0 +1,52 @@
+/**
+ * NASCONDERE IL SITO DI MARKETING, TENERE L'APP.
+ *
+ * Su un'installazione self-hosted la homepage, il pricing e il resto del pitch
+ * di anomalia.so sono mobili di un altro prodotto. `HIDE_MARKETING=1` (anche
+ * `true` / `yes`) reindirizza quelle rotte a `/app`, che già manda chi non è
+ * loggato al login. Non è nella guida: è un interruttore per chi installa e
+ * non vuole il sito commerciale in casa.
+ *
+ * Si legge a ogni richiesta (`$env/dynamic/private`): si accende senza
+ * ricostruire. Spento (default) il hosted product non cambia di una riga.
+ *
+ * Cosa NON è. Non toglie i file dal repo, non è una build. I blog dei brand
+ * (`/_site`, `/blog/…`), login, auth, API, admin restano. `/start` (il funnel
+ * ospite della landing) segue il marketing: senza landing non c'è funnel.
+ */
+import { env } from '$env/dynamic/private';
+
+function truthy(raw: string | undefined): boolean {
+	const v = raw?.trim().toLowerCase();
+	return v === '1' || v === 'true' || v === 'yes';
+}
+
+/** True quando questa installazione non deve mostrare il sito commerciale. */
+export function hideMarketing(): boolean {
+	return truthy(env.HIDE_MARKETING);
+}
+
+/**
+ * Rotte del pitch: il gruppo `[[lang=locale]]` (homepage, pricing, tools, docs
+ * pubbliche, waitlist, …) e `/start`. Tutto il resto — app, auth, API, blog,
+ * asset, sitemap — non è marketing.
+ *
+ * Si giudica `route.id` e non il pathname: su un dominio custom del brand il
+ * path è `/` ma la rotta è `/_site`. Guardare l'URL manderebbe il blog in `/app`.
+ */
+export function isMarketingRoute(routeId: string | null | undefined): boolean {
+	if (!routeId) return false;
+	if (routeId === '/start' || routeId.startsWith('/start/')) return true;
+	return routeId === '/[[lang=locale]]' || routeId.startsWith('/[[lang=locale]]/');
+}
+
+/**
+ * Destinazione del redirect, o `null` se questa richiesta deve restare dov'è.
+ * `/app` decide il resto: anonimo → `/login`, un tenant → lo slug, molti →
+ * ultimo brand. Non si duplica quella logica qui.
+ */
+export function marketingShellTarget(routeId: string | null | undefined): '/app' | null {
+	if (!hideMarketing()) return null;
+	if (!isMarketingRoute(routeId)) return null;
+	return '/app';
+}

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -11,6 +11,7 @@ import { INSIGHT_SLUGS } from '$lib/data/insights';
 import { STYLE_PRESETS } from '$lib/design/presets';
 import { createAdminClient } from '$lib/server/supabase-admin';
 import { listWallSlugs } from '$lib/server/wall';
+import { hideMarketing } from '$lib/server/marketing-shell';
 import type { Locale } from '$lib/i18n/locale';
 
 function alternateLinks(site: string, path: string): string {
@@ -46,35 +47,46 @@ function localizedUrlEntries(
 export const GET: RequestHandler = async ({ url }) => {
   const site = siteUrl(url.origin);
   const loc = (p: string) => site + (p === '/' ? '/' : p);
+  // Con HIDE_MARKETING le URL del pitch 303-ano in /app: elencarle nel sitemap è un
+  // invito a indicizzare dei redirect. Restano solo i blog ospitati, che non sono marketing.
+  const appOnly = hideMarketing();
 
-  const marketingEntries = MARKETING_PATHS.flatMap((path) => {
-    const priority =
-      path === '/' ? '1.0' : path.startsWith('/insights') || path.startsWith('/tools') ? '0.8' : '0.7';
-    return localizedUrlEntries(site, path, priority);
-  });
+  const marketingEntries = appOnly
+    ? []
+    : MARKETING_PATHS.flatMap((path) => {
+        const priority =
+          path === '/' ? '1.0' : path.startsWith('/insights') || path.startsWith('/tools') ? '0.8' : '0.7';
+        return localizedUrlEntries(site, path, priority);
+      });
 
-  const staticEntries = STATIC_SITEMAP_PATHS.map(
-    (path) => `  <url>
+  const staticEntries = appOnly
+    ? []
+    : STATIC_SITEMAP_PATHS.map(
+        (path) => `  <url>
     <loc>${loc(path)}</loc>
     <changefreq>monthly</changefreq>
     <priority>0.3</priority>
   </url>`
-  );
+      );
 
-  const playbookEntries = PLAYBOOK_SLUGS.flatMap((slug) =>
-    localizedUrlEntries(site, `/playbooks/${slug}`, '0.6')
-  );
+  const playbookEntries = appOnly
+    ? []
+    : PLAYBOOK_SLUGS.flatMap((slug) => localizedUrlEntries(site, `/playbooks/${slug}`, '0.6'));
 
-  const insightEntries = INSIGHT_SLUGS.flatMap((slug) =>
-    localizedUrlEntries(site, `/insights/${slug}`, '0.75', 'monthly')
-  );
+  const insightEntries = appOnly
+    ? []
+    : INSIGHT_SLUGS.flatMap((slug) => localizedUrlEntries(site, `/insights/${slug}`, '0.75', 'monthly'));
 
   const admin = createAdminClient();
   const [{ data: blogs }, { data: talentRows }, { data: agentRows }, wallSlugs] = await Promise.all([
     admin.from('brands').select('blog_slug').not('blog_slug', 'is', null),
-    admin.from('talents').select('slug').eq('status', 'active'),
-    admin.from('agent_templates').select('slug').eq('status', 'published'),
-    listWallSlugs(admin)
+    appOnly
+      ? Promise.resolve({ data: [] as { slug: string }[] | null })
+      : admin.from('talents').select('slug').eq('status', 'active'),
+    appOnly
+      ? Promise.resolve({ data: [] as { slug: string }[] | null })
+      : admin.from('agent_templates').select('slug').eq('status', 'published'),
+    appOnly ? Promise.resolve([] as Awaited<ReturnType<typeof listWallSlugs>>) : listWallSlugs(admin)
   ]);
   const blogEntries = (blogs ?? []).map(
     (b) => `  <url>
@@ -95,9 +107,9 @@ export const GET: RequestHandler = async ({ url }) => {
 
   // Style presets live in code, not in a table — no query, just the library itself.
   // The /styles index is already in MARKETING_PATHS; these are the per-preset pages.
-  const styleEntries = STYLE_PRESETS.flatMap((p) =>
-    localizedUrlEntries(site, `/styles/${p.slug}`, '0.6', 'monthly')
-  );
+  const styleEntries = appOnly
+    ? []
+    : STYLE_PRESETS.flatMap((p) => localizedUrlEntries(site, `/styles/${p.slug}`, '0.6', 'monthly'));
 
   // One entry per post on the design wall. `lastmod` is the day it was published to the wall — the
   // page's content does not change after that, and claiming it did would train the crawler to

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -12,6 +12,7 @@ import { STYLE_PRESETS } from '$lib/design/presets';
 import { createAdminClient } from '$lib/server/supabase-admin';
 import { listWallSlugs } from '$lib/server/wall';
 import { hideMarketing } from '$lib/server/marketing-shell';
+import { env } from '$env/dynamic/private';
 import type { Locale } from '$lib/i18n/locale';
 
 function alternateLinks(site: string, path: string): string {
@@ -77,17 +78,32 @@ export const GET: RequestHandler = async ({ url }) => {
     ? []
     : INSIGHT_SLUGS.flatMap((slug) => localizedUrlEntries(site, `/insights/${slug}`, '0.75', 'monthly'));
 
-  const admin = createAdminClient();
-  const [{ data: blogs }, { data: talentRows }, { data: agentRows }, wallSlugs] = await Promise.all([
-    admin.from('brands').select('blog_slug').not('blog_slug', 'is', null),
-    appOnly
-      ? Promise.resolve({ data: [] as { slug: string }[] | null })
-      : admin.from('talents').select('slug').eq('status', 'active'),
-    appOnly
-      ? Promise.resolve({ data: [] as { slug: string }[] | null })
-      : admin.from('agent_templates').select('slug').eq('status', 'published'),
-    appOnly ? Promise.resolve([] as Awaited<ReturnType<typeof listWallSlugs>>) : listWallSlugs(admin)
-  ]);
+  // The dynamic entries live in Postgres. Only the "admin key not configured" case degrades to a
+  // static-only map: it is a structural state (CI smoke tier, minimal self-host), and a permanent
+  // 500 would be worse. In production the key exists, so a real query failure still throws and
+  // returns 500 — the crawler keeps its last good copy of the sitemap instead of seeing half
+  // the dynamic URLs vanish (missing lastmod signals) for exactly one fetch.
+  let blogs: { blog_slug: string }[] | null = null;
+  let talentRows: { slug: string }[] | null = null;
+  let agentRows: { slug: string }[] | null = null;
+  let wallSlugs: Awaited<ReturnType<typeof listWallSlugs>> = [];
+  if (!appOnly) {
+    try {
+      const admin = createAdminClient();
+      const [blogRes, talentRes, agentRes, wall] = await Promise.all([
+        admin.from('brands').select('blog_slug').not('blog_slug', 'is', null),
+        admin.from('talents').select('slug').eq('status', 'active'),
+        admin.from('agent_templates').select('slug').eq('status', 'published'),
+        listWallSlugs(admin)
+      ]);
+      blogs = blogRes.data;
+      talentRows = talentRes.data;
+      agentRows = agentRes.data;
+      wallSlugs = wall;
+    } catch (e) {
+      if (env.SUPABASE_SERVICE_ROLE_KEY) throw e;
+    }
+  }
   const blogEntries = (blogs ?? []).map(
     (b) => `  <url>
     <loc>${site}/blog/${b.blog_slug}/</loc>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Non c’era una flag. `TENANT_BRAND_ID` salta lo switcher, `BILLING_PROVIDER=open` toglie i crediti, ma `/` restava la landing di anomalia.so.

**`HIDE_MARKETING=1`** (anche `true` / `yes`) reindirizza homepage, pricing, `/start` e il resto del gruppo `[[lang=locale]]` a `/app`. `/app` manda già chi non è loggato al login, e con un tenant solo va dritto al brand.

- Opt-in, letta a ogni richiesta, **spenta di default**: il prodotto hosted non cambia.
- Non è in `SELF_HOSTING.md` né in `.env.example`. In compose si passa con `HIDE_MARKETING` nell’env dell’app.
- Un bounce OAuth/magic-link sul Site URL con `?code=` passa ancora da `/auth/callback` prima del redirect.
- Blog dei brand (`/_site`, `/blog/…`), login, auth, API e admin restano.
- Lo sitemap smette di elencare le pagine che ormai 303-ano.
- Healthcheck di compose spostato da `/` a `/robots.txt`: busybox wget tratta un 303 come errore.

```sh
HIDE_MARKETING=1
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-747c87cd-1959-4a78-9c78-5ed7332e0776?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-747c87cd-1959-4a78-9c78-5ed7332e0776&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

