### PR TITLE
Kill stale process on port 5173 before starting dev server

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "packages/*"
   ],
   "scripts": {
-    "dev": "vite dev",
+    "dev": "lsof -ti tcp:5173 | xargs kill -9 2>/dev/null; vite dev",
     "dev:stable": "NO_HMR=1 vite dev",
     "dev:vercel": "vercel dev --listen 5173",
     "build": "node scripts/typecheck-runtime.mjs && vite build",


### PR DESCRIPTION
## What?
The `dev` npm script now clears whatever is listening on port 5173 (`lsof -ti tcp:5173 | xargs kill -9`) before launching Vite, then starts `vite dev` as before.

## Why?
Starting `bun run dev` while a previous dev server (or any stray process) still held port 5173 failed with a busy-port error and forced a manual `kill` lookup. This makes the local workflow self-healing.

## How?
A one-line shell chain in the existing script using macOS-native `lsof`: find the PID bound to TCP 5173, kill it if present (silently when none), then exec vite. Chosen over adding a dependency like `fkill-cli` — no install cost, works in the default environment.

## Testing?
- Verified the chain runs clean with no listener on 5173 and that Vite boots ("VITE ready" output, server responding).
- Verified it handles an occupied port by killing the occupant before binding.
- Not tested on Linux/Windows since the target environment is macOS (darwin); on Linux `lsof -ti tcp:` behaves the same.

## Evidence
Console capture of the new script running from scratch:

<details>
<summary>Vite startup after port cleanup</summary>

```
$ lsof -ti tcp:5173 | xargs kill -9 2>/dev/null; vite dev

  VITE v5.4.21  ready in 1856 ms

  ➜  Local:   http://localhost:5173/
```
</details>

## Anything Else?
If we ever want cross-platform support for Windows contributors, swap to a tiny node pre-script instead of the shell pipeline.