### PR TITLE
Homepage hero leans on the GitHub positioning; pricing defaults to monthly and pitches self-hosting

### DIFF
--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -39,10 +39,10 @@
       "pricing": "Pricing"
     },
     "hero": {
-      "eyebrow": "Your AI marketing team",
+      "eyebrow": "Your AI marketing team · Apache 2.0 · Self-hosted available",
       "titleLead": "Your marketing department,",
       "titleMain": "",
-      "titleEm": "already hired.",
+      "titleEm": "automated.",
       "titleCalm": "",
       "phrases": [
         "everywhere they're searching for what you sell.",
@@ -51,7 +51,7 @@
         "wherever it counts most.",
         "where they find you before your competitors."
       ],
-      "subhead": "Team, distribution and sales: five specialists make the work, publish it across nine channels and your blog, and draft the replies to people already asking about you — nothing goes out until you approve it.",
+      "subhead": "The open-source alternative specialized in marketing, distribution and sales: five specialists make the work, publish it across nine channels and your blog, and draft the replies to people already asking about you — nothing goes out until you approve it.",
       "seeHow": "See how it works",
       "note": "Or just ask your AI to start using Anomalia",
       "ctaSecondary": "Book a call",
@@ -2229,7 +2229,7 @@
       "title": "Your social media, on autopilot.",
       "lede": "Hand a brand to Anomalia and it plans, creates and posts for you — week after week. Cancel anytime."
     },
-    "freePill": "Free includes {credits} in credits",
+    "freePill": "Free forever — or self-host Anomalia under Apache 2.0",
     "localCurrency": "Prices shown in EUR. Outside the eurozone, amounts are shown and billed in USD.",
     "toggle": {
       "monthly": "Monthly",

--- a/src/lib/i18n/locales/es.json
+++ b/src/lib/i18n/locales/es.json
@@ -39,12 +39,12 @@
       "pricing": "Precios"
     },
     "hero": {
-      "eyebrow": "Tu equipo de marketing con IA",
+      "eyebrow": "Tu equipo de marketing con IA · Apache 2.0 · Disponible self-hosted",
       "titleLead": "Tu departamento de marketing,",
       "titleMain": "",
-      "titleEm": "ya contratado.",
+      "titleEm": "automatizado.",
       "titleCalm": "",
-      "subhead": "Equipo, distribución y ventas: cinco especialistas crean el contenido, lo publican en nueve canales y en tu blog, y redactan las respuestas para quienes ya preguntan por ti — nada sale sin tu aprobación.",
+      "subhead": "La alternativa open source especializada en marketing, distribución y ventas: cinco especialistas crean el contenido, lo publican en nueve canales y en tu blog, y redactan las respuestas para quienes ya preguntan por ti — nada sale sin tu aprobación.",
       "seeHow": "Descubre cómo funciona",
       "note": "O simplemente pídele a tu IA que empiece a usar Anomalia",
       "ctaSecondary": "Agenda una llamada",
@@ -2229,7 +2229,7 @@
       "title": "Tus redes sociales, en piloto automático.",
       "lede": "Entrega una marca a Anomalia y él planifica, crea y publica por ti — semana tras semana. Cancela cuando quieras."
     },
-    "freePill": "Free incluye {credits} en créditos",
+    "freePill": "Gratis para siempre — o autohospédalo bajo la licencia Apache 2.0",
     "localCurrency": "Precios mostrados en EUR. Fuera de la eurozona los importes se muestran y facturan en USD.",
     "toggle": {
       "monthly": "Mensual",

--- a/src/lib/i18n/locales/fr.json
+++ b/src/lib/i18n/locales/fr.json
@@ -39,12 +39,12 @@
       "pricing": "Tarifs"
     },
     "hero": {
-      "eyebrow": "Votre équipe marketing IA",
+      "eyebrow": "Votre équipe marketing IA · Apache 2.0 · Auto-hébergement disponible",
       "titleLead": "Votre service marketing,",
       "titleMain": "",
-      "titleEm": "déjà recruté.",
+      "titleEm": "automatisé.",
       "titleCalm": "",
-      "subhead": "Équipe, distribution et ventes : cinq spécialistes créent les contenus, les publient sur neuf canaux et sur votre blog, et rédigent les réponses aux gens qui vous cherchent déjà — rien ne part sans votre accord.",
+      "subhead": "L'alternative open source spécialisée en marketing, distribution et ventes : cinq spécialistes créent les contenus, les publient sur neuf canaux et sur votre blog, et rédigent les réponses aux gens qui vous cherchent déjà — rien ne part sans votre accord.",
       "seeHow": "Découvrez comment ça marche",
       "note": "Ou demandez simplement à votre IA de commencer à utiliser Anomalia",
       "ctaSecondary": "Réserver un appel",
@@ -2229,7 +2229,7 @@
       "title": "Vos réseaux sociaux, en pilote automatique.",
       "lede": "Confiez une marque à Anomalia et il planifie, crée et publie pour vous — semaine après semaine. Résiliez quand vous voulez."
     },
-    "freePill": "Le Gratuit inclut {credits} de crédits",
+    "freePill": "Gratuit pour toujours — ou auto-hébergez-le sous licence Apache 2.0",
     "localCurrency": "Prix affichés en EUR. En dehors de la zone euro, les montants sont affichés et facturés en USD.",
     "toggle": {
       "monthly": "Mensuel",

--- a/src/lib/i18n/locales/it.json
+++ b/src/lib/i18n/locales/it.json
@@ -39,10 +39,10 @@
       "pricing": "Prezzi"
     },
     "hero": {
-      "eyebrow": "La tua squadra marketing AI",
+      "eyebrow": "La tua squadra marketing AI · Apache 2.0 · Disponibile self-hosted",
       "titleLead": "Il tuo reparto marketing,",
       "titleMain": "",
-      "titleEm": "già assunto.",
+      "titleEm": "automatizzato.",
       "titleCalm": "",
       "phrases": [
         "ovunque cercano quello che vendi.",
@@ -51,7 +51,7 @@
         "dove conta esserci davvero.",
         "dove ti trovano prima dei concorrenti."
       ],
-      "subhead": "Squadra, distribuzione e vendite: cinque specialisti creano i contenuti, li pubblicano su nove canali e sul tuo blog, e preparano le risposte a chi ti sta già cercando — niente esce prima del tuo sì.",
+      "subhead": "L'alternativa open source specializzata in marketing, distribuzione e vendite: cinque specialisti creano i contenuti, li pubblicano su nove canali e sul tuo blog, e preparano le risposte a chi ti sta già cercando — niente esce prima del tuo sì.",
       "seeHow": "Scopri come funziona",
       "note": "Oppure chiedi direttamente alla tua AI di iniziare a usare Anomalia",
       "ctaSecondary": "Prenota una call",
@@ -2229,7 +2229,7 @@
       "title": "I tuoi social, in autopilot.",
       "lede": "Affida un brand a Anomalia e lei pianifica, crea e pubblica per te — settimana dopo settimana. Cancelli quando vuoi."
     },
-    "freePill": "Il Free include {credits} di crediti",
+    "freePill": "Gratis per sempre — oppure self-hostalo sotto licenza Apache 2.0",
     "localCurrency": "Prezzi mostrati in EUR. Al di fuori dell'eurozona gli importi sono mostrati e addebitati in USD.",
     "toggle": {
       "monthly": "Mensile",

--- a/src/routes/[[lang=locale]]/pricing/+page.svelte
+++ b/src/routes/[[lang=locale]]/pricing/+page.svelte
@@ -25,7 +25,7 @@
   const startHref = $derived(marketingStartHref({ loggedIn, waitlistActive }));
   const lp = $derived((p: string) => localePath(p, (($locale as Locale) ?? 'en')));
 
-  let cycle = $state<'month' | 'year'>('year');
+  let cycle = $state<'month' | 'year'>('month');
   // Default from geo (eurozone → EUR, else USD); URL ?currency= overrides for shareable links.
   let currency = $state<Currency>(
     untrack(() => {
@@ -35,7 +35,8 @@
     })
   );
 
-  // Il Free si racconta con la sua dotazione di crediti, non più con un "valore API" in euro.
+  // La pill del Free parla di self-host (Apache 2.0); freePillValues resta solo per l'FAQ,
+  // che continua a raccontare la dotazione di crediti.
   const freePillValues = $derived({ credits: FREE_CREDITS.toLocaleString($locale ?? 'en') });
 
   function faqAnswer(key: string): string {
@@ -104,11 +105,8 @@
 
       <div class="free-pill">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M13 2L3 14h7l-1 8 10-12h-7l1-8z" /></svg>
-        {$_('pricing.freePill', { values: freePillValues })}
+        {$_('pricing.freePill')}
       </div>
-      <p class="credits-docs-link">
-        <a href={lp('/docs/credits')}>{$_('pricing.creditsDocsLink')}</a>
-      </p>
 
       <div class="price-toggles">
         <div class="bill-toggle" role="group" aria-label={$_('pricing.toggle.cycleAria')}>
@@ -137,6 +135,9 @@
       <p class="perbrand-note">
         {$_('pricing.note.pre')}
         <b>{$_('pricing.note.stripe')}</b>.
+      </p>
+      <p class="credits-docs-link">
+        <a href={lp('/docs/credits')}>{$_('pricing.creditsDocsLink')}</a>
       </p>
     </div>
   </section>
@@ -235,7 +236,7 @@
     height: 14px;
   }
   .credits-docs-link {
-    margin: -6px auto 22px;
+    margin: 18px auto 0;
     font-size: 13px;
     color: var(--ink-soft);
   }


### PR DESCRIPTION
## What?
The homepage hero copy is reworked so the first screen carries the open-source story: the chip above the title now reads "Your AI marketing team · Apache 2.0 · Self-hosted available", the title ends with "automated." (previously "already hired."), and the subhead opens with "The open-source alternative specialized in marketing, distribution and sales…" — wording taken from the anomaliaso/anomalia GitHub repo description. On /pricing, the billing toggle defaults to Monthly instead of Annual, the green "Free" pill now says "Free forever — or self-host Anomalia under Apache 2.0" (dropping the free-credits framing), and the "How credits & limits work →" link moves from under that pill to below the plan cards. All four locales (en/it/es/fr) are updated in sync.

## Why?
Marketing wants the homepage to lead with what differentiates Anomalia right now: it's open source, Apache 2.0 licensed and can be self-hosted — currently this signal only lives in the README. The pricing page was selling annual by default and explaining the Free plan through credits, while the clearer story for visitors arriving from the repo is "free forever if you host it yourself".

## How?
All strings live in the i18n locale files (`src/lib/i18n/locales/{en,it,es,fr}.json`), so no component changes were needed on the homepage. On the pricing page the edit is threefold: `cycle` initial state flips to `'month'`, the pill renders `$_('pricing.freePill')` without interpolation values (the FAQ still uses `FREE_CREDITS` for its credits answer, so the import stays), and the existing `.credits-docs-link` paragraph is relocated after the Stripe note with a positive top margin replacing the old negative one. No new dependencies, no library choices.

## Testing?
- `npm run check`: no errors in any touched file (the pre-existing svelte-check noise elsewhere on dev is unchanged).
- Locale JSONs parse cleanly after editing.
- Manual verification against the local dev server: SSR HTML for / shows the new chip/title/subhead (EN + IT), /pricing shows the monthly toggle active by default, the new pill text, and the credits link rendered below the plan cards.
- Not tested: full e2e suite; risk is limited to presentation strings.

## Evidence (screenshots/videos)
Verified in a visible browser against the local stack — tabs open on http://localhost:5199/en and http://localhost:5199/en/pricing showing the new hero and pricing layout. Screenshot attachments to follow in the PR comments if needed.

## Anything Else?
The waitlist/copy in other marketing sub-pages still says "already hired"-style variants? No — those pages use their own per-page hero keys, untouched here. Possible follow-up: give the Free plan row a dedicated self-host blurb once the docs landing page for OSS users exists.