### PR TITLE
Point website GitHub references to anomaliaso/anomalia

### DIFF
--- a/src/lib/components/SiteFooter.svelte
+++ b/src/lib/components/SiteFooter.svelte
@@ -75,7 +75,7 @@
         </a>
         <a
           class="foot-social-link"
-          href="https://github.com/andreabuttarelli/anomalia-cli"
+          href="https://github.com/anomaliaso/anomalia"
           target="_blank"
           rel="noopener noreferrer"
           aria-label="GitHub"

--- a/src/lib/components/SiteNav.svelte
+++ b/src/lib/components/SiteNav.svelte
@@ -6,7 +6,7 @@
   import LangToggle from '$lib/components/LangToggle.svelte';
   import BrandMark from '$lib/components/BrandMark.svelte';
 
-  const GITHUB_CLI_URL = 'https://github.com/andreabuttarelli/anomalia-cli';
+  const GITHUB_CLI_URL = 'https://github.com/anomaliaso/anomalia';
 
   let {
     cta = 'Start',

--- a/src/lib/i18n/locales/docs/en.json
+++ b/src/lib/i18n/locales/docs/en.json
@@ -1232,7 +1232,7 @@
     "s18": "Pick a transport: local stdio is simplest on your machine; remote HTTP is for cloud hosts.",
     "s19": "Option A — Local stdio",
     "s20": "Best for Cursor and other local agents.",
-    "s21": "Install Bun and clone the anomalia-cli repo (or install the CLI binary so anomalia-mcp is on your PATH).",
+    "s21": "Install Bun and clone the anomalia repo (or install the CLI binary so anomalia-mcp is on your PATH).",
     "s22": "Authenticate once:",
     "s23": "Add to Cursor MCP config (absolute path required when using Bun):",
     "s24": "If the binary is on PATH after install:",

--- a/src/lib/i18n/locales/docs/es.json
+++ b/src/lib/i18n/locales/docs/es.json
@@ -1232,7 +1232,7 @@
     "s18": "Elige un transporte: stdio local es lo más simple en tu máquina; HTTP remoto para hosts en la nube.",
     "s19": "Opción A — Stdio local",
     "s20": "Ideal para Cursor y otros agentes locales.",
-    "s21": "Instala Bun y clona el repo anomalia-cli (o instala el binario CLI para tener anomalia-mcp en el PATH).",
+    "s21": "Instala Bun y clona el repo anomalia (o instala el binario CLI para tener anomalia-mcp en el PATH).",
     "s22": "Autentícate una vez:",
     "s23": "Añade a la config MCP de Cursor (ruta absoluta obligatoria con Bun):",
     "s24": "Si el binario está en el PATH tras la instalación:",

--- a/src/lib/i18n/locales/docs/fr.json
+++ b/src/lib/i18n/locales/docs/fr.json
@@ -1232,7 +1232,7 @@
     "s18": "Choisissez un transport : stdio local est le plus simple sur votre machine ; HTTP distant pour les hôtes cloud.",
     "s19": "Option A — Stdio local",
     "s20": "Idéal pour Cursor et les autres agents locaux.",
-    "s21": "Installez Bun et clonez le repo anomalia-cli (ou installez le binaire CLI pour avoir anomalia-mcp dans le PATH).",
+    "s21": "Installez Bun et clonez le repo anomalia (ou installez le binaire CLI pour avoir anomalia-mcp dans le PATH).",
     "s22": "Authentifiez-vous une fois :",
     "s23": "Ajoutez à la config MCP de Cursor (chemin absolu requis avec Bun) :",
     "s24": "Si le binaire est dans le PATH après l'installation :",

--- a/src/lib/i18n/locales/docs/it.json
+++ b/src/lib/i18n/locales/docs/it.json
@@ -1232,7 +1232,7 @@
     "s18": "Scegli un trasporto: stdio locale è il più semplice sulla tua macchina; HTTP remoto per host cloud.",
     "s19": "Opzione A — Stdio locale",
     "s20": "Ideale per Cursor e altri agenti locali.",
-    "s21": "Installa Bun e clona il repo anomalia-cli (oppure installa il binario CLI così anomalia-mcp è nel PATH).",
+    "s21": "Installa Bun e clona il repo anomalia (oppure installa il binario CLI così anomalia-mcp è nel PATH).",
     "s22": "Autenticati una volta:",
     "s23": "Aggiungi alla config MCP di Cursor (serve il path assoluto con Bun):",
     "s24": "Se il binario è nel PATH dopo l'installazione:",

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -2229,7 +2229,7 @@
       "title": "Your social media, on autopilot.",
       "lede": "Hand a brand to Anomalia and it plans, creates and posts for you — week after week. Cancel anytime."
     },
-    "freePill": "Free forever — or self-host Anomalia under Apache 2.0",
+    "freePill": "Free forever, self-host Anomalia under Apache 2.0",
     "localCurrency": "Prices shown in EUR. Outside the eurozone, amounts are shown and billed in USD.",
     "toggle": {
       "monthly": "Monthly",

--- a/src/lib/i18n/locales/es.json
+++ b/src/lib/i18n/locales/es.json
@@ -2229,7 +2229,7 @@
       "title": "Tus redes sociales, en piloto automático.",
       "lede": "Entrega una marca a Anomalia y él planifica, crea y publica por ti — semana tras semana. Cancela cuando quieras."
     },
-    "freePill": "Gratis para siempre — o autohospédalo bajo la licencia Apache 2.0",
+    "freePill": "Gratis para siempre, autohospédalo bajo la licencia Apache 2.0",
     "localCurrency": "Precios mostrados en EUR. Fuera de la eurozona los importes se muestran y facturan en USD.",
     "toggle": {
       "monthly": "Mensual",

--- a/src/lib/i18n/locales/fr.json
+++ b/src/lib/i18n/locales/fr.json
@@ -2229,7 +2229,7 @@
       "title": "Vos réseaux sociaux, en pilote automatique.",
       "lede": "Confiez une marque à Anomalia et il planifie, crée et publie pour vous — semaine après semaine. Résiliez quand vous voulez."
     },
-    "freePill": "Gratuit pour toujours — ou auto-hébergez-le sous licence Apache 2.0",
+    "freePill": "Gratuit pour toujours, auto-hébergez-le sous licence Apache 2.0",
     "localCurrency": "Prix affichés en EUR. En dehors de la zone euro, les montants sont affichés et facturés en USD.",
     "toggle": {
       "monthly": "Mensuel",

--- a/src/lib/i18n/locales/it.json
+++ b/src/lib/i18n/locales/it.json
@@ -2229,7 +2229,7 @@
       "title": "I tuoi social, in autopilot.",
       "lede": "Affida un brand a Anomalia e lei pianifica, crea e pubblica per te — settimana dopo settimana. Cancelli quando vuoi."
     },
-    "freePill": "Gratis per sempre — oppure self-hostalo sotto licenza Apache 2.0",
+    "freePill": "Gratis per sempre, self-hostalo sotto licenza Apache 2.0",
     "localCurrency": "Prezzi mostrati in EUR. Al di fuori dell'eurozona gli importi sono mostrati e addebitati in USD.",
     "toggle": {
       "monthly": "Mensile",

--- a/src/lib/server/oauth.ts
+++ b/src/lib/server/oauth.ts
@@ -174,7 +174,7 @@ export function anonClient() {
  * Quindi l'issuer sta sull'unico host che risponde 200: issuer, endpoint e host che serve i
  * metadata diventano lo stesso origin e la discovery non dipende più da un redirect.
  *
- * L'altra metà della coppia vive in anomalia-cli (`authServerUrl()` in `lib/config.ts`, che
+ * L'altra metà della coppia vive in anomalia (`authServerUrl()` in `lib/config.ts`, che
  * riempie `authorization_servers` nel documento RFC 9728 di mcp.anomalia.so): i due valori
  * devono restare identici byte per byte, o i client severi rifiutano i metadata. Si spostano
  * insieme, sempre.

--- a/src/routes/[[lang=locale]]/docs/agents/+page.svelte
+++ b/src/routes/[[lang=locale]]/docs/agents/+page.svelte
@@ -62,7 +62,7 @@
 
 <h2 id="install-skill">{$_('docs.agents.s23')}</h2>
 <p>{$_('docs.agents.s44')}</p>
-<pre><code>npx skills add andreabuttarelli/anomalia-cli --skill anomalia</code></pre>
+<pre><code>npx skills add anomaliaso/anomalia --skill anomalia</code></pre>
 <p>{$_('docs.agents.s45')}</p>
 <pre><code>curl -sSL https://anomalia.so/install-skill.sh | bash</code></pre>
 <p>{$_('docs.agents.s24')}</p>
@@ -125,8 +125,8 @@ anomalia ai &lt;slug&gt; --message "..." --pipe</code></pre>
   <li><a href={lp('/docs/mcp')}>{$_('docs.agents.s67')}</a> — {$_('docs.agents.s68')}</li>
   <li><a href={lp('/docs/cli')}>{$_('docs.agents.s69')}</a> — {$_('docs.agents.s70')}</li>
   <li>
-    <a href="https://github.com/andreabuttarelli/anomalia-cli" target="_blank" rel="noopener noreferrer"
-      >anomalia-cli</a
+    <a href="https://github.com/anomaliaso/anomalia" target="_blank" rel="noopener noreferrer"
+      >anomalia</a
     >
     — {$_('docs.agents.s71')}
   </li>

--- a/src/routes/[[lang=locale]]/docs/mcp/+page.svelte
+++ b/src/routes/[[lang=locale]]/docs/mcp/+page.svelte
@@ -59,7 +59,7 @@ Anomalia API  (/api/v1/*)</code></pre>
   "mcpServers": &#123;
     "anomalia": &#123;
       "command": "bun",
-      "args": ["run", "/ABS/PATH/to/anomalia-cli/mcp/stdio.ts"]
+      "args": ["run", "/ABS/PATH/to/anomalia/mcp/stdio.ts"]
     &#125;
   &#125;
 &#125;</code></pre>
@@ -204,8 +204,8 @@ bun run mcp:http
   <li><a href={lp('/docs/cli')}>{$_('docs.mcp.s74')}</a> — {$_('docs.mcp.s75')}</li>
   <li><a href={lp('/docs/api')}>{$_('docs.mcp.s76')}</a> — {$_('docs.mcp.s77')}</li>
   <li>
-    <a href="https://github.com/andreabuttarelli/anomalia-cli" target="_blank" rel="noopener noreferrer"
-      >anomalia-cli</a
+    <a href="https://github.com/anomaliaso/anomalia" target="_blank" rel="noopener noreferrer"
+      >anomalia</a
     >
     — {$_('docs.mcp.s78')}
   </li>


### PR DESCRIPTION
## What?
Updates every website-facing GitHub link from the old personal repository (`andreabuttarelli/anomalia-cli`) to the organization repository (`anomaliaso/anomalia`): site nav CTA, footer social link, the MCP and Agents docs pages (source links, `npx skills add` snippet, local clone paths), the docs i18n strings in all four locales, plus the minor freePill copy tweak that was pending locally (em-dash → comma, all locales).

## Why?
The project now lives under the `anomaliaso` organization; visitors landing on the old personal repo should be directed to the canonical repository instead.

## How?
- Swapped URLs and visible labels in `SiteNav.svelte`, `SiteFooter.svelte`, `docs/mcp/+page.svelte`, `docs/agents/+page.svelte`.
- Extended the original local patch (which only covered nav/footer) after grepping the codebase for remaining `anomalia-cli` / `andreabuttarelli/anomalia` references, so the change is conclusive for site content: docs pages + `locales/docs/*.json` + the `oauth.ts` code comment now use the new repo name.
- Deliberately left untouched: raw install URLs and paths that resolve inside the `anomalia-cli` repository itself (`raw.githubusercontent.com/.../scripts/install.sh`, `/ABS/PATH/to/anomalia/mcp/stdio.ts` clone path, `install-skill.sh`, `skills-lock.json`, `.agents/skills` references) because those files ship with the CLI repo, not this one — changing them without moving the code would break installation flows. Personal `@andreabuttarelli` showcase handles and test fixtures are unrelated and unchanged.

## Testing?
- Codebase-wide grep confirms no remaining site-facing references to the old repo.
- i18n files are JSON-only string edits; Svelte changes are attribute/URL swaps.
- Not tested: browser walkthrough of the docs pages (asset/link-only changes, no logic). Risk: low.

## Evidence (screenshots/videos)
<details>
<summary>Changed references (grep after)</summary>

```
SiteNav.svelte:        GITHUB_CLI_URL = 'https://github.com/anomaliaso/anomalia'
SiteFooter.svelte:     href="https://github.com/anomaliaso/anomalia"
docs/mcp:              github.com/anomaliaso/anomalia · /ABS/PATH/to/anomalia/mcp/stdio.ts
docs/agents:           npx skills add anomaliaso/anomalia --skill anomalia
locales/docs/*.json:   "clone the anomalia repo" (en/it/es/fr)
```
</details>

## Anything Else?
Follow-up needed if the CLI/MCP code moves into this repo: update `raw.githubusercontent.com` install URLs, the `mcp/stdio.ts` path, `.agents/skills` docs and `skills-lock.json` accordingly. GitHub will also keep redirecting the old personal repo in the meantime.