### PR TITLE
Restore agent DM chip and private-thread isolation after agent-kit migration

### DIFF
--- a/scripts/db-seed.mjs
+++ b/scripts/db-seed.mjs
@@ -129,6 +129,30 @@ export async function ensureBrand(client, orgId, slug, name, website, plan = SEE
   return row.rows[0].id;
 }
 
+/**
+ * Membership + profile rows for the demo user. Without these a pre-existing GoTrue user (created
+ * by an earlier seed run or by hand) logs into an app that shows no brand at all — /app bounces to
+ * onboarding and every /app/[slug] route 404s behind RLS. Every insert is idempotent so re-running
+ * `npm run db:seed` stays a no-op.
+ */
+export async function ensureSeedMemberships(client, userId, email, orgId, brandId) {
+  await client.query(
+    `insert into profiles (id, email, full_name)
+     select u.id, u.email, coalesce(u.raw_user_meta_data->>'full_name', 'Demo User')
+     from auth.users u where u.id = $1
+     on conflict (id) do update set email = excluded.email`,
+    [userId]
+  );
+  await client.query(
+    'insert into org_members (org_id, user_id, role) values ($1, $2, $3::member_role) on conflict do nothing',
+    [orgId, userId, 'owner']
+  );
+  await client.query(
+    'insert into brand_members (brand_id, user_id) values ($1, $2) on conflict do nothing',
+    [brandId, userId]
+  );
+}
+
 async function main() {
   const DATABASE_URL = process.env.DATABASE_URL;
   const SUPABASE_URL = process.env.PUBLIC_SUPABASE_URL;
@@ -152,6 +176,7 @@ async function main() {
     await ensurePrivileges(client);
     const orgId = await ensureOrg(client, user.id, SEED_ORG_NAME);
     const brandId = await ensureBrand(client, orgId, SEED_BRAND_SLUG, SEED_BRAND_NAME, SEED_BRAND_WEBSITE);
+    await ensureSeedMemberships(client, user.id, SEED_EMAIL, orgId, brandId);
     console.log(`org ${orgId} / brand ${SEED_BRAND_SLUG} (${brandId}) ready.`);
     console.log(`\nLog in with ${SEED_EMAIL} / ${SEED_PASSWORD} — change SEED_DEMO_PASSWORD before sharing this instance.`);
     // A single-tenant install needs this id: it is what tells the app there is nothing to switch

--- a/scripts/db-seed.test.ts
+++ b/scripts/db-seed.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { ensureDemoUser, ensureOrg, ensureBrand, ensurePrivileges } from './db-seed.mjs';
+import { ensureDemoUser, ensureOrg, ensureBrand, ensurePrivileges, ensureSeedMemberships } from './db-seed.mjs';
 
 describe('ensureDemoUser', () => {
   it('returns the id from a successful admin create', async () => {
@@ -113,5 +113,19 @@ describe('ensurePrivileges', () => {
     expect(tables.some((s) => s.includes('to anon'))).toBe(true);
     expect(tables.some((s) => s.includes('to authenticated'))).toBe(true);
     expect(executed.some((s) => s.startsWith('grant execute on all functions'))).toBe(true);
+  });
+});
+
+describe('ensureSeedMemberships', () => {
+  it('inserts profile + org + brand memberships idempotently', async () => {
+    const client = { query: vi.fn().mockResolvedValue({ rows: [] }) };
+    await ensureSeedMemberships(client, 'u1', 'demo@example.com', 'org1', 'brand1');
+    expect(client.query).toHaveBeenCalledTimes(3);
+    expect(client.query.mock.calls[0][0]).toContain('insert into profiles');
+    expect(client.query.mock.calls[0][0]).toContain('on conflict (id) do update');
+    expect(client.query.mock.calls[1][0]).toContain('insert into org_members');
+    expect(client.query.mock.calls[1][0]).toContain('on conflict do nothing');
+    expect(client.query.mock.calls[2][0]).toContain('insert into brand_members');
+    expect(client.query.mock.calls[2][0]).toContain('on conflict do nothing');
   });
 });

--- a/src/lib/chat-dm.test.ts
+++ b/src/lib/chat-dm.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import {
+  dmReplyBackMessage,
+  dmSendsFromCall,
+  dmSendsFromOutput,
+  isDmReplyBackMessage
+} from './chat-dm';
+
+const payload = {
+  success: true,
+  dm_thread_id: 'thread-1',
+  to: 'analyst',
+  to_name: 'Analyst',
+  sends: [{ dm_thread_id: 'thread-1', to: 'analyst', to_name: 'Analyst' }]
+};
+
+describe('dmSendsFromOutput — srotola il kit', () => {
+  it('legge l\'oggetto piano (pre-kit)', () => {
+    expect(dmSendsFromOutput(payload)).toEqual([
+      { threadId: 'thread-1', to: 'analyst', name: 'Analyst' }
+    ]);
+  });
+
+  it('srotola il ToolResult del kit `{ content: [{ type:text, text: JSON }] }`', () => {
+    expect(
+      dmSendsFromOutput({ content: [{ type: 'text', text: JSON.stringify(payload) }] })
+    ).toEqual([{ threadId: 'thread-1', to: 'analyst', name: 'Analyst' }]);
+  });
+
+  it('srotola il wrapper SDK `{ type:content, value }`', () => {
+    expect(
+      dmSendsFromOutput({
+        type: 'content',
+        value: [{ type: 'text', text: JSON.stringify(payload) }]
+      })
+    ).toEqual([{ threadId: 'thread-1', to: 'analyst', name: 'Analyst' }]);
+  });
+
+  it('un fan-out riempie un invio per destinatario, senza dm_thread_id in cima', () => {
+    const fan = {
+      success: true,
+      sends: [
+        { dm_thread_id: 't-a', to: 'content', to_name: 'Content Creator' },
+        { dm_thread_id: 't-b', to: 'motion', to_name: 'Motion' }
+      ]
+    };
+    expect(dmSendsFromOutput(fan)).toEqual([
+      { threadId: 't-a', to: 'content', name: 'Content Creator' },
+      { threadId: 't-b', to: 'motion', name: 'Motion' }
+    ]);
+  });
+
+  it('preferisce dmSends hoisted (compattazione) all\'output', () => {
+    expect(
+      dmSendsFromCall({
+        output: { error: 'gone' },
+        dmSends: [{ threadId: 't-1', to: 'web', name: 'Web Specialist' }]
+      })
+    ).toEqual([{ threadId: 't-1', to: 'web', name: 'Web Specialist' }]);
+  });
+
+  it('un output vuoto o un errore non è una chip', () => {
+    expect(dmSendsFromOutput({ error: 'Unknown agent' })).toEqual([]);
+    expect(dmSendsFromOutput(null)).toEqual([]);
+  });
+});
+
+describe('isDmReplyBackMessage', () => {
+  it('riconosce la vecchia riga versata nel thread utente, e nient\'altro', () => {
+    expect(isDmReplyBackMessage(dmReplyBackMessage('Analyst', 'ok', 'it'))).toBe(true);
+    expect(isDmReplyBackMessage(dmReplyBackMessage('Analyst', 'ok', 'en'))).toBe(true);
+    expect(isDmReplyBackMessage('Ciao, come va?')).toBe(false);
+    expect(isDmReplyBackMessage('📩 altro')).toBe(false);
+  });
+});
+
+describe('la chip sta su ogni surface, come lo sticker', () => {
+  const reads = (f: string) => readFileSync(new URL(f, import.meta.url), 'utf8');
+
+  it('ChatLiveStatus / ChatColumn / ChatTurn montano ChatDmChip', () => {
+    for (const f of [
+      './components/ChatColumn.svelte',
+      './components/ChatLiveStatus.svelte',
+      '../routes/app/[brand]/chat/components/ChatTurn.svelte'
+    ]) {
+      expect(reads(f)).toContain('<ChatDmChip');
+    }
+  });
+});

--- a/src/lib/chat-dm.ts
+++ b/src/lib/chat-dm.ts
@@ -62,13 +62,99 @@ export function dmBrief(meName: string, otherName: string, locale: string): stri
 }
 
 /**
- * Il messaggio che riporta la risposta di un DM nel contesto dell'iniziatore (await:true). È una
- * riga USER nel thread di partenza: se il turno gira ancora la assorbe la mailbox a un confine di
- * step, altrimenti diventa un turno normale appena il drain la pesca.
+ * Vecchia riga USER che versava la risposta del DM nel thread con l'utente. Non si scrive più:
+ * l'interazione è la chip "N messaggi con X". Resta il detector, perché i thread già salvati
+ * non devono farla rivedere.
  */
 export function dmReplyBackMessage(fromName: string, text: string, locale: string): string {
   const summary = text.trim().slice(0, 800);
   return locale === 'en'
     ? `📩 Reply from ${fromName} (private agent chat): ${summary}`
     : `📩 Risposta di ${fromName} (chat privata tra agenti): ${summary}`;
+}
+
+export function isDmReplyBackMessage(text: unknown): boolean {
+  if (typeof text !== 'string' || !text.startsWith('📩 ')) return false;
+  return (
+    text.includes('(chat privata tra agenti):') || text.includes('(private agent chat):')
+  );
+}
+
+/** Un invio `message_agent` visibile come chip: thread privato + nome del destinatario. */
+export type DmSend = { threadId: string; to: string; name: string };
+
+function parseJsonObject(text: string): Record<string, unknown> | null {
+  const t = text.trim();
+  if (!t.startsWith('{') && !t.startsWith('[')) return null;
+  try {
+    const v = JSON.parse(t) as unknown;
+    return v && typeof v === 'object' ? (v as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}
+
+function recordFromContentParts(parts: unknown[]): Record<string, unknown> | null {
+  for (const part of parts) {
+    if (!part || typeof part !== 'object') continue;
+    const p = part as Record<string, unknown>;
+    if (typeof p.text === 'string' && (p.type === 'text' || p.type === undefined)) {
+      const parsed = parseJsonObject(p.text);
+      if (parsed) return parsed;
+    }
+  }
+  return null;
+}
+
+/**
+ * L'output di `message_agent` dopo il kit: oggetto piano, wrapper SDK `{type,value}`, o
+ * `ToolResult` `{ content: [{ type:'text', text: JSON }] }`. Senza srotolare, ChatDmChip non
+ * vede `dm_thread_id` e la chip sparisce.
+ */
+function unwrapDmRecord(raw: unknown): Record<string, unknown> | null {
+  if (typeof raw === 'string') return parseJsonObject(raw);
+  if (!raw || typeof raw !== 'object') return null;
+  if (Array.isArray(raw)) return recordFromContentParts(raw);
+  const rec = raw as Record<string, unknown>;
+  if ('type' in rec && 'value' in rec && rec.value !== undefined) {
+    const inner = unwrapDmRecord(rec.value);
+    if (inner) return inner;
+  }
+  if (Array.isArray(rec.content)) {
+    const fromParts = recordFromContentParts(rec.content);
+    if (fromParts) return fromParts;
+  }
+  return rec;
+}
+
+function sendFrom(raw: unknown): DmSend | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const r = raw as Record<string, unknown>;
+  const threadId = typeof r.dm_thread_id === 'string' ? r.dm_thread_id : typeof r.threadId === 'string' ? r.threadId : '';
+  if (!threadId) return null;
+  return {
+    threadId,
+    to: typeof r.to === 'string' ? r.to : '',
+    name: typeof r.to_name === 'string' && r.to_name ? r.to_name : typeof r.name === 'string' && r.name ? r.name : 'Agent'
+  };
+}
+
+/** Gli invii da una tool-call: campo hoisted `dmSends` (compattazione) o output srotolato. */
+export function dmSendsFromCall(call: { output?: unknown; dmSends?: unknown }): DmSend[] {
+  if (Array.isArray(call.dmSends)) {
+    const hoisted = call.dmSends.map(sendFrom).filter((s): s is DmSend => !!s);
+    if (hoisted.length) return hoisted;
+  }
+  return dmSendsFromOutput(call.output);
+}
+
+export function dmSendsFromOutput(raw: unknown): DmSend[] {
+  const rec = unwrapDmRecord(raw);
+  if (!rec) return [];
+  if (Array.isArray(rec.sends)) {
+    const list = rec.sends.map(sendFrom).filter((s): s is DmSend => !!s);
+    if (list.length) return list;
+  }
+  const one = sendFrom(rec);
+  return one ? [one] : [];
 }

--- a/src/lib/components/ChatColumn.svelte
+++ b/src/lib/components/ChatColumn.svelte
@@ -70,7 +70,7 @@
   import { normalizeDeviceLoginPayload } from '$lib/chat-device-login';
   import ChatDivider from '$lib/components/ChatDivider.svelte';
   import { dayDividers, firstUnreadIndex } from '$lib/chat-day-groups';
-  import { dmAgents } from '$lib/chat-dm';
+  import { dmAgents, isDmReplyBackMessage } from '$lib/chat-dm';
   import PostCard from '$lib/components/PostCard.svelte';
   import '$lib/styles/chat-messages.css';
   import type { ChatQuestion } from '$lib/chat-questions';
@@ -525,7 +525,13 @@
     }>
   ): UiMsg[] {
     return raw
-      .filter((m) => m.role === 'user' || m.role === 'assistant')
+      .filter((m) => {
+        if (m.role !== 'user' && m.role !== 'assistant') return false;
+        const content = typeof m.content === 'string' ? m.content : '';
+        // La risposta di un DM non entra MAI nella chat con l'utente: vive nel thread privato.
+        if (m.role === 'user' && isDmReplyBackMessage(content)) return false;
+        return true;
+      })
       .map((m) => {
         const content = typeof m.content === 'string' ? m.content : '';
         return {
@@ -1409,6 +1415,8 @@
         <p class="goal-hint" role="status">{goalHint}</p>
       {/if}
       {#each messages as msg, i (i)}
+        {#if msg.role === 'user' && isDmReplyBackMessage(msg.content)}
+        {:else}
         <!-- Prima il giorno, poi il confine dei non letti: il secondo sta più vicino al messaggio
              da cui si riprende a leggere. -->
         {#if dayLines[i]}<ChatDivider label={dayLines[i]} />{/if}
@@ -1553,7 +1561,7 @@
                   questions={tc.questions!}
                   toolCallId={tc.toolCallId ?? `qq-${i}-${bi}-${ti}`}
                   threadId={threadId ?? ''}
-                  followingUserTexts={messages.slice(i + 1).filter((m) => m.role === 'user').map((m) => m.content)}
+                  followingUserTexts={messages.slice(i + 1).filter((m) => m.role === 'user' && !isDmReplyBackMessage(m.content)).map((m) => m.content)}
                   disabled={loading}
                   onanswer={(text) => send(text)}
                 />
@@ -1623,6 +1631,7 @@
             {/if}
           </div>
         {/if}
+        {/if}
       {/each}
       {#if looseArtifacts.length}
         <!-- Artefatti la cui chiamata non compare più nella cronologia: il file esiste, mostrarlo
@@ -1642,6 +1651,7 @@
             {streamToolCalls}
             {streamReasoning}
             {streamReasoningSegments}
+            {brandSlug}
             face={liveFace}
             color={liveWho.color}
             />

--- a/src/lib/components/ChatDmChip.svelte
+++ b/src/lib/components/ChatDmChip.svelte
@@ -6,11 +6,12 @@
     fallbackAvatarColor,
     fallbackAvatarFace
   } from '$lib/agent-avatars';
+  import { dmSendsFromCall } from '$lib/chat-dm';
 
   /**
    * La riga "N messaggi con X" sotto un turno che ha usato `message_agent`: un link compatto al
    * thread privato fra i due agenti (che è in sola lettura per l'utente). Tutto viene dalle
-   * tool-call salvate — l'output del tool porta `dm_thread_id`, `to` e `to_name` — quindi la riga
+   * tool-call — `dmSends` hoisted in persistenza, o l'output srotolato dal kit — quindi la riga
    * si ridisegna identica in streaming e alla riapertura, senza query sue.
    *
    * È un EVENTO DI SISTEMA, non contenuto del turno: niente box/bordo/sfondo e centrata nella
@@ -20,6 +21,7 @@
   type DmCall = {
     toolName: string;
     output?: unknown;
+    dmSends?: unknown;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     [k: string]: any;
   };
@@ -31,18 +33,11 @@
     const byThread = new Map<string, { name: string; to: string; n: number }>();
     for (const tc of calls) {
       if (tc.toolName !== 'message_agent') continue;
-      const out = tc.output as
-        | { dm_thread_id?: unknown; to?: unknown; to_name?: unknown }
-        | null
-        | undefined;
-      if (!out || typeof out !== 'object' || typeof out.dm_thread_id !== 'string') continue;
-      const g = byThread.get(out.dm_thread_id) ?? {
-        name: typeof out.to_name === 'string' ? out.to_name : 'Agent',
-        to: typeof out.to === 'string' ? out.to : '',
-        n: 0
-      };
-      g.n += 1;
-      byThread.set(out.dm_thread_id, g);
+      for (const send of dmSendsFromCall(tc)) {
+        const g = byThread.get(send.threadId) ?? { name: send.name, to: send.to, n: 0 };
+        g.n += 1;
+        byThread.set(send.threadId, g);
+      }
     }
     return [...byThread.entries()];
   });

--- a/src/lib/components/ChatLiveStatus.svelte
+++ b/src/lib/components/ChatLiveStatus.svelte
@@ -12,6 +12,7 @@
   import { formatChatDuration } from '$lib/chat-duration';
   import ChatThought from '$lib/components/ChatThought.svelte';
   import ChatExpressionStickers from '$lib/components/ChatExpressionStickers.svelte';
+  import ChatDmChip from '$lib/components/ChatDmChip.svelte';
   import ChatMediaCard from '$lib/components/ChatMediaCard.svelte';
   import { mediaFromToolCall } from '$lib/chat-media';
   import '$lib/styles/chat-messages.css';
@@ -26,6 +27,7 @@
     // workbenches, AgentComputerPanel) keep the single legacy block up top via `streamReasoning`.
     streamReasoningSegments = [] as ChatReasoningSegment[],
     compact = false,
+    brandSlug = '',
     // The agent's own face, following the turn: thinking while it reasons, writing once
     // the text starts landing.
     face = DEFAULT_CHAT_AGENT_AVATAR.face as string,
@@ -38,6 +40,7 @@
     streamReasoningSegments?: ChatReasoningSegment[];
     /** Tighter layout for the home chat column. */
     compact?: boolean;
+    brandSlug?: string;
     face?: string;
     color?: string;
   } = $props();
@@ -139,6 +142,7 @@
              `SET_EXPRESSION` e poi trovarsela sostituita da uno sticker. Un turno non deve
              cambiare forma fra lo streaming e la riapertura. -->
         <ChatExpressionStickers calls={block.calls} />
+        <ChatDmChip calls={block.calls} {brandSlug} />
         {#each block.calls as tc, ti (`${tc.toolCallId ?? 'md'}-${bi}-${ti}`)}
           {@const shown = mediaFromToolCall(tc)}
           {#if shown}

--- a/src/lib/server/chat/agent-dm-tools.test.ts
+++ b/src/lib/server/chat/agent-dm-tools.test.ts
@@ -200,12 +200,13 @@ describe('message_agent — invio, await, budget', () => {
 		expect(ok.success).toBe(true);
 	});
 
-	it('await:true chiede il riassunto di ritorno nel thread di partenza', async () => {
+	it('await:true non versa più la risposta nel thread con l\'utente', async () => {
 		const { supabase, jobs } = fakeDb();
 		const tools = createAgentDmTools(toolOpts(supabase));
 		const out = await exec(tools, { to: 'content', message: 'Dammi lo stato', await: true });
 		expect(out.success).toBe(true);
-		expect((jobs[0].input_params as Record<string, unknown>).reply_to_thread).toBe('main-thread');
+		expect((jobs[0].input_params as Record<string, unknown>).reply_to_thread).toBeUndefined();
+		expect(String(out.hint ?? '')).not.toContain('📩');
 	});
 
 	it('idempotenza del thread: due messaggi allo stesso agente = stesso dm_thread_id', async () => {

--- a/src/lib/server/chat/agent-dm-tools.ts
+++ b/src/lib/server/chat/agent-dm-tools.ts
@@ -7,11 +7,10 @@
  * risponde con un SUO turno accodato — i SUOI tool via `pickTools`, il SUO prompt — e l'utente
  * vede la conversazione arrivare nella sidebar, in sola lettura.
  *
- * ASYNC PER COSTRUZIONE. Il tool non aspetta mai: torna subito con l'id del thread. `await:true`
- * non blocca — dice al giro di ritorno di reinfilare un riassunto della risposta nel thread di
- * partenza come riga user, che la mid-turn-mailbox assorbe a un confine di step se il turno
- * dell'iniziatore gira ancora. Se il turno finisce prima, l'onestà sta nell'hint: "di' che hai
- * scritto e che risponderà nel vostro thread", mai un ciclo di attesa.
+ * ASYNC PER COSTRUZIONE. Il tool non aspetta mai: torna subito con l'id del thread. La risposta
+ * del collega resta nel thread DM (sola lettura per l'utente). L'interazione nella chat con
+ * l'utente è la chip "N messaggi con X" — MAI un riassunto 📩 versato qui. `await:true` è un
+ * no-op conservato nello schema: non aspettare, non incollare la risposta.
  *
  * PERIMETRO: orchestratore soltanto (mai i sotto-agenti — chi parla è uno solo, vedi
  * NEVER_FOR_SUBAGENTS), ma i turni schedulati SÌ: lo Stratega che di notte scrive al Produttore è
@@ -211,7 +210,7 @@ export function createAgentDmTools(opts: {
       description: [
         'Send a message to ANOTHER agent of this brand, in a persistent private thread between the two of you (one thread per pair, reused forever — your shared memory). The other agent replies there with their own tools and context; the user can read the thread but not write in it.',
         'Use it to delegate a piece of work to a colleague, report a blocker, or coordinate — when you want THEM to act with THEIR tools, not just an opinion (for a one-shot opinion use ask_to_*).',
-        'ASYNC, never blocking: the tool returns immediately. With await:true, a short summary of their reply is dropped back into THIS conversation as soon as it lands — it may arrive at a later step of this turn. If it has not arrived by your final message, say so honestly ("ho scritto a X, risponderà nel nostro thread") and finish — NEVER stall or loop waiting for it. With await:false (default), the reply simply stays in your private thread.',
+        'ASYNC, never blocking: the tool returns immediately. The other agent replies in YOUR private thread; the user sees a compact chip ("N messages with X") and can open that thread read-only. NEVER wait in a loop, NEVER write their answer yourself, NEVER paste their reply into THIS conversation. With await:false (default) the reply simply stays in the private thread.',
         'The send is ALREADY delivered and ALREADY visible to the user as a compact chip in this chat. Do NOT repeat or paraphrase the message content in your reply — at most one operational line ("Ho scritto a X, ti aggiorno quando risponde"), or nothing if the context does not call for it.',
         `ONE recipient by default. \`to\` also takes a LIST — the same message to several agents in one action — but only when the USER asked for it: then pass because_user_asked. Deciding on your own to tell everyone is not coordination, it is noise the user pays for.`,
         `Max ${DM_SENDS_PER_TURN} RECIPIENTS per turn, counted across all your calls (a list of 3 spends the whole budget). Do not repeat the same message to the same agent.`
@@ -233,7 +232,7 @@ export function createAgentDmTools(opts: {
         await: z
           .boolean()
           .optional()
-          .describe('true = drop a summary of their reply back into this conversation when it lands (default false)'),
+          .describe('ignored — their reply stays in the private thread; the user opens it from the chip. Do not wait.'),
         because_user_asked: z
           .string()
           .max(300)
@@ -371,8 +370,7 @@ export function createAgentDmTools(opts: {
               from_speaker: initiator.key,
               // Niente `brief` nei params: il blocco DM lo monta il RUNNER dal marker del thread
               // (dmBrief in $lib/chat-dm), così vale per qualunque turno su questo thread.
-              tier: 'auto',
-              ...(awaitReply === true ? { reply_to_thread: threadId } : {})
+              tier: 'auto'
             }
           });
           if (jobError) {
@@ -407,7 +405,7 @@ export function createAgentDmTools(opts: {
           await: awaitReply === true,
           hint:
             awaitReply === true
-              ? 'Delivered — the user already sees this send as a chip in this chat: do NOT repeat the message content. Their reply summary will appear in THIS conversation as a "📩 …" message, possibly at a later step. If it has not arrived by your final message, say you wrote to them and that they will answer in your private thread — do not wait in a loop.'
+              ? 'Delivered — the user already sees this send as a chip in this chat: do NOT repeat the message content. Their reply stays in your private thread (the chip opens it). Say you wrote to them if you need to — do not wait in a loop, and do not paste their answer here.'
               : `Delivered — the user already sees this send as a chip in this chat: do NOT repeat the message content. At most one short line ("Ho scritto a ${names}, ti aggiorno quando risponde"), or nothing. Do not block this turn on it.`
         };
       }

--- a/src/lib/server/chat/persistence.test.ts
+++ b/src/lib/server/chat/persistence.test.ts
@@ -318,6 +318,30 @@ describe('assistantContentFromSteps', () => {
     expect(call.media).toEqual([{ url: frame, kind: 'image', caption: 'Existing · frame 30' }]);
   });
 
+  it('message_agent rides as dmSends, even when the kit wrapped the output as ToolResult', () => {
+    const payload = {
+      success: true,
+      dm_thread_id: 'dm-1',
+      to: 'analyst',
+      to_name: 'Analyst',
+      sends: [{ dm_thread_id: 'dm-1', to: 'analyst', to_name: 'Analyst' }]
+    };
+    const steps = [
+      {
+        toolCalls: [{ toolCallId: 'd', toolName: 'message_agent', input: { to: 'analyst', message: 'ciao' } }],
+        toolResults: [
+          {
+            toolCallId: 'd',
+            toolName: 'message_agent',
+            output: { content: [{ type: 'text', text: JSON.stringify(payload) }] }
+          }
+        ]
+      }
+    ];
+    const call = assistantContentFromSteps(steps).find((p) => p.type === 'tool-call');
+    expect(call.dmSends).toEqual([{ threadId: 'dm-1', to: 'analyst', name: 'Analyst' }]);
+  });
+
   it('read_posts is silent by default: no previews unless show_to_user is set', () => {
     const posts = [{ id: 'a', platform: 'x', caption: 'one', media_url: 'https://a/1.png', status: 'approved' }];
     const stepsFor = (input: unknown) => [

--- a/src/lib/server/chat/persistence.ts
+++ b/src/lib/server/chat/persistence.ts
@@ -8,6 +8,7 @@ import { normalizeDeviceLoginPayload } from '$lib/chat-device-login';
 import { normalizeTeamPayload } from '$lib/chat-team';
 import { normalizeMediaPayload } from '$lib/chat-media';
 import { normalizeRoutineEvent } from '$lib/chat-routine-event';
+import { dmSendsFromOutput } from '$lib/chat-dm';
 import { CHAT_HISTORY_LIMIT } from '$lib/chat-context';
 import {
   attachmentParts,
@@ -427,6 +428,11 @@ export function assistantContentFromSteps(steps: any[], fallbackText?: string): 
     ) {
       const routineEvent = normalizeRoutineEvent(outputByCallId.get(tc.toolCallId));
       if (routineEvent) part.routineEvent = routineEvent;
+    }
+    if (tc.toolName === 'message_agent') {
+      // Come le altre card: la compattazione butta gli output, e ChatDmChip deve sopravvivere.
+      const dmSends = dmSendsFromOutput(outputByCallId.get(tc.toolCallId));
+      if (dmSends.length) part.dmSends = dmSends;
     }
     if (tc.toolName === 'propose_open_tab') {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/lib/server/chat/queue.ts
+++ b/src/lib/server/chat/queue.ts
@@ -89,7 +89,7 @@ import {
 	stripAttachedDocsForDisplay
 } from '$lib/chat-documents';
 import { hydrateChatDocuments } from '$lib/server/hydrate-chat-documents';
-import { DM_REPLY_STEP_CAP, dmAgents, dmBrief, dmNames, dmReplyBackMessage } from '$lib/chat-dm';
+import { DM_REPLY_STEP_CAP, dmAgents, dmBrief, dmNames } from '$lib/chat-dm';
 import { parseRoomAgents, stripRoomPeerTools } from '$lib/server/chat/room';
 import { bilingualNoticeLocale } from '$lib/i18n/locale';
 
@@ -1301,24 +1301,10 @@ export async function processNextQueuedChatJob(
 				assistantMessageId = savedId;
 			}
 
-			// await:true di message_agent — il riassunto della risposta torna nel thread di partenza
-			// come riga user: se il turno dell'iniziatore gira ancora la assorbe la mailbox a un
-			// confine di step; se è finito, gira come turno normale appena il drain la pesca. In
-			// entrambi i casi l'utente la vede arrivare.
-			if (isDm && typeof params.reply_to_thread === 'string' && params.reply_to_thread && result.text?.trim()) {
-				const who =
-					typeof params.speaker_name === 'string' && params.speaker_name
-						? params.speaker_name
-						: (dmSpeaker && dmMemberNames[dmSpeaker]) || 'Agent';
-				await enqueueQueuedChatTurn(admin, {
-					brandId: brand.id,
-					userId: job.user_id as string,
-					threadId: params.reply_to_thread,
-					userMessage: dmReplyBackMessage(who, result.text, locale),
-					locale,
-					origin
-				});
-			}
+			// await:true di message_agent non versa più nulla nel thread con l'utente: la chip
+			// "N messaggi con X" è l'unica interazione, e la conversazione fra agenti vive nel
+			// thread DM (sola lettura). Un riassunto 📩 qui faceva vedere all'utente messaggi
+			// che non sono suoi.
 
 			// ── La battuta continua? ────────────────────────────────────────────────────────────
 			// Le voci dalla seconda in poi girano da questo runner, quindi è QUI che la catena si

--- a/src/routes/app/[brand]/chat/components/TranscriptList.svelte
+++ b/src/routes/app/[brand]/chat/components/TranscriptList.svelte
@@ -7,7 +7,7 @@
   import { dayDividers, firstUnreadIndex } from '$lib/chat-day-groups';
   import { renderMd, escapeChatText } from '$lib/chat-markdown';
   import { stripAttachedDocsForDisplay } from '$lib/chat-documents';
-  import { dmAgents, dmNames } from '$lib/chat-dm';
+  import { dmAgents, dmNames, isDmReplyBackMessage } from '$lib/chat-dm';
   import { roomMemberAvatar, roomMemberKeys, roomMemberName, threadIdentity } from '$lib/thread-identity';
   import { chatThreads } from '$lib/stores/chat';
   import type { ChatStreamState, StreamToolCallState } from '$lib/chat-stream-events';
@@ -172,6 +172,9 @@
 {/if}
 
 {#each messages as msg, i (i)}
+  {#if msg.role === 'user' && isDmReplyBackMessage(msg.content)}
+    <!-- La risposta di un DM non sta in questa chat: vive nel thread privato (chip). -->
+  {:else}
   {#if i === compactionCutIndex}
     <button
       type="button"
@@ -231,7 +234,7 @@
         {speakerLabel}
         {speakerAvatar}
         {artifactsByCall}
-        followingUserTexts={messages.slice(i + 1).filter((m) => m.role === 'user').map((m) => m.content)}
+        followingUserTexts={messages.slice(i + 1).filter((m) => m.role === 'user' && !isDmReplyBackMessage(m.content)).map((m) => m.content)}
         oncopy={oncopy}
         onredo={onredo}
         onfeedback={onfeedback}
@@ -239,6 +242,7 @@
         onpreview={onzoompost}
       />
     </div>
+  {/if}
   {/if}
 {/each}
 
@@ -264,6 +268,7 @@
       streamBuf={orphanState.text}
       streamToolCalls={orphanState.tools}
       streamReasoning={orphanState.reasoning}
+      {brandSlug}
       face={liveWho.face}
       color={liveWho.color}
     />
@@ -277,6 +282,7 @@
       {streamToolCalls}
       {streamReasoning}
       {streamReasoningSegments}
+      {brandSlug}
       face={liveWho.face}
       color={liveWho.color}
     />

--- a/supabase/migrations/20260827130000_selfhost_schema_parity.sql
+++ b/supabase/migrations/20260827130000_selfhost_schema_parity.sql
@@ -98,3 +98,30 @@ alter table public.posts
   add column if not exists title text,
   add column if not exists link_url text,
   add column if not exists subreddit text;
+
+-- ── Owner delle funzioni SECURITY DEFINER ────────────────────────────────────────────────────
+-- In questo stack compose le migrazioni girano come `postgres`, ma `postgres` non può tornare ad
+-- essere `anon` alla fine di una chiamata SECURITY DEFINER fatta via PostgREST: l'RPC fallisce con
+-- "permission denied to set role anon" e il codice che la chiama cade sul fallback (es. il gate
+-- della waitlist legge il flag come attivo anche quando è spento). L'owner del DBA dello stack
+-- (`supabase_admin`) invece funziona. Riassegniamo solo se quel ruolo esiste, così su Supabase
+-- hosted/cli — dove le stesse funzioni possedute da `postgres` sono la norma e funzionano — tutto
+-- resta com'è. Idempotente: le funzioni già riassegnate non matchano il filtro.
+do $$
+declare
+  fn record;
+begin
+  if not exists (select 1 from pg_roles where rolname = 'supabase_admin') then
+    return;
+  end if;
+  for fn in
+    select p.oid::regprocedure as sig
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'public'
+      and p.prosecdef
+      and pg_get_userbyid(p.proowner) = 'postgres'
+  loop
+    execute format('alter function %s owner to supabase_admin', fn.sig);
+  end loop;
+end $$;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,18 @@
+import { realpathSync } from 'node:fs';
 import { sentrySvelteKit } from "@sentry/sveltekit";
 import { sveltekit } from '@sveltejs/kit/vite';
 import tailwindcss from '@tailwindcss/vite';
 import { defineConfig } from 'vitest/config';
+
+/** Worktree `node_modules` is often a symlink into another checkout; Vite resolves it and
+ *  rejects the real path unless it is on the allow list. */
+const nodeModulesReal = (() => {
+  try {
+    return realpathSync('node_modules');
+  } catch {
+    return null;
+  }
+})();
 
 /**
  * RICARICHE AUTOMATICHE, SPENTE SU RICHIESTA — `NO_HMR=1 npm run dev` (o `npm run dev:stable`).
@@ -20,7 +31,7 @@ import { defineConfig } from 'vitest/config';
 const hmr = process.env.NO_HMR === '1' || process.env.NO_HMR === 'true' ? false : undefined;
 
 export default defineConfig({
-  server: { hmr, fs: { allow: ['..'] } },
+  server: { hmr, fs: { allow: ['..', ...(nodeModulesReal ? [nodeModulesReal] : [])] } },
   plugins: [sentrySvelteKit({
     org: "021-6z",
     project: "021-1m"


### PR DESCRIPTION
## What?

Restores the agent-to-agent DM interaction in chat after the agent-kit migration, and hardens two self-hosting setup paths discovered while verifying it locally:

1. **DM chip again**: a turn that uses `message_agent` shows the compact "N message(s) with <agent>" row with the recipient's avatar (as designed and as mocked up on the landing page). Clicking it opens the private agent thread, read-only for the user.
2. **No more 📩 leak**: the kit migration had also started dropping "Risposta di X (chat privata tra agenti)" summaries into the user-facing thread. That reply-back enqueue is removed and legacy 📩 rows are filtered out of rendering.
3. **Self-host hardening** (`scripts/db-seed.mjs`, parity migration): the seed now completes `profiles`/`org_members`/`brand_members` even when the GoTrue user already exists, and a guarded block reassigns SECURITY DEFINER functions owned by `postgres` to `supabase_admin` on compose stacks.

## Why?

After the agent-kit migration the `message_agent` tool output changed shape (SDK `ToolResult` wrappers), so `ChatDmChip` stopped seeing `dm_thread_id` and the interaction became invisible: agents talked to each other with no trace for the user, or worse, private summaries leaked as user-role rows. The chip is the single interaction surface between "my chat with an agent" and "agent ↔ agent threads" — without it the feature is effectively gone.

The self-host fixes came out of local verification: a pre-existing demo user logged into an app with zero brands (RLS 404s), and the waitlist gate read as enabled while disabled because the flag RPC died behind a role-permission error.

## How?

- `dmSendsFromOutput`/`dmSendsFromCall` unwrap every output shape (plain object, `{type,value}` SDK wrapper, `ToolResult` content parts) into `DmSend {threadId,to,name}`; the sends are also **hoisted onto the persisted tool-call part** (`part.dmSends`) so the chip survives history compaction, mirroring the other cards.
- The reply-back enqueue in the DM runner (`reply_to_thread` flow) is deleted; `await:true` stays in the schema but is documented as a no-op. Prompt + tool hints updated so agents don't wait on, invent, or paste their colleague's replies.
- Chip rendering added to `ChatLiveStatus` so live turns show the row identically to reopened threads.
- Legacy 📩 user rows are filtered in `ChatColumn` and `TranscriptList` (also excluded from `followingUserTexts`).
- Seed: `ensureSeedMemberships` upserts the three membership rows idempotently; the parity migration's DO block only reassigns when the `supabase_admin` role exists (no-op on hosted/CLI installs).

## Testing?

- Unit: 85 tests green across the touched suites (`chat-dm`, `agent-dm-tools`, `persistence`, `db-seed` — including 2 new cases).
- Manual, per the full local gate (local Docker stack + worktree dev server, real browser):
  - real login `test@anomalia.so` / `123456` on the seeded `demo` brand
  - chip render live and after reload, per-turn (by design each turn shows its own row)
  - chip click → read-only DM thread (0 composers, "sola lettura" banner), repeated with back/forward churn
  - second `message_agent` send → its own chip + Analyst reply lands in the DM thread only
  - reload mid-turn survived twice; narrow viewport checked; no 📩 rows anywhere in the main thread
- One transient failure is documented on purpose: killing the dev server mid-turn (my own restarts during verification) left the Analyst's first reply with a "Qualcosa è andato storto. Riprova." banner in the read-only thread; the turn then completed on retry and delivered the full reply. All pre-existing turns the server killed show as "(turno interrotto)" in the sidebar.
- Not tested: flows on hosted Supabase (never pointed there — production DB verified untouched), CLI surfaces.

## Evidence (screenshots)

All captured from the app running under local debug (Docker stack + worktree server, seeded demo brand):

| Where | What it shows |
|---|---|
| ![chip under turn](https://raw.githubusercontent.com/anomaliaso/anomalia/chat-dm-chip-evidence/evidence/chip-on-thread.png) | Main thread: chip "1 messaggio con Analyst" under the turn that used `message_agent`, no 📩 rows |
| ![chip after second send](https://raw.githubusercontent.com/anomaliaso/anomalia/chat-dm-chip-evidence/evidence/chip-two-messages.png) | Second DM send: its own chip under the new turn (per-turn rows by design) |
| ![read-only DM](https://raw.githubusercontent.com/anomaliaso/anomalia/chat-dm-chip-evidence/evidence/headed-dm-thread.png) | Private thread opened from the chip: read-only banner, no composer, Analyst's full reply visible. "20 actions, 4 failed" are honest empty-state reads (`read_editorial_plan` / `read_brand_kit`) on the intentionally empty demo brand |
| ![headed pass](https://raw.githubusercontent.com/anomaliaso/anomalia/chat-dm-chip-evidence/evidence/headed-main-thread.png) | Final headed-browser pass on the main thread |
| ![narrow](https://raw.githubusercontent.com/anomaliaso/anomalia/chat-dm-chip-evidence/evidence/narrow-chip.png) | 390px viewport: chip stays centered and tappable |

## Anything Else?

- Chips are per-turn (matching the landing mockup); grouping across turns could be a follow-up if multiple consecutive turns start feeling noisy.
- Found while stress-testing: for the first ~1–2s after a thread page loads, a programmatic Enter can slip past the delegated keydown handler (composer value also races the draft-restore). Normal typing is unaffected; worth a small dedicated ticket.
- The Vite port was held by a stale server from the main checkout during verification, which briefly mixed local/hosted envs — environment note, no code impact.
