### PR TITLE
Add cloud vs self-host pricing cards to homepage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## 2026-08-27
 
+### Homepage: la scelta cloud / self-host prima della FAQ
+
+La homepage raccontava il prodotto ma non diceva mai che ci sono due modi di
+averlo. Ora, fra «Why us» e la FAQ, c'è una griglia a due card nello stile
+delle comparison-card di Rakazo: **Cloud** (badge «Ready to go», feature list,
+CTA «Start free» che punta al `startHref` già calcolato dalla pagina — quindi
+waitlist-aware e login-aware) e **Self-host** (badge «Apache-2.0», feature
+list, CTA «View on GitHub» verso `anomaliaso/anomalia`). Sotto, una riga
+muta: app mobile e desktop «coming soon». Componente nuovo `HomePricing`
+con scoped styles sui token di landing.css; testi nuovi sotto
+`landing.pricing.*` in en/it/es/fr, `svelte-check` non aggiunge errori.
+
 ### Self-host: nascondere il sito di marketing, partire dall'app
 
 Non c'era. `TENANT_BRAND_ID` salta lo switcher dei brand, `BILLING_PROVIDER=open`

--- a/src/lib/components/HomePricing.svelte
+++ b/src/lib/components/HomePricing.svelte
@@ -1,0 +1,163 @@
+<script lang="ts">
+  import { _ } from 'svelte-i18n';
+
+  let { startHref }: { startHref: string } = $props();
+
+  const GITHUB_URL = 'https://github.com/anomaliaso/anomalia';
+
+  const cloudFeatures = $derived([
+    $_('landing.pricing.cloud.f0'),
+    $_('landing.pricing.cloud.f1'),
+    $_('landing.pricing.cloud.f2'),
+    $_('landing.pricing.cloud.f3')
+  ]);
+
+  const selfHostFeatures = $derived([
+    $_('landing.pricing.selfhost.f0'),
+    $_('landing.pricing.selfhost.f1'),
+    $_('landing.pricing.selfhost.f2'),
+    $_('landing.pricing.selfhost.f3')
+  ]);
+</script>
+
+<section class="hp-sec">
+  <div class="wrap">
+    <div class="sec-head reveal">
+      <div class="kicker">{$_('landing.pricing.kicker')}</div>
+      <h2>{$_('landing.pricing.titleLead')} <span class="gr-accent">{$_('landing.pricing.titleAccent')}</span></h2>
+      <p>{$_('landing.pricing.lede')}</p>
+    </div>
+
+    <div class="hp-grid">
+      <article class="hp-card reveal" data-d="1">
+        <div class="hp-card-head">
+          <h3>{$_('landing.pricing.cloud.name')}</h3>
+          <span class="hp-badge hp-badge-accent">{$_('landing.pricing.cloud.badge')}</span>
+        </div>
+        <p class="hp-meta">{$_('landing.pricing.cloud.meta')}</p>
+        <ul class="hp-list">
+          {#each cloudFeatures as f}
+            <li><span class="hp-check" aria-hidden="true">✓</span>{f}</li>
+          {/each}
+        </ul>
+        <a class="btn btn-primary hp-cta" href={startHref}>{$_('landing.pricing.cloud.cta')}</a>
+      </article>
+
+      <article class="hp-card hp-card-muted reveal" data-d="2">
+        <div class="hp-card-head">
+          <h3>{$_('landing.pricing.selfhost.name')}</h3>
+          <span class="hp-badge">{$_('landing.pricing.selfhost.badge')}</span>
+        </div>
+        <p class="hp-meta">{$_('landing.pricing.selfhost.meta')}</p>
+        <ul class="hp-list">
+          {#each selfHostFeatures as f}
+            <li><span class="hp-check" aria-hidden="true">✓</span>{f}</li>
+          {/each}
+        </ul>
+        <a class="btn btn-ghost hp-cta" href={GITHUB_URL} target="_blank" rel="noopener noreferrer">
+          {$_('landing.pricing.selfhost.cta')} <span class="arr">→</span>
+        </a>
+      </article>
+    </div>
+
+    <p class="hp-apps reveal" data-d="3">{$_('landing.pricing.apps')}</p>
+  </div>
+</section>
+
+<style>
+  .hp-sec { padding-block: 120px; }
+
+  .hp-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 24px;
+    max-width: 940px;
+    margin-inline: auto;
+    align-items: stretch;
+  }
+
+  .hp-card {
+    display: flex;
+    flex-direction: column;
+    padding: 36px;
+    border-radius: 20px;
+    background: var(--paper-2);
+    border: 1px solid var(--line);
+  }
+
+  .hp-card-muted { background: transparent; }
+
+  .hp-card-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+  }
+
+  .hp-card-head h3 {
+    font-family: var(--serif);
+    font-size: 1.6rem;
+    font-weight: var(--heading-weight);
+    letter-spacing: -0.03em;
+  }
+
+  .hp-badge {
+    flex-shrink: 0;
+    padding: 4px 12px;
+    border-radius: 999px;
+    border: 1px solid var(--line);
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--ink-faint);
+  }
+
+  .hp-badge-accent {
+    border-color: transparent;
+    background: var(--accent);
+    color: #fff;
+  }
+
+  .hp-meta {
+    margin-top: 10px;
+    color: var(--ink-faint);
+    font-size: 0.92rem;
+    line-height: 1.5;
+  }
+
+  .hp-list {
+    list-style: none;
+    margin: 24px 0 32px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    flex-grow: 1;
+  }
+
+  .hp-list li {
+    display: flex;
+    gap: 10px;
+    font-size: 0.98rem;
+    line-height: 1.45;
+    color: var(--ink-soft);
+  }
+
+  .hp-check {
+    color: var(--accent);
+    font-weight: 700;
+    flex-shrink: 0;
+  }
+
+  .hp-cta { align-self: flex-start; }
+
+  .hp-apps {
+    margin: 28px auto 0;
+    text-align: center;
+    color: var(--ink-faint);
+    font-size: 0.9rem;
+  }
+
+  @media (max-width: 768px) {
+    .hp-sec { padding-block: 64px; }
+    .hp-grid { grid-template-columns: 1fr; }
+  }
+</style>

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -620,6 +620,33 @@
       ],
       "subtitle": "Connect your brand, let the AI build strategy and content, publish, then let the radar find opportunities — all from one dashboard."
     },
+    "pricing": {
+      "kicker": "Pricing",
+      "titleLead": "Ready to run or",
+      "titleAccent": "yours to host.",
+      "lede": "One product, two ways to own it. Same agents, same approvals — pick where it lives.",
+      "apps": "Mobile and desktop apps — coming soon.",
+      "cloud": {
+        "name": "Cloud",
+        "badge": "Ready to go",
+        "meta": "We run everything. Sign up, connect a brand, approve.",
+        "f0": "Agents plan, write and publish for you, week after week",
+        "f1": "Nothing goes live without your approval",
+        "f2": "Free plan with monthly AI credits",
+        "f3": "No servers, no setup — it just works",
+        "cta": "Start free"
+      },
+      "selfhost": {
+        "name": "Self-host",
+        "badge": "Apache-2.0",
+        "meta": "Your machine, your keys, your data. Clone it and go.",
+        "f0": "Runs with Docker Compose on your own server",
+        "f1": "Your model and API keys — nothing leaves your stack",
+        "f2": "Same agents as the cloud, unlimited brands",
+        "f3": "CLI and MCP server included for your own agents",
+        "cta": "View on GitHub"
+      }
+    },
     "whyus": {
       "kicker": "Why us",
       "title": "We built this for ourselves first.",

--- a/src/lib/i18n/locales/es.json
+++ b/src/lib/i18n/locales/es.json
@@ -598,6 +598,33 @@
       ],
       "subtitle": "Conecta tu marca, deja que la IA construya estrategia y contenido, publica, y deja que el radar encuentre oportunidades — todo desde un solo panel."
     },
+    "pricing": {
+      "kicker": "Precios",
+      "titleLead": "Listo para usar o",
+      "titleAccent": "en tu servidor.",
+      "lede": "Un producto, dos formas de tenerlo. Mismos agentes, mismas aprobaciones — elige dónde vive.",
+      "apps": "Apps móviles y de escritorio — próximamente.",
+      "cloud": {
+        "name": "Cloud",
+        "badge": "Listo ahora",
+        "meta": "Lo gestionamos todo. Regístrate, conecta una marca, aprueba.",
+        "f0": "Los agentes planifican, escriben y publican por ti, semana tras semana",
+        "f1": "Nada se publica sin tu aprobación",
+        "f2": "Plan gratuito con créditos de IA cada mes",
+        "f3": "Sin servidores ni configuración — funciona al instante",
+        "cta": "Empieza gratis"
+      },
+      "selfhost": {
+        "name": "Self-host",
+        "badge": "Apache-2.0",
+        "meta": "Tu máquina, tus claves, tus datos. Clona y listo.",
+        "f0": "Funciona con Docker Compose en tu propio servidor",
+        "f1": "Tus claves de modelo y API — nada sale de tu infraestructura",
+        "f2": "Los mismos agentes que la nube, marcas ilimitadas",
+        "f3": "CLI y servidor MCP incluidos para tus agentes",
+        "cta": "Ver en GitHub"
+      }
+    },
     "whyus": {
       "kicker": "Por qué nosotros",
       "title": "Esto lo construimos para nosotros primero.",

--- a/src/lib/i18n/locales/fr.json
+++ b/src/lib/i18n/locales/fr.json
@@ -598,6 +598,33 @@
       ],
       "subtitle": "Connectez votre marque, laissez l'IA construire la stratégie et le contenu, publiez, puis laissez le radar trouver des opportunités — tout depuis un seul tableau de bord."
     },
+    "pricing": {
+      "kicker": "Tarifs",
+      "titleLead": "Prêt à l'emploi ou",
+      "titleAccent": "sur votre serveur.",
+      "lede": "Un produit, deux façons de l'avoir. Mêmes agents, mêmes validations — choisissez où il vit.",
+      "apps": "Applications mobiles et bureau — bientôt disponibles.",
+      "cloud": {
+        "name": "Cloud",
+        "badge": "Prêt à l'emploi",
+        "meta": "On gère tout. Inscrivez-vous, connectez une marque, validez.",
+        "f0": "Les agents planifient, écrivent et publient pour vous, semaine après semaine",
+        "f1": "Rien n'est publié sans votre validation",
+        "f2": "Formule gratuite avec des crédits IA chaque mois",
+        "f3": "Aucun serveur, aucune configuration — ça marche tout de suite",
+        "cta": "Commencer gratuitement"
+      },
+      "selfhost": {
+        "name": "Self-host",
+        "badge": "Apache-2.0",
+        "meta": "Votre machine, vos clés, vos données. Clonez et c'est parti.",
+        "f0": "Tourne avec Docker Compose sur votre propre serveur",
+        "f1": "Vos clés de modèle et d'API — rien ne quitte votre infrastructure",
+        "f2": "Les mêmes agents que le cloud, marques illimitées",
+        "f3": "CLI et serveur MCP inclus pour vos agents",
+        "cta": "Voir sur GitHub"
+      }
+    },
     "whyus": {
       "kicker": "Pourquoi nous",
       "title": "Nous avons construit ça pour nous-mêmes d'abord.",

--- a/src/lib/i18n/locales/it.json
+++ b/src/lib/i18n/locales/it.json
@@ -620,6 +620,33 @@
       ],
       "subtitle": "Collega il tuo brand, lascia che l'AI costruisca strategia e contenuti, pubblica, poi lascia che il radar trovi opportunità — tutto da una sola dashboard."
     },
+    "pricing": {
+      "kicker": "Prezzi",
+      "titleLead": "Pronto all'uso o",
+      "titleAccent": "sul tuo server.",
+      "lede": "Un prodotto, due modi di averlo. Stessi agenti, stesse approvazioni — scegli dove vive.",
+      "apps": "App mobile e desktop — in arrivo.",
+      "cloud": {
+        "name": "Cloud",
+        "badge": "Pronto subito",
+        "meta": "Gestiamo tutto. Registrati, collega un brand, approva.",
+        "f0": "Gli agenti pianificano, scrivono e pubblicano per te, settimana dopo settimana",
+        "f1": "Niente va online senza la tua approvazione",
+        "f2": "Piano gratuito con crediti AI ogni mese",
+        "f3": "Nessun server, nessuna configurazione — funziona subito",
+        "cta": "Inizia gratis"
+      },
+      "selfhost": {
+        "name": "Self-host",
+        "badge": "Apache-2.0",
+        "meta": "La tua macchina, le tue chiavi, i tuoi dati. Clona e via.",
+        "f0": "Gira con Docker Compose sul tuo server",
+        "f1": "Le tue chiavi di modello e API — nulla esce dal tuo stack",
+        "f2": "Stessi agenti del cloud, brand illimitati",
+        "f3": "CLI e server MCP inclusi per i tuoi agenti",
+        "cta": "Vedi su GitHub"
+      }
+    },
     "whyus": {
       "kicker": "Perché noi",
       "title": "L'abbiamo costruito prima per noi.",

--- a/src/routes/[[lang=locale]]/+page.svelte
+++ b/src/routes/[[lang=locale]]/+page.svelte
@@ -8,6 +8,7 @@
   import TeamRoster from '$lib/components/TeamRoster.svelte';
   import HomeChatMockup from '$lib/components/HomeChatMockup.svelte';
   import WhyUs from '$lib/components/WhyUs.svelte';
+  import HomePricing from '$lib/components/HomePricing.svelte';
   import LandingFaq from '$lib/components/LandingFaq.svelte';
   import { localePath, type Locale } from '$lib/i18n/locale';
   import SiteNav from '$lib/components/SiteNav.svelte';
@@ -159,6 +160,8 @@
   </section>
 
   <WhyUs />
+
+  <HomePricing startHref={startHref} />
 
   <LandingFaq />
 

--- a/src/routes/[[lang=locale]]/changelog/+page.svelte
+++ b/src/routes/[[lang=locale]]/changelog/+page.svelte
@@ -9,6 +9,7 @@
       date: 'August 27, 2026',
       title: 'Tools work on every message, not just the first',
       items: [
+        'The homepage now shows the two ways to use Anomalia side by side — ready-to-go cloud or self-hosted on your own server — with mobile and desktop apps marked as coming soon.',
         'Sending a second message in a chat no longer makes every tool refuse with “turn closed by the system”: the agent keeps working for the whole conversation.',
         'Self-hosting: the production build now reads your .env on start, the database is reachable on whatever port you set, and a fresh install boots instead of stopping on an empty ORIGIN.',
         'Self-hosting: usage and cost are recorded again on a fresh install — eight columns the app writes were missing from the database. Run the migrations once more to get them.',


### PR DESCRIPTION
## What?
The homepage now has a pricing section between "Why us" and the FAQ: two side-by-side cards — **Cloud** (ready to go, CTA "Start free" → platform signup) and **Self-host** (Apache-2.0, CTA "View on GitHub" → anomaliaso/anomalia) — plus a muted line stating that mobile and desktop apps are coming soon. Texts are localized in en/it/es/fr.

## Why?
The homepage told the product story but never said there are two ways to own it. Visitors had to dig into docs to discover self-hosting, and self-hosters had no clear entry point from the landing page.

## How?
- New `HomePricing.svelte` component in the Rakazo comparison-card style, using existing landing.css tokens (`.sec-head`, `.kicker`, `--paper-2/--line/--accent`), scoped styles, `reveal` animation classes already wired by the layout.
- Cloud CTA reuses the page-computed `startHref` (login-aware and waitlist-aware — no new auth logic); GitHub CTA points to the org repo.
- Feature lists are deliberately short and honest (approvals, free credits, Docker Compose, your keys, CLI+MCP included).
- Both changelogs updated (internal + public entry line for August 27).

## Testing?
- `svelte-check` on the worktree reports no errors in the new/modified files (the pre-existing repo-wide count is unchanged).
- All four locale files parse and carry the full `landing.pricing.*` subtree (key parity checked).
- Not tested yet in a running browser: visual layout desktop/narrow, reveal animations, CTA targets. Local stack wasn't up for this session — UI verification pending before merge is recommended. Risk: layout-only change, no logic.

## Evidence (screenshots/videos)
Pending — will attach after browser verification on the local stack.

## Anything Else?
If the self-host install flow should be highlighted further, the card can later link the compose quickstart instead of the repo root.