### PR TITLE
Fix kit chat dying on the second message

### DIFF
--- a/packages/agent-adapters/src/runtime/ai-runtime.test.ts
+++ b/packages/agent-adapters/src/runtime/ai-runtime.test.ts
@@ -50,4 +50,27 @@ describe('buildTools — la traduzione ToolSpec[] → ToolSet che i motori condi
 		)({}, { toolCallId: 'call-9' });
 		expect(calls[0]?.id).toBe('call-9');
 	});
+
+	it('un risultato senza content non uccide il turno: content mancante → modello vede testo vuoto', async () => {
+		// Incidente reale (kit_turn_died, agente content): un plugin ha risposto senza `content`
+		// e `toModelContent` è morto su `.map` di undefined nel passaggio al prossimo step — il
+		// run restava `running` col battito fermo fino al reaper. Il confine qui, dove il
+		// ToolResult del plugin diventa messaggio per il modello.
+		const exec = async (): Promise<ToolResult> => ({}) as ToolResult;
+		const tools = buildTools([BURN_TOOL], exec, ctx);
+		const out = await (tools.burn.execute as (input: unknown) => Promise<ToolResult>)({});
+		const value = ((tools.burn as { toModelOutput?: (o: { output: ToolResult }) => unknown }).toModelOutput?.({ output: out }) as { value?: unknown })?.value;
+		expect(value).toEqual([]);
+	});
+
+	it('un output interamente undefined non deve nemmeno far compiere il modello', () => {
+		const toModelOutput = (toolsUnder()
+			.burn as { toModelOutput?: (o: unknown) => unknown }).toModelOutput;
+		expect(() => toModelOutput?.({ output: undefined as never })).not.toThrow();
+	});
 });
+
+function toolsUnder() {
+	// buildTools di nuovo: nessuno stato condiviso, il test guarda solo la funzione di conversione.
+	return buildTools([BURN_TOOL], noopExec, ctx);
+}

--- a/packages/agent-adapters/src/runtime/ai-runtime.ts
+++ b/packages/agent-adapters/src/runtime/ai-runtime.ts
@@ -4,14 +4,19 @@ import type { AdapterContext, ToolCall, ToolResult, ToolSpec } from '@anomalia/a
 export type ExecToolCall = (call: ToolCall, context: AdapterContext) => Promise<ToolResult>;
 
 function toModelContent(content: ToolResult['content']) {
-	return content.map((item) =>
+	// Un plugin può rispondere senza `content` (o con l'output interamente assente): qui muore
+	// il turno INTERO — «reading 'map'» nella conversione al prossimo step, run inchiodato su
+	// `running` fino al reaper. Il modello vede testo vuoto, che è esattamente ciò che è.
+	return (content ?? []).map((item) =>
 		item.type === 'text'
 			? { type: 'text' as const, text: item.text }
 			: { type: 'media' as const, data: item.base64, mediaType: item.mimeType }
 	);
 }
 
-function toModelOutput({ output }: { output: ToolResult }) {
+function toModelOutput(args: { output?: ToolResult }) {
+	const output = args?.output;
+	if (!output) return { type: 'content' as const, value: [] };
 	const value = toModelContent(output.content);
 	return output.isError ? ({ type: 'error-json' as const, value: { content: value } }) : ({ type: 'content' as const, value });
 }

--- a/src/lib/agent/bridge/live.test.ts
+++ b/src/lib/agent/bridge/live.test.ts
@@ -136,6 +136,8 @@ type FakeTurn = {
 	calls?: FakeCall[];
 	totalUsage?: Record<string, unknown>;
 	onStreamStart?: () => void;
+	/** Non produce MAI il primo evento: la sessione riusata che non parte (incidente reale). */
+	hang?: boolean;
 	capture?: (opts: { system: string; messages: unknown; tools: Record<string, unknown>; stopWhen: unknown[] }) => void;
 };
 
@@ -178,6 +180,7 @@ function buildFakeHarnessResult(turn: FakeTurn, opts: { tools: Record<string, { 
 
 	const run = async (): Promise<void> => {
 		turn.onStreamStart?.();
+		if (turn.hang) await new Promise<void>(() => {});
 		for (const delta of turn.texts ?? []) {
 			text += delta;
 			uiChunks.push({ type: 'text-delta', id: 't1', delta });
@@ -270,6 +273,14 @@ vi.mock('./adapters', async (importOriginal) => {
 			const idx = Math.min(harnessServed, harnessQueue.length - 1);
 			harnessServed += 1;
 			const turn = harnessQueue[idx];
+			console.log(`[MOCK] start idx=${idx} hang=${!!turn?.hang} fresh=${String(opts.freshSession)}`);
+			if (turn?.hang) {
+				// L'incidente reale è lo START appeso (pi non risolve `stream()`), non lo stream:
+				// una promessa mai risolta è ciò che fa scattare il timeout di partenza. L'opzione
+				// arriva comunque al registro: il test vuole vedere ANCHE il tentativo morto.
+				harnessTurnOpts.push(opts);
+				return new Promise<never>(() => {}) as never;
+			}
 			if (!turn) throw new Error('nessun turno scripted per la startHarnessTurn finta');
 			let tools = opts.tools;
 			if (opts.sessionKey) {
@@ -851,6 +862,70 @@ describe('i tool dei plugin sono ANNUNCIATI al modello, non solo eseguibili', ()
 		// Il set che i worker ricevono si riempie DOPO buildTools: alla creazione è vuoto per
 		// costruzione (i plugin stanno nel catalogo che buildTools stesso produce).
 		expect(src).toMatch(/Object\.assign\(scopedTools, toolSet\)/);
+	});
+});
+
+describe('runKitTurn — il turno abortito non può restare appeso se il gateway ignora lo Stop', () => {
+	it('dopo l’abort del cane da guardia esiste una chiusura forzata con scadenza, dentro il ramo che ferma il turno muto', async () => {
+		// Incidente (kit_turn_died): aborting non sblocca `consumeStream` quando il trasporto
+		// ignora l'abortSignal — la riga restava `running` col battito in funzione e il reaper la
+		// raccoglieva solo al congelamento dell'istanza. Il pin: nel ramo del silenzio il turno
+		// viene chiuso FORZA se `settled` è ancora falso dopo una grazia.
+		const fs = await import('node:fs');
+		const src = fs.readFileSync(new URL('./live.ts', import.meta.url), 'utf8');
+		const watchdogIdx = src.indexOf('muto da');
+		expect(watchdogIdx).toBeGreaterThan(-1);
+		const tail = src.slice(watchdogIdx, watchdogIdx + 2500);
+		expect(tail).toContain('turnAbort.abort()');
+		expect(tail).toMatch(/forceCloseAbortedTurn|chiusura forzata/);
+	});
+});
+
+describe('runKitTurn — la sessione avvelenata non uccide il secondo turno', () => {
+	it('il primo start che non parte sfratta la sessione e riprova UNA volta con freshSession', async () => {
+		// Incidente reale (msg1 ok, msg2 muore con 500 dopo 60s): dopo un turno FINITO la sessione
+		// pi riusata non parte («Request was aborted») e `harness_start_timeout` propagava il
+		// 500. Ora il timeout scarta la sessione e riprova con una fresca — stesso gesto che già
+		// faceva il catch, ma senza far pagare il turno all'utente.
+		vi.stubEnv('HARNESS_START_TIMEOUT_MS', '250');
+		try {
+			textThenReplyModel(['uno '], 'prima risposta');
+			const first = fakeDb();
+			const res1 = await runKitTurn({
+				supabase: fakeSupabase,
+				admin: first.db,
+				brand: { id: 'b1' },
+				user: { id: 'u1' },
+				threadId: 't-reuse',
+				spec,
+				messages: [{ role: 'user', content: 'ciao' }],
+				locale: 'it'
+			});
+			await res1.text();
+			expect(first.rows[0].state).toBe('done');
+
+			scriptTurns({ hang: true }, { texts: ['due '], calls: [replyCall('seconda risposta')] });
+			const second = fakeDb();
+			const res2 = await runKitTurn({
+				supabase: fakeSupabase,
+				admin: second.db,
+				brand: { id: 'b1' },
+				user: { id: 'u1' },
+				threadId: 't-reuse',
+				spec,
+				messages: [{ role: 'user', content: 'ancora' }],
+				locale: 'it'
+			});
+			await res2.text();
+
+			const optsForThread = harnessTurnOpts.filter((o) => o.sessionKey === 't-reuse');
+			expect(optsForThread).toHaveLength(3);
+			expect(optsForThread[2]?.freshSession).toBe(true);
+			expect(second.rows[0].state).toBe('done');
+			expect(second.rows[0].reason).toBe('reply');
+		} finally {
+			vi.unstubAllEnvs();
+		}
 	});
 });
 
@@ -1921,10 +1996,14 @@ describe('un turno che non da` segni di vita si ferma da solo', async () => {
 	const fs = await import('node:fs');
 	const src = fs.readFileSync(new URL('./live.ts', import.meta.url), 'utf8');
 
-	it('partire ha un tetto, e allo scadere la sessione se ne va', () => {
-		expect(src).toContain('HARNESS_START_TIMEOUT_MS');
-		const race = src.slice(src.indexOf('Promise.race'), src.indexOf('const result = turn.result'));
-		expect(race).toContain('dropLiveHarnessSession');
+	it('partire ha un tetto, e allo scadere la sessione se ne va — poi si riprova con una fresca', () => {
+		// Il timeout è leggibile a chiamata (`harnessStartTimeoutMs`): i test lo accorciano via
+		// env senza toccare il default di deploy. La sessione morta si scarta, e il turno non
+		// muore con lei: un solo tentativo con `freshSession` prima di dichiarare il guasto.
+		expect(src).toContain('harnessStartTimeoutMs()');
+		const startBlock = src.slice(src.indexOf('const startTurnOnce'), src.indexOf('const result = turn.result'));
+		expect(startBlock).toContain('dropLiveHarnessSession');
+		expect(startBlock).toMatch(/startTurnOnce\(true\)/);
 	});
 
 	it('il cane da guardia si mette IN PAUSA mentre un tool e` in volo', () => {

--- a/src/lib/agent/bridge/live.ts
+++ b/src/lib/agent/bridge/live.ts
@@ -27,8 +27,9 @@ import {
 	chatTurnDeadline,
 	kitRunIsAlive,
 	turnTruncatedNotice,
-	HARNESS_START_TIMEOUT_MS,
+	harnessStartTimeoutMs,
 	HARNESS_SILENCE_TIMEOUT_MS,
+	HARNESS_ABORT_FORCE_CLOSE_MS,
 	type KitRunLiveness
 } from '$lib/server/chat/turn-limits';
 import { logAiCall, extractSdkUsage } from '$lib/server/ai-log';
@@ -729,7 +730,8 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
 		}
 		}
 		const brandSandbox = savedResume ? null : await openBrandHarnessSession(brand.id, run.id, spec.id);
-		const startedTurn = startHarnessTurn({
+		const startTurnOnce = (fresh: boolean) => {
+			const startedTurn = startHarnessTurn({
 			runId: run.id,
 			model: modelRef,
 			system,
@@ -746,27 +748,42 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
 			abortSignal: turnAbort.signal,
 			stopWhen: [isStepCount(TURN_MAX_STEPS)],
 			sessionKey: threadId,
+				...(fresh ? { freshSession: true } : {}),
 				sandboxSession: brandSandbox?.session
 		});
+			return Promise.race([
+				startedTurn,
+				new Promise<never>((_, reject) =>
+					setTimeout(
+						() => reject(new Error('harness_start_timeout: la sessione non e` partita')),
+						harnessStartTimeoutMs()
+					).unref?.()
+				)
+			]);
+		};
 		/**
 		 * PARTIRE NON E` INFERENZA. Un run e` rimasto sei minuti `running` con zero caratteri, zero
 		 * ragionamento, `partial` mai scritto e NESSUNA chiamata al modello: appeso qui dentro,
 		 * prima che esistesse uno stream. Il battito e` un timer e continuava a battere, quindi il
 		 * reaper lo credeva vivo e la chat diceva «sta generando» finche` qualcuno non uccideva la
 		 * sessione a mano. Se non parte, la sessione se ne va e il turno lo dice.
+		 *
+		 * E SE NON PARTE LA SESSIONE RIUSATA: dopo un turno FINITO, pi la riprende e muore dentro
+		 * («Request was aborted») — msg1 ok, msg2 morto con 500 dopo il timeout. Un solo tentativo
+		 * con sessione fresca: il riuso e` un'ottimizzazione, la risposta dell'utente no.
 		 */
-		const turn = await Promise.race([
-			startedTurn,
-			new Promise<never>((_, reject) =>
-				setTimeout(
-					() => reject(new Error('harness_start_timeout: la sessione non e` partita')),
-					HARNESS_START_TIMEOUT_MS
-				).unref?.()
-			)
-		]).catch(async (e) => {
+		let turn: Awaited<ReturnType<typeof startTurnOnce>>;
+		try {
+			turn = await startTurnOnce(false);
+		} catch (firstStartError) {
 			await dropLiveHarnessSession(threadId).catch(() => undefined);
-			throw e;
-		});
+			try {
+				turn = await startTurnOnce(true);
+			} catch {
+				throw firstStartError;
+			}
+			console.warn(`[AGENT_KIT] run ${run.id} la sessione riusata non partiva: ripreso con sessione fresca`);
+		}
 		const result = turn.result;
 		const silenceWatch = setInterval(() => {
 			if (toolsInFlight > 0 || turnAbort.signal.aborted) return;
@@ -775,9 +792,29 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
 				`[AGENT_KIT] run ${run.id} muto da ${Math.round((Date.now() - lastSign) / 1000)}s senza tool in volo: lo fermo`
 			);
 			turnAbort.abort();
+			// CHIUSURA FORZATA — l'abort del watchdog non è garantito venga onorato dal trasporto:
+			// il gateway può lasciare la chiamata appesa per sempre e `consumeStream` non torna.
+			// Senza questo, la riga resta `running` col battito vivo e il reaper la raccoglie
+			// solo quando l'istanza serverless congela — l'utente intanto vede «sta generando»
+			// per sempre. Se nel frattempo il turno ha finito ONESTAMENTE (`settled`), CAS e
+			// guardia non fanno nulla di doppio.
+			const forceCloseAbortedTurn = setTimeout(() => {
+				if (settled) return;
+				console.error(`[AGENT_KIT] run ${run.id} il trasporto non ha onorato l'abort: chiusura forzata della riga`);
+				closeRunSaving(
+					admin,
+					run.id,
+					{ kind: 'finish', reason: 'aborted' },
+					closeMessageFields([{ type: 'text', text: '_(turno chiuso: il modello non ha risposto in tempo)_' }], [])
+				).catch(() => finish(admin, run.id, 'aborted').catch(() => undefined));
+				kickQueue();
+			}, HARNESS_ABORT_FORCE_CLOSE_MS);
+			forceCloseAbortedTurn.unref?.();
+			stopForceClose = () => clearTimeout(forceCloseAbortedTurn);
 		}, CHAT_HEARTBEAT_INTERVAL_MS);
 		silenceWatch.unref?.();
-		const stopSilenceWatch = () => clearInterval(silenceWatch);
+		const stopSilenceWatch = () => { clearInterval(silenceWatch); stopForceClose?.(); };
+		let stopForceClose: (() => void) | null = null;
 
 		const handleFinish = async ({ steps, text }: { steps: Awaited<typeof result.steps>; text: string }) => {
 			if (settled) return;

--- a/src/lib/server/chat/turn-limits.ts
+++ b/src/lib/server/chat/turn-limits.ts
@@ -64,6 +64,12 @@ export const CHAT_HEARTBEAT_INTERVAL_MS = 10_000;
  */
 export const HARNESS_START_TIMEOUT_MS = 60_000;
 
+/** Letto a CHIAMATA, non a import: i test accorciano l'attesa senza toccare il default di deploy. */
+export function harnessStartTimeoutMs(): number {
+	const raw = Number(process.env.HARNESS_START_TIMEOUT_MS);
+	return Number.isFinite(raw) && raw > 0 ? raw : HARNESS_START_TIMEOUT_MS;
+}
+
 /**
  * QUANTO PUO` STARE ZITTO UN TURNO GIA` PARTITO — e perche` non sono dieci secondi.
  *
@@ -73,6 +79,9 @@ export const HARNESS_START_TIMEOUT_MS = 60_000;
  * per questo il cane da guardia si mette in pausa quando un tool e` in volo.
  */
 export const HARNESS_SILENCE_TIMEOUT_MS = 120_000;
+
+/** Grazia dopo l'abort prima di chiudere FORZA la riga del run: se il trasporto ignora l'abortSignal, `consumeStream` non torna mai e il reaper troverebbe una riga `running` col battito fermo solo al congelamento dell'istanza. */
+export const HARNESS_ABORT_FORCE_CLOSE_MS = 30_000;
 
 /** Well above the heartbeat interval, so a slow UPDATE or a GC pause is never read as death. */
 export const CHAT_HEARTBEAT_STALE_MS = 90_000;


### PR DESCRIPTION
## What?

Standalone fix for the production `kit_turn_died` cluster: a chat that answers fine to the first message dies on the second one. Three faults, all at the boundary between a kit turn and its process:

1. **Poisoned session reuse** — after a turn finished via the terminal `reply` tool, the pi session's teardown emits an abort-flavored error; the next `stream()` on the same session never starts. The start timeout now discards the dead session and retries **once** with a fresh one (`freshSession` skips only the live-session cache for that attempt — the cache stays the first-choice optimization).
2. **Abort not honored** — when the silence watchdog aborts a mute turn, the transport can leave `consumeStream` pending forever; the run row stayed `running` with a live heartbeat until the instance froze, and the sweep emailed `kit_turn_died`. A 30s forced `closeRunSaving` now arms after the watchdog abort (CAS-protected, no-op if the turn settled honestly).
3. **Tool result without `content`** — `toModelContent` crashed on `.map` of undefined during the next-step conversion, wedging the turn. The model now sees empty text, which is what it is.

## Why?

Production emails (27/8, 15:11, three runs, multiple brands) + local reproduction. Root cause analysis: [comment on PR #10](https://github.com/anomaliaso/anomalia/pull/10#issuecomment-5440771865). This fix is independent of the LLM-gateway migration (PR #10) — the poison comes from the terminal-tool teardown in `harness-pi`, not from the model provider — so it can ship first, without any env setup.

## How?

- `turn-limits.ts`: `HARNESS_ABORT_FORCE_CLOSE_MS = 30_000` + `harnessStartTimeoutMs()` (env-overridable for tests, 60s default unchanged).
- `live.ts`: `startTurnOnce(fresh)` wraps the start race; on start-timeout the session is dropped and one fresh-session retry runs before propagating the failure; the silence watchdog arms a forced close guarded by `settled`.
- `agent-adapters` `ai-runtime.ts`: `toModelOutput` tolerates missing `content` / `output`.
- Upstream report candidate (stale terminal error leaking into the next turn's subscriber) is tracked in Notion; the retry is the app-boundary mitigation.

## Testing?

- Unit: `live.test.ts` new deterministic test — first start hangs → timeout → `freshSession: true` retry → run row `done` (`reason: reply`); static test pins the forced close. `ai-runtime.test.ts`: missing-content and undefined-output no longer throw. **Full suite 5777/5777 (495 files), no network.**
- Local stack (compose Supabase + worktree dev server, user `test@anomalia.so`, brand `demo`, agent `content`): message 1 `200` 22.8s → run `done`; message 2 (same thread) was `500` in 61.5s before, `200` in 13.6s after → run `done`.
- NOT tested: Vercel instance-freeze behavior of the forced close (covered by source-contract test + local repro).

## Evidence

<details>
<summary>Before / after (same flow, local stack)</summary>

- Before: `msg2:500 time:61.5s`, log `[harness:pi:error] harness stream error: Error: Request was aborted.` → `Error: harness_start_timeout: la sessione non è partita`.
- After: `msg1:200 22.8s`, `msg2:200 13.6s`, both run rows `done`.
</details>

## Anything Else?

The LLM-gateway PR (#10) keeps its own copy of these hunks; after this PR merges, #10 rebases onto `dev` and the hunks dedupe cleanly (identical content). The gateway-specific Auto→Pro gate fix stays in #10.