### PR TITLE
Craft UGC video briefs with a pro-tier agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## 2026-08-27
 
+### La resa dei video generativi/UGC passa al secondo agente con tier pro
+
+Come per il motion (`motion_write` accoda, la resa gira su un agente con modello avanzato),
+la resa dei video generativi AI e UGC aveva lo stesso buco: lo shot brief per il generatore
+veniva composto da template deterministici (`buildUgcShotBrief` + `formatUgcShotBrief`) e il
+piano dal planner flash. Nessun file decideva il tier di questo mestiere: tutti i call site
+usavano `IMAGE_AGENT_MODEL()` o il modello del turno.
+
+Ora:
+- `craft-model.ts` — la fabbrica condivisa del modello di resa (tier pro del provider attivo,
+  scappatoia esplicita in env, fallback dichiarato su Gemini). `motion-video/model.ts` la usa
+  ed è la stessa cosa che ora usa l'UGC; `UGC_VIDEO_MODEL` è la scappatoia del mestiere.
+- `media-generator/ugc-craft.ts` — il secondo agente: prende il brief deterministico (la rete,
+  con le RULE del generatore) e lo riscrive come farebbe un regista. Output senza le RULE, o
+  modello a terra, o muto → si torna al deterministico: mai un render senza brief.
+- `ugc-batch.ts` — `briefFor` passa dal crafter prima del render: batch UGC e ads remix
+  ereditano gratis. Il planner resta sul flash: è il PIANO, non la resa.
+
+Test: tier del modello (pro del provider, override env, fabbrica condivisa col motion), il
+prompt del crafter porta tutti i contesti e il divieto di toccare le RULE, e i tre percorsi
+(successo, modello a terra, output muto) con il deterministico come rete.
+
+## 2026-08-27
+
 ### La direttiva del minimo entra nel contratto di consegna
 
 La task chiedeva «scrivi pochissimo, diretto al punto, il più minimo possibile». Il contratto

--- a/src/lib/server/craft-model.ts
+++ b/src/lib/server/craft-model.ts
@@ -1,0 +1,38 @@
+/**
+ * IL MODELLO DELLE RESE, in un punto solo — la fabbrica condivisa.
+ *
+ * `motion-video/model.ts` l'ha fissata per il motion: il tier di questo mestiere è il PRO del
+ * provider attivo (il fast ha già dimostrato di non saperlo fare — 23 minuti, zero output),
+ * con la scappatoia esplicita in env e il fallback dichiarato su Gemini. Le rese dei video
+ * generativi/UGC sono lo stesso mestiere: stessa fabbrica, stesso ragionamento, zero copie.
+ */
+import { env } from '$env/dynamic/private';
+import { createGoogleGenerativeAI } from '@ai-sdk/google';
+import type { LanguageModel } from 'ai';
+import { harnessSdkModel } from '$lib/agent/bridge/adapters';
+import { geminiFlash } from '$lib/server/gemini';
+
+export type CraftAgentModel = {
+	model: LanguageModel;
+	modelId: string;
+	provider: 'gemini' | 'kie' | 'openrouter' | 'opencode';
+};
+
+function google(id: string): LanguageModel {
+	return createGoogleGenerativeAI({ apiKey: env.GEMINI_API_KEY ?? env.GOOGLE_API_KEY })(id);
+}
+
+export function craftAgentModel(opts: {
+	/** La scappatoia esplicita del mestiere (es. MOTION_VIDEO_MODEL / UGC_VIDEO_MODEL). */
+	envModel: string | undefined;
+	/** Il fallback dichiarato: senza nessun provider si cade qui, e lo si dice. */
+	fallbackId: string;
+}): CraftAgentModel {
+	const forced = opts.envModel?.trim();
+	if (forced) return { model: google(forced), modelId: forced, provider: 'gemini' };
+
+	const routed = harnessSdkModel('pro');
+	if (routed) return routed;
+
+	return { model: google(opts.fallbackId), modelId: opts.fallbackId, provider: 'gemini' };
+}

--- a/src/lib/server/media-generator/ugc-batch.ts
+++ b/src/lib/server/media-generator/ugc-batch.ts
@@ -711,23 +711,37 @@ export async function runOneUgcClip(ctx: UgcClipRunContext, plan: UgcClipPlan): 
       ].slice(0, 4);
       // Il brief si serializza DOPO aver reso i frame: le REFERENCES devono dire cosa è
       // ogni immagine allegata, e prima di renderle non si sa quante sono.
-      const briefFor = (references: string[]) =>
-        formatUgcShotBrief(
-          buildUgcShotBrief({
-            seconds: clipSeconds,
-            hook: plan.script.hook,
-            hookVisual: plan.hookVisual ?? undefined,
-            format: plan.format ?? null,
-            platform,
-            product: productName,
-            setting: plan.setting,
-            person: hasPerson
-              ? plan.model?.name || 'reference person'
-              : undefined,
-            desire: 'less chaos / get the work done / look competent'
-          }),
-          { script: spoken, product: productName, references }
-        );
+      // La RESA passa dal secondo agente (tier pro, ugc-craft.ts): il deterministico è la
+      // base e la rete — il crafter lo riscrive come farebbe un regista, o lo si ritrova.
+      const briefFor = async (references: string[]) => {
+        const base = buildUgcShotBrief({
+          seconds: clipSeconds,
+          hook: plan.script.hook,
+          hookVisual: plan.hookVisual ?? undefined,
+          format: plan.format ?? null,
+          platform,
+          product: productName,
+          setting: plan.setting,
+          person: hasPerson
+            ? plan.model?.name || 'reference person'
+            : undefined,
+          desire: 'less chaos / get the work done / look competent'
+        });
+        const { craftUgcShotBrief } = await import('$lib/server/media-generator/ugc-craft');
+        return craftUgcShotBrief({
+          baseBrief: formatUgcShotBrief(base, { script: spoken, product: productName, references }),
+          script: spoken,
+          product: productName,
+          references,
+          platform,
+          seconds: clipSeconds,
+          hook: plan.script.hook,
+          hookVisual: plan.hookVisual ?? undefined,
+          setting: plan.setting,
+          person: hasPerson ? plan.model?.name || 'reference person' : undefined,
+          format: plan.format ?? null
+        });
+      };
 
       const { renderVideo, isKnownVideoModel } = await import('$lib/server/video');
       // UGC Creator defaults to Seedance 2.5. Remake from a selected grid video
@@ -909,7 +923,7 @@ export async function runOneUgcClip(ctx: UgcClipRunContext, plan: UgcClipPlan): 
             )
           ]
         : [];
-      const shotBrief = briefFor(referenceLines);
+      const shotBrief = await briefFor(referenceLines);
       const remakeBrief = remakeMode
         ? `${shotBrief}\n\nREMAKE:\n@Video1 is the selected clip to remake — keep identity, framing energy and UGC feel; apply the user brief changes; speak the new line exactly.`
         : shotBrief;

--- a/src/lib/server/media-generator/ugc-craft.test.ts
+++ b/src/lib/server/media-generator/ugc-craft.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+
+const { env } = await import('$env/dynamic/private');
+const { craftAgentModel } = await import('$lib/server/craft-model');
+const { ugcAgentModel, buildCraftPrompt, craftUgcShotBrief } = await import('./ugc-craft');
+const { buildUgcShotBrief, formatUgcShotBrief } = await import('$lib/server/ugc');
+
+/**
+ * LA RESA DI UN VIDEO GENERATIVO NON È IL TIER VELOCE — stessa misura del motion: il brief che
+ * il generatore esegue è la cosa più difficile che il prodotto chiede a un modello, e la chat
+ * (o il planner flash) resta sul veloce mentre questa resa no. `ugcAgentModel` segue il
+ * provider attivo dell'harness con tier PRO, come `motionAgentModel`.
+ */
+describe('ugcAgentModel — la resa UGC segue il provider attivo, non il flash cablato', () => {
+	beforeEach(() => {
+		for (const key of Object.keys(env)) {
+			if (/MODEL|MODELS|PROVIDER|API_KEY/.test(key)) delete env[key];
+		}
+	});
+
+	it('la resa prende il tier PRO del provider attivo', () => {
+		env.OPENROUTER_API_KEY = 'k';
+		env.CHAT_PROVIDER = 'openrouter';
+		env.OPENROUTER_FAST_MODEL = 'z-ai/glm-5.3-flash';
+		env.OPENROUTER_PRO_MODEL = 'openai/gpt-5.6-sol';
+		const m = ugcAgentModel();
+		expect(m.provider).toBe('openrouter');
+		expect(m.modelId).toBe('openai/gpt-5.6-sol');
+	});
+
+	it('UGC_VIDEO_MODEL è la scappatoia esplicita e vince sul provider', () => {
+		env.OPENROUTER_API_KEY = 'k';
+		env.CHAT_PROVIDER = 'openrouter';
+		env.OPENROUTER_PRO_MODEL = 'openai/gpt-5.6-sol';
+		env.UGC_VIDEO_MODEL = 'gemini-3.7-flash';
+		const m = ugcAgentModel();
+		expect(m.modelId).toBe('gemini-3.7-flash');
+		expect(m.provider).toBe('gemini');
+	});
+
+	it('craftAgentModel è la stessa fabbrica del motion: nessuna seconda fonte di verità', async () => {
+		const { motionAgentModel } = await import('$lib/server/motion-video/model');
+		env.OPENROUTER_API_KEY = 'k';
+		env.CHAT_PROVIDER = 'openrouter';
+		env.OPENROUTER_PRO_MODEL = 'openai/gpt-5.6-sol';
+		const viaShared = craftAgentModel({ envModel: env.UGC_VIDEO_MODEL, fallbackId: 'gemini-3.7-flash' });
+		expect(viaShared.modelId).toBe('openai/gpt-5.6-sol');
+		expect(motionAgentModel().modelId).toBe('openai/gpt-5.6-sol');
+	});
+});
+
+describe('craftUgcShotBrief — il secondo agente scrive la resa, il deterministico è la rete', () => {
+	const base = buildUgcShotBrief({
+		seconds: 12,
+		hook: 'Still drowning in spreadsheets',
+		hookVisual: 'close-up on a cluttered desk',
+		format: 'tutorial',
+		platform: 'tiktok',
+		product: 'FlowDeck',
+		setting: 'a home office at night',
+		person: 'Maya',
+		desire: 'look competent'
+	});
+	const baseBrief = formatUgcShotBrief(base, { script: 'you close books in minutes', product: 'FlowDeck' });
+
+	it('il prompt porta hook, setting, prodotto, battuto, riferimenti e il divieto di toccare le RULE', () => {
+		const p = buildCraftPrompt({
+			baseBrief,
+			script: 'you close books in minutes',
+			product: 'FlowDeck',
+			platform: 'tiktok',
+			seconds: 12,
+			hook: 'Still drowning in spreadsheets',
+			setting: 'a home office at night',
+			person: 'Maya',
+			references: ['@Image1 is the product cover']
+		});
+		expect(p).toContain('Still drowning in spreadsheets');
+		expect(p).toContain('a home office at night');
+		expect(p).toContain('FlowDeck');
+		expect(p).toContain('you close books in minutes');
+		expect(p).toContain('@Image1 is the product cover');
+		// Le invarianti di sicurezza del generatore non sono negoziabili: il crafter non le riscrive.
+		expect(p).toMatch(/RULE lines? verbatim|keep every RULE/i);
+	});
+
+	it('il modello risponde: il brief craftato torna pulito', async () => {
+		const out = await craftUgcShotBrief(
+			{ baseBrief, product: 'FlowDeck', platform: 'tiktok', seconds: 12 },
+			async () => '  CRAFTED BRIEF — RULE lines kept verbatim  \n'
+		);
+		expect(out).toBe('CRAFTED BRIEF — RULE lines kept verbatim');
+	});
+
+	it('modello a terra o muto: si torna al brief deterministico, mai un render senza brief', async () => {
+		const down = await craftUgcShotBrief(
+			{ baseBrief, product: 'FlowDeck', platform: 'tiktok', seconds: 12 },
+			async () => {
+				throw new Error('provider down');
+			}
+		);
+		expect(down).toBe(baseBrief);
+
+		const mute = await craftUgcShotBrief(
+			{ baseBrief, product: 'FlowDeck', platform: 'tiktok', seconds: 12 },
+			async () => '   '
+		);
+		expect(mute).toBe(baseBrief);
+	});
+});

--- a/src/lib/server/media-generator/ugc-craft.ts
+++ b/src/lib/server/media-generator/ugc-craft.ts
@@ -1,0 +1,87 @@
+/**
+ * IL SECONDO AGENTE DELLA RESA UGC — il brief che il generatore esegue non lo scrive il modello
+ * veloce.
+ *
+ * Come per il motion (`motion_write` accoda, e la resa gira su un agente con tier pro), la
+ * sequenza di un video UGC ha due momenti che chiedono modelli diversi: il PIANO (hook, battute,
+ * setting — va bene il flash) e la RESA (lo shot brief Seedance: composizione, movimenti,
+ * continuità — il mestiere difficile). Qui c'è il secondo: un agente sul tier pro che prende il
+ * brief deterministico di `ugc.ts` (la rete di sicurezza, con tutte le RULE) e lo riscrive con
+ * vera direzione fotografica.
+ *
+ * IL DETERMINISTICO È LA RETE: un errore del modello, un output vuoto o senza le RULE tornano al
+ * brief di template. Mai un render senza brief.
+ */
+import { generateText } from 'ai';
+import { env } from '$env/dynamic/private';
+import { geminiFlash } from '$lib/server/gemini';
+import { craftAgentModel } from '$lib/server/craft-model';
+
+export type UgcCraftModel = ReturnType<typeof ugcAgentModel>;
+
+export function ugcAgentModel() {
+	return craftAgentModel({ envModel: env.UGC_VIDEO_MODEL, fallbackId: geminiFlash() });
+}
+
+export type UgcCraftInput = {
+	/** Il brief deterministico di `formatUgcShotBrief`: la base da superare, con le RULE. */
+	baseBrief: string;
+	script?: string;
+	product?: string;
+	references?: string[];
+	platform?: string;
+	seconds?: number;
+	hook?: string;
+	hookVisual?: string;
+	setting?: string;
+	person?: string;
+	format?: string | null;
+};
+
+/** Il runner del modello, iniettabile per i test: default è `generateText` sul tier pro. */
+export type CraftRunner = (opts: { system: string; prompt: string }) => Promise<string>;
+
+const generateCraft: CraftRunner = async ({ system, prompt }) => {
+	const m = ugcAgentModel();
+	const { text } = await generateText({ model: m.model, system, prompt, temperature: 0.6 });
+	return text ?? '';
+};
+
+export function buildCraftPrompt(input: UgcCraftInput): string {
+	const refs = input.references?.length
+		? `REFERENCES (already attached to the render — mention them with their tags, never invent new ones):\n${input.references.join('\n')}`
+		: '';
+	return `You are the CRAFT agent for a UGC video render. A planner already decided the beats; the block below is the mechanical shot brief built from them. Your job is the RESA: rewrite it as a real director would — camera moves, framing, timing per beat, what the person does with hands and eyes — so the video generator has something worth executing.
+
+STRICT RULES:
+- Keep every RULE line of the brief VERBATIM, in place. They are generator guardrails (hands, on-screen text, speech completeness): you may not reword, reorder or drop one.
+- Same duration (${input.seconds ?? 15}s), same platform (${input.platform ?? 'organic'}), same spoken line if present.
+- Output ONLY the rewritten brief. No preamble, no explanations, no markdown fences.
+
+CONTEXT: platform ${input.platform ?? 'organic'} · ${input.seconds ?? 15}s${input.hook ? ` · hook: ${input.hook}` : ''}${input.hookVisual ? ` · hook visual: ${input.hookVisual}` : ''}${input.setting ? ` · setting: ${input.setting}` : ''}${input.person ? ` · person: ${input.person}` : ''}${input.product ? ` · product: ${input.product}` : ''}${input.script ? `\nSPOKEN LINE: ${input.script}` : ''}
+
+${refs}
+
+SHOT BRIEF TO REWRITE:
+${input.baseBrief}`;
+}
+
+export async function craftUgcShotBrief(
+	input: UgcCraftInput,
+	run: CraftRunner = generateCraft
+): Promise<string> {
+	try {
+		const out = (
+			await run({
+				system:
+					'You are a senior UGC video director writing shot briefs for an AI video generator. You rewrite mechanical briefs into precise, filmable direction. You never drop the RULE lines.',
+				prompt: buildCraftPrompt(input)
+			})
+		).trim();
+		// Un output senza le RULE non è una resa migliore: è un render senza guardrail.
+		if (!out || !/RULE/i.test(out)) return input.baseBrief;
+		return out;
+	} catch {
+		return input.baseBrief;
+	}
+}

--- a/src/lib/server/motion-video/model.ts
+++ b/src/lib/server/motion-video/model.ts
@@ -13,10 +13,9 @@
  * `ai_calls` che mente sul provider e` un conto che non torna.
  */
 import { env } from '$env/dynamic/private';
-import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import type { LanguageModel } from 'ai';
-import { harnessSdkModel } from '$lib/agent/bridge/adapters';
 import { geminiFlash } from '$lib/server/gemini';
+import { craftAgentModel } from '$lib/server/craft-model';
 
 export type MotionAgentModel = {
 	model: LanguageModel;
@@ -33,19 +32,8 @@ export type MotionAgentModel = {
  * composizione Remotion e` la cosa piu` difficile che il prodotto chiede a un modello, e la chat
  * puo` restare sul veloce mentre questo no.
  */
-const MOTION_TIER = 'pro' as const;
-
-function google(id: string): LanguageModel {
-	return createGoogleGenerativeAI({ apiKey: env.GEMINI_API_KEY ?? env.GOOGLE_API_KEY })(id);
-}
-
 export function motionAgentModel(): MotionAgentModel {
-	const forced = env.MOTION_VIDEO_MODEL?.trim();
-	if (forced) return { model: google(forced), modelId: forced, provider: 'gemini' };
-
-	const routed = harnessSdkModel(MOTION_TIER);
-	if (routed) return routed;
-
-	const id = geminiFlash();
-	return { model: google(id), modelId: id, provider: 'gemini' };
+	// La fabbrica è condivisa (craft-model.ts): stessa misura delle rese UGC, un posto solo
+	// che decide su cosa gira una resa. Il fallback su Gemini resta dichiarato.
+	return craftAgentModel({ envModel: env.MOTION_VIDEO_MODEL, fallbackId: geminiFlash() });
 }

--- a/src/routes/[[lang=locale]]/changelog/+page.svelte
+++ b/src/routes/[[lang=locale]]/changelog/+page.svelte
@@ -9,6 +9,7 @@
       date: 'August 27, 2026',
       title: 'Tools work on every message, not just the first',
       items: [
+        'AI and UGC video renders now get their shot brief written by a director-grade agent (the same advanced model tier as motion videos), with the old template brief kept as a safety net.',
         'Agents now write minimal replies by rule, not by taste: every sentence must carry a fact — no greetings, no transitions, no filler.',
         'Sending your first message now shows a spinner right away: no more silent gap while the conversation is being created.',
         'The homepage now shows the two ways to use Anomalia side by side — ready-to-go cloud or self-hosted on your own server — with mobile and desktop apps marked as coming soon.',


### PR DESCRIPTION
## What?

Generative AI and UGC videos now get their shot brief written by a second, director-grade agent on the pro model tier — the same pattern motion_write already uses — with the previous template brief kept as a safety net.

> **Stacked PR**: base `feat/ai-minimal-prose` (PR #17). Re-target to `dev` right after #17 merges; only the last commit is this task's change.

## Why?

The task: bring the motion_write pattern (fast orchestrator, advanced model does the render craft) to generative/UGC video production. Today the shot brief executed by the generator came from deterministic templates and the plan from a flash-tier planner; nothing decided the tier of this craft, so every call site leaned on `IMAGE_AGENT_MODEL()` (flash) or the chat model.

## How?

- **`src/lib/server/craft-model.ts`** — the shared factory for render-tier agents: tier `pro` of the active harness provider, explicit env escape hatch, declared Gemini fallback. `motion-video/model.ts` is refactored onto it (one source of truth, no behavior change) and the new UGC crafter uses it with `UGC_VIDEO_MODEL` as its escape hatch.
- **`src/lib/server/media-generator/ugc-craft.ts`** — the second agent: takes the deterministic brief (base + guardrails), rewrites it as filmable direction. The RULE lines (hands, on-screen text, speech completeness) must come back verbatim; model down, empty output, or output without RULE → deterministic fallback. Never a render without a brief.
- **`ugc-batch.ts`** — `briefFor` crafts before rendering, so UGC batches **and ads remix** inherit it for free. The planner stays on flash: planning is not the craft.
- Chat single-video path (`create_post` → `submitVideoRender`) deliberately NOT touched in this PR: it renders through a different enqueue path (`video.ts` / `enqueueVideoRender`) and deserves its own reviewable change; noted as follow-up.

## Testing?

- New `ugc-craft.test.ts` (6 tests, written first): pro-tier routing of the shared factory (mirrors `motionAgentModel` tests), `UGC_VIDEO_MODEL` override, prompt carries hook/setting/product/spoken line/references and the RULE-verbatim prohibition, and the three outcomes (crafted → trimmed, error → fallback, mute → fallback) via injected runner.
- `motion-video/model.test.ts` still green after the factory refactor.
- Full suite 5788 passed / 497 files. `svelte-check`: no errors or warnings in the new files (remaining delta vs old baseline snapshots is cross-worktree type-resolution noise, verified pre-existing on dev).
- No browser gate: this runs inside the designer worker's render pipeline; exercising it end-to-end requires a real Seedance render with API keys and spend — the fallback contract is unit-pinned instead. Eval script absent in this tree (noted before merge).

## Evidence (screenshots/videos)

N/A — no UI change; the deliverable is the render brief quality inside the async worker.

## Anything Else?

- Follow-ups: chat single-video path (`create_post`/`ugc_generate_video`) onto the same crafter; per-task job rows for parallel sub-agents (PR #14); eval phase-1 run before merging this branch.