### PR TITLE
Give every agent its own dev port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2026-08-28
+
+### `bun run dev` non uccide più la porta di nessuno
+
+Ogni agente che lavorava con `bun run dev` partiva uccidendo chiunque stesse
+già sulla 5173: due agenti in parallelo nei test e2e si facevano la guerra,
+e chi stava lavorando perdeva il server a metà sessione. Ora `bun run dev` è
+solo `vite dev` — la porta se la prende libera, e se è occupata bumpa sulla
+successiva invece di sparare al vicino. Il kill della 5173 vive in un comando
+suo, `bun run dev:5173`, che dopo il kill lega con `--strictPort`: o prende
+esattamente la 5173 (CLI e doc la presumono) o fallisce rumorosamente, senza
+spostarsi in silenzio su un'altra porta. Un test (`scripts/dev-scripts.test.ts`)
+impedisce che il kill torni dentro `dev`.
+
 ## 2026-08-27
 
 ### Ogni agente può aprire una sessione utente, e la delega si distingue in due modi

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "packages/*"
   ],
   "scripts": {
-    "dev": "lsof -ti tcp:5173 | xargs kill -9 2>/dev/null; vite dev",
+    "dev": "vite dev",
+    "dev:5173": "lsof -ti tcp:5173 | xargs kill -9 2>/dev/null; vite dev --strictPort",
     "dev:stable": "NO_HMR=1 vite dev",
     "dev:vercel": "vercel dev --listen 5173",
     "build": "node scripts/typecheck-runtime.mjs && vite build",

--- a/scripts/dev-scripts.test.ts
+++ b/scripts/dev-scripts.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+
+type Scripts = Record<string, string>;
+
+async function readScripts(): Promise<Scripts> {
+	const raw = await readFile(fileURLToPath(new URL('../package.json', import.meta.url)), 'utf8');
+	return JSON.parse(raw).scripts;
+}
+
+describe('dev server scripts', () => {
+	it('bun run dev never kills a port: every agent gets its own free port', async () => {
+		const scripts = await readScripts();
+		expect(scripts.dev).not.toContain('kill');
+	});
+
+	it('bun run dev:5173 owns port 5173: kills the stale owner then binds strictly', async () => {
+		const scripts = await readScripts();
+		expect(scripts['dev:5173']).toMatch(/lsof .*5173/);
+		expect(scripts['dev:5173']).toContain('--strictPort');
+	});
+
+	it('bun run dev:5173 still starts the vite dev server', async () => {
+		const scripts = await readScripts();
+		expect(scripts['dev:5173']).toContain('vite dev');
+	});
+});


### PR DESCRIPTION
## What?
`bun run dev` no longer kills whoever holds port 5173 — it just starts Vite, which bumps to the next free port when 5173 is taken. The port kill moves to a new dedicated command, `bun run dev:5173`, which kills the stale owner first and then binds `--strictPort`. A new test (`scripts/dev-scripts.test.ts`) locks this contract.

## Why?
Two agents working in parallel (e2e tests, eval runs, multiple worktrees) each fired `bun run dev` and shot each other's dev server mid-session — task #25 in Team Tasks. The repo's own convention ("mai la 5173: è il dev server del proprietario", see `scripts/chat-knowledge-panel-check.mjs:44`) was contradicted by `dev` itself.

## How?
- `dev` = plain `vite dev`: Vite auto-bumps to 5174, 5175… when the port is taken, so each process gets its own port with zero coordination.
- `dev:5173` = kill 5173, then `vite dev --strictPort`: the explicit "I own 5173" path for the CLI and docs, which fail loudly instead of silently drifting to another port.
- No config changes: `vite.config.ts` has no `strictPort` set, so auto-bump is the default behavior.

## Testing?
- Unit: `scripts/dev-scripts.test.ts` (written first, observed failing, then green) — asserts `dev` contains no `kill`, and `dev:5173` kills 5173, binds strict, and still starts Vite.
- Manual, on the local worktree:
  - With a live server on 5173, `bun run dev` did NOT kill it (same PIDs before/after) and started on `http://localhost:5174/`.
  - `bun run dev:5173` killed the owner and bound exactly `http://localhost:5173/` (strict — no bump possible).
- Not tested: Playwright e2e suite (change is script-level only); CI will run unit tests.

## Evidence (screenshots/videos)
- `bun run dev` with 5173 occupied: `Port 5173 is in use, trying another one...` → `Local: http://localhost:5174/`; the 5173 owner PIDs (1126, 33283, 63910) identical before and after.
- `bun run dev:5173`: `Local: http://localhost:5173/` — strict bind after the kill.
- Unit suite: `Test Files 1 passed (1) · Tests 3 passed (3)`.

<details>
<summary>Backend evidence</summary>

```
pids su 5173 prima: 1126 33283 63910
Port 5173 is in use, trying another one...
  ➜  Local:   http://localhost:5174/
pids su 5173 dopo:  1126 33283 63910

bun run dev:5173 →
  ➜  Local:   http://localhost:5173/

 ✓ scripts/dev-scripts.test.ts (3 tests) 2ms
```
</details>

## Anything Else?
The worktree used for verification had no `.env` (env files don't follow worktrees), so the `dev:5173` run showed an unrelated Supabase client error on request handling — server bind and port behavior are unaffected. The main checkout's dev server on 5173 was restored after testing.