### PR TITLE
Move CLI, MCP and skills into the monorepo

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -8,7 +8,7 @@
       "name": "anomalia",
       "source": {
         "source": "local",
-        "path": "./plugins/anomalia"
+        "path": "./cli/plugins/anomalia"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/.agents/skills/anomalia/SKILL.md
+++ b/.agents/skills/anomalia/SKILL.md
@@ -13,7 +13,7 @@ metadata:
   author: andreabuttarelli
   version: "1.0.0"
   homepage: https://anomalia.so
-  repository: https://github.com/andreabuttarelli/anomalia-cli
+  repository: https://github.com/anomaliaso/anomalia
   mcp: https://mcp.anomalia.so/mcp
 ---
 
@@ -65,7 +65,7 @@ Setup details: [references/mcp.md](references/mcp.md).
 ## Install this skill
 
 ```bash
-npx skills add andreabuttarelli/anomalia-cli --skill anomalia
+npx skills add anomaliaso/anomalia --skill anomalia
 ```
 
 Or copy `skills/anomalia/` into `.cursor/skills/anomalia/` / `~/.claude/skills/anomalia/`.

--- a/.agents/skills/anomalia/references/cli.md
+++ b/.agents/skills/anomalia/references/cli.md
@@ -5,14 +5,14 @@ Use when MCP is not connected. Same OAuth session as MCP (`~/.config/anomalia/se
 ## Install
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/andreabuttarelli/anomalia-cli/main/scripts/install.sh | bash
+curl -sSL https://raw.githubusercontent.com/anomaliaso/anomalia/main/cli/scripts/install.sh | bash
 anomalia login
 ```
 
 From source (Bun):
 
 ```bash
-git clone https://github.com/andreabuttarelli/anomalia-cli.git
+git clone https://github.com/anomaliaso/anomalia.git
 cd anomalia-cli && bun install
 bun run cli.ts --help
 ```
@@ -38,5 +38,5 @@ anomalia web <slug> generate --topic "..."
 anomalia ai <slug> --message "..." --pipe
 ```
 
-Full dump: repo root [`llms.txt`](https://github.com/andreabuttarelli/anomalia-cli/blob/main/llms.txt).
+Full dump: repo root [`llms.txt`](https://github.com/anomaliaso/anomalia/blob/main/cli/llms.txt).
 Tool mapping: [tools.md](tools.md).

--- a/.agents/skills/anomalia/references/mcp.md
+++ b/.agents/skills/anomalia/references/mcp.md
@@ -71,7 +71,7 @@ The host must send OAuth Bearer. If it cannot yet, use [mcp-remote](https://www.
 ### From source (dev)
 
 ```bash
-git clone https://github.com/andreabuttarelli/anomalia-cli.git
+git clone https://github.com/anomaliaso/anomalia.git
 cd anomalia-cli
 bun install
 bun run mcp          # stdio
@@ -116,4 +116,4 @@ Ids from list tools accept short unambiguous prefixes (same rule as the CLI).
 
 - Full tool list: [tools.md](tools.md)
 - CLI fallback: [cli.md](cli.md)
-- Product: https://anomalia.so · Repo: https://github.com/andreabuttarelli/anomalia-cli
+- Product: https://anomalia.so · Repo: https://github.com/anomaliaso/anomalia

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
   "plugins": [
     {
       "name": "anomalia",
-      "source": "./plugins/anomalia",
+      "source": "./cli/plugins/anomalia",
       "description": "Operate Anomalia via MCP or CLI: brands, posts, plans, studio, SEO/GEO, and blog.",
       "version": "1.0.0",
       "author": {
@@ -21,7 +21,7 @@
         "url": "https://github.com/andreabuttarelli"
       },
       "homepage": "https://anomalia.so",
-      "repository": "https://github.com/andreabuttarelli/anomalia-cli",
+      "repository": "https://github.com/anomaliaso/anomalia",
       "license": "AGPL-3.0-or-later",
       "keywords": [
         "social-media",

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -1,93 +1,120 @@
+# Builds the standalone CLI binaries + npm package from cli/, attaches GitHub
+# Release assets, updates the Homebrew formula and publishes to npm.
 name: CLI Release
 
 on:
   push:
-    tags:
-      - 'cli-v*'
+    tags: ['cli-v*']
   workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version (e.g. 0.2.0)'
-        required: true
+
+permissions:
+  contents: write
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        include:
-          - os: macos-latest
-            target: bun-darwin-arm64
-            name: macos-arm64
-          - os: macos-latest
-            target: bun-darwin-x64
-            name: macos-x64
-          - os: ubuntu-latest
-            target: bun-linux-x64
-            name: linux-x64
-          - os: ubuntu-latest
-            target: bun-linux-arm64
-            name: linux-arm64
-
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ startsWith(github.ref, 'refs/tags/cli-v') }}
     steps:
       - uses: actions/checkout@v4
 
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
 
-      - name: Install dependencies
-        working-directory: cli
-        run: bun install
-
-      - name: Build binary
+      - name: Install, check, test
         working-directory: cli
         run: |
-          bun build --compile --minify --target ${{ matrix.target }} \
-            index.ts --outfile dist/anomalia-${{ matrix.name }}
+          bun install --frozen-lockfile
+          bun run typecheck
+          bun test
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: anomalia-${{ matrix.name }}
-          path: cli/dist/anomalia-${{ matrix.name }}
-
-  release:
-    needs: build
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/cli-v')
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: dist
-
-      - name: Prepare release files
+      - name: Sync package version from tag
+        if: startsWith(github.ref, 'refs/tags/cli-v')
+        working-directory: cli
         run: |
-          mkdir -p release
-          for dir in dist/anomalia-*; do
-            cp "$dir/anomalia-"* release/
-          done
-          chmod +x release/anomalia-*
-          cp cli/README.md release/
-          cp -r cli/docs release/
+          TAG="${GITHUB_REF_NAME#cli-v}"
+          node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json','utf8')); p.version=process.argv[1]; fs.writeFileSync('package.json', JSON.stringify(p,null,2)+'\n');" "$TAG"
+          sed -i.bak "s/\.version('[^']*')/.version('${TAG}')/" cli.ts && rm cli.ts.bak
 
-      - name: Create release
+      - name: Build binaries + npm package
+        working-directory: cli
+        run: |
+          bun run build:all
+          bun run build:npm
+
+      - name: Checksums
+        working-directory: cli/dist
+        run: sha256sum anomalia-* > SHA256SUMS.txt
+
+      - name: Update Homebrew formula
+        if: startsWith(github.ref, 'refs/tags/cli-v')
+        working-directory: cli
+        run: |
+          chmod +x scripts/update-homebrew-formula.sh
+          scripts/update-homebrew-formula.sh "${GITHUB_REF_NAME#cli-v}"
+
+      - name: Publish binaries to GitHub Release
+        if: startsWith(github.ref, 'refs/tags/cli-v')
         uses: softprops/action-gh-release@v2
         with:
-          files: release/*
+          files: |
+            cli/dist/anomalia-*
+            cli/dist/SHA256SUMS.txt
           generate_release_notes: true
-          draft: false
-          prerelease: false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Update installer URL
+      - name: Commit Homebrew formula bump to main
+        if: startsWith(github.ref, 'refs/tags/cli-v')
         run: |
-          echo "Release created! Users can install with:"
-          echo "  curl -sSL https://anomalia.so/install.sh | bash"
-          echo ""
-          echo "Or download directly from GitHub Releases."
+          cp cli/Formula/anomalia.rb /tmp/anomalia.rb
+          git fetch origin main
+          git checkout -B cli-formula-bump origin/main
+          cp /tmp/anomalia.rb cli/Formula/anomalia.rb
+          if git diff --quiet cli/Formula/anomalia.rb; then
+            echo "Formula unchanged"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add cli/Formula/anomalia.rb
+          git commit -m "chore: bump Homebrew formula to ${GITHUB_REF_NAME}"
+          git push origin cli-formula-bump:main
+
+      - name: Push formula to Homebrew tap
+        if: startsWith(github.ref, 'refs/tags/cli-v') && env.TAP_TOKEN != ''
+        env:
+          TAP_TOKEN: ${{ secrets.TAP_TOKEN }}
+        run: |
+          git clone https://x-access-token:${TAP_TOKEN}@github.com/anomaliaso/homebrew-tap.git tap
+          mkdir -p tap/Formula
+          cp cli/Formula/anomalia.rb tap/Formula/anomalia.rb
+          cd tap
+          if git diff --quiet; then
+            echo "Tap unchanged"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula/anomalia.rb
+          git commit -m "anomalia ${GITHUB_REF_NAME#cli-v}"
+          git push
+
+      - name: Publish to npm
+        if: startsWith(github.ref, 'refs/tags/cli-v')
+        working-directory: cli/dist-npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Upload build artifacts (manual runs)
+        if: github.ref != 'refs/tags/cli-v'
+        uses: actions/upload-artifact@v4
+        with:
+          name: anomalia-dist
+          path: |
+            cli/dist/anomalia-*
+            cli/dist/SHA256SUMS.txt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,5 @@ SECURITY, the public changelog, package READMEs — is English.
 4. In the PR body, say what you ran and what you did not. "I didn't run the e2e suite" is a fine
    sentence; a silent gap is not.
 
-Not everything belongs here: the `anomalia` CLI lives in its own repo
-([anomalia-cli](https://github.com/andreabuttarelli/anomalia-cli), AGPL-3.0). Changes to the CLI
-go there; changes to the endpoints it calls go here.
+The `anomalia` CLI, its MCP server and the publishable agent skills live in [`cli/`](cli/) of this
+same repository (AGPL-3.0, released from `cli-v*` tags). CLI changes are PRs here like any other.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ stack yourself.
 
 - Weekly editorial plan, then on-brand posts, carousels, and video
 - Calendar and one-tap approve — from the app, email, or
-  [CLI / MCP](https://github.com/andreabuttarelli/anomalia-cli)
+  [CLI / MCP](cli/)
 - Studio: brand kit, products, people, competitors, and voice
 - Radar: news and conversations turned into drafts and lead replies
 - Blog, SEO, and GEO — rank on Google and get cited by AI assistants
@@ -36,7 +36,7 @@ stack yourself.
 - TypeScript and SvelteKit
 - Supabase (Postgres, Auth, Storage)
 - Node.js 22 and Docker Compose
-- MCP server and CLI in [anomalia-cli](https://github.com/andreabuttarelli/anomalia-cli)
+- MCP server and CLI in [`cli/`](cli/) — installable binary, npm, Homebrew
 
 ## Quick start
 

--- a/changelog/2026-08-28-cli-login-password.md
+++ b/changelog/2026-08-28-cli-login-password.md
@@ -1,0 +1,8 @@
+# `anomalia login --email --password [--password-stdin]`
+
+Oltre al flusso browser (che resta il default: unico che supporta provider SSO
+e non mette la password negli argomenti di shell) il login accetta ora le
+credenziali direttamente, per script e CI: due flag insieme o niente flag,
+niente prompt interattivi da nascondere. `--password-stdin` legge la password
+da standard input, fuori da shell history e `ps aux`. Stessa sessione su
+`~/.config/anomalia/session.json`, stesso refresh silenzioso di sempre.

--- a/changelog/2026-08-28-cli-mcp-skills-in-monorepo.md
+++ b/changelog/2026-08-28-cli-mcp-skills-in-monorepo.md
@@ -1,0 +1,16 @@
+# CLI, MCP e skill vivono in questa repo (`cli/`)
+
+La repo pubblica `andreabuttarelli/anomalia-cli` chiude: sorgente di CLI, MCP
+server (stdio e HTTP), skill agente, plugin Claude/Codex e formula Homebrew
+traslocano in `cli/`, senza copie divergenti da tenere allineate a mano.
+
+La release è un tag `cli-vX.Y.Z` qui: il workflow `cli-release.yml` builda i
+binari standalone (macOS/Linux, arm64/x64) + checksum, li attacca alla GitHub
+Release, aggiorna la formula Homebrew, la pusha su `anomaliaso/homebrew-tap`
+(serve il secret `TAP_TOKEN`) e pubblica `anomalia-cli` su npm (secret
+`NPM_TOKEN`). `install.sh`, `anomalia update`, npm e Homebrew cambiano tutti
+puntamento alla nuova posizione; i manifest dei marketplace plugin
+(`.claude-plugin/`, `.agents/plugins/`) salgono alla root della repo perché
+`/plugin marketplace add anomaliaso/anomalia` li trovi lì. La vecchia repo va
+archiviata dopo la prima release da qui — prima un ultimo commit che reindirizza
+il suo `install.sh` ai nuovi asset, così chi ha già installato non si rompe.

--- a/cli/.agents/plugins/marketplace.json
+++ b/cli/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "anomalia",
+  "interface": {
+    "displayName": "Anomalia"
+  },
+  "plugins": [
+    {
+      "name": "anomalia",
+      "source": {
+        "source": "local",
+        "path": "./plugins/anomalia"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/cli/.claude-plugin/marketplace.json
+++ b/cli/.claude-plugin/marketplace.json
@@ -1,0 +1,36 @@
+{
+  "name": "anomalia",
+  "owner": {
+    "name": "Andrea Buttarelli",
+    "email": "andreabuttarelli.design@gmail.com",
+    "url": "https://github.com/andreabuttarelli"
+  },
+  "metadata": {
+    "description": "Anomalia — social media AI autopilot (CLI, MCP, agent skill)",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "anomalia",
+      "source": "./plugins/anomalia",
+      "description": "Operate Anomalia via MCP or CLI: brands, posts, plans, studio, SEO/GEO, and blog.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Andrea Buttarelli",
+        "email": "andreabuttarelli.design@gmail.com",
+        "url": "https://github.com/andreabuttarelli"
+      },
+      "homepage": "https://anomalia.so",
+      "repository": "https://github.com/andreabuttarelli/anomalia-cli",
+      "license": "AGPL-3.0-or-later",
+      "keywords": [
+        "social-media",
+        "content",
+        "mcp",
+        "seo",
+        "geo",
+        "anomalia"
+      ]
+    }
+  ]
+}

--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -1,0 +1,16 @@
+node_modules/
+dist/
+dist-npm/
+.env
+.env.*
+!.env.example
+.DS_Store
+*.log
+api/_bundle.js
+api/mcp.js
+api/oauth-protected-resource.js
+api/_mcp.bundle.js
+api/_oauth.bundle.js
+api/_bundle.cjs
+api/_bundle.cjs.map
+api/*.cjs

--- a/cli/Formula/anomalia.rb
+++ b/cli/Formula/anomalia.rb
@@ -1,0 +1,57 @@
+# typed: false
+# frozen_string_literal: true
+
+# Homebrew formula for the Anomalia CLI (prebuilt binaries from GitHub Releases).
+#
+# Install (same-repo tap):
+#   brew tap andreabuttarelli/anomalia-cli https://github.com/andreabuttarelli/anomalia-cli
+#   brew install anomalia
+#
+# Or after a dedicated homebrew-anomalia tap is published:
+#   brew install andreabuttarelli/anomalia/anomalia
+#
+# SHA256 placeholders below are filled by .github/workflows/release.yml on each v* tag.
+
+class Anomalia < Formula
+  desc "Command-line client for Anomalia — social media AI autopilot"
+  homepage "https://anomalia.so"
+  version "0.1.0"
+  license "AGPL-3.0-or-later"
+
+  livecheck do
+    url "https://github.com/andreabuttarelli/anomalia-cli/releases/latest"
+    strategy :github_latest
+  end
+
+  on_macos do
+    on_arm do
+      url "https://github.com/andreabuttarelli/anomalia-cli/releases/download/v#{version}/anomalia-macos-arm64.tar.gz"
+      sha256 "REPLACE_SHA256_MACOS_ARM64"
+    end
+    on_intel do
+      url "https://github.com/andreabuttarelli/anomalia-cli/releases/download/v#{version}/anomalia-macos-x64.tar.gz"
+      sha256 "REPLACE_SHA256_MACOS_X64"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "https://github.com/andreabuttarelli/anomalia-cli/releases/download/v#{version}/anomalia-linux-arm64.tar.gz"
+      sha256 "REPLACE_SHA256_LINUX_ARM64"
+    end
+    on_intel do
+      url "https://github.com/andreabuttarelli/anomalia-cli/releases/download/v#{version}/anomalia-linux-x64.tar.gz"
+      sha256 "REPLACE_SHA256_LINUX_X64"
+    end
+  end
+
+  def install
+    binary = Dir["anomalia-*"].first
+    odie "Anomalia binary missing from archive" if binary.nil?
+    bin.install binary => "anomalia"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/anomalia --version")
+  end
+end

--- a/cli/Formula/anomalia.rb
+++ b/cli/Formula/anomalia.rb
@@ -3,12 +3,9 @@
 
 # Homebrew formula for the Anomalia CLI (prebuilt binaries from GitHub Releases).
 #
-# Install (same-repo tap):
-#   brew tap andreabuttarelli/anomalia-cli https://github.com/andreabuttarelli/anomalia-cli
+# Install (dedicated tap, kept in sync by the cli-v* release workflow):
+#   brew tap anomaliaso/tap https://github.com/anomaliaso/homebrew-tap
 #   brew install anomalia
-#
-# Or after a dedicated homebrew-anomalia tap is published:
-#   brew install andreabuttarelli/anomalia/anomalia
 #
 # SHA256 placeholders below are filled by .github/workflows/release.yml on each v* tag.
 
@@ -19,28 +16,28 @@ class Anomalia < Formula
   license "AGPL-3.0-or-later"
 
   livecheck do
-    url "https://github.com/andreabuttarelli/anomalia-cli/releases/latest"
+    url "https://github.com/anomaliaso/anomalia/releases/latest"
     strategy :github_latest
   end
 
   on_macos do
     on_arm do
-      url "https://github.com/andreabuttarelli/anomalia-cli/releases/download/v#{version}/anomalia-macos-arm64.tar.gz"
+      url "https://github.com/anomaliaso/anomalia/releases/download/v#{version}/anomalia-macos-arm64.tar.gz"
       sha256 "REPLACE_SHA256_MACOS_ARM64"
     end
     on_intel do
-      url "https://github.com/andreabuttarelli/anomalia-cli/releases/download/v#{version}/anomalia-macos-x64.tar.gz"
+      url "https://github.com/anomaliaso/anomalia/releases/download/v#{version}/anomalia-macos-x64.tar.gz"
       sha256 "REPLACE_SHA256_MACOS_X64"
     end
   end
 
   on_linux do
     on_arm do
-      url "https://github.com/andreabuttarelli/anomalia-cli/releases/download/v#{version}/anomalia-linux-arm64.tar.gz"
+      url "https://github.com/anomaliaso/anomalia/releases/download/v#{version}/anomalia-linux-arm64.tar.gz"
       sha256 "REPLACE_SHA256_LINUX_ARM64"
     end
     on_intel do
-      url "https://github.com/andreabuttarelli/anomalia-cli/releases/download/v#{version}/anomalia-linux-x64.tar.gz"
+      url "https://github.com/anomaliaso/anomalia/releases/download/v#{version}/anomalia-linux-x64.tar.gz"
       sha256 "REPLACE_SHA256_LINUX_X64"
     end
   end

--- a/cli/LICENSE
+++ b/cli/LICENSE
@@ -1,0 +1,662 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.
+

--- a/cli/README.md
+++ b/cli/README.md
@@ -153,7 +153,7 @@ using the custom-scheme OAuth callback — use **stdio** above, update Cursor (l
 `http://localhost:8787/callback`), or see [`docs/mcp.md`](docs/mcp.md#cursor--remote-http-oauth).
 
 - Local stdio: `login` tool or existing `anomalia login` → `~/.config/anomalia/session.json`
-  (script/CI alternative: `anomalia login --email tu@email --password …`, no browser)
+  (script/CI alternative: `anomalia login --email tu@email --password …` or `--password-stdin`, no browser)
 - Remote HTTP: `Authorization: Bearer <access_token>` (401 without it is expected)
 
 ---

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,252 @@
+# Anomalia CLI — Social Media AI Automation CLI, MCP Server & Agent Skill
+
+**Automate your social media from the terminal.** [Anomalia](https://anomalia.so) is the social
+media AI autopilot that plans, writes, designs and publishes posts, blog articles and SEO/GEO
+audits on autopilot. This repository is its command-line client, [MCP server](docs/mcp.md)
+(Model Context Protocol — `stdio` + HTTP) and agent skill: everything you need to run social
+media automation, content generation and approval workflows from a terminal or an AI agent.
+
+This repository ships **three ways** to drive the same product (same OAuth, same API, **no static tokens**):
+
+| | What | Who it’s for |
+|---|------|----------------|
+| **CLI** | `anomalia` terminal commands | Humans & scripts |
+| **MCP** | Model Context Protocol server (`stdio` + HTTP) | Cursor, Claude, other MCP hosts |
+| **Skill** | Agent Skill (`skills/anomalia/`) | Coding agents / skills.sh / `npx skills` |
+
+> **You need an Anomalia account.** This is a client, not a standalone tool: every call talks to
+> the Anomalia API over HTTPS. Without an account there is nothing to drive.
+
+With the Anomalia CLI you can automate social media posting, approve AI-generated content in one
+tap, edit a carousel slide by slide, turn a post into a video, run SEO and GEO audits, and manage
+your blog — from the terminal **or** from an AI agent like Cursor or Claude.
+
+```text
+┌─────────────┐   ┌─────────────┐   ┌──────────────────┐
+│  anomalia   │   │  MCP host   │   │  Agent + Skill   │
+│    CLI      │   │ (Cursor…)   │   │  (npx skills)    │
+└──────┬──────┘   └──────┬──────┘   └────────┬─────────┘
+       │                 │                   │
+       │    lib/api.ts + OAuth session       │
+       └─────────────────┼───────────────────┘
+                         ▼
+                 Anomalia /api/v1/*
+```
+
+---
+
+## 1. CLI
+
+### Install
+
+Pick one:
+
+| Method | Command | Notes |
+|--------|---------|--------|
+| **npm** | `npm install -g anomalia-cli` | Needs Node.js ≥ 20 |
+| **Homebrew** | see below | macOS / Linux, standalone binary |
+| **Installer** | see below | curl script → binary on PATH |
+| **From source** | see below | Needs [Bun](https://bun.sh) |
+
+**npm**
+
+```bash
+npm install -g anomalia-cli
+# or:  pnpm add -g anomalia-cli   /   bun add -g anomalia-cli
+anomalia login
+```
+
+**Homebrew**
+
+```bash
+brew tap andreabuttarelli/anomalia-cli https://github.com/andreabuttarelli/anomalia-cli
+brew install anomalia
+anomalia login
+```
+
+**Installer (standalone binary)** — macOS arm64/x64 and Linux arm64/x64, no Node/Bun required:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/andreabuttarelli/anomalia-cli/main/scripts/install.sh | bash
+anomalia login
+```
+
+Update later with `anomalia update`, or `npm install -g anomalia-cli@latest` / `brew upgrade anomalia` depending on how you installed. More detail: [`docs/distribute.md`](docs/distribute.md).
+
+### Quick start
+
+```bash
+anomalia brands
+anomalia dashboard my-brand
+anomalia content my-brand --status pending_user
+anomalia approve my-brand --all
+anomalia seo my-brand
+anomalia web my-brand generate --topic "..."
+anomalia ai my-brand --message "..." --pipe
+```
+
+Every command takes the brand slug as its first argument. `anomalia --help` lists them all;
+`anomalia <command> --help` details one. Short id prefixes from tables are accepted; ambiguous
+prefixes error instead of guessing.
+
+| Area | Commands |
+|------|----------|
+| Posts | `content`, `approve`, `post <id> [show\|edit\|regenerate\|slide\|reorder\|video\|publish]` |
+| Planning | `plan`, `weekly-plan`, `calendar`, `gtm` |
+| Brand | `studio`, `voice`, `people`, `products` |
+| Web | `seo`, `geo`, `keywords`, `web` |
+| Ads | `ads` — campaigns, spend, boost proposals, duplicate/delete (`--sync`, `--propose`, `--create`, `--approve`, `--pause`, `--resume`, `--duplicate`, `--delete`, `--reject`, `--ad` per singola creatività) |
+| Insight | `dashboard`, `status`, `analytics` |
+| AI | `ai --message "..."` — natural language, full read/write access |
+
+Full command dump: [`llms.txt`](llms.txt) · more docs: [`docs/`](docs/)
+
+### From source
+
+Requires [Bun](https://bun.sh).
+
+```bash
+git clone https://github.com/andreabuttarelli/anomalia-cli.git
+cd anomalia-cli
+bun install
+bun run cli.ts --help
+```
+
+---
+
+## 2. MCP server
+
+Same tools and OAuth as the CLI. Docs: **[`docs/mcp.md`](docs/mcp.md)**.
+
+```bash
+bun run mcp          # stdio (local hosts)
+bun run mcp:http     # http://localhost:8787/mcp
+```
+
+Remote: `https://mcp.anomalia.so/mcp` (Bearer JWT required). Health: `GET /health`.
+
+**Cursor — stdio**
+
+```json
+{
+  "mcpServers": {
+    "anomalia": {
+      "command": "bun",
+      "args": ["run", "/ABS/PATH/to/anomalia-cli/mcp/stdio.ts"]
+    }
+  }
+}
+```
+
+**Cursor — HTTP**
+
+```json
+{
+  "mcpServers": {
+    "anomalia": { "url": "https://mcp.anomalia.so/mcp" }
+  }
+}
+```
+
+If Connect fails with `Not an https or loopback URI: cursor://…`, your Cursor build is still
+using the custom-scheme OAuth callback — use **stdio** above, update Cursor (loopback
+`http://localhost:8787/callback`), or see [`docs/mcp.md`](docs/mcp.md#cursor--remote-http-oauth).
+
+- Local stdio: `login` tool or existing `anomalia login` → `~/.config/anomalia/session.json`
+- Remote HTTP: `Authorization: Bearer <access_token>` (401 without it is expected)
+
+---
+
+## 3. Agent Skill & plugins
+
+Publishable [Agent Skill](https://agentskills.io) for Cursor, Claude, skills.sh, and friends:
+
+```bash
+npx skills add andreabuttarelli/anomalia-cli --skill anomalia
+# or
+bash scripts/install-skill.sh --project
+```
+
+Package: [`skills/anomalia/`](skills/anomalia/) → [`plugins/anomalia/skills/anomalia/`](plugins/anomalia/) (`SKILL.md` + `references/` for MCP setup, tool map, CLI).
+
+When the skill is active, agents prefer **MCP tools** if connected, otherwise the **CLI**.
+
+### Claude Code / Codex marketplace plugin
+
+Same skill + remote MCP, packaged for plugin install and directory submit:
+
+```bash
+# Claude Code
+/plugin marketplace add andreabuttarelli/anomalia-cli
+/plugin install anomalia@anomalia
+
+# Codex
+codex plugin marketplace add andreabuttarelli/anomalia-cli
+```
+
+Submit checklist (Claude community directory + OpenAI Plugins Directory): **[`docs/plugins.md`](docs/plugins.md)**.
+
+---
+
+## Configuration
+
+Zero config by default → `https://anomalia.so`, with automatic fallback to
+`http://localhost:5173` when a local app is answering.
+
+| Variable | Purpose |
+|----------|---------|
+| `PUBLIC_APP_URL` | Point CLI/MCP at another Anomalia instance |
+| `SENTRY_DSN` | (MCP HTTP / Vercel) Errors → Sentry |
+| `SUPABASE_SERVICE_ROLE_KEY` | (MCP HTTP / Vercel) Rows in `mcp_logs` |
+| `MCP_PUBLIC_URL` | Public MCP base URL for OAuth metadata |
+
+Session: `~/.config/anomalia/session.json`. `anomalia logout` clears it. No secrets are embedded
+in this repo or the binary.
+
+---
+
+## Architecture
+
+Thin HTTPS client — no DB access, no coupling to the Anomalia server codebase:
+
+```
+CLI  ──┐
+MCP  ──┼── HTTPS ──►  /api/v1/*  ──►  Anomalia
+Skill ─┘   (guides agents to CLI or MCP)
+```
+
+- CLI commands: `commands/` + `cli.ts`
+- HTTP client: `lib/api.ts` only
+- MCP: `mcp/` (reuses `lib/api.ts`, registers tools)
+- Skill / plugins: `skills/anomalia/` → `plugins/anomalia/` (Claude + Codex marketplace manifests)
+
+---
+
+## Development
+
+```bash
+bun install
+bun run cli.ts --help
+bun run mcp
+bun run mcp:http
+bun run typecheck
+bun test
+bun run build             # binary → dist/
+bun run build:all         # all four targets
+bun run vercel-build      # MCP bundles under mcp/api/
+```
+
+Releases: push a `v*` tag → CI typechecks, tests, cross-compiles binaries + `.tar.gz` +
+`SHA256SUMS.txt` on the GitHub Release, bumps [`Formula/anomalia.rb`](Formula/anomalia.rb),
+and publishes `anomalia-cli` to npm when `NPM_TOKEN` is set. Details: [`docs/distribute.md`](docs/distribute.md).
+
+---
+
+## License
+
+Copyright © 2026 Andrea Buttarelli.
+
+Licensed under the [GNU Affero General Public License v3.0 or later](LICENSE). You may use, modify
+and redistribute it, but derivative works must stay open source under the same license, must keep
+the copyright notice, and must state their changes — including when offered to users over a
+network.

--- a/cli/README.md
+++ b/cli/README.md
@@ -153,6 +153,7 @@ using the custom-scheme OAuth callback — use **stdio** above, update Cursor (l
 `http://localhost:8787/callback`), or see [`docs/mcp.md`](docs/mcp.md#cursor--remote-http-oauth).
 
 - Local stdio: `login` tool or existing `anomalia login` → `~/.config/anomalia/session.json`
+  (script/CI alternative: `anomalia login --email tu@email --password …`, no browser)
 - Remote HTTP: `Authorization: Bearer <access_token>` (401 without it is expected)
 
 ---

--- a/cli/README.md
+++ b/cli/README.md
@@ -56,10 +56,10 @@ npm install -g anomalia-cli
 anomalia login
 ```
 
-**Homebrew**
+**Homebrew** — formula lives in the [`anomaliaso/homebrew-tap`](https://github.com/anomaliaso/homebrew-tap) repository:
 
 ```bash
-brew tap andreabuttarelli/anomalia-cli https://github.com/andreabuttarelli/anomalia-cli
+brew tap anomaliaso/tap https://github.com/anomaliaso/homebrew-tap
 brew install anomalia
 anomalia login
 ```
@@ -67,7 +67,7 @@ anomalia login
 **Installer (standalone binary)** — macOS arm64/x64 and Linux arm64/x64, no Node/Bun required:
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/andreabuttarelli/anomalia-cli/main/scripts/install.sh | bash
+curl -sSL https://raw.githubusercontent.com/anomaliaso/anomalia/main/cli/scripts/install.sh | bash
 anomalia login
 ```
 
@@ -106,7 +106,7 @@ Full command dump: [`llms.txt`](llms.txt) · more docs: [`docs/`](docs/)
 Requires [Bun](https://bun.sh).
 
 ```bash
-git clone https://github.com/andreabuttarelli/anomalia-cli.git
+git clone https://github.com/anomaliaso/anomalia.git
 cd anomalia-cli
 bun install
 bun run cli.ts --help
@@ -162,7 +162,7 @@ using the custom-scheme OAuth callback — use **stdio** above, update Cursor (l
 Publishable [Agent Skill](https://agentskills.io) for Cursor, Claude, skills.sh, and friends:
 
 ```bash
-npx skills add andreabuttarelli/anomalia-cli --skill anomalia
+npx skills add anomaliaso/anomalia --skill anomalia
 # or
 bash scripts/install-skill.sh --project
 ```
@@ -177,11 +177,11 @@ Same skill + remote MCP, packaged for plugin install and directory submit:
 
 ```bash
 # Claude Code
-/plugin marketplace add andreabuttarelli/anomalia-cli
+/plugin marketplace add anomaliaso/anomalia
 /plugin install anomalia@anomalia
 
 # Codex
-codex plugin marketplace add andreabuttarelli/anomalia-cli
+codex plugin marketplace add anomaliaso/anomalia
 ```
 
 Submit checklist (Claude community directory + OpenAI Plugins Directory): **[`docs/plugins.md`](docs/plugins.md)**.

--- a/cli/api/health.js
+++ b/cli/api/health.js
@@ -1,0 +1,31 @@
+/**
+ * Ultra-minimal health endpoint (ESM).
+ * Kept dependency-free so /health stays up even if the MCP bundle fails to build.
+ */
+export default function handler(req, res) {
+  if (req.method === 'OPTIONS') {
+    res.statusCode = 204;
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
+    res.setHeader(
+      'Access-Control-Allow-Headers',
+      'Content-Type, Authorization, mcp-session-id, Last-Event-ID, mcp-protocol-version',
+    );
+    res.end();
+    return;
+  }
+
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'application/json');
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.end(
+    JSON.stringify({
+      ok: true,
+      name: 'anomalia-mcp',
+      transport: 'streamable-http',
+      mcp: '/mcp',
+    }),
+  );
+}
+
+export const config = { maxDuration: 10 };

--- a/cli/bun.lock
+++ b/cli/bun.lock
@@ -1,0 +1,788 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "021-cli",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.30.0",
+        "@sentry/node": "^10.69.0",
+        "@supabase/supabase-js": "^2.46.1",
+        "chalk": "^5.3.0",
+        "cli-table3": "^0.6.5",
+        "commander": "^12.1.0",
+        "esbuild": "^0.28.2",
+        "open": "^10.1.0",
+        "ora": "^8.1.1",
+        "zod": "^4.4.3",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.3.14",
+        "@types/node": "^26.2.0",
+        "@vercel/node": "^5.9.7",
+        "typescript": "5.8.3",
+      },
+    },
+  },
+  "packages": {
+    "@apm-js-collab/code-transformer": ["@apm-js-collab/code-transformer@0.18.1", "", { "dependencies": { "@types/estree": "^1.0.8", "astring": "^1.9.0", "esquery": "^1.7.0", "meriyah": "^6.1.4", "semifies": "^1.0.0", "source-map": "^0.6.0" }, "bin": { "code-transformer": "cli.js" } }, "sha512-u1Hb6bHjWtkSpiprwVP6YaHC1DTN4RAU3zYkUDUe7WMnJwdyU1pwTL9dFKiSJB9IiLue/EQovmyx6xhU7FFtAQ=="],
+
+    "@apm-js-collab/code-transformer-bundler-plugins": ["@apm-js-collab/code-transformer-bundler-plugins@0.7.4", "", { "dependencies": { "@apm-js-collab/code-transformer": "^0.18.1", "es-module-lexer": "^2.1.0", "magic-string": "^0.30.21", "module-details-from-path": "^1.0.4" } }, "sha512-nAfOeZPSUAQvJa1iFT/5oCrTm5YQhMMrfCNthNnaXHZiOQhu1KGuLoIx7HtbAi3wfwaBYLaICPIeenIaEwcXIg=="],
+
+    "@apm-js-collab/tracing-hooks": ["@apm-js-collab/tracing-hooks@0.13.0", "", { "dependencies": { "@apm-js-collab/code-transformer": "^0.18.0", "debug": "^4.4.1", "module-details-from-path": "^1.0.4" } }, "sha512-mTvWz9rnQwx1U3h0XPTHaX7bgfkpipLLTQyjlC2cdhQpQEuoLT0AGzoydeoq2NxfEVv6fWOOETcSbb2nptleyw=="],
+
+    "@bytecodealliance/preview2-shim": ["@bytecodealliance/preview2-shim@0.17.6", "", {}, "sha512-n3cM88gTen5980UOBAD6xDcNNL3ocTK8keab21bpx1ONdA+ARj7uD1qoFxOWCyKlkpSi195FH+GeAut7Oc6zZw=="],
+
+    "@colors/colors": ["@colors/colors@1.5.0", "", {}, "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="],
+
+    "@edge-runtime/format": ["@edge-runtime/format@2.2.1", "", {}, "sha512-JQTRVuiusQLNNLe2W9tnzBlV/GvSVcozLl4XZHk5swnRZ/v6jp8TqR8P7sqmJsQqblDZ3EztcWmLDbhRje/+8g=="],
+
+    "@edge-runtime/node-utils": ["@edge-runtime/node-utils@2.3.0", "", {}, "sha512-uUtx8BFoO1hNxtHjp3eqVPC/mWImGb2exOfGjMLUoipuWgjej+f4o/VP4bUI8U40gu7Teogd5VTeZUkGvJSPOQ=="],
+
+    "@edge-runtime/ponyfill": ["@edge-runtime/ponyfill@2.4.2", "", {}, "sha512-oN17GjFr69chu6sDLvXxdhg0Qe8EZviGSuqzR9qOiKh4MhFYGdBBcqRNzdmYeAdeRzOW2mM9yil4RftUQ7sUOA=="],
+
+    "@edge-runtime/primitives": ["@edge-runtime/primitives@4.1.0", "", {}, "sha512-Vw0lbJ2lvRUqc7/soqygUX216Xb8T3WBZ987oywz6aJqRxcwSVWwr9e+Nqo2m9bxobA9mdbWNNoRY6S9eko1EQ=="],
+
+    "@edge-runtime/vm": ["@edge-runtime/vm@3.2.0", "", { "dependencies": { "@edge-runtime/primitives": "4.1.0" } }, "sha512-0dEVyRLM/lG4gp1R/Ik5bfPl/1wX00xFwd5KcNH602tzBa09oF7pbTKETEhR1GjZ75K6OJnYFu8II2dyMhONMw=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.28.2", "", { "os": "android", "cpu": "arm" }, "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.2", "", { "os": "android", "cpu": "arm64" }, "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.28.2", "", { "os": "android", "cpu": "x64" }, "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.2", "", { "os": "linux", "cpu": "arm" }, "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.2", "", { "os": "linux", "cpu": "ia32" }, "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.2", "", { "os": "linux", "cpu": "none" }, "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.2", "", { "os": "linux", "cpu": "none" }, "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.2", "", { "os": "linux", "cpu": "none" }, "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.2", "", { "os": "linux", "cpu": "x64" }, "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.2", "", { "os": "none", "cpu": "arm64" }, "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.2", "", { "os": "none", "cpu": "x64" }, "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.2", "", { "os": "none", "cpu": "arm64" }, "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.2", "", { "os": "win32", "cpu": "x64" }, "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g=="],
+
+    "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
+
+    "@hono/node-server": ["@hono/node-server@2.1.0", "", { "peerDependencies": { "hono": "^4" } }, "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg=="],
+
+    "@isaacs/balanced-match": ["@isaacs/balanced-match@4.0.1", "", {}, "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ=="],
+
+    "@isaacs/brace-expansion": ["@isaacs/brace-expansion@5.0.1", "", { "dependencies": { "@isaacs/balanced-match": "^4.0.1" } }, "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ=="],
+
+    "@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@mapbox/node-pre-gyp": ["@mapbox/node-pre-gyp@2.0.3", "", { "dependencies": { "consola": "^3.2.3", "detect-libc": "^2.0.0", "https-proxy-agent": "^7.0.5", "node-fetch": "^2.6.7", "nopt": "^8.0.0", "semver": "^7.5.3", "tar": "^7.4.0" }, "bin": { "node-pre-gyp": "bin/node-pre-gyp" } }, "sha512-uwPAhccfFJlsfCxMYTwOdVfOz3xqyj8xYL3zJj8f0pb30tLohnnFPhLuqp4/qoEz8sNxe4SESZedcBojRefIzg=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.30.0", "", { "dependencies": { "@hono/node-server": "^1.19.9 || ^2.0.5", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA=="],
+
+    "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
+
+    "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
+
+    "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
+
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
+
+    "@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.220.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w=="],
+
+    "@opentelemetry/core": ["@opentelemetry/core@2.10.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ=="],
+
+    "@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.220.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.220.0", "import-in-the-middle": "^3.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw=="],
+
+    "@opentelemetry/resources": ["@opentelemetry/resources@2.10.0", "", { "dependencies": { "@opentelemetry/core": "2.10.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA=="],
+
+    "@opentelemetry/sdk-trace": ["@opentelemetry/sdk-trace@2.10.0", "", { "dependencies": { "@opentelemetry/core": "2.10.0", "@opentelemetry/resources": "2.10.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ=="],
+
+    "@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.10.0", "", { "dependencies": { "@opentelemetry/core": "2.10.0", "@opentelemetry/resources": "2.10.0", "@opentelemetry/sdk-trace": "2.10.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ=="],
+
+    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.43.0", "", {}, "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg=="],
+
+    "@renovatebot/pep440": ["@renovatebot/pep440@4.2.1", "", {}, "sha512-2FK1hF93Fuf1laSdfiEmJvSJPVIDHEUTz68D3Fi9s0IZrrpaEcj6pTFBTbYvsgC5du4ogrtf5re7yMMvrKNgkw=="],
+
+    "@rollup/pluginutils": ["@rollup/pluginutils@5.4.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^2.0.2", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg=="],
+
+    "@sentry/conventions": ["@sentry/conventions@0.16.0", "", {}, "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ=="],
+
+    "@sentry/core": ["@sentry/core@10.69.0", "", { "dependencies": { "@sentry/conventions": "^0.16.0" } }, "sha512-+uuqVEeiDzYuAKjZLqsROKXvRTbl/QeH0gfGRtpYib1cud4rAFWRIkFmcR7Jb7JGFYwmReyQotiTj/hcDszTZg=="],
+
+    "@sentry/node": ["@sentry/node@10.69.0", "", { "dependencies": { "@opentelemetry/api": "^1.9.1", "@opentelemetry/instrumentation": "^0.220.0", "@opentelemetry/sdk-trace-base": "^2.9.0", "@sentry/conventions": "^0.16.0", "@sentry/core": "10.69.0", "@sentry/node-core": "10.69.0", "@sentry/opentelemetry": "10.69.0", "@sentry/server-utils": "10.69.0", "import-in-the-middle": "^3.0.0" } }, "sha512-xEXA1YGIiTZbrW6MWV34uS6JGQuQg2ijTI0zed+FsJb9JZKPYel/GZK8Km26vfTVb+yCXFmWZNBesKegNcVdzg=="],
+
+    "@sentry/node-core": ["@sentry/node-core@10.69.0", "", { "dependencies": { "@sentry/conventions": "^0.16.0", "@sentry/core": "10.69.0", "@sentry/opentelemetry": "10.69.0", "import-in-the-middle": "^3.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/core": "^1.30.1 || ^2.1.0", "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1", "@opentelemetry/instrumentation": ">=0.57.1 <1", "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0" }, "optionalPeers": ["@opentelemetry/api", "@opentelemetry/core", "@opentelemetry/exporter-trace-otlp-http", "@opentelemetry/instrumentation", "@opentelemetry/sdk-trace-base"] }, "sha512-IgArHczrZJxkgxoffHscj0NxQrG6kCazgmGQnlf3j58J1ec21YaUu8Tu+7G4Lo5tCiW3teQnwlKW1ttMXSqWRw=="],
+
+    "@sentry/opentelemetry": ["@sentry/opentelemetry@10.69.0", "", { "dependencies": { "@sentry/conventions": "^0.16.0", "@sentry/core": "10.69.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/core": "^1.30.1 || ^2.1.0", "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0" } }, "sha512-3FyWV6YcEJuvLrlaKGE1dHXCI+1YO0a62w7PkwlRg8yp6K6YXkmdwu9GjqaYD+Ju4tm7uC7mHIsGFQMm0M7pqQ=="],
+
+    "@sentry/server-utils": ["@sentry/server-utils@10.69.0", "", { "dependencies": { "@apm-js-collab/code-transformer-bundler-plugins": "^0.7.3", "@apm-js-collab/tracing-hooks": "^0.13.0", "@sentry/conventions": "^0.16.0", "@sentry/core": "10.69.0", "meriyah": "^6.1.4" } }, "sha512-0MwHrA8+nNvMIsqf8m3cXwCBlUjr6AS7N6CZvHJtY1DkqEvQqEbD5VIrhzEyHN/KMZIgQ8XeDCQRhjnXFQGRhg=="],
+
+    "@supabase/auth-js": ["@supabase/auth-js@2.112.1", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-TBacB69YXSYYFFet9ISgNC2jsPExFPIWngmzeLHAWrp/xvKWfYIyhh0nyvDLryi8WP6KoexkXO9kRF6Y9oBUTA=="],
+
+    "@supabase/functions-js": ["@supabase/functions-js@2.112.1", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-t5L8qBpRC2ZswHD4A7DNL/sNpFLEeflaYaZVe5dCWvAD82pm2WOysU8EKgiJub3doxo/QU8RuDvYFlRyRk8ghw=="],
+
+    "@supabase/phoenix": ["@supabase/phoenix@0.4.5", "", {}, "sha512-aAn9H9ovVyeApKy11OWOrrOGq8DV68yWeH4ud2lN9fzn4aO8Zb5GLL9m1pUg9nLqIcT+ZDfAcsZe0E/nqdv2lw=="],
+
+    "@supabase/postgrest-js": ["@supabase/postgrest-js@2.112.1", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-oX42JgoVT8bP73/XYE1+kQdj6/Ql1j6lD6zpCoL8aq1B0uhZsz4FSoT+cBJB3pi4aPZEA0Ntkid6w7uzuAH5jQ=="],
+
+    "@supabase/realtime-js": ["@supabase/realtime-js@2.112.1", "", { "dependencies": { "@supabase/phoenix": "0.4.5", "tslib": "2.8.1" } }, "sha512-jp5TgXXTb1m2rqF6kiirOhVnvAoFHrjj7ZHOzWRa+SL+Am0BbcMcQr6FyHkJJS1ngw0TAL2DeymfGgKkSanN0A=="],
+
+    "@supabase/storage-js": ["@supabase/storage-js@2.112.1", "", { "dependencies": { "iceberg-js": "^0.8.1", "tslib": "2.8.1" } }, "sha512-FHKAQTw4KUV9nF3bnOLvZvjB3bkmtl6ltavlJfdJKdabvqMtQQ2iyBliFyp2dSHMCn9qA8c6WoZoRkgV5nxAmg=="],
+
+    "@supabase/supabase-js": ["@supabase/supabase-js@2.112.1", "", { "dependencies": { "@supabase/auth-js": "2.112.1", "@supabase/functions-js": "2.112.1", "@supabase/postgrest-js": "2.112.1", "@supabase/realtime-js": "2.112.1", "@supabase/storage-js": "2.112.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-KooEPqALZNkQCr1PBhbEImnPm6Ko6TKWiOrj3UxQki74g2KWlXGleQgEudUwRAKZs5U1ilSssO0TpxgVOspihQ=="],
+
+    "@ts-morph/common": ["@ts-morph/common@0.11.1", "", { "dependencies": { "fast-glob": "^3.2.7", "minimatch": "^3.0.4", "mkdirp": "^1.0.4", "path-browserify": "^1.0.1" } }, "sha512-7hWZS0NRpEsNV8vWJzg7FEz6V8MaLNeJOmwmghqUXTpzk16V1LLZhdo+4QvE/+zv4cVci0OviuJFnqhEfoV3+g=="],
+
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
+    "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
+
+    "@types/node": ["@types/node@26.2.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg=="],
+
+    "@vercel/build-utils": ["@vercel/build-utils@14.0.3", "", { "dependencies": { "@vercel/python-analysis": "0.13.1", "cjs-module-lexer": "1.2.3", "es-module-lexer": "1.5.0" } }, "sha512-yfK9NmS/P9p7Sk5XebxwpIqIUQCj2qRdHMmlZ+r4mp45Xy4jJeLoCN5TsyZc3yUN7wJmJHcRYdTy421pCMA2PQ=="],
+
+    "@vercel/error-utils": ["@vercel/error-utils@2.2.1", "", {}, "sha512-9DhP8jP7raLML4hGsBemxX5fXuQnu5xxMV+HjGygGbzEmVK/+KyJ3QP2Cw7PdF0uXdb9N0Qa4c3tRGH34ZX6vw=="],
+
+    "@vercel/nft": ["@vercel/nft@1.10.0", "", { "dependencies": { "@mapbox/node-pre-gyp": "^2.0.0", "@rollup/pluginutils": "^5.1.3", "acorn": "^8.6.0", "acorn-import-attributes": "^1.9.5", "async-sema": "^3.1.1", "bindings": "^1.4.0", "estree-walker": "2.0.2", "glob": "^13.0.0", "graceful-fs": "^4.2.9", "node-gyp-build": "^4.2.2", "picomatch": "^4.0.2", "resolve-from": "^5.0.0" }, "bin": { "nft": "out/cli.js" } }, "sha512-iLOW4fcsgkipfOh2Bw3wB38YDfxTlxr7+j4uFeui2OswkNT28jIitS/aMce7tS0mef1YPQ8zLIDYr3a0aahNrA=="],
+
+    "@vercel/node": ["@vercel/node@5.9.7", "", { "dependencies": { "@edge-runtime/node-utils": "2.3.0", "@edge-runtime/primitives": "4.1.0", "@edge-runtime/vm": "3.2.0", "@types/node": "20.11.0", "@vercel/build-utils": "14.0.3", "@vercel/error-utils": "2.2.1", "@vercel/nft": "1.10.0", "@vercel/static-config": "3.4.1", "async-listen": "3.0.0", "cjs-module-lexer": "1.2.3", "edge-runtime": "2.5.9", "es-module-lexer": "1.4.1", "esbuild": "0.27.0", "etag": "1.8.1", "mime-types": "2.1.35", "node-fetch": "2.6.9", "path-to-regexp": "6.1.0", "path-to-regexp-updated": "npm:path-to-regexp@6.3.0", "ts-morph": "12.0.0", "tsx": "4.21.0", "typescript": "npm:typescript@5.9.3", "undici": "5.28.4" } }, "sha512-ekJSoPjuoeyCSsFm5Z7LEsFQoBXHCoBT4UMISjWIP5jLNKKTWxTSyTpwceLbPmBbc5q88iwMjhkIRRQWMm8LBQ=="],
+
+    "@vercel/python-analysis": ["@vercel/python-analysis@0.13.1", "", { "dependencies": { "@bytecodealliance/preview2-shim": "0.17.6", "@renovatebot/pep440": "4.2.1", "fs-extra": "11.1.1", "js-yaml": "4.1.1", "minimatch": "10.1.1", "smol-toml": "1.5.2", "zod": "3.22.4" } }, "sha512-ec4tii9I7i6eHfvsvG/eaNaKh0TxmxBsc904V7yjwZImeyFTEVvDSLQ/+510FB+wBG6gCvpyqBH5aAKP9llqsw=="],
+
+    "@vercel/static-config": ["@vercel/static-config@3.4.1", "", { "dependencies": { "ajv": "8.6.3", "json-schema-to-ts": "1.6.4", "ts-morph": "12.0.0" } }, "sha512-kJKTyOg25JDRgDkHEkc+vWlvURxmSQkVKyRPO4EEGD/8HpJT+4u9Z/VGxwnCZ6zZBxYPpma283qBsHwY0gXjfw=="],
+
+    "abbrev": ["abbrev@3.0.1", "", {}, "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg=="],
+
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "acorn": ["acorn@8.18.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ=="],
+
+    "acorn-import-attributes": ["acorn-import-attributes@1.9.5", "", { "peerDependencies": { "acorn": "^8" } }, "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ=="],
+
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "astring": ["astring@1.9.0", "", { "bin": { "astring": "bin/astring" } }, "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg=="],
+
+    "async-listen": ["async-listen@3.0.0", "", {}, "sha512-V+SsTpDqkrWTimiotsyl33ePSjA5/KrithwupuvJ6ztsqPvGv6ge4OredFhPffVXiLN/QUWvE0XcqJaYgt6fOg=="],
+
+    "async-sema": ["async-sema@3.1.1", "", {}, "sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg=="],
+
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "bindings": ["bindings@1.5.0", "", { "dependencies": { "file-uri-to-path": "1.0.0" } }, "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="],
+
+    "body-parser": ["body-parser@2.3.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^2.0.0", "debug": "^4.4.3", "http-errors": "^2.0.1", "iconv-lite": "^0.7.2", "on-finished": "^2.4.1", "qs": "^6.15.2", "raw-body": "^3.0.2", "type-is": "^2.1.0" } }, "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw=="],
+
+    "brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
+
+    "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
+
+    "cjs-module-lexer": ["cjs-module-lexer@1.2.3", "", {}, "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ=="],
+
+    "cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
+
+    "cli-spinners": ["cli-spinners@2.9.2", "", {}, "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg=="],
+
+    "cli-table3": ["cli-table3@0.6.5", "", { "dependencies": { "string-width": "^4.2.0" }, "optionalDependencies": { "@colors/colors": "1.5.0" } }, "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ=="],
+
+    "code-block-writer": ["code-block-writer@10.1.1", "", {}, "sha512-67ueh2IRGst/51p0n6FvPrnRjAGHY5F8xdjkgrYE7DDzpJe6qA07RYQ9VcoUeo5ATOjSOiWpSL3SWBRRbempMw=="],
+
+    "commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
+
+    "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
+
+    "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
+
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "convert-hrtime": ["convert-hrtime@3.0.0", "", {}, "sha512-7V+KqSvMiHp8yWDuwfww06XleMWVVB9b9tURBx+G7UTADuo5hYPuowKloz4OzOqbPezxgo+fdQ1522WzPG4OeA=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "default-browser": ["default-browser@5.5.0", "", { "dependencies": { "bundle-name": "^4.1.0", "default-browser-id": "^5.0.0" } }, "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw=="],
+
+    "default-browser-id": ["default-browser-id@5.0.1", "", {}, "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q=="],
+
+    "define-lazy-prop": ["define-lazy-prop@3.0.0", "", {}, "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "edge-runtime": ["edge-runtime@2.5.9", "", { "dependencies": { "@edge-runtime/format": "2.2.1", "@edge-runtime/ponyfill": "2.4.2", "@edge-runtime/vm": "3.2.0", "async-listen": "3.0.1", "mri": "1.2.0", "picocolors": "1.0.0", "pretty-ms": "7.0.1", "signal-exit": "4.0.2", "time-span": "4.0.0" }, "bin": { "edge-runtime": "dist/cli/index.js" } }, "sha512-pk+k0oK0PVXdlT4oRp4lwh+unuKB7Ng4iZ2HB+EZ7QCEQizX360Rp/F4aRpgpRgdP2ufB35N+1KppHmYjqIGSg=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-module-lexer": ["es-module-lexer@1.4.1", "", {}, "sha512-cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
+
+    "esbuild": ["esbuild@0.28.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.2", "@esbuild/android-arm": "0.28.2", "@esbuild/android-arm64": "0.28.2", "@esbuild/android-x64": "0.28.2", "@esbuild/darwin-arm64": "0.28.2", "@esbuild/darwin-x64": "0.28.2", "@esbuild/freebsd-arm64": "0.28.2", "@esbuild/freebsd-x64": "0.28.2", "@esbuild/linux-arm": "0.28.2", "@esbuild/linux-arm64": "0.28.2", "@esbuild/linux-ia32": "0.28.2", "@esbuild/linux-loong64": "0.28.2", "@esbuild/linux-mips64el": "0.28.2", "@esbuild/linux-ppc64": "0.28.2", "@esbuild/linux-riscv64": "0.28.2", "@esbuild/linux-s390x": "0.28.2", "@esbuild/linux-x64": "0.28.2", "@esbuild/netbsd-arm64": "0.28.2", "@esbuild/netbsd-x64": "0.28.2", "@esbuild/openbsd-arm64": "0.28.2", "@esbuild/openbsd-x64": "0.28.2", "@esbuild/openharmony-arm64": "0.28.2", "@esbuild/sunos-x64": "0.28.2", "@esbuild/win32-arm64": "0.28.2", "@esbuild/win32-ia32": "0.28.2", "@esbuild/win32-x64": "0.28.2" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "esquery": ["esquery@1.7.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
+    "estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.1.0", "", {}, "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.6.2", "", { "dependencies": { "debug": "^4.4.3", "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
+
+    "fast-uri": ["fast-uri@3.1.5", "", {}, "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="],
+
+    "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
+
+    "file-uri-to-path": ["file-uri-to-path@1.0.0", "", {}, "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="],
+
+    "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "fs-extra": ["fs-extra@11.1.1", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "get-tsconfig": ["get-tsconfig@4.14.1", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-Dz/6HxkrxgNehhxLVeyv8sad9UzF2xBVeaKBQNDfJ5XiSXmp2gTR0eO0RWiT2NCKS5aGP9jjkOMggTN90qU50A=="],
+
+    "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
+
+    "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
+
+    "hono": ["hono@4.13.1", "", {}, "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "iceberg-js": ["iceberg-js@0.8.1", "", {}, "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA=="],
+
+    "iconv-lite": ["iconv-lite@0.7.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ=="],
+
+    "import-in-the-middle": ["import-in-the-middle@3.3.3", "", { "dependencies": { "cjs-module-lexer": "^2.2.0", "es-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-AiohS3H80sXO6owEltjGX+glb7qXaDhBoJb9XcQVH4UI207xu/bDLUcadVKp7Qe576reg9yr/PXZjV5qx8gfbA=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ip-address": ["ip-address@10.4.0", "", {}, "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
+
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "is-inside-container": ["is-inside-container@1.0.0", "", { "dependencies": { "is-docker": "^3.0.0" }, "bin": { "is-inside-container": "cli.js" } }, "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA=="],
+
+    "is-interactive": ["is-interactive@2.0.0", "", {}, "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ=="],
+
+    "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "is-unicode-supported": ["is-unicode-supported@2.1.0", "", {}, "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ=="],
+
+    "is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jose": ["jose@6.2.8", "", {}, "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ=="],
+
+    "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
+    "json-schema-to-ts": ["json-schema-to-ts@1.6.4", "", { "dependencies": { "@types/json-schema": "^7.0.6", "ts-toolbelt": "^6.15.5" } }, "sha512-pR4yQ9DHz6itqswtHCm26mw45FSNfQ9rEQjosaZErhn5J3J2sIViQiz8rDaezjKAhFGpmsoczYVBgGHzFw/stA=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
+
+    "jsonfile": ["jsonfile@6.2.1", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q=="],
+
+    "log-symbols": ["log-symbols@6.0.0", "", { "dependencies": { "chalk": "^5.3.0", "is-unicode-supported": "^1.3.0" } }, "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw=="],
+
+    "lru-cache": ["lru-cache@11.5.2", "", {}, "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.1", "", {}, "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
+
+    "meriyah": ["meriyah@6.1.4", "", {}, "sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ=="],
+
+    "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
+
+    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
+
+    "minimatch": ["minimatch@10.1.1", "", { "dependencies": { "@isaacs/brace-expansion": "^5.0.0" } }, "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ=="],
+
+    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
+    "minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
+
+    "mkdirp": ["mkdirp@1.0.4", "", { "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="],
+
+    "module-details-from-path": ["module-details-from-path@1.0.4", "", {}, "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="],
+
+    "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "node-fetch": ["node-fetch@2.6.9", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg=="],
+
+    "node-gyp-build": ["node-gyp-build@4.8.4", "", { "bin": { "node-gyp-build": "bin.js", "node-gyp-build-optional": "optional.js", "node-gyp-build-test": "build-test.js" } }, "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ=="],
+
+    "nopt": ["nopt@8.1.0", "", { "dependencies": { "abbrev": "^3.0.0" }, "bin": { "nopt": "bin/nopt.js" } }, "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
+
+    "open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
+
+    "ora": ["ora@8.2.0", "", { "dependencies": { "chalk": "^5.3.0", "cli-cursor": "^5.0.0", "cli-spinners": "^2.9.2", "is-interactive": "^2.0.0", "is-unicode-supported": "^2.0.0", "log-symbols": "^6.0.0", "stdin-discarder": "^0.2.2", "string-width": "^7.2.0", "strip-ansi": "^7.1.0" } }, "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw=="],
+
+    "parse-ms": ["parse-ms@2.1.0", "", {}, "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
+
+    "path-to-regexp": ["path-to-regexp@6.1.0", "", {}, "sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw=="],
+
+    "path-to-regexp-updated": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
+
+    "picocolors": ["picocolors@1.0.0", "", {}, "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="],
+
+    "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
+    "pretty-ms": ["pretty-ms@7.0.1", "", { "dependencies": { "parse-ms": "^2.1.0" } }, "sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "qs": ["qs@6.15.3", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A=="],
+
+    "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
+
+    "range-parser": ["range-parser@1.3.0", "", {}, "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "require-in-the-middle": ["require-in-the-middle@8.0.1", "", { "dependencies": { "debug": "^4.3.5", "module-details-from-path": "^1.0.3" } }, "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ=="],
+
+    "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
+
+    "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
+
+    "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
+
+    "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
+
+    "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "semifies": ["semifies@1.0.0", "", {}, "sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw=="],
+
+    "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4", "side-channel-list": "^1.0.1", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "signal-exit": ["signal-exit@4.0.2", "", {}, "sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q=="],
+
+    "smol-toml": ["smol-toml@1.5.2", "", {}, "sha512-QlaZEqcAH3/RtNyet1IPIYPsEWAaYyXXv1Krsi+1L/QHppjX4Ifm8MQsBISz9vE8cHicIq3clogsheili5vhaQ=="],
+
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "stdin-discarder": ["stdin-discarder@0.2.2", "", {}, "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ=="],
+
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "tar": ["tar@7.5.22", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA=="],
+
+    "time-span": ["time-span@4.0.0", "", { "dependencies": { "convert-hrtime": "^3.0.0" } }, "sha512-MyqZCTGLDZ77u4k+jqg4UlrzPTPZ49NDlaekU6uuFaJLzPIN1woaRXCbGeqOfxwc3Y37ZROGAJ614Rdv7Olt+g=="],
+
+    "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
+
+    "ts-morph": ["ts-morph@12.0.0", "", { "dependencies": { "@ts-morph/common": "~0.11.0", "code-block-writer": "^10.1.1" } }, "sha512-VHC8XgU2fFW7yO1f/b3mxKDje1vmyzFXHWzOYmKEkCEwcLjDtbdLgBQviqj4ZwP4MJkQtRo6Ha2I29lq/B+VxA=="],
+
+    "ts-toolbelt": ["ts-toolbelt@6.15.5", "", {}, "sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
+
+    "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
+
+    "typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
+
+    "undici": ["undici@5.28.4", "", { "dependencies": { "@fastify/busboy": "^2.0.0" } }, "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
+    "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
+
+    "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "wsl-utils": ["wsl-utils@0.1.0", "", { "dependencies": { "is-wsl": "^3.1.0" } }, "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw=="],
+
+    "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
+
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
+    "@apm-js-collab/code-transformer-bundler-plugins/es-module-lexer": ["es-module-lexer@2.3.1", "", {}, "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA=="],
+
+    "@ts-morph/common/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
+    "@vercel/build-utils/es-module-lexer": ["es-module-lexer@1.5.0", "", {}, "sha512-pqrTKmwEIgafsYZAGw9kszYzmagcE/n4dbgwGWLEXg7J4QFJVQRBld8j3Q3GNez79jzxZshq0bcT962QHOghjw=="],
+
+    "@vercel/node/@types/node": ["@types/node@20.11.0", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-o9bjXmDNcF7GbM4CNQpmi+TutCgap/K3w1JyKgxAjqx41zp9qlIAVFi0IhCNsJcXolEqLWhbFbEeL0PvYm4pcQ=="],
+
+    "@vercel/node/esbuild": ["esbuild@0.27.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.0", "@esbuild/android-arm": "0.27.0", "@esbuild/android-arm64": "0.27.0", "@esbuild/android-x64": "0.27.0", "@esbuild/darwin-arm64": "0.27.0", "@esbuild/darwin-x64": "0.27.0", "@esbuild/freebsd-arm64": "0.27.0", "@esbuild/freebsd-x64": "0.27.0", "@esbuild/linux-arm": "0.27.0", "@esbuild/linux-arm64": "0.27.0", "@esbuild/linux-ia32": "0.27.0", "@esbuild/linux-loong64": "0.27.0", "@esbuild/linux-mips64el": "0.27.0", "@esbuild/linux-ppc64": "0.27.0", "@esbuild/linux-riscv64": "0.27.0", "@esbuild/linux-s390x": "0.27.0", "@esbuild/linux-x64": "0.27.0", "@esbuild/netbsd-arm64": "0.27.0", "@esbuild/netbsd-x64": "0.27.0", "@esbuild/openbsd-arm64": "0.27.0", "@esbuild/openbsd-x64": "0.27.0", "@esbuild/openharmony-arm64": "0.27.0", "@esbuild/sunos-x64": "0.27.0", "@esbuild/win32-arm64": "0.27.0", "@esbuild/win32-ia32": "0.27.0", "@esbuild/win32-x64": "0.27.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA=="],
+
+    "@vercel/node/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "@vercel/python-analysis/zod": ["zod@3.22.4", "", {}, "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg=="],
+
+    "@vercel/static-config/ajv": ["ajv@8.6.3", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2", "uri-js": "^4.2.2" } }, "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw=="],
+
+    "accepts/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
+    "bun-types/@types/node": ["@types/node@26.1.2", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg=="],
+
+    "edge-runtime/async-listen": ["async-listen@3.0.1", "", {}, "sha512-cWMaNwUJnf37C/S5TfCkk/15MwbPRwVYALA2jtjkbHjCmAPiDXyNJy2q3p1KAZzDLHAWyarUWSujUoHR4pEgrA=="],
+
+    "express/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "glob/minimatch": ["minimatch@10.2.6", "", { "dependencies": { "brace-expansion": "^5.0.8" } }, "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A=="],
+
+    "import-in-the-middle/cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
+
+    "import-in-the-middle/es-module-lexer": ["es-module-lexer@2.3.1", "", {}, "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA=="],
+
+    "log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
+
+    "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
+    "ora/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "restore-cursor/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "router/path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
+    "send/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "tsx/esbuild": ["esbuild@0.27.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.0", "@esbuild/android-arm": "0.27.0", "@esbuild/android-arm64": "0.27.0", "@esbuild/android-x64": "0.27.0", "@esbuild/darwin-arm64": "0.27.0", "@esbuild/darwin-x64": "0.27.0", "@esbuild/freebsd-arm64": "0.27.0", "@esbuild/freebsd-x64": "0.27.0", "@esbuild/linux-arm": "0.27.0", "@esbuild/linux-arm64": "0.27.0", "@esbuild/linux-ia32": "0.27.0", "@esbuild/linux-loong64": "0.27.0", "@esbuild/linux-mips64el": "0.27.0", "@esbuild/linux-ppc64": "0.27.0", "@esbuild/linux-riscv64": "0.27.0", "@esbuild/linux-s390x": "0.27.0", "@esbuild/linux-x64": "0.27.0", "@esbuild/netbsd-arm64": "0.27.0", "@esbuild/netbsd-x64": "0.27.0", "@esbuild/openbsd-arm64": "0.27.0", "@esbuild/openbsd-x64": "0.27.0", "@esbuild/openharmony-arm64": "0.27.0", "@esbuild/sunos-x64": "0.27.0", "@esbuild/win32-arm64": "0.27.0", "@esbuild/win32-ia32": "0.27.0", "@esbuild/win32-x64": "0.27.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA=="],
+
+    "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
+    "type-is/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "@ts-morph/common/minimatch/brace-expansion": ["brace-expansion@1.1.18", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw=="],
+
+    "@vercel/node/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
+
+    "@vercel/node/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.0", "", { "os": "aix", "cpu": "ppc64" }, "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A=="],
+
+    "@vercel/node/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.0", "", { "os": "android", "cpu": "arm" }, "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ=="],
+
+    "@vercel/node/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.0", "", { "os": "android", "cpu": "arm64" }, "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ=="],
+
+    "@vercel/node/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.0", "", { "os": "android", "cpu": "x64" }, "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q=="],
+
+    "@vercel/node/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg=="],
+
+    "@vercel/node/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g=="],
+
+    "@vercel/node/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw=="],
+
+    "@vercel/node/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g=="],
+
+    "@vercel/node/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.0", "", { "os": "linux", "cpu": "arm" }, "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ=="],
+
+    "@vercel/node/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ=="],
+
+    "@vercel/node/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.0", "", { "os": "linux", "cpu": "ia32" }, "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw=="],
+
+    "@vercel/node/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg=="],
+
+    "@vercel/node/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg=="],
+
+    "@vercel/node/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA=="],
+
+    "@vercel/node/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ=="],
+
+    "@vercel/node/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w=="],
+
+    "@vercel/node/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.0", "", { "os": "linux", "cpu": "x64" }, "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw=="],
+
+    "@vercel/node/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.0", "", { "os": "none", "cpu": "arm64" }, "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w=="],
+
+    "@vercel/node/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.0", "", { "os": "none", "cpu": "x64" }, "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA=="],
+
+    "@vercel/node/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.0", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ=="],
+
+    "@vercel/node/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A=="],
+
+    "@vercel/node/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.0", "", { "os": "none", "cpu": "arm64" }, "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA=="],
+
+    "@vercel/node/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.0", "", { "os": "sunos", "cpu": "x64" }, "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA=="],
+
+    "@vercel/node/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg=="],
+
+    "@vercel/node/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ=="],
+
+    "@vercel/node/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.0", "", { "os": "win32", "cpu": "x64" }, "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg=="],
+
+    "accepts/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "express/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "ora/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "send/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.0", "", { "os": "aix", "cpu": "ppc64" }, "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A=="],
+
+    "tsx/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.0", "", { "os": "android", "cpu": "arm" }, "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ=="],
+
+    "tsx/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.0", "", { "os": "android", "cpu": "arm64" }, "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ=="],
+
+    "tsx/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.0", "", { "os": "android", "cpu": "x64" }, "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q=="],
+
+    "tsx/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg=="],
+
+    "tsx/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g=="],
+
+    "tsx/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw=="],
+
+    "tsx/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g=="],
+
+    "tsx/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.0", "", { "os": "linux", "cpu": "arm" }, "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ=="],
+
+    "tsx/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ=="],
+
+    "tsx/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.0", "", { "os": "linux", "cpu": "ia32" }, "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw=="],
+
+    "tsx/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg=="],
+
+    "tsx/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg=="],
+
+    "tsx/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA=="],
+
+    "tsx/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ=="],
+
+    "tsx/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w=="],
+
+    "tsx/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.0", "", { "os": "linux", "cpu": "x64" }, "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw=="],
+
+    "tsx/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.0", "", { "os": "none", "cpu": "arm64" }, "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w=="],
+
+    "tsx/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.0", "", { "os": "none", "cpu": "x64" }, "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA=="],
+
+    "tsx/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.0", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ=="],
+
+    "tsx/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A=="],
+
+    "tsx/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.0", "", { "os": "none", "cpu": "arm64" }, "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA=="],
+
+    "tsx/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.0", "", { "os": "sunos", "cpu": "x64" }, "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA=="],
+
+    "tsx/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg=="],
+
+    "tsx/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ=="],
+
+    "tsx/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.0", "", { "os": "win32", "cpu": "x64" }, "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg=="],
+
+    "type-is/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "@ts-morph/common/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+  }
+}

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1,0 +1,321 @@
+#!/usr/bin/env bun
+import { Command } from 'commander';
+import { loadEnv, assertEnv } from './lib/config.ts';
+
+await loadEnv();
+
+const program = new Command();
+
+// Validate required env vars before any command runs (not before --help).
+program.hook('preAction', () => assertEnv());
+
+program
+  .name('anomalia')
+  .description('CLI per gestire Anomalia — social media AI autopilot')
+  .version('0.1.0')
+  .addHelpText('after', `
+Esempi:
+  $ anomalia brands                   Lista tutti i brand
+  $ anomalia dashboard my-brand       Dashboard completa
+  $ anomalia approve my-brand --all   Approva tutti i post pending
+  $ anomalia seo my-brand             Grade SEO, iniziative, audit tecnico
+  $ anomalia geo my-brand             Visibilità AI, share of voice, citazioni
+  $ anomalia keywords my-brand        Keyword strategy e opportunità
+  $ anomalia web my-brand             Articoli blog (draft + pubblicati)
+
+Documentazione completa: cli/README.md
+`);
+
+program
+  .command('login')
+  .description('Accedi a Anomalia (apre il browser)')
+  .action(async () => {
+    const { cmdLogin } = await import('./commands/login.ts');
+    await cmdLogin();
+  });
+
+program
+  .command('logout')
+  .description('Disconnettiti da Anomalia')
+  .action(async () => {
+    const { cmdLogout } = await import('./commands/logout.ts');
+    await cmdLogout();
+  });
+
+program
+  .command('brands')
+  .description('Elenca tutti i brand con status e autopilot')
+  .action(async () => {
+    const { cmdBrands } = await import('./commands/brands.ts');
+    await cmdBrands();
+  });
+
+program
+  .command('status <slug>')
+  .description('Status dettagliato di un brand (post pending, quota, ultimi run)')
+  .action(async (slug: string) => {
+    const { cmdStatus } = await import('./commands/status.ts');
+    await cmdStatus(slug);
+  });
+
+program
+  .command('health')
+  .description('Verifica lo stato delle API (Supabase, Gemini, Zernio)')
+  .action(async () => {
+    const { cmdHealth } = await import('./commands/health.ts');
+    await cmdHealth();
+  });
+
+program
+  .command('approve <slug>')
+  .description('Approva e pubblica i post pending di un brand')
+  .option('--all', 'Approva senza chiedere conferma')
+  .option('--dry', 'Mostra i post senza approvarli')
+  .action(async (slug: string, opts: { all?: boolean; dry?: boolean }) => {
+    const { cmdApprove } = await import('./commands/approve.ts');
+    await cmdApprove(slug, opts);
+  });
+
+program
+  .command('analytics <slug>')
+  .description('Analytics di un brand: engagement, top post, attività recente')
+  .action(async (slug: string) => {
+    const { cmdAnalytics } = await import('./commands/analytics.ts');
+    await cmdAnalytics(slug);
+  });
+
+program
+  .command('plan <slug> [action]')
+  .description('Piano editoriale: show, propose, revise, approve, discard, save-brief, replan')
+  .option('--feedback <text>', 'Feedback per revisione')
+  .option('--week <n>', 'Indice settimana (0-3)', parseInt)
+  .option('--brief <text>', 'Brief per la settimana')
+  .option('--products <list>', 'Prodotti da featuring (nomi esatti, separati da virgola)')
+  .option('--clear-products', 'Azzera i prodotti featured della settimana (l\'AI sceglie liberamente)')
+  .action(async (slug: string, action: string | undefined, opts: Record<string, string | number | boolean>) => {
+    const { cmdPlan } = await import('./commands/plan.ts');
+    await cmdPlan(slug, { action: action ?? 'show', ...opts as any });
+  });
+
+program
+  .command('dashboard <slug>')
+  .description('Dashboard completa di un brand: stats, pipeline, stato autopilot')
+  .action(async (slug: string) => {
+    const { cmdDashboard } = await import('./commands/dashboard.ts');
+    await cmdDashboard(slug);
+  });
+
+program
+  .command('weekly-plan <slug> [action]')
+  .description('Piano settimanale: show, plan (genera seeds), produce (genera post), render (genera immagini)')
+  .option('--week <n>', 'Numero settimana (0-3)', parseInt)
+  .option('--verbose', 'Mostra il verdetto QC del review immagini (con render)')
+  .action(async (slug: string, action: string | undefined, opts: { week?: number; verbose?: boolean }) => {
+    const { cmdWeeklyPlan } = await import('./commands/weekly-plan.ts');
+    await cmdWeeklyPlan(slug, { action: action ?? 'show', ...opts });
+  });
+
+program
+  .command('products <slug> [action]')
+  .description('Prodotti: list (elenca), sync (reimporta dal sito e-commerce)')
+  .action(async (slug: string, action: string | undefined) => {
+    const { cmdProducts } = await import('./commands/products.ts');
+    await cmdProducts(slug, { action: action ?? 'list' });
+  });
+
+program
+  .command('people <slug> [action]')
+  .description('Persone: list, add (--name --gender …), remove (--id)')
+  .option('--name <text>', 'Nome persona')
+  .option('--role <text>', 'Ruolo')
+  .option('--description <text>', 'Descrizione')
+  .option('--gender <g>', 'Genere (female/male)')
+  .option('--ageRange <range>', 'Fascia età (es. 26-35)')
+  .option('--kind <kind>', 'ai (genera foto) o real (default)')
+  .option('--id <id>', 'ID persona (per remove)')
+  .action(async (slug: string, action: string | undefined, opts: Record<string, string>) => {
+    const { cmdPeople } = await import('./commands/people.ts');
+    await cmdPeople(slug, { action: action ?? 'list', ...opts as any });
+  });
+
+program
+  .command('gtm <slug>')
+  .description('GTM Roadmap: fasi di crescita, KPI, strategia platform')
+  .action(async (slug: string) => {
+    const { cmdGtm } = await import('./commands/gtm.ts');
+    await cmdGtm(slug);
+  });
+
+program
+  .command('studio <slug> [action]')
+  .description('Studio: visualizza e gestisci knowledge base, brand kit, persone, competitors, knowledge')
+  .option('--about <text>', 'Descrizione brand (kit-update)')
+  .option('--category <text>', 'Categoria brand (kit-update)')
+  .option('--audience <text>', 'Target audience (kit-update)')
+  .option('--style <text>', 'Stile visivo (kit-update)')
+  .option('--language <lang>', 'Lingua post (kit-update)')
+  .option('--colors <hex>', 'Colori brand separati da virgola (colors)')
+  .option('--name <name>', 'Nome persona/competitor')
+  .option('--role <role>', 'Ruolo persona')
+  .option('--description <text>', 'Descrizione persona')
+  .option('--kind <kind>', 'Tipo: real|ai (people) o direct|indirect (competitors)')
+  .option('--gender <gender>', 'Genere persona AI: female|male|non-binary')
+  .option('--ageRange <range>', 'Fascia età AI: 18-25|26-35|36-50|50+')
+  .option('--vibe <vibe>', 'Stile AI: professional|casual|luxury|sporty|creative|natural')
+  .option('--title <title>', 'Titolo nota (add-note)')
+  .option('--text <text>', 'Testo nota (add-note)')
+  .option('--website <url>', 'Sito web competitor')
+  .option('--compKind <kind>', 'Tipo competitor: direct|indirect')
+  .option('--rationale <text>', 'Motivo competitor')
+  .option('--id <uuid>', 'ID da eliminare (people-delete, delete-doc, delete-competitor)')
+  .action(async (slug: string, action: string | undefined, opts: Record<string, string>) => {
+    const { cmdStudio } = await import('./commands/studio.ts');
+    await cmdStudio(slug, { action: action ?? 'show', ...opts });
+  });
+
+program
+  .command('voice <slug>')
+  .description('Voice: tono, registro, regole per platform, parole vietate')
+  .action(async (slug: string) => {
+    const { cmdVoice } = await import('./commands/voice.ts');
+    await cmdVoice(slug);
+  });
+
+program
+  .command('content <slug>')
+  .description('Content Library: tutti i post con filtri per status')
+  .option('--status <status>', 'Filtra per status: all, pending_user, approved, scheduled, published, failed')
+  .option('--clear <status>', 'Elimina in blocco i post con questo status (es. pending_user)')
+  .action(async (slug: string, opts: { status?: string; clear?: string }) => {
+    const { cmdContent } = await import('./commands/content.ts');
+    await cmdContent(slug, opts);
+  });
+
+program
+  .command('calendar <slug>')
+  .description('Calendario mensile dei post schedulati')
+  .option('--month <YYYY-MM>', 'Mese da visualizzare (default: mese corrente)')
+  .action(async (slug: string, opts: { month?: string }) => {
+    const { cmdCalendar } = await import('./commands/calendar.ts');
+    await cmdCalendar(slug, opts);
+  });
+
+program
+  .command('post <slug> <postId> [action]')
+  .description('Post singolo: show, edit, regenerate, slide, reorder, video, render, approve, publish, reject, reschedule')
+  .option('--caption <text>', 'Nuova caption')
+  .option('--title <text>', 'Titolo (Reddit, carosello, link post)')
+  .option('--link <url>', 'URL del link post ("" per rimuoverlo)')
+  .option('--subreddit <name>', 'Subreddit di destinazione')
+  .option('--firstComment <text>', 'Primo commento (hashtag / CTA)')
+  .option('--imagePrompt <text>', 'Nuovo prompt immagine')
+  .option('--media <url>', 'Media URL ("" per renderlo text-only)')
+  .option('--format <format>', 'single_image | carousel | text_post | link_post | video')
+  .option('--platforms <list>', 'Piattaforme (separata da virgola)')
+  .option('--platformCaption <pair>', 'Caption per piattaforma: x="testo" (ripetibile)', (v: string, acc: string[]) => [...acc, v], [] as string[])
+  .option('--contentType <type>', 'Tipo contenuto')
+  .option('--slot <datetime>', 'Data/ora slot')
+  .option('--product <name>', 'Prodotto associato')
+  .option('--scheduledFor <datetime>', 'Nuova data programmazione (reschedule)')
+  .option('--instruction <text>', 'Cosa cambiare (regenerate, slide, video)')
+  .option('--prompt <text>', 'Prompt completo sostitutivo (regenerate, slide)')
+  .option('--index <n>', 'Indice slide, 0 = copertina (slide)')
+  .option('--order <list>', 'Nuovo ordine slide, es. "0,2,1" (reorder)')
+  .option('--duration <seconds>', 'Durata del clip in secondi (video)')
+  .option('--script <text>', 'Battuta parlata/on-screen, tagliata sulla durata (video)')
+  .option('--aspectRatio <ratio>', '9:16 | 1:1 | 16:9 | 4:3 | 3:4 | 21:9 (video)')
+  .action(async (slug: string, postId: string, action: string | undefined, opts: Record<string, unknown>) => {
+    const { cmdPost } = await import('./commands/post.ts');
+    await cmdPost(slug, postId, { action: action ?? 'show', ...opts as any });
+  });
+
+program
+  .command('seo <slug> [action]')
+  .description('SEO: show, run (audit tecnico), plan, more (altre iniziative), asset --id, article --id')
+  .option('--id <id>', 'ID iniziativa (anche solo il prefisso mostrato in tabella)')
+  .option('--guidance <text>', 'Indicazione per le nuove iniziative (more)')
+  .action(async (slug: string, action: string | undefined, opts: { id?: string; guidance?: string }) => {
+    const { cmdSeo } = await import('./commands/seo.ts');
+    await cmdSeo(slug, { action: action ?? 'show', ...opts });
+  });
+
+program
+  .command('geo <slug> [action]')
+  .description('GEO: show (share of voice, citazioni), run (audit), fix (genera artifact)')
+  .action(async (slug: string, action: string | undefined) => {
+    const { cmdGeo } = await import('./commands/geo.ts');
+    await cmdGeo(slug, { action: action ?? 'show' });
+  });
+
+program
+  .command('keywords <slug> [action]')
+  .description('Keyword strategy: show, refresh (rigenera la ricerca)')
+  .action(async (slug: string, action: string | undefined) => {
+    const { cmdKeywords } = await import('./commands/keywords.ts');
+    await cmdKeywords(slug, { action: action ?? 'show' });
+  });
+
+program
+  .command('web <slug> [action]')
+  .description('Blog: list, generate --topic, publish/unpublish/optimize/delete --id')
+  .option('--status <status>', 'Filtro: all, draft, scheduled, published', 'all')
+  .option('--topic <text>', 'Argomento dell\'articolo (generate)')
+  .option('--id <id>', 'ID articolo (anche solo il prefisso mostrato in tabella)')
+  .action(async (slug: string, action: string | undefined, opts: { status?: string; topic?: string; id?: string }) => {
+    const { cmdWeb } = await import('./commands/web.ts');
+    await cmdWeb(slug, { action: action ?? 'list', ...opts });
+  });
+
+program
+  .command('ads <slug>')
+  .description('Ads via Zernio: list, propose boosts, approve spend, create standalone')
+  .option('--propose', 'Crea proposte di boost dai post organici migliori')
+  .option('--approve <id>', 'Approva e lancia una campagna proposta (spende budget)')
+  .option('--reject <id>', 'Rifiuta una proposta')
+  .option('--duplicate <id>', 'Duplica una campagna live (copia in pausa, poi approva)')
+  .option('--delete <id>', 'Elimina una campagna sulla piattaforma (storico conservato)')
+  .option('--pause <id>', 'Metti in pausa una campagna attiva')
+  .option('--resume <id>', 'Riattiva una campagna in pausa')
+  .option('--ad <adId>', 'Singola creatività: con --pause/--resume agisce solo su quella ad')
+  .option('--sync', 'Sincronizza ad account + metrics da Zernio')
+  .option('--budget <amount>', 'Budget daily (con --approve o --create)')
+  .option('--create', 'Crea proposta standalone (serve --name --headline)')
+  .option('--platform <platform>', 'metaads|googleads|tiktokads|linkedinads|xads|pinterestads', 'metaads')
+  .option('--name <name>', 'Nome campagna (--create)')
+  .option('--headline <text>', 'Headline creative (--create)')
+  .option('--body <text>', 'Body creative (--create)')
+  .option('--url <url>', 'Landing page (--create)')
+  .option('--image <url>', 'Image URL (--create)')
+  .option('--goal <goal>', 'engagement|traffic|awareness|…')
+  .action(async (slug: string, opts) => {
+    const { cmdAds } = await import('./commands/ads.ts');
+    await cmdAds(slug, opts);
+  });
+
+program
+  .command('upgrade <slug>')
+  .description('Upgrade piano — apre la pagina di checkout nel browser')
+  .action(async (slug: string) => {
+    const { cmdUpgrade } = await import('./commands/upgrade.ts');
+    await cmdUpgrade(slug);
+  });
+
+program
+  .command('update')
+  .description('Aggiorna Anomalia CLI all\'ultima versione')
+  .action(async () => {
+    const { cmdUpdate } = await import('./commands/update.ts');
+    await cmdUpdate();
+  });
+
+program
+  .command('ai <slug>')
+  .description('Chatta con l\'AI di Anomalia — tutto ciò che fa il chatbot web, da CLI')
+  .option('--message <text>', 'Messaggio da inviare all\'AI')
+  .option('--pipe', 'Output raw (per agenti AI)')
+  .action(async (slug: string, opts: { message?: string; pipe?: boolean }) => {
+    const { cmdAi } = await import('./commands/ai.ts');
+    await cmdAi(slug, opts);
+  });
+
+program.parse();

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -29,8 +29,9 @@ Documentazione completa: cli/README.md
 program
   .command('login')
   .description('Accedi a Anomalia (default: apre il browser)')
-  .option('--email <email>', 'email per login non interattivo (richiede --password)')
+  .option('--email <email>', 'email per login non interattivo (richiede --password o --password-stdin)')
   .option('--password <password>', 'password per login non interattivo (richiede --email)')
+  .option('--password-stdin', 'legge la password da stdin, fuori da history e process list')
   .action(async (options) => {
     const { cmdLogin } = await import('./commands/login.ts');
     await cmdLogin(options);

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -28,10 +28,12 @@ Documentazione completa: cli/README.md
 
 program
   .command('login')
-  .description('Accedi a Anomalia (apre il browser)')
-  .action(async () => {
+  .description('Accedi a Anomalia (default: apre il browser)')
+  .option('--email <email>', 'email per login non interattivo (richiede --password)')
+  .option('--password <password>', 'password per login non interattivo (richiede --email)')
+  .action(async (options) => {
     const { cmdLogin } = await import('./commands/login.ts');
-    await cmdLogin();
+    await cmdLogin(options);
   });
 
 program

--- a/cli/commands/ads.ts
+++ b/cli/commands/ads.ts
@@ -1,0 +1,216 @@
+import ora from 'ora';
+import { loadSession } from '../lib/auth.ts';
+import { api } from '../lib/api.ts';
+import { ok, warn, c, table } from '../lib/display.ts';
+
+export async function cmdAds(
+  slug: string,
+  opts: {
+    propose?: boolean;
+    approve?: string;
+    reject?: string;
+    pause?: string;
+    resume?: string;
+    duplicate?: string;
+    delete?: string;
+    ad?: string;
+    sync?: boolean;
+    budget?: string;
+    create?: boolean;
+    platform?: string;
+    name?: string;
+    headline?: string;
+    body?: string;
+    url?: string;
+    image?: string;
+    goal?: string;
+  }
+) {
+  const session = await loadSession();
+  if (!session) {
+    console.error('Sessione scaduta o non trovata. Esegui: anomalia login');
+    process.exit(1);
+  }
+  const token = session.access_token;
+
+  if (opts.sync) {
+    const spinner = ora('Sync ad accounts + metrics…').start();
+    try {
+      const r = await api.adsAction(token, slug, { action: 'sync' });
+      spinner.stop();
+      ok(`Accounts: ${r.accounts ?? 0}, metrics: ${r.metrics ?? 0}`);
+    } catch (e) {
+      spinner.fail(String(e));
+      process.exit(1);
+    }
+    return;
+  }
+
+  if (opts.propose) {
+    const spinner = ora('Proposing boosts from top organic posts…').start();
+    try {
+      const r = await api.adsAction(token, slug, { action: 'propose' });
+      spinner.stop();
+      ok(`Created ${r.created ?? 0} proposals from ${r.candidates ?? 0} candidates`);
+    } catch (e) {
+      spinner.fail(String(e));
+      process.exit(1);
+    }
+    return;
+  }
+
+  if (opts.approve) {
+    const spinner = ora(`Approving campaign ${opts.approve}…`).start();
+    try {
+      const r = await api.adsAction(token, slug, {
+        action: 'approve',
+        campaignId: opts.approve,
+        budgetAmount: opts.budget ? Number(opts.budget) : undefined,
+        goal: opts.goal
+      });
+      spinner.stop();
+      ok(`Live on Zernio: ${r.zernioAdId}`);
+    } catch (e) {
+      spinner.fail(String(e));
+      process.exit(1);
+    }
+    return;
+  }
+
+  if (opts.pause || opts.resume) {
+    const next = opts.pause ? 'paused' : 'active';
+    const id = opts.pause ?? opts.resume!;
+    const spinner = ora(
+      opts.ad
+        ? `${opts.pause ? 'Pausing' : 'Resuming'} creative ${opts.ad}…`
+        : `${opts.pause ? 'Pausing' : 'Resuming'} campaign ${id}…`
+    ).start();
+    try {
+      const r = await api.adsAction(token, slug, {
+        action: 'toggle',
+        campaignId: id,
+        ...(opts.ad ? { adId: opts.ad } : {}),
+        next
+      });
+      spinner.stop();
+      ok(opts.ad ? `Creative ${opts.ad} → ${r.next}` : `Campaign ${id} → ${r.next}`);
+    } catch (e) {
+      spinner.fail(String(e));
+      process.exit(1);
+    }
+    return;
+  }
+
+  if (opts.reject) {
+    await api.adsAction(token, slug, { action: 'reject', campaignId: opts.reject });
+    ok('Rejected');
+    return;
+  }
+
+  if (opts.duplicate) {
+    const spinner = ora(`Duplicating campaign ${opts.duplicate}…`).start();
+    try {
+      const r = await api.adsAction(token, slug, { action: 'duplicate', campaignId: opts.duplicate });
+      spinner.stop();
+      ok(
+        `Copy ${r.id} (${r.copiedCampaignId}) created paused — approve with: anomalia ads ${slug} --approve ${r.id}`
+      );
+    } catch (e) {
+      spinner.fail(String(e));
+      process.exit(1);
+    }
+    return;
+  }
+
+  if (opts.delete) {
+    const spinner = ora(`Deleting campaign ${opts.delete}…`).start();
+    try {
+      await api.adsAction(token, slug, { action: 'delete', campaignId: opts.delete });
+      spinner.stop();
+      ok('Deleted (cancelled on platform + history kept)');
+    } catch (e) {
+      spinner.fail(String(e));
+      process.exit(1);
+    }
+    return;
+  }
+
+  if (opts.create) {
+    if (!opts.name || !opts.headline) {
+      warn('Serve --name e --headline per create');
+      process.exit(1);
+    }
+    const spinner = ora('Creating standalone proposal…').start();
+    try {
+      const r = await api.adsAction(token, slug, {
+        action: 'create',
+        platform: opts.platform ?? 'metaads',
+        name: opts.name,
+        headline: opts.headline,
+        body: opts.body,
+        landingPageUrl: opts.url,
+        imageUrl: opts.image,
+        goal: opts.goal ?? 'traffic',
+        budgetAmount: opts.budget ? Number(opts.budget) : 25
+      });
+      spinner.stop();
+      ok(`Proposal ${r.id} — approve with: anomalia ads ${slug} --approve ${r.id}`);
+    } catch (e) {
+      spinner.fail(String(e));
+      process.exit(1);
+    }
+    return;
+  }
+
+  // Default: list
+  const spinner = ora('Loading ads…').start();
+  try {
+    const data = await api.getAds(token, slug);
+    spinner.stop();
+    console.log(`\n${c.bold(slug)} — ads\n`);
+    console.log(
+      `Spend ${data.summary.totals.spend.toFixed(2)} · Imp ${data.summary.totals.impressions} · Clicks ${data.summary.totals.clicks} · Active ${data.summary.totals.active} · Proposed ${data.summary.totals.proposed}\n`
+    );
+
+    if (data.adAccounts?.length) {
+      console.log(c.bold('Ad accounts'));
+      table(
+        ['Platform', 'Name', 'Status'],
+        data.adAccounts.map((a) => [a.platform, a.name ?? a.zernio_ad_account_id, a.status])
+      );
+      console.log('');
+    }
+
+    if (data.summary.campaigns.length) {
+      console.log(c.bold('Campaigns'));
+      table(
+        ['ID', 'Status', 'Type', 'Platform', 'Budget', 'Name'],
+        data.summary.campaigns.map((c) => [
+          c.id.slice(0, 8),
+          c.status,
+          c.ad_type,
+          c.platform,
+          `${c.budget_amount}/${c.budget_type}`,
+          c.name.slice(0, 40)
+        ])
+      );
+    } else {
+      warn('Nessuna campagna. Prova: anomalia ads <slug> --propose');
+    }
+
+    if (data.candidates?.length) {
+      console.log(`\n${c.bold('Boost candidates')}`);
+      table(
+        ['Platform', 'Score', 'Reason'],
+        data.candidates.slice(0, 8).map((c) => [
+          c.platform,
+          String(Math.round(c.score)),
+          c.reason.slice(0, 50)
+        ])
+      );
+    }
+  } catch (e) {
+    spinner.fail(String(e));
+    process.exit(1);
+  }
+}

--- a/cli/commands/ai.ts
+++ b/cli/commands/ai.ts
@@ -1,0 +1,49 @@
+import { loadSession } from '../lib/auth.ts';
+import { api } from '../lib/api.ts';
+import { c } from '../lib/display.ts';
+
+export async function cmdAi(slug: string, opts: { message?: string; pipe?: boolean }) {
+  const session = await loadSession();
+  if (!session) { console.error('Sessione scaduta o non trovata. Esegui: anomalia login'); process.exit(1); }
+
+  let message = opts.message;
+
+  // Read from stdin if piped
+  if (!message && !process.stdin.isTTY) {
+    const chunks: Uint8Array[] = [];
+    for await (const chunk of process.stdin) {
+      chunks.push(typeof chunk === 'string' ? new TextEncoder().encode(chunk) : new Uint8Array(chunk));
+    }
+    const total = chunks.reduce((n, c) => n + c.byteLength, 0);
+    const buf = new Uint8Array(total);
+    let offset = 0;
+    for (const c of chunks) {
+      buf.set(c, offset);
+      offset += c.byteLength;
+    }
+    message = new TextDecoder().decode(buf).trim();
+  }
+
+  if (!message) {
+    console.error('Specifica un messaggio con --message "..." o pipe da stdin');
+    console.error('');
+    console.error('Esempi:');
+    console.error(`  anomalia ai ${slug} --message "Analizza i miei ultimi post"`);
+    console.error(`  echo "Cambia il tone a friendly" | anomalia ai ${slug}`);
+    console.error(`  anomalia ai ${slug} --message "Aggiungi competitor Notion"`);
+    process.exit(1);
+  }
+
+  try {
+    const response = await api.chat(session.access_token, slug, message);
+    // In pipe mode, output raw text (for AI agents)
+    if (opts.pipe || !process.stdout.isTTY) {
+      process.stdout.write(response);
+    } else {
+      console.log(response);
+    }
+  } catch (e) {
+    console.error(`Errore: ${String(e)}`);
+    process.exit(1);
+  }
+}

--- a/cli/commands/analytics.ts
+++ b/cli/commands/analytics.ts
@@ -1,0 +1,82 @@
+import { loadSession } from '../lib/auth.ts';
+import { api } from '../lib/api.ts';
+import { section, table, formatDate, c, info } from '../lib/display.ts';
+
+export async function cmdAnalytics(slug: string) {
+  const session = await loadSession();
+  if (!session) { console.error('Sessione scaduta o non trovata. Esegui: anomalia login'); process.exit(1); }
+
+  const data = await api.getAnalytics(session.access_token, slug);
+
+  console.log(c.bold(`\nAnalytics — ${slug}\n`));
+
+  // Status distribution
+  section('Distribuzione post');
+  // Tuple-typed so the `n > 0` filter sees a number, not `string | number`.
+  const statusRows: [string, number][] = [
+    ['pending', data.pending],
+    ['scheduled', data.scheduled],
+    ['failed', data.failed],
+    ['total', data.total],
+  ];
+  table(['Status', 'Count'], statusRows.filter(([, n]) => n > 0));
+
+  // Platform distribution
+  if (data.platforms.length) {
+    console.log();
+    table(
+      ['Platform', 'Post totali'],
+      data.platforms.map(([p, n]) => [p, n])
+    );
+  }
+
+  // Top posts
+  if (data.topPosts.length) {
+    section('Top post');
+    table(
+      ['Platform', 'Data', 'Likes', 'Commenti', 'Caption'],
+      data.topPosts.map((p) => [
+        p.platform ?? '—',
+        formatDate(p.published_at),
+        String(p.metrics?.likes ?? 0),
+        String(p.metrics?.comments ?? 0),
+        (p.caption ?? '').slice(0, 55) + ((p.caption?.length ?? 0) > 55 ? '…' : ''),
+      ])
+    );
+  }
+
+  // Engagement per platform
+  if (data.socialPerformance.length) {
+    section('Engagement per platform');
+    table(
+      ['Platform', 'Post', 'Likes', 'Commenti', 'Views', 'Shares'],
+      data.socialPerformance.map(sp => [
+        sp.platform,
+        String(sp.posts),
+        String(sp.totals.likes),
+        String(sp.totals.comments),
+        String(sp.totals.views),
+        String(sp.totals.shares),
+      ])
+    );
+  }
+
+  // Upcoming
+  if (data.upcomingPosts.length) {
+    section('Prossimi post');
+    for (const p of data.upcomingPosts) {
+      console.log(`  ${c.dim(p.scheduled_for?.slice(0, 16) ?? '—')}  ${(p.platform ?? '—').padEnd(15)}${(p.caption ?? '').slice(0, 40)}`);
+    }
+  }
+
+  // Recent activity
+  if (data.recentActivity.length) {
+    section('Attività recente');
+    for (const a of data.recentActivity.slice(0, 5)) {
+      const color = a.status === 'published' ? c.green : a.status === 'failed' ? c.red : c.yellow;
+      console.log(`  ${c.dim(a.created_at?.slice(0, 16) ?? '—')}  ${(a.platform ?? '—').padEnd(15)}${color(a.status)}`);
+    }
+  }
+
+  console.log();
+}

--- a/cli/commands/approve.ts
+++ b/cli/commands/approve.ts
@@ -1,0 +1,49 @@
+import ora from 'ora';
+import { loadSession } from '../lib/auth.ts';
+import { api } from '../lib/api.ts';
+import { ok, warn, c, table } from '../lib/display.ts';
+
+export async function cmdApprove(slug: string, opts: { all?: boolean; dry?: boolean }) {
+  const session = await loadSession();
+  if (!session) { console.error('Sessione scaduta o non trovata. Esegui: anomalia login'); process.exit(1); }
+
+  const posts = await api.getPosts(session.access_token, slug);
+  const pending = posts.filter(p => p.status === 'pending_user');
+
+  if (!pending.length) {
+    warn('Nessun post in attesa di approvazione.');
+    return;
+  }
+
+  console.log(`\n${c.bold(slug)} — ${pending.length} post in pending:\n`);
+  table(
+    ['#', 'Platform', 'Slot', 'Caption'],
+    pending.map((p, i) => [
+      String(i + 1),
+      p.platform ?? '—',
+      p.slot ?? '—',
+      (p.caption ?? '').slice(0, 60) + ((p.caption?.length ?? 0) > 60 ? '…' : ''),
+    ])
+  );
+
+  if (opts.dry) {
+    warn('Dry run — nessun post approvato.');
+    return;
+  }
+
+  if (!opts.all) {
+    console.log(`\n${c.dim('Usa --all per approvare tutti, --dry per vedere senza approvare.')}`);
+    return;
+  }
+
+  const spinner = ora('Approvazione in corso…').start();
+  try {
+    const result = await api.approveAll(session.access_token, slug);
+    const done = result.results?.filter(r => r.ok).length ?? 0;
+    const failedCount = result.results?.filter(r => !r.ok).length ?? 0;
+    spinner.stop();
+    ok(`${done}/${pending.length} approvati${failedCount ? `, ${failedCount} falliti` : ''}.`);
+  } catch (e) {
+    spinner.fail(`Errore: ${String(e)}`);
+  }
+}

--- a/cli/commands/brands.ts
+++ b/cli/commands/brands.ts
@@ -1,0 +1,31 @@
+import { loadSession } from '../lib/auth.ts';
+import { api } from '../lib/api.ts';
+import { table, statusBadge, autopilotBadge, formatDate, c } from '../lib/display.ts';
+
+export async function cmdBrands() {
+  const session = await loadSession();
+  if (!session) { console.error('Sessione scaduta o non trovata. Esegui: anomalia login'); process.exit(1); }
+
+  const brands = await api.listBrands(session.access_token);
+
+  if (!brands.length) {
+    console.log(c.dim('Nessun brand trovato.'));
+    return;
+  }
+
+  console.log(c.bold(`\n${brands.length} brand\n`));
+
+  table(
+    ['Brand', 'Slug', 'Piano', 'Status', 'Pending', 'Autopilot', 'Ultimo run'],
+    brands.map((b) => [
+      c.bold(b.name),
+      c.dim(b.slug),
+      b.plan ?? '—',
+      statusBadge(b.status ?? ''),
+      b.pendingCount > 0 ? c.yellow(String(b.pendingCount)) : c.dim('0'),
+      autopilotBadge(b.autopilot_enabled) +
+        (b.autopilot_failure_count > 0 ? c.red(` (${b.autopilot_failure_count} fail)`) : ''),
+      formatDate(b.last_autopilot_run_at),
+    ])
+  );
+}

--- a/cli/commands/calendar.ts
+++ b/cli/commands/calendar.ts
@@ -1,0 +1,69 @@
+import { loadSession } from '../lib/auth.ts';
+import { api } from '../lib/api.ts';
+import { section, c, info } from '../lib/display.ts';
+
+export async function cmdCalendar(slug: string, opts: { month?: string }) {
+  const session = await loadSession();
+  if (!session) { console.error('Sessione scaduta o non trovata. Esegui: anomalia login'); process.exit(1); }
+
+  const data = await api.getCalendar(session.access_token, slug, opts.month);
+
+  section('Calendario');
+  console.log(`  ${c.bold(data.monthLabel)}`);
+  console.log();
+
+  // Group by day
+  const byDay = new Map<string, Record<string, unknown>[]>();
+  for (const p of data.posts) {
+    const dateStr = String(p.scheduled_for ?? p.slot ?? '');
+    const day = dateStr.slice(0, 10);
+    if (!day) continue;
+    if (!byDay.has(day)) byDay.set(day, []);
+    byDay.get(day)!.push(p);
+  }
+
+  // Calendar grid
+  const dayNames = ['Lu', 'Ma', 'Me', 'Gi', 'Ve', 'Sa', 'Do'];
+  const colWidth = 14;
+  console.log(dayNames.map(d => d.padEnd(colWidth)).join(''));
+
+  const firstDay = new Date(data.year, data.month - 1, 1);
+  const lastDay = new Date(data.year, data.month, 0);
+  let startDow = firstDay.getDay() - 1;
+  if (startDow < 0) startDow = 6;
+
+  let col = 0;
+  let line = '';
+  for (let i = 0; i < startDow; i++) {
+    line += ' '.repeat(colWidth);
+    col++;
+  }
+
+  for (let day = 1; day <= lastDay.getDate(); day++) {
+    const dateKey = `${data.year}-${String(data.month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+    const dayPosts = byDay.get(dateKey) ?? [];
+    const dayStr = String(day).padStart(2);
+    const count = dayPosts.length;
+    const indicator = count > 0 ? c.green(`(${count})`.padEnd(4)) : '    ';
+    line += `${dayStr} ${indicator}    `;
+    col++;
+    if (col === 7) { console.log(line); line = ''; col = 0; }
+  }
+  if (col > 0) console.log(line);
+
+  // Upcoming
+  const upcoming = data.posts.filter(p => !p.isDraft).slice(0, 7);
+  if (upcoming.length) {
+    section('Prossimi post');
+    for (const p of upcoming) {
+      const date = String(p.scheduled_for ?? p.slot ?? '').slice(0, 16);
+      const cap = String(p.caption ?? '').slice(0, 45) + (String(p.caption ?? '').length > 45 ? '…' : '');
+      const statusColor = p.status === 'scheduled' ? c.green : p.status === 'pending_user' ? c.yellow : c.dim;
+      console.log(`  ${c.dim(date)}  ${String(p.platform ?? '—').padEnd(12)} ${statusColor(cap)}`);
+    }
+  }
+
+  console.log();
+  info(`  ${c.green('●')} scheduled   ${c.dim('○')} draft`);
+  console.log();
+}

--- a/cli/commands/content.ts
+++ b/cli/commands/content.ts
@@ -1,0 +1,66 @@
+import { loadSession } from '../lib/auth.ts';
+import { api } from '../lib/api.ts';
+import { section, statusBadge, formatDate, c, table, info, ok } from '../lib/display.ts';
+
+export async function cmdContent(slug: string, opts: { status?: string; clear?: string }) {
+  const session = await loadSession();
+  if (!session) { console.error('Sessione scaduta o non trovata. Esegui: anomalia login'); process.exit(1); }
+
+  // Bulk-clear takes priority when requested.
+  if (opts.clear) {
+    const validClear = ['pending_user', 'approved', 'scheduled', 'failed'];
+    if (!validClear.includes(opts.clear)) {
+      console.error(`--clear "${opts.clear}" non valido. Usa: ${validClear.join(', ')}`);
+      process.exit(1);
+    }
+    const res = await api.deletePostsByStatus(session.access_token, slug, opts.clear);
+    ok(`${res.deleted} post (${opts.clear}) eliminati.`);
+    return;
+  }
+
+  const filter = opts.status ?? 'all';
+  const validFilters = ['all', 'pending_user', 'approved', 'scheduled', 'published', 'failed'];
+  if (!validFilters.includes(filter)) {
+    console.error(`Status "${filter}" non valido. Usa: ${validFilters.join(', ')}`);
+    process.exit(1);
+  }
+
+  const posts = await api.getPosts(session.access_token, slug, filter === 'all' ? undefined : filter);
+
+  section('Content Library');
+
+  const filterLabels: Record<string, string> = {
+    all: 'Tutti', pending_user: 'Pending', approved: 'Approved',
+    scheduled: 'Scheduled', published: 'Published', failed: 'Failed',
+  };
+  console.log(`  Filtro: ${c.bold(filterLabels[filter] ?? filter)}`);
+  console.log();
+
+  if (!posts.length) {
+    info('Nessun contenuto trovato.');
+  } else {
+    table(
+      ['Platform', 'Slot', 'Status', 'Pillar', 'Prodotto', 'Caption'],
+      posts.map(p => [
+        p.platform ?? '—',
+        formatDate(p.slot || p.scheduled_for),
+        statusBadge(p.status),
+        p.pillar ?? '—',
+        p.product_name ?? '—',
+        (p.caption ?? '').slice(0, 40) + ((p.caption?.length ?? 0) > 40 ? '…' : ''),
+      ])
+    );
+  }
+
+  // Status summary
+  const allPosts = await api.getPosts(session.access_token, slug);
+  const statusCounts = new Map<string, number>();
+  for (const p of allPosts) statusCounts.set(p.status, (statusCounts.get(p.status) ?? 0) + 1);
+  console.log();
+  const summary = ['pending_user', 'approved', 'scheduled', 'published', 'failed']
+    .filter(s => (statusCounts.get(s) ?? 0) > 0)
+    .map(s => `${statusBadge(s)}: ${statusCounts.get(s)}`)
+    .join('  ');
+  console.log(`  ${summary}`);
+  console.log();
+}

--- a/cli/commands/dashboard.ts
+++ b/cli/commands/dashboard.ts
@@ -1,0 +1,55 @@
+import { loadSession } from '../lib/auth.ts';
+import { api } from '../lib/api.ts';
+import { section, statusBadge, formatDate, autopilotBadge, c, info } from '../lib/display.ts';
+
+export async function cmdDashboard(slug: string) {
+  const session = await loadSession();
+  if (!session) { console.error('Sessione scaduta o non trovata. Esegui: anomalia login'); process.exit(1); }
+
+  const detail = await api.getBrand(session.access_token, slug);
+  const brand = detail.brand;
+
+  section(`${brand.name}  (${brand.slug})`);
+
+  // Stats
+  console.log(`  Prodotti:        ${c.bold(String(detail.productCount))}   Account: ${c.bold(String(detail.accountCount))}   In approvazione: ${detail.pendingCount > 0 ? c.yellow(String(detail.pendingCount)) : c.dim('0')}   Piano: ${c.bold(brand.plan ?? '—')}`);
+
+  // Pipeline
+  const stages = [
+    { label: 'Ricerca', detail: 'Studio e brand kit', done: detail.hasGtm },
+    { label: 'Strategia', detail: 'GTM + piano editoriale', done: detail.hasGtm && !!detail.plan },
+    { label: 'Generazione', detail: 'Seeds e contenuti', done: !!detail.plan && (detail.hasContentPlans || detail.pendingCount > 0) },
+    { label: 'Pubblicazione', detail: 'Scheduling e post', done: detail.scheduledCount > 0 || detail.publishedCount > 0 },
+    { label: 'Analisi', detail: 'Metriche e ottimizzazione', done: detail.hasHistory },
+  ];
+  const firstIncomplete = stages.findIndex(s => !s.done);
+  if (firstIncomplete >= 0) stages[firstIncomplete].done = false;
+
+  section('Autopilot Pipeline');
+  const pipelineStr = stages.map((s, i) => {
+    const isCurrent = i === firstIncomplete || (firstIncomplete === -1 && i === stages.length - 1);
+    const icon = s.done ? c.green('●') : isCurrent ? c.yellow('◉') : c.dim('○');
+    const label = s.done ? c.green(s.label) : isCurrent ? c.yellow(s.label) : c.dim(s.label);
+    return `${icon} ${label}`;
+  }).join(` ${c.dim('─')} `);
+  console.log(`  ${pipelineStr}`);
+  if (firstIncomplete >= 0) console.log(`  ${c.dim(stages[firstIncomplete].detail)}`);
+
+  // Status
+  section('Stato');
+  console.log(`  Autopilot: ${autopilotBadge(brand.autopilot_enabled)}`);
+  console.log(`  Status:    ${statusBadge(brand.status ?? '')}`);
+  if (brand.autopilot_failure_count > 0) {
+    console.log(`  ${c.red(`⚠ ${brand.autopilot_failure_count} fallimenti consecutivi`)}`);
+  }
+  if (detail.runs[0]) {
+    const runErr = detail.runs[0].status === 'failed' ? c.red(`  ✗ ${detail.runs[0].error ?? ''}`) : '';
+    console.log(`  Ultimo run: ${formatDate(detail.runs[0].created_at)} — ${detail.runs[0].posts_created} post${runErr}`);
+  }
+  if (detail.plan) {
+    const weekCount = Array.isArray(detail.plan.weeks) ? detail.plan.weeks.length : '?';
+    console.log(`  Piano editoriale: ${c.green('attivo')} · ${detail.plan.cadence ?? '—'} · ${weekCount} settimane`);
+  }
+
+  console.log();
+}

--- a/cli/commands/geo.ts
+++ b/cli/commands/geo.ts
@@ -1,0 +1,55 @@
+import { requireSession } from '../lib/auth.ts';
+import { api } from '../lib/api.ts';
+import { section, table, c, info, ok, fail, formatDate } from '../lib/display.ts';
+
+export async function cmdGeo(slug: string, opts: { action: string }) {
+  const { access_token: t } = await requireSession();
+
+  if (opts.action === 'run' || opts.action === 'fix') {
+    const action = opts.action === 'run' ? 'audit' : 'fix';
+    info(action === 'audit' ? 'Probe di citazione in corso (può richiedere 1-2 min)…' : 'Generazione fix in corso…');
+    const res = await api.geoAction(t, slug, action);
+    ok(action === 'audit'
+      ? `Audit completato — tech ${res.techScore ?? '—'}, share of voice ${Math.round((res.shareOfVoice ?? 0) * 100)}%`
+      : `${res.generated} artifact generati`);
+    return;
+  }
+  if (opts.action !== 'show') { fail(`Azione sconosciuta: ${opts.action} (show, run, fix)`); process.exit(1); }
+
+  const data = await api.getGeo(t, slug);
+
+  section('GEO — visibilità AI');
+  if (!data.audit) { info(`Nessun audit. Lancia: anomalia geo ${slug} run\n`); return; }
+
+  console.log(`  Share of voice: ${c.bold(`${Math.round((data.audit.share_of_voice ?? 0) * 100)}%`)}`);
+  console.log(`  Tech score:     ${c.bold(String(data.audit.tech_score ?? '—'))}/100`);
+  console.log(`  Ultimo run:     ${formatDate(data.audit.created_at)}`);
+
+  if (data.trend.length > 1) {
+    const spark = data.trend.map((p) => '▁▂▃▄▅▆▇█'[Math.min(7, Math.round(((p.shareOfVoice ?? 0) * 100) / 14))]).join('');
+    console.log(`  Trend SoV:      ${c.cyan(spark)}`);
+  }
+
+  const cits = data.audit.citations ?? [];
+  if (cits.length) {
+    section('Citazioni per prompt');
+    table(
+      ['prompt', 'superficie', 'citato'],
+      cits.slice(0, 20).map((x) => [
+        String(x.prompt ?? '—').slice(0, 52),
+        x.surface ?? '—',
+        x.cited ? c.green('✓') : x.mentioned ? c.yellow('~') : c.dim('✗')
+      ])
+    );
+  }
+
+  if (data.artifacts.length) {
+    section(`Fix pronti (${data.artifacts.length})`);
+    for (const a of data.artifacts.slice(0, 10)) {
+      console.log(`  ${c.dim('·')} ${a.title} ${c.dim(`[${a.kind}${a.target_path ? ` → ${a.target_path}` : ''}]`)}`);
+    }
+  } else {
+    info(`\nNessun fix generato. Lancia: anomalia geo ${slug} fix`);
+  }
+  console.log();
+}

--- a/cli/commands/gtm.ts
+++ b/cli/commands/gtm.ts
@@ -1,0 +1,67 @@
+import { loadSession } from '../lib/auth.ts';
+import { api } from '../lib/api.ts';
+import { section, c, info } from '../lib/display.ts';
+
+export async function cmdGtm(slug: string) {
+  const session = await loadSession();
+  if (!session) { console.error('Sessione scaduta o non trovata. Esegui: anomalia login'); process.exit(1); }
+
+  const data = await api.getGtm(session.access_token, slug);
+  const gtm = data.gtm as Record<string, unknown> | null;
+
+  section('GTM Roadmap');
+
+  if (!gtm) {
+    info('Nessun piano GTM attivo.');
+    console.log();
+    return;
+  }
+
+  console.log(`  Orizzonte: ${c.bold(String(gtm.horizon ?? '—'))}`);
+  if (gtm.objective) console.log(`  Obiettivo: ${gtm.objective}`);
+  console.log();
+
+  const phases = (gtm.phases ?? []) as Record<string, unknown>[];
+  section('Fasi');
+
+  for (let i = 0; i < phases.length; i++) {
+    const phase = phases[i];
+    const status = data.phaseStatuses[i] ?? 'next';
+    const color = status === 'done' ? c.green : status === 'now' ? c.yellow : c.dim;
+    const prefix = status === 'now' ? c.yellow('▶') : ' ';
+    const name = String(phase.name ?? `Fase ${i + 1}`);
+    const obj = String(phase.objective ?? '—').slice(0, 70);
+
+    console.log(`${prefix} ${color(name)}  ${c.dim(`[${status}]`)}`);
+    console.log(`   ${obj}`);
+
+    if (status === 'now') {
+      const sd = phase.start_date ? new Date(phase.start_date as string) : null;
+      const ed = phase.end_date ? new Date(phase.end_date as string) : null;
+      if (sd && ed) {
+        const now = new Date();
+        const total = ed.getTime() - sd.getTime();
+        const elapsed = now.getTime() - sd.getTime();
+        const pct = Math.min(100, Math.max(0, Math.round((elapsed / total) * 100)));
+        const barLen = 25;
+        const filled = Math.round((pct / 100) * barLen);
+        const bar = c.green('█'.repeat(filled)) + c.dim('░'.repeat(barLen - filled));
+        console.log(`   [${bar}] ${c.bold(`${pct}%`)}`);
+      }
+      if (phase.platform_weights) {
+        const weights = phase.platform_weights as Record<string, number>;
+        const parts = Object.entries(weights).sort(([, a], [, b]) => (b as number) - (a as number)).map(([p, w]) => `${p} ${Math.round((w as number) * 100)}%`);
+        console.log(`   Platform: ${c.dim(parts.join(' · '))}`);
+      }
+      if (Array.isArray(phase.pillars) && phase.pillars.length) {
+        console.log(`   Pilastri: ${c.dim((phase.pillars as string[]).join(', '))}`);
+      }
+      if (Array.isArray(phase.goals) && phase.goals.length) {
+        for (const goal of (phase.goals as Record<string, unknown>[]).slice(0, 5)) {
+          console.log(`   KPI: ${String(goal.kpi ?? '—')} → ${c.bold(String(goal.target ?? '—'))}`);
+        }
+      }
+    }
+    console.log();
+  }
+}

--- a/cli/commands/health.ts
+++ b/cli/commands/health.ts
@@ -1,0 +1,53 @@
+import chalk from 'chalk';
+import { section, c, info } from '../lib/display.ts';
+import { appUrl } from '../lib/config.ts';
+
+interface ServiceCheck {
+  name: string;
+  status: 'ok' | 'error';
+  latencyMs: number;
+  error?: string;
+}
+
+interface StatusResponse {
+  status: 'ok' | 'degraded';
+  timestamp: string;
+  services: ServiceCheck[];
+}
+
+export async function cmdHealth() {
+  const base = appUrl();
+  const url = `${base}/api/status`;
+
+  try {
+    const res = await fetch(url, { signal: AbortSignal.timeout(15_000) });
+    const data: StatusResponse = await res.json();
+
+    section('Anomalia API Status');
+
+    const overall = data.status === 'ok'
+      ? chalk.green.bold('● All systems operational')
+      : chalk.red.bold('● Degraded');
+    console.log(`  ${overall}  ${info(`(${new Date(data.timestamp).toLocaleTimeString('it-IT')})`)}`);
+    console.log();
+
+    for (const svc of data.services) {
+      const icon = svc.status === 'ok'
+        ? chalk.green('✓')
+        : chalk.red('✗');
+      const latency = chalk.dim(`${svc.latencyMs}ms`);
+      const name = c.bold(svc.name.padEnd(10));
+      const detail = svc.status === 'ok'
+        ? chalk.green('operational')
+        : chalk.red(svc.error ?? 'error');
+      console.log(`  ${icon} ${name} ${detail}  ${latency}`);
+    }
+
+    console.log();
+    if (data.status !== 'ok') process.exit(1);
+  } catch (e) {
+    console.error(chalk.red('✗'), `Impossibile contattare ${url}`);
+    if (e instanceof Error) console.error(chalk.dim(`  ${e.message}`));
+    process.exit(1);
+  }
+}

--- a/cli/commands/keywords.ts
+++ b/cli/commands/keywords.ts
@@ -1,0 +1,43 @@
+import { requireSession } from '../lib/auth.ts';
+import { api } from '../lib/api.ts';
+import { section, table, c, info, ok, fail, formatDate } from '../lib/display.ts';
+
+export async function cmdKeywords(slug: string, opts: { action: string }) {
+  const { access_token: t } = await requireSession();
+
+  if (opts.action === 'refresh') {
+    info('Keyword research in corso (DataForSEO + AI, può richiedere 1-2 min)…');
+    const res = await api.refreshKeywords(t, slug);
+    ok(`Strategy rigenerata — ${res.keywords} keyword`);
+    return;
+  }
+  if (opts.action !== 'show') { fail(`Azione sconosciuta: ${opts.action} (show, refresh)`); process.exit(1); }
+
+  const { strategy, citations, updatedAt } = await api.getKeywords(t, slug);
+
+  section('Keyword strategy');
+  if (!strategy) { info(`Nessuna strategy. Lancia: anomalia keywords ${slug} refresh\n`); return; }
+
+  console.log(`  ${strategy.focusSummary}`);
+  console.log(`  ${c.dim(`aggiornata ${formatDate(updatedAt)}`)}\n`);
+
+  const color = (o?: string) => o === 'high' ? c.green : o === 'medium' ? c.yellow : c.dim;
+  table(
+    ['keyword', 'intent', 'volume', 'kd', 'opp.', 'azione'],
+    strategy.keywords.map((k) => [
+      k.keyword.slice(0, 40),
+      k.intent ?? '—',
+      k.volume ?? '—',
+      k.difficulty ?? '—',
+      color(k.opportunity)(k.opportunity ?? '—'),
+      (k.action ?? '—').slice(0, 24)
+    ])
+  );
+
+  if (strategy.competitorGaps.length) {
+    section('Gap sui competitor');
+    for (const g of strategy.competitorGaps) console.log(`  ${c.bold(g.competitor)} — ${g.gap}`);
+  }
+  if (citations.length) info(`\n${citations.length} fonti consultate`);
+  console.log();
+}

--- a/cli/commands/login.ts
+++ b/cli/commands/login.ts
@@ -1,7 +1,19 @@
 import { startBrowserLogin, passwordLogin, loadSession } from '../lib/auth.ts';
 import { c, ok } from '../lib/display.ts';
 
-export type LoginOptions = { email?: string; password?: string };
+export type LoginOptions = { email?: string; password?: string; passwordStdin?: boolean };
+
+// La password via stdin non finisce né in shell history né in `ps aux`.
+async function readStdinPassword(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
+  return Buffer.concat(chunks).toString('utf8').trim();
+}
+
+function fail(message: string): never {
+  console.error(`  ${c.red('✗')} ${message}`);
+  process.exit(1);
+}
 
 export async function cmdLogin(options: LoginOptions = {}) {
   console.log(c.bold('\nLogin a Anomalia\n'));
@@ -15,20 +27,28 @@ export async function cmdLogin(options: LoginOptions = {}) {
     return;
   }
 
-  if (options.email && options.password) {
-    try {
-      const session = await passwordLogin(options.email, options.password);
-      ok(`Autenticato come ${c.bold(session.user.email)}`);
-    } catch (e) {
-      console.error(`\n  ${c.red('✗')} Login fallito: ${String(e)}`);
-      process.exit(1);
-    }
-    return;
+  if (options.password && options.passwordStdin) {
+    fail('Usa --password o --password-stdin, non entrambi');
+  }
+  if (options.passwordStdin && !options.email) {
+    fail('--password-stdin richiede --email');
+  }
+  if (options.email && !options.password && !options.passwordStdin) {
+    fail('--email richiede --password o --password-stdin (o niente flag: login via browser)');
   }
 
-  if (options.email || options.password) {
-    console.error(`  ${c.red('✗')} --email e --password vanno passati insieme (o niente flag: login via browser)`);
-    process.exit(1);
+  if (options.email) {
+    const password = options.passwordStdin ? await readStdinPassword() : options.password;
+    if (!password) {
+      fail('Password vuota su stdin');
+    }
+    try {
+      const session = await passwordLogin(options.email, password);
+      ok(`Autenticato come ${c.bold(session.user.email)}`);
+    } catch (e) {
+      fail(`Login fallito: ${String(e)}`);
+    }
+    return;
   }
 
   console.log('  Il browser si aprirà automaticamente…');

--- a/cli/commands/login.ts
+++ b/cli/commands/login.ts
@@ -1,7 +1,9 @@
-import { startBrowserLogin, loadSession } from '../lib/auth.ts';
+import { startBrowserLogin, passwordLogin, loadSession } from '../lib/auth.ts';
 import { c, ok } from '../lib/display.ts';
 
-export async function cmdLogin() {
+export type LoginOptions = { email?: string; password?: string };
+
+export async function cmdLogin(options: LoginOptions = {}) {
   console.log(c.bold('\nLogin a Anomalia\n'));
 
   // Check if already logged in
@@ -11,6 +13,22 @@ export async function cmdLogin() {
     console.log(`  Sessione valida fino a: ${new Date(existing.expires_at * 1000).toLocaleDateString('it-IT')}`);
     console.log(`\n  Per forzare il re-login, esegui: anomalia logout && anomalia login`);
     return;
+  }
+
+  if (options.email && options.password) {
+    try {
+      const session = await passwordLogin(options.email, options.password);
+      ok(`Autenticato come ${c.bold(session.user.email)}`);
+    } catch (e) {
+      console.error(`\n  ${c.red('✗')} Login fallito: ${String(e)}`);
+      process.exit(1);
+    }
+    return;
+  }
+
+  if (options.email || options.password) {
+    console.error(`  ${c.red('✗')} --email e --password vanno passati insieme (o niente flag: login via browser)`);
+    process.exit(1);
   }
 
   console.log('  Il browser si aprirà automaticamente…');

--- a/cli/commands/login.ts
+++ b/cli/commands/login.ts
@@ -1,0 +1,29 @@
+import { startBrowserLogin, loadSession } from '../lib/auth.ts';
+import { c, ok } from '../lib/display.ts';
+
+export async function cmdLogin() {
+  console.log(c.bold('\nLogin a Anomalia\n'));
+
+  // Check if already logged in
+  const existing = await loadSession();
+  if (existing) {
+    console.log(`  Già autenticato come: ${c.bold(existing.user.email)}`);
+    console.log(`  Sessione valida fino a: ${new Date(existing.expires_at * 1000).toLocaleDateString('it-IT')}`);
+    console.log(`\n  Per forzare il re-login, esegui: anomalia logout && anomalia login`);
+    return;
+  }
+
+  console.log('  Il browser si aprirà automaticamente…');
+  console.log('  Accedi e premi "Autorizza" per completare.\n');
+
+  try {
+    const session = await startBrowserLogin((msg) => {
+      console.log(`  ${msg}`);
+    });
+    console.log('');
+    ok(`Autenticato come ${c.bold(session.user.email)}`);
+  } catch (e) {
+    console.error(`\n  ${c.red('✗')} Login fallito: ${String(e)}`);
+    process.exit(1);
+  }
+}

--- a/cli/commands/logout.ts
+++ b/cli/commands/logout.ts
@@ -1,0 +1,12 @@
+import { clearSession, loadSession } from '../lib/auth.ts';
+import { c, ok } from '../lib/display.ts';
+
+export async function cmdLogout() {
+  const session = await loadSession();
+  if (session) {
+    console.log(`  Disconnessione di ${c.bold(session.user.email)}…`);
+  }
+
+  clearSession();
+  ok('Disconnesso. Esegui `anomalia` per riaccedere.');
+}

--- a/cli/commands/people.ts
+++ b/cli/commands/people.ts
@@ -1,0 +1,93 @@
+import { loadSession } from '../lib/auth.ts';
+import { api } from '../lib/api.ts';
+import { section, c, table, info, ok } from '../lib/display.ts';
+
+export async function cmdPeople(slug: string, opts: {
+  action?: string;
+  name?: string;
+  role?: string;
+  description?: string;
+  gender?: string;
+  ageRange?: string;
+  kind?: string;
+  id?: string;
+}) {
+  const session = await loadSession();
+  if (!session) { console.error('Sessione scaduta o non trovata. Esegui: anomalia login'); process.exit(1); }
+
+  const action = opts.action ?? 'list';
+  switch (action) {
+    case 'list':
+      return listPeople(session.access_token, slug);
+    case 'add':
+      return addPerson(session.access_token, slug, opts);
+    case 'remove':
+      return removePerson(session.access_token, slug, opts.id);
+    default:
+      console.error(`Azione sconosciuta: ${action}`);
+      printHelp();
+      process.exit(1);
+  }
+}
+
+function printHelp() {
+  console.log(`
+${c.bold('Azioni Persone:')}
+
+  ${c.green('list')}                    Elenca le persone del brand (default)
+
+  ${c.green('add')}                     Aggiunge una persona
+    --name "Andrea"               Nome (obbligatorio)
+    --gender female               Genere (female/male) — IMPORTANTE per le immagini
+    --ageRange "26-35"            Fascia d'età
+    --role "Founder"              Ruolo
+    --description "..."           Descrizione
+    --kind ai|real                ai = genera foto AI; real = persona reale (default real)
+
+  ${c.green('remove')}                  Rimuove una persona
+    --id <personId>               ID persona (da \`people list\`)
+`);
+}
+
+async function listPeople(token: string, slug: string) {
+  const studio = await api.getStudio(token, slug);
+  const people = studio.people ?? [];
+  section(`Persone (${people.length})`);
+  if (!people.length) {
+    info('Nessuna persona. Aggiungine una con `anomalia people ' + slug + ' add --name "..." --gender female`.');
+    return;
+  }
+  table(
+    ['ID', 'Nome', 'Tipo', 'Ruolo', 'Foto'],
+    people.map(p => [
+      p.id.slice(0, 8),
+      p.name,
+      p.kind,
+      p.role ?? '—',
+      p.imageCount > 0 ? String(p.imageCount) : c.red('0'),
+    ])
+  );
+  console.log();
+}
+
+async function addPerson(token: string, slug: string, opts: { name?: string; role?: string; description?: string; gender?: string; ageRange?: string; kind?: string }) {
+  if (!opts.name) { console.error('--name è obbligatorio'); process.exit(1); }
+  const kind = opts.kind === 'ai' ? 'ai' : 'real';
+  if (kind === 'ai') console.log(c.yellow('Generazione persona AI con foto in corso…'));
+  const result = await api.addPerson(token, slug, {
+    name: opts.name,
+    role: opts.role,
+    description: opts.description,
+    gender: opts.gender,
+    ageRange: opts.ageRange,
+    kind,
+  });
+  ok(`Persona "${result.person.name}" aggiunta (${result.person.kind}).`);
+  if (kind === 'real') info('Persona reale senza foto: carica le foto dalla web app perché appaia nelle immagini generate.');
+}
+
+async function removePerson(token: string, slug: string, id?: string) {
+  if (!id) { console.error('--id è obbligatorio (vedi `people list`)'); process.exit(1); }
+  await api.deletePerson(token, slug, id);
+  ok('Persona rimossa.');
+}

--- a/cli/commands/plan.ts
+++ b/cli/commands/plan.ts
@@ -1,0 +1,209 @@
+import { loadSession } from '../lib/auth.ts';
+import { api } from '../lib/api.ts';
+import { section, table, formatDate, c, info, ok, warn } from '../lib/display.ts';
+
+export async function cmdPlan(slug: string, opts: {
+  action?: string;
+  feedback?: string;
+  week?: number;
+  brief?: string;
+  products?: string;
+  clearProducts?: boolean;
+}) {
+  const session = await loadSession();
+  if (!session) { console.error('Sessione scaduta o non trovata. Esegui: anomalia login'); process.exit(1); }
+
+  const action = opts.action ?? 'show';
+
+  switch (action) {
+    case 'show':
+      return showPlan(session.access_token, slug);
+    case 'propose':
+      return proposePlan(session.access_token, slug);
+    case 'revise':
+      return revisePlan(session.access_token, slug, opts.feedback);
+    case 'approve':
+      return approvePlan(session.access_token, slug);
+    case 'discard':
+      return discardPlan(session.access_token, slug);
+    case 'save-brief':
+      return saveBrief(session.access_token, slug, opts.week, opts.brief, opts.products, opts.clearProducts);
+    case 'replan':
+      return replanWeek(session.access_token, slug, opts.week, opts.brief);
+    default:
+      console.error(`Azione sconosciuta: ${action}`);
+      printHelp();
+      process.exit(1);
+  }
+}
+
+function printHelp() {
+  console.log(`
+${c.bold('Azioni Piano Editoriale:')}
+
+  ${c.green('show')}                    Mostra piano attivo (default)
+
+  ${c.green('propose')}                 Genera primo piano editoriale
+    Per brand senza piano attivo
+
+  ${c.green('revise')}                  Richiedi revisione
+    --feedback "Voglio più behind-the-scenes"
+
+  ${c.green('approve')}                 Approva piano proposto
+
+  ${c.green('discard')}                 Scarta piano proposto
+
+  ${c.green('save-brief')}              Salva brief e/o prodotti per una settimana
+    --week 0                        Indice settimana (0-3)
+    --brief "Mostra il processo creativo"
+    --products "TKD Pt.1,INTRO S100"  Prodotti da featuring (nomi esatti, separati da virgola)
+
+  ${c.green('replan')}                  Rigenera una settimana
+    --week 0                        Indice settimana (0-3)
+    --brief "Dietro le quinte"      Brief obbligatorio
+`);
+}
+
+async function showPlan(token: string, slug: string) {
+  const data = await api.getEditorialPlan(token, slug);
+  const plan = data.plan as Record<string, unknown> | null;
+  const proposed = data.proposed as Record<string, unknown> | null;
+
+  section('Piano Editoriale');
+
+  // ── Proposed plan (if any) ──
+  if (proposed) {
+    console.log(c.yellow('\n  ⚠ PIANO PROPOSTO IN ATTESA'));
+    if (data.proposedFeedback) {
+      console.log(`  Feedback: ${c.dim(data.proposedFeedback)}`);
+    }
+    const changes = proposed.changes_summary as string[] | undefined;
+    if (changes?.length) {
+      console.log('  Modifiche:');
+      for (const ch of changes) console.log(`    • ${ch}`);
+    }
+    console.log(`\n  ${c.dim('Usa:')} anomalia plan ${slug} approve  ${c.dim('per approvare')}`);
+    console.log(`  ${c.dim('Usa:')} anomalia plan ${slug} discard  ${c.dim('per scartare')}`);
+    console.log();
+  }
+
+  // ── Active plan ──
+  if (!plan) {
+    info('Nessun piano editoriale attivo.');
+    console.log(`\n  ${c.dim('Usa:')} anomalia plan ${slug} propose  ${c.dim('per generare il primo piano')}`);
+    console.log();
+    return;
+  }
+
+  console.log(`  Cadenza:     ${c.bold(String(plan.cadence ?? '—'))}`);
+  if (data.currentWeek != null) {
+    console.log(`  Settimana:   ${c.green(String(data.currentWeek + 1))} di 4`);
+  }
+
+  // Voice
+  const voice = plan.voice as Record<string, unknown> | undefined;
+  if (voice) {
+    console.log(`  Voice:       ${voice.mood ?? '—'} / ${voice.tone ?? '—'} / ${voice.goal ?? '—'}`);
+  }
+
+  // Platform mix
+  const mix = plan.platform_mix as Array<{ platform: string; share: string }> | undefined;
+  if (mix?.length) {
+    const parts = mix.map(m => `${m.platform} ${m.share}`);
+    console.log(`  Platform:    ${parts.join(' · ')}`);
+  }
+
+  // Strategy
+  if (plan.strategy) {
+    console.log(`\n  ${c.dim('Strategia:')}`);
+    console.log(`  ${String(plan.strategy).slice(0, 300)}${String(plan.strategy).length > 300 ? '…' : ''}`);
+  }
+
+  // Weeks
+  const weeks = (plan.weeks ?? []) as Record<string, unknown>[];
+  section(`Settimane (${weeks.length})`);
+
+  for (let i = 0; i < weeks.length; i++) {
+    const w = weeks[i];
+    const isCurrent = i === data.currentWeek;
+    const prefix = isCurrent ? c.green('▶') : ' ';
+    const theme = String(w.theme ?? '—');
+    const focus = String(w.focus ?? '');
+    const status = String(w.status ?? 'planned');
+    const brief = w.brief as string | null;
+
+    console.log(`\n  ${prefix} ${c.bold(`Settimana ${i + 1}`)} ${c.dim(`[${status}]`)}  ${theme}`);
+    if (focus) console.log(`    Focus: ${c.dim(focus.slice(0, 100))}`);
+    if (brief) console.log(`    Brief: ${c.yellow(brief.slice(0, 100))}`);
+    const weekProducts = w.products as string[] | null;
+    if (weekProducts?.length) {
+      console.log(`    Prodotti: ${c.cyan(weekProducts.join(', '))}`);
+    }
+
+    // Content mix
+    const contentMix = w.content_mix as Array<{ type: string; count: number }> | undefined;
+    if (contentMix?.length) {
+      const parts = contentMix.map(cm => `${cm.count}× ${cm.type}`);
+      console.log(`    Mix: ${c.dim(parts.join(', '))}`);
+    }
+
+    if (w.rationale) {
+      console.log(`    ${c.dim(String(w.rationale).slice(0, 120))}`);
+    }
+  }
+
+  // Commands
+  console.log(`\n  ${c.dim('Comandi:')}`);
+  console.log(`  anomalia plan ${slug} revise --feedback "..."   ${c.dim('→ richiedi revisione')}`);
+  console.log(`  anomalia plan ${slug} save-brief --week 0 --brief "..."  ${c.dim('→ salva brief')}`);
+  console.log(`  anomalia plan ${slug} replan --week 0 --brief "..."      ${c.dim('→ rigenera settimana')}`);
+
+  console.log();
+}
+
+async function proposePlan(token: string, slug: string) {
+  console.log(c.yellow('Generazione piano editoriale in corso…'));
+  const result = await api.proposePlan(token, slug);
+  ok('Piano proposto. Usa `anomalia plan ' + slug + '` per vederlo e `anomalia plan ' + slug + ' approve` per attivarlo.');
+}
+
+async function revisePlan(token: string, slug: string, feedback?: string) {
+  if (!feedback) {
+    console.error('--feedback è obbligatorio');
+    process.exit(1);
+  }
+  console.log(c.yellow('Revisione in corso…'));
+  await api.revisePlan(token, slug, feedback);
+  ok('Revisione proposta. Usa `anomalia plan ' + slug + '` per vederla.');
+}
+
+async function approvePlan(token: string, slug: string) {
+  await api.approvePlan(token, slug);
+  ok('Piano editoriale attivato.');
+}
+
+async function discardPlan(token: string, slug: string) {
+  await api.discardPlan(token, slug);
+  ok('Piano proposto scartato.');
+}
+
+async function saveBrief(token: string, slug: string, week?: number, brief?: string, products?: string, clearProducts?: boolean) {
+  if (week === undefined) { console.error('--week è obbligatorio (0-3)'); process.exit(1); }
+  if (!brief && !products && !clearProducts) { console.error('--brief, --products o --clear-products è obbligatorio'); process.exit(1); }
+  // --clear-products sends an explicit empty array; --products sends the parsed list.
+  const productList = clearProducts ? [] : (products ? products.split(',').map(p => p.trim()).filter(Boolean) : undefined);
+  await api.saveBrief(token, slug, week, brief ?? '', productList);
+  const parts = [];
+  if (brief) parts.push('brief');
+  if (clearProducts) parts.push('prodotti azzerati');
+  else if (productList?.length) parts.push(`${productList.length} prodotti`);
+  ok(`${parts.join(' + ')} per settimana ${week + 1}.`);
+}
+
+async function replanWeek(token: string, slug: string, week?: number, brief?: string) {
+  if (week === undefined) { console.error('--week è obbligatorio (0-3)'); process.exit(1); }
+  if (!brief) { console.error('--brief è obbligatorio'); process.exit(1); }
+  console.log(c.yellow(`Rigenerazione settimana ${week + 1}…`));
+  await api.replanWeek(token, slug, week, brief);
+  ok(`Settimana ${week + 1} rigenerata.`);
+}

--- a/cli/commands/post.ts
+++ b/cli/commands/post.ts
@@ -1,0 +1,220 @@
+import { requireSession } from '../lib/auth.ts';
+import { api, type PostPatch, type PostState } from '../lib/api.ts';
+import { c, ok, warn, info, fail, table } from '../lib/display.ts';
+import { parseKeyValuePairs } from '../lib/select.ts';
+
+type Opts = {
+  action?: string;
+  caption?: string; imagePrompt?: string; platforms?: string; contentType?: string;
+  format?: string; slot?: string; product?: string; scheduledFor?: string;
+  title?: string; link?: string; subreddit?: string; firstComment?: string;
+  media?: string; platformCaption?: string[];
+  instruction?: string; prompt?: string; index?: string; order?: string;
+  duration?: string; script?: string; aspectRatio?: string;
+};
+
+export async function cmdPost(slug: string, postId: string, opts: Opts) {
+  const { access_token: t } = await requireSession();
+  const action = opts.action ?? 'show';
+
+  switch (action) {
+    case 'show': return showPost(t, slug, postId);
+    case 'edit': return editPost(t, slug, postId, opts);
+    case 'approve': return api.approvePost(t, slug, postId).then(() => ok('Post approvato e schedulato.'));
+    case 'reject': return api.deletePost(t, slug, postId).then(() => ok('Post eliminato.'));
+    case 'publish': return publishNow(t, slug, postId);
+    case 'reschedule': return reschedulePost(t, slug, postId, opts.scheduledFor);
+    case 'render': return renderImage(t, slug, postId);
+    case 'regenerate': return regenerate(t, slug, postId, opts);
+    case 'slide': return editSlide(t, slug, postId, opts);
+    case 'reorder': return reorder(t, slug, postId, opts);
+    case 'video': return makeVideo(t, slug, postId, opts);
+    default:
+      fail(`Azione sconosciuta: ${action}`);
+      printHelp();
+      process.exit(1);
+  }
+}
+
+function printHelp() {
+  console.log(`
+${c.bold('Azioni Post:')}
+
+  ${c.green('show')}                    Dettaglio post — testo, media, slide del carosello
+
+  ${c.green('edit')}                    Modifica i campi (nessun render, nessun credito)
+    --caption "..."             Caption
+    --title "..."               Titolo (Reddit, carosello, link post)
+    --link "https://..."        URL del link post ("" per rimuoverlo)
+    --subreddit "r/..."         Subreddit di destinazione
+    --firstComment "..."        Primo commento (hashtag / CTA)
+    --imagePrompt "..."         Prompt immagine
+    --media "https://..."       Media URL ("" per renderlo text-only)
+    --format carousel           single_image | carousel | text_post | link_post | video
+    --platforms "ig,linkedin"   Piattaforme di cross-post
+    --platformCaption x="..."   Caption dedicata a una piattaforma (ripetibile)
+    --slot "2026-06-20T10:00"   Slot orario
+    --product "Nome"            Prodotto associato
+
+  ${c.green('regenerate')}              Rigenera l'immagine ${c.dim('(post a immagine singola — costa un render)')}
+    --instruction "sfondo più caldo"
+    --prompt "..."              Prompt completo sostitutivo (invece del refine)
+
+  ${c.green('slide')}                   Rigenera UNA slide del carosello ${c.dim('(costa un render)')}
+    --index 2                   Slide da modificare (0 = copertina)
+    --instruction "..."         Cosa cambiare
+    --prompt "..."              Prompt completo sostitutivo
+
+  ${c.green('reorder')}                 Riordina / elimina slide ${c.dim('(nessun render)')}
+    --order "0,2,1"             Nuovo ordine per indice; ometti un indice per eliminarlo
+
+  ${c.green('video')}                   Anima la cover in un clip ${c.dim('(costa budget video del mese)')}
+    --duration 6                Secondi (1-15, default dal brand)
+    --script "..."              Battuta parlata/on-screen, tagliata sulla durata
+    --instruction "..."         Direzione del clip (camera, movimento, mood)
+    --aspectRatio 9:16          9:16 | 1:1 | 16:9 | 4:3 | 3:4 | 21:9
+    ${c.dim('Funziona anche per riprovare un video fallito rimasto foto.')}
+
+  ${c.green('render')}                  Genera l'immagine mancante dal prompt
+  ${c.green('approve')}                 Approva e schedula
+  ${c.green('publish')}                 Pubblica subito
+  ${c.green('reject')}                  Elimina (solo pending)
+  ${c.green('reschedule')}              Riprogramma  --scheduledFor "2026-06-20T10:00"
+`);
+}
+
+async function showPost(t: string, slug: string, postId: string) {
+  const s: PostState = await api.getPostMedia(t, slug, postId);
+
+  const kind = s.is_carousel ? `carosello · ${s.slide_count} slide`
+    : s.text_only ? (s.link_url ? 'link post' : 'text post')
+    : s.format === 'video' ? 'video' : 'immagine singola';
+
+  console.log(`
+${c.bold('Post')} ${c.dim(postId)}  ${c.cyan(kind)}
+
+  Status:      ${s.status}
+  Platform:    ${s.platform ?? '—'}${s.platforms?.length ? c.dim(` (+ ${s.platforms.join(', ')})`) : ''}
+  Format:      ${s.format ?? '—'}${s.content_type ? c.dim(` / ${s.content_type}`) : ''}`);
+
+  if (s.title) console.log(`  Titolo:      ${s.title}`);
+  if (s.link_url) console.log(`  Link:        ${s.link_url}`);
+  if (s.subreddit) console.log(`  Subreddit:   ${s.subreddit}`);
+  console.log(`  Caption:     ${s.caption ?? c.dim('—')}`);
+  if (s.first_comment) console.log(`  1° commento: ${s.first_comment}`);
+  if (!s.is_carousel) {
+    console.log(`  Media:       ${s.media_url ?? c.dim('— (nessuna immagine)')}`);
+    if (s.image_prompt) console.log(`  Prompt:      ${c.dim(s.image_prompt.slice(0, 120))}`);
+  }
+  console.log();
+
+  if (s.slides?.length) {
+    table(
+      ['#', 'img', 'prompt'],
+      s.slides.map((sl) => [
+        sl.index === 0 ? `${sl.index} ${c.dim('(cover)')}` : String(sl.index),
+        sl.has_image ? c.green('✓') : c.red('✗'),
+        (sl.image_prompt ?? '—').slice(0, 60)
+      ])
+    );
+    info(`\nModifica una slide: anomalia post ${slug} ${postId} slide --index 1 --instruction "..."`);
+    info(`Riordina:           anomalia post ${slug} ${postId} reorder --order "0,2,1"\n`);
+  }
+}
+
+async function editPost(t: string, slug: string, postId: string, opts: Opts) {
+  const patch: PostPatch = {};
+  if (opts.caption !== undefined) patch.caption = opts.caption;
+  if (opts.title !== undefined) patch.title = opts.title;
+  if (opts.imagePrompt !== undefined) patch.image_prompt = opts.imagePrompt;
+  if (opts.contentType !== undefined) patch.content_type = opts.contentType;
+  if (opts.format !== undefined) patch.format = opts.format;
+  if (opts.slot !== undefined) patch.slot = opts.slot;
+  if (opts.product !== undefined) patch.product_name = opts.product;
+  if (opts.firstComment !== undefined) patch.first_comment = opts.firstComment;
+  if (opts.subreddit !== undefined) patch.subreddit = opts.subreddit;
+  if (opts.platforms !== undefined) patch.platforms = opts.platforms.split(',').map((s) => s.trim()).filter(Boolean);
+  // Empty string is the explicit "clear it" signal for both — null makes the post text-only.
+  if (opts.link !== undefined) patch.link_url = opts.link || null;
+  if (opts.media !== undefined) patch.media_url = opts.media || null;
+
+  // --platformCaption x="testo", repeatable. No pairs → don't touch the column.
+  if (opts.platformCaption?.length) {
+    const overrides = parseKeyValuePairs(opts.platformCaption);
+    if (!overrides) { fail('--platformCaption vuole platform=testo (es. x="testo breve")'); process.exit(1); }
+    patch.platform_captions = Object.keys(overrides).length ? overrides : null;
+  }
+
+  if (Object.keys(patch).length === 0) {
+    fail('Specifica almeno un campo da modificare');
+    printHelp();
+    process.exit(1);
+  }
+
+  await api.updatePost(t, slug, postId, patch);
+  ok(`Post aggiornato (${Object.keys(patch).join(', ')}).`);
+}
+
+async function regenerate(t: string, slug: string, postId: string, opts: Opts) {
+  if (!opts.instruction && !opts.prompt) { fail('Serve --instruction "cosa cambiare" o --prompt "prompt completo"'); process.exit(1); }
+  info('Rigenerazione immagine in corso…');
+  const r = await api.postMedia(t, slug, postId, { action: 'regenerate', instruction: opts.instruction, prompt: opts.prompt });
+  if (r.error) { fail(r.error); process.exit(1); }
+  if (r.rendered) ok(`Immagine rigenerata: ${r.media_url}`);
+  else warn('Nessuna immagine prodotta — il prompt è stato comunque salvato.');
+  if (r.notes) info(r.notes);
+}
+
+async function editSlide(t: string, slug: string, postId: string, opts: Opts) {
+  const index = Number(opts.index);
+  if (!Number.isInteger(index) || index < 0) { fail('Serve --index <n> (0 = copertina)'); process.exit(1); }
+  if (!opts.instruction && !opts.prompt) { fail('Serve --instruction o --prompt'); process.exit(1); }
+  info(`Rigenerazione slide ${index} in corso…`);
+  const r = await api.postMedia(t, slug, postId, { action: 'slide', index, instruction: opts.instruction, prompt: opts.prompt });
+  if (r.error) { fail(r.error); process.exit(1); }
+  ok(r.rendered ? `Slide ${index} rigenerata.` : `Slide ${index}: prompt aggiornato, nessuna immagine prodotta.`);
+}
+
+async function reorder(t: string, slug: string, postId: string, opts: Opts) {
+  if (!opts.order) { fail('Serve --order "0,2,1" (ometti un indice per eliminare quella slide)'); process.exit(1); }
+  const order = opts.order.split(',').map((s) => Number(s.trim()));
+  if (order.some((n) => !Number.isInteger(n) || n < 0)) { fail('--order vuole indici interi separati da virgola'); process.exit(1); }
+  const r = await api.postMedia(t, slug, postId, { action: 'restructure', order });
+  if (r.error) { fail(r.error); process.exit(1); }
+  ok(`Carosello riordinato — ${r.slide_count} slide.`);
+}
+
+async function makeVideo(t: string, slug: string, postId: string, opts: Opts) {
+  const duration = opts.duration === undefined ? undefined : Number(opts.duration);
+  if (duration !== undefined && (!Number.isInteger(duration) || duration < 1 || duration > 15)) {
+    fail('--duration vuole un intero tra 1 e 15 secondi'); process.exit(1);
+  }
+  info('Rendering del clip in corso — è la chiamata più costosa del motore, può richiedere qualche minuto…');
+  const r = await api.postMedia(t, slug, postId, {
+    action: 'video', duration, script: opts.script,
+    instruction: opts.instruction, aspectRatio: opts.aspectRatio
+  });
+  if (r.error) { fail(r.error); process.exit(1); }
+  ok(`Clip da ${r.duration_seconds}s allegato: ${r.media_url}`);
+  if (r.videos_left !== undefined) info(`Video rimasti questo mese: ${r.videos_left}`);
+}
+
+async function publishNow(t: string, slug: string, postId: string) {
+  info('Pubblicazione in corso…');
+  await api.publishPost(t, slug, postId);
+  ok('Post pubblicato.');
+}
+
+async function reschedulePost(t: string, slug: string, postId: string, scheduledFor?: string) {
+  if (!scheduledFor) { fail('--scheduledFor è obbligatorio (formato: 2026-06-20T10:00)'); process.exit(1); }
+  await api.reschedulePost(t, slug, postId, scheduledFor);
+  ok(`Post riprogrammato per ${scheduledFor}.`);
+}
+
+async function renderImage(t: string, slug: string, postId: string) {
+  info('Generazione immagine in corso…');
+  const result = await api.renderPost(t, slug, postId);
+  if (result.url) ok(`Immagine generata: ${result.url}`);
+  else if (result.error) warn(`Immagine non generata: ${result.error}`);
+  else warn('Immagine non generata (potrebbe essere un post text-only).');
+}

--- a/cli/commands/products.ts
+++ b/cli/commands/products.ts
@@ -1,0 +1,53 @@
+import { loadSession } from '../lib/auth.ts';
+import { api } from '../lib/api.ts';
+import { section, c, table, info, ok } from '../lib/display.ts';
+
+export async function cmdProducts(slug: string, opts: { action?: string }) {
+  const session = await loadSession();
+  if (!session) { console.error('Sessione scaduta o non trovata. Esegui: anomalia login'); process.exit(1); }
+
+  const action = opts.action ?? 'list';
+  switch (action) {
+    case 'list':
+      return listProducts(session.access_token, slug);
+    case 'sync':
+      return syncProducts(session.access_token, slug);
+    default:
+      console.error(`Azione sconosciuta: ${action}`);
+      console.log(`\n  ${c.green('list')}  Elenca i prodotti (default)\n  ${c.green('sync')}  Reimporta tutti i prodotti dal sito e-commerce\n`);
+      process.exit(1);
+  }
+}
+
+async function listProducts(token: string, slug: string) {
+  const { products } = await api.listProducts(token, slug);
+  section(`Prodotti (${products.length})`);
+  if (!products.length) {
+    info('Nessun prodotto. Usa `anomalia products ' + slug + ' sync` per importarli dal sito.');
+    return;
+  }
+  // Group by category for a readable overview.
+  const byKind = new Map<string, typeof products>();
+  for (const p of products) {
+    const k = p.kind || 'product';
+    (byKind.get(k) ?? byKind.set(k, []).get(k)!).push(p);
+  }
+  table(
+    ['Categoria', 'Prezzo', 'Img', 'Prodotto'],
+    products.map(p => [
+      p.kind || '—',
+      p.pricing ? `${p.pricing}` : '—',
+      p.imageCount > 0 ? String(p.imageCount) : c.red('0'),
+      p.title.slice(0, 60),
+    ])
+  );
+  const withImg = products.filter(p => p.imageCount > 0).length;
+  console.log(`\n  ${c.dim(`${withImg}/${products.length} con immagini · ${byKind.size} categorie`)}`);
+  console.log();
+}
+
+async function syncProducts(token: string, slug: string) {
+  console.log(c.yellow('Reimportazione prodotti dal sito…'));
+  const result = await api.syncProducts(token, slug);
+  ok(`${result.synced} prodotti importati da ${result.platform}.`);
+}

--- a/cli/commands/seo.ts
+++ b/cli/commands/seo.ts
@@ -1,0 +1,71 @@
+import { requireSession } from '../lib/auth.ts';
+import { api, type SeoInitiative } from '../lib/api.ts';
+import { section, table, c, info, ok, fail } from '../lib/display.ts';
+import { resolveByPrefix } from '../lib/select.ts';
+
+type Opts = { action: string; id?: string; guidance?: string };
+
+export async function cmdSeo(slug: string, opts: Opts) {
+  const { access_token: t } = await requireSession();
+
+  if (opts.action !== 'show') {
+    const map: Record<string, string> = { run: 'audit', plan: 'plan', more: 'more', asset: 'asset', article: 'article' };
+    const action = map[opts.action];
+    if (!action) { fail(`Azione sconosciuta: ${opts.action} (show, run, plan, more, asset, article)`); process.exit(1); }
+    let initiativeId = opts.id;
+    if (action === 'asset' || action === 'article') {
+      if (!initiativeId) { fail('Serve --id <initiativeId>'); process.exit(1); }
+      // The table prints short ids — expand the prefix against the live plan.
+      const { plan } = await api.getSeo(t, slug);
+      const hit = resolveByPrefix(plan?.initiatives ?? [], initiativeId);
+      if (!hit.ok) { fail(hit.reason === 'ambiguous' ? `Prefisso ambiguo: ${hit.count} iniziative` : 'Iniziativa non trovata'); process.exit(1); }
+      initiativeId = hit.item.id;
+    }
+
+    info(action === 'audit' ? 'Audit tecnico + piano in corso (può richiedere 1-2 min)…' : 'Generazione in corso…');
+    const res = await api.seoAction(t, slug, { action, initiativeId, guidance: opts.guidance });
+    if (res.error) { fail(res.error); process.exit(1); }
+    ok(
+      action === 'audit' ? `Audit completato — tech score ${res.techScore ?? '—'}`
+      : action === 'plan' ? `Piano generato — grade ${res.grade}, ${res.initiatives} iniziative`
+      : action === 'more' ? `${res.added} iniziative aggiunte`
+      : action === 'article' ? `Articolo generato — id ${res.articleId}`
+      : `${res.generated} asset generati`
+    );
+    return;
+  }
+
+  const data = await api.getSeo(t, slug);
+
+  section('SEO');
+  const audit = data.audit;
+  const tech = (audit?.tech ?? {}) as { issues?: { severity?: string; title?: string }[] };
+  const search = (audit?.search ?? {}) as { clicks?: number; impressions?: number; position?: number };
+  if (!audit) info('Nessun audit. Lancia: anomalia seo ' + slug + ' run');
+  else {
+    console.log(`  Tech score: ${c.bold(String(audit.tech_score ?? '—'))}/100`);
+    if (search.clicks != null) console.log(`  Search: ${search.clicks} click · ${search.impressions} impression · pos. media ${search.position?.toFixed?.(1) ?? '—'}`);
+    const issues = tech.issues ?? [];
+    if (issues.length) {
+      console.log(`  Problemi: ${c.yellow(String(issues.length))}`);
+      for (const i of issues.slice(0, 5)) console.log(`   ${c.dim('·')} ${i.title ?? ''} ${c.dim(`[${i.severity ?? '—'}]`)}`);
+    }
+  }
+
+  const plan = data.plan;
+  if (!plan?.initiatives?.length) { info('\nNessun piano SEO. Lancia: anomalia seo ' + slug + ' plan\n'); return; }
+
+  section(`Piano — grade ${plan.evaluation?.grade ?? plan.grade ?? '—'}`);
+  if (plan.evaluation?.summary) console.log(`  ${plan.evaluation.summary}\n`);
+
+  table(
+    ['id', 'tipo', 'titolo', 'impatto', 'sforzo', 'asset'],
+    plan.initiatives.map((i: SeoInitiative) => [
+      i.id.slice(0, 8), i.type, i.title.slice(0, 48),
+      i.impact ?? '—', i.effort ?? '—',
+      data.assets[i.id] ? c.green('✓') : c.dim('—')
+    ])
+  );
+  info(`\nGenera un asset:    anomalia seo ${slug} asset --id <id>`);
+  info(`Genera un articolo: anomalia seo ${slug} article --id <id>\n`);
+}

--- a/cli/commands/status.ts
+++ b/cli/commands/status.ts
@@ -1,0 +1,41 @@
+import { loadSession } from '../lib/auth.ts';
+import { api } from '../lib/api.ts';
+import { section, statusBadge, formatDate, autopilotBadge, c, table, info } from '../lib/display.ts';
+
+export async function cmdStatus(slug: string) {
+  const session = await loadSession();
+  if (!session) { console.error('Sessione scaduta o non trovata. Esegui: anomalia login'); process.exit(1); }
+
+  const detail = await api.getBrand(session.access_token, slug);
+  const brand = detail.brand;
+
+  section(`${brand.name}  (${brand.slug})`);
+  console.log(`  Piano:      ${c.bold(brand.plan ?? '—')}   Stato: ${statusBadge(brand.status ?? '')}`);
+  console.log(`  Autopilot:  ${autopilotBadge(brand.autopilot_enabled)}` +
+    (brand.autopilot_failure_count > 0 ? c.red(`  ⚠ ${brand.autopilot_failure_count} fallimenti consecutivi`) : ''));
+  if (detail.runs[0]) {
+    const runErr = detail.runs[0].status === 'failed' ? c.red(`  ✗ ${detail.runs[0].error ?? ''}`) : '';
+    console.log(`  Ultimo run: ${formatDate(detail.runs[0].created_at)} — ${detail.runs[0].posts_created} post${runErr}`);
+  }
+
+  section('Post');
+  const posts = await api.getPosts(session.access_token, slug);
+  const pending = posts.filter(p => p.status === 'pending_user');
+  const scheduled = posts.filter(p => p.status === 'scheduled');
+  console.log(`  In approvazione: ${c.yellow(String(pending.length))}   Schedulati: ${c.green(String(scheduled.length))}   Totale: ${posts.length}`);
+
+  if (pending.length) {
+    table(
+      ['Platform', 'Slot', 'Caption'],
+      pending.slice(0, 10).map(p => [
+        p.platform ?? '—',
+        p.slot ?? '—',
+        (p.caption ?? '').slice(0, 60) + ((p.caption?.length ?? 0) > 60 ? '…' : ''),
+      ])
+    );
+  }
+
+  section('Quota');
+  console.log(`  Prodotti: ${detail.productCount}   Account: ${detail.accountCount}`);
+  console.log();
+}

--- a/cli/commands/studio.ts
+++ b/cli/commands/studio.ts
@@ -1,0 +1,301 @@
+import { loadSession } from '../lib/auth.ts';
+import { api } from '../lib/api.ts';
+import { section, c, info, ok, warn } from '../lib/display.ts';
+
+export async function cmdStudio(slug: string, opts: {
+  action?: string;
+  // Brand kit
+  about?: string;
+  category?: string;
+  audience?: string;
+  style?: string;
+  language?: string;
+  // Colors
+  colors?: string;
+  // People
+  name?: string;
+  role?: string;
+  description?: string;
+  kind?: string;
+  gender?: string;
+  ageRange?: string;
+  vibe?: string;
+  // Documents
+  title?: string;
+  text?: string;
+  // Competitors
+  website?: string;
+  compKind?: string;
+  rationale?: string;
+  // Delete
+  id?: string;
+}) {
+  const session = await loadSession();
+  if (!session) { console.error('Sessione scaduta o non trovata. Esegui: anomalia login'); process.exit(1); }
+
+  const action = opts.action ?? 'show';
+
+  switch (action) {
+    case 'show':
+      return showStudio(session.access_token, slug);
+    case 'kit-update':
+      return updateKit(session.access_token, slug, opts);
+    case 'colors':
+      return setColors(session.access_token, slug, opts.colors);
+    case 'people-add':
+      return addPerson(session.access_token, slug, opts);
+    case 'people-generate':
+      return generatePerson(session.access_token, slug, opts);
+    case 'people-delete':
+      return deletePerson(session.access_token, slug, opts.id);
+    case 'add-note':
+      return addNote(session.access_token, slug, opts);
+    case 'delete-doc':
+      return deleteDocument(session.access_token, slug, opts.id);
+    case 'add-competitor':
+      return addCompetitor(session.access_token, slug, opts);
+    case 'delete-competitor':
+      return deleteCompetitor(session.access_token, slug, opts.id);
+    case 'research':
+      return researchCompetitors(session.access_token, slug);
+    case 'sync-history':
+      return syncHistory(session.access_token, slug);
+    default:
+      console.error(`Azione sconosciuta: ${action}`);
+      printHelp();
+      process.exit(1);
+  }
+}
+
+function printHelp() {
+  console.log(`
+${c.bold('Azioni Studio:')}
+
+  ${c.green('show')}                    Mostra lo studio completo (default)
+
+  ${c.green('kit-update')}              Aggiorna dati brand kit
+    --about "..."               Descrizione brand
+    --category "..."            Categoria
+    --audience "..."            Target audience
+    --style "..."               Stile visivo
+    --language "it"             Lingua post
+
+  ${c.green('colors')}                 Imposta colori brand
+    --colors "#ff0000,#00ff00"  Lista hex separata da virgola
+
+  ${c.green('people-add')}             Aggiungi persona reale
+    --name "Nome"               Nome (obbligatorio)
+    --role "Ruolo"              Ruolo
+    --description "..."         Descrizione
+
+  ${c.green('people-generate')}        Genera persona AI
+    --name "Nome"               Nome (obbligatorio)
+    --role "Ruolo"              Ruolo
+    --gender female|male        Genere
+    --ageRange 26-35            Fascia età
+    --vibe professional|casual  Stile
+
+  ${c.green('people-delete')}          Elimina persona
+    --id <uuid>                 ID persona
+
+  ${c.green('add-note')}               Aggiungi nota/conoscenza
+    --title "Titolo"            Titolo (default: "Note")
+    --text "Contenuto..."       Testo (obbligatorio)
+
+  ${c.green('delete-doc')}             Elimina documento
+    --id <uuid>                 ID documento
+
+  ${c.green('add-competitor')}         Aggiungi competitor
+    --name "Nome"               Nome (obbligatorio)
+    --website "example.com"     Sito web
+    --compKind direct|indirect  Tipo
+    --rationale "..."           Motivo
+
+  ${c.green('delete-competitor')}      Elimina competitor
+    --id <uuid>                 ID competitor
+
+  ${c.green('research')}               Ricerca competitor con AI
+
+  ${c.green('sync-history')}           Sincronizza storico post dai social
+`);
+}
+
+async function showStudio(token: string, slug: string) {
+  const data = await api.getStudio(token, slug);
+
+  section('Studio');
+
+  // Completeness
+  const barLen = 25;
+  const filled = Math.round((data.studioPct / 100) * barLen);
+  const scoreColor = data.studioPct >= 80 ? c.green : data.studioPct >= 50 ? c.yellow : c.red;
+  const bar = scoreColor('█'.repeat(filled)) + c.dim('░'.repeat(barLen - filled));
+  console.log(`  Completeness: [${bar}] ${c.bold(`${data.studioPct}%`)}`);
+  console.log();
+
+  // Brand kit
+  section('Brand Kit');
+  const kit = data.kit as Record<string, unknown> | null;
+  if (kit) {
+    if (kit.category) console.log(`  Categoria:     ${kit.category}`);
+    if (kit.about) console.log(`  About:         ${c.dim(String(kit.about).slice(0, 100))}${String(kit.about).length > 100 ? '…' : ''}`);
+    if (kit.target_audience) console.log(`  Audience:      ${c.dim(String(kit.target_audience).slice(0, 100))}`);
+    if (kit.brand_style) console.log(`  Stile:         ${kit.brand_style}`);
+    if (kit.visual_style) console.log(`  Stile visivo:  ${kit.visual_style}`);
+  }
+  if (data.language) console.log(`  Lingua:        ${data.language}`);
+
+  // Colors
+  const colors = (kit?.brand_colors as string[]) ?? [];
+  if (colors.length) {
+    console.log(`  Colori:        ${colors.map(col => c.hex(col)(col)).join(' ')}`);
+  }
+
+  console.log();
+
+  // Products
+  section(`Prodotti (${data.products.length})`);
+  for (const p of data.products) {
+    console.log(`  ${c.bold(p.title)}${p.pricing ? ` · ${p.pricing}` : ''}`);
+  }
+  console.log();
+
+  // People
+  section(`Persone (${data.people.length})`);
+  for (const p of data.people) {
+    const badge = p.kind === 'ai' ? c.cyan('🤖') : '👤';
+    console.log(`  ${badge} ${c.bold(p.name)} — ${p.role ?? '—'}  ${c.dim(p.id.slice(0, 8))}`);
+  }
+  console.log();
+
+  // Competitors
+  section(`Competitors (${data.competitors.length})`);
+  for (const comp of data.competitors) {
+    const src = comp.source === 'ai' ? c.cyan('🤖') : '👤';
+    console.log(`  ${src} ${c.bold(comp.name)} — ${comp.website ?? '—'} (${comp.kind})  ${c.dim(comp.id.slice(0, 8))}`);
+  }
+  console.log();
+
+  // Knowledge
+  section(`Knowledge (${data.documents.length})`);
+  for (const doc of data.documents) {
+    const icon = doc.kind === 'image' ? '🖼' : doc.kind === 'document' ? '📄' : '📝';
+    console.log(`  ${icon} ${doc.title}  ${c.dim(doc.id.slice(0, 8))}`);
+  }
+  console.log();
+
+  // Platform instructions
+  const instrEntries = Object.entries(data.platformInstructions).filter(([, v]) => v);
+  if (instrEntries.length) {
+    section('Istruzioni per platform');
+    for (const [plat, instr] of instrEntries) {
+      console.log(`  ${c.bold(plat)}: ${c.dim(instr.slice(0, 80))}${instr.length > 80 ? '…' : ''}`);
+    }
+    console.log();
+  }
+}
+
+async function updateKit(token: string, slug: string, opts: { about?: string; category?: string; audience?: string; style?: string; language?: string }) {
+  await api.updateBrandKit(token, slug, {
+    about: opts.about,
+    category: opts.category,
+    target_audience: opts.audience,
+    brand_style: opts.style,
+    language: opts.language,
+  });
+  ok('Brand kit aggiornato.');
+}
+
+async function setColors(token: string, slug: string, colorsStr?: string) {
+  if (!colorsStr) {
+    console.error('Specifica i colori con --colors "#hex1,#hex2,..."');
+    process.exit(1);
+  }
+  const colors = colorsStr.split(',').map(s => s.trim()).filter(Boolean);
+  const result = await api.updateColors(token, slug, colors);
+  ok(`Colori aggiornati: ${result.colors.join(', ')}`);
+}
+
+async function addPerson(token: string, slug: string, opts: { name?: string; role?: string; description?: string }) {
+  if (!opts.name) { console.error('--name è obbligatorio'); process.exit(1); }
+  const result = await api.addPerson(token, slug, {
+    name: opts.name,
+    role: opts.role,
+    description: opts.description,
+    kind: 'real',
+  });
+  ok(`Persona aggiunta: ${result.person.name} (${result.person.id})`);
+}
+
+async function generatePerson(token: string, slug: string, opts: { name?: string; role?: string; gender?: string; ageRange?: string; vibe?: string; description?: string }) {
+  if (!opts.name) { console.error('--name è obbligatorio'); process.exit(1); }
+  console.log(c.yellow('Generazione persona AI in corso (può richiedere qualche secondo)…'));
+  const result = await api.addPerson(token, slug, {
+    name: opts.name,
+    role: opts.role,
+    kind: 'ai',
+    gender: opts.gender,
+    ageRange: opts.ageRange,
+    vibe: opts.vibe,
+    description: opts.description,
+  });
+  ok(`Persona AI generata: ${result.person.name} (${result.person.id})`);
+}
+
+async function deletePerson(token: string, slug: string, id?: string) {
+  if (!id) { console.error('--id è obbligatorio'); process.exit(1); }
+  await api.deletePerson(token, slug, id);
+  ok('Persona eliminata.');
+}
+
+async function addNote(token: string, slug: string, opts: { title?: string; text?: string }) {
+  if (!opts.text) { console.error('--text è obbligatorio'); process.exit(1); }
+  const result = await api.addDocument(token, slug, {
+    title: opts.title ?? 'Note',
+    content_text: opts.text,
+    kind: 'note',
+  });
+  ok(`Nota aggiunta: ${result.document.title} (${result.document.id})`);
+}
+
+async function deleteDocument(token: string, slug: string, id?: string) {
+  if (!id) { console.error('--id è obbligatorio'); process.exit(1); }
+  await api.deleteDocument(token, slug, id);
+  ok('Documento eliminato.');
+}
+
+async function addCompetitor(token: string, slug: string, opts: { name?: string; website?: string; compKind?: string; rationale?: string }) {
+  if (!opts.name) { console.error('--name è obbligatorio'); process.exit(1); }
+  const result = await api.addCompetitor(token, slug, {
+    name: opts.name,
+    website: opts.website,
+    kind: opts.compKind ?? 'direct',
+    rationale: opts.rationale,
+  });
+  ok(`Competitor aggiunto: ${result.competitor.name} (${result.competitor.id})`);
+}
+
+async function deleteCompetitor(token: string, slug: string, id?: string) {
+  if (!id) { console.error('--id è obbligatorio'); process.exit(1); }
+  await api.deleteCompetitor(token, slug, id);
+  ok('Competitor eliminato.');
+}
+
+async function researchCompetitors(token: string, slug: string) {
+  console.log(c.yellow('Ricerca competitor con AI in corso…'));
+  const result = await api.researchCompetitors(token, slug);
+  ok(`Trovati ${result.found} competitor, ${result.added} nuovi aggiunti.`);
+}
+
+async function syncHistory(token: string, slug: string) {
+  console.log(c.yellow('Sincronizzazione storico post…'));
+  const result = await api.syncHistory(token, slug);
+  if (result.noAccounts) {
+    warn('Nessun account social collegato.');
+  } else {
+    ok(`${result.synced} post sincronizzati.`);
+    if (result.errors?.length) {
+      warn(`${result.errors.length} errori: ${result.errors.slice(0, 3).join(', ')}`);
+    }
+  }
+}

--- a/cli/commands/update.ts
+++ b/cli/commands/update.ts
@@ -68,7 +68,7 @@ export async function cmdUpdate() {
 
   console.log('  Download in corso…');
 
-  const url = `https://github.com/andreabuttarelli/anomalia-cli/releases/latest/download/anomalia-${platformName}`;
+  const url = `https://github.com/anomaliaso/anomalia/releases/latest/download/anomalia-${platformName}`;
   const binPath = selfPath;
 
   try {
@@ -76,7 +76,7 @@ export async function cmdUpdate() {
     if (!res.ok) {
       if (res.status === 404) {
         console.error(`  ✗ Release non trovata per ${platformName}`);
-        console.log(`  Scarica manualmente da: https://github.com/andreabuttarelli/anomalia-cli/releases`);
+        console.log(`  Scarica manualmente da: https://github.com/anomaliaso/anomalia/releases`);
       } else {
         console.error(`  ✗ Errore download: ${res.status}`);
       }
@@ -93,7 +93,7 @@ export async function cmdUpdate() {
   } catch (e) {
     console.error(`  ✗ Errore: ${String(e)}`);
     console.log(`\n  Aggiorna manualmente:`);
-    console.log(`  curl -sSL https://raw.githubusercontent.com/andreabuttarelli/anomalia-cli/main/scripts/install.sh | bash\n`);
+    console.log(`  curl -sSL https://raw.githubusercontent.com/anomaliaso/anomalia/main/cli/scripts/install.sh | bash\n`);
     process.exit(1);
   }
 }

--- a/cli/commands/update.ts
+++ b/cli/commands/update.ts
@@ -1,0 +1,99 @@
+import { c } from '../lib/display.ts';
+import { existsSync, writeFileSync, renameSync, chmodSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+function runningPath(): string {
+  // Compiled Bun binary: execPath is the CLI itself.
+  const exec = process.execPath.replace(/\\/g, '/');
+  if (/(^|\/)anomalia(-|$)/.test(exec.split('/').pop() ?? '')) return exec;
+  // Node/npm: argv[1] is the entry script under node_modules.
+  if (process.argv[1]) return process.argv[1].replace(/\\/g, '/');
+  return exec;
+}
+
+function detectInstallChannel(path: string): 'source' | 'homebrew' | 'npm' | 'binary' {
+  if (path.includes('/Cellar/') || path.includes('/homebrew/')) return 'homebrew';
+  if (path.includes('/node_modules/')) return 'npm';
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    if (existsSync(join(here, '..', '..', '.git'))) return 'source';
+  } catch {
+    // bundled entry may not expose a filesystem URL
+  }
+  return 'binary';
+}
+
+export async function cmdUpdate() {
+  console.log(c.bold('\nAggiornamento Anomalia CLI…\n'));
+
+  const platform = process.platform;
+  const arch = process.arch;
+  let platformName: string;
+
+  if (platform === 'darwin') {
+    platformName = arch === 'arm64' ? 'macos-arm64' : 'macos-x64';
+  } else if (platform === 'linux') {
+    platformName = arch === 'arm64' ? 'linux-arm64' : 'linux-x64';
+  } else {
+    console.error(`Piattaforma non supportata: ${platform}-${arch}`);
+    process.exit(1);
+  }
+
+  console.log(`  Piattaforma: ${platformName}`);
+
+  const selfPath = runningPath();
+  const channel = detectInstallChannel(selfPath);
+
+  if (channel === 'source') {
+    console.log('  Installazione da sorgente rilevata');
+    console.log(`\n  Per aggiornare:`);
+    console.log(`  git pull && bun install\n`);
+    return;
+  }
+
+  if (channel === 'homebrew') {
+    console.log('  Installazione Homebrew rilevata');
+    console.log(`\n  Per aggiornare:`);
+    console.log(`  brew update && brew upgrade anomalia\n`);
+    return;
+  }
+
+  if (channel === 'npm') {
+    console.log('  Installazione npm rilevata');
+    console.log(`\n  Per aggiornare:`);
+    console.log(`  npm install -g anomalia-cli@latest\n`);
+    return;
+  }
+
+  console.log('  Download in corso…');
+
+  const url = `https://github.com/andreabuttarelli/anomalia-cli/releases/latest/download/anomalia-${platformName}`;
+  const binPath = selfPath;
+
+  try {
+    const res = await fetch(url);
+    if (!res.ok) {
+      if (res.status === 404) {
+        console.error(`  ✗ Release non trovata per ${platformName}`);
+        console.log(`  Scarica manualmente da: https://github.com/andreabuttarelli/anomalia-cli/releases`);
+      } else {
+        console.error(`  ✗ Errore download: ${res.status}`);
+      }
+      process.exit(1);
+    }
+
+    const tempPath = `${binPath}.tmp`;
+    writeFileSync(tempPath, Buffer.from(await res.arrayBuffer()));
+    chmodSync(tempPath, 0o755);
+    renameSync(tempPath, binPath);
+
+    console.log(`\n  ${c.green('✓')} Anomalia CLI aggiornato!`);
+    console.log(`  Riavvia la CLI per usare la nuova versione.\n`);
+  } catch (e) {
+    console.error(`  ✗ Errore: ${String(e)}`);
+    console.log(`\n  Aggiorna manualmente:`);
+    console.log(`  curl -sSL https://raw.githubusercontent.com/andreabuttarelli/anomalia-cli/main/scripts/install.sh | bash\n`);
+    process.exit(1);
+  }
+}

--- a/cli/commands/upgrade.ts
+++ b/cli/commands/upgrade.ts
@@ -1,0 +1,26 @@
+import { loadSession } from '../lib/auth.ts';
+import { api } from '../lib/api.ts';
+import { c, info } from '../lib/display.ts';
+
+export async function cmdUpgrade(slug: string) {
+  const session = await loadSession();
+  if (!session) { console.error('Sessione scaduta o non trovata. Esegui: anomalia login'); process.exit(1); }
+
+  const detail = await api.getBrand(session.access_token, slug);
+  const brand = detail.brand;
+
+  console.log(c.bold(`\nUpgrade — ${brand.name}\n`));
+  console.log(`  Piano attuale: ${c.bold(brand.plan ?? '—')}`);
+  console.log(`  Status: ${brand.status ?? '—'}`);
+  console.log();
+
+  const url = `${process.env.PUBLIC_APP_URL}/app/${slug}/activate`;
+  console.log(`  Apertura pagina di upgrade…`);
+  console.log(`  ${c.dim(url)}`);
+
+  const { default: open } = await import('open');
+  await open(url);
+
+  info('\n  Dopo il pagamento, la CLI aggiornerà automaticamente il piano.');
+  console.log();
+}

--- a/cli/commands/voice.ts
+++ b/cli/commands/voice.ts
@@ -1,0 +1,56 @@
+import { loadSession } from '../lib/auth.ts';
+import { api } from '../lib/api.ts';
+import { section, c, info } from '../lib/display.ts';
+
+export async function cmdVoice(slug: string) {
+  const session = await loadSession();
+  if (!session) { console.error('Sessione scaduta o non trovata. Esegui: anomalia login'); process.exit(1); }
+
+  const data = await api.getVoice(session.access_token, slug);
+
+  section('Voice');
+
+  console.log(`  Modalità: ${data.voiceMode === 'auto' ? c.green('● Auto (da Studio)') : c.yellow('○ Manuale')}`);
+  console.log();
+
+  section('Framework vocale');
+  const fw = data.voiceFramework;
+  const fields: [string, string][] = [
+    ['Purpose', String(fw.purpose ?? '—')],
+    ['Audience', String(fw.audience ?? '—')],
+    ['Tone', String(fw.tone ?? '—')],
+    ['Register', fw.register != null ? `${fw.register}/100` : '—'],
+    ['Emotion', String(fw.emotion ?? '—')],
+    ['Character', String(fw.character ?? '—')],
+    ['Syntax', String(fw.syntax ?? '—')],
+    ['Terminology', String(fw.terminology ?? '—')],
+  ];
+  for (const [label, value] of fields) {
+    console.log(`  ${label.padEnd(14)}${c.dim(value)}`);
+  }
+  console.log();
+
+  if (data.platforms.length && Object.keys(data.platformRules).length) {
+    section('Regole per platform');
+    console.log(`  ${'Platform'.padEnd(14)}${'Tone'.padEnd(14)}${'Lunghezza'.padEnd(14)}${'Emoji'.padEnd(10)}Hashtags`);
+    for (const plat of data.platforms) {
+      const rules = data.platformRules[plat] ?? {};
+      console.log(`  ${plat.padEnd(14)}${c.dim(String(rules.tone ?? '—').padEnd(14))}${c.dim(String(rules.length ?? '—').padEnd(14))}${c.dim(String(rules.emoji ?? '—').padEnd(10))}${c.dim(String(rules.hashtags ?? '—'))}`);
+    }
+    console.log();
+  }
+
+  if (data.avoid.length) {
+    section('Parole vietate');
+    console.log(`  ${c.red(data.avoid.join(', '))}`);
+    console.log();
+  }
+
+  if (Object.keys(data.platformInstructions).length) {
+    section('Istruzioni per platform');
+    for (const [plat, instr] of Object.entries(data.platformInstructions)) {
+      if (instr) console.log(`  ${c.bold(plat)}: ${c.dim(instr.slice(0, 100))}${instr.length > 100 ? '…' : ''}`);
+    }
+    console.log();
+  }
+}

--- a/cli/commands/web.ts
+++ b/cli/commands/web.ts
@@ -1,0 +1,60 @@
+import { requireSession } from '../lib/auth.ts';
+import { api, type WebArticle } from '../lib/api.ts';
+import { section, table, c, info, ok, fail, formatDate, statusBadge } from '../lib/display.ts';
+import { resolveByPrefix } from '../lib/select.ts';
+
+type Opts = { action: string; status?: string; topic?: string; id?: string };
+
+export async function cmdWeb(slug: string, opts: Opts) {
+  const { access_token: t } = await requireSession();
+
+  if (opts.action === 'list') {
+    const { articles } = await api.getWeb(t, slug, opts.status);
+    section(`Articoli blog${opts.status && opts.status !== 'all' ? ` — ${opts.status}` : ''}`);
+    if (!articles.length) { info(`Nessun articolo. Lancia: anomalia web ${slug} generate --topic "..."\n`); return; }
+
+    table(
+      ['id', 'titolo', 'status', 'meta', 'data'],
+      articles.map((a: WebArticle) => [
+        a.id.slice(0, 8),
+        a.title.slice(0, 46),
+        statusBadge(a.status),
+        // The two SEO fields that decide the snippet — missing ones are the common defect.
+        `${a.meta_title ? c.green('T') : c.red('T')}${a.meta_description ? c.green('D') : c.red('D')}`,
+        formatDate(a.published_at ?? a.scheduled_for ?? a.created_at)
+      ])
+    );
+    info(`\nPubblica:  anomalia web ${slug} publish --id <id>`);
+    info(`Ottimizza: anomalia web ${slug} optimize --id <id>\n`);
+    return;
+  }
+
+  if (opts.action === 'generate') {
+    if (!opts.topic) { fail('Serve --topic "argomento"'); process.exit(1); }
+    info('Generazione articolo in corso (può richiedere qualche minuto)…');
+    const res = await api.webAction(t, slug, { action: 'generate', topic: opts.topic });
+    ok(`Articolo generato in draft — id ${res.articleId}`);
+    return;
+  }
+
+  if (['publish', 'unpublish', 'delete', 'optimize'].includes(opts.action)) {
+    if (!opts.id) { fail('Serve --id <articleId>'); process.exit(1); }
+    // The table prints short ids — expand the prefix against the live list.
+    const { articles } = await api.getWeb(t, slug, 'all');
+    const hit = resolveByPrefix(articles, opts.id);
+    if (!hit.ok) { fail(hit.reason === 'ambiguous' ? `Prefisso ambiguo: ${hit.count} articoli` : 'Articolo non trovato'); process.exit(1); }
+    const matches = [hit.item];
+
+    if (opts.action === 'optimize') info('Ottimizzazione SEO in corso…');
+    const res = await api.webAction(t, slug, { action: opts.action, id: matches[0].id });
+    ok(
+      opts.action === 'delete' ? `Eliminato: ${matches[0].title}`
+      : opts.action === 'optimize' ? `Ottimizzato: ${matches[0].title}`
+      : `${matches[0].title} → ${res.status}`
+    );
+    return;
+  }
+
+  fail(`Azione sconosciuta: ${opts.action} (list, generate, publish, unpublish, optimize, delete)`);
+  process.exit(1);
+}

--- a/cli/commands/weekly-plan.ts
+++ b/cli/commands/weekly-plan.ts
@@ -1,0 +1,150 @@
+import { loadSession } from '../lib/auth.ts';
+import { api } from '../lib/api.ts';
+import { section, statusBadge, formatDate, c, table, info, ok, warn } from '../lib/display.ts';
+
+export async function cmdWeeklyPlan(slug: string, opts: {
+  action?: string;
+  week?: number;
+  verbose?: boolean;
+}) {
+  const session = await loadSession();
+  if (!session) { console.error('Sessione scaduta o non trovata. Esegui: anomalia login'); process.exit(1); }
+
+  const action = opts.action ?? 'show';
+
+  switch (action) {
+    case 'show':
+      return showWeeklyPlan(session.access_token, slug, opts.week);
+    case 'plan':
+      return planWeek(session.access_token, slug, opts.week);
+    case 'produce':
+      return produceWeek(session.access_token, slug, opts.week);
+    case 'render':
+      return renderWeek(session.access_token, slug, opts.week, opts.verbose);
+    default:
+      console.error(`Azione sconosciuta: ${action}`);
+      printHelp();
+      process.exit(1);
+  }
+}
+
+function printHelp() {
+  console.log(`
+${c.bold('Azioni Piano Settimanale:')}
+
+  ${c.green('show')}                    Mostra piano settimanale (default)
+    --week N                        Numero settimana (default: corrente)
+
+  ${c.green('plan')}                    Genera seeds per una settimana
+    --week N                        Numero settimana (0-3)
+
+  ${c.green('produce')}                 Produci tutti i seeds in post
+    --week N                        Numero settimana (0-3)
+
+  ${c.green('render')}                  Genera le immagini di tutti i post della settimana
+    --week N                        Numero settimana (default: tutti i pending)
+`);
+}
+
+async function showWeeklyPlan(token: string, slug: string, week?: number) {
+  const data = await api.getWeeklyPlan(token, slug);
+
+  section('Piano Settimanale');
+
+  if (!data.plan) {
+    info('Nessun piano editoriale attivo.');
+    console.log(`\n  ${c.dim('Usa:')} anomalia plan ${slug} propose  ${c.dim('per generare il piano')}`);
+    console.log();
+    return;
+  }
+
+  // Week navigator
+  const weekIdx = week ?? data.currentWeekIdx;
+  console.log('  Settimane:');
+  const weekLine = data.plan.weeks.map((w, i) => {
+    const isCurrent = i === weekIdx;
+    return isCurrent ? c.green(`▶W${i + 1} ${w.theme.slice(0, 15)}`) : c.dim(`  W${i + 1} ${w.theme.slice(0, 15)}`);
+  }).join(c.dim(' │ '));
+  console.log(`  ${weekLine}`);
+
+  // Current week info
+  const currentWeek = weekIdx != null ? data.plan.weeks[weekIdx] : null;
+  if (currentWeek) {
+    console.log(`\n  ${c.bold(`Settimana ${weekIdx! + 1}:`)} ${currentWeek.theme}`);
+  }
+
+  // Posts
+  if (data.posts.length) {
+    section('Post generati');
+    table(
+      ['Platform', 'Slot', 'Status', 'Pillar', 'Caption'],
+      data.posts.slice(0, 20).map(p => [
+        p.platform ?? '—',
+        formatDate(p.slot || p.scheduled_for),
+        statusBadge(p.status),
+        p.pillar ?? '—',
+        (p.caption ?? '').slice(0, 40) + ((p.caption?.length ?? 0) > 40 ? '…' : ''),
+      ])
+    );
+  }
+
+  // Seeds
+  if (data.seeds) {
+    const seeds = (data.seeds.seeds ?? []) as Record<string, unknown>[];
+    if (seeds.length) {
+      section(`Seeds (${seeds.length})`);
+      table(
+        ['Platform', 'Format', 'Pillar', 'Angle'],
+        seeds.map(s => [
+          String(s.platform ?? '—'),
+          String(s.format ?? '—'),
+          String(s.pillar ?? '—'),
+          String(s.angle ?? '—').slice(0, 50),
+        ])
+      );
+      console.log(`\n  ${c.dim('Usa:')} anomalia weekly-plan ${slug} produce --week ${weekIdx ?? 0}  ${c.dim('→ produci tutti')}`);
+    }
+  } else {
+    info('\n  Nessun seed per questa settimana.');
+    console.log(`  ${c.dim('Usa:')} anomalia weekly-plan ${slug} plan --week ${weekIdx ?? 0}  ${c.dim('→ genera seeds')}`);
+  }
+
+  // Quota
+  const q = data.quota;
+  console.log(`\n  Quota: ${q.used}/${q.max} post questo mese`);
+
+  console.log();
+}
+
+async function planWeek(token: string, slug: string, week?: number) {
+  if (week === undefined) { console.error('--week è obbligatorio (0-3)'); process.exit(1); }
+  console.log(c.yellow(`Generazione seeds per settimana ${week + 1}…`));
+  const result = await api.planWeek(token, slug, week);
+  ok(`Seeds generati. Usa ` + c.bold(`anomalia weekly-plan ${slug}`) + ` per vederli.`);
+}
+
+async function produceWeek(token: string, slug: string, week?: number) {
+  // Get the draft
+  const data = await api.getWeeklyPlan(token, slug);
+  if (!data.seeds) { warn('Nessun seed da produrre.'); return; }
+
+  console.log(c.yellow('Produzione post in corso…'));
+  const result = await api.produceWeek(token, slug, data.seeds.id);
+  ok(`${result.produced} post prodotti.`);
+}
+
+async function renderWeek(token: string, slug: string, week?: number, verbose?: boolean) {
+  console.log(c.yellow('Generazione immagini in corso (review attivo)…'));
+  const result = await api.renderWeek(token, slug, week);
+  if (!result.results.length) { info('Nessun post da renderizzare (immagini già presenti o solo text).'); return; }
+  for (const r of result.results) {
+    const label = r.product ? c.dim(` [${r.product.slice(0, 40)}]`) : '';
+    if (r.ok) console.log(`  ${c.green('✓')}${label} ${r.url}`);
+    else console.log(`  ${c.red('✗')}${label} ${r.id}: ${r.error ?? 'errore'}`);
+    if (verbose && r.qc) {
+      const tag = r.qc.pass ? c.green(`QC ${r.qc.score}/10`) : c.yellow(`QC ${r.qc.score}/10${r.qc.retried ? ' (retry)' : ''}`);
+      console.log(`     ${tag}${r.qc.issues.length ? c.dim(` — ${r.qc.issues.join('; ')}`) : ''}`);
+    }
+  }
+  ok(`${result.rendered} immagini generate${result.failed ? `, ${result.failed} fallite` : ''}.`);
+}

--- a/cli/docs/ai.md
+++ b/cli/docs/ai.md
@@ -1,0 +1,122 @@
+# AI Chat — Guida
+
+Il comando `ai` ti permette di chattare con l'AI di Anomalia direttamente dalla CLI. Può fare tutto ciò che fa il chatbot nella dashboard web.
+
+## Uso base
+
+```bash
+anomalia ai my-brand --message "Il tuo messaggio"
+```
+
+## Esempi per categoria
+
+### Analisi
+
+```bash
+# Analizza i post
+anomalia ai my-brand --message "Analizza i miei ultimi 10 post e dimmi quali funzionano meglio"
+
+# Benchmark competitor
+anomalia ai my-brand --message "Confronta la mia strategia con i competitor"
+
+# Suggerimenti
+anomalia ai my-brand --message "Cosa posso migliorare nella mia strategia di contenuto?"
+```
+
+### Modifiche brand
+
+```bash
+# Brand kit
+anomalia ai my-brand --message "Cambia la descrizione del brand in 'Ristorante fusion italiano'"
+anomalia ai my-brand --message "Aggiorna il target audience a 'giovani professionisti 25-35'"
+
+# Colori
+anomalia ai my-brand --message "Imposta i colori del brand a #7c5cff e #ffffff"
+
+# Voice
+anomalia ai my-brand --message "Cambia il tone a friendly e professionale"
+anomalia ai my-brand --message "Aggiungi 'costoso' alle parole vietate"
+```
+
+### Modifiche contenuto
+
+```bash
+# Caption
+anomalia ai my-brand --message "Riscrivi la caption dell'ultimo post in modo più breve"
+anomalia ai my-brand --message "Rendi la caption più emozionale"
+
+# Approvazione
+anomalia ai my-brand --message "Approva tutti i post pending"
+anomalia ai my-brand --message "Approva il post con caption '...'"
+
+# Scheduling
+anomalia ai my-brand --message "Sposta il prossimo post a lunedì alle 10"
+anomalia ai my-brand --message "Pubblica subito il post più recente"
+```
+
+### Strategia
+
+```bash
+# Piano editoriale
+anomalia ai my-brand --message "Cambia il tema della settimana 2 a 'dietro le quinte'"
+anomalia ai my-brand --message "Aumenta la frequenza a 5 post a settimana"
+anomalia ai my-brand --message "Aggiungi LinkedIn al platform mix"
+
+# GTM
+anomalia ai my-brand --message "Cambia l'obiettivo GTM a 'aumentare le vendite online'"
+anomalia ai my-brand --message "Aggiorna i KPI della fase corrente"
+```
+
+### Studio
+
+```bash
+# Competitor
+anomalia ai my-brand --message "Aggiungi competitor Notion e Asana"
+anomalia ai my-brand --message "Ricerca nuovi competitor"
+
+# Prodotti
+anomalia ai my-brand --message "Aggiorna il prezzo della Pizza Margherita a €14"
+
+# Persone
+anomalia ai my-brand --message "Aggiungi Marco come CEO del brand"
+
+# Conoscenza
+anomalia ai my-brand --message "Aggiungi una nota: il nostro pubblico preferisce video brevi"
+```
+
+## Pipe mode (per agenti AI)
+
+Quando usi la CLI da un agente AI o in un pipeline, usa `--pipe` per output raw:
+
+```bash
+# Input da pipe
+echo "Analizza i miei post" | anomalia ai my-brand --pipe
+
+# Output raw (senza formattazione)
+anomalia ai my-brand --message "Riassumi il brand" --pipe
+
+# In uno script
+response=$(anomalia ai my-brand --message "Quali sono i KPI?" --pipe)
+echo "$response"
+```
+
+## Come funziona internamente
+
+1. La CLI invia il messaggio a `POST /app/{slug}/chat`
+2. Il backend costruisce il system prompt con tutti i dati del brand
+3. L'AI (Gemini 3.5 Flash) risponde usando i suoi tools (read/write)
+4. La risposta viene streamata alla CLI
+5. Se l'AI esegue un'azione (es. modifica un post), i dati vengono aggiornati nel DB
+
+## Limiti
+
+- Le operazioni async (ricerca competitor, sync social, generazione persone AI) richiedono più tempo e possono non completarsi in una singola chiamata
+- Per operazioni complesse, usa i comandi CLI dedicati (`anomalia studio`, `anomalia post`, etc.)
+- L'AI ha accesso in lettura/scrittura a tutti i dati del brand
+
+## Suggerimenti
+
+- Sii specifico nei messaggi per risultati migliori
+- Puoi fare riferimento a post, prodotti, persone per nome
+- L'AI ricorda il contesto della conversazione (ultimi 50 messaggi)
+- Usa `anomalia ai my-brand --message "aiuto"` per vedere cosa può fare

--- a/cli/docs/api.md
+++ b/cli/docs/api.md
@@ -1,0 +1,390 @@
+# API Reference
+
+Tutti gli endpoint sono sotto `/api/v1/` e richiedono autenticazione Bearer token.
+
+## Autenticazione
+
+```
+Authorization: Bearer <jwt_token>
+```
+
+Il token viene ottenuto tramite il flow OAuth della CLI. Viene salvato in `~/.config/anomalia/session.json` e rinnovato automaticamente.
+
+## Brand
+
+### GET /api/v1/brands
+
+Lista tutti i brand dell'utente.
+
+**Response:**
+```json
+[
+  {
+    "id": "uuid",
+    "name": "My Brand",
+    "slug": "my-brand",
+    "plan": "pro",
+    "status": "active",
+    "autopilot_enabled": true,
+    "autopilot_failure_count": 0,
+    "last_autopilot_run_at": "2026-06-19T10:00:00Z",
+    "timezone": "Europe/Rome",
+    "pendingCount": 3
+  }
+]
+```
+
+### GET /api/v1/brands/:slug
+
+Dettaglio completo di un brand.
+
+**Response:**
+```json
+{
+  "brand": { ... },
+  "pendingCount": 3,
+  "runs": [{ "status": "completed", "posts_created": 5, "created_at": "...", "error": null }],
+  "plan": { "id": "...", "status": "active", "cadence": "5/week", "weeks": [...] },
+  "productCount": 12,
+  "accountCount": 3,
+  "scheduledCount": 8,
+  "publishedCount": 45,
+  "hasGtm": true,
+  "hasContentPlans": true,
+  "hasHistory": true,
+  "kit": { "about": "...", "brand_colors": ["#fff"] },
+  "logoUrl": "https://..."
+}
+```
+
+## Posts
+
+### GET /api/v1/brands/:slug/posts
+
+Lista post con filtro opzionale.
+
+**Query params:**
+- `status` (opzionale): `pending_user`, `approved`, `scheduled`, `published`, `failed`
+
+**Response:**
+```json
+[
+  {
+    "id": "uuid",
+    "brand_id": "uuid",
+    "platform": "instagram",
+    "caption": "...",
+    "status": "pending_user",
+    "slot": "2026-06-20T10:00:00Z",
+    "scheduled_for": "2026-06-20T10:00:00Z",
+    "pillar": "educational",
+    "format": "carousel",
+    "product_name": "Pizza Margherita",
+    "created_at": "2026-06-19T08:00:00Z"
+  }
+]
+```
+
+### POST /api/v1/brands/:slug/posts/:id/approve
+
+Approva e pubblica un singolo post.
+
+**Response:**
+```json
+{ "ok": true, "status": "published" }
+```
+
+### POST /api/v1/brands/:slug/posts/approve-all
+
+Approva tutti i post pending.
+
+**Response:**
+```json
+{
+  "results": [
+    { "id": "uuid", "ok": true },
+    { "id": "uuid", "ok": false, "error": "..." }
+  ]
+}
+```
+
+## Strategia
+
+### GET /api/v1/brands/:slug/editorial-plan
+
+Piano editoriale attivo e proposto.
+
+### GET /api/v1/brands/:slug/weekly-plan
+
+Piano settimanale con seeds e quota.
+
+### GET /api/v1/brands/:slug/gtm
+
+GTM Roadmap con fasi e KPI.
+
+### GET /api/v1/brands/:slug/voice
+
+Voice framework e regole per platform.
+
+## Analytics
+
+### GET /api/v1/brands/:slug/analytics
+
+Analytics completi.
+
+### GET /api/v1/brands/:slug/calendar?month=YYYY-MM
+
+Calendario mensile.
+
+## Studio
+
+### GET /api/v1/brands/:slug/studio
+
+Studio completo (brand kit, products, people, competitors, documents).
+
+### PUT /api/v1/brands/:slug/studio/kit
+
+Aggiorna brand kit.
+
+**Body:**
+```json
+{
+  "about": "...",
+  "category": "...",
+  "target_audience": "...",
+  "brand_style": "...",
+  "language": "it"
+}
+```
+
+### PUT /api/v1/brands/:slug/studio/colors
+
+Imposta colori brand.
+
+**Body:**
+```json
+{ "colors": ["#7c5cff", "#ffffff"] }
+```
+
+### POST /api/v1/brands/:slug/studio/people
+
+Crea persona (reale o AI).
+
+**Body (persona reale):**
+```json
+{
+  "name": "Marco",
+  "role": "CEO",
+  "description": "...",
+  "kind": "real"
+}
+```
+
+**Body (persona AI):**
+```json
+{
+  "name": "Sofia",
+  "role": "Influencer",
+  "kind": "ai",
+  "gender": "female",
+  "ageRange": "26-35",
+  "vibe": "professional"
+}
+```
+
+### DELETE /api/v1/brands/:slug/studio/people/:id
+
+Elimina persona.
+
+### POST /api/v1/brands/:slug/studio/documents
+
+Aggiungi nota o documento.
+
+**Body:**
+```json
+{
+  "title": "Tone of voice",
+  "content_text": "Siamo amichevoli...",
+  "kind": "note"
+}
+```
+
+### DELETE /api/v1/brands/:slug/studio/documents/:id
+
+Elimina documento.
+
+### POST /api/v1/brands/:slug/studio/competitors
+
+Aggiungi competitor.
+
+**Body:**
+```json
+{
+  "name": "RivalCo",
+  "website": "rivalco.com",
+  "kind": "direct",
+  "rationale": "Compete nel nostro settore"
+}
+```
+
+### PUT /api/v1/brands/:slug/studio/competitors/:id
+
+Modifica competitor.
+
+### DELETE /api/v1/brands/:slug/studio/competitors/:id
+
+Elimina competitor.
+
+### POST /api/v1/brands/:slug/studio/competitors/research
+
+Ricerca competitor con AI.
+
+**Response:**
+```json
+{ "ok": true, "found": 5, "added": 3 }
+```
+
+### POST /api/v1/brands/:slug/studio/history/sync
+
+Sincronizza storico post dai social.
+
+**Response:**
+```json
+{ "synced": 24 }
+```
+
+## Posts (editing)
+
+### PUT /api/v1/brands/:slug/posts/:id
+
+Modifica un post.
+
+**Body:**
+```json
+{
+  "caption": "Nuovo testo",
+  "image_prompt": "Un caffè artigianale",
+  "platforms": ["instagram", "facebook"],
+  "content_type": "carousel",
+  "slot": "2026-06-20T10:00:00Z",
+  "product_name": "Pizza Margherita"
+}
+```
+
+### DELETE /api/v1/brands/:slug/posts/:id
+
+Elimina un post (solo status `pending_user`).
+
+### POST /api/v1/brands/:slug/posts/:id/reschedule
+
+Riprogramma un post.
+
+**Body:**
+```json
+{ "scheduled_for": "2026-06-20T10:00:00Z" }
+```
+
+### POST /api/v1/brands/:slug/posts/:id/publish
+
+Pubblica immediatamente un post.
+
+## Strategia
+
+### POST /api/v1/brands/:slug/editorial-plan/update
+
+Modifica il piano editoriale.
+
+**Body:**
+```json
+{
+  "voice": { "mood": "friendly", "tone": "casual" },
+  "cadence": "5/week",
+  "platform_mix": { "instagram": 0.6, "tiktok": 0.4 },
+  "week_index": 0,
+  "week_theme": "Dietro le quinte",
+  "week_brief": "Mostra il processo creativo"
+}
+```
+
+### POST /api/v1/brands/:slug/gtm/update
+
+Modifica il piano GTM.
+
+**Body:**
+```json
+{
+  "objective": "Aumentare brand awareness",
+  "phase_index": 0,
+  "phase_name": "Lancio",
+  "phase_objective": "Raggiungere 1000 follower",
+  "platform_weights": { "instagram": 0.7, "tiktok": 0.3 },
+  "pillars": ["educational", "behind-the-scenes"]
+}
+```
+
+### POST /api/v1/brands/:slug/voice/update
+
+Modifica il voice framework.
+
+**Body:**
+```json
+{
+  "mood": "energico",
+  "tone": "friendly",
+  "register": 40,
+  "emotion": "entusiasta",
+  "character": "amichevole",
+  "syntax": "short",
+  "platform_instructions": { "instagram": "Usa emoji con moderazione" },
+  "avoid": ["costoso", "economico"]
+}
+```
+
+## Prodotti
+
+### PUT /api/v1/brands/:slug/products/:id
+
+Modifica un prodotto.
+
+**Body:**
+```json
+{
+  "title": "Pizza Gourmet",
+  "description": "La nostra pizza signature",
+  "pricing": "€12",
+  "featured": true
+}
+```
+
+### DELETE /api/v1/brands/:slug/products/:id
+
+Elimina un prodotto.
+
+## Persone
+
+### PUT /api/v1/brands/:slug/people/:id
+
+Modifica una persona.
+
+**Body:**
+```json
+{
+  "name": "Marco Rossi",
+  "role": "CEO",
+  "description": "Fondatore",
+  "attributes": { "gender": "male", "ageRange": "36-50" }
+}
+```
+
+## Errori
+
+Tutti gli endpoint restituiscono errori in questo formato:
+
+```json
+{ "error": "Messaggio di errore" }
+```
+
+Codici HTTP:
+- `401` — Token mancante o invalido
+- `404` — Brand o risorsa non trovata
+- `500` — Errore interno del server

--- a/cli/docs/distribute.md
+++ b/cli/docs/distribute.md
@@ -5,8 +5,8 @@
 | Channel | Command |
 |---------|---------|
 | **npm** | `npm install -g anomalia-cli` |
-| **Homebrew** | `brew tap andreabuttarelli/anomalia-cli https://github.com/andreabuttarelli/anomalia-cli && brew install anomalia` |
-| **curl** | `curl -sSL https://raw.githubusercontent.com/andreabuttarelli/anomalia-cli/main/scripts/install.sh \| bash` |
+| **Homebrew** | `brew tap anomaliaso/tap https://github.com/anomaliaso/homebrew-tap && brew install anomalia` (tap repo created once, see below) |
+| **curl** | `curl -sSL https://raw.githubusercontent.com/anomaliaso/anomalia/main/cli/scripts/install.sh \| bash` |
 | **From source** | `bun install && bun run cli.ts` |
 
 ## npm
@@ -26,27 +26,30 @@ One-time npm setup:
 1. Create the package scope/name on [npmjs.com](https://www.npmjs.com) if needed (`anomalia-cli`).
 2. Create a granular access token (read/write for `anomalia-cli`) or classic automation token.
 3. Add it as GitHub Actions secret `NPM_TOKEN` on this repo.
-4. Push a tag: `git tag v0.1.0 && git push origin v0.1.0`.
+4. Push a tag: `git tag cli-v0.1.0 && git push origin cli-v0.1.0`.
 
 Optional: configure [Trusted Publishing](https://docs.npmjs.com/trusted-publishers) for
-`andreabuttarelli/anomalia-cli` → workflow `release.yml` and drop the token later.
+`anomaliaso/anomalia` → workflow `cli-release.yml` and drop the token later.
 
 ## Homebrew
 
-Formula: [`Formula/anomalia.rb`](../Formula/anomalia.rb) (same-repo tap).
+Formula: [`Formula/anomalia.rb`](../Formula/anomalia.rb). A Homebrew tap must be its own
+repository, so the formula is published to [`anomaliaso/homebrew-tap`](https://github.com/anomaliaso/homebrew-tap)
+(create it once by copying the formula from this repo):
 
 ```bash
-brew tap andreabuttarelli/anomalia-cli https://github.com/andreabuttarelli/anomalia-cli
+brew tap anomaliaso/tap https://github.com/anomaliaso/homebrew-tap
 brew install anomalia
 anomalia --version
 ```
 
-On each `v*` release, CI:
+On each `cli-v*` release, CI on `anomaliaso/anomalia`:
 
 1. Builds `anomalia-<platform>` binaries and `.tar.gz` archives
 2. Attaches them to the GitHub Release (raw binaries keep `install.sh` working)
 3. Rewrites formula `version` + `sha256` via `scripts/update-homebrew-formula.sh`
-4. Commits the formula bump to `main`
+4. Commits the formula bump to `main` here; pushes it to the tap when the `TAP_TOKEN`
+   secret is set
 
 Users update with:
 

--- a/cli/docs/distribute.md
+++ b/cli/docs/distribute.md
@@ -1,0 +1,64 @@
+# Distribute the Anomalia CLI (npm + Homebrew)
+
+## Install channels
+
+| Channel | Command |
+|---------|---------|
+| **npm** | `npm install -g anomalia-cli` |
+| **Homebrew** | `brew tap andreabuttarelli/anomalia-cli https://github.com/andreabuttarelli/anomalia-cli && brew install anomalia` |
+| **curl** | `curl -sSL https://raw.githubusercontent.com/andreabuttarelli/anomalia-cli/main/scripts/install.sh \| bash` |
+| **From source** | `bun install && bun run cli.ts` |
+
+## npm
+
+The publishable package is built into `dist-npm/` (Node-targeted bundles, no Bun required at runtime):
+
+```bash
+bun run build:npm
+cd dist-npm && npm publish --access public
+```
+
+CI does this on every `v*` tag when the `NPM_TOKEN` repository secret is set
+(npm Access Token with publish rights for `anomalia-cli`).
+
+One-time npm setup:
+
+1. Create the package scope/name on [npmjs.com](https://www.npmjs.com) if needed (`anomalia-cli`).
+2. Create a granular access token (read/write for `anomalia-cli`) or classic automation token.
+3. Add it as GitHub Actions secret `NPM_TOKEN` on this repo.
+4. Push a tag: `git tag v0.1.0 && git push origin v0.1.0`.
+
+Optional: configure [Trusted Publishing](https://docs.npmjs.com/trusted-publishers) for
+`andreabuttarelli/anomalia-cli` → workflow `release.yml` and drop the token later.
+
+## Homebrew
+
+Formula: [`Formula/anomalia.rb`](../Formula/anomalia.rb) (same-repo tap).
+
+```bash
+brew tap andreabuttarelli/anomalia-cli https://github.com/andreabuttarelli/anomalia-cli
+brew install anomalia
+anomalia --version
+```
+
+On each `v*` release, CI:
+
+1. Builds `anomalia-<platform>` binaries and `.tar.gz` archives
+2. Attaches them to the GitHub Release (raw binaries keep `install.sh` working)
+3. Rewrites formula `version` + `sha256` via `scripts/update-homebrew-formula.sh`
+4. Commits the formula bump to `main`
+
+Users update with:
+
+```bash
+brew update && brew upgrade anomalia
+```
+
+## Local smoke checks
+
+```bash
+bun test
+bun run build:npm
+node dist-npm/cli.js --help
+node dist-npm/cli.js --version
+```

--- a/cli/docs/mcp.md
+++ b/cli/docs/mcp.md
@@ -106,7 +106,7 @@ Full map: [`skills/anomalia/references/tools.md`](../skills/anomalia/references/
 Publishable Agent Skill (agentskills.io):
 
 ```bash
-npx skills add andreabuttarelli/anomalia-cli --skill anomalia
+npx skills add anomaliaso/anomalia --skill anomalia
 ```
 
 Sources: [`skills/anomalia/`](../skills/anomalia/) (`SKILL.md` + `references/`).  

--- a/cli/docs/mcp.md
+++ b/cli/docs/mcp.md
@@ -1,0 +1,189 @@
+# Anomalia MCP — how to use it
+
+Anomalia exposes a [Model Context Protocol](https://modelcontextprotocol.io) server so coding agents
+(Cursor, Claude, etc.) can manage brands, posts, plans, studio, SEO/GEO, and blog — with the **same
+OAuth login as the CLI**. There are **no static API tokens**.
+
+```
+Your agent
+   │  stdio (local)     →  bun run mcp  /  anomalia-mcp
+   │  HTTPS (remote)    →  https://mcp.anomalia.so/mcp  + Bearer
+   ▼
+Anomalia API  (/api/v1/*)
+```
+
+## Quick start
+
+### Option A — Local stdio (simplest)
+
+1. Install [Bun](https://bun.sh) and clone the repo (or install the CLI binary).
+2. Authenticate once:
+
+```bash
+anomalia login
+# or, after MCP is connected, call the `login` tool
+```
+
+3. Add to Cursor MCP config (absolute path required):
+
+```json
+{
+  "mcpServers": {
+    "anomalia": {
+      "command": "bun",
+      "args": ["run", "/ABS/PATH/to/anomalia-cli/mcp/stdio.ts"]
+    }
+  }
+}
+```
+
+4. Restart Cursor / reload MCP. Call `list_brands`, then work with a brand `slug`.
+
+Session file (shared with the CLI): `~/.config/anomalia/session.json`.
+
+### Option B — Remote HTTP (`mcp.anomalia.so`)
+
+1. Confirm the server is up:
+
+```bash
+curl -sS https://mcp.anomalia.so/health
+```
+
+Expect: `{"ok":true,"name":"anomalia-mcp","mcp":"/mcp",...}`.
+
+2. Cursor MCP config:
+
+```json
+{
+  "mcpServers": {
+    "anomalia": {
+      "url": "https://mcp.anomalia.so/mcp"
+    }
+  }
+}
+```
+
+3. The host must send **`Authorization: Bearer <access_token>`** on every request.  
+   Use the Supabase access token from Anomalia OAuth (same value the CLI stores after `anomalia login`).  
+   Without Bearer you get **401** — that is correct, not a crash.
+
+If your client cannot attach Bearer yet, use [mcp-remote](https://www.npmjs.com/package/mcp-remote) or prefer **Option A**.
+
+### Option C — Local HTTP
+
+```bash
+bun install
+bun run mcp:http
+# → http://localhost:8787/mcp
+#    http://localhost:8787/health
+```
+
+Auth: Bearer **or** the local session file.
+
+## What to call first
+
+1. `list_brands` — discover slugs  
+2. `get_dashboard` — brand overview  
+3. `list_posts` with status `pending_user` — approval queue  
+4. Prefer specific tools (`approve_posts`, `edit_post`, …) over `chat` for precise actions  
+
+Post and article ids accept **short unambiguous prefixes** from list results (same rule as the CLI).
+
+## Tool areas
+
+| Area | Examples |
+|------|----------|
+| Auth | `login`, `logout`, `whoami`, `list_brands` |
+| Posts | `list_posts`, `get_post`, `edit_post`, `approve_posts`, `regenerate_slide`, `make_video` |
+| Plans | `get_plan`, `propose_plan`, `plan_week`, `produce_week` |
+| Studio | `get_studio`, `add_note`, `research_competitors` |
+| Web | `get_seo`, `get_geo`, `generate_article`, `chat` |
+
+Full map: [`skills/anomalia/references/tools.md`](../skills/anomalia/references/tools.md).
+
+## Agent skill (directories / `npx skills`)
+
+Publishable Agent Skill (agentskills.io):
+
+```bash
+npx skills add andreabuttarelli/anomalia-cli --skill anomalia
+```
+
+Sources: [`skills/anomalia/`](../skills/anomalia/) (`SKILL.md` + `references/`).  
+Claude/Codex marketplace plugin (skill + remote MCP): [`plugins/anomalia/`](../plugins/anomalia/) — see [`plugins.md`](plugins.md).
+
+## Auth rules (summary)
+
+| Context | How you authenticate |
+|---------|----------------------|
+| Local stdio / local HTTP | Browser `login` tool or `anomalia login` → session file |
+| Remote HTTP | `Authorization: Bearer <jwt>` required |
+| Static API key | **Not supported** |
+
+Protected resource metadata: `GET /.well-known/oauth-protected-resource`.
+
+## Cursor + remote HTTP OAuth
+
+Cursor’s remote MCP connector discovers Anomalia’s authorization server and runs
+[Dynamic Client Registration](https://datatracker.ietf.org/doc/html/rfc7591). Some Cursor
+builds still register the custom-scheme callback:
+
+```text
+cursor://anysphere.cursor-mcp/oauth/callback
+```
+
+Anomalia’s `/oauth/register` only accepts **https** or **loopback http** redirect URIs, so that
+registration fails with:
+
+```text
+Not an https or loopback URI: cursor://anysphere.cursor-mcp/oauth/callback
+```
+
+**Workarounds (pick one):**
+
+1. **Prefer stdio locally** (recommended) — no remote OAuth handshake:
+
+```json
+{
+  "mcpServers": {
+    "anomalia": {
+      "command": "bun",
+      "args": ["run", "/ABS/PATH/to/anomalia-cli/mcp/stdio.ts"]
+    }
+  }
+}
+```
+
+Then call the `login` tool (or run `anomalia login` first).
+
+2. **Update Cursor** so MCP OAuth uses the loopback callback
+   `http://localhost:8787/callback` (RFC 8252). That URI **is** accepted by Anomalia DCR.
+
+3. **Bearer header** — after `anomalia login`, put the access token from
+   `~/.config/anomalia/session.json` in the MCP config `headers.Authorization` (if your Cursor
+   build supports headers on URL servers), or bridge with
+   [mcp-remote](https://www.npmjs.com/package/mcp-remote).
+
+**Permanent fix (Anomalia app, not this repo):** allowlist Cursor’s known redirect URIs in the
+authorization server’s DCR validator (`/oauth/register`), including
+`cursor://anysphere.cursor-mcp/oauth/callback` and
+`https://www.cursor.com/agents/mcp/oauth/callback`, while keeping loopback `http://localhost`
+/ `http://127.0.0.1` allowed.
+
+## Deploy notes (operators)
+
+Vercel project **Root Directory = `mcp`**. Artifacts: `mcp/api/*`, `mcp/vercel.json`.  
+Rebuild bundles from repo root: `bun run vercel-build`.  
+Optional env: `SENTRY_DSN`, `SUPABASE_SERVICE_ROLE_KEY`, `MCP_PUBLIC_URL`, `PUBLIC_APP_URL`.
+
+## Development
+
+```bash
+bun run mcp
+bun run mcp:http
+bun test
+bun run typecheck
+npx @modelcontextprotocol/inspector bun run mcp/stdio.ts
+```
+
+Architecture: `mcp/stdio.ts` / `mcp/http.ts` + `mcp/api/*.js` → `http-router` → `http-app` → `server` → `lib/api.ts`.

--- a/cli/docs/plan.md
+++ b/cli/docs/plan.md
@@ -1,0 +1,244 @@
+# Piano Editoriale — Guida completa
+
+Il piano editoriale è il cuore della strategia di contenuto. Definisce cosa pubblicare, quando, dove e con quale tono.
+
+## Panoramica
+
+Il piano editoriale ha 3 livelli:
+
+```
+Strategia (piano editoriale)
+  └── Piano settimanale (seeds)
+       └── Contenuti (post)
+```
+
+**Strategia** → definisce voice, cadenza, platform mix, 4 settimane con temi
+**Piano settimanale** → genera seeds (righe) per ogni settimana
+**Contenuti** → produce i seeds in post reali
+
+## Visualizzare il piano
+
+```bash
+anomalia plan my-brand
+```
+
+Mostra:
+- Piano proposto (se presente) con le modifiche suggerite
+- Cadenza (3/week, 5/week, daily)
+- Settimana corrente
+- Voice (mood, tone, goal)
+- Platform mix con percentuali
+- Strategia completa
+- 4 settimane con tema, focus, content mix, rationale, brief
+
+## Lifecycle completo
+
+### 1. Generare il primo piano
+
+Per brand senza piano attivo:
+
+```bash
+anomalia plan my-brand propose
+```
+
+L'AI analizza il brand kit, i prodotti, lo storico post e i competitor per generare un piano a 4 settimane.
+
+### 2. Visualizzare e valutare
+
+```bash
+anomalia plan my-brand
+```
+
+Se c'è un piano proposto, mostra:
+- Le modifiche suggerite (`changes_summary`)
+- Il feedback originale (se era una revisione)
+- Il piano completo in anteprima
+
+### 3. Approvare o scartare
+
+```bash
+# Approva — il piano diventa attivo
+anomalia plan my-brand approve
+
+# Scarta — il piano viene rifiutato
+anomalia plan my-brand discard
+```
+
+### 4. Richiedere una revisione
+
+Se vuoi modificare il piano senza riscriverlo da zero:
+
+```bash
+anomalia plan my-brand revise --feedback "Voglio più behind-the-scenes e meno promozionale"
+```
+
+L'AI produce un nuovo piano proposto con le modifiche. Poi approvi o scarti.
+
+Puoi anche usare l'AI chat per feedback più naturali:
+
+```bash
+anomalia ai my-brand --message "Voglio più focus su Instagram e meno su TikTok"
+anomalia ai my-brand --message "Aumenta la frequenza a 5 post a settimana"
+anomalia ai my-brand --message "Aggiungi LinkedIn al platform mix"
+```
+
+### 5. Salvare un brief per una settimana
+
+Ogni settimana può avere un brief utente che guida la generazione dei contenuti:
+
+```bash
+anomalia plan my-brand save-brief --week 0 --brief "Mostra il processo creativo del brand"
+anomalia plan my-brand save-brief --week 1 --brief "Focus sui prodotti nuovi"
+anomalia plan my-brand save-brief --week 2 --brief "Behind the scenes e persone del team"
+anomalia plan my-brand save-brief --week 3 --brief "User generated content e testimonianze"
+```
+
+Il brief viene salvato senza rigenerare nulla.
+
+### 6. Rigenerare una settimana
+
+Se vuoi rigenerare una settimana specifica con un nuovo brief:
+
+```bash
+anomalia plan my-brand replan --week 0 --brief "Dietro le quinte del brand"
+```
+
+L'AI ricostruisce solo quella settimana, mantenendo le altre 3 invariate.
+
+### 7. Modificare inline via AI
+
+```bash
+# Cambia tema settimana
+anomalia ai my-brand --message "Cambia il tema della settimana 2 a 'dietro le quinte'"
+
+# Cambia voice
+anomalia ai my-brand --message "Cambia il tone a friendly e casuale"
+
+# Cambia cadenza
+anomalia ai my-brand --message "Aumenta la frequenza a 5 post a settimana"
+
+# Cambia platform mix
+anomalia ai my-brand --message "Dai più peso a Instagram (60%) e meno a TikTok (40%)"
+```
+
+## Piano Settimanale (Seeds)
+
+Una volta che il piano editoriale è attivo, ogni settimana ha dei "seeds" — righe che definiscono cosa pubblicare.
+
+### Visualizzare i seeds
+
+```bash
+anomalia weekly-plan my-brand
+anomalia weekly-plan my-brand --week 2
+```
+
+Mostra:
+- Week navigator (W1, W2, W3, W4 con tema)
+- Settimana corrente con tema
+- Post già generati con status
+- Seeds in attesa con platform, format, pillar, angle
+- Quota mensile
+
+### Generare seeds per una settimana
+
+```bash
+anomalia weekly-plan my-brand plan --week 0
+```
+
+L'AI genera le righe (seeds) per la settimana, basandosi su:
+- Piano editoriale (tema, focus, content mix)
+- GTM phase (platform weights)
+- Prodotti e persone del brand
+- Brief utente (se presente)
+
+### Produrre i seeds in post
+
+```bash
+# Produci tutti i seeds
+anomalia weekly-plan my-brand produce --week 0
+
+# Produci singolo seed via AI
+anomalia ai my-brand --message "Produci solo il primo seed della settimana"
+```
+
+Ogni seed diventa un post reale con caption, immagine e scheduling.
+
+### Modificare i seeds via AI
+
+```bash
+# Cambia platform di un seed
+anomalia ai my-brand --message "Cambia il primo seed da Instagram a TikTok"
+
+# Cambia format
+anomalia ai my-brand --message "Cambia il formato del secondo seed da post a carousel"
+
+# Aggiungi un seed
+anomalia ai my-brand --message "Aggiungi un reel per venerdì alle 18"
+
+# Rimuovi un seed
+anomalia ai my-brand --message "Rimuovi il seed del weekend"
+```
+
+## Struttura del piano
+
+Ogni piano editoriale contiene:
+
+| Campo | Descrizione |
+|-------|-------------|
+| `strategy` | Dichiarazione strategica (2-4 frasi) |
+| `voice` | `{ mood, tone, goal, personality }` |
+| `cadence` | `3/week`, `5/week`, `daily` |
+| `platform_mix` | `[{ platform, share, role }]` |
+| `gtm` | Sezione go-to-market (stage, summary, platform_recs, plays) |
+| `weeks` | 4 settimane con theme, focus, content_mix, rationale, brief |
+
+Ogni settimana:
+
+| Campo | Descrizione |
+|-------|-------------|
+| `theme` | Tema della settimana |
+| `focus` | Focus specifico |
+| `content_mix` | `[{ type, count }]` — es. 2 post, 2 reel, 1 carousel |
+| `rationale` | Motivo della scelta |
+| `brief` | Brief utente (opzionale) |
+| `status` | `upcoming`, `planned`, `done` |
+
+## Stati del piano
+
+| Stato | Significato |
+|-------|-------------|
+| `proposed` | In attesa di approvazione |
+| `active` | Piano corrente |
+| `superseded` | Sostituito da un nuovo piano |
+| `rejected` | Scartato |
+
+## Storico
+
+Ogni piano sostituito viene conservato. Puoi vedere lo storico con:
+
+```bash
+anomalia ai my-brand --message "Mostrami lo storico dei piani editoriali"
+```
+
+## Combinazione con altri comandi
+
+```bash
+# 1. Configura il brand
+anomalia studio my-brand kit-update --about "..." --audience "..."
+anomalia studio my-brand add-note --text "Il nostro pubblico preferisce video brevi"
+
+# 2. Definisci la strategia
+anomalia plan my-brand propose
+anomalia plan my-brand approve
+
+# 3. Genera i contenuti
+anomalia weekly-plan my-brand plan --week 0
+anomalia weekly-plan my-brand produce --week 0
+
+# 4. Rivedi e approva
+anomalia content my-brand --status pending_user
+anomalia approve my-brand --all
+
+# 5. Analizza i risultati
+anomalia analytics my-brand
+```

--- a/cli/docs/plugins.md
+++ b/cli/docs/plugins.md
@@ -10,8 +10,8 @@ Repo marketplaces (self-host / team install):
 
 | Agent | Marketplace file | Add / install |
 |-------|------------------|---------------|
-| Claude Code | [`.claude-plugin/marketplace.json`](../.claude-plugin/marketplace.json) | `/plugin marketplace add andreabuttarelli/anomalia-cli` then `/plugin install anomalia@anomalia` |
-| Codex / ChatGPT | [`.agents/plugins/marketplace.json`](../.agents/plugins/marketplace.json) | `codex plugin marketplace add andreabuttarelli/anomalia-cli` |
+| Claude Code | [`.claude-plugin/marketplace.json`](../.claude-plugin/marketplace.json) | `/plugin marketplace add anomaliaso/anomalia` then `/plugin install anomalia@anomalia` |
+| Codex / ChatGPT | [`.agents/plugins/marketplace.json`](../.agents/plugins/marketplace.json) | `codex plugin marketplace add anomaliaso/anomalia` |
 
 Local test (Claude):
 

--- a/cli/docs/plugins.md
+++ b/cli/docs/plugins.md
@@ -1,0 +1,55 @@
+# Anomalia plugin — Claude Code & Codex submit
+
+The installable plugin lives in [`plugins/anomalia/`](../plugins/anomalia/). It bundles:
+
+- Agent skill → `skills/anomalia/` (`SKILL.md` + `references/`)
+- Remote MCP → `.mcp.json` → `https://mcp.anomalia.so/mcp`
+- Manifests → `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json`
+
+Repo marketplaces (self-host / team install):
+
+| Agent | Marketplace file | Add / install |
+|-------|------------------|---------------|
+| Claude Code | [`.claude-plugin/marketplace.json`](../.claude-plugin/marketplace.json) | `/plugin marketplace add andreabuttarelli/anomalia-cli` then `/plugin install anomalia@anomalia` |
+| Codex / ChatGPT | [`.agents/plugins/marketplace.json`](../.agents/plugins/marketplace.json) | `codex plugin marketplace add andreabuttarelli/anomalia-cli` |
+
+Local test (Claude):
+
+```bash
+claude --plugin-dir ./plugins/anomalia
+claude plugin validate ./plugins/anomalia
+claude plugin validate .   # marketplace + plugin
+```
+
+Canonical Agent Skill for `npx skills`: `skills/anomalia/`.  
+After editing it, sync into the plugin with `bash scripts/sync-plugin-skill.sh`.
+
+## Submit to Claude community directory
+
+1. Push this repo publicly (already on GitHub).
+2. Run `claude plugin validate ./plugins/anomalia` and fix issues.
+3. Submit the **GitHub repo URL** at one of:
+   - [platform.claude.com/plugins/submit](https://platform.claude.com/plugins/submit) (Console — individuals)
+   - [claude.ai admin submissions](https://claude.ai/admin-settings/directory/submissions/plugins/new) (Team / Enterprise)
+4. After approval, the plugin is pinned in [`anthropics/claude-plugins-community`](https://github.com/anthropics/claude-plugins-community) (catalog sync can take up to ~24h).
+5. Later commits to this repo are re-screened automatically — no re-submit for routine updates.
+
+Docs: [Submitting your plugin](https://claude.com/docs/plugins/submit) · [Plugins](https://code.claude.com/docs/en/plugins)
+
+## Submit to Codex / ChatGPT Plugins Directory
+
+1. OpenAI Platform org with **Apps Management → Write** and a **verified** developer/business identity.
+2. Open the [plugin submission portal](https://developers.openai.com/plugins/deploy/submission).
+3. Create plugin → prefer **With MCP** (skills + MCP):
+   - MCP URL: `https://mcp.anomalia.so/mcp` (Universal)
+   - Scan Tools, domain verification, tool annotations
+   - Skills: upload the `plugins/anomalia/skills/` tree **or** import static skills from MCP if exposed
+4. Fill listing (logo, privacy `https://www.anomalia.so/privacy`, terms `https://www.anomalia.so/terms`, support/website).
+5. Add starter prompts + **5 positive / 3 negative** test cases; demo credentials without MFA if reviewers need login.
+6. Submit for review → after approval, **publish** from the portal (not automatic).
+
+Docs: [Submit plugins](https://developers.openai.com/plugins/deploy/submission) · [Build plugins](https://developers.openai.com/codex/plugins/build)
+
+## Auth note
+
+Remote MCP requires an Anomalia OAuth Bearer JWT (same session as `anomalia login`). Hosts that cannot attach Bearer should use local stdio MCP (`anomalia-mcp` / `bun run mcp`) after CLI login — see [`docs/mcp.md`](mcp.md).

--- a/cli/docs/post.md
+++ b/cli/docs/post.md
@@ -1,0 +1,112 @@
+# Post — Guida all'editing
+
+Il comando `post` permette di gestire singoli post: modificare, approvare, pubblicare, riprogrammare, eliminare.
+
+## Visualizzare un post
+
+```bash
+anomalia post my-brand <post-id>
+```
+
+Mostra tutti i dettagli del post: platform, status, caption, pillar, format, slot, product.
+
+## Modificare un post
+
+### Caption
+
+```bash
+anomalia post my-brand <post-id> edit --caption "Nuovo testo della caption"
+```
+
+### Prompt immagine
+
+```bash
+anomalia post my-brand <post-id> edit --imagePrompt "Un caffè artigianale su sfondo chiaro"
+```
+
+### Piattaforme
+
+```bash
+anomalia post my-brand <post-id> edit --platforms "instagram,facebook"
+```
+
+### Tipo contenuto
+
+```bash
+anomalia post my-brand <post-id> edit --contentType carousel
+```
+
+### Data/ora
+
+```bash
+anomalia post my-brand <post-id> edit --slot "2026-06-20T10:00"
+```
+
+### Prodotto associato
+
+```bash
+anomalia post my-brand <post-id> edit --product "Pizza Margherita"
+```
+
+### Modifiche multiple
+
+```bash
+anomalia post my-brand <post-id> edit \
+  --caption "Nuovo testo" \
+  --platforms "instagram" \
+  --slot "2026-06-20T10:00"
+```
+
+## Approvare un post
+
+```bash
+anomalia post my-brand <post-id> approve
+```
+
+Approva il post e lo schedula per la pubblicazione tramite Zernio.
+
+## Pubblicare immediatamente
+
+```bash
+anomalia post my-brand <post-id> publish
+```
+
+Pubblica il post subito, indipendentemente dallo scheduling.
+
+## Riprogrammare
+
+```bash
+anomalia post my-brand <post-id> reschedule --scheduledFor "2026-06-20T10:00"
+```
+
+Cancella lo scheduling esistente e programma il post per la nuova data.
+
+## Eliminare un post
+
+```bash
+anomalia post my-brand <post-id> reject
+```
+
+Elimina il post. Funziona solo per post con status `pending_user`.
+
+## Uso con AI
+
+Tutte queste operazioni possono essere fatte anche tramite il comando `ai`:
+
+```bash
+# Modifica caption
+anomalia ai my-brand --message "Riscrivi la caption del post <id> in modo più breve"
+
+# Approva
+anomalia ai my-brand --message "Approva il post <id>"
+
+# Riprogramma
+anomalia ai my-brand --message "Sposta il post <id> a domani alle 10"
+```
+
+## ID del post
+
+L'ID del post si ottiene da:
+- `anomalia content my-brand` — lista tutti i post con ID
+- `anomalia ai my-brand --message "Quali sono gli ultimi post?"` — l'AI li elenca
+- Dashboard web — click su un post per vedere l'ID

--- a/cli/docs/quickref.md
+++ b/cli/docs/quickref.md
@@ -1,0 +1,112 @@
+# Quick Reference — Anomalia CLI
+
+## Comandi rapidi
+
+```bash
+# Panoramica
+anomalia brands                              # Lista brand
+anomalia dashboard <slug>                    # Dashboard completa
+anomalia status <slug>                       # Status dettagliato
+
+# Contenuti
+anomalia content <slug>                      # Tutti i post
+anomalia content <slug> --status pending     # Solo pending
+anomalia approve <slug> --all                # Approva tutti
+
+# Post (editing)
+anomalia post <slug> <id>                    # Dettaglio post
+anomalia post <slug> <id> edit --caption "..."  # Modifica caption
+anomalia post <slug> <id> approve            # Approva
+anomalia post <slug> <id> reject             # Elimina
+anomalia post <slug> <id> publish            # Pubblica ora
+anomalia post <slug> <id> reschedule --scheduledFor "2026-06-20T10:00"
+
+# Piano editoriale
+anomalia plan <slug>                         # Visualizza
+anomalia plan <slug> propose                 # Genera primo piano
+anomalia plan <slug> approve                 # Approva proposta
+anomalia plan <slug> discard                 # Scarta proposta
+anomalia plan <slug> revise --feedback "..." # Richiedi revisione
+anomalia plan <slug> save-brief --week 0 --brief "..."
+anomalia plan <slug> replan --week 0 --brief "..."
+
+# Piano settimanale
+anomalia weekly-plan <slug>                  # Visualizza
+anomalia weekly-plan <slug> plan --week 0    # Genera seeds
+anomalia weekly-plan <slug> produce --week 0 # Produci post
+
+# GTM
+anomalia gtm <slug>                          # GTM Roadmap
+
+# Voice
+anomalia voice <slug>                        # Voice rules
+
+# AI Chat
+anomalia ai <slug> --message "..."           # Chatta con l'AI
+echo "..." | anomalia ai <slug>             # Pipe mode
+
+# Analytics
+anomalia analytics <slug>                    # Analytics
+anomalia calendar <slug>                     # Calendario
+anomalia calendar <slug> --month 2026-07     # Mese specifico
+
+# Studio
+anomalia studio <slug>                       # Mostra tutto
+anomalia studio <slug> kit-update --about "..."
+anomalia studio <slug> colors --colors "#hex,#hex"
+anomalia studio <slug> add-note --text "..."
+anomalia studio <slug> people-add --name "..."
+anomalia studio <slug> people-generate --name "..." --gender female
+anomalia studio <slug> add-competitor --name "..."
+anomalia studio <slug> research              # Ricerca AI
+anomalia studio <slug> sync-history          # Sync social
+
+# Web / SEO / GEO
+anomalia seo <slug>                          # Grade, iniziative, audit
+anomalia seo <slug> run|plan|more            # Audit / piano / altre iniziative
+anomalia seo <slug> asset|article --id <id>  # Genera da un'iniziativa
+anomalia geo <slug>                          # Share of voice, citazioni
+anomalia geo <slug> run|fix                  # Audit / genera fix
+anomalia keywords <slug> [refresh]           # Keyword strategy
+anomalia web <slug> [--status draft]         # Articoli blog
+anomalia web <slug> generate --topic "..."   # Nuovo articolo
+anomalia web <slug> optimize|publish --id <id>
+anomalia ads <slug>                          # Campagne + metriche paid
+anomalia ads <slug> --propose                # Proposte boost dai top post
+anomalia ads <slug> --approve <id> [--budget N]
+anomalia ads <slug> --pause <id>             # Pausa campagna (tutte le creatività)
+anomalia ads <slug> --resume <id>            # Riattiva campagna
+anomalia ads <slug> --pause <id> --ad <adId> # Pausa UNA creatività (A/B)
+anomalia ads <slug> --resume <id> --ad <adId>
+anomalia ads <slug> --duplicate <id>          # Copia in pausa → nuova proposta
+anomalia ads <slug> --delete <id>             # Elimina sulla piattaforma (storico ok)
+anomalia ads <slug> --create --name "..." --headline "..." [--platform metaads|googleads]
+```
+
+## Status post
+
+| Status | Colore | Significato |
+|--------|--------|-------------|
+| `pending_user` | 🟡 Giallo | In attesa di approvazione |
+| `approved` | 🔵 Blu | Approvato, in attesa di scheduling |
+| `scheduled` | 🟢 Verde | Schedulato per pubblicazione |
+| `published` | 🟢 Verde | Pubblicato |
+| `failed` | 🔴 Rosso | Pubblicazione fallita |
+
+## Pipeline autopilot
+
+```
+● Ricerca ─ ◉ Strategia ─ ○ Generazione ─ ○ Pubblicazione ─ ○ Analisi
+```
+
+- `●` Completato
+- `◉` Fase corrente
+- `○` Futuro
+
+## Score completeness
+
+| Score | Stato |
+|-------|-------|
+| 80-100% | Eccellente |
+| 50-79% | Buono |
+| 0-49% | Incompleto |

--- a/cli/docs/studio.md
+++ b/cli/docs/studio.md
@@ -1,0 +1,184 @@
+# Studio — Guida completa
+
+Lo Studio è la knowledge base del brand. Contiene tutte le informazioni che l'AI usa per generare contenuti.
+
+## Visualizzare lo Studio
+
+```bash
+bun run cli.ts studio my-brand
+```
+
+Mostra:
+- Completeness score (0-100%)
+- Brand kit (categoria, about, audience)
+- Prodotti
+- Persone (reali e AI)
+- Competitors
+- Knowledge (note, documenti, immagini)
+
+## Brand Kit
+
+Il brand kit contiene le informazioni fondamentali del brand.
+
+### Aggiornare il brand kit
+
+```bash
+bun run cli.ts studio my-brand kit-update \
+  --about "Siamo un ristorante italiano specializzato in cucina fusion" \
+  --category "Ristorante" \
+  --audience "Giovani professionisti 25-35 anni, appassionati di food" \
+  --style "Minimalista e moderno" \
+  --language it
+```
+
+Tutti i parametri sono opzionali — puoi aggiornare solo i campi che vuoi:
+
+```bash
+# Aggiorna solo la lingua
+bun run cli.ts studio my-brand kit-update --language it
+
+# Aggiorna solo l'audience
+bun run cli.ts studio my-brand kit-update --audience "Famiglie con bambini"
+```
+
+### Imposta colori brand
+
+```bash
+bun run cli.ts studio my-brand colors --colors "#7c5cff,#ffffff,#1a1a1a"
+```
+
+- Massimo 8 colori
+- Formato hex: `#rgb` o `#rrggbb`
+- Separati da virgola
+
+## Persone
+
+Le persone possono essere reali o generate dall'AI.
+
+### Aggiungi persona reale
+
+```bash
+bun run cli.ts studio my-brand people-add \
+  --name "Marco Rossi" \
+  --role "CEO" \
+  --description "Fondatore dell'azienda, appassionato di innovazione"
+```
+
+### Genera persona AI
+
+```bash
+bun run cli.ts studio my-brand people-generate \
+  --name "Sofia" \
+  --role "Influencer fitness" \
+  --gender female \
+  --ageRange 26-35 \
+  --ethnicity "mediterranea" \
+  --vibe professional \
+  --description "Personal trainer con passione per il wellness"
+```
+
+Parametri per la generazione AI:
+- `--gender`: `female`, `male`, `non-binary` (opzionale)
+- `--ageRange`: `18-25`, `26-35`, `36-50`, `50+` (opzionale)
+- `--vibe`: `professional`, `casual`, `luxury`, `sporty`, `creative`, `natural` (opzionale)
+- `--ethnicity`: qualsiasi stringa (opzionale)
+
+### Elimina persona
+
+```bash
+bun run cli.ts studio my-brand people-delete --id <uuid>
+```
+
+L'ID si ottiene dalla lista dello studio (`studio my-brand` mostra gli ID troncati).
+
+## Knowledge
+
+La knowledge base contiene note, documenti e immagini che l'AI usa come contesto.
+
+### Aggiungi nota
+
+```bash
+bun run cli.ts studio my-brand add-note \
+  --title "Tone of voice" \
+  --text "Siamo amichevoli ma professionali. Evitiamo il linguaggio troppo formale. Usiamo emoji con moderazione."
+```
+
+### Aggiungi nota (senza titolo)
+
+```bash
+bun run cli.ts studio my-brand add-note --text "Il nostro prodotto principale è la pizza gourmet."
+```
+
+Il titolo default è "Note".
+
+### Elimina documento
+
+```bash
+bun run cli.ts studio my-brand delete-doc --id <uuid>
+```
+
+## Competitors
+
+### Aggiungi competitor manualmente
+
+```bash
+bun run cli.ts studio my-brand add-competitor \
+  --name "RivalCo" \
+  --website "rivalco.com" \
+  --compKind direct \
+  --rationale "Compete nel nostro stesso segmento di mercato"
+```
+
+- `--compKind`: `direct` (default) o `indirect`
+- `--website`: opzionale, viene normalizzato con `https://`
+- `--rationale`: opzionale
+
+### Ricerca competitor con AI
+
+```bash
+bun run cli.ts studio my-brand research
+```
+
+L'AI:
+1. Analizza il brand (nome, categoria, prodotti, audience)
+2. Cerca competitor online
+3. Deduplica con quelli esistenti
+4. Aggiunge i nuovi con `source: ai`
+
+### Elimina competitor
+
+```bash
+bun run cli.ts studio my-brand delete-competitor --id <uuid>
+```
+
+## Sync Storico Post
+
+Sincronizza i post pubblicati dai social accounts collegati:
+
+```bash
+bun run cli.ts studio my-brand sync-history
+```
+
+- Recupera i post da Instagram, TikTok, Facebook, etc.
+- Aggiorna la tabella `social_post_history`
+- Ricostruisce il contesto del brand
+
+## Completeness Score
+
+Il completeness score indica quanto è completo il brand kit:
+
+| Score | Significato |
+|-------|-------------|
+| 80-100% | Eccellente — l'AI ha tutti i dati necessari |
+| 50-79% | Buono — mancano alcuni dettagli |
+| 0-49% | Incompleto — aggiungi più informazioni |
+
+Il score è calcolato su 8 fattori:
+1. Prodotti (3+ = pieno)
+2. Storico post (synced)
+3. Voice/Tone (definito)
+4. About (presente)
+5. Audience (presente)
+6. Logo (presente)
+7. Colori (presenti)
+8. Knowledge (documenti)

--- a/cli/lib/api.ts
+++ b/cli/lib/api.ts
@@ -1,0 +1,494 @@
+/**
+ * Thin HTTP client for the Anomalia CLI.
+ * No Supabase, no DB access, no secrets — just HTTP calls to the Anomalia API.
+ */
+
+import { appUrl } from './config.ts';
+
+async function request<T>(path: string, token: string, opts?: RequestInit): Promise<T> {
+  // Resolved per call, not at import time: loadEnv() sets PUBLIC_APP_URL after the module
+  // graph is already loaded, so a module-level constant would freeze the production default
+  // and ignore the local dev server.
+  const url = `${appUrl()}${path}`;
+  const res = await fetch(url, {
+    ...opts,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      ...opts?.headers,
+    },
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`API ${res.status}: ${body.slice(0, 200)}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+function get<T>(path: string, token: string): Promise<T> {
+  return request<T>(path, token);
+}
+
+function post<T>(path: string, token: string, body?: unknown): Promise<T> {
+  return request<T>(path, token, {
+    method: 'POST',
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+// ── Types ───────────────────────────────────────────────────────────────
+
+export type BrandSummary = {
+  id: string;
+  name: string;
+  slug: string;
+  plan: string | null;
+  status: string | null;
+  autopilot_enabled: boolean;
+  autopilot_failure_count: number;
+  last_autopilot_run_at: string | null;
+  timezone: string;
+  pendingCount: number;
+};
+
+export type BrandDetail = {
+  brand: BrandSummary;
+  pendingCount: number;
+  runs: { status: string; posts_created: number; created_at: string; error: string | null }[];
+  plan: { id: string; status: string; cadence: string; weeks: unknown[] } | null;
+  productCount: number;
+  accountCount: number;
+  scheduledCount: number;
+  publishedCount: number;
+  hasGtm: boolean;
+  hasContentPlans: boolean;
+  hasHistory: boolean;
+  kit: { about: string | null; brand_colors: unknown } | null;
+  logoUrl: string | null;
+};
+
+export type Post = {
+  id: string;
+  brand_id: string;
+  platform: string | null;
+  platforms: string[] | null;
+  caption: string | null;
+  image_prompt: string | null;
+  slot: string | null;
+  media_url: string | null;
+  status: string;
+  content_type: string | null;
+  scheduled_for: string | null;
+  published_url: string | null;
+  product_name: string | null;
+  revisions_count: number | null;
+  pillar: string | null;
+  format: string | null;
+  created_at: string;
+};
+
+export type EditorialPlanData = {
+  plan: Record<string, unknown> | null;
+  proposed: Record<string, unknown> | null;
+  proposedFeedback: string | null;
+  currentWeek: number | null;
+  quota: { used: number; remaining: number };
+};
+
+export type WeeklyPlanData = {
+  plan: {
+    cadence: string;
+    weeks: { index: number; theme: string; status: string }[];
+    platform_mix: unknown;
+    strategy: string | null;
+  } | null;
+  currentWeekIdx: number | null;
+  posts: { id: string; platform: string | null; caption: string | null; status: string; slot: string | null; scheduled_for: string | null; pillar: string | null; format: string | null }[];
+  seeds: { id: string; seeds: unknown; editorial_week: number | null } | null;
+  quota: { used: number; max: number };
+};
+
+export type GtmData = {
+  gtm: Record<string, unknown> | null;
+  proposed: Record<string, unknown> | null;
+  proposedFeedback: string | null;
+  currentPhase: number | null;
+  phaseStatuses: ('done' | 'now' | 'next')[];
+  horizons: readonly string[];
+  studioPct: number;
+};
+
+export type AnalyticsData = {
+  total: number;
+  scheduled: number;
+  pending: number;
+  failed: number;
+  platforms: [string, number][];
+  upcomingPosts: { id: string; platform: string | null; caption: string | null; scheduled_for: string | null }[];
+  recentActivity: { id: string; platform: string | null; status: string; caption: string | null; error: string | null; created_at: string }[];
+  socialPerformance: { platform: string; posts: number; totals: { views: number; likes: number; comments: number; shares: number } }[];
+  topPosts: { id: string; platform: string; caption: string | null; thumbnail_url: string | null; url: string | null; published_at: string | null; metrics: Record<string, number> }[];
+  products: number;
+  accounts: number;
+};
+
+export type StudioData = {
+  kit: Record<string, unknown> | null;
+  products: { id: string; title: string; pricing: string | null; images: unknown; featured: boolean | null }[];
+  documents: { id: string; kind: string; title: string; content_text: string | null }[];
+  history: { id: string; platform: string; content: string | null; metrics: Record<string, number> }[];
+  people: { id: string; name: string; role: string | null; kind: string; description: string | null; consent: boolean; imageCount: number }[];
+  competitors: { id: string; name: string; website: string | null; kind: string; rationale: string | null; source: string }[];
+  targetPlatforms: string[];
+  platformInstructions: Record<string, string>;
+  language: string;
+  studioPct: number;
+};
+
+export type VoiceData = {
+  platforms: string[];
+  voiceMode: string;
+  voiceFramework: Record<string, unknown>;
+  platformRules: Record<string, Record<string, unknown>>;
+  avoid: string[];
+  platformInstructions: Record<string, string>;
+  studioPct: number;
+};
+
+export type CalendarData = {
+  posts: Record<string, unknown>[];
+  year: number;
+  month: number;
+  monthLabel: string;
+  prevYM: string;
+  nextYM: string;
+  timezone: string;
+};
+
+export type SeoData = {
+  audit: { tech_score: number | null; tech: Record<string, unknown> | null; search: Record<string, unknown> | null; backlinks: Record<string, unknown> | null; created_at: string } | null;
+  plan: { grade: string | null; evaluation: { grade: string; summary: string; strengths: string[]; weaknesses: string[] } | null; initiatives: SeoInitiative[]; created_at: string } | null;
+  assets: Record<string, { id: string; kind: string; title: string; format: string | null; target_path: string | null }>;
+};
+
+export type SeoInitiative = {
+  id: string; type: string; title: string; targetQuery?: string;
+  impact?: string; effort?: string; rationale?: string;
+};
+
+export type GeoData = {
+  audit: { tech_score: number | null; share_of_voice: number | null; citations: GeoCitation[] | null; created_at: string } | null;
+  aiOverview: Record<string, unknown> | null;
+  trend: { techScore: number | null; shareOfVoice: number | null; at: string }[];
+  artifacts: { id: string; kind: string; title: string; format: string | null; target_path: string | null }[];
+};
+
+export type GeoCitation = { prompt?: string; surface?: string; cited?: boolean; mentioned?: boolean; competitors?: string[] };
+
+export type KeywordsData = {
+  strategy: { focusSummary: string; keywords: KeywordRow[]; competitorGaps: { competitor: string; gap: string }[] } | null;
+  citations: { uri: string; title: string }[];
+  updatedAt: string | null;
+};
+
+export type KeywordRow = {
+  keyword: string; intent?: string; volume?: number | null; difficulty?: number | null;
+  opportunity?: string; action?: string; rationale?: string;
+};
+
+export type WebArticle = {
+  id: string; slug: string; title: string;
+  meta_title: string | null; meta_description: string | null;
+  status: string; scheduled_for: string | null; published_at: string | null;
+  source_initiative_id: string | null; created_at: string;
+};
+
+/** Every scalar field the post editor can write. `media_url: null` clears the image (text-only). */
+export type PostPatch = {
+  caption?: string; image_prompt?: string; platforms?: string[]; content_type?: string;
+  format?: string; slot?: string; product_name?: string; first_comment?: string;
+  title?: string; link_url?: string | null; subreddit?: string;
+  media_url?: string | null; platform_captions?: Record<string, string> | null;
+};
+
+export type PostState = {
+  content_type: string | null; format: string | null;
+  platform: string | null; platforms: string[] | null;
+  caption: string | null; title: string | null; first_comment: string | null;
+  link_url: string | null; subreddit: string | null;
+  media_url: string | null; image_prompt?: string | null;
+  is_carousel: boolean; slide_count: number;
+  slides: { index: number; image_prompt: string | null; has_image: boolean; url: string }[] | null;
+  status: string; text_only: boolean;
+};
+
+// ── API methods ─────────────────────────────────────────────────────────
+
+export const api = {
+  // Brands
+  listBrands: (t: string) => get<BrandSummary[]>('/api/v1/brands', t),
+  getBrand: (t: string, slug: string) => get<BrandDetail>(`/api/v1/brands/${slug}`, t),
+
+  // Posts
+  getPosts: (t: string, slug: string, status?: string) =>
+    get<Post[]>(`/api/v1/brands/${slug}/posts${status ? `?status=${status}` : ''}`, t),
+
+  // Editorial plan
+  getEditorialPlan: (t: string, slug: string) =>
+    get<EditorialPlanData>(`/api/v1/brands/${slug}/editorial-plan`, t),
+
+  // Weekly plan
+  getWeeklyPlan: (t: string, slug: string) =>
+    get<WeeklyPlanData>(`/api/v1/brands/${slug}/weekly-plan`, t),
+
+  // GTM
+  getGtm: (t: string, slug: string) =>
+    get<GtmData>(`/api/v1/brands/${slug}/gtm`, t),
+
+  // Analytics
+  getAnalytics: (t: string, slug: string) =>
+    get<AnalyticsData>(`/api/v1/brands/${slug}/analytics`, t),
+
+  // Studio
+  getStudio: (t: string, slug: string) =>
+    get<StudioData>(`/api/v1/brands/${slug}/studio`, t),
+
+  // Studio — Brand Kit
+  updateBrandKit: (t: string, slug: string, data: { about?: string; category?: string; target_audience?: string; brand_style?: string; language?: string }) =>
+    request<{ ok: boolean }>(`/api/v1/brands/${slug}/studio/kit`, t, { method: 'PUT', body: JSON.stringify(data) }),
+
+  updateColors: (t: string, slug: string, colors: string[]) =>
+    request<{ ok: boolean; colors: string[] }>(`/api/v1/brands/${slug}/studio/colors`, t, { method: 'PUT', body: JSON.stringify({ colors }) }),
+
+  // Studio — People
+  addPerson: (t: string, slug: string, data: { name: string; role?: string; description?: string; kind?: string; gender?: string; ageRange?: string; ethnicity?: string; vibe?: string }) =>
+    post<{ ok: boolean; person: { id: string; name: string; role: string | null; kind: string } }>(`/api/v1/brands/${slug}/studio/people`, t, data),
+
+  deletePerson: (t: string, slug: string, personId: string) =>
+    request<{ ok: boolean }>(`/api/v1/brands/${slug}/studio/people/${personId}`, t, { method: 'DELETE' }),
+
+  // Studio — Documents/Knowledge
+  addDocument: (t: string, slug: string, data: { title?: string; content_text: string; kind?: string }) =>
+    post<{ ok: boolean; document: { id: string; kind: string; title: string } }>(`/api/v1/brands/${slug}/studio/documents`, t, data),
+
+  deleteDocument: (t: string, slug: string, docId: string) =>
+    request<{ ok: boolean }>(`/api/v1/brands/${slug}/studio/documents/${docId}`, t, { method: 'DELETE' }),
+
+  // Studio — Competitors
+  addCompetitor: (t: string, slug: string, data: { name: string; website?: string; kind?: string; rationale?: string }) =>
+    post<{ ok: boolean; competitor: { id: string; name: string; website: string | null; kind: string; source: string } }>(`/api/v1/brands/${slug}/studio/competitors`, t, data),
+
+  updateCompetitor: (t: string, slug: string, compId: string, data: { name?: string; website?: string; kind?: string; rationale?: string }) =>
+    request<{ ok: boolean }>(`/api/v1/brands/${slug}/studio/competitors/${compId}`, t, { method: 'PUT', body: JSON.stringify(data) }),
+
+  deleteCompetitor: (t: string, slug: string, compId: string) =>
+    request<{ ok: boolean }>(`/api/v1/brands/${slug}/studio/competitors/${compId}`, t, { method: 'DELETE' }),
+
+  researchCompetitors: (t: string, slug: string) =>
+    post<{ ok: boolean; found: number; added: number }>(`/api/v1/brands/${slug}/studio/competitors/research`, t),
+
+  // Studio — History
+  syncHistory: (t: string, slug: string) =>
+    post<{ synced: number; noAccounts?: boolean; errors?: string[] }>(`/api/v1/brands/${slug}/studio/history/sync`, t),
+
+  // Voice
+  getVoice: (t: string, slug: string) =>
+    get<VoiceData>(`/api/v1/brands/${slug}/voice`, t),
+
+  // Calendar
+  getCalendar: (t: string, slug: string, month?: string) =>
+    get<CalendarData>(`/api/v1/brands/${slug}/calendar${month ? `?month=${month}` : ''}`, t),
+
+  // Actions
+  approvePost: (t: string, slug: string, postId: string) =>
+    post<{ ok?: boolean; error?: string }>(`/api/v1/brands/${slug}/posts/${postId}/approve`, t),
+
+  approveAll: (t: string, slug: string) =>
+    post<{ results: { id: string; ok: boolean; error?: string }[] }>(`/api/v1/brands/${slug}/posts/approve-all`, t),
+
+  tick: (t: string, slug: string) =>
+    post<Record<string, unknown>>(`/api/v1/brands/${slug}/tick`, t),
+
+  // ── Post editing ──────────────────────────────────────────────────────
+
+  updatePost: (t: string, slug: string, postId: string, data: PostPatch) =>
+    request<{ ok: boolean }>(`/api/v1/brands/${slug}/posts/${postId}`, t, { method: 'PUT', body: JSON.stringify(data) }),
+
+  // Post state incl. carousel slides — richer than the row in getPosts.
+  getPostMedia: (t: string, slug: string, postId: string) =>
+    get<PostState>(`/api/v1/brands/${slug}/posts/${postId}/media`, t),
+
+  postMedia: (t: string, slug: string, postId: string, body: { action: string; instruction?: string; prompt?: string; index?: number; order?: number[]; duration?: number; script?: string; aspectRatio?: string }) =>
+    post<{ success?: boolean; error?: string; rendered?: boolean; media_url?: string; slide_index?: number; slide_count?: number; notes?: string; duration_seconds?: number; videos_left?: number }>(`/api/v1/brands/${slug}/posts/${postId}/media`, t, body),
+
+  deletePost: (t: string, slug: string, postId: string) =>
+    request<{ ok: boolean }>(`/api/v1/brands/${slug}/posts/${postId}`, t, { method: 'DELETE' }),
+
+  reschedulePost: (t: string, slug: string, postId: string, scheduled_for: string) =>
+    post<{ ok: boolean; scheduled_for: string }>(`/api/v1/brands/${slug}/posts/${postId}/reschedule`, t, { scheduled_for }),
+
+  renderPost: (t: string, slug: string, postId: string) =>
+    post<{ ok: boolean; url: string | null; error?: string | null }>(`/api/v1/brands/${slug}/posts/${postId}/render`, t),
+
+  publishPost: (t: string, slug: string, postId: string) =>
+    post<{ ok: boolean; status: string }>(`/api/v1/brands/${slug}/posts/${postId}/publish`, t),
+
+  // ── Editorial plan editing ────────────────────────────────────────────
+
+  updateEditorialPlan: (t: string, slug: string, data: { voice?: unknown; cadence?: string; platform_mix?: unknown; week_index?: number; week_theme?: string; week_brief?: string }) =>
+    post<{ ok: boolean }>(`/api/v1/brands/${slug}/editorial-plan/update`, t, data),
+
+  proposePlan: (t: string, slug: string) =>
+    post<{ ok: boolean; plan: unknown }>(`/api/v1/brands/${slug}/editorial-plan/propose`, t),
+
+  revisePlan: (t: string, slug: string, feedback: string) =>
+    post<{ ok: boolean; plan: unknown }>(`/api/v1/brands/${slug}/editorial-plan/revise`, t, { feedback }),
+
+  approvePlan: (t: string, slug: string) =>
+    post<{ ok: boolean }>(`/api/v1/brands/${slug}/editorial-plan/approve`, t),
+
+  discardPlan: (t: string, slug: string) =>
+    post<{ ok: boolean }>(`/api/v1/brands/${slug}/editorial-plan/discard`, t),
+
+  replanWeek: (t: string, slug: string, week_index: number, brief: string) =>
+    post<{ ok: boolean }>(`/api/v1/brands/${slug}/editorial-plan/replan-week`, t, { week_index, brief }),
+
+  saveBrief: (t: string, slug: string, week_index: number, brief: string, products?: string[]) =>
+    post<{ ok: boolean }>(`/api/v1/brands/${slug}/editorial-plan/save-brief`, t, { week_index, brief, products }),
+
+  // ── Weekly plan ───────────────────────────────────────────────────────
+
+  planWeek: (t: string, slug: string, week_index: number) =>
+    post<{ ok: boolean; draft: unknown }>(`/api/v1/brands/${slug}/weekly-plan/plan`, t, { week_index }),
+
+  saveWeekDraft: (t: string, slug: string, draft_id: string, seeds: unknown[]) =>
+    post<{ ok: boolean }>(`/api/v1/brands/${slug}/weekly-plan/save`, t, { draft_id, seeds }),
+
+  produceWeek: (t: string, slug: string, draft_id: string, row_index?: number) =>
+    post<{ ok: boolean; produced: number }>(`/api/v1/brands/${slug}/weekly-plan/produce`, t, { draft_id, row_index }),
+
+  renderWeek: (t: string, slug: string, week_index?: number) =>
+    post<{ ok: boolean; rendered: number; failed: number; results: { id: string; ok: boolean; url?: string; error?: string; product?: string; qc?: { score: number; pass: boolean; issues: string[]; retried: boolean } }[] }>(`/api/v1/brands/${slug}/weekly-plan/render`, t, week_index !== undefined ? { week_index } : {}),
+
+  // ── Products ──────────────────────────────────────────────────────────
+  listProducts: (t: string, slug: string) =>
+    get<{ products: { id: string; title: string; kind: string; pricing: string | null; imageCount: number; featured: boolean }[] }>(`/api/v1/brands/${slug}/products`, t),
+
+  syncProducts: (t: string, slug: string) =>
+    post<{ ok: boolean; platform: string; synced: number }>(`/api/v1/brands/${slug}/products`, t),
+
+  deletePostsByStatus: (t: string, slug: string, status: string) =>
+    request<{ ok: boolean; deleted: number }>(`/api/v1/brands/${slug}/posts?status=${encodeURIComponent(status)}`, t, { method: 'DELETE' }),
+
+  // ── GTM editing ───────────────────────────────────────────────────────
+
+  updateGtmPlan: (t: string, slug: string, data: { objective?: string; phase_index?: number; phase_name?: string; phase_objective?: string; platform_weights?: unknown; pillars?: string[] }) =>
+    post<{ ok: boolean }>(`/api/v1/brands/${slug}/gtm/update`, t, data),
+
+  // ── Voice editing ─────────────────────────────────────────────────────
+
+  updateVoice: (t: string, slug: string, data: { mood?: string; tone?: string; register?: number; emotion?: string; character?: string; syntax?: string; platform_instructions?: Record<string, string>; avoid?: string[] }) =>
+    post<{ ok: boolean }>(`/api/v1/brands/${slug}/voice/update`, t, data),
+
+  // ── Product editing ───────────────────────────────────────────────────
+
+  updateProduct: (t: string, slug: string, productId: string, data: { title?: string; description?: string; pricing?: string; featured?: boolean }) =>
+    request<{ ok: boolean }>(`/api/v1/brands/${slug}/products/${productId}`, t, { method: 'PUT', body: JSON.stringify(data) }),
+
+  deleteProduct: (t: string, slug: string, productId: string) =>
+    request<{ ok: boolean }>(`/api/v1/brands/${slug}/products/${productId}`, t, { method: 'DELETE' }),
+
+  // ── Person editing ────────────────────────────────────────────────────
+
+  updatePerson: (t: string, slug: string, personId: string, data: { name?: string; role?: string; description?: string; attributes?: unknown }) =>
+    request<{ ok: boolean }>(`/api/v1/brands/${slug}/people/${personId}`, t, { method: 'PUT', body: JSON.stringify(data) }),
+
+  // ── SEO ───────────────────────────────────────────────────────────────
+
+  getSeo: (t: string, slug: string) => get<SeoData>(`/api/v1/brands/${slug}/seo`, t),
+
+  seoAction: (t: string, slug: string, body: { action: string; initiativeId?: string; guidance?: string }) =>
+    post<{ ok?: boolean; error?: string; grade?: string; initiatives?: number; added?: number; generated?: number; articleId?: string; techScore?: number | null }>(`/api/v1/brands/${slug}/seo`, t, body),
+
+  // ── GEO ───────────────────────────────────────────────────────────────
+
+  getGeo: (t: string, slug: string) => get<GeoData>(`/api/v1/brands/${slug}/geo`, t),
+
+  geoAction: (t: string, slug: string, action: 'audit' | 'fix') =>
+    post<{ ok?: boolean; techScore?: number | null; shareOfVoice?: number; generated?: number }>(`/api/v1/brands/${slug}/geo`, t, { action }),
+
+  // ── Keywords ──────────────────────────────────────────────────────────
+
+  getKeywords: (t: string, slug: string) => get<KeywordsData>(`/api/v1/brands/${slug}/keywords`, t),
+
+  refreshKeywords: (t: string, slug: string) =>
+    post<{ ok: boolean; keywords: number }>(`/api/v1/brands/${slug}/keywords`, t),
+
+  // ── Web / Blog ────────────────────────────────────────────────────────
+
+  getWeb: (t: string, slug: string, status?: string) =>
+    get<{ articles: WebArticle[] }>(`/api/v1/brands/${slug}/web${status ? `?status=${status}` : ''}`, t),
+
+  webAction: (t: string, slug: string, body: { action: string; topic?: string; id?: string }) =>
+    post<{ ok?: boolean; articleId?: string; status?: string }>(`/api/v1/brands/${slug}/web`, t, body),
+
+  // ── Ads ───────────────────────────────────────────────────────────────
+
+  getAds: (t: string, slug: string) =>
+    get<{
+      summary: {
+        campaigns: {
+          id: string;
+          name: string;
+          platform: string;
+          ad_type: string;
+          status: string;
+          goal: string;
+          budget_amount: number;
+          budget_type: string;
+        }[];
+        totals: { spend: number; impressions: number; clicks: number; active: number; proposed: number };
+      };
+      candidates: { platform: string; score: number; reason: string; caption: string | null }[];
+      adAccounts: { id: string; platform: string; name: string | null; status: string; zernio_ad_account_id: string }[];
+    }>(`/api/v1/brands/${slug}/ads`, t),
+
+  adsAction: (
+    t: string,
+    slug: string,
+    body: Record<string, unknown>
+  ) =>
+    post<{
+      ok?: boolean;
+      error?: string;
+      created?: number;
+      candidates?: number;
+      zernioAdId?: string;
+      accounts?: number;
+      metrics?: number;
+      id?: string;
+      next?: 'active' | 'paused';
+      copiedCampaignId?: string;
+    }>(`/api/v1/brands/${slug}/ads`, t, body),
+
+  // ── Chat ──────────────────────────────────────────────────────────────
+
+  chat: async (t: string, slug: string, message: string): Promise<string> => {
+    const res = await fetch(`${appUrl()}/app/${slug}/chat`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${t}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ messages: [{ role: 'user', content: message }] }),
+    });
+    if (!res.ok) throw new Error(`Chat error: ${res.status}`);
+    // Read streaming response
+    const reader = res.body!.getReader();
+    const decoder = new TextDecoder();
+    let result = '';
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      result += decoder.decode(value, { stream: true });
+    }
+    return result;
+  },
+};

--- a/cli/lib/auth.ts
+++ b/cli/lib/auth.ts
@@ -1,0 +1,200 @@
+import { createClient } from '@supabase/supabase-js';
+import { existsSync, mkdirSync, readFileSync, writeFileSync, unlinkSync } from 'fs';
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { homedir } from 'os';
+import { join } from 'path';
+import { appUrl as resolveAppUrl } from './config.ts';
+
+const CONFIG_DIR = join(homedir(), '.config', 'anomalia');
+const SESSION_FILE = join(CONFIG_DIR, 'session.json');
+
+export type StoredSession = {
+  access_token: string;
+  refresh_token: string;
+  expires_at: number;
+  user: { id: string; email: string };
+};
+
+// Reads the stored session. If the access_token is expired, transparently
+// refreshes it using the refresh_token (valid for weeks) and saves the new
+// tokens — so the user never has to login again unless they explicitly logout
+// or Supabase revokes the refresh token.
+export async function loadSession(): Promise<StoredSession | null> {
+  try {
+    if (!existsSync(SESSION_FILE)) return null;
+    const stored = JSON.parse(readFileSync(SESSION_FILE, 'utf8')) as StoredSession;
+    if (!stored.refresh_token) return null;
+
+    const stillValid = stored.expires_at && Date.now() / 1000 < stored.expires_at - 30;
+    if (stillValid) return stored;
+
+    // access_token expired — use refresh_token to get a new one silently.
+    const sb = anonClient();
+    const { data, error } = await sb.auth.setSession({
+      access_token: stored.access_token,
+      refresh_token: stored.refresh_token
+    });
+    if (error || !data.session) {
+      // Refresh failed — session is dead, clear it
+      clearSession();
+      return null;
+    }
+
+    const refreshed: StoredSession = {
+      access_token: data.session.access_token,
+      refresh_token: data.session.refresh_token,
+      expires_at: data.session.expires_at ?? Math.floor(Date.now() / 1000) + 3600,
+      user: { id: data.session.user.id, email: data.session.user.email! }
+    };
+    saveSession(refreshed);
+    return refreshed;
+  } catch {
+    return null;
+  }
+}
+
+/** loadSession, but exits with a helpful message instead of returning null. */
+export async function requireSession(): Promise<StoredSession> {
+  const s = await loadSession();
+  if (!s) {
+    console.error('Sessione scaduta o non trovata. Esegui: anomalia login');
+    process.exit(1);
+  }
+  return s;
+}
+
+export function saveSession(s: StoredSession) {
+  mkdirSync(CONFIG_DIR, { recursive: true });
+  writeFileSync(SESSION_FILE, JSON.stringify(s, null, 2));
+}
+
+export function clearSession() {
+  try { unlinkSync(SESSION_FILE); } catch {}
+}
+
+function anonClient() {
+  return createClient(
+    process.env.PUBLIC_SUPABASE_URL!,
+    process.env.PUBLIC_SUPABASE_ANON_KEY!,
+    { auth: { persistSession: false } }
+  );
+}
+
+function readJsonBody(req: IncomingMessage): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (c) => chunks.push(Buffer.isBuffer(c) ? c : Buffer.from(c)));
+    req.on('end', () => {
+      try {
+        const raw = Buffer.concat(chunks).toString('utf8');
+        resolve(raw ? JSON.parse(raw) : {});
+      } catch (e) {
+        reject(e);
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
+function send(
+  res: ServerResponse,
+  status: number,
+  body: string,
+  headers: Record<string, string> = {},
+) {
+  res.writeHead(status, { 'content-length': Buffer.byteLength(body), ...headers });
+  res.end(body);
+}
+
+// Opens the web app's login page in the browser and waits for the user to
+// authenticate and grant consent. The web app's /cli/callback page POSTs
+// the tokens directly to our local server (browser → localhost works in
+// all environments). A random state token prevents CSRF.
+//
+// Uses node:http (not Bun.serve) so the same code runs under Bun and the
+// Node-targeted npm bundle.
+export async function startBrowserLogin(
+  onStatus: (msg: string) => void
+): Promise<StoredSession> {
+  const port = 54320 + Math.floor(Math.random() * 60);
+  const state = crypto.randomUUID();
+  const appUrl = resolveAppUrl();
+  const appOrigin = new URL(appUrl).origin;
+
+  let resolveSession!: (s: StoredSession) => void;
+  let rejectSession!: (e: Error) => void;
+  const settled = new Promise<StoredSession>((res, rej) => {
+    resolveSession = res;
+    rejectSession = rej;
+  });
+
+  const corsHeaders = {
+    'access-control-allow-origin': appOrigin,
+    'access-control-allow-methods': 'POST, OPTIONS',
+    'access-control-allow-headers': 'Content-Type',
+  };
+
+  const server = createServer(async (req, res) => {
+    const url = new URL(req.url ?? '/', `http://127.0.0.1:${port}`);
+    if (req.method === 'OPTIONS') {
+      send(res, 204, '', corsHeaders);
+      return;
+    }
+    if (url.pathname === '/session' && req.method === 'POST') {
+      try {
+        const body = (await readJsonBody(req)) as {
+          access_token: string;
+          refresh_token: string;
+          expires_at: number;
+          state: string;
+        };
+        if (body.state !== state) {
+          send(res, 400, 'Invalid state', corsHeaders);
+          return;
+        }
+        const sb = createClient(
+          process.env.PUBLIC_SUPABASE_URL!,
+          process.env.PUBLIC_SUPABASE_ANON_KEY!,
+          { auth: { persistSession: false } }
+        );
+        const { data } = await sb.auth.getUser(body.access_token);
+        const stored: StoredSession = {
+          access_token: body.access_token,
+          refresh_token: body.refresh_token,
+          expires_at: body.expires_at || Math.floor(Date.now() / 1000) + 3600,
+          user: { id: data.user!.id, email: data.user!.email! }
+        };
+        saveSession(stored);
+        resolveSession(stored);
+        send(res, 200, 'OK', corsHeaders);
+      } catch (e) {
+        rejectSession(new Error(String(e)));
+        send(res, 500, 'Error', corsHeaders);
+      }
+      return;
+    }
+    send(res, 404, 'Not found');
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, '127.0.0.1', () => resolve());
+  });
+
+  const loginUrl = `${appUrl}/login?cli_port=${port}&cli_state=${state}`;
+  onStatus('Apertura browser per il login…');
+  const { default: open } = await import('open');
+  await open(loginUrl);
+  onStatus('Browser aperto — accedi e premi "Autorizza" per completare.');
+
+  const timeout = new Promise<never>((_, reject) =>
+    setTimeout(() => reject(new Error('Timeout: nessun login nei 5 minuti')), 5 * 60 * 1000)
+  );
+
+  try {
+    const session = await Promise.race([settled, timeout]);
+    return session;
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}

--- a/cli/lib/auth.ts
+++ b/cli/lib/auth.ts
@@ -63,6 +63,25 @@ export async function requireSession(): Promise<StoredSession> {
   return s;
 }
 
+// Email + password against the same Supabase project the app uses — no browser,
+// no consent page. For scripts and CI; the browser flow stays the default because
+// it is the only one that supports SSO providers and never puts a password on argv.
+export async function passwordLogin(email: string, password: string): Promise<StoredSession> {
+  const sb = anonClient();
+  const { data, error } = await sb.auth.signInWithPassword({ email, password });
+  if (error || !data.session) {
+    throw new Error(error?.message ?? 'Credenziali non valide');
+  }
+  const stored: StoredSession = {
+    access_token: data.session.access_token,
+    refresh_token: data.session.refresh_token,
+    expires_at: data.session.expires_at ?? Math.floor(Date.now() / 1000) + 3600,
+    user: { id: data.session.user.id, email: data.session.user.email! }
+  };
+  saveSession(stored);
+  return stored;
+}
+
 export function saveSession(s: StoredSession) {
   mkdirSync(CONFIG_DIR, { recursive: true });
   writeFileSync(SESSION_FILE, JSON.stringify(s, null, 2));

--- a/cli/lib/config.test.ts
+++ b/cli/lib/config.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { appUrl, authServerUrl, PRODUCTION_URL } from './config.ts';
+
+const original = process.env.PUBLIC_APP_URL;
+afterEach(() => {
+  if (original === undefined) delete process.env.PUBLIC_APP_URL;
+  else process.env.PUBLIC_APP_URL = original;
+});
+
+describe('appUrl', () => {
+  // The apex 308s to www, and fetch drops Authorization across origins — every API call made
+  // against the apex comes back 401 "Missing or invalid Authorization header".
+  test('production base is the canonical www host, never the redirecting apex', () => {
+    expect(PRODUCTION_URL).toBe('https://www.anomalia.so');
+    delete process.env.PUBLIC_APP_URL;
+    expect(appUrl()).toBe('https://www.anomalia.so');
+  });
+
+  test('an explicit PUBLIC_APP_URL wins, trailing slash stripped', () => {
+    process.env.PUBLIC_APP_URL = 'http://localhost:5173/';
+    expect(appUrl()).toBe('http://localhost:5173');
+  });
+});
+
+describe('authServerUrl', () => {
+  // Deve combaciare con issuerFor() in 021-app: RFC 8414 confronta l'issuer byte per byte con
+  // l'identificatore da cui il client ha costruito l'URL di discovery. L'apex 308-redirecta,
+  // quindi l'unico identificatore che regge è quello che risponde 200 — www.
+  test('never advertises the apex: it 308-redirects and discovery dies there', () => {
+    delete process.env.PUBLIC_APP_URL;
+    expect(authServerUrl()).toBe('https://www.anomalia.so');
+    expect(authServerUrl()).toBe(appUrl());
+  });
+
+  test('follows a local dev server so local OAuth works', () => {
+    process.env.PUBLIC_APP_URL = 'http://localhost:5173';
+    expect(authServerUrl()).toBe('http://localhost:5173');
+  });
+});

--- a/cli/lib/config.ts
+++ b/cli/lib/config.ts
@@ -1,0 +1,93 @@
+/**
+ * Configuration for the Anomalia CLI.
+ * All values are public (no secrets) — hardcoded for zero-config installation.
+ *
+ * The CLI auto-detects if a local dev server is running on localhost:5174.
+ * If yes, uses it. Otherwise, uses the production URL.
+ *
+ * Override with: PUBLIC_APP_URL=http://my-server:3000 anomalia brands
+ */
+
+const LOCAL_URL = 'http://localhost:5173';
+
+/**
+ * Canonical production origin — **www, not the apex**.
+ *
+ * `https://anomalia.so` 308-redirects to `https://www.anomalia.so`, which is a *cross-origin*
+ * redirect, and fetch drops the `Authorization` header across origins. Every API call made
+ * against the apex therefore arrives unauthenticated and the server answers
+ * `401 {"error":"Missing or invalid Authorization header"}` — which reads like a broken login
+ * but is really a redirect eating the token. Point at the host that answers directly.
+ *
+ * Single source of truth on purpose: this literal used to be copy-pasted into api.ts, auth.ts,
+ * health.ts and the MCP HTTP layer, so the bug had to be fixed in six places or none.
+ */
+export const PRODUCTION_URL = 'https://www.anomalia.so';
+
+/** Resolved API/base origin: explicit override, else auto-detected dev server, else production. */
+export function appUrl(): string {
+  return (process.env.PUBLIC_APP_URL || PRODUCTION_URL).replace(/\/$/, '');
+}
+
+const isLocal = (url: string) => /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])/.test(url);
+
+/**
+ * Identificativo dell'authorization server annunciato ai client MCP in `authorization_servers`
+ * (RFC 9728, `/.well-known/oauth-protected-resource`). È **www**, come PRODUCTION_URL.
+ *
+ * Qui c'era l'apex, in coppia con `issuerFor()` di 021-app. Il vincolo RFC 8414 è reale — il
+ * client prende questa stringa, ci attacca `/.well-known/oauth-authorization-server`, e pretende
+ * che l'`issuer` nel JSON sia identico — ma l'apex non serve quel JSON: `https://anomalia.so`
+ * 308-redirecta a www a livello di dominio Vercel. Un client che non segue i redirect in
+ * discovery (Smithery) muore prima di vedere i metadata:
+ *   {"code":"oauth/auth_server_discovery_http_error", "status":308}
+ *
+ * www è l'unico host che risponde 200, quindi l'identificatore è www da entrambe le parti.
+ * Resta decoupled da appUrl() perché un PUBLIC_APP_URL di dev deve comunque vincere: in locale
+ * l'OAuth punta al dev server.
+ */
+export function authServerUrl(): string {
+  const app = appUrl();
+  return isLocal(app) ? app : PRODUCTION_URL;
+}
+
+// Public Supabase keys (safe to embed — anon key, no secrets)
+process.env.PUBLIC_SUPABASE_URL ??= 'https://kszazivzwievqixcnanp.supabase.co';
+process.env.PUBLIC_SUPABASE_ANON_KEY ??= 'sb_publishable_gXzHd-4PxJ8UJ-US7mO15Q_bgiGGHvB';
+
+let resolved = false;
+
+export async function loadEnv() {
+  if (resolved) return;
+
+  // On Vercel / remote MCP, never probe localhost.
+  if (process.env.VERCEL || process.env.MCP_REQUIRE_BEARER === '1') {
+    process.env.PUBLIC_APP_URL ??= PRODUCTION_URL;
+    resolved = true;
+    return;
+  }
+
+  // If user explicitly set PUBLIC_APP_URL, use it
+  if (process.env.PUBLIC_APP_URL && process.env.PUBLIC_APP_URL !== PRODUCTION_URL) {
+    resolved = true;
+    return;
+  }
+
+  // Auto-detect: try localhost first (dev server), fall back to production
+  try {
+    await fetch(`${LOCAL_URL}/api/v1/brands`, {
+      method: 'HEAD',
+      signal: AbortSignal.timeout(1000),
+    });
+    // If we get any response (even 401), the server is running
+    process.env.PUBLIC_APP_URL = LOCAL_URL;
+  } catch {
+    process.env.PUBLIC_APP_URL = PRODUCTION_URL;
+  }
+
+  resolved = true;
+}
+
+export function assertEnv() {
+  // No required vars — everything has defaults.
+}

--- a/cli/lib/display.ts
+++ b/cli/lib/display.ts
@@ -1,0 +1,48 @@
+import chalk from 'chalk';
+import Table from 'cli-table3';
+
+export const c = chalk;
+
+export function table(head: string[], rows: (string | number)[][]): void {
+  const t = new Table({
+    head: head.map((h) => chalk.bold(h)),
+    style: { head: [], border: ['grey'] }
+  });
+  for (const row of rows) t.push(row.map(String));
+  console.log(t.toString());
+}
+
+export function ok(msg: string) { console.log(chalk.green('✓'), msg); }
+export function warn(msg: string) { console.log(chalk.yellow('⚠'), msg); }
+export function fail(msg: string) { console.error(chalk.red('✗'), msg); }
+export function info(msg: string) { console.log(chalk.dim(msg)); }
+
+export function section(title: string) {
+  console.log('\n' + chalk.bold.underline(title));
+}
+
+export function formatDate(iso: string | null | undefined): string {
+  if (!iso) return chalk.dim('—');
+  const d = new Date(iso);
+  return d.toLocaleDateString('it-IT', { day: '2-digit', month: 'short' }) +
+    ' ' + d.toLocaleTimeString('it-IT', { hour: '2-digit', minute: '2-digit' });
+}
+
+export function autopilotBadge(enabled: boolean): string {
+  return enabled ? chalk.green('● autopilot') : chalk.dim('○ manuale');
+}
+
+export function statusBadge(status: string): string {
+  const map: Record<string, string> = {
+    active: chalk.green('active'),
+    trial: chalk.yellow('trial'),
+    paused: chalk.dim('paused'),
+    canceled: chalk.red('canceled'),
+    pending_user: chalk.yellow('pending'),
+    approved: chalk.cyan('approved'),
+    scheduled: chalk.blue('scheduled'),
+    published: chalk.green('published'),
+    failed: chalk.red('failed'),
+  };
+  return map[status] ?? chalk.dim(status);
+}

--- a/cli/lib/select.test.ts
+++ b/cli/lib/select.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'bun:test';
+import { parseKeyValuePairs, resolveByPrefix } from './select.ts';
+
+const items = [
+  { id: '3f2a91b0-1111-4aaa-8bbb-000000000001' },
+  { id: '3f2a91b0-2222-4aaa-8bbb-000000000002' },
+  { id: 'a91c3f20-3333-4aaa-8bbb-000000000003' }
+];
+
+describe('resolveByPrefix', () => {
+  it('resolves a unique prefix', () => {
+    const r = resolveByPrefix(items, 'a91c3f20');
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.item.id).toBe(items[2].id);
+  });
+
+  // The important one: two posts sharing a prefix must NOT silently pick the first — that would
+  // publish or delete the wrong thing.
+  it('refuses an ambiguous prefix instead of guessing', () => {
+    const r = resolveByPrefix(items, '3f2a91b0');
+    expect(r).toEqual({ ok: false, reason: 'ambiguous', count: 2 });
+  });
+
+  it('reports no match, and treats an empty prefix as no match', () => {
+    expect(resolveByPrefix(items, 'deadbeef')).toEqual({ ok: false, reason: 'none', count: 0 });
+    expect(resolveByPrefix(items, '  ')).toEqual({ ok: false, reason: 'none', count: 0 });
+  });
+
+  it('prefers an exact id over a longer id it happens to prefix', () => {
+    const both = [{ id: 'ab' }, { id: 'abcdef' }];
+    const r = resolveByPrefix(both, 'ab');
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.item.id).toBe('ab');
+  });
+});
+
+describe('parseKeyValuePairs', () => {
+  it('splits on the FIRST = so values may contain =', () => {
+    expect(parseKeyValuePairs(['x=a=b', 'threads=hello'])).toEqual({ x: 'a=b', threads: 'hello' });
+  });
+
+  it('lowercases keys and trims', () => {
+    expect(parseKeyValuePairs([' X = testo '])).toEqual({ x: 'testo' });
+  });
+
+  it('drops empty values (used to clear a platform override)', () => {
+    expect(parseKeyValuePairs(['x='])).toEqual({});
+  });
+
+  it('returns null on a malformed pair rather than dropping input silently', () => {
+    expect(parseKeyValuePairs(['nope'])).toBeNull();
+    expect(parseKeyValuePairs(['=orphan'])).toBeNull();
+  });
+});

--- a/cli/lib/select.ts
+++ b/cli/lib/select.ts
@@ -1,0 +1,42 @@
+/**
+ * Small pure helpers shared by the commands. Kept separate from the command modules so they
+ * can be unit-tested without a session or a live API.
+ */
+
+export type PrefixMatch<T> =
+  | { ok: true; item: T }
+  | { ok: false; reason: 'none' | 'ambiguous'; count: number };
+
+/**
+ * Tables print short id prefixes (a full UUID column is unreadable), so `--id` accepts a prefix.
+ * Ambiguity must be an error, never a silent "first match": picking the wrong post or article
+ * would publish or delete the wrong thing.
+ */
+export function resolveByPrefix<T extends { id: string }>(items: T[], prefix: string): PrefixMatch<T> {
+  const p = prefix.trim();
+  if (!p) return { ok: false, reason: 'none', count: 0 };
+  // An exact id always wins, even if it happens to prefix another id.
+  const exact = items.find((i) => i.id === p);
+  if (exact) return { ok: true, item: exact };
+  const matches = items.filter((i) => i.id.startsWith(p));
+  if (matches.length === 1) return { ok: true, item: matches[0] };
+  return { ok: false, reason: matches.length ? 'ambiguous' : 'none', count: matches.length };
+}
+
+/**
+ * Parse repeatable `key=value` flags (e.g. --platformCaption x="short cut").
+ * The value may itself contain '=', so only the FIRST separator splits.
+ * Returns null on a malformed pair so the caller can fail loudly instead of dropping input.
+ */
+export function parseKeyValuePairs(pairs: string[]): Record<string, string> | null {
+  const out: Record<string, string> = {};
+  for (const pair of pairs) {
+    const i = pair.indexOf('=');
+    if (i < 1) return null;
+    const key = pair.slice(0, i).trim().toLowerCase();
+    const value = pair.slice(i + 1).trim();
+    if (!key) return null;
+    if (value) out[key] = value; // empty value = clear that key
+  }
+  return out;
+}

--- a/cli/llms.txt
+++ b/cli/llms.txt
@@ -1,0 +1,149 @@
+# Anomalia CLI
+
+CLI for managing Anomalia social media AI autopilot brands from the terminal.
+
+## Installation
+
+```bash
+curl -sSL https://raw.githubusercontent.com/andreabuttarelli/anomalia-cli/main/scripts/install.sh | bash
+```
+
+## Commands
+
+### Overview
+- `anomalia brands` — List all brands
+- `anomalia dashboard <slug>` — Full brand dashboard
+- `anomalia status <slug>` — Detailed status
+
+### Posts
+- `anomalia content <slug> [--status <status>]` — List/filter posts (status: pending_user, approved, scheduled, published, failed)
+- `anomalia approve <slug> [--all] [--dry]` — Approve pending posts
+- `anomalia post <slug> <id>` — Show post: text, media, carousel slides
+- `anomalia post <slug> <id> edit [--caption|--title|--link|--subreddit|--firstComment|--imagePrompt|--media|--format|--platforms|--platformCaption|--slot|--product]` — Edit fields (no render, no credits)
+- `anomalia post <slug> <id> regenerate --instruction "warmer background"` — Refine a single image (bills one render)
+- `anomalia post <slug> <id> slide --index 1 --instruction "..."` — Re-render ONE carousel slide (0 = cover)
+- `anomalia post <slug> <id> reorder --order "0,2,1"` — Reorder/drop slides (no render)
+- `anomalia post <slug> <id> video [--duration 6] [--script "..."] [--instruction "..."]` — Animate the cover into a clip; also retries a video that fell back to a photo
+- `anomalia post <slug> <id> render` — Generate the missing image from the prompt
+- `anomalia post <slug> <id> approve` — Approve single post
+- `anomalia post <slug> <id> publish` — Publish immediately
+- `anomalia post <slug> <id> reschedule --scheduledFor "2026-06-20T10:00"` — Reschedule
+- `anomalia post <slug> <id> reject` — Delete pending post
+
+Editing a SCHEDULED post re-syncs it to Zernio automatically, so what goes out is what you edited.
+
+### Editorial Plan
+- `anomalia plan <slug>` — View active plan + proposals
+- `anomalia plan <slug> propose` — Generate first editorial plan
+- `anomalia plan <slug> revise --feedback "..."` — Request revision
+- `anomalia plan <slug> approve` — Approve proposed plan
+- `anomalia plan <slug> discard` — Discard proposed plan
+- `anomalia plan <slug> save-brief --week 0 --brief "..."` — Save week brief
+- `anomalia plan <slug> replan --week 0 --brief "..."` — Regenerate week
+
+### Weekly Plan
+- `anomalia weekly-plan <slug> [--week N]` — View weekly plan + seeds
+- `anomalia weekly-plan <slug> plan --week N` — Generate seeds for a week
+- `anomalia weekly-plan <slug> produce --week N` — Produce seeds into posts
+
+### Strategy
+- `anomalia gtm <slug>` — View GTM roadmap
+- `anomalia voice <slug>` — View voice rules
+
+### Studio
+- `anomalia studio <slug>` — View full studio
+- `anomalia studio <slug> kit-update --about "..." [--category "..."] [--audience "..."]` — Update brand kit
+- `anomalia studio <slug> colors --colors "#hex,#hex"` — Set brand colors
+- `anomalia studio <slug> add-note --title "..." --text "..."` — Add knowledge note
+- `anomalia studio <slug> delete-doc --id <uuid>` — Delete document
+- `anomalia studio <slug> people-add --name "..." [--role "..."]` — Add real person
+- `anomalia studio <slug> people-generate --name "..." [--gender female] [--vibe professional]` — Generate AI person
+- `anomalia studio <slug> people-delete --id <uuid>` — Delete person
+- `anomalia studio <slug> add-competitor --name "..." [--website "..."]` — Add competitor
+- `anomalia studio <slug> delete-competitor --id <uuid>` — Delete competitor
+- `anomalia studio <slug> research` — AI competitor research
+- `anomalia studio <slug> sync-history` — Sync social post history
+
+### SEO
+- `anomalia seo <slug>` — Tech score, search performance, SEO grade + initiatives
+- `anomalia seo <slug> run` — Run the technical audit (also refreshes the plan)
+- `anomalia seo <slug> plan` — Generate the SEO growth plan
+- `anomalia seo <slug> more [--guidance "..."]` — Append more initiatives
+- `anomalia seo <slug> asset --id <initiativeId>` — Turn an initiative into a ready asset
+- `anomalia seo <slug> article --id <initiativeId>` — Turn an initiative into a full article draft
+
+### GEO (AI visibility)
+- `anomalia geo <slug>` — Share of voice, per-prompt citations, ready fixes
+- `anomalia geo <slug> run` — Run the citation audit
+- `anomalia geo <slug> fix` — Generate fix artifacts for the gaps found
+
+### Keywords
+- `anomalia keywords <slug>` — Keyword strategy: volume, difficulty, opportunity, action
+- `anomalia keywords <slug> refresh` — Regenerate the keyword research
+
+### Web / Blog
+- `anomalia web <slug> [--status draft|scheduled|published|all]` — List articles (drafts included)
+- `anomalia web <slug> generate --topic "..."` — Generate an article draft from a topic
+- `anomalia web <slug> optimize --id <id>` — Rewrite for SEO score (meta title/description included)
+- `anomalia web <slug> publish|unpublish|delete --id <id>` — Manage an article
+
+Note: `--id` accepts the short prefix printed in the tables.
+
+### Ads
+- `anomalia ads <slug>` — Ad campaigns, spend, metrics + boost candidates
+- `anomalia ads <slug> --sync` — Sync ad accounts + metrics
+- `anomalia ads <slug> --propose` — Propose boosts from top organic posts
+- `anomalia ads <slug> --create --name "..." --headline "..." [--platform metaads|googleads] [--budget N]` — Create a standalone proposal
+- `anomalia ads <slug> --approve <id> [--budget N] [--goal ...]` — Approve + launch on Zernio
+- `anomalia ads <slug> --pause <id>` — Pause a campaign (all its creatives)
+- `anomalia ads <slug> --resume <id>` — Resume a paused campaign
+- `anomalia ads <slug> --pause <id> --ad <adId>` — Pause one creative only (A/B)
+- `anomalia ads <slug> --resume <id> --ad <adId>` — Resume one creative only
+- `anomalia ads <slug> --duplicate <id>` — Duplicate a campaign (paused copy as new proposal)
+- `anomalia ads <slug> --delete <id>` — Delete a campaign on the platform (history kept)
+- `anomalia ads <slug> --reject <id>` — Reject a proposal
+
+### Analytics
+- `anomalia analytics <slug>` — View analytics
+- `anomalia calendar <slug> [--month YYYY-MM]` — View calendar
+
+### AI Chat
+- `anomalia ai <slug> --message "..."` — Chat with AI (full read/write access)
+- `echo "..." | anomalia ai <slug>` — Pipe mode for AI agents
+- `anomalia ai <slug> --message "..." --pipe` — Raw output (no formatting)
+
+### System
+- `anomalia update` — Update CLI to latest version
+- `anomalia upgrade <slug>` — Open plan upgrade page
+- `021 --help` — Show help
+
+## Environment
+
+- `PUBLIC_APP_URL` — Backend URL (default: http://localhost:5173)
+
+## Auth
+
+Run `anomalia login` once to authenticate via browser. Session is saved in `~/.config/anomalia/session.json`.
+
+## MCP
+
+MCP server in `mcp/` — stdio + Streamable HTTP. Same OAuth identity as the CLI (no static API tokens).
+
+```bash
+bun run mcp          # stdio
+bun run mcp:http     # http://localhost:8787/mcp
+```
+
+Remote (Vercel / `mcp.anomalia.so`): `Authorization: Bearer <access_token>`. Full map: `docs/mcp.md`.
+
+## Observability (Sentry + Supabase)
+
+MCP HTTP logs/errors → Vercel stderr, optional Sentry (`SENTRY_DSN`), optional Supabase `mcp_logs` (`SUPABASE_SERVICE_ROLE_KEY`). See `docs/mcp.md`.
+
+## Architecture
+
+The CLI is a thin HTTP client. All operations go through `/api/v1/*` endpoints. No direct database access. No secrets embedded.
+
+```
+CLI / MCP → HTTP → /api/v1/* → Supabase → Database
+```

--- a/cli/llms.txt
+++ b/cli/llms.txt
@@ -123,7 +123,7 @@ Note: `--id` accepts the short prefix printed in the tables.
 
 ## Auth
 
-Run `anomalia login` once to authenticate via browser, or non-interactively with `anomalia login --email you@example.com --password …`. Session is saved in `~/.config/anomalia/session.json`.
+Run `anomalia login` once to authenticate via browser, or non-interactively with `anomalia login --email you@example.com --password …` (or `--password-stdin` to keep the password out of shell history and `ps`). Session is saved in `~/.config/anomalia/session.json`.
 
 ## MCP
 

--- a/cli/llms.txt
+++ b/cli/llms.txt
@@ -123,7 +123,7 @@ Note: `--id` accepts the short prefix printed in the tables.
 
 ## Auth
 
-Run `anomalia login` once to authenticate via browser. Session is saved in `~/.config/anomalia/session.json`.
+Run `anomalia login` once to authenticate via browser, or non-interactively with `anomalia login --email you@example.com --password …`. Session is saved in `~/.config/anomalia/session.json`.
 
 ## MCP
 

--- a/cli/llms.txt
+++ b/cli/llms.txt
@@ -5,7 +5,7 @@ CLI for managing Anomalia social media AI autopilot brands from the terminal.
 ## Installation
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/andreabuttarelli/anomalia-cli/main/scripts/install.sh | bash
+curl -sSL https://raw.githubusercontent.com/anomaliaso/anomalia/main/cli/scripts/install.sh | bash
 ```
 
 ## Commands

--- a/cli/mcp/api/health.js
+++ b/cli/mcp/api/health.js
@@ -1,0 +1,31 @@
+/**
+ * Ultra-minimal health endpoint (ESM).
+ * Kept dependency-free so /health stays up even if the MCP bundle fails to build.
+ */
+export default function handler(req, res) {
+  if (req.method === 'OPTIONS') {
+    res.statusCode = 204;
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
+    res.setHeader(
+      'Access-Control-Allow-Headers',
+      'Content-Type, Authorization, mcp-session-id, Last-Event-ID, mcp-protocol-version',
+    );
+    res.end();
+    return;
+  }
+
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'application/json');
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.end(
+    JSON.stringify({
+      ok: true,
+      name: 'anomalia-mcp',
+      transport: 'streamable-http',
+      mcp: '/mcp',
+    }),
+  );
+}
+
+export const config = { maxDuration: 10 };

--- a/cli/mcp/context.ts
+++ b/cli/mcp/context.ts
@@ -1,0 +1,19 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+/** Per-request auth for HTTP transport (Bearer JWT). Stdio leaves this empty and uses the session file. */
+export type RequestAuth = {
+  access_token: string;
+  user: { id: string; email: string };
+  expires_at?: number;
+  source: 'bearer' | 'session';
+};
+
+export const requestAuth = new AsyncLocalStorage<RequestAuth>();
+
+export function getRequestAuth(): RequestAuth | undefined {
+  return requestAuth.getStore();
+}
+
+export function runWithRequestAuth<T>(auth: RequestAuth, fn: () => T): T {
+  return requestAuth.run(auth, fn);
+}

--- a/cli/mcp/entries/mcp.ts
+++ b/cli/mcp/entries/mcp.ts
@@ -1,0 +1,2 @@
+import { mcp } from '../vercel-handler.ts';
+export default mcp;

--- a/cli/mcp/entries/oauth-protected-resource.ts
+++ b/cli/mcp/entries/oauth-protected-resource.ts
@@ -1,0 +1,2 @@
+import { oauthProtectedResource } from '../vercel-handler.ts';
+export default oauthProtectedResource;

--- a/cli/mcp/http-app.test.ts
+++ b/cli/mcp/http-app.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from 'bun:test';
+import { handleMcpFetch } from './http-app.ts';
+
+describe('mcp HTTP transport', () => {
+  test('health endpoint', async () => {
+    const res = await handleMcpFetch(new Request('http://localhost/health'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.mcp).toBe('/mcp');
+  });
+
+  test('oauth protected resource metadata', async () => {
+    const res = await handleMcpFetch(
+      new Request('http://localhost/.well-known/oauth-protected-resource'),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.resource).toContain('/mcp');
+    expect(Array.isArray(body.authorization_servers)).toBe(true);
+    expect(body.authorization_servers.length).toBeGreaterThan(0);
+  });
+
+  test('initialize + tools/list over streamable HTTP (JSON)', async () => {
+    const initRes = await handleMcpFetch(
+      new Request('http://localhost/mcp', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json, text/event-stream',
+        },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'initialize',
+          params: {
+            protocolVersion: '2024-11-05',
+            capabilities: {},
+            clientInfo: { name: 'test', version: '0.0.1' },
+          },
+        }),
+      }),
+    );
+    expect(initRes.status).toBe(200);
+    const initBody = await initRes.json();
+    expect(initBody.result?.serverInfo?.name).toBe('anomalia');
+
+    const listRes = await handleMcpFetch(
+      new Request('http://localhost/mcp', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json, text/event-stream',
+        },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 2,
+          method: 'tools/list',
+          params: {},
+        }),
+      }),
+    );
+    expect(listRes.status).toBe(200);
+    const listBody = await listRes.json();
+    const names = (listBody.result?.tools ?? []).map((t: { name: string }) => t.name);
+    expect(names).toContain('list_brands');
+    expect(names).toContain('login');
+    expect(names.length).toBeGreaterThan(50);
+  });
+
+  test('requires bearer when MCP_REQUIRE_BEARER=1', async () => {
+    const prev = process.env.MCP_REQUIRE_BEARER;
+    process.env.MCP_REQUIRE_BEARER = '1';
+    try {
+      const res = await handleMcpFetch(
+        new Request('http://localhost/mcp', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json, text/event-stream',
+          },
+          body: JSON.stringify({
+            jsonrpc: '2.0',
+            id: 1,
+            method: 'initialize',
+            params: {
+              protocolVersion: '2024-11-05',
+              capabilities: {},
+              clientInfo: { name: 'test', version: '0.0.1' },
+            },
+          }),
+        }),
+      );
+      expect(res.status).toBe(401);
+      expect(res.headers.get('www-authenticate') ?? '').toContain('Bearer');
+    } finally {
+      if (prev === undefined) delete process.env.MCP_REQUIRE_BEARER;
+      else process.env.MCP_REQUIRE_BEARER = prev;
+    }
+  });
+});

--- a/cli/mcp/http-app.ts
+++ b/cli/mcp/http-app.ts
@@ -1,0 +1,157 @@
+import { authServerUrl, loadEnv } from '../lib/config.ts';
+import { runWithRequestAuth } from './context.ts';
+import { mcpLog } from './observability.ts';
+import { extractBearer, toAuthInfo, verifyBearerToken } from './verify-token.ts';
+
+const CORS_HEADERS: Record<string, string> = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
+  'Access-Control-Allow-Headers':
+    'Content-Type, Authorization, mcp-session-id, Last-Event-ID, mcp-protocol-version',
+  'Access-Control-Expose-Headers': 'mcp-session-id, mcp-protocol-version',
+};
+
+function withCors(res: Response): Response {
+  const headers = new Headers(res.headers);
+  for (const [k, v] of Object.entries(CORS_HEADERS)) headers.set(k, v);
+  return new Response(res.body, { status: res.status, statusText: res.statusText, headers });
+}
+
+function json(data: unknown, status = 200): Response {
+  return withCors(
+    new Response(JSON.stringify(data), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  );
+}
+
+function mcpResourceUrl(req: Request): string {
+  const envUrl = process.env.MCP_PUBLIC_URL?.replace(/\/$/, '');
+  if (envUrl) return `${envUrl}/mcp`;
+  const url = new URL(req.url);
+  return `${url.origin}/mcp`;
+}
+
+function authServers(): string[] {
+  return [authServerUrl()];
+}
+
+/**
+ * Web-standard fetch handler for Streamable HTTP MCP (stateless + JSON responses).
+ * Suitable for Bun.serve and Vercel Node/Edge adapters.
+ */
+export async function handleMcpFetch(req: Request): Promise<Response> {
+  await loadEnv();
+  const url = new URL(req.url);
+
+  if (req.method === 'OPTIONS') {
+    return withCors(new Response(null, { status: 204 }));
+  }
+
+  if (url.pathname === '/health' || url.pathname === '/') {
+    return json({
+      ok: true,
+      name: 'anomalia-mcp',
+      transport: 'streamable-http',
+      mcp: '/mcp',
+    });
+  }
+
+  if (url.pathname === '/.well-known/oauth-protected-resource') {
+    return json({
+      resource: mcpResourceUrl(req),
+      authorization_servers: authServers(),
+      scopes_supported: ['anomalia'],
+      bearer_methods_supported: ['header'],
+    });
+  }
+
+  if (url.pathname !== '/mcp' && !url.pathname.endsWith('/mcp')) {
+    return json({ error: 'Not found' }, 404);
+  }
+
+  const bearer = extractBearer(req);
+  const verified = await verifyBearerToken(bearer);
+
+  // Remote/public: require Bearer. Local HTTP may also fall back to CLI session file inside tools.
+  const requireBearer = process.env.MCP_REQUIRE_BEARER === '1' || process.env.VERCEL === '1';
+  if (requireBearer && !verified) {
+    mcpLog({
+      level: 'warn',
+      event: 'auth.unauthorized',
+      message: 'Missing or invalid Bearer token',
+      method: req.method,
+      path: url.pathname,
+      statusCode: 401,
+    });
+    return withCors(
+      new Response(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          error: {
+            code: -32001,
+            message:
+              'Unauthorized. Pass Authorization: Bearer <access_token> from an Anomalia OAuth session.',
+          },
+          id: null,
+        }),
+        {
+          status: 401,
+          headers: {
+            'Content-Type': 'application/json',
+            'WWW-Authenticate': `Bearer realm="anomalia", resource_metadata="${new URL('/.well-known/oauth-protected-resource', req.url).toString()}"`,
+          },
+        },
+      ),
+    );
+  }
+
+  const run = async (): Promise<Response> => {
+    const { WebStandardStreamableHTTPServerTransport } = await import(
+      '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js'
+    );
+    const { createAnomaliaMcpServer } = await import('./server.ts');
+
+    const server = createAnomaliaMcpServer();
+    const transport = new WebStandardStreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+      enableJsonResponse: true,
+    });
+    await server.connect(transport);
+    try {
+      return await transport.handleRequest(req, {
+        authInfo: verified ? toAuthInfo(verified) : undefined,
+      });
+    } finally {
+      await transport.close().catch(() => {});
+      await server.close().catch(() => {});
+    }
+  };
+
+  try {
+    const res = verified
+      ? await runWithRequestAuth(verified, run)
+      : await run();
+    return withCors(res);
+  } catch (e) {
+    mcpLog({
+      level: 'error',
+      event: 'mcp.handler_error',
+      message: e instanceof Error ? e.message : String(e),
+      method: req.method,
+      path: url.pathname,
+      userId: verified?.user.id,
+      error: e,
+      statusCode: 500,
+    });
+    return json(
+      {
+        jsonrpc: '2.0',
+        error: { code: -32603, message: e instanceof Error ? e.message : 'Internal error' },
+        id: null,
+      },
+      500,
+    );
+  }
+}

--- a/cli/mcp/http-router.ts
+++ b/cli/mcp/http-router.ts
@@ -1,0 +1,62 @@
+import { handleMcpFetch } from '../mcp/http-app.ts';
+import { authServerUrl } from '../lib/config.ts';
+
+const CORS: Record<string, string> = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
+  'Access-Control-Allow-Headers':
+    'Content-Type, Authorization, mcp-session-id, Last-Event-ID, mcp-protocol-version',
+  'Access-Control-Expose-Headers': 'mcp-session-id, mcp-protocol-version',
+};
+
+function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...CORS },
+  });
+}
+
+/**
+ * Shared HTTP router for local Bun (`mcp/http.ts`) and Vercel (`api/*`).
+ * Kept free of framework detection at the repo root (no Hono in app.ts).
+ */
+export async function routeMcpHttp(req: Request): Promise<Response> {
+  const url = new URL(req.url);
+
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: CORS });
+  }
+
+  if (url.pathname === '/health' || url.pathname === '/' || url.pathname === '/api/health') {
+    return json({
+      ok: true,
+      name: 'anomalia-mcp',
+      transport: 'streamable-http',
+      mcp: '/mcp',
+    });
+  }
+
+  if (
+    url.pathname === '/.well-known/oauth-protected-resource' ||
+    url.pathname === '/api/oauth-protected-resource'
+  ) {
+    const appUrl = authServerUrl();
+    const publicUrl = (process.env.MCP_PUBLIC_URL ?? url.origin).replace(/\/$/, '');
+    return json({
+      resource: `${publicUrl}/mcp`,
+      authorization_servers: [appUrl],
+      scopes_supported: ['anomalia'],
+      bearer_methods_supported: ['header'],
+    });
+  }
+
+  if (url.pathname === '/mcp' || url.pathname === '/api/mcp' || url.pathname.endsWith('/mcp')) {
+    // Normalize path so the MCP handler sees /mcp
+    const normalized = new URL(req.url);
+    normalized.pathname = '/mcp';
+    const forwarded = new Request(normalized, req);
+    return handleMcpFetch(forwarded);
+  }
+
+  return json({ error: 'Not found', hint: 'Use /mcp or /health' }, 404);
+}

--- a/cli/mcp/http.ts
+++ b/cli/mcp/http.ts
@@ -1,0 +1,53 @@
+#!/usr/bin/env bun
+/**
+ * Anomalia MCP server (Streamable HTTP) — local Bun.serve.
+ * Production on Vercel uses api/*.ts (Node), not this file.
+ */
+import { loadEnv } from '../lib/config.ts';
+import { routeMcpHttp } from './http-router.ts';
+import { mcpLog } from './observability.ts';
+
+await loadEnv();
+
+const port = Number(process.env.MCP_PORT ?? process.env.PORT ?? 8787);
+
+const server = Bun.serve({
+  port,
+  fetch: async (req) => {
+    const started = Date.now();
+    try {
+      const res = await routeMcpHttp(req);
+      if (res.status >= 500) {
+        mcpLog({
+          level: 'error',
+          source: 'mcp-http',
+          event: 'http.response',
+          message: `status ${res.status}`,
+          method: req.method,
+          path: new URL(req.url).pathname,
+          statusCode: res.status,
+          durationMs: Date.now() - started,
+        });
+      }
+      return res;
+    } catch (e) {
+      mcpLog({
+        level: 'error',
+        source: 'mcp-http',
+        event: 'http.unhandled',
+        message: e instanceof Error ? e.message : String(e),
+        method: req.method,
+        path: new URL(req.url).pathname,
+        error: e,
+        durationMs: Date.now() - started,
+      });
+      return new Response(JSON.stringify({ error: 'Internal error' }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+  },
+});
+
+console.error(`Anomalia MCP (HTTP) on http://localhost:${server.port}/mcp`);
+console.error(`Health: http://localhost:${server.port}/health`);

--- a/cli/mcp/observability.test.ts
+++ b/cli/mcp/observability.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'bun:test';
+import { mcpLogAsync } from './observability.ts';
+import { routeMcpHttp } from './http-router.ts';
+
+describe('mcp observability', () => {
+  test('mcpLogAsync no-ops without Sentry/Supabase env', async () => {
+    const prevDsn = process.env.SENTRY_DSN;
+    const prevKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    delete process.env.SENTRY_DSN;
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    try {
+      await mcpLogAsync({
+        level: 'info',
+        event: 'test.event',
+        message: 'hello',
+      });
+    } finally {
+      if (prevDsn !== undefined) process.env.SENTRY_DSN = prevDsn;
+      if (prevKey !== undefined) process.env.SUPABASE_SERVICE_ROLE_KEY = prevKey;
+    }
+  });
+});
+
+describe('mcp http router', () => {
+  test('health via router', async () => {
+    const res = await routeMcpHttp(new Request('http://localhost/health'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+  });
+});

--- a/cli/mcp/observability.ts
+++ b/cli/mcp/observability.ts
@@ -1,0 +1,155 @@
+/**
+ * MCP observability: Sentry (errors) + Supabase mcp_logs (structured logs).
+ * All sinks are optional — missing env vars disable that sink silently.
+ */
+import * as Sentry from '@sentry/node';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export type McpLogEvent = {
+  level: LogLevel;
+  source?: 'mcp-http' | 'mcp-stdio' | 'mcp';
+  event: string;
+  message: string;
+  requestId?: string;
+  method?: string;
+  path?: string;
+  toolName?: string;
+  userId?: string;
+  brandSlug?: string;
+  statusCode?: number;
+  durationMs?: number;
+  error?: unknown;
+  context?: Record<string, unknown>;
+};
+
+let sentryReady = false;
+let supabaseAdmin: SupabaseClient | null | undefined;
+
+function ensureSentry() {
+  if (sentryReady) return;
+  sentryReady = true;
+  const dsn = process.env.SENTRY_DSN;
+  if (!dsn) return;
+  Sentry.init({
+    dsn,
+    environment: process.env.SENTRY_ENVIRONMENT ?? process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? 'development',
+    tracesSampleRate: Number(process.env.SENTRY_TRACES_SAMPLE_RATE ?? '0.1'),
+    enableLogs: false,
+    initialScope: {
+      tags: { service: 'anomalia-mcp' },
+    },
+  });
+}
+
+function getSupabaseAdmin(): SupabaseClient | null {
+  if (supabaseAdmin !== undefined) return supabaseAdmin;
+  const url = process.env.PUBLIC_SUPABASE_URL ?? process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    supabaseAdmin = null;
+    return null;
+  }
+  supabaseAdmin = createClient(url, key, { auth: { persistSession: false, autoRefreshToken: false } });
+  return supabaseAdmin;
+}
+
+function errorFields(error: unknown): { error_name?: string; error_stack?: string; message?: string } {
+  if (error instanceof Error) {
+    return { error_name: error.name, error_stack: error.stack, message: error.message };
+  }
+  if (error === undefined || error === null) return {};
+  return { error_name: typeof error, message: String(error) };
+}
+
+/** Fire-and-forget structured log to stderr + Sentry + Supabase mcp_logs. */
+export function mcpLog(entry: McpLogEvent): void {
+  void mcpLogAsync(entry);
+}
+
+export async function mcpLogAsync(entry: McpLogEvent): Promise<void> {
+  ensureSentry();
+  const err = errorFields(entry.error);
+  const line = {
+    level: entry.level,
+    source: entry.source ?? 'mcp-http',
+    event: entry.event,
+    message: entry.message,
+    requestId: entry.requestId,
+    method: entry.method,
+    path: entry.path,
+    toolName: entry.toolName,
+    userId: entry.userId,
+    brandSlug: entry.brandSlug,
+    statusCode: entry.statusCode,
+    durationMs: entry.durationMs,
+    errorName: err.error_name,
+    context: entry.context,
+  };
+
+  // Always mirror to stderr (Vercel function logs)
+  const payload = JSON.stringify(line);
+  if (entry.level === 'error') console.error(`[mcp] ${payload}`);
+  else if (entry.level === 'warn') console.warn(`[mcp] ${payload}`);
+  else console.error(`[mcp] ${payload}`); // stdout reserved on stdio MCP; stderr is safe for both
+
+  try {
+    if (process.env.SENTRY_DSN) {
+      if (entry.level === 'error') {
+        Sentry.withScope((scope) => {
+          scope.setTag('mcp.event', entry.event);
+          scope.setTag('mcp.source', entry.source ?? 'mcp-http');
+          if (entry.toolName) scope.setTag('mcp.tool', entry.toolName);
+          if (entry.brandSlug) scope.setTag('mcp.brand', entry.brandSlug);
+          if (entry.requestId) scope.setTag('mcp.request_id', entry.requestId);
+          if (entry.userId) scope.setUser({ id: entry.userId });
+          scope.setContext('mcp', line as Record<string, unknown>);
+          if (entry.error instanceof Error) Sentry.captureException(entry.error);
+          else Sentry.captureMessage(entry.message, 'error');
+        });
+      } else if (entry.level === 'warn') {
+        Sentry.captureMessage(entry.message, 'warning');
+      }
+      // info/debug stay in stderr + supabase only (avoid Sentry noise)
+    }
+  } catch (e) {
+    console.error('[mcp] sentry log failed', e);
+  }
+
+  try {
+    const sb = getSupabaseAdmin();
+    if (sb) {
+      const { error } = await sb.from('mcp_logs').insert({
+        level: entry.level,
+        source: entry.source ?? 'mcp-http',
+        event: entry.event,
+        message: entry.message,
+        request_id: entry.requestId ?? null,
+        method: entry.method ?? null,
+        path: entry.path ?? null,
+        tool_name: entry.toolName ?? null,
+        user_id: entry.userId ?? null,
+        brand_slug: entry.brandSlug ?? null,
+        status_code: entry.statusCode ?? null,
+        duration_ms: entry.durationMs ?? null,
+        error_name: err.error_name ?? null,
+        error_stack: err.error_stack ?? null,
+        context: entry.context ?? {},
+      });
+      if (error) console.error('[mcp] supabase mcp_logs insert failed', error.message);
+    }
+  } catch (e) {
+    console.error('[mcp] supabase log failed', e);
+  }
+}
+
+export async function flushObservability(): Promise<void> {
+  if (!process.env.SENTRY_DSN) return;
+  try {
+    ensureSentry();
+    await Sentry.flush(2000);
+  } catch {
+    // ignore
+  }
+}

--- a/cli/mcp/package.json
+++ b/cli/mcp/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "anomalia-mcp-http",
+  "private": true,
+  "type": "module",
+  "description": "Vercel Root Directory is this folder (mcp/). Handlers are prebundled under api/.",
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/cli/mcp/server.ts
+++ b/cli/mcp/server.ts
@@ -1,0 +1,34 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { registerAuthTools } from './tools/auth.ts';
+import { registerBrandTools } from './tools/brand-content.ts';
+import { registerPlanTools } from './tools/plan.ts';
+import { registerStudioTools } from './tools/studio.ts';
+import { registerWebTools } from './tools/web.ts';
+
+export function createAnomaliaMcpServer(): McpServer {
+  const server = new McpServer(
+    {
+      name: 'anomalia',
+      version: '0.1.0',
+      description:
+        'Anomalia social media AI autopilot — manage brands, posts, plans, studio, SEO/GEO, and blog via OAuth.',
+    },
+    {
+      instructions: [
+        'Auth: browser OAuth via the `login` tool (local stdio/HTTP) or Authorization: Bearer <access_token> (remote HTTP). No static API tokens.',
+        'Local MCP shares ~/.config/anomalia/session.json with the Anomalia CLI.',
+        'Always start with `list_brands` (or `whoami`) to learn brand slugs.',
+        'Post and article ids accept short unambiguous prefixes from list tools.',
+        'Prefer specific tools for deterministic actions; use `chat` for open-ended multi-step work.',
+      ].join(' '),
+    },
+  );
+
+  registerAuthTools(server);
+  registerBrandTools(server);
+  registerPlanTools(server);
+  registerStudioTools(server);
+  registerWebTools(server);
+
+  return server;
+}

--- a/cli/mcp/stdio.ts
+++ b/cli/mcp/stdio.ts
@@ -1,0 +1,29 @@
+#!/usr/bin/env bun
+/**
+ * Anomalia MCP server (stdio).
+ *
+ * Auth is browser OAuth only — same flow as `anomalia login`, same session file.
+ * No static API tokens.
+ *
+ * Cursor / Claude Desktop example:
+ * {
+ *   "mcpServers": {
+ *     "anomalia": {
+ *       "command": "bun",
+ *       "args": ["run", "/absolute/path/to/anomalia-cli/mcp/stdio.ts"]
+ *     }
+ *   }
+ * }
+ */
+
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { loadEnv } from '../lib/config.ts';
+import { createAnomaliaMcpServer } from './server.ts';
+
+await loadEnv();
+
+const server = createAnomaliaMcpServer();
+const transport = new StdioServerTransport();
+await server.connect(transport);
+
+console.error('Anomalia MCP server running on stdio (OAuth session via login tool / anomalia login)');

--- a/cli/mcp/tools/auth.ts
+++ b/cli/mcp/tools/auth.ts
@@ -1,0 +1,127 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { api } from '../../lib/api.ts';
+import {
+  clearSession,
+  loadSession,
+  startBrowserLogin,
+} from '../../lib/auth.ts';
+import { getRequestAuth } from '../context.ts';
+import { fail, ok, withAuth } from '../util.ts';
+
+export function registerAuthTools(server: McpServer) {
+  server.registerTool(
+    'login',
+    {
+      title: 'Login',
+      description:
+        'Sign in to Anomalia via browser OAuth. Opens the login page, waits for consent, and stores a refreshable session in ~/.config/anomalia/session.json (same file as the CLI). No static API tokens.',
+      inputSchema: z.object({}),
+      annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
+    },
+    async () => {
+      try {
+        const bearer = getRequestAuth();
+        if (bearer) {
+          return ok({
+            alreadyAuthenticated: true,
+            email: bearer.user.email,
+            source: 'bearer',
+            hint: 'Request already carries a Bearer access token. No browser login needed.',
+          });
+        }
+
+        const existing = await loadSession();
+        if (existing) {
+          return ok({
+            alreadyAuthenticated: true,
+            email: existing.user.email,
+            expiresAt: existing.expires_at,
+            source: 'session',
+            hint: 'Already signed in. Call logout first if you need to switch accounts.',
+          });
+        }
+
+        if (process.env.VERCEL === '1' || process.env.MCP_REQUIRE_BEARER === '1') {
+          return fail(
+            'Browser login is not available on the remote MCP. Pass Authorization: Bearer <access_token> from your Anomalia OAuth session (same JWT stored by `anomalia login`).',
+          );
+        }
+
+        const session = await startBrowserLogin((msg: string) => {
+          // stdout is the MCP JSON-RPC channel — log only to stderr
+          console.error(`[anomalia-mcp] ${msg}`);
+        });
+
+        return ok({
+          authenticated: true,
+          email: session.user.email,
+          expiresAt: session.expires_at,
+          source: 'session',
+        });
+      } catch (e) {
+        return fail(e instanceof Error ? e.message : String(e));
+      }
+    },
+  );
+
+  server.registerTool(
+    'logout',
+    {
+      title: 'Logout',
+      description: 'Clear the local Anomalia OAuth session (CLI + MCP share the same session file).',
+      inputSchema: z.object({}),
+      annotations: { readOnlyHint: false, destructiveHint: true },
+    },
+    async () => {
+      clearSession();
+      return ok({ loggedOut: true });
+    },
+  );
+
+  server.registerTool(
+    'whoami',
+    {
+      title: 'Who am I',
+      description: 'Show the currently authenticated Anomalia user, if any.',
+      inputSchema: z.object({}),
+      annotations: { readOnlyHint: true },
+    },
+    async () => {
+      const bearer = getRequestAuth();
+      if (bearer) {
+        return ok({
+          authenticated: true,
+          email: bearer.user.email,
+          userId: bearer.user.id,
+          source: 'bearer',
+        });
+      }
+      const session = await loadSession();
+      if (!session) {
+        return ok({
+          authenticated: false,
+          hint: 'Call login (local) or send Authorization: Bearer <access_token> (remote HTTP).',
+        });
+      }
+      return ok({
+        authenticated: true,
+        email: session.user.email,
+        userId: session.user.id,
+        expiresAt: session.expires_at,
+        source: 'session',
+      });
+    },
+  );
+
+  server.registerTool(
+    'list_brands',
+    {
+      title: 'List brands',
+      description: 'List all Anomalia brands for the signed-in user (slug, plan, pending posts, autopilot).',
+      inputSchema: z.object({}),
+      annotations: { readOnlyHint: true },
+    },
+    async () => withAuth(async (token) => api.listBrands(token)),
+  );
+}

--- a/cli/mcp/tools/brand-content.ts
+++ b/cli/mcp/tools/brand-content.ts
@@ -1,0 +1,396 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { api } from '../../lib/api.ts';
+import { resolvePostId, withAuth } from '../util.ts';
+
+const slug = z.string().min(1).describe('Brand URL slug');
+
+export function registerBrandTools(server: McpServer) {
+  server.registerTool(
+    'get_dashboard',
+    {
+      title: 'Brand dashboard',
+      description: 'Full brand overview: pending count, plan, products, accounts, kit, recent autopilot runs.',
+      inputSchema: z.object({ slug }),
+      annotations: { readOnlyHint: true },
+    },
+    async ({ slug }) => withAuth((token) => api.getBrand(token, slug)),
+  );
+
+  server.registerTool(
+    'get_status',
+    {
+      title: 'Brand status',
+      description: 'Compact status: pending posts, quota signals, last runs.',
+      inputSchema: z.object({ slug }),
+      annotations: { readOnlyHint: true },
+    },
+    async ({ slug }) =>
+      withAuth(async (token) => {
+        const detail = await api.getBrand(token, slug);
+        const pending = await api.getPosts(token, slug, 'pending_user');
+        return {
+          brand: detail.brand,
+          pendingCount: detail.pendingCount,
+          pendingPreview: pending.slice(0, 10).map((p) => ({
+            id: p.id,
+            platform: p.platform,
+            status: p.status,
+            caption: (p.caption ?? '').slice(0, 80),
+            scheduled_for: p.scheduled_for,
+          })),
+          scheduledCount: detail.scheduledCount,
+          publishedCount: detail.publishedCount,
+          runs: detail.runs,
+        };
+      }),
+  );
+
+  server.registerTool(
+    'get_analytics',
+    {
+      title: 'Analytics',
+      description: 'Brand analytics: totals, engagement, recent activity.',
+      inputSchema: z.object({ slug }),
+      annotations: { readOnlyHint: true },
+    },
+    async ({ slug }) => withAuth((token) => api.getAnalytics(token, slug)),
+  );
+
+  server.registerTool(
+    'get_calendar',
+    {
+      title: 'Calendar',
+      description: 'Content calendar for a brand. Optional month as YYYY-MM.',
+      inputSchema: z.object({
+        slug,
+        month: z.string().regex(/^\d{4}-\d{2}$/).optional().describe('Month YYYY-MM'),
+      }),
+      annotations: { readOnlyHint: true },
+    },
+    async ({ slug, month }) => withAuth((token) => api.getCalendar(token, slug, month)),
+  );
+
+  server.registerTool(
+    'get_gtm',
+    {
+      title: 'GTM roadmap',
+      description: 'View the go-to-market roadmap for a brand.',
+      inputSchema: z.object({ slug }),
+      annotations: { readOnlyHint: true },
+    },
+    async ({ slug }) => withAuth((token) => api.getGtm(token, slug)),
+  );
+
+  server.registerTool(
+    'get_voice',
+    {
+      title: 'Voice rules',
+      description: 'View brand voice framework and platform rules.',
+      inputSchema: z.object({ slug }),
+      annotations: { readOnlyHint: true },
+    },
+    async ({ slug }) => withAuth((token) => api.getVoice(token, slug)),
+  );
+
+  server.registerTool(
+    'update_voice',
+    {
+      title: 'Update voice',
+      description: 'Patch brand voice fields (mood, tone, register, avoid list, platform instructions).',
+      inputSchema: z.object({
+        slug,
+        mood: z.string().optional(),
+        tone: z.string().optional(),
+        register: z.number().optional(),
+        emotion: z.string().optional(),
+        character: z.string().optional(),
+        syntax: z.string().optional(),
+        avoid: z.array(z.string()).optional(),
+        platform_instructions: z.record(z.string(), z.string()).optional(),
+      }),
+      annotations: { readOnlyHint: false, destructiveHint: false },
+    },
+    async ({ slug, ...data }) => withAuth((token) => api.updateVoice(token, slug, data)),
+  );
+
+  server.registerTool(
+    'list_products',
+    {
+      title: 'List products',
+      description: 'List products in the brand catalog.',
+      inputSchema: z.object({ slug }),
+      annotations: { readOnlyHint: true },
+    },
+    async ({ slug }) => withAuth((token) => api.listProducts(token, slug)),
+  );
+
+  server.registerTool(
+    'list_posts',
+    {
+      title: 'List posts',
+      description:
+        'List posts for a brand. Filter by status: pending_user, approved, scheduled, published, failed.',
+      inputSchema: z.object({
+        slug,
+        status: z
+          .enum(['pending_user', 'approved', 'scheduled', 'published', 'failed'])
+          .optional()
+          .describe('Optional status filter'),
+      }),
+      annotations: { readOnlyHint: true },
+    },
+    async ({ slug, status }) => withAuth((token) => api.getPosts(token, slug, status)),
+  );
+
+  server.registerTool(
+    'approve_posts',
+    {
+      title: 'Approve all pending posts',
+      description: 'Approve and publish all posts in pending_user status for a brand.',
+      inputSchema: z.object({ slug }),
+      annotations: { readOnlyHint: false, destructiveHint: true },
+    },
+    async ({ slug }) => withAuth((token) => api.approveAll(token, slug)),
+  );
+
+  server.registerTool(
+    'get_post',
+    {
+      title: 'Get post',
+      description: 'Show a single post including carousel slides / media state. id accepts a short prefix.',
+      inputSchema: z.object({
+        slug,
+        id: z.string().min(1).describe('Post id or unambiguous prefix'),
+      }),
+      annotations: { readOnlyHint: true },
+    },
+    async ({ slug, id }) =>
+      withAuth(async (token) => {
+        const postId = await resolvePostId(token, slug, id);
+        const media = await api.getPostMedia(token, slug, postId);
+        return { id: postId, ...media };
+      }),
+  );
+
+  server.registerTool(
+    'edit_post',
+    {
+      title: 'Edit post',
+      description:
+        'Edit post fields without rendering (no credits). Editing a scheduled post re-syncs to Zernio. id accepts a short prefix.',
+      inputSchema: z.object({
+        slug,
+        id: z.string().min(1).describe('Post id or unambiguous prefix'),
+        caption: z.string().optional(),
+        title: z.string().optional(),
+        link_url: z.string().nullable().optional(),
+        subreddit: z.string().optional(),
+        first_comment: z.string().optional(),
+        image_prompt: z.string().optional(),
+        format: z.string().optional(),
+        slot: z.string().optional(),
+        product_name: z.string().optional(),
+        platforms: z.array(z.string()).optional(),
+        media_url: z.string().nullable().optional().describe('Set null to clear image (text-only)'),
+        platform_captions: z.record(z.string(), z.string()).nullable().optional(),
+      }),
+      annotations: { readOnlyHint: false, destructiveHint: false },
+    },
+    async ({ slug, id, ...patch }) =>
+      withAuth(async (token) => {
+        const postId = await resolvePostId(token, slug, id);
+        await api.updatePost(token, slug, postId, patch);
+        return { ok: true, id: postId, patch };
+      }),
+  );
+
+  server.registerTool(
+    'approve_post',
+    {
+      title: 'Approve post',
+      description: 'Approve a single pending post. id accepts a short prefix.',
+      inputSchema: z.object({
+        slug,
+        id: z.string().min(1),
+      }),
+      annotations: { readOnlyHint: false, destructiveHint: true },
+    },
+    async ({ slug, id }) =>
+      withAuth(async (token) => {
+        const postId = await resolvePostId(token, slug, id);
+        return { id: postId, ...(await api.approvePost(token, slug, postId)) };
+      }),
+  );
+
+  server.registerTool(
+    'publish_post',
+    {
+      title: 'Publish post',
+      description: 'Publish a post immediately. id accepts a short prefix.',
+      inputSchema: z.object({
+        slug,
+        id: z.string().min(1),
+      }),
+      annotations: { readOnlyHint: false, destructiveHint: true },
+    },
+    async ({ slug, id }) =>
+      withAuth(async (token) => {
+        const postId = await resolvePostId(token, slug, id);
+        return { id: postId, ...(await api.publishPost(token, slug, postId)) };
+      }),
+  );
+
+  server.registerTool(
+    'reject_post',
+    {
+      title: 'Reject / delete post',
+      description: 'Delete a pending post. id accepts a short prefix.',
+      inputSchema: z.object({
+        slug,
+        id: z.string().min(1),
+      }),
+      annotations: { readOnlyHint: false, destructiveHint: true },
+    },
+    async ({ slug, id }) =>
+      withAuth(async (token) => {
+        const postId = await resolvePostId(token, slug, id);
+        await api.deletePost(token, slug, postId);
+        return { ok: true, id: postId, deleted: true };
+      }),
+  );
+
+  server.registerTool(
+    'reschedule_post',
+    {
+      title: 'Reschedule post',
+      description: 'Reschedule a post. scheduled_for is an ISO datetime. id accepts a short prefix.',
+      inputSchema: z.object({
+        slug,
+        id: z.string().min(1),
+        scheduled_for: z.string().min(1).describe('ISO datetime, e.g. 2026-06-20T10:00'),
+      }),
+      annotations: { readOnlyHint: false, destructiveHint: false },
+    },
+    async ({ slug, id, scheduled_for }) =>
+      withAuth(async (token) => {
+        const postId = await resolvePostId(token, slug, id);
+        return { id: postId, ...(await api.reschedulePost(token, slug, postId, scheduled_for)) };
+      }),
+  );
+
+  server.registerTool(
+    'render_post',
+    {
+      title: 'Render post image',
+      description: 'Generate the missing image from the prompt. Bills a render. id accepts a short prefix.',
+      inputSchema: z.object({
+        slug,
+        id: z.string().min(1),
+      }),
+      annotations: { readOnlyHint: false, destructiveHint: false },
+    },
+    async ({ slug, id }) =>
+      withAuth(async (token) => {
+        const postId = await resolvePostId(token, slug, id);
+        return { id: postId, ...(await api.renderPost(token, slug, postId)) };
+      }),
+  );
+
+  server.registerTool(
+    'regenerate_post_media',
+    {
+      title: 'Regenerate post media',
+      description: 'Refine a single image with an instruction (bills one render). id accepts a short prefix.',
+      inputSchema: z.object({
+        slug,
+        id: z.string().min(1),
+        instruction: z.string().min(1).describe('How to refine the image'),
+      }),
+      annotations: { readOnlyHint: false, destructiveHint: false },
+    },
+    async ({ slug, id, instruction }) =>
+      withAuth(async (token) => {
+        const postId = await resolvePostId(token, slug, id);
+        return {
+          id: postId,
+          ...(await api.postMedia(token, slug, postId, { action: 'regenerate', instruction })),
+        };
+      }),
+  );
+
+  server.registerTool(
+    'regenerate_slide',
+    {
+      title: 'Regenerate carousel slide',
+      description: 'Re-render one carousel slide (index 0 = cover). Bills a render. id accepts a short prefix.',
+      inputSchema: z.object({
+        slug,
+        id: z.string().min(1),
+        index: z.number().int().min(0).describe('Slide index (0 = cover)'),
+        instruction: z.string().min(1),
+      }),
+      annotations: { readOnlyHint: false, destructiveHint: false },
+    },
+    async ({ slug, id, index, instruction }) =>
+      withAuth(async (token) => {
+        const postId = await resolvePostId(token, slug, id);
+        return {
+          id: postId,
+          ...(await api.postMedia(token, slug, postId, { action: 'slide', index, instruction })),
+        };
+      }),
+  );
+
+  server.registerTool(
+    'reorder_slides',
+    {
+      title: 'Reorder carousel slides',
+      description: 'Reorder or drop slides without rendering. order is e.g. [0,2,1]. id accepts a short prefix.',
+      inputSchema: z.object({
+        slug,
+        id: z.string().min(1),
+        order: z.array(z.number().int().min(0)).min(1),
+      }),
+      annotations: { readOnlyHint: false, destructiveHint: false },
+    },
+    async ({ slug, id, order }) =>
+      withAuth(async (token) => {
+        const postId = await resolvePostId(token, slug, id);
+        return {
+          id: postId,
+          ...(await api.postMedia(token, slug, postId, { action: 'reorder', order })),
+        };
+      }),
+  );
+
+  server.registerTool(
+    'make_video',
+    {
+      title: 'Animate post to video',
+      description:
+        'Animate the cover into a video clip (also retries a video that fell back to a photo). id accepts a short prefix.',
+      inputSchema: z.object({
+        slug,
+        id: z.string().min(1),
+        duration: z.number().optional().describe('Duration in seconds, e.g. 6'),
+        script: z.string().optional(),
+        instruction: z.string().optional(),
+      }),
+      annotations: { readOnlyHint: false, destructiveHint: false },
+    },
+    async ({ slug, id, duration, script, instruction }) =>
+      withAuth(async (token) => {
+        const postId = await resolvePostId(token, slug, id);
+        return {
+          id: postId,
+          ...(await api.postMedia(token, slug, postId, {
+            action: 'video',
+            duration,
+            script,
+            instruction,
+          })),
+        };
+      }),
+  );
+}

--- a/cli/mcp/tools/plan.ts
+++ b/cli/mcp/tools/plan.ts
@@ -1,0 +1,143 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { api } from '../../lib/api.ts';
+import { withAuth } from '../util.ts';
+
+const slug = z.string().min(1).describe('Brand URL slug');
+
+export function registerPlanTools(server: McpServer) {
+  server.registerTool(
+    'get_plan',
+    {
+      title: 'Editorial plan',
+      description: 'View active editorial plan and any pending proposal.',
+      inputSchema: z.object({ slug }),
+      annotations: { readOnlyHint: true },
+    },
+    async ({ slug }) => withAuth((token) => api.getEditorialPlan(token, slug)),
+  );
+
+  server.registerTool(
+    'propose_plan',
+    {
+      title: 'Propose editorial plan',
+      description: 'Generate the first / a new editorial plan proposal.',
+      inputSchema: z.object({ slug }),
+      annotations: { readOnlyHint: false, destructiveHint: false },
+    },
+    async ({ slug }) => withAuth((token) => api.proposePlan(token, slug)),
+  );
+
+  server.registerTool(
+    'revise_plan',
+    {
+      title: 'Revise editorial plan',
+      description: 'Request a revision of the proposed plan with feedback.',
+      inputSchema: z.object({
+        slug,
+        feedback: z.string().min(1),
+      }),
+      annotations: { readOnlyHint: false, destructiveHint: false },
+    },
+    async ({ slug, feedback }) => withAuth((token) => api.revisePlan(token, slug, feedback)),
+  );
+
+  server.registerTool(
+    'approve_plan',
+    {
+      title: 'Approve editorial plan',
+      description: 'Approve the proposed editorial plan.',
+      inputSchema: z.object({ slug }),
+      annotations: { readOnlyHint: false, destructiveHint: true },
+    },
+    async ({ slug }) => withAuth((token) => api.approvePlan(token, slug)),
+  );
+
+  server.registerTool(
+    'discard_plan',
+    {
+      title: 'Discard editorial plan',
+      description: 'Discard the proposed editorial plan.',
+      inputSchema: z.object({ slug }),
+      annotations: { readOnlyHint: false, destructiveHint: true },
+    },
+    async ({ slug }) => withAuth((token) => api.discardPlan(token, slug)),
+  );
+
+  server.registerTool(
+    'save_brief',
+    {
+      title: 'Save week brief',
+      description: 'Save the brief for an editorial week (0-based index). Optional featured products.',
+      inputSchema: z.object({
+        slug,
+        week: z.number().int().min(0),
+        brief: z.string(),
+        products: z.array(z.string()).optional().describe('Exact product names to feature'),
+      }),
+      annotations: { readOnlyHint: false, destructiveHint: false },
+    },
+    async ({ slug, week, brief, products }) =>
+      withAuth((token) => api.saveBrief(token, slug, week, brief, products)),
+  );
+
+  server.registerTool(
+    'replan_week',
+    {
+      title: 'Replan week',
+      description: 'Regenerate an editorial week from a brief.',
+      inputSchema: z.object({
+        slug,
+        week: z.number().int().min(0),
+        brief: z.string().min(1),
+      }),
+      annotations: { readOnlyHint: false, destructiveHint: false },
+    },
+    async ({ slug, week, brief }) => withAuth((token) => api.replanWeek(token, slug, week, brief)),
+  );
+
+  server.registerTool(
+    'get_weekly_plan',
+    {
+      title: 'Weekly plan',
+      description: 'View weekly plan seeds and related posts.',
+      inputSchema: z.object({ slug }),
+      annotations: { readOnlyHint: true },
+    },
+    async ({ slug }) => withAuth((token) => api.getWeeklyPlan(token, slug)),
+  );
+
+  server.registerTool(
+    'plan_week',
+    {
+      title: 'Generate weekly seeds',
+      description: 'Generate content seeds for a week (0-based index).',
+      inputSchema: z.object({
+        slug,
+        week: z.number().int().min(0),
+      }),
+      annotations: { readOnlyHint: false, destructiveHint: false },
+    },
+    async ({ slug, week }) => withAuth((token) => api.planWeek(token, slug, week)),
+  );
+
+  server.registerTool(
+    'produce_week',
+    {
+      title: 'Produce weekly seeds',
+      description: 'Produce the current week seeds into posts. Uses the active seeds draft for the brand.',
+      inputSchema: z.object({
+        slug,
+        week: z.number().int().min(0).optional().describe('Unused for API resolve — seeds draft is auto-detected'),
+        row_index: z.number().int().min(0).optional().describe('Produce a single seed row only'),
+      }),
+      annotations: { readOnlyHint: false, destructiveHint: false },
+    },
+    async ({ slug, row_index }) =>
+      withAuth(async (token) => {
+        const data = await api.getWeeklyPlan(token, slug);
+        if (!data.seeds?.id) throw new Error('No weekly seeds draft found. Call plan_week first.');
+        return api.produceWeek(token, slug, data.seeds.id, row_index);
+      }),
+  );
+}

--- a/cli/mcp/tools/studio.ts
+++ b/cli/mcp/tools/studio.ts
@@ -1,0 +1,202 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { api } from '../../lib/api.ts';
+import { withAuth } from '../util.ts';
+
+const slug = z.string().min(1).describe('Brand URL slug');
+
+export function registerStudioTools(server: McpServer) {
+  server.registerTool(
+    'get_studio',
+    {
+      title: 'Studio',
+      description: 'Full studio dump: kit, people, documents, competitors, products, history summary.',
+      inputSchema: z.object({ slug }),
+      annotations: { readOnlyHint: true },
+    },
+    async ({ slug }) => withAuth((token) => api.getStudio(token, slug)),
+  );
+
+  server.registerTool(
+    'update_brand_kit',
+    {
+      title: 'Update brand kit',
+      description: 'Update brand kit fields (about, category, audience, style, language).',
+      inputSchema: z.object({
+        slug,
+        about: z.string().optional(),
+        category: z.string().optional(),
+        target_audience: z.string().optional(),
+        brand_style: z.string().optional(),
+        language: z.string().optional(),
+      }),
+      annotations: { readOnlyHint: false, destructiveHint: false },
+    },
+    async ({ slug, ...data }) => withAuth((token) => api.updateBrandKit(token, slug, data)),
+  );
+
+  server.registerTool(
+    'set_colors',
+    {
+      title: 'Set brand colors',
+      description: 'Set brand colors as hex values, e.g. ["#7c5cff","#ffffff"].',
+      inputSchema: z.object({
+        slug,
+        colors: z.array(z.string().regex(/^#?[0-9a-fA-F]{3,8}$/)).min(1),
+      }),
+      annotations: { readOnlyHint: false, destructiveHint: false },
+    },
+    async ({ slug, colors }) =>
+      withAuth((token) =>
+        api.updateColors(
+          token,
+          slug,
+          colors.map((c) => (c.startsWith('#') ? c : `#${c}`)),
+        ),
+      ),
+  );
+
+  server.registerTool(
+    'add_note',
+    {
+      title: 'Add knowledge note',
+      description: 'Add a knowledge document / note to the studio.',
+      inputSchema: z.object({
+        slug,
+        text: z.string().min(1),
+        title: z.string().optional(),
+      }),
+      annotations: { readOnlyHint: false, destructiveHint: false },
+    },
+    async ({ slug, text, title }) =>
+      withAuth((token) => api.addDocument(token, slug, { title, content_text: text, kind: 'note' })),
+  );
+
+  server.registerTool(
+    'delete_document',
+    {
+      title: 'Delete studio document',
+      description: 'Delete a knowledge document by UUID.',
+      inputSchema: z.object({
+        slug,
+        id: z.string().uuid(),
+      }),
+      annotations: { readOnlyHint: false, destructiveHint: true },
+    },
+    async ({ slug, id }) => withAuth((token) => api.deleteDocument(token, slug, id)),
+  );
+
+  server.registerTool(
+    'add_person',
+    {
+      title: 'Add person',
+      description: 'Add a real person to the brand studio.',
+      inputSchema: z.object({
+        slug,
+        name: z.string().min(1),
+        role: z.string().optional(),
+        description: z.string().optional(),
+      }),
+      annotations: { readOnlyHint: false, destructiveHint: false },
+    },
+    async ({ slug, name, role, description }) =>
+      withAuth((token) =>
+        api.addPerson(token, slug, { name, role, description, kind: 'real' }),
+      ),
+  );
+
+  server.registerTool(
+    'generate_person',
+    {
+      title: 'Generate AI person',
+      description: 'Generate an AI persona for the brand (may bill image generation).',
+      inputSchema: z.object({
+        slug,
+        name: z.string().min(1),
+        role: z.string().optional(),
+        gender: z.string().optional(),
+        vibe: z.string().optional(),
+        description: z.string().optional(),
+      }),
+      annotations: { readOnlyHint: false, destructiveHint: false },
+    },
+    async ({ slug, name, role, gender, vibe, description }) =>
+      withAuth((token) =>
+        api.addPerson(token, slug, {
+          name,
+          role,
+          description,
+          gender,
+          vibe,
+          kind: 'ai',
+        }),
+      ),
+  );
+
+  server.registerTool(
+    'delete_person',
+    {
+      title: 'Delete person',
+      description: 'Delete a studio person by UUID.',
+      inputSchema: z.object({
+        slug,
+        id: z.string().uuid(),
+      }),
+      annotations: { readOnlyHint: false, destructiveHint: true },
+    },
+    async ({ slug, id }) => withAuth((token) => api.deletePerson(token, slug, id)),
+  );
+
+  server.registerTool(
+    'add_competitor',
+    {
+      title: 'Add competitor',
+      description: 'Add a competitor to the studio.',
+      inputSchema: z.object({
+        slug,
+        name: z.string().min(1),
+        website: z.string().optional(),
+        rationale: z.string().optional(),
+      }),
+      annotations: { readOnlyHint: false, destructiveHint: false },
+    },
+    async ({ slug, name, website, rationale }) =>
+      withAuth((token) => api.addCompetitor(token, slug, { name, website, rationale })),
+  );
+
+  server.registerTool(
+    'delete_competitor',
+    {
+      title: 'Delete competitor',
+      description: 'Delete a competitor by UUID.',
+      inputSchema: z.object({
+        slug,
+        id: z.string().uuid(),
+      }),
+      annotations: { readOnlyHint: false, destructiveHint: true },
+    },
+    async ({ slug, id }) => withAuth((token) => api.deleteCompetitor(token, slug, id)),
+  );
+
+  server.registerTool(
+    'research_competitors',
+    {
+      title: 'Research competitors',
+      description: 'Run AI competitor research and add findings to the studio.',
+      inputSchema: z.object({ slug }),
+      annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
+    },
+    async ({ slug }) => withAuth((token) => api.researchCompetitors(token, slug)),
+  );
+
+  server.registerTool(
+    'sync_history',
+    {
+      title: 'Sync social history',
+      description: 'Sync historical social posts into the studio.',
+      inputSchema: z.object({ slug }),
+      annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
+    },
+    async ({ slug }) => withAuth((token) => api.syncHistory(token, slug)),
+  );
+}

--- a/cli/mcp/tools/web.ts
+++ b/cli/mcp/tools/web.ts
@@ -1,0 +1,247 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { api } from '../../lib/api.ts';
+import { resolveArticleId, withAuth } from '../util.ts';
+
+const slug = z.string().min(1).describe('Brand URL slug');
+
+export function registerWebTools(server: McpServer) {
+  server.registerTool(
+    'get_seo',
+    {
+      title: 'SEO overview',
+      description: 'Tech score, search performance, SEO grade and initiatives.',
+      inputSchema: z.object({ slug }),
+      annotations: { readOnlyHint: true },
+    },
+    async ({ slug }) => withAuth((token) => api.getSeo(token, slug)),
+  );
+
+  server.registerTool(
+    'seo_action',
+    {
+      title: 'SEO action',
+      description:
+        'Run SEO actions: run (tech audit), plan, more (append initiatives), asset, article. For asset/article pass initiativeId.',
+      inputSchema: z.object({
+        slug,
+        action: z.enum(['run', 'plan', 'more', 'asset', 'article']),
+        initiativeId: z.string().optional(),
+        guidance: z.string().optional().describe('Optional guidance when action=more'),
+      }),
+      annotations: { readOnlyHint: false, destructiveHint: false },
+    },
+    async ({ slug, action, initiativeId, guidance }) =>
+      withAuth((token) => api.seoAction(token, slug, { action, initiativeId, guidance })),
+  );
+
+  server.registerTool(
+    'get_geo',
+    {
+      title: 'GEO overview',
+      description: 'AI visibility: share of voice, citations, ready fixes.',
+      inputSchema: z.object({ slug }),
+      annotations: { readOnlyHint: true },
+    },
+    async ({ slug }) => withAuth((token) => api.getGeo(token, slug)),
+  );
+
+  server.registerTool(
+    'geo_action',
+    {
+      title: 'GEO action',
+      description: 'Run GEO citation audit or generate fix artifacts.',
+      inputSchema: z.object({
+        slug,
+        action: z.enum(['audit', 'fix']),
+      }),
+      annotations: { readOnlyHint: false, destructiveHint: false },
+    },
+    async ({ slug, action }) => withAuth((token) => api.geoAction(token, slug, action)),
+  );
+
+  server.registerTool(
+    'get_keywords',
+    {
+      title: 'Keywords',
+      description: 'Keyword strategy: volume, difficulty, opportunity, action.',
+      inputSchema: z.object({ slug }),
+      annotations: { readOnlyHint: true },
+    },
+    async ({ slug }) => withAuth((token) => api.getKeywords(token, slug)),
+  );
+
+  server.registerTool(
+    'refresh_keywords',
+    {
+      title: 'Refresh keywords',
+      description: 'Regenerate keyword research for the brand.',
+      inputSchema: z.object({ slug }),
+      annotations: { readOnlyHint: false, destructiveHint: false },
+    },
+    async ({ slug }) => withAuth((token) => api.refreshKeywords(token, slug)),
+  );
+
+  server.registerTool(
+    'list_articles',
+    {
+      title: 'List blog articles',
+      description: 'List web/blog articles. status: draft, scheduled, published, or all.',
+      inputSchema: z.object({
+        slug,
+        status: z.enum(['draft', 'scheduled', 'published', 'all']).optional(),
+      }),
+      annotations: { readOnlyHint: true },
+    },
+    async ({ slug, status }) => withAuth((token) => api.getWeb(token, slug, status)),
+  );
+
+  server.registerTool(
+    'generate_article',
+    {
+      title: 'Generate article',
+      description: 'Generate a blog article draft from a topic.',
+      inputSchema: z.object({
+        slug,
+        topic: z.string().min(1),
+      }),
+      annotations: { readOnlyHint: false, destructiveHint: false },
+    },
+    async ({ slug, topic }) =>
+      withAuth((token) => api.webAction(token, slug, { action: 'generate', topic })),
+  );
+
+  server.registerTool(
+    'optimize_article',
+    {
+      title: 'Optimize article',
+      description: 'Rewrite an article for SEO (meta title/description included). id accepts a short prefix.',
+      inputSchema: z.object({
+        slug,
+        id: z.string().min(1),
+      }),
+      annotations: { readOnlyHint: false, destructiveHint: false },
+    },
+    async ({ slug, id }) =>
+      withAuth(async (token) => {
+        const articleId = await resolveArticleId(token, slug, id);
+        return {
+          id: articleId,
+          ...(await api.webAction(token, slug, { action: 'optimize', id: articleId })),
+        };
+      }),
+  );
+
+  server.registerTool(
+    'publish_article',
+    {
+      title: 'Publish article',
+      description: 'Publish a blog article. id accepts a short prefix.',
+      inputSchema: z.object({
+        slug,
+        id: z.string().min(1),
+      }),
+      annotations: { readOnlyHint: false, destructiveHint: true },
+    },
+    async ({ slug, id }) =>
+      withAuth(async (token) => {
+        const articleId = await resolveArticleId(token, slug, id);
+        return {
+          id: articleId,
+          ...(await api.webAction(token, slug, { action: 'publish', id: articleId })),
+        };
+      }),
+  );
+
+  server.registerTool(
+    'unpublish_article',
+    {
+      title: 'Unpublish article',
+      description: 'Unpublish a blog article. id accepts a short prefix.',
+      inputSchema: z.object({
+        slug,
+        id: z.string().min(1),
+      }),
+      annotations: { readOnlyHint: false, destructiveHint: true },
+    },
+    async ({ slug, id }) =>
+      withAuth(async (token) => {
+        const articleId = await resolveArticleId(token, slug, id);
+        return {
+          id: articleId,
+          ...(await api.webAction(token, slug, { action: 'unpublish', id: articleId })),
+        };
+      }),
+  );
+
+  server.registerTool(
+    'delete_article',
+    {
+      title: 'Delete article',
+      description: 'Delete a blog article. id accepts a short prefix.',
+      inputSchema: z.object({
+        slug,
+        id: z.string().min(1),
+      }),
+      annotations: { readOnlyHint: false, destructiveHint: true },
+    },
+    async ({ slug, id }) =>
+      withAuth(async (token) => {
+        const articleId = await resolveArticleId(token, slug, id);
+        return {
+          id: articleId,
+          ...(await api.webAction(token, slug, { action: 'delete', id: articleId })),
+        };
+      }),
+  );
+
+  server.registerTool(
+    'get_ads',
+    {
+      title: 'Ads overview',
+      description: 'Ad campaigns summary, candidates, and connected ad accounts.',
+      inputSchema: z.object({ slug }),
+      annotations: { readOnlyHint: true },
+    },
+    async ({ slug }) => withAuth((token) => api.getAds(token, slug)),
+  );
+
+  server.registerTool(
+    'ads_action',
+    {
+      title: 'Ads action',
+      description:
+        'Run an ads action. Common actions: sync, propose, create, reject, pause, resume, toggle, duplicate, delete. Pass campaignId; for a single creative add adId (and next active|paused for toggle). duplicate creates a paused copy as a new proposal; approve it to launch. Pass extra fields as needed.',
+      inputSchema: z.object({
+        slug,
+        action: z.string().min(1),
+        campaignId: z.string().optional(),
+        extra: z.record(z.string(), z.unknown()).optional().describe('Additional action payload fields'),
+      }),
+      annotations: { readOnlyHint: false, destructiveHint: true },
+    },
+    async ({ slug, action, campaignId, extra }) =>
+      withAuth((token) =>
+        api.adsAction(token, slug, { action, campaignId, ...(extra ?? {}) }),
+      ),
+  );
+
+  server.registerTool(
+    'chat',
+    {
+      title: 'Anomalia AI chat',
+      description:
+        'Natural-language assistant with full read/write access to the brand (same as the web chatbot / `anomalia ai`). Prefer specific tools for deterministic ops; use chat for multi-step or exploratory work.',
+      inputSchema: z.object({
+        slug,
+        message: z.string().min(1),
+      }),
+      annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
+    },
+    async ({ slug, message }) =>
+      withAuth(async (token) => {
+        const reply = await api.chat(token, slug, message);
+        return { reply };
+      }),
+  );
+}

--- a/cli/mcp/util.test.ts
+++ b/cli/mcp/util.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'bun:test';
+import { fail, ok } from './util.ts';
+
+describe('mcp util results', () => {
+  test('ok wraps objects as structuredContent', () => {
+    const r = ok({ hello: 'world' });
+    expect(r.isError).toBeUndefined();
+    expect(r.content[0]?.type).toBe('text');
+    expect(r.content[0]?.text).toContain('hello');
+    expect(r.structuredContent).toEqual({ hello: 'world' });
+  });
+
+  test('ok wraps arrays under result', () => {
+    const r = ok([1, 2]);
+    expect(r.structuredContent).toEqual({ result: [1, 2] });
+  });
+
+  test('fail marks isError', () => {
+    const r = fail('nope');
+    expect(r.isError).toBe(true);
+    expect(r.content[0]?.text).toBe('nope');
+  });
+});

--- a/cli/mcp/util.ts
+++ b/cli/mcp/util.ts
@@ -1,0 +1,102 @@
+import { api } from '../lib/api.ts';
+import { loadSession, type StoredSession } from '../lib/auth.ts';
+import { resolveByPrefix } from '../lib/select.ts';
+import { getRequestAuth } from './context.ts';
+
+export type ToolResult = {
+  content: { type: 'text'; text: string }[];
+  isError?: boolean;
+  structuredContent?: Record<string, unknown>;
+};
+
+export function ok(data: unknown): ToolResult {
+  const text = typeof data === 'string' ? data : JSON.stringify(data, null, 2);
+  const structured =
+    data !== null && typeof data === 'object' && !Array.isArray(data)
+      ? (data as Record<string, unknown>)
+      : { result: data };
+  return {
+    content: [{ type: 'text', text }],
+    structuredContent: structured,
+  };
+}
+
+export function fail(message: string): ToolResult {
+  return {
+    content: [{ type: 'text', text: message }],
+    isError: true,
+  };
+}
+
+function sessionFromRequestAuth(): StoredSession | null {
+  const ctx = getRequestAuth();
+  if (!ctx) return null;
+  return {
+    access_token: ctx.access_token,
+    refresh_token: '',
+    expires_at: ctx.expires_at ?? Math.floor(Date.now() / 1000) + 3600,
+    user: ctx.user,
+  };
+}
+
+/** Active OAuth session (HTTP Bearer or local CLI session file). */
+export async function requireAuth(): Promise<
+  { ok: true; session: StoredSession } | { ok: false; result: ToolResult }
+> {
+  const fromHttp = sessionFromRequestAuth();
+  if (fromHttp) return { ok: true, session: fromHttp };
+
+  const session = await loadSession();
+  if (!session) {
+    return {
+      ok: false,
+      result: fail(
+        'Not authenticated. For local stdio/HTTP: call the `login` tool (browser OAuth) or run `anomalia login`. ' +
+          'For remote HTTP (mcp.anomalia.so): send Authorization: Bearer <access_token> from your Anomalia OAuth session. ' +
+          'No static API tokens are supported.',
+      ),
+    };
+  }
+  return { ok: true, session };
+}
+
+export async function withAuth(
+  fn: (token: string, session: StoredSession) => Promise<unknown>,
+): Promise<ToolResult> {
+  const auth = await requireAuth();
+  if (!auth.ok) return auth.result;
+  try {
+    const data = await fn(auth.session.access_token, auth.session);
+    return ok(data);
+  } catch (e) {
+    return fail(e instanceof Error ? e.message : String(e));
+  }
+}
+
+export async function resolvePostId(token: string, slug: string, idOrPrefix: string): Promise<string> {
+  const posts = await api.getPosts(token, slug);
+  const match = resolveByPrefix(posts, idOrPrefix);
+  if (!match.ok) {
+    if (match.reason === 'ambiguous') {
+      throw new Error(
+        `Ambiguous post id prefix "${idOrPrefix}" (${match.count} matches). Use a longer prefix.`,
+      );
+    }
+    throw new Error(`No post found for id/prefix "${idOrPrefix}". List posts first.`);
+  }
+  return match.item.id;
+}
+
+export async function resolveArticleId(token: string, slug: string, idOrPrefix: string): Promise<string> {
+  const { articles } = await api.getWeb(token, slug, 'all');
+  const match = resolveByPrefix(articles, idOrPrefix);
+  if (!match.ok) {
+    if (match.reason === 'ambiguous') {
+      throw new Error(
+        `Ambiguous article id prefix "${idOrPrefix}" (${match.count} matches). Use a longer prefix.`,
+      );
+    }
+    throw new Error(`No article found for id/prefix "${idOrPrefix}". List articles first.`);
+  }
+  return match.item.id;
+}

--- a/cli/mcp/vercel-handler.ts
+++ b/cli/mcp/vercel-handler.ts
@@ -1,0 +1,127 @@
+/**
+ * Vercel Node handler source — bundled by scripts/build-vercel.mjs into api/*.js
+ * so @vercel/node never has to resolve Bun-style `.ts` import specifiers at runtime.
+ */
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { routeMcpHttp } from './http-router.ts';
+import { flushObservability, mcpLog } from './observability.ts';
+
+type VercelReq = IncomingMessage & {
+  query?: Record<string, string | string[]>;
+  body?: unknown;
+  cookies?: Record<string, string>;
+};
+
+type VercelRes = ServerResponse & {
+  status: (code: number) => VercelRes;
+  json: (body: unknown) => void;
+  send: (body: unknown) => void;
+};
+
+async function readBody(req: IncomingMessage): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks);
+}
+
+async function toWebRequest(req: VercelReq, forcePath: string): Promise<Request> {
+  const headersIn = req.headers;
+  const host = headersIn['x-forwarded-host'] ?? headersIn.host ?? 'localhost';
+  const proto = (headersIn['x-forwarded-proto'] as string) ?? 'https';
+  const incoming = req.url ?? '/';
+  const search = incoming.includes('?') ? incoming.slice(incoming.indexOf('?')) : '';
+  const url = `${proto}://${host}${forcePath}${search}`;
+
+  const headers = new Headers();
+  for (const [key, value] of Object.entries(headersIn)) {
+    if (value === undefined) continue;
+    if (Array.isArray(value)) value.forEach((v) => headers.append(key, v));
+    else headers.set(key, value);
+  }
+
+  const method = req.method ?? 'GET';
+  if (method === 'GET' || method === 'HEAD') {
+    return new Request(url, { method, headers });
+  }
+
+  const body = await readBody(req);
+  return new Request(url, {
+    method,
+    headers,
+    body: body.length ? new Uint8Array(body) : undefined,
+  });
+}
+
+function createHandler(forcePath: string) {
+  return async function handler(req: VercelReq, res: VercelRes) {
+    const started = Date.now();
+    const requestId =
+      (req.headers['x-vercel-id'] as string | undefined) ??
+      (req.headers['x-request-id'] as string | undefined) ??
+      crypto.randomUUID();
+
+    try {
+      const request = await toWebRequest(req, forcePath);
+      mcpLog({
+        level: 'info',
+        event: 'http.request',
+        message: `${req.method ?? 'GET'} ${forcePath}`,
+        requestId,
+        method: req.method,
+        path: forcePath,
+      });
+
+      const response = await routeMcpHttp(request);
+      res.statusCode = response.status;
+      response.headers.forEach((value, key) => {
+        if (key.toLowerCase() === 'transfer-encoding') return;
+        res.setHeader(key, value);
+      });
+      const buf = Buffer.from(await response.arrayBuffer());
+      res.end(buf);
+
+      mcpLog({
+        level: response.status >= 500 ? 'error' : response.status >= 400 ? 'warn' : 'info',
+        event: 'http.response',
+        message: `status ${response.status}`,
+        requestId,
+        method: req.method,
+        path: forcePath,
+        statusCode: response.status,
+        durationMs: Date.now() - started,
+      });
+    } catch (e) {
+      mcpLog({
+        level: 'error',
+        event: 'http.unhandled',
+        message: e instanceof Error ? e.message : String(e),
+        requestId,
+        method: req.method,
+        path: forcePath,
+        statusCode: 500,
+        durationMs: Date.now() - started,
+        error: e,
+      });
+      if (!res.headersSent) {
+        res.statusCode = 500;
+        res.setHeader('Content-Type', 'application/json');
+        res.end(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            error: { code: -32603, message: e instanceof Error ? e.message : 'Internal error' },
+            id: null,
+          }),
+        );
+      }
+    } finally {
+      await flushObservability();
+    }
+  };
+}
+
+export default createHandler;
+export const health = createHandler('/health');
+export const mcp = createHandler('/mcp');
+export const oauthProtectedResource = createHandler('/.well-known/oauth-protected-resource');

--- a/cli/mcp/vercel.json
+++ b/cli/mcp/vercel.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": null,
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "Access-Control-Allow-Origin", "value": "*" },
+        {
+          "key": "Access-Control-Allow-Headers",
+          "value": "Content-Type, Authorization, mcp-session-id, Last-Event-ID, mcp-protocol-version"
+        },
+        {
+          "key": "Access-Control-Expose-Headers",
+          "value": "mcp-session-id, mcp-protocol-version"
+        }
+      ]
+    }
+  ],
+  "functions": {
+    "api/mcp.js": {
+      "maxDuration": 60,
+      "memory": 1024,
+      "includeFiles": "api/_bundle.js"
+    },
+    "api/oauth-protected-resource.js": {
+      "maxDuration": 30,
+      "includeFiles": "api/_bundle.js"
+    },
+    "api/health.js": { "maxDuration": 10 }
+  },
+  "rewrites": [
+    { "source": "/mcp", "destination": "/api/mcp" },
+    { "source": "/health", "destination": "/api/health" },
+    {
+      "source": "/.well-known/oauth-protected-resource",
+      "destination": "/api/oauth-protected-resource"
+    },
+    { "source": "/", "destination": "/api/health" }
+  ]
+}

--- a/cli/mcp/verify-token.ts
+++ b/cli/mcp/verify-token.ts
@@ -1,0 +1,50 @@
+import { createClient } from '@supabase/supabase-js';
+import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
+import type { RequestAuth } from './context.ts';
+
+function anonClient() {
+  return createClient(
+    process.env.PUBLIC_SUPABASE_URL!,
+    process.env.PUBLIC_SUPABASE_ANON_KEY!,
+    { auth: { persistSession: false } },
+  );
+}
+
+/**
+ * Validate an Anomalia / Supabase access token (same JWT the CLI stores after OAuth).
+ * Returns undefined if missing/invalid — never accepts a static API key.
+ */
+export async function verifyBearerToken(bearerToken?: string): Promise<RequestAuth | undefined> {
+  if (!bearerToken) return undefined;
+  const token = bearerToken.trim();
+  if (!token) return undefined;
+
+  try {
+    const { data, error } = await anonClient().auth.getUser(token);
+    if (error || !data.user?.id || !data.user.email) return undefined;
+    return {
+      access_token: token,
+      user: { id: data.user.id, email: data.user.email },
+      source: 'bearer',
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+export function toAuthInfo(auth: RequestAuth): AuthInfo {
+  return {
+    token: auth.access_token,
+    clientId: auth.user.id,
+    scopes: ['anomalia'],
+    expiresAt: auth.expires_at,
+    extra: { email: auth.user.email, source: auth.source },
+  };
+}
+
+export function extractBearer(req: Request): string | undefined {
+  const header = req.headers.get('authorization') ?? req.headers.get('Authorization');
+  if (!header) return undefined;
+  const m = header.match(/^Bearer\s+(.+)$/i);
+  return m?.[1]?.trim();
+}

--- a/cli/package.json
+++ b/cli/package.json
@@ -6,11 +6,12 @@
   "author": "Andrea Buttarelli",
   "repository": {
     "type": "git",
-    "url": "https://github.com/andreabuttarelli/anomalia-cli.git"
+    "url": "git+https://github.com/anomaliaso/anomalia.git",
+    "directory": "cli"
   },
   "homepage": "https://anomalia.so",
   "bugs": {
-    "url": "https://github.com/andreabuttarelli/anomalia-cli/issues"
+    "url": "https://github.com/anomaliaso/anomalia/issues"
   },
   "type": "module",
   "bin": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "anomalia-cli",
+  "version": "0.1.0",
+  "description": "Command-line client for Anomalia — the social media AI autopilot.",
+  "license": "AGPL-3.0-or-later",
+  "author": "Andrea Buttarelli",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/andreabuttarelli/anomalia-cli.git"
+  },
+  "homepage": "https://anomalia.so",
+  "bugs": {
+    "url": "https://github.com/andreabuttarelli/anomalia-cli/issues"
+  },
+  "type": "module",
+  "bin": {
+    "anomalia": "./cli.ts",
+    "anomalia-mcp": "./mcp/stdio.ts"
+  },
+  "keywords": [
+    "anomalia",
+    "cli",
+    "social-media",
+    "mcp",
+    "content",
+    "seo"
+  ],
+  "scripts": {
+    "dev": "bun run cli.ts",
+    "mcp": "bun run mcp/stdio.ts",
+    "mcp:http": "bun run mcp/http.ts",
+    "build": "bun run scripts/build.ts",
+    "build:all": "bun run scripts/build.ts --all",
+    "build:npm": "bun run scripts/build-npm.ts",
+    "vercel-build": "node scripts/build-vercel.mjs",
+    "typecheck": "tsc --noEmit",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.30.0",
+    "@sentry/node": "^10.69.0",
+    "@supabase/supabase-js": "^2.46.1",
+    "chalk": "^5.3.0",
+    "cli-table3": "^0.6.5",
+    "commander": "^12.1.0",
+    "esbuild": "^0.28.2",
+    "open": "^10.1.0",
+    "ora": "^8.1.1",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.3.14",
+    "@types/node": "^26.2.0",
+    "@vercel/node": "^5.9.7",
+    "typescript": "5.8.3"
+  }
+}

--- a/cli/plugins/anomalia/.claude-plugin/plugin.json
+++ b/cli/plugins/anomalia/.claude-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "anomalia",
+  "displayName": "Anomalia",
+  "version": "1.0.0",
+  "description": "Operate Anomalia (social media AI autopilot) via MCP or CLI: brands, posts, plans, studio, SEO/GEO, and blog.",
+  "author": {
+    "name": "Andrea Buttarelli",
+    "email": "andreabuttarelli.design@gmail.com",
+    "url": "https://github.com/andreabuttarelli"
+  },
+  "homepage": "https://anomalia.so",
+  "repository": "https://github.com/andreabuttarelli/anomalia-cli",
+  "license": "AGPL-3.0-or-later",
+  "keywords": [
+    "social-media",
+    "content",
+    "mcp",
+    "seo",
+    "geo",
+    "anomalia",
+    "autopilot"
+  ]
+}

--- a/cli/plugins/anomalia/.claude-plugin/plugin.json
+++ b/cli/plugins/anomalia/.claude-plugin/plugin.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/andreabuttarelli"
   },
   "homepage": "https://anomalia.so",
-  "repository": "https://github.com/andreabuttarelli/anomalia-cli",
+  "repository": "https://github.com/anomaliaso/anomalia",
   "license": "AGPL-3.0-or-later",
   "keywords": [
     "social-media",

--- a/cli/plugins/anomalia/.codex-plugin/plugin.json
+++ b/cli/plugins/anomalia/.codex-plugin/plugin.json
@@ -1,0 +1,40 @@
+{
+  "name": "anomalia",
+  "version": "1.0.0",
+  "description": "Operate Anomalia (social media AI autopilot) via MCP or CLI: brands, posts, plans, studio, SEO/GEO, and blog.",
+  "author": {
+    "name": "Andrea Buttarelli",
+    "email": "andreabuttarelli.design@gmail.com",
+    "url": "https://github.com/andreabuttarelli"
+  },
+  "homepage": "https://anomalia.so",
+  "repository": "https://github.com/andreabuttarelli/anomalia-cli",
+  "license": "AGPL-3.0-or-later",
+  "keywords": [
+    "social-media",
+    "content",
+    "mcp",
+    "seo",
+    "geo",
+    "anomalia",
+    "autopilot"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "Anomalia",
+    "shortDescription": "Social media AI autopilot — MCP + skill",
+    "longDescription": "Drive Anomalia from Codex or ChatGPT: approve and edit social posts, run editorial plans, SEO/GEO audits, and blog workflows. Prefer the bundled MCP tools when connected; otherwise use the anomalia CLI after OAuth login.",
+    "developerName": "Andrea Buttarelli",
+    "category": "Productivity",
+    "capabilities": ["Read", "Write"],
+    "websiteURL": "https://anomalia.so",
+    "privacyPolicyURL": "https://www.anomalia.so/privacy",
+    "termsOfServiceURL": "https://www.anomalia.so/terms",
+    "defaultPrompt": [
+      "List my Anomalia brands and show pending posts for the first one.",
+      "Approve all pending posts for brand <slug>.",
+      "Run an SEO audit for brand <slug> and summarize the top issues."
+    ]
+  }
+}

--- a/cli/plugins/anomalia/.codex-plugin/plugin.json
+++ b/cli/plugins/anomalia/.codex-plugin/plugin.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/andreabuttarelli"
   },
   "homepage": "https://anomalia.so",
-  "repository": "https://github.com/andreabuttarelli/anomalia-cli",
+  "repository": "https://github.com/anomaliaso/anomalia",
   "license": "AGPL-3.0-or-later",
   "keywords": [
     "social-media",

--- a/cli/plugins/anomalia/.mcp.json
+++ b/cli/plugins/anomalia/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "anomalia": {
+      "type": "http",
+      "url": "https://mcp.anomalia.so/mcp"
+    }
+  }
+}

--- a/cli/plugins/anomalia/plugin-skill.test.ts
+++ b/cli/plugins/anomalia/plugin-skill.test.ts
@@ -32,10 +32,11 @@ describe('plugin skill mirror', () => {
   });
 
   test('plugin manifests exist', () => {
+    const MONO_ROOT = join(ROOT, '..');
     expect(existsSync(join(ROOT, 'plugins/anomalia/.claude-plugin/plugin.json'))).toBe(true);
     expect(existsSync(join(ROOT, 'plugins/anomalia/.codex-plugin/plugin.json'))).toBe(true);
     expect(existsSync(join(ROOT, 'plugins/anomalia/.mcp.json'))).toBe(true);
-    expect(existsSync(join(ROOT, '.claude-plugin/marketplace.json'))).toBe(true);
-    expect(existsSync(join(ROOT, '.agents/plugins/marketplace.json'))).toBe(true);
+    expect(existsSync(join(MONO_ROOT, '.claude-plugin/marketplace.json'))).toBe(true);
+    expect(existsSync(join(MONO_ROOT, '.agents/plugins/marketplace.json'))).toBe(true);
   });
 });

--- a/cli/plugins/anomalia/plugin-skill.test.ts
+++ b/cli/plugins/anomalia/plugin-skill.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'bun:test';
+import { existsSync, readdirSync, readFileSync, statSync } from 'fs';
+import { join } from 'path';
+
+const ROOT = join(import.meta.dir, '..', '..');
+const CANONICAL = join(ROOT, 'skills', 'anomalia');
+const PLUGIN = join(ROOT, 'plugins', 'anomalia', 'skills', 'anomalia');
+
+function listFiles(dir: string, prefix = ''): string[] {
+  const out: string[] = [];
+  for (const name of readdirSync(dir).sort()) {
+    const rel = prefix ? `${prefix}/${name}` : name;
+    const full = join(dir, name);
+    if (statSync(full).isDirectory()) out.push(...listFiles(full, rel));
+    else out.push(rel);
+  }
+  return out;
+}
+
+describe('plugin skill mirror', () => {
+  test('plugins/anomalia/skills/anomalia matches skills/anomalia', () => {
+    expect(existsSync(join(CANONICAL, 'SKILL.md'))).toBe(true);
+    expect(existsSync(join(PLUGIN, 'SKILL.md'))).toBe(true);
+    const a = listFiles(CANONICAL);
+    const b = listFiles(PLUGIN);
+    expect(b).toEqual(a);
+    for (const rel of a) {
+      expect(readFileSync(join(PLUGIN, rel), 'utf8')).toBe(
+        readFileSync(join(CANONICAL, rel), 'utf8'),
+      );
+    }
+  });
+
+  test('plugin manifests exist', () => {
+    expect(existsSync(join(ROOT, 'plugins/anomalia/.claude-plugin/plugin.json'))).toBe(true);
+    expect(existsSync(join(ROOT, 'plugins/anomalia/.codex-plugin/plugin.json'))).toBe(true);
+    expect(existsSync(join(ROOT, 'plugins/anomalia/.mcp.json'))).toBe(true);
+    expect(existsSync(join(ROOT, '.claude-plugin/marketplace.json'))).toBe(true);
+    expect(existsSync(join(ROOT, '.agents/plugins/marketplace.json'))).toBe(true);
+  });
+});

--- a/cli/plugins/anomalia/skills/anomalia/SKILL.md
+++ b/cli/plugins/anomalia/skills/anomalia/SKILL.md
@@ -13,7 +13,7 @@ metadata:
   author: andreabuttarelli
   version: "1.0.0"
   homepage: https://anomalia.so
-  repository: https://github.com/andreabuttarelli/anomalia-cli
+  repository: https://github.com/anomaliaso/anomalia
   mcp: https://mcp.anomalia.so/mcp
 ---
 
@@ -65,18 +65,18 @@ Setup details: [references/mcp.md](references/mcp.md).
 ## Install this skill
 
 ```bash
-npx skills add andreabuttarelli/anomalia-cli --skill anomalia
+npx skills add anomaliaso/anomalia --skill anomalia
 ```
 
 Or install the marketplace plugin (skill + remote MCP):
 
 ```bash
 # Claude Code
-/plugin marketplace add andreabuttarelli/anomalia-cli
+/plugin marketplace add anomaliaso/anomalia
 /plugin install anomalia@anomalia
 
 # Codex
-codex plugin marketplace add andreabuttarelli/anomalia-cli
+codex plugin marketplace add anomaliaso/anomalia
 ```
 
 Or copy this folder into `.cursor/skills/anomalia/` / `~/.claude/skills/anomalia/`.  

--- a/cli/plugins/anomalia/skills/anomalia/SKILL.md
+++ b/cli/plugins/anomalia/skills/anomalia/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: anomalia
+description: >-
+  Operate Anomalia (social media AI autopilot) via MCP tools or the anomalia CLI:
+  brands, posts, plans, studio, SEO/GEO, blog, and AI chat. Use when the user
+  mentions Anomalia, anomalia.so, approving social posts, editorial plans,
+  SEO/GEO audits, or managing brand content from an agent.
+license: AGPL-3.0-or-later
+compatibility: >-
+  Requires network access to anomalia.so (or PUBLIC_APP_URL). Prefer Anomalia MCP
+  when connected; otherwise the anomalia CLI (Bun or installed binary) after OAuth login.
+metadata:
+  author: andreabuttarelli
+  version: "1.0.0"
+  homepage: https://anomalia.so
+  repository: https://github.com/andreabuttarelli/anomalia-cli
+  mcp: https://mcp.anomalia.so/mcp
+---
+
+# Anomalia
+
+Drive [Anomalia](https://anomalia.so) — social media AI autopilot — through **MCP tools**
+(preferred) or the **`anomalia` CLI**. Same OAuth identity. **No static API tokens.**
+
+## Choose interface
+
+| Situation | Action |
+|-----------|--------|
+| Anomalia MCP is connected | Call MCP tools (`list_brands`, `list_posts`, …) |
+| MCP not available | Shell: `anomalia …` after `anomalia login` |
+| Vague / multi-step ask | MCP `chat` or `anomalia ai <slug> --message "…" --pipe` |
+
+Never invent REST endpoints or API keys.
+
+## Auth (always OAuth)
+
+1. **Local MCP / CLI:** shared session at `~/.config/anomalia/session.json`. MCP tool `login` opens the browser, or run `anomalia login`.
+2. **Remote MCP** (`https://mcp.anomalia.so/mcp`): send `Authorization: Bearer <access_token>` (same JWT the CLI stores). Missing Bearer → 401.
+3. Verify with `whoami` / `list_brands` or `anomalia brands`.
+
+Setup details: [references/mcp.md](references/mcp.md).
+
+## Operating rules
+
+1. Start with `list_brands` (or `anomalia brands`) to learn **slugs**.
+2. Pass `slug` on every brand-scoped call.
+3. Post/article ids accept **short unambiguous prefixes** from list output — never guess if ambiguous.
+4. Prefer specific tools (`approve_posts`, `edit_post`, …) over `chat` for precise edits.
+5. Confirm before reject / delete / discard unless the user clearly asked.
+
+## Quick workflows
+
+**Approve pending posts** → `list_posts` (status pending) → optional `get_post` → `approve_posts`.
+
+**Fix one carousel slide** → `get_post` → `regenerate_slide` (`index`, instruction; 0 = cover).
+
+**Blog draft** → `generate_article` → optional `optimize_article` → `publish_article` when asked.
+
+## References (load on demand)
+
+- [references/mcp.md](references/mcp.md) — connect MCP (stdio / HTTP), Cursor config, auth
+- [references/tools.md](references/tools.md) — full MCP tool catalog + CLI equivalents
+- [references/cli.md](references/cli.md) — install CLI and common commands
+
+## Install this skill
+
+```bash
+npx skills add andreabuttarelli/anomalia-cli --skill anomalia
+```
+
+Or install the marketplace plugin (skill + remote MCP):
+
+```bash
+# Claude Code
+/plugin marketplace add andreabuttarelli/anomalia-cli
+/plugin install anomalia@anomalia
+
+# Codex
+codex plugin marketplace add andreabuttarelli/anomalia-cli
+```
+
+Or copy this folder into `.cursor/skills/anomalia/` / `~/.claude/skills/anomalia/`.  
+Submit / packaging details: [`docs/plugins.md`](../../../../docs/plugins.md).

--- a/cli/plugins/anomalia/skills/anomalia/references/cli.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/cli.md
@@ -1,0 +1,42 @@
+# Anomalia CLI (fallback)
+
+Use when MCP is not connected. Same OAuth session as MCP (`~/.config/anomalia/session.json`).
+
+## Install
+
+```bash
+curl -sSL https://raw.githubusercontent.com/andreabuttarelli/anomalia-cli/main/scripts/install.sh | bash
+anomalia login
+```
+
+From source (Bun):
+
+```bash
+git clone https://github.com/andreabuttarelli/anomalia-cli.git
+cd anomalia-cli && bun install
+bun run cli.ts --help
+```
+
+## Common commands
+
+```bash
+anomalia brands
+anomalia dashboard <slug>
+anomalia content <slug> --status pending_user
+anomalia approve <slug> --all
+anomalia post <slug> <id> edit --caption "..."
+anomalia post <slug> <id> regenerate --instruction "..."
+anomalia post <slug> <id> slide --index 1 --instruction "..."
+anomalia post <slug> <id> approve|publish|reject
+anomalia plan <slug> propose
+anomalia weekly-plan <slug> plan --week 0
+anomalia weekly-plan <slug> produce --week 0
+anomalia studio <slug> add-note --text "..."
+anomalia seo <slug>
+anomalia geo <slug>
+anomalia web <slug> generate --topic "..."
+anomalia ai <slug> --message "..." --pipe
+```
+
+Full dump: repo root [`llms.txt`](https://github.com/andreabuttarelli/anomalia-cli/blob/main/llms.txt).
+Tool mapping: [tools.md](tools.md).

--- a/cli/plugins/anomalia/skills/anomalia/references/cli.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/cli.md
@@ -5,14 +5,14 @@ Use when MCP is not connected. Same OAuth session as MCP (`~/.config/anomalia/se
 ## Install
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/andreabuttarelli/anomalia-cli/main/scripts/install.sh | bash
+curl -sSL https://raw.githubusercontent.com/anomaliaso/anomalia/main/cli/scripts/install.sh | bash
 anomalia login
 ```
 
 From source (Bun):
 
 ```bash
-git clone https://github.com/andreabuttarelli/anomalia-cli.git
+git clone https://github.com/anomaliaso/anomalia.git
 cd anomalia-cli && bun install
 bun run cli.ts --help
 ```
@@ -38,5 +38,5 @@ anomalia web <slug> generate --topic "..."
 anomalia ai <slug> --message "..." --pipe
 ```
 
-Full dump: repo root [`llms.txt`](https://github.com/andreabuttarelli/anomalia-cli/blob/main/llms.txt).
+Full dump: repo root [`llms.txt`](https://github.com/anomaliaso/anomalia/blob/main/cli/llms.txt).
 Tool mapping: [tools.md](tools.md).

--- a/cli/plugins/anomalia/skills/anomalia/references/mcp.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/mcp.md
@@ -1,0 +1,119 @@
+# Anomalia MCP — setup & usage
+
+Model Context Protocol server for Anomalia. Same HTTPS client and OAuth as the CLI.
+**No static API tokens.**
+
+```
+Host (Cursor / Claude / …)
+  ├─ stdio  → bun run mcp / anomalia-mcp
+  └─ HTTPS  → https://mcp.anomalia.so/mcp  (+ Bearer on remote)
+         └─ Anomalia API /api/v1/*
+```
+
+## 1. Pick a transport
+
+| Mode | When | Endpoint / command | Auth |
+|------|------|--------------------|------|
+| **stdio** | Local agent on your machine | `bun run mcp` or `anomalia-mcp` | `login` tool or existing `anomalia login` session |
+| **HTTP local** | Local Streamable HTTP | `bun run mcp:http` → `http://localhost:8787/mcp` | Bearer **or** session file |
+| **HTTP remote** | Shared / cloud host | `https://mcp.anomalia.so/mcp` | **Bearer required** |
+
+Health check (HTTP):
+
+```bash
+curl -sS https://mcp.anomalia.so/health
+# {"ok":true,"name":"anomalia-mcp","transport":"streamable-http","mcp":"/mcp"}
+```
+
+OAuth resource metadata: `GET /.well-known/oauth-protected-resource`.
+
+## 2. Configure the host
+
+### Cursor — stdio (recommended locally)
+
+Clone or install the repo, then in Cursor MCP settings:
+
+```json
+{
+  "mcpServers": {
+    "anomalia": {
+      "command": "bun",
+      "args": ["run", "/ABS/PATH/to/anomalia-cli/mcp/stdio.ts"]
+    }
+  }
+}
+```
+
+If the binary is on `PATH` after install:
+
+```json
+{
+  "mcpServers": {
+    "anomalia": { "command": "anomalia-mcp" }
+  }
+}
+```
+
+### Cursor — HTTP remote
+
+```json
+{
+  "mcpServers": {
+    "anomalia": {
+      "url": "https://mcp.anomalia.so/mcp"
+    }
+  }
+}
+```
+
+The host must send OAuth Bearer. If it cannot yet, use [mcp-remote](https://www.npmjs.com/package/mcp-remote) as a bridge, or prefer **stdio** locally.
+
+### From source (dev)
+
+```bash
+git clone https://github.com/andreabuttarelli/anomalia-cli.git
+cd anomalia-cli
+bun install
+bun run mcp          # stdio
+bun run mcp:http     # http://localhost:8787/mcp
+```
+
+## 3. Authenticate
+
+**Local (stdio / local HTTP)**
+
+1. Call MCP tool `login` (opens browser), **or** run `anomalia login` in a terminal.
+2. Session is stored at `~/.config/anomalia/session.json` and shared with the CLI.
+3. `whoami` / `list_brands` to confirm.
+
+**Remote HTTP**
+
+1. Obtain a Supabase access token via Anomalia OAuth (same token inside `session.json` after CLI login: field used as Bearer).
+2. Send on every request: `Authorization: Bearer <access_token>`.
+3. Without it you get JSON-RPC **401** — that is expected, not a server crash.
+
+There is **no** `ANOMALIA_TOKEN` / API-key path by design.
+
+## 4. First calls
+
+1. `list_brands` — learn brand **slugs**.
+2. `get_dashboard` with `slug` — overview.
+3. `list_posts` with `slug` and status `pending_user` — approval queue.
+4. Use specific tools for edits; use `chat` only for open-ended multi-step work.
+
+Ids from list tools accept short unambiguous prefixes (same rule as the CLI).
+
+## 5. Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| 401 on `/mcp` | Missing/invalid Bearer on remote | Login locally and pass access token, or use stdio |
+| 404 on `/health` | Wrong deploy root / path | Expect `/health` and `/mcp` on the MCP host |
+| Tools missing | MCP not connected in host | Check Cursor MCP panel; restart host |
+| Auth works in CLI but not MCP | Different machine / no session file | Run `login` in the MCP process environment |
+
+## 6. More
+
+- Full tool list: [tools.md](tools.md)
+- CLI fallback: [cli.md](cli.md)
+- Product: https://anomalia.so · Repo: https://github.com/andreabuttarelli/anomalia-cli

--- a/cli/plugins/anomalia/skills/anomalia/references/mcp.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/mcp.md
@@ -71,7 +71,7 @@ The host must send OAuth Bearer. If it cannot yet, use [mcp-remote](https://www.
 ### From source (dev)
 
 ```bash
-git clone https://github.com/andreabuttarelli/anomalia-cli.git
+git clone https://github.com/anomaliaso/anomalia.git
 cd anomalia-cli
 bun install
 bun run mcp          # stdio
@@ -111,9 +111,10 @@ Ids from list tools accept short unambiguous prefixes (same rule as the CLI).
 | 404 on `/health` | Wrong deploy root / path | Expect `/health` and `/mcp` on the MCP host |
 | Tools missing | MCP not connected in host | Check Cursor MCP panel; restart host |
 | Auth works in CLI but not MCP | Different machine / no session file | Run `login` in the MCP process environment |
+| `Not an https or loopback URI: cursor://anysphere.cursor-mcp/oauth/callback` | Cursor DCR uses a custom-scheme callback; Anomalia OAuth only allows https/loopback | Use **stdio** MCP, update Cursor (localhost `:8787` callback), or pass Bearer; see [docs/mcp.md](../../../docs/mcp.md#cursor--remote-http-oauth) |
 
 ## 6. More
 
 - Full tool list: [tools.md](tools.md)
 - CLI fallback: [cli.md](cli.md)
-- Product: https://anomalia.so · Repo: https://github.com/andreabuttarelli/anomalia-cli
+- Product: https://anomalia.so · Repo: https://github.com/anomaliaso/anomalia

--- a/cli/plugins/anomalia/skills/anomalia/references/tools.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/tools.md
@@ -64,5 +64,5 @@ All tools take a brand `slug` when brand-scoped. Ids accept short unambiguous pr
 | `get_keywords` / `refresh_keywords` | `anomalia keywords <slug> [refresh]` |
 | `list_articles` / `generate_article` / `optimize_article` | `anomalia web <slug> …` |
 | `publish_article` / `unpublish_article` / `delete_article` | `anomalia web <slug> publish\|…` |
-| `get_ads` / `ads_action` | (ads via MCP / product UI) |
+| `get_ads` / `ads_action` | `anomalia ads <slug> [--propose\|--create\|--approve\|--pause\|--resume\|--duplicate\|--delete\|--reject] [--ad <adId>]` |
 | `chat` | `anomalia ai <slug> --message "…" --pipe` |

--- a/cli/plugins/anomalia/skills/anomalia/references/tools.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/tools.md
@@ -1,0 +1,68 @@
+# Anomalia MCP tools ↔ CLI
+
+All tools take a brand `slug` when brand-scoped. Ids accept short unambiguous prefixes.
+
+## Auth
+
+| MCP | CLI |
+|-----|-----|
+| `login` | `anomalia login` |
+| `logout` | `anomalia logout` |
+| `whoami` | (session file / brands imply identity) |
+| `list_brands` | `anomalia brands` |
+
+## Brand & posts
+
+| MCP | CLI |
+|-----|-----|
+| `get_dashboard` | `anomalia dashboard <slug>` |
+| `get_status` | `anomalia status <slug>` |
+| `get_analytics` | `anomalia analytics <slug>` |
+| `get_calendar` | `anomalia calendar <slug> [--month YYYY-MM]` |
+| `get_gtm` | `anomalia gtm <slug>` |
+| `get_voice` / `update_voice` | `anomalia voice <slug>` |
+| `list_products` | (studio / products views) |
+| `list_posts` | `anomalia content <slug> [--status …]` |
+| `approve_posts` | `anomalia approve <slug> --all` |
+| `get_post` | `anomalia post <slug> <id>` |
+| `edit_post` | `anomalia post <slug> <id> edit …` |
+| `approve_post` / `publish_post` / `reject_post` | `anomalia post <slug> <id> approve\|publish\|reject` |
+| `reschedule_post` | `anomalia post <slug> <id> reschedule --scheduledFor …` |
+| `render_post` | `anomalia post <slug> <id> render` |
+| `regenerate_post_media` | `anomalia post <slug> <id> regenerate --instruction "…"` |
+| `regenerate_slide` | `anomalia post <slug> <id> slide --index N --instruction "…"` |
+| `reorder_slides` | `anomalia post <slug> <id> reorder --order "0,2,1"` |
+| `make_video` | `anomalia post <slug> <id> video …` |
+
+## Plans
+
+| MCP | CLI |
+|-----|-----|
+| `get_plan` | `anomalia plan <slug>` |
+| `propose_plan` / `revise_plan` / `approve_plan` / `discard_plan` | `anomalia plan <slug> propose\|revise\|approve\|discard` |
+| `save_brief` / `replan_week` | `anomalia plan <slug> save-brief\|replan --week N …` |
+| `get_weekly_plan` | `anomalia weekly-plan <slug>` |
+| `plan_week` / `produce_week` | `anomalia weekly-plan <slug> plan\|produce --week N` |
+
+## Studio
+
+| MCP | CLI |
+|-----|-----|
+| `get_studio` | `anomalia studio <slug>` |
+| `update_brand_kit` / `set_colors` | `anomalia studio <slug> kit-update\|colors …` |
+| `add_note` / `delete_document` | `anomalia studio <slug> add-note\|delete-doc …` |
+| `add_person` / `generate_person` / `delete_person` | `anomalia studio <slug> people-*` |
+| `add_competitor` / `delete_competitor` / `research_competitors` | `anomalia studio <slug> add-competitor\|…\|research` |
+| `sync_history` | `anomalia studio <slug> sync-history` |
+
+## SEO / GEO / blog / ads / AI
+
+| MCP | CLI |
+|-----|-----|
+| `get_seo` / `seo_action` | `anomalia seo <slug> [run\|plan\|…]` |
+| `get_geo` / `geo_action` | `anomalia geo <slug> [run\|fix]` |
+| `get_keywords` / `refresh_keywords` | `anomalia keywords <slug> [refresh]` |
+| `list_articles` / `generate_article` / `optimize_article` | `anomalia web <slug> …` |
+| `publish_article` / `unpublish_article` / `delete_article` | `anomalia web <slug> publish\|…` |
+| `get_ads` / `ads_action` | (ads via MCP / product UI) |
+| `chat` | `anomalia ai <slug> --message "…" --pipe` |

--- a/cli/scripts/build-npm.ts
+++ b/cli/scripts/build-npm.ts
@@ -1,0 +1,95 @@
+#!/usr/bin/env bun
+/**
+ * Build Node-targeted JS bundles for npm (`npm i -g anomalia-cli`).
+ *
+ *   bun run scripts/build-npm.ts
+ *
+ * Output:
+ *   dist-npm/cli.js        → bin `anomalia`
+ *   dist-npm/mcp-stdio.js  → bin `anomalia-mcp`
+ *   dist-npm/package.json  → publishable package root (copied fields)
+ */
+
+import { mkdirSync, existsSync, rmSync, writeFileSync, readFileSync, cpSync } from 'fs';
+import { join } from 'path';
+
+const ROOT = join(import.meta.dir, '..');
+const OUT = join(ROOT, 'dist-npm');
+
+if (existsSync(OUT)) rmSync(OUT, { recursive: true });
+mkdirSync(OUT, { recursive: true });
+
+const entries = [
+  { entry: join(ROOT, 'cli.ts'), outfile: join(OUT, 'cli.js') },
+  { entry: join(ROOT, 'mcp/stdio.ts'), outfile: join(OUT, 'mcp-stdio.js') },
+];
+
+for (const { entry, outfile } of entries) {
+  console.log(`  Bundling ${outfile.replace(ROOT + '/', '')}…`);
+  const proc = Bun.spawnSync([
+    'bun', 'build',
+    entry,
+    '--target=node',
+    '--outfile', outfile,
+    '--minify',
+  ], {
+    cwd: ROOT,
+    stdout: 'inherit',
+    stderr: 'inherit',
+  });
+  if (proc.exitCode !== 0) {
+    console.error(`  ✗ Failed: ${entry}`);
+    process.exit(1);
+  }
+
+  // Ensure Node shebang (bun build may leave none or a bun shebang).
+  let src = readFileSync(outfile, 'utf8');
+  if (src.startsWith('#!')) {
+    src = src.replace(/^#!.*\n/, '#!/usr/bin/env node\n');
+  } else {
+    src = `#!/usr/bin/env node\n${src}`;
+  }
+  writeFileSync(outfile, src, { mode: 0o755 });
+  console.log(`  ✓ ${outfile.replace(ROOT + '/', '')}`);
+}
+
+const pkg = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8')) as Record<string, unknown>;
+const publishPkg = {
+  name: pkg.name,
+  version: pkg.version,
+  description: pkg.description,
+  license: pkg.license,
+  author: pkg.author,
+  repository: pkg.repository,
+  homepage: pkg.homepage,
+  bugs: pkg.bugs,
+  type: 'module',
+  bin: {
+    anomalia: './cli.js',
+    'anomalia-mcp': './mcp-stdio.js',
+  },
+  engines: {
+    node: '>=20',
+  },
+  keywords: [
+    'anomalia',
+    'cli',
+    'social-media',
+    'mcp',
+    'content',
+    'seo',
+  ],
+  files: [
+    'cli.js',
+    'mcp-stdio.js',
+    'README.md',
+    'LICENSE',
+  ],
+};
+
+writeFileSync(join(OUT, 'package.json'), JSON.stringify(publishPkg, null, 2) + '\n');
+cpSync(join(ROOT, 'README.md'), join(OUT, 'README.md'));
+cpSync(join(ROOT, 'LICENSE'), join(OUT, 'LICENSE'));
+
+console.log('\nDone. Publish with:');
+console.log('  cd dist-npm && npm publish --access public');

--- a/cli/scripts/build-vercel.mjs
+++ b/cli/scripts/build-vercel.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+/**
+ * Bundle MCP HTTP handlers into self-contained ESM under mcp/api/.
+ *
+ * Vercel project Root Directory is `mcp`, so runtime artifacts must live there.
+ * The bundle inlines ../lib so the deploy does not need the repo root on Vercel.
+ */
+import { mkdirSync, unlinkSync, existsSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import * as esbuild from 'esbuild';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const API = join(ROOT, 'mcp/api');
+mkdirSync(API, { recursive: true });
+
+const bundleName = '_bundle.js';
+const bundlePath = join(API, bundleName);
+
+await esbuild.build({
+  entryPoints: [join(ROOT, 'mcp/vercel-handler.ts')],
+  outfile: bundlePath,
+  bundle: true,
+  platform: 'node',
+  target: 'node20',
+  format: 'esm',
+  sourcemap: false,
+  logLevel: 'info',
+  banner: {
+    js: `import { createRequire as __anomaCreateRequire } from 'module'; const require = __anomaCreateRequire(import.meta.url);`,
+  },
+});
+
+const wrappers = [
+  { file: 'mcp.js', exportName: 'mcp', maxDuration: 60 },
+  { file: 'oauth-protected-resource.js', exportName: 'oauthProtectedResource', maxDuration: 30 },
+];
+
+const healthSrc = `/**
+ * Ultra-minimal health endpoint (ESM).
+ * Kept dependency-free so /health stays up even if the MCP bundle fails to build.
+ */
+export default function handler(req, res) {
+  if (req.method === 'OPTIONS') {
+    res.statusCode = 204;
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
+    res.setHeader(
+      'Access-Control-Allow-Headers',
+      'Content-Type, Authorization, mcp-session-id, Last-Event-ID, mcp-protocol-version',
+    );
+    res.end();
+    return;
+  }
+
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'application/json');
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.end(
+    JSON.stringify({
+      ok: true,
+      name: 'anomalia-mcp',
+      transport: 'streamable-http',
+      mcp: '/mcp',
+    }),
+  );
+}
+
+export const config = { maxDuration: 10 };
+`;
+
+for (const w of wrappers) {
+  writeFileSync(
+    join(API, w.file),
+    `import { ${w.exportName} as handler } from './${bundleName}';
+export default handler;
+export const config = { api: { bodyParser: false }, maxDuration: ${w.maxDuration} };
+`,
+  );
+}
+
+writeFileSync(join(API, 'health.js'), healthSrc);
+
+// Keep a copy at repo-root api/health.js for local reference / if Root Directory is ever ".".
+mkdirSync(join(ROOT, 'api'), { recursive: true });
+writeFileSync(join(ROOT, 'api', 'health.js'), healthSrc);
+
+for (const stale of [
+  '_vercel.ts',
+  '_mcp.bundle.js',
+  '_oauth.bundle.js',
+  '_bundle.cjs',
+  '_bundle.cjs.map',
+  'health.ts',
+  'health.cjs',
+  'mcp.ts',
+  'mcp.cjs',
+  'mcp.js',
+  'oauth-protected-resource.ts',
+  'oauth-protected-resource.cjs',
+  'oauth-protected-resource.js',
+  '_bundle.js',
+]) {
+  // Only scrub stale generated files from repo-root api/ (not mcp/api live outputs).
+  if (stale === 'health.js') continue;
+  const p = join(ROOT, 'api', stale);
+  if (existsSync(p)) {
+    unlinkSync(p);
+    console.log('removed', p);
+  }
+}
+
+console.log('Done. Deploy path: mcp/api/* (Vercel Root Directory = mcp)');

--- a/cli/scripts/build.ts
+++ b/cli/scripts/build.ts
@@ -1,0 +1,126 @@
+#!/usr/bin/env bun
+/**
+ * Build script for Anomalia CLI.
+ * Compiles the CLI into standalone binaries using `bun build --compile`.
+ *
+ * Usage:
+ *   bun run scripts/build.ts          # Build for current platform
+ *   bun run scripts/build.ts --all    # Build for all platforms
+ *   bun run scripts/build.ts --linux  # Build for Linux only
+ */
+
+import { mkdirSync, existsSync, cpSync } from 'fs';
+import { join } from 'path';
+
+const ROOT = join(import.meta.dir, '..');
+const DIST = join(ROOT, 'dist');
+
+// Ensure dist directory
+if (!existsSync(DIST)) {
+  mkdirSync(DIST, { recursive: true });
+}
+
+// Platform targets
+const targets: { name: string; target: string; ext: string }[] = [
+  { name: 'macos-arm64', target: 'bun-darwin-arm64', ext: '' },
+  { name: 'macos-x64', target: 'bun-darwin-x64', ext: '' },
+  { name: 'linux-x64', target: 'bun-linux-x64', ext: '' },
+  { name: 'linux-arm64', target: 'bun-linux-arm64', ext: '' },
+];
+
+// Parse args
+const args = process.argv.slice(2);
+const buildAll = args.includes('--all');
+const buildLinux = args.includes('--linux');
+const buildMac = args.includes('--mac');
+
+// Determine which targets to build
+let selectedTargets = targets;
+if (!buildAll) {
+  if (buildLinux) {
+    selectedTargets = targets.filter(t => t.name.startsWith('linux'));
+  } else if (buildMac) {
+    selectedTargets = targets.filter(t => t.name.startsWith('macos'));
+  } else {
+    // Default: current platform
+    const platform = process.platform;
+    const arch = process.arch;
+    if (platform === 'darwin') {
+      selectedTargets = targets.filter(t => t.name === (arch === 'arm64' ? 'macos-arm64' : 'macos-x64'));
+    } else if (platform === 'linux') {
+      selectedTargets = targets.filter(t => t.name === (arch === 'arm64' ? 'linux-arm64' : 'linux-x64'));
+    } else {
+      console.error(`Unsupported platform: ${platform}-${arch}`);
+      process.exit(1);
+    }
+  }
+}
+
+console.log(`Building Anomalia CLI for: ${selectedTargets.map(t => t.name).join(', ')}\n`);
+
+// Build each target
+for (const target of selectedTargets) {
+  const outName = `anomalia-${target.name}`;
+  const outPath = join(DIST, outName);
+
+  console.log(`  Building ${outName}...`);
+
+  const proc = Bun.spawnSync([
+    'bun', 'build',
+    '--compile',
+    '--minify',
+    '--target', target.target,
+    join(ROOT, 'cli.ts'),
+    '--outfile', outPath,
+  ], {
+    cwd: ROOT,
+    stdout: 'inherit',
+    stderr: 'inherit',
+  });
+
+  if (proc.exitCode !== 0) {
+    console.error(`  ✗ Failed to build ${outName}`);
+    continue;
+  }
+
+  console.log(`  ✓ ${outName} (${(Bun.file(outPath).size / 1024 / 1024).toFixed(1)} MB)`);
+}
+
+// Copy README and docs
+console.log('\n  Copying docs...');
+const docsDist = join(DIST, 'docs');
+if (!existsSync(docsDist)) {
+  mkdirSync(docsDist, { recursive: true });
+}
+
+try {
+  cpSync(join(ROOT, 'README.md'), join(DIST, 'README.md'));
+  cpSync(join(ROOT, 'docs'), docsDist, { recursive: true });
+  console.log('  ✓ Docs copied to dist/');
+} catch (e) {
+  console.log(`  ⚠ Could not copy docs: ${e}`);
+}
+
+// Homebrew formulas prefer archives over raw binaries.
+for (const target of selectedTargets) {
+  const outName = `anomalia-${target.name}`;
+  const outPath = join(DIST, outName);
+  if (!existsSync(outPath)) continue;
+  const tarPath = `${outPath}.tar.gz`;
+  const tar = Bun.spawnSync(['tar', '-czf', tarPath, '-C', DIST, outName], {
+    cwd: ROOT,
+    stdout: 'inherit',
+    stderr: 'inherit',
+  });
+  if (tar.exitCode !== 0) {
+    console.error(`  ✗ Failed to archive ${outName}`);
+    continue;
+  }
+  console.log(`  ✓ ${outName}.tar.gz`);
+}
+
+console.log('\nDone! Binaries are in dist/');
+console.log('\nTo install locally:');
+console.log('  sudo cp dist/anomalia-macos-arm64 /usr/local/bin/anomalia');
+console.log('\nTo distribute:');
+console.log('  Upload dist/ files to your hosting or create a GitHub release');

--- a/cli/scripts/install-skill.sh
+++ b/cli/scripts/install-skill.sh
@@ -32,7 +32,7 @@ warn()    { echo -e "${YELLOW}⚠${NC} $1"; }
 
 read_skill_content() {
   # Try to download from GitHub, fallback to embedded
-  local url="https://raw.githubusercontent.com/andreabuttarelli/anomalia-cli/main/skills/anomalia-cli.md"
+  local url="https://raw.githubusercontent.com/anomaliaso/anomalia/main/cli/skills/anomalia-cli.md"
   local content
   content=$(curl -sSL "$url" 2>/dev/null) || true
 
@@ -80,7 +80,7 @@ SKILL_EOF
 install_cursor_skill() {
   local dest_dir="$1"
   local label="$2"
-  local base="https://raw.githubusercontent.com/andreabuttarelli/anomalia-cli/main/skills/anomalia"
+  local base="https://raw.githubusercontent.com/anomaliaso/anomalia/main/cli/skills/anomalia"
   local script_dir
   script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   local local_skill=""
@@ -136,7 +136,7 @@ while [[ $# -gt 0 ]]; do
       echo "  --project   Install in current project (all tools)"
       echo ""
       echo "Publishable skill (skills.sh / npx skills):"
-      echo "  npx skills add andreabuttarelli/anomalia-cli --skill anomalia"
+      echo "  npx skills add anomaliaso/anomalia --skill anomalia"
       echo ""
       echo "Supported tools:"
       echo "  Claude Code, Cursor, GitHub Copilot, Windsurf, Cline,"
@@ -262,7 +262,7 @@ AIDER_EOF
 
   # llms.txt (universal standard)
   if [[ ! -f "llms.txt" ]]; then
-    curl -sSL "https://raw.githubusercontent.com/andreabuttarelli/anomalia-cli/main/llms.txt" -o "llms.txt" 2>/dev/null && \
+    curl -sSL "https://raw.githubusercontent.com/anomaliaso/anomalia/main/cli/llms.txt" -o "llms.txt" 2>/dev/null && \
       success "llms.txt creato" || true
   else
     info "llms.txt già esistente"
@@ -294,6 +294,6 @@ echo "  Ora puoi dire alla tua AI:"
 echo -e "  ${BOLD}\"Usa Anomalia MCP (o la CLI) per elencare i brand\"${NC}"
 echo ""
 echo "  Cursor Agent Skill: skills/anomalia/SKILL.md"
-echo "  Directory install:  npx skills add andreabuttarelli/anomalia-cli --skill anomalia"
-echo "  Docs MCP: https://github.com/andreabuttarelli/anomalia-cli/blob/main/docs/mcp.md"
+echo "  Directory install:  npx skills add anomaliaso/anomalia --skill anomalia"
+echo "  Docs MCP: https://github.com/anomaliaso/anomalia/blob/main/cli/docs/mcp.md"
 echo ""

--- a/cli/scripts/install-skill.sh
+++ b/cli/scripts/install-skill.sh
@@ -1,0 +1,299 @@
+#!/bin/bash
+#
+# Install Anomalia CLI skill for ALL AI coding assistants
+#
+# Supported tools:
+#   Claude Code, Cursor, GitHub Copilot, Windsurf, Cline,
+#   Roo Code, Aider, OpenAI Codex, Mimo Code, Kimi Code,
+#   Antigravity CLI, and any tool that reads AGENTS.md or llms.txt
+#
+# Usage:
+#   curl -sSL https://anomalia.so/install-skill.sh | bash              # Interactive
+#   curl -sSL https://anomalia.so/install-skill.sh | bash -s -- --global   # Global
+#   curl -sSL https://anomalia.so/install-skill.sh | bash -s -- --project  # Current project
+#
+
+set -euo pipefail
+
+# ── Colors ─────────────────────────────────────────────────────────────
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+info()    { echo -e "${BLUE}ℹ${NC} $1"; }
+success() { echo -e "${GREEN}✓${NC} $1"; }
+warn()    { echo -e "${YELLOW}⚠${NC} $1"; }
+
+# ── Skill content ──────────────────────────────────────────────────────
+
+read_skill_content() {
+  # Try to download from GitHub, fallback to embedded
+  local url="https://raw.githubusercontent.com/andreabuttarelli/anomalia-cli/main/skills/anomalia-cli.md"
+  local content
+  content=$(curl -sSL "$url" 2>/dev/null) || true
+
+  if [[ -z "$content" ]] || ! echo "$content" | grep -q "Anomalia Skill"; then
+    # Embedded fallback (MCP + CLI)
+    read -r -d '' content << 'SKILL_EOF' || true
+# Anomalia Skill (MCP + CLI)
+
+Prefer Anomalia MCP tools when connected; otherwise use the `anomalia` CLI.
+OAuth only — session at ~/.config/anomalia/session.json. No static API tokens.
+
+## MCP (preferred)
+
+Stdio: bun run /path/to/anomalia-cli/mcp/stdio.ts
+HTTP: https://mcp.anomalia.so/mcp (Bearer required remotely)
+Start with list_brands / whoami. Use specific tools; chat for open-ended work.
+
+## CLI quick reference
+
+```bash
+anomalia login
+anomalia brands
+anomalia dashboard <slug>
+anomalia content <slug> --status pending_user
+anomalia approve <slug> --all
+anomalia post <slug> <id> edit --caption "..."
+anomalia plan <slug> propose
+anomalia weekly-plan <slug> plan --week 0
+anomalia weekly-plan <slug> produce --week 0
+anomalia studio <slug> add-note --text "..."
+anomalia ai <slug> --message "..." --pipe
+```
+
+## Tips
+
+- Prefer MCP tools over shell when the server is connected
+- Use --pipe for machine-readable AI output
+- Post IDs: short prefixes from list tables (never guess if ambiguous)
+SKILL_EOF
+  fi
+
+  echo "$content"
+}
+
+install_cursor_skill() {
+  local dest_dir="$1"
+  local label="$2"
+  local base="https://raw.githubusercontent.com/andreabuttarelli/anomalia-cli/main/skills/anomalia"
+  local script_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  local local_skill=""
+
+  # Prefer local package when installer runs from this repo
+  if [[ -f "$script_dir/../skills/anomalia/SKILL.md" ]]; then
+    local_skill="$script_dir/../skills/anomalia"
+  elif [[ -f "./skills/anomalia/SKILL.md" ]]; then
+    local_skill="./skills/anomalia"
+  fi
+
+  mkdir -p "$dest_dir/references"
+
+  if [[ -n "$local_skill" ]]; then
+    cp "$local_skill/SKILL.md" "$dest_dir/SKILL.md"
+    if [[ -d "$local_skill/references" ]]; then
+      cp -R "$local_skill/references/." "$dest_dir/references/"
+    fi
+    success "$label → $dest_dir/SKILL.md"
+    return
+  fi
+
+  if curl -sSL "$base/SKILL.md" -o "$dest_dir/SKILL.md" 2>/dev/null && grep -q "name: anomalia" "$dest_dir/SKILL.md" 2>/dev/null; then
+    for f in mcp.md tools.md cli.md; do
+      curl -sSL "$base/references/$f" -o "$dest_dir/references/$f" 2>/dev/null || true
+    done
+    success "$label → $dest_dir/SKILL.md"
+  else
+    {
+      echo '---'
+      echo 'name: anomalia'
+      echo 'description: Operate Anomalia via MCP tools or the anomalia CLI.'
+      echo '---'
+      echo ''
+      echo "$SKILL_CONTENT"
+    } > "$dest_dir/SKILL.md"
+    success "$label (fallback) → $dest_dir/SKILL.md"
+  fi
+}
+
+# ── Parse args ─────────────────────────────────────────────────────────
+
+MODE=""
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --global)   MODE="global"; shift ;;
+    --project)  MODE="project"; shift ;;
+    -h|--help)
+      echo "Usage: curl -sSL https://anomalia.so/install-skill.sh | bash"
+      echo ""
+      echo "Options:"
+      echo "  --global    Install globally (~/.claude/skills/ + ~/.cursor/skills/)"
+      echo "  --project   Install in current project (all tools)"
+      echo ""
+      echo "Publishable skill (skills.sh / npx skills):"
+      echo "  npx skills add andreabuttarelli/anomalia-cli --skill anomalia"
+      echo ""
+      echo "Supported tools:"
+      echo "  Claude Code, Cursor, GitHub Copilot, Windsurf, Cline,"
+      echo "  Roo Code, Aider, OpenAI Codex, Mimo Code, Kimi Code,"
+      echo "  Antigravity CLI, and any tool that reads AGENTS.md"
+      exit 0
+      ;;
+    *)  shift ;;
+  esac
+done
+
+# ── Install function ───────────────────────────────────────────────────
+
+install_file() {
+  local target="$1"
+  local label="$2"
+  local dir
+  dir=$(dirname "$target")
+
+  mkdir -p "$dir"
+
+  # If file exists and already has our content, skip
+  if [[ -f "$target" ]] && grep -qE "Anomalia (CLI|Skill)" "$target" 2>/dev/null; then
+    info "$label già configurato"
+    return
+  fi
+
+  # If file exists, append (don't overwrite user content)
+  if [[ -f "$target" ]]; then
+    echo "" >> "$target"
+    echo "$SKILL_CONTENT" >> "$target"
+    success "$label aggiornato → $target"
+  else
+    echo "$SKILL_CONTENT" > "$target"
+    success "$label creato → $target"
+  fi
+}
+
+# ── Main ───────────────────────────────────────────────────────────────
+
+echo ""
+echo -e "${BOLD}Anomalia CLI — AI Skill Installer${NC}"
+echo ""
+
+# Ask mode if not specified
+if [[ -z "$MODE" ]]; then
+  echo "  Dove vuoi installare la skill?"
+  echo ""
+  echo "  1) Progetto corrente (tutti i tool)"
+  echo "  2) Globale (~/.claude/skills/)"
+  echo ""
+  read -p "  Scelta [1/2]: " choice
+  case "$choice" in
+    2) MODE="global" ;;
+    *) MODE="project" ;;
+  esac
+  echo ""
+fi
+
+# Load skill content
+info "Caricamento skill..."
+SKILL_CONTENT=$(read_skill_content)
+
+if [[ -z "$SKILL_CONTENT" ]]; then
+  echo -e "${RED}✗${NC} Impossibile caricare la skill"
+  exit 1
+fi
+
+info "Modalità: $MODE"
+echo ""
+
+# ── Install ────────────────────────────────────────────────────────────
+
+if [[ "$MODE" == "global" ]]; then
+  # Global: Claude Code + Cursor Agent Skills
+  install_file "$HOME/.claude/skills/anomalia-cli.md" "Claude Code (globale)"
+  install_cursor_skill "$HOME/.cursor/skills/anomalia" "Cursor Agent Skill (globale)"
+else
+  # Project: all tools
+
+  # Claude Code (uses CLAUDE.md which is auto-read)
+  install_file "CLAUDE.md" "Claude Code (CLAUDE.md)"
+  install_file ".claude/skills/anomalia-cli.md" "Claude Code skill file"
+
+  # Cursor (legacy rules + Agent Skills)
+  install_file ".cursorrules" "Cursor (.cursorrules)"
+  install_cursor_skill ".cursor/skills/anomalia" "Cursor Agent Skill"
+
+  # GitHub Copilot
+  install_file ".github/copilot-instructions.md" "GitHub Copilot"
+
+  # Windsurf (Codeium)
+  install_file ".windsurfrules" "Windsurf"
+
+  # Cline (VS Code extension)
+  install_file ".clinerules" "Cline"
+
+  # Roo Code
+  install_file ".roomodes" "Roo Code"
+
+  # Aider
+  if [[ -f ".aider.conf.yml" ]]; then
+    if ! grep -qE "Anomalia (CLI|Skill)" ".aider.conf.yml" 2>/dev/null; then
+      echo "" >> ".aider.conf.yml"
+      echo "# Anomalia Skill" >> ".aider.conf.yml"
+      echo "$SKILL_CONTENT" >> ".aider.conf.yml"
+      success "Aider aggiornato → .aider.conf.yml"
+    else
+      info "Aider già configurato"
+    fi
+  else
+    # Aider uses YAML, create a proper file
+    cat > ".aider.conf.yml" << AIDER_EOF
+# Anomalia Skill instructions
+# See: https://anomalia.so
+AIDER_EOF
+    echo "$SKILL_CONTENT" >> ".aider.conf.yml"
+    success "Aider creato → .aider.conf.yml"
+  fi
+
+  # AGENTS.md (OpenAI Codex, Mimo Code, Kimi Code, Antigravity, generic)
+  install_file "AGENTS.md" "AGENTS.md (Codex/Mimo/Kimi/Antigravity)"
+
+  # llms.txt (universal standard)
+  if [[ ! -f "llms.txt" ]]; then
+    curl -sSL "https://raw.githubusercontent.com/andreabuttarelli/anomalia-cli/main/llms.txt" -o "llms.txt" 2>/dev/null && \
+      success "llms.txt creato" || true
+  else
+    info "llms.txt già esistente"
+  fi
+fi
+
+# ── Summary ────────────────────────────────────────────────────────────
+
+echo ""
+success "Skill installata!"
+echo ""
+
+if [[ "$MODE" == "project" ]]; then
+  echo "  File installati:"
+  [[ -f ".claude/skills/anomalia-cli.md" ]] && echo "    • .claude/skills/anomalia-cli.md  (Claude Code)"
+  [[ -f ".cursor/skills/anomalia/SKILL.md" ]] && echo "    • .cursor/skills/anomalia/SKILL.md  (Cursor Agent Skill)"
+  [[ -f ".cursorrules" ]] && echo "    • .cursorrules                (Cursor)"
+  [[ -f ".github/copilot-instructions.md" ]] && echo "    • .github/copilot-instructions.md  (Copilot)"
+  [[ -f ".windsurfrules" ]] && echo "    • .windsurfrules              (Windsurf)"
+  [[ -f ".clinerules" ]] && echo "    • .clinerules                 (Cline)"
+  [[ -f ".roomodes" ]] && echo "    • .roomodes                   (Roo Code)"
+  [[ -f ".aider.conf.yml" ]] && echo "    • .aider.conf.yml             (Aider)"
+  [[ -f "AGENTS.md" ]] && echo "    • AGENTS.md                   (Codex/Mimo/Kimi)"
+  [[ -f "llms.txt" ]] && echo "    • llms.txt                    (universal)"
+fi
+
+echo ""
+echo "  Ora puoi dire alla tua AI:"
+echo -e "  ${BOLD}\"Usa Anomalia MCP (o la CLI) per elencare i brand\"${NC}"
+echo ""
+echo "  Cursor Agent Skill: skills/anomalia/SKILL.md"
+echo "  Directory install:  npx skills add andreabuttarelli/anomalia-cli --skill anomalia"
+echo "  Docs MCP: https://github.com/andreabuttarelli/anomalia-cli/blob/main/docs/mcp.md"
+echo ""

--- a/cli/scripts/install.sh
+++ b/cli/scripts/install.sh
@@ -1,0 +1,252 @@
+#!/bin/bash
+#
+# Anomalia CLI Installer
+#
+# Usage:
+#   curl -sSL https://raw.githubusercontent.com/andreabuttarelli/anomalia-cli/main/scripts/install.sh | bash              # Install
+#   curl -sSL https://raw.githubusercontent.com/andreabuttarelli/anomalia-cli/main/scripts/install.sh | bash -s -- --update  # Update
+#
+# Options:
+#   --version <ver>   Install a specific version (default: latest)
+#   --dir <path>      Install directory (default: /usr/local/bin)
+#   --no-sudo         Skip sudo prompt (install to ~/.local/bin)
+#   --update          Update existing installation
+#
+
+set -euo pipefail
+
+# ── Configuration ──────────────────────────────────────────────────────
+
+REPO="andreabuttarelli/anomalia-cli"  # GitHub org/repo
+BINARY_NAME="anomalia"
+DEFAULT_DIR="/usr/local/bin"
+FALLBACK_DIR="$HOME/.local/bin"
+VERSION="latest"
+
+# ── Colors ─────────────────────────────────────────────────────────────
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+# ── Helpers ────────────────────────────────────────────────────────────
+
+info()    { echo -e "${BLUE}ℹ${NC} $1"; }
+success() { echo -e "${GREEN}✓${NC} $1"; }
+warn()    { echo -e "${YELLOW}⚠${NC} $1"; }
+error()   { echo -e "${RED}✗${NC} $1" >&2; }
+fatal()   { error "$1"; exit 1; }
+
+# ── Detect platform ───────────────────────────────────────────────────
+
+detect_platform() {
+  local os arch
+
+  case "$(uname -s)" in
+    Darwin*)  os="macos" ;;
+    Linux*)   os="linux" ;;
+    *)        fatal "Unsupported OS: $(uname -s). Only macOS and Linux are supported." ;;
+  esac
+
+  case "$(uname -m)" in
+    x86_64|amd64)  arch="x64" ;;
+    arm64|aarch64) arch="arm64" ;;
+    *)             fatal "Unsupported architecture: $(uname -m)" ;;
+  esac
+
+  echo "${os}-${arch}"
+}
+
+# ── Parse args ─────────────────────────────────────────────────────────
+
+INSTALL_DIR=""
+NO_SUDO=false
+UPDATE=false
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --version)  VERSION="$2"; shift 2 ;;
+    --dir)      INSTALL_DIR="$2"; shift 2 ;;
+    --no-sudo)  NO_SUDO=true; shift ;;
+    --update)   UPDATE=true; shift ;;
+    -h|--help)
+      echo "Usage: curl -sSL https://raw.githubusercontent.com/andreabuttarelli/anomalia-cli/main/scripts/install.sh | bash"
+      echo ""
+      echo "Options:"
+      echo "  --version <ver>   Install a specific version"
+      echo "  --dir <path>      Install directory (default: /usr/local/bin)"
+      echo "  --no-sudo         Install to ~/.local/bin (no sudo needed)"
+      echo "  --update          Update existing installation"
+      exit 0
+      ;;
+    *)  warn "Unknown option: $1"; shift ;;
+  esac
+done
+
+# ── Main ───────────────────────────────────────────────────────────────
+
+echo ""
+echo -e "${BOLD}Anomalia CLI Installer${NC}"
+echo ""
+
+# Detect platform
+PLATFORM="$(detect_platform)"
+info "Platform: ${PLATFORM}"
+
+# Update mode — find existing installation
+if [[ "$UPDATE" == true ]]; then
+  EXISTING="$(which anomalia 2>/dev/null || true)"
+  if [[ -n "$EXISTING" ]]; then
+    INSTALL_DIR="$(dirname "$EXISTING")"
+    CURRENT_VERSION="$($EXISTING --version 2>/dev/null || echo 'unknown')"
+    info "Found existing installation: $EXISTING (v${CURRENT_VERSION})"
+    info "Updating in $INSTALL_DIR..."
+  else
+    warn "anomalia not found in PATH. Installing fresh."
+    UPDATE=false
+  fi
+fi
+
+# Determine install dir
+if [[ -z "$INSTALL_DIR" ]]; then
+  if [[ "$NO_SUDO" == true ]]; then
+    INSTALL_DIR="$FALLBACK_DIR"
+  else
+    INSTALL_DIR="$DEFAULT_DIR"
+  fi
+fi
+
+# Check if directory is writable
+if [[ ! -d "$INSTALL_DIR" ]]; then
+  info "Creating $INSTALL_DIR..."
+  mkdir -p "$INSTALL_DIR" 2>/dev/null || {
+    warn "Cannot create $INSTALL_DIR. Falling back to $FALLBACK_DIR"
+    INSTALL_DIR="$FALLBACK_DIR"
+    mkdir -p "$INSTALL_DIR"
+  }
+fi
+
+# Check write permission
+if [[ ! -w "$INSTALL_DIR" ]]; then
+  warn "Need sudo to write to $INSTALL_DIR"
+  SUDO="sudo"
+else
+  SUDO=""
+fi
+
+# Determine download URL
+if [[ "$VERSION" == "latest" ]]; then
+  DOWNLOAD_URL="https://github.com/${REPO}/releases/latest/download/anomalia-${PLATFORM}"
+else
+  DOWNLOAD_URL="https://github.com/${REPO}/releases/download/v${VERSION}/anomalia-${PLATFORM}"
+fi
+
+info "Downloading Anomalia CLI..."
+info "URL: ${DOWNLOAD_URL}"
+
+# Download
+TEMP_FILE="$(mktemp)"
+if command -v curl &> /dev/null; then
+  curl -sSL -o "$TEMP_FILE" "$DOWNLOAD_URL" || fatal "Download failed"
+elif command -v wget &> /dev/null; then
+  wget -qO "$TEMP_FILE" "$DOWNLOAD_URL" || fatal "Download failed"
+else
+  fatal "Neither curl nor wget found. Please install one."
+fi
+
+# Verify download
+FILE_SIZE="$(wc -c < "$TEMP_FILE" | tr -d ' ')"
+if [[ "$FILE_SIZE" -lt 1000 ]]; then
+  error "Downloaded file is too small ($FILE_SIZE bytes). Release may not exist for $PLATFORM."
+  cat "$TEMP_FILE"
+  rm -f "$TEMP_FILE"
+  fatal "Download verification failed"
+fi
+
+# Make executable
+chmod +x "$TEMP_FILE"
+
+# Install
+info "Installing to ${INSTALL_DIR}/${BINARY_NAME}..."
+$SUDO mv "$TEMP_FILE" "${INSTALL_DIR}/${BINARY_NAME}" || fatal "Installation failed"
+
+success "Anomalia CLI installed to ${INSTALL_DIR}/${BINARY_NAME}"
+
+# Install AI skill (ask user)
+echo ""
+read -p "  Installare la skill per AI coding assistants? [Y/n]: " install_skill
+if [[ "$install_skill" != "n" && "$install_skill" != "N" ]]; then
+  echo ""
+  echo "  1) Progetto corrente (.claude/skills/, .cursorrules, etc.)"
+  echo "  2) Globale (~/.claude/skills/)"
+  read -p "  Scelta [1/2]: " skill_choice
+  echo ""
+
+  SKILL_URL="https://raw.githubusercontent.com/andreabuttarelli/anomalia-cli/main/skills/anomalia-cli.md"
+
+  if [[ "$skill_choice" == "2" ]]; then
+    # Global install
+    CLAUDE_SKILLS_DIR="$HOME/.claude/skills"
+    mkdir -p "$CLAUDE_SKILLS_DIR"
+    curl -sSL "$SKILL_URL" -o "$CLAUDE_SKILLS_DIR/anomalia-cli.md" 2>/dev/null && \
+      success "Skill installata globalmente → $CLAUDE_SKILLS_DIR/anomalia-cli.md" || \
+      warn "Could not install skill (non-critical)"
+  else
+    # Project install
+    mkdir -p ".claude/skills"
+    curl -sSL "$SKILL_URL" -o ".claude/skills/anomalia-cli.md" 2>/dev/null && \
+      success "Skill installata nel progetto → .claude/skills/anomalia-cli.md" || \
+      warn "Could not install skill (non-critical)"
+
+    # Also install for Cursor if .cursor exists
+    if [[ -d ".cursor" ]] || command -v cursor &> /dev/null; then
+      curl -sSL "$SKILL_URL" -o ".cursorrules" 2>/dev/null && \
+        success "Cursor rules installato → .cursorrules" || true
+    fi
+
+    # Also install llms.txt
+    curl -sSL "https://raw.githubusercontent.com/andreabuttarelli/anomalia-cli/main/llms.txt" -o "llms.txt" 2>/dev/null && \
+      success "llms.txt installato" || true
+  fi
+fi
+
+# Check if in PATH
+if [[ ":$PATH:" != *":$INSTALL_DIR:"* ]]; then
+  warn "${INSTALL_DIR} is not in your PATH"
+  echo ""
+  echo "  Add it to your shell profile:"
+  echo ""
+  if [[ "$SHELL" == */zsh ]]; then
+    echo "    echo 'export PATH=\"${INSTALL_DIR}:\$PATH\"' >> ~/.zshrc"
+    echo "    source ~/.zshrc"
+  elif [[ "$SHELL" == */bash ]]; then
+    echo "    echo 'export PATH=\"${INSTALL_DIR}:\$PATH\"' >> ~/.bashrc"
+    echo "    source ~/.bashrc"
+  else
+    echo "    export PATH=\"${INSTALL_DIR}:\$PATH\""
+  fi
+  echo ""
+fi
+
+# Verify installation
+echo ""
+if command -v anomalia &> /dev/null; then
+  NEW_VERSION="$(anomalia --version 2>/dev/null || echo 'unknown')"
+  if [[ "$UPDATE" == true ]]; then
+    success "Anomalia CLI updated! (v${CURRENT_VERSION} → v${NEW_VERSION})"
+  else
+    success "Anomalia CLI installed! (v${NEW_VERSION})"
+  fi
+  echo ""
+  echo "  Run 'anomalia --help' to get started"
+  echo "  Run 'anomalia update' to update to the latest version"
+else
+  info "Installation complete! You may need to restart your terminal."
+  echo ""
+  echo "  Run '${INSTALL_DIR}/anomalia --help' to get started"
+fi
+
+echo ""

--- a/cli/scripts/install.sh
+++ b/cli/scripts/install.sh
@@ -3,8 +3,8 @@
 # Anomalia CLI Installer
 #
 # Usage:
-#   curl -sSL https://raw.githubusercontent.com/andreabuttarelli/anomalia-cli/main/scripts/install.sh | bash              # Install
-#   curl -sSL https://raw.githubusercontent.com/andreabuttarelli/anomalia-cli/main/scripts/install.sh | bash -s -- --update  # Update
+#   curl -sSL https://raw.githubusercontent.com/anomaliaso/anomalia/main/cli/scripts/install.sh | bash              # Install
+#   curl -sSL https://raw.githubusercontent.com/anomaliaso/anomalia/main/cli/scripts/install.sh | bash -s -- --update  # Update
 #
 # Options:
 #   --version <ver>   Install a specific version (default: latest)
@@ -17,7 +17,7 @@ set -euo pipefail
 
 # ── Configuration ──────────────────────────────────────────────────────
 
-REPO="andreabuttarelli/anomalia-cli"  # GitHub org/repo
+REPO="anomaliaso/anomalia"  # GitHub org/repo
 BINARY_NAME="anomalia"
 DEFAULT_DIR="/usr/local/bin"
 FALLBACK_DIR="$HOME/.local/bin"
@@ -73,7 +73,7 @@ while [[ $# -gt 0 ]]; do
     --no-sudo)  NO_SUDO=true; shift ;;
     --update)   UPDATE=true; shift ;;
     -h|--help)
-      echo "Usage: curl -sSL https://raw.githubusercontent.com/andreabuttarelli/anomalia-cli/main/scripts/install.sh | bash"
+      echo "Usage: curl -sSL https://raw.githubusercontent.com/anomaliaso/anomalia/main/cli/scripts/install.sh | bash"
       echo ""
       echo "Options:"
       echo "  --version <ver>   Install a specific version"
@@ -185,7 +185,7 @@ if [[ "$install_skill" != "n" && "$install_skill" != "N" ]]; then
   read -p "  Scelta [1/2]: " skill_choice
   echo ""
 
-  SKILL_URL="https://raw.githubusercontent.com/andreabuttarelli/anomalia-cli/main/skills/anomalia-cli.md"
+  SKILL_URL="https://raw.githubusercontent.com/anomaliaso/anomalia/main/cli/skills/anomalia-cli.md"
 
   if [[ "$skill_choice" == "2" ]]; then
     # Global install
@@ -208,7 +208,7 @@ if [[ "$install_skill" != "n" && "$install_skill" != "N" ]]; then
     fi
 
     # Also install llms.txt
-    curl -sSL "https://raw.githubusercontent.com/andreabuttarelli/anomalia-cli/main/llms.txt" -o "llms.txt" 2>/dev/null && \
+    curl -sSL "https://raw.githubusercontent.com/anomaliaso/anomalia/main/cli/llms.txt" -o "llms.txt" 2>/dev/null && \
       success "llms.txt installato" || true
   fi
 fi

--- a/cli/scripts/sync-plugin-skill.sh
+++ b/cli/scripts/sync-plugin-skill.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Keep plugins/anomalia/skills/anomalia in sync with the canonical skills/anomalia tree
+# (npx skills / skills.sh). Run after editing the skill.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SRC="$ROOT/skills/anomalia"
+DST="$ROOT/plugins/anomalia/skills/anomalia"
+if [[ ! -f "$SRC/SKILL.md" ]]; then
+  echo "Missing canonical skill at $SRC/SKILL.md" >&2
+  exit 1
+fi
+mkdir -p "$(dirname "$DST")"
+rm -rf "$DST"
+cp -a "$SRC" "$DST"
+echo "Synced $SRC → $DST"

--- a/cli/scripts/update-homebrew-formula.sh
+++ b/cli/scripts/update-homebrew-formula.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Fill Formula/anomalia.rb version + sha256 from dist/*.tar.gz (run after packaging).
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DIST="$ROOT/dist"
+FORMULA="$ROOT/Formula/anomalia.rb"
+
+VERSION="${1:-}"
+if [[ -z "$VERSION" ]]; then
+  VERSION="$(node -p "require('$ROOT/package.json').version")"
+fi
+VERSION="${VERSION#v}"
+
+sha() {
+  local f="$1"
+  if command -v sha256sum >/dev/null; then
+    sha256sum "$f" | awk '{print $1}'
+  else
+    shasum -a 256 "$f" | awk '{print $1}'
+  fi
+}
+
+need() {
+  [[ -f "$1" ]] || { echo "Missing $1 — run release packaging first" >&2; exit 1; }
+}
+
+need "$DIST/anomalia-macos-arm64.tar.gz"
+need "$DIST/anomalia-macos-x64.tar.gz"
+need "$DIST/anomalia-linux-arm64.tar.gz"
+need "$DIST/anomalia-linux-x64.tar.gz"
+
+export FORMULA VERSION
+export MAC_ARM="$(sha "$DIST/anomalia-macos-arm64.tar.gz")"
+export MAC_X64="$(sha "$DIST/anomalia-macos-x64.tar.gz")"
+export LIN_ARM="$(sha "$DIST/anomalia-linux-arm64.tar.gz")"
+export LIN_X64="$(sha "$DIST/anomalia-linux-x64.tar.gz")"
+
+python3 - <<'PY'
+import os
+from pathlib import Path
+
+path = Path(os.environ["FORMULA"])
+text = path.read_text()
+replacements = {
+    "REPLACE_SHA256_MACOS_ARM64": os.environ["MAC_ARM"],
+    "REPLACE_SHA256_MACOS_X64": os.environ["MAC_X64"],
+    "REPLACE_SHA256_LINUX_ARM64": os.environ["LIN_ARM"],
+    "REPLACE_SHA256_LINUX_X64": os.environ["LIN_X64"],
+}
+# Also rewrite previous release hashes when re-running on an already-filled formula:
+# match each on_* block's sha256 line by regenerating from the template tokens if present,
+# otherwise replace by platform URL order.
+import re
+version = os.environ["VERSION"]
+text = re.sub(r'version "[^"]+"', f'version "{version}"', text, count=1)
+
+for token, digest in replacements.items():
+    text = text.replace(token, digest)
+
+# If tokens were already replaced in a prior release, bump sha256 next to each platform URL.
+platform_digests = [
+    ("anomalia-macos-arm64.tar.gz", os.environ["MAC_ARM"]),
+    ("anomalia-macos-x64.tar.gz", os.environ["MAC_X64"]),
+    ("anomalia-linux-arm64.tar.gz", os.environ["LIN_ARM"]),
+    ("anomalia-linux-x64.tar.gz", os.environ["LIN_X64"]),
+]
+for artifact, digest in platform_digests:
+    text = re.sub(
+        rf'(url "[^"]*{re.escape(artifact)}"\n\s*sha256 ")[a-f0-9]{{64}}(")',
+        rf"\g<1>{digest}\2",
+        text,
+    )
+    # Keep version interpolation in URLs: .../download/v#{version}/artifact
+    text = re.sub(
+        rf'(releases/download/)v[^/]+(/{re.escape(artifact)}")',
+        rf"\g<1>v#{{version}}\2",
+        text,
+    )
+
+path.write_text(text)
+print(f"Updated {path} → v{version}")
+for artifact, digest in platform_digests:
+    print(f"  {artifact}: {digest}")
+PY

--- a/cli/skills/COMPATIBILITY.md
+++ b/cli/skills/COMPATIBILITY.md
@@ -1,0 +1,56 @@
+# AI Coding Tools — skill compatibility
+
+## Publishable Agent Skill (recommended)
+
+Package: [`skills/anomalia/`](./anomalia/) — follows [agentskills.io](https://agentskills.io/specification).  
+Canonical for `npx skills` / skills.sh. The Claude/Codex plugin mirrors the same tree at [`plugins/anomalia/skills/anomalia/`](../plugins/anomalia/skills/anomalia/) — run `bash scripts/sync-plugin-skill.sh` after skill edits.
+
+```bash
+npx skills add andreabuttarelli/anomalia-cli --skill anomalia
+npx skills add andreabuttarelli/anomalia-cli --skill anomalia -g   # global
+```
+
+Appears on directories that index public GitHub skills (e.g. skills.sh) via install telemetry — no separate submission.
+
+| File | Role |
+|------|------|
+| `anomalia/SKILL.md` | Frontmatter + short instructions |
+| `anomalia/references/mcp.md` | MCP connect / auth |
+| `anomalia/references/tools.md` | Tool ↔ CLI map |
+| `anomalia/references/cli.md` | CLI install + commands |
+
+## Claude Code & Codex plugins (marketplace submit)
+
+Installable plugin: [`plugins/anomalia/`](../plugins/anomalia/) (skill + remote MCP).  
+Full submit checklist: [`docs/plugins.md`](../docs/plugins.md).
+
+```bash
+# Claude Code — add this repo as a marketplace, then install
+/plugin marketplace add andreabuttarelli/anomalia-cli
+/plugin install anomalia@anomalia
+
+# Codex — add marketplace from the repo
+codex plugin marketplace add andreabuttarelli/anomalia-cli
+```
+
+Public directory submit forms:
+
+- Claude: [platform.claude.com/plugins/submit](https://platform.claude.com/plugins/submit)
+- Codex / ChatGPT: [plugin submission portal](https://developers.openai.com/plugins/deploy/submission)
+
+## Legacy / multi-tool installer
+
+[`anomalia-cli.md`](./anomalia-cli.md) + `bash scripts/install-skill.sh` still copies into Claude, `.cursorrules`, `AGENTS.md`, etc.
+
+| Tool | File | Location |
+|------|------|----------|
+| **Cursor Agent Skills** | `SKILL.md` | `.cursor/skills/anomalia/` |
+| **Claude Code** | `anomalia-cli.md` or skill dir | `.claude/skills/` |
+| **Cursor rules** | `.cursorrules` | Project root |
+| **GitHub Copilot** | `copilot-instructions.md` | `.github/` |
+| **AGENTS.md / llms.txt** | project docs | Root |
+
+```bash
+bash scripts/install-skill.sh --project
+bash scripts/install-skill.sh --global
+```

--- a/cli/skills/COMPATIBILITY.md
+++ b/cli/skills/COMPATIBILITY.md
@@ -6,8 +6,8 @@ Package: [`skills/anomalia/`](./anomalia/) — follows [agentskills.io](https://
 Canonical for `npx skills` / skills.sh. The Claude/Codex plugin mirrors the same tree at [`plugins/anomalia/skills/anomalia/`](../plugins/anomalia/skills/anomalia/) — run `bash scripts/sync-plugin-skill.sh` after skill edits.
 
 ```bash
-npx skills add andreabuttarelli/anomalia-cli --skill anomalia
-npx skills add andreabuttarelli/anomalia-cli --skill anomalia -g   # global
+npx skills add anomaliaso/anomalia --skill anomalia
+npx skills add anomaliaso/anomalia --skill anomalia -g   # global
 ```
 
 Appears on directories that index public GitHub skills (e.g. skills.sh) via install telemetry — no separate submission.
@@ -26,11 +26,11 @@ Full submit checklist: [`docs/plugins.md`](../docs/plugins.md).
 
 ```bash
 # Claude Code — add this repo as a marketplace, then install
-/plugin marketplace add andreabuttarelli/anomalia-cli
+/plugin marketplace add anomaliaso/anomalia
 /plugin install anomalia@anomalia
 
 # Codex — add marketplace from the repo
-codex plugin marketplace add andreabuttarelli/anomalia-cli
+codex plugin marketplace add anomaliaso/anomalia
 ```
 
 Public directory submit forms:

--- a/cli/skills/anomalia-cli.md
+++ b/cli/skills/anomalia-cli.md
@@ -1,0 +1,52 @@
+# Anomalia Skill (MCP + CLI)
+
+Flat copy for Claude Code / multi-tool installers.  
+**Canonical publishable skill:** [`anomalia/SKILL.md`](./anomalia/SKILL.md) (Agent Skills / skills.sh).
+
+```bash
+npx skills add andreabuttarelli/anomalia-cli --skill anomalia
+bash scripts/install-skill.sh --project
+```
+
+Prefer **MCP tools** when connected; otherwise the **`anomalia` CLI**. OAuth only — no static tokens.
+Details: [anomalia/references/mcp.md](./anomalia/references/mcp.md) · [tools.md](./anomalia/references/tools.md) · [cli.md](./anomalia/references/cli.md).
+
+## Auth
+
+- Local: MCP `login` or `anomalia login` → `~/.config/anomalia/session.json`
+- Remote MCP (`https://mcp.anomalia.so/mcp`): `Authorization: Bearer <access_token>`
+- Start with `list_brands` / `anomalia brands`
+
+## Cursor MCP (stdio)
+
+```json
+{
+  "mcpServers": {
+    "anomalia": {
+      "command": "bun",
+      "args": ["run", "/ABS/PATH/to/anomalia-cli/mcp/stdio.ts"]
+    }
+  }
+}
+```
+
+## Cursor MCP (HTTP)
+
+```json
+{
+  "mcpServers": {
+    "anomalia": { "url": "https://mcp.anomalia.so/mcp" }
+  }
+}
+```
+
+## CLI fallback
+
+```bash
+curl -sSL https://raw.githubusercontent.com/andreabuttarelli/anomalia-cli/main/scripts/install.sh | bash
+anomalia login
+anomalia brands
+anomalia content <slug> --status pending_user
+anomalia approve <slug> --all
+anomalia ai <slug> --message "..." --pipe
+```

--- a/cli/skills/anomalia-cli.md
+++ b/cli/skills/anomalia-cli.md
@@ -4,7 +4,7 @@ Flat copy for Claude Code / multi-tool installers.
 **Canonical publishable skill:** [`anomalia/SKILL.md`](./anomalia/SKILL.md) (Agent Skills / skills.sh).
 
 ```bash
-npx skills add andreabuttarelli/anomalia-cli --skill anomalia
+npx skills add anomaliaso/anomalia --skill anomalia
 bash scripts/install-skill.sh --project
 ```
 
@@ -43,7 +43,7 @@ Details: [anomalia/references/mcp.md](./anomalia/references/mcp.md) · [tools.md
 ## CLI fallback
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/andreabuttarelli/anomalia-cli/main/scripts/install.sh | bash
+curl -sSL https://raw.githubusercontent.com/anomaliaso/anomalia/main/cli/scripts/install.sh | bash
 anomalia login
 anomalia brands
 anomalia content <slug> --status pending_user

--- a/cli/skills/anomalia/SKILL.md
+++ b/cli/skills/anomalia/SKILL.md
@@ -13,7 +13,7 @@ metadata:
   author: andreabuttarelli
   version: "1.0.0"
   homepage: https://anomalia.so
-  repository: https://github.com/andreabuttarelli/anomalia-cli
+  repository: https://github.com/anomaliaso/anomalia
   mcp: https://mcp.anomalia.so/mcp
 ---
 
@@ -65,18 +65,18 @@ Setup details: [references/mcp.md](references/mcp.md).
 ## Install this skill
 
 ```bash
-npx skills add andreabuttarelli/anomalia-cli --skill anomalia
+npx skills add anomaliaso/anomalia --skill anomalia
 ```
 
 Or install the marketplace plugin (skill + remote MCP):
 
 ```bash
 # Claude Code
-/plugin marketplace add andreabuttarelli/anomalia-cli
+/plugin marketplace add anomaliaso/anomalia
 /plugin install anomalia@anomalia
 
 # Codex
-codex plugin marketplace add andreabuttarelli/anomalia-cli
+codex plugin marketplace add anomaliaso/anomalia
 ```
 
 Or copy this folder into `.cursor/skills/anomalia/` / `~/.claude/skills/anomalia/`.  

--- a/cli/skills/anomalia/SKILL.md
+++ b/cli/skills/anomalia/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: anomalia
+description: >-
+  Operate Anomalia (social media AI autopilot) via MCP tools or the anomalia CLI:
+  brands, posts, plans, studio, SEO/GEO, blog, and AI chat. Use when the user
+  mentions Anomalia, anomalia.so, approving social posts, editorial plans,
+  SEO/GEO audits, or managing brand content from an agent.
+license: AGPL-3.0-or-later
+compatibility: >-
+  Requires network access to anomalia.so (or PUBLIC_APP_URL). Prefer Anomalia MCP
+  when connected; otherwise the anomalia CLI (Bun or installed binary) after OAuth login.
+metadata:
+  author: andreabuttarelli
+  version: "1.0.0"
+  homepage: https://anomalia.so
+  repository: https://github.com/andreabuttarelli/anomalia-cli
+  mcp: https://mcp.anomalia.so/mcp
+---
+
+# Anomalia
+
+Drive [Anomalia](https://anomalia.so) — social media AI autopilot — through **MCP tools**
+(preferred) or the **`anomalia` CLI**. Same OAuth identity. **No static API tokens.**
+
+## Choose interface
+
+| Situation | Action |
+|-----------|--------|
+| Anomalia MCP is connected | Call MCP tools (`list_brands`, `list_posts`, …) |
+| MCP not available | Shell: `anomalia …` after `anomalia login` |
+| Vague / multi-step ask | MCP `chat` or `anomalia ai <slug> --message "…" --pipe` |
+
+Never invent REST endpoints or API keys.
+
+## Auth (always OAuth)
+
+1. **Local MCP / CLI:** shared session at `~/.config/anomalia/session.json`. MCP tool `login` opens the browser, or run `anomalia login`.
+2. **Remote MCP** (`https://mcp.anomalia.so/mcp`): send `Authorization: Bearer <access_token>` (same JWT the CLI stores). Missing Bearer → 401.
+3. Verify with `whoami` / `list_brands` or `anomalia brands`.
+
+Setup details: [references/mcp.md](references/mcp.md).
+
+## Operating rules
+
+1. Start with `list_brands` (or `anomalia brands`) to learn **slugs**.
+2. Pass `slug` on every brand-scoped call.
+3. Post/article ids accept **short unambiguous prefixes** from list output — never guess if ambiguous.
+4. Prefer specific tools (`approve_posts`, `edit_post`, …) over `chat` for precise edits.
+5. Confirm before reject / delete / discard unless the user clearly asked.
+
+## Quick workflows
+
+**Approve pending posts** → `list_posts` (status pending) → optional `get_post` → `approve_posts`.
+
+**Fix one carousel slide** → `get_post` → `regenerate_slide` (`index`, instruction; 0 = cover).
+
+**Blog draft** → `generate_article` → optional `optimize_article` → `publish_article` when asked.
+
+## References (load on demand)
+
+- [references/mcp.md](references/mcp.md) — connect MCP (stdio / HTTP), Cursor config, auth
+- [references/tools.md](references/tools.md) — full MCP tool catalog + CLI equivalents
+- [references/cli.md](references/cli.md) — install CLI and common commands
+
+## Install this skill
+
+```bash
+npx skills add andreabuttarelli/anomalia-cli --skill anomalia
+```
+
+Or install the marketplace plugin (skill + remote MCP):
+
+```bash
+# Claude Code
+/plugin marketplace add andreabuttarelli/anomalia-cli
+/plugin install anomalia@anomalia
+
+# Codex
+codex plugin marketplace add andreabuttarelli/anomalia-cli
+```
+
+Or copy this folder into `.cursor/skills/anomalia/` / `~/.claude/skills/anomalia/`.  
+Submit / packaging details: [`docs/plugins.md`](../../../../docs/plugins.md).

--- a/cli/skills/anomalia/references/cli.md
+++ b/cli/skills/anomalia/references/cli.md
@@ -1,0 +1,42 @@
+# Anomalia CLI (fallback)
+
+Use when MCP is not connected. Same OAuth session as MCP (`~/.config/anomalia/session.json`).
+
+## Install
+
+```bash
+curl -sSL https://raw.githubusercontent.com/andreabuttarelli/anomalia-cli/main/scripts/install.sh | bash
+anomalia login
+```
+
+From source (Bun):
+
+```bash
+git clone https://github.com/andreabuttarelli/anomalia-cli.git
+cd anomalia-cli && bun install
+bun run cli.ts --help
+```
+
+## Common commands
+
+```bash
+anomalia brands
+anomalia dashboard <slug>
+anomalia content <slug> --status pending_user
+anomalia approve <slug> --all
+anomalia post <slug> <id> edit --caption "..."
+anomalia post <slug> <id> regenerate --instruction "..."
+anomalia post <slug> <id> slide --index 1 --instruction "..."
+anomalia post <slug> <id> approve|publish|reject
+anomalia plan <slug> propose
+anomalia weekly-plan <slug> plan --week 0
+anomalia weekly-plan <slug> produce --week 0
+anomalia studio <slug> add-note --text "..."
+anomalia seo <slug>
+anomalia geo <slug>
+anomalia web <slug> generate --topic "..."
+anomalia ai <slug> --message "..." --pipe
+```
+
+Full dump: repo root [`llms.txt`](https://github.com/andreabuttarelli/anomalia-cli/blob/main/llms.txt).
+Tool mapping: [tools.md](tools.md).

--- a/cli/skills/anomalia/references/cli.md
+++ b/cli/skills/anomalia/references/cli.md
@@ -5,14 +5,14 @@ Use when MCP is not connected. Same OAuth session as MCP (`~/.config/anomalia/se
 ## Install
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/andreabuttarelli/anomalia-cli/main/scripts/install.sh | bash
+curl -sSL https://raw.githubusercontent.com/anomaliaso/anomalia/main/cli/scripts/install.sh | bash
 anomalia login
 ```
 
 From source (Bun):
 
 ```bash
-git clone https://github.com/andreabuttarelli/anomalia-cli.git
+git clone https://github.com/anomaliaso/anomalia.git
 cd anomalia-cli && bun install
 bun run cli.ts --help
 ```
@@ -38,5 +38,5 @@ anomalia web <slug> generate --topic "..."
 anomalia ai <slug> --message "..." --pipe
 ```
 
-Full dump: repo root [`llms.txt`](https://github.com/andreabuttarelli/anomalia-cli/blob/main/llms.txt).
+Full dump: repo root [`llms.txt`](https://github.com/anomaliaso/anomalia/blob/main/cli/llms.txt).
 Tool mapping: [tools.md](tools.md).

--- a/cli/skills/anomalia/references/mcp.md
+++ b/cli/skills/anomalia/references/mcp.md
@@ -1,0 +1,120 @@
+# Anomalia MCP — setup & usage
+
+Model Context Protocol server for Anomalia. Same HTTPS client and OAuth as the CLI.
+**No static API tokens.**
+
+```
+Host (Cursor / Claude / …)
+  ├─ stdio  → bun run mcp / anomalia-mcp
+  └─ HTTPS  → https://mcp.anomalia.so/mcp  (+ Bearer on remote)
+         └─ Anomalia API /api/v1/*
+```
+
+## 1. Pick a transport
+
+| Mode | When | Endpoint / command | Auth |
+|------|------|--------------------|------|
+| **stdio** | Local agent on your machine | `bun run mcp` or `anomalia-mcp` | `login` tool or existing `anomalia login` session |
+| **HTTP local** | Local Streamable HTTP | `bun run mcp:http` → `http://localhost:8787/mcp` | Bearer **or** session file |
+| **HTTP remote** | Shared / cloud host | `https://mcp.anomalia.so/mcp` | **Bearer required** |
+
+Health check (HTTP):
+
+```bash
+curl -sS https://mcp.anomalia.so/health
+# {"ok":true,"name":"anomalia-mcp","transport":"streamable-http","mcp":"/mcp"}
+```
+
+OAuth resource metadata: `GET /.well-known/oauth-protected-resource`.
+
+## 2. Configure the host
+
+### Cursor — stdio (recommended locally)
+
+Clone or install the repo, then in Cursor MCP settings:
+
+```json
+{
+  "mcpServers": {
+    "anomalia": {
+      "command": "bun",
+      "args": ["run", "/ABS/PATH/to/anomalia-cli/mcp/stdio.ts"]
+    }
+  }
+}
+```
+
+If the binary is on `PATH` after install:
+
+```json
+{
+  "mcpServers": {
+    "anomalia": { "command": "anomalia-mcp" }
+  }
+}
+```
+
+### Cursor — HTTP remote
+
+```json
+{
+  "mcpServers": {
+    "anomalia": {
+      "url": "https://mcp.anomalia.so/mcp"
+    }
+  }
+}
+```
+
+The host must send OAuth Bearer. If it cannot yet, use [mcp-remote](https://www.npmjs.com/package/mcp-remote) as a bridge, or prefer **stdio** locally.
+
+### From source (dev)
+
+```bash
+git clone https://github.com/andreabuttarelli/anomalia-cli.git
+cd anomalia-cli
+bun install
+bun run mcp          # stdio
+bun run mcp:http     # http://localhost:8787/mcp
+```
+
+## 3. Authenticate
+
+**Local (stdio / local HTTP)**
+
+1. Call MCP tool `login` (opens browser), **or** run `anomalia login` in a terminal.
+2. Session is stored at `~/.config/anomalia/session.json` and shared with the CLI.
+3. `whoami` / `list_brands` to confirm.
+
+**Remote HTTP**
+
+1. Obtain a Supabase access token via Anomalia OAuth (same token inside `session.json` after CLI login: field used as Bearer).
+2. Send on every request: `Authorization: Bearer <access_token>`.
+3. Without it you get JSON-RPC **401** — that is expected, not a server crash.
+
+There is **no** `ANOMALIA_TOKEN` / API-key path by design.
+
+## 4. First calls
+
+1. `list_brands` — learn brand **slugs**.
+2. `get_dashboard` with `slug` — overview.
+3. `list_posts` with `slug` and status `pending_user` — approval queue.
+4. Use specific tools for edits; use `chat` only for open-ended multi-step work.
+
+Ids from list tools accept short unambiguous prefixes (same rule as the CLI).
+
+## 5. Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| 401 on `/mcp` | Missing/invalid Bearer on remote | Login locally and pass access token, or use stdio |
+| 404 on `/health` | Wrong deploy root / path | Expect `/health` and `/mcp` on the MCP host |
+| Tools missing | MCP not connected in host | Check Cursor MCP panel; restart host |
+| Auth works in CLI but not MCP | Different machine / no session file | Run `login` in the MCP process environment |
+| `Not an https or loopback URI: cursor://anysphere.cursor-mcp/oauth/callback` | Cursor DCR uses a custom-scheme callback; Anomalia OAuth only allows https/loopback | Use **stdio** MCP, update Cursor (localhost `:8787` callback), or pass Bearer; see [docs/mcp.md](../../../docs/mcp.md#cursor--remote-http-oauth) |
+
+## 6. More
+
+- Full tool list: [tools.md](tools.md)
+- CLI fallback: [cli.md](cli.md)
+- Product: https://anomalia.so · Repo: https://github.com/andreabuttarelli/anomalia-cli

--- a/cli/skills/anomalia/references/mcp.md
+++ b/cli/skills/anomalia/references/mcp.md
@@ -71,7 +71,7 @@ The host must send OAuth Bearer. If it cannot yet, use [mcp-remote](https://www.
 ### From source (dev)
 
 ```bash
-git clone https://github.com/andreabuttarelli/anomalia-cli.git
+git clone https://github.com/anomaliaso/anomalia.git
 cd anomalia-cli
 bun install
 bun run mcp          # stdio
@@ -117,4 +117,4 @@ Ids from list tools accept short unambiguous prefixes (same rule as the CLI).
 
 - Full tool list: [tools.md](tools.md)
 - CLI fallback: [cli.md](cli.md)
-- Product: https://anomalia.so · Repo: https://github.com/andreabuttarelli/anomalia-cli
+- Product: https://anomalia.so · Repo: https://github.com/anomaliaso/anomalia

--- a/cli/skills/anomalia/references/tools.md
+++ b/cli/skills/anomalia/references/tools.md
@@ -1,0 +1,68 @@
+# Anomalia MCP tools ↔ CLI
+
+All tools take a brand `slug` when brand-scoped. Ids accept short unambiguous prefixes.
+
+## Auth
+
+| MCP | CLI |
+|-----|-----|
+| `login` | `anomalia login` |
+| `logout` | `anomalia logout` |
+| `whoami` | (session file / brands imply identity) |
+| `list_brands` | `anomalia brands` |
+
+## Brand & posts
+
+| MCP | CLI |
+|-----|-----|
+| `get_dashboard` | `anomalia dashboard <slug>` |
+| `get_status` | `anomalia status <slug>` |
+| `get_analytics` | `anomalia analytics <slug>` |
+| `get_calendar` | `anomalia calendar <slug> [--month YYYY-MM]` |
+| `get_gtm` | `anomalia gtm <slug>` |
+| `get_voice` / `update_voice` | `anomalia voice <slug>` |
+| `list_products` | (studio / products views) |
+| `list_posts` | `anomalia content <slug> [--status …]` |
+| `approve_posts` | `anomalia approve <slug> --all` |
+| `get_post` | `anomalia post <slug> <id>` |
+| `edit_post` | `anomalia post <slug> <id> edit …` |
+| `approve_post` / `publish_post` / `reject_post` | `anomalia post <slug> <id> approve\|publish\|reject` |
+| `reschedule_post` | `anomalia post <slug> <id> reschedule --scheduledFor …` |
+| `render_post` | `anomalia post <slug> <id> render` |
+| `regenerate_post_media` | `anomalia post <slug> <id> regenerate --instruction "…"` |
+| `regenerate_slide` | `anomalia post <slug> <id> slide --index N --instruction "…"` |
+| `reorder_slides` | `anomalia post <slug> <id> reorder --order "0,2,1"` |
+| `make_video` | `anomalia post <slug> <id> video …` |
+
+## Plans
+
+| MCP | CLI |
+|-----|-----|
+| `get_plan` | `anomalia plan <slug>` |
+| `propose_plan` / `revise_plan` / `approve_plan` / `discard_plan` | `anomalia plan <slug> propose\|revise\|approve\|discard` |
+| `save_brief` / `replan_week` | `anomalia plan <slug> save-brief\|replan --week N …` |
+| `get_weekly_plan` | `anomalia weekly-plan <slug>` |
+| `plan_week` / `produce_week` | `anomalia weekly-plan <slug> plan\|produce --week N` |
+
+## Studio
+
+| MCP | CLI |
+|-----|-----|
+| `get_studio` | `anomalia studio <slug>` |
+| `update_brand_kit` / `set_colors` | `anomalia studio <slug> kit-update\|colors …` |
+| `add_note` / `delete_document` | `anomalia studio <slug> add-note\|delete-doc …` |
+| `add_person` / `generate_person` / `delete_person` | `anomalia studio <slug> people-*` |
+| `add_competitor` / `delete_competitor` / `research_competitors` | `anomalia studio <slug> add-competitor\|…\|research` |
+| `sync_history` | `anomalia studio <slug> sync-history` |
+
+## SEO / GEO / blog / ads / AI
+
+| MCP | CLI |
+|-----|-----|
+| `get_seo` / `seo_action` | `anomalia seo <slug> [run\|plan\|…]` |
+| `get_geo` / `geo_action` | `anomalia geo <slug> [run\|fix]` |
+| `get_keywords` / `refresh_keywords` | `anomalia keywords <slug> [refresh]` |
+| `list_articles` / `generate_article` / `optimize_article` | `anomalia web <slug> …` |
+| `publish_article` / `unpublish_article` / `delete_article` | `anomalia web <slug> publish\|…` |
+| `get_ads` / `ads_action` | `anomalia ads <slug> [--propose\|--create\|--approve\|--pause\|--resume\|--duplicate\|--delete\|--reject] [--ad <adId>]` |
+| `chat` | `anomalia ai <slug> --message "…" --pipe` |

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    // Source is run directly by Bun, which resolves the `.ts` specifiers we import with.
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "types": ["bun"]
+  },
+  "include": ["./**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/cli/vercel.json
+++ b/cli/vercel.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": null,
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "Access-Control-Allow-Origin", "value": "*" },
+        {
+          "key": "Access-Control-Allow-Headers",
+          "value": "Content-Type, Authorization, mcp-session-id, Last-Event-ID, mcp-protocol-version"
+        },
+        {
+          "key": "Access-Control-Expose-Headers",
+          "value": "mcp-session-id, mcp-protocol-version"
+        }
+      ]
+    }
+  ],
+  "functions": {
+    "api/mcp.js": {
+      "maxDuration": 60,
+      "memory": 1024,
+      "includeFiles": "api/_bundle.js"
+    },
+    "api/oauth-protected-resource.js": {
+      "maxDuration": 30,
+      "includeFiles": "api/_bundle.js"
+    },
+    "api/health.js": { "maxDuration": 10 }
+  },
+  "rewrites": [
+    { "source": "/mcp", "destination": "/api/mcp" },
+    { "source": "/health", "destination": "/api/health" },
+    {
+      "source": "/.well-known/oauth-protected-resource",
+      "destination": "/api/oauth-protected-resource"
+    },
+    { "source": "/", "destination": "/api/health" }
+  ]
+}

--- a/docs/api/01-overview.md
+++ b/docs/api/01-overview.md
@@ -101,4 +101,4 @@ Gli endpoint che spendono AI richiedono **piano a pagamento + crediti** e scope 
 - Gli endpoint **cron** (`/tick`, `/work`) protetti da `CRON_SECRET` non fanno parte della API pubblica
   e sono documentati nelle rispettive doc di feature.
 - `GET /api/v1/brands/:slug/strategy-lab` esiste ma è dev-only, senza auth — non documentato qui.
-- I comandi CLI che consumano questi endpoint sono in `CLAUDE.md` (repo anomalia-cli).
+- I comandi CLI che consumano questi endpoint sono in `cli/` (fonte unica di CLI, MCP e skill).

--- a/scripts/export-oss.mjs
+++ b/scripts/export-oss.mjs
@@ -22,6 +22,8 @@ export const EXCLUSION_RULES = [
   "docs/archive/",
   "scripts/eval/",
   "scripts/chat-live/",
+  // La CLI ha la sua distribuzione (releases, npm, Homebrew): l'export resta la build aperta dell'app.
+  "cli/",
   "src/lib/server/billing/anomalia-provider.ts",
   "src/lib/server/billing/anomalia-provider.test.ts",
   "src/lib/server/billing/index.test.ts",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -2,9 +2,9 @@
   "version": 1,
   "skills": {
     "anomalia": {
-      "source": "andreabuttarelli/anomalia-cli",
+      "source": "anomaliaso/anomalia",
       "sourceType": "github",
-      "skillPath": "skills/anomalia/SKILL.md",
+      "skillPath": "cli/skills/anomalia/SKILL.md",
       "computedHash": "344d850749e5dce157c886effa52e1d2691516d8ce3ee4f0d33bf38d6fd6edf6"
     },
     "composio": {

--- a/src/lib/content/changelog/2026-08-28-one-repo-for-everything-anomalia.ts
+++ b/src/lib/content/changelog/2026-08-28-one-repo-for-everything-anomalia.ts
@@ -1,0 +1,12 @@
+// Il formato lo definisce ./index.ts (PR changelog-entry-files): qui solo i dati.
+// Finché il loader non è merged il file è inerte — nessun conflitto in arrivo.
+const entry = {
+  date: 'August 28, 2026',
+  title: 'One repository for everything Anomalia',
+  items: [
+    'The CLI, the MCP server and the agent skills now live in this repository — releases, installs and updates all come from here.',
+    'Logging in from scripts and CI no longer needs a browser: `anomalia login --email … --password …` stores the same session the browser flow does, with `--password-stdin` to keep the password out of shell history.',
+  ],
+};
+
+export default entry;

--- a/src/routes/[[lang=locale]]/changelog/+page.svelte
+++ b/src/routes/[[lang=locale]]/changelog/+page.svelte
@@ -10,6 +10,7 @@
       title: 'One repository for everything Anomalia',
       items: [
         'The CLI, the MCP server and the agent skills now live in this repository — releases, installs and updates all come from here.',
+        'Logging in from scripts and CI no longer needs a browser: `anomalia login --email … --password …` stores the same session the browser flow does.',
       ],
     },
     {

--- a/src/routes/[[lang=locale]]/changelog/+page.svelte
+++ b/src/routes/[[lang=locale]]/changelog/+page.svelte
@@ -10,7 +10,7 @@
       title: 'One repository for everything Anomalia',
       items: [
         'The CLI, the MCP server and the agent skills now live in this repository — releases, installs and updates all come from here.',
-        'Logging in from scripts and CI no longer needs a browser: `anomalia login --email … --password …` stores the same session the browser flow does.',
+        'Logging in from scripts and CI no longer needs a browser: `anomalia login --email … --password …` stores the same session the browser flow does, with `--password-stdin` to keep the password out of shell history.',
       ],
     },
     {

--- a/src/routes/[[lang=locale]]/changelog/+page.svelte
+++ b/src/routes/[[lang=locale]]/changelog/+page.svelte
@@ -6,14 +6,6 @@
 
   const entries = [
     {
-      date: 'August 28, 2026',
-      title: 'One repository for everything Anomalia',
-      items: [
-        'The CLI, the MCP server and the agent skills now live in this repository — releases, installs and updates all come from here.',
-        'Logging in from scripts and CI no longer needs a browser: `anomalia login --email … --password …` stores the same session the browser flow does, with `--password-stdin` to keep the password out of shell history.',
-      ],
-    },
-    {
       date: 'August 27, 2026',
       title: 'Your project setup is a conversation with the Analyst',
       items: [

--- a/src/routes/[[lang=locale]]/changelog/+page.svelte
+++ b/src/routes/[[lang=locale]]/changelog/+page.svelte
@@ -6,6 +6,13 @@
 
   const entries = [
     {
+      date: 'August 28, 2026',
+      title: 'One repository for everything Anomalia',
+      items: [
+        'The CLI, the MCP server and the agent skills now live in this repository — releases, installs and updates all come from here.',
+      ],
+    },
+    {
       date: 'August 27, 2026',
       title: 'Your project setup is a conversation with the Analyst',
       items: [

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -166,9 +166,9 @@ Examples: https://anomalia.so/docs.md · https://anomalia.so/docs/api.md · http
 - [CLI Installation](https://anomalia.so/install.sh) — Install the Anomalia CLI: `curl -sSL https://anomalia.so/install.sh | bash`
 - [MCP](https://anomalia.so/docs/mcp) — Connect Cursor/Claude via Model Context Protocol (stdio or https://mcp.anomalia.so/mcp). OAuth only — no static API tokens.
 - [MCP (Italian)](https://anomalia.so/it/docs/mcp) — Collega Cursor/Claude via Model Context Protocol. Solo OAuth.
-- [Agent skill](https://anomalia.so/docs/agents) — Install the Anomalia skill (`npx skills add andreabuttarelli/anomalia-cli --skill anomalia`). Prefer MCP tools; fall back to the CLI.
+- [Agent skill](https://anomalia.so/docs/agents) — Install the Anomalia skill (`npx skills add anomaliaso/anomalia --skill anomalia`). Prefer MCP tools; fall back to the CLI.
 - [Agent skill (Italian)](https://anomalia.so/it/docs/agents) — Installa lo skill Anomalia. Preferisci MCP; fallback sulla CLI.
-- [anomalia-cli (GitHub)](https://github.com/andreabuttarelli/anomalia-cli) — CLI, MCP server, and publishable agent skill (AGPL-3.0).
+- [CLI + MCP source](https://github.com/anomaliaso/anomalia/tree/main/cli) — CLI, MCP server, and publishable agent skill (AGPL-3.0).
 
 ### Legal
 


### PR DESCRIPTION
## What?

The CLI, the MCP server and the agent skills now live in this repository, under `cli/`:

- **New `cli/`** — verbatim copy of `andreabuttarelli/anomalia-cli@0b3a79c` (AGPL-3.0): the Bun CLI (`cli.ts`, `commands/`, `lib/`), the MCP server (`mcp/`, stdio + HTTP + Vercel handlers), the publishable agent skills (`skills/`), the Claude/Codex plugins, the Homebrew formula, `install.sh`, `llms.txt`. History stays in the archived source repo; provenance is recorded in the move commit message.
- **Marketplace manifests** (`.claude-plugin/marketplace.json`, `.agents/plugins/marketplace.json`) move to the **repo root** with plugin `source` pointing at `./cli/plugins/anomalia`, so `/plugin marketplace add anomaliaso/anomalia` keeps resolving.
- **Release pipeline rewritten** (`.github/workflows/cli-release.yml`, triggered by `cli-v*` tags): 4 cross-compiled binaries + `.tar.gz` + SHA256SUMS → GitHub Release, Homebrew formula version/sha bump (committed back to `main`), optional push to `anomaliaso/homebrew-tap` when `TAP_TOKEN` is set, npm publish of `anomalia-cli` when `NPM_TOKEN` is set. Version sync from tag into `package.json` and `cli.ts`.
- **Every URL repointed** to `anomaliaso/anomalia`: `install.sh` (REPO var + raw URLs under `cli/`), `anomalia update` self-update endpoint, npm `repository`/`bugs`, Homebrew formula release URLs, skill docs, `llms.txt`, `static/llms.txt`, main README, CONTRIBUTING, `docs/api`, `skills-lock.json`, the repo-local dev skill.
- **New feature**: `anomalia login --email <e> --password <p>` and `--password-stdin` — non-interactive login for scripts/CI via Supabase `signInWithPassword`, storing the same session file the browser flow writes (silent refresh included). Flag pairs validated before anything reads stdin; the browser flow remains the default.
- `scripts/export-oss.mjs` excludes `cli/` (the CLI ships through its own channels, not the app export); both changelogs updated; local `CLAUDE.md` CLI section rewritten (untracked, not part of the diff).

## Why?

One repo, one release flow. The separate public repo forced two places to change on every CLI+API PR, kept two divergent copies of the same skill, and ran a second CI that had to be kept aligned by hand. The consolidation was already half-wired: this repo carried a `cli-release.yml` that expected a `cli/` directory and `cli-v*` tags that didn't exist yet. After this lands and the first `cli-v*` release runs from here, `andreabuttarelli/anomalia-cli` gets a final redirect commit and is archived.

## How?

- The move is a **verbatim copy** in its own commit; all adaptations (URLs, workflow, marketplaces, docs) come in a separate commit, so the reorder and the behavior change are reviewable independently. History was not rewritten into the monorepo (`git filter-repo`/subtree) — the old repo keeps it, and the move commit cites the exact source SHA.
- `cli/` stays a **Bun package with its own `bun.lock`**, deliberately outside the root npm workspaces: two toolchains, zero coupling; CI runs `bun install` scoped to `cli/`.
- Marketplace manifests live at the root because Claude Code/Codex discovery looks there, not in subdirectories.
- Password login uses the Supabase JS client the CLI already ships with; `--password-stdin` exists because argv leaks twice (shell history + `ps aux`). Both flags required together — no silent half-flag fallback that would open a browser from a script.
- The formula cannot be served from inside the monorepo (Homebrew taps must be their own repo), so `cli/Formula/anomalia.rb` stays the source of truth that CI pushes to a dedicated tap repo.

## Testing?

- `bun run typecheck` + `bun test` in `cli/` — 23/23 pass (after re-syncing the plugin skill mirror and updating the manifest test to the monorepo root).
- `npx vitest run scripts/export-oss.test.ts` — 21/21 (asserts the new `cli/` exclusion alongside existing rules).
- Workflow YAML parses (`js-yaml`); both marketplace manifests are valid JSON; version-sync step from the release workflow exercised locally on a scratch copy (tag → `package.json` + `cli.ts` rewritten).
- Built the `macos-arm64` binary and the npm package bundle from `cli/`; `--version`, `--help` respond.
- **Live against the local dev server** (`localhost:5173`, the architecture the app actually authenticates against): password login as the seeded user, `--password-stdin` login after `logout`, both guard errors (stdin without email, both flags together), `brands`, `status`, `dashboard` rendering real data, and a clean 404 on a slug owned by another user.

**Not tested, and why**: the full release pipeline end-to-end (needs `NPM_TOKEN` on this repo plus a real tag — first release will be the test), the Vercel MCP redeploy (dashboard-side change), `brew install` from the new tap (repo not created yet), and the e2e suite (no UI logic touched — the only `src/` change is a data entry in the public changelog page). Eval suite skipped for the same reason: no chat path, prompt or tool surface changes.

## Evidence (screenshots/videos)

No UI changes — evidence is CLI terminal output on the local architecture:

<details>
<summary>Login non-interattivo + sessione</summary>

```
$ echo 123456 | ./dist/anomalia-macos-arm64 login --email test@anomalia.so --password-stdin
✓ Autenticato come test@anomalia.so
```
</details>

<details>
<summary>brands / status / dashboard (dev server locale)</summary>

```
$ ./dist/anomalia-macos-arm64 brands
6 brand
│ Brand          │ Slug           │ Piano │ Status │ Pending │ Autopilot  │
│ Anomalia       │ anomalia-3     │ —     │ trial  │ 3       │ ○ manuale  │
│ Fornace Brera  │ eval-mt8fw0j8  │ pro   │ active │ 2       │ ○ manuale  │

$ ./dist/anomalia-macos-arm64 dashboard anomalia-3
Anomalia  (anomalia-3)
  Prodotti: 8   In approvazione: 3
  ● Ricerca ─ ● Strategia ─ ● Generazione ─ ◉ Pubblicazione ─ ○ Analisi
```
</details>

<details>
<summary>Guardie dei flag</summary>

```
$ anomalia login --password-stdin
  ✗ --password-stdin richiede --email
$ anomalia login --email x@y.z --password p --password-stdin
  ✗ Usa --password o --password-stdin, non entrambi
```
</details>

<details>
<summary>Verifiche di build</summary>

```
$ bun run typecheck && bun test   # cli/
  23 pass, 0 fail
$ npx vitest run scripts/export-oss.test.ts
  21 passed (21)
$ node scripts/export-oss.mjs --dry-run
tracked: 3038   excluded: 107   would copy: 2931   # cli/ fuori dall'export
```
</details>

## Anything Else?

Manual steps that can't live in a PR, in order:

1. Add `NPM_TOKEN` (granular, publish rights on `anomalia-cli`) as a repo secret.
2. On the Vercel MCP project (mcp.anomalia.so): switch the Git source to `anomaliaso/anomalia` with **Root Directory `cli/mcp`** (was `mcp` in the old repo). `cli/mcp/vercel.json` is already the live config.
3. Create `anomaliaso/homebrew-tap` (seed `Formula/anomalia.rb` from `cli/Formula/anomalia.rb`) and add `TAP_TOKEN`; until then Homebrew users should move to `install.sh`/npm — the old tap goes stale when the source repo is archived.
4. After the first `cli-v*` release from here: one last commit in `andreabuttarelli/anomalia-cli` pointing its `install.sh` at the new release assets, then archive.

Known leftovers: `skills-lock.json` `computedHash` is stale until the next `npx skills` sync (path is already correct); `npx skills add anomaliaso/anomalia --skill anomalia` recursive discovery of `cli/skills/` should be confirmed once at the next sync; the duplicate `cli/vercel.json` (root) vs `cli/mcp/vercel.json` (live) predates the move and can be dropped in a follow-up.
