### PR TITLE
Add humanizer and stop-slop skills to the chat agent

### DIFF
--- a/changelog/2026-08-28-brand-writing-skills.md
+++ b/changelog/2026-08-28-brand-writing-skills.md
@@ -1,0 +1,34 @@
+# Skill di scrittura di brand sempre nell'agente chat
+
+## Perché
+
+Il prodotto di Anomalia è testo che parla per un brand, e il testo che sa di
+chatbot è un difetto di qualità che i test non vedono (i modelli finto-agente
+non giudicano la prosa). Le valutazioni misurano fatti, non slop: serve una
+barra strutturale dentro il modello, non una regola di stile nel prompt.
+
+## Cosa
+
+Tre candidate valutate da skills.sh, vendorate in `src/lib/agent-docs/skills/`
+e cucite direttamente in `HarnessAgent` (`skills: []`) dentro `startHarnessTurn`:
+
+- **humanizer** (blader/humanizer, MIT, v2.11.2) — 28 pattern di AI-writing da
+  Wikipedia "Signs of AI writing", con procedura di rewrite che preserva i
+  claim. Modalità revisione.
+- **stop-slop** (hardikpandya/stop-slop, MIT) — regole di generazione:
+  struttura, ritmo, false agency, attivo. Modalità stesura. I riferimenti
+  (`phrases.md`, `structures.md`, `examples.md`) viaggiano come `files` della
+  skill, come da contratto `HarnessV1Skill`.
+- **understand-anything** (egonex-ai) — scartata: nove skill di comprensione
+  codice per agenti di coding, fuori dal dominio dei brand e già coperte nel
+  repo dalle nostre skill.
+
+## Decisioni
+
+- Sempre attive, senza varco: il gate `HARNESS_SKILLS` resta per le skill del
+  repo (default off perché pensate per agenti di codice); queste due sono
+  brand-facing e viaggiano al di fuori della selezione.
+- I markdown restano file veri inlineati con `?raw` (pattern già in uso in
+  `agent-files.ts`): diffabili contro upstream, niente 43KB in template
+  literal dove backtick e `${` sono mine sul percorso.
+- Il frontmatter passa da `parseSkillFrontmatter` — un solo parser, due usi.

--- a/src/lib/agent-docs/skills/humanizer/SKILL.md
+++ b/src/lib/agent-docs/skills/humanizer/SKILL.md
@@ -1,0 +1,456 @@
+---
+name: humanizer
+description: |
+  Rewrite AI-sounding text so it reads naturally without changing what it says.
+  Use when editing or reviewing prose for inflated claims,
+  sales language, vague sources, repetitive structure, stock AI words, passive
+  voice, filler, or chatbot artifacts. Based on Wikipedia's "Signs of AI writing."
+license: MIT
+metadata:
+  version: "2.11.2"
+---
+
+# Humanizer: remove AI writing patterns
+
+Rewrite AI-sounding text so it reads like the writer, not a chatbot. Do not change what it says or make up details.
+
+The patterns below come from Wikipedia's ["Signs of AI writing"](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing), maintained by WikiProject AI Cleanup.
+
+## What to do
+
+When given text to humanize:
+
+1. **Find AI patterns.** Check the text against the patterns below.
+2. **Keep every claim.** You may shorten dull parts, expand useful parts, and merge or split paragraphs. Keep the information even when you change the structure.
+3. **Do not invent facts.** Do not add a fact, name, number, date, quote, or citation unless it comes from the source or the user. If a sentence needs a missing detail, ask for it or use a simpler sentence. You may add an opinion or reaction when the writer's voice calls for one, but you may not add a factual claim. Fiction is exempt because invented details are part of the task.
+4. **Match the voice.** Use the right tone for the text, such as formal, casual, or technical. Add personality only when the text and the writer call for it.
+
+The input type controls what you return. See [How to return the result](#how-to-return-the-result). Use the same rewrite process in every mode.
+
+## Match the writer's voice
+
+If the user provides a writing sample (their own previous writing), analyze it before rewriting:
+
+1. Read the sample first. Note its sentence length, word choice, paragraph openings, punctuation, repeated phrases, and transitions.
+2. Match those habits. Do not replace casual words with formal ones or remove deliberate quirks.
+3. If there is no sample, use the guidance below.
+
+A writing sample takes priority over these style rules. If the sample uses em dashes, keep them at about the same rate. Do not apply §14 as a ban.
+
+## Add personality only when it fits
+
+Removing AI patterns is only half the job. The result should still sound like a person.
+
+Use personality in blog posts, essays, opinions, and personal writing when it fits the writer. Keep reference, technical, legal, and factual text neutral. Do not add opinions or first-person language where they do not belong.
+
+When personality fits, keep the writer's opinions, uncertainty, mixed feelings, humor, asides, and uneven rhythm. Never invent facts to make the text feel personal.
+
+## Content patterns
+
+### 1. Inflated claims about importance and legacy
+
+**Words to watch:** stands/serves as, is a testament/reminder, a vital/significant/crucial/pivotal/key role/moment, underscores/highlights its importance/significance, reflects broader, symbolizing its ongoing/enduring/lasting, contributing to the, setting the stage for, marking/shaping the, represents/marks a shift, key turning point, evolving landscape, focal point, indelible mark, deeply rooted
+**Problem:** AI writing often claims that ordinary details mark a major change, prove a legacy, or reflect a broad trend.
+**Before:**
+> The Statistical Institute of Catalonia was officially established in 1989, marking a pivotal moment in the evolution of regional statistics in Spain. This initiative was part of a broader movement across Spain to decentralize administrative functions and enhance regional governance.
+**After:**
+> The Statistical Institute of Catalonia was established in 1989, part of a wider decentralization of administrative functions in Spain.
+
+### 2. Name-dropping to prove importance
+
+**Words to watch:** independent coverage, local/regional/national media outlets, written by a leading expert, active social media presence
+**Problem:** AI writing often lists well-known publications or follower counts to prove that a person matters. The list usually gives no useful context.
+**Before:**
+> Her views have been cited in The New York Times, BBC, Financial Times, and The Hindu. She maintains an active social media presence with over 500,000 followers.
+**After:**
+> Her views have been cited in The New York Times and the BBC.
+
+If the source explains what the person said and where, keep that useful citation. Do not invent context for a shorter version.
+
+### 3. Shallow analysis with -ing phrases
+
+**Words to watch:** highlighting/underscoring/emphasizing..., ensuring..., reflecting/symbolizing..., contributing to..., cultivating/fostering..., encompassing..., showcasing...
+**Problem:** AI writing often adds an -ing phrase to make a simple fact sound deeper than it is.
+**Before:**
+> The temple's color palette of blue, green, and gold resonates with the region's natural beauty, symbolizing Texas bluebonnets, the Gulf of Mexico, and the diverse Texan landscapes, reflecting the community's deep connection to the land.
+**After:**
+> The temple is painted blue, green, and gold, colors meant to evoke Texas bluebonnets and the Gulf of Mexico.
+
+### 4. Sales language
+
+**Words to watch:** boasts a, vibrant, rich (figurative), profound, enhancing its, showcasing, exemplifies, commitment to, natural beauty, nestled, in the heart of, groundbreaking (figurative), renowned, breathtaking, must-visit, stunning
+**Problem:** AI writing often sounds like an advertisement, especially when it describes places, culture, products, or organizations.
+**Before:**
+> Nestled within the breathtaking region of Gonder in Ethiopia, Alamata Raya Kobo stands as a vibrant town with a rich cultural heritage and stunning natural beauty.
+**After:**
+> Alamata Raya Kobo is a town in the Gonder region of Ethiopia.
+
+### 5. Vague sources
+
+**Words to watch:** Industry reports, Observers have cited, Experts argue, Some critics argue, several sources/publications (when few cited)
+**Problem:** AI writing often assigns a claim to unnamed experts, critics, reports, or observers.
+**Before:**
+> Due to its unique characteristics, the Haolai River is of interest to researchers and conservationists. Experts believe it plays a crucial role in the regional ecosystem.
+**After:**
+> Researchers and conservationists study the Haolai River for its unusual characteristics.
+
+Name a real source when the source text provides one. Otherwise, remove the unsupported claim. Never invent a source.
+
+### 6. Formulaic challenges and outlook sections
+
+**Words to watch:** Despite its... faces several challenges..., Despite these challenges, Challenges and Legacy, Future Outlook
+**Problem:** AI articles often add a stock section about challenges, future prospects, or continued growth. These sections usually repeat vague claims instead of adding facts.
+**Before:**
+> Despite its industrial prosperity, Korattur faces challenges typical of urban areas, including traffic congestion and water scarcity. Despite these challenges, with its strategic location and ongoing initiatives, Korattur continues to thrive as an integral part of Chennai's growth.
+**After:**
+> Korattur has recurring traffic congestion and water shortages.
+
+Add details such as dates or public actions only when they come from the source or the user.
+
+## Language and grammar patterns
+
+### 7. Overused AI words
+
+**High-frequency AI words:** Actually, additionally, align with, crucial, delve, emphasizing, enduring, enhance, fostering, garner, gate/gated/gating (figurative; preserve established technical usage), highlight (verb), interplay, intricate/intricacies, key (adjective), landscape (abstract noun), pivotal, quietly, showcase, tapestry (abstract noun), testament, underscore (verb), valuable, vibrant
+**Problem:** AI writing uses these words much more often than most people do, especially in groups.
+**Before:**
+> Additionally, a distinctive feature of Somali cuisine is the incorporation of camel meat. An enduring testament to Italian colonial influence is the widespread adoption of pasta in the local culinary landscape, showcasing how these dishes have integrated into the traditional diet.
+**After:**
+> Somali cuisine also includes camel meat, which is considered a delicacy. Pasta dishes, introduced during Italian colonization, remain common, especially in the south.
+
+### 8. Avoiding is and are
+
+**Words to watch:** serves as/stands as/marks/represents [a], boasts/features/offers [a]
+**Problem:** AI writing often replaces simple verbs such as *is*, *are*, and *has* with longer phrases.
+**Before:**
+> Gallery 825 serves as LAAA's exhibition space for contemporary art. The gallery features four separate spaces and boasts over 3,000 square feet.
+**After:**
+> Gallery 825 is LAAA's exhibition space for contemporary art. The gallery has four rooms totaling 3,000 square feet.
+
+### 9. Not X but Y and clipped negative endings
+**Problem:** AI writing overuses forms such as "Not only...but..." and "It's not just X, it's Y."
+
+It also adds clipped endings such as "no guessing" instead of writing a clear clause.
+**Before:**
+> It's not just about the beat riding under the vocals; it's part of the aggression and atmosphere. It's not merely a song, it's a statement.
+**After:**
+> The heavy beat adds to the aggressive tone.
+**Before (tailing negation):**
+> The options come from the selected item, no guessing.
+**After:**
+> The options come from the selected item without forcing the user to guess.
+
+### 10. Forced groups of three
+**Problem:** AI writing often forces ideas into groups of three to sound complete.
+**Before:**
+> The event features keynote sessions, panel discussions, and networking opportunities. Attendees can expect innovation, inspiration, and industry insights.
+**After:**
+> The event includes talks and panels. There's also time for informal networking between sessions.
+
+### 11. Changing names and repeating sentence openings
+**Problem:** AI writing handles repetition by rule instead of by ear. It may keep renaming the same person or thing. It may also start several sentences with the same subject, often *she* or *he*.
+
+Use one clear name for the same subject. For repeated openings, merge sentences, change the subject when that helps, or begin with the action.
+**Before (synonym cycling):**
+> The protagonist faces many challenges. The main character must overcome obstacles. The central figure eventually triumphs. The hero returns home.
+**After:**
+> The protagonist faces many challenges but eventually triumphs and returns home.
+**Before (repeated openings):**
+> She noted the door. She noted the lock on it. She filed both away.
+**After:**
+> She noted the door and its lock, then filed both away.
+
+Do not ban the repeated word. Fix the repeated sentence pattern. The remaining sentence may still start with "She."
+
+### 12. False from X to Y ranges
+**Problem:** AI writing often uses "from X to Y" when X and Y do not form a real range.
+**Before:**
+> Our journey through the universe has taken us from the singularity of the Big Bang to the grand cosmic web, from the birth and death of stars to the enigmatic dance of dark matter.
+**After:**
+> The book covers the Big Bang, star formation, and current theories about dark matter.
+
+### 13. Passive voice and missing subjects
+**Problem:** AI writing often hides who acts or drops the subject. Use active voice when it makes the actor and action clearer.
+**Before:**
+> No configuration file needed. The results are preserved automatically.
+**After:**
+> You do not need a configuration file. The system preserves the results automatically.
+
+## Style patterns
+
+### 14. Em and en dashes
+
+**Rule:** The final rewrite must not contain em dashes (—) or en dashes (–), unless the writer's sample uses them. Replace a dash with a period, comma, colon, or parentheses, or rewrite the sentence. Also check for spaced dashes (` — `) and double hyphens (` -- `) used as dashes.
+**Before:**
+> The term is primarily promoted by Dutch institutions—not by the people themselves. You don't say "Netherlands, Europe" as an address—yet this mislabeling continues—even in official documents.
+**After:**
+> The term is primarily promoted by Dutch institutions, not by the people themselves. You don't say "Netherlands, Europe" as an address, yet this mislabeling continues in official documents.
+**Before:**
+> The new policy — announced without warning — affects thousands of workers. The changes -- long overdue according to critics -- will take effect immediately.
+**After:**
+> The new policy, announced without warning, affects thousands of workers. The changes, long overdue according to critics, will take effect immediately.
+
+Before returning the rewrite, search for `—` and `–`. Remove each one unless the writer's sample uses that mark. In that case, match the sample's rate.
+
+### 15. Too much bold text
+**Problem:** AI chatbots often bold words and phrases without a clear reason.
+**Before:**
+> It blends **OKRs (Objectives and Key Results)**, **KPIs (Key Performance Indicators)**, and visual strategy tools such as the **Business Model Canvas (BMC)** and **Balanced Scorecard (BSC)**.
+**After:**
+> It blends OKRs, KPIs, and visual strategy tools like the Business Model Canvas and Balanced Scorecard.
+
+### 16. Lists with bold mini-headings
+**Problem:** AI writing often uses vertical lists in which every item starts with a bold label and a colon.
+**Before:**
+> - **User Experience:** The user experience has been significantly improved with a new interface.
+> - **Performance:** Performance has been enhanced through optimized algorithms.
+> - **Security:** Security has been strengthened with end-to-end encryption.
+**After:**
+> The update improves the interface, speeds up load times through optimized algorithms, and adds end-to-end encryption.
+
+### 17. Title case in headings
+**Problem:** AI chatbots often capitalize every main word in a heading.
+**Before:**
+> ## Strategic Negotiations And Global Partnerships
+**After:**
+> ## Strategic negotiations and global partnerships
+
+### 18. Emojis
+**Problem:** AI chatbots often add emojis to headings and list items as decoration.
+**Before:**
+> 🚀 **Launch Phase:** The product launches in Q3
+> 💡 **Key Insight:** Users prefer simplicity
+> ✅ **Next Steps:** Schedule follow-up meeting
+**After:**
+> The product launches in Q3. User research showed a preference for simplicity. Next step: schedule a follow-up meeting.
+
+### 19. Curly quotation marks
+**Problem:** ChatGPT often uses curly quotes (“...”) where the writer or target format uses straight quotes ("...").
+**Before:**
+> He said “the project is on track” but others disagreed.
+**After:**
+> He said "the project is on track" but others disagreed.
+
+## Chatbot patterns
+
+### 20. Chatbot text left in the answer
+
+**Words to watch:** I hope this helps, Of course!, Certainly!, You're absolutely right!, Would you like..., Want me to...?, Want me to give examples?, Should I continue?, let me know, here is a...
+**Problem:** A chatbot's greeting, offer, or closing sometimes remains in text that should stand on its own.
+**Before:**
+> Here is an overview of the French Revolution. I hope this helps! Let me know if you'd like me to expand on any section.
+**After:**
+> The French Revolution began in 1789 when financial crisis and food shortages led to widespread unrest.
+
+### 21. Knowledge-limit disclaimers and guesses
+
+**Words to watch:** as of [date], Up to my last training update, While specific details are limited/scarce..., based on available information, not publicly available, maintains a low profile, keeps personal details private, prefers to stay out of the spotlight, likely [grew up/studied/began], it is believed that
+**Problem:** Older models may mention the date when their knowledge ends. A model may also explain that it could not find a source, then fill the gap with a plausible guess. State what the source does not show, or remove the sentence. Do not present a guess as a fact.
+**Before (cutoff disclaimer):**
+> While specific details about the company's founding are not extensively documented in readily available sources, it appears to have been established sometime in the 1990s.
+**After:**
+> The company's founding date is not documented in the available sources. (Or cut the sentence. State a date only if a source provides one.)
+**Before (speculative gap-fill):**
+> Information about her early life is not publicly available, suggesting she maintains a low profile and keeps personal details private. She likely grew up in a middle-class household, which shaped her later interest in education reform.
+**After:**
+> Her early life is not documented in the available sources. (Or omit the section.)
+
+### 22. Overly agreeable tone
+**Problem:** AI assistants often praise the user or agree before giving the answer.
+**Before:**
+> Great question! You're absolutely right that this is a complex topic. That's an excellent point about the economic factors.
+**After:**
+> The economic factors you mentioned are relevant here.
+
+## Filler and hedging
+
+### 23. Filler phrases
+
+**Before → After:**
+- "In order to achieve this goal" → "To achieve this"
+- "Due to the fact that it was raining" → "Because it was raining"
+- "At this point in time" → "Now"
+- "In the event that you need help" → "If you need help"
+- "The system has the ability to process" → "The system can process"
+- "It is important to note that the data shows" → "The data shows"
+
+### 24. Too many qualifiers
+
+**Phrases to watch:** to be fair, it's also possible, could potentially, might arguably, in some cases it may, this is an inference
+**Problem:** Repeated editing can add one qualifier after another until every claim sounds uncertain. Keep a qualifier only when the source supports it and the meaning needs it. Remove caveats that only repair an earlier overstatement.
+**Before:**
+> It could potentially possibly be argued that the policy might have some effect on outcomes.
+**After:**
+> The policy may affect outcomes.
+
+### 25. Generic positive endings
+**Problem:** AI writing often ends with vague optimism instead of the last useful fact.
+**Before:**
+> The future looks bright for the company. Exciting times lie ahead as they continue their journey toward excellence. This represents a major step in the right direction.
+**After:**
+> (Cut the paragraph. End on the last concrete fact instead of a send-off. If the source states real plans, use those.)
+
+### 26. Too many hyphenated word pairs
+
+**Words to watch:** third-party, cross-functional, client-facing, data-driven, decision-making, well-known, high-quality, real-time, long-term, end-to-end
+**Problem:** AI writing often hyphenates these pairs everywhere. Keep the hyphen before a noun when grammar needs it, as in `a high-quality report`. Drop it after the noun, as in `the report is high quality`.
+**Before:**
+> The cross-functional team delivered a high-quality, data-driven report. The team is cross-functional, the report is high-quality, and the methodology is data-driven.
+**After:**
+> The cross-functional team delivered a high-quality, data-driven report. The team is cross functional, the report is high quality, and the methodology is data driven.
+
+### 27. Pretending to reveal a deeper truth
+
+**Phrases to watch:** The real question is, at its core, in reality, what really matters, fundamentally, the deeper issue, the heart of the matter
+**Problem:** AI writing uses these phrases to make an ordinary point sound like a hidden truth.
+**Before:**
+> The real question is whether teams can adapt. At its core, what really matters is organizational readiness.
+**After:**
+> The question is whether teams can adapt. That mostly depends on whether the organization is ready to change its habits.
+
+### 28. Announcing the next point
+
+**Phrases to watch:** Let's dive in, let's explore, let's break this down, here's what you need to know, now let's look at, without further ado, heads up, quick note, before I forget
+**Problem:** AI writing often announces the next point instead of stating it. A casual phrase such as "one thing that bit me" can have the same problem. Remove the announcement, not just its formal tone.
+**Before:**
+> Let's dive into how caching works in Next.js. Here's what you need to know.
+**After:**
+> Next.js caches data at multiple layers, including request memoization, the data cache, and the router cache.
+**Before (casual register):**
+> One thing that bit me hard, so pay attention to this part: the webpack dev server doesn't send the CORS header by default.
+**After:**
+> The webpack dev server doesn't send the CORS header by default.
+
+### 29. A heading repeated in the first sentence
+
+**Signs to watch:** A heading followed by a one-line paragraph that simply restates the heading before the real content begins.
+**Problem:** AI writing often follows a heading with a sentence that only repeats the heading. Remove the repeated sentence.
+**Before:**
+> ## Performance
+>
+> Speed matters.
+>
+> When users hit a slow page, they leave.
+**After:**
+> ## Performance
+>
+> When users hit a slow page, they leave.
+
+### 30. Writing about the previous version
+**Problem:** Documentation and comments should describe the current behavior. Mention the previous version only in change logs, release notes, migration guides, and other documents about change.
+**Before:**
+> This function was added to replace the previous approach of iterating through all items, which caused O(n²) performance.
+**After:**
+> This function uses a hash map for O(1) lookups, avoiding the O(n²) cost of naive iteration.
+
+### 31. Forced punchlines and dramatic fragments
+**Problem:** AI writing often turns each sentence into a dramatic closing line. One short sentence can add emphasis. A row of short fragments usually feels forced.
+**Before:**
+> Then AlphaEvolve arrived. It had no preference for symmetry. No aesthetic prior. No nostalgia for human taste. The old rules were gone.
+**After:**
+> AlphaEvolve changed the search because it did not favor symmetry or human-looking designs. That made some of the older assumptions less useful.
+
+### 32. Formulaic sayings
+
+**Words to watch:** X is the Y of Z, X becomes a trap, X is not a tool but a mirror, the language of, the currency of, the architecture of
+**Problem:** AI writing often turns an ordinary claim into a saying that sounds deep but adds no detail. Replace the saying with the specific claim.
+**Before:**
+> Symmetry is the language of trust. Efficiency becomes a trap when teams forget the human layer.
+**After:**
+> Symmetric layouts often feel more predictable to users. Teams can over-optimize workflows and miss how people actually use them.
+
+### 33. Fake-candid openings
+
+**Phrases to watch:** Honestly?, Look, Here's the thing, The thing is, Let's be honest, Real talk, when used as standalone hooks or fake-candid pauses before an ordinary point.
+**Problem:** AI writing often starts with a staged pause or claim of honesty before making a routine point. State the point directly.
+**Before:**
+> Is it worth the price? Honestly? It depends on how often you'll use it.
+**After:**
+> Whether it's worth the price depends on how often you'll use it.
+
+### 34. Answering objections no one raised
+
+**Phrases to watch:** This isn't (mainly/really) about, I'm not saying/arguing/trying to, To be clear, Don't get me wrong, This is not to say, You could argue/frame this differently but, Some might say... but
+**Problem:** AI writing may answer an objection that does not appear in the text. Watch for an unattributed statement about what the writer does not mean, especially when the topic appears nowhere else. A direct claim such as "the API is not thread-safe" is not this pattern.
+**Before:**
+> This isn't mainly about prompt length, and I'm not arguing that documentation doesn't matter. You could categorize the problem another way, but the issue is whether the agent can use the instruction when it acts.
+**After:**
+> The issue is whether the agent can use the instruction when it acts.
+
+Remove only the unsupported defense. If it contains a real claim, state that claim directly. Keep an objection when the text names its source or answers it in full.
+
+### 35. Rejecting fake alternatives
+
+**Phrases to watch:** A tempting option/approach would be, One might be tempted to, An obvious approach would be, You might think... but, It would be easy to just, Some would suggest
+**Problem:** AI writing may introduce an option that no reader would consider, reject it in a clause, and never mention it again. This often leaves an old drafting idea in the final text. Remove the fake option and state the real constraint directly.
+**Before:**
+> Session tokens are rotated every 24 hours. A tempting approach would be to rotate them by restarting the auth service on a cron job, but that would drop every active session. Rotation happens in place, and clients refresh transparently.
+**After:**
+> Session tokens are rotated every 24 hours, in place, and clients refresh transparently.
+
+One rejected option may be valid. Several short, unrelated rejections are a stronger sign. Ask what new information each sentence adds. If it only records an earlier edit, rewrite the paragraph around its main point.
+
+## Check for false positives
+
+### What not to flag
+
+A person may use some of these patterns. Do not treat any item below as proof by itself:
+
+- **Perfect grammar and consistent style.** Many writers are professionals or have been edited. Polish does not equal AI.
+- **Mixed casual and formal styles.** This can reflect the writer's field, age, or personal habits.
+- **"Bland" or "robotic" prose.** AI prose has *specific* tells. Generic dryness without those tells is just dry writing.
+- **Formal or academic words.** §7 lists specific words that AI writing overuses. Do not simplify every formal word.
+- **Letter-style opening or closing on a comment.** Salutations and sign-offs predate ChatGPT by centuries.
+- **Common transition words in isolation.** *Additionally*, *moreover*, *consequently* are AI-coded only when piled up. One *however* is not a tell.
+- **Curly quotes alone.** macOS, Word, Google Docs, and most CMSes auto-curl by default. Curly quotes only count when stacked with other tells.
+- **Em dashes alone.** Many editors and journalists use them often. Em dashes are evidence only when paired with formulaic sales-y rhythm.
+- **One short sentence for emphasis.** Flag dramatic fragments only when several appear in a row.
+- **Deliberate repeated openings.** Writers may repeat an opening to build rhythm or pressure, as in "She came. She saw. She conquered." Change it only when the repetition adds nothing.
+- **"Honestly" or "look" mid-sentence.** These are ordinary in casual writing. The tell is the standalone theatrical opener, not the word itself.
+- **Useful limits and disclaimers.** Keep scope statements, legal and safety notices, real corrections, named objections, replies, and FAQ answers.
+- **Real alternatives.** Keep options that a reader may consider in a design document, tutorial, or argument. Remove only an unlikely option that the text dismisses and never uses again.
+- **Unsourced claims.** Most of the web is unsourced. Lack of citations doesn't prove anything.
+- **Correct, complex formatting.** Visual editors and templates produce clean output without any AI.
+- **Secondhand text.** Do not rewrite watched phrases inside quotations, titles, proper names, or examples where the phrase is being discussed rather than used.
+
+When unsure, look for several patterns together. One em dash proves nothing. Several stock patterns in the same passage are stronger evidence.
+
+### Human details to keep
+
+These details often carry the writer's voice. Keep them unless they hurt the meaning:
+
+- **Specific, unusual details.** Keep a real address, an odd quote, or a phrase such as "the lawyer who used to work upstairs from my dentist."
+- **Mixed feelings and unresolved tension.** Keep lines such as "I think this is mostly good, but it bothers me, and I can't fully explain why."
+- **Dated, era-bound references.** Slang, memes, or in-jokes that map to a specific year and subculture. Models lag by a year or more.
+- **Deliberate first-person choices.** Keep a cut or word choice when the writer can explain why it belongs.
+- **Variety in sentence length.** Real writing alternates short and long. AI writing tends toward an even, mid-length cadence.
+- **Genuine asides, parentheticals, or self-corrections.** "(I keep wanting to say 'almost' here, but it really was certain.)" Models rarely interrupt themselves like this.
+- **Edits made before November 30, 2022.** ChatGPT's public launch. Anything older than that is, with very rare exceptions, not AI-written.
+
+---
+
+## How to return the result
+
+**Pasted text (default).** Return the draft, a short list of remaining AI patterns, and the final rewrite.
+
+**File mode.** When the user names a file, run the full rewrite process but write only the final text to the file. Change prose only. Keep code blocks, YAML metadata, data, and link targets unchanged. Then give the user a short summary.
+
+**Embedded mode.** When another task uses this skill for a pull request, commit message, or document, return only the final text.
+
+## Rewrite process
+
+1. Read the source and mark each AI pattern.
+2. Write a draft. Read it aloud. Check the rhythm, details, simple verbs such as *is* and *has*, and the right level of formality.
+3. Ask two questions:
+   - **"What still sounds AI-generated?"**
+   - **"Did the rewrite add or remove any fact, name, number, date, quote, citation, ranking, or other claim?"**
+   Treat any unsupported addition or lost claim as an error.
+4. Write the final version. State each point naturally instead of patching one flagged phrase at a time. If a sentence stays awkward, rewrite the paragraph around its main point. Apply the dash rule in §14.
+
+Return the result required by [How to return the result](#how-to-return-the-result).
+
+## Source
+
+This skill is based on [Wikipedia: Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing), maintained by WikiProject AI Cleanup. Its patterns come from reviews of AI-generated text on Wikipedia.
+
+Wikipedia's main point: "LLMs use statistical algorithms to guess what should come next. The result tends toward the most statistically likely result that applies to the widest variety of cases."

--- a/src/lib/agent-docs/skills/stop-slop/SKILL.md
+++ b/src/lib/agent-docs/skills/stop-slop/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: stop-slop
+description: Remove AI writing patterns from prose. Use when drafting, editing, or reviewing text to eliminate predictable AI tells.
+metadata:
+  trigger: Writing prose, editing drafts, reviewing content for AI patterns
+  author: Hardik Pandya (https://hvpandya.com)
+---
+
+# Stop Slop
+
+Eliminate predictable AI writing patterns from prose.
+
+## Core Rules
+
+1. **Cut filler phrases.** Remove throat-clearing openers, emphasis crutches, and all adverbs. See [references/phrases.md](references/phrases.md).
+
+2. **Break formulaic structures.** Avoid binary contrasts, negative listings, dramatic fragmentation, rhetorical setups, false agency. See [references/structures.md](references/structures.md).
+
+3. **Use active voice.** Every sentence needs a human subject doing something. No passive constructions. No inanimate objects performing human actions ("the complaint becomes a fix").
+
+4. **Be specific.** No vague declaratives ("The reasons are structural"). Name the specific thing. No lazy extremes ("every," "always," "never") doing vague work.
+
+5. **Put the reader in the room.** No narrator-from-a-distance voice. "You" beats "People." Specifics beat abstractions.
+
+6. **Vary rhythm.** Mix sentence lengths. Two items beat three. End paragraphs differently. No em dashes.
+
+7. **Trust readers.** State facts directly. Skip softening, justification, hand-holding.
+
+8. **Cut quotables.** If it sounds like a pull-quote, rewrite it.
+
+## Quick Checks
+
+Before delivering prose:
+
+- Any adverbs? Kill them.
+- Any passive voice? Find the actor, make them the subject.
+- Inanimate thing doing a human verb ("the decision emerges")? Name the person.
+- Sentence starts with a Wh- word? Restructure it.
+- Any "here's what/this/that" throat-clearing? Cut to the point.
+- Any "not X, it's Y" contrasts? State Y directly.
+- Three consecutive sentences match length? Break one.
+- Paragraph ends with punchy one-liner? Vary it.
+- Em-dash anywhere? Remove it.
+- Vague declarative ("The implications are significant")? Name the specific implication.
+- Narrator-from-a-distance ("Nobody designed this")? Put the reader in the scene.
+- Meta-joiners ("The rest of this essay...")? Delete. Let the essay move.
+
+## Scoring
+
+Rate 1-10 on each dimension:
+
+| Dimension | Question |
+|-----------|----------|
+| Directness | Statements or announcements? |
+| Rhythm | Varied or metronomic? |
+| Trust | Respects reader intelligence? |
+| Authenticity | Sounds human? |
+| Density | Anything cuttable? |
+
+Below 35/50: revise.
+
+## Examples
+
+See [references/examples.md](references/examples.md) for before/after transformations.
+
+## License
+
+MIT

--- a/src/lib/agent-docs/skills/stop-slop/references/examples.md
+++ b/src/lib/agent-docs/skills/stop-slop/references/examples.md
@@ -1,0 +1,59 @@
+# Before/After Examples
+
+## Example 1: Throat-Clearing + Binary Contrast
+
+**Before:**
+> "Here's the thing: building products is hard. Not because the technology is complex. Because people are complex. Let that sink in."
+
+**After:**
+> "Building products is hard. Technology is manageable. People aren't."
+
+**Changes:** Removed opener, binary contrast structure, and emphasis crutch. Direct statements.
+
+---
+
+## Example 2: Filler + Unnecessary Reassurance
+
+**Before:**
+> "It turns out that most teams struggle with alignment. The uncomfortable truth is that nobody wants to admit they're confused. And that's okay."
+
+**After:**
+> "Teams struggle with alignment. Nobody admits confusion."
+
+**Changes:** Cut hedging ("most"), removed throat-clearing phrases, deleted permission-granting ending.
+
+---
+
+## Example 3: Business Jargon Stack
+
+**Before:**
+> "In today's fast-paced landscape, we need to lean into discomfort and navigate uncertainty with clarity. This matters because your competition isn't waiting."
+
+**After:**
+> "Move faster. Your competition is."
+
+**Changes:** Eliminated jargon entirely. Core message in six words.
+
+---
+
+## Example 4: Dramatic Fragmentation
+
+**Before:**
+> "Speed. Quality. Cost. You can only pick two. That's it. That's the tradeoff."
+
+**After:**
+> "Speed, quality, cost—pick two."
+
+**Changes:** Single sentence. No performative emphasis.
+
+---
+
+## Example 5: Rhetorical Setup
+
+**Before:**
+> "What if I told you that the best teams don't optimize for productivity? Here's what I mean: they optimize for learning. Think about it."
+
+**After:**
+> "The best teams optimize for learning, not productivity."
+
+**Changes:** Direct claim. No rhetorical scaffolding.

--- a/src/lib/agent-docs/skills/stop-slop/references/phrases.md
+++ b/src/lib/agent-docs/skills/stop-slop/references/phrases.md
@@ -1,0 +1,128 @@
+# Phrases to Remove
+
+## Throat-Clearing Openers
+
+Remove these announcement phrases. State the content directly.
+
+- "Here's the thing:"
+- "Here's what [X]"
+- "Here's this [X]"
+- "Here's that [X]"
+- "Here's why [X]"
+- "The uncomfortable truth is"
+- "It turns out"
+- "The real [X] is"
+- "Let me be clear"
+- "The truth is,"
+- "I'll say it again:"
+- "I'm going to be honest"
+- "Can we talk about"
+- "Here's what I find interesting"
+- "Here's the problem though"
+
+Any "here's what/this/that" construction is throat-clearing before the point. Cut it and state the point.
+
+## Emphasis Crutches
+
+These add no meaning. Delete them.
+
+- "Full stop." / "Period."
+- "Let that sink in."
+- "This matters because"
+- "Make no mistake"
+- "Here's why that matters"
+
+## Business Jargon
+
+Replace with plain language.
+
+| Avoid | Use instead |
+|-------|-------------|
+| Navigate (challenges) | Handle, address |
+| Unpack (analysis) | Explain, examine |
+| Lean into | Accept, embrace |
+| Landscape (context) | Situation, field |
+| Game-changer | Significant, important |
+| Double down | Commit, increase |
+| Deep dive | Analysis, examination |
+| Take a step back | Reconsider |
+| Moving forward | Next, from now |
+| Circle back | Return to, revisit |
+| On the same page | Aligned, agreed |
+
+## Adverbs
+
+Kill all adverbs. No -ly words. No softeners, no intensifiers, no hedges.
+
+Specific offenders:
+
+- "really"
+- "just"
+- "literally"
+- "genuinely"
+- "honestly"
+- "simply"
+- "actually"
+- "deeply"
+- "truly"
+- "fundamentally"
+- "inherently"
+- "inevitably"
+- "interestingly"
+- "importantly"
+- "crucially"
+
+Also cut these filler phrases:
+
+- "At its core"
+- "In today's [X]"
+- "It's worth noting"
+- "At the end of the day"
+- "When it comes to"
+- "In a world where"
+- "The reality is"
+
+## Meta-Commentary
+
+Remove self-referential asides. The essay should move, not announce its own structure.
+
+- "Hint:"
+- "Plot twist:" / "Spoiler:"
+- "You already know this, but"
+- "But that's another post"
+- "X is a feature, not a bug"
+- "Dressed up as"
+- "The rest of this essay explains..."
+- "Let me walk you through..."
+- "In this section, we'll..."
+- "As we'll see..."
+- "I want to explore..."
+
+## Performative Emphasis
+
+False intimacy or manufactured sincerity:
+
+- "creeps in"
+- "I promise"
+- "They exist, I promise"
+
+## Telling Instead of Showing
+
+Announcing difficulty or significance rather than demonstrating it:
+
+- "This is genuinely hard"
+- "This is what leadership actually looks like"
+- "This is what X actually looks like"
+- "actually matters"
+
+## Vague Declaratives
+
+Sentences that announce importance without naming the specific thing. Kill these.
+
+- "The reasons are structural"
+- "The implications are significant"
+- "This is the deepest problem"
+- "The stakes are high"
+- "The consequences are real"
+
+If a sentence says something is important/deep/structural without showing the specific thing, cut it or replace it with the specific thing.

--- a/src/lib/agent-docs/skills/stop-slop/references/structures.md
+++ b/src/lib/agent-docs/skills/stop-slop/references/structures.md
@@ -1,0 +1,134 @@
+# Structures to Avoid
+
+## Binary Contrasts
+
+These create false drama. State the point directly.
+
+| Pattern | Problem |
+|---------|---------|
+| "Not because X. Because Y." / "Not because X, but because Y." | Telegraphed reversal |
+| "[X] isn't the problem. [Y] is." | Formulaic reframe |
+| "The answer isn't X. It's Y." | Predictable pivot |
+| "It feels like X. It's actually Y." | Setup/reveal cliche |
+| "The question isn't X. It's Y." | Rhetorical misdirection |
+| "Not X. But Y." / "not X, it's Y" / "isn't X, it's Y" | Mechanical contrast |
+| "It's not this. It's that." | Same formula, different words |
+| "stops being X and starts being Y" | False transformation arc |
+| "doesn't mean X, but actually Y" | Negation-then-assertion crutch |
+| "is about X but not Y" | False distinction |
+| "not just X but also Y" | Additive hedge |
+
+**Instead:** State Y directly. "The problem is Y." "Y matters here." Drop the negation entirely.
+
+## Negative Listing
+
+Listing what something is *not* before revealing what it *is*. A rhetorical striptease.
+
+| Pattern | Problem |
+|---------|---------|
+| "Not a X... Not a Y... A Z." | Dramatic buildup through negation |
+| "It wasn't X. It wasn't Y. It was Z." | Same structure, past tense |
+
+**Instead:** State Z. The reader doesn't need the runway.
+
+## Dramatic Fragmentation
+
+Sentence fragments for emphasis read as manufactured profundity.
+
+| Pattern | Problem |
+|---------|---------|
+| "[Noun]. That's it. That's the [thing]." | Performative simplicity |
+| "X. And Y. And Z." | Staccato drama |
+| "This unlocks something. [Word]." | Artificial revelation |
+
+**Instead:** Complete sentences. Trust content over presentation.
+
+## Rhetorical Setups
+
+These announce insight rather than deliver it.
+
+| Pattern | Problem |
+|---------|---------|
+| "What if [reframe]?" | Socratic posturing |
+| "Here's what I mean:" | Redundant preview |
+| "Think about it:" | Condescending prompt |
+| "And that's okay." | Unnecessary permission |
+
+**Instead:** Make the point. Let readers draw conclusions.
+
+## Formulaic Constructions
+
+| Pattern | Problem |
+|---------|---------|
+| "By the time X, I was Y." | Narrative template |
+| "X that isn't Y" | Indirect. Say "X is broken" |
+
+## False Agency
+
+Giving inanimate things human verbs. Complaints don't "become" fixes. Bets don't "live or die." Decisions don't "emerge." A person does something to make those things happen. AI loves this because it avoids naming the actor.
+
+| Pattern | Problem |
+|---------|---------|
+| "a complaint becomes a fix" | The complaint did nothing. Someone fixed it. |
+| "a bet lives or dies in days" | Bets don't have lifespans. Someone kills the project or ships it. |
+| "the decision emerges" | Decisions don't emerge. Someone decides. |
+| "the culture shifts" | Cultures don't shift on their own. People change behavior. |
+| "the conversation moves toward" | Conversations don't move. Someone steers. |
+| "the data tells us" | Data sits there. Someone reads it and draws a conclusion. |
+| "the market rewards" | Markets don't reward. Buyers pay for things. |
+
+**Instead:** Name the human. "The team fixed it that week" beats "the complaint becomes a fix." If no specific person fits, use "you" to put the reader in the seat.
+
+## Narrator-from-a-Distance
+
+Floating above the scene instead of putting the reader in it.
+
+| Pattern | Problem |
+|---------|---------|
+| "Nobody designed this." | Disembodied observation |
+| "This happens because..." | Lecturer voice |
+| "This is why..." | Same |
+| "People tend to..." | Armchair sociologist |
+
+**Instead:** Put the reader in the room. "You don't sit down one day and decide to..." beats "Nobody designed this."
+
+## Passive Voice
+
+Every sentence needs a subject doing something. Passive voice hides the actor and drains energy.
+
+| Pattern | Fix |
+|---------|-----|
+| "X was created" | Name who created it |
+| "It is believed that" | Name who believes it |
+| "Mistakes were made" | Name who made them |
+| "The decision was reached" | Name who decided |
+
+**Instead:** Find the actor. Put them at the front of the sentence.
+
+## Sentence Starters to Avoid
+
+| Pattern | Fix |
+|---------|-----|
+| Sentences starting with What, When, Where, Which, Who, Why, How | Restructure. Lead with the subject or the verb. |
+| Paragraphs starting with "So" | Start with content |
+| Sentences starting with "Look," | Remove |
+
+Wh- openers become a crutch. "What makes this hard is..." becomes "The constraint is..." or better, name the specific constraint.
+
+## Rhythm Patterns
+
+| Pattern | Fix |
+|---------|-----|
+| Three-item lists | Use two items or one |
+| Questions answered immediately | Let questions breathe or cut them |
+| Every paragraph ends punchily | Vary endings |
+| Em-dashes | Remove. Use commas or periods. No em dashes at all. |
+| Staccato fragmentation | Don't stack short punchy sentences |
+| "Not always. Not perfectly." | Hedging disguised as reassurance |
+
+## Word Patterns
+
+| Pattern | Problem |
+|---------|---------|
+| Lazy extremes (every, always, never, everyone, everybody, nobody) | False authority. Use specifics instead of sweeping claims. |
+| All adverbs (-ly words, "really," "just," "literally," "genuinely," "honestly," "simply," "actually") | Empty emphasis. See phrases.md for full list. |

--- a/src/lib/agent/bridge/adapters.ts
+++ b/src/lib/agent/bridge/adapters.ts
@@ -46,6 +46,7 @@ import { HarnessRuntime } from '@anomalia/agent-adapters/runtime/harness-runtime
 import { HARNESS_SETUPS, stickySessionExtension } from '@anomalia/agent-adapters/runtime/harness-runtime';
 import { HarnessAgent } from '@ai-sdk/harness/agent';
 import { loadHarnessSkills, parseHarnessSkillSelection } from '$lib/server/harness-skills';
+import { brandSkills } from '$lib/server/brand-skills';
 import { createJustBashSandbox } from '@ai-sdk/sandbox-just-bash';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import type { StreamTextResult, ToolSet } from 'ai';
@@ -354,7 +355,7 @@ export async function startHarnessTurn(opts: {
 	const agentDir = opts.agentDir ?? ensureKieAgentDir();
 	const setup = knownSetup ?? (agentDir ? HARNESS_SETUPS.custom : HARNESS_SETUPS.pi);
 	const skillSelection = parseHarnessSkillSelection(env.HARNESS_SKILLS);
-	const skills = await loadHarnessSkills(skillSelection);
+	const skills = [...brandSkills, ...(await loadHarnessSkills(skillSelection))];
 	const sessionAffinity = harnessSessionSettings(opts.sessionKey);
 	const agent = new HarnessAgent({
 		harness: setup.harness(opts.model.id || undefined, agentDir, sessionAffinity),

--- a/src/lib/content/changelog/2026-08-28-brand-writing-skills.ts
+++ b/src/lib/content/changelog/2026-08-28-brand-writing-skills.ts
@@ -1,0 +1,10 @@
+// Il formato lo definisce ./index.ts (PR changelog-entry-files): qui solo i dati.
+const entry = {
+  date: 'August 28, 2026',
+  title: 'Copy that never reads like a chatbot',
+  items: [
+    'Every text your agents write now passes through two writing disciplines — one governs how it is drafted, the other reviews it — so posts and captions stop carrying the usual AI tells.',
+  ],
+};
+
+export default entry;

--- a/src/lib/server/brand-skills.test.ts
+++ b/src/lib/server/brand-skills.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { brandSkills } from './brand-skills';
+
+describe('brandSkills', () => {
+	it('porta esattamente humanizer e stop-slop, entrambi MIT', () => {
+		expect(brandSkills.map((s) => s.name).sort()).toEqual(['humanizer', 'stop-slop']);
+	});
+
+	it('ogni skill ha descrizione e contenuto pieni', () => {
+		for (const skill of brandSkills) {
+			expect(skill.description.trim().length).toBeGreaterThan(40);
+			expect(skill.content.trim().length).toBeGreaterThan(1000);
+		}
+	});
+
+	it('humanizer arriva intero fino alle sezioni finali, non troncato', () => {
+		const humanizer = brandSkills.find((s) => s.name === 'humanizer');
+		expect(humanizer?.content).toContain('Rewrite process');
+		expect(humanizer?.content).toContain('How to return the result');
+		expect(humanizer?.content).toContain('Wikipedia:Signs_of_AI_writing');
+	});
+
+	it('stop-slop porta i riferimenti come file allegati alla skill', () => {
+		const stopSlop = brandSkills.find((s) => s.name === 'stop-slop');
+		const paths = (stopSlop?.files ?? []).map((f) => f.path);
+		expect(paths).toContain('references/phrases.md');
+		expect(paths).toContain('references/structures.md');
+		expect(paths).toContain('references/examples.md');
+		for (const file of stopSlop?.files ?? []) {
+			expect(file.content.trim().length).toBeGreaterThan(200);
+		}
+	});
+
+	it('nessuna skill supera il tetto di 64KB che il loader impone ai file', () => {
+		const MAX_TEXT_BYTES = 64 * 1024;
+		for (const skill of brandSkills) {
+			expect(Buffer.byteLength(skill.content)).toBeLessThan(MAX_TEXT_BYTES);
+			for (const file of skill.files ?? []) {
+				expect(Buffer.byteLength(file.content)).toBeLessThan(MAX_TEXT_BYTES);
+			}
+		}
+	});
+
+	it('startHarnessTurn cucina le skill di brand dentro HarnessAgent, sempre', () => {
+		const src = readFileSync('src/lib/agent/bridge/adapters.ts', 'utf8');
+		expect(src).toMatch(/\[\.\.\.brandSkills, \.\.\.\(await loadHarnessSkills\(skillSelection\)\)\]/);
+		expect(src).toMatch(/skills\.length > 0 \? \{ skills \} : \{\}/);
+	});
+});

--- a/src/lib/server/brand-skills.ts
+++ b/src/lib/server/brand-skills.ts
@@ -1,0 +1,34 @@
+/**
+ * LE SKILL DI SCRITTURA CHE IL BRAND CHAT PORTA SEMPRE ADDOSSO, vendorate da upstream e cucite
+ * dentro `HarnessAgent` a ogni turno — senza varchi né selezioni: il prodotto è testo, e il testo
+ * che sa di chatbot è un difetto di qualità, non un'opzione.
+ *
+ * I markdown restano file veri (`$lib/agent-docs/skills/**`) diffabili contro upstream e inlineati
+ * con `?raw`; il frontmatter passa da `parseSkillFrontmatter`, lo stesso parser del loader del repo.
+ */
+import HUMANIZER from '$lib/agent-docs/skills/humanizer/SKILL.md?raw';
+import STOP_SLOP from '$lib/agent-docs/skills/stop-slop/SKILL.md?raw';
+import STOP_SLOP_PHRASES from '$lib/agent-docs/skills/stop-slop/references/phrases.md?raw';
+import STOP_SLOP_STRUCTURES from '$lib/agent-docs/skills/stop-slop/references/structures.md?raw';
+import STOP_SLOP_EXAMPLES from '$lib/agent-docs/skills/stop-slop/references/examples.md?raw';
+import { parseSkillFrontmatter, type HarnessRepoSkill } from './harness-skills';
+
+function toSkill(markdown: string, files?: HarnessRepoSkill['files']): HarnessRepoSkill {
+	const { attrs, body } = parseSkillFrontmatter(markdown);
+	return {
+		name: attrs.name,
+		description: attrs.description.replace(/\s+/g, ' ').trim(),
+		content: body.trim(),
+		...(files && files.length > 0 ? { files } : {})
+	};
+}
+
+const humanizer = toSkill(HUMANIZER);
+
+const stopSlop = toSkill(STOP_SLOP, [
+	{ path: 'references/phrases.md', content: STOP_SLOP_PHRASES.trim() },
+	{ path: 'references/structures.md', content: STOP_SLOP_STRUCTURES.trim() },
+	{ path: 'references/examples.md', content: STOP_SLOP_EXAMPLES.trim() }
+]);
+
+export const brandSkills: HarnessRepoSkill[] = [humanizer, stopSlop];


### PR DESCRIPTION
## What?

**Two commits, one arc — from "the agent carries writing skills" to "each agent carries its own kit".**

The brand chat agent now carries vendored writing skills inside `HarnessAgent` via the `skills: []` contract, and each agent of the team gets its own selection: `startHarnessTurn` takes `agentId`, and `skillsForAgent` maps every specialist to its skill set. All five specialists and the generalist get `humanizer` + `stop-slop`; the Motion specialist additionally gets the repo's `remotion-best-practices` — the only craft that writes Remotion source. Skills are wired in `startHarnessTurn` (`src/lib/agent/bridge/adapters.ts`), outside the `HARNESS_SKILLS` gate that stays reserved and global. Three candidates from skills.sh were evaluated; `egonex-ai/understand-anything` was rejected (code-comprehension skills for coding agents, not brand copy). Vendored markdown lives under `src/lib/agent-docs/skills/**`.

## Why?

Anomalia's product is text that speaks for a brand, and text that reads like a chatbot is a quality defect no unit test can see (eval scenarios use fake models and judge facts, not prose). The brand voice framework governs tone, but nothing structural stopped the usual AI tells. These two skills put a bar inside the model itself: stop-slop governs how prose is drafted, humanizer governs how it is reviewed. Both are MIT. Per-agent distribution answers Notion task 35 ("do team agents carry different skills?"): until now every turn received the identical bundle; the map in `brand-skills.ts` is now the single place where "this agent knows X, that one doesn't" becomes a one-line change.

## How?

- **Skills flow**: `const skills = [...(await skillsForAgent(opts.agentId)), ...(await loadHarnessSkills(skillSelection))]` — per-agent kit first, env gate as a global additive layer (repo skills default off because they target coding agents).
- **Per-agent map, not a new subsystem**: `SKILLS_BY_AGENT` is a plain `Record<TeamAgentId, string[]>`; names resolve against both sources (brand skills, repo `.agents/skills`), and a name existing nowhere falls silently. Unknown agent id → the writing skills, never an empty kit.
- **Custom agents stay classic**: a `skills` column on `custom_agents` was considered and dropped — custom agents run on the classic engine, outside the kit path, so nothing would consume it today. Surface returns if they ever move onto the kit.
- **Vendored markdown, not inline strings**: the upstream `SKILL.md` files stay as real files inlined with Vite `?raw` imports (pattern already used in `agent-files.ts`). This keeps them diffable against upstream and avoids 43KB in template literals where backticks and `${` are landmines.
- **One frontmatter parser**: `parseSkillFrontmatter` from `harness-skills.ts` extracts name/description/content — no duplicated YAML parsing.
- **stop-slop references as skill files**: `phrases.md`, `structures.md` and `examples.md` ride along as `files[]` on the skill, per the `HarnessV1Skill` contract of `@ai-sdk/harness` (progressive disclosure: only name+description sit in context until triggered).

## Testing?

- TDD: `src/lib/server/brand-skills.test.ts` written first and observed failing, then green — twice (module missing, then `skillsForAgent`/wiring missing). It covers exact skill set, full content (humanizer reaches its final sections — no truncation), attached reference files, the 64KB cap the file loader imposes, per-agent distribution (Motion's Remotion skill actually loads from the repo with content), and the fallback for unknown agents.
- Full unit suite: 5831 tests in 503 files, all passing.
- `svelte-check`: zero new errors; the 11 existing errors in `adapters.ts` are identical on `dev` (line numbers shifted only by the new import).
- Not tested: a real model run through the eval harness (`npm run eval`) — left for a scheduled run since this change adds context only, no tool or model-path logic. Risk: negligible context cost per turn (progressive disclosure loads only name+description).

## Evidence (screenshots/videos)

No UI change — server-side wiring only. Backend evidence:

<details>
<summary>Test run: new suite + adjacent suites (25 tests)</summary>

```
Test Files  3 passed (3)
     Tests  25 passed (25)
```
</details>

<details>
<summary>Full unit suite</summary>

```
Test Files  503 passed (503)
   Tests  5831 passed (5831)
```
</details>

<details>
<summary>Commit contents (16 files, +1079/−7 across both commits)</summary>

```
src/lib/agent-docs/skills/humanizer/SKILL.md       | 456 +++++
src/lib/agent-docs/skills/stop-slop/SKILL.md       |  68 ++
src/lib/agent-docs/skills/stop-slop/references/*   | 321 +++
src/lib/agent/bridge/adapters.ts                   |   5 +-
src/lib/agent/bridge/live.ts                       |   1 +
src/lib/content/changelog/2026-08-28-…​.ts          |  20 +
src/lib/server/brand-skills.ts                     |  52 ++−
src/lib/server/brand-skills.test.ts                |  86 ++−
changelog/2026-08-28-*.md                          |  71 +
```
</details>

## Anything Else?

- Known overlap between the two skills (both target AI tells) is intentional: one operates at drafting time, the other at revision time, and both load only their descriptions until triggered.
- Per-agent distribution is mechanism-first: today's map differentiates Motion only because that's the one real, existing fit. The next agent-specific skill is one line in `SKILLS_BY_AGENT`.
- Future direction: if evals surface brand-voice conflicts (e.g. a brand whose voice legitimately uses em dashes), the humanizer skill already includes an escape hatch for a writer's sample; a brand-specific override could hook into the existing voice framework rather than forking the skill.
