### PR TITLE
Give each team agent its own skill kit

### DIFF
--- a/changelog/2026-08-28-agent-skills-map.md
+++ b/changelog/2026-08-28-agent-skills-map.md
@@ -1,0 +1,30 @@
+# Skill per agente, non per tutti
+
+## Perché
+
+Con le skill di scrittura sempre addosso a tutti (entry precedente) il passo
+successivo era chiedersi CHI riceve COSA: la task Notion 35 chiedeva se ogni
+agente del team ha skill diverse. La risposta era no — lo stesso mazzo per
+ogni turno — ma la cucitura esisteva già: `startHarnessTurn` è per-turno e il
+chiamante (`live.ts`) conosce `spec.id`.
+
+## Cosa
+
+- `startHarnessTurn` prende `agentId` e il bridge lo passa (`live.ts`).
+- `skillsForAgent(agentId)` in `brand-skills.ts` è la mappa: ogni specialista
+  e il generalista ricevono le due skill di scrittura; il Motion aggiunge
+  `remotion-best-practices` dal repo — l'unico mestiere che scrive sorgente
+  Remotion. Agente sconosciuto = le due di scrittura (fallback, non vuoto).
+- `HARNESS_SKILLS` resta additivo e globale, com'era.
+
+## Scartato
+
+Una colonna `skills` su `custom_agents`: i custom agent girano sul motore
+classico (il drain esclude DM, persona e stanze dal percorso kit), quindi non
+consumerebbero skill harness — peso morto. La superficie arriva quando (se)
+i custom agent salgono sul kit.
+
+## Da fare quando cresce il mazzo
+
+Nuova skill + riga nella mappa. Il nome vale per entrambe le sorgenti; un
+nome che non esiste da nessuna parte cade in silenzio.

--- a/src/lib/agent/bridge/adapters.ts
+++ b/src/lib/agent/bridge/adapters.ts
@@ -46,7 +46,7 @@ import { HarnessRuntime } from '@anomalia/agent-adapters/runtime/harness-runtime
 import { HARNESS_SETUPS, stickySessionExtension } from '@anomalia/agent-adapters/runtime/harness-runtime';
 import { HarnessAgent } from '@ai-sdk/harness/agent';
 import { loadHarnessSkills, parseHarnessSkillSelection } from '$lib/server/harness-skills';
-import { brandSkills } from '$lib/server/brand-skills';
+import { skillsForAgent } from '$lib/server/brand-skills';
 import { createJustBashSandbox } from '@ai-sdk/sandbox-just-bash';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import type { StreamTextResult, ToolSet } from 'ai';
@@ -337,6 +337,7 @@ export async function dropLiveHarnessSession(sessionKey?: string | null): Promis
 
 export async function startHarnessTurn(opts: {
 	runId: string;
+	agentId?: string;
 	agentDir?: string;
 	model: { provider: string; id?: string };
 	system: string;
@@ -359,7 +360,7 @@ export async function startHarnessTurn(opts: {
 	const agentDir = opts.agentDir ?? ensureKieAgentDir();
 	const setup = knownSetup ?? (agentDir ? HARNESS_SETUPS.custom : HARNESS_SETUPS.pi);
 	const skillSelection = parseHarnessSkillSelection(env.HARNESS_SKILLS);
-	const skills = [...brandSkills, ...(await loadHarnessSkills(skillSelection))];
+	const skills = [...(await skillsForAgent(opts.agentId)), ...(await loadHarnessSkills(skillSelection))];
 	const sessionAffinity = harnessSessionSettings(opts.sessionKey);
 	const agent = new HarnessAgent({
 		harness: setup.harness(opts.model.id || undefined, agentDir, sessionAffinity),

--- a/src/lib/agent/bridge/live.ts
+++ b/src/lib/agent/bridge/live.ts
@@ -737,6 +737,7 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
 		const startTurnOnce = (fresh: boolean) => {
 			const startedTurn = startHarnessTurn({
 			runId: run.id,
+			agentId: spec.id,
 			model: modelRef,
 			system,
 				historyMd: savedResume

--- a/src/lib/content/changelog/2026-08-28-agent-specific-skills.ts
+++ b/src/lib/content/changelog/2026-08-28-agent-specific-skills.ts
@@ -1,0 +1,10 @@
+// Il formato lo definisce ./index.ts (PR changelog-entry-files): qui solo i dati.
+const entry = {
+  date: 'August 28, 2026',
+  title: 'A skill kit of their own',
+  items: [
+    'Each agent of your team now carries its own set of skills instead of one shared bundle — starting with the Motion specialist, who picks up the Remotion playbook nobody else needs.',
+  ],
+};
+
+export default entry;

--- a/src/lib/server/brand-skills.test.ts
+++ b/src/lib/server/brand-skills.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
-import { brandSkills } from './brand-skills';
+import { brandSkills, skillsForAgent } from './brand-skills';
+
+const WRITING = ['humanizer', 'stop-slop'];
 
 describe('brandSkills', () => {
 	it('porta esattamente humanizer e stop-slop, entrambi MIT', () => {
@@ -41,10 +43,38 @@ describe('brandSkills', () => {
 			}
 		}
 	});
+});
 
-	it('startHarnessTurn cucina le skill di brand dentro HarnessAgent, sempre', () => {
+describe('skillsForAgent — ogni agente ha le sue skill', () => {
+	it('i prose-writer (content, ugc, web, analyst, auto) ricevono le due skill di scrittura', async () => {
+		for (const agentId of ['content', 'ugc', 'web', 'analyst', 'auto']) {
+			const names = (await skillsForAgent(agentId)).map((s) => s.name).sort();
+			expect(names, agentId).toEqual(WRITING);
+		}
+	});
+
+	it('il Motion riceve anche la skill Remotion presa dal repo', async () => {
+		const names = (await skillsForAgent('motion')).map((s) => s.name).sort();
+		expect(names).toEqual([...WRITING, 'remotion-best-practices'].sort());
+		const remotion = (await skillsForAgent('motion')).find((s) => s.name === 'remotion-best-practices');
+		expect(remotion?.content).toContain('Remotion');
+	});
+
+	it('senza agente noto non lascia il turno a mani vuote: cadono le skill di scrittura', async () => {
+		for (const agentId of [undefined, null, 'chimera']) {
+			const names = (await skillsForAgent(agentId as string | undefined)).map((s) => s.name).sort();
+			expect(names).toEqual(WRITING);
+		}
+	});
+
+	it('startHarnessTurn cucina le skill PER AGENTE dentro HarnessAgent', () => {
 		const src = readFileSync('src/lib/agent/bridge/adapters.ts', 'utf8');
-		expect(src).toMatch(/\[\.\.\.brandSkills, \.\.\.\(await loadHarnessSkills\(skillSelection\)\)\]/);
+		expect(src).toMatch(/skillsForAgent\(opts\.agentId\)/);
 		expect(src).toMatch(/skills\.length > 0 \? \{ skills \} : \{\}/);
+	});
+
+	it('il bridge porta l’identità dell’agente fino a startHarnessTurn', () => {
+		const src = readFileSync('src/lib/agent/bridge/live.ts', 'utf8');
+		expect(src).toMatch(/agentId:\s*spec\.id/);
 	});
 });

--- a/src/lib/server/brand-skills.ts
+++ b/src/lib/server/brand-skills.ts
@@ -11,7 +11,8 @@ import STOP_SLOP from '$lib/agent-docs/skills/stop-slop/SKILL.md?raw';
 import STOP_SLOP_PHRASES from '$lib/agent-docs/skills/stop-slop/references/phrases.md?raw';
 import STOP_SLOP_STRUCTURES from '$lib/agent-docs/skills/stop-slop/references/structures.md?raw';
 import STOP_SLOP_EXAMPLES from '$lib/agent-docs/skills/stop-slop/references/examples.md?raw';
-import { parseSkillFrontmatter, type HarnessRepoSkill } from './harness-skills';
+import { loadHarnessSkills, parseSkillFrontmatter, type HarnessRepoSkill } from './harness-skills';
+import type { TeamAgentId } from '$lib/agent-owners';
 
 function toSkill(markdown: string, files?: HarnessRepoSkill['files']): HarnessRepoSkill {
 	const { attrs, body } = parseSkillFrontmatter(markdown);
@@ -32,3 +33,28 @@ const stopSlop = toSkill(STOP_SLOP, [
 ]);
 
 export const brandSkills: HarnessRepoSkill[] = [humanizer, stopSlop];
+
+const WRITING_SKILLS = brandSkills.map((s) => s.name);
+
+/**
+ * IL MAZZO DI SKILL DI OGNI AGENTE DEL TEAM — il posto dove "motion sa Remotion, gli altri no"
+ * diventa una riga. I nomi valgono per entrambe le sorgenti: le skill di brand (sopra) o quelle
+ * del repo (`.agents/skills`); un nome che non esiste da nessuna parte non dà errore, cade.
+ * Agenti sconosciuti (il default è il caso normale finché il chiamante non porta l'identità)
+ * ricevono le skill di scrittura: ogni agente del team scrive, e nessuno deve suonare un bot.
+ */
+const SKILLS_BY_AGENT: Record<TeamAgentId, string[]> = {
+	content: WRITING_SKILLS,
+	ugc: WRITING_SKILLS,
+	web: WRITING_SKILLS,
+	analyst: WRITING_SKILLS,
+	auto: WRITING_SKILLS,
+	motion: [...WRITING_SKILLS, 'remotion-best-practices']
+};
+
+export async function skillsForAgent(agentId?: string | null): Promise<HarnessRepoSkill[]> {
+	const names = SKILLS_BY_AGENT[agentId as TeamAgentId] ?? WRITING_SKILLS;
+	const brand = brandSkills.filter((skill) => names.includes(skill.name));
+	const repo = await loadHarnessSkills(names.filter((name) => !brandSkills.some((skill) => skill.name === name)));
+	return [...brand, ...repo];
+}


### PR DESCRIPTION
## What?

Each agent of the brand team now receives its own set of skills instead of one shared bundle. `startHarnessTurn` takes `agentId` (passed by `live.ts` as `spec.id`), and `skillsForAgent` (`src/lib/server/brand-skills.ts`) maps every specialist to its kit: the five specialists and the generalist get `humanizer` + `stop-slop`, and the Motion specialist additionally gets the repo's `remotion-best-practices` — the only craft that writes Remotion source.

## Why?

Until now every turn received the identical bundle, so the answer to "do our team agents carry different skills?" (Notion task 35) was no. The distribution map makes per-agent kits the default shape: the next agent-specific skill is one line in `SKILLS_BY_AGENT`, and `SKILL.md` files stay diffable against upstream.

## How?

- `SKILLS_BY_AGENT: Record<TeamAgentId, string[]>` — plain map, names resolve against both sources (brand skills and repo `.agents/skills`); a name that exists nowhere falls silently, an unknown agent id falls back to the writing skills rather than an empty kit.
- `HARNESS_SKILLS` stays global and additive, with its original purpose (repo coding skills default off).
- A `skills` column on `custom_agents` was considered and dropped: custom agents run on the classic engine, outside the kit path, so nothing would consume it today. The surface returns if they ever move onto the kit.

## Testing?

- TDD: tests written first and observed failing (`skillsForAgent` and the wiring missing), then green. Coverage: per-agent distribution (Motion's Remotion skill actually loads from the repo with real content), the fallback for unknown agents, and the existing suite extended for the map.
- Targeted suites: `brand-skills.test.ts` + full bridge directory, 112 tests green. Failure subset re-run in isolation: green.
- Full unit suite on this branch and on pure `dev` were compared run-for-run: both fail the same flaky class (timing tests like `redact` ≤ 200 ms, JPEG compression, drain races) under machine load — pre-existing on `dev`, not introduced here. One real fix was needed along the way: the worktree needed a fresh `npm ci` after `dev` gained #24/#25 (stale lockfile made `extractUserText is not a function` fail deterministically).
- Not tested: a real model run through the eval harness — this change adds context selection only, no tool or model-path logic. Risk: negligible (progressive disclosure loads only name+description until a skill triggers).

## Evidence (screenshots/videos)

No UI change — server-side wiring only. Backend evidence:

<details>
<summary>Targeted suites (brand-skills + bridge)</summary>

```
Test Files  6 passed (6)
     Tests  112 passed (112)
```
</details>

<details>
<summary>Full suite, this branch vs pure dev — same flaky failures on both</summary>

```
this branch:  13 failed | 5823 passed (5836)   (run 1: 12 failed, different set)
pure dev:     13 failed | 5819 passed (5832)
```
</details>

<details>
<summary>Commit contents (6 files, +104/−6)</summary>

```
src/lib/agent/bridge/adapters.ts                   |   5 +-
src/lib/agent/bridge/live.ts                       |   1 +
src/lib/server/brand-skills.ts                     |  24 ++++++
src/lib/server/brand-skills.test.ts                |  50 ++++++++----
changelog/2026-08-28-agent-skills-map.md           |  31 +++++++
src/lib/content/changelog/2026-08-28-agent-….ts    |  10 ++
```
</details>

## Anything Else?

- Follow-up candidates, deliberately out of scope here: per-agent kits for custom agents (blocked on the classic engine), and surfacing the map in the Agent Library UI.
- Related Notion task: 35 — "Capire se ogni agente del team ha skills diverse dagli altri".