### PR TITLE
Render _..._ as italic in chat markdown

### DIFF
--- a/changelog/2026-08-28-chat-underscore-italic.md
+++ b/changelog/2026-08-28-chat-underscore-italic.md
@@ -1,0 +1,27 @@
+# Il corsivo `_…_` che arrivava crudo
+
+Prima: `renderMd` (`src/lib/chat-markdown.ts`) sapeva rendere `**…**`, `__…__`,
+`*…*`, `~~…~~` ma non `_…_` — l'unico stile che il server scrive da solo, e non
+per eleganza. `failChatJob` (queue.ts) quando una ripresa in background muore
+senza produrre nulla scrive una riga `_…_` nel thread (la «ripresa che muore
+senza dirlo», v. `CHANGELOG.md:4574`), e i goal notice in forma vecchia
+portano `_…_`. Resultato: gli underscore crudi a schermo, nel caso
+evidenziato dall'utente («La ripresa in background non è partita — …»).
+
+Ora: `renderMd` rende `_…_` in `<em>`. Le guard sono parola-per-parola
+(lookbehind/lookahead `[\w]`), così `foo_bar_baz` resta intatto e `_…_` non
+ruba testo dentro identificatori. Il filtro sta dopo `__…__` → `<strong>`:
+il bold ha sempre la precedenza.
+
+Decisioni:
+
+- **Guard a confini di parola, non regex ingorda.** Il markdown di CommonMark
+  esclude underscore intraparo; senza guard, codici e slug del testo del
+  modello (`run_seo_geo_audit`, `foo_bar_baz`) diventerebbero corsivo spezzato.
+- **Niente post-processing tipo goal-status.** `splitGoalStatus` converte
+  `_…_` in `*…*` perché il suo paragrafo vive anche nel transcript del modello
+  e nella CLI. In chat il testo può essere reso direttamente: un fix nel
+  renderer è più in basso e serve ogni surface che passa da `renderMd`
+  (chat globale, thread, editor del post, pannello goal).
+- **Test a tre quase:** notice del server in corsivo vero, snake_case
+  intatto, `__…__` ancora bold (non doppio consumo).

--- a/src/lib/chat-markdown.test.ts
+++ b/src/lib/chat-markdown.test.ts
@@ -52,6 +52,24 @@ describe('escapeChatText / renderMd', () => {
   });
 });
 
+describe('renderMd emphasis', () => {
+  it('renders `_…_` in italic — the server notice must not show raw underscores', () => {
+    const html = renderMd('_La ripresa in background non è partita: dimmi di riprovare._');
+    expect(html).toContain('<em>La ripresa in background non è partita: dimmi di riprovare.</em>');
+    expect(html).not.toContain('_');
+  });
+
+  it('leaves snake_case alone', () => {
+    expect(renderMd('foo_bar_baz')).toBe('foo_bar_baz<br>');
+  });
+
+  it('keeps `__…__` bold, not italic', () => {
+    const html = renderMd('__bold__');
+    expect(html).toContain('<strong>bold</strong>');
+    expect(html).not.toContain('<em>');
+  });
+});
+
 describe('renderMd images', () => {
   const OURS = `${new URL(PUBLIC_SUPABASE_URL).origin}/storage/v1/object/public/media/u/a.png`;
 

--- a/src/lib/chat-markdown.ts
+++ b/src/lib/chat-markdown.ts
@@ -118,6 +118,8 @@ export function renderMd(text: string): string {
       .replace(/`([^`]+)`/g, '<code>$1</code>')
       .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
       .replace(/__(.*?)__/g, '<strong>$1</strong>')
+      // After __…__ so bold wins; word guards keep foo_bar_baz intact.
+      .replace(/(?<![\w])_(\S(?:[^_]*?\S)?)_(?![\w])/g, '<em>$1</em>')
       .replace(/\*(.*?)\*/g, '<em>$1</em>')
       .replace(/~~(.*?)~~/g, '<del>$1</del>')
       // Images before links — same []() shape, leading !

--- a/src/lib/content/changelog/2026-08-28-chat-underscore-italic.ts
+++ b/src/lib/content/changelog/2026-08-28-chat-underscore-italic.ts
@@ -1,0 +1,11 @@
+import type { ChangelogEntry } from './index';
+
+const entry: ChangelogEntry = {
+  date: 'August 28, 2026',
+  title: 'System notices read as italic, not raw underscores',
+  items: [
+    'Short system notices in chat — like the one telling you a background task did not start — now show in italic instead of displaying raw underscores around the text.'
+  ]
+};
+
+export default entry;


### PR DESCRIPTION
## What?
`renderMd` now renders `_..._` as `<em>`. Before, the only emphasis the server writes by itself — the background-resume notice in `failChatJob` and legacy goal notices — arrived on screen with raw underscores: _La ripresa in background non è partita — …_.

## Why?
Those notices are meant to read as italic system notes, not literal underscores. Reported by the user on a real thread: the notice text showed raw `_..._` because the markdown renderer knew `**...**`, `__...__`, `*...*`, `~~...~~` but not `_..._`.

## How?
A single replace in the inline chain (`src/lib/chat-markdown.ts`), placed **after** the `__...__` → `<strong>` pass so bold always wins. Word-boundary guards (lookbehind before the opening `_`, lookahead after the closing one) keep intraword underscores intact: `foo_bar_baz` and identifiers like `run_seo_geo_audit` are never converted — the CommonMark intraword rule.

## Testing?
- TDD: 3 new tests written first and watched fail, then pass:
  - the actual server notice renders in `<em>` with zero raw `_`;
  - `foo_bar_baz` untouched;
  - `__bold__` stays bold, never double-consumed.
- Full unit suite: 5854/5855 green. The single failure (`tool-job-background.test.ts`, 5s timeout) is a pre-existing load flake — passes twice in isolation, unrelated module.
- `svelte-check` on touched files clean (454 baseline errors on dev, all in files not touched).
- Not verified in the browser: no local stack was running; the fix is a pure function covered by tests against the exact production string.

## Evidence (screenshots/videos)
None: no UI change beyond text styling, no local stack available in this session. The failing case before and after:

```
in:  '_La ripresa in background non è partita: dimmi di riprovare._'
out (before): _La ripresa in background non è partita: dimmi di riprovare._<br>
out (after):  <em>La ripresa in background non è partita: dimmi di riprovare.</em><br>
```

## Anything Else?
`splitGoalStatus` still converts `_..._` → `*...*` for goal notices — correct, since that text also lives in the model transcript and CLI. Chat rendering now handles `_..._` natively, so that translation remains a compatibility shim, removable later.

Notion task: https://app.notion.com/p/3ca2944ee2a78148bcbdf3d6a3711c20