### PR TITLE
Add HackerOne-style PR description template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,38 @@
+<!--
+Reference: https://www.hackerone.com/blog/writing-great-pull-request-description
+Title: short prose sentence summarizing the change (not just "fix bug").
+-->
+
+## What?
+
+<!-- What changes, in a few explicit sentences graspable in seconds. Explain the change first, then the ticket.
+Do NOT write: "Closes #123" alone. -->
+
+## Why?
+
+<!-- The business/engineering goal this change achieves. Complete sentences, active voice, present tense. -->
+
+## How?
+
+<!-- The diff tells part of the story: highlight significant design decisions here,
+rejected alternatives, libraries used and why. -->
+
+## Testing?
+
+<!-- What was tested (unit + manual verification), how to reproduce locally, what was NOT tested and why, associated risks. -->
+
+## Evidence
+
+<!-- Proof backing this PR, captured from the real app under local debug (never hosted/production):
+- Before/after screenshots for UI changes (+ at least one stressed edge case)
+- CLI output / API responses / plans for backend inside <details><summary>
+- Every image captioned: where it was captured (URL/brand/thread), what it shows, why it proves the point.
+
+Verification architecture used:
+- Local DB: [ ]
+- Worktree app running: [ ]
+- Login: test@anomalia.so / 123456 on the demo brand -->
+
+## Anything Else?
+
+<!-- Known tech debt, deferred optimizations, future directions. -->


### PR DESCRIPTION
## What?
Adds `.github/PULL_REQUEST_TEMPLATE.md`: the HackerOne-style PR description structure (What? / Why? / How? / Testing? / Evidence / Anything Else?) that this repo's AGENTS.md already prescribes, now pre-loaded by GitHub on every new pull request.

## Why?
Until now the structure lived only in AGENTS.md, so it was enforced only when an agent opened the PR. Anyone opening a PR from the browser gets a blank description. The template makes the mandatory structure visible and copy-paste ready for human contributors too.

## How?
One static markdown file in `.github/`, the standard GitHub PR template location. The comment blocks carry the writing guidance (explicit prose, no bare "Closes #123", evidence before assertions) copied from the AGENTS.md rule, with a link to the HackerOne reference article. No workflow or config change needed — GitHub picks it up automatically.

## Testing?
Not applicable beyond content review: a static template file has no runtime behavior. Verification is structural — the file sits at `.github/PULL_REQUEST_TEMPLATE.md`, so GitHub will render it in the PR creation form on the next PR opened via the web UI. This very PR was written following the same structure manually.

## Evidence (screenshots/videos)
None: no UI change. After merge, opening a new PR on GitHub will show the pre-filled template — one visual check anyone can do.

## Anything Else?
None. Single-commit, single-file change.