### PR TITLE
Record local testing lessons from the onboarding audit

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -24,6 +24,26 @@ PR squash-mergiata + branch di lavoro con più commit: `git rebase origin/dev` r
 ### Guarda lo stato della PR prima di diagnosticare lag
 `gh pr view` che mostra il vecchio head per minuti sembra cache di GitHub. Può essere che la PR sia **chiusa** e il branch cancellato — e che il tuo push l'abbia ricreato come orfano. `gh api repos/:org/:repo/pulls/N --jq '.state'` prima di ipotesi sulla freschezza dell'API.
 
+## Testare la piattaforma nel browser: worker locale ed ambiente
+
+### Il worker locale è un build vecchio che compete per la stessa coda
+La stack Docker porta un'app pronta (`anomalia-app`, immagine `anomalia-selfhost-app`) che prosciuga `chat_jobs` dallo stesso DB del dev server: il cron chiama `app:3000`, non la tua porta. Con l'immagine più vecchia del checkout, il codice nuovo **non gira mai** (il team contact post-onboarding non parte) e i due reaper si contendono i turni: `chat turn died mid-flight (heartbeat lost)` su turni vivi, `Failed to load url credits.ts` da moduli che nel checkout esistono. Segnale: `chat_jobs` failed con errori che il codice attuale non può produrre. Mossa: identificare chi prosciuga la coda prima di giudicare il flusso — `docker logs anomalia-app`, data dell'immagine (`docker images`) contro `git log -1` — e fermare o ricostruire il container stantio (ricordarsi di riaccenderlo).
+
+### Le env del repo puntano all'hosted; la stack locale porta le sue chiavi in kong.yml
+Il `.env` del repo punta a un progetto Supabase hosted, mentre la compose gira da un altro checkout con le chiavi veramente valide dentro `anomalia-kong:/usr/local/kong/kong.yml`. Il seed (`scripts/db-seed.mjs`) pretende `DATABASE_URL` e fallisce con parse error leggendo `.env` a mano (contiene valori con `<...>`). Mossa: overlay env a parte — `PUBLIC_SUPABASE_URL=http://localhost:8000`, chiavi estratte da kong.yml, `DATABASE_URL` dalla compose — e avviare il dev con quello; mai puntare all'hosted "per comodità".
+
+### La porta 5173 può appartenere al vite di un altro worktree
+Un `vite dev` di un altro worktree risponde 404 a tutto e resta lì in ascolto; il CLI ci si punta da solo. Mossa: `lsof -nP -iTCP:5173 -sTCP:LISTEN` e `ps` sul PID prima di `npm run dev`; se occupata, porta esplicita (`npm run dev -- --port 5175`).
+
+### Il profilo del browser di test conserva sessioni e localStorage
+`agent-browser` riutilizza cookie e localStorage tra le run: un test "guest" parte loggato, e l'onboarding di un utente nuovo legge `localStorage['anomalia:first-agent:<altro-brand>']` dell'utente prima — fetch di thread altrui (404 rumorosi ma disordini nella diagnosi). Mossa: `cookies clear` **e** `storage local clear` prima di ogni persona nuova; verificate sempre chi siete (`location.href`, sidebar) prima del primo click.
+
+### I rimount (`{#key}`) rendono stale i ref dell'automazione browser
+Un click su un ref catturato prima del re-render non arriva a nessuno: il carosello dell'onboarding sembrava bloccato prima del pick — era il bottone rimontato ad ogni slide. Mossa: snapshot fresco e selettori stabili (`.wide-btn`), click lenti; un "blocco" va riprodotto con click lenti e selelettori nuovi prima di chiamarlo bug. Il falso positivo costa un'ora, la prudenza tre secondi.
+
+### Un cookie di sessione malformato abbatte il dev server
+Una curl con `sb-<host>-auth-token` corrotto produce `Invalid Base64-URL character` non gestito nella recovery della sessione e il processo muore (`curl` → 000, niente più risposte). È un finding prodotto, non rumore: la recovery non tollera input corrotto. Mossa: quando curl dà 000, guardare il log del server prima di incolpare la rete; e la richiesta che ha ucciso il server diventa un test.
+
 ## Codice
 
 ### Markdown venduto: file veri + `?raw`, non template literal


### PR DESCRIPTION
## What?

Aggiunge a `LESSONS.md` una nuova sezione, "Testare la piattaforma nel browser: worker locale ed ambiente", con sei lezioni pagate durante l'audit dell'onboarding (task #39 su Notion). Nessun codice toccato: solo documentazione operativa.

## Why?

Chi testa la piattaforma localmente incontra sempre gli stessi guasti ambientali senza sapere che non sono difetti di codice — e viceversa rischia di scartare come "rumore" difetti veri. Le lezioni registrano il segnale che riconosce ogni guasto e la mossa che lo risolve: la coda locale con più worker in gara, le env del repo che puntano all'hosted, la porta 5173 occupata da vite di altri worktree, il profilo browser che conserva sessioni e localStorage, i ref stale dell'automazione dopo un remount, e un cookie di sessione malformato che abbatte il dev server.

## How?

Sei voci, ognuna col formato del file (segnale → mossa, niente storie):

1. **Worker stantio sulla stessa coda** — `anomalia-app` (immagine `anomalia-selfhost-app`) prosciuga `chat_jobs` via cron su `app:3000`, non dalla porta del dev server. Con l'immagine più vecchia del checkout il codice nuovo non gira mai e i reaper si contendono i turni.
2. **Env del repo vs chiavi locali** — `.env` punta a un progetto hosted; le chiavi valide della stack compose stanno in `anomalia-kong:/usr/local/kong/kong.yml`. Overlay env a parte, mai hosted "per comodità".
3. **Porta 5173** — può appartenere al vite di un altro worktree (404 su tutto): `lsof` prima, porta esplicita dopo.
4. **Profilo browser** — cookie e localStorage sopravvivono tra le run: `cookies clear` + `storage local clear` per ogni persona nuova.
5. **Ref stale dopo `{#key}`** — un click su bottone rimontato non arriva a nessuno; il falso positivo "carosello bloccato" costa un'ora, i selettori freschi tre secondi.
6. **Cookie malformato** — un `sb-<host>-auth-token` corrotto produce `Invalid Base64-URL character` non gestito nella recovery della sessione e il processo muore: è un finding prodotto, da trasformare in test.

Alternativa scartata: una guida separata `docs/testing-local.md`. LESSONS è già il posto dove chi diagnosa guarda prima (regola in AGENTS.md) — un secondo file non viene letto.

## Testing?

Niente da lanciare: la modifica è un file markdown, nessun test unitario toccato. Le sei lezioni sono verificate dagli incidenti dell'audit della task #39 (3 onboarding completi su stack locale con utenti `audit39*`, brand `bowora`/`bowora-m7ww`/`example-domain`, dev server su porta 5175 contro la stack Docker locale): ogni voce riporta il segnale osservato in quella sessione (job `chat turn died mid-flight (heartbeat lost)`, `Failed to load url credits.ts`, `curl` → 000 con server morto, carosello "bloccato" che con selettori freschi arriva al pick). Non verificato: nulla da verificare oltre alla lettura.

## Evidence

Nessuno screenshot: cambiamento invisibile all'utente. Le prove degli incidenti che hanno pagato le lezioni stanno nel commento di audit sulla task #39 (Notion, "Anomalia > Tasks").

Verification architecture used:
- Local DB: [x] (stack compose `anomalia-*`, kong su :8000, db su :5432)
- Worktree app running: [x] (`npm run dev -- --port 5175` dal worktree/checkout, env overlay locale)
- Login: test@anomalia.so / 123456 on the demo brand

## Anything Else?

La lezione 6 (cookie malformato che uccide il processo) merita un test di regression su `hooks.server.ts` in un PR futuro: la registrazione in LESSONS è la mossa immediata, il test la segue. La lezione 1 ha già prodotto la diagnosi del difetto registrato nella task Notion "AGENT_KIT=on: il team non contatta mai il nuovo utente" — il fix è altrove.
