### PR TITLE
Stabilize flaky test suite under load

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -7,6 +7,12 @@ Lezioni imparate lavorando a questo repo: problemi veri, il segnale che li fa ri
 ### Il worktree nuovo ha bisogno di `npm ci` — e ancora dopo ogni rebase su dev
 Un worktree parte senza `node_modules`, e `vite.config.ts` muore subito (`Cannot find package '@sentry/sveltekit'`). Ma il caso insidioso è l'altro: dopo aver ribasato su dev che ha accolto PR nuove, il `node_modules` installato col vecchio lockfile produce guasti **deterministici e fuori posto** — v. `extractUserText is not a function` in un test di immagini: il codice era giusto, le dipendenze vecchie. Segnale: un errore `X is not a function` su codice mai toccato, in un worktree ribasato. Mossa: `npm ci` nel worktree, sempre, dopo il rebase.
 
+### Il worktree nuovo ha bisogno anche del `.env`
+Dopo il `npm ci` la suite parte ma cade su 40+ test con `SUPABASE_SERVICE_ROLE_KEY not configured`: Vitest carica l'env dal `.env` del worktree, che non c'è. Segnale: errori di env mancante in un worktree fresco, deterministici, su file che passano nel checkout principale. Mossa: `cp ../anomalia/.env .` alla creazione del worktree, accanto al `npm ci`.
+
+### Un test che sceglie un ramo in base all'env locale non è un test
+`queue-dm.test` girava o no il ramo kit secondo `AGENT_KIT` del `.env` locale: sul laptop di chi lo ha spento passava, su chi lo ha acceso il turno andava nel kit e `harnessCalls` restava vuoto (`expected +0 to be 1`). Segnale: un test che fallisce solo su un'altra macchina, senza cambiamento di codice. Mossa: chi fissa `$env/dynamic/private` nel test (`vi.mock('$env/dynamic/private', () => ({ env: { AGENT_KIT: 'off' } }))`), come già fa `queue-kit-heartbeat.test` — la scelta del ramo è parte del test, non del computer che lo esegue.
+
 ### `@anomalia/*` si risolve dal `node_modules` del checkout principale
 Un eval o un test lanciato da un worktree misura un ibrido: `$lib` punta alla copia del worktree, i pacchetti interni vengono dal checkout madre. Se hai toccato `packages/`, il worktree non lo vede. Per un confronto pulito: worktree di verifica con `node_modules` symlinkato a quello fresco.
 
@@ -17,6 +23,12 @@ Con più worktree aperti (feature + verifica), un edit fatto nel checkout sbagli
 
 ### La suite completa fallisce da sola: confronta run-per-run con dev puro
 Sotto carico (worker paralleli) i test di timing e race cadono da soli: `redact` ≤ 200ms che ne impiega 404, JPEG ≤ 2MB, drain "executes exactly once". Lo stesso sottoinsieme, rilanciato isolato, passa. Prima di imputarsi un fallimento della suite completa: (1) rilancia il sottoinsieme isolato, (2) lancia la suite completa su **dev puro** nello stesso setup. Se dev fallisce uguale, il rumore non è tuo. Vero anche il rovescio: "tutta verde" sul tuo branch non dice niente se dev non lo è.
+
+### Il numero di file rossi che cambia tra run è un timeout, non una race
+"9 file rossi, poi 11, sullo stesso albero": quando l'insieme dei falliti varia tra run e la stragrande maggioranza dei test dice `Test timed out in 5000ms`, non cercare una race — è il timeout per-test al default di Vitest (5s) che i test I/O-bound attraversano in modo non deterministico secondo il carico della macchina (misurato: 38 timeout su 43 test falliti in una run, con picchi fino a 15 file su 509). Mossa: `testTimeout` esplicito in `vite.config.ts` (120s: i turni kit completi toccano i 40s da soli e oltre il minuto con la macchina satura da altre sessioni, e un hang vero brucia in minuti, non in secondi) e soglie perf ben sopra il rumore (`redact` da 200ms a 1s: il regex catastrofico che il guardrail caccia brucia in secondi, i 342ms di rumore no).
+
+### Il sonno fisso prima dell'asserzione è la race in nuce
+`await new Promise(r => setTimeout(r, 250))` e poi asserire su righe salvate in background: sotto il carico della suite intera i 250ms non bastano e l'asserzione vede lo stato a metà (`expected false to be true` su un `every(done)`). Segnale: test che passa da solo e cade solo nella suite completa, su un'asserzione che riguarda lavoro asincrono post-fine-turno. Mossa: `vi.waitFor(() => expect(statoFinale)...)` — aspettare la CONDIZIONE, non un numero di millisecondi sperato; già usato in `tool-job-drain.test`.
 
 ### Il `git rebase` scarta da solo il commit già squashato in dev
 PR squash-mergiata + branch di lavoro con più commit: `git rebase origin/dev` riconosce il contenuto identico, salta il commit e resta solo quello nuovo. Zero conflitti. Poi `push --force-with-lease` e PR nuova con un commit solo.

--- a/changelog/2026-08-28-test-suite-stabilize.md
+++ b/changelog/2026-08-28-test-suite-stabilize.md
@@ -1,0 +1,34 @@
+# Stabilizzazione della suite: il numero di file rossi non è più una lotteria
+
+La task #20 descriveva "9 poi 11 file rossi sullo stesso albero". La diagnosi
+ha trovato tre cause sovrapposte, non una.
+
+**Prima.** Vitest girava al default: `testTimeout` 5s, niente config. La suite
+(509 file, test I/O-bound con pipeline asincrone vere su modelli finti) produceva
+22–43 fallimenti a run, quasi tutti `Test timed out in 5000ms`; l'insieme dei
+file rossi variava col carico della macchina. In più `queue-dm.test` sceglieva
+il ramo kit/classico secondo l'`AGENT_KIT` del `.env` locale — passava su un
+laptop e moriva sull'altro — e i test di fine turno di `live.test` aspettavano
+il salvataggio asincrono con sonni fissi da 250ms.
+
+**Decisioni.**
+- `testTimeout: 120_000` in `vite.config.ts`: i turni kit completi toccano 40s da soli e
+  oltre il minuto con la macchina satura. Un hang vero brucia in minuti, quindi la
+  soglia resta un rilevatore.
+- Guardrail perf di `redact` allargato da 200ms a 1s: misura 48ms da solo,
+  ~300ms sotto carico; il regex catastrofico che il guardrail caccia brucia
+  in secondi. Soglia sopra il rumore, sotto il disastro.
+- `queue-dm.test` fissa `$env/dynamic/private` con `AGENT_KIT: 'off'`: la
+  scelta del ramo è parte del test, non del computer che lo esegue.
+- I tre test "thread incastrato" aspettano `vi.waitFor` sulla condizione
+  finale invece del sonno fisso.
+
+**Scartato.** Timeout per-test espliciti sui soli test lenti: un diff largo e
+fragile a ogni nuovo test I/O-bound; il default largo uniforme costa al massimo
+60s una volta su un hang vero.
+
+**Ambiente, non codice.** Le 5 failure "deterministiche" di
+`harness-pi-images` (`extractUserImages is not a function`) erano `node_modules`
+stantie in worktree: `npm ci` + copia `.env` e la classe sparisce. Le lezioni
+(nuovo worktree, env locale nei test, sonni fissi, timeout variabile) sono in
+LESSONS.md.

--- a/src/lib/agent/bridge/live.test.ts
+++ b/src/lib/agent/bridge/live.test.ts
@@ -1541,7 +1541,15 @@ describe('lo scenario del thread incastrato e61c5136: partito da lì, l’agente
 			locale: 'it'
 		});
 		await res.text();
-		await new Promise((r) => setTimeout(r, 250));
+		await vi.waitFor(
+			() => {
+				const threadRuns = rows.filter((r) => r.thread_id === 't-stuck');
+				expect(threadRuns.at(-1)?.state).toBe('waiting_input');
+				expect(threadRuns.slice(0, -1).every((r) => r.state === 'done')).toBe(true);
+				expect(savedMessages.some((m) => JSON.stringify(m.content).includes('Cosa ti aspettavi'))).toBe(true);
+			},
+			{ timeout: 15_000, interval: 100 }
+		);
 
 		for (const m of savedMessages) {
 			expect(JSON.stringify(m.content)).not.toContain('502 frame');
@@ -1610,7 +1618,15 @@ describe('lo scenario del thread incastrato e61c5136: partito da lì, l’agente
 			locale: 'it'
 		});
 		await res.text();
-		await new Promise((r) => setTimeout(r, 250));
+		// Il salvataggio di fine turno è best-effort asincrono: si aspetta lo stato finale invece
+		// di sperare in un sonno fisso, che sotto il carico della suite intera non basta mai.
+		await vi.waitFor(
+			() => {
+				expect(rows.filter((r) => r.thread_id === 't-no-repeat').every((r) => r.state === 'done')).toBe(true);
+				expect(savedMessages.some((m) => JSON.stringify(m.content).includes('502 frame'))).toBe(true);
+			},
+			{ timeout: 15_000, interval: 100 }
+		);
 
 		const withReply = savedMessages.filter((m) => JSON.stringify(m.content).includes('502 frame'));
 		expect(withReply).toHaveLength(1);
@@ -1633,7 +1649,13 @@ describe('lo scenario del thread incastrato e61c5136: partito da lì, l’agente
 			locale: 'it'
 		});
 		await res.text();
-		await new Promise((r) => setTimeout(r, 250));
+		await vi.waitFor(
+			() => {
+				expect(rows.filter((r) => r.thread_id === 't-repeat-cap').every((r) => r.state === 'done')).toBe(true);
+				expect(savedMessages.some((m) => JSON.stringify(m.content).includes('Mi sto ripetendo'))).toBe(true);
+			},
+			{ timeout: 15_000, interval: 100 }
+		);
 
 		for (const m of savedMessages) {
 			expect(JSON.stringify(m.content)).not.toContain('502 frame');

--- a/src/lib/server/chat/queue-dm.test.ts
+++ b/src/lib/server/chat/queue-dm.test.ts
@@ -14,6 +14,10 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Row = Record<string, any>;
 
+// Il percorso sotto test è quello classico del queue: il kit si spegne qui, non nel .env
+// locale — altrimenti la suite passa sul laptop di chi lo ha spento e muore su chi lo ha acceso.
+vi.mock('$env/dynamic/private', () => ({ env: { AGENT_KIT: 'off' } }));
+
 // ── Il confine mockato: modello, prompt base, tool pesanti. Il resto è codice vero. ────────────
 const harnessCalls: Array<{ system: string; messages: Array<{ role: string; content: unknown }> }> = [];
 vi.mock('$lib/server/harness', () => ({

--- a/src/lib/server/redact.test.ts
+++ b/src/lib/server/redact.test.ts
@@ -123,12 +123,14 @@ describe('fail-closed', () => {
 });
 
 describe('costo', () => {
-  // Guardrail contro un regex catastrofico aggiunto in futuro: misurato 48 ms su 1 MB.
-  it('sta sotto i 200 ms su 1 MB', () => {
+  // Guardrail contro un regex catastrofico aggiunto in futuro: misurato 48 ms su 1 MB,
+  // ~300 ms con la suite in parallelo. Un regex esplosivo brucia in secondi: la soglia
+  // sta sopra il rumore e sotto il disastro.
+  it('sta sotto 1 s su 1 MB', () => {
     const big = ('riga di traccia con un po di testo e un uuid 0a1b2c3d-4e5f-4a6b-8c7d-9e0f1a2b3c4d\n').repeat(11000);
     const t0 = Date.now();
     redactSecrets(big, KNOWN);
-    expect(Date.now() - t0).toBeLessThan(200);
+    expect(Date.now() - t0).toBeLessThan(1000);
   });
 });
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,6 +30,14 @@ const nodeModulesReal = (() => {
  */
 const hmr = process.env.NO_HMR === '1' || process.env.NO_HMR === 'true' ? false : undefined;
 
+/**
+ * Timeout per-test a 120s: test I/O-bound (turni kit completi, 40s+ da soli e oltre il minuto
+ * con la macchina satura) su 509 file in parallelo sforano il default di 5s in modo non
+ * deterministico col carico. Un hang vero brucia in minuti, quindi la soglia resta un rilevatore.
+ * Dettagli e lezione in LESSONS.md ("Il numero di file rossi che cambia tra run è un timeout").
+ */
+const TEST_TIMEOUT_MS = 120_000;
+
 export default defineConfig({
   server: { hmr, fs: { allow: ['..', ...(nodeModulesReal ? [nodeModulesReal] : [])] } },
   plugins: [sentrySvelteKit({
@@ -69,6 +77,7 @@ export default defineConfig({
     noExternal: ['simple-icons']
   },
   test: {
+    testTimeout: TEST_TIMEOUT_MS,
     include: [
       'src/**/*.{test,spec}.{js,ts}',
       'packages/*/src/**/*.{test,spec}.{js,ts}',


### PR DESCRIPTION
## What?

The unit suite (509 files) failed inconsistently between runs on the same tree: 9-15 red files one run, a different set the next. Diagnosis traced it to three overlapping causes, all fixed here: Vitest's 5s default test timeout (38 of 43 failures in one measured run were `Test timed out in 5000ms`), one test whose branch selection depended on the local `.env`, and fixed-sleep assertions on async end-of-turn saves. Also sets an explicit `testTimeout: 120s` in `vite.config.ts`, widens a perf guardrail that sat below parallel-load noise, and records four paid lessons in LESSONS.md.

## Why?

The red-file count changing per run made every CI/local run a lottery and every green run meaningless — a flaky suite hides real defects. Stabilizing it restores the suite as a pass/fail signal, which is the precondition for trusting any future change.

## How?

- `testTimeout: 120_000` in `vite.config.ts`: the suite's I/O-bound tests (full kit turns with `verdictLaps`) reach 40s on their own and over a minute when the machine is saturated by other sessions; an unmodified 5s default flaked non-deterministically with machine load. A real hang still burns in minutes, so the threshold stays a detector. Rejected alternative: per-test explicit timeouts on the ~15 slow tests — a wide, fragile diff that every new slow test would have to remember.
- `redact.test.ts` perf guardrail 200ms → 1s: measures 48ms idle, ~300ms under parallel load; the catastrophic regex it guards against burns in seconds. Threshold now sits above noise, below disaster.
- `queue-dm.test.ts`: pins `/dynamic/private` with `AGENT_KIT: 'off'` so the kit-vs-classic branch choice is part of the test, not of the machine running it (it passed on laptops with AGENT_KIT off and died on the on one).
- `live.test.ts` stuck-thread tests: fixed 250ms sleeps before asserting on async post-save state replaced with `vi.waitFor` on the final condition (`{ timeout: 15_000, interval: 100 }` — the 1s default waitFor budget is not enough under load).
- LESSONS.md: four new entries (fresh worktree needs `.env`, env-dependent branch selection, varying red-file count = timeout, fixed sleep vs waitFor).

Out of scope but discovered during diagnosis: the 5 'deterministic' `harness-pi-images` failures (`extractUserImages is not a function`) were stale worktree `node_modules`, not code — `npm ci` + `.env` copy fixed them; LESSONS.md already documented that class, no code change needed.

## Testing?

- Full suite on dev baseline: 22-43 tests red per run (mostly 5s timeouts). After the fix: 509/509 green in a normal-load run.
- Under external CPU saturation (other sessions active) one B5 test crossed even 60s, which drove the threshold to 120s.
- `npm run typecheck:runtime` ok; the touched files pass repeatedly in isolation (live.test 62/62 x3, redact 52/52, queue-dm 4/4).
- Not verified: CI runner (ubuntu) behavior — the fix targets the same class of load there, but a real CI run is the only proof. Risk: none beyond the config change itself.
- Reproduce locally: `npx vitest run` twice on dev vs this branch.

## Evidence (screenshots/videos)

Test-only/config change: no UI, so screenshots do not apply. Terminal evidence:

<details>
<summary>Baseline on dev (main checkout, normal load): 12 files / 22 tests red</summary>

```
 Test Files  12 failed | 497 passed (509)
      Tests  22 failed | 5846 passed (5868)
   Start at  14:17:19   Duration  153.20s
```
</details>

<details>
<summary>Failure taxonomy (one full run): 38 of 43 failures were 5s timeouts</summary>

```
  38 → Test timed out in 5000ms.
   1 → expected 342 to be less than 200      (redact perf guardrail)
   1 → expected spy to be called 1 times ... (downstream of a timeout)
```
</details>

<details>
<summary>After the fix (worktree, .env + npm ci, normal load): all green</summary>

```
 Test Files  509 passed (509)
      Tests  5868 passed (5868)
   Duration  179.51s
```
</details>

<details>
<summary>Stressed edge case: saturated machine (CPU ~131%, suite 8m31s) — one 60s timeout, threshold raised to 120s, live.test 62/62 after</summary>

```
 FAIL  live.test.ts > B5 > in Agent (e senza modalità) — Test timed out in 60000ms
 → testTimeout raised to 120s → live.test.ts alone: Tests 62 passed (62)
```
</details>

## Anything Else?

Remaining known limitation: under extreme external saturation no wall-clock threshold guarantees green — LESSONS.md already documents how to tell machine noise from a real defect (re-run the subset in isolation, compare dev against the same setup). The suite's own parallelism (collect time dominates wall time) is the next lever if run time matters more than stability.