### PR TITLE
Fix chat dying on OpenRouter streams without finish_reason

### DIFF
--- a/changelog/2026-08-28-openrouter-stream-finish.md
+++ b/changelog/2026-08-28-openrouter-stream-finish.md
@@ -1,0 +1,14 @@
+# OpenRouter chat streams ended as errors without a finish reason
+
+OpenRouter can close a valid OpenAI-compatible stream after sending response
+text but omit `finish_reason`. The bundled Pi adapter treated that provider
+behavior as a fatal error, so chat turns were marked failed even when the
+response had already arrived. The failure was specific to the legacy
+`@earendil-works/pi-ai` dependency used by `@ai-sdk/harness-pi`.
+
+The dependency patch now marks OpenRouter as tolerant of missing finish
+reasons and infers `stop` for text responses or `toolUse` when a tool call was
+received. Explicit provider errors and missing finish reasons from other
+providers remain fatal. A regression test feeds the adapter an OpenRouter SSE
+response with valid text and no finish reason, then verifies the completed
+result.

--- a/patches/@earendil-works+pi-ai+0.74.2.patch
+++ b/patches/@earendil-works+pi-ai+0.74.2.patch
@@ -1,0 +1,45 @@
+diff --git a/node_modules/@earendil-works/pi-ai/dist/providers/openai-completions.js b/node_modules/@earendil-works/pi-ai/dist/providers/openai-completions.js
+index 4f2e1d5..e451ae9 100644
+--- a/node_modules/@earendil-works/pi-ai/dist/providers/openai-completions.js
++++ b/node_modules/@earendil-works/pi-ai/dist/providers/openai-completions.js
+@@ -305,7 +305,10 @@ export const streamOpenAICompletions = (model, context, options) => {
+             if (output.stopReason === "error") {
+                 throw new Error(output.errorMessage || "Provider returned an error stop reason");
+             }
+-            if (!hasFinishReason) {
++            if (!hasFinishReason && compat.supportsFinishReason === false) {
++                output.stopReason = output.content.some((block) => block.type === "toolCall") ? "toolUse" : "stop";
++            }
++            if (!hasFinishReason && compat.supportsFinishReason !== false) {
+                 throw new Error("Stream ended without finish_reason");
+             }
+             stream.push({ type: "done", reason: output.stopReason, message: output });
+@@ -888,6 +891,7 @@ function detectCompat(model) {
+         supportsDeveloperRole: !isNonStandard,
+         supportsReasoningEffort: !isGrok && !isZai && !isMoonshot && !isTogether && !isCloudflareAiGateway,
+         supportsUsageInStreaming: true,
++        supportsFinishReason: !(provider === "openrouter" || baseUrl.includes("openrouter.ai")),
+         maxTokensField: useMaxTokens ? "max_tokens" : "max_completion_tokens",
+         requiresToolResultName: false,
+         requiresAssistantAfterToolResult: false,
+@@ -924,6 +928,7 @@ function getCompat(model) {
+         supportsDeveloperRole: model.compat.supportsDeveloperRole ?? detected.supportsDeveloperRole,
+         supportsReasoningEffort: model.compat.supportsReasoningEffort ?? detected.supportsReasoningEffort,
+         supportsUsageInStreaming: model.compat.supportsUsageInStreaming ?? detected.supportsUsageInStreaming,
++        supportsFinishReason: model.compat.supportsFinishReason ?? detected.supportsFinishReason,
+         maxTokensField: model.compat.maxTokensField ?? detected.maxTokensField,
+         requiresToolResultName: model.compat.requiresToolResultName ?? detected.requiresToolResultName,
+         requiresAssistantAfterToolResult: model.compat.requiresAssistantAfterToolResult ?? detected.requiresAssistantAfterToolResult,
+diff --git a/node_modules/@earendil-works/pi-ai/dist/types.d.ts b/node_modules/@earendil-works/pi-ai/dist/types.d.ts
+index 4527475..90288bd 100644
+--- a/node_modules/@earendil-works/pi-ai/dist/types.d.ts
++++ b/node_modules/@earendil-works/pi-ai/dist/types.d.ts
+@@ -313,6 +313,8 @@ export interface OpenAICompletionsCompat {
+     supportsReasoningEffort?: boolean;
+     /** Whether the provider supports `stream_options: { include_usage: true }` for token usage in streaming responses. Default: true. */
+     supportsUsageInStreaming?: boolean;
++    /** Whether streamed responses include `finish_reason`. Default: true. */
++    supportsFinishReason?: boolean;
+     /** Which field to use for max tokens. Default: auto-detected from URL. */
+     maxTokensField?: "max_completion_tokens" | "max_tokens";
+     /** Whether tool results require the `name` field. Default: auto-detected from URL. */

--- a/src/lib/agent/bridge/pi-stream.test.ts
+++ b/src/lib/agent/bridge/pi-stream.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest';
+import { streamOpenAICompletions } from '@earendil-works/pi-ai/openai-completions';
+import type { Context, Model } from '@earendil-works/pi-ai/types';
+
+const model: Model<'openai-completions'> = {
+	id: 'test-model',
+	name: 'Test model',
+	api: 'openai-completions',
+	provider: 'openrouter',
+	baseUrl: 'https://openrouter.ai/api/v1',
+	reasoning: false,
+	input: ['text'],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 128_000,
+	maxTokens: 1_000
+};
+
+const context: Context = {
+	messages: [{ role: 'user', content: 'hello', timestamp: 0 }]
+};
+
+describe('OpenRouter OpenAI-compatible stream', () => {
+	it('accepts a completed response whose provider omits finish_reason', async () => {
+		const body = [
+			`data: ${JSON.stringify({
+				id: 'chatcmpl-test',
+				model: 'test-model',
+				choices: [{ delta: { content: 'hello' }, finish_reason: null }]
+			})}`,
+			'data: [DONE]'
+		].join('\n\n') + '\n\n';
+		vi.stubGlobal('fetch', vi.fn(async () => new Response(body, {
+			status: 200,
+			headers: { 'content-type': 'text/event-stream' }
+		})));
+
+		try {
+			const stream = streamOpenAICompletions(model, context, { apiKey: 'test' });
+			for await (const _event of stream) {}
+
+			const result = await stream.result();
+			expect(result.stopReason).toBe('stop');
+			expect(result.content).toEqual([{ type: 'text', text: 'hello' }]);
+		} finally {
+			vi.unstubAllGlobals();
+		}
+	});
+});

--- a/src/lib/content/changelog/2026-08-28-openrouter-stream-finish.ts
+++ b/src/lib/content/changelog/2026-08-28-openrouter-stream-finish.ts
@@ -1,0 +1,9 @@
+import type { ChangelogEntry } from './index';
+
+const entry: ChangelogEntry = {
+  date: 'August 28, 2026',
+  title: 'OpenRouter chat streams no longer fail silently',
+  items: ['Chat turns now complete when OpenRouter omits a finish signal after delivering a response.']
+};
+
+export default entry;


### PR DESCRIPTION
## What?
Chat turns on the kit engine died with `Stream ended without finish_reason` even when the model had already answered. The bundled Pi transport (`@earendil-works/pi-ai` 0.74.2, pinned by `@ai-sdk/harness-pi`) throws a fatal error when an OpenAI-compatible stream ends without a terminal `finish_reason` chunk. OpenRouter does that on valid streams. The patch adds the upstream `supportsFinishReason` compat: OpenRouter is marked tolerant, `stop`/`toolUse` is inferred from the received content, and every other provider keeps the strict behavior. Closes Notion task 45.

## Why?
OpenRouter is the only chat provider, and this error broke real conversations repeatedly (the thread in the local stack shows the failed turn verbatim). A stream that delivered text is a completed turn, not an error.

## How?
A `patch-package` patch (same mechanism already used for `@ai-sdk/harness-pi`) ports the upstream pi fix (commit `2c30412`, "fix(ai): support streams without finish reasons") to the pinned 0.74.2: `detectCompat` marks OpenRouter as tolerant, `getCompat` propagates the override, and the parser infers the stop reason instead of throwing. Alternatives rejected: bumping pi-ai to 0.84.x (peer/gating churn beyond a P0 fix) and retrying the turn at the bridge level (duplicates cost and hides the real contract).

## Testing?
- Regression test `src/lib/agent/bridge/pi-stream.test.ts`: red before the patch (stopReason `error`), green after (`stop`, content preserved). Reproduces the exact failure.
- Targeted suites green: `pi-stream.test.ts`, `adapters.test.ts` (16), `live.test.ts` (62). `typecheck:runtime` ok. `npm ci` re-applies the patch cleanly.
- Not run: full 5k unit suite and eval (provider-touching change, eval budget) — flagged for post-merge.
- Reproduce locally: run the regression test, or send a chat message against OpenRouter and reload mid/after the turn.

## Evidence (screenshots/videos)
Local stack (Docker Supabase + worktree dev server on :5176), headed Chromium, user `test@anomalia.so` on brand `demo`:

<details><summary>Browser verification (two real turns, reload persistence)</summary>

- Login via UI, `/app/demo` opened, message sent from the real composer.
- Turn 1: user "Rispondi solo con OK" → assistant "OK" saved; page reload → message still present.
- Turn 2 (same thread, the historically poisoned-session path): "Rispondi solo con SECOND_OK" → response received and still present after reload.
- Before the fix, the same stack's thread contains the failed turn verbatim: "Errore del turno: Stream ended without finishreason".
</details>

<details><summary>Red test before the patch</summary>

```
FAIL src/lib/agent/bridge/pi-stream.test.ts > ... omits finish_reason
AssertionError: expected 'error' to be 'stop'
```
</details>

<details><summary>Green after the patch</summary>

```
✓ src/lib/agent/bridge/pi-stream.test.ts (1 test)
✓ src/lib/agent/bridge/adapters.test.ts (16 tests)
✓ src/lib/agent/bridge/live.test.ts (62 tests)
Test Files  3 passed (3)
```
</details>

## Anything Else?
Both changelogs included (`changelog/2026-08-28-openrouter-stream-finish.md` + public EN entry). The patch is pinned to pi-ai 0.74.2: a dependency bump invalidates it and the postinstall will surface that immediately. If upstream backports the fix into a version we can adopt, the patch can be dropped.