### PR TITLE
Fix static errors (2026-08-28): 152 errors

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -13,6 +13,9 @@ Un eval o un test lanciato da un worktree misura un ibrido: `$lib` punta alla co
 ### Verifica il `workdir` prima di ogni Edit
 Con più worktree aperti (feature + verifica), un edit fatto nel checkout sbagliato tocca dev. È successo: `live.ts` modificato nel checkout principale per un secondo, poi `git checkout --` e riapplicato nel posto giusto. Il tool Edit non ti proteggere — proteggiti tu: guarda il percorso del file che stai per toccare, sempre.
 
+### Un test verde sul checkout principale può essere rosso nel worktree: il `.env` locale entra nei test
+`$env/dynamic/private` in vitest porta dentro il `.env` DELLA MACCHINA. Il checkout principale può passare per cache Vite stantia (env congelata prima di una variabile), il worktree con cache fresca fallisce — v. `queue-dm.test`: con `AGENT_KIT=on` locale il turno scappava nel ramo kit e il mock di `./subagents` moriva su `createSubagentTools`. Segnale: stesso codice, esito opposto fra checkout e worktree, e nessuna differenza nel diff. Mossa: il test che prova un percorso specifico fissa le variabili che gli servono spente (`vi.mock('$env/dynamic/private')` con override), non conta sul `.env` di chi lo lancia.
+
 ## Test: distinguere il tuo difetto dal rumore
 
 ### La suite completa fallisce da sola: confronta run-per-run con dev puro

--- a/changelog/2026-08-28-static-errors-ai-sdk7-generics.md
+++ b/changelog/2026-08-28-static-errors-ai-sdk7-generics.md
@@ -1,0 +1,43 @@
+# Static errors: 415 → 263 (tsc), 456 → 304 (svelte-check)
+
+## Perché
+
+Il reaper dei static errors trova il debito: `tsc --noEmit` e `svelte-check` su `dev`
+riportavano centinaia di errori, così un errore nuovo si annega in quelli vecchi e la
+gate `typecheck-runtime` (che filtra solo TS2304/18004/2552/2554/2555) resta l'unica
+difesa. Questo run accende la prima fetta di silenzio: i cluster a radice unica.
+
+## Cosa c'era prima
+
+Il codice era scritto contro l'API precedente di `ai` (v6): `ToolExecutionOptions`
+senza tipo generico, `StreamTextResult<ToolSet>` a un argomento. L'upgrade a `ai@7`
+ha reso `ToolExecutionOptions<CONTEXT>` e `StreamTextResult<TOOLS, RUNTIME_CONTEXT,
+OUTPUT>` generici obbligatori: 78 errori `TS2314` su 21 file, tutti la stessa radice.
+
+## Decisioni
+
+- `ToolExecutionOptions<unknown>` nei 21 file: nessun tool di chat legge `opts.context`,
+  quindi `unknown` è il tipo onesto (il default dell'SDK è `any`; qui si dice unknown).
+- `StreamTextResult` in `adapters.ts` non si annota a mano: il tipo vero è quello che
+  `HarnessAgent.stream` restituisce, e il cast a `StreamTextResult<ToolSet>` lo nascondeva.
+  Alias `HarnessStreamResult = Awaited<ReturnType<InstanceType<typeof HarnessAgent>['stream']>>`
+  e i due cast spariscono.
+- `wrapTools` restituiva `out as T` — una menzogna: l'execute avvolto accetta due
+  argomenti, l'originale anche zero. Mapped type `WrappedTools<T>`: l'execute del tool
+  avvolto è `(input, opts) => Promise<unknown>`; i test che chiamavano `.execute(a, b)`
+  su execute a zero argomenti smettono di essere errori perché ORA il tipo dice la verità.
+- `attachHarness` sostituisce `prepareStep` con uno che accetta `{ stepNumber }` e torna
+  `Record<string, unknown>`: i test che seminavano `prepareStep: () => ({})` annotano
+  ora la firma reale.
+- `queue-dm.test` non era ermetico: `$env/dynamic/private` in vitest porta dentro il
+  `.env` LOCALE, e con `AGENT_KIT=on` il turno scappava nel ramo kit (live.ts), dove il
+  mock di `./subagents` non ha `createSubagentTools`. Sul checkout principale passava
+  solo per cache Vite stantia. Fix: il test fissa `AGENT_KIT: 'off'` — percorso classico,
+  che è quello che intende provare. Lezione in LESSONS.md.
+
+## Scartato
+
+- `as any` / `@ts-ignore` come scorciatoia: proibiti dalle regole del repo, ogni errore
+  risolto alla radice.
+- `ToolExecutionOptions<Record<string, unknown>>` ovunque: `unknown` basta dove il
+  context non si tocca; `Record` solo nell'agent-lab, dove l'execute lo esige.

--- a/src/lib/agent/bridge/adapters.ts
+++ b/src/lib/agent/bridge/adapters.ts
@@ -49,7 +49,7 @@ import { loadHarnessSkills, parseHarnessSkillSelection } from '$lib/server/harne
 import { skillsForAgent } from '$lib/server/brand-skills';
 import { createJustBashSandbox } from '@ai-sdk/sandbox-just-bash';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
-import type { StreamTextResult, ToolSet } from 'ai';
+import type { ToolSet } from 'ai';
 import type { GraphicalBootstrapDeps } from '@anomalia/agent-adapters/graphical-bootstrap';
 
 export function createServerBrandFs(supabase: SupabaseClient, agent?: string | null): ServerBrandFs {
@@ -272,8 +272,10 @@ export async function openBrandHarnessSession(
 	return { session: await provider.createSession(), name: handle.name };
 }
 
+type HarnessStreamResult = Awaited<ReturnType<InstanceType<typeof HarnessAgent>['stream']>>;
+
 export interface HarnessTurnStream {
-	result: StreamTextResult<ToolSet>;
+	result: HarnessStreamResult;
 	detach(): Promise<unknown>;
 	destroy(): Promise<void>;
 }
@@ -398,11 +400,11 @@ export async function startHarnessTurn(opts: {
 				} catch {}
 			}
 			return {
-				result: (await (cached.agent as typeof agent).stream({
+				result: await (cached.agent as typeof agent).stream({
 					session: cached.session,
 					messages: opts.messages,
 					abortSignal: opts.abortSignal
-				})) as StreamTextResult<ToolSet>,
+				}),
 				detach: async () => {
 					const st = await (cached.session as { detach?: () => Promise<unknown> }).detach?.();
 					return st;
@@ -425,11 +427,11 @@ export async function startHarnessTurn(opts: {
 			});
 	if (opts.sessionKey) liveSessions.set(opts.sessionKey, { agent, session });
 	return {
-		result: (await agent.stream({
+		result: await agent.stream({
 			session,
 			messages: opts.messages,
 			abortSignal: opts.abortSignal
-		})) as StreamTextResult<ToolSet>,
+		}),
 		detach: async () => {
 			const st = await (session as { detach?: () => Promise<unknown> }).detach?.();
 			if (opts.sessionKey) moduleLiveSessions.delete(opts.sessionKey);

--- a/src/lib/agent/plugins/chat-bridge.ts
+++ b/src/lib/agent/plugins/chat-bridge.ts
@@ -60,8 +60,9 @@ export async function execChatTool(
 		const out = (await t.execute(args as never, {
 			toolCallId: `${toolName}:${runId}`,
 			messages: [],
-			abortSignal: signal
-		} as ToolExecutionOptions)) as Record<string, unknown>;
+			abortSignal: signal,
+			context: {}
+		} as ToolExecutionOptions<unknown>)) as Record<string, unknown>;
 		return {
 			content: [{ type: 'text', text: JSON.stringify(out) }],
 			isError: !!out && typeof out === 'object' && 'error' in out

--- a/src/lib/agent/plugins/delegation.test.ts
+++ b/src/lib/agent/plugins/delegation.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
-import type { ToolCall } from '../kit';
+import type { AdapterContext, ToolCall } from '../kit';
 import { createDelegationPlugin } from './delegation';
 
-const ctx = { brandId: 'b1', userId: 'u1', runId: 'r1', locale: 'it' };
+const ctx: AdapterContext = { brandId: 'b1', userId: 'u1', runId: 'r1', locale: 'it' };
 
 function fakeTool(result: unknown) {
 	return {
@@ -17,7 +17,7 @@ function fakeTools() {
 		delegate_task: fakeTool({ role: 'research', report: 'FINDINGS', steps: 2, tools_used: ['brand_read'] }),
 		run_task_pipeline: fakeTool({ verdict: 'pass', phases: [] }),
 		run_parallel_tasks: fakeTool({ tasks: [], failed: 0 })
-	} as Record<string, never>;
+	};
 }
 
 const call = (name: string, args: Record<string, unknown> = { role: 'research' }): ToolCall => ({ name, args });
@@ -38,7 +38,8 @@ describe('delegation plugin — la delega del motore classico, montata sul kit',
 			expect.objectContaining({ role: 'verify' }),
 			expect.objectContaining({ abortSignal: undefined })
 		);
-		expect(JSON.parse(res.content[0].text)).toMatchObject({ role: 'research', report: 'FINDINGS' });
+		const text = res.content[0].type === 'text' ? res.content[0].text : '';
+		expect(JSON.parse(text)).toMatchObject({ role: 'research', report: 'FINDINGS' });
 		expect(res.isError).toBeFalsy();
 	});
 

--- a/src/lib/contracts/contracts.test.ts
+++ b/src/lib/contracts/contracts.test.ts
@@ -106,7 +106,7 @@ describe('contracts: schema dagli stessi valori del codice', () => {
 // ── Sample call strutturali: il campo promesso dal contratto viene prodotto davvero ──
 // Solo i rami che toccano SOLO supabase (nessun Zernio/publish): post pending_user.
 
-const OPTS = { toolCallId: 't1', messages: [] } as unknown as ToolExecutionOptions;
+const OPTS = { toolCallId: 't1', messages: [] } as unknown as ToolExecutionOptions<unknown>;
 
 function toolsWithPosts(posts: Record<string, unknown>[]) {
   const kit = createTestSupabase({ posts });

--- a/src/lib/contracts/tool-contract.ts
+++ b/src/lib/contracts/tool-contract.ts
@@ -57,7 +57,7 @@ export const defineContract =
  */
 export function toolFromContract<In extends z.ZodType, Out extends Record<string, unknown>>(
   contract: ToolContract<In, Out>,
-  execute: (input: z.infer<In>, opts: ToolExecutionOptions) => Promise<Out | ToolFailure>
+  execute: (input: z.infer<In>, opts: ToolExecutionOptions<unknown>) => Promise<Out | ToolFailure>
 ): Tool<z.infer<In>, Out | ToolFailure> {
   // Il cast e' confinato qui: la garanzia sul tipo di risposta e' gia' imposta dalla firma
   // di QUESTA funzione (execute deve produrre Out | ToolFailure); gli overload di tool()

--- a/src/lib/server/chat/agent-files.ts
+++ b/src/lib/server/chat/agent-files.ts
@@ -538,13 +538,13 @@ function resultIsError(raw: unknown): boolean {
 export function gateOnFileRead<T extends Record<string, unknown>>(tools: T): T {
   const out: Record<string, unknown> = { ...tools };
   for (const [name, path] of Object.entries(REQUIRED_READS)) {
-    const t = out[name] as { execute?: (i: unknown, o: ToolExecutionOptions) => unknown } | undefined;
+    const t = out[name] as { execute?: (i: unknown, o: ToolExecutionOptions<unknown>) => unknown } | undefined;
     if (!t?.execute) continue;
     if (!AGENT_FILES[path]) continue; // fail-open: il file non esiste, si passa
     const inner = t.execute.bind(t);
     out[name] = {
       ...t,
-      execute: async (input: unknown, opts: ToolExecutionOptions) => {
+      execute: async (input: unknown, opts: ToolExecutionOptions<unknown>) => {
         const f = AGENT_FILES[path];
         if (f?.only && !f.only(input)) return inner(input, opts);
         if (!hasReadFile(opts?.messages, path)) {

--- a/src/lib/server/chat/artifact-tools.ts
+++ b/src/lib/server/chat/artifact-tools.ts
@@ -47,7 +47,7 @@ export function createArtifactTools(opts: {
       }),
       execute: async (
         input: { title: string; file_name: string; content: string; description?: string },
-        toolOpts: ToolExecutionOptions
+        toolOpts: ToolExecutionOptions<unknown>
       ) => {
         if (!threadId) return { error: 'No thread — an artifact must belong to a conversation.' };
         if (published >= MAX_ARTIFACTS_PER_TURN) {

--- a/src/lib/server/chat/post-editor-tools.ts
+++ b/src/lib/server/chat/post-editor-tools.ts
@@ -1045,7 +1045,7 @@ export function createPostEditorTools(
         title: z.string().optional().describe('New title (Reddit / YouTube / carousels)'),
         first_comment: z.string().optional().describe('First comment (hashtags / CTA)')
       }),
-      execute: async (patch: AnyRec, _opts: ToolExecutionOptions) => setPostText(t, patch)
+      execute: async (patch: AnyRec, _opts: ToolExecutionOptions<unknown>) => setPostText(t, patch)
     }),
 
     youtube_thumbnail: tool({

--- a/src/lib/server/chat/queue-dm.test.ts
+++ b/src/lib/server/chat/queue-dm.test.ts
@@ -28,6 +28,10 @@ vi.mock('./system-prompt', () => ({
 	wrapTurnMessage: (_block: string, message: unknown) => message
 }));
 vi.mock('./tools', () => ({ createChatTools: () => ({}) }));
+vi.mock('$env/dynamic/private', async (importOriginal) => {
+	const original = (await importOriginal()) as { env: Record<string, string> };
+	return { ...original, env: { ...original.env, AGENT_KIT: 'off' } };
+});
 vi.mock('./subagents', () => ({ withSubagentTools: (t: unknown) => t }));
 vi.mock('./sandbox-tools', () => ({
 	withSandboxTools: (t: unknown) => ({ tools: t, close: async () => undefined })

--- a/src/lib/server/chat/sandbox-device-login.ts
+++ b/src/lib/server/chat/sandbox-device-login.ts
@@ -141,7 +141,7 @@ export function createSandboxDeviceLoginTool(deps: DeviceLoginDeps) {
       }),
       execute: async (
         input: { provider: 'github'; action?: 'start' | 'check'; scopes?: string },
-        toolOpts: ToolExecutionOptions
+        toolOpts: ToolExecutionOptions<unknown>
       ) => {
         const action = input.action ?? 'start';
         const clientId = deps.clientId !== undefined ? deps.clientId : env.GITHUB_DEVICE_CLIENT_ID || null;
@@ -160,7 +160,7 @@ export function createSandboxDeviceLoginTool(deps: DeviceLoginDeps) {
         if (action === 'start') {
           const scopes = input.scopes?.trim() || 'repo';
           const res = await githubPost(fetchImpl, GITHUB_DEVICE_CODE_URL, { client_id: clientId, scope: scopes }).catch(
-            (e: unknown) => ({ error: e instanceof Error ? e.message : String(e) })
+            (e: unknown): Record<string, unknown> => ({ error: e instanceof Error ? e.message : String(e) })
           );
           if (typeof res.error === 'string' || typeof res.device_code !== 'string' || typeof res.user_code !== 'string') {
             record('sandbox_device_login', { action, status: 'start_failed' }, { ok: false });
@@ -212,7 +212,7 @@ export function createSandboxDeviceLoginTool(deps: DeviceLoginDeps) {
             client_id: clientId,
             device_code: state.device_code,
             grant_type: 'urn:ietf:params:oauth:grant-type:device_code'
-          }).catch((e: unknown) => ({ error: e instanceof Error ? e.message : String(e) }));
+          }).catch((e: unknown): Record<string, unknown> => ({ error: e instanceof Error ? e.message : String(e) }));
 
           if (typeof res.access_token === 'string' && res.access_token) {
             // IL TOKEN SI FERMA QUI: file nella run della VM, mai nel valore di ritorno, mai nei log.

--- a/src/lib/server/chat/sandbox-tools.ts
+++ b/src/lib/server/chat/sandbox-tools.ts
@@ -348,7 +348,7 @@ export function createSandboxTools(opts: SandboxToolsOptions): SandboxSession {
       }),
       execute: async (
         input: { cmd: string; args?: string[]; cwd?: string; timeout_ms?: number },
-        toolOpts: ToolExecutionOptions
+        toolOpts: ToolExecutionOptions<unknown>
       ) => {
         const blocked = budget('cmd');
         if (blocked) return blocked;
@@ -399,7 +399,7 @@ export function createSandboxTools(opts: SandboxToolsOptions): SandboxSession {
         path: z.string().min(1).max(200).describe('Relative path, e.g. "work/analysis.py"'),
         content: z.string().max(400_000).describe('Full file content')
       }),
-      execute: async (input: { path: string; content: string }, toolOpts: ToolExecutionOptions) => {
+      execute: async (input: { path: string; content: string }, toolOpts: ToolExecutionOptions<unknown>) => {
         const bad = rejectPath(input.path);
         if (bad) return { error: bad };
         try {
@@ -419,7 +419,7 @@ export function createSandboxTools(opts: SandboxToolsOptions): SandboxSession {
         path: z.string().min(1).max(200).describe('Relative path'),
         max_chars: z.number().min(200).max(40_000).optional().describe('Truncate after this many characters (default 12000)')
       }),
-      execute: async (input: { path: string; max_chars?: number }, toolOpts: ToolExecutionOptions) => {
+      execute: async (input: { path: string; max_chars?: number }, toolOpts: ToolExecutionOptions<unknown>) => {
         const p = (input.path ?? '').trim();
         // Era un controllo in linea, più debole di `rejectPath`: `.github.env` ci passava.
         const bad = rejectReadPath(p);
@@ -458,7 +458,7 @@ export function createSandboxTools(opts: SandboxToolsOptions): SandboxSession {
       }),
       execute: async (
         input: { url: string; wait_for?: string; screenshot?: string; full_page?: boolean; max_chars?: number },
-        toolOpts: ToolExecutionOptions
+        toolOpts: ToolExecutionOptions<unknown>
       ) => {
         if (mode !== 'research') {
           return { error: 'This sandbox has no internet access (compute profile). Browsing is only available to a research run.' };
@@ -536,7 +536,7 @@ export function createSandboxTools(opts: SandboxToolsOptions): SandboxSession {
       }),
       execute: async (
         input: { path: string; title: string; kind: 'artifact' | 'image' | 'document'; description?: string },
-        toolOpts: ToolExecutionOptions
+        toolOpts: ToolExecutionOptions<unknown>
       ) => {
         const blocked = budget('save');
         if (blocked) return blocked;

--- a/src/lib/server/chat/subagents.ts
+++ b/src/lib/server/chat/subagents.ts
@@ -1118,7 +1118,7 @@ export function createSubagentTools(opts: SubagentFactoryOpts) {
           network?: SandboxNetworkMode;
           brand_data?: boolean;
         },
-        toolOpts: ToolExecutionOptions
+        toolOpts: ToolExecutionOptions<unknown>
       ) => {
         const blocked = budgetError();
         if (blocked) return blocked;
@@ -1201,7 +1201,7 @@ export function createSubagentTools(opts: SubagentFactoryOpts) {
           skip_research?: boolean;
           repair?: boolean;
         },
-        toolOpts: ToolExecutionOptions
+        toolOpts: ToolExecutionOptions<unknown>
       ) => {
         const blocked = budgetError();
         if (blocked) return blocked;
@@ -1283,7 +1283,7 @@ export function createSubagentTools(opts: SubagentFactoryOpts) {
           agent?: AgentId;
           max_steps?: number;
         },
-        toolOpts: ToolExecutionOptions
+        toolOpts: ToolExecutionOptions<unknown>
       ) => {
         const blocked = budgetError();
         if (blocked) return blocked;

--- a/src/lib/server/chat/tools/brand-write-tools.ts
+++ b/src/lib/server/chat/tools/brand-write-tools.ts
@@ -47,7 +47,7 @@ export function brandWriteTools(ctx: ChatToolCtx) {
           .optional()
           .describe('Typography for composed graphics. Both families are checked against Google Fonts before saving — an unavailable name is refused, not silently rendered as Inter.')
       }),
-      execute: async (input: Record<string, unknown>, opts: ToolExecutionOptions) => {
+      execute: async (input: Record<string, unknown>, opts: ToolExecutionOptions<unknown>) => {
         const patch: AnyRec = {};
         const brandPatch: AnyRec = {};
         const updated: string[] = [];
@@ -180,7 +180,7 @@ export function brandWriteTools(ctx: ChatToolCtx) {
         week_theme: z.string().optional().describe('New theme for the specified week'),
         week_brief: z.string().optional().describe('User brief for the specified week (drives replanning)')
       }),
-      execute: async ({ voice, cadence, platform_mix, week_index, week_theme, week_brief }: AnyRec, opts: ToolExecutionOptions) => {
+      execute: async ({ voice, cadence, platform_mix, week_index, week_theme, week_brief }: AnyRec, opts: ToolExecutionOptions<unknown>) => {
         const { data: plan } = await supabase.from('editorial_plans').select('id, voice, cadence, platform_mix, weeks').eq('brand_id', brandId).eq('status', 'active').maybeSingle();
         if (!plan) return { error: 'No active editorial plan found' };
 
@@ -220,7 +220,7 @@ export function brandWriteTools(ctx: ChatToolCtx) {
         })).optional().describe('Updated platform weights for the phase'),
         pillars: z.array(z.string()).optional().describe('Updated pillars for the phase')
       }),
-      execute: async ({ objective, phase_index, phase_name, phase_objective, platform_weights, pillars }: AnyRec, opts: ToolExecutionOptions) => {
+      execute: async ({ objective, phase_index, phase_name, phase_objective, platform_weights, pillars }: AnyRec, opts: ToolExecutionOptions<unknown>) => {
         const { data: plan } = await supabase.from('gtm_plans').select('id, objective, phases').eq('brand_id', brandId).eq('status', 'active').maybeSingle();
         if (!plan) return { error: 'No active GTM plan found' };
 
@@ -267,7 +267,7 @@ export function brandWriteTools(ctx: ChatToolCtx) {
           .optional()
           .describe('Real past posts of this brand, one per entry, used as writing-style references. REPLACES the list; [] clears it.')
       }),
-      execute: async (patch: Record<string, unknown>, opts: ToolExecutionOptions) => {
+      execute: async (patch: Record<string, unknown>, opts: ToolExecutionOptions<unknown>) => {
         // I sei campi voce vivono sul piano editoriale attivo. Senza piano NON si perdono in
         // silenzio: prima il tool rispondeva success anche quando li aveva scartati tutti, e il
         // modello raccontava all'utente una voce mai salvata.
@@ -347,7 +347,7 @@ export function brandWriteTools(ctx: ChatToolCtx) {
     // Schema, description e tipo di risposta vivono nel contratto (contracts/post-tools.ts):
     // i valori di content_type sono interpolati dalla costante POST_CONTENT_TYPES e ora lo
     // schema è z.enum — "carousel" non arriva più in DB, torna un errore di validazione.
-    update_post: toolFromContract(updatePostContract, async ({ post_id, ...patch }: AnyRec, opts: ToolExecutionOptions) => {
+    update_post: toolFromContract(updatePostContract, async ({ post_id, ...patch }: AnyRec, opts: ToolExecutionOptions<unknown>) => {
         const clean: AnyRec = {};
         for (const [k, v] of Object.entries(patch)) {
           if (v !== undefined) clean[k] = v;
@@ -410,7 +410,7 @@ export function brandWriteTools(ctx: ChatToolCtx) {
           caption?: string;
           script?: string;
         },
-        opts: ToolExecutionOptions
+        opts: ToolExecutionOptions<unknown>
       ) => {
         return withBrandContext(brandId, async () => {
           const { extraReviewOpts, parseVideoStandard, resolveReviewVideoUrl, reviewVideo } = await import('$lib/server/video-review');
@@ -498,7 +498,7 @@ export function brandWriteTools(ctx: ChatToolCtx) {
       }
     }),
 
-    approve_post: toolFromContract(approvePostContract(tz), async ({ post_id, scheduled_for }: { post_id: string; scheduled_for?: string }, opts: ToolExecutionOptions) => {
+    approve_post: toolFromContract(approvePostContract(tz), async ({ post_id, scheduled_for }: { post_id: string; scheduled_for?: string }, opts: ToolExecutionOptions<unknown>) => {
         // Prima il guard di stato, POI la scrittura: qui scheduled_for veniva salvato prima del
         // check, così un approve rifiutato aveva comunque già spostato l'orario di un post
         // scheduled/published — una mutazione senza riga di risposta che la ammetta.
@@ -562,7 +562,7 @@ export function brandWriteTools(ctx: ChatToolCtx) {
         }
     }),
 
-    reject_post: toolFromContract(rejectPostContract, async ({ post_id, confirm }: { post_id: string; confirm: boolean }, opts: ToolExecutionOptions) => {
+    reject_post: toolFromContract(rejectPostContract, async ({ post_id, confirm }: { post_id: string; confirm: boolean }, opts: ToolExecutionOptions<unknown>) => {
         if (!confirm) return { error: 'Deletion not confirmed' };
         const { data: post } = await supabase.from('posts').select('id, status').eq('id', post_id).eq('brand_id', brandId).maybeSingle();
         if (!post) return { error: 'Post not found' };
@@ -585,7 +585,7 @@ export function brandWriteTools(ctx: ChatToolCtx) {
         return { success: true, deleted: post_id };
     }),
 
-    reschedule_post: toolFromContract(reschedulePostContract(tz), async ({ post_id, scheduled_for }: { post_id: string; scheduled_for: string }, opts: ToolExecutionOptions) => {
+    reschedule_post: toolFromContract(reschedulePostContract(tz), async ({ post_id, scheduled_for }: { post_id: string; scheduled_for: string }, opts: ToolExecutionOptions<unknown>) => {
         // Validate BEFORE touching Zernio: a rejected time must leave the existing schedule intact.
         const parsed = resolveScheduleInput(scheduled_for, tz);
         if ('error' in parsed) return parsed;
@@ -614,7 +614,7 @@ export function brandWriteTools(ctx: ChatToolCtx) {
 
     // L'annotazione esplicita del ritorno fa il narrowing dei literal di `status` contro
     // PostStatus — senza, TS li allarga a string e il contratto non combacia.
-    cross_post: toolFromContract(crossPostContract, async ({ post_id, platforms }: { post_id: string; platforms: string[] }, opts: ToolExecutionOptions): Promise<CrossPostResult | ToolFailure> => {
+    cross_post: toolFromContract(crossPostContract, async ({ post_id, platforms }: { post_id: string; platforms: string[] }, opts: ToolExecutionOptions<unknown>): Promise<CrossPostResult | ToolFailure> => {
         if (!platforms?.length) return { error: 'Specifica almeno una piattaforma' };
 
         const { data: post } = await supabase

--- a/src/lib/server/chat/tools/catalog-tools.ts
+++ b/src/lib/server/chat/tools/catalog-tools.ts
@@ -73,7 +73,7 @@ export function catalogTools(ctx: ChatToolCtx) {
       inputSchema: z.object({
         status: z.enum(['draft', 'planned', 'approved', 'published']).optional().describe('Filter by status')
       }),
-      execute: async ({ status }: { status?: string }, opts: ToolExecutionOptions) => {
+      execute: async ({ status }: { status?: string }, opts: ToolExecutionOptions<unknown>) => {
         let q = supabase.from('brand_articles').select('id, title, status, scheduled_for, created_at').eq('brand_id', brandId).order('created_at', { ascending: false }).limit(50);
         if (status) q = q.eq('status', status);
         const { data, error } = await q;
@@ -93,7 +93,7 @@ export function catalogTools(ctx: ChatToolCtx) {
       inputSchema: z.object({
         article_id: z.string().describe('The article ID to read')
       }),
-      execute: async ({ article_id }: { article_id: string }, opts: ToolExecutionOptions) => {
+      execute: async ({ article_id }: { article_id: string }, opts: ToolExecutionOptions<unknown>) => {
         const { data, error } = await supabase.from('brand_articles')
           .select('id, slug, title, meta_title, meta_description, body_md, status, scheduled_for, cover_image, language, created_at')
           .eq('id', article_id).eq('brand_id', brandId).maybeSingle();
@@ -115,7 +115,7 @@ export function catalogTools(ctx: ChatToolCtx) {
         article_id: z.string().describe('The article ID'),
         scheduled_for: z.string().optional().describe(`Future datetime to publish at, in the BRAND's local time (${tz}) — e.g. "2026-07-15T10:00". Add a Z/offset only for a real UTC instant. Omit to unschedule.`)
       }),
-      execute: async ({ article_id, scheduled_for }: { article_id: string; scheduled_for?: string }, opts: ToolExecutionOptions) => {
+      execute: async ({ article_id, scheduled_for }: { article_id: string; scheduled_for?: string }, opts: ToolExecutionOptions<unknown>) => {
         const { admin } = await blogAdmin();
         const { data: art } = await admin.from('brand_articles').select('id, title, status').eq('id', article_id).eq('brand_id', brandId).maybeSingle();
         if (!art) return { error: 'Article not found' };
@@ -153,7 +153,7 @@ export function catalogTools(ctx: ChatToolCtx) {
         meta_description: z.string().optional(),
         body_md: z.string().optional().describe('The COMPLETE new markdown body (replaces the old one entirely)')
       }),
-      execute: async ({ article_id, ...patch }: AnyRec, opts: ToolExecutionOptions) => {
+      execute: async ({ article_id, ...patch }: AnyRec, opts: ToolExecutionOptions<unknown>) => {
         const clean: AnyRec = {};
         for (const [k, v] of Object.entries(patch)) if (v !== undefined) clean[k] = v;
         if (!Object.keys(clean).length) return { error: 'No changes specified' };
@@ -172,7 +172,7 @@ export function catalogTools(ctx: ChatToolCtx) {
       inputSchema: z.object({
         article_id: z.string().describe('The article ID to optimize')
       }),
-      execute: async ({ article_id }: { article_id: string }, opts: ToolExecutionOptions) => {
+      execute: async ({ article_id }: { article_id: string }, opts: ToolExecutionOptions<unknown>) => {
         const { admin, brand } = await blogAdmin();
         if (!brand) return { error: 'Brand not found' };
         const { optimizeArticleForScore } = await import('$lib/server/blog-generate');
@@ -190,7 +190,7 @@ export function catalogTools(ctx: ChatToolCtx) {
       inputSchema: z.object({
         article_id: z.string().describe('The article ID')
       }),
-      execute: async ({ article_id }: { article_id: string }, opts: ToolExecutionOptions) => {
+      execute: async ({ article_id }: { article_id: string }, opts: ToolExecutionOptions<unknown>) => {
         const { admin, brand } = await blogAdmin();
         if (!brand) return { error: 'Brand not found' };
         const { data: art } = await admin.from('brand_articles').select('title, meta_description').eq('id', article_id).eq('brand_id', brandId).maybeSingle();
@@ -209,7 +209,7 @@ export function catalogTools(ctx: ChatToolCtx) {
       inputSchema: z.object({
         article_id: z.string().describe('The article ID')
       }),
-      execute: async ({ article_id }: { article_id: string }, opts: ToolExecutionOptions) => {
+      execute: async ({ article_id }: { article_id: string }, opts: ToolExecutionOptions<unknown>) => {
         const { admin, brand } = await blogAdmin();
         if (!brand) return { error: 'Brand not found' };
         const { data: art } = await admin.from('brand_articles').select('title, body_md').eq('id', article_id).eq('brand_id', brandId).maybeSingle();
@@ -229,7 +229,7 @@ export function catalogTools(ctx: ChatToolCtx) {
       inputSchema: z.object({
         article_id: z.string().describe('The planned placeholder\'s article ID')
       }),
-      execute: async ({ article_id }: { article_id: string }, opts: ToolExecutionOptions) => {
+      execute: async ({ article_id }: { article_id: string }, opts: ToolExecutionOptions<unknown>) => {
         const { admin, brand } = await blogAdmin();
         if (!brand) return { error: 'Brand not found' };
         const { generatePlannedArticle } = await import('$lib/server/blog-generate');
@@ -250,7 +250,7 @@ export function catalogTools(ctx: ChatToolCtx) {
         url: z.string().optional().describe('Product page URL on the brand site (https)'),
         remove: z.boolean().optional().describe('true to delete this product from the catalog')
       }),
-      execute: async ({ product_id, remove, ...patch }: AnyRec, opts: ToolExecutionOptions) => {
+      execute: async ({ product_id, remove, ...patch }: AnyRec, opts: ToolExecutionOptions<unknown>) => {
         if (remove) {
           const { error } = await supabase.from('products').delete().eq('id', product_id).eq('brand_id', brandId);
           if (error) return { error: error.message };
@@ -290,7 +290,7 @@ export function catalogTools(ctx: ChatToolCtx) {
           .describe('true ONLY when the USER has just stated, in their own words, that they have this person\'s consent. Never infer it. False or omitted changes nothing.'),
         remove: z.boolean().optional().describe('true to delete this person and their photos')
       }),
-      execute: async ({ person_id, consent, remove, ...patch }: AnyRec, opts: ToolExecutionOptions) => {
+      execute: async ({ person_id, consent, remove, ...patch }: AnyRec, opts: ToolExecutionOptions<unknown>) => {
         if (remove) {
           // Come deletePerson nel form: prima i file, poi la riga. Lasciare le foto nel bucket
           // significa tenere il volto di una persona reale dopo che è stata cancellata.
@@ -342,7 +342,7 @@ export function catalogTools(ctx: ChatToolCtx) {
         rationale: z.string().optional().describe('Why they are a competitor'),
         remove: z.boolean().optional().describe('true to delete this competitor')
       }),
-      execute: async ({ competitor_id, name, website, kind, rationale, remove }: AnyRec, _opts: ToolExecutionOptions) => {
+      execute: async ({ competitor_id, name, website, kind, rationale, remove }: AnyRec, _opts: ToolExecutionOptions<unknown>) => {
         if (remove) {
           if (!competitor_id) return { error: 'competitor_id is required to remove a competitor' };
           const { error } = await supabase.from('competitors').delete().eq('id', competitor_id).eq('brand_id', brandId);
@@ -406,7 +406,7 @@ export function catalogTools(ctx: ChatToolCtx) {
         markdown: z.string().optional().describe('Replace the document text. It is re-chunked for search.'),
         remove: z.boolean().optional().describe('true to delete the document and its stored file')
       }),
-      execute: async ({ document_id, title, collection, markdown, remove }: AnyRec, _opts: ToolExecutionOptions) => {
+      execute: async ({ document_id, title, collection, markdown, remove }: AnyRec, _opts: ToolExecutionOptions<unknown>) => {
         const { data: doc } = await supabase
           .from('brand_documents')
           .select('id, file_url, kind, updated_at')
@@ -480,7 +480,7 @@ export function catalogTools(ctx: ChatToolCtx) {
         history_post_id: z.string().optional().describe('Id of one of the brand\'s own past posts (from read_posts history) to use its image'),
         remove_id: z.string().optional().describe('brand_documents id of a reference to remove')
       }),
-      execute: async ({ image_url, history_post_id, remove_id }: AnyRec, _opts: ToolExecutionOptions) => {
+      execute: async ({ image_url, history_post_id, remove_id }: AnyRec, _opts: ToolExecutionOptions<unknown>) => {
         if (remove_id) {
           const { data: doc } = await supabase
             .from('brand_documents').select('file_url, kind').eq('id', remove_id).eq('brand_id', brandId).maybeSingle();

--- a/src/lib/server/chat/tools/create-content-tools.ts
+++ b/src/lib/server/chat/tools/create-content-tools.ts
@@ -155,7 +155,7 @@ export function createContentTools(ctx: ChatToolCtx) {
           graphic_brief?: string;
           caption?: string;
         },
-        opts: ToolExecutionOptions
+        opts: ToolExecutionOptions<unknown>
       ) => {
         const { data: brandRow } = await supabase.from('brands').select('name, plan, timezone, content_prefs, target_platforms').eq('id', brandId).maybeSingle();
         const budget = await remaining(supabase, brandId, brandRow?.plan, brandRow?.timezone ?? tz);
@@ -666,7 +666,7 @@ export function createContentTools(ctx: ChatToolCtx) {
           talent_ids?: string[];
           reference_image_urls?: string[];
         },
-        opts: ToolExecutionOptions
+        opts: ToolExecutionOptions<unknown>
       ) => {
         const {
           resolvePeopleVisualRefsDetailed,

--- a/src/lib/server/chat/tools/expression-memory-tools.ts
+++ b/src/lib/server/chat/tools/expression-memory-tools.ts
@@ -66,7 +66,7 @@ export function expressionMemoryTools(ctx: ChatToolCtx) {
       }),
       execute: async (
         { category, include_session }: { category?: string; include_session?: boolean },
-        opts: ToolExecutionOptions
+        opts: ToolExecutionOptions<unknown>
       ) => {
         const { loadMemoryEntries, recordMemoryUsage } = await import('$lib/server/brand-memory');
         const cat = category
@@ -129,7 +129,7 @@ export function expressionMemoryTools(ctx: ChatToolCtx) {
           category,
           scope
         }: { key: string; value: string; category: string; scope?: 'session' | 'project' | 'mine' },
-        opts: ToolExecutionOptions
+        opts: ToolExecutionOptions<unknown>
       ) => {
         const { writeMemory } = await import('$lib/server/brand-memory');
         // A skill is a standing procedure — session scope would throw it away with the thread.
@@ -164,7 +164,7 @@ export function expressionMemoryTools(ctx: ChatToolCtx) {
       inputSchema: z.object({
         entry_id: z.string().describe('The memory entry ID to remove')
       }),
-      execute: async ({ entry_id }: { entry_id: string }, opts: ToolExecutionOptions) => {
+      execute: async ({ entry_id }: { entry_id: string }, opts: ToolExecutionOptions<unknown>) => {
         // Un id `builtin:` non è una riga: è una skill di prodotto (default-skills.ts). Senza
         // questa guardia il delete passerebbe un non-uuid alla colonna id e verrebbe giù un
         // errore Postgres invece di una risposta.

--- a/src/lib/server/chat/tools/pipeline-tools.ts
+++ b/src/lib/server/chat/tools/pipeline-tools.ts
@@ -23,7 +23,7 @@ export function pipelineTools(ctx: ChatToolCtx) {
       }),
       execute: async (
         { title, markdown, summary }: { title: string; markdown: string; summary?: string },
-        opts: ToolExecutionOptions
+        opts: ToolExecutionOptions<unknown>
       ) => {
         const { data, error } = await supabase
           .from('brand_documents')
@@ -77,7 +77,7 @@ export function pipelineTools(ctx: ChatToolCtx) {
           kind?: string;
           from_attachment?: string;
         },
-        _opts: ToolExecutionOptions
+        _opts: ToolExecutionOptions<unknown>
       ) => {
         const { ingestDocument, kickKnowledgeWork } = await import('$lib/server/knowledge');
         const { matchTurnDocument } = await import('$lib/chat-documents');
@@ -140,7 +140,7 @@ export function pipelineTools(ctx: ChatToolCtx) {
           how_to_use,
           where_to_use
         }: AnyRec,
-        _opts: ToolExecutionOptions
+        _opts: ToolExecutionOptions<unknown>
       ) => {
         const patch: AnyRec = { updated_at: new Date().toISOString() };
         if (title != null) patch.title = String(title).trim() || null;
@@ -201,7 +201,7 @@ export function pipelineTools(ctx: ChatToolCtx) {
       inputSchema: z.object({
         objective: z.string().optional().describe("The user's stated objective/goal for the coming months, if any")
       }),
-      execute: async ({ objective }: { objective?: string }, opts: ToolExecutionOptions) => {
+      execute: async ({ objective }: { objective?: string }, opts: ToolExecutionOptions<unknown>) => {
         return startLongToolJob(
           supabase,
           brandId,
@@ -220,7 +220,7 @@ export function pipelineTools(ctx: ChatToolCtx) {
       description:
         'Generate (and auto-activate) the EDITORIAL PLAN — a 4-week plan with voice, cadence, platform mix and weekly themes. Runs in the BACKGROUND: it returns immediately with a job id and the result comes back to you as a NEW message when it lands, so say one line and end your turn. Onboarding: only after Strategy exists; the plan is activated immediately — do not ask the user to approve. When the result lands, briefly summarize it; only then ask about photos/videos before first-week content.',
       inputSchema: z.object({}),
-      execute: async (_input: Record<string, never>, opts: ToolExecutionOptions) => {
+      execute: async (_input: Record<string, never>, opts: ToolExecutionOptions<unknown>) => {
         return startLongToolJob(
           supabase,
           brandId,
@@ -239,7 +239,7 @@ export function pipelineTools(ctx: ChatToolCtx) {
       description:
         'ONBOARDING: generate the FIRST WEEK of draft posts (captions + images together) from the approved editorial plan. Runs in the BACKGROUND: it returns immediately with a job id and the result comes back to you as a NEW message when it lands, so say one line and end your turn. Only AFTER the editorial plan is approved AND you have already asked about photos/videos. Prefer produce_week for later weeks. When the result lands, confirm the drafts are ready with images.',
       inputSchema: z.object({}),
-      execute: async (_input: Record<string, never>, opts: ToolExecutionOptions) => {
+      execute: async (_input: Record<string, never>, opts: ToolExecutionOptions<unknown>) => {
         return startLongToolJob(
           supabase,
           brandId,
@@ -260,7 +260,7 @@ export function pipelineTools(ctx: ChatToolCtx) {
       inputSchema: z.object({
         week: z.number().int().min(0).max(11).optional().describe('0-based week index in the editorial plan. Omit for the current week.')
       }),
-      execute: async ({ week }: { week?: number }, opts: ToolExecutionOptions) => {
+      execute: async ({ week }: { week?: number }, opts: ToolExecutionOptions<unknown>) => {
         return startLongToolJob(
           supabase,
           brandId,
@@ -286,7 +286,7 @@ export function pipelineTools(ctx: ChatToolCtx) {
       }),
       execute: async (
         { name, event_date, brief, platform }: { name: string; event_date: string; brief: string; platform?: string },
-        opts: ToolExecutionOptions
+        opts: ToolExecutionOptions<unknown>
       ) => {
         return startLongToolJob(
           supabase,
@@ -309,7 +309,7 @@ export function pipelineTools(ctx: ChatToolCtx) {
       inputSchema: z.object({
         platforms: z.array(z.string()).optional().describe('Platforms to focus on (e.g. ["instagram", "tiktok"]). Omit to use brand\'s target_platforms.')
       }),
-      execute: async ({ platforms: inputPlatforms }: { platforms?: string[] }, opts: ToolExecutionOptions) => {
+      execute: async ({ platforms: inputPlatforms }: { platforms?: string[] }, opts: ToolExecutionOptions<unknown>) => {
         return startLongToolJob(supabase, brandId, userId, 'discover_competitors', { platforms: inputPlatforms }, threadId, opts.abortSignal, origin, locale);
       }
     }),
@@ -319,7 +319,7 @@ export function pipelineTools(ctx: ChatToolCtx) {
       inputSchema: z.object({
         platform: z.string().optional().describe('Specific platform to sync (e.g. "instagram"). Omit to sync all connected platforms.')
       }),
-      execute: async ({ platform }: { platform?: string }, opts: ToolExecutionOptions) => {
+      execute: async ({ platform }: { platform?: string }, opts: ToolExecutionOptions<unknown>) => {
         return startLongToolJob(supabase, brandId, userId, 'sync_social_history', { platform }, threadId, opts.abortSignal, origin, locale);
       }
     }),
@@ -333,7 +333,7 @@ export function pipelineTools(ctx: ChatToolCtx) {
           .optional()
           .describe('Optional owner focus for this review (platform, format, goal).')
       }),
-      execute: async ({ guidance }: { guidance?: string }, opts: ToolExecutionOptions) => {
+      execute: async ({ guidance }: { guidance?: string }, opts: ToolExecutionOptions<unknown>) => {
         return startLongToolJob(
           supabase,
           brandId,
@@ -351,7 +351,7 @@ export function pipelineTools(ctx: ChatToolCtx) {
     analyze_post_people: tool({
       description: 'Analyze the brand\'s post history to detect recurring people, best posting times, top formats, and engagement patterns. Use when the user wants to understand what works in their content.',
       inputSchema: z.object({}),
-      execute: async (_input: Record<string, never>, opts: ToolExecutionOptions) => {
+      execute: async (_input: Record<string, never>, opts: ToolExecutionOptions<unknown>) => {
         const { analyzePostHistory, historyInsightsDigest } = await import('$lib/server/post-history-insights');
         const { data: posts } = await supabase.from('social_post_history')
           .select('content, media_type, published_at, metrics, platform')
@@ -386,7 +386,7 @@ export function pipelineTools(ctx: ChatToolCtx) {
         gender: z.string().optional().describe('Gender (for AI generation only)'),
         age_range: z.string().optional().describe('Age range (for AI generation only)')
       }),
-      execute: async ({ name, role, description, photo_urls, gender, age_range }: AnyRec, opts: ToolExecutionOptions) => {
+      execute: async ({ name, role, description, photo_urls, gender, age_range }: AnyRec, opts: ToolExecutionOptions<unknown>) => {
         return startLongToolJob(supabase, brandId, userId, 'generate_person', { name, role, description, photo_urls, gender, age_range }, threadId, opts.abortSignal, origin, locale);
       }
     }),
@@ -396,7 +396,7 @@ export function pipelineTools(ctx: ChatToolCtx) {
       inputSchema: z.object({
         url: z.string().optional().describe('Website URL to analyze. Omit to use the brand\'s existing website.')
       }),
-      execute: async ({ url: inputUrl }: { url?: string }, opts: ToolExecutionOptions) => {
+      execute: async ({ url: inputUrl }: { url?: string }, opts: ToolExecutionOptions<unknown>) => {
         return startLongToolJob(supabase, brandId, userId, 'reanalyze_brand', { url: inputUrl }, threadId, opts.abortSignal, origin, locale);
       }
     }),
@@ -406,7 +406,7 @@ export function pipelineTools(ctx: ChatToolCtx) {
       inputSchema: z.object({
         image_url: z.string().describe('URL of the image to extract colors from')
       }),
-      execute: async ({ image_url }: { image_url: string }, opts: ToolExecutionOptions) => {
+      execute: async ({ image_url }: { image_url: string }, opts: ToolExecutionOptions<unknown>) => {
         const { extractColorsFromImage } = await import('$lib/server/brand-analysis');
         // Anche qui il filtro del form: l'estrattore è un modello, e un modello che torna
         // "rgb(12,30,44)" o dieci colori scriverebbe una palette che la UI non accetterebbe mai.
@@ -433,7 +433,7 @@ export function pipelineTools(ctx: ChatToolCtx) {
       inputSchema: z.object({
         colors: z.array(z.string()).describe('Array of hex color values (e.g. ["#FF5733", "#33FF57", "#000000"])')
       }),
-      execute: async ({ colors }: { colors: string[] }, opts: ToolExecutionOptions) => {
+      execute: async ({ colors }: { colors: string[] }, opts: ToolExecutionOptions<unknown>) => {
         // Stesso filtro del form (sanitizeBrandColors), non una regex scritta qui: un tool più
         // permesso del form scrive una palette che la UI non potrebbe produrre, e il colore
         // sbagliato non fallisce da nessuna parte — esce stampato.
@@ -467,7 +467,7 @@ export function pipelineTools(ctx: ChatToolCtx) {
       }),
       execute: async (
         { image_url, type = 'logo', remove }: { image_url?: string; type?: string; remove?: boolean },
-        opts: ToolExecutionOptions
+        opts: ToolExecutionOptions<unknown>
       ) => {
         const { data: kit } = await supabase.from('brand_kit').select('logos, favicon_url').eq('brand_id', brandId).maybeSingle();
         const previous =
@@ -516,7 +516,7 @@ export function pipelineTools(ctx: ChatToolCtx) {
     sync_products: tool({
       description: 'Sync products from the brand\'s e-commerce platform (Shopify/WooCommerce). Runs in the BACKGROUND: it returns immediately with a job id and the result comes back to you as a NEW message when it lands, so say one line and end your turn.',
       inputSchema: z.object({}),
-      execute: async (_input: Record<string, never>, opts: ToolExecutionOptions) => {
+      execute: async (_input: Record<string, never>, opts: ToolExecutionOptions<unknown>) => {
         return startLongToolJob(supabase, brandId, userId, 'sync_products', {}, threadId, opts.abortSignal, origin, locale);
       }
     }),
@@ -526,7 +526,7 @@ export function pipelineTools(ctx: ChatToolCtx) {
       inputSchema: z.object({
         job_id: z.string().describe('The job ID returned when the async tool was launched')
       }),
-      execute: async ({ job_id }: { job_id: string }, opts: ToolExecutionOptions) => {
+      execute: async ({ job_id }: { job_id: string }, opts: ToolExecutionOptions<unknown>) => {
         const { data: job } = await supabase.from('chat_jobs')
           .select('id, tool_name, status, result, error, created_at, completed_at')
           .eq('id', job_id)

--- a/src/lib/server/chat/tools/read-tools.ts
+++ b/src/lib/server/chat/tools/read-tools.ts
@@ -35,7 +35,7 @@ export function readTools(ctx: ChatToolCtx) {
     read_brand_kit: tool({
       description: 'Read the full brand kit: identity, audience, colors, fonts, AI character, content pillars, visual style, and brand context brief.',
       inputSchema: z.object({}),
-      execute: async (_input: Record<string, never>, opts: ToolExecutionOptions) => {
+      execute: async (_input: Record<string, never>, opts: ToolExecutionOptions<unknown>) => {
         const { data } = await supabase.from('brand_kit').select('*').eq('brand_id', brandId).maybeSingle();
         if (!data) return { error: 'No brand kit found' };
         const { ai_context, visual_style, ...rest } = data;
@@ -338,7 +338,7 @@ export function readTools(ctx: ChatToolCtx) {
     read_strategy: tool({
       description: 'Read the brand strategy: competitive research report, positioning, active editorial plan summary, and active GTM plan summary.',
       inputSchema: z.object({}),
-      execute: async (_input: Record<string, never>, opts: ToolExecutionOptions) => {
+      execute: async (_input: Record<string, never>, opts: ToolExecutionOptions<unknown>) => {
         const [
           { data: strategy },
           { data: editorial },
@@ -361,7 +361,7 @@ export function readTools(ctx: ChatToolCtx) {
     read_seo_geo_audit: tool({
       description: 'Read the latest SEO & GEO audit: technical score, top issues, on-page content summary, AI share-of-voice, and the category questions where the brand is NOT cited by AI answers (with which competitors ARE cited). Use before advising, or after run_seo_geo_audit finishes.',
       inputSchema: z.object({}),
-      execute: async (_input: Record<string, never>, opts: ToolExecutionOptions) => {
+      execute: async (_input: Record<string, never>, opts: ToolExecutionOptions<unknown>) => {
         const { data } = await supabase.from('brand_geo_audits').select('tech_score, tech, share_of_voice, citations, created_at').eq('brand_id', brandId).order('created_at', { ascending: false }).limit(1).maybeSingle();
         if (!data) return { error: 'No audit yet. Run run_seo_geo_audit first.' };
         const tech = (data.tech ?? {}) as AnyRec;
@@ -381,7 +381,7 @@ export function readTools(ctx: ChatToolCtx) {
     read_seo_plan: tool({
       description: 'Read the latest SEO growth plan: the qualitative evaluation (grade, strengths, weaknesses) and the recommended initiatives (blog, landing pages, free tools, comparisons) with target query, effort and impact.',
       inputSchema: z.object({}),
-      execute: async (_input: Record<string, never>, opts: ToolExecutionOptions) => {
+      execute: async (_input: Record<string, never>, opts: ToolExecutionOptions<unknown>) => {
         const { data } = await supabase.from('brand_seo_plans').select('grade, evaluation, initiatives, created_at').eq('brand_id', brandId).order('created_at', { ascending: false }).limit(1).maybeSingle();
         if (!data) return { error: 'No SEO plan yet. Run generate_seo_plan first.' };
         const ev = (data.evaluation ?? {}) as AnyRec;
@@ -396,19 +396,19 @@ export function readTools(ctx: ChatToolCtx) {
     run_seo_geo_audit: tool({
       description: 'Run a fresh SEO & GEO audit of the brand website (technical crawl + on-page content + AI citation share-of-voice). Runs in the BACKGROUND: it returns immediately with a job id and the result comes back to you as a NEW message when it lands, so say one line and end your turn. When the result lands, call read_seo_geo_audit to read the numbers.',
       inputSchema: z.object({}),
-      execute: async (_input: Record<string, never>, opts: ToolExecutionOptions) => startLongToolJob(supabase, brandId, userId, 'seo_geo_audit', {}, threadId, opts.abortSignal, origin, locale)
+      execute: async (_input: Record<string, never>, opts: ToolExecutionOptions<unknown>) => startLongToolJob(supabase, brandId, userId, 'seo_geo_audit', {}, threadId, opts.abortSignal, origin, locale)
     }),
 
     generate_seo_plan: tool({
       description: 'Generate the SEO growth plan: a qualitative evaluation + prioritized initiatives (blog, landing pages for specific queries, free tools, comparisons), grounded in the real search landscape. Run run_seo_geo_audit first for a site-grounded plan. Runs in the BACKGROUND: it returns immediately with a job id and the result comes back to you as a NEW message when it lands, so say one line and end your turn. Replaces the current plan.',
       inputSchema: z.object({}),
-      execute: async (_input: Record<string, never>, opts: ToolExecutionOptions) => startLongToolJob(supabase, brandId, userId, 'seo_plan', {}, threadId, opts.abortSignal, origin, locale)
+      execute: async (_input: Record<string, never>, opts: ToolExecutionOptions<unknown>) => startLongToolJob(supabase, brandId, userId, 'seo_plan', {}, threadId, opts.abortSignal, origin, locale)
     }),
 
     add_seo_initiatives: tool({
       description: "Add MORE recommended SEO initiatives to the existing plan WITHOUT removing the current ones. Pass the user's direction if they told you what to focus on (e.g. 'target local searches', 'free tools for developers'). Runs in the BACKGROUND: it returns immediately with a job id and the result comes back to you as a NEW message when it lands, so say one line and end your turn.",
       inputSchema: z.object({ guidance: z.string().optional().describe("What the user wants to focus on, in their words. Optional.") }),
-      execute: async ({ guidance }: { guidance?: string }, opts: ToolExecutionOptions) => startLongToolJob(supabase, brandId, userId, 'seo_add_initiatives', { guidance: guidance ?? '' }, threadId, opts.abortSignal, origin, locale)
+      execute: async ({ guidance }: { guidance?: string }, opts: ToolExecutionOptions<unknown>) => startLongToolJob(supabase, brandId, userId, 'seo_add_initiatives', { guidance: guidance ?? '' }, threadId, opts.abortSignal, origin, locale)
     }),
 
     read_backlink_network: tool({
@@ -425,7 +425,7 @@ export function readTools(ctx: ChatToolCtx) {
       description:
         'Regenerate ranked give/receive backlink opportunities across the Anomalia network (partner articles to link to, and your posts partners may link). Requires Starter plan or above. Returns counts when done.',
       inputSchema: z.object({}),
-      execute: async (_input: Record<string, never>, opts: ToolExecutionOptions) => {
+      execute: async (_input: Record<string, never>, opts: ToolExecutionOptions<unknown>) => {
         const { createAdminClient } = await import('$lib/server/supabase-admin');
         const { generateBacklinkOpportunities } = await import('$lib/server/backlink-network');
         const { hasBacklinkNetwork } = await import('$lib/plans');
@@ -446,7 +446,7 @@ export function readTools(ctx: ChatToolCtx) {
     read_editorial_plan: tool({
       description: 'Read the active editorial plan in full detail: all 4 weeks with themes, focus, content mix, and briefs.',
       inputSchema: z.object({}),
-      execute: async (_input: Record<string, never>, opts: ToolExecutionOptions) => {
+      execute: async (_input: Record<string, never>, opts: ToolExecutionOptions<unknown>) => {
         const { data } = await supabase.from('editorial_plans').select('*').eq('brand_id', brandId).eq('status', 'active').maybeSingle();
         if (!data) return { error: 'No active editorial plan found' };
         return {
@@ -473,7 +473,7 @@ export function readTools(ctx: ChatToolCtx) {
             'Default false. When true, the posts returned by THIS call also render as PostCard previews (image + caption) under your message. Set it only when you deliberately want the user to look at these posts; leave it out when you are just reading for context.'
           )
       }),
-      execute: async ({ status, limit = 20 }: { status?: string; limit?: number }, opts: ToolExecutionOptions) => {
+      execute: async ({ status, limit = 20 }: { status?: string; limit?: number }, opts: ToolExecutionOptions<unknown>) => {
         let query = supabase
           .from('posts')
           .select(`${EDITOR_POST_COLS}, pillar, first_comment`)
@@ -647,7 +647,7 @@ export function readTools(ctx: ChatToolCtx) {
     read_products: tool({
       description: 'Read the products and services catalog for this brand (includes page URLs and image URLs when synced from Shopify/WooCommerce).',
       inputSchema: z.object({}),
-      execute: async (_input: Record<string, never>, opts: ToolExecutionOptions) => {
+      execute: async (_input: Record<string, never>, opts: ToolExecutionOptions<unknown>) => {
         const { data } = await supabase.from('products').select('id, title, description, pricing, kind, featured, url, images').eq('brand_id', brandId);
         return { products: data ?? [] };
       }
@@ -749,7 +749,7 @@ export function readTools(ctx: ChatToolCtx) {
     read_competitors: tool({
       description: 'Read competitor data: names, websites, rationale, benchmarks.',
       inputSchema: z.object({}),
-      execute: async (_input: Record<string, never>, opts: ToolExecutionOptions) => {
+      execute: async (_input: Record<string, never>, opts: ToolExecutionOptions<unknown>) => {
         const { data } = await supabase.from('competitors').select('id, name, website, kind, rationale, handles, benchmark').eq('brand_id', brandId);
         return { competitors: data ?? [] };
       }
@@ -771,7 +771,7 @@ export function readTools(ctx: ChatToolCtx) {
           country,
           limit
         }: { company_name?: string; query?: string; country?: string; limit?: number },
-        opts: ToolExecutionOptions
+        opts: ToolExecutionOptions<unknown>
       ) => {
         return withBrandContext(brandId, async () => {
           const {
@@ -887,7 +887,7 @@ export function readTools(ctx: ChatToolCtx) {
       inputSchema: z.object({
         kind: z.enum(['note', 'document', 'image']).optional().describe('Filter by document kind')
       }),
-      execute: async ({ kind }: { kind?: string }, opts: ToolExecutionOptions) => {
+      execute: async ({ kind }: { kind?: string }, opts: ToolExecutionOptions<unknown>) => {
         // Prefer search tools for text; keep image listing here.
         if (kind === 'image' || !kind) {
           let query = supabase

--- a/src/lib/server/harness/pipeline.ts
+++ b/src/lib/server/harness/pipeline.ts
@@ -28,12 +28,20 @@ export type ToolPipeline = {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyTool = { execute?: (...args: any[]) => any; [k: string]: unknown };
 
+type WrappedTool<T> = T extends { execute: (...args: never[]) => unknown }
+	? Omit<T, 'execute'> & { execute: (input: unknown, opts: unknown) => Promise<unknown> }
+	: T;
+
+export type WrappedTools<T> = T extends undefined
+	? T
+	: { [K in keyof T]: WrappedTool<T[K]> };
+
 export function wrapTools<T extends Record<string, unknown> | undefined>(
 	session: HarnessSession,
 	tools: T,
 	pipeline?: ToolPipeline
-): T {
-	if (!tools) return tools;
+): WrappedTools<T> {
+	if (!tools) return tools as WrappedTools<T>;
 	const out: Record<string, unknown> = {};
 	for (const [name, raw] of Object.entries(tools)) {
 		const tool = raw as AnyTool | undefined;
@@ -76,5 +84,5 @@ export function wrapTools<T extends Record<string, unknown> | undefined>(
 			}
 		};
 	}
-	return out as T;
+	return out as WrappedTools<T>;
 }

--- a/src/lib/server/harness/steward.test.ts
+++ b/src/lib/server/harness/steward.test.ts
@@ -206,7 +206,9 @@ describe('session steward on the harness', () => {
 				read_brand_studio: { execute: async () => ({}) },
 				search_web: { execute: async () => ({}) }
 			},
-			prepareStep: () => ({ system: 'base\n[budget] 1' })
+			prepareStep: (args?: { stepNumber?: number }): Record<string, unknown> => ({
+				system: 'base\n[budget] 1'
+			})
 		});
 		const prepared = instrumented.prepareStep({});
 		expect(prepared.system).toContain('base\n[budget] 1');
@@ -223,7 +225,7 @@ describe('session steward on the harness', () => {
 		const instrumented = attachHarness(session, {
 			system: 'PRODUCT FIDELITY — keep this',
 			messages: [{ role: 'user', content: 'go' }],
-			prepareStep: () => original,
+			prepareStep: (args?: { stepNumber?: number }): Record<string, unknown> => original,
 			onStepFinish: () => {}
 		});
 		expect(instrumented.prepareStep({})).toBe(original);
@@ -263,7 +265,7 @@ describe('i tool bloccati spariscono dal tavolo (activeTools)', () => {
 				read_brand_kit: { execute: async () => ({}) },
 				finish: { execute: async () => ({}) }
 			},
-			prepareStep: () => ({})
+			prepareStep: (args?: { stepNumber?: number }): Record<string, unknown> => ({})
 		});
 		const prepared = instrumented.prepareStep({ stepNumber: 3 });
 		expect(prepared.activeTools).toEqual(['read_brand_kit', 'finish']);
@@ -280,7 +282,7 @@ describe('i tool bloccati spariscono dal tavolo (activeTools)', () => {
 				search_web: { execute: async () => ({}) },
 				finish: { execute: async () => ({}) }
 			},
-			prepareStep: () => ({})
+			prepareStep: (args?: { stepNumber?: number }): Record<string, unknown> => ({})
 		});
 		const before = instrumented.prepareStep({ stepNumber: 1 });
 		expect(before.activeTools).toEqual(['read_brand_studio', 'finish']);
@@ -300,7 +302,7 @@ describe('i tool bloccati spariscono dal tavolo (activeTools)', () => {
 				publish_post: { execute: async () => ({}) },
 				finish: { execute: async () => ({}) }
 			},
-			prepareStep: () => ({ activeTools: ['publish_post'] })
+			prepareStep: (args?: { stepNumber?: number }): Record<string, unknown> => ({ activeTools: ['publish_post'] })
 		});
 		const prepared = instrumented.prepareStep({ stepNumber: 3 });
 		expect(prepared.activeTools).toEqual(['publish_post']);
@@ -312,7 +314,7 @@ describe('i tool bloccati spariscono dal tavolo (activeTools)', () => {
 			system: 'base',
 			tools: { read_brand_kit: { execute: async () => ({}) } },
 			messages: [{ role: 'user', content: 'ciao' }],
-			prepareStep: () => ({})
+			prepareStep: (args?: { stepNumber?: number }): Record<string, unknown> => ({})
 		});
 		const prepared = instrumented.prepareStep({ stepNumber: 1 });
 		expect(prepared.activeTools).toBeUndefined();

--- a/src/routes/app/[brand]/agent-lab/turn/+server.ts
+++ b/src/routes/app/[brand]/agent-lab/turn/+server.ts
@@ -50,7 +50,12 @@ const noSandbox: SandboxProvider = {
 function buildQueryTool(supabase: SupabaseClient, brandId: string, userId: string, threadId: string) {
 	const { query } = createQueryTool({ supabase, brandId, userId, threadId });
 	return async (args: Record<string, unknown>, ctx: AdapterContext): Promise<ToolResult> => {
-		const opts: ToolExecutionOptions = { toolCallId: `query:${ctx.runId}`, messages: [], abortSignal: ctx.signal };
+		const opts: ToolExecutionOptions<Record<string, unknown>> = {
+			toolCallId: `query:${ctx.runId}`,
+			messages: [],
+			abortSignal: ctx.signal,
+			context: {}
+		};
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		const out = await query.execute!(args as any, opts);
 		return { content: [{ type: 'text', text: JSON.stringify(out) }], isError: Boolean(out && 'error' in (out as object)) };


### PR DESCRIPTION
## What?
Fixes 152 static type errors and one environment-dependent test failure on top of `dev`:

- **ai-sdk v7 generic drift (131 errors, 24 files):** the `ai@7` upgrade made `ToolExecutionOptions` and `StreamTextResult` generic-required. Tool `execute` options are now annotated `ToolExecutionOptions<unknown>` where the context is never read, `ToolExecutionOptions<Record<string, unknown>>` in agent-lab where the SDK requires a context record, and `adapters.ts` uses the real `HarnessAgent.stream` return type instead of the unsound `StreamTextResult<ToolSet>` cast.
- **Unsound `wrapTools` return type (pipeline.ts):** the wrapper replaced `execute` with a two-argument function but claimed to return `T`. A `WrappedTools<T>` mapped type now states the wrapped signature `(input, opts) => Promise<unknown>`.
- **`sandbox-device-login.ts` (19 errors):** the `.catch` fallback is typed `Record<string, unknown>` so the response union collapses instead of failing property access.
- **`attachHarness`/steward tests:** test seeds now declare the real wrapped `prepareStep` signature `(args?: { stepNumber?: number }) => Record<string, unknown>`.
- **`queue-dm.test.ts` hermeticity (1 real test failure):** `$env/dynamic/private` in vitest carries the developer's local `.env`; with `AGENT_KIT=on` the turn escaped into the kit branch, where the `./subagents` mock has no `createSubagentTools`, and the job died before the model. The test now pins `AGENT_KIT: 'off'` — the classic queue path is what it intends to prove. Lesson recorded in `LESSONS.md`.

## Why?
`tsc --noEmit` reported 415 errors and `svelte-check` 456 on `dev`: any new error drowns in the old ones, and the `typecheck-runtime` deploy gate (which filters only undefined-name/arity codes) is the sole remaining defense. This run clears the single-root-cause clusters so the next error is visible. Test hermeticity matters because a suite that passes only on the machine where its Vite cache predates a `.env` variable lies about CI.

## How?
- Suppressions (`as any`, `@ts-ignore`) were not used anywhere; every error is resolved at the root.
- `ToolExecutionOptions<unknown>` rather than `any`: no chat tool reads `opts.context`, so `unknown` is the honest type.
- The `HarnessStreamResult` alias avoids re-stating the SDK's three generics by hand: the type comes from the function that produces the value.
- The failing `queue-dm` test was diagnosed by bisection: reproduced with changes stashed, isolated via `AGENT_KIT=off` shell override, then fixed by mocking `$env/dynamic/private` with an explicit override instead of counting on the launcher's `.env`.

## Testing?
- `npx tsc --noEmit -p tsconfig.json`: 415 → 263 errors, **zero new** (verified by set-diff against the baseline).
- `npx svelte-check`: 456 → 304 errors, 243 warnings unchanged, **zero new** (set-diff on file+message pairs).
- `npx vitest run`: **5868 passed, 0 failed** (before the fix the `queue-dm` test failed deterministically in a fresh worktree).
- `npm run build:node`: completes successfully (`typecheck-runtime` gate green).
- Not tested: browser/e2e paths (no runtime behavior change — type annotations and a test mock only). Risk: low; the only runtime-code edits are type-level annotations and one added `context: {}` field on synthetic tool-execution options.

## Evidence (screenshots/videos)
Backend-only change; no UI surfaces touched. Evidence in command outputs above (tsc/svelte-check/vitest/build counts, before vs after).

<details>
<summary>Baseline vs final error counts</summary>

| Tool | Baseline (dev) | Final | New errors |
|---|---|---|---|
| tsc --noEmit | 415 (394 after local .env artifact excluded) | 263 | 0 |
| svelte-check | 456 errors / 243 warnings | 304 errors / 243 warnings | 0 |
| vitest | 1 failed / 5867 passed | 5868 passed | — |
| build:node | passes | passes | — |
</details>

## Anything Else?
- 263 tsc / 304 svelte-check errors remain (next clusters: `goal-tools.test.ts` ModelMessage literals, `week-planner-agent.ts`, implicit-any in tool input literals). Intentionally left for the next reaper run — batch size keeps the diff reviewable.
- The `$env` static-import errors (18) were a worktree artifact (missing `.env` before `svelte-kit sync`), not code debt.
- `queue-room.test.ts` and `system-prompt.cache-layout.test.ts` share the queue-dm fragility pattern but are currently guarded by their test data (room threads skip the kit branch); flagged for the next run if data changes.
