### PR TITLE
Fix kit branch skipping onboarding team ignition

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -16,6 +16,9 @@ Dopo il `npm ci` la suite parte ma cade su 40+ test con `SUPABASE_SERVICE_ROLE_K
 ### `@anomalia/*` si risolve dal `node_modules` del checkout principale
 Un eval o un test lanciato da un worktree misura un ibrido: `$lib` punta alla copia del worktree, i pacchetti interni vengono dal checkout madre. Se hai toccato `packages/`, il worktree non lo vede. Per un confronto pulito: worktree di verifica con `node_modules` symlinkato a quello fresco.
 
+### Il worktree DENTRO la repo dir: la pagina è viva ma non risponde (403 su `entry.js`)
+Un worktree creato dentro la cartella della repo (`anomalia/anomalia-wt/<slug>`) risolve `@sveltejs/kit` dal `node_modules` del checkout padre: vite lo serve via `/@fs/...` **fuori dalla root del worktree** e risponde 403 — il bundle client non parte, la hydratazione non arriva, e ogni click "riuscito" dell'automazione browser non cambia nulla (SSR morto senza errori in console). Segnale: `performance.getEntriesByType('resource')` mostra `entry.js` con `responseStatus: 403`, i click vanno a un DOM senza handler. Mossa: il worktree sta **fuori** dalla repo (`../anomalia-wt/<slug>`, come da docs/e2e-testing.md §1) con `npm ci` proprio.
+
 ### Verifica il `workdir` prima di ogni Edit
 Con più worktree aperti (feature + verifica), un edit fatto nel checkout sbagliato tocca dev. È successo: `live.ts` modificato nel checkout principale per un secondo, poi `git checkout --` e riapplicato nel posto giusto. Il tool Edit non ti proteggere — proteggiti tu: guarda il percorso del file che stai per toccare, sempre.
 
@@ -49,6 +52,12 @@ Un `vite dev` di un altro worktree risponde 404 a tutto e resta lì in ascolto; 
 
 ### Il profilo del browser di test conserva sessioni e localStorage
 `agent-browser` riutilizza cookie e localStorage tra le run: un test "guest" parte loggato, e l'onboarding di un utente nuovo legge `localStorage['anomalia:first-agent:<altro-brand>']` dell'utente prima — fetch di thread altrui (404 rumorosi ma disordini nella diagnosi). Mossa: `cookies clear` **e** `storage local clear` prima di ogni persona nuova; verificate sempre chi siete (`location.href`, sidebar) prima del primo click.
+
+### `agent-browser` è un daemon: path relativi e storage Puliti col suo contesto
+Il CLI parla con un daemon che gira col **suo** cwd: una screenshot con path relativo muore con `No such file or directory` anche se la cartella esiste nel caller. E `storage local clear` alza `Uncaught` se non c'è una pagina aperta. Mossa: path **assoluti** per le evidenze, e per partire puliti: open → `cookies clear` → `storage local clear` → reopen.
+
+### La prima risposta non è il turno finito: la finestra del poll parte dalla fine del turno
+Il turno di setup dell'onboarding consegna la prima risposta in ~20s e continua a lavorare per **minuti** (tool, memoria); il contatto del team nasce alla chiusura del job, non alla prima bolla. L'eval:ux misurava il contatto con la finestra della prima risposta: scaduta pochi secondi prima dei thread, riportava `team-of-agents-contact: ❌` per un contatto avvenuto (thread e firme in DB). Segnale: report FAIL ma le righe in DB dicono il contrario, con timestamp pochi secondi dopo la scadenza del poll. Mossa: aspettare la CONDIZIONE con la finestra giusta — poll del team separato (TEAM_WAIT_MS) dal poll della prima risposta.
 
 ### I rimount (`{#key}`) rendono stale i ref dell'automazione browser
 Un click su un ref catturato prima del re-render non arriva a nessuno: il carosello dell'onboarding sembrava bloccato prima del pick — era il bottone rimontato ad ogni slide. Mossa: snapshot fresco e selettori stabili (`.wide-btn`), click lenti; un "blocco" va riprodotto con click lenti e selelettori nuovi prima di chiamarlo bug. Il falso positivo costa un'ora, la prudenza tre secondi.

--- a/changelog/2026-08-28-kit-onboarding-ignite.md
+++ b/changelog/2026-08-28-kit-onboarding-ignite.md
@@ -1,0 +1,40 @@
+# Il team contatta il nuovo utente anche sul motore kit
+
+## Perché esiste
+
+PR #32 ("Team contacts the new user") seminava il primo contatto degli specialisti
+dopo il turno di setup dell'onboarding. Ma il blocco che la eseguiva era stato
+scritto **solo nel percorso classico** del queue worker: con `AGENT_KIT=on`
+(default del `.env`, quindi anche in produzione) il turno di setup gira sul ramo
+kit di `queue.ts`, che chiude il job e fa `return` prima di arrivare al blocco
+`igniteOnboardingTeam` del percorso classico. Risultato misurato dall'audit della
+task #39 (3 onboarding completi su stack locale): setup `done`, DM fra agenti
+creati, **zero thread `surface='team'`** — nessun collega contattava mai
+l'utente. La funzione era sana (invocazione diretta funzionava, idempotenza
+garantita da `teamThreadContacted`): era solo il percorso che non la raggiungeva.
+
+## Cosa cambia
+
+L'ignite è estratto in `igniteTeamAfterSetupTurn` e chiamato dal **punto di
+completamento condiviso** da entrambi i motori: il ramo kit lo esegue dopo aver
+chiuso il job (e solo se il job è davvero stato eseguito — un 409 `kit_busy`
+torna pending senza seminare nulla), il percorso classico lo esegue come prima.
+Una sola copia della regola.
+
+## Decisioni
+
+- **Percorso condiviso, non duplicazione**: la quarta regola del design semplice.
+  L'alternativa (copiare il blocco nel ramo kit prima del return) lasciava due
+  copie della regola che divergono alla prima modifica.
+- **Nessuna nuova blindatura**: il try/catch con log `[onboarding-team] contact
+  failed` esiste già dentro `igniteOnboardingTeam` — il ramo kit non ne ha
+  bisogno di uno proprio.
+- **Test guardian**: `queue-kit-onboarding-ignite.test.ts` riproduce il difetto
+  (job kit su thread `surface='onboarding'` → thread `surface='team'` di
+  `teamContactsForPlan(plan)` devono esistere); scritto prima del fix, visto
+  fallire, poi verde.
+- **Guardia eval**: `eval:ux` ora decide il motore nel run, non ereditandolo
+  dal `.env` del momento (`AGENT_KIT=on npm run eval:ux` misura il ramo kit);
+  il report registra `agentKit` in meta e il runId distingue la variante
+  (`ux-kit-*`). Senza questo, la guardia non copriva il ramo che in produzione
+  gira davvero.

--- a/scripts/eval/ux.ts
+++ b/scripts/eval/ux.ts
@@ -20,7 +20,13 @@ const HEALTH_TIMEOUT_MS = 90_000;
 const CHAT_SNAPSHOT_CHARS = 8_000;
 const PICK_SNAPSHOT_CHARS = 4_000;
 
-const runId = `ux-${new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)}`;
+// Il ramo che il run misura va DECISO qui, non ereditato dal .env del momento: due run con lo
+// stesso codice e .env diversi non sono paragonabili. `AGENT_KIT=on npm run eval:ux` misura il
+// ramo kit (quello che in produzione gira davvero) — la variante che ha trovato il difetto
+// dell'onboarding-team mai contattato (task #47).
+const AGENT_KIT: 'on' | 'off' = process.env.AGENT_KIT === 'on' ? 'on' : 'off';
+
+const runId = `ux${AGENT_KIT === 'on' ? '-kit' : ''}-${new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)}`;
 const runDir = join(RESULTS_ROOT, runId);
 const evidenceDir = join(runDir, 'evidence');
 mkdirSync(evidenceDir, { recursive: true });
@@ -44,7 +50,7 @@ function startViteServer(): Promise<() => Promise<void>> {
   return new Promise((resolve, reject) => {
     const logFd = openSync(join(runDir, 'server.log'), 'a');
     const child = spawn('npx', ['vite', 'dev', '--port', String(VITE_PORT), '--strictPort'], {
-      env: { ...process.env, NO_HMR: '1' },
+      env: { ...process.env, NO_HMR: '1', AGENT_KIT },
       detached: true,
       stdio: ['ignore', logFd, logFd]
     });
@@ -211,6 +217,7 @@ async function main(): Promise<number> {
         runId,
         appUrl: APP_URL,
         judgeModel: judged.modelId,
+        agentKit: AGENT_KIT,
         startedAt: new Date(stamp).toISOString(),
         finishedAt: new Date().toISOString(),
         durationMs: Date.now() - stamp

--- a/scripts/eval/ux.ts
+++ b/scripts/eval/ux.ts
@@ -14,6 +14,10 @@ import { writeReport, type FlowFact, type JudgeUsage } from './ux/report';
 const APP_URL = process.env.EVAL_UX_APP_URL ?? 'http://localhost:4180';
 const VITE_PORT = Number(APP_URL.split(':').pop() ?? 4180);
 const REPLY_WAIT_MS = Number(process.env.EVAL_UX_WAIT_MS ?? 240_000);
+// Il contatto del team nasce quando il TURNO di setup chiude, non quando la prima risposta
+// arriva: il turno continua a lavorare per minuti dopo (tool, memoria) e la finestra della
+// prima risposta scadde troppo presto. Il poll del team ha la sua finestra, più larga.
+const TEAM_WAIT_MS = Number(process.env.EVAL_UX_TEAM_WAIT_MS ?? 420_000);
 const RESULTS_ROOT = process.env.EVAL_UX_RESULTS_DIR ?? 'eval-results';
 const BRAND_POLL_MS = 60_000;
 const HEALTH_TIMEOUT_MS = 90_000;
@@ -151,7 +155,7 @@ async function main(): Promise<number> {
     const { replied, facts: chat } = await waitForAssistantReply(admin, brand.id, REPLY_WAIT_MS);
     log(`[chat] replied=${replied} assistant=${chat.assistantMessages} latency=${chat.firstAssistantLatencyMs}ms`);
 
-    const team = await waitForTeamContact(admin, brand.id, REPLY_WAIT_MS);
+    const team = await waitForTeamContact(admin, brand.id, TEAM_WAIT_MS);
     log(`[team] contatti firmati: ${team.agents.join(', ') || 'nessuno'}`);
 
     // Prova di delega: una domanda cross-craft (audit + idee post). Il fatto misurato è se

--- a/scripts/eval/ux.ts
+++ b/scripts/eval/ux.ts
@@ -1,6 +1,6 @@
 import { spawn } from 'node:child_process';
 import { openSync, mkdirSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { generateText } from 'ai';
 import { createAdminClient } from '$lib/server/supabase-admin';
 import { geminiFast } from '$lib/server/chat/model';
@@ -28,7 +28,9 @@ const AGENT_KIT: 'on' | 'off' = process.env.AGENT_KIT === 'on' ? 'on' : 'off';
 
 const runId = `ux${AGENT_KIT === 'on' ? '-kit' : ''}-${new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)}`;
 const runDir = join(RESULTS_ROOT, runId);
-const evidenceDir = join(runDir, 'evidence');
+// Il daemon agent-browser risolve i path relativi col SUO cwd: le evidenze devono essere
+// assolute o la screenshot muore con "No such file or directory".
+const evidenceDir = resolve(join(runDir, 'evidence'));
 mkdirSync(evidenceDir, { recursive: true });
 
 const transcriptLines: string[] = [];

--- a/scripts/eval/ux/report.test.ts
+++ b/scripts/eval/ux/report.test.ts
@@ -7,6 +7,7 @@ const report: RunReport = {
     runId: 'ux-test',
     appUrl: 'http://localhost:4180',
     judgeModel: 'gemini-flash',
+    agentKit: 'off',
     startedAt: '2026-08-28T09:00:00.000Z',
     finishedAt: '2026-08-28T09:04:00.000Z',
     durationMs: 240_000
@@ -31,6 +32,7 @@ describe('renderMarkdown', () => {
     expect(md).toContain('# Eval UX — ux-test');
     expect(md).toContain('**FAIL**');
     expect(md).toContain('2/4 criteri');
+    expect(md).toContain('kit off');
   });
 
   it('distinguishes gate facts from info facts', () => {

--- a/scripts/eval/ux/report.ts
+++ b/scripts/eval/ux/report.ts
@@ -13,6 +13,7 @@ export type RunMeta = {
   runId: string;
   appUrl: string;
   judgeModel: string;
+  agentKit: 'on' | 'off';
   startedAt: string;
   finishedAt: string;
   durationMs: number;
@@ -48,7 +49,7 @@ export function renderMarkdown(report: RunReport): string {
   lines.push(`# Eval UX — ${meta.runId}`);
   lines.push('');
   lines.push(
-    `Esito: **${grade.allPass ? 'PASS' : 'FAIL'}** · ${grade.passCount}/${grade.criteria.length} criteri · app ${meta.appUrl} · giudice ${meta.judgeModel}`
+    `Esito: **${grade.allPass ? 'PASS' : 'FAIL'}** · ${grade.passCount}/${grade.criteria.length} criteri · app ${meta.appUrl} · giudice ${meta.judgeModel} · kit ${meta.agentKit}`
   );
   lines.push('');
   if (grade.summary) {

--- a/scripts/eval/ux/walk.ts
+++ b/scripts/eval/ux/walk.ts
@@ -20,6 +20,11 @@ export async function walkOnboarding(
 ): Promise<WalkResult> {
   const steps: string[] = [];
 
+  // Il profilo del browser sopravvive tra le run: una sessione aperta manda /login in redirect
+  // e la walk parte nel posto sbagliato (LESSONS, *Il profilo del browser conserva sessioni*).
+  await browser.run('cookies', 'clear');
+  await browser.run('storage', 'local', 'clear');
+
   await browser.open(`${appUrl}/login`);
   await browser.run('fill', 'input[name="email"]', creds.email);
   await browser.run('fill', 'input[name="password"]', creds.password);

--- a/scripts/eval/ux/walk.ts
+++ b/scripts/eval/ux/walk.ts
@@ -22,9 +22,10 @@ export async function walkOnboarding(
 
   // Il profilo del browser sopravvive tra le run: una sessione aperta manda /login in redirect
   // e la walk parte nel posto sbagliato (LESSONS, *Il profilo del browser conserva sessioni*).
+  // La pulizia vuole una pagina aperta: si apre, si pulisce, si riapre puliti.
+  await browser.open(`${appUrl}/login`);
   await browser.run('cookies', 'clear');
   await browser.run('storage', 'local', 'clear');
-
   await browser.open(`${appUrl}/login`);
   await browser.run('fill', 'input[name="email"]', creds.email);
   await browser.run('fill', 'input[name="password"]', creds.password);

--- a/src/lib/content/changelog/2026-08-28-kit-onboarding-ignite.ts
+++ b/src/lib/content/changelog/2026-08-28-kit-onboarding-ignite.ts
@@ -1,0 +1,11 @@
+import type { ChangelogEntry } from './index';
+
+const entry: ChangelogEntry = {
+  date: 'August 28, 2026',
+  title: 'Your whole team greets you on day one',
+  items: [
+    'The specialists matched to your plan now reach out in their own conversations after setup on every engine, not just one — no matter which one handled your first conversation.'
+  ]
+};
+
+export default entry;

--- a/src/lib/server/chat/queue-kit-onboarding-ignite.test.ts
+++ b/src/lib/server/chat/queue-kit-onboarding-ignite.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Il difetto del ramo kit: il turno di setup dell'onboarding girava sul ramo kit (AGENT_KIT=on)
+ * che chiudeva il job e tornava PRIMA del blocco `igniteOnboardingTeam` del percorso classico.
+ * Il team non contattava mai il nuovo utente: PR #32 restava morta sul motore che in produzione
+ * gira davvero. La guardia: a turno kit completato su un thread surface='onboarding', i thread
+ * surface='team' di teamContactsForPlan(brand.plan) devono esistere.
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Row = Record<string, any>;
+
+const KIT_TURN_OK = () => new Response(null, { status: 200 });
+
+vi.mock('$env/dynamic/private', () => ({ env: { AGENT_KIT: 'on' } }));
+vi.mock('./compaction', () => ({ maybeCompactThread: async () => false }));
+vi.mock('$lib/agent/bridge/live', () => ({
+	shouldUseKit: () => ({ id: 'analyst' }),
+	runKitTurn: vi.fn(async () => KIT_TURN_OK())
+}));
+vi.mock('./persistence', () => ({
+	getThread: vi.fn(async () => ({
+		id: 'thread-onboarding',
+		agent: 'analyst',
+		custom_agent_id: null,
+		room_agents: null,
+		surface: 'onboarding',
+		model: null
+	})),
+	loadHistory: vi.fn(async () => [{ role: 'user', content: 'crea il mio brand' }]),
+	saveMessages: vi.fn(async () => ['m1']),
+	renameThread: vi.fn(async () => undefined),
+	createThread: vi.fn(async () => null),
+	assistantContentFromSteps: () => []
+}));
+vi.mock('./rate-limits', () => ({
+	getChatRateUsage: vi.fn(async () => ({ ok: true })),
+	chatCreditsBlocked: vi.fn(async () => false)
+}));
+vi.mock('$lib/server/hydrate-chat-documents', () => ({ hydrateChatDocuments: vi.fn(async () => []) }));
+vi.mock('$lib/server/ai-log', () => ({
+	logAiCall: () => undefined,
+	extractSdkUsage: () => ({}),
+	withBrandContext: (_id: string, fn: () => unknown) => fn()
+}));
+
+const TEAM_AGENTS: Record<string, string[]> = {
+	content: ['content', 'web', 'motion'],
+	web: ['web', 'content', 'motion'],
+	motion: ['motion', 'content', 'web'],
+	ugc: ['ugc', 'content', 'web'],
+	analyst: ['analyst', 'content', 'web'],
+	auto: ['auto', 'content', 'web']
+};
+
+vi.mock('$lib/server/team-ignition', () => ({
+	getOrCreateTeamThread: vi.fn(async (admin: Row, brandId: string, agentId: string) => {
+		const table = (admin.tables.chat_threads ??= []);
+		const existing = table.find(
+			(r: Row) => r.brand_id === brandId && r.surface === 'team' && r.surface_key === agentId
+		);
+		if (existing) {
+			return { threadId: existing.id, userId: 'user-1', locale: 'it', created: false };
+		}
+		const id = `team-thread-${table.length + 1}`;
+		table.push({
+			id,
+			brand_id: brandId,
+			user_id: 'user-1',
+			agent: agentId,
+			surface: 'team',
+			surface_key: agentId,
+			locale: 'it'
+		});
+		return { threadId: id, userId: 'user-1', locale: 'it', created: true };
+	})
+}));
+
+const { processNextQueuedChatJob } = await import('./queue');
+const { teamContactsForPlan } = await import('$lib/server/onboarding-team');
+
+function makeDb(seed: Record<string, Row[]>) {
+	const tables: Record<string, Row[]> = {};
+	for (const [name, rows] of Object.entries(seed)) tables[name] = rows.map((r) => ({ ...r }));
+
+	function build(name: string, mode: 'select' | 'update' | 'insert', patch?: Row) {
+		const table = (tables[name] ??= []);
+		const filters: Array<(r: Row) => boolean> = [];
+		const run = () => {
+			if (mode === 'insert' && patch) {
+				const row = { id: `${name}-${table.length + 1}`, ...patch };
+				table.push(row);
+				return [row];
+			}
+			const hits = table.filter((r) => filters.every((f) => f(r)));
+			if (mode === 'update') hits.forEach((r) => Object.assign(r, patch));
+			return hits;
+		};
+		const api: Row = {
+			eq: (c: string, v: unknown) => (filters.push((r) => r[c] === v), api),
+			neq: (c: string, v: unknown) => (filters.push((r) => r[c] !== v), api),
+			in: (c: string, v: unknown[]) => (filters.push((r) => v.includes(r[c])), api),
+			gte: (c: string, v: string) => (filters.push((r) => String(r[c]) >= v), api),
+			lt: (c: string, v: string) => (filters.push((r) => String(r[c]) < v), api),
+			is: (c: string, v: unknown) => (filters.push((r) => (r[c] ?? null) === v), api),
+			not: () => api,
+			order: () => api,
+			limit: () => api,
+			select: () => api,
+			maybeSingle: async () => ({ data: run()[0] ?? null, error: null }),
+			then: (res?: (v: { data: Row[]; error: null }) => unknown) =>
+				Promise.resolve(res ? res({ data: run(), error: null }) : { data: run(), error: null })
+		};
+		return api;
+	}
+
+	return {
+		tables,
+		client: {
+			tables,
+			from: (name: string) => ({
+				select: () => build(name, 'select'),
+				update: (patch: Row) => build(name, 'update', patch),
+				insert: (row: Row) => build(name, 'insert', row)
+			})
+		}
+	};
+}
+
+describe('il turno kit di setup accende il contatto del team', () => {
+	it('a turno completato esistono i thread surface=team per il piano del brand', async () => {
+		const db = makeDb({
+			chat_jobs: [
+				{
+					id: 'job-setup',
+					brand_id: 'brand-1',
+					user_id: 'user-1',
+					thread_id: 'thread-onboarding',
+					tool_name: 'chat_response',
+					status: 'pending',
+					created_at: new Date().toISOString(),
+					input_params: { user_message: 'crea il mio brand', locale: 'it' }
+				}
+			],
+			chat_threads: [],
+			brands: [{ id: 'brand-1', name: 'Bowora', slug: 'bowora', plan: 'pro', status: 'active' }],
+			agent_kit_runs: [],
+			ai_calls: []
+		});
+
+		const res = await processNextQueuedChatJob(db.client as never, '');
+
+		expect(res).toMatchObject({ processed: true, jobId: 'job-setup' });
+		const expected = teamContactsForPlan('pro');
+		const teamThreads = db.tables.chat_threads.filter((r) => r.surface === 'team');
+		expect(new Set(teamThreads.map((r) => r.surface_key))).toEqual(new Set(expected));
+		expect(teamThreads.every((r) => TEAM_AGENTS[r.agent]?.includes(r.surface_key))).toBe(true);
+	});
+});

--- a/src/lib/server/chat/queue.ts
+++ b/src/lib/server/chat/queue.ts
@@ -387,6 +387,33 @@ async function failChatJob(
 		.eq('last_job_id', jobId);
 }
 
+// Il team si presenta: chiuso il primo turno di setup, gli specialisti del piano contattano
+// l'utente nei loro thread. È il punto di completamento CONDIVISO dai due motori: il ramo kit
+// chiude il job e tornava prima di questo blocco, e il team non salutava mai nessuno (PR #32
+// morta sul motore che in produzione gira davvero). Import dinamico: il modulo accoda turni qui.
+async function igniteTeamAfterSetupTurn(
+	admin: SupabaseClient,
+	opts: {
+		brand: { id: string; name?: unknown; website?: unknown; plan?: unknown };
+		userId: string;
+		threadRow: { surface?: string | null } | null | undefined;
+		locale: string;
+		origin: string;
+	}
+): Promise<void> {
+	if (opts.threadRow?.surface !== 'onboarding') return;
+	const { igniteOnboardingTeam } = await import('$lib/server/onboarding-team');
+	await igniteOnboardingTeam(admin, {
+		brandId: opts.brand.id,
+		userId: opts.userId,
+		brandName: String(opts.brand.name ?? ''),
+		website: (opts.brand.website as string | null) ?? null,
+		plan: (opts.brand.plan as string | null) ?? null,
+		locale: opts.locale,
+		origin: opts.origin
+	});
+}
+
 /**
  * Claim the oldest pending queued chat_response that has no sibling still running
  * on the same thread, then generate + persist the assistant reply.
@@ -737,9 +764,16 @@ export async function processNextQueuedChatJob(
 							partial: null,
 							completed_at: new Date().toISOString()
 						})
-						.eq('id', jobId)
-						.in('status', ['pending', 'running']);
-					return { processed: true, jobId };
+					.eq('id', jobId)
+					.in('status', ['pending', 'running']);
+				await igniteTeamAfterSetupTurn(admin, {
+					brand,
+					userId: job.user_id as string,
+					threadRow,
+					locale,
+					origin
+				});
+				return { processed: true, jobId };
 				}).finally(stopHeartbeat);
 			}
 		}
@@ -1380,20 +1414,13 @@ export async function processNextQueuedChatJob(
 				.eq('id', jobId)
 				.in('status', ['pending', 'running', 'failed']);
 
-			// Il team si presenta: chiuso il primo turno di setup, gli specialisti del piano
-			// contattano l'utente nei loro thread. Import dinamico: il modulo accoda turni qui.
-			if (threadRow?.surface === 'onboarding') {
-				const { igniteOnboardingTeam } = await import('$lib/server/onboarding-team');
-				await igniteOnboardingTeam(admin, {
-					brandId: brand.id,
-					userId: job.user_id as string,
-					brandName: String(brand.name ?? ''),
-					website: (brand.website as string | null) ?? null,
-					plan: (brand.plan as string | null) ?? null,
-					locale,
-					origin
-				});
-			}
+			await igniteTeamAfterSetupTurn(admin, {
+				brand,
+				userId: job.user_id as string,
+				threadRow,
+				locale,
+				origin
+			});
 
 			try {
 				const { sendPushToUser } = await import('$lib/server/web-push');


### PR DESCRIPTION
## What?
With `AGENT_KIT=on` (the production default), the onboarding setup turn runs on the **kit branch** of the queue worker. That branch marked the job done and returned before the `igniteOnboardingTeam` block, which existed only on the classic path — so the team never contacted the new user, and PR #32 was dead on the engine that actually runs in production. The ignition is now one shared rule (`igniteTeamAfterSetupTurn` in queue.ts) called from both completion paths, and the eval harness gained a kit-on variant.

Closes task #47 (Notion, Anomalia > Tasks).

## Why?
Measured during the task #39 audit (3 full onboardings on the local stack): setup turn done, agent-to-agent DMs created, **zero threads with `surface='team'`** — no colleague ever greeted the user. Direct invocation of `igniteOnboardingTeam` worked, so the function was healthy: the kit path simply never reached it.

## How?
- **Shared rule, not a copy**: `igniteTeamAfterSetupTurn` is extracted once and called after job completion on both the kit and the classic path. The kit 409 (`kit_busy`) path returns before it, so a turn that was not executed seeds nothing. No new error guarding: `igniteOnboardingTeam` already swallows and logs its own failures.
- **Test first (Kent Beck)**: `queue-kit-onboarding-ignite.test.ts` creates a kit job on an `surface='onboarding'` thread and asserts the team threads of `teamContactsForPlan(plan)` exist after the turn — watched it fail (`Set{} vs Set{content, web, motion}`), then pass.
- **Eval guardian**: `eval:ux` now decides the engine per run (`AGENT_KIT=on npm run eval:ux`) instead of inheriting the moment's `.env`, records `agentKit` in the report meta, and names kit runs `ux-kit-*`. Harness fixes along the way: session cleanup before each walk, absolute evidence paths, and a separate, longer window for the team-contact poll (team threads are born when the setup turn completes, minutes after the first reply).
- LESSONS.md gains the incidents this cost: worktree inside the repo dir kills hydration (403 on the kit client entry via `/@fs`), agent-browser daemon path semantics, and poll windows opened at the first reply instead of turn completion.

## Testing?
- Unit: new test red → green; full suite **511 files / 5874 tests green** on this branch (`npm ci` after rebase, per docs/e2e-testing.md §1).
- E2E on the local stack (headed browser, `AGENT_KIT=on`, `anomalia-app` stopped to keep one queue worker, restarted afterwards): full onboarding walk (login → entry → pick → setup chat). Setup reply in 21s; after turn completion the DB shows the team threads for the brand's plan (empty plan → default `content` + `web`), each with the unsigned seed and the **signed opener** (`chat_messages.name` = agent), and the Web Specialist started its first SEO audit (`chat_jobs.tool_name='seo_geo_audit'`, running). First-run eval report: `eval-results/ux-kit-2026-08-28T16-58-14/report.md` — its `team-of-agents-contact` ❌ is a timing artifact (poll window expired at 17:02:59, threads born 17:03:03), fixed by the separate poll window; the DB rows are the decisive evidence.
- Login verified first-try as `test@anomalia.so` on `/app/demo` per the e2e guide.
- NOT tested: the `starter`/`pro` contact variants of `teamContactsForPlan` on a paid brand end-to-end (covered by unit assertions only).

## Evidence (screenshots/videos)
- `eval-results/ux-kit-2026-08-28T16-58-14/evidence/01-pick.png`, `02-chat.png` — onboarding walk on the local stack, headed browser.
- DB after the kit setup turn (local stack, brand `eval-ux-brand`):
  <details><summary>chat_threads — team threads born after turn completion</summary>

  ```
  surface     | surface_key | agent   | created_at
  onboarding  | <brand>     | analyst | 16:58:31
  team        | content     | content | 17:03:03
  team        | web         | web     | 17:03:03
  ```
  </details>
  <details><summary>chat_messages — signed openers and first work per specialist</summary>

  ```
  content | assistant | content | I'm your Content Creator: the content is my job. Starting no…
  web     | assistant | web     | I'm your Web Specialist: SEO, AI visibility and the site are…
  web     | assistant | (tool)  | No SEO audit existed yet, so I kicked off the first full craw…
  content | assistant | (tool)  | Ho aperto la tua Studio: per ora è tutto da scrivere…
  ```
  </details>

## Anything Else?
- `schema-drift-check` surfaced two pre-existing code bugs on hosted (nothing to apply, code names columns that no migration creates): `chat_messages.speaker` (`team-activity-tools.ts:76`) and `talents.body` (`scripts/talent/save-valeria.mjs:167`). Worth tasks.
- Local-stack-only: `agent_sessions.id` has no default in the local DB (migration 0205), so kit sessions log `insert failed` locally; patched locally with `set default gen_random_uuid()`, production unaffected.
- Eval run 2 aborted mid-setup (turn budget + one `heartbeat lost` under machine load) and honestly reported no team contact — kept as-is; rerun on a quiet machine for a green report.
