### PR TITLE
Resolve testTimeout duplicate left by the gateway merge

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -84,10 +84,6 @@ export default defineConfig({
       'packages/*.{test,spec}.{js,ts}',
       'scripts/**/*.{test,spec}.{js,ts}'
     ],
-    // Il grafo di import dei moduli server pesa diversi secondi da freddo (strategy-agent,
-    // queue, ugc): sotto carico il default di 5s molla a metà setup e un file passa e fallisce
-    // a seconda della parallelismo. 30s valutano la LOGICA, non la macchina.
-    testTimeout: 30_000,
     hookTimeout: 30_000
   }
 });


### PR DESCRIPTION
## What?
Removes the duplicate `testTimeout` key from `vite.config.ts` left by PR #10's merge.

## Why?
The second key silently wins in JS object literals, so kit-turn tests ran with 30s instead of the intended 120s — violating lesson #37 in LESSONS.md.

## How?
Kept `testTimeout: TEST_TIMEOUT_MS` (120s), kept `hookTimeout: 30_000` and the `include` block, removed the stale 30s key and its comment.

## Testing?
`npx vitest run src/lib/server/chat/queue-dm.test.ts` — 4/4 passed (2.6s).

## Evidence
Before (vite.config.ts:79-92):
```ts
test: {
  testTimeout: TEST_TIMEOUT_MS,
  include: [...],
  testTimeout: 30_000,   // silently wins
  hookTimeout: 30_000
}
```
After:
```ts
test: {
  testTimeout: TEST_TIMEOUT_MS,
  include: [...],
  hookTimeout: 30_000
}
```
<details><summary>Test output</summary>

```
 ✓ src/lib/server/chat/queue-dm.test.ts (4 tests) 14ms
 Test Files  1 passed (1)
      Tests  4 passed (4)
```
</details>

## Anything Else?
None. Config-only fix, no behavior change beyond restoring the 120s timeout.