### PR TITLE
Leads compliance: contact guard, gist + retention, legal pages

### DIFF
--- a/changelog/2026-08-29-lead-contact-guard.md
+++ b/changelog/2026-08-29-lead-contact-guard.md
@@ -1,0 +1,31 @@
+# Lead contact guard — soppressione globale e frequency cap
+
+Prima: il radar proponeva commenti e DM senza alcuna memoria di chi era già stato
+contattato, da questo o da qualsiasi altro brand dell'istanza. Nessun canale di
+opt-out, nessun limite di frequenza: il secondo tocco alla stessa persona dipendeva
+solo dalla sorte.
+
+Ora: un gate unico (`lead-contact.ts`) interrogato in tre punti.
+
+1. Al drafting (`radarEngage`): se l'autore ha soppresso o ha già ricevuto il suo
+   tocco (status `posted` o `done_at` valorizzato, su qualunque brand), l'item
+   salta con `skip_reason` esplicito.
+2. Alla rilettura dei thread (outcome check): un segnale di opt-out nel thread
+   sopprime l'autore (best-effort — vede solo quella lettura).
+3. Manuale: nuovo pulsante "Non contattare mai più" in `/leads` → soppressione
+   globale + dismiss.
+
+Decisioni prese e scartate:
+
+- La riga opt-out va SOLO nei DM (`dmWithOptOut`, garanzia server-side via marker
+  "stop"), non nei commenti: non leggiamo le risposte ai commenti in modo
+  affidabile, una riga opt-out lì sarebbe teatro. Nei commenti la protezione è il
+  tappo one-touch.
+- Soppressione globale (tabella senza brand_id, RLS senza policy, service-role
+  only), non per brand: l'opposizione è della persona, non del cliente. È anche la
+  difesa del processor che sa e comunque consentirebbe.
+- L'impronta dell'autore (`author_handle`/`author_platform`) si scrive al momento
+  dell'engage: i lead passati non hanno l'impronta e restano fuori dal tappo —
+  onesto e dichiarato.
+- Il setaccio opt-out è stretto di proposito (verbo di contatto accanto al
+  segnale): "stop wasting time" non è un opt-out.

--- a/changelog/2026-08-29-lead-gist-retention.md
+++ b/changelog/2026-08-29-lead-gist-retention.md
@@ -1,0 +1,27 @@
+# Lead gist + retention — il contenuto del post non resta nel database
+
+Prima: `brand_news_items.snippet` specchiava fino a 1000 caratteri del testo
+verbatim del post di una persona, senza nessuna scadenza — lead, esiti e
+telemetria crescevano senza limiti.
+
+Ora:
+
+- Il judge del radar distilla un `gist` (≤140 caratteri: cosa ha chiesto la
+  persona) nella STESSA chiamata AI che già giudicava la pertinenza — zero
+  chiamate extra. Al momento della stesura del verdetto lo snippet verbatim viene
+  messo a null: il testo vero vive solo sulla piattaforma, al permalink.
+- Chi approva vede il gist con l'etichetta "riassunto AI" e il permalink a un
+  click; il drafting (engage) legge comunque il contenuto live.
+- Sweep di retention (`sweepLeadRetention`) dentro il tick del radar, no-throw:
+  gist a 14 giorni; righe non convertite (proposed/suggested/skipped/dismissed)
+  eliminate a 90 giorni; lead_outcomes a 12 mesi; radar_searches a 90 giorni.
+
+Decisioni:
+
+- 14 giorni per il contenuto e 90 per la riga, non 14 per tutto: gli outcome
+  check girano tra 48h e 14 giorni dal done — cancellare la riga a 14 giorni
+  ucciderebbe l'ultimo controllo a metà.
+- I lead convertiti (done) restano: sono l'àncora degli outcome e la storia del
+  rapporto; il loro contenuto (gist) scade comunque a 14 giorni.
+- I lead passati senza `gist` mostrano lo snippet storico: nessuna migrazione
+  retroattiva dei dati esistenti.

--- a/changelog/2026-08-29-lead-legal-pages.md
+++ b/changelog/2026-08-29-lead-legal-pages.md
@@ -1,0 +1,25 @@
+# Carta del lead sourcing — privacy, termini, digest
+
+Prima: la privacy policy dichiarava ScrapeCreators come "cronologia dei post
+dagli account collegati" — cioè suggeriva i post dell'UTENTE, mentre il radar
+legge contenuti pubblici di TERZI. Nessuna finalità lead, nessuna retention per
+categoria, nessuna clausola sul sourcing nei termini, DPA inesistente.
+
+Ora:
+
+- Privacy §3: riga di finalità "ricerca di contatti commerciali" con base
+  legittimo interesse (art. 6(1)(f)).
+- Privacy §6: la voce ScrapeCreators dichiara ciò che accade davvero — lettura in
+  tempo reale di contenuti pubblici di terzi + cronologia degli account collegati.
+- Privacy §9: retention per categoria (gist 14g, lead non convertiti 90g, esiti
+  12m) e canale di opposizione per i terzi contattati.
+- Termini §13: clausola sul sourcing — l'utente è l'unico mittente, titolare dei
+  contatti che invia, responsabile del messaggio e dei ToS della piattaforma col
+  proprio account; il Servizio minimizza i dati ed esclude chi chiede di non
+  essere ricontattato.
+- Digest radar: link di disiscrizione nel CORPO della mail, non solo nell'header
+  List-Unsubscribe.
+
+La LIA completa (valutazione del legittimo interesse, fonte per fonte) vive su
+Notion, non nella repo: la repo OSS pubblica la dichiarazione, non il
+ragionamento. Da far revisionare al legale prima di considerarla definitiva.

--- a/src/lib/content/changelog/2026-08-29-lead-gist-retention.ts
+++ b/src/lib/content/changelog/2026-08-29-lead-gist-retention.ts
@@ -1,0 +1,10 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-08-29',
+  title: 'Leads now show an AI summary of the post — the copied text expires',
+  items: [
+    'Lead cards and the drawer show a short AI summary of what the person is asking, with the original post one click away.',
+    'Lead content is automatically deleted after 14 days, unconverted leads after 90 days, and outcome metrics after a year — nothing about a lead is kept forever.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/content/changelog/2026-08-29-lead-legal-pages.ts
+++ b/src/lib/content/changelog/2026-08-29-lead-legal-pages.ts
@@ -1,0 +1,11 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-08-29',
+  title: 'Clearer legal pages about how Leads sources public conversations',
+  items: [
+    'The privacy policy now states exactly what Leads does: reads public third-party content on social platforms, keeps only a short summary and the post link, and deletes it on short schedules.',
+    'The terms clarify that you are the only sender of any outreach: drafts are always human-reviewed, never automated.',
+    'The Radar digest email now carries an unsubscribe link in the body, not just in the mail headers.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/content/changelog/2026-08-29-lead-one-touch.ts
+++ b/src/lib/content/changelog/2026-08-29-lead-one-touch.ts
@@ -1,0 +1,11 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-08-29',
+  title: 'Leads: one contact per person, with a real opt-out',
+  items: [
+    'The radar now suggests each external person to at most one brand, ever — a lead who already received a touch is never proposed again.',
+    'Every suggested DM carries an opt-out line, and a "Never contact again" action in Leads removes that person from every future suggestion, for every brand.',
+    'When someone asks not to be contacted in a monitored thread, the radar stops suggesting them automatically.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -6438,6 +6438,7 @@
       "openAndDm": "Open profile & DM →",
       "dismiss": "Ignore",
       "restore": "Restore",
+      "dontContact": "Never contact again",
       "empty": "No leads here yet.",
       "rewrite": "Rewrite",
       "feedbackPh": "e.g. shorter, more casual, mention our product…",

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -7562,7 +7562,11 @@
         },
         "notePre": "We use the content and public post history you provide to generate posts with AI. We do",
         "noteStrong": "not",
-        "notePost": "sell your personal data, and we do not use your content to train third-party AI models for purposes unrelated to providing you the service."
+        "notePost": "sell your personal data, and we do not use your content to train third-party AI models for purposes unrelated to providing you the service.",
+        "row7": {
+          "purpose": "Business contact research (radar/leads): reading third-party public content on social platforms to propose conversations to join and contact drafts",
+          "basis": "Legitimate interest — Art. 6(1)(f)"
+        }
       },
       "s4": {
         "heading": "4. AI-generated content",
@@ -7587,7 +7591,7 @@
         "stripe": "Subscription billing and payment processing",
         "google": "AI text and image generation",
         "kie": "AI image / video generation",
-        "scrapecreators": "Collecting public post history from connected accounts",
+        "scrapecreators": "Real-time reading of public content (posts and profiles) from social platforms for the news and leads radar, and collection of the public history of connected accounts",
         "resend": "Sending transactional and notification emails",
         "metaProvider": "Meta (Instagram, Facebook) & TikTok",
         "meta": "Publishing posts to your connected accounts",
@@ -7618,7 +7622,8 @@
       },
       "s9": {
         "heading": "9. How long we keep your data",
-        "body": "We keep your personal data for as long as your account is active and as needed to provide the service. After you close your account we delete or anonymise your data within a reasonable period, except where we must keep it longer to comply with legal obligations (for example, invoices for tax purposes) or to resolve disputes."
+        "body": "We keep your personal data for as long as your account is active and as needed to provide the service. After you close your account we delete or anonymise your data within a reasonable period, except where we must keep it longer to comply with legal obligations (for example, invoices for tax purposes) or to resolve disputes.",
+        "body2": " Third-party content found by the radar has its own retention: the post summary is deleted after 14 days, unconverted leads after 90 days, comment outcomes after 12 months. Anyone who does not want to be contacted again can say so in a reply to the message they received, or through the customer who contacted them: their profile is excluded from all future suggestions, for every brand."
       },
       "s10": {
         "heading": "10. Your rights",
@@ -7760,7 +7765,8 @@
       "s13": {
         "heading": "13. Third-party services",
         "body": "The Service relies on third-party providers (for hosting, AI, analytics, payments, email and social platforms). We are not responsible for those providers’ services, and your use of connected platforms is also governed by their own terms.",
-        "body2": "Some features drive a real browser on your behalf — for example capturing screenshots of your own product after signing in with demo credentials you save. You may only save credentials for a service you own or are authorised to automate, and that authorisation is your responsibility. We will not use them to sign in to third-party platforms such as Instagram, Facebook, LinkedIn or TikTok: automated sign-in and automated posting generally breach those platforms’ terms and can get an account restricted, so the Service refuses it. Publishing happens only through the official APIs of the accounts you connect, after you approve the content."
+        "body2": "Some features drive a real browser on your behalf — for example capturing screenshots of your own product after signing in with demo credentials you save. You may only save credentials for a service you own or are authorised to automate, and that authorisation is your responsibility. We will not use them to sign in to third-party platforms such as Instagram, Facebook, LinkedIn or TikTok: automated sign-in and automated posting generally breach those platforms’ terms and can get an account restricted, so the Service refuses it. Publishing happens only through the official APIs of the accounts you connect, after you approve the content.",
+        "body3": " Some features (radar/leads) read third-party public content on social platforms to suggest conversations worth joining, with draft comments and messages. The user is the only sender: the Service never messages third parties automatically — every draft requires the user’s review and manual sending from their own account. The user is therefore the data controller of the contacts they send and is responsible for the message content, for complying with the terms of the platform they post on, and for honoring people’s requests not to be contacted again. The Service minimizes the data of the people it finds (a summary and the post link, no copy of the text) and excludes them from all future suggestions when they ask not to be contacted."
       },
       "s14": {
         "heading": "14. Availability & changes",
@@ -9525,14 +9531,14 @@
     "tier": {
       "label": "Model",
       "custom": "Custom",
-    "modelFamily": {
-      "luna": "Luna",
-      "grok": "Grok 4.6",
-      "gemini-flash": "Gemini Flash",
-      "deepseek-pro": "DeepSeek V4 Pro",
-      "gpt-terra": "GPT 5.6 Terra",
-      "gpt-sol": "GPT 5.6 Sol"
-    },
+      "modelFamily": {
+        "luna": "Luna",
+        "grok": "Grok 4.6",
+        "gemini-flash": "Gemini Flash",
+        "deepseek-pro": "DeepSeek V4 Pro",
+        "gpt-terra": "GPT 5.6 Terra",
+        "gpt-sol": "GPT 5.6 Sol"
+      },
       "auto": "Auto",
       "fast": "Fast",
       "pro": "Pro",

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -6454,6 +6454,7 @@
       "searchPh": "Search content, comment or DM…",
       "markDone": "Done",
       "postLabel": "Original post",
+      "postGist": "What the person is asking (AI summary — the original post is one link away)",
       "openPost": "Open",
       "relevanceLabel": "AI relevance",
       "close": "Close",

--- a/src/lib/i18n/locales/es.json
+++ b/src/lib/i18n/locales/es.json
@@ -6061,6 +6061,7 @@
       "openAndDm": "Abrir perfil y DM →",
       "dismiss": "Ignorar",
       "restore": "Restaurar",
+      "dontContact": "No contactar nunca más",
       "empty": "Aún no hay leads aquí.",
       "rewrite": "Reescribir",
       "feedbackPh": "e.g. shorter, more casual, mention our product…",

--- a/src/lib/i18n/locales/es.json
+++ b/src/lib/i18n/locales/es.json
@@ -6077,6 +6077,7 @@
       "searchPh": "Busca contenido, comentario o DM…",
       "markDone": "Hecho",
       "postLabel": "Publicación original",
+      "postGist": "Lo que pide la persona (resumen IA — la publicación original está en el enlace)",
       "openPost": "Abrir",
       "relevanceLabel": "Relevancia según la IA",
       "close": "Cerrar",

--- a/src/lib/i18n/locales/es.json
+++ b/src/lib/i18n/locales/es.json
@@ -7563,7 +7563,11 @@
         },
         "notePre": "Usamos el contenido y el historial de publicaciones públicas que usted proporciona para generar publicaciones con IA. Nosotros lo hacemos",
         "noteStrong": "not",
-        "notePost": "vendemos sus datos personales y no utilizamos su contenido para entrenar modelos de IA de terceros con fines no relacionados con la prestación del servicio."
+        "notePost": "vendemos sus datos personales y no utilizamos su contenido para entrenar modelos de IA de terceros con fines no relacionados con la prestación del servicio.",
+        "row7": {
+          "purpose": "Búsqueda de contactos comerciales (radar/leads): lectura de contenido público de terceros en redes sociales para proponer conversaciones y borradores de contacto",
+          "basis": "Interés legítimo — art. 6, ap. 1, letra f)"
+        }
       },
       "s4": {
         "heading": "4. AI-generated content",
@@ -7588,7 +7592,7 @@
         "stripe": "Facturación de suscripciones y procesamiento de pagos",
         "google": "Generación de texto e imagen con IA",
         "kie": "Generación de imagen/video con IA",
-        "scrapecreators": "Collecting public post history from connected accounts",
+        "scrapecreators": "Lectura en tiempo real de contenido público (publicaciones y perfiles) de plataformas sociales para el radar de noticias y leads, y recopilación del historial público de las cuentas conectadas",
         "resend": "Envío de emails transaccionales y de notificación",
         "metaProvider": "Meta (Instagram, Facebook) & TikTok",
         "meta": "Publicación en tus cuentas conectadas",
@@ -7619,7 +7623,8 @@
       },
       "s9": {
         "heading": "9. Cuánto tiempo conservamos tus datos",
-        "body": "Conservamos sus datos personales mientras su cuenta esté activa y según sea necesario para brindar el servicio. Después de cerrar su cuenta, eliminamos o anonimizamos sus datos dentro de un período razonable, excepto cuando debemos conservarlos por más tiempo para cumplir con obligaciones legales (por ejemplo, facturas a efectos fiscales) o para resolver disputas."
+        "body": "Conservamos sus datos personales mientras su cuenta esté activa y según sea necesario para brindar el servicio. Después de cerrar su cuenta, eliminamos o anonimizamos sus datos dentro de un período razonable, excepto cuando debemos conservarlos por más tiempo para cumplir con obligaciones legales (por ejemplo, facturas a efectos fiscales) o para resolver disputas.",
+        "body2": " El contenido de terceros encontrado por el radar tiene una retención propia: el resumen de la publicación se elimina a los 14 días, los leads no convertidos a los 90 días y los resultados de comentarios a los 12 meses. Quien no desee ser contactado de nuevo puede indicarlo respondiendo al mensaje recibido o a través del cliente que lo contactó: su perfil queda excluido de todas las propuestas futuras, para todas las marcas."
       },
       "s10": {
         "heading": "10. Tus derechos",
@@ -7761,7 +7766,8 @@
       "s13": {
         "heading": "13. Third-party services",
         "body": "El Servicio depende de proveedores externos (para alojamiento, inteligencia artificial, análisis, pagos, correo electrónico y plataformas sociales). No somos responsables de los servicios de esos proveedores y su uso de las plataformas conectadas también se rige por sus propios términos.",
-        "body2": "Algunas funciones controlan un navegador real en tu nombre — por ejemplo, la captura de pantallas de tu propio producto tras iniciar sesión con credenciales de demostración que guardes. Solo puedes guardar credenciales de un servicio del que seas titular o que estés autorizado a automatizar, y esa autorización es tu responsabilidad. No las usaremos para iniciar sesión en plataformas de terceros como Instagram, Facebook, LinkedIn o TikTok: el inicio de sesión y la publicación automatizados infringen por lo general los términos de esas plataformas y pueden acarrear restricciones de la cuenta, por lo que el Servicio lo rechaza. La publicación se realiza únicamente a través de las API oficiales de las cuentas que conectes, previa aprobación del contenido."
+        "body2": "Algunas funciones controlan un navegador real en tu nombre — por ejemplo, la captura de pantallas de tu propio producto tras iniciar sesión con credenciales de demostración que guardes. Solo puedes guardar credenciales de un servicio del que seas titular o que estés autorizado a automatizar, y esa autorización es tu responsabilidad. No las usaremos para iniciar sesión en plataformas de terceros como Instagram, Facebook, LinkedIn o TikTok: el inicio de sesión y la publicación automatizados infringen por lo general los términos de esas plataformas y pueden acarrear restricciones de la cuenta, por lo que el Servicio lo rechaza. La publicación se realiza únicamente a través de las API oficiales de las cuentas que conectes, previa aprobación del contenido.",
+        "body3": " Algunas funciones (radar/leads) leen contenido público de terceros en redes sociales para sugerir conversaciones a las que participar, con borradores de comentarios y mensajes. El usuario es el único remitente: el Servicio nunca envía mensajes a terceros automáticamente — cada borrador requiere la revisión y el envío manual por parte del usuario con su propia cuenta. El usuario es, por tanto, responsable del tratamiento de los contactos que envía y responde del contenido del mensaje, del cumplimiento de los términos de la plataforma donde lo publica y de atender las solicitudes de las personas de no ser contactadas. El Servicio minimiza los datos de las personas encontradas (resumen y enlace a la publicación, sin copia del texto) y las excluye de todas las propuestas futuras cuando lo solicitan."
       },
       "s14": {
         "heading": "14. Availability & changes",
@@ -9431,14 +9437,14 @@
     "tier": {
       "label": "Modelo",
       "custom": "Personalizado",
-    "modelFamily": {
-      "luna": "Luna",
-      "grok": "Grok 4.6",
-      "gemini-flash": "Gemini Flash",
-      "deepseek-pro": "DeepSeek V4 Pro",
-      "gpt-terra": "GPT 5.6 Terra",
-      "gpt-sol": "GPT 5.6 Sol"
-    },
+      "modelFamily": {
+        "luna": "Luna",
+        "grok": "Grok 4.6",
+        "gemini-flash": "Gemini Flash",
+        "deepseek-pro": "DeepSeek V4 Pro",
+        "gpt-terra": "GPT 5.6 Terra",
+        "gpt-sol": "GPT 5.6 Sol"
+      },
       "auto": "Auto",
       "fast": "Fast",
       "pro": "Pro",

--- a/src/lib/i18n/locales/fr.json
+++ b/src/lib/i18n/locales/fr.json
@@ -6061,6 +6061,7 @@
       "openAndDm": "Open profile & DM →",
       "dismiss": "Ignore",
       "restore": "Restore",
+      "dontContact": "Ne plus jamais contacter",
       "empty": "No leads here yet.",
       "rewrite": "Rewrite",
       "feedbackPh": "ex. plus court, plus décontracté, mentionner notre produit…",

--- a/src/lib/i18n/locales/fr.json
+++ b/src/lib/i18n/locales/fr.json
@@ -6077,6 +6077,7 @@
       "searchPh": "Rechercher contenu, commentaire ou DM…",
       "markDone": "Terminé",
       "postLabel": "Publication d'origine",
+      "postGist": "Ce que demande la personne (résumé IA — le post original est dans le lien)",
       "openPost": "Ouvrir",
       "relevanceLabel": "Pertinence selon l'IA",
       "close": "Fermer",

--- a/src/lib/i18n/locales/fr.json
+++ b/src/lib/i18n/locales/fr.json
@@ -7563,7 +7563,11 @@
         },
         "notePre": "Nous utilisons le contenu et l'historique public de posts que vous fournissez pour générer des posts avec l'IA. Nous",
         "noteStrong": "ne",
-        "notePost": "vendons pas vos données personnelles, et nous n'utilisons pas votre contenu pour entraîner des modèles d'IA tiers à des fins autres que la prestation de notre service."
+        "notePost": "vendons pas vos données personnelles, et nous n'utilisons pas votre contenu pour entraîner des modèles d'IA tiers à des fins autres que la prestation de notre service.",
+        "row7": {
+          "purpose": "Recherche de contacts commerciaux (radar/leads) : lecture de contenus publics de tiers sur les réseaux sociaux pour proposer des conversations à rejoindre et des brouillons de contact",
+          "basis": "Intérêt légitime — art. 6, par. 1, f)"
+        }
       },
       "s4": {
         "heading": "4. AI-generated content",
@@ -7588,7 +7592,7 @@
         "stripe": "Facturation d'abonnement et traitement des paiements",
         "google": "Génération de texte et d'images par IA",
         "kie": "AI image / video generation",
-        "scrapecreators": "Collecte de l'historique public des posts des comptes connectés",
+        "scrapecreators": "Lecture en temps réel de contenus publics (posts et profils) sur les plateformes sociales pour le radar d’actualités et de leads, et collecte de l’historique public des comptes connectés",
         "resend": "Envoi d'emails transactionnels et de notification",
         "metaProvider": "Meta (Instagram, Facebook) & TikTok",
         "meta": "Publication de posts sur vos comptes connectés",
@@ -7619,7 +7623,8 @@
       },
       "s9": {
         "heading": "9. Combien de temps nous conservons vos données",
-        "body": "Nous conservons vos données personnelles tant que votre compte est actif et aussi longtemps que nécessaire pour fournir le service. Lorsque vous supprimez votre compte, nous effaçons ou anonymisons vos données dans un délai de 30 jours, sauf obligation légale de conservation plus longue."
+        "body": "Nous conservons vos données personnelles tant que votre compte est actif et aussi longtemps que nécessaire pour fournir le service. Lorsque vous supprimez votre compte, nous effaçons ou anonymisons vos données dans un délai de 30 jours, sauf obligation légale de conservation plus longue.",
+        "body2": " Les contenus de tiers trouvés par le radar ont une durée de conservation propre : le résumé du post est supprimé après 14 jours, les leads non convertis après 90 jours, les résultats des commentaires après 12 mois. Toute personne qui ne souhaite plus être contactée peut le dire en réponse au message reçu ou via le client qui l’a contactée : son profil est exclu de toute proposition future, pour toutes les marques."
       },
       "s10": {
         "heading": "10. Vos droits",
@@ -7761,7 +7766,8 @@
       "s13": {
         "heading": "13. Third-party services",
         "body": "Le Service s'appuie sur des prestataires tiers (pour l'hébergement, l'IA, l'analyse, les paiements, l'email et les réseaux sociaux). Nous ne sommes pas responsables des interruptions, retards ou problèmes causés par ces prestataires.",
-        "body2": "Certaines fonctionnalités pilotent un navigateur réel pour votre compte — par exemple la capture d’écrans de votre propre produit après connexion avec des identifiants de démonstration que vous enregistrez. Vous ne pouvez enregistrer des identifiants que pour un service dont vous êtes titulaire ou que vous êtes autorisé à automatiser, et cette autorisation relève de votre responsabilité. Nous ne les utiliserons pas pour nous connecter à des plateformes tierces telles qu’Instagram, Facebook, LinkedIn ou TikTok : la connexion et la publication automatisées enfreignent généralement les conditions de ces plateformes et peuvent entraîner des restrictions de compte, c’est pourquoi le Service les refuse. La publication passe uniquement par les API officielles des comptes que vous connectez, après votre approbation du contenu."
+        "body2": "Certaines fonctionnalités pilotent un navigateur réel pour votre compte — par exemple la capture d’écrans de votre propre produit après connexion avec des identifiants de démonstration que vous enregistrez. Vous ne pouvez enregistrer des identifiants que pour un service dont vous êtes titulaire ou que vous êtes autorisé à automatiser, et cette autorisation relève de votre responsabilité. Nous ne les utiliserons pas pour nous connecter à des plateformes tierces telles qu’Instagram, Facebook, LinkedIn ou TikTok : la connexion et la publication automatisées enfreignent généralement les conditions de ces plateformes et peuvent entraîner des restrictions de compte, c’est pourquoi le Service les refuse. La publication passe uniquement par les API officielles des comptes que vous connectez, après votre approbation du contenu.",
+        "body3": " Certaines fonctions (radar/leads) lisent des contenus publics de tiers sur les réseaux sociaux pour suggérer à l’utilisateur des conversations à rejoindre, avec des brouillons de commentaires et de messages. L’utilisateur est l’unique expéditeur : le Service n’envoie jamais de messages à des tiers automatiquement — chaque brouillon exige la relecture et l’envoi manuel par l’utilisateur depuis son propre compte. L’utilisateur est donc responsable du traitement des contacts qu’il envoie et répond du contenu du message, du respect des conditions de la plateforme où il publie et de l’honneur des demandes des personnes de ne plus être contactées. Le Service minimise les données des personnes trouvées (résumé et lien vers le post, sans copie du texte) et les exclut de toute proposition future lorsqu’elles le demandent."
       },
       "s14": {
         "heading": "14. Availability & changes",
@@ -9431,14 +9437,14 @@
     "tier": {
       "label": "Modèle",
       "custom": "Personnalisé",
-    "modelFamily": {
-      "luna": "Luna",
-      "grok": "Grok 4.6",
-      "gemini-flash": "Gemini Flash",
-      "deepseek-pro": "DeepSeek V4 Pro",
-      "gpt-terra": "GPT 5.6 Terra",
-      "gpt-sol": "GPT 5.6 Sol"
-    },
+      "modelFamily": {
+        "luna": "Luna",
+        "grok": "Grok 4.6",
+        "gemini-flash": "Gemini Flash",
+        "deepseek-pro": "DeepSeek V4 Pro",
+        "gpt-terra": "GPT 5.6 Terra",
+        "gpt-sol": "GPT 5.6 Sol"
+      },
       "auto": "Auto",
       "fast": "Fast",
       "pro": "Pro",

--- a/src/lib/i18n/locales/it.json
+++ b/src/lib/i18n/locales/it.json
@@ -7563,7 +7563,11 @@
         },
         "notePre": "Utilizziamo i contenuti e la cronologia pubblica dei post forniti dall’utente per generare contenuti tramite intelligenza artificiale.",
         "noteStrong": "Non",
-        "notePost": "vendiamo i dati personali dell’utente e non utilizziamo i suoi contenuti per addestrare modelli di intelligenza artificiale di terze parti per finalità estranee alla fornitura del servizio."
+        "notePost": "vendiamo i dati personali dell’utente e non utilizziamo i suoi contenuti per addestrare modelli di intelligenza artificiale di terze parti per finalità estranee alla fornitura del servizio.",
+        "row7": {
+          "purpose": "Ricerca di contatti commerciali (radar/leads): lettura di contenuti pubblici di terzi su piattaforme social per proporre conversazioni da raggiungere e bozze di contatto",
+          "basis": "Legittimo interesse — art. 6, par. 1, lett. f)"
+        }
       },
       "s4": {
         "heading": "4. Contenuti generati dall’intelligenza artificiale",
@@ -7588,7 +7592,7 @@
         "stripe": "Fatturazione degli abbonamenti ed elaborazione dei pagamenti",
         "google": "Generazione di testi e immagini tramite IA",
         "kie": "Generazione di immagini / video tramite IA",
-        "scrapecreators": "Raccolta della cronologia pubblica dei post dagli account collegati",
+        "scrapecreators": "Lettura in tempo reale di contenuti pubblici (post e profili) da piattaforme social per il radar di notizie e lead, e raccolta della cronologia pubblica degli account collegati",
         "resend": "Invio di email transazionali e di notifica",
         "metaProvider": "Meta (Instagram, Facebook) e TikTok",
         "meta": "Pubblicazione dei contenuti sugli account collegati",
@@ -7619,7 +7623,8 @@
       },
       "s9": {
         "heading": "9. Per quanto tempo conserviamo i dati",
-        "body": "Conserviamo i dati personali dell’utente per tutto il tempo in cui l’account è attivo e per quanto necessario a fornire il servizio. Dopo la chiusura dell’account, cancelliamo o rendiamo anonimi i dati entro un periodo ragionevole, salvo i casi in cui sia necessario conservarli più a lungo per adempiere a obblighi di legge (ad esempio, le fatture a fini fiscali) o per la risoluzione di controversie."
+        "body": "Conserviamo i dati personali dell’utente per tutto il tempo in cui l’account è attivo e per quanto necessario a fornire il servizio. Dopo la chiusura dell’account, cancelliamo o rendiamo anonimi i dati entro un periodo ragionevole, salvo i casi in cui sia necessario conservarli più a lungo per adempiere a obblighi di legge (ad esempio, le fatture a fini fiscali) o per la risoluzione di controversie.",
+        "body2": " Per i contenuti di terzi trovati dal radar vale una retention dedicata: il riassunto del post si cancella dopo 14 giorni, i lead non convertiti dopo 90 giorni, gli esiti dei commenti dopo 12 mesi. Chi non vuole essere ricontattato può dirlo in risposta al messaggio ricevuto o tramite il cliente che lo ha contattato: il profilo viene escluso da ogni proposta futura, per tutti i brand."
       },
       "s10": {
         "heading": "10. I diritti dell’utente",
@@ -7761,7 +7766,8 @@
       "s13": {
         "heading": "13. Servizi di terze parti",
         "body": "Il Servizio si avvale di fornitori di terze parti (per hosting, IA, analisi, pagamenti, email e piattaforme social). Non siamo responsabili dei servizi di tali fornitori e l’utilizzo delle piattaforme collegate è altresì disciplinato dai rispettivi termini.",
-        "body2": "Alcune funzioni pilotano un browser reale per conto dell’utente — per esempio la cattura di screenshot del proprio prodotto dopo l’accesso con credenziali demo salvate dall’utente. È possibile salvare credenziali solo per un servizio di cui si è titolari o che si è autorizzati ad automatizzare, e tale autorizzazione è responsabilità dell’utente. Non le utilizzeremo per accedere a piattaforme di terzi come Instagram, Facebook, LinkedIn o TikTok: l’accesso automatizzato e la pubblicazione automatizzata violano generalmente i termini di tali piattaforme e possono comportare limitazioni dell’account, quindi il Servizio li rifiuta. La pubblicazione avviene esclusivamente tramite le API ufficiali degli account collegati, previa approvazione dei contenuti da parte dell’utente."
+        "body2": "Alcune funzioni pilotano un browser reale per conto dell’utente — per esempio la cattura di screenshot del proprio prodotto dopo l’accesso con credenziali demo salvate dall’utente. È possibile salvare credenziali solo per un servizio di cui si è titolari o che si è autorizzati ad automatizzare, e tale autorizzazione è responsabilità dell’utente. Non le utilizzeremo per accedere a piattaforme di terzi come Instagram, Facebook, LinkedIn o TikTok: l’accesso automatizzato e la pubblicazione automatizzata violano generalmente i termini di tali piattaforme e possono comportare limitazioni dell’account, quindi il Servizio li rifiuta. La pubblicazione avviene esclusivamente tramite le API ufficiali degli account collegati, previa approvazione dei contenuti da parte dell’utente.",
+        "body3": " Alcune funzioni (radar/leads) leggono contenuti pubblici di terzi su piattaforme social per suggerire all’utente conversazioni a cui partecipare, con bozze di commento e messaggio. L’utente è l’unico mittente: il Servizio non invia mai messaggi a terzi in automatico — ogni bozza richiede la revisione e l’invio manuale da parte dell’utente con il proprio account. L’utente è pertanto titolare del trattamento dei contatti che invia e risponde del contenuto del messaggio, del rispetto dei termini della piattaforma su cui lo pubblica e di onorare le richieste delle persone di non essere ricontattate. Il Servizio minimizza i dati delle persone trovate (riassunto e link al post, senza copia del testo) e le esclude da ogni proposta futura quando chiedono di non essere ricontattate."
       },
       "s14": {
         "heading": "14. Disponibilità e modifiche",
@@ -9526,14 +9532,14 @@
     "tier": {
       "label": "Modello",
       "custom": "Custom",
-    "modelFamily": {
-      "luna": "Luna",
-      "grok": "Grok 4.6",
-      "gemini-flash": "Gemini Flash",
-      "deepseek-pro": "DeepSeek V4 Pro",
-      "gpt-terra": "GPT 5.6 Terra",
-      "gpt-sol": "GPT 5.6 Sol"
-    },
+      "modelFamily": {
+        "luna": "Luna",
+        "grok": "Grok 4.6",
+        "gemini-flash": "Gemini Flash",
+        "deepseek-pro": "DeepSeek V4 Pro",
+        "gpt-terra": "GPT 5.6 Terra",
+        "gpt-sol": "GPT 5.6 Sol"
+      },
       "auto": "Auto",
       "fast": "Fast",
       "pro": "Pro",

--- a/src/lib/i18n/locales/it.json
+++ b/src/lib/i18n/locales/it.json
@@ -6439,6 +6439,7 @@
       "openAndDm": "Apri profilo e invia DM →",
       "dismiss": "Ignora",
       "restore": "Ripristina",
+      "dontContact": "Non contattare mai più",
       "empty": "Nessun lead qui per ora.",
       "rewrite": "Riscrivi",
       "feedbackPh": "es. più breve, più informale, menziona il nostro prodotto…",

--- a/src/lib/i18n/locales/it.json
+++ b/src/lib/i18n/locales/it.json
@@ -6455,6 +6455,7 @@
       "searchPh": "Cerca contenuto, commento o DM…",
       "markDone": "Fatto",
       "postLabel": "Post originale",
+      "postGist": "Cosa chiede la persona (riassunto AI — il post originale è nel link)",
       "openPost": "Apri",
       "relevanceLabel": "Affinità stimata dall'AI",
       "close": "Chiudi",

--- a/src/lib/server/chat/system-prompt.ts
+++ b/src/lib/server/chat/system-prompt.ts
@@ -217,7 +217,7 @@ export async function buildSystemPrompt(
     needGrow || needPublish
       ? supabase
           .from('brand_news_items')
-          .select('title, url, source_name, snippet, status, relevance')
+          .select('title, url, source_name, gist, snippet, status, relevance')
           .eq('brand_id', brandId)
           .eq('status', 'suggested')
           .not('suggestion', 'is', null)

--- a/src/lib/server/lead-contact.test.ts
+++ b/src/lib/server/lead-contact.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { platformOf, isOptOutSignal, dmWithOptOut, gateVerdict, contactGate, suppressAuthor } from './lead-contact';
+
+describe('platformOf (una sola fonte di verità per la piattaforma di un lead)', () => {
+  it('riconosce le quattro piattaforme di engage e manda il resto a web', () => {
+    expect(platformOf('https://www.reddit.com/r/SaaS/comments/abc/hi/')).toBe('reddit');
+    expect(platformOf('https://www.threads.net/@ciao/post/123')).toBe('threads');
+    expect(platformOf('https://x.com/pippo/status/1')).toBe('x');
+    expect(platformOf('https://twitter.com/pippo/status/1')).toBe('x');
+    expect(platformOf('https://www.linkedin.com/posts/pippo-123')).toBe('linkedin');
+    expect(platformOf('https://news.google.com/rss/articolo')).toBe('web');
+  });
+});
+
+describe('isOptOutSignal (setaccio del consenso ritirato: stretto, non generico)', () => {
+  it('becca le richieste di non essere ricontattati, in inglese e in italiano', () => {
+    expect(isOptOutSignal('Stop contacting me please.')).toBe(true);
+    expect(isOptOutSignal("Please don't contact me again")).toBe(true);
+    expect(isOptOutSignal('Non contattarmi più, grazie')).toBe(true);
+    expect(isOptOutSignal('Smettila di scrivermi')).toBe(true);
+    expect(isOptOutSignal('please unsubscribe me from this')).toBe(true);
+  });
+
+  it('non scatta su testo normale che contiene parole vicine', () => {
+    expect(isOptOutSignal('Stop wasting time on paid ads.')).toBe(false);
+    expect(isOptOutSignal('I stopped using that tool months ago')).toBe(false);
+    expect(isOptOutSignal('Grazie mille, molto utile!')).toBe(false);
+    expect(isOptOutSignal('')).toBe(false);
+  });
+});
+
+describe('dmWithOptOut (la riga di opt-out nel DM è garantita dal server, non dal modello)', () => {
+  it('aggiunge la riga a un DM che non la contiene', () => {
+    const out = dmWithOptOut('Ciao! Ti consiglio di provare X.');
+    expect(out.startsWith('Ciao! Ti consiglio di provare X.')).toBe(true);
+    expect(out).toContain('stop');
+  });
+
+  it('non duplica quando il DM già contiene il segnale', () => {
+    const dm = 'Ciao! Reply "stop" if you want no more messages.';
+    expect(dmWithOptOut(dm)).toBe(dm);
+  });
+
+  it('ignora il vuoto', () => {
+    expect(dmWithOptOut('')).toBe('');
+  });
+});
+
+describe('gateVerdict (la soppressione batte il contatto passato)', () => {
+  it('ordina i casi nel verso giusto', () => {
+    expect(gateVerdict({ suppressed: true, contacted: true })).toBe('suppressed');
+    expect(gateVerdict({ suppressed: false, contacted: true })).toBe('contacted');
+    expect(gateVerdict({ suppressed: false, contacted: false })).toBe('ok');
+  });
+});
+
+describe('contactGate (interroga soppressione globale e contatti passati)', () => {
+  function fakeAdmin(tables: Record<string, unknown[]>) {
+    const calls: string[] = [];
+    const build = (table: string) => {
+      const rows = tables[table] ?? [];
+      const b: Record<string, unknown> = {};
+      b.select = () => { calls.push(`${table}:select`); return b; };
+      b.eq = () => { return b; };
+      b.or = () => { calls.push(`${table}:or`); return b; };
+      b.limit = () => b;
+      b.maybeSingle = () => Promise.resolve({ data: rows[0] ?? null, error: null });
+      b.then = (resolve: (v: { data: unknown[]; error: null }) => void) => resolve({ data: rows, error: null });
+      return b;
+    };
+    return {
+      client: { from: (t: string) => { calls.push(t); return build(t); } } as unknown as SupabaseClient,
+      calls
+    };
+  }
+
+  it('becca prima la soppressione e non guarda oltre', async () => {
+    const { client, calls } = fakeAdmin({ lead_suppressions: [{ handle: 'pippo' }] });
+    const gate = await contactGate(client, 'reddit', 'pippo');
+    expect(gate).toEqual({ suppressed: true, contacted: false });
+    expect(calls).toContain('lead_suppressions');
+    expect(calls).not.toContain('brand_news_items');
+  });
+
+  it('un contatto passato (status posted o done) blocca il secondo tocco', async () => {
+    const { client, calls } = fakeAdmin({ brand_news_items: [{ id: 'l1' }] });
+    const gate = await contactGate(client, 'reddit', 'pippo');
+    expect(gate).toEqual({ suppressed: false, contacted: true });
+    expect(calls.some((c) => c === 'brand_news_items:or')).toBe(true);
+  });
+
+  it('mano pulita: ok', async () => {
+    const { client } = fakeAdmin({});
+    expect(await contactGate(client, 'reddit', 'pippo')).toEqual({ suppressed: false, contacted: false });
+  });
+});
+
+describe('suppressAuthor (upsert idempotente, mai duplicati)', () => {
+  it('scrive platform+handle+source con onConflict sulla coppia', async () => {
+    const ups: Array<{ payload: Record<string, unknown>; options: Record<string, unknown> }> = [];
+    const client = {
+      from: () => ({
+        upsert: (payload: Record<string, unknown>, options: Record<string, unknown>) => {
+          ups.push({ payload, options });
+          return Promise.resolve({ error: null });
+        }
+      })
+    } as unknown as SupabaseClient;
+
+    await suppressAuthor(client, { platform: 'reddit', handle: 'pippo', source: 'manual', reason: 'chiede di essere lasciato in pace' });
+    expect(ups[0].payload).toMatchObject({ platform: 'reddit', handle: 'pippo', source: 'manual' });
+    expect(ups[0].options).toMatchObject({ onConflict: 'platform,handle', ignoreDuplicates: true });
+  });
+
+  it('non lancia quando il db rifiuta: il guard non deve mai far morire la scansione', async () => {
+    const client = {
+      from: () => ({ upsert: () => Promise.resolve({ error: { message: 'boom' } }) })
+    } as unknown as SupabaseClient;
+    await expect(suppressAuthor(client, { platform: 'x', handle: 'pippo', source: 'reply' })).resolves.toBe(false);
+  });
+});

--- a/src/lib/server/lead-contact.test.ts
+++ b/src/lib/server/lead-contact.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { SupabaseClient } from '@supabase/supabase-js';
-import { platformOf, isOptOutSignal, dmWithOptOut, gateVerdict, contactGate, suppressAuthor } from './lead-contact';
+import { platformOf, isOptOutSignal, dmWithOptOut, gateVerdict, contactGate, suppressAuthor, sweepLeadRetention } from './lead-contact';
 
 describe('platformOf (una sola fonte di verità per la piattaforma di un lead)', () => {
   it('riconosce le quattro piattaforme di engage e manda il resto a web', () => {
@@ -118,5 +118,51 @@ describe('suppressAuthor (upsert idempotente, mai duplicati)', () => {
       from: () => ({ upsert: () => Promise.resolve({ error: { message: 'boom' } }) })
     } as unknown as SupabaseClient;
     await expect(suppressAuthor(client, { platform: 'x', handle: 'pippo', source: 'reply' })).resolves.toBe(false);
+  });
+});
+
+describe('sweepLeadRetention (il contenuto scade, la riga minima e gli esiti no)', () => {
+  type Op = { table: string; op: string; payload?: Record<string, unknown>; filters: string[] };
+  function fakeAdmin() {
+    const ops: Op[] = [];
+    const chain = (op: Op) => {
+      const b: Record<string, unknown> = {};
+      const add = (f: string) => { op.filters.push(f); return b; };
+      b.update = (payload: Record<string, unknown>) => { op.op = 'update'; op.payload = payload; return b; };
+      b.delete = () => { op.op = 'delete'; return b; };
+      b.lt = (col: string, v: unknown) => add(`lt:${col}`);
+      b.in = (col: string, v: unknown) => add(`in:${col}=${JSON.stringify(v)}`);
+      b.is = (col: string) => add(`is:${col}=null`);
+      b.not = (col: string, word: string) => add(`not:${col}.${word}`);
+      b.then = (resolve: (v: { data: []; error: null }) => void) => resolve({ data: [], error: null });
+      return b;
+    };
+    const client = {
+      from: (table: string) => {
+        const op: Op = { table, op: 'unknown', filters: [] };
+        ops.push(op);
+        return chain(op);
+      }
+    } as unknown as SupabaseClient;
+    return { client, ops };
+  }
+
+  it('applica le quattro scadenze alle tabelle giuste', async () => {
+    const { client, ops } = fakeAdmin();
+    await sweepLeadRetention(client);
+    const byKey = Object.fromEntries(ops.map((o) => [`${o.table}:${o.op}`, o]));
+    expect(byKey['brand_news_items:update']).toMatchObject({ payload: { gist: null }, filters: ['lt:created_at', 'not:gist.is'] });
+    expect(byKey['brand_news_items:delete']?.filters.join(' ')).toContain("in:status=");
+    expect(byKey['brand_news_items:delete']?.filters.join(' ')).toContain('is:done_at=null');
+    expect(byKey['brand_news_items:delete']?.filters.join(' ')).toContain('lt:created_at');
+    expect(byKey['lead_outcomes:delete']?.op).toBe('delete');
+    expect(byKey['radar_searches:delete']?.op).toBe('delete');
+  });
+
+  it('non lancia mai: una scadenza rotta non deve fermare il tick', async () => {
+    const client = {
+      from: () => { throw new Error('boom'); }
+    } as unknown as SupabaseClient;
+    await expect(sweepLeadRetention(client)).resolves.toBeUndefined();
   });
 });

--- a/src/lib/server/lead-contact.ts
+++ b/src/lib/server/lead-contact.ts
@@ -93,3 +93,33 @@ export function dmWithOptOut(dm: string): string {
   if (clean.toLowerCase().includes('stop')) return clean;
   return `${clean}\n\n${DM_OPT_OUT_LINE}`;
 }
+
+// Retention (giorni): il contenuto derivato dal post è il dato delicato — 14 giorni e poi nulla.
+// La riga minima (permalink, handle, stato) tiene 90 giorni ma SOLO per i lead non convertiti: un
+// 'done' è storia del rapporto e ancora gli outcome. Esiti 12 mesi, telemetria di scansione 90.
+const GIST_RETENTION_DAYS = 14;
+const UNCONVERTED_LEAD_DAYS = 90;
+const OUTCOME_RETENTION_DAYS = 365;
+const SCAN_TELEMETRY_DAYS = 90;
+const UNCONVERTED_STATUSES = ['proposed', 'suggested', 'skipped', 'dismissed'];
+
+export async function sweepLeadRetention(admin: SupabaseClient): Promise<void> {
+  const daysAgo = (days: number) => new Date(Date.now() - days * 24 * 3600 * 1000).toISOString();
+  // I builder Supabase sono thenable ma non promesse: niente .catch — il try sta qua.
+  const quiet = async (what: string, run: () => unknown) => {
+    try {
+      await run();
+    } catch (e) {
+      swallow(`lead retention: ${what}`, e);
+    }
+  };
+
+  await quiet('gist purge', () =>
+    admin.from('brand_news_items').update({ gist: null }).lt('created_at', daysAgo(GIST_RETENTION_DAYS)).not('gist', 'is', null));
+  await quiet('unconverted rows', () =>
+    admin.from('brand_news_items').delete().lt('created_at', daysAgo(UNCONVERTED_LEAD_DAYS)).in('status', UNCONVERTED_STATUSES).is('done_at', null));
+  await quiet('outcomes', () =>
+    admin.from('lead_outcomes').delete().lt('checked_at', daysAgo(OUTCOME_RETENTION_DAYS)));
+  await quiet('scan telemetry', () =>
+    admin.from('radar_searches').delete().lt('created_at', daysAgo(SCAN_TELEMETRY_DAYS)));
+}

--- a/src/lib/server/lead-contact.ts
+++ b/src/lib/server/lead-contact.ts
@@ -1,0 +1,95 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { swallow } from './swallow';
+
+export type LeadPlatform = 'reddit' | 'threads' | 'x' | 'linkedin' | 'web';
+
+export type ContactGate = { suppressed: boolean; contacted: boolean };
+
+export type SuppressSource = 'reply' | 'manual' | 'thread_scan';
+
+// Una persona, un tocco: il frequency cap è globale per istanza, non per brand. Il prospect che
+// ha già ricevuto un messaggio da UN cliente non viene mai più proposto a nessun altro.
+export async function contactGate(
+  admin: SupabaseClient,
+  platform: string,
+  handle: string
+): Promise<ContactGate> {
+  const { data: hit } = await admin
+    .from('lead_suppressions')
+    .select('handle')
+    .eq('platform', platform)
+    .eq('handle', handle)
+    .maybeSingle();
+  if (hit) return { suppressed: true, contacted: false };
+
+  const { data: past } = await admin
+    .from('brand_news_items')
+    .select('id')
+    .eq('author_platform', platform)
+    .eq('author_handle', handle)
+    .or('status.eq.posted,done_at.not.is.null')
+    .limit(1);
+  return { suppressed: false, contacted: (past?.length ?? 0) > 0 };
+}
+
+export function gateVerdict(gate: ContactGate): 'suppressed' | 'contacted' | 'ok' {
+  if (gate.suppressed) return 'suppressed';
+  if (gate.contacted) return 'contacted';
+  return 'ok';
+}
+
+export async function suppressAuthor(
+  admin: SupabaseClient,
+  input: { platform: string; handle: string; source: SuppressSource; reason?: string }
+): Promise<boolean> {
+  try {
+    const { error } = await admin
+      .from('lead_suppressions')
+      .upsert(
+        { platform: input.platform, handle: input.handle, source: input.source, reason: input.reason ?? null },
+        { onConflict: 'platform,handle', ignoreDuplicates: true }
+      );
+    if (error) {
+      console.warn('[lead-contact] suppress:', error.message.slice(0, 120));
+      return false;
+    }
+    return true;
+  } catch (e) {
+    swallow('suppress author', e);
+    return false;
+  }
+}
+
+export function platformOf(url: string): LeadPlatform {
+  const u = (url ?? '').toLowerCase();
+  if (u.includes('reddit.com')) return 'reddit';
+  if (u.includes('threads.net')) return 'threads';
+  if (u.includes('x.com') || u.includes('twitter.com')) return 'x';
+  if (u.includes('linkedin.com')) return 'linkedin';
+  return 'web';
+}
+
+// Setaccio stretto di proposito: "stop" da solocompare in mezzo a frasi normali ("stop wasting
+// time"), quindi ogni regola vuole il verbo di contatto accanto al segnale.
+const OPT_OUT_RULES: RegExp[] = [
+  /\b(?:do\s?not|don'?t)\s+(?:contact|message|dm|write|email)\b/i,
+  /\bstop\s+(?:contacting|messaging|dm(?:ing)?|writing|emailing|replying)\b/i,
+  /\bnon\s+(?:contattarmi|scrivermi|mandarmi)\b/i,
+  /\bsmett\w*\s+di\s+(?:contattarmi|scrivermi|mandarmi)\b/i,
+  /\bunsubscribe\b|\bopt[-\s]?out\b|\brimuovimi\b/i
+];
+
+export function isOptOutSignal(text: string | null | undefined): boolean {
+  const raw = (text ?? '').trim();
+  if (raw.length < 10) return false;
+  return OPT_OUT_RULES.some((re) => re.test(raw));
+}
+
+export const DM_OPT_OUT_LINE = '(Reply "stop" and we won\'t reach out again.)';
+
+export function dmWithOptOut(dm: string): string {
+  const clean = (dm ?? '').trim();
+  if (!clean) return '';
+  if (clean.toLowerCase().includes('stop')) return clean;
+  return `${clean}\n\n${DM_OPT_OUT_LINE}`;
+}

--- a/src/lib/server/lead-outcomes.ts
+++ b/src/lib/server/lead-outcomes.ts
@@ -1,6 +1,7 @@
 import { swallow } from '$lib/server/swallow';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { scrapeCreatorsGet } from '$lib/server/scrapecreators';
+import { isOptOutSignal, platformOf, suppressAuthor } from './lead-contact';
 
 // ── L'esito di un lead: cosa è successo al commento dopo che l'hai incollato ─────────────────────
 //
@@ -170,13 +171,26 @@ export type OutcomeRow = {
  * finirebbe dritto nelle regole del profilo di community.
  */
 export async function checkLeadOutcome(
-  lead: { id: string; brand_id: string; url: string; suggestion: string | null },
-  handle?: string | null
+  lead: { id: string; brand_id: string; url: string; suggestion: string | null; author_handle?: string | null; author_platform?: string | null },
+  handle?: string | null,
+  admin?: SupabaseClient
 ): Promise<OutcomeRow | null> {
   if (!lead.suggestion || !isCheckable(lead.url)) return null;
 
   const comments = await fetchThreadComments(lead.url);
   if (comments === null) return null; // thread non leggibile: si riproverà
+
+  // Best-effort opt-out: il thread viene comunque letto — un "non contattarmi" dentro di esso
+  // sopprime l'autore a livello globale. È un bonus, non una promessa: lo sweep vede solo questa
+  // lettura, e serve l'autore noto dal momento dell'engage.
+  if (admin && lead.author_handle && comments.some((c) => isOptOutSignal(c.body))) {
+    await suppressAuthor(admin, {
+      platform: lead.author_platform ?? platformOf(lead.url),
+      handle: lead.author_handle,
+      source: 'thread_scan',
+      reason: 'opt-out signal in the thread'
+    });
+  }
 
   const hit = pickMatch(lead.suggestion, comments, { handle });
   if (!hit) {
@@ -210,7 +224,7 @@ export async function pendingOutcomeChecks(
 
   const { data } = await admin
     .from('brand_news_items')
-    .select('id, brand_id, url, suggestion, done_at')
+    .select('id, brand_id, url, suggestion, done_at, author_handle, author_platform')
     .eq('status', 'done')
     .not('done_at', 'is', null)
     .gte('done_at', from)
@@ -226,7 +240,14 @@ export async function pendingOutcomeChecks(
   return data
     .filter((l) => !done.has(l.id as string) && isCheckable(String(l.url)))
     .slice(0, limit)
-    .map((l) => ({ id: l.id as string, brand_id: l.brand_id as string, url: String(l.url), suggestion: l.suggestion as string | null }));
+    .map((l) => ({
+      id: l.id as string,
+      brand_id: l.brand_id as string,
+      url: String(l.url),
+      suggestion: l.suggestion as string | null,
+      author_handle: (l.author_handle as string | null) ?? null,
+      author_platform: (l.author_platform as string | null) ?? null
+    }));
 }
 
 /** Una passata: controlla i lead maturi e scrive gli esiti. Non lancia mai. */
@@ -239,7 +260,7 @@ export async function runOutcomeChecks(
 
   for (const lead of leads) {
     try {
-      const row = await checkLeadOutcome(lead);
+      const row = await checkLeadOutcome(lead, undefined, admin);
       if (!row) continue;
       const { error } = await admin.from('lead_outcomes').insert(row);
       if (error) { console.warn('[lead-outcomes] insert:', error.message.slice(0, 120)); continue; }

--- a/src/lib/server/radar.test.ts
+++ b/src/lib/server/radar.test.ts
@@ -477,3 +477,11 @@ describe('radarDigestHtml (la mail porta la merce: testo pronto + link diretto)'
     expect(html).toContain('https://app.example.com/api/radar/reject/tok-r');
   });
 });
+
+describe('sorgenti Reddit (solo ScrapeCreators e RSS: niente OAuth ufficiale)', () => {
+  it('non resta alcun riferimento al client OAuth Reddit nel radar', async () => {
+    const { readFile } = await import('node:fs/promises');
+    const src = await readFile(new URL('./radar.ts', import.meta.url), 'utf8');
+    expect(src).not.toMatch(/oauth\.reddit\.com|REDDIT_CLIENT_(ID|SECRET)|redditAccessToken|redditGet/);
+  });
+});

--- a/src/lib/server/radar.test.ts
+++ b/src/lib/server/radar.test.ts
@@ -450,6 +450,16 @@ describe('selectTopComments (il cap è "gli N migliori", non "i primi N")', () =
 });
 
 describe('radarDigestHtml (la mail porta la merce: testo pronto + link diretto)', () => {
+  it('con radarUrl porta il link di disiscrizione nel corpo, non solo negli header', () => {
+    const html = radarDigestHtml(false, 'https://app.example.com', [], [], [], 'https://app.example.com/app/acme/radar');
+    expect(html).toContain('https://app.example.com/app/acme/radar');
+    expect(html.toLowerCase()).toContain('unsubscribe');
+  });
+
+  it('senza radarUrl nessun footer: il corpo resta come prima', () => {
+    const html = radarDigestHtml(false, 'https://app.example.com', [], [], []);
+    expect(html).not.toContain('unsubscribe');
+  });
   it('carries the ready-to-paste comment, the direct thread link and the DM', () => {
     const html = radarDigestHtml(true, 'https://app.example.com', [], [{
       title: 'Best organic olive oil?',

--- a/src/lib/server/radar.ts
+++ b/src/lib/server/radar.ts
@@ -603,9 +603,10 @@ const VERDICT_SCHEMA = {
           action: { type: 'string' as const, enum: ['post', 'comment', 'article', 'none'] as const, description: "How the brand should react: 'post' = publish its own social post about this news; 'comment' = join the conversation with a useful reply (ONLY for Reddit/Threads/X threads where the brand's expertise genuinely helps — never pure promotion); 'article' = a deep, substantive blog article draft expanding on this from the brand's expertise (ONLY when the brand's blog is active and the topic has enough depth for long-form, not just a quick social reaction); 'none' = not relevant." },
           pillar: { type: 'string' as const, description: "Which of the brand's content pillars this serves. Empty if none." },
           intent: { type: 'string' as const, enum: ['seeking_now', 'comparing', 'researching', 'venting', 'none'] as const, description: "For CONVERSATIONS only, how close this PERSON is to buying — judge the person, not the topic: 'seeking_now' = explicitly asking for a recommendation or a solution right now; 'comparing' = weighing named options; 'researching' = trying to understand the problem, no purchase in sight; 'venting' = complaining, wants peers not vendors; 'none' = not a person with this problem (news and feed items are always 'none')." },
-          skip_reason: { type: 'string' as const, description: 'One short line on WHY it was skipped (empty when relevant) — shown to the user for transparency.' }
+          skip_reason: { type: 'string' as const, description: 'One short line on WHY it was skipped (empty when relevant) — shown to the user for transparency.' },
+          gist: { type: 'string' as const, description: 'For CONVERSATIONS only: ≤140 characters capturing what this person asked or needs, distilled — never a quote of their words, always in the item\'s language. Empty for news items.' }
         },
-        required: ['index', 'relevant', 'relevance', 'angle', 'urgency', 'pillar', 'action', 'intent', 'skip_reason']
+        required: ['index', 'relevant', 'relevance', 'angle', 'urgency', 'pillar', 'action', 'intent', 'skip_reason', 'gist']
       }
     }
   },
@@ -971,12 +972,18 @@ Duplicated stories: keep the best one, skip the rest ("duplicate"). Never invent
     const id = idByHash.get(h);
     const relevant = v?.relevant === true && Number(v?.relevance) >= 50 && v?.urgency !== 'none' && v?.action !== 'none';
     const intent = normalizeIntent(v?.intent);
+    // Minimizzazione: il testo verbatim del post NON resta nel database. Il judge distilla il
+    // gist (cosa ha chiesto la persona); lo snippet viene cancellato alla stessa stesura. Il
+    // drafting e l'utente leggono il contenuto vero dal permalink, non da una copia nostra.
+    const gist = relevant && intent !== 'none' ? String(v?.gist ?? '').slice(0, 200) || null : null;
     await admin.from('brand_news_items').update({
       status: relevant ? 'proposed' : 'skipped',
       relevance: Math.max(0, Math.min(100, Number(v?.relevance) || 0)),
       angle: relevant ? String(v?.angle ?? '') : null,
       urgency: relevant ? String(v?.urgency ?? 'timely') : null,
       intent: relevant ? intent : null,
+      gist,
+      snippet: null,
       skip_reason: relevant ? null : String(v?.skip_reason ?? '').slice(0, 300) || null
     }).eq('id', id ?? '');
     if (relevant && id) {

--- a/src/lib/server/radar.ts
+++ b/src/lib/server/radar.ts
@@ -1537,7 +1537,8 @@ export function radarDigestHtml(
   appBase: string,
   posts: DigestPostRow[],
   comments: DigestCommentRow[],
-  articles: DigestArticleRow[]
+  articles: DigestArticleRow[],
+  radarUrl = ''
 ): string {
   const postBlocks = posts.map((r) => `
     <div style="border:1px solid #e5e5e5;border-radius:12px;padding:16px;margin:0 0 14px;">
@@ -1574,6 +1575,7 @@ export function radarDigestHtml(
     ${posts.length ? `<p style="color:#555;margin:14px 0 10px;"><b>${it ? 'Post pronti (approva con un click)' : 'Posts ready (one-click approve)'}</b></p>${postBlocks}` : ''}
     ${articles.length ? `<p style="color:#555;margin:14px 0 10px;"><b>${it ? 'Articoli blog pronti da rivedere' : 'Blog articles ready to review'}</b></p>${articleBlocks}` : ''}
     ${comments.length ? `<p style="color:#555;margin:14px 0 10px;"><b>${it ? 'Conversazioni dove dire la tua — commento pronto da incollare (pubblichi tu, mai in automatico)' : 'Conversations worth joining — comment ready to paste (you post it, never automated)'}</b></p>${commentBlocks}` : ''}
+    ${radarUrl ? `<p style="color:#999;font-size:12px;margin:20px 0 0;">${it ? 'Non vuoi più il Radar? <a href="' + radarUrl + '">Disiscriviti qui</a>.' : 'No more Radar? <a href="' + radarUrl + '">Unsubscribe here</a>.'}</p>` : ''}
   </div>`;
 }
 
@@ -1596,7 +1598,7 @@ async function sendRadarDigest(admin: SupabaseClient, brand: AnyRec, posts: Dige
       await sendEmail({
         to: contact.email,
         subject,
-        html: radarDigestHtml(it, appBase, posts, comments, articles),
+        html: radarDigestHtml(it, appBase, posts, comments, articles, radarUrl),
         text: [
           ...posts.map((r) => `${r.title}\n${r.sourceUrl}\n${r.caption}`),
           ...articles.map((a) => `${a.title} (draft)\n${appBase}/blog-preview/${a.articleId}`),

--- a/src/lib/server/radar.ts
+++ b/src/lib/server/radar.ts
@@ -29,6 +29,7 @@ import { brandContacts } from './scheduler';
 import { generateBlogFromNews } from './blog-generate';
 import { hasProRadarLeads, isRadarKindAllowed, leadEngagePlatforms, radarSourceLimit, type RadarPlatformKey, RADAR_PLATFORM_KEYS } from './plans';
 import { ALT_CAPTION_PLATFORMS, ensureShortNetworkCuts } from '$lib/platform-limits';
+import { contactGate, dmWithOptOut, gateVerdict, platformOf, suppressAuthor } from './lead-contact';
 // Re-exported: Settings → Radar imports the type from here, next to the functions that use it.
 export type { RadarPlatformKey } from './plans';
 import { INTENT_RANK, normalizeIntent, type LeadIntent } from '$lib/leads-intent';
@@ -1161,10 +1162,11 @@ export async function radarEngage(
       let postBody = '';
       let topComments = '';
       let author = '';
-      const isThreads = it.url.includes('threads.net');
-      const isX = it.url.includes('x.com') || it.url.includes('twitter.com');
-      const isLinkedIn = it.url.includes('linkedin.com');
-      const isReddit = !isThreads && !isX && !isLinkedIn;
+      const platform = platformOf(it.url);
+      const isLinkedIn = platform === 'linkedin';
+      const isThreads = platform === 'threads';
+      const isX = platform === 'x';
+      const isReddit = platform === 'reddit';
       try {
         if (isLinkedIn) {
           // The search already returned the post's full text in `snippet` — no comment API for
@@ -1193,6 +1195,17 @@ export async function radarEngage(
         }
       } catch (e) {
         console.warn('[radar] thread fetch failed:', e instanceof Error ? e.message.slice(0, 120) : e);
+      }
+
+      // One gate before anything gets drafted: whoever opted out, and whoever already got their
+      // one touch — across every brand on the instance, not just this one.
+      if (author) {
+        const gate = await contactGate(admin, platform, author).catch((error) => { swallow('lead contact gate', error); return null; });
+        const verdict = gate ? gateVerdict(gate) : 'ok';
+        if (verdict !== 'ok') {
+          await admin.from('brand_news_items').update({ status: 'skipped', skip_reason: `engage: ${verdict} — ${author}` }).eq('id', it.id);
+          continue;
+        }
       }
 
       // Reddit-only fallback, and ONLY when the primary came back empty. This block used to run
@@ -1248,7 +1261,14 @@ export async function radarEngage(
       }
       const dm = String(draft?.dm ?? '').trim();
       const dmProfileUrl = dm ? authorProfileUrl(it.url, author) : '';
-      await admin.from('brand_news_items').update({ status: 'suggested', suggestion: comment, dm_draft: dm || null, dm_target: author || null }).eq('id', it.id);
+      await admin.from('brand_news_items').update({
+        status: 'suggested',
+        suggestion: comment,
+        dm_draft: dm ? dmWithOptOut(dm) : null,
+        dm_target: author || null,
+        author_handle: author || null,
+        author_platform: author ? platform : null
+      }).eq('id', it.id);
       out.push({ title: it.title, url: it.url, sourceName: it.sourceName, comment, dm, dmTarget: author, dmProfileUrl });
     } catch (e) {
       console.error('[radar] engage failed for item:', e instanceof Error ? e.message : e);

--- a/src/lib/server/radar.ts
+++ b/src/lib/server/radar.ts
@@ -264,8 +264,7 @@ async function fetchFeed(source: { kind: string; value: string; lang?: string | 
 // A good comment lands on a thread that's RISING right now. Reddit's unauthenticated JSON API is
 // gone (403), but the RSS endpoints still serve: /r/{sub}/rising/.rss for the timing signal and
 // {permalink}/.rss for a thread's body + comments. READ-ONLY by design: Anomalia never posts or
-// comments; it only drafts a suggestion for the human. ponytail: on a 429 the catch returns [] —
-// if reddit tightens further, the upgrade path is the official OAuth API (read scope).
+// comments; it only drafts a suggestion for the human. ponytail: on a 429 the catch returns [].
 const ENGAGE_MAX_AGE_HOURS = 12;
 // Threads / X / LinkedIn are a different clock. Their search endpoints rank by relevance, not
 // recency (Threads has no date filter at all), and a post there stays live for days instead of
@@ -314,57 +313,10 @@ async function fetchRedditText(url: string): Promise<string | null> {
   }
 }
 
-// Read-only OAuth (script app, client_credentials): Reddit fingerprints and 429s non-browser
-// clients on the anonymous endpoints, and the OFFICIAL API is also the TOS-clean way to read.
-// Token cached ~50min. Missing env → null (subreddit sources are skipped with a warn, everything
-// else keeps working). Setup: create a "script" app on reddit.com/prefs/apps and set
-// REDDIT_CLIENT_ID + REDDIT_CLIENT_SECRET.
-let redditToken: { token: string; exp: number } | null = null;
-async function redditAccessToken(): Promise<string | null> {
-  const id = env.REDDIT_CLIENT_ID;
-  const secret = env.REDDIT_CLIENT_SECRET;
-  if (!id || !secret) return null;
-  if (redditToken && Date.now() < redditToken.exp) return redditToken.token;
-  try {
-    const res = await fetch('https://www.reddit.com/api/v1/access_token', {
-      method: 'POST',
-      signal: AbortSignal.timeout(FEED_TIMEOUT_MS),
-      headers: {
-        Authorization: `Basic ${Buffer.from(`${id}:${secret}`).toString('base64')}`,
-        'Content-Type': 'application/x-www-form-urlencoded',
-        'User-Agent': REDDIT_UA
-      },
-      body: 'grant_type=client_credentials'
-    });
-    if (!res.ok) return null;
-    const d = (await res.json()) as AnyRec;
-    if (!d?.access_token) return null;
-    redditToken = { token: String(d.access_token), exp: Date.now() + 50 * 60 * 1000 };
-    return redditToken.token;
-  } catch {
-    return null;
-  }
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function redditGet(path: string): Promise<any | null> {
-  const token = await redditAccessToken();
-  if (!token) return null;
-  try {
-    const res = await fetch(`https://oauth.reddit.com${path}`, {
-      signal: AbortSignal.timeout(FEED_TIMEOUT_MS),
-      headers: { Authorization: `Bearer ${token}`, 'User-Agent': REDDIT_UA }
-    });
-    return res.ok ? await res.json() : null;
-  } catch {
-    return null;
-  }
-}
-
 // NOTE (verified live 2026-07-03): Exa (exa.ai) is NOT an option for Reddit — the API rejects
 // includeDomains:['reddit.com'] ("domain not available") and its index contains zero reddit URLs
-// (Reddit's data is exclusively licensed). For server-side Reddit reads the ONLY reliable path is
-// the official OAuth API below.
+// (Reddit's data is exclusively licensed). For server-side Reddit reads the paths are
+// ScrapeCreators and the RSS feeds.
 // Fair-share selection: round-robin one item per origin per pass, up to `cap`. Guarantees every
 // source with fresh content contributes before any single source takes a second slot — so a
 // high-volume source can't starve the others (see radarScan). Pure + exported for tests.
@@ -384,8 +336,8 @@ export function roundRobin<T>(byOrigin: Map<string, T[]>, cap: number): T[] {
 async function fetchSubredditRising(sub: string): Promise<RedditItem[]> {
   const clean = sub.replace(/^r\//, '').replace(/\/+$/, '');
   // PRIMARY: ScrapeCreators' Reddit endpoint — same key/gateway the whole app already uses for
-  // IG/TikTok/etc., with real `rising` sort and full post fields. The chains below (OAuth, RSS)
-  // stay as fallbacks.
+  // IG/TikTok/etc., with real `rising` sort and full post fields. The RSS chain below stays as
+  // fallback.
   try {
     const data = await scrapeCreatorsGet(`/v1/reddit/subreddit?subreddit=${encodeURIComponent(clean)}&sort=rising&trim=true`);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -404,27 +356,11 @@ async function fetchSubredditRising(sub: string): Promise<RedditItem[]> {
   } catch (e) {
     console.warn(`[radar] scrapecreators reddit r/${clean} failed:`, e instanceof Error ? e.message.slice(0, 120) : e);
   }
-  // Primary: official API (rich data — created_utc, selftext). Fallback: the RSS endpoint, which
-  // works from some networks (curl-like clients) but is fingerprint-blocked from most servers.
-  const data = await redditGet(`/r/${encodeURIComponent(clean)}/rising?limit=15`);
-  if (data) {
-    return ((data?.data?.children ?? []) as AnyRec[])
-      .map((c) => {
-        const d = c?.data ?? {};
-        return {
-          title: String(d.title ?? ''),
-          url: `https://www.reddit.com${d.permalink ?? ''}`,
-          snippet: String(d.selftext ?? '').slice(0, 1000),
-          sourceName: `r/${clean}`,
-          publishedAt: d.created_utc ? new Date(Number(d.created_utc) * 1000).toISOString() : null,
-          createdUtc: Number(d.created_utc) || 0
-        };
-      })
-      .filter((i) => i.title && i.url.includes('/comments/'));
-  }
+  // Fallback: the RSS endpoint, which works from some networks (curl-like clients) but is
+  // fingerprint-blocked from most servers.
   const xml = await fetchRedditText(redditRssAuth(`https://old.reddit.com/r/${encodeURIComponent(clean)}/rising/.rss`));
   if (!xml) {
-    console.warn(`[radar] reddit r/${clean} unavailable — set REDDIT_FEED_TOKEN/USER (prefs/feeds) or REDDIT_CLIENT_ID/SECRET`);
+    console.warn(`[radar] reddit r/${clean} unavailable — set REDDIT_FEED_TOKEN/USER (prefs/feeds)`);
     return [];
   }
   return parseFeed(xml)
@@ -1221,7 +1157,7 @@ export async function radarEngage(
   for (const it of items) {
     try {
       // Full thread context: ScrapeCreators first (post body + comments, same key as everything
-      // else), then — for Reddit only — the official API, then RSS.
+      // else), then — for Reddit only — RSS.
       let postBody = '';
       let topComments = '';
       let author = '';
@@ -1259,27 +1195,18 @@ export async function radarEngage(
         console.warn('[radar] thread fetch failed:', e instanceof Error ? e.message.slice(0, 120) : e);
       }
 
-      // Reddit-only fallbacks, and ONLY when the primary came back empty. This block used to run
+      // Reddit-only fallback, and ONLY when the primary came back empty. This block used to run
       // for EVERY platform whenever the official API returned nothing: it fetched
       // <threads|x|linkedin url>/.rss, got nothing back, and then overwrote the body and the top
       // comments ScrapeCreators had just returned with the empty result.
       if (isReddit && !postBody) {
-        const thread = (await redditGet(`${new URL(it.url).pathname}?limit=8`)) as AnyRec[] | null;
-        if (thread) {
-          postBody = String(thread?.[0]?.data?.children?.[0]?.data?.selftext ?? '');
-          author = author || String(thread?.[0]?.data?.children?.[0]?.data?.author ?? '');
-          topComments = ((thread?.[1]?.data?.children ?? []) as AnyRec[])
-            .map((c) => String(c?.data?.body ?? '')).filter(Boolean).slice(0, 5)
-            .map((b) => `- ${b.replace(/\s+/g, ' ').slice(0, 220)}`).join('\n');
-        } else {
-          const xml = await fetchRedditText(redditRssAuth(`${it.url.replace(/\/$/, '').replace('://www.', '://old.')}/.rss`));
-          const entries = xml ? parseFeed(xml) : [];
-          postBody = entries[0]?.snippet ?? '';
-          topComments = entries.slice(1, 6)
-            .map((e) => `- ${e.snippet.replace(/\s+/g, ' ').slice(0, 220)}`)
-            .filter((l) => l.length > 4)
-            .join('\n');
-        }
+        const xml = await fetchRedditText(redditRssAuth(`${it.url.replace(/\/$/, '').replace('://www.', '://old.')}/.rss`));
+        const entries = xml ? parseFeed(xml) : [];
+        postBody = entries[0]?.snippet ?? '';
+        topComments = entries.slice(1, 6)
+          .map((e) => `- ${e.snippet.replace(/\s+/g, ' ').slice(0, 220)}`)
+          .filter((l) => l.length > 4)
+          .join('\n');
       }
 
       // What we know about the room this reply is going into: their words, what they already

--- a/src/routes/[[lang=locale]]/privacy/+page.svelte
+++ b/src/routes/[[lang=locale]]/privacy/+page.svelte
@@ -59,6 +59,7 @@
       <tr><td class="text-left align-top py-2.5 px-3 border-b border-border font-semibold whitespace-nowrap">{$_('legal.privacy.s3.row4.purpose')}</td><td class="text-left align-top py-2.5 px-3 border-b border-border">{$_('legal.privacy.s3.row4.basis')}</td></tr>
       <tr><td class="text-left align-top py-2.5 px-3 border-b border-border font-semibold whitespace-nowrap">{$_('legal.privacy.s3.row5.purpose')}</td><td class="text-left align-top py-2.5 px-3 border-b border-border">{$_('legal.privacy.s3.row5.basis')}</td></tr>
       <tr><td class="text-left align-top py-2.5 px-3 border-b border-border font-semibold whitespace-nowrap">{$_('legal.privacy.s3.row6.purpose')}</td><td class="text-left align-top py-2.5 px-3 border-b border-border">{$_('legal.privacy.s3.row6.basis')}</td></tr>
+      <tr><td class="text-left align-top py-2.5 px-3 border-b border-border font-semibold whitespace-nowrap">{$_('legal.privacy.s3.row7.purpose')}</td><td class="text-left align-top py-2.5 px-3 border-b border-border">{$_('legal.privacy.s3.row7.basis')}</td></tr>
     </tbody>
   </table>
   <p class="text-base text-foreground/80 mb-3.5">
@@ -122,6 +123,9 @@
   <h2 class="font-[family-name:var(--serif)] text-xl mt-11 mb-3 pt-2" style="font-weight: var(--heading-weight); letter-spacing: var(--heading-tracking)">{$_('legal.privacy.s9.heading')}</h2>
   <p class="text-base text-foreground/80 mb-3.5">
     {$_('legal.privacy.s9.body')}
+  </p>
+  <p class="text-base text-foreground/80 mb-3.5">
+    {$_('legal.privacy.s9.body2')}
   </p>
 
   <h2 class="font-[family-name:var(--serif)] text-xl mt-11 mb-3 pt-2" style="font-weight: var(--heading-weight); letter-spacing: var(--heading-tracking)">{$_('legal.privacy.s10.heading')}</h2>

--- a/src/routes/[[lang=locale]]/terms/+page.svelte
+++ b/src/routes/[[lang=locale]]/terms/+page.svelte
@@ -122,6 +122,9 @@
   <p class="text-base text-foreground/80 mb-3.5">
     {$_('legal.terms.s13.body2')}
   </p>
+  <p class="text-base text-foreground/80 mb-3.5">
+    {$_('legal.terms.s13.body3')}
+  </p>
 
   <h2 class="font-[family-name:var(--serif)] text-xl mt-11 mb-3 pt-2" style="font-weight: var(--heading-weight); letter-spacing: var(--heading-tracking)">{$_('legal.terms.s14.heading')}</h2>
   <p class="text-base text-foreground/80 mb-3.5">

--- a/src/routes/api/v1/radar/tick/+server.ts
+++ b/src/routes/api/v1/radar/tick/+server.ts
@@ -2,6 +2,7 @@ import type { RequestHandler } from './$types';
 import { createAdminClient } from '$lib/server/supabase-admin';
 import { cronAuthorized } from '$lib/server/cron-auth';
 import { radarPrefsOf, buildRadarFeedCache, kickRadarWork } from '$lib/server/radar';
+import { sweepLeadRetention } from '$lib/server/lead-contact';
 
 // Radar ORCHESTRATOR: fetch every distinct source ONCE → DB cache → create one job per brand →
 // fan out N workers (calculated from brand count) so the fleet drains in parallel chains, not one
@@ -36,6 +37,7 @@ async function run(request: Request, platform: Platform): Promise<Response> {
     admin.from('radar_jobs').delete().lt('created_at', old),
     admin.from('radar_feed_cache').delete().lt('fetched_at', old)
   ]);
+  await sweepLeadRetention(admin);
 
   let q = admin
     .from('brands')

--- a/src/routes/app/[brand]/leads/+page.server.ts
+++ b/src/routes/app/[brand]/leads/+page.server.ts
@@ -129,6 +129,43 @@ async function setStatus(
   return { saved: true };
 }
 
+// "Non contattare mai più": soppressione globale (ogni brand dell'istanza) per l'autore del lead,
+// poi il lead esce dalla coda come gli altri ignorati. Senza handle noto niente da sopprimere:
+// resta comunque un dismiss.
+async function suppressLead(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  supabase: any,
+  params: { brand: string },
+  request: Request
+) {
+  const brand = await brandBySlug(supabase, params.brand);
+  if (!brand) return fail(404, { error: 'Brand not found' });
+  const fd = await request.formData();
+  const id = String(fd.get('id') ?? '');
+  if (!id) return fail(400, { error: 'Missing id' });
+  const { createAdminClient } = await import('$lib/server/supabase-admin');
+  const admin = createAdminClient();
+  const { data: lead } = await admin
+    .from('brand_news_items')
+    .select('url, dm_target, author_handle, author_platform')
+    .eq('id', id)
+    .eq('brand_id', brand.id)
+    .maybeSingle();
+  const handle = lead?.author_handle || lead?.dm_target;
+  if (lead && handle) {
+    const { suppressAuthor, platformOf } = await import('$lib/server/lead-contact');
+    await suppressAuthor(admin, {
+      platform: lead.author_platform ?? platformOf(String(lead.url ?? '')),
+      handle: String(handle),
+      source: 'manual',
+      reason: 'marked by the brand in /leads'
+    });
+  }
+  const { error } = await admin.from('brand_news_items').update({ status: 'dismissed' }).eq('id', id).eq('brand_id', brand.id);
+  if (error) return fail(500, { error: error.message });
+  return { saved: true };
+}
+
 // AI rewrite — re-drafts the comment/DM incorporating user feedback, using stored context.
 async function rewriteSuggestion(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -251,5 +288,6 @@ export const actions: Actions = {
   markDone: ({ request, params, locals: { supabase } }) => setStatus(supabase, params as { brand: string }, request, 'done'),
   dismiss: ({ request, params, locals: { supabase } }) => setStatus(supabase, params as { brand: string }, request, 'dismissed'),
   restore: ({ request, params, locals: { supabase } }) => setStatus(supabase, params as { brand: string }, request, 'suggested'),
+  suppress: ({ request, params, locals: { supabase } }) => suppressLead(supabase, params as { brand: string }, request),
   rewrite: ({ request, params, locals: { supabase } }) => rewriteSuggestion(supabase, params as { brand: string }, request)
 };

--- a/src/routes/app/[brand]/leads/+page.server.ts
+++ b/src/routes/app/[brand]/leads/+page.server.ts
@@ -29,7 +29,7 @@ export const load: PageServerLoad = async (event) => {
     const [{ data: leads }, { data: recent }] = await Promise.all([
       supabase
         .from('brand_news_items')
-        .select('id, title, url, source_name, snippet, status, relevance, intent, suggestion, dm_draft, dm_target, created_at')
+        .select('id, title, url, source_name, snippet, gist, status, relevance, intent, suggestion, dm_draft, dm_target, created_at')
         .eq('brand_id', brand.id)
         .in('status', ['suggested', 'done', 'dismissed'])
         .not('suggestion', 'is', null)
@@ -189,7 +189,7 @@ async function rewriteSuggestion(
   // Fetch the lead (brand_id guard = authorization).
   const { data: lead, error: leadErr } = await admin
     .from('brand_news_items')
-    .select('id, title, url, source_name, snippet, suggestion, dm_draft, dm_target')
+    .select('id, title, url, source_name, snippet, gist, suggestion, dm_draft, dm_target')
     .eq('id', id)
     .eq('brand_id', brand.id)
     .maybeSingle();
@@ -232,7 +232,7 @@ async function rewriteSuggestion(
 Brand: ${brandRow?.name ?? ''} — ${String(kit?.about ?? '').slice(0, 300)}
 ${siteUrl ? `Brand site: ${siteUrl}\n` : ''}${kit?.ai_context ? `Voice & expertise:\n${String(kit.ai_context).slice(0, 1200)}\n` : ''}
 THREAD "${lead.title}":
-${(lead.snippet || '').slice(0, 1500) || '(no body — title only)'}
+${(lead.gist || lead.snippet || '').slice(0, 1500) || '(no body — title only)'}
 ${lead.source_name ? `SOURCE: ${lead.source_name}` : ''}
 ${lead.dm_target ? `POST AUTHOR: ${lead.dm_target}` : ''}
 

--- a/src/routes/app/[brand]/leads/+page.svelte
+++ b/src/routes/app/[brand]/leads/+page.svelte
@@ -20,7 +20,7 @@
   };
 
   type Lead = {
-    id: string; title: string; url: string; source_name: string | null; snippet: string | null; status: string;
+    id: string; title: string; url: string; source_name: string | null; snippet: string | null; gist: string | null; status: string;
     relevance: number | null; intent: string | null; suggestion: string | null; dm_draft: string | null; dm_target: string | null; created_at: string;
     // Com'è andata al commento 48h dopo che l'hai incollato. Null finché il controllo non è passato.
     outcome: { found: boolean; upvotes: number | null; replies: number | null; removed: boolean | null } | null;
@@ -111,7 +111,7 @@
     const q = query.trim().toLowerCase();
     if (!q) return bySource;
     return bySource.filter((l) =>
-      [l.title, l.snippet, l.suggestion, l.dm_draft, l.dm_target, l.source_name]
+      [l.title, l.gist, l.snippet, l.suggestion, l.dm_draft, l.dm_target, l.source_name]
         .filter(Boolean)
         .join(' ')
         .toLowerCase()
@@ -284,7 +284,7 @@
                 <span class="lead-time">{ago(l.created_at)}</span>
               </span>
               <span class="lead-card-title">{l.title}</span>
-              {#if l.snippet}<span class="lead-card-snippet">{snippetPreview(l.snippet, 220)}</span>{/if}
+              {#if l.gist || l.snippet}<span class="lead-card-snippet">{snippetPreview(l.gist ?? l.snippet, 220)}</span>{/if}
               <span class="lead-card-foot">
                 {#if l.dm_target}<span class="lead-user">{handleOf(l)}</span>{/if}
                 <span class="lead-chips">
@@ -336,12 +336,12 @@
     <div class="sugg-block post-block">
       <div class="sugg-header">
         <span class="sugg-icon"><FileText size={13} /></span>
-        <span class="sugg-label">{$_('app.leads.postLabel')}</span>
+        <span class="sugg-label">{selectedLead.gist ? $_('app.leads.postGist') : $_('app.leads.postLabel')}</span>
         <a class="head-link" href={openUrl(selectedLead.url)} target="_blank" rel="noopener noreferrer">{$_('app.leads.openPost')} <ArrowUpRight size={12} /></a>
       </div>
       <a href={openUrl(selectedLead.url)} target="_blank" rel="noopener noreferrer" class="lead-title">{selectedLead.title}</a>
-      {#if selectedLead.snippet}
-        <p class="lead-snippet-full">{snippetPreview(selectedLead.snippet, 4000)}</p>
+      {#if selectedLead.gist || selectedLead.snippet}
+        <p class="lead-snippet-full">{snippetPreview(selectedLead.gist ?? selectedLead.snippet, 4000)}</p>
       {/if}
     </div>
 

--- a/src/routes/app/[brand]/leads/+page.svelte
+++ b/src/routes/app/[brand]/leads/+page.svelte
@@ -418,6 +418,10 @@
           <input type="hidden" name="id" value={selectedLead.id} />
           <button class="btn ghost sm" type="submit" disabled={busy}>{$_('app.leads.dismiss')}</button>
         </form>
+        <form method="POST" action="?/suppress" use:enhance={withBusy}>
+          <input type="hidden" name="id" value={selectedLead.id} />
+          <button class="btn ghost sm" type="submit" disabled={busy}>{$_('app.leads.dontContact')}</button>
+        </form>
       {:else}
         <form method="POST" action="?/restore" use:enhance={withBusy}>
           <input type="hidden" name="id" value={selectedLead.id} />

--- a/supabase/migrations/20260829100000_lead_contact_guard.sql
+++ b/supabase/migrations/20260829100000_lead_contact_guard.sql
@@ -12,7 +12,8 @@
 
 alter table public.brand_news_items
   add column if not exists author_handle text,
-  add column if not exists author_platform text;
+  add column if not exists author_platform text,
+  add column if not exists gist text;
 
 create table if not exists public.lead_suppressions (
   id uuid primary key default gen_random_uuid(),

--- a/supabase/migrations/20260829100000_lead_contact_guard.sql
+++ b/supabase/migrations/20260829100000_lead_contact_guard.sql
@@ -1,0 +1,34 @@
+-- ── Lead contact guard: soppressione globale + impronta dell'autore ──────────────────────────
+--
+-- Due dati, un solo scopo: mai un secondo tocco alla stessa persona.
+--
+--   lead_suppressions  → chi ha detto "stop" (o l'utente lo ha segnalato) NON viene più proposto
+--                        a nessun brand. Globale di proposito: l'opposizione è della persona,
+--                        non del cliente. Solo service-role la tocca: RLS attiva senza policy.
+--
+--   brand_news_items.author_handle / author_platform → l'impronta (piattaforma, handle) scritta
+--                        al momento dell'engage. È la chiave con cui il gate riconosce i contatti
+--                        passati: status 'posted' o done_at valorizzato = un tocco già dato.
+
+alter table public.brand_news_items
+  add column if not exists author_handle text,
+  add column if not exists author_platform text;
+
+create table if not exists public.lead_suppressions (
+  id uuid primary key default gen_random_uuid(),
+  platform text not null,
+  handle text not null,
+  source text not null,
+  reason text,
+  created_at timestamptz not null default now(),
+  unique (platform, handle)
+);
+
+alter table public.lead_suppressions enable row level security;
+
+create index if not exists idx_lead_suppressions_lookup
+  on public.lead_suppressions (platform, handle);
+
+create index if not exists idx_brand_news_items_author
+  on public.brand_news_items (author_platform, author_handle)
+  where author_handle is not null;


### PR DESCRIPTION
## What?

Makes the Leads/Radar feature legally and operationally sane, in four committed steps:

1. **Dead code removed** — the never-configured official Reddit OAuth client (`redditAccessToken`, `redditGet`, both fallback call sites) is gone. Every Reddit read flows through ScrapeCreators and the published RSS feeds, which is what actually ran in production. A guard test keeps the radar free of official-API references.
2. **Lead contact guard** — new module `lead-contact.ts` + `lead_suppressions` table (global, per-instance): an author who opted out, or who already received their one touch *on any brand*, is never suggested again. The gate runs at three points: before drafting in `radarEngage`, on the outcome thread re-reads (best-effort opt-out sweep), and a new manual "Never contact again" action in `/leads`. Every suggested DM carries an opt-out line, appended server-side — comments rely on the one-touch cap instead, because reply threads are not reliably monitored.
3. **Gist + retention** — `brand_news_items.snippet` used to mirror up to 1000 characters of a person's post with no expiry. The radar judge now distills a ≤140-char AI gist (what the person is asking) inside the same structured call that already scored the item — zero extra AI calls — and nulls the verbatim snippet when the verdict lands. A retention sweep rides the radar tick: gist after 14 days, unconverted lead rows after 90, outcome metrics after a year, scan telemetry after 90.
4. **Legal pages tell the truth** — the privacy policy described ScrapeCreators as collecting the *user's own* connected-account history while the radar reads *third-party* public content. Now: a lead-sourcing purpose row under legitimate interest (Art. 6(1)(f)), the corrected ScrapeCreators scope, per-category retention, and the opt-out channel for contacted people. The terms state the user is the only sender of outreach and the data controller of the contacts they send. The radar digest email carries an unsubscribe link in the body, not only in the headers.

## Why?

The radar contacts people. Without a memory of who was already contacted, without an opt-out channel, and with verbatim third-party text stored forever, the feature carried a real GDPR exposure (no lawful-basis documentation, no data minimization, no way to honor an objection) and a spam profile that platforms punish. This makes the practice defensible: minimized data, one touch per person ever, a real opt-out, a human always in the sending loop, and legal pages that declare what actually happens. The full legitimate-interest assessment lives in Notion (linked in the team doc), not in the OSS repo — the public gets the declaration, not the reasoning.

## How?

- **One gate, three doors.** All contact-blocking logic lives in a single module (`lead-contact.ts`) queried from drafting, outcome re-reads, and the manual action — no scattered conditions. `platformOf()` replaces the per-platform URL substring checks that were repeated in the engage loop.
- **Global suppression by design.** `lead_suppressions` has no `brand_id`: the objection belongs to the person, not to the customer. RLS enabled with no policies — service-role only, same pattern as `app_flags`/`article_views`.
- **The drafting gate IS the send gate.** Verified during research: no code path auto-sends outreach anywhere. The human pastes. So enforcing the gate at draft time is enforcing it at send time, and keeps the brand as the controller of the outreach (the keel documented in the terms).
- **Gist is free.** The verdict `aiStructured` call already reads every item; the gist is one more field in its schema, so minimization costs zero additional AI spend.
- **Retention never kills a live check.** The 14-day content / 90-day row split exists because outcome checks run up to 14 days after a lead is done — purging rows at 14 would kill the last check mid-flight. Converted leads (done) keep their minimal row; their gist still expires.
- **Opt-out screen is deliberately strict** (contact verb next to the signal): "stop wasting time" is not an opt-out; "stop contacting me" is.

## Testing?

- **Unit**: 14 new tests in `lead-contact.test.ts` (platform mapping, strict opt-out screen, DM opt-out guarantee, gate priority, idempotent suppression, retention schedule), guard test for the OAuth removal, digest footer tests. Full suite: **5905 passed / 513 files**. `svelte-check` at exact parity with the `dev` baseline (300 = 300 errors, all pre-existing). Runtime typecheck OK.
- **Schema**: migration applied to the local docker stack **and to production via MCP** (additive only: 3 columns, 1 table, 2 indexes). `schema-drift-check` now reports the branch code and the database in agreement.
- **Browser (local architecture, port 5174)**: real login with the seeded demo user, then two full stress cycles on `/app/demo/leads` with seeded leads: drawer shows the AI-summary label + gist, DM shows the opt-out line, "Never contact again" dismisses the item and writes the global suppression row (verified in `psql` after each cycle). Suppression initially failed until PostgREST's schema cache was reloaded (`NOTIFY pgrst, 'reload schema'`) — one-time local quirk, worth knowing for self-hosters.
- **Not tested**: the AI gist quality (needs the eval run against the real judge call — recommended before merge), and live ScrapeCreators/Reddit fetches (mocked paths only).

## Evidence (screenshots/videos)

All at `/tmp/opencode/leads-verify/` (local run on the docker stack):

- `01-login.png` → `02-after-login.png` — real login flow with `test@anomalia.so` on the worktree server (5174).
- `03-leads-list.png` — leads list with seeded leads, filters, search.
- `04-lead-drawer.png` — drawer: "WHAT THE PERSON IS ASKING (AI SUMMARY — THE ORIGINAL POST IS ONE LINK AWAY)" with the gist, comment, DM block, and the **"Never contact again"** action pinned next to Done/Ignore.
- `05-after-suppress.png` — after the action: DM shows `(Reply "stop" and we won't reach out again.)`, item row now offers only "Restore".
- `06-leads-after-suppress.png` — suggested count drops 2 → 1; second cycle confirmed repeatable.
- `07-empty-search.png`, `08-narrow-viewport.png` — empty state and 400px viewport.

<details>
<summary>DB evidence — suppression written by the UI action (local)</summary>

```
 platform |   handle   | source |                   reason
----------+------------+--------+---------------------------------------------
 reddit   | spam_hater | manual | seed: ha chiesto di non essere ricontattato
 reddit   | marco_rosa | manual | marked by the brand in /leads
 reddit   | giulia_t   | manual | marked by the brand in /leads

 url_hash  |  status
-----------+-----------
 h-lead-a  | dismissed
 h-lead-b  | suggested
 h-lead-c  | done
```
</details>

<details>
<summary>Production migration verified via MCP</summary>

```sql
select column_name from information_schema.columns
where table_name='brand_news_items'
  and column_name in ('author_handle','author_platform','gist');
→ author_handle, author_platform, gist

select tablename, rowsecurity from pg_tables where tablename='lead_suppressions';
→ lead_suppressions | true (RLS on, no policies — service-role only, intentional)

select indexname from pg_indexes where indexname in
  ('idx_lead_suppressions_lookup','idx_brand_news_items_author');
→ both present
```
`NOTIFY pgrst, 'reload schema'` issued after DDL. Security advisor flags `lead_suppressions` under `rls_enabled_no_policy` (INFO) — same intentional class as the existing service-role-only tables.
</details>

## Anything Else?

- **LLM eval recommended before merge**: the judge prompt gained the `gist` field, so the verdict call changed. `npm run eval -- --only <radar scenario>` on a trial brand would confirm no quality regression; unit tests cannot see it.
- The legitimate-interest assessment (Notion) states its own invalidation conditions: introducing profile enrichment (names, companies, emails) or automated sending voids it — the assessment must be rewritten *before* either ships.
- Legacy lead rows keep their old `snippet` (shown as fallback in the UI); no retroactive data migration was run. The retention sweep handles expiry going forward.
- Known accepted risks, documented in the LIA: handles can be renamed or duplicated (the cap is per handle, honestly phrased), the thread opt-out sweep is best-effort, and the third-party transport carries the operational risk of a source going dark (the radar degrades, never dies).
