### PR TITLE
Run custom-agent turns on the Agent Kit

### DIFF
--- a/changelog/2026-08-29-dm-reaches-custom-agents.md
+++ b/changelog/2026-08-29-dm-reaches-custom-agents.md
@@ -1,0 +1,21 @@
+# Il DM raggiunge i custom agent per nome (e senza routine)
+
+Difetto trovato al gate del ticket 2: `message_agent` non riusciva a consegnare
+un DM a "Scriba Fischietto". Il modello conosce solo il NOME; `resolveDmTarget`
+accettava l'id — ma lo cercava in `custom_agent_schedules`, la tabella delle
+ROUTINE. Dalla 0210 l'identità sta in `custom_agents`: un agente custom senza
+nessuna routine (il caso normale di chi lo crea dalla pagina Agenti) era
+irraggiungibile anche con l'id esatto, e per nome lo era per costruzione. Il
+modello bruciava i suoi step a provare grafie del nome finché il turno moriva
+per `step_limit` — con l'utente che vedeva solo un'escusa.
+
+Fix: `resolveDmTarget` legge l'identità via `listCustomAgents` (con il ponte
+pre-0210 che il modulo foglia già porta) e accetta tre forme: id nudo,
+`custom:<uuid>`, e il nome esatto case-insensitive. `resolveDmInitiator` aveva
+lo stesso difetto di tabella e ora passa da `getCustomAgent`: chi scrive da un
+thread custom si firma con la sua identità anche se non ha routine. L'errore di
+destinatario sconosciuto dice ora al modello che il NOME va bene.
+
+Test prima del fix, visti rossi: DM per nome, DM per id di un agente senza
+routine, firma dell'initiator dal thread custom. Il fake del test non conosce
+più `custom_agent_schedules`: se qualcuno ci torna, il test lo urla.

--- a/changelog/2026-08-29-kit-custom-agents.md
+++ b/changelog/2026-08-29-kit-custom-agents.md
@@ -20,6 +20,11 @@ risolto dal selettore dei destinatari) con la persona come OVERLAY sul turno kit
 Modello: il ramo kit passava solo `threadRow.model`; ora porta anche la preferenza permanente
 dell'agente (`persona.model`), stessa `turnModelFamily` del classico.
 
+Difetto trovato al gate del ticket 2: il ramo INTERATTIVO (+server.ts) buttava via `systemPrompt`
+dopo che `buildTurnContext` ci aveva già montato il persona — il brief dell'utente si perdeva a ogni
+turno live, MENSO parità della coda. L'overlay ora si costruisce con un helper solo
+(`kitPersonaOverlay` in custom-agent-persona.ts) che coda e percorso interattivo condividono.
+
 La persona si carica UNA volta prima del gate e serve entrambi i rami (prima era caricata solo dal
 classico, a ~170 righe sotto).
 

--- a/changelog/2026-08-29-kit-custom-agents.md
+++ b/changelog/2026-08-29-kit-custom-agents.md
@@ -1,0 +1,28 @@
+# Gli agenti custom al Kit
+
+Secondo strappo della strangolazione (ADR-0001): i turni di conversazione di un agente custom
+(thread con `custom_agent_id`) girano sul bridge del Kit quando AGENT_KIT=on, con la loro persona.
+
+Prima: il gate del drain escludeva qualunque thread con persona (`!personaId`) e il commento lo
+dichiarava voluto — il persona era una meccanica solo classica. Ora un agente custom NON ha un
+AgentSpec suo: è lo spec del mestiere del thread (`custom_agents.agent` → `thread.agent`, già
+risolto dal selettore dei destinatari) con la persona come OVERLAY sul turno kit,
+`RunKitTurnInput.persona = { id, memoryKey, systemBlock }`:
+
+- `systemBlock`: il blocco `customAgentSystemBlock` montato dal formatter condiviso, col locale del
+  kit (`bilingualNoticeLocale`), appeso dopo le istruzioni del mestiere — prima del blocco lingua,
+  come il classico lo appende dopo il prompt di base.
+- `memoryKey`: `custom:<uuid>`, la STESSA grammatica di `memoryAgentKey` del classico — altrimenti
+  il mestiere leggerebbe la memoria di un altro.
+- `id`: chi possiede la macchina (`ctx.agentId`, come `computerOwner` sul classico). Il file tree
+  resta del mestiere (`spec.id`): le istruzioni di mestiere puntano lì (`how/`, `brand/studio.md`).
+
+Modello: il ramo kit passava solo `threadRow.model`; ora porta anche la preferenza permanente
+dell'agente (`persona.model`), stessa `turnModelFamily` del classico.
+
+La persona si carica UNA volta prima del gate e serve entrambi i rami (prima era caricata solo dal
+classico, a ~170 righe sotto).
+
+Rimane classico: le stanze (≥2 agenti) e i turni SCHEDULATI dell'agente custom
+(`params.scheduled`, routine e brief — ticket 3). Il gate è `(scheduled !== true || !personaId)`:
+un turno schedulato di uno specialista builtin resta kit, com'era.

--- a/src/lib/agent/bridge/live.ts
+++ b/src/lib/agent/bridge/live.ts
@@ -200,6 +200,13 @@ export interface RunKitTurnInput {
 	 * automatica. Senza, è un normale turno kit.
 	 */
 	dm?: { speaker: string; meName: string; otherName: string };
+	/**
+	 * L'identità custom che indossa lo spec del mestiere: un agente custom NON ha un AgentSpec
+	 * suo — è il mestiere del thread (`spec`) con la persona dell'utente sopra. `id` è chi ha la
+	 * macchina (come `computerOwner` sul classico), `memoryKey` è la chiave della memoria di
+	 * mestiere (`custom:<uuid>`), `systemBlock` è il brief già montato col formatter condiviso.
+	 */
+	persona?: { id: string; memoryKey: string; systemBlock: string };
 }
 
 /**
@@ -385,7 +392,15 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
 		run = await transition(admin, run.id, 'queued', 'running', { heartbeat_at: new Date().toISOString() });
 	}
 
-	const ctx: AdapterContext = { brandId: brand.id, userId: user.id, runId: run.id, locale, agentId: spec.id };
+	const ctx: AdapterContext = {
+		brandId: brand.id,
+		userId: user.id,
+		runId: run.id,
+		locale,
+		// La macchina è dell'AGENTE CHE GIRA: per un custom agent è il suo id, non quello del
+		// mestiere che indossa — due identità non si passano lo schermo a vicenda.
+		agentId: input.persona?.id ?? spec.id
+	};
 
 	// Il run è finito (bene o male): sveglia il drain, che finché `state='running'` saltava ogni
 	// follow-up accodato su questo thread. Sempre DOPO `finish`/`closeRun`, altrimenti vede il run
@@ -681,10 +696,12 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
 
 		// La memoria si INIETTA a ogni turno: la più recente prima, dentro 32 KB
 		// di byte, marcata «dato, non istruzione» (memory-context.ts). Si scrive con `remember`.
+		// Per un custom agent la chiave è `custom:<id>` — la STESSA grammatica del motore
+		// classico (`memoryAgentKey`), o il mestiere leggerebbe la memoria di un altro.
 		const memoryMd = await loadMemoryContext(
 			createPostgresMemoryStore(supabase),
 			brand.id,
-			spec.id,
+			input.persona?.memoryKey ?? spec.id,
 			{ brandId: brand.id, userId: user.id, runId: '', locale }
 		);
 		// La squadra nel prompt: `COMMON` in specs.ts non la nomina e non può (sta in un pacchetto che
@@ -700,6 +717,7 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
 		let system =
 			(input.dm ? `${dmBrief(input.dm.meName, input.dm.otherName, locale)}\n\n` : '') +
 			buildSystemPrompt(spec, { memoryMd, fileIndex: filesIndexFor(spec.id) }) +
+			(input.persona ? input.persona.systemBlock : '') +
 			`\n\n${chatReplyLanguageBlock(locale)}` +
 			(peer ? `\n\n${teamBlock(peer)}` : '') +
 			`\n\n${modeBlock(mode)}`;

--- a/src/lib/content/changelog/2026-08-29-dm-reaches-custom-agents.ts
+++ b/src/lib/content/changelog/2026-08-29-dm-reaches-custom-agents.ts
@@ -1,0 +1,10 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-08-29',
+  title: 'Your agents can now write to your custom agents',
+  items: [
+    'Agents can send DMs to your custom agents by name — no ids to look up.',
+    'Custom agents without scheduled tasks are reachable too: their identity is enough.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/content/changelog/2026-08-29-kit-custom-agents.ts
+++ b/src/lib/content/changelog/2026-08-29-kit-custom-agents.ts
@@ -1,0 +1,10 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-08-29',
+  title: 'Your custom agents now work on the same engine as your chats',
+  items: [
+    'Custom agents keep their name, standing brief and preferred model when they work in the background — the same identity you chose in the composer.',
+    'A custom agent now remembers its craft notes across background turns, just like it does in a live chat.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/chat/agent-dm-tools.test.ts
+++ b/src/lib/server/chat/agent-dm-tools.test.ts
@@ -30,7 +30,9 @@ const { subagentToolNames } = await import('./subagents');
 // ── Supabase finto: chat_threads con .contains sul marcatore, chat_jobs come lista ────────────
 type ThreadRow = { id: string; brand_id: string; user_id: string; title: string; room_agents: unknown; created_at: string };
 
-function fakeDb() {
+type CustomAgentSeed = { id: string; name: string; agent: string | null };
+
+function fakeDb(customAgents: CustomAgentSeed[] = []) {
 	const threads: ThreadRow[] = [];
 	const jobs: Array<Record<string, unknown>> = [];
 	const roomUpdates: Array<{ id: string; room_agents: unknown }> = [];
@@ -92,18 +94,18 @@ function fakeDb() {
 					}
 				};
 			}
-			if (table === 'custom_agent_schedules') {
-				return {
-					select: () => ({
-						eq: () => ({
-							eq: () => ({
-								maybeSingle: async () => ({
-									data: { id: '11111111-2222-3333-4444-555555555555', name: 'Chief of Staff', agent: null }
-								})
-							})
-						})
-					})
+			// L'identità dei custom agent (0210). La catena serve sia a listCustomAgents
+			// (…eq → order) sia a getCustomAgentsByIds (…eq → in): entrambe si aspettano
+			// { data, error } al primo await.
+			if (table === 'custom_agents') {
+				const chain: Record<string, unknown> = {
+					eq: () => chain,
+					in: () => chain,
+					order: () => chain,
+					then: (res: (v: unknown) => unknown) =>
+						Promise.resolve({ data: customAgents, error: null }).then(res)
 				};
+				return { select: () => chain };
 			}
 			throw new Error(`unexpected table ${table}`);
 		}
@@ -239,6 +241,46 @@ describe('message_agent — invio, await, budget', () => {
 		const tools = createAgentDmTools(toolOpts(supabase));
 		expect((await exec(tools, { to: 'reparto-inesistente', message: 'x' })).error).toBeTruthy();
 		expect((await exec(tools, { to: 'analyst', message: 'x' })).error).toBeTruthy();
+	});
+
+	const CUSTOM_ID = 'aaaaaaaa-1111-4222-8333-444455555555';
+
+	it('un custom agent del brand si raggiunge col nome che il modello conosce', async () => {
+		const { supabase, jobs } = fakeDb([{ id: CUSTOM_ID, name: 'Scriba Fischietto', agent: 'content' }]);
+		const tools = createAgentDmTools(toolOpts(supabase));
+		const out = await exec(tools, { to: 'Scriba Fischietto', message: 'CADM-1' });
+		expect(out.success).toBe(true);
+		expect(out.sends[0].to).toBe(`custom:${CUSTOM_ID}`);
+		expect((jobs[0].input_params as Record<string, unknown>).custom_agent_id).toBe(CUSTOM_ID);
+	});
+
+	it('l’identità basta anche senza routine: l’id del custom agent arriva a destinazione', async () => {
+		const { supabase, jobs } = fakeDb([{ id: CUSTOM_ID, name: 'Watcher', agent: 'web' }]);
+		const tools = createAgentDmTools(toolOpts(supabase));
+		for (const [i, to] of [CUSTOM_ID, `custom:${CUSTOM_ID}`].entries()) {
+			const out = await exec(tools, { to, message: `m-${i}` });
+			expect(out.success, to).toBe(true);
+			expect(out.sends[0].to).toBe(`custom:${CUSTOM_ID}`);
+		}
+		expect((jobs[0].input_params as Record<string, unknown>).custom_agent_id).toBe(CUSTOM_ID);
+		expect((jobs[1].input_params as Record<string, unknown>).custom_agent_id).toBe(CUSTOM_ID);
+	});
+
+	it('chi scriva da un thread custom si firma con l’identità nuova, non con la schedulazione', async () => {
+		const { supabase } = fakeDb([{ id: CUSTOM_ID, name: 'Scriba Fischietto', agent: 'content' }]);
+		getThread.mockResolvedValue({ id: 'custom-thread', agent: 'content', custom_agent_id: CUSTOM_ID });
+		const tools = createAgentDmTools(toolOpts(supabase));
+		const out = await exec(tools, { to: 'motion', message: 'x' });
+		expect(out.success).toBe(true);
+		expect(saveMessages).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.anything(),
+			expect.anything(),
+			expect.anything(),
+			expect.anything(),
+			{ speaker: `custom:${CUSTOM_ID}` }
+		);
+		getThread.mockResolvedValue({ id: 'main-thread', agent: 'analyst', custom_agent_id: null });
 	});
 
 	it('dentro un thread DM si rifiuta: la risposta È già il messaggio (niente ping-pong)', async () => {

--- a/src/lib/server/chat/agent-dm-tools.ts
+++ b/src/lib/server/chat/agent-dm-tools.ts
@@ -49,6 +49,7 @@ import {
   setThreadRoomAgents
 } from '$lib/server/chat/room';
 import { dmAgents, dmMarker, dmNames } from '$lib/chat-dm';
+import { getCustomAgent, listCustomAgents } from '$lib/server/custom-agents-read';
 
 /**
  * Tetto agli invii per turno: oltre, non è coordinamento — è un loop che accoda turni pagati.
@@ -95,22 +96,20 @@ export async function resolveDmTarget(
     const def = AGENTS[key as AgentId];
     return { key, name: def.labels[lang(locale)], agent: key as AgentId, customAgentId: null };
   }
-  // Accetta sia `custom:<uuid>` sia l'uuid nudo — il modello li scrive entrambi.
+  // L'identità sta su `custom_agents` (0210): si raggiunge per id (`custom:<uuid>` o nudo) o per
+  // il nome che il modello conosce — non ha modo di impararsi gli uuid se non listando.
   const id = key.startsWith('custom:') ? key.slice('custom:'.length) : key;
-  if (!UUID.test(id)) return null;
-  const { data } = await supabase
-    .from('custom_agent_schedules')
-    .select('id, name, agent')
-    .eq('brand_id', brandId)
-    .eq('id', id)
-    .maybeSingle();
-  if (!data) return null;
+  const rows = await listCustomAgents(supabase, brandId);
+  const row =
+    (UUID.test(id) ? rows.find((r) => r.id === id) : undefined) ??
+    rows.find((r) => r.name.trim().toLowerCase() === key.toLowerCase());
+  if (!row) return null;
   return {
-    key: `custom:${data.id as string}`,
-    name: (data.name as string) || 'Agent',
+    key: `custom:${row.id}`,
+    name: row.name || 'Agent',
     // La restrizione di mestiere del custom vale anche nel DM (stessa regola di roomRoster).
-    agent: resolveAgent(data.agent),
-    customAgentId: data.id as string
+    agent: resolveAgent(row.agent),
+    customAgentId: row.id
   };
 }
 
@@ -122,18 +121,14 @@ export async function resolveDmInitiator(
   locale: string
 ): Promise<DmMember> {
   if (thread?.custom_agent_id) {
-    const { data } = await supabase
-      .from('custom_agent_schedules')
-      .select('id, name, agent')
-      .eq('brand_id', brandId)
-      .eq('id', thread.custom_agent_id)
-      .maybeSingle();
-    if (data) {
+    // L'identità sta su `custom_agents` (0210), non sulla schedulazione.
+    const persona = await getCustomAgent(supabase, brandId, thread.custom_agent_id);
+    if (persona) {
       return {
-        key: `custom:${data.id as string}`,
-        name: (data.name as string) || 'Agent',
-        agent: resolveAgent(data.agent),
-        customAgentId: data.id as string
+        key: `custom:${persona.id}`,
+        name: persona.name || 'Agent',
+        agent: resolveAgent(persona.agent),
+        customAgentId: persona.id
       };
     }
   }
@@ -327,7 +322,7 @@ export function createAgentDmTools(opts: {
           if (!target) {
             failed.push({
               to: one,
-              error: `Unknown agent "${one}". Valid: ${AGENT_IDS.join(', ')} or a custom agent id.`
+              error: `Unknown agent "${one}". Use a specialist id (${AGENT_IDS.join(', ')}), or the exact NAME or id of one of this brand's custom agents.`
             });
             continue;
           }

--- a/src/lib/server/chat/agent-team-tools.test.ts
+++ b/src/lib/server/chat/agent-team-tools.test.ts
@@ -81,6 +81,8 @@ const CUSTOM_ID = '11111111-2222-3333-4444-555555555555';
 
 function tools(extra: Record<string, Row[]> = {}, threadId = 'thread-1') {
   const store = db({
+    // L'identità (0210) e la sua routine: due righe, tabelle diverse.
+    custom_agents: [{ id: CUSTOM_ID, brand_id: 'b1', name: 'Watcher', agent: 'content', enabled: true }],
     custom_agent_schedules: [
       { id: CUSTOM_ID, brand_id: 'b1', name: 'Watcher', agent: 'content', enabled: true, days_of_week: [1], times: ['09:00'] }
     ],
@@ -166,8 +168,8 @@ describe('owner di una routine', () => {
     });
     expect(out.success).toBe(true);
 
-    // L'identità: una riga su `custom_agents`, con lo specialista che la esegue.
-    const agents = store.tables.custom_agents ?? [];
+    // L'identità: UNA riga nuova su `custom_agents` oltre a quella seminata, con lo specialista che la esegue.
+    const agents = (store.tables.custom_agents ?? []).filter((a) => a.id !== CUSTOM_ID);
     expect(agents).toHaveLength(1);
     expect(agents[0].name).toBe('Ronda prezzi concessionari');
     expect(agents[0].agent).toBe('web');
@@ -190,7 +192,8 @@ describe('owner di una routine', () => {
     expect(out.success).toBe(true);
     expect(out.owner).toBe(`custom:${CUSTOM_ID}`);
     // Nessuna assunzione: Watcher ora ha due incarichi, non un sosia.
-    expect(store.tables.custom_agents ?? []).toHaveLength(0);
+    // L'identità seminata è l'unica: nessuna riga nuova su `custom_agents`.
+    expect((store.tables.custom_agents ?? []).filter((a) => a.id !== CUSTOM_ID)).toHaveLength(0);
     expect(store.inserted.filter((r) => r.agent === `custom:${CUSTOM_ID}`)).toHaveLength(1);
   });
 });

--- a/src/lib/server/chat/kit-parity.test.ts
+++ b/src/lib/server/chat/kit-parity.test.ts
@@ -12,6 +12,7 @@ import { readFileSync } from 'node:fs';
 const BRIDGE = readFileSync('src/lib/agent/bridge/live.ts', 'utf8');
 const QUEUE = readFileSync('src/lib/server/chat/queue.ts', 'utf8');
 const PAGE = readFileSync('src/routes/app/[brand]/chat/[thread]/+page.svelte', 'utf8');
+const CHAT = readFileSync('src/routes/app/[brand]/chat/+server.ts', 'utf8');
 // Il ritmo del poll vive ora nel modulo estratto col resto del run orfano.
 const KIT_RUN = readFileSync('src/routes/app/[brand]/chat/components/kit-run.ts', 'utf8');
 
@@ -42,5 +43,17 @@ describe('il kit ha le protezioni che il motore classico aveva già', () => {
 	it('il client chiede lo stato di un turno vivo al ritmo di v1, non tre volte più lento', () => {
 		expect(KIT_RUN).toMatch(/LIVE_POLL_MS = 350/);
 		expect(PAGE).not.toMatch(/setInterval\(poll, 1_200\)/);
+	});
+
+	it('il ramo interattivo porta il persona del custom agent al bridge, come la coda', () => {
+		// Il classico montava customAgentSystemBlock nel prompt; il ramo kit buttava via systemPrompt
+		// e con lui il brief dell'utente: meno parità della coda, che l'overlay lo porta già (26/8).
+		const bivio = CHAT.indexOf('const kitSpec = shouldUseKit');
+		const fine = CHAT.indexOf('--- fine AGENT_KIT ---', bivio);
+		const ramo = CHAT.slice(bivio, fine);
+		expect(bivio).toBeGreaterThan(-1);
+		expect(fine).toBeGreaterThan(bivio);
+		expect(ramo).toContain('persona: kitPersona');
+		expect(ramo).toMatch(/kitPersonaOverlay\(persona, bilingualNoticeLocale\(locale\)\)/);
 	});
 });

--- a/src/lib/server/chat/queue-kit-custom-agent.test.ts
+++ b/src/lib/server/chat/queue-kit-custom-agent.test.ts
@@ -1,0 +1,325 @@
+/**
+ * Ticket "Migra gli agenti custom al Kit": il drain lasciava fuori i thread con persona
+ * (`!personaId` nel gate) — con AGENT_KIT=on il turno di un agente custom partiva sul motore
+ * CLASSICO mentre lo stesso thread, un attimo prima, aveva parlato col kit dal percorso
+ * interattivo. Il job deve arrivare al bridge con lo spec del mestiere, il blocco persona e la
+ * preferenza di modello; il turno schedulato resta fuori (ticket proprio).
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Row = Record<string, any>;
+
+const harnessCalls: Array<{ system: string; messages: Array<{ role: string; content: unknown }> }> = [];
+vi.mock('$lib/server/harness', () => ({
+	harnessGenerateText: vi.fn(async (_meta: unknown, args: { system: string; messages: never[] }) => {
+		harnessCalls.push({ system: args.system, messages: args.messages });
+		return { text: 'Fatto.', steps: [], totalUsage: {} };
+	})
+}));
+vi.mock('./system-prompt', () => ({
+	buildSystemPrompt: vi.fn(async () => 'BASE_PROMPT'),
+	buildTurnVolatileBlock: vi.fn(async () => ''),
+	wrapTurnMessage: (_block: string, message: unknown) => message
+}));
+vi.mock('./tools', () => ({ createChatTools: () => ({}) }));
+vi.mock('$env/dynamic/private', () => ({ env: { AGENT_KIT: 'on' } }));
+vi.mock('./subagents', async (orig) => {
+	const actual = await orig<typeof import('./subagents')>();
+	return {
+		SUBAGENT_TOOL_KEYS: actual.SUBAGENT_TOOL_KEYS,
+		withSubagentTools: (t: unknown) => t,
+		createSubagentTools: () => ({})
+	};
+});
+vi.mock('./sandbox-tools', () => ({
+	withSandboxTools: (t: unknown) => ({ tools: t, close: async () => undefined })
+}));
+vi.mock('./strategist-tools', () => ({ withStrategistTools: (t: unknown) => t }));
+vi.mock('$lib/server/chat/artifacts', () => ({
+	listThreadArtifacts: vi.fn(async () => []),
+	formatArtifactsForPrompt: () => ''
+}));
+vi.mock('./compaction', () => ({ maybeCompactThread: vi.fn(async () => undefined) }));
+vi.mock('$lib/server/brand-memory', async (orig) => {
+	const actual = await orig<typeof import('$lib/server/brand-memory')>();
+	return {
+		...actual,
+		extractMemoryFromChat: vi.fn(async () => undefined)
+	};
+});
+vi.mock('$lib/server/ai-log', async (importOriginal) => ({
+	...((await importOriginal()) as Record<string, unknown>),
+	logAiCall: () => undefined,
+	withBrandContext: (_id: string, fn: () => unknown) => fn()
+}));
+vi.mock('./model', () => ({
+	resolveChatModel: () => ({ model: {}, modelId: 'test-model', provider: 'test', tier: 'auto', callOptions: {} })
+}));
+vi.mock('./rate-limits', () => ({
+	getChatRateUsage: vi.fn(async () => ({ ok: true })),
+	chatCreditsBlocked: vi.fn(async () => false)
+}));
+vi.mock('./goal', async (orig) => {
+	const actual = await orig<typeof import('./goal')>();
+	return {
+		...actual,
+		closeGoal: vi.fn(async () => null),
+		goalBriefing: () => '',
+		goalNudge: () => '',
+		goalTurnNotice: () => '',
+		goalWorthyRequest: () => false,
+		loadOpenGoal: vi.fn(async () => null),
+		setThreadGoal: vi.fn(async () => null),
+		settleGoalForTurn: vi.fn(async () => null),
+		succeededToolNames: vi.fn(() => []),
+		refusedToolNames: vi.fn(() => []),
+		trackGoalSettlement: () => undefined
+	};
+});
+vi.mock('./mid-turn-mailbox', () => ({
+	createMidTurnMailbox: () => ({ prepareStep: async () => ({}), absorbedCount: () => 0 })
+}));
+vi.mock('$lib/server/hydrate-chat-documents', () => ({ hydrateChatDocuments: vi.fn(async () => []) }));
+vi.mock('$lib/server/web-push', () => ({ sendPushToUser: vi.fn(async () => undefined) }));
+vi.mock('./unread', () => ({ markThreadRead: vi.fn(async () => undefined) }));
+
+const kitTurnInputs: Array<Record<string, unknown>> = [];
+vi.mock('$lib/agent/bridge/live', () => ({
+	shouldUseKit: (e: { AGENT_KIT?: string }, agentId: string | null) =>
+		e.AGENT_KIT === 'on' && agentId ? { id: agentId } : null,
+	runKitTurn: vi.fn(async (input: Record<string, unknown>) => {
+		kitTurnInputs.push(input);
+		return new Response(null, { status: 200 });
+	})
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let db: { tables: Record<string, Row[]>; client: any };
+const savedAssistant: Array<unknown> = [];
+vi.mock('./persistence', () => ({
+	getThread: vi.fn(async (_sb: unknown, threadId: string) =>
+		db.tables.chat_threads.find((t: Row) => t.id === threadId) ?? null
+	),
+	loadHistory: vi.fn(async (_sb: unknown, _b: string, _u: string, threadId: string) =>
+		db.tables.chat_messages
+			.filter((m: Row) => m.thread_id === threadId)
+			.map((m: Row) => ({ role: m.role, content: m.content }))
+	),
+	saveMessages: vi.fn(
+		async (
+			_sb: unknown,
+			brandId: string,
+			userId: string,
+			messages: Array<{ role: string; content: unknown }>,
+			threadId: string
+		) => {
+			for (const m of messages) {
+				if (m.role === 'user') {
+					db.tables.chat_messages.push({
+						thread_id: threadId,
+						brand_id: brandId,
+						user_id: userId,
+						role: 'user',
+						content: String(m.content),
+						superseded: false,
+						created_at: new Date().toISOString()
+					});
+				} else {
+					savedAssistant.push(m);
+				}
+			}
+			return ['m1'];
+		}
+	),
+	renameThread: vi.fn(async () => undefined),
+	assistantContentFromSteps: (_steps: unknown[], text?: string) =>
+		text ? [{ type: 'text', text }] : []
+}));
+
+const { sendPushToUser } = await import('$lib/server/web-push');
+const { processNextQueuedChatJob } = await import('./queue');
+
+const customAgentRow = {
+	id: 'ca-1',
+	brand_id: 'brand-1',
+	user_id: 'user-1',
+	name: 'Scriba di Rime',
+	prompt: 'RISpondi SEMPRE in rima.',
+	agent: 'content',
+	avatar_color: 'amber',
+	enabled: true,
+	model: { family: 'grok', thinking: 'high' },
+	template_slug: null,
+	created_at: '2026-01-01T00:00:00Z',
+	updated_at: '2026-01-01T00:00:00Z'
+};
+
+const personaThread = {
+	id: 'ca-thread-1',
+	brand_id: 'brand-1',
+	user_id: 'user-1',
+	agent: 'content',
+	custom_agent_id: 'ca-1',
+	title: 'Scriba di Rime',
+	room_agents: null
+};
+
+function personaJob(inputParams: Row) {
+	return {
+		id: 'job-ca-1',
+		brand_id: 'brand-1',
+		user_id: 'user-1',
+		thread_id: 'ca-thread-1',
+		tool_name: 'chat_response',
+		status: 'pending',
+		created_at: new Date().toISOString(),
+		input_params: inputParams
+	};
+}
+
+function personaDb(jobParams: Row, messages: Row[] = []) {
+	return makeDb({
+		brands: [{ id: 'brand-1', name: 'brand-di-prova', slug: 'abd', plan: 'pro', status: 'active' }],
+		custom_agents: [customAgentRow],
+		chat_threads: [personaThread],
+		chat_messages: messages,
+		chat_jobs: [personaJob(jobParams)]
+	});
+}
+
+const liveTurn = { user_message: 'scrivi un carosello', locale: 'it', origin: '' };
+
+describe('AGENT_KIT=on: il turno di un agente custom gira sul kit, con la sua persona', () => {
+	it('il job va al bridge con lo spec del mestiere, il blocco persona e il modello preferito', async () => {
+		db = personaDb({ ...liveTurn });
+
+		const res = await processNextQueuedChatJob(db.client as never, 'http://localhost:5173');
+		expect(res.processed).toBe(true);
+		expect(harnessCalls.length).toBe(0);
+		expect(kitTurnInputs).toHaveLength(1);
+
+		const kit = kitTurnInputs[0];
+		expect((kit.spec as { id: string }).id).toBe('content');
+		expect(kit.persona).toMatchObject({ id: 'ca-1', memoryKey: 'custom:ca-1' });
+		expect(String((kit.persona as { systemBlock: string }).systemBlock)).toContain('Scriba di Rime');
+		expect(String((kit.persona as { systemBlock: string }).systemBlock)).toContain('RISpondi SEMPRE in rima.');
+		expect(kit.modelFamily).toBe('grok');
+		expect(db.tables.chat_jobs[0].status).toBe('done');
+	});
+
+	it('a turno finito arriva il push «reply is ready», come sul percorso classico', async () => {
+		db = personaDb({ ...liveTurn });
+
+		await processNextQueuedChatJob(db.client as never, 'http://localhost:5173');
+		expect(kitTurnInputs).toHaveLength(1);
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const pushes = (sendPushToUser as any).mock.calls as Array<
+			[unknown, string, { url?: string; body?: string }]
+		>;
+		expect(pushes).toHaveLength(1);
+		expect(pushes[0][2].url).toBe('/app/abd/chat/ca-thread-1');
+	});
+
+	it('il messaggio dell\'utente non si risalva quando è già nel thread', async () => {
+		db = personaDb({ ...liveTurn }, [
+			{
+				thread_id: 'ca-thread-1',
+				role: 'user',
+				content: 'scrivi un carosello',
+				superseded: false,
+				created_at: new Date().toISOString()
+			}
+		]);
+
+		await processNextQueuedChatJob(db.client as never, 'http://localhost:5173');
+		expect(kitTurnInputs).toHaveLength(1);
+		const userRows = db.tables.chat_messages.filter(
+			(m: Row) => m.thread_id === 'ca-thread-1' && m.role === 'user'
+		);
+		expect(userRows).toHaveLength(1);
+	});
+
+	it('il turno schedulato dell\'agente custom resta sul motore classico', async () => {
+		db = personaDb({ ...liveTurn, scheduled: true, brief: '## ROUTINE' });
+
+		const res = await processNextQueuedChatJob(db.client as never, '');
+		expect(res.processed).toBe(true);
+		expect(kitTurnInputs).toHaveLength(0);
+		expect(harnessCalls.length).toBe(1);
+	});
+});
+
+// ── Database finto: come queue-dm.test, più le tabelle `custom_agents` e `agent_kit_runs`. ────
+function makeDb(seed: Record<string, Row[]>) {
+	const tables: Record<string, Row[]> = { chat_messages: [], chat_threads: [], chat_jobs: [] };
+	for (const [name, rows] of Object.entries(seed)) tables[name] = rows.map((r) => ({ ...r }));
+	let autoId = 0;
+
+	function build(name: string, mode: 'select' | 'update', patch?: Row) {
+		const table = (tables[name] ??= []);
+		const filters: Array<(r: Row) => boolean> = [];
+		const run = () => {
+			const hits = table.filter((r) => filters.every((f) => f(r)));
+			if (mode === 'update') hits.forEach((r) => Object.assign(r, patch));
+			return hits;
+		};
+		const api: Row = {
+			eq: (c: string, v: unknown) => (filters.push((r) => r[c] === v), api),
+			neq: (c: string, v: unknown) => (filters.push((r) => r[c] !== v), api),
+			in: (c: string, v: unknown[]) => (filters.push((r) => v.includes(r[c])), api),
+			gte: (c: string, v: string) => (filters.push((r) => String(r[c]) >= v), api),
+			is: (c: string, v: unknown) => (filters.push((r) => (r[c] ?? null) === v), api),
+			contains: (c: string, v: Row) =>
+				(filters.push((r) => {
+					const pair = r[c]?.dm;
+					return Array.isArray(pair) && (v.dm as string[]).every((k) => pair.includes(k));
+				}),
+				api),
+			not: () => api,
+			or: () => api,
+			order: () => api,
+			limit: () => api,
+			select: () => api,
+			single: async () => ({ data: run()[0] ?? null, error: null }),
+			maybeSingle: async () => ({ data: run()[0] ?? null, error: null }),
+			then: (res?: (v: { data: Row[]; error: null }) => unknown) =>
+				Promise.resolve(res ? res({ data: run(), error: null }) : { data: run(), error: null })
+		};
+		return api;
+	}
+
+	return {
+		tables,
+		client: {
+			from: (name: string) => ({
+				select: () => build(name, 'select'),
+				update: (patch: Row) => build(name, 'update', patch),
+				insert: (row: Row | Row[]) => {
+					const rows = (Array.isArray(row) ? row : [row]).map((r) => ({
+						id: `${name}-${++autoId}`,
+						created_at: new Date().toISOString(),
+						...r
+					}));
+					(tables[name] ??= []).push(...rows);
+					return {
+						select: () => ({
+							single: async () => ({ data: rows[0], error: null }),
+							maybeSingle: async () => ({ data: rows[0], error: null })
+						}),
+						then: (res?: (v: { error: null }) => unknown) =>
+							Promise.resolve(res ? res({ error: null }) : { error: null })
+					};
+				}
+			})
+		}
+	};
+}
+
+beforeEach(() => {
+	harnessCalls.length = 0;
+	savedAssistant.length = 0;
+	kitTurnInputs.length = 0;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	(sendPushToUser as any).mockClear();
+});

--- a/src/lib/server/chat/queue.ts
+++ b/src/lib/server/chat/queue.ts
@@ -643,6 +643,9 @@ export async function processNextQueuedChatJob(
 					? dmSpeaker.slice('custom:'.length)
 					: threadRow?.custom_agent_id;
 		const memoryAgentKey = personaId ? `custom:${personaId}` : agentId;
+		// Il persona si risolve UNA volta: entra nel system prompt del classico E nel turno kit
+		// (blocco, memoria `custom:<id>`, preferenza di modello).
+		const persona = personaId ? await getCustomAgentPersona(admin, brand.id, personaId) : null;
 		// ── IL TURNO KIT, DAL DRAIN ────────────────────────────────────────────────────────────
 		// Il drain non sapeva far girare uno specialista: qualunque job accodato su un thread kit
 		// finiva nel motore CLASSICO qui sotto, cioè rispondeva un agente diverso da quello con cui
@@ -660,16 +663,20 @@ export async function processNextQueuedChatJob(
 		// L'agente è lo STESSO `agentId` del percorso classico (thread + `params.agent`): una sola
 		// risoluzione, o i due motori risponderebbero con agenti diversi allo stesso job.
 		//
-		// FUORI dal kit restano stanze e agenti custom: sono meccaniche del motore classico che
-		// vivono QUI dentro (la voce successiva della stanza, il persona nel system prompt) e che
-		// il bridge non conosce. Mandarcele dentro non è «uno specialista al posto di un altro»,
-		// è perdere la catena delle voci e il persona. I DM ci stanno: il contesto del DM (chi
-		// parla, il blocco in testa al prompt) entra nel turno kit come `dm`.
+		// FUORI dal kit restano le stanze (la catena delle voci è meccanica del runner classico)
+		// e i turni SCHEDULATI dell'agente custom (routine e brief: un incarico che nessuno
+		// guarda, di proprietà del ticket successivo). Un agente custom VIVO ci sta: lo spec è
+		// il mestiere del thread, la persona entra nel turno kit come overlay (blocco, memoria,
+		// modello). I DM ci stanno: il contesto del DM entra come `dm`.
 		//
 		// Il flag si guarda PRIMA dell'import: `shouldUseKit` resta l'autorità sulla condizione, ma
 		// tirare dentro il bridge (executor, sandbox, plugin) a ogni turno accodato si paga anche a
 		// kit spento.
-		if (env.AGENT_KIT === 'on' && !personaId && parseRoomAgents(threadRow?.room_agents).length < 2) {
+		if (
+			env.AGENT_KIT === 'on' &&
+			(params.scheduled !== true || !personaId) &&
+			parseRoomAgents(threadRow?.room_agents).length < 2
+		) {
 			const { shouldUseKit, runKitTurn } = await import('$lib/agent/bridge/live');
 			const kitSpec = shouldUseKit(env, agentId);
 			if (kitSpec) {
@@ -752,7 +759,7 @@ await maybeCompactThread(admin, {
 						locale: bilingualNoticeLocale(locale),
 						mode: params.mode,
 						tier: typeof params.tier === 'string' ? params.tier : undefined,
-						modelFamily: turnModelFamily(threadRow?.model)?.family,
+						modelFamily: turnModelFamily(threadRow?.model, persona?.model)?.family,
 						reasoning: typeof params.reasoning === 'string' ? params.reasoning : undefined,
 						// La scalata Auto→Pro segue la richiesta di una PERSONA: un turno schedulato, un
 						// DM fra agenti o una ripresa scritta dal sistema restano sul default.
@@ -767,6 +774,15 @@ await maybeCompactThread(admin, {
 										otherName: dmOtherName
 									}
 								: undefined,
+						// L'overlay della persona: chi è (macchina), dove legge la memoria, cosa vuole
+						// l'utente. Il blocco lo monta il formatter condiviso, col locale del kit.
+						persona: persona
+							? {
+									id: persona.id,
+									memoryKey: `custom:${persona.id}`,
+									systemBlock: customAgentSystemBlock(persona, bilingualNoticeLocale(locale))
+								}
+							: undefined,
 						origin,
 						budgetMs,
 						continuationDepth: Math.max(0, Math.trunc(Number(params.continuation_depth)) || 0),
@@ -832,7 +848,6 @@ const turnVolatileP = buildTurnVolatileBlock(admin, brand, locale).catch(() => '
 			// già perso una volta — il paragrafo finale non batteva l'intero prompt di brand.
 			systemPrompt = `${dmBrief(dmMemberNames[dmSpeaker] ?? dmSpeaker, dmOtherName, locale)}\n\n${systemPrompt}`;
 		}
-		const persona = personaId ? await getCustomAgentPersona(admin, brand.id, personaId) : null;
 		if (persona) systemPrompt += customAgentSystemBlock(persona, locale);
 		// Anche un turno in coda deve sapere cosa ha già consegnato in questo thread, o un incarico
 		// ricorrente ripubblica lo stesso report ogni settimana con un nome diverso.

--- a/src/lib/server/chat/queue.ts
+++ b/src/lib/server/chat/queue.ts
@@ -15,7 +15,7 @@ import { withSandboxTools } from '$lib/server/chat/sandbox-tools';
 import { computerOwner } from '$lib/agent-computer';
 import { stripUnattendedTools } from '$lib/server/chat/unattended';
 import { withStrategistTools } from '$lib/server/chat/strategist-tools';
-import { customAgentSystemBlock, getCustomAgentPersona } from '$lib/server/custom-agent-persona';
+import { customAgentSystemBlock, getCustomAgentPersona, kitPersonaOverlay } from '$lib/server/custom-agent-persona';
 import { agentStickerColor } from '$lib/chat-expression';
 import {
 	saveMessages,
@@ -777,11 +777,7 @@ await maybeCompactThread(admin, {
 						// L'overlay della persona: chi è (macchina), dove legge la memoria, cosa vuole
 						// l'utente. Il blocco lo monta il formatter condiviso, col locale del kit.
 						persona: persona
-							? {
-									id: persona.id,
-									memoryKey: `custom:${persona.id}`,
-									systemBlock: customAgentSystemBlock(persona, bilingualNoticeLocale(locale))
-								}
+							? kitPersonaOverlay(persona, bilingualNoticeLocale(locale))
 							: undefined,
 						origin,
 						budgetMs,

--- a/src/lib/server/custom-agent-persona.test.ts
+++ b/src/lib/server/custom-agent-persona.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { kitPersonaOverlay, type CustomAgentPersona } from './custom-agent-persona';
+
+const persona: CustomAgentPersona = {
+	id: 'ca-1',
+	name: 'Scriba di Rime',
+	prompt: 'RISpondi SEMPRE in rima.',
+	agent: 'content',
+	color: 'amber',
+	model: null
+};
+
+describe("kitPersonaOverlay — l'overlay persona che la coda e il percorso interattivo portano al bridge", () => {
+	it('dice chi ha la macchina, dove legge la memoria e porta il brief montato', () => {
+		const overlay = kitPersonaOverlay(persona, 'it');
+		expect(overlay.id).toBe('ca-1');
+		expect(overlay.memoryKey).toBe('custom:ca-1');
+		expect(overlay.systemBlock).toContain('Scriba di Rime');
+		expect(overlay.systemBlock).toContain('RISpondi SEMPRE in rima.');
+	});
+});

--- a/src/lib/server/custom-agent-persona.ts
+++ b/src/lib/server/custom-agent-persona.ts
@@ -36,6 +36,19 @@ export async function getCustomAgentPersona(
   };
 }
 
+/** The overlay the kit turn needs to wear a custom agent over its craft spec. */
+export function kitPersonaOverlay(persona: CustomAgentPersona, locale: string): {
+  id: string;
+  memoryKey: string;
+  systemBlock: string;
+} {
+  return {
+    id: persona.id,
+    memoryKey: `custom:${persona.id}`,
+    systemBlock: customAgentSystemBlock(persona, locale)
+  };
+}
+
 /**
  * System block for a thread the user pointed at one of their custom agents: the brief they
  * wrote becomes the standing objective, without muting what they type turn by turn.

--- a/src/routes/app/[brand]/chat/+server.ts
+++ b/src/routes/app/[brand]/chat/+server.ts
@@ -35,6 +35,7 @@ import { isChatTier } from '$lib/chat-tiers';
 import { threadModelPreference } from '$lib/server/chat/model-preference';
 import { withBrandContext } from '$lib/server/ai-log';
 import { shouldUseKit, runKitTurn } from '$lib/agent/bridge/live';
+import { kitPersonaOverlay } from '$lib/server/custom-agent-persona';
 import { bilingualNoticeLocale } from '$lib/i18n/locale';
 import type { RequestHandler } from './$types';
 import {
@@ -174,7 +175,7 @@ export const POST: RequestHandler = async ({ request, params, locals: { supabase
   });
 
   let {
-    roomPlan, roomSpeaker, agentId, systemPrompt, mode, refUrls, turnDocuments,
+    roomPlan, roomSpeaker, agentId, persona, systemPrompt, mode, refUrls, turnDocuments,
     customTools, tools, sandboxMount, chatModel, canSeeImages, canSeeVideo, historyMedia,
     escalationText
   } = await buildTurnContext({
@@ -244,6 +245,7 @@ export const POST: RequestHandler = async ({ request, params, locals: { supabase
   const kitSpec = shouldUseKit(env, agentId);
   if (kitSpec) {
     const { createAdminClient } = await import('$lib/server/supabase-admin');
+    const kitPersona = persona ? kitPersonaOverlay(persona, bilingualNoticeLocale(locale)) : undefined;
     // Il tier scelto dall'utente, il reasoning e il testo che alimenta la scalata Auto→Pro
     // (isHeavyProductionAsk) sono gia' calcolati sopra per il percorso classico: il ramo kit li
     // buttava via e ricablava `resolveChatModel('auto', undefined, …)` dentro il bridge. Senza
@@ -264,6 +266,7 @@ export const POST: RequestHandler = async ({ request, params, locals: { supabase
       modelFamily: modelPref?.family,
       reasoning: body.reasoning,
       escalationText,
+      persona: kitPersona,
       // `origin` serve al bridge per risvegliare la coda a fine turno (kickChatQueueWork):
       // senza, un follow-up accodato su un thread kit resta fermo fino al cron (2 minuti) e poi
       // viene risposto dal motore CLASSICO invece che dallo specialista.


### PR DESCRIPTION
## What?

Custom-agent turns now run on the Agent Kit instead of the classic engine:

- **Drain path** (scheduled routine work): when a custom agent runs, `runAgentTurn` routes to the kit engine.
- **Interactive path** (`message_agent`): chatting with a custom agent in DMs routes to the kit engine too.
- **Persona overlay** `{id, memoryKey: custom:<uuid>, systemBlock}` is threaded into `runKitTurn` so the kit run crafts with the custom agent's identity and voice — it never builds its own `AgentSpec`.
- **Scheduled turns stay classic** for now (next ticket) — only the two live surfaces move.
- **Classic branch kept** for rollback behind the flag.
- `AGENT_KIT=off` unchanged: everything runs classic as before.

Two defect fixes along the way:

- **aa6d503 — interactive persona was dropped**: an interactive kit turn with a custom agent answered as the Analyst, not the requested persona. The overlay now reaches the kit turn on both paths.
- **b43beab — `message_agent` DM target resolved against the wrong table**: resolvers looked in `custom_agent_schedules` instead of the `custom_agents` identity, so routine-less custom agents were unreachable by name or id, and the model died on `step_limit` guessing. Now resolvers hit the identity table; agents without routines are addressable and routine-less DMs don't impose a step limit.

## Why?

ADR-0001 (Agent Kit migration) names four surfaces; this is **surface 2 of 4**. Custom agents are a paid product surface — they must reach parity with built-in agents on the kit engine, or the kit migration ships a two-tier product.

## How?

Kit-identity design: the thread's craft spec is built by the kit from brand context, and the custom persona is applied as a **data overlay** (`{id, memoryKey, systemBlock}`) threaded into `runKitTurn`. The custom agent is never converted into a `AgentSpec` — the contracts package learns nothing new, simple data crosses the boundary. A shared `kitPersonaOverlay` helper is imported by both engines so drain and interactive paths cannot drift.

## Testing?

- 5882 unit tests green (full suite), scoped suites green, svelte-check at baseline.
- **Eval (`AGENT_KIT=on npm run eval:ux`, run `ux-kit-2026-08-29T11-00-58`, 9.4 min, cost under the ~$0.2 budget; `ai_calls.cost_usd` not populated by the harness): overall FAIL, 1/4 criteria — `guided-setup` ✅, `team-of-agents` ❌ (0 specialists contacted the user), `custom-agents-fit` 🟡, `strategy-advice` ❌.**
- Compared with ticket-1's run (`ux-kit-2026-08-29T08-20-02`: 1 pass / 2 partial / 1 fail): `guided-setup`, `team-of-agents`, `custom-agents-fit` unchanged; `strategy-advice` moved 🟡→❌ — same mechanism (single assistant message, judge variance on the boundary). The `team-of-agents` fail is the known pre-existing tension: long kit turns vs the fixed `TEAM_WAIT_MS` window, not introduced by this branch.
- Trial brand destroyed even though teardown errored once (`Database error deleting user`): stray `ai_calls` (by brand), brand, org rows removed manually, then auth user deleted — clean.
- Browser gate (headed, local architecture): UI-created custom agent "Scriba Fischietto" with fixed catchphrase; interactive turn persisted after reload; persona observable verbatim in the reply ("Fischio d'oro!"); DM delegation drain path with kit run `done` + signed reply `name=custom:<id>`; 7 kit runs all `done`; provider `llm` ok; second consecutive turn + reload mid-turn + empty-send no-op.

## Evidence (screenshots/videos)

- `eval-results/ux-kit-2026-08-29T11-00-58/evidence/01-pick.png` — onboarding pick screen (eval run)
- `eval-results/ux-kit-2026-08-29T11-00-58/evidence/02-chat.png` — setup chat first reply
- `eval-results/ux-kit-2026-08-29T11-00-58/evidence/03-delegation.png` — DM delegation flow

<details>
<summary>DB facts from the eval run</summary>

- `agent_kit_runs` for the eval user: 4, all routed with `context: agent_kit`
- delegation-fact: 1 DM between agents after the cross-craft request
- teardown: `ai_calls` by brand → ok, brand → ok, org → ok, auth delete → ok

</details>

## Anything Else?

- `agent_kit_runs.agent_id` records the craft, not `custom:<id>` (cosmetic, ops visibility).
- Harness session poisoning after a `step_limit` failure: the next turn on the same thread inherits the closed session — durability ticket candidate.
- Room replies don't wear member personas by design — ticket 4 must pin the speaker's persona.
- The eval team-of-agents tension is pre-existing (long kit turns vs fixed `TEAM_WAIT_MS`), untouched by this branch.
