### PR TITLE
Stop sandboxes when the last holder leaves

### DIFF
--- a/changelog/2026-08-29-sandbox-refcount-stop.md
+++ b/changelog/2026-08-29-sandbox-refcount-stop.md
@@ -1,0 +1,42 @@
+# La macchina si spegne quando il lavoro finisce, non quando scade l'affitto
+
+## Perché esiste
+
+Vercel Sandbox fattura la memoria a orologio fino alla scadenza del lease, idle incluso: un
+turno di chat che usa la VM per 40 secondi pagava fino a 15 minuti (`SANDBOX_MAX_LEASE_MS`),
+perché l'unica cosa che spegneva la macchina era il timeout. Il commento su `release()` in
+`sandbox.ts` lo sapeva e lo documentava come limite accettato: senza un refcount fuori processo,
+uno `stop()` diretto spegne la VM sotto i piedi di un altro turno in un altro processo.
+
+## Cosa c'era prima
+
+`release()` rimuoveva solo la directory della run; la macchina correva fino al lease. Le docs
+Vercel raccomandano da sempre lo stop esplicito («Call sandbox.stop() when done rather than
+waiting for timeout»), e il resume da snapshot è automatico nell'SDK: il vincolo era solo
+nostro, non della piattaforma.
+
+## La decisione
+
+Contatore di holder per nome macchina in Postgres (`sandbox_holders`, una riga per holder con
+`expires_at`). Le scelte che contano:
+
+- **Righe che scadono**, non contatori puri: un processo serverless morto a metà turno non
+  lascia holder fantasma che bloccano lo stop per sempre. L'alternativa (contatore con
+  decremento solo esplicito) richiedeva heartbeat affidabili per ogni chiamante.
+- **Chiave `(sandbox_name, holder_key)`**: upsert, non insert. Chi ripassa di qui — il poll del
+  pannello desktop ogni 2.5s — rinfresca la propria riga invece di accumularne. Per il desktop
+  l'upsert È l'heartbeat: nessuna release, perché il ciclo di vita lo conosce solo il browser.
+- **Lo stop sta in `releaseHolder`, non in `sandbox.ts`**: la release cancella la riga e, se era
+  l'ultima, chiama `stop()`. Lo `stop()` inline nel modulo sandbox resta vietato (test
+  guardiano): spegnere è una decisione di contabilità, non di chi finisce per primo.
+- **`KEEP_LAST_SNAPSHOTS` 2 → 1**: raccomandazione docs ("keeps snapshot storage flat"); il
+  drift allinea le VM esistenti al prossimo giro, senza bump di generazione.
+
+Scartato: il cron reaper (più lento di stop-at-zero, e con una code di minuti per brand), il
+short-lease per uso (dopo lo stop sicuro il cricchetto perde il morso: ogni sessione fredda
+riparte col lease giusto, e il render resta a 15 minuti).
+
+## Cosa guarda il test guardiano
+
+`sandbox.test.ts` non vietava più lo stop — vietava lo stop SENZA refcount. Ora vieta uno
+`.stop()` diretto in `sandbox.ts`: spegnere passa da `releaseHolder`, sempre.

--- a/src/lib/content/changelog/2026-08-29-sandbox-refcount-stop.ts
+++ b/src/lib/content/changelog/2026-08-29-sandbox-refcount-stop.ts
@@ -1,0 +1,10 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-08-29',
+  title: 'Agent sandboxes power down the moment work finishes',
+  items: [
+    'Sandbox machines now shut down as soon as the last job using them ends, instead of idling until their rental window expires — idle time no longer burns through credits.',
+    'Watching an agent’s live desktop keeps its machine awake while the panel is open, and the machine powers down shortly after you close it.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/sandbox-config.test.ts
+++ b/src/lib/server/sandbox-config.test.ts
@@ -107,7 +107,7 @@ describe('openBrandSandbox riallinea la VM che esisteva già', () => {
   beforeEach(() => getOrCreate.mockReset());
 
   it('chiama `update` quando la configurazione della VM non è quella che abbiamo chiesto', async () => {
-    const sb = fakeSandbox({ timeout: 120_000, snapshotExpiration: WEEK, keepLastSnapshots: { count: 2 } });
+    const sb = fakeSandbox({ timeout: 120_000, snapshotExpiration: WEEK, keepLastSnapshots: { count: 1 } });
     getOrCreate.mockResolvedValue(sb);
     const { openBrandSandbox } = await import('./sandbox');
 
@@ -118,7 +118,7 @@ describe('openBrandSandbox riallinea la VM che esisteva già', () => {
   });
 
   it('e NON lo chiama su una VM appena creata, che i parametri li ha già ricevuti', async () => {
-    const sb = fakeSandbox({ timeout: 600_000, snapshotExpiration: WEEK, keepLastSnapshots: { count: 2 } });
+    const sb = fakeSandbox({ timeout: 600_000, snapshotExpiration: WEEK, keepLastSnapshots: { count: 1 } });
     getOrCreate.mockResolvedValue(sb);
     const { openBrandSandbox } = await import('./sandbox');
 

--- a/src/lib/server/sandbox-leases.test.ts
+++ b/src/lib/server/sandbox-leases.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { acquireHolder, releaseHolder } from './sandbox-leases';
+
+type Row = {
+  id: string;
+  sandbox_name: string;
+  holder_key: string;
+  kind: string;
+  expires_at: string;
+};
+
+function fakeDb() {
+  const rows: Row[] = [];
+  const stop = vi.fn(async () => {});
+  let seq = 0;
+
+  const builder = (table: string) => {
+    if (table !== 'sandbox_holders') throw new Error(`unexpected table ${table}`);
+    const state: { mode: 'upsert' | 'delete' | 'count'; row?: Partial<Row>; id?: string; name?: string; since?: string } = { mode: 'count' };
+    const chain = {
+      upsert(row: Partial<Row>) {
+        state.mode = 'upsert';
+        state.row = row;
+        return chain;
+      },
+      delete() {
+        state.mode = 'delete';
+        return chain;
+      },
+      eq(column: string, value: string) {
+        if (column === 'id') state.id = value;
+        if (column === 'sandbox_name') state.name = value;
+        return chain;
+      },
+      gt(column: string, value: string) {
+        if (column === 'expires_at') state.since = value;
+        return chain;
+      },
+      select(_columns: string, _opts?: { count?: string; head?: boolean }) {
+        return chain;
+      },
+      async single() {
+        seq += 1;
+        const key = `${state.row?.sandbox_name}:${state.row?.holder_key}`;
+        const existing = rows.find((r) => `${r.sandbox_name}:${r.holder_key}` === key);
+        if (existing) {
+          existing.expires_at = state.row!.expires_at!;
+          return { data: { id: existing.id }, error: null };
+        }
+        const row: Row = {
+          id: `h${seq}`,
+          sandbox_name: state.row!.sandbox_name!,
+          holder_key: state.row!.holder_key!,
+          kind: state.row!.kind!,
+          expires_at: state.row!.expires_at!
+        };
+        rows.push(row);
+        return { data: { id: row.id }, error: null };
+      },
+      async maybeSingle() {
+        const i = rows.findIndex((r) => r.id === state.id);
+        if (i === -1) return { data: null, error: null };
+        const [row] = rows.splice(i, 1);
+        return { data: { sandbox_name: row.sandbox_name }, error: null };
+      },
+      async then(resolve: (v: { count: number | null }) => void) {
+        const live = rows.filter(
+          (r) => (!state.name || r.sandbox_name === state.name) && (!state.since || r.expires_at > state.since)
+        );
+        resolve({ count: live.length });
+      }
+    };
+    return chain;
+  };
+
+  return { db: { from: builder } as never, rows, stop };
+}
+
+const BASE = { name: 'anomalia-vm-g5', brandId: 'b1', kind: 'turn' as const };
+
+describe('acquireHolder', () => {
+  it('una seconda acquire con la stessa chiave rinfresca, non duplica', async () => {
+    const f = fakeDb();
+    const call = { ...BASE, key: 'desktop:ag1', kind: 'desktop' as const, ttlMs: 120_000, db: f.db };
+    const first = await acquireHolder(call);
+    const second = await acquireHolder(call);
+    expect(f.rows).toHaveLength(1);
+    expect(second).toBe(first);
+  });
+});
+
+describe('releaseHolder', () => {
+  it("l'ultimo holder che esce spegne la macchina", async () => {
+    const f = fakeDb();
+    const id = await acquireHolder({ ...BASE, key: 'turn:r1', ttlMs: 60_000, db: f.db });
+    
+    await releaseHolder(id!, { stop: f.stop }, f.db);
+    
+    expect(f.stop).toHaveBeenCalledTimes(1);
+    expect(f.rows).toHaveLength(0);
+  });
+
+  it("due turni simultanei: il primo che esce non ferma la macchina dell'altro", async () => {
+    const f = fakeDb();
+    const a = await acquireHolder({ ...BASE, key: 'turn:r1', ttlMs: 60_000, db: f.db });
+    const b = await acquireHolder({ ...BASE, key: 'turn:r2', ttlMs: 60_000, db: f.db });
+    await releaseHolder(a!, { stop: f.stop }, f.db);
+    expect(f.stop).not.toHaveBeenCalled();
+    await releaseHolder(b!, { stop: f.stop }, f.db);
+    expect(f.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('un holder scaduto non tiene accesa la macchina', async () => {
+    const f = fakeDb();
+    f.rows.push({
+      id: 'h9',
+      sandbox_name: BASE.name,
+      holder_key: 'desktop:ag1',
+      kind: 'desktop',
+      expires_at: new Date(Date.now() - 60_000).toISOString()
+    });
+    const id = await acquireHolder({ ...BASE, key: 'turn:r1', ttlMs: 60_000, db: f.db });
+    await releaseHolder(id!, { stop: f.stop }, f.db);
+    expect(f.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('lo stop fallito non rompe la release', async () => {
+    const f = fakeDb();
+    f.stop.mockImplementationOnce(async () => {
+      throw new Error('stop exploded');
+    });
+    const id = await acquireHolder({ ...BASE, key: 'turn:r1', ttlMs: 60_000, db: f.db });
+    await expect(releaseHolder(id!, { stop: f.stop }, f.db)).resolves.toBeUndefined();
+  });
+
+  it('una release senza riga non chiama stop', async () => {
+    const f = fakeDb();
+    await releaseHolder('inesistente', { stop: f.stop }, f.db);
+    expect(f.stop).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/server/sandbox-leases.ts
+++ b/src/lib/server/sandbox-leases.ts
@@ -1,0 +1,99 @@
+/**
+ * CHI TIENE ACCESA LA MACCHINA, E QUANDO SPARLA.
+ *
+ * Vercel fattura la memoria della sandbox a orologio fino allo scadere del lease, idle incluso:
+ * un turno di 40 secondi su una VM con lease a 15 minuti ne paga 15. Da qui il contatore:
+ * ogni uso registra una riga, la macchina si spegne con `stop()` quando l'ultima esce.
+ *
+ * La riga SCADE: un processo serverless che muore a metà turno non lascia holder fantasma che
+ * bloccano lo stop per sempre. Un holder per ciclo di vita noto (turno, render) viene rilasciato
+ * alla fine; uno per ciclo di vita ignoto (chi guarda il desktop, la sessione harness) vive fino
+ * alla scadenza e il prossimo evento spegne la VM.
+ *
+ * Ogni funzione ingoia i suoi errori: un database morto non deve spezzare un turno di AI.
+ */
+import { createAdminClient } from '$lib/server/supabase-admin';
+import { swallow } from '$lib/server/swallow';
+
+const TABLE = 'sandbox_holders';
+
+/** Il pannello ripassa ogni ~2.5s: il TTL deve coprire più poll, non più di tanto. */
+export const DESKTOP_HOLDER_TTL_MS = 120_000;
+
+/**
+ * L'holder di chi guarda il desktop. Nessuna release: il ciclo di vita lo conosce solo il browser,
+ * quindi la riga scade da sola e ogni poll la rinfresca. Se il tab muore, la VM si spegne al
+ * prossimo evento di contabilità — mai sotto gli occhi di chi la sta guardando.
+ */
+export function holdDesktop(name: string, brandId: string, agentId?: string): Promise<string | null> {
+  return acquireHolder({
+    name,
+    brandId,
+    key: `desktop:${agentId ?? 'brand'}`,
+    kind: 'desktop',
+    ttlMs: DESKTOP_HOLDER_TTL_MS
+  });
+}
+
+export type HolderKind = 'turn' | 'desktop';
+
+type Db = ReturnType<typeof createAdminClient>;
+type Stoppable = { stop: () => Promise<unknown> };
+
+async function stopWhenIdle(name: string, raw: Stoppable | undefined, db: Db): Promise<void> {
+  if (!raw) return;
+  try {
+    const { count } = await db
+      .from(TABLE)
+      .select('id', { count: 'exact', head: true })
+      .eq('sandbox_name', name)
+      .gt('expires_at', new Date().toISOString());
+    if (count === 0) await raw.stop();
+  } catch (err) {
+    swallow('stopIfIdle failed', err);
+  }
+}
+
+/**
+ * Registra (o rinfresca) un holder. La chiave deduplica: chi ripassa di qui — un poll del
+ * pannello desktop ogni 2.5s — rinfresca la scadenza della SUA riga invece di accumularne.
+ * Ritorna l'id della riga, o `null` se il database non c'è: il turno prosegue uguale.
+ */
+export async function acquireHolder(opts: {
+  name: string;
+  brandId: string;
+  key: string;
+  kind: HolderKind;
+  ttlMs: number;
+  db?: Db;
+}): Promise<string | null> {
+  try {
+    const db = opts.db ?? createAdminClient();
+    const expires_at = new Date(Date.now() + opts.ttlMs).toISOString();
+    const { data, error } = await db
+      .from(TABLE)
+      .upsert(
+        { sandbox_name: opts.name, brand_id: opts.brandId, holder_key: opts.key, kind: opts.kind, expires_at },
+        { onConflict: 'sandbox_name,holder_key' }
+      )
+      .select('id')
+      .single();
+    if (error) return null;
+    return (data as { id: string }).id;
+  } catch {
+    return null;
+  }
+}
+
+/** Chiude il ciclo di vita: via la riga, e se era l'ultima la macchina si spegne. */
+export async function releaseHolder(id: string, raw: Stoppable | undefined, db?: Db): Promise<void> {
+  try {
+    const client = db ?? createAdminClient();
+    const { data } = await client.from(TABLE).delete().eq('id', id).select('sandbox_name').maybeSingle();
+    const name = data ? (data as { sandbox_name: string }).sandbox_name : null;
+    if (!name) return;
+    await stopWhenIdle(name, raw, client);
+  } catch {
+    // Il turno è già finito: una contabilità persa qui non rompe niente.
+  }
+}

--- a/src/lib/server/sandbox.test.ts
+++ b/src/lib/server/sandbox.test.ts
@@ -345,18 +345,17 @@ describe('una VM terminated non è riprendibile in volo', () => {
   });
 });
 
-describe('release() non spegne la macchina — decisione, non dimenticanza', () => {
+describe('release() spegne la macchina solo quando è l’ultimo holder', () => {
   /**
-   * I docs di Vercel dicono l'opposto («Call sandbox.stop() when done rather than waiting for
-   * timeout») e la mediana di un turno è 40,6 s contro un lease che dura sempre fino a 900 s: la
-   * differenza è reale e si paga. Ma la sandbox è del BRAND e la condividono turni che vivono in
-   * processi diversi: chi finisce prima staccherebbe la corrente all'altro, e non esiste un
-   * refcount fuori processo che sappia dire «sono l'ultimo». Finché non esiste, non si spegne.
+   * Le docs di Vercel dicono «Call sandbox.stop() when done» e la mediana di un turno è 40,6 s
+   * contro un lease fino a 900 s: la differenza si paga. Ma la VM è condivisa: uno `stop()` diretto
+   * spegnerebbe la macchina sotto un altro turno o sotto chi guarda il desktop. La decisione sta in
+   * `releaseHolder` (sandbox-leases.ts), che conta gli holder vivi e ferma solo l'ultima uscita.
    *
-   * Questo test rifiuta l'imitazione: il giorno in cui qualcuno «ottimizza» aggiungendo uno
-   * `stop()`, fallisce qui invece che in produzione, su un comando di un altro turno.
+   * Questo test rifiuta l'imitazione: uno `stop()` inline qui torna a pagare lease interi per
+   * turni brevi E a spegnere la VM sotto gli altri — fallisce qui, non in produzione.
    */
-  it('nessuno `.stop()` nel codice di sandbox.ts', async () => {
+  it('nessuno `.stop()` diretto nel codice di sandbox.ts', async () => {
     const { readFileSync } = await import('node:fs');
     const src = readFileSync(new URL('./sandbox.ts', import.meta.url), 'utf8');
     // Solo il CODICE: nei commenti la citazione dei docs contiene `sandbox.stop()` apposta.
@@ -367,10 +366,10 @@ describe('release() non spegne la macchina — decisione, non dimenticanza', () 
     expect(code).not.toMatch(/\.stop\s*\(/);
   });
 
-  it('e la ragione è scritta accanto, o fra sei mesi sembra una svista da correggere', async () => {
+  it('e la mano alla contabilità c’è: la release passa la VM a chi conta gli holder', async () => {
     const { readFileSync } = await import('node:fs');
     const src = readFileSync(new URL('./sandbox.ts', import.meta.url), 'utf8');
-    expect(src).toContain('Call sandbox.stop() when done rather than waiting for timeout');
-    expect(src).toContain('refcount');
+    expect(src).toContain('releaseHolder(holderId');
+    expect(src).toContain("from './sandbox-leases'");
   });
 });

--- a/src/lib/server/sandbox.ts
+++ b/src/lib/server/sandbox.ts
@@ -18,6 +18,7 @@
  */
 import { swallow } from '$lib/server/swallow';
 import { env } from '$env/dynamic/private';
+import { acquireHolder, releaseHolder } from './sandbox-leases';
 import { DESKTOP_PORT, DISPLAY, X_SOCKET } from '@anomalia/agent-adapters/graphical-bootstrap';
 
 /** `research` è l'UNICO profilo con internet aperto: `compute` e `agent` vedono solo i registry. */
@@ -132,7 +133,7 @@ export const SANDBOX_MAX_LEASE_MS = 15 * 60_000;
 
 /** Retention degli snapshot. Qui e non inline, perché `sandboxConfigDrift` deve confrontarli. */
 export const SNAPSHOT_EXPIRATION_MS = 7 * 24 * 60 * 60_000;
-export const KEEP_LAST_SNAPSHOTS = { count: 2 } as const;
+export const KEEP_LAST_SNAPSHOTS = { count: 1 } as const;
 
 export function isSandboxConfigured(): boolean {
   if (env.SANDBOX_DISABLED === '1') return false;
@@ -380,17 +381,16 @@ export type SandboxHandle = {
   read(path: string): Promise<string>;
   readBuffer(path: string): Promise<Buffer>;
   /**
-   * Chiude la RUN, non la macchina — e **non è una dimenticanza**.
+   * Chiude il ciclo di vita del chiamante: via la directory della run e via l'holder.
    *
-   * I docs dicono l'opposto (*«Call sandbox.stop() when done rather than waiting for timeout»*) e
-   * il conto è reale: mediana di un turno 40,6 s contro un lease fino a 900 s. Ma quella VM è del
-   * BRAND e due turni girano in due PROCESSI diversi: chi finisce prima staccherebbe la corrente
-   * all'altro. Il risveglio automatico di v2 non copre il caso — `withResume` riprende solo su un
-   * 410/422 di richiesta, non su un comando già in volo, che vede uno stream troncato.
+   * NON chiama `sandbox.stop()` direttamente: la VM è condivisa e un altro holder — un turno
+   * simultaneo, chi guarda il desktop — può essere ancora vivo. È `releaseHolder` a decidere:
+   * cancellata la riga di questo chiamante, se era l'ultima la macchina si spegne; altrimenti
+   * resta accesa per chi la usa. Gli holder scadono da soli (vedi `sandbox-leases.ts`), quindi un
+   * processo serverless morto a metà turno non la tiene accesa per sempre.
    *
-   * Spegnere diventa lecito il giorno in cui esiste un refcount fuori processo (contatore per nome
-   * in Postgres/Redis, `stop()` a zero). Finché non c'è, la spegne il suo `timeout`.
-   * `sandbox.test.ts` fa fallire un `.stop()` aggiunto qui.
+   * Il lease di `SANDBOX_MAX_LEASE_MS` resta la rete di sicurezza: se lo stop o la contabilità
+   * falliscono, la macchina muore comunque alla scadenza.
    */
   release(): Promise<void>;
 };
@@ -672,6 +672,16 @@ export async function openBrandSandbox(opts: {
 
   const root = runRootFor(opts.runId);
 
+  // L'holder di QUESTO chiamante. Chiave per run: riaperture della stessa run rinfrescano la riga
+  // invece di accumularne. La release dell'handle la cancella e, se era l'ultima, spegne la VM.
+  const holderId = await acquireHolder({
+    name,
+    brandId: opts.brandId,
+    key: `turn:${opts.runId}`,
+    kind: 'turn',
+    ttlMs: SANDBOX_MAX_LEASE_MS
+  });
+
   const handle: SandboxHandle = {
     name,
     mode: opts.mode,
@@ -725,6 +735,7 @@ export async function openBrandSandbox(opts: {
     async release() {
       // Lo snapshot deve contenere Chromium e i pacchetti, non il workspace di un brand.
       await handle.run('rm', ['-rf', root]).catch(swallow('handle.run failed'));
+      if (holderId) await releaseHolder(holderId, sandbox as unknown as { stop: () => Promise<unknown> });
     }
   };
 

--- a/src/routes/app/[brand]/agents/computer/desktop/+server.ts
+++ b/src/routes/app/[brand]/agents/computer/desktop/+server.ts
@@ -18,6 +18,7 @@ import { ensureGraphicalMode, ensureRemoteDesktop } from '$lib/agent/adapters/gr
 import { createVercelSandboxProvider, graphicalBootstrapDeps, sandboxPortUrl } from '$lib/agent/bridge/adapters';
 import { desktopPassword, desktopUrl, publishComputerRunning } from '$lib/server/agent-desktop';
 import { SANDBOX_MAX_LEASE_MS } from '$lib/server/sandbox';
+import { holdDesktop } from '$lib/server/sandbox-leases';
 import { createAdminClient } from '$lib/server/supabase-admin';
 import { env } from '$env/dynamic/private';
 import type { AdapterContext } from '$lib/agent/kit/types';
@@ -49,6 +50,9 @@ export const POST: RequestHandler = async ({ params, url, locals: { supabase, sa
 	// con i 5 minuti di default la macchina gli muore sotto senza dire niente. La pagina ripassa
 	// di qui a intervalli per tenerla viva (`update` alza la scadenza anche a sessione in corso).
 	const ref = await sandbox.provision({ brandId: brand.id, agentId, timeoutMs: SANDBOX_MAX_LEASE_MS }, ctx);
+	// Chi guarda è un holder: finché il pannello ripassa di qui, la VM resta accesa anche se nessun
+	// turno è in corso. Il TTL scade da solo quando il tab muore.
+	await holdDesktop(ref.name, brand.id, agentId);
 	// Lo stato lo scrive il service role: `agent_computers` è in sola lettura per i membri (0217),
 	// e senza questa riga il pannello continuerebbe a dire «dorme» col desktop acceso davanti.
 	await publishComputerRunning(createAdminClient(), brand.id, ref.name, agentId);

--- a/src/routes/app/[brand]/agents/computer/screen/+server.ts
+++ b/src/routes/app/[brand]/agents/computer/screen/+server.ts
@@ -20,6 +20,7 @@ import { swallow } from '$lib/server/swallow';
 import { bilingualNoticeLocale } from '$lib/i18n/locale';
 import { captureScreenshot, ensureGraphicalMode } from '$lib/agent/adapters/graphical-bootstrap';
 import { createVercelSandboxProvider, graphicalBootstrapDeps } from '$lib/agent/bridge/adapters';
+import { holdDesktop } from '$lib/server/sandbox-leases';
 import type { AdapterContext } from '$lib/agent/kit/types';
 import type { RequestHandler } from './$types';
 
@@ -54,6 +55,8 @@ export const GET: RequestHandler = async ({ params, url, locals: { supabase, saf
 		const sandbox = createVercelSandboxProvider();
 		const ctx: AdapterContext = { brandId: brand.id, userId: user.id, runId: 'computer-screen', locale: bilingualNoticeLocale(uiLocale), agentId: url.searchParams.get('agent') || undefined };
 		const ref = await sandbox.provision({ brandId: brand.id, agentId: url.searchParams.get('agent') || undefined }, ctx);
+		// Il poll è il battito di chi guarda: rinfresca l'holder del desktop mentre la pagina è viva.
+		await holdDesktop(ref.name, brand.id, url.searchParams.get('agent') || undefined);
 		let shot = await captureScreenshot(sandbox, ref, ctx);
 		// Xvfb muore col riavvio della VM ma il marker resta: la cattura fallisce con «unable to
 		// open X server» per sempre, finché nessuno rilancia i processi. Il rilancio è la parte

--- a/supabase/migrations/20260829120000_sandbox_holders.sql
+++ b/supabase/migrations/20260829120000_sandbox_holders.sql
@@ -1,0 +1,17 @@
+-- Chi tiene viva una sandbox, per nome macchina. Righe con expires_at nel futuro = holder vivi;
+-- a zero la macchina si spegne subito invece di correre fino al lease.
+create table if not exists public.sandbox_holders (
+  id uuid primary key default gen_random_uuid(),
+  sandbox_name text not null,
+  brand_id uuid not null,
+  holder_key text not null,
+  kind text not null default 'turn',
+  expires_at timestamptz not null,
+  created_at timestamptz not null default now()
+);
+
+create unique index if not exists sandbox_holders_name_key_idx
+  on public.sandbox_holders (sandbox_name, holder_key);
+
+-- Nessuna policy: scrive solo il service role. I membri non leggono la contabilità delle VM.
+alter table public.sandbox_holders enable row level security;


### PR DESCRIPTION
## What?
A sandbox VM now powers down as soon as the last user of that machine finishes, instead of running until its 15-minute lease expires. A new `sandbox_holders` table counts who is using each machine: turns and renders release their holder when done, and `releaseHolder` calls `sandbox.stop()` when the count reaches zero. The desktop panel and its screen poll act as expiring holders, so watching an agent's live desktop keeps the VM awake and closing the tab lets it power down. Snapshot retention drops from 2 kept snapshots to the docs-recommended 1.

## Why?
Vercel bills provisioned memory for the full lease, idle included (docs: "billed for the full time it runs, even while idle", 1-minute increments). The median chat turn touches the VM for ~40 seconds but paid up to 900 seconds of idle memory per cold start — roughly 4x waste on every short turn, with no benefit. Vercel's own pricing page says "Call sandbox.stop() when done rather than waiting for timeout", and persistent-sandbox auto-resume makes stopping safe: the next SDK call restarts the session from the snapshot. The old code comment forbade `stop()` only because an out-of-process refcount didn't exist yet — this PR builds exactly that unlock.

## How?
- **Expiring rows, not a bare counter** (`sandbox_holders.expires_at`): a crashed serverless process cannot pin a VM forever. Live holders are rows with `expires_at > now()`.
- **Keyed upsert** on `(sandbox_name, holder_key)`: the desktop panel polls every ~2.5s and each poll refreshes its own row — the upsert IS the heartbeat, no frontend changes.
- **Stop lives in `releaseHolder`, never inline** in `sandbox.ts`: stopping is a bookkeeping decision, not something whoever finishes first gets to do. A guardian test keeps `.stop()` out of sandbox.ts code (updated from the old guardian that forbade stopping entirely).
- **One integration point**: `openBrandSandbox` acquires on open (key `turn:<runId>`, TTL = max lease), `handle.release()` releases — chat, render and bridge paths inherit without changes. The desktop route adds a `desktop:<agentId>` holder (TTL 120s, refreshed by screen polls).
- **Costs charged to users are untouched**: `withSandboxBilling` still meters measured work, so billing symmetricy improves on its own.
- Rejected: cron reaper (minutes of extra idle per stop) and per-use short leases (with safe stop, each fresh session starts with the right lease; renders keep 15 minutes).

## Testing?
- New `sandbox-leases.test.ts` (6 tests, fake DB): last holder out stops the VM; two concurrent turns don't stop each other; expired holders don't count; a failed `stop()` never breaks the release; keyed re-acquire refreshes instead of duplicating. Written red-first (failed against the no-stop code) before the integration.
- Updated guardians: `sandbox.test.ts` release-decision tests now enforce the refcount delegation; `sandbox-config.test.ts` fake VMs aligned to snapshot count 1.
- Full unit suite: **5882 tests, 512 files, all green**.
- `scripts/schema-drift-check.mjs`: only remaining divergence for this branch was the new table, applied manually (deploys don't run migrations); Postgres security advisor reports no findings on it (RLS on, no policies, service-role only).
- Not tested: live Vercel billing behavior (needs a production day of data — `sandbox.*` rows in `ai_calls` vs the Vercel invoice is the comparison to run next); desktop E2E with a real VNC session (no local sandbox stack).

## Evidence (screenshots/videos)
<details>
<summary>Unit suite + focused sandbox tests (all green)</summary>

```
 npm run test:unit
 Test Files  512 passed (512)
      Tests  5882 passed (5882)
```
```
npx vitest run src/lib/server/sandbox-leases.test.ts
 Test Files  1 passed (1)
      Tests  6 passed (6)
```
</details>
<details>
<summary>Schema drift check — new table applied, no code/schema mismatch</summary>

```
supabase/migrations/20260829120000_sandbox_holders.sql applied
```
</details>
<details>
<summary>Cost model (from Vercel pricing, iad1)</summary>

```
Provisioned memory: $0.0212/GB-hr → 4 GB (2 vCPU) = $0.00141/min
Cold-start turn today: 900s lease × $0.00141 ≈ $0.021  (median work: 40.6s)
With stop-at-zero:     40s × $0.00141   ≈ $0.001
Savings on a short turn: ≈ 95% of the memory tail
```
</details>

## Anything Else?
Desktop holders expire (120s TTL) rather than release: after a viewer closes the tab the VM lives at most until the next bookkeeping event or the lease, whichever comes first — bounded, and never under the viewer's eyes. A follow-up worth doing once production data accumulates: recalibrate the per-second sandbox rate in `sandbox-credits.ts` against the real Vercel invoice.