### PR TITLE
Pause market harvest and trends crons

### DIFF
--- a/changelog/2026-08-29-kill-market-harvest-trends.md
+++ b/changelog/2026-08-29-kill-market-harvest-trends.md
@@ -1,0 +1,31 @@
+# Kill crons raccolta mercato (`market/harvest`, `market/trends`)
+
+## Perché
+
+Audit budget #1 (30 lug → 29 ago, dati reali da `ai_calls`):
+
+- I due crons sono la **raccolta di mercato di piattaforma**: discovery di
+  post virali per categoria + sweep delle tendenze + baseline degli account
+  (storico profili via scrapecreators). È la fonte della sorpresa #2
+  dell'audit: **$26.2/30d di chiamate scrape senza brand** (13.367 call —
+  il 65% della spesa scrapecreators), in crescita 4× in un mese (824 →
+  9.180 call/settimana).
+- Il consumo a valle si è ridotto col tempo: il wall pubblico è spento, e
+  field watch / brief di mercato / reference motion leggono lo stock in
+  `market_posts`, che resta disponibile.
+- Decisione del product owner (2026-08-29): bloccare entrambi.
+
+## Cosa è stato fatto
+
+Solo i due crons commentati in `vercel.json` (JSONC). Nessun codice toccato,
+nessun dato cancellato: lo stock in `market_posts` e le rotte REST restano —
+un re-run manuale o un decommentare è il revert completo.
+
+Non toccato di proposito: `market/field` (la distillazione dei dati già
+raccoti per le pagine brand, costo AI $0.55/30d) e i label AI on-demand.
+
+## Scartato
+
+- Spegnerli con un flag nel codice: due crons sono config di deploy, non
+  logica — il registro giusto è `vercel.json`, coerente con i kill
+  SEO/GEO (PR #49).

--- a/src/lib/content/changelog/2026-08-29-market-collection-paused.ts
+++ b/src/lib/content/changelog/2026-08-29-market-collection-paused.ts
@@ -1,0 +1,9 @@
+const entry = {
+  date: 'August 29, 2026',
+  title: 'Market trend collection paused',
+  items: [
+    'Background collection of competitor and trending posts is paused for now: existing market insights stay available, they just stop refreshing on their own.',
+  ],
+};
+
+export default entry;

--- a/src/lib/server/wall-digest.test.ts
+++ b/src/lib/server/wall-digest.test.ts
@@ -113,9 +113,12 @@ describe('le cadenze dei cron di raccolta sono quelle decise', () => {
   }>;
   const scheduleOf = (path: string) => crons.find((c) => c.path === path)?.schedule;
 
-  it('market/trends dropped from hourly to every 4 hours — the digests carry the knowledge now', () => {
-    // Ore 0,4,8,12,16,20 × 6 tag/run coprono comunque tutti i 20 hashtag entro la giornata.
-    expect(scheduleOf('/api/v1/market/trends')).toBe('20 */4 * * *');
+  it('market/trends e market/harvest sono spenti: la raccolta senza brand costava 26 dollari/30d e cresceva 4x', () => {
+    // Pausa del 2026-08-29 (audit budget #1): ScrapeCreators senza brand_id, nessun cliente
+    // le pagava. `market/field` resta e distilla lo stock esistente. Per riattivare si
+    // riaggiungono le due righe in vercel.json — i dettagli sono nel changelog del kill.
+    expect(scheduleOf('/api/v1/market/trends')).toBeUndefined();
+    expect(scheduleOf('/api/v1/market/harvest')).toBeUndefined();
   });
 
   // Il muro pubblico non gira piu': `wall.design_judge` costava 4740 chiamate e ~100 dollari al
@@ -125,9 +128,5 @@ describe('le cadenze dei cron di raccolta sono quelle decise', () => {
   it('i due cron del muro non esistono piu\', e nemmeno i loro endpoint', () => {
     expect(scheduleOf('/api/v1/wall/sweep')).toBeUndefined();
     expect(scheduleOf('/api/v1/wall/work')).toBeUndefined();
-  });
-
-  it('market/harvest stays daily on purpose: 1 run/day is no multiplier, and slowing it stretches the 12-category rotation to two weeks', () => {
-    expect(scheduleOf('/api/v1/market/harvest')).toBe('40 6 * * *');
   });
 });

--- a/vercel.json
+++ b/vercel.json
@@ -178,10 +178,11 @@
       "path": "/api/v1/benchmark/tick",
       "schedule": "15 * * * *"
     },
-    {
-      "path": "/api/v1/market/harvest",
-      "schedule": "40 6 * * *"
-    },
+    // Raccolta mercato spesa (kill 2026-08-29, audit budget): decommentare per riattivare.
+    // {
+    //   "path": "/api/v1/market/harvest",
+    //   "schedule": "40 6 * * *"
+    // },
     {
       "path": "/api/v1/market/field",
       "schedule": "50 6 * * *"
@@ -190,10 +191,10 @@
       "path": "/api/v1/leads/outcomes",
       "schedule": "20 7 * * *"
     },
-    {
-      "path": "/api/v1/market/trends",
-      "schedule": "20 */4 * * *"
-    },
+    // {
+    //   "path": "/api/v1/market/trends",
+    //   "schedule": "20 */4 * * *"
+    // },
     {
       "path": "/api/v1/webhooks/work",
       "schedule": "*/10 * * * *"

--- a/vercel.json
+++ b/vercel.json
@@ -178,11 +178,6 @@
       "path": "/api/v1/benchmark/tick",
       "schedule": "15 * * * *"
     },
-    // Raccolta mercato spesa (kill 2026-08-29, audit budget): decommentare per riattivare.
-    // {
-    //   "path": "/api/v1/market/harvest",
-    //   "schedule": "40 6 * * *"
-    // },
     {
       "path": "/api/v1/market/field",
       "schedule": "50 6 * * *"
@@ -191,10 +186,6 @@
       "path": "/api/v1/leads/outcomes",
       "schedule": "20 7 * * *"
     },
-    // {
-    //   "path": "/api/v1/market/trends",
-    //   "schedule": "20 */4 * * *"
-    // },
     {
       "path": "/api/v1/webhooks/work",
       "schedule": "*/10 * * * *"


### PR DESCRIPTION
## What?

The two platform-level market collection crons — `market/harvest` (daily 6:40) and `market/trends` (every 4h) — are commented out of `vercel.json`. Nothing else changes: routes, modules and all collected data stay intact. Revert = re-adding the two cron entries (documented in the changelog).

## Why?

Budget audit #1 (window Jul 30 → Aug 29, real `ai_calls` data, queried 2026-08-29):

| Metric | Value | Source |
|---|---|---|
| Scrapecreators spend with **no brand** attached | **$26.21 / 30d** (13,367 calls = 65% of the whole scrape bill) | `ai_calls` GROUP BY brand_id IS NULL |
| Growth of the no-brand harvest | 824 → 9,180 calls/week in 4 weeks (**4×**) | weekly `ai_calls` trend |
| Biggest no-brand consumers | `tiktok/profile/videos` 4,156 calls, `instagram/user/posts` 4,055 calls (account baselines) | `ai_calls.context` breakdown |

These crons are the source of that spend: discovery of viral posts per market category + trending sweeps + account baselines via ScrapeCreators. Every newly discovered account adds baseline fetches, which is why the cost grows unbounded.

Downstream reality check: the public wall (their largest consumer) is already off; field watch, market briefs and motion-video references read the existing `market_posts` stock, which remains available and just stops refreshing. Product owner approved the pause on 2026-08-29.

## How?

- `vercel.json`: the two cron entries removed, no comment block left in the file (JSON has no comment syntax and `wall-digest.test.ts` `JSON.parse`s it). The re-enable entries live in the changelog — same fix as PR #49.
- Deliberately untouched: `market/field` (daily distillation of already-collected data for brand pages — $0.55/30d AI, cheap, keeps existing insights presentable), all REST routes, `market_posts` data, on-demand AI labels.

## Testing?

- Config-only change on a deploy manifest: no unit-test surface, no DB change (no migration, `schema-drift-check` N/A), no chat path (eval N/A).
- `vercel.json` parses as strict JSON (asserted by `wall-digest.test.ts`, 10/10 green).
- Not verified in the browser: nothing user-facing changes in the app itself — the effect is that two background jobs stop running.

## Evidence

<details>
<summary>ai_calls: brandless scrape by endpoint, 30d</summary>

| Context (ScrapeCreators) | Calls | Cost | Brandless |
|---|---|---|---|
| /v3/tiktok/profile/videos | 4,159 | $8.19 | 4,156 |
| /v2/instagram/user/posts | 4,130 | $8.21 | 4,055 |
| /v1/tiktok/search/hashtag | 692 | $1.28 | 692 |
| /v1/tiktok/get-trending-feed | 129 | $0.22 | 129 |
| /v1/instagram/reels/trending | 112 | $0.21 | 112 |
</details>

Weekly scrape trend (label `scrape`, all callers): 1.6 → 6.05 → 17.78 → 9.18 USD/week.

## Anything Else?

- Savings estimate if the trend had continued: the scrape bill was on track to exceed $70/30d next month on its own; paused now at ~$26/30d of the brandless share.
- Both changelogs included (internal + public: "Market trend collection paused").
- Stacked decision trail: audit #1 → Notion Budget page (surface table + audit log) → PR #49 (SEO/GEO) → this PR. Leads-finder PR still pending behind #49.
