### PR TITLE
Fix form actions for pages hosted in the settings modal

### DIFF
--- a/changelog/2026-08-29-page-modal-form-actions.md
+++ b/changelog/2026-08-29-page-modal-form-actions.md
@@ -1,0 +1,20 @@
+# Fix azioni form nel PageModal
+
+Le sezioni impostazioni aperte nel modal ospitano la `+page.svelte` vera senza
+cambiare l'URL del browser. I form di quelle pagine usano action relativi
+(`?/disconnect`): SvelteKit li risolve contro l'URL corrente, che nella modal
+non è mai la rotta ospitata — il POST andava alla pagina sotto e il server
+rispondeva 404 "No action with name 'disconnect' found".
+
+Fix a livello di modal, non pagina per pagina (42 action su 21 sezioni
+avrebbero avuto lo stesso difetto):
+
+- capture sul submit che riscrive `action`/`formaction` relativi sulla rotta
+  ospitata prima che `use:enhance` li legga;
+- patch di `fetch` (solo mentre la modal è aperta, solo per POST alla rotta
+  ospitata) che applica il risultato a `page.form` via `applyAction`: il
+  fallback di SvelteKit salta `applyAction` quando il pathname non coincide,
+  e senza quello né i toast né il ricarico della sezione partirebbero.
+
+Scartato il fix pagina per pagina con URL assoluti: anche con l'action giusto
+il risultato non sarebbe arrivato a `page.form`, stesso sintomo.

--- a/src/lib/components/PageModal.svelte
+++ b/src/lib/components/PageModal.svelte
@@ -44,6 +44,7 @@
   import { setContext } from 'svelte';
   import { writable } from 'svelte/store';
   import { preloadData } from '$app/navigation';
+  import { applyAction, deserialize } from '$app/forms';
   import { _ } from 'svelte-i18n';
   import { fade, scale } from 'svelte/transition';
   import XIcon from '@lucide/svelte/icons/x';
@@ -180,6 +181,49 @@
     loadError = null;
   }
 
+  /**
+   * Le azioni delle pagine ospitate sono relative (`?/disconnect`) e SvelteKit le risolve
+   * contro l'URL del BROWSER — che nella modal non è mai la rotta ospitata → 404
+   * "No action". Riscriviamo form/button sulla rotta vera in fase di submit (capture,
+   * prima che `use:enhance` legga `action`), e applichiamo noi il risultato a `page.form`:
+   * il fallback di SvelteKit salta `applyAction` quando il pathname non coincide, e senza
+   * quello né i toast né il ricarico della sezione partirebbero.
+   */
+  const actionUrlFor = (relative: string) =>
+    routeSearch ? `${base}/${route}${routeSearch}&${relative.slice(1)}` : `${base}/${route}${relative}`;
+
+  function onFormSubmitCapture(e: SubmitEvent) {
+    if (route === null) return;
+    const rewrite = (el: Element, attr: 'action' | 'formaction') => {
+      const value = el.getAttribute(attr);
+      if (value?.startsWith('?/')) el.setAttribute(attr, actionUrlFor(value));
+    };
+    if (e.target instanceof HTMLFormElement) rewrite(e.target, 'action');
+    if (e.submitter) rewrite(e.submitter, 'formaction');
+  }
+
+  $effect(() => {
+    const nativeFetch: typeof window.fetch = window.fetch.bind(window);
+    window.fetch = async (input, init) => {
+      const res = await nativeFetch(input as RequestInfo, init);
+      try {
+        const r = route;
+        const url = new URL(input instanceof Request ? input.url : String(input), location.origin);
+        const method = init?.method ?? (input instanceof Request ? input.method : 'GET');
+        if (r && method.toUpperCase() === 'POST' && url.pathname === `${base}/${r}` && res.ok) {
+          const result = deserialize(await res.clone().text());
+          if (result.type === 'success' || result.type === 'failure') void applyAction(result);
+        }
+      } catch {
+        // risposta non-azione (o body non JSON): passa indietro intatta
+      }
+      return res;
+    };
+    return () => {
+      window.fetch = nativeFetch;
+    };
+  });
+
   // Il marker su <html> dice "da adesso un click su una pagina del brand apre la modal invece di
   // navigare": prima dell'idratazione i link sono link normali e nessun JS può impedirlo, quindi
   // lo si dichiara invece di fingere. scripts/settings-modal-check.mjs lo aspetta prima di cliccare.
@@ -291,7 +335,7 @@
   });
 </script>
 
-<svelte:window onclickcapture={onClickCapture} onkeydown={onKeydown} />
+<svelte:window onclickcapture={onClickCapture} onkeydown={onKeydown} onsubmitcapture={onFormSubmitCapture} />
 
 <!-- Mai un corpo vuoto e muto: se la sezione non si carica lo si dice, con la via d'uscita verso
      la pagina piena. È l'UNICA uscita da un carico fallito, per questo `app.settings.modalExpand`

--- a/src/lib/content/changelog/2026-08-29-page-modal-form-actions.ts
+++ b/src/lib/content/changelog/2026-08-29-page-modal-form-actions.ts
@@ -1,0 +1,9 @@
+import type { ChangelogEntry } from './index';
+
+const entry: ChangelogEntry = {
+  date: '2026-08-29',
+  title: 'Settings modal fixes',
+  items: ['Actions like disconnecting a social account now work inside the settings modal']
+};
+
+export default entry;


### PR DESCRIPTION
## What?
Form actions inside pages hosted in the settings modal (PageModal) now target the hosted route instead of the page underneath. Fixes the 404 `No action with name 'disconnect' found` when removing a connected social account from Settings → Connected accounts.

## Why?
Every settings section opened in the modal was broken for any write action — the browser URL never changes in the modal, so relative `?/action` forms posted to the current URL, which has no actions.

## How?
Systemic fix in `PageModal.svelte`, not per-page:
- Submit capture listener rewrites relative `action`/`formaction` onto the hosted route before `use:enhance` reads them.
- A scoped `fetch` patch (active only while the modal is open, only for POSTs to the hosted route) applies the action result via `applyAction` — SvelteKit skips it when the pathname doesn't match, which would have left toasts and list refresh dead.
- Rejected alternative: absolute action URLs per page. Even with the right URL, `page.form` would never update, same symptom.

## Testing?
- `npm run check`: no errors in the touched file (pre-existing errors elsewhere untouched).
- Manual: disconnect flow in Settings → Connected accounts inside the modal to be re-verified in the browser by the reporter.

## Evidence (screenshots/videos)
Pending browser retest by the reporter — will attach.

## Anything Else?
Same latent bug affected all 21 hosted sections (42 form actions); fix covers them all at once. Two changelog entries included per repo convention.