### PR TITLE
Restore Designer section in the brand sidebar

### DIFF
--- a/changelog/2026-08-29-designer-nav.md
+++ b/changelog/2026-08-29-designer-nav.md
@@ -1,0 +1,24 @@
+# Designer di nuovo in sidebar
+
+La sezione Designer era uscita dalla nav (2026-08-22) per scelta: le pagine
+restavano su disco e raggiungibili dai link della chat, da `propose_open_tab` e
+da ⌘K. Questa modifica la rimette in sidebar come prima.
+
+Cosa c'era prima: la voce mancava da `macros` (nav legacy, flag
+`FEATURE_NAV_TEAM` OFF) e da `HUB_TABS`/`WORKBENCH_PAGES`/`WORKBENCH_HUBS` in
+`workbench-paths.ts`. Pagine e i18n (`app.hub.designer.*`, `app.hub.overview.designer.*`)
+sono sempre esistite: la landing `/designer` con le sue quattro card e le rotte
+`media-generator`, `ugc-creator`, `motion-video`, `media`.
+
+Decisioni:
+- Ripristino nel percorso legacy (quello attivo col flag OFF, che è il default):
+  voce di `macros` con icona `Sparkles` + riga di `HUB_TABS.designer`. I pin del
+  test `workbench-paths.test.ts` (HUB_TABS e WORKBENCH_HUBS.length) son stati
+  aggiornati di conseguenza.
+- La nav "La squadra" (flag ON) resta com'era: `NAV_TEAM_TOOLS` la escludeva
+  per scelta ("non deve tornare col flag"). Non l'ho toccata: è una gerarchia
+  diversa e spenta di default. Se in futuro si vuole, è un secondo intervento.
+
+Scartato: aggiungere Designer alla nav team nel stesso commit — sarebbe stato
+un cambio di gerarchia (flag ON) mescolato a un ripristino del percorso legacy
+(flag OFF), due comportamenti distinti da valutare a parte.

--- a/src/lib/components/CommandPalette.svelte
+++ b/src/lib/components/CommandPalette.svelte
@@ -217,8 +217,8 @@
       }
     }
     // Solo le rotte che la nav conosce e quelle che si aprono in overlay. Le pagine a schermo
-    // pieno NON si cercano: se una sezione esce dalla nav (come Designer) le sue pagine escono
-    // anche da qui — è voluto, la palette non è un archivio di tutto ciò che esiste su disco.
+    // pieno NON si cercano: se una sezione esce dalla nav le sue pagine escono anche da qui —
+    // è voluto, la palette non è un archivio di tutto ciò che esiste su disco.
     for (const route of BRAND_MODAL_ROUTES) {
       const href = `${base}/${route}`;
       if (seen.has(href)) continue;

--- a/src/lib/content/changelog/2026-08-29-designer-nav.ts
+++ b/src/lib/content/changelog/2026-08-29-designer-nav.ts
@@ -1,0 +1,10 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-08-29',
+  title: 'Designer is back in the sidebar',
+  items: [
+    'The Designer section returns to the sidebar: Media generator, UGC Creator, Motion video and the media library are all one click away again.',
+    'The pages were still reachable through links and search, but now they sit where they used to, as a section of their own.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/workbench-paths.test.ts
+++ b/src/lib/workbench-paths.test.ts
@@ -58,9 +58,14 @@ describe('nav team (FEATURE_NAV_TEAM)', () => {
         { key: 'keywords', path: '/keywords' },
         { key: 'backlinks', path: '/backlinks' },
         { key: 'blog', path: '/site' }
+      ],
+      designer: [
+        { key: 'overview', path: '/designer' },
+        { key: 'mediaGenerator', path: '/media-generator' },
+        { key: 'ugcCreator', path: '/ugc-creator' },
+        { key: 'motionVideo', path: '/motion-video' },
+        { key: 'mediaLibrary', path: '/media' }
       ]
-      // Niente `designer`: la sezione è uscita dalla nav (2026-08-22). Le pagine restano su
-      // disco — le classifica page-modal-tiers.test.ts, non questo pin.
     });
   });
 
@@ -94,7 +99,7 @@ describe('nav team (FEATURE_NAV_TEAM)', () => {
     const spaces = NAV_TEAM_SPACES.map((t) => t.path);
     const tools = NAV_TEAM_TOOLS.map((t) => t.path);
     expect(spaces.filter((p) => tools.includes(p))).toEqual([]);
-    expect(WORKBENCH_HUBS.length).toBe(6);
+    expect(WORKBENCH_HUBS.length).toBe(7);
   });
 
   /**

--- a/src/lib/workbench-paths.ts
+++ b/src/lib/workbench-paths.ts
@@ -126,15 +126,18 @@ export const WORKBENCH_PAGES: WorkbenchPageDef[] = [
   { hub: 'web', segment: 'geo', labelKey: 'app.hub.web.geo' },
   { hub: 'web', segment: 'keywords', labelKey: 'app.hub.web.keywords' },
   { hub: 'web', segment: 'backlinks', labelKey: 'app.hub.web.backlinks' },
-  { hub: 'web', segment: 'site', labelKey: 'app.hub.web.blog' }
-  // Il hub `designer` non è più elencato: le pagine restano su disco e raggiungibili per link.
+  { hub: 'web', segment: 'site', labelKey: 'app.hub.web.blog' },
+  { hub: 'designer', segment: 'designer', labelKey: 'app.hub.designer.label' },
+  { hub: 'designer', segment: 'media-generator', labelKey: 'app.hub.designer.mediaGenerator' },
+  { hub: 'designer', segment: 'ugc-creator', labelKey: 'app.hub.designer.ugcCreator' },
+  { hub: 'designer', segment: 'motion-video', labelKey: 'app.hub.designer.motionVideo' },
+  { hub: 'designer', segment: 'media', labelKey: 'app.hub.designer.mediaLibrary' },
 ];
 
-export const WORKBENCH_HUBS: WorkbenchPageHub[] = ['brand', 'strategy', 'publish', 'web', 'ads', 'automations'];
+export const WORKBENCH_HUBS: WorkbenchPageHub[] = ['brand', 'strategy', 'publish', 'web', 'ads', 'automations', 'designer'];
 
 /**
  * Sotto-pagine di ogni hub (sidebar). Le chiavi combaciano con `app.hub.{hub}.{key}`.
- * `Partial` perché il hub `designer` non ha più una voce di nav: il tipo resta, la sua riga no.
  */
 export const HUB_TABS: Partial<Record<WorkbenchPageHub, { key: string; path: string; adsOnly?: boolean }[]>> = {
   brand: [
@@ -176,6 +179,13 @@ export const HUB_TABS: Partial<Record<WorkbenchPageHub, { key: string; path: str
     { key: 'keywords', path: '/keywords' },
     { key: 'backlinks', path: '/backlinks' },
     { key: 'blog', path: '/site' },
+  ],
+  designer: [
+    { key: 'overview', path: '/designer' },
+    { key: 'mediaGenerator', path: '/media-generator' },
+    { key: 'ugcCreator', path: '/ugc-creator' },
+    { key: 'motionVideo', path: '/motion-video' },
+    { key: 'mediaLibrary', path: '/media' },
   ],
 };
 

--- a/src/routes/app/[brand]/+layout.svelte
+++ b/src/routes/app/[brand]/+layout.svelte
@@ -16,6 +16,7 @@
   import FolderOpen from '@lucide/svelte/icons/folder-open';
   import Wrench from '@lucide/svelte/icons/wrench';
   import SettingsIcon from '@lucide/svelte/icons/settings';
+  import Sparkles from '@lucide/svelte/icons/sparkles';
   import { setCredits, refreshCredits } from '$lib/stores/credits';
   import WarningCenter from '$lib/components/WarningCenter.svelte';
   import ChatColumn from '$lib/components/ChatColumn.svelte';
@@ -376,8 +377,18 @@
       badge: 'leads' as const,
       also: [`${base}/automations`, `${base}/radar`, `${base}/leads`, `${base}/agents`],
     },
-    // Designer: fuori dalla nav per scelta. Le sue pagine restano vive e raggiungibili dai link
-    // della chat, da `propose_open_tab` e da ⌘K.
+    {
+      href: `${base}/designer`,
+      key: 'designer' as WorkbenchPageHub,
+      icon: Sparkles,
+      also: [
+        `${base}/designer`,
+        `${base}/media-generator`,
+        `${base}/ugc-creator`,
+        `${base}/motion-video`,
+        `${base}/media`,
+      ],
+    },
   ]);
 
   function isSubActive(href: string) {


### PR DESCRIPTION
## What?

Restores the **Designer** section in the `/app/[brand]` sidebar, with its sub-pages — Media generator, UGC Creator, Motion video, and the media library — visible again exactly as they were before the section was pulled from the nav.

The pages themselves never disappeared: their routes, hub overview and i18n keys all still exist. What had been removed was only the navigation entries, so this PR puts the navigational wiring back.

## Why?

The Designer hub was removed from the sidebar by choice (pages stayed reachable via chat links, agent `propose_open_tab`, and ⌘K). That left a discoverability gap: the product's own media/motion/UGC generators, some of its most-used tools, were no longer one click away. This reverses that specific decision so the tools return to where users expect to find them.

## How?

The active nav path is the **legacy macro nav** (`FEATURE_NAV_TEAM` is off by default), which is built from the `macros` array in `src/routes/app/[brand]/+layout.svelte` plus `HUB_TABS`/`WORKBENCH_PAGES`/`WORKBENCH_HUBS` in `src/lib/workbench-paths.ts`. Both had the Designer entry removed; the restoration is:

- Re-added the `designer` entry to the `macros` array (icon = `Sparkles`, matching the hub's overview).
- Re-added `designer` to `HUB_TABS` (overview + `mediaGenerator`/`ugcCreator`/`motionVideo`/`mediaLibrary`), `WORKBENCH_PAGES` and `WORKBENCH_HUBS`.
- Kept pages in their existing modal/full-width split — Designer overview and media library open in the panel (modal route), the three workbenches are full-page canvases (`BRAND_PAGE_ROUTES`, unchanged).
- Updated the pinned HUB_TABS test and the `WORKBENCH_HUBS` count accordingly.

Rejected alternatives: adding Designer to the **team nav** (`NAV_TEAM_TOOLS`, flag-gated, off by default). That is a separate hierarchy that excluded Designer deliberately; mixing a flag-on behavior change into this flag-off restoration would blur what changed. It stays as-is.

## Testing?

- `vitest` on the affected suites: `workbench-paths.test.ts`, `page-modal-tiers.test.ts`, `locales.test.ts` — all pass (35 tests).
- Edited `+layout.svelte` parses cleanly via the Svelte compiler.
- The `Sparkles` icon import matches the canonical pattern used in five other components, and the macro entry mirrors the exact shape of the existing `Layers`/`Send`/`Globe`/`Zap` entries.
- **Not exercised:** a full `svelte-check` run could not complete in this environment — the host was at load average ~29 from concurrent worktree jobs, and the whole-project scan did not finish within two attempts. The two files that matter were verified by the unit suite (which type-checks the workbench-paths import) and the compiler parse above. A CI svelte-check will settle the rest.

No browser verification: this is a navigation wiring change; the rendered sidebar output was not manually exercised here.

## Evidence?

Not applicable — navigation/config change, no visual output to capture.

## Anything Else?

- Does not touch the `FEATURE_NAV_TEAM` (team) nav: Designer remains excluded there. If it should also appear once that flag is on, that's a separate, deliberately-scoped change.
- Adds both changelogs (internal `changelog/` + public `src/lib/content/changelog/`) as the repo requires.
