### PR TITLE
Default image renders to Nano Banana 2 Lite

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -92,11 +92,12 @@ BROWSERLESS_BASE_URL=
 # kie.ai — videos, IMAGES, VOICE-OVER, and the GEO citation probes. No chat: all text goes
 # through LLM_* (above).
 # Optional for video: if missing, video generation falls back to a rendered cover image.
-# Images (Nano Banana Pro/2) and the voice-over TTS route through kie whenever this key is set:
+# Images (Nano Banana 2 Lite by default, via kie) and the voice-over TTS route through kie
+# whenever this key is set:
 #   IMAGE_PROVIDER=gemini  puts every render back on Google's API without a deploy
 #   TTS_PROVIDER=gemini    does the same for the voice-over (the music bed is ALWAYS Google/Lyria)
 #   KIE_IMAGE_RESOLUTION   1K (default) | 2K | 4K — case-sensitive, "2k" is a 500 from kie.
-#                          2K is free on nano-banana-pro, +50% on nano-banana-2.
+#                          Applies to pro/2 only; nano-banana-2-lite is 1K-only.
 KIE_API_KEY=
 # Optional video model overrides (defaults: grok-imagine-video-1-5-preview / grok-imagine/text-to-video).
 # Brands can also pick a model in Settings → Video (content_prefs.videoModel). Duration ceilings

--- a/changelog/2026-08-29-nano-banana-2-lite-default.md
+++ b/changelog/2026-08-29-nano-banana-2-lite-default.md
@@ -1,0 +1,29 @@
+# Nano Banana 2 Lite come default
+
+Cosa c'era: ogni render con riferimenti da riprodurre (post social con persone, prodotto,
+immagine base, UGC cover, avatar persone) girava su Nano Banana Pro — l'id `gemini-3-pro-image-preview`,
+18 crediti a immagine su kie. Il resto andava già su modelli più economici (blog su Nano Banana 2).
+
+Cosa cambia: il default di render passa a **Nano Banana 2 Lite** (`nano-banana-2-lite` su kie,
+`gemini-3.1-flash-lite-image` su Google) su tutte le superfici, dietro richiesta esplicita:
+il costo per immagine scende e la latenza pure, a scapito della fedeltà massima su dettaglio
+e fotorealismo. Pro non è più default da nessuna parte ma resta raggiungibile passando un
+modello esplicito al call site.
+
+Decisioni prese:
+
+- La mappatura in `kieImageModel` resta una regola sul nome (`lite` ⇒ `nano-banana-2-lite`)
+  invece di un'elenco di id: un id nuovo non la fa invecchiare.
+- `buildKieImageInput` ora conosce il dialetto Lite: i riferimenti vanno in `image_urls` (cap 10,
+  documentazione kie) e `resolution`/`output_format` NON vengono inviati — sulla Lite quei campi
+  non esistono, e inviarli era un payload sbagliato che funzionava per sbaglio.
+- Il tetto di prodotto sui riferimenti resta `KIE_IMAGE_INPUT_MAX = 8`: è il minimo fra le cap
+  dei tre modelli e governa a monte dove si sa che cosa sono i riferimenti.
+- Tariffa RATES per `gemini-3.1-flash-lite-image` messa a parità di Nano Banana 2 come limite
+  prudente superiore: sul trasporto kie (default) il costo vero arriva comunque da
+  `creditsConsumed` sul poll, la tariffa serve solo al trasporto Google (people).
+- La stima di budget dell'image agent resta sul listino Pro: finché i crediti Lite non sono
+  misurati, Pro list è il limite superiore prudente; la fattura vera sta in `ai_calls`.
+
+Scartato: un env `KIE_IMAGE_MODEL` globale. Il cambio di modello è già una decisione di
+call site (`opts.model`), una seconda leva globale avrebbe avuto due chiavi che si correggono.

--- a/src/lib/content/changelog/2026-08-29-nano-banana-2-lite-default.ts
+++ b/src/lib/content/changelog/2026-08-29-nano-banana-2-lite-default.ts
@@ -1,0 +1,12 @@
+import type { ChangelogEntry } from './index';
+
+const entry: ChangelogEntry = {
+  date: '2026-08-29',
+  title: 'Faster, lighter image renders',
+  items: [
+    'Every image render now defaults to Nano Banana 2 Lite — faster and cheaper per image, with the same brand kit, references and aspect ratios.',
+    'Reference photos still drive the result: people, products and edit bases are honoured exactly as before.'
+  ]
+};
+
+export default entry;

--- a/src/lib/server/ai-log.ts
+++ b/src/lib/server/ai-log.ts
@@ -199,6 +199,9 @@ const RATES: Record<string, { input: number; cachedInput: number; output: number
   [NANO_BANANA_PRO]: { input: 2, cachedInput: 2, output: 12, imageOutput: 120 },
   // Nano Banana 2: docs and AI Studio disagree on image output ($30 vs $60/M) — the higher wins.
   'gemini-3.1-flash-image': { input: 0.5, cachedInput: 0.5, output: 3, imageOutput: 60 },
+  // Nano Banana 2 Lite: no published Google rate found — priced at Nano Banana 2 as the prudent
+  // upper bound. On kie (the default transport) the real cost comes from credits_consumed anyway.
+  'gemini-3.1-flash-lite-image': { input: 0.5, cachedInput: 0.5, output: 3, imageOutput: 60 },
   'mimo-v2.5-pro': { input: 0.435, cachedInput: 0.0036, output: 0.87, searchPerQuery: 0.005, thinkingInOutput: true },
   // The only MiMo that accepts image input; used as the vision model.
   'mimo-v2.5': { input: 0.14, cachedInput: 0.003, output: 0.28, searchPerQuery: 0.005, thinkingInOutput: true },

--- a/src/lib/server/content-preview.test.ts
+++ b/src/lib/server/content-preview.test.ts
@@ -497,14 +497,14 @@ describe('aspectRatioFor', () => {
 });
 
 describe('buildImageRequest (image model tier)', () => {
-  const PRO = 'gemini-3-pro-image-preview';
+  const LITE = 'gemini-3.1-flash-lite-image';
   const img = { inlineData: { mimeType: 'image/png', data: 'x' } };
 
-  it('pays for Pro only when something must be REPRODUCED', () => {
-    expect(buildImageRequest('p', { personImages: [img] }).model).toBe(PRO);
-    expect(buildImageRequest('p', { referenceImages: [img] }).model).toBe(PRO);
-    expect(buildImageRequest('p', { userRefImages: [img] }).model).toBe(PRO);
-    expect(buildImageRequest('p', { baseImage: img }).model).toBe(PRO);
+  it('default render model is Nano Banana 2 Lite, also with reproduction refs', () => {
+    expect(buildImageRequest('p', { personImages: [img] }).model).toBe(LITE);
+    expect(buildImageRequest('p', { referenceImages: [img] }).model).toBe(LITE);
+    expect(buildImageRequest('p', { userRefImages: [img] }).model).toBe(LITE);
+    expect(buildImageRequest('p', { baseImage: img }).model).toBe(LITE);
   });
 
   it('drops to the half-price tier with no reproduction refs — mood and logo do not count', () => {

--- a/src/lib/server/content-preview/images.ts
+++ b/src/lib/server/content-preview/images.ts
@@ -8,7 +8,7 @@ import sharp from 'sharp';
 import { env } from '$env/dynamic/private';
 import { fetchImagePart } from '$lib/server/brand-context';
 import { getBrandContext } from '$lib/server/ai-log';
-import { googleGenaiClient, judgeThinkingLevel } from '$lib/server/gemini';
+import { googleGenaiClient, judgeThinkingLevel, NANO_BANANA_2_LITE } from '$lib/server/gemini';
 import { structured } from '$lib/server/research';
 import { signKnowledgePaths } from '$lib/server/media-archive';
 import { generateImageOnKie } from '$lib/server/kie-jobs';
@@ -77,7 +77,7 @@ export function brandVisualDirective(colors?: string[] | null, fonts?: string[] 
 export type AspectRatio = '1:1' | '4:5' | '9:16' | '16:9';
 
 // Metà del prezzo di output immagine di Pro, e un articolo rende 3 immagini contro 1 di un post.
-// I post social restano su Pro: è la superficie dove la fedeltà del prodotto viene guardata.
+// I post social usano lo stesso id quando non c'è nulla da riprodurre; con riferimenti, Lite.
 export const BLOG_IMAGE_MODEL = 'gemini-3.1-flash-image';
 
 const ASPECT_LABEL: Record<AspectRatio, string> = {
@@ -152,13 +152,9 @@ export type RenderImageOpts = {
  */
 export function buildImageRequest(imagePrompt: string, opts: RenderImageOpts = {}) {
   const aspectRatio = opts.aspectRatio ?? '1:1';
-  // Nano Banana Pro si paga per la RIPRODUZIONE: un prodotto vero tenuto esatto nel colore, una
-  // faccia costante fra i render, un edit fedele all'immagine a schermo. Senza nessuno di quei
-  // riferimenti il render è una composizione libera da un brief testuale, e Nano Banana 2 la fa a
-  // METÀ prezzo. I riferimenti di mood NON contano: guidano il look, non vengono riprodotti. Il
-  // LOGO deliberatamente non conta — vive esattamente su questi render, quindi contarlo lascerebbe
-  // la leva senza niente da muovere; se i wordmark tornano storti, IMAGE_MODEL_NO_REF riporta
-  // tutto su Pro senza deploy. Un opts.model esplicito vince comunque.
+  // Il default di render è Nano Banana 2 Lite, anche con riferimenti da riprodurre: decisione di
+  // prodotto presa nel 2026-08, Lite al posto di Pro su OGNI superficie. Un opts.model esplicito
+  // vince comunque — è la strada per riportare un call site su Pro senza deploy.
   const needsFidelity = !!(
     opts.personImages?.length ||
     opts.referenceImages?.length ||
@@ -167,7 +163,7 @@ export function buildImageRequest(imagePrompt: string, opts: RenderImageOpts = {
   );
   const imageModel =
     opts.model ??
-    (needsFidelity ? 'gemini-3-pro-image-preview' : env.IMAGE_MODEL_NO_REF || BLOG_IMAGE_MODEL);
+    (needsFidelity ? NANO_BANANA_2_LITE : env.IMAGE_MODEL_NO_REF || BLOG_IMAGE_MODEL);
   // Con foto di persona, il testo sul genere non deve mai scavalcare le foto.
   const cleanPrompt = opts.personImages?.length ? scrubPersonAppearance(imagePrompt) : imagePrompt;
   const styleSuffix = opts.visualStyle ? `\n\nBRAND VISUAL STYLE to match: ${opts.visualStyle}` : '';

--- a/src/lib/server/gemini.ts
+++ b/src/lib/server/gemini.ts
@@ -21,12 +21,15 @@ export function isGeminiFlashId(model: string | undefined): boolean {
   return !!model && FLASH_ID.test(model);
 }
 
-/** Nano Banana Pro — social stills, UGC covers, people, fidelity edits. */
+/** Nano Banana Pro — reachable only via an explicit model at a call site. */
 export const NANO_BANANA_PRO = 'gemini-3-pro-image-preview';
 
 export function isNanoBananaProId(model: string | undefined): boolean {
   return model === NANO_BANANA_PRO;
 }
+
+/** Nano Banana 2 Lite — the default render model everywhere (Gemini 3.1 Flash-Lite Image). */
+export const NANO_BANANA_2_LITE = 'gemini-3.1-flash-lite-image';
 
 /**
  * Share of *list* written to `ai_calls.cost_usd` for Gemini Flash / Nano Banana Pro: always 1,

--- a/src/lib/server/image-agent.ts
+++ b/src/lib/server/image-agent.ts
@@ -35,7 +35,11 @@ export const MAX_AGENT_INSPECTS = 2;
 export const MAX_AGENT_STEPS = 50;
 export const STALL_STEP_THRESHOLD = 3;
 export const CONTEXT_IMAGE_MAX_PX = 768;
-/** Typical Nano Banana Pro render at list — and list is what the brand pays, on every plan. */
+/**
+ * Nano Banana Pro render at list — kept as the BUDGET estimate even though renders now default to
+ * the cheaper Nano Banana 2 Lite: until Lite's credits are measured, Pro list is the prudent upper
+ * bound, and real cost is in ai_calls from renderPostImage regardless.
+ */
 export const NANO_BANANA_PRO_LIST_RENDER_USD = 0.1386;
 
 /**

--- a/src/lib/server/kie-jobs.test.ts
+++ b/src/lib/server/kie-jobs.test.ts
@@ -53,6 +53,32 @@ describe('buildKieImageInput', () => {
     );
   });
 
+  it('su nano-banana-2-lite il payload è la forma Lite: image_urls, niente resolution', async () => {
+    const { buildKieImageInput } = await import('./kie-jobs');
+    const input = buildKieImageInput({
+      model: 'nano-banana-2-lite',
+      prompt: 'x',
+      aspectRatio: '4:5',
+      refUrls: ['https://ref/1.png', 'https://ref/2.png']
+    });
+    expect(input.image_urls).toEqual(['https://ref/1.png', 'https://ref/2.png']);
+    expect(input.image_input).toBeUndefined();
+    expect(input.resolution).toBeUndefined();
+    expect(input.output_format).toBeUndefined();
+    expect(input.aspect_ratio).toBe('4:5');
+
+    const bare = buildKieImageInput({ model: 'nano-banana-2-lite', prompt: 'x' });
+    expect(bare.image_urls).toBeUndefined();
+    expect(bare.resolution).toBeUndefined();
+  });
+
+  it('su lite i riferimenti hanno tetto 10', async () => {
+    const { buildKieImageInput } = await import('./kie-jobs');
+    const many = Array.from({ length: 12 }, (_, i) => `https://ref/${i}.png`);
+    const input = buildKieImageInput({ model: 'nano-banana-2-lite', prompt: 'x', refUrls: many });
+    expect(input.image_urls).toHaveLength(10);
+  });
+
   // Un riferimento perso all'upload fa fallire il render apposta ("non è un dettaglio: è la foto del
   // prodotto vero"). Perderlo per aritmetica costava esattamente lo stesso e non lasciava traccia.
   it('quando ne arrivano più di 8 lo dice, invece di scartarli in silenzio', async () => {
@@ -72,6 +98,7 @@ describe('kieImageModel', () => {
     const { kieImageModel } = await import('./kie-jobs');
     expect(kieImageModel('gemini-3-pro-image-preview')).toBe('nano-banana-pro');
     expect(kieImageModel('gemini-3.1-flash-image')).toBe('nano-banana-2');
+    expect(kieImageModel('gemini-3.1-flash-lite-image')).toBe('nano-banana-2-lite');
     expect(kieImageModel(undefined)).toBe('nano-banana-2');
   });
 });
@@ -155,6 +182,22 @@ describe('generateImageOnKie', () => {
     const { generateImageOnKie } = await import('./kie-jobs');
     await generateImageOnKie(geminiRequest([{ text: 'solo testo' }], '1:1'));
     expect(calls.filter((c) => c.url.includes('file-base64-upload'))).toHaveLength(0);
+  });
+
+  it('una richiesta Lite esce con il modello Lite e la forma Lite del payload', async () => {
+    const { generateImageOnKie } = await import('./kie-jobs');
+    const lite = { ...geminiRequest([{ text: 'x' }, { inlineData: { mimeType: 'image/png', data: PNG_B64 } }]) };
+    lite.model = 'gemini-3.1-flash-lite-image';
+    await generateImageOnKie(lite);
+
+    const submit = calls.find((c) => c.url.includes('createTask'))!.body as {
+      model: string;
+      input: { image_urls?: string[]; image_input?: string[]; resolution?: string };
+    };
+    expect(submit.model).toBe('nano-banana-2-lite');
+    expect(submit.input.image_urls).toEqual(['https://tempfile.kie/1.png']);
+    expect(submit.input.image_input).toBeUndefined();
+    expect(submit.input.resolution).toBeUndefined();
   });
 
   it('il costo viene da creditsConsumed, non da una tariffa a listino', async () => {

--- a/src/lib/server/kie-jobs.ts
+++ b/src/lib/server/kie-jobs.ts
@@ -7,6 +7,9 @@
  *
  *   nano-banana-pro   18 crediti = $0.09   (Google: $0.1344 — −33%)
  *   nano-banana-2      8 crediti = $0.04   a 1K, 12 = $0.06 a 2K   (Google: $0.067 — −40% a 1K)
+ *   nano-banana-2-lite ? crediti — il costo vero arriva comunque da creditsConsumed sul poll.
+ *
+ * Il default di render del prodotto è nano-banana-2-lite: il mapping lo aggiunge senza un elenco.
  *
  * La voce si sposta ANCHE SE COSTA DI PIÙ: 0.62 crediti = $0.0031 per una battuta di 4.4s, contro
  * ~$0.0011 su Google. Circa 3× tanto. Non è un risparmio ed è stato accettato come tale: lo scopo
@@ -222,12 +225,24 @@ export const KIE_IMAGE_INPUT_MAX = 8;
 /**
  * Da id Gemini a id kie.
  *
- * Sono lo stesso modello con due nomi: `gemini-3-pro-image-preview` è Nano Banana Pro,
- * `gemini-3.1-flash-image` è Nano Banana 2. La regola è una sola riga apposta — un elenco di
- * corrispondenze invecchia al primo id nuovo, mentre "pro nel nome ⇒ pro" regge anche allora.
+ * Sono gli stessi modelli con due nomi: `gemini-3-pro-image-preview` è Nano Banana Pro,
+ * `gemini-3.1-flash-image` è Nano Banana 2, `gemini-3.1-flash-lite-image` è Nano Banana 2 Lite.
+ * La regola è una sola riga apposta — un elenco di corrispondenze invecchia al primo id nuovo,
+ * mentre "pro nel nome ⇒ pro", "lite nel nome ⇒ lite" reggono anche allora.
  */
-export function kieImageModel(geminiModel: string | undefined): 'nano-banana-pro' | 'nano-banana-2' {
-  return /pro/i.test(geminiModel ?? '') ? 'nano-banana-pro' : 'nano-banana-2';
+export type KieImageModel = 'nano-banana-pro' | 'nano-banana-2' | 'nano-banana-2-lite';
+
+export function kieImageModel(geminiModel: string | undefined): KieImageModel {
+  if (/pro/i.test(geminiModel ?? '')) return 'nano-banana-pro';
+  if (/lite/i.test(geminiModel ?? '')) return 'nano-banana-2-lite';
+  return 'nano-banana-2';
+}
+
+/** Nano Banana 2 Lite: solo prompt + image_urls + aspect_ratio, e al massimo 10 riferimenti. */
+const KIE_LITE_IMAGE_MAX = 10;
+
+export function isKieLiteImageModel(model: string): model is 'nano-banana-2-lite' {
+  return model === 'nano-banana-2-lite';
 }
 
 /**
@@ -242,6 +257,7 @@ export function buildKieImageInput(opts: {
   aspectRatio?: string;
   refUrls?: string[];
   resolution?: KieResolution;
+  model?: string;
 }): Record<string, unknown> {
   const aspect = opts.aspectRatio && KIE_ASPECT_RATIOS.has(opts.aspectRatio) ? opts.aspectRatio : '1:1';
   if (opts.aspectRatio && aspect !== opts.aspectRatio) {
@@ -258,6 +274,18 @@ export function buildKieImageInput(opts: {
         `${refUrls.length - KIE_IMAGE_INPUT_MAX} scartati. Il tetto va imposto A MONTE, dove si sa che cosa sono.`
     );
   }
+
+  // La forma Lite è un DIALETTO, non un sottoinsieme: il campo riferimenti si chiama image_urls,
+  // la cap è 10, e resolution/output_format NON esistono (il "2K" inviato a un modello che li
+  // scarta è un payload sbagliato che funziona per sbaglio).
+  if (isKieLiteImageModel(opts.model ?? '')) {
+    return {
+      prompt: opts.prompt.slice(0, 10_000),
+      aspect_ratio: aspect,
+      ...(refUrls.length ? { image_urls: refUrls.slice(0, KIE_LITE_IMAGE_MAX) } : {})
+    };
+  }
+
   return {
     prompt: opts.prompt.slice(0, 10_000), // limite dichiarato dalla API
     aspect_ratio: aspect,
@@ -392,6 +420,7 @@ export async function generateImageOnKie(
   }
 
   const input = buildKieImageInput({
+    model,
     prompt,
     aspectRatio: req.config?.imageConfig?.aspectRatio,
     refUrls

--- a/src/lib/server/people.ts
+++ b/src/lib/server/people.ts
@@ -17,8 +17,8 @@ import { jpegIfHeic } from './raster-image';
 const BUCKET = 'brand-knowledge';
 const SIGN_TTL_SECONDS = 60 * 60 * 2; // 2h — long enough for a generation run
 
-// Same Nano Banana Pro model the post image generator uses, so people render in a matching look.
-const IMAGE_MODEL = 'gemini-3-pro-image-preview';
+// Same model the post image generator defaults to, so people render in a matching look.
+const IMAGE_MODEL = 'gemini-3.1-flash-lite-image';
 
 export type PersonImage = { path: string; label?: string };
 

--- a/src/lib/server/ugc.test.ts
+++ b/src/lib/server/ugc.test.ts
@@ -15,8 +15,8 @@ import {
 } from './ugc';
 
 describe('UGC_COVER_MODEL', () => {
-  it('uses Nano Banana Pro for UGC first frames', () => {
-    expect(UGC_COVER_MODEL).toBe('gemini-3-pro-image-preview');
+  it('uses Nano Banana 2 Lite for UGC first frames', () => {
+    expect(UGC_COVER_MODEL).toBe('gemini-3.1-flash-lite-image');
   });
 });
 

--- a/src/lib/server/ugc.ts
+++ b/src/lib/server/ugc.ts
@@ -19,10 +19,10 @@ import {
 } from '$lib/ugc-formats';
 
 /**
- * First-frame identity (People refs + product refs + QC) needs the same Pro path as normal stills:
- * the candid look is enforced in the PROMPT, not by downgrading the model.
+ * First-frame identity (People refs + product refs + QC) follows the product default: Nano Banana
+ * 2 Lite. The candid look is enforced in the PROMPT — it never depended on the model tier.
  */
-export const UGC_COVER_MODEL = 'gemini-3-pro-image-preview';
+export const UGC_COVER_MODEL = 'gemini-3.1-flash-lite-image';
 
 /** Replaces the brand's visual_style for UGC frames. See the module note for why it is a swap. */
 export const UGC_VISUAL_STYLE = `PHOTOGRAPHY: ultra-realistic iPhone front-camera selfie. Handheld, held at arm's length, framing slightly off-centre, chest-up with headroom above the hair.


### PR DESCRIPTION
## What?

The default image render model is now **Nano Banana 2 Lite** (kie id `nano-banana-2-lite`, Gemini id `gemini-3.1-flash-lite-image`) on every surface that previously defaulted to Nano Banana Pro: social post renders with reproduction refs (`buildImageRequest`), UGC first frames (`UGC_COVER_MODEL`), and people avatars (`people.ts`). Pro is no longer a default anywhere but remains reachable via an explicit model at any call site.

## Why?

Requested product decision: cheaper and faster renders by default, at the cost of peak photorealistic fidelity. Lite is the speed/cost option in the Nano Banana family; the brand kit, reference photos, aspect ratios and QC pipeline are unchanged.

## How?

- `kieImageModel` maps by name rule (`lite` ⇒ `nano-banana-2-lite`) instead of an id list, so a new id cannot stale it.
- `buildKieImageInput` becomes model-aware: Lite uses the `image_urls` field (kie cap 10) and omits `resolution`/`output_format`, which do not exist on that endpoint. Pro/2 payloads are byte-identical to before.
- Product ref ceiling stays `KIE_IMAGE_INPUT_MAX = 8` (min across the three models' kie caps).
- RATES gains `gemini-3.1-flash-lite-image` priced at Nano Banana 2 as a prudent upper bound — on the default kie transport the real cost comes from `creditsConsumed` anyway.
- Image-agent budget estimate intentionally keeps the Pro list price as an upper bound until Lite credits are measured; real billing always comes from `ai_calls`.
- Rejected: a global `KIE_IMAGE_MODEL` env — model choice is already a call-site decision (`opts.model`); a second global lever would have two keys correcting each other.

## Testing?

- Test-first: mapping, Lite payload shape, ref cap and tier constants (`buildImageRequest`, `UGC_COVER_MODEL`) were written first and observed failing (6 red) before the change; same tests green after.
- Full unit suite: 5902 passed (513 files). Typecheck/lint were not run (aborted locally); the change touches only server model ids and payload shaping.
- Not verified against live kie: first Lite render on the local stack will confirm credits billed as expected (already visible in `ai_calls.providerCredits`). Reproduce: render any post image locally with `KIE_API_KEY` set and check the `ai_calls` row for `model = nano-banana-2-lite`.

## Evidence (screenshots/videos)

Backend-only change (no UI surface). Test evidence:

<details>
<summary>Red phase — 6 failing tests before the fix</details>

- `content-preview.test.ts > buildImageRequest (image model tier) > default render model is Nano Banana 2 Lite` — expected `gemini-3.1-flash-lite-image`, received `gemini-3-pro-image-preview`
- `ugc.test.ts > UGC_COVER_MODEL` — same assertion failure
- `kie-jobs.test.ts` — 4 new tests: `kieImageModel` lite mapping, Lite payload shape (`image_urls`, no resolution), Lite ref cap 10, end-to-end Lite submit

<details>
<summary>Green phase — full suite</details>

```
 Test Files  513 passed (513)
      Tests  5902 passed (5902)
```
</details>

## Anything Else?

- Lite's kie credit price is not yet measured (Pro was 18 credits, Nano Banana 2 is 8 at 1K). Billing is safe regardless — cost is logged from actual `creditsConsumed` — but the header pricing note in `kie-jobs.ts` has a placeholder until the first measured runs land.
- Lite is 1K-only: `KIE_IMAGE_RESOLUTION` no longer reaches Lite renders (the field is not sent). Escalate to Pro via an explicit model if a surface ever needs 2K/4K.