### PR TITLE
Close the sandbox review gaps, take the desktop out of the product

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -432,3 +432,7 @@ CHAT_CONTROLLER=shadow
 # computer. Senza, il desktop si installa a runtime (lento). Si ricostruisce con
 # `node sandbox-desktop/build.mjs`.
 SANDBOX_DESKTOP_IMAGE=desktop:latest
+
+# Desktop grafico della VM (anteprima, controllo utente, tool observe/act dell'agente).
+# RIMOSSO dal prodotto di default: l'agente usa solo browse. Metti 1 per rimetterlo in piedi.
+AGENT_DESKTOP_ENABLED=

--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,4 @@ AGENT-CHAT-*.md
 /mcp.json
 /.mcp.json
 .mimocode/
+vite.config.ts.timestamp-*.mjs

--- a/changelog/2026-08-29-sandbox-refcount-stop.md
+++ b/changelog/2026-08-29-sandbox-refcount-stop.md
@@ -36,6 +36,29 @@ Scartato: il cron reaper (più lento di stop-at-zero, e con una code di minuti p
 short-lease per uso (dopo lo stop sicuro il cricchetto perde il morso: ogni sessione fredda
 riparte col lease giusto, e il render resta a 15 minuti).
 
+## Round 2 — review indipendente e rimozione del desktop
+
+La review indipendente (docs + SDK riga per riga) conferma le quattro basi del piano e trova due
+problemi IMPORTANT, chiusi qui (#56, #57):
+
+- **Le rotte del pannello perdevano un holder a 15 minuti.** `provision()` passa da
+  `openBrandSandbox`, che acquisiva un holder `turn:<runId>` mai rilasciato: chi chiudeva il tab
+  lasciava la VM accesa fino al lease. Ora `provision()` usa un TTL corto
+  (`PROVISION_HOLDER_TTL_MS`, 120s) — il keep-alive vero è il poll che rinfresca.
+- **Il test non poteva vedere un drift di `onConflict`**: la stringa è ora la costante
+  `HOLDER_CONFLICT_TARGET`, e il test la confronta letteralmente col SQL della migration — se
+  divergono, il test urla invece di tacere.
+
+Percorso DM: `openBrandHarnessSession` ora ritorna l'handle e `live.ts` lo rilascia nel
+`finally` del turno — un consulto che non tocca la VM smette di pagarla a fine turno invece che
+a fine lease. Per farlo sicuro, `release()` non lancia più `rm -rf` su una VM che credevamo
+ferma: lo riaccenderebbe solo per cancellare una directory (che poi resta nello snapshot —
+sporcizia accettata, documentata nel codice).
+
+**Il desktop grafico esce dal prodotto** (`AGENT_DESKTOP_ENABLED`, default spento): niente
+anteprima, niente controllo utente, niente `observe`/`act` nei toolset — l'agente lavora sul
+web solo con `browse`. Il codice resta da parte, non cancellato.
+
 ## Cosa guarda il test guardiano
 
 `sandbox.test.ts` non vietava più lo stop — vietava lo stop SENZA refcount. Ora vieta uno

--- a/packages/agent-adapters/src/vercel-sandbox.ts
+++ b/packages/agent-adapters/src/vercel-sandbox.ts
@@ -48,6 +48,8 @@ export interface VercelSandboxDeps {
 		runId: string;
 		agentId?: string;
 		ports?: number[];
+		/** TTL dell'holder: breve per chi ripassa spesso (i poll del pannello), lease intero di default. */
+		holderTtlMs?: number;
 		abortSignal?: AbortSignal;
 		onLog?: (line: string) => void;
 	}) => Promise<SandboxHandle>;
@@ -73,6 +75,13 @@ const DEFAULT_TIMEOUT_MS = 5 * 60_000;
 const MODE: SandboxNetworkMode = 'agent';
 
 import { DESKTOP_PORT } from './graphical-bootstrap';
+
+/**
+ * Quanto a lungo provision() tiene viva la contabilità della VM dopo l'ultima richiesta.
+ * Chi guarda il pannello ripassa ogni ~2.5s e rinfresca la riga: se il tab muore, la VM si
+ * spegne al prossimo evento invece di correre fino al lease di 15 minuti.
+ */
+export const PROVISION_HOLDER_TTL_MS = 120_000;
 
 /** Gli handle vivi di questo processo, per nome di sandbox. */
 const handles = new Map<string, SandboxHandle>();
@@ -111,6 +120,9 @@ export class VercelSandboxProvider implements SandboxProvider {
 			// e chiederla dopo su una VM già nata non ha effetto. Finché nessuno ascolta, quella
 			// porta risponde 502 «not listening» — nessuna superficie in più.
 			ports: [DESKTOP_PORT],
+			// Il keep-alive vero di chi guarda è l'holder desktop (rinfrescato dai poll): il turno
+			// di provision copre solo la richiesta, non quindici minuti di pannello chiuso.
+			holderTtlMs: PROVISION_HOLDER_TTL_MS,
 			abortSignal: context.signal,
 			onLog: (line) => context.log?.({ label: 'sandbox', detail: { line } })
 		});

--- a/src/lib/agent/bridge/adapters.ts
+++ b/src/lib/agent/bridge/adapters.ts
@@ -22,7 +22,8 @@ import {
 	oidcTokenFromRequestContext,
 	openBrandSandbox,
 	resolvePlaywrightEnv,
-	SANDBOX_MAX_LEASE_MS
+	SANDBOX_MAX_LEASE_MS,
+	type SandboxHandle
 } from '$lib/server/sandbox';
 import { createFileTools, isOverridable, OVERRIDABLE_PREFIXES, AGENT_DOCS_BUCKET } from '$lib/server/chat/agent-files';
 import { KIE_CODEX_BASE } from '$lib/server/kie';
@@ -170,6 +171,8 @@ export function createHarnessRuntime(execToolCall: ExecToolCall): HarnessRuntime
 export interface HarnessSandboxSession {
 	session: unknown;
 	name: string;
+	/** L'handle aperto: chi ha il turno in mano lo rilascia, o la VM corre fino al lease. */
+	handle: SandboxHandle;
 }
 
 /** La STESSA macchina del brand (getOrCreate per nome): i builtin Pi atterrano lì, un solo canone. */
@@ -187,7 +190,7 @@ export async function openBrandHarnessSession(
 		runId
 	});
 	const provider = createVercelSandbox({ sandbox: handle.raw as never });
-	return { session: await provider.createSession(), name: handle.name };
+	return { session: await provider.createSession(), name: handle.name, handle };
 }
 
 type HarnessStreamResult = Awaited<ReturnType<InstanceType<typeof HarnessAgent>['stream']>>;

--- a/src/lib/agent/bridge/live.test.ts
+++ b/src/lib/agent/bridge/live.test.ts
@@ -261,7 +261,11 @@ vi.mock('./adapters', async (importOriginal) => {
 	return {
 		...actual,
 		resolveHarnessModelRef: () => ({ provider: 'kie', id: 'kie/test-luna', label: 'test-luna' }),
-		openBrandHarnessSession: async () => ({ session: { fake: true }, name: 'brand-vm' }),
+		openBrandHarnessSession: async () => ({
+			session: { fake: true },
+			name: 'brand-vm',
+			handle: { release: vi.fn(async () => {}) }
+		}),
 		startHarnessTurn: async (opts: {
 			system: string;
 			messages: unknown;
@@ -848,7 +852,8 @@ describe('i tool dei plugin sono ANNUNCIATI al modello, non solo eseguibili', ()
 		const src = fs.readFileSync(new URL('./live.ts', import.meta.url), 'utf8');
 		// Dichiarare un plugin senza esporlo era il buco: l'executor rispondeva a motion_*,
 		// il modello non sapeva di poterlo chiedere. Questo pinna la fusione nel catalogo.
-		expect(src).toMatch(/\.\.\.BUILTIN_TOOLS, \.\.\.plugins\.flatMap\(\(p\) => p\.tools\)/);
+		// Il filtro observe/act (desktop tolto dal prodotto) non spezza la fusione.
+		expect(src).toMatch(/\.\.\.\(?agentDesktopEnabled\(\) \? BUILTIN_TOOLS : BUILTIN_TOOLS\.filter\(\(t\) => t\.name !== 'observe' && t\.name !== 'act'\)\)?,?\s*\.\.\.plugins\.flatMap\(\(p\) => p\.tools\)/);
 	});
 
 	it('il catalogo che arriva al modello porta i builtin E quelli del mestiere', async () => {

--- a/src/lib/agent/bridge/live.ts
+++ b/src/lib/agent/bridge/live.ts
@@ -33,6 +33,7 @@ import {
 	type KitRunLiveness
 } from '$lib/server/chat/turn-limits';
 import { DM_REPLY_STEP_CAP, dmBrief } from '$lib/chat-dm';
+import { agentDesktopEnabled } from '$lib/server/agent-desktop';
 import { UNATTENDED_TOOL_EXCLUSIONS, UNATTENDED_KIT_TOOL_EXCLUSIONS } from '$lib/server/chat/unattended';
 import { logAiCall, extractSdkUsage } from '$lib/server/ai-log';
 import { filesIndexFor } from '$lib/server/chat/agent-files';
@@ -719,7 +720,15 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
 		const tokenBudget = chatTokenBudget();
 		let settled = false;
 		const loopGuard = createChatLoopGuard();
-		const turnTools = toolsForMode([...BUILTIN_TOOLS, ...plugins.flatMap((p) => p.tools)], mode);
+		const turnTools = toolsForMode(
+			[
+				// Il desktop grafico è fuori dal prodotto: l'agente vede il web con `browse`, non
+				// pilotando uno schermo. Con AGENT_DESKTOP_ENABLED=1 tornano com'erano.
+				...(agentDesktopEnabled() ? BUILTIN_TOOLS : BUILTIN_TOOLS.filter((t) => t.name !== 'observe' && t.name !== 'act')),
+				...plugins.flatMap((p) => p.tools)
+			],
+			mode
+		);
 		// Le esclusioni del turno non presidiato valgono per entrambi i cataloghi: nel kit la sola
 		// voce che ricade è `ask_user` — una domanda senza nessuno che possa rispondere lascerebbe
 		// il run in waiting_input per sempre.
@@ -754,6 +763,7 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
 		}
 		}
 		const brandSandbox = savedResume ? null : await openBrandHarnessSession(brand.id, run.id, spec.id);
+		try {
 		const startTurnOnce = (fresh: boolean) => {
 			const startedTurn = startHarnessTurn({
 			runId: run.id,
@@ -1394,6 +1404,13 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
 					void broadcastToBrand(brand.id, { event: 'kit_stream_done', payload: { runId: run.id, threadId } });
 				}
 			})();
+		}
+		} finally {
+			// Il turno è finito, bene o male: via l'holder e, se era l'ultimo, la VM si spegne.
+			// La sessione cached del prossimo messaggio riaccende da sola al primo comando.
+			if (brandSandbox) {
+				await brandSandbox.handle.release().catch((e) => console.warn(`[AGENT_KIT] run ${run.id} sandbox release`, e));
+			}
 		}
 	} catch (err) {
 		stopTurnHeartbeat();

--- a/src/lib/content/changelog/2026-08-29-sandbox-refcount-stop.ts
+++ b/src/lib/content/changelog/2026-08-29-sandbox-refcount-stop.ts
@@ -5,6 +5,7 @@ export default {
   title: 'Agent sandboxes power down the moment work finishes',
   items: [
     'Sandbox machines now shut down as soon as the last job using them ends, instead of idling until their rental window expires — idle time no longer burns through credits.',
-    'Watching an agent’s live desktop keeps its machine awake while the panel is open, and the machine powers down shortly after you close it.'
+    'A conversational turn that never touches its machine no longer pays for it at all: the machine is released the moment the turn ends.',
+    'The agent’s graphical desktop (screen preview, remote control, GUI actions) has been removed — agents work on the web exclusively through the fast, scriptable browser tool.'
   ]
 } satisfies ChangelogEntry;

--- a/src/lib/server/agent-desktop.ts
+++ b/src/lib/server/agent-desktop.ts
@@ -10,7 +10,17 @@
  * ricostruisce identica a ogni chiamata, e cambiarlo invalida tutti i desktop già aperti.
  */
 import { createHmac } from 'node:crypto';
+import { env } from '$env/dynamic/private';
 import type { SupabaseClient } from '@supabase/supabase-js';
+
+/**
+ * Il desktop grafico è TOGLIUTO dal prodotto: nessuna anteprima, nessun controllo utente,
+ * l'agente lavora solo con `browse`. Il codice resta qui da parte: `AGENT_DESKTOP_ENABLED=1`
+ * lo rimette in piedi senza ritoccare niente.
+ */
+export function agentDesktopEnabled(): boolean {
+	return env.AGENT_DESKTOP_ENABLED === '1';
+}
 
 /**
  * L'autenticazione classica di VNC guarda 8 caratteri: quelli oltre non li legge nessuno, e una

--- a/src/lib/server/sandbox-leases.test.ts
+++ b/src/lib/server/sandbox-leases.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { acquireHolder, releaseHolder } from './sandbox-leases';
+import { acquireHolder, HOLDER_CONFLICT_TARGET, releaseHolder } from './sandbox-leases';
 
 type Row = {
   id: string;
@@ -13,15 +13,17 @@ type Row = {
 function fakeDb() {
   const rows: Row[] = [];
   const stop = vi.fn(async () => {});
+  const upsertConflicts: string[] = [];
   let seq = 0;
 
   const builder = (table: string) => {
     if (table !== 'sandbox_holders') throw new Error(`unexpected table ${table}`);
     const state: { mode: 'upsert' | 'delete' | 'count'; row?: Partial<Row>; id?: string; name?: string; since?: string } = { mode: 'count' };
     const chain = {
-      upsert(row: Partial<Row>) {
+      upsert(row: Partial<Row>, opts?: { onConflict?: string }) {
         state.mode = 'upsert';
         state.row = row;
+        if (opts?.onConflict) upsertConflicts.push(opts.onConflict);
         return chain;
       },
       delete() {
@@ -74,10 +76,34 @@ function fakeDb() {
     return chain;
   };
 
-  return { db: { from: builder } as never, rows, stop };
+  return { db: { from: builder } as never, rows, stop, upsertConflicts };
 }
 
 const BASE = { name: 'anomalia-vm-g5', brandId: 'b1', kind: 'turn' as const };
+
+describe('HOLDER_CONFLICT_TARGET', () => {
+  /**
+   * Un onConflict che non coincide con l'unique index non dà errori vistosi: ogni upsert
+   * fallisce, acquireHolder torna null, la contabilità tace e le VM restano accese. Il test
+   * confronta la costante col SQL della migration — le due metà devono viaggiare insieme.
+   */
+  it('coincide con l’unique index scritto nella migration', async () => {
+    const { readFileSync } = await import('node:fs');
+    const migration = readFileSync(
+      new URL('../../../supabase/migrations/20260829120000_sandbox_holders.sql', import.meta.url),
+      'utf8'
+    );
+    expect(migration).toMatch(new RegExp(`unique index[^;]*on public.sandbox_holders \\(${HOLDER_CONFLICT_TARGET.replace(',', ', ')}\\)`));
+    expect(migration).toContain('enable row level security');
+  });
+
+  it('ogni upsert lo dichiara', async () => {
+    const f = fakeDb();
+    await acquireHolder({ ...BASE, key: 'turn:r1', ttlMs: 60_000, db: f.db });
+    await acquireHolder({ ...BASE, key: 'desktop:ag1', kind: 'desktop', ttlMs: 60_000, db: f.db });
+    expect(f.upsertConflicts).toEqual([HOLDER_CONFLICT_TARGET, HOLDER_CONFLICT_TARGET]);
+  });
+});
 
 describe('acquireHolder', () => {
   it('una seconda acquire con la stessa chiave rinfresca, non duplica', async () => {

--- a/src/lib/server/sandbox-leases.ts
+++ b/src/lib/server/sandbox-leases.ts
@@ -17,6 +17,14 @@ import { swallow } from '$lib/server/swallow';
 
 const TABLE = 'sandbox_holders';
 
+/**
+ * IL NOME DELL'INDICE IN COLONNE: l'upsert deduplica solo se questa coppia coincide con
+ * l'unique index della migration. Un drift qui non dà errori vistosi — ogni upsert fallisce,
+ * acquireHolder torna null, la contabilità tace e le VM restano accese. `sandbox-leases.test.ts`
+ * confronta questa costante col file SQL: se divergono, il test lo urla.
+ */
+export const HOLDER_CONFLICT_TARGET = 'sandbox_name,holder_key';
+
 /** Il pannello ripassa ogni ~2.5s: il TTL deve coprire più poll, non più di tanto. */
 export const DESKTOP_HOLDER_TTL_MS = 120_000;
 
@@ -74,7 +82,7 @@ export async function acquireHolder(opts: {
       .from(TABLE)
       .upsert(
         { sandbox_name: opts.name, brand_id: opts.brandId, holder_key: opts.key, kind: opts.kind, expires_at },
-        { onConflict: 'sandbox_name,holder_key' }
+        { onConflict: HOLDER_CONFLICT_TARGET }
       )
       .select('id')
       .single();

--- a/src/lib/server/sandbox.ts
+++ b/src/lib/server/sandbox.ts
@@ -563,6 +563,12 @@ export async function openBrandSandbox(opts: {
    * dietro (un cron, uno script) non devono inventarsene uno.
    */
   agentId?: string;
+  /**
+   * Quanto a lungo QUESTO chiamante tiene viva la contabilità della VM, quando il suo ciclo di
+   * vita non ha una release nota. Il default è il lease intero (chi lavora e rilascia); chi
+   * ripassa spesso — i poll del pannello — passa un TTL corto e rinfresca a ogni giro.
+   */
+  holderTtlMs?: number;
   needsBrowser?: boolean;
   /**
    * Porte raggiungibili da fuori (`sandbox.domain(p)`). Parametro di CREAZIONE: su un nome che
@@ -679,7 +685,7 @@ export async function openBrandSandbox(opts: {
     brandId: opts.brandId,
     key: `turn:${opts.runId}`,
     kind: 'turn',
-    ttlMs: SANDBOX_MAX_LEASE_MS
+    ttlMs: opts.holderTtlMs ?? SANDBOX_MAX_LEASE_MS
   });
 
   const handle: SandboxHandle = {
@@ -733,8 +739,12 @@ export async function openBrandSandbox(opts: {
       return buf as Buffer;
     },
     async release() {
-      // Lo snapshot deve contenere Chromium e i pacchetti, non il workspace di un brand.
-      await handle.run('rm', ['-rf', root]).catch(swallow('handle.run failed'));
+      // Lo snapshot deve contenere Chromium e i pacchetti, non il workspace di un brand. Ma su
+      // una VM ferma il comando la riaccenderebbe solo per cancellare una directory: lo stato
+      // è quello letto all'apertura — se dice stopped, la directory sta nello snapshot e la
+      // pulizia si può anche perdere.
+      const cold = (sandbox as { status?: unknown }).status === 'stopped';
+      if (!cold) await handle.run('rm', ['-rf', root]).catch(swallow('handle.run failed'));
       if (holderId) await releaseHolder(holderId, sandbox as unknown as { stop: () => Promise<unknown> });
     }
   };

--- a/src/routes/app/[brand]/agent-lab/turn/+server.ts
+++ b/src/routes/app/[brand]/agent-lab/turn/+server.ts
@@ -9,6 +9,7 @@ import { runTurn } from '$lib/agent/turn';
 import { resume } from '$lib/agent/run-store';
 import { createApplyTool } from '$lib/agent/executor';
 import { BUILTIN_TOOLS } from '$lib/agent/tools/builtin';
+import { agentDesktopEnabled } from '$lib/server/agent-desktop';
 import { createServerBrandFs, createPostgresMemoryStore, createHarnessRuntime, resolveHarnessModelRef } from '$lib/agent/bridge/adapters';
 import { createAdminClient } from '$lib/server/supabase-admin';
 import { createQueryTool } from '$lib/server/chat/query-tool';
@@ -146,7 +147,7 @@ export const POST: RequestHandler = async ({ request, params, locals: { supabase
 			userId: user.id,
 			locale: bilingualNoticeLocale(uiLocale),
 			messages,
-			tools: BUILTIN_TOOLS,
+			tools: agentDesktopEnabled() ? BUILTIN_TOOLS : BUILTIN_TOOLS.filter((t) => t.name !== 'observe' && t.name !== 'act'),
 			// ponytail: fileIndex vuoto — costruirlo richiede un altro giro su agent-files.ts che il
 			// lab non ha ancora; l'agente vede comunque l'albero via brand_ls/brand_read/brand_grep. Aggiungere quando
 			// il lab deve mostrare "cosa l'agente sa" senza che lo chieda lui.
@@ -172,7 +173,7 @@ export const POST: RequestHandler = async ({ request, params, locals: { supabase
 							userId: user.id,
 							locale: bilingualNoticeLocale(uiLocale),
 							messages,
-							tools: BUILTIN_TOOLS,
+							tools: agentDesktopEnabled() ? BUILTIN_TOOLS : BUILTIN_TOOLS.filter((t) => t.name !== 'observe' && t.name !== 'act'),
 							extras: { memoryMd, fileIndex: '' },
 							limits: { maxSteps: 20, tokenBudget: 500_000, deadlineMs: 240_000 },
 							sessionKey: `agent-lab:${agentId}`,

--- a/src/routes/app/[brand]/agents/computer/clipboard/+server.ts
+++ b/src/routes/app/[brand]/agents/computer/clipboard/+server.ts
@@ -14,6 +14,7 @@
  */
 import { json } from '@sveltejs/kit';
 import { bilingualNoticeLocale } from '$lib/i18n/locale';
+import { agentDesktopEnabled } from '$lib/server/agent-desktop';
 import { readClipboard, writeClipboard } from '$lib/agent/adapters/graphical-bootstrap';
 import { createVercelSandboxProvider } from '$lib/agent/bridge/adapters';
 import type { AdapterContext } from '$lib/agent/kit/types';
@@ -36,6 +37,7 @@ async function brandFor(supabase: App.Locals['supabase'], slug: string) {
 export const GET: RequestHandler = async ({ params, url, locals: { supabase, safeGetSession, locale: uiLocale } }) => {
 	const { user } = await safeGetSession();
 	if (!user) return new Response('Unauthorized', { status: 401 });
+	if (!agentDesktopEnabled()) return new Response(null, { status: 404 });
 	const brand = await brandFor(supabase, params.brand);
 	if (!brand) return new Response('Not found', { status: 404 });
 

--- a/src/routes/app/[brand]/agents/computer/desktop/+server.ts
+++ b/src/routes/app/[brand]/agents/computer/desktop/+server.ts
@@ -14,6 +14,7 @@
  */
 import { json } from '@sveltejs/kit';
 import { bilingualNoticeLocale } from '$lib/i18n/locale';
+import { agentDesktopEnabled } from '$lib/server/agent-desktop';
 import { ensureGraphicalMode, ensureRemoteDesktop } from '$lib/agent/adapters/graphical-bootstrap';
 import { createVercelSandboxProvider, graphicalBootstrapDeps, sandboxPortUrl } from '$lib/agent/bridge/adapters';
 import { desktopPassword, desktopUrl, publishComputerRunning } from '$lib/server/agent-desktop';
@@ -27,6 +28,7 @@ import type { RequestHandler } from './$types';
 export const POST: RequestHandler = async ({ params, url, locals: { supabase, safeGetSession, locale: uiLocale } }) => {
 	const { user } = await safeGetSession();
 	if (!user) return new Response('Unauthorized', { status: 401 });
+	if (!agentDesktopEnabled()) return new Response(null, { status: 404 });
 
 	const { data: brand } = await supabase.from('brands').select('id').eq('slug', params.brand).maybeSingle();
 	if (!brand) return new Response('Not found', { status: 404 });

--- a/src/routes/app/[brand]/agents/computer/input/+server.ts
+++ b/src/routes/app/[brand]/agents/computer/input/+server.ts
@@ -10,6 +10,7 @@
  */
 import { json } from '@sveltejs/kit';
 import { bilingualNoticeLocale } from '$lib/i18n/locale';
+import { agentDesktopEnabled } from '$lib/server/agent-desktop';
 import { runActions } from '$lib/agent/adapters/graphical-bootstrap';
 import { createVercelSandboxProvider } from '$lib/agent/bridge/adapters';
 import type { AdapterContext } from '$lib/agent/kit/types';
@@ -27,6 +28,7 @@ const ALLOWED_KEYS = new Set([
 export const POST: RequestHandler = async ({ params, request, url, locals: { supabase, safeGetSession, locale: uiLocale } }) => {
 	const { user } = await safeGetSession();
 	if (!user) return new Response('Unauthorized', { status: 401 });
+	if (!agentDesktopEnabled()) return new Response(null, { status: 404 });
 
 	const { data: brand } = await supabase.from('brands').select('id').eq('slug', params.brand).maybeSingle();
 	if (!brand) return new Response('Not found', { status: 404 });

--- a/src/routes/app/[brand]/agents/computer/screen/+server.ts
+++ b/src/routes/app/[brand]/agents/computer/screen/+server.ts
@@ -18,6 +18,7 @@
  */
 import { swallow } from '$lib/server/swallow';
 import { bilingualNoticeLocale } from '$lib/i18n/locale';
+import { agentDesktopEnabled } from '$lib/server/agent-desktop';
 import { captureScreenshot, ensureGraphicalMode } from '$lib/agent/adapters/graphical-bootstrap';
 import { createVercelSandboxProvider, graphicalBootstrapDeps } from '$lib/agent/bridge/adapters';
 import { holdDesktop } from '$lib/server/sandbox-leases';
@@ -31,6 +32,7 @@ const cache = new Map<string, { at: number; png: Buffer }>();
 export const GET: RequestHandler = async ({ params, url, locals: { supabase, safeGetSession, locale: uiLocale } }) => {
 	const { user } = await safeGetSession();
 	if (!user) return new Response('Unauthorized', { status: 401 });
+	if (!agentDesktopEnabled()) return new Response(null, { status: 404 });
 
 	const { data: brand } = await supabase.from('brands').select('id').eq('slug', params.brand).maybeSingle();
 	if (!brand) return new Response('Not found', { status: 404 });

--- a/src/routes/app/[brand]/agents/computer/screen/server.test.ts
+++ b/src/routes/app/[brand]/agents/computer/screen/server.test.ts
@@ -9,6 +9,7 @@ const captureScreenshotMock = vi.fn();
 
 // La route monta la sandbox via `$lib/agent/bridge/adapters` (il cablaggio DI del lotto 2b), non
 // più con `new VercelSandboxProvider()` diretto — mockare quel modulo, non il pacchetto sotto.
+vi.mock('$lib/server/agent-desktop', () => ({ agentDesktopEnabled: () => true }));
 vi.mock('$lib/agent/bridge/adapters', () => ({
 	createVercelSandboxProvider: () => ({ provision: provisionMock })
 }));

--- a/src/routes/app/[brand]/agents/computer/status/+server.ts
+++ b/src/routes/app/[brand]/agents/computer/status/+server.ts
@@ -11,6 +11,7 @@
  */
 import { json } from '@sveltejs/kit';
 import { bilingualNoticeLocale } from '$lib/i18n/locale';
+import { agentDesktopEnabled } from '$lib/server/agent-desktop';
 import { probeGraphicalMode } from '$lib/agent/adapters/graphical-bootstrap';
 import { createVercelSandboxProvider } from '$lib/agent/bridge/adapters';
 import type { AdapterContext } from '$lib/agent/kit/types';
@@ -19,6 +20,7 @@ import type { RequestHandler } from './$types';
 export const GET: RequestHandler = async ({ params, url, locals: { supabase, safeGetSession, locale: uiLocale } }) => {
 	const { user } = await safeGetSession();
 	if (!user) return new Response('Unauthorized', { status: 401 });
+	if (!agentDesktopEnabled()) return new Response(null, { status: 404 });
 
 	const { data: brand } = await supabase.from('brands').select('id').eq('slug', params.brand).maybeSingle();
 	if (!brand) return new Response('Not found', { status: 404 });

--- a/src/routes/app/[brand]/agents/computer/status/server.test.ts
+++ b/src/routes/app/[brand]/agents/computer/status/server.test.ts
@@ -5,6 +5,7 @@ const probeGraphicalModeMock = vi.fn();
 
 // La route monta la sandbox via `$lib/agent/bridge/adapters` (il cablaggio DI del lotto 2b), non
 // più con `new VercelSandboxProvider()` diretto — mockare quel modulo, non il pacchetto sotto.
+vi.mock('$lib/server/agent-desktop', () => ({ agentDesktopEnabled: () => true }));
 vi.mock('$lib/agent/bridge/adapters', () => ({
 	createVercelSandboxProvider: () => ({ provision: provisionMock })
 }));

--- a/src/routes/app/[brand]/chat/[thread]/+page.server.ts
+++ b/src/routes/app/[brand]/chat/[thread]/+page.server.ts
@@ -1,5 +1,6 @@
 import { error, fail } from '@sveltejs/kit';
 import { getThread, loadHistoryForUI } from '$lib/server/chat/persistence';
+import { agentDesktopEnabled } from '$lib/server/agent-desktop';
 import { listThreadArtifacts } from '$lib/server/chat/artifacts';
 import { chatJobFreshSince, reapStaleChatJobs } from '$lib/server/chat/job-cancel';
 import { loadLastReads } from '$lib/server/chat/unread';
@@ -225,6 +226,7 @@ export const load: PageServerLoad = async ({ params, locals: { supabase, safeGet
   return {
     thread,
     agentPanel,
+    agentDesktopEnabled: agentDesktopEnabled(),
     messages,
     artifacts,
     brandSlug: brand.slug,

--- a/src/routes/app/[brand]/chat/[thread]/+page.svelte
+++ b/src/routes/app/[brand]/chat/[thread]/+page.svelte
@@ -879,19 +879,21 @@
 {/snippet}
 
 {#snippet agentPanelContent()}
-  <AgentComputerPanel
-    brandSlug={data.brandSlug}
-    thread={data.thread}
-    job={data.agentPanel?.job ?? null}
-    custom={data.agentPanel?.custom ?? null}
-    renders={data.agentPanel?.renders ?? []}
-    live={{ loading, streamBuf, streamToolCalls, streamReasoning }}
-    backgroundLabels={panelBgLabels}
-    lastReport={panelLastReport}
-    lastPostId={panelWork.post}
-    lastPlanId={panelWork.plan}
-    onclose={() => (agentPanelOpen = false)}
-  />
+  {#if data.agentDesktopEnabled}
+    <AgentComputerPanel
+      brandSlug={data.brandSlug}
+      thread={data.thread}
+      job={data.agentPanel?.job ?? null}
+      custom={data.agentPanel?.custom ?? null}
+      renders={data.agentPanel?.renders ?? []}
+      live={{ loading, streamBuf, streamToolCalls, streamReasoning }}
+      backgroundLabels={panelBgLabels}
+      lastReport={panelLastReport}
+      lastPostId={panelWork.post}
+      lastPlanId={panelWork.plan}
+      onclose={() => (agentPanelOpen = false)}
+    />
+  {/if}
 {/snippet}
 
 <div class="chat-thread-shell">


### PR DESCRIPTION
## What?
Three things, one commit on top of #55:

1. **The two IMPORTANT findings of the independent review are closed** (Fixes #56, Fixes #57): the desktop/screen/status/input routes no longer leak a 15-minute sandbox holder per request (provision now carries a 120 s holder TTL, refreshed by every poll), and the holder tests now pin the upsert conflict target against the migration SQL — an onConflict/index drift used to fail silently with green tests.
2. **The agent-DM machine is released at turn end**: `openBrandHarnessSession` returns its handle and `live.ts` releases it in the turn's finally. A consult turn that never touches the VM stops paying for it when the turn ends instead of at the 15-minute lease. `release()` no longer boots a stopped VM just to delete a run directory (review minor #5).
3. **The graphical desktop leaves the product** behind a flag (`AGENT_DESKTOP_ENABLED`, default off): the chat page's computer panel is gone, the desktop/screen/status/input/clipboard routes answer 404, and `observe`/`act` are filtered out of every agent toolset — the agent works on the web exclusively through `browse`. The code stays in the repo; the flag puts it back.

## Why?
The review found the panel's polling re-created exactly the idle billing the refcount exists to kill: a fixed `runId: 'computer-screen'` holder refreshed out to +15 minutes after the viewer left. The DM turn was the other leak — its session was opened at turn start and never released. The desktop removal is a product decision: the scripted browser tool covers what the agent needs (fast, textual, cheap), while the GUI path costs vision round-trips and exists mainly for user take-over, which is also being removed.

## How?
- `PROVISION_HOLDER_TTL_MS` (120 s) lives in `packages/agent-adapters` and flows through `provision()` → `openBrandSandbox({ holderTtlMs })`; default stays the full lease for real work paths (chat, render).
- `HOLDER_CONFLICT_TARGET` is the single source of the conflict columns; the test reads the migration file and asserts the unique index matches it verbatim.
- `release()` consults the handle's status: on a stopped VM it skips the `rm -rf` (which would auto-resume the VM just to delete a directory) and only drops the holder.
- `agentDesktopEnabled()` gates routes server-side (404) and the panel via `+page.server.ts` data; tool filtering happens at the two call sites that build toolsets from `BUILTIN_TOOLS`.

## Testing?
- Full unit suite: **5901 tests / 522 files, all green** (including 8 new holder tests, the migration-pin test, and the updated guardian tests).
- Updated to the new defaults: `live.test.ts` mocks now include the released handle (the missing one was the actual cause of 44 red tests), the bridge source-pin test matches the filtered tool fusion, and the computer-route server tests run with the flag mocked on.
- Not tested: a real VNC session with the flag on (the feature is off by default now), and production billing behavior — the `ai_calls`-vs-Vercel-invoice comparison remains the follow-up.

## Evidence (screenshots/videos)
<details>
<summary>Full unit suite after all changes</summary>

```
npx vitest run
 Test Files  522 passed (522)
      Tests  5901 passed (5901)
```
</details>
<details>
<summary>What the review found and what closed it</summary>

```
#56  provision() 15-min holder leak      → holderTtlMs: 120s on every provision() caller
#57  onConflict drift undetectable       → HOLDER_CONFLICT_TARGET pinned against migration SQL
minor 5  release() boots stopped VM      → status guard in release()
DM turn  session never released          → handle returned + released in live.ts finally
```
</details>

## Anything Else?
The desktop code paths (graphical bootstrap, VNC routes, observe/act executor) are now dead by default but alive behind `AGENT_DESKTOP_ENABLED=1` — if the flag stays off for a release cycle or two, deleting them outright is a clean follow-up. The remaining review minors (stopWhenIdle error logging, expired-row purge, billing rate recalibration) are noted and unassigned.