### PR TITLE
Fix chat image vision on rebuilt turns, kit relaunches and turn finalize

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -118,6 +118,9 @@ Il typechecker rifiuta: `Type '{ [k: string]: ... }' is missing properties from 
 ### L'ordine atteso va calcolato, non scritto a memoria
 `expect(sorted).toEqual(['a', 'z', 'm'])` fallisce perché l'hai scritto in ordine di pensiero. `[...base, extra].sort()`, come il ricevente.
 
+### La PR che dice "risolto" è verificata solo sul primo invio, non sul redo
+La PR #24 verificava l'immagine allegata al primo messaggio: viaggia come data-URL, una **stringa**, e sopravvive a ogni trasformazione. Sul redo la history ricostruita porta l'URL come **oggetto `URL`**, e `stripProviderRefs` lo ricostruiva via `Object.entries` — che per un `URL` restituisce `[]` — lasciando `image: {}`: l'adattatore pi scarta in silenzio e il modello risponde di vedere solo il testo `[attached: url]`. Il difetto visivo tornava solo sui turni ricostruiti (redo, retry, continuazione), mai su quelli che la verifica aveva coperto. Segnale: il reasoning dell'agente dice "l'utente ha allegato un'immagine via URL… non percepisso nessun contenuto visivo". Mossa: riprodurre l'INTERA catena di trasformazioni che il messaggio subisce (ricostruzione history → strip → adattatore), non solo l'invio felice; e ogni funzione che riscrive ricorsivamente i messaggi ha il suo unit test su parti multimodali, non solo su parti testuali.
+
 ## Prodotto
 
 ### La differenza per-agente si chiama mappa, non sottosistema

--- a/changelog/2026-08-29-chat-image-redo-vision.md
+++ b/changelog/2026-08-29-chat-image-redo-vision.md
@@ -1,0 +1,39 @@
+# Le immagini allegate non raggiungevano il modello sui turni ricostruiti dalla history
+
+La PR #24 aveva sistemato il primo invio: l'immagine viaggia come data-URL, una
+stringa, e attraversa indenne ogni trasformazione fino a `extractUserImages` del
+patch pi. Ma sui turni RICOSTRUITI dalla history — redo, retry di un turno morto,
+continuazioni di obiettivo e anti-ripetizione — `messagesFromRow` produce parti
+immagine con `image: new URL(...)`, un OGGETTO. `stripProviderRefs` (live.ts) ricostruiva
+ogni oggetto con `Object.entries`, che per un `URL` restituisce `[]`: la parte
+arrivava all'adattatore come `image: {}`, veniva scartata in silenzio, e il modello
+riceveva solo il testo `[attached: <url>]` — rispondendo di non vedere l'immagine.
+Prova di produzione: reasoning del 28/8 18:05 UTC («They attached an image via URL…
+I don't actually perceive any image content»), 5 minuti prima della task #57.
+
+Riproduzione deterministica (`scripts/debug/pi-kit-image-loop.mjs`, harness pi reale
++ OpenRouter vero): URL oggetto senza strip → l'immagine arriva; URL oggetto con
+`stripProviderRefs` → 3/3 turni senza immagine nel body, «Non vedo alcuna immagine».
+
+Fix: `stripProviderRefs` estratto in `provider-refs.ts` (modulo puro, testabile senza
+tirarsi dietro `live.ts`) con la conservazione degli `URL` — serializzati come stringa
+https che `extractUserImages` scarica — e unit test sulle parti multimodali
+(`provider-refs.test.ts`, rosso→verde). Lezione in LESSONS.md: la PR che dice
+«risolto» era verificata solo sul primo invio, non sul redo.
+
+## Il crash del secondo turno (stessa sessione di diagnosi)
+
+Il giorno stesso, il run c0c11b3d (agente content, glm su openrouter) moriva a fine
+turno con «HarnessAgent: received terminal finish with unclosed step content»: la
+chain è `finish()` dell'harness che lancia quando lo step non è chiuso → `fail()` →
+`result.steps` rigettato → `handleFinish` catch → «Errore del turno» salvato in chat.
+La forma: `stopReason 'error' | 'aborted'` in pi-agent-core emette `turn_end` col
+messaggio che CONTIENE ancora la tool call mai eseguita; l'adattatore aggiunge gli id
+ai `pendingStepToolCallIds`, `finishStep` resta muto (`size > 0`), e il `finish`
+terminale dopo `session.prompt` trova lo step aperto.
+
+Il contratto dell'harness è esplicito («adapters must emit `finish-step` before
+`finish`»): il patch ora chiude lo step aperto (finish-step con unified `"other"`,
+unico valore onesto nell'enum) prima del `finish` terminale e prima dell'emissione
+d'errore — no-op quando lo step è già chiuso. Verificato coi tre scenari del loop
+(errore dopo toolcall, socket cut, turno sano) e dalla suite bridge (118 verdi).

--- a/changelog/2026-08-29-chat-image-redo-vision.md
+++ b/changelog/2026-08-29-chat-image-redo-vision.md
@@ -37,3 +37,16 @@ Il contratto dell'harness è esplicito («adapters must emit `finish-step` befor
 unico valore onesto nell'enum) prima del `finish` terminale e prima dell'emissione
 d'errore — no-op quando lo step è già chiuso. Verificato coi tre scenari del loop
 (errore dopo toolcall, socket cut, turno sano) e dalla suite bridge (118 verdi).
+
+## Rilanci e composer (stessa catena, stessa giornata)
+
+- I RILANCI del kit (verdetto, anti-ripetizione) e le CONTINUAZIONI accodate ricostruiscono il
+  turno con l'ultimo messaggio utente testuale: l'harness collassa la catena su quello, le
+  immagini di un turno precedente non arrivano, e l'agente smentisce («l'immagine non mi è mai
+  arrivata») dopo averla vista. Il messaggio di continuazione ora porta con sé le parti immagine
+  (`carryImagesToContinuation`); il drain carica la storia col media attivo.
+- Il COMPOSER può inviare con il downscale ancora in volo (nessun indicatore, payload senza
+  l'immagine): chip "in elaborazione" nella strip, invio bloccato finché l'allegato non è pronto.
+- Il decode/encode browser (createImageBitmap, canvas.toBlob, FileReader) è resolve-only: se il
+  callback non arriva, l'allegato sparisce in silenzio. Tetto di stall (15s) che rifiuta e mostra
+  l'errore — nessuna perdita silenziosa è più possibile.

--- a/patches/@ai-sdk+harness-pi+1.0.89.patch
+++ b/patches/@ai-sdk+harness-pi+1.0.89.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@ai-sdk/harness-pi/dist/index.js b/node_modules/@ai-sdk/harness-pi/dist/index.js
-index 258bb62..69002a1 100644
+index 258bb62..f47ea6a 100644
 --- a/node_modules/@ai-sdk/harness-pi/dist/index.js
 +++ b/node_modules/@ai-sdk/harness-pi/dist/index.js
 @@ -967,16 +967,60 @@ function extractUserText(prompt) {
@@ -69,7 +69,30 @@ index 258bb62..69002a1 100644
  function serializeToolOutput(output) {
    if (typeof output === "string") {
      return output;
-@@ -2407,6 +2451,7 @@ async function createPiSession(input) {
+@@ -1060,6 +1104,22 @@ function finishStep(state) {
+     }
+   ];
+ }
++function closeOpenStepForTerminal(state) {
++  if (!state.stepOpen) return [];
++  state.stepOpen = false;
++  state.pendingStepToolCallIds.clear();
++  return [
++    {
++      type: "finish-step",
++      finishReason: { unified: "other", raw: void 0 },
++      usage: {
++        inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
++        outputTokens: { total: 0, text: 0, reasoning: 0 }
++      },
++      harnessMetadata: { pi: { inferredStep: true } }
++    }
++  ];
++}
+ function finishPiApprovalStep(state, toolCallId) {
+   state.stepOpen = true;
+   state.pendingStepToolCallIds.delete(toolCallId);
+@@ -2407,6 +2467,7 @@ async function createPiSession(input) {
      if (stopped) {
        throw new Error("Pi session has been stopped.");
      }
@@ -77,7 +100,7 @@ index 258bb62..69002a1 100644
      const userTools = turnOpts.tools;
      currentEmit = turnOpts.emit;
      const turnAbortController = new AbortController();
-@@ -2483,7 +2528,7 @@ async function createPiSession(input) {
+@@ -2483,7 +2544,7 @@ async function createPiSession(input) {
            }
          });
          try {
@@ -86,7 +109,27 @@ index 258bb62..69002a1 100644
            if (terminalError) {
              if (suspending && isAbortError(terminalError)) return;
              currentEmit?.({ type: "error", error: new Error(terminalError) });
-@@ -2593,6 +2638,7 @@ async function createPiSession(input) {
+@@ -2507,6 +2568,9 @@ async function createPiSession(input) {
+               reasoning: void 0
+             }
+           };
++          for (const part of closeOpenStepForTerminal(translatorState)) {
++            currentEmit?.(part);
++          }
+           currentEmit?.({
+             type: "finish",
+             finishReason,
+@@ -2514,6 +2578,9 @@ async function createPiSession(input) {
+           });
+         } catch (err) {
+           if (suspending && isAbortError(err)) return;
++          for (const part of closeOpenStepForTerminal(translatorState)) {
++            currentEmit?.(part);
++          }
+           currentEmit?.({ type: "error", error: err });
+         } finally {
+           unsubErr();
+@@ -2593,6 +2660,7 @@ async function createPiSession(input) {
        }
        return runTurn({
          text: extractUserText(promptOpts.prompt),
@@ -94,7 +137,7 @@ index 258bb62..69002a1 100644
          tools: promptOpts.tools ?? [],
          instructions: promptOpts.instructions,
          emit: promptOpts.emit,
-@@ -3079,6 +3125,8 @@ var pi = createPi();
+@@ -3079,6 +3147,8 @@ var pi = createPi();
  export {
    VERSION,
    createPi,

--- a/scripts/debug/e2e-image-vision.mjs
+++ b/scripts/debug/e2e-image-vision.mjs
@@ -1,0 +1,143 @@
+/**
+ * GATE E2E — immagine allegata in chat, primo invio e REDO (turno ricostruito dalla history).
+ *
+ * Browser visibile, login reale, thread content NUOVO (agent=content via /chat/new) per non
+ * ereditare l'inquinamento dei turni di verifica. L'immagine è disegnata a runtime (sfondo
+ * rosso, testo bianco "A7X"): l'asserzione è che l'agente RIPORTI il testo — un agente cieco
+ * dice di non vedere l'immagine. Il verdetto del kit può rilanciare un giro correttivo dopo
+ * la risposta: per questo l'asserzione è «una riga assistant dopo il turno contiene il
+ * marker», non «l'ultima riga».
+ *
+ * Uso: node scripts/debug/e2e-image-vision.mjs
+ */
+import { chromium } from 'playwright';
+import { execFileSync } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
+
+const BASE = 'http://localhost:5185';
+const BRAND = 'demo';
+const MARKER = 'A7X';
+const TURN_TIMEOUT_MS = 300_000;
+
+const psql = (sql) =>
+  execFileSync('docker', ['exec', 'anomalia-db', 'psql', '-U', 'postgres', '-d', 'postgres', '-tAc', sql], {
+    encoding: 'utf8'
+  });
+
+const log = (...a) => console.log('[e2e]', ...a);
+let failed = false;
+const check = (name, ok, detail = '') => {
+  console.log(`${ok ? 'PASS' : 'FAIL'} — ${name}${detail ? ` (${detail})` : ''}`);
+  if (!ok) failed = true;
+};
+
+const browser = await chromium.launch({ headless: false, slowMo: 100 });
+const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
+try {
+  // ── Login reale ─────────────────────────────────────────────────────────
+  await page.goto(`${BASE}/login`, { waitUntil: 'domcontentloaded', timeout: 120_000 });
+  await page.locator('input[name="email"]').fill('test@anomalia.so');
+  await page.locator('input[name="password"]').fill('123456');
+  await page.locator('form[action="?/login"] button[type="submit"]').click({ timeout: 120_000 });
+  await page.waitForURL(/\/app/, { timeout: 180_000 });
+  check('login', page.url().includes('/app'), page.url());
+
+  // ── Immagine di prova: canvas nel contesto pagina → PNG su disco ────────
+  const dataUrl = await page.evaluate((mk) => {
+    const c = document.createElement('canvas');
+    c.width = 240; c.height = 240;
+    const x = c.getContext('2d');
+    x.fillStyle = '#c0392b';
+    x.fillRect(0, 0, 240, 240);
+    x.fillStyle = '#ffffff';
+    x.font = 'bold 72px sans-serif';
+    x.textAlign = 'center';
+    x.textBaseline = 'middle';
+    x.fillText(mk, 120, 120);
+    return c.toDataURL('image/png');
+  }, MARKER);
+  const pngPath = '/tmp/e2e-attach.png';
+  writeFileSync(pngPath, Buffer.from(dataUrl.split(',')[1], 'base64'));
+
+  // ── Thread content NUOVO dal composer ───────────────────────────────────
+  const t0 = new Date().toISOString();
+  await page.goto(`${BASE}/app/${BRAND}/chat/new?agent=content`, { waitUntil: 'domcontentloaded' });
+  await page.waitForSelector('textarea.ch-input', { timeout: 60_000 });
+  await page
+    .locator('textarea.ch-input')
+    .fill(`Cosa c'è scritto nell'immagine allegata? Riporta ESATTAMENTE il testo che vedi.`);
+  // Il downscale è async e l'idratazione del composer può rimontare l'input: si ritenta
+  // finché la strip di preview non mostra l'allegato (il segnale che viaggerà col send).
+  let attached = false;
+  for (let i = 0; i < 5 && !attached; i++) {
+    await page.locator('input[type="file"][accept*="image"]').first().setInputFiles(pngPath);
+    attached = await page
+      .locator('.ch-refs .ch-ref')
+      .first()
+      .waitFor({ state: 'visible', timeout: 5_000 })
+      .then(() => true)
+      .catch(() => false);
+  }
+  check('allegato in composer (strip visibile)', attached);
+  await page.locator('button.ch-send[type="submit"]').click();
+  log('primo invio partito…');
+
+  // Il thread nasce al primo invio: aspetta il thread_id nuovo e la risposta.
+  await page.waitForURL(/\/chat\//, { timeout: 60_000 });
+  const threadId = page.url().split('/chat/')[1].split(/[?#]/)[0];
+  check('thread content creato', /^[0-9a-f-]{36}$/.test(threadId), threadId);
+
+  // ── Aspetta una riga assistant che contiene il marker (o un errore) ─────
+  const waitMarker = async (sinceIso, label) => {
+    const since = sinceIso.replace('T', ' ').replace('Z', '');
+    const deadline = Date.now() + TURN_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+      const out = psql(
+        `select substr(replace(content, E'\\n', ' '), 1, 400) from chat_messages
+         where thread_id = '${threadId}' and role = 'assistant'
+           and created_at > '${since}'::timestamptz
+           and content ILIKE '%${MARKER}%'
+         limit 1;`
+      ).trim();
+      if (out) return out;
+      const err = psql(
+        `select substr(content, 1, 200) from chat_messages
+         where thread_id = '${threadId}' and role = 'assistant'
+           and created_at > '${since}'::timestamptz
+           and (content ILIKE '%Errore del turno%' OR content ILIKE '%Turn error%')
+         limit 1;`
+      ).trim();
+      if (err) return null;
+      await new Promise((r) => setTimeout(r, 4000));
+    }
+    return null;
+  };
+
+  const firstText = await waitMarker(t0, 'primo invio');
+  check('primo invio: l’agente legge il testo dell’immagine', !!firstText, (firstText ?? 'NESSUNA RISPOSTA').slice(0, 160));
+
+  // ── REDO: il turno ricostruito dalla history (IL PERCORSO DEL BUG) ──────
+  const beforeRedo = new Date().toISOString();
+  await page.waitForTimeout(2500); // hydratazione delle azioni messaggio
+  const redoBtns = page.locator('button[aria-label="Rigenera"]');
+  check('bottone Rigenera presente', (await redoBtns.count()) >= 1);
+  await redoBtns.first().click();
+  log('redo partito…');
+
+  const redoText = await waitMarker(beforeRedo, 'redo');
+  check('redo: l’agente legge ANCORA l’immagine', !!redoText, (redoText ?? 'NESSUNA RISPOSTA').slice(0, 160));
+
+  // ── Persistenza dopo reload ─────────────────────────────────────────────
+  await page.reload({ waitUntil: 'domcontentloaded' });
+  await page.waitForSelector('textarea.ch-input', { timeout: 60_000 });
+  const bodyText = await page.evaluate(() => document.body.innerText);
+  check('risposta visibile in pagina dopo reload', bodyText.toUpperCase().includes(MARKER));
+} catch (e) {
+  failed = true;
+  console.log('[e2e] ERRORE:', e.message?.slice(0, 400));
+} finally {
+  await page.screenshot({ path: '/tmp/e2e-final.png', fullPage: true }).catch(() => {});
+  await browser.close();
+}
+console.log(failed ? '=== GATE ROSSO ===' : '=== GATE VERDE ===');
+process.exit(failed ? 1 : 0);

--- a/scripts/debug/e2e-send-once.mjs
+++ b/scripts/debug/e2e-send-once.mjs
@@ -1,0 +1,34 @@
+// Un solo invio con immagine: strumento per leggere [DEBUG-img] nel log del dev server.
+import { chromium } from 'playwright';
+const BASE = 'http://localhost:5185';
+const browser = await chromium.launch({ headless: false, slowMo: 100 });
+const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
+await page.goto(`${BASE}/login`, { waitUntil: 'domcontentloaded', timeout: 120_000 });
+await page.locator('input[name="email"]').fill('test@anomalia.so');
+await page.locator('input[name="password"]').fill('123456');
+await page.locator('form[action="?/login"] button[type="submit"]').click({ timeout: 120_000 });
+await page.waitForURL(/\/app/, { timeout: 180_000 });
+const dataUrl = await page.evaluate(() => {
+  const c = document.createElement('canvas');
+  c.width = 240; c.height = 240;
+  const x = c.getContext('2d');
+  x.fillStyle = '#c0392b'; x.fillRect(0, 0, 240, 240);
+  x.fillStyle = '#ffffff'; x.font = 'bold 72px sans-serif';
+  x.textAlign = 'center'; x.textBaseline = 'middle';
+  x.fillText('A7X', 120, 120);
+  return c.toDataURL('image/png');
+});
+import { writeFileSync } from 'node:fs';
+writeFileSync('/tmp/e2e-attach.png', Buffer.from(dataUrl.split(',')[1], 'base64'));
+await page.goto(`${BASE}/app/demo/chat/new?agent=content`, { waitUntil: 'domcontentloaded' });
+await page.waitForSelector('textarea.ch-input', { timeout: 60_000 });
+await page.locator('textarea.ch-input').fill(`Cosa c'è scritto nell'immagine allegata? Riporta ESATTAMENTE il testo che vedi.`);
+await page.locator('input[type="file"][accept*="image"]').first().setInputFiles('/tmp/e2e-attach.png');
+await page.waitForTimeout(1500); // il downscale è async: lasciare finire
+await page.locator('button.ch-send[type="submit"]').click();
+console.log('inviato — thread:', await page.url());
+await page.waitForTimeout(90_000);
+const body = await page.evaluate(() => document.body.innerText);
+const m = body.split('\n').filter(l => /A7X|vedo|allegat|immagine/i.test(l)).slice(0, 6).join(' | ');
+console.log('page says:', m.slice(0, 400));
+await browser.close();

--- a/scripts/debug/pi-kit-image-loop.mjs
+++ b/scripts/debug/pi-kit-image-loop.mjs
@@ -1,0 +1,227 @@
+/**
+ * LOOP DI RIPRODUZIONE — immagini in chat sul percorso kit (pi) + ordine degli eventi di fine turno.
+ *
+ * Monte un server OpenAI-compatibile finto (stream SSE senza `finish_reason`, lo stesso difetto
+ * misurato su glm/openrouter) e fa girare l'harness pi REALE (patch compresa) contro di esso.
+ * Rosso quando:
+ *   (a) le parti immagine del messaggio utente NON arrivano nel body della richiesta, oppure
+ *   (b) il turno si chiude senza un `finish-step` prima del `finish` terminale
+ *       ("received terminal finish with unclosed step content").
+ *
+ * Uso: node scripts/debug/pi-kit-image-loop.mjs [--no-image] [--with-finish-reason]
+ */
+import { createServer } from 'node:http';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { HarnessAgent } from '@ai-sdk/harness/agent';
+import { createPi } from '@ai-sdk/harness-pi';
+import { createJustBashSandbox } from '@ai-sdk/sandbox-just-bash';
+
+const args = new Set(process.argv.slice(2));
+const SEND_IMAGE = !args.has('--no-image');
+const SEND_FINISH_REASON = args.has('--with-finish-reason');
+// S5: il turno termina normalmente ma l'ultimo messaggio contiene una tool call che nessuno
+// esegue (finish_reason 'stop', non 'tool_calls'): message_end aggiunge l'id ai pending,
+// turn_end non chiude lo step e l'adattatore emette il finish terminale → crash harness.
+const ORPHAN_TOOLCALL = args.has('--orphan-toolcall');
+// S6: errore di stream DOPO una tool call → pi-agent-core emette turn_end con il messaggio
+// che contiene ancora la tool call (stopReason 'error', nessun tool-result) → pending non
+// svuotato, step aperto, finish terminale → crash "unclosed step content". La forma del crash
+// di produzione (glm su openrouter, run c0c11b3d).
+const ERROR_AFTER_TOOLCALL = args.has('--error-after-toolcall');
+// S2: glm-like — provider 'openrouter' senza finish_reason: attiva supportsFinishReason=false
+// del patch pi-ai e riproduce il crash "unclosed step content" visto in produzione.
+const GLM_MODE = args.has('--glm');
+// S3: OpenRouter VERO (chiave da .env), modello reale di produzione. Nessun server finto.
+const REAL_MODE = args.has('--real');
+const PROVIDER_KEY = REAL_MODE ? 'openrouter' : GLM_MODE ? 'openrouter' : 'fake';
+
+const PORT = 8899 + Math.floor(Math.random() * 100);
+let lastRequestBody = null;
+
+const server = createServer((req, res) => {
+  if (req.method === 'POST' && req.url.endsWith('/chat/completions')) {
+    let raw = '';
+    req.on('data', (c) => (raw += c));
+    req.on('end', () => {
+      lastRequestBody = JSON.parse(raw);
+      res.writeHead(200, { 'content-type': 'text/event-stream' });
+      const sse = (obj) => res.write(`data: ${JSON.stringify(obj)}\n\n`);
+      sse({ id: '1', object: 'chat.completion.chunk', model: 'fake-model', choices: [{ index: 0, delta: { role: 'assistant', content: '' }, finish_reason: null }] });
+      // glm-style: reasoning prima del testo, come si vede in produzione su openrouter.
+      sse({ id: '2', object: 'chat.completion.chunk', model: 'fake-model', choices: [{ index: 0, delta: { reasoning_content: 'the user attached something' }, finish_reason: null }] });
+      sse({ id: '3', object: 'chat.completion.chunk', model: 'fake-model', choices: [{ index: 0, delta: { content: 'I received ' + (JSON.stringify(lastRequestBody.messages.at(-1).content).includes('image_url') ? 'AN IMAGE' : 'TEXT ONLY') }, finish_reason: null }] });
+      if (ORPHAN_TOOLCALL) {
+        sse({ id: '5', object: 'chat.completion.chunk', model: 'fake-model', choices: [{ index: 0, delta: { tool_calls: [{ index: 0, id: 'call_orphan', type: 'function', function: { name: 'nonexistent_tool', arguments: '{}' } }] }, finish_reason: null }] });
+        sse({ id: '6', object: 'chat.completion.chunk', model: 'fake-model', choices: [{ index: 0, delta: {}, finish_reason: 'stop' }] });
+      } else if (ERROR_AFTER_TOOLCALL) {
+        sse({ id: '5', object: 'chat.completion.chunk', model: 'fake-model', choices: [{ index: 0, delta: { tool_calls: [{ index: 0, id: 'call_orphan', type: 'function', function: { name: 'nonexistent_tool', arguments: '{}' } }] }, finish_reason: null }] });
+        if (args.has('--socket-cut')) {
+          // Troncamento AL SOCKET, senza frame d'errore: pi-ai marca il messaggio
+          // 'aborted' → l'agent-loop termina NORMALMENTE (turn_end → agent_end) con la
+          // tool call mai eseguita → step aperto al finish terminale.
+          setTimeout(() => res.destroy(), 20);
+          return;
+        }
+        // Errore del provider a metà stream, dopo la tool call.
+        res.write(`data: ${JSON.stringify({ error: { message: 'upstream overloaded', code: 500 } })}\n\n`);
+        res.end();
+        return;
+      } else {
+        sse({ id: '4', object: 'chat.completion.chunk', model: 'fake-model', choices: [{ index: 0, delta: {}, finish_reason: SEND_FINISH_REASON ? 'stop' : null }] });
+      }
+      res.write('data: [DONE]\n\n');
+      res.end();
+    });
+    return;
+  }
+  res.writeHead(404).end();
+});
+
+await new Promise((ok) => server.listen(PORT, '127.0.0.1', ok));
+
+const agentDir = mkdtempSync(join(tmpdir(), 'pi-loop-'));
+const REAL_MODEL = process.env.OPENROUTER_REAL_MODEL || 'z-ai/glm-5.3-flash';
+writeFileSync(
+  join(agentDir, 'models.json'),
+  JSON.stringify({
+    providers: {
+      [PROVIDER_KEY]: {
+        baseUrl: REAL_MODE ? 'https://openrouter.ai/api/v1' : `http://127.0.0.1:${PORT}/v1`,
+        api: 'openai-completions',
+        apiKey: REAL_MODE ? process.env.OPENROUTER_API_KEY : 'test-key',
+        models: [{ id: REAL_MODE ? REAL_MODEL : 'fake-model', input: ['text', 'image'] }]
+      }
+    }
+  })
+);
+
+const harness = createPi({ agentDir, model: `${PROVIDER_KEY}/${REAL_MODE ? REAL_MODEL : 'fake-model'}` });
+const agent = new HarnessAgent({
+  harness,
+  sandbox: createJustBashSandbox(),
+  instructions: 'You are a test agent.',
+  tools: {},
+  stopWhen: []
+});
+
+const session = await agent.createSession({ sessionId: 'loop-session' });
+
+const IMAGE_1PX = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+// La forma che produce MESSAGESFROMROW su un redo: l'URL remoto come OGGETTO URL
+// (attachmentParts fa `new URL(url)`), non una stringa.
+const IMAGE_REMOTE_URL = process.env.LOOP_IMAGE_URL
+  ?? 'https://kszazivzwievqixcnanp.supabase.co/storage/v1/object/public/media/bd58d38a-b6ce-4e17-a909-1a334f8bf09f/chat/35572eac-2294-4878-92c3-e6a5c0769220.jpeg';
+const imagePart = REAL_MODE ? { type: 'image', image: new URL(IMAGE_REMOTE_URL) } : { type: 'image', image: IMAGE_1PX };
+const messages = [
+  {
+    role: 'user',
+    content: [
+      { type: 'text', text: 'Cosa vede nella img?' },
+      ...(SEND_IMAGE ? [imagePart] : [])
+    ]
+  }
+];
+
+const events = [];
+const modelText = [];
+const partErrors = [];
+
+// Copia di stripProviderRefs (src/lib/agent/bridge/provider-refs.ts) — il passo che runKitTurn
+// fa su OGNI messaggio prima di passarli all'harness. --strip lo applica al loop.
+function stripProviderRefs(value) {
+  if (Array.isArray(value)) return value.map(stripProviderRefs);
+  if (value instanceof URL) return value.toString();
+  if (value && typeof value === 'object') {
+    const out = {};
+    for (const [k, v] of Object.entries(value)) {
+      if (k === 'providerOptions' || k === 'providerMetadata') continue;
+      out[k] = stripProviderRefs(v);
+    }
+    return out;
+  }
+  return value;
+}
+const APPLY_STRIP = args.has('--strip');
+// S4: abort a metà stream (Stop dell'utente / watchdog del silenzio). Il pi adapter deve
+// chiudere lo step aperto PRIMA dell'evento di errore, o l'harness muore con
+// "received terminal finish with unclosed step content".
+const ABORT_MODE = args.has('--abort');
+const abortController = new AbortController();
+
+// Intercetta il body HTTP reale inviato al provider (solo modalità --real).
+let wireBody = null;
+const origFetch = globalThis.fetch;
+if (REAL_MODE) {
+  globalThis.fetch = async (input, init) => {
+    const url = typeof input === 'string' ? input : input?.url ?? '';
+    if (url.includes('/chat/completions') && init?.body) {
+      try { wireBody = JSON.parse(String(init.body)); } catch { /* lascia passare */ }
+    }
+    return origFetch(input, init);
+  };
+}
+
+let textDeltasSeen = 0;
+const result = await agent.stream({
+  session,
+  messages: APPLY_STRIP ? stripProviderRefs(messages) : messages,
+  abortSignal: ABORT_MODE ? abortController.signal : undefined
+});
+for await (const part of result.fullStream) {
+  events.push(part.type);
+  if (part.type === 'text-delta') {
+    modelText.push(part.delta ?? part.textDelta ?? part.text ?? '');
+    // Abort DOPO il primo contenuto: lo step è aperto e pieno, come nel crash di produzione.
+    textDeltasSeen += 1;
+    if (ABORT_MODE && textDeltasSeen === 3 && !abortController.signal.aborted) {
+      console.log('  [loop] abort a metà stream (contenuto aperto)');
+      abortController.abort(new Error('user stop'));
+    }
+  }
+  if (part.type === 'error') {
+    partErrors.push(part.error?.message ?? String(part.error));
+    console.log('  [event error]', part.error?.message ?? part.error);
+  }
+}
+
+const hadFinishStep = events.includes('finish-step');
+const hadFinish = events.includes('finish');
+const finishOrderOk = hadFinish && events.indexOf('finish-step') < events.indexOf('finish');
+const lastMsg = lastRequestBody?.messages?.at(-1);
+const providerSawImage = JSON.stringify(lastMsg?.content ?? '').includes('image_url');
+const modelSawImage = (lastRequestBody && JSON.stringify(lastRequestBody)) ? undefined : null;
+
+console.log('--- VERDETTO ---');
+console.log('risposta del modello:', modelText.join('').slice(0, 400) || '(vuota)');
+console.log('eventi:', events.join(' '));
+if (REAL_MODE) {
+  const lastWire = wireBody?.messages?.at(-1);
+  console.log('body HTTP → provider, ultimo messaggio:', lastWire ? JSON.stringify(lastWire.content).slice(0, 300) : 'NON CATTURATO');
+}
+console.log('provider ha ricevuto una parte immagine:', providerSawImage ? 'SÌ' : 'NO — il modello vede solo testo/URL');
+console.log('finish-step prima di finish:', finishOrderOk ? 'SÌ' : 'NO — turno muore con unclosed step content');
+
+let failed = false;
+if (ABORT_MODE || ERROR_AFTER_TOOLCALL) {
+  const sawUnclosedStep = partErrors.join(' ').includes('unclosed step content');
+  if (sawUnclosedStep) {
+    console.log('RED: il crash "unclosed step content" è riprodotto');
+    failed = true;
+  } else {
+    console.log('GREEN: nessun crash "unclosed step content" — il turno si chiude con un evento terminale pulito');
+  }
+  if (!REAL_MODE) server.close();
+  process.exit(failed ? 1 : 0);
+}
+if (SEND_IMAGE && REAL_MODE && !/image|foto|immagine|pixel|photo/i.test(modelText.join(''))) {
+  console.log('RED: il modello non riferisce di avere ricevuto un\'immagine');
+  failed = true;
+}
+if (SEND_IMAGE && !REAL_MODE && !providerSawImage) { console.log('RED: le immagini non raggiungono il provider'); failed = true; }
+if (!finishOrderOk) { console.log('RED: ordine finish-step/finish violato'); failed = true; }
+if (!failed) console.log('GREEN: immagini consegnate e turno chiuso correttamente');
+
+if (!REAL_MODE) server.close();
+process.exit(failed ? 1 : 0);

--- a/scripts/debug/pi-resolved-model.mjs
+++ b/scripts/debug/pi-resolved-model.mjs
@@ -1,0 +1,41 @@
+/**
+ * Cosa risolve pi per il modello di produzione? Stampa id/provider/input del modello
+ * che l'harness usa davvero, con e senza refresh della rete.
+ *
+ * Uso: node scripts/debug/pi-resolved-model.mjs [agentDir]
+ */
+import { ModelRuntime } from '@earendil-works/pi-coding-agent';
+import { mkdtempSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const argDir = process.argv[2];
+const agentDir = argDir ?? mkdtempSync(join(tmpdir(), 'pi-resolve-'));
+if (!argDir) {
+  writeFileSync(
+    join(agentDir, 'models.json'),
+    JSON.stringify({
+      providers: {
+        openrouter: {
+          baseUrl: 'https://openrouter.ai/api/v1',
+          api: 'openai-completions',
+          apiKey: 'test-key',
+          models: [{ id: 'z-ai/glm-5.3-flash', input: ['text', 'image'] }]
+        }
+      }
+    })
+  );
+}
+console.log('models.json:', readFileSync(join(agentDir, 'models.json'), 'utf8').slice(0, 300));
+if (existsSync(join(agentDir, 'models-store.json'))) {
+  const s = readFileSync(join(agentDir, 'models-store.json'), 'utf8');
+  console.log('models-store.json (refreshed catalog, primi 400):', s.slice(0, 400));
+}
+
+for (const offline of [true, false]) {
+  process.env.PI_OFFLINE = offline ? '1' : '';
+  const runtime = await ModelRuntime.create({ modelsPath: join(agentDir, 'models.json') });
+  const all = runtime.getModels('openrouter');
+  const m = all.find((x) => x.id === 'z-ai/glm-5.3-flash');
+  console.log(`offline=${offline} → modello trovato:`, m ? `${m.provider}/${m.id} input=${JSON.stringify(m.input)} api=${m.api} baseUrl=${m.baseUrl}` : 'ASSENTE');
+}

--- a/scripts/debug/probe-attach.mjs
+++ b/scripts/debug/probe-attach.mjs
@@ -1,0 +1,23 @@
+import { chromium } from 'playwright';
+const BASE = 'http://localhost:5185';
+const browser = await chromium.launch({ headless: false, slowMo: 80 });
+const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
+page.on('console', (m) => { if (m.type() === 'error') console.log('[console]', m.text().slice(0, 200)); });
+await page.goto(`${BASE}/login`, { waitUntil: 'domcontentloaded' });
+await page.locator('input[name="email"]').fill('test@anomalia.so');
+await page.locator('input[name="password"]').fill('123456');
+await page.locator('form[action="?/login"] button[type="submit"]').click({ timeout: 120_000 });
+await page.waitForURL(/\/app/, { timeout: 180_000 });
+await page.goto(`${BASE}/app/demo/chat/new?agent=content`, { waitUntil: 'domcontentloaded' });
+await page.waitForSelector('textarea.ch-input', { timeout: 60_000 });
+await page.locator('textarea.ch-input').fill('test');
+await page.locator('input[type="file"][accept*="image"]').first().setInputFiles('/tmp/e2e-attach.png');
+for (let i = 0; i < 10; i++) {
+  await page.waitForTimeout(1000);
+  const refs = await page.locator('.ch-refs .ch-ref').count();
+  const err = await page.locator('.ch-ref-err').innerText().catch(() => '');
+  if (refs > 0 || err) { console.log(`t+${i+1}s refs=${refs} err="${err}"`); break; }
+}
+const refCount = await page.locator('.ch-refs .ch-ref').count();
+console.log('refs finali:', refCount);
+await browser.close();

--- a/scripts/debug/probe-login.mjs
+++ b/scripts/debug/probe-login.mjs
@@ -1,0 +1,13 @@
+import { chromium } from 'playwright';
+const BASE = 'http://localhost:5185';
+const browser = await chromium.launch({ headless: false });
+const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
+await page.goto(`${BASE}/login`, { waitUntil: 'domcontentloaded' });
+await page.locator('input[name="email"]').fill('test@anomalia.so');
+await page.locator('input[name="password"]').fill('123456');
+await page.locator('form[action="?/login"] button[type="submit"]').click({ timeout: 60_000 });
+await page.waitForTimeout(8000);
+console.log('url:', page.url());
+const formText = await page.locator('form[action="?/login"]').innerText().catch(() => '(form gone)');
+console.log('form:', formText.replace(/\n+/g, ' | ').slice(0, 300));
+await browser.close();

--- a/scripts/debug/probe-redo.mjs
+++ b/scripts/debug/probe-redo.mjs
@@ -1,0 +1,30 @@
+import { chromium } from 'playwright';
+const BASE = 'http://localhost:5185';
+const THREAD_ID = '772c2578-f459-41e4-afc9-3c2cd4dafc93';
+const browser = await chromium.launch({ headless: false, slowMo: 100 });
+const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
+page.on('response', async (r) => {
+  if (r.url().includes('/chat') && r.request().method() === 'POST') {
+    console.log('POST', r.url(), '→', r.status());
+    const body = await r.text().catch(() => '');
+    if (!r.ok() || r.status() >= 400) console.log('   body:', body.slice(0, 300));
+  }
+});
+page.on('console', (m) => { if (m.type() === 'error') console.log('[console]', m.text().slice(0, 200)); });
+await page.goto(`${BASE}/login`, { waitUntil: 'domcontentloaded' });
+await page.locator('input[name="email"]').fill('test@anomalia.so');
+await page.locator('input[name="password"]').fill('123456');
+await page.locator('form[action="?/login"] button[type="submit"]').click({ timeout: 120_000 });
+await page.waitForURL(/\/app/, { timeout: 180_000 });
+await page.goto(`${BASE}/app/demo/chat/${THREAD_ID}`, { waitUntil: 'domcontentloaded' });
+await page.waitForSelector('textarea.ch-input', { timeout: 60_000 });
+await page.waitForTimeout(2500); // hydratazione
+const btns = await page.locator('button[aria-label="Rigenera"]').count();
+console.log('bottone Rigenera trovati:', btns);
+const btn = page.locator('button[aria-label="Rigenera"]').first();
+console.log('disabled?', await btn.isDisabled());
+await btn.click();
+await page.waitForTimeout(20_000);
+const rows = await page.evaluate(() => document.querySelectorAll('button[aria-label="Rigenera"]').length);
+console.log('finito attesa — bollard Rigenera in pagina:', rows);
+await browser.close();

--- a/src/lib/agent/bridge/live.ts
+++ b/src/lib/agent/bridge/live.ts
@@ -207,19 +207,9 @@ export interface RunKitTurnInput {
  * risposta precedente: il provider Responses li ritraduce in `item_reference`, che kie
  * rifiuta con un 422 («unknown item type "item_reference"») — successo davvero alle 13:06
  * del 23/8, turno morto. La storia riparte pulita: il contenuto resta, i riferimenti no.
+ * (Vedi provider-refs.ts per il perché delle parti immagine.)
  */
-function stripProviderRefs<T>(value: T): T {
-	if (Array.isArray(value)) return value.map(stripProviderRefs) as T;
-	if (value && typeof value === 'object') {
-		const out: Record<string, unknown> = {};
-		for (const [k, v] of Object.entries(value)) {
-			if (k === 'providerOptions' || k === 'providerMetadata') continue;
-			out[k] = stripProviderRefs(v);
-		}
-		return out as T;
-	}
-	return value;
-}
+import { stripProviderRefs } from './provider-refs';
 
 /** L'ultima tool call del turno, su tutti gli step — decide come si chiude il run. */
 type StepLike = { toolCalls?: ReadonlyArray<{ toolName: string; input?: unknown }> };

--- a/src/lib/agent/bridge/live.ts
+++ b/src/lib/agent/bridge/live.ts
@@ -209,7 +209,7 @@ export interface RunKitTurnInput {
  * del 23/8, turno morto. La storia riparte pulita: il contenuto resta, i riferimenti no.
  * (Vedi provider-refs.ts per il perché delle parti immagine.)
  */
-import { stripProviderRefs } from './provider-refs';
+import { stripProviderRefs, carryImagesToContinuation } from './provider-refs';
 
 /** L'ultima tool call del turno, su tutti gli step — decide come si chiude il run. */
 type StepLike = { toolCalls?: ReadonlyArray<{ toolName: string; input?: unknown }> };
@@ -936,7 +936,7 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
 							...input,
 							messages: [
 								...messages,
-								{ role: 'user', content: repeatedReplyContinuation(locale) } as ModelMessage
+								carryImagesToContinuation(messages, repeatedReplyContinuation(locale)) as ModelMessage
 							],
 							verdictLaps: laps + 1
 						});
@@ -1113,7 +1113,7 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
 								messages: [
 									...messages,
 									...turnMessages,
-									{ role: 'user', content: verdict.continuation } as ModelMessage
+									carryImagesToContinuation(messages, verdict.continuation) as ModelMessage
 								],
 								verdictLaps: laps + 1
 							});

--- a/src/lib/agent/bridge/provider-refs.test.ts
+++ b/src/lib/agent/bridge/provider-refs.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+const { stripProviderRefs } = await import('./provider-refs');
+
+describe('stripProviderRefs — le parti immagine sopravvivono al giro', () => {
+	it('un URL oggetto in una parte immagine resta fruibile dal modello', () => {
+		const messages = [
+			{
+				role: 'user',
+				content: [
+					{ type: 'text', text: 'Cosa vede nella img?' },
+					{ type: 'image', image: new URL('https://cdn.example/a.jpeg') }
+				]
+			}
+		];
+		const out = stripProviderRefs(messages) as typeof messages;
+		const img = (out[0].content as Array<{ type: string; image?: unknown }>)[1];
+		expect(img.type).toBe('image');
+		// URL oggetto o stringa https: extractUserImages legge entrambe. Un {} lo uccide.
+		const image = img.image;
+		const usable =
+			typeof image === 'string' && /^https?:\/\//.test(image) ? true : image instanceof URL;
+		expect(usable).toBe(true);
+	});
+
+	it('una data-URL (primo invio) resta identica', () => {
+		const messages = [
+			{ role: 'user', content: [{ type: 'image', image: 'data:image/png;base64,AAAA' }] }
+		];
+		const out = stripProviderRefs(messages) as typeof messages;
+		expect((out[0].content as Array<{ image?: string }>)[0].image).toBe('data:image/png;base64,AAAA');
+	});
+
+	it('providerOptions e providerMetadata sparisono, il resto resta', () => {
+		const messages = [
+			{
+				role: 'assistant',
+				content: [{ type: 'text', text: 'ciao' }],
+				providerOptions: { openai: { itemId: 'x' } },
+				providerMetadata: { openai: { itemId: 'x' } }
+			}
+		];
+		const out = stripProviderRefs(messages) as Array<Record<string, unknown>>;
+		expect(out[0].providerOptions).toBeUndefined();
+		expect(out[0].providerMetadata).toBeUndefined();
+		expect(out[0].content).toEqual([{ type: 'text', text: 'ciao' }]);
+	});
+});

--- a/src/lib/agent/bridge/provider-refs.test.ts
+++ b/src/lib/agent/bridge/provider-refs.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-const { stripProviderRefs } = await import('./provider-refs');
+const { stripProviderRefs, carryImagesToContinuation } = await import('./provider-refs');
 
 describe('stripProviderRefs — le parti immagine sopravvivono al giro', () => {
 	it('un URL oggetto in una parte immagine resta fruibile dal modello', () => {
@@ -44,5 +44,30 @@ describe('stripProviderRefs — le parti immagine sopravvivono al giro', () => {
 		expect(out[0].providerOptions).toBeUndefined();
 		expect(out[0].providerMetadata).toBeUndefined();
 		expect(out[0].content).toEqual([{ type: 'text', text: 'ciao' }]);
+	});
+});
+
+describe('carryImagesToContinuation — il rilancio non perde le immagini del turno', () => {
+	const imagePart = { type: 'image', image: 'data:image/png;base64,AAAA' };
+
+	it('il messaggio di continuazione porta le parti immagine dell’ultimo turno utente', () => {
+		const messages = [
+			{ role: 'assistant', content: 'prima risposta' },
+			{ role: 'user', content: [{ type: 'text', text: 'guarda' }, imagePart] },
+			{ role: 'assistant', content: [{ type: 'text', text: 'risposta' }] }
+		];
+		const msg = carryImagesToContinuation(messages, 'completa il lavoro') as {
+			role: string;
+			content: Array<{ type: string }>;
+		};
+		expect(msg.role).toBe('user');
+		expect(msg.content[0].type).toBe('text');
+		expect(msg.content.some((p) => p.type === 'image')).toBe(true);
+	});
+
+	it('senza immagini resta il testo nudo, com’era', () => {
+		const messages = [{ role: 'user', content: 'solo testo' }];
+		const msg = carryImagesToContinuation(messages, 'completa') as { content: string };
+		expect(msg.content).toBe('completa');
 	});
 });

--- a/src/lib/agent/bridge/provider-refs.ts
+++ b/src/lib/agent/bridge/provider-refs.ts
@@ -1,0 +1,24 @@
+/**
+ * La storia riparicata porta `providerOptions`/`providerMetadata` con gli `itemId` della
+ * risposta precedente: il provider Responses li ritraduce in `item_reference`, che kie
+ * rifiuta con un 422 («unknown item type "item_reference"»). La storia riparte pulita:
+ * il contenuto resta, i riferimenti no.
+ *
+ * LE PARTI IMMAGINE SOPRAVVIVONO AL GIRO: un `URL` oggetto attraversa Object.entries
+ * come un oggetto vuoto e l'adattatore pi lo scarta in silenzio — il modello riceve solo
+ * il testo `[attached: url]`. Qui l'URL si conserva (come stringa https, che
+ * `extractUserImages` scarica).
+ */
+export function stripProviderRefs<T>(value: T): T {
+	if (Array.isArray(value)) return value.map(stripProviderRefs) as T;
+	if (value instanceof URL) return value.toString() as T;
+	if (value && typeof value === 'object') {
+		const out: Record<string, unknown> = {};
+		for (const [k, v] of Object.entries(value)) {
+			if (k === 'providerOptions' || k === 'providerMetadata') continue;
+			out[k] = stripProviderRefs(v);
+		}
+		return out as T;
+	}
+	return value;
+}

--- a/src/lib/agent/bridge/provider-refs.ts
+++ b/src/lib/agent/bridge/provider-refs.ts
@@ -22,3 +22,23 @@ export function stripProviderRefs<T>(value: T): T {
 	}
 	return value;
 }
+
+/**
+ * IL RILANCIO (verdetto, anti-ripetizione) appende un messaggio utente testuale a una catena
+ * in cui le immagini stanno su un turno PRECEDENTE: l'harness collassa i messaggi all'ULTIMO
+ * turno utente, così le immagini non arrivano e l'agente smentisce («l'immagine non mi è mai
+ * arrivata») dopo averla vista. Il messaggio di continuazione porta con sé le parti immagine
+ * dell'ultimo turno utente che le ha.
+ */
+export function carryImagesToContinuation(messages: unknown[], prompt: string): unknown {
+	const images: unknown[] = [];
+	for (const m of messages) {
+		const rec = m as { role?: string; content?: unknown };
+		if (rec?.role !== 'user' || !Array.isArray(rec.content)) continue;
+		for (const part of rec.content as Array<{ type?: string }>) {
+			if (part?.type === 'image') images.push(part);
+		}
+	}
+	if (!images.length) return { role: 'user', content: prompt };
+	return { role: 'user', content: [{ type: 'text', text: prompt }, ...images] };
+}

--- a/src/lib/components/ChatPrompt.svelte
+++ b/src/lib/components/ChatPrompt.svelte
@@ -167,6 +167,9 @@
   let rootEl = $state<HTMLFormElement>();
   let uploads = $state<string[]>([]);
   let uploadError = $state('');
+  // Downscale in corso: l'invio con un allegato ancora in elaborazione lo lascia a terra
+  // (il payload nasce senza l'immagine e il turno parte cieco). Conta i file in volo.
+  let attaching = $state(0);
   let docs = $state<Array<ChatDocument & { converting?: boolean; error?: string }>>([]);
   let picks = $state<ChatAttachmentPick[]>([]);
   let pendingCommand = $state<string | undefined>(undefined);
@@ -244,6 +247,7 @@
   let recTimer: ReturnType<typeof setInterval> | null = null;
 
   const canSend = $derived(!!value.trim() || hasAttachments);
+  const attachReady = $derived(attaching === 0);
   const showMic = $derived(sttSupported && !!brandSlug && !canSend && !loading && !sending);
 
   /**
@@ -485,7 +489,9 @@
     const text = value.trim();
     micError = '';
     // While a reply is generating, submit still works — the parent queues the message.
-    if ((!text && !hasAttachments) || convertingDocs) return;
+    // Un allegato ancora in elaborazione NON parte col messaggio: blocchiamo l'invio
+    // anziché consegnare un turno cieco (la strip mostra il chip "in elaborazione").
+    if ((!text && !hasAttachments) || convertingDocs || !attachReady) return;
     const attachments = buildAttachmentsPayload(uploads, picks);
     const command = pendingCommand;
     // The same thumbs the strip is showing — the chat puts them straight on the sent bubble
@@ -565,6 +571,7 @@
     input.value = '';
     menu = 'none';
     for (const f of files.slice(0, MAX_UPLOADS - uploads.length)) {
+      attaching += 1;
       try {
         // A clip goes to Storage and travels as a URL; an image still rides inline as a data URL.
         uploads = [
@@ -576,6 +583,8 @@
           (err as Error)?.message === 'video_too_large'
             ? $_('chat.attach.videoTooLarge')
             : $_('chat.attach.uploadFailed');
+      } finally {
+        attaching -= 1;
       }
     }
   }
@@ -794,9 +803,15 @@
   {#if micError}
     <p class="ch-ref-err" role="status" aria-live="polite">{micError}</p>
   {/if}
-  {#if strip.length || docs.length}
+  {#if strip.length || docs.length || attaching > 0}
     <div class="ch-refs">
-      {#each strip as item (item.key)}
+      {#each Array(attaching) as pend, pi (pi)}
+        <div class="ch-ref ch-ref-busy" title={$_('chat.attach.processing')} aria-label={$_('chat.attach.processing')}>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round">
+            <path d="M12 3a9 9 0 1 0 9 9" />
+          </svg>
+        </div>
+      {/each}      {#each strip as item (item.key)}
         <div
           class="ch-ref"
           class:ch-ref-video={/\.(mp4|mov|webm)(\?|$)/i.test(item.url)}
@@ -1384,7 +1399,7 @@
         <button
           type="submit"
           class="ch-send"
-          disabled={!canSend || convertingDocs}
+          disabled={!canSend || convertingDocs || !attachReady}
           aria-label={$_('chat.send')}
         >
           <svg viewBox="0 0 24 24" fill="currentColor"><path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z" /></svg>
@@ -1512,6 +1527,23 @@
     background-size: cover;
     background-position: center;
     border: 1px solid var(--line);
+  }
+  /* Il downscale sta girando: il chip esiste, l'immagine non c'è ancora. */
+  .ch-ref-busy {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--muted);
+  }
+  .ch-ref-busy svg {
+    width: 18px;
+    height: 18px;
+    animation: ch-ref-spin 0.9s linear infinite;
+  }
+  @keyframes ch-ref-spin {
+    to {
+      transform: rotate(360deg);
+    }
   }
   /* A clip has no poster frame — show a film glyph instead of an empty tile. */
   .ch-ref-video {

--- a/src/lib/content/changelog/2026-08-29-chat-attached-images-redo.ts
+++ b/src/lib/content/changelog/2026-08-29-chat-attached-images-redo.ts
@@ -1,0 +1,11 @@
+// Il formato lo definisce ./index.ts (PR changelog-entry-files): qui solo i dati.
+const entry = {
+  date: 'August 29, 2026',
+  title: 'Attached images now reach the agent on every turn',
+  items: [
+    'Regenerating or continuing a conversation no longer makes the agent blind to images you attached earlier — it sees them again, exactly like on the first message.',
+    'Chat turns that got cut off mid-answer now end with an honest error instead of a crash about the conversation itself.',
+  ],
+};
+
+export default entry;

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -9398,7 +9398,8 @@
       "importFailed": "Import failed",
       "remove": "Remove",
       "videoTooLarge": "Video too large (max 18MB).",
-      "uploadFailed": "Upload failed."
+      "uploadFailed": "Upload failed.",
+      "processing": "Processing image…"
     },
     "commands": {
       "label": "Commands",

--- a/src/lib/i18n/locales/it.json
+++ b/src/lib/i18n/locales/it.json
@@ -9399,7 +9399,8 @@
       "importFailed": "Importazione non riuscita",
       "remove": "Rimuovi",
       "videoTooLarge": "Video troppo grande (max 18MB).",
-      "uploadFailed": "Upload fallito."
+      "uploadFailed": "Upload fallito.",
+      "processing": "Elaboro l'immagine…"
     },
     "commands": {
       "label": "Commands",

--- a/src/lib/raster-image-client.stall.test.ts
+++ b/src/lib/raster-image-client.stall.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const { withStallTimeout, CONVERT_STALL_TIMEOUT_MS } = await import('./raster-image-client');
+
+describe('withStallTimeout — un browser API appesa diventa un errore visibile', () => {
+	it('una promessa che non risolve mai rifiuta entro il tetto di stall', async () => {
+		vi.useFakeTimers();
+		const p = withStallTimeout(new Promise<never>(() => {}), 'canvas.toBlob');
+		const outcome = p.then(
+			() => 'resolved',
+			(e: Error) => `rejected: ${e.message}`
+		);
+		await vi.advanceTimersByTimeAsync(CONVERT_STALL_TIMEOUT_MS + 1);
+		expect(await outcome).toBe('rejected: convert_stalled: canvas.toBlob');
+		vi.useRealTimers();
+	});
+
+	it('una promessa che risolve passa indenne', async () => {
+		await expect(withStallTimeout(Promise.resolve('ok'), 'x')).resolves.toBe('ok');
+	});
+});

--- a/src/lib/raster-image-client.ts
+++ b/src/lib/raster-image-client.ts
@@ -38,7 +38,10 @@ async function canvasJpeg(
 	const ctx = canvas.getContext('2d');
 	if (!ctx) return null;
 	ctx.drawImage(bitmap, 0, 0, width, height);
-	return new Promise((resolve) => canvas.toBlob((b) => resolve(b), 'image/jpeg', quality));
+	return withStallTimeout(
+		new Promise<Blob | null>((resolve) => canvas.toBlob((b) => resolve(b), 'image/jpeg', quality)),
+		'canvas.toBlob'
+	);
 }
 
 async function bitmapToJpegBlob(
@@ -78,9 +81,27 @@ export async function fileLooksLikeHeic(file: File): Promise<boolean> {
 	return sniffHeifBrand(head) === 'heic';
 }
 
+/**
+ * I browser API di decode/encode (createImageBitmap, canvas.toBlob, FileReader) sono promesse
+ * resolve-only: se il callback non arriva mai, la catena resta appesa e l'allegato sparisce in
+ * silenzio — nessun errore, nessuna strip, e il turno parte cieco. Il tetto di stall trasforma
+ * ogni appendersi in un rifiuto che la UI mostra.
+ */
+export const CONVERT_STALL_TIMEOUT_MS = 15_000;
+
+export function withStallTimeout<T>(p: Promise<T>, what: string): Promise<T> {
+	return new Promise<T>((resolve, reject) => {
+		const timer = setTimeout(() => reject(new Error(`convert_stalled: ${what}`)), CONVERT_STALL_TIMEOUT_MS);
+		p.then(
+			(v) => { clearTimeout(timer); resolve(v); },
+			(e) => { clearTimeout(timer); reject(e); }
+		);
+	});
+}
+
 async function decodeToBitmap(file: File): Promise<ImageBitmap> {
 	try {
-		return await createImageBitmap(file);
+		return await withStallTimeout(createImageBitmap(file), 'createImageBitmap');
 	} catch (err) {
 		if (!(await fileLooksLikeHeic(file))) throw err;
 		const jpeg = await convertHeicOnServer(file);
@@ -166,12 +187,15 @@ export async function prepareYoutubeThumbnailFile(
 }
 
 function blobToDataUrl(blob: Blob): Promise<string> {
-	return new Promise((resolve, reject) => {
-		const reader = new FileReader();
-		reader.onload = () => resolve(String(reader.result ?? ''));
-		reader.onerror = () => reject(reader.error);
-		reader.readAsDataURL(blob);
-	});
+	return withStallTimeout(
+		new Promise<string>((resolve, reject) => {
+			const reader = new FileReader();
+			reader.onload = () => resolve(String(reader.result ?? ''));
+			reader.onerror = () => reject(reader.error);
+			reader.readAsDataURL(blob);
+		}),
+		'FileReader.readAsDataURL'
+	);
 }
 
 /** Downscale an image file to a JPEG data URL (chat, media generator, motion, post refs). */

--- a/src/lib/server/chat/queue.ts
+++ b/src/lib/server/chat/queue.ts
@@ -92,6 +92,7 @@ import { hydrateChatDocuments } from '$lib/server/hydrate-chat-documents';
 import { DM_REPLY_STEP_CAP, dmAgents, dmBrief, dmNames } from '$lib/chat-dm';
 import { parseRoomAgents, stripRoomPeerTools } from '$lib/server/chat/room';
 import { bilingualNoticeLocale } from '$lib/i18n/locale';
+import { carryImagesToContinuation } from '$lib/agent/bridge/provider-refs';
 
 export function kickChatQueueWork(origin: string): Promise<void> {
 	const headers: Record<string, string> = {};
@@ -709,15 +710,27 @@ await maybeCompactThread(admin, {
 							plan: brand.plan
 						});
 					})().catch((e) => console.warn('[Chat Queue] compattazione kit saltata:', e));
-					let hist = await loadHistory(admin, brand.id, job.user_id as string, threadId);
+					// LLM di chat vision-native: la storia ricaricata per il kit porta le parti
+					// immagine, o un rilancio su un thread con allegati riparte cieco.
+					let hist = await loadHistory(admin, brand.id, job.user_id as string, threadId, undefined, 'images');
 					const tail = hist[hist.length - 1];
 					// Un DM è SEMPRE già salvato: message_agent scrive la riga (firmata col mittente) al
 					// momento dell'invio — risalvarla qui la duplicherebbe senza firma.
+					// Il confronto legge anche il content a PARTI (storia col media attivo): il testo
+					// è il primo pezzo, non l'array intero.
+					const tailText =
+						typeof tail?.content === 'string'
+							? tail.content
+							: Array.isArray(tail?.content)
+								? (tail.content as Array<{ type?: string; text?: string }>)
+										.filter((p) => p?.type === 'text')
+										.map((p) => p.text ?? '')
+										.join('\n')
+								: '';
 					const alreadySaved =
 						isDm ||
 						replay ||
-						(tail?.role === 'user' &&
-							(typeof tail.content === 'string' ? tail.content : '') === userMessageContent);
+						(tail?.role === 'user' && tailText === userMessageContent);
 					if (!alreadySaved) {
 						await saveMessages(
 							admin,
@@ -735,7 +748,13 @@ await maybeCompactThread(admin, {
 					// un DM, l'identità del mittente DENTRO il contenuto — sostituisce l'ultima riga
 					// user invece di duplicarla, stesso gesto del percorso classico.
 					const kitMessages: ModelMessage[] = replay
-						? [...hist, { role: 'user', content: modelUserContent } as ModelMessage]
+						? [
+								...hist,
+								// La continuazione è un messaggio UTENTE per l'harness, che collassa la catena
+								// all'ultimo turno: senza le immagini del turno che si continua, l'agente
+								// riparte cieco e smentisce di averle mai viste.
+								carryImagesToContinuation(hist, modelUserContent) as ModelMessage
+							]
 						: (turnDocuments.length || dmTaggedContent) && hist[hist.length - 1]?.role === 'user'
 							? [...hist.slice(0, -1), { role: 'user', content: modelUserContent } as ModelMessage]
 							: hist;


### PR DESCRIPTION
## What?

Four fixes on the chat image path, all found while closing task #57 ("the AI cannot see attached images"). Net change:

- `stripProviderRefs` (kit bridge) now preserves `URL` objects — previously rebuilt via `Object.entries` (which yields `[]` for a `URL`), image parts arrived at pi as `image: {}` and were silently dropped. Extracted to `provider-refs.ts` with unit tests over multimodal parts.
- The pi harness adapter (patch-package, same pinned 1.0.89) now closes an open step (`finish-step` with unified `"other"`) before the terminal `finish` and before emitting an error. Previously any turn whose last step never closed (e.g. a stream ending with a tool call pi never executed) died at finalize with "received terminal finish with unclosed step content" and the whole run closed as "Errore del turno".
- Kit relaunches (closing verdict, anti-repeat) and queued continuations append a text-only user message; the harness collapses the message chain onto the LAST user turn, so images riding an earlier turn never arrived and the agent denied ever having seen them ("l'immagine non mi è mai arrivata") right after describing it. The continuation message now carries the image parts of the last image-bearing user turn (`carryImagesToContinuation`); the queue drain loads history with media enabled and its duplicate-save comparison is now part-aware.
- The chat composer could send while a downscale was still in flight: no indicator, payload without the image, blind turn. Pending chips now render in the strip, send is blocked until settle, and the browser encode/decode chain (`createImageBitmap`, `canvas.toBlob`, `FileReader`) got a 15s stall timeout so a stalled callback surfaces as a visible composer error instead of a silent loss forever.

## Why?

Production evidence (thread on the `content` agent, Aug 28 18:05 UTC, post-PR-#24): the agent's reasoning read "They attached an image via URL: … I don't actually perceive any image content" — the exact defect task #57 reports against the merged #24. A deterministic reproduction followed: with the history-rebuild shape (`image: new URL(...)`), the provider request body had NO image part in 3/3 runs; without the rebuild transform, the image arrived and the model described it. The unclosed-step crash was reproduced live by the owner on dev (run `c0c11b3d`).

## How?

- `provider-refs.ts`: pure module (testable without importing `live.ts`); `stripProviderRefs` serializes `URL` as the https string `extractUserImages` already knows how to download; `carryImagesToContinuation` attaches prior-turn image parts onto continuation messages.
- `patches/@ai-sdk+harness-pi+1.0.89.patch`: regenerated with a `closeOpenStepForTerminal` helper — no-op when the step is already closed; `unified: "other"` because `"abort"` is not in the harness finish-reason enum.
- `ChatPrompt.svelte`: `attaching` counter drives a pending chip in the strip and blocks send/Enter; `raster-image-client.ts` wraps the three resolve-only browser APIs with `withStallTimeout`.
- Rejected alternative for the relaunch fix: replaying the whole message chain into the session (pi's `_resolveTurnInput` discards it by design — the session owns prior turns), so the images must ride on the collapsed last message.

## Testing?

- Unit: `provider-refs.test.ts` (URL survival red→green witnessed), `raster-image-client.stall.test.ts` (stall timeout with fake timers), bridge suite green (118 → 132 tests across the branch), `svelte-check` error count identical to dev baseline (299, all pre-existing).
- Loop harness `scripts/debug/pi-kit-image-loop.mjs` (kept, documented): real harness + real OpenRouter; scenarios S1 (healthy turn, image delivered), S2 (--glm), S3 (--real), --strip, --abort, --error-after-toolcall all green after fixes.
- Browser (local stack, real login as test user, real provider): first send AND redo both describe the attached image ("Il testo nell'immagine è: **A7X**"), answer persists after reload; captured twice (headed and headless runs). Run `npm run dev` in this worktree with a `.env` pointed at the local stack, then `node scripts/debug/e2e-image-vision.mjs`.
- NOT covered: the eval suite (`npm run eval -- --compare`) was not run — the change touches the chat path, so it should run before merge; and one known flake remains in the gate driver itself (attach step, ~1 in 3 runs), tracked as #64 with a Notion task — the gate fails loudly on it instead of producing false greens.

## Evidence

All from the local stack (worktree dev server, port 5185), never production:

<details>
<summary>Reproduction table — real harness, real OpenRouter (scripts/debug/pi-kit-image-loop.mjs)</summary>

| scenario | result |
|---|---|
| data-URL string, with strip | image in wire body → model describes it |
| URL object, without strip | image downloaded by the patched adapter → described |
| URL object, WITH `stripProviderRefs` (the bug) | 3/3: body has NO image part, "Non vedo alcuna immagine allegata" |
| after fix, with strip | body has the image part → described |

</details>

<details>
<summary>Browser gate (scripts/debug/e2e-image-vision.mjs) — headed run, all checks pass</summary>

```
PASS — login
PASS — allegato in composer (strip visibile)
PASS — thread content creato
PASS — primo invio: l'agente legge il testo dell'immagine (Nell'immagine è scritto: A7X …)
PASS — bottone Rigenera presente
PASS — redo: l'agente legge ANCORA l'immagine (Il testo nell'immagine è: A7X …)
PASS — risposta visibile in pagina dopo reload
=== GATE VERDE ===
```

DB cross-check for the same thread: two distinct kit runs (first send + redo), each assistant row contains the marker; no "Errore del turno" rows.

</details>

<details>
<summary>Stress edge exercised during the gate sessions</summary>

- mid-turn reload (answer persisted, marker still in page after reload)
- double-send / busy path (409 → enqueue) hit while driving the UI
- poisoned harness session ("Request was aborted" on reuse) → fresh-session retry inside the run, turn completes
- the verdict-relaunch path fired naturally during tests: after the fix the relaunch also sees the image instead of denying it

</details>

## Anything Else?

- Known open flake: the gate driver's attach step (~1 in 3 runs the strip never appears) — tracked as [#64](https://github.com/anomaliaso/anomalia/issues/64) + Notion task #58. The gate fails loudly on it; it does not produce false greens.
- The 8s debug instrumentation in the patched dist was removed before regenerating the patch (`[DEBUG-img]` lines are not in the committed patch).
- `scripts/debug/*` stay in the repo on purpose: they are the deterministic reproducers for both defects, and the gate driver is the reusable browser recipe.
- Before merging, per repo rules: run `npm run eval -- --compare` (chat path touched).