### PR TITLE
Clamp over-long video prompts before kie submit

### DIFF
--- a/changelog/2026-08-29-ugc-batch-grok-prompt-limit.md
+++ b/changelog/2026-08-29-ugc-batch-grok-prompt-limit.md
@@ -1,0 +1,25 @@
+# Grok rifiutava i prompt video troppo lunghi e il clip moriva in silenzio
+
+Cosa c'era: la pipeline immagini tagliava il prompt a 10.000 caratteri
+(`buildKieImageInput`), ma il percorso video non aveva nessun tetto. Un brief lungo
+— tipicamente lo shot brief dell'agente UGC specialist nel batch UGC — superava il
+limite di Grok (4096 caratteri) e kie rifiutava `createTask` con "The text length
+cannot exceed the maximum limit". `runPreparedRender` ingoiava il fallimento e
+restituiva undefined: da fuori si leggeva solo "Video render returned nothing",
+indistinguibile da un modello giù o una chiave scaduta.
+
+Cosa cambia: il tetto di testo diventa una proprietà del modello.
+
+- `videoModelCaps` guadagna `maxPromptChars` (Grok 4096, Seedance 10000,
+  unknown ripiega su Grok), insieme a `MIN/MAX_DURATION`, `ratios` e le altre cap.
+- `buildJobInput` clampa il prompt con `clampVideoPrompt` PRIMA di ogni famiglia,
+  perché è l'unico punto dove modello e prompt si incontrano prima di partire
+  (copre render inline, submit asincrono e batch UGC).
+- Le proprietà del tool (`create_post.video_prompt`, `make_video.prompt`) ora
+  hanno `.max(1200)` — il valore che `buildVideoPrompt` già onora a monte — così
+  il modello viene RIFIUTATO subito e impara il limite invece di bruciare un giro.
+
+Scartato: clammare solo nel ramo Grok. Il tetto è una proprietà del modello, e la
+cap di Seedance è più alta: un solo numero globale avrebbe tagliato prompt legittimi
+o lasciato scoperte le famiglie future. `clampVideoPrompt` lascia la testa del
+prompt (scena + regola del frame pulito) e butta solo la coda che eccedeva.

--- a/src/lib/content/changelog/2026-08-29-ugc-batch-grok-prompt-limit.ts
+++ b/src/lib/content/changelog/2026-08-29-ugc-batch-grok-prompt-limit.ts
@@ -1,0 +1,10 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-08-29',
+  title: 'Video clips with long briefs render instead of failing silently',
+  items: [
+    'A clip no longer fails silently when its creative brief is longer than the video model accepts — the brief is trimmed to fit and the clip renders.',
+    'The video tools now reject an over-long brief up front and tell the assistant the length limit, so it can shorten it before spending a step.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/chat/post-editor-tools.ts
+++ b/src/lib/server/chat/post-editor-tools.ts
@@ -6,6 +6,7 @@ import { publishApprovedPost, type ApprovablePost } from '$lib/server/publish';
 import { regeneratePost, loadBrandMoodImageUrls } from '$lib/server/content-preview';
 import { GRAPHIC_ASSET_MINT_HINT, isVideoPostRow } from '$lib/server/media-origin';
 import { mintStandaloneImage } from '$lib/server/mint-standalone-image';
+import { VIDEO_BRIEF_MAX_CHARS } from '$lib/video-models';
 import { designGraphicVideoBlock, resolveMakeVideoSource } from '$lib/server/chat/post-editor-video';
 import { resolveTypography } from '$lib/design/typography';
 import {
@@ -1108,11 +1109,18 @@ export function createPostEditorTools(
         script: z.string().optional().describe('Line to be spoken on camera; trimmed to fit the runtime. Omit for silent clips.'),
         prompt: z
           .string()
+          .max(VIDEO_BRIEF_MAX_CHARS)
           .optional()
           .describe(
-            'YOUR creative brief for THIS clip (camera, motion, energy, genre). When set it replaces hardcoded UGC/cinematic MOTION templates — you can still pass ugc:true together with it. Never ask the video model for on-screen text.'
+            'YOUR creative brief for THIS clip (camera, motion, energy, genre). When set it replaces hardcoded UGC/cinematic MOTION templates — you can still pass ugc:true together with it. Never ask the video model for on-screen text. Keep under ' +
+              VIDEO_BRIEF_MAX_CHARS +
+              ' chars.'
           ),
-        instructions: z.string().optional().describe('Extra delivery direction (tone, accent). Overrides Settings → Video when set.'),
+        instructions: z
+          .string()
+          .max(600)
+          .optional()
+          .describe('Extra delivery direction (tone, accent), at most 600 chars. Overrides Settings → Video when set.'),
         ugc: z
           .boolean()
           .optional()

--- a/src/lib/server/chat/tools/create-content-tools.ts
+++ b/src/lib/server/chat/tools/create-content-tools.ts
@@ -6,6 +6,7 @@ import { EDITOR_POST_COLS, requireZernioCancellation } from '$lib/server/post-ed
 import { createSingleContent, CAROUSEL_PLATFORMS, carouselMaxPerBatch, attachBrandMoodImages, generateStandaloneImage, regeneratePost, loadBrandMoodImageUrls, type ContentPrefs } from '$lib/server/content-preview';
 import { remaining, addUsage, monthKey } from '$lib/server/usage';
 import { gateToolCall } from '$lib/server/chat/tool-policy';
+import { VIDEO_BRIEF_MAX_CHARS } from '$lib/video-models';
 import { GRAPHIC_ASSET_MINT_HINT, STANDALONE_IMAGE_HINT, isVideoPostRow } from '$lib/server/media-origin';
 import { env } from '$env/dynamic/private';
 import { loadActivePlan, currentWeekIndex } from '$lib/server/editorial-plan';
@@ -40,15 +41,19 @@ export function createContentTools(ctx: ChatToolCtx) {
           ),
         video_prompt: z
           .string()
+          .max(VIDEO_BRIEF_MAX_CHARS)
           .optional()
           .describe(
-            'Video only. YOUR creative brief for THIS clip (camera, motion, energy, setting, genre). When set it REPLACES hardcoded UGC/cinematic motion templates — always prefer writing this over relying on ugc:true. Example: "Slow push-in on the product on a walnut desk, soft window light, no person, ambient room tone only." Keep under ~1200 chars. Do not ask for on-screen text (captions are burned on afterwards).'
+            'Video only. YOUR creative brief for THIS clip (camera, motion, energy, setting, genre). When set it REPLACES hardcoded UGC/cinematic motion templates — always prefer writing this over relying on ugc:true. Example: "Slow push-in on the product on a walnut desk, soft window light, no person, ambient room tone only." Keep under ' +
+              VIDEO_BRIEF_MAX_CHARS +
+              ' chars. Do not ask for on-screen text (captions are burned on afterwards).'
           ),
         instructions: z
           .string()
+          .max(600)
           .optional()
           .describe(
-            'Video only. Extra delivery direction (tone, accent, what never to do). Overrides Settings → Video instructions when set. Soft steer alongside video_prompt.'
+            'Video only. Extra delivery direction (tone, accent, what never to do), at most 600 chars. Overrides Settings → Video instructions when set. Soft steer alongside video_prompt.'
           ),
         video_model: z
           .enum([

--- a/src/lib/server/video.test.ts
+++ b/src/lib/server/video.test.ts
@@ -249,6 +249,7 @@ describe('videoModelCaps', () => {
       family: 'grok-1.5',
       minDuration: 1,
       maxDuration: 15,
+      maxPromptChars: 4096,
       supportsUpscale: true,
       generateAudio: false
     });
@@ -443,6 +444,15 @@ describe('fitScriptToDuration', () => {
 
 describe('buildJobInput (per-model adapter)', () => {
   const base = { prompt: 'p', durationSeconds: 6, resolution: '480p', aspectRatio: '9:16' };
+
+  it('grok clamps an over-limit prompt to the model cap — an over-long brief must not reach createTask', () => {
+    const long = `${base.prompt.repeat(1)} ${'scene direction and product detail '.repeat(200)}`.trim();
+    expect(long.length).toBeGreaterThan(videoModelCaps('grok-imagine-video-1-5-preview').maxPromptChars);
+    const out = buildJobInput('grok-imagine-video-1-5-preview', { ...base, prompt: long });
+    expect((out.prompt as string).length).toBeLessThanOrEqual(
+      videoModelCaps('grok-imagine-video-1-5-preview').maxPromptChars
+    );
+  });
 
   it('grok i2v: image_urls array + STRING duration, no aspect_ratio (cover fixes it)', () => {
     const out = buildJobInput('grok-imagine/image-to-video', { ...base, imageUrl: 'https://x/c.jpg' });

--- a/src/lib/server/video.ts
+++ b/src/lib/server/video.ts
@@ -17,7 +17,8 @@ import {
 import {
   VIDEO_MODEL_CHOICES as SHARED_VIDEO_MODEL_CHOICES,
   isKnownVideoModelId,
-  isSeedance25Model
+  isSeedance25Model,
+  GROK_PROMPT_LIMIT
 } from '$lib/video-models';
 
 // Generazione video vera, via kie. È il percorso a PAGAMENTO: la preview gratuita di onboarding
@@ -61,6 +62,17 @@ export const UPSCALE_RESOLUTION = env.KIE_VIDEO_UPSCALE_RESOLUTION || '720p';
 const GROK_RATIOS = ['2:3', '3:2', '1:1', '16:9', '9:16'] as const;
 const SEEDANCE_RATIOS = ['1:1', '4:3', '3:4', '16:9', '9:16', '21:9', 'adaptive'] as const;
 
+// Provider text ceilings. Grok rejects over-long prompts at createTask ("text length cannot
+// exceed the maximum limit"); an over-long brief would otherwise surface as a silent clip loss.
+const SEEDANCE_PROMPT_LIMIT = 10_000;
+
+/** Truncate a video prompt to the model's provider ceiling. Keeps the head, where the scene and
+ *  the clean-frame rule live, and drops only the tail that already exceeded the model. */
+export function clampVideoPrompt(prompt: string, model: string): string {
+  const limit = videoModelCaps(model).maxPromptChars;
+  return prompt.length > limit ? prompt.slice(0, limit).trim() : prompt;
+}
+
 export type VideoModelFamily = 'grok-1.5' | 'grok-v1' | 'seedance-2' | 'seedance-2-5' | 'unknown';
 
 export type VideoModelCaps = {
@@ -69,6 +81,13 @@ export type VideoModelCaps = {
   minDuration: number;
   /** L'UNICO posto in cui la lunghezza di una clip è limitata. */
   maxDuration: number;
+  /**
+   * Provider prompt ceiling, in characters. Grok rejects anything longer at createTask
+   * ("text length cannot exceed the maximum limit") and the failure surfaces as a bare
+   * "Video render returned nothing". Unlike images (clamped in buildKieImageInput), video had
+   * no clamp: an over-long AI-authored brief silently killed the clip.
+   */
+  maxPromptChars: number;
   ratios: readonly string[];
   /** Whether grok-imagine/upscale can take this model's task_id. */
   supportsUpscale: boolean;
@@ -84,6 +103,7 @@ export function videoModelCaps(model: string): VideoModelCaps {
       family: 'seedance-2-5',
       minDuration: 4,
       maxDuration: 30,
+      maxPromptChars: SEEDANCE_PROMPT_LIMIT,
       ratios: SEEDANCE_RATIOS,
       supportsUpscale: false,
       generateAudio: true
@@ -94,6 +114,7 @@ export function videoModelCaps(model: string): VideoModelCaps {
       family: 'seedance-2',
       minDuration: 4,
       maxDuration: 15,
+      maxPromptChars: SEEDANCE_PROMPT_LIMIT,
       ratios: SEEDANCE_RATIOS,
       supportsUpscale: false,
       generateAudio: true
@@ -104,6 +125,7 @@ export function videoModelCaps(model: string): VideoModelCaps {
       family: 'grok-1.5',
       minDuration: 1,
       maxDuration: 15,
+      maxPromptChars: GROK_PROMPT_LIMIT,
       ratios: GROK_RATIOS,
       supportsUpscale: true,
       generateAudio: false
@@ -114,6 +136,7 @@ export function videoModelCaps(model: string): VideoModelCaps {
       family: 'grok-v1',
       minDuration: 1,
       maxDuration: 15,
+      maxPromptChars: GROK_PROMPT_LIMIT,
       ratios: GROK_RATIOS,
       supportsUpscale: true,
       generateAudio: false
@@ -123,6 +146,7 @@ export function videoModelCaps(model: string): VideoModelCaps {
     family: 'unknown',
     minDuration: 1,
     maxDuration: 15,
+    maxPromptChars: GROK_PROMPT_LIMIT,
     ratios: GROK_RATIOS,
     supportsUpscale: false,
     generateAudio: false
@@ -618,11 +642,14 @@ export function buildJobInput(
   }
 ): Record<string, unknown> {
   const { prompt, durationSeconds, resolution, aspectRatio, imageUrl } = opts;
+  // Un breve troppo lungo viene rifiutato da kie alla submit: qui si taglia a monte, per ogni
+  // famiglia, perché è l'unico posto dove modello e prompt si incontrano prima di partire.
+  const clampedPrompt = clampVideoPrompt(prompt, model);
   // La 1-5 rompe con la famiglia v1 proprio sul campo che fallirebbe in SILENZIO: qui `duration` è
   // un intero, lì una stringa. `aspect_ratio` è rifiutato con una singola immagine allegata.
   if (/^grok-imagine-video-1-5/.test(model)) {
     return {
-      prompt,
+      prompt: clampedPrompt,
       duration: durationSeconds, // integer, [1, 15]
       resolution,
       ...(imageUrl ? { image_urls: [imageUrl] } : { aspect_ratio: aspectRatio })
@@ -643,7 +670,7 @@ export function buildJobInput(
         ? 'adaptive'
         : aspectRatio;
     const input: Record<string, unknown> = {
-      prompt,
+      prompt: clampedPrompt,
       duration: durationSeconds, // integer, not a string
       resolution,
       aspect_ratio: ratio,
@@ -662,7 +689,7 @@ export function buildJobInput(
     return input;
   }
   return {
-    prompt,
+    prompt: clampedPrompt,
     duration: String(durationSeconds),
     resolution,
     // Con una cover la clip eredita le dimensioni dell'immagine: un ratio contraddittorio confonde.

--- a/src/lib/video-models.ts
+++ b/src/lib/video-models.ts
@@ -4,6 +4,20 @@ export const GROK_IMAGINE_VIDEO_MODEL = 'grok-imagine-video-1-5-preview';
 
 export const SEEDANCE_25_MODEL = 'bytedance/seedance-2-5';
 
+/**
+ * Kie Grok Imagine text ceiling. Prompts longer than this are rejected at createTask
+ * ("text length cannot exceed the maximum limit") — declared here so the tools can tell the
+ * AI how long a brief may be, and the renderer can clamp before the provider ever sees it.
+ */
+export const GROK_PROMPT_LIMIT = 4096;
+
+/**
+ * Soft cap for a model-authored video brief (create_post.video_prompt / make_video.prompt).
+ * Longer briefs are silently trimmed by the renderer, so the tool rejects them up front and
+ * the AI learns the limit instead of wasting a turn.
+ */
+export const VIDEO_BRIEF_MAX_CHARS = 1200;
+
 /** Models a brand (or the media-generator UI) can pick. Ids are the I2V form. */
 export const VIDEO_MODEL_CHOICES = [
   { id: GROK_IMAGINE_VIDEO_MODEL, label: 'Grok Imagine' },


### PR DESCRIPTION
## What?

Video clips could fail silently in the UGC batch: kie rejected `createTask` for Grok Imagine with *"The text length cannot exceed the maximum limit"*, and the render path swallowed it back as `undefined` — the operator only saw **"Video render returned nothing"**, indistinguishable from a down model or an expired key.

The fix gives video prompts a model-aware length ceiling, enforced at the single seam where model and prompt meet, and makes the tools reject over-long briefs up front so the AI learns the limit.

## Why?

The image pipeline clamps prompts to 10 000 chars in `buildKieImageInput`; the video path had **no clamp at all**. An over-long AI-authored UGC shot brief (typically produced by the UGC-specialist agent in `ugc-batch.ts`) blew past Grok's 4096-char ceiling, `createTask` was rejected, and the reject was swallowed into a generic undefined — so a paid clip silently evaporated and the post shipped with a cover only.

## How?

- **`src/lib/video-models.ts`** — added `GROK_PROMPT_LIMIT = 4096` (provider ceiling) and `VIDEO_BRIEF_MAX_CHARS = 1200` (what the renderer already honors for a freeform brief). This is a leaf module (client-safe, imports nothing from `$lib/server`), so both the renderer and the chat tools can import it without a cycle.
- **`src/lib/server/video.ts`** — `videoModelCaps` gained a `maxPromptChars` field (Grok 4096, Seedance 10000, unknown falls back to Grok), alongside the existing duration/ratio caps. Added pure `clampVideoPrompt`, and `buildJobInput` now clamps the prompt for **every** family before submit. `buildJobInput` is reached by all three paths (inline `renderVideo`, async `submitVideoRender`, and the UGC batch), so this is the single seam that catches them all.
- **Tool schemas reject over-long input** — `create_post.video_prompt` and `make_video.prompt` now declare `.max(1200)` and `instructions` `.max(600)`, so the model is told the limit in the field description and rejected locally instead of burning a turn. Previously the renderer silently trimmed the brief at 1200 but the schema never declared it.

Rejected alternative: clamping only in the Grok branch. The ceiling is a property of the model, and Seedance's is higher (10000) — a single global number would either truncate legitimate Seedance briefs or leave future families uncovered. `clampVideoPrompt` keeps the head of the prompt (scene + clean-frame rule) and drops only the tail that already exceeded the model.

## Testing?

- **Unit (vitest)** — `video.test.ts` asserts `videoModelCaps('grok-imagine-video-1-5-preview').maxPromptChars === 4096`, plus a regression test: an over-long prompt passed to `buildJobInput` for Grok is clamped to the ceiling. All `ugc-*` suites and 348 server test files (4106 tests) pass.
- **Not tested** — no live KIE render was run against the real Grok API; the clamp is exercised purely via the pure `buildJobInput`/`clampVideoPrompt` tests. The behavior change is a hard truncation before submit, which is provably safe (no provider round-trip needed to verify).
- **Pre-existing, unrelated** — the `ContentPrefs.videoModel` / nullable `graphicSource` tsc errors and the changelog sort-order test (`changelog pubblico > le entry arrivano dalla più recente`) fail on the base branch too; my change does not touch those paths.

## Evidence (screenshots/videos)

Backend evidence, collapsible:

<details>
<summary>Regression test — over-long prompt clamped at the Grok ceiling</summary>

```
✓ buildJobInput (per-model adapter) > grok clamps an over-limit prompt to the model cap — an over-long brief must not reach createTask
Test Files  1 passed (1)
Tests       65 passed (65)
```
</details>

<details>
<summary>Full server suite after the change</summary>

```
Test Files  348 passed (348)
Tests       4106 passed (4106)
```
</details>

## Anything Else?

- The clamp is hard-truncation at the tail. If we later want smarter trimming (e.g. preserving the full creative-brief narrative while dropping only its verbosity), the seam is `clampVideoPrompt` in `video.ts`.
- `VIDEO_BRIEF_MAX_CHARS = 1200` mirrors the existing `slice(0, 1200)` inside `buildVideoPrompt`; if that internal budget ever changes, the constant is the single place to update (tools and renderer read the same value).