### PR TITLE
Add idempotent tool-effect ledger to prevent duplicate posts on resume

### DIFF
--- a/changelog/2026-08-29-ledger-effects-idempotent.md
+++ b/changelog/2026-08-29-ledger-effects-idempotent.md
@@ -1,0 +1,62 @@
+# Il ledger degli effetti dei tool: un post/schedulazione, mai due
+
+## Perché esiste
+
+Un turno agent che muore a metà (funzione terminata dalla piattaforma, crash, deadline) e viene
+ripreso ripartiva dalla storia e rieseguiva i tool di scrittura alla cieca. Il caso concreto:
+un turno crea un post (`content_create_post`) o lo schedula (`content_schedule`), il segmento
+muore dopo che l'effetto è avvenuto ma prima che il run si chiuda, il resume o un takeover
+rieseguono la stessa intenzione e il post esce due volte. Oggi il rischio era governato da guard
+ad-hoc per-tool, non da idempotenza dichiarativa: ogni tool riscriveva la propria regola, e la
+regola divergeva silenziosamente al primo cambio.
+
+## Cosa c'era prima
+
+Nessun ledger. Il patch `@ai-sdk/harness-pi` re-inviava gli step al resume, `recoverDeadPartial`
+promuoveva il partial salvato, ma nessuno dei due sapeva dire "questo effetto è già stato fatto".
+
+## La decisione
+
+Portare il pattern `ExternalEffect` di Rakazo: una tabella `agent_kit_effects` (migration
+`20260829130000`) con una riga per effetto, `idempotency_key` deterministica e una macchina a
+stati `intended -> completed|failed`, coi ripieghi `ambiguous` (segmento morto a metà) e
+`reconciled` (confermato fuori). Le scelte che contano:
+
+- **La chiave contiene brand + nome tool + args canonicalizzati, NON il run_id.** Così
+  l'idempotenza riconosce la stessa intenzione attraverso un resume (che riparte da zero) e un
+  takeover, non solo alla ripresa dello stesso run. Order-insensitive (chiavi ordinate), e la
+  lunghezza del payload è codificata nella chiave per evitare collisioni da troncamento. L'hash
+  è FNV-1a a 64 bit: la chiave è un indice, non un segreto, e niente `crypto` asincrona.
+- **Il gate vive in `createApplyTool`, non nei singoli plugin.** È l'unico punto che esegue i
+  tool; un tool dichiara `effectful: true` nel proprio `ToolSpec` e il gate lo avvolge — `intend`
+  prima di eseguire, `resolve` dopo. I plugin (content, motion, ugc) non riscrivono la regola:
+  la marcano. `buildTools` non cambia: il gate è sotto l'executor, il modello vede solo il
+  catalogo di sempre.
+- **`decide()` è puro e testato.** `null` e `failed` rieseguono (nessun esito, o esito negativo:
+  non è un doppione); `completed`/`ambiguous`/`reconciled` congelano. `intended` è il caso "il
+  run corrente è il primo autore" (il segmento è vivo): decide() lo lascia riprovare, perché
+  congelarlo bloccherebbe l'unico tentativo vero.
+- **`reconcileRun` tira gli orfani a `ambiguous`.** Chiamato dallo sweep alla morte di un run:
+  gli `intended` rimasti soli diventano `ambiguous`, e il gate li congelatile. Solo `intended` è
+  toccato: un `completed` è un esito vero.
+- **Il port è nel contratto (`EffectsLedger`), l'implementazione in `effects-store.ts`, la logica
+  in `effects.ts`.** L'executor dipende dall'interfaccia, la superficie (`live.ts`) passa
+  l'implementazione col client admin. Il lab e i test senza ledger non cambiano comportamento.
+
+Scartato: chiave per-run (non sopravvive a resume/takeover, che è il caso che il spec nomina);
+gate per-tool nei plugin (una seconda fonte di verità); `reconciled` automatico (richiede di
+sapere se l'effetto è davvero avvenuto, che è dominio del tool — oggi resta un esercizio manuale).
+
+## Cosa guarda il test
+
+- `effects.test.ts`: la macchina a stati di `decide`, e che `effectKey` è deterministica e
+  order-insensitive e non collida tra intenzioni diverse.
+- `effects-store.test.ts`: `intend`/`find`/`resolve`/`reconcileRun` su un finto client che
+  applica i filtri per davvero (il compare-and-swap si verifica col codice di produzione).
+- `executor.test.ts`: il gate — abort → resume con la stessa intenzione esegue UNA volta;
+  un `ambiguous` non viene rieseguito nemmeno su un run nuovo; `failed` riesegue; solo i tool
+  marcat `effectful` passano dal ledger.
+
+## Da applicare a mano
+
+La migration `20260829130000_agent_kit_effects.sql` (i deploy non eseguono le migration).

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -9,6 +9,8 @@
     "./run-store": "./src/run-store.ts",
     "./computer": "./src/computer.ts",
     "./memory-context": "./src/memory-context.ts",
+    "./effects": "./src/effects.ts",
+    "./effects-store": "./src/effects-store.ts",
     "./tools/builtin": "./src/tools/builtin.ts"
   },
   "dependencies": {

--- a/packages/agent-core/src/effects-store.test.ts
+++ b/packages/agent-core/src/effects-store.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { createEffectsLedger, effectKey } from './effects-store';
+
+type Row = Record<string, unknown>;
+
+/** Il finto client parla con una tabella in memoria, applicando i filtri `eq` per davvero. */
+function fakeDb(seed: Row[] = []) {
+	const rows: Row[] = seed.map((r) => ({ ...r }));
+
+	function from(_table: string) {
+		let op: 'select' | 'insert' | 'update' = 'select';
+		let payload: Row | undefined;
+		const eqFilters: Array<[string, unknown]> = [];
+		let insertId = `e-${rows.length + 1}`;
+
+		function apply(): { data: Row[] | null; error: { message: string } | null } {
+			let matched = rows;
+			for (const [col, val] of eqFilters) matched = matched.filter((r) => r[col] === val);
+			if (op === 'insert' && payload) {
+				const row: Row = {
+					...payload,
+					id: insertId,
+					created_at: '2026-08-29T00:00:00.000Z',
+					updated_at: '2026-08-01T00:00:00.000Z'
+				};
+				rows.push(row);
+				return { data: [row], error: null };
+			}
+			if (op === 'update' && payload) {
+				for (const r of matched) Object.assign(r, payload);
+				return { data: matched, error: null };
+			}
+			return { data: matched, error: null };
+		}
+
+		const b: Record<string, unknown> = {
+			insert(p: Row) {
+				op = 'insert';
+				payload = p;
+				return b;
+			},
+			update(p: Row) {
+				op = 'update';
+				payload = p;
+				return b;
+			},
+			select(_cols?: string) {
+				return b;
+			},
+			eq(col: string, val: unknown) {
+				eqFilters.push([col, val]);
+				return b;
+			},
+			single() {
+				const { data, error } = apply();
+				if (error) return Promise.resolve({ data: null, error });
+				if (!data || data.length !== 1) return Promise.resolve({ data: null, error: { message: 'not exactly one row' } });
+				return Promise.resolve({ data: data[0], error: null });
+			},
+			maybeSingle() {
+				const { data, error } = apply();
+				return Promise.resolve({ data: data?.[0] ?? null, error });
+			},
+			then(resolve: (v: unknown) => void, reject?: (e: unknown) => void) {
+				return Promise.resolve(apply()).then(resolve, reject);
+			}
+		};
+		return b;
+	}
+
+	return { db: { from } as unknown as SupabaseClient, rows };
+}
+
+const ROW = (over: Row = {}): Row => ({
+	id: 'e-1',
+	brand_id: 'b1',
+	run_id: 'r1',
+	tool_name: 'content_schedule',
+	idempotency_key: 'k1',
+	status: 'intended',
+	created_at: '2026-08-29T00:00:00.000Z',
+	updated_at: '2026-08-29T00:00:00.000Z',
+	...over
+});
+
+describe('createEffectsLedger — intend', () => {
+	it('registra intended col request e mappa la riga nel ToolEffect', async () => {
+		const { db } = fakeDb();
+		const ledger = createEffectsLedger(db);
+		const effect = await ledger.intend({ brandId: 'b1', runId: 'r1', toolName: 'content_schedule', key: 'k1', request: { post_id: 'p1' } });
+		expect(effect.status).toBe('intended');
+		expect(effect.brandId).toBe('b1');
+		expect(effect.runId).toBe('r1');
+		expect(effect.idempotencyKey).toBe('k1');
+		expect(effect.request).toEqual({ post_id: 'p1' });
+	});
+});
+
+describe('createEffectsLedger — find', () => {
+	it('la stessa chiave di brand torna la riga esistente', async () => {
+		const { db } = fakeDb([ROW({ idempotency_key: 'k1', status: 'completed', result: { ok: true } })]);
+		const effect = await createEffectsLedger(db).find('b1', 'k1');
+		expect(effect?.status).toBe('completed');
+		expect(effect?.result).toEqual({ ok: true });
+	});
+
+	it('una chiave diversa torna null', async () => {
+		const { db } = fakeDb([ROW({ idempotency_key: 'k1' })]);
+		const effect = await createEffectsLedger(db).find('b1', 'k2');
+		expect(effect).toBeNull();
+	});
+
+	it('un altro brand non condivide la chiave (lo scoping è per brand)', async () => {
+		const { db } = fakeDb([ROW({ brand_id: 'b1', idempotency_key: 'k1' })]);
+		const effect = await createEffectsLedger(db).find('b2', 'k1');
+		expect(effect).toBeNull();
+	});
+});
+
+describe('createEffectsLedger — resolve', () => {
+	it('sposta intended → completed col result', async () => {
+		const { db, rows } = fakeDb([ROW({ idempotency_key: 'k1', status: 'intended' })]);
+		await createEffectsLedger(db).resolve('e-1', 'completed', { post_id: 'p1' });
+		expect(rows[0].status).toBe('completed');
+		expect(rows[0].result).toEqual({ post_id: 'p1' });
+	});
+
+	it('sposta intended → failed in caso di errore', async () => {
+		const { db, rows } = fakeDb([ROW({ idempotency_key: 'k1', status: 'intended' })]);
+		await createEffectsLedger(db).resolve('e-1', 'failed', { message: 'net' });
+		expect(rows[0].status).toBe('failed');
+	});
+});
+
+describe('createEffectsLedger — reconcileRun', () => {
+	it('tira verso ambiguous solo gli intended del run, mai i completed', async () => {
+		const { db, rows } = fakeDb([
+			ROW({ id: 'e-1', run_id: 'r1', status: 'intended' }),
+			ROW({ id: 'e-2', run_id: 'r1', status: 'completed' }),
+			ROW({ id: 'e-3', run_id: 'r2', status: 'intended' })
+		]);
+		const n = await createEffectsLedger(db).reconcileRun('r1');
+		expect(n).toBe(1);
+		expect(rows.find((r) => r.id === 'e-1')?.status).toBe('ambiguous');
+		expect(rows.find((r) => r.id === 'e-2')?.status).toBe('completed');
+		expect(rows.find((r) => r.id === 'e-3')?.status).toBe('intended');
+	});
+});
+
+describe('effectKey — solo il contratto del key non cambia', () => {
+	it('produce una chiave che contiene il nome del tool', () => {
+		expect(effectKey('content_schedule', { post_id: 'p1' })).toContain('content_schedule');
+	});
+});

--- a/packages/agent-core/src/effects-store.ts
+++ b/packages/agent-core/src/effects-store.ts
@@ -1,0 +1,117 @@
+/**
+ * IL LEDGER SU POSTGRES. L'unico punto che scrive `agent_kit_effects`: `intend` prima di eseguire,
+ * `resolve` dopo, `reconcileRun` quando un segmento muore. Il resto (decidere congelare) sta in
+ * `effects.ts`, la logica pura.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { EffectsLedger, ToolEffect } from '@anomalia/agent-kit';
+
+const TABLE = 'agent_kit_effects';
+
+type Row = {
+	id: string;
+	brand_id: string;
+	run_id: string | null;
+	tool_name: string;
+	idempotency_key: string;
+	status: ToolEffect['status'];
+	request?: unknown;
+	result?: unknown;
+	created_at: string;
+	updated_at: string;
+};
+
+function toEffect(r: Row): ToolEffect {
+	return {
+		id: r.id,
+		brandId: r.brand_id,
+		runId: r.run_id ?? null,
+		toolName: r.tool_name,
+		idempotencyKey: r.idempotency_key,
+		status: r.status,
+		request: r.request,
+		result: r.result,
+		createdAt: r.created_at,
+		updatedAt: r.updated_at
+	};
+}
+
+/**
+ * Chiave deterministica dell'effetto: brand + tool + args canonicalizzati. NON contiene il run_id:
+ * l'idempotenza deve riconoscere la stessa intenzione attraverso un resume (che riparte da zero) e
+ * un takeover. Due args che coincidono in fondo = stessa intenzione = stesso effetto.
+ */
+export function effectKey(toolName: string, args: Record<string, unknown>): string {
+	const canonical = stableSerialize(args);
+	const bytes = new TextEncoder().encode(`${toolName}\n${canonical}`);
+	// FNV-1a 64-bit, esadecimale — niente crypto asincrona: il key è un indice, non un segreto.
+	let hash = 0x811c9dc5;
+	for (const b of bytes) {
+		hash ^= b;
+		hash = Math.imul(hash, 0x01000193);
+	}
+	return `${toolName}:${(hash >>> 0).toString(36)}:${canonical.length}`;
+}
+
+function stableSerialize(value: unknown): string {
+	if (Array.isArray(value)) return `[${value.map(stableSerialize).join(',')}]`;
+	if (value && typeof value === 'object') {
+		return `{${Object.keys(value)
+			.sort()
+			.map((k) => `${JSON.stringify(k)}:${stableSerialize((value as Record<string, unknown>)[k])}`)
+			.join(',')}}`;
+	}
+	return JSON.stringify(value);
+}
+
+export function createEffectsLedger(db: SupabaseClient): EffectsLedger {
+	return {
+		async intend(record): Promise<ToolEffect> {
+			const { data, error } = await db
+				.from(TABLE)
+				.insert({
+					brand_id: record.brandId,
+					run_id: record.runId,
+					tool_name: record.toolName,
+					idempotency_key: record.key,
+					status: 'intended',
+					request: record.request
+				})
+				.select()
+				.single();
+			if (error) throw new Error(`effects: intend fallito — ${error.message}`);
+			return toEffect(data as Row);
+		},
+
+		async resolve(id, status, result): Promise<void> {
+			const { error } = await db
+				.from(TABLE)
+				.update({ status, result, updated_at: new Date().toISOString() })
+				.eq('id', id);
+			if (error) throw new Error(`effects: resolve fallito — ${error.message}`);
+		},
+
+		async find(brandId, key): Promise<ToolEffect | null> {
+			const { data, error } = await db
+				.from(TABLE)
+				.select()
+				.eq('brand_id', brandId)
+				.eq('idempotency_key', key)
+				.maybeSingle();
+			if (error) throw new Error(`effects: find fallito — ${error.message}`);
+			return data ? toEffect(data as Row) : null;
+		},
+
+		async reconcileRun(runId): Promise<number> {
+			// Solo le righe ancora `intended`: un `completed` è un esito vero, non va toccato.
+			const { data, error } = await db
+				.from(TABLE)
+				.update({ status: 'ambiguous', updated_at: new Date().toISOString() })
+				.eq('run_id', runId)
+				.eq('status', 'intended')
+				.select('id');
+			if (error) throw new Error(`effects: reconcile fallito — ${error.message}`);
+			return data?.length ?? 0;
+		}
+	};
+}

--- a/packages/agent-core/src/effects.test.ts
+++ b/packages/agent-core/src/effects.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { decide, frozenResult, isFrozen, EFFECT_LID_NOTE } from './effects';
+import { effectKey } from './effects-store';
+import type { ToolEffect } from '@anomalia/agent-kit';
+
+function effect(status: ToolEffect['status'], result?: unknown, over: Partial<ToolEffect> = {}): ToolEffect {
+	return {
+		id: 'e1',
+		brandId: 'b1',
+		runId: 'r1',
+		toolName: 'content_schedule',
+		idempotencyKey: 'k',
+		status,
+		result,
+		createdAt: '2026-08-29T00:00:00.000Z',
+		updatedAt: '2026-08-29T00:00:00.000Z',
+		...over
+	};
+}
+
+const RESULT = { content: [{ type: 'text' as const, text: 'post creato' }] };
+
+describe('decide — la macchina a stati del gate', () => {
+	it('null e failed lasciano RIESEGUIRE (non c\'è ancora un esito), gli altri congelano', () => {
+		expect(decide(null).run).toBe(true);
+		expect(decide(effect('failed')).run).toBe(true);
+		expect(decide(effect('intended')).run).toBe(false);
+		expect(decide(effect('completed')).run).toBe(false);
+		expect(decide(effect('ambiguous')).run).toBe(false);
+		expect(decide(effect('reconciled')).run).toBe(false);
+	});
+
+	it('il congelamento dichiara la ragione, il rieseguire no', () => {
+		const d = decide(effect('completed'));
+		expect(d.run).toBe(false);
+		expect(d.note).toBe(EFFECT_LID_NOTE);
+		expect(decide(effect('failed')).note).toBe('');
+	});
+});
+
+describe('isFrozen / frozenResult', () => {
+	it('completed, ambiguous e reconciled sono congelati; intended e failed no', () => {
+		expect(isFrozen('completed')).toBe(true);
+		expect(isFrozen('ambiguous')).toBe(true);
+		expect(isFrozen('reconciled')).toBe(true);
+		expect(isFrozen('intended')).toBe(false);
+		expect(isFrozen('failed')).toBe(false);
+	});
+
+	it('frozenResult restituisce il result solo per i congelati', () => {
+		expect(frozenResult(effect('completed', RESULT))).toEqual(RESULT);
+		expect(frozenResult(effect('ambiguous', RESULT))).toEqual(RESULT);
+		expect(frozenResult(effect('reconciled', RESULT))).toEqual(RESULT);
+		expect(frozenResult(effect('intended', RESULT))).toBeNull();
+		expect(frozenResult(effect('failed', RESULT))).toBeNull();
+	});
+
+	it('un effetto congelato senza result (segue un esito igienico) non inventa un risposta', () => {
+		expect(frozenResult(effect('ambiguous', null))).toBeNull();
+	});
+});
+
+describe('effectKey — deterministica e stabile', () => {
+	it('stessa intenzione = stessa chiave, a prescindere dall\'ordine delle chiavi e dal run', () => {
+		const a = effectKey('content_schedule', { post_id: 'p1', scheduled_for: '2026-09-01T10:00' });
+		const b = effectKey('content_schedule', { scheduled_for: '2026-09-01T10:00', post_id: 'p1' });
+		expect(a).toBe(b);
+		expect(a).toContain('content_schedule');
+	});
+
+	it('argomenti diversi = chiavi diverse (lo stesso tool su due post non collidono)', () => {
+		const a = effectKey('content_schedule', { post_id: 'p1' });
+		const b = effectKey('content_schedule', { post_id: 'p2' });
+		expect(a).not.toBe(b);
+	});
+
+	it('tool diversi sugli stessi argomenti non collidono', () => {
+		expect(effectKey('content_create_post', { caption: 'x' })).not.toBe(effectKey('content_schedule', { caption: 'x' }));
+	});
+
+	it('la lunghezza è codificata nella chiave, così due intenzioni non collidono per troncamento', () => {
+		expect(effectKey('a', {})).toContain(`:${'{}'.length}`);
+	});
+});

--- a/packages/agent-core/src/effects.ts
+++ b/packages/agent-core/src/effects.ts
@@ -1,0 +1,35 @@
+/**
+ * LA LOGICA PURA del gate degli effetti — niente db, niente framework. Decide se un tool con un
+ * effetto collaterale va rieseguito o se è già stato (o è stato avviato e lasciato in dubbio) e
+ * quindi va congelato. La macchina a stati: `intended -> completed|failed`, con i ripieghi
+ * `ambiguous` (il segmento è morto a metà) e `reconciled` (confermato fuori). Prima di rieseguire
+ * l'executor legge per chiave: se esiste già un esito non-rieseguibile, NON riesegue.
+ */
+import type { EffectStatus, ToolEffect, ToolResult } from '@anomalia/agent-kit';
+
+export const EFFECT_LID_NOTE = 'questo effetto è già stato registrato: non rieseguo per evitare un doppione';
+
+/** Stati a cui l'effetto è già avvenuto (o è avviato ma di esito ignoto): NON vanno rieseguiti. */
+const FROZEN_STATUSES: ReadonlySet<EffectStatus> = new Set(['completed', 'ambiguous', 'reconciled']);
+
+/** C'è già un esito non-rieseguibile per questa chiave? */
+export function isFrozen(status: EffectStatus): boolean {
+	return FROZEN_STATUSES.has(status);
+}
+
+/**
+ * Decide se eseguire o congelare. `intended` NON congela: è un ripiego di sicurezza, ma corrisponde
+ * a un segmento ancora vivo o appena morto — a differenza di `ambiguous` (morto confermato), il
+ * run corrente è il primo e solo autore, quindi può riprovare.
+ */
+export function decide(effect: ToolEffect | null): { run: boolean; note: string } {
+	if (!effect) return { run: true, note: '' };
+	if (effect.status === 'failed') return { run: true, note: '' };
+	return { run: false, note: EFFECT_LID_NOTE };
+}
+
+/** Il result memorizzato per un effetto congelato — da restituire al posto di rieseguire. */
+export function frozenResult(effect: ToolEffect): ToolResult | null {
+	if (!isFrozen(effect.status)) return null;
+	return (effect.result as ToolResult | null) ?? null;
+}

--- a/packages/agent-core/src/executor.test.ts
+++ b/packages/agent-core/src/executor.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { createApplyTool, buildSystemPrompt, type ApplyToolDeps } from './executor';
 import { BUILTIN_TOOLS } from './tools/builtin';
+import { effectKey } from './effects-store';
 import { SYSTEM_PROMPT_MAX_CHARS, type AgentSpec } from '@anomalia/agent-contracts/contracts';
 import { SandboxEmulator } from '@anomalia/agent-adapters/sandbox-emulator';
 import {
@@ -8,7 +9,8 @@ import {
 	createMemorySandbox,
 	createMemoryStore,
 	fakeContext,
-	fakePlugin
+	fakePlugin,
+	createMemoryEffectsLedger
 } from '@anomalia/agent-kit/testkit';
 
 function baseDeps(overrides: Partial<ApplyToolDeps> = {}): ApplyToolDeps {
@@ -256,5 +258,85 @@ describe('attach — mai più lo stub che mente', () => {
 		const out = await apply({ name: 'attach', args: { path: '/tmp/x.mp4' } }, fakeContext());
 		expect(out.isError).toBeFalsy();
 		expect((out.content[0] as { text: string }).text).toBe('fatto:/tmp/x.mp4');
+	});
+});
+
+describe('createApplyTool — il gate sugli effetti', () => {
+	function effectfulPlugin(counter: { calls: number }) {
+		return {
+			name: 'content',
+			tools: [{ name: 'content_schedule', description: 'schedula', inputSchema: { type: 'object' }, effectful: true }],
+			async execute() {
+				counter.calls += 1;
+				return { content: [{ type: 'text' as const, text: `post ${counter.calls}` }] };
+			}
+		};
+	}
+
+	const CALL = { name: 'content_schedule', args: { post_id: 'p1' } };
+
+	it('intend PRIMA di eseguire, resolve completed dopo', async () => {
+		const counter = { calls: 0 };
+		const ledger = createMemoryEffectsLedger();
+		const apply = createApplyTool(baseDeps({ plugins: [effectfulPlugin(counter)], effects: ledger }));
+		const out = await apply(CALL, fakeContext());
+		expect(out.isError).toBeFalsy();
+		expect(ledger.rows).toHaveLength(1);
+		expect(ledger.rows[0].status).toBe('completed');
+		expect(counter.calls).toBe(1);
+	});
+
+	it('abort → resume: la SECONDA chiamata con la stessa intenzione congelate invece di rieseguire', async () => {
+		const counter = { calls: 0 };
+		const ledger = createMemoryEffectsLedger();
+		const apply = createApplyTool(baseDeps({ plugins: [effectfulPlugin(counter)], effects: ledger }));
+
+		// primo turno: esegue e registra completed
+		await apply(CALL, fakeContext({ runId: 'run-1' }));
+		expect(counter.calls).toBe(1);
+
+		// il segmento muore a metà e si riprende: il run è DIVERSO (run-2) ma la chiave è la stessa
+		const out = await apply(CALL, fakeContext({ runId: 'run-2' }));
+		expect(counter.calls).toBe(1); // non riesegue: un solo post
+		expect(out.isError).toBeFalsy();
+		expect((out.content[0] as { text: string }).text).toContain('post 1');
+	});
+
+	it('un effect ambiguous NON viene rieseguito, nemmeno su un run nuovo', async () => {
+		const counter = { calls: 0 };
+		const { brandId } = fakeContext();
+		const injected = createMemoryEffectsLedger();
+		await injected.intend({ brandId, runId: 'run-dead', toolName: 'content_schedule', key: effectKey('content_schedule', { post_id: 'p1' }), request: { post_id: 'p1' } });
+		await injected.resolve(injected.rows[0].id, 'ambiguous', null);
+		const apply = createApplyTool(baseDeps({ plugins: [effectfulPlugin(counter)], effects: injected }));
+
+		const out = await apply({ name: 'content_schedule', args: { post_id: 'p1' } }, fakeContext({ runId: 'run-new' }));
+		expect(counter.calls).toBe(0);
+		expect(out.isError).toBe(true);
+		expect((out.content[0] as { text: string }).text).toMatch(/già stato registrato/);
+	});
+
+	it('failed lascia rieseguire (l\'effetto non è avvenuto, non è un doppione)', async () => {
+		const counter = { calls: 0 };
+		const { brandId } = fakeContext();
+		const injected = createMemoryEffectsLedger();
+		await injected.intend({ brandId, runId: 'r0', toolName: 'content_schedule', key: effectKey('content_schedule', { post_id: 'p1' }), request: { post_id: 'p1' } });
+		await injected.resolve(injected.rows[0].id, 'failed', { message: 'net' });
+		const apply = createApplyTool(baseDeps({ plugins: [effectfulPlugin(counter)], effects: injected }));
+
+		const out = await apply({ name: 'content_schedule', args: { post_id: 'p1' } }, fakeContext());
+		expect(counter.calls).toBe(1);
+		expect((out.content[0] as { text: string }).text).toBe('post 1');
+	});
+
+	it('solo i tool marcat effectful passano dal gate; gli altri no', async () => {
+		const counter = { calls: 0 };
+		const ledger = createMemoryEffectsLedger();
+		const plugin = { ...effectfulPlugin(counter), tools: [{ name: 'content_read', description: 'legge', inputSchema: { type: 'object' } }] };
+		const apply = createApplyTool(baseDeps({ plugins: [plugin], effects: ledger }));
+		const out = await apply({ name: 'content_read', args: {} }, fakeContext());
+		expect(out.isError).toBeFalsy();
+		expect(ledger.rows).toHaveLength(0); // nessuna riga: il tool non ha effetti
+		expect(counter.calls).toBe(1);
 	});
 });

--- a/packages/agent-core/src/executor.ts
+++ b/packages/agent-core/src/executor.ts
@@ -3,10 +3,12 @@
  * reply/ask_user/plan restano no-op qui — il loro effetto è di chi orchestra il run (turn.ts).
  */
 import type { SupabaseClient } from '@supabase/supabase-js';
-import type { AdapterContext, ToolCall, ToolResult } from '@anomalia/agent-kit';
+import type { AdapterContext, EffectsLedger, ToolCall, ToolResult } from '@anomalia/agent-kit';
 import type { BrandFs, CheckpointStore, MemoryStore, SandboxProvider, SandboxRef, ToolPlugin } from '@anomalia/agent-kit';
 import { SYSTEM_PROMPT_MAX_CHARS, type AgentSpec } from '@anomalia/agent-contracts/contracts';
 import { BUILTIN_TOOLS, TERMINAL_TOOL_NAMES } from './tools/builtin';
+import { decide, frozenResult } from './effects';
+import { effectKey } from './effects-store';
 import { ensureComputer, touchComputer } from './computer';
 import {
 	ensureGraphicalMode,
@@ -75,6 +77,13 @@ export interface ApplyToolDeps {
 	computer?: { db: SupabaseClient; home: CheckpointStore };
 	/** Senza, `observe`/`act` rispondono con l'errore-che-insegna invece di esplodere. */
 	graphicalBootstrap?: GraphicalBootstrapDeps;
+	/**
+	 * Presente: i tool con `effectful: true` passano dal ledger degli effetti — `intend` prima di
+	 * eseguire, `resolve` dopo, e su un resume che rivede la stessa chiave congelano invece di
+	 * rieseguire (un doppio post/schedulazione è un danno, non un errore da riprovare).
+	 * Assente: nessun gate, si esegue e basta (il lab, i test, le superfici senza righe).
+	 */
+	effects?: EffectsLedger;
 }
 
 export type ApplyTool = (call: ToolCall, ctx: AdapterContext) => Promise<ToolResult>;
@@ -93,7 +102,8 @@ async function resolveSandboxRef(deps: ApplyToolDeps, ctx: AdapterContext): Prom
 }
 
 export function createApplyTool(deps: ApplyToolDeps): ApplyTool {
-	return async (call: ToolCall, ctx: AdapterContext): Promise<ToolResult> => {
+	// L'esecuzione vera, senza gate: la chiude in una closure che ha `deps` nel suo scope.
+	const execute = async (call: ToolCall, ctx: AdapterContext): Promise<ToolResult> => {
 		const { args } = call;
 		const name = LEGACY_TOOL_ALIASES[call.name] ?? call.name;
 
@@ -214,6 +224,45 @@ export function createApplyTool(deps: ApplyToolDeps): ApplyTool {
 			}
 		}
 	};
+
+	return async (call: ToolCall, ctx: AdapterContext): Promise<ToolResult> => {
+		const name = LEGACY_TOOL_ALIASES[call.name] ?? call.name;
+
+		if (!deps.effects || !isEffectful(name, deps.plugins)) return execute(call, ctx);
+
+		// GATE: una stessa chiave (brand + tool + args) che ha già un esito non-rieseguibile NON va
+		// rieseguita. `intended` è un ripiego di sicurezza (il segmento è vivo, è il primo autore),
+		// quindi decide() lo lascia riprovare; `ambiguous`/`completed`/`reconciled` congelano.
+		const key = effectKey(name, call.args);
+		const existing = await deps.effects.find(ctx.brandId, key);
+		const decision = decide(existing);
+		if (!decision.run) {
+			const frozen = frozenResult(existing!);
+			if (frozen) return frozen;
+			return err(`${decision.note}. Esito registrato: ${existing!.status}`);
+		}
+
+		const effect = await deps.effects.intend({ brandId: ctx.brandId, runId: ctx.runId, toolName: name, key, request: call.args });
+		try {
+			const result = await execute(call, ctx);
+			await deps.effects.resolve(effect.id, result.isError ? 'failed' : 'completed', result);
+			return result;
+		} catch (err) {
+			// L'effetto resta `intended`: sarà `reconcileRun` (morte del segmento) a tirarlo verso
+			// `ambiguous`. Espongo l'errore vero, mai un esito finto.
+			await deps.effects.resolve(effect.id, 'failed', { message: err instanceof Error ? err.message : String(err) });
+			throw err;
+		}
+	};
+}
+
+/** Un tool è `effectful` se la sua dichiarazione (builtin o plugin) lo marca tale. */
+function isEffectful(name: string, plugins: ToolPlugin[]): boolean {
+	const builtin = BUILTIN_TOOLS.find((t) => t.name === name);
+	if (builtin) return Boolean(builtin.effectful);
+	return (
+		plugins.find((p) => p.tools.some((t) => t.name === name))?.tools.find((t) => t.name === name)?.effectful ?? false
+	);
 }
 
 /**

--- a/packages/agent-core/src/tools/builtin.ts
+++ b/packages/agent-core/src/tools/builtin.ts
@@ -50,6 +50,7 @@ export const BUILTIN_TOOLS: ToolSpec[] = [
 	{
 		name: 'brand_write',
 		requiresMode: 'plan',
+		effectful: true,
 		description:
 			"Scrive un file dove l'albero del brand lo consente (studio, piano, post, artefatti) — NON il filesystem della macchina, per quello c'è `shell`. Fallisce se il path non è scrivibile: non è un errore da nascondere, è un permesso.",
 		inputSchema: {
@@ -74,6 +75,7 @@ export const BUILTIN_TOOLS: ToolSpec[] = [
 	{
 		name: 'shell',
 		requiresMode: 'agent',
+		effectful: true,
 		description:
 			"Esegue un comando nella VM del brand (si accende da sola al primo uso). Rete CHIUSA: passano solo i registry dei pacchetti (npm, pip) — internet no. Un fetch verso un sito qualsiasi fallisce per firewall, non per guasto DNS: non riprovarlo, e per leggere il web usa i tool di lettura del brand invece della shell.",
 		inputSchema: {
@@ -84,6 +86,7 @@ export const BUILTIN_TOOLS: ToolSpec[] = [
 	},
 	{
 		name: 'attach',
+		effectful: true,
 		description: 'Allega un file o un media alla chat, così resta visibile senza incollarne il contenuto nel testo.',
 		inputSchema: {
 			type: 'object',
@@ -93,6 +96,7 @@ export const BUILTIN_TOOLS: ToolSpec[] = [
 	{
 		name: 'remember',
 		requiresMode: 'plan',
+		effectful: true,
 		description: 'Scrive un fatto in memoria durevole: sopravvive al turno e ai run successivi. Non per appunti temporanei del piano.',
 		inputSchema: {
 			type: 'object',
@@ -146,6 +150,7 @@ export const BUILTIN_TOOLS: ToolSpec[] = [
 	{
 		name: 'act',
 		requiresMode: 'agent',
+		effectful: true,
 		description: "Esegue fino a 24 azioni sullo schermo grafico della VM e torna uno screenshot aggiornato. Accende il modo grafico da solo se serve. kind:'click'/'move' vogliono x,y (pixel); 'type' vuole text; 'key' vuole key (es. 'Return', 'ctrl+l'); 'scroll' vuole amount (righe, negativo = verso l'alto); 'wait' vuole ms.",
 		inputSchema: {
 			type: 'object',

--- a/packages/agent-kit/src/interfaces.ts
+++ b/packages/agent-kit/src/interfaces.ts
@@ -10,6 +10,7 @@ import type {
 	AdapterContext,
 	AdapterDescriptor,
 	CommandRequest,
+	EffectStatus,
 	FileEntry,
 	MemoryCapabilities,
 	MemoryEntry,
@@ -20,9 +21,26 @@ import type {
 	SandboxCapabilities,
 	SandboxRef,
 	ToolCall,
+	ToolEffect,
 	ToolResult,
 	ToolSpec
 } from './types';
+
+/**
+ * IL LEDGER DEGLI EFFETTI — il port che l'executor usa per non rieseguire un tool dal un effetto
+ * collaterale già avvenuto (o avviato e lasciato ambiguo da un segmento morto). Declarato qui, nel
+ * contratto: l'executor non sa dove viva la riga, la superficie gliela passa come implementazione.
+ */
+export interface EffectsLedger {
+	/** Registra `intended` PRIMA di eseguire. Se esiste già la chiave, la restituisce senza toccare. */
+	intend(record: { brandId: string; runId: string; toolName: string; key: string; request: unknown }): Promise<ToolEffect>;
+	/** Risolve dopo l'esecuzione: completed (con result) o failed. */
+	resolve(id: string, status: 'completed' | 'failed', result: unknown): Promise<void>;
+	/** Legge per chiave: la riga esistente, o null. */
+	find(brandId: string, key: string): Promise<ToolEffect | null>;
+	/** Attira gli `intended` orfani di un run morto verso `ambiguous` — il ripiego che non duplica. */
+	reconcileRun(runId: string): Promise<number>;
+}
 
 /** Chi fa girare il ciclo. Oggi: ai-runtime (SDK v6). */
 export interface AgentRuntime {

--- a/packages/agent-kit/src/testkit.ts
+++ b/packages/agent-kit/src/testkit.ts
@@ -6,6 +6,7 @@ import type {
 	AdapterContext,
 	AdapterDescriptor,
 	CommandRequest,
+	EffectsLedger,
 	FileEntry,
 	MemoryCapabilities,
 	MemoryEntry,
@@ -13,6 +14,7 @@ import type {
 	SandboxCapabilities,
 	SandboxRef,
 	ToolCall,
+	ToolEffect,
 	ToolResult
 } from './index';
 import type { BrandFs, MemoryStore, SandboxProvider, ToolPlugin } from './index';
@@ -130,6 +132,73 @@ export function fakePlugin(name: string, reply: ToolResult): ToolPlugin {
 		tools: [{ name, description: `tool di test per ${name}`, inputSchema: { type: 'object' } }],
 		async execute(_call: ToolCall) {
 			return reply;
+		}
+	};
+}
+
+/**
+ * IL LEDGER IN MEMORIA per i test del gate: `intend`/`resolve`/`find`/`reconcileRun` su una mappa
+ * per (brand, chiave). Così il gate dell'executor si verifica col suo comportamento vero — decidere
+ * se rieseguire o congelare — senza montare un database.
+ */
+export function createMemoryEffectsLedger(seed: { [key: string]: unknown } = {}): EffectsLedger & { rows: ToolEffect[] } {
+	const rows: ToolEffect[] = [];
+
+	for (const [status, request] of Object.entries(seed)) {
+		rows.push({
+			id: `e-${rows.length + 1}`,
+			brandId: 'brand-test',
+			runId: 'run-test',
+			toolName: 'content_schedule',
+			idempotencyKey: 'seed',
+			status: status as ToolEffect['status'],
+			request: request as unknown,
+			result: null,
+			createdAt: '2026-08-29T00:00:00.000Z',
+			updatedAt: '2026-08-29T00:00:00.000Z'
+		});
+	}
+
+	return {
+		rows,
+		async intend(record) {
+			const existing = rows.find((r) => r.brandId === record.brandId && r.idempotencyKey === record.key);
+			if (existing) return existing;
+			const effect: ToolEffect = {
+				id: `e-${rows.length + 1}`,
+				brandId: record.brandId,
+				runId: record.runId,
+				toolName: record.toolName,
+				idempotencyKey: record.key,
+				status: 'intended',
+				request: record.request,
+				result: null,
+				createdAt: '2026-08-29T00:00:00.000Z',
+				updatedAt: '2026-08-29T00:00:00.000Z'
+			};
+			rows.push(effect);
+			return effect;
+		},
+		async resolve(id, status, result) {
+			const effect = rows.find((r) => r.id === id);
+			if (effect) {
+				effect.status = status;
+				effect.result = result;
+				effect.updatedAt = '2026-08-29T00:00:00.000Z';
+			}
+		},
+		async find(brandId, key) {
+			return rows.find((r) => r.brandId === brandId && r.idempotencyKey === key) ?? null;
+		},
+		async reconcileRun(runId) {
+			let n = 0;
+			for (const r of rows) {
+				if (r.runId === runId && r.status === 'intended') {
+					r.status = 'ambiguous';
+					n += 1;
+				}
+			}
+			return n;
 		}
 	};
 }

--- a/packages/agent-kit/src/types.ts
+++ b/packages/agent-kit/src/types.ts
@@ -41,6 +41,11 @@ export interface ToolSpec {
 	 */
 	requiresMode?: 'plan' | 'agent';
 	terminal?: boolean;
+	/**
+	 * Il tool ha un effetto collaterale reale (scrive/post/schedula/rende un file): va avvolto dal
+	 * ledger, così un resume a metà turno non lo riesegue. Assente = si legge e basta, mai una riga.
+	 */
+	effectful?: boolean;
 }
 
 /** Testo e/o immagini, più un flag d'errore che INSEGNA. */
@@ -51,6 +56,23 @@ export type ToolResultContent =
 export interface ToolResult {
 	content: ToolResultContent[];
 	isError?: boolean;
+}
+
+/** Lo stato di un effetto collaterale nel ledger — la macchina a stati di `agent_kit_effects`. */
+export type EffectStatus = 'intended' | 'completed' | 'failed' | 'ambiguous' | 'reconciled';
+
+/** Una riga del ledger degli effetti: chi, cosa, con quale chiave, in che stato. */
+export interface ToolEffect {
+	id: string;
+	brandId: string;
+	runId: string | null;
+	toolName: string;
+	idempotencyKey: string;
+	status: EffectStatus;
+	request?: unknown;
+	result?: unknown;
+	createdAt: string;
+	updatedAt: string;
 }
 
 export interface ToolCall {

--- a/src/lib/agent/bridge/live.ts
+++ b/src/lib/agent/bridge/live.ts
@@ -91,6 +91,7 @@ import { attachForChat } from './attach';
 import { buildTools } from '@anomalia/agent-adapters/runtime/ai-runtime';
 import { createCheckpointStorage } from '@anomalia/agent-adapters/checkpoint-storage';
 import { markComputerRunning, touchComputer } from '@anomalia/agent-core/computer';
+import { createEffectsLedger } from '@anomalia/agent-core/effects-store';
 import {
 	createServerBrandFs,
 	createPostgresMemoryStore,
@@ -491,6 +492,9 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
 			queryTool: queryToolAdapter({ supabase, brandId: brand.id, userId: user.id, threadId }),
 			attach: async (a, c) => attachForChat(a, c, { supabase, admin, sandbox, brandId: brand.id, userId: user.id, collect: turnAttachments }),
 			graphicalBootstrap: graphicalBootstrapDeps,
+			// Adesso un post creato/schedulato in un turno abortito NON viene ricreato al resume: il
+			// ledger ha già la chiave e il gate congelare invece di rieseguire.
+			effects: createEffectsLedger(admin),
 			plugins
 		});
 		// LO STOP DELL'UTENTE arriva da un'ALTRA invocazione (`cancelKitRun`, chiamata dall'endpoint

--- a/src/lib/agent/plugins/content.ts
+++ b/src/lib/agent/plugins/content.ts
@@ -29,43 +29,52 @@ export interface ContentPluginDeps {
 }
 
 /** Nome nel kit → tool reale in `createChatTools` (stesso schema, stessa execute, stessi gate). */
-const MAP: Record<string, { source: string; description: string; requiresMode?: ToolSpec['requiresMode'] }> = {
+type ContentSource = { source: string; description: string; requiresMode?: ToolSpec['requiresMode']; effectful?: boolean };
+
+const MAP: Record<string, ContentSource> = {
 	content_create_post: {
 		source: 'create_post',
 		requiresMode: 'agent',
+		effectful: true,
 		description:
 			'Create a social post (caption + visual) as a pending_user draft — image, carousel, or video. MEDIA FIRST: pass media_ids to reuse a library asset instead of minting a new AI image (free). content_type "video" submits the clip in the BACKGROUND and ships the QC\'d cover as a stand-in — the result carries video_render_status/video_note honestly, never claims a finished video that has not landed. Real people in people_ids without recorded consent are silently DROPPED from the visual (server-logged, not refused) — content_generate_image refuses instead. Runs out of AI credits or monthly post quota → an error naming which, not a retry loop. Naming a `platform` the brand has NOT connected is REFUSED before any generation (error platform_not_connected, nothing spent) — tell the user to connect it, or pass allow_unconnected if they want a draft anyway.'
 	},
 	content_design_graphic: {
 		source: 'design_graphic',
 		requiresMode: 'agent',
+		effectful: true,
 		description:
 			"Compose or revise a post's typographic graphic (words on a brand-coloured canvas, optional embedded photos) as HTML/TSX, via the same composer + render gate the post editor uses. Needs an existing post_id — create the post first. Real people without recorded consent are silently dropped from the canvas (same as content_create_post, not a refusal)."
 	},
 	content_generate_image: {
 		source: 'generate_image',
 		requiresMode: 'agent',
+		effectful: true,
 		description:
 			'Mint or edit an AI photo (Nano Banana). Standalone (no post_id): returns image_url, does not touch a post. With post_id on an ai_generated post: regenerates that image using the prompt as feedback. Real people in people_ids/talent_ids without recorded consent make this REFUSE outright (AI Act gate, error names who is blocked) — unlike content_create_post. Reference images are capped by the renderer\'s real input limit; past it, extras are dropped oldest-priority-last, never an error.'
 	},
 	content_schedule: {
 		source: 'approve_post',
 		requiresMode: 'agent',
+		effectful: true,
 		description:
 			"Approve a pending_user draft and schedule it for publishing (Zernio). The prepublish gate REFUSES a post with no image/video — a visual post cannot go out empty — and refuses while a video render for it is still in flight. Only approved/pending_user posts qualify; omit scheduled_for to keep the post's existing slot. With no connected account for the post's platform the result is success:false + noAccount:true: the post stays approved and does NOT go out — say so, never call it scheduled."
 	},
 	content_update_post: {
 		source: 'update_post',
+		effectful: true,
 		description:
 			"Edit an existing post in place: caption, first comment, platform(s), pillar, slot. Only the fields passed change. On an already-scheduled post the old Zernio schedule is cancelled and the post re-sent, so the published copy stays in sync with the row — the result says so with rescheduled: true. To move the time use content_reschedule_post; to add a platform use content_cross_post."
 	},
 	content_reschedule_post: {
 		source: 'reschedule_post',
+		effectful: true,
 		description:
 			"Move an approved or scheduled post to a new time (brand timezone). REFUSED on a pending_user draft — rescheduling one would publish it without approval; approve it with content_schedule instead. The old Zernio schedule is cancelled before the new one is sent, so a moved post never goes out twice."
 	},
 	content_cross_post: {
 		source: 'cross_post',
+		effectful: true,
 		description:
 			"Add platforms to an existing post. pending_user: the platform list is widened on the draft. scheduled: the schedule is cancelled and re-sent with the wider list. published: a CLONE is created for the new platforms only — the live post is never touched. Refused when the post already covers every platform asked for."
 	},
@@ -94,6 +103,7 @@ export function createContentPlugin(deps: ContentPluginDeps): ToolPlugin {
 		name,
 		description: m.description,
 		requiresMode: m.requiresMode,
+		effectful: m.effectful,
 		inputSchema: jsonSchemaOf(chatTools[m.source])
 	}));
 

--- a/src/lib/content/changelog/2026-08-29-ledger-effects-idempotent.ts
+++ b/src/lib/content/changelog/2026-08-29-ledger-effects-idempotent.ts
@@ -1,0 +1,10 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-08-29',
+  title: 'Interrupted turns no longer publish or schedule the same post twice',
+  items: [
+    'If a turn is interrupted after it creates or schedules a post, resuming it no longer re-runs the same action — the post is published or scheduled exactly once.',
+    'Work left indeterminate by a crashed turn is treated as already attempted, never silently redone.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/agent-kit-recover.ts
+++ b/src/lib/server/agent-kit-recover.ts
@@ -7,6 +7,7 @@ import {
 } from '$lib/server/chat/turn-limits';
 import { ChatTurnDeadError } from '$lib/server/chat/job-cancel';
 import { assistantContentFromPartial, type ChatPartialSnapshot } from '$lib/server/chat/partial-persist';
+import { createEffectsLedger } from '@anomalia/agent-core/effects-store';
 
 /**
  * IL RECUPERO DEL LAVORO MORTO, per una riga sola — estratto dal loop del cron perché `sweep.test.ts`
@@ -118,6 +119,15 @@ export async function reapDeadKitRuns(
       .maybeSingle();
     if (!claimed) continue;
     reaped += 1;
+
+    // Gli effetti di questo run ancora `intended` (un tool di scrittura avviato, mai risolto)
+    // diventano `ambiguous`: il risiko del doppio post/schedulazione. Prima di rieseguire, il gate
+    // li legge e congela — mai due volte la stessa scrittura perché il segmento è morto a metà.
+    try {
+      await createEffectsLedger(db).reconcileRun(run.id);
+    } catch (e) {
+      console.error('[sweep] reconciliazione effetti fallita', run.id, e);
+    }
 
     try {
       await recoverDeadPartial(db, run.id);

--- a/supabase/migrations/20260829130000_agent_kit_effects.sql
+++ b/supabase/migrations/20260829130000_agent_kit_effects.sql
@@ -1,0 +1,43 @@
+-- DA APPLICARE A MANO: i deploy di questo repo non eseguono le migration.
+--
+-- IL LEDGER DEGLI EFFETTI DEI TOOL — il pezzo che Rakazo ha come `ExternalEffect` e noi no.
+-- Un tool che scrive/post/schedula (pubblicazione, schedulazione, file, render) ha un effetto
+-- collaterale reale: se il run muore a metà e riparte, lo stesso tool può essere rieseguito e
+-- lo stesso effetto accade due volte. Qui ogni effetto ha una `idempotency_key` deterministica e
+-- una macchina a stati: `intended` (registrato PRIMA di eseguire) -> `completed`/`failed`, con gli
+-- stati di ripiego `ambiguous` (eseguito ma esito sconosciuto: il segmento è morto) e `reconciled`
+-- (confermato a mano/fuori). Prima di rieseguire, l'executor legge per chiave: se esiste già un
+-- effetto non-fallback, NON riesegue.
+--
+-- La chiave NON contiene il run_id: l'idempotenza deve sopravvivere a un resume che riparte da
+-- zero e a un takeover, non solo alla ripresa dello stesso run. Contiene brand + nome + args
+-- (canonicalizzati), così due turni diversi con la stessa intenzione si riconoscono.
+
+create table if not exists public.agent_kit_effects (
+  id uuid primary key default gen_random_uuid(),
+  brand_id uuid not null references public.brands (id) on delete cascade,
+  run_id uuid null references public.agent_kit_runs (id) on delete set null,
+  tool_name text not null,
+  idempotency_key text not null,
+  status text not null default 'intended' check (
+    status in ('intended', 'completed', 'failed', 'ambiguous', 'reconciled')
+  ),
+  request jsonb null,
+  result jsonb null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+-- Un solo effetto per (brand, chiave): la seconda esecuzione della stessa intenzione COLLIDE,
+-- e il gate la risolve leggendo la riga invece di rieseguire.
+create unique index if not exists agent_kit_effects_brand_key_idx
+  on public.agent_kit_effects (brand_id, idempotency_key);
+
+create index if not exists agent_kit_effects_run_idx on public.agent_kit_effects (run_id);
+create index if not exists agent_kit_effects_status_idx on public.agent_kit_effects (status);
+
+alter table public.agent_kit_effects enable row level security;
+
+-- Come agent_kit_runs (0216): i membri del brand possono leggere, scrive solo il service role.
+create policy "agent_kit_effects readable by brand members" on public.agent_kit_effects
+  for select using (brand_id in (select public.auth_brand_ids()));


### PR DESCRIPTION
## What?

Adds a durable ledger for the side effects of agent tools, so a tool that writes/posts/schedules records an `intended -> completed|failed|ambiguous|reconciled` row keyed by a deterministic `idempotency_key`. Before re-running, the executor consults the ledger: an effect that already holds a non-retryable outcome is frozen (the stored result is returned) instead of executed a second time.

Closes Notion task "Adottare il ledger idempotente degli effetti dei tool (ExternalEffect) per evitare doppi post/schedulazioni su resume" (ID 99).

## Why?

A turn that dies mid-way (platform kill, crash, deadline) and is resumed started again from the history and re-ran its write tools blindly. The concrete case: a turn created a post (`content_create_post`) or scheduled it (`content_schedule`), the segment died after the effect happened but before the run closed, and the resume/takeover re-ran the same intent — the post went out twice. Today this risk is governed by ad-hoc per-tool guards, not declarative idempotency: each tool rewrites its own rule, and the rule drifts silently at the first change. Turns cost real money and a duplicate post/schedule is a real defect, not a cheap retry.

## How?

Ports the `ExternalEffect` pattern from Rakazo. The choices that matter:

- **Idempotency key = brand + tool name + canonicalized args, WITHOUT the run_id.** The whole point is dedupe across a resume (which starts from zero) and a takeover, not just within one run. Object keys are sorted so key order doesn't change the key; the payload length is encoded in the key to avoid truncation collisions. Hash is FNV-1a 64-bit: the key is an index, not a secret, so no async crypto.
- **The gate lives in `createApplyTool`, not in the plugins.** It is the single place that executes tools. A tool declares `effectful: true` in its `ToolSpec` and the gate wraps it — `intend` before, `resolve` after. `buildTools` is untouched: the model still sees the same catalogue. Rejected: per-tool gates in each plugin (a second source of truth), per-run keys (do not survive resume/takeover).
- **`decide()` is pure and tested.** `null` and `failed` re-run (no outcome, or a negative one: not a duplicate); `completed`/`ambiguous`/`reconciled` freeze. `intended` is the case "the current run is the first author" (the segment is alive), so `decide()` lets it retry — freezing it would block the only real attempt.
- **`reconcileRun` promotes orphans to `ambiguous`.** Called from the sweep when a run dies: `intended` rows left alone become `ambiguous`, and the gate freezes them. Only `intended` is touched; a `completed` is a real outcome.
- **Port in the contract, implementation in agent-core, wiring at the surface.** The executor depends on the `EffectsLedger` interface; `live.ts` passes the Postgres implementation with the admin client. The lab and the tests (no ledger) keep their current behavior.

## Testing?

- **Unit, state machine** (`effects.test.ts`): `decide` picks retry/freeze for every state; `effectKey` is deterministic, order-insensitive, and does not collide across different intents.
- **Unit, ledger** (`effects-store.test.ts`): `intend`/`find`/`resolve`/`reconcileRun` against a fake client that applies filters for real (so the compare-and-swap is verified with the production code path).
- **Unit, gate** (`executor.test.ts`): abort → resume with the same intent executes exactly **once**; an `ambiguous` effect is not re-run even on a new run; `failed` re-runs; only tools marked `effectful` pass through the ledger.
- **Fake-model/db constraint**: these run on the testkit (memory db + memory ledger), as the repo's agent unit suite does — they verify the gate's behavior, not the product end-to-end. An eval run covering a real abort → resume on the chat path is the remaining risk; not done here (costs a real turn and needs the full stack).
- Verified on the worktree: 248 package tests, 223 agent tests, 43 plugin/registry tests, and `typecheck:runtime` all pass. The 4 failing tests in the full suite (`ui-tokens`, `locales` es/fr, `changelog`) fail identically on pristine `dev` — pre-existing, unrelated to this change.

## Evidence

Unit/gate test showing the abort → resume single-execution freeze:

<details>
<summary>executor.test.ts — abort → resume</summary>

```
✓ packages/agent-core/src/executor.test.ts > createApplyTool — il gate sugli effetti
    > abort → resume: la SECONDA chiamata con la stessa intenzione congelate invece di rieseguire 2ms
```

Ledger state-machine tests:

<details>
<summary>effects.test.ts / effects-store.test.ts</summary>

```
✓ packages/agent-core/src/effects.test.ts (9 tests)
✓ packages/agent-core/src/effects-store.test.ts (8 tests)
```
</details>

Migration (applied by hand, deploys do not run migrations):

<details>
<summary>supabase/migrations/20260829130000_agent_kit_effects.sql</summary>

```sql
create table if not exists public.agent_kit_effects (
  id uuid primary key default gen_random_uuid(),
  brand_id uuid not null references public.brands (id) on delete cascade,
  run_id uuid null references public.agent_kit_runs (id) on delete set null,
  tool_name text not null,
  idempotency_key text not null,
  status text not null default 'intended' check (
    status in ('intended', 'completed', 'failed', 'ambiguous', 'reconciled')
  ),
  request jsonb null,
  result jsonb null,
  created_at timestamptz not null default now(),
  updated_at timestamptz not null default now()
);

create unique index if not exists agent_kit_effects_brand_key_idx
  on public.agent_kit_effects (brand_id, idempotency_key);
-- + run/status indexes + RLS readable-by-brand-members
```
</details>

## Anything Else?

- **`reconciled` is never produced automatically.** Deciding whether an effect actually happened is the tool's domain; for now it is a manual exercise. `ambiguous` (segment died) is the automatic safety net.
- **Immutable args assumption.** If a tool has volatile args (timestamps, ids), two "same" intents produce different keys and won't dedupe. The tools marked `effectful` today (write/schedule/cross-post/generate/attach/shell/remember/brand_write/act) have stable args in practice.
- **Migration must be applied by hand** before the sweep path uses the ledger; until then `createEffectsLedger` writes would fail on a missing table (the executor gate is only reached on `effectful` tools running through `live.ts`).
