### PR TITLE
Add HITL action judge

### DIFF
--- a/changelog/2026-08-29-hitl-judge.md
+++ b/changelog/2026-08-29-hitl-judge.md
@@ -1,0 +1,16 @@
+# 2026-08-29 — HITL action judge
+
+## Perché
+
+Il gate dei tool distingue ora le azioni conseguenziali dalle letture. Prima ogni tool passava
+dalla stessa decisione binaria e non c'era un punto comune per l'auto-review.
+
+## Decisioni
+
+- `ToolSpec` richiede una classificazione esplicita `consequential`.
+- `planActionGate` conserva le regole esplicite: `ask` e `allow` vincono sempre.
+- Il percorso di default diventa `judge` solo per azioni conseguenziali con auto-review e checker.
+- Un checker che fallisce restituisce `ask` per un'azione conseguenziale; l'executor non viene
+  chiamato.
+- Il gate vive nel kit e la traduzione verso l'AI SDK resta nell'adapter, senza una seconda
+  classificazione nei plugin.

--- a/packages/agent-adapters/src/runtime/ai-runtime.approval.test.ts
+++ b/packages/agent-adapters/src/runtime/ai-runtime.approval.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { AdapterContext, ToolResult, ToolSpec } from '@anomalia/agent-kit/types';
+import { buildTools } from './ai-runtime';
+
+const context: AdapterContext = { brandId: 'b1', userId: 'u1', runId: 'r1', locale: 'it' };
+
+const CONSEQUENT: ToolSpec = {
+	name: 'publish',
+	description: 'publish',
+	inputSchema: { type: 'object' },
+	consequential: true
+};
+
+const READ: ToolSpec = {
+	name: 'read',
+	description: 'read',
+	consequential: false,
+	inputSchema: { type: 'object' }
+};
+
+const ok: ToolResult = { content: [{ type: 'text', text: 'ok' }] };
+
+describe('buildTools — action approval', () => {
+	it('fails closed when the checker errors before a consequential tool executes', async () => {
+		const execute = vi.fn(async () => ok);
+		const tools = buildTools([CONSEQUENT], execute, context, {
+			autoReviewEnabled: true,
+			checker: async () => 'error'
+		});
+
+		const result = await (tools.publish.execute as (input: Record<string, unknown>) => Promise<ToolResult>)({});
+
+		expect(execute).not.toHaveBeenCalled();
+		expect(result.isError).toBe(true);
+	});
+
+	it('executes a consequential tool after a passing judge without a user prompt', async () => {
+		const execute = vi.fn(async () => ok);
+		const checker = vi.fn(async () => 'pass' as const);
+		const tools = buildTools([CONSEQUENT], execute, context, { autoReviewEnabled: true, checker });
+		const needsApproval = tools.publish.needsApproval as (input: Record<string, unknown>, options: { toolCallId: string }) => Promise<boolean>;
+
+		expect(await needsApproval({}, { toolCallId: 'publish-1' })).toBe(false);
+		await (tools.publish.execute as (input: Record<string, unknown>, options: { toolCallId: string }) => Promise<ToolResult>)({}, { toolCallId: 'publish-1' });
+
+		expect(checker).toHaveBeenCalledOnce();
+		expect(execute).toHaveBeenCalledOnce();
+	});
+
+	it('lets a nonconsequential tool through without invoking the checker', async () => {
+		const execute = vi.fn(async () => ok);
+		const checker = vi.fn(async () => 'error' as const);
+		const tools = buildTools([READ], execute, context, { autoReviewEnabled: true, checker });
+		const needsApproval = tools.read.needsApproval as (input: Record<string, unknown>, options: { toolCallId: string }) => Promise<boolean>;
+
+		expect(await needsApproval({}, { toolCallId: 'read-1' })).toBe(false);
+
+		await (tools.read.execute as (input: Record<string, unknown>) => Promise<ToolResult>)({});
+
+		expect(execute).toHaveBeenCalledOnce();
+		expect(checker).not.toHaveBeenCalled();
+	});
+
+	it('publishes approval metadata only for consequential tools', () => {
+		const tools = buildTools([CONSEQUENT, READ], vi.fn(async () => ok), context);
+
+		expect(tools.publish.needsApproval).toBeTypeOf('function');
+		expect(tools.read.needsApproval).toBeTypeOf('function');
+});
+});

--- a/packages/agent-adapters/src/runtime/ai-runtime.test.ts
+++ b/packages/agent-adapters/src/runtime/ai-runtime.test.ts
@@ -7,12 +7,14 @@ const ctx: AdapterContext = { brandId: 'b1', userId: 'u1', runId: 'run-1', local
 const BURN_TOOL: ToolSpec = {
 	name: 'burn',
 	description: 'brucia token',
+	consequential: false,
 	inputSchema: { type: 'object', properties: {}, additionalProperties: false }
 };
 
 const REPLY_TOOL: ToolSpec = {
 	name: 'reply',
 	description: 'chiude il turno',
+	consequential: false,
 	inputSchema: { type: 'object', properties: { message: { type: 'string' } }, required: ['message'] },
 	terminal: true
 };

--- a/packages/agent-adapters/src/runtime/ai-runtime.ts
+++ b/packages/agent-adapters/src/runtime/ai-runtime.ts
@@ -1,5 +1,6 @@
 import { tool, jsonSchema, type JSONSchema7, type ToolSet } from 'ai';
-import type { AdapterContext, ToolCall, ToolResult, ToolSpec } from '@anomalia/agent-kit/types';
+import { gateAction, type ActionGateResult } from '@anomalia/agent-kit/action-approval';
+import type { ActionApprovalConfig, AdapterContext, ToolCall, ToolResult, ToolSpec } from '@anomalia/agent-kit/types';
 
 export type ExecToolCall = (call: ToolCall, context: AdapterContext) => Promise<ToolResult>;
 
@@ -21,26 +22,60 @@ function toModelOutput(args: { output?: ToolResult }) {
 	return output.isError ? ({ type: 'error-json' as const, value: { content: value } }) : ({ type: 'content' as const, value });
 }
 
-export function buildTools(specs: ToolSpec[], execToolCall: ExecToolCall, context: AdapterContext): ToolSet {
+function approvalError(name: string, reason?: string): ToolResult {
+	return {
+		content: [{ type: 'text', text: `${name}: ${reason ?? 'human approval required'}` }],
+		isError: true
+	};
+}
+
+export function buildTools(
+	specs: ToolSpec[],
+	execToolCall: ExecToolCall,
+	context: AdapterContext,
+	approval?: ActionApprovalConfig
+): ToolSet {
 	const tools: ToolSet = {};
 	for (const spec of specs) {
+		const approvalResults = new Map<string, ActionGateResult>();
+		const approvalFor = async (input: Record<string, unknown>, toolCallId?: string) => {
+			if (!approval) return spec.consequential;
+			const result = await gateAction({
+				spec,
+				call: { name: spec.name, args: input ?? {}, ...(toolCallId ? { id: toolCallId } : {}) },
+				context,
+				config: approval
+			});
+			if (toolCallId) approvalResults.set(toolCallId, result);
+			return result.source === 'rule' || result.source === 'judge-ask';
+		};
+		const execute = async (input: Record<string, unknown>, options?: { toolCallId?: string }) => {
+			const call: ToolCall = {
+				name: spec.name,
+				args: input ?? {},
+				...(options?.toolCallId ? { id: options.toolCallId } : {})
+			};
+			if (approval) {
+				const cached = options?.toolCallId ? approvalResults.get(options.toolCallId) : undefined;
+				if (options?.toolCallId) approvalResults.delete(options.toolCallId);
+				const gate = cached ?? (await gateAction({ spec, call, context, config: approval }));
+				if (gate.decision === 'ask' && (!cached || gate.source === 'judge-error')) {
+					return approvalError(spec.name, gate.reason);
+				}
+			}
+			return execToolCall(call, context);
+		};
 		tools[spec.name] = spec.terminal
 			? tool({
 					description: spec.description,
 					inputSchema: jsonSchema<Record<string, unknown>>(spec.inputSchema as JSONSchema7)
 				})
-			: tool({
+				: tool({
 					description: spec.description,
 					inputSchema: jsonSchema<Record<string, unknown>>(spec.inputSchema as JSONSchema7),
-					execute: async (input: Record<string, unknown>, options) =>
-						execToolCall(
-							{
-								name: spec.name,
-								args: input ?? {},
-								...(options?.toolCallId ? { id: options.toolCallId } : {})
-							},
-							context
-						),
+					needsApproval: (input: Record<string, unknown>, options: { toolCallId: string }) =>
+						approvalFor(input, options.toolCallId),
+					execute,
 					toModelOutput
 				});
 	}

--- a/packages/agent-adapters/src/runtime/harness-runtime.test.ts
+++ b/packages/agent-adapters/src/runtime/harness-runtime.test.ts
@@ -7,6 +7,7 @@ const ctx: AdapterContext = { brandId: 'b1', userId: 'u1', runId: 'r1', locale: 
 const spec: ToolSpec = {
 	name: 'publish_post',
 	description: 'publish',
+	consequential: true,
 	inputSchema: { type: 'object', properties: {} }
 };
 

--- a/packages/agent-adapters/src/runtime/harness-runtime.ts
+++ b/packages/agent-adapters/src/runtime/harness-runtime.ts
@@ -230,7 +230,7 @@ export class HarnessRuntime implements AgentRuntime {
 			harness: setup.harness(request.model.id),
 			sandbox: this.deps.sandboxProvider ?? setup.sandbox(),
 			instructions: request.system,
-			tools: buildTools(request.tools, this.deps.execToolCall, context),
+			tools: buildTools(request.tools, this.deps.execToolCall, context, request.approval),
 			stopWhen: request.tools.filter((tool) => tool.terminal).map((tool) => hasToolCall(tool.name))
 		};
 	}

--- a/packages/agent-core/src/executor.test.ts
+++ b/packages/agent-core/src/executor.test.ts
@@ -265,7 +265,7 @@ describe('createApplyTool — il gate sugli effetti', () => {
 	function effectfulPlugin(counter: { calls: number }) {
 		return {
 			name: 'content',
-			tools: [{ name: 'content_schedule', description: 'schedula', inputSchema: { type: 'object' }, effectful: true }],
+			tools: [{ name: 'content_schedule', description: 'schedula', inputSchema: { type: 'object' }, effectful: true, consequential: true }],
 			async execute() {
 				counter.calls += 1;
 				return { content: [{ type: 'text' as const, text: `post ${counter.calls}` }] };
@@ -307,7 +307,7 @@ describe('createApplyTool — il gate sugli effetti', () => {
 		const { brandId } = fakeContext();
 		const injected = createMemoryEffectsLedger();
 		await injected.intend({ brandId, runId: 'run-dead', toolName: 'content_schedule', key: effectKey('content_schedule', { post_id: 'p1' }), request: { post_id: 'p1' } });
-		await injected.resolve(injected.rows[0].id, 'ambiguous', null);
+		await injected.reconcileRun('run-dead');
 		const apply = createApplyTool(baseDeps({ plugins: [effectfulPlugin(counter)], effects: injected }));
 
 		const out = await apply({ name: 'content_schedule', args: { post_id: 'p1' } }, fakeContext({ runId: 'run-new' }));
@@ -332,7 +332,7 @@ describe('createApplyTool — il gate sugli effetti', () => {
 	it('solo i tool marcat effectful passano dal gate; gli altri no', async () => {
 		const counter = { calls: 0 };
 		const ledger = createMemoryEffectsLedger();
-		const plugin = { ...effectfulPlugin(counter), tools: [{ name: 'content_read', description: 'legge', inputSchema: { type: 'object' } }] };
+		const plugin = { ...effectfulPlugin(counter), tools: [{ name: 'content_read', description: 'legge', inputSchema: { type: 'object' }, consequential: false }] };
 		const apply = createApplyTool(baseDeps({ plugins: [plugin], effects: ledger }));
 		const out = await apply({ name: 'content_read', args: {} }, fakeContext());
 		expect(out.isError).toBeFalsy();

--- a/packages/agent-core/src/tools/builtin.test.ts
+++ b/packages/agent-core/src/tools/builtin.test.ts
@@ -13,6 +13,7 @@ describe('BUILTIN_TOOLS', () => {
 			expect(tool.name).toMatch(/^[a-z_]+$/);
 			expect(tool.description.length).toBeGreaterThan(0);
 			expect(tool.inputSchema.type).toBe('object');
+			expect(typeof tool.consequential).toBe('boolean');
 		}
 	});
 

--- a/packages/agent-core/src/tools/builtin.ts
+++ b/packages/agent-core/src/tools/builtin.ts
@@ -14,6 +14,7 @@ import type { ToolSpec } from '@anomalia/agent-kit';
 export const BUILTIN_TOOLS: ToolSpec[] = [
 	{
 		name: 'brand_ls',
+		consequential: false,
 		description:
 			"Elenca i file dell'albero del brand (studio, piano, post, artefatti) a un path — NON il filesystem della macchina, per quello c'è `shell`. Usalo per orientarti prima di leggere; recursive:true per l'albero intero.",
 		inputSchema: {
@@ -26,6 +27,7 @@ export const BUILTIN_TOOLS: ToolSpec[] = [
 	},
 	{
 		name: 'brand_read',
+		consequential: false,
 		description:
 			"Legge per intero un file dell'albero del brand (studio, piano, post, artefatti) — NON il filesystem della macchina, per quello c'è `shell`. Non indovinare il contenuto: leggilo.",
 		inputSchema: {
@@ -36,6 +38,7 @@ export const BUILTIN_TOOLS: ToolSpec[] = [
 	},
 	{
 		name: 'brand_grep',
+		consequential: false,
 		description:
 			"Cerca un pattern nei file dell'albero del brand (studio, piano, post, artefatti) — NON il filesystem della macchina, per quello c'è `shell`. Più economico di leggere tutto quando cerchi una cosa sola; path limita la ricerca a un sottoalbero.",
 		inputSchema: {
@@ -51,6 +54,7 @@ export const BUILTIN_TOOLS: ToolSpec[] = [
 		name: 'brand_write',
 		requiresMode: 'plan',
 		effectful: true,
+		consequential: true,
 		description:
 			"Scrive un file dove l'albero del brand lo consente (studio, piano, post, artefatti) — NON il filesystem della macchina, per quello c'è `shell`. Fallisce se il path non è scrivibile: non è un errore da nascondere, è un permesso.",
 		inputSchema: {
@@ -61,6 +65,7 @@ export const BUILTIN_TOOLS: ToolSpec[] = [
 	},
 	{
 		name: 'query',
+		consequential: false,
 		description: "Legge dal database coi permessi dell'utente corrente. Usalo per dati strutturati (post, metriche); per file usa brand_ls/brand_read/brand_grep.",
 		inputSchema: {
 			type: 'object',
@@ -76,6 +81,7 @@ export const BUILTIN_TOOLS: ToolSpec[] = [
 		name: 'shell',
 		requiresMode: 'agent',
 		effectful: true,
+		consequential: true,
 		description:
 			"Esegue un comando nella VM del brand (si accende da sola al primo uso). Rete CHIUSA: passano solo i registry dei pacchetti (npm, pip) — internet no. Un fetch verso un sito qualsiasi fallisce per firewall, non per guasto DNS: non riprovarlo, e per leggere il web usa i tool di lettura del brand invece della shell.",
 		inputSchema: {
@@ -87,6 +93,7 @@ export const BUILTIN_TOOLS: ToolSpec[] = [
 	{
 		name: 'attach',
 		effectful: true,
+		consequential: true,
 		description: 'Allega un file o un media alla chat, così resta visibile senza incollarne il contenuto nel testo.',
 		inputSchema: {
 			type: 'object',
@@ -97,6 +104,7 @@ export const BUILTIN_TOOLS: ToolSpec[] = [
 		name: 'remember',
 		requiresMode: 'plan',
 		effectful: true,
+		consequential: true,
 		description: 'Scrive un fatto in memoria durevole: sopravvive al turno e ai run successivi. Non per appunti temporanei del piano.',
 		inputSchema: {
 			type: 'object',
@@ -109,6 +117,7 @@ export const BUILTIN_TOOLS: ToolSpec[] = [
 	},
 	{
 		name: 'reply',
+		consequential: false,
 		description: "L'atto esplicito di parlare all'utente: cosa esiste adesso (con gli id), cosa non è riuscito, cosa serve da lui. Il turno finisce SOLO qui o con ask_user — mai in silenzio dopo un tool.",
 		terminal: true,
 		inputSchema: {
@@ -122,6 +131,7 @@ export const BUILTIN_TOOLS: ToolSpec[] = [
 	},
 	{
 		name: 'ask_user',
+		consequential: false,
 		description: "Domanda bloccante: il run va in waiting_input e RESTA VIVO in attesa della risposta. Usalo solo quando non puoi procedere senza saperlo, non per confermare l'ovvio.",
 		terminal: true,
 		inputSchema: {
@@ -135,6 +145,7 @@ export const BUILTIN_TOOLS: ToolSpec[] = [
 	},
 	{
 		name: 'plan',
+		consequential: false,
 		description: 'Dichiara il piano del turno per la UI. Facoltativo: non serve per turni di un solo passo.',
 		inputSchema: {
 			type: 'object',
@@ -144,6 +155,7 @@ export const BUILTIN_TOOLS: ToolSpec[] = [
 	},
 	{
 		name: 'observe',
+		consequential: false,
 		description: "Scatta uno screenshot dello schermo grafico della VM del brand (desktop reale, non un'immagine finta). Accende il modo grafico da solo se non è già attivo — la primissima volta può volerci qualche minuto, e il risultato lo dice. Usalo prima di 'act' per vedere dove cliccare.",
 		inputSchema: { type: 'object', properties: {} }
 	},
@@ -151,6 +163,7 @@ export const BUILTIN_TOOLS: ToolSpec[] = [
 		name: 'act',
 		requiresMode: 'agent',
 		effectful: true,
+		consequential: true,
 		description: "Esegue fino a 24 azioni sullo schermo grafico della VM e torna uno screenshot aggiornato. Accende il modo grafico da solo se serve. kind:'click'/'move' vogliono x,y (pixel); 'type' vuole text; 'key' vuole key (es. 'Return', 'ctrl+l'); 'scroll' vuole amount (righe, negativo = verso l'alto); 'wait' vuole ms.",
 		inputSchema: {
 			type: 'object',

--- a/packages/agent-core/src/turn.ts
+++ b/packages/agent-core/src/turn.ts
@@ -35,6 +35,7 @@ export interface TurnInput {
 	extras: { memoryMd: string; fileIndex: string };
 	limits: RunRequest['limits'];
 	model: RunRequest['model'];
+	approval?: RunRequest['approval'];
 	sessionKey?: string;
 }
 
@@ -84,6 +85,7 @@ export async function runTurn(
 		system: buildSystemPrompt(input.spec, input.extras),
 		messages: input.messages,
 		tools: input.tools,
+		approval: input.approval,
 		model: input.model,
 		limits: input.limits
 	};

--- a/packages/agent-kit/package.json
+++ b/packages/agent-kit/package.json
@@ -8,6 +8,7 @@
     "./types": "./src/types.ts",
     "./interfaces": "./src/interfaces.ts",
     "./registry": "./src/registry.ts",
+    "./action-approval": "./src/action-approval.ts",
     "./testkit": "./src/testkit.ts"
   }
 }

--- a/packages/agent-kit/src/action-approval.test.ts
+++ b/packages/agent-kit/src/action-approval.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import {
+	applyJudgeDecision,
+	planActionGate,
+	resolveActionApprovalDetail,
+	type ActionApprovalResolved
+} from './action-approval';
+
+const DEFAULT: ActionApprovalResolved = {
+	decision: 'allow',
+	source: 'default',
+	matchingRules: []
+};
+
+describe('action approval', () => {
+	it('nonconsequential tool stays on allow without a prompt', () => {
+		expect(
+			planActionGate({
+				resolved: DEFAULT,
+				consequential: false,
+				autoReviewEnabled: true,
+				checkerConfigured: true
+			})
+		).toBe('allow');
+	});
+
+	it('default consequential tool enters judge only with auto-review and checker', () => {
+		expect(
+			planActionGate({
+				resolved: DEFAULT,
+				consequential: true,
+				autoReviewEnabled: true,
+				checkerConfigured: true
+			})
+		).toBe('judge');
+	});
+
+	it('explicit rules win over the judge', () => {
+		expect(
+			planActionGate({
+				resolved: { decision: 'ask', source: 'require_approval', matchingRules: [] },
+				consequential: true,
+				autoReviewEnabled: true,
+				checkerConfigured: true
+			})
+		).toBe('ask');
+		expect(
+			planActionGate({
+				resolved: { decision: 'allow', source: 'always_allow', matchingRules: [] },
+				consequential: true,
+				autoReviewEnabled: true,
+				checkerConfigured: true
+			})
+		).toBe('allow');
+	});
+
+	it('a broken checker asks instead of allowing a consequential action', () => {
+		expect(applyJudgeDecision({ decision: 'error', consequential: true })).toBe('ask');
+	});
+
+	it('resolves the most specific approval rule deterministically', () => {
+		const result = resolveActionApprovalDetail({
+			toolName: 'gmail_send',
+			rules: [
+				{ effect: 'require_approval', matchKind: 'category', matchValue: 'email' },
+				{ effect: 'always_allow', matchKind: 'tool', matchValue: 'gmail_send' }
+			]
+		});
+		expect(result.decision).toBe('allow');
+		expect(result.source).toBe('always_allow');
+	});
+});

--- a/packages/agent-kit/src/action-approval.ts
+++ b/packages/agent-kit/src/action-approval.ts
@@ -1,0 +1,191 @@
+import type {
+	ActionApprovalConfig,
+	ActionApprovalRule,
+	AdapterContext,
+	ToolCall,
+	ToolSpec
+} from './types';
+
+export type { ActionApprovalConfig, ActionApprovalRule, ActionApprovalChecker } from './types';
+
+export type ActionApprovalSource = 'require_approval' | 'always_allow' | 'default';
+
+export type ActionApprovalResolved = {
+	decision: 'ask' | 'allow';
+	source: ActionApprovalSource;
+	matchingRules: readonly ActionApprovalRule[];
+};
+
+export type AutoReviewJudgeDecision = 'pass' | 'ask' | 'error';
+
+export type ActionGateSource = 'rule' | 'default' | 'judge-pass' | 'judge-ask' | 'judge-error';
+
+export type ActionGateResult = {
+	decision: 'ask' | 'allow';
+	source: ActionGateSource;
+	reason?: string;
+};
+
+const APPROVAL_EXEMPT_TOOLS = new Set([
+	'computer_observe',
+	'computer_act',
+	'list_files',
+	'read_file',
+	'write_file',
+	'shell',
+	'open_path',
+	'launch_app',
+	'remember',
+	'request_takeover',
+	'request_secret',
+	'run_subagent',
+	'spawn_bot',
+	'schedule_create',
+	'schedule_list',
+	'schedule_cancel'
+]);
+
+const APPROVAL_REQUIRED_BUILTIN_TOOLS = new Set(['destination.write', 'delete_bot', 'archive_bot']);
+const READ_ONLY_CONNECTOR_PATTERN = /(^|_)(get|list|search|find|read)(_|$)/i;
+const MUTATING_CONNECTOR_PATTERN =
+	/(^|_)(accept|add|approve|archive|assign|buy|cancel|charge|checkout|close|commit|copy|create|delete|deploy|disable|enable|execute|forward|grant|invite|link|mark|merge|modify|move|patch|pay|post|publish|purchase|put|register|reject|remove|rename|replace|reply|reset|revoke|run|schedule|send|set|share|start|stop|submit|subscribe|trigger|unassign|unlink|unsubscribe|update|upload|upsert|write)(_|$)/i;
+const COMPOUND_CONNECTOR_ACTION_PATTERN = /_(and|or|then)_/i;
+const EMAIL_CONNECTOR_SLUGS = new Set(['gmail', 'outlook', 'microsoft_outlook']);
+const PURCHASE_CONNECTOR_SLUGS = new Set(['stripe', 'shopify', 'paypal', 'square']);
+
+export function connectorKindFromToolName(toolName: string, connectorKinds: string[] = []): string {
+	const normalizedTool = toolName.toLowerCase();
+	const matched = connectorKinds
+		.map((kind) => kind.toLowerCase())
+		.filter((kind) => normalizedTool === kind || normalizedTool.startsWith(`${kind}_`))
+		.sort((left, right) => right.length - left.length)[0];
+	if (matched) return matched;
+	return toolName.split('_')[0]?.toLowerCase() ?? toolName.toLowerCase();
+}
+
+export function connectorToolRequiresApproval(toolName: string): boolean {
+	if (MUTATING_CONNECTOR_PATTERN.test(toolName)) return true;
+	if (COMPOUND_CONNECTOR_ACTION_PATTERN.test(toolName)) return true;
+	return !READ_ONLY_CONNECTOR_PATTERN.test(toolName);
+}
+
+export function toolRequiresApproval(toolName: string, viaConnector: boolean): boolean {
+	if (APPROVAL_EXEMPT_TOOLS.has(toolName)) return false;
+	if (APPROVAL_REQUIRED_BUILTIN_TOOLS.has(toolName)) return true;
+	if (viaConnector) return connectorToolRequiresApproval(toolName);
+	return false;
+}
+
+function categoryMatches(category: string, toolName: string, connectorKind: string): boolean {
+	const consequential = connectorToolRequiresApproval(toolName);
+	if (category.toLowerCase() === 'email') {
+		if (EMAIL_CONNECTOR_SLUGS.has(connectorKind.toLowerCase())) return consequential;
+		return consequential && /send.*mail|gmail_send|outlook_send/i.test(toolName);
+	}
+	if (category.toLowerCase() === 'purchase') {
+		if (PURCHASE_CONNECTOR_SLUGS.has(connectorKind.toLowerCase())) return consequential;
+		return consequential && /purchase|pay_|charge|checkout|buy_/i.test(toolName);
+	}
+	return false;
+}
+
+function matches(rule: ActionApprovalRule, toolName: string, connectorKind: string): boolean {
+	const value = rule.matchValue.toLowerCase();
+	const name = toolName.toLowerCase();
+	if (rule.matchKind === 'tool') return name === value;
+	if (rule.matchKind === 'connector') return name === value || name.startsWith(`${value}_`);
+	return categoryMatches(value, name, connectorKind);
+}
+
+function specificity(rule: ActionApprovalRule): number {
+	if (rule.matchKind === 'tool') return 3;
+	if (rule.matchKind === 'connector') return 2;
+	return 1;
+}
+
+export function resolveActionApprovalDetail(input: {
+	toolName: string;
+	connectorKind?: string;
+	connectorKinds?: string[];
+	rules: readonly ActionApprovalRule[];
+}): ActionApprovalResolved {
+	const connectorKind = input.connectorKind ?? connectorKindFromToolName(input.toolName, input.connectorKinds);
+	const matchingRules = input.rules.filter((rule) => matches(rule, input.toolName, connectorKind));
+	if (matchingRules.length === 0) {
+		return { decision: 'allow', source: 'default', matchingRules };
+	}
+
+	const highest = Math.max(...matchingRules.map(specificity));
+	const winners = matchingRules.filter((rule) => specificity(rule) === highest);
+	if (winners.some((rule) => rule.effect === 'require_approval')) {
+		return { decision: 'ask', source: 'require_approval', matchingRules };
+	}
+	return { decision: 'allow', source: 'always_allow', matchingRules };
+}
+
+export function resolveActionApproval(input: {
+	toolName: string;
+	connectorKind?: string;
+	connectorKinds?: string[];
+	rules: readonly ActionApprovalRule[];
+}): 'ask' | 'allow' {
+	return resolveActionApprovalDetail(input).decision;
+}
+
+export function planActionGate(input: {
+	resolved: ActionApprovalResolved;
+	consequential: boolean;
+	autoReviewEnabled: boolean;
+	checkerConfigured: boolean;
+}): 'ask' | 'allow' | 'judge' {
+	if (input.resolved.decision === 'ask') return 'ask';
+	if (input.resolved.source === 'always_allow') return 'allow';
+	if (input.consequential && input.autoReviewEnabled && input.checkerConfigured && input.resolved.source === 'default') {
+		return 'judge';
+	}
+	return 'allow';
+}
+
+export function applyJudgeDecision(input: {
+	decision: AutoReviewJudgeDecision;
+	consequential: boolean;
+}): 'ask' | 'allow' {
+	if (input.decision === 'pass') return 'allow';
+	if (input.decision === 'ask') return 'ask';
+	return input.consequential ? 'ask' : 'allow';
+}
+
+export async function gateAction(input: {
+	spec: ToolSpec;
+	call: ToolCall;
+	context: AdapterContext;
+	config: ActionApprovalConfig;
+}): Promise<ActionGateResult> {
+	const resolved = resolveActionApprovalDetail({ toolName: input.spec.name, rules: input.config.rules ?? [] });
+	const plan = planActionGate({
+		resolved,
+		consequential: input.spec.consequential === true,
+		autoReviewEnabled: input.config.autoReviewEnabled,
+		checkerConfigured: input.config.checker != null
+	});
+	if (plan === 'allow') {
+		return { decision: 'allow', source: resolved.source === 'default' ? 'default' : 'rule' };
+	}
+	if (plan === 'ask') return { decision: 'ask', source: 'rule', reason: 'human approval required' };
+
+	try {
+		const decision = await input.config.checker!({ spec: input.spec, call: input.call, context: input.context });
+		const result = applyJudgeDecision({
+			decision,
+			consequential: input.spec.consequential === true
+		});
+		if (result === 'allow') return { decision: 'allow', source: 'judge-pass' };
+		return {
+			decision: 'ask',
+			source: decision === 'error' ? 'judge-error' : 'judge-ask',
+			reason: decision === 'error' ? 'auto-review failed' : 'auto-review requires approval'
+		};
+	} catch {
+		return { decision: 'ask', source: 'judge-error', reason: 'auto-review failed' };
+	}
+}

--- a/packages/agent-kit/src/index.ts
+++ b/packages/agent-kit/src/index.ts
@@ -1,3 +1,4 @@
 export * from './types';
 export * from './interfaces';
 export * from './registry';
+export * from './action-approval';

--- a/packages/agent-kit/src/testkit.ts
+++ b/packages/agent-kit/src/testkit.ts
@@ -129,7 +129,7 @@ export function createMemoryStore(): MemoryStore & { entries: MemoryEntry[] } {
 export function fakePlugin(name: string, reply: ToolResult): ToolPlugin {
 	return {
 		name: `plugin-${name}`,
-		tools: [{ name, description: `tool di test per ${name}`, inputSchema: { type: 'object' } }],
+		tools: [{ name, description: `tool di test per ${name}`, consequential: false, inputSchema: { type: 'object' } }],
 		async execute(_call: ToolCall) {
 			return reply;
 		}

--- a/packages/agent-kit/src/types.ts
+++ b/packages/agent-kit/src/types.ts
@@ -40,6 +40,7 @@ export interface ToolSpec {
 	 * quindi vive anche dove si può solo leggere.
 	 */
 	requiresMode?: 'plan' | 'agent';
+	consequential: boolean;
 	terminal?: boolean;
 	/**
 	 * Il tool ha un effetto collaterale reale (scrive/post/schedula/rende un file): va avvolto dal
@@ -47,6 +48,24 @@ export interface ToolSpec {
 	 */
 	effectful?: boolean;
 }
+
+export type ActionApprovalRule = {
+	effect: 'require_approval' | 'always_allow';
+	matchKind: 'tool' | 'connector' | 'category';
+	matchValue: string;
+};
+
+export type ActionApprovalChecker = (input: {
+	spec: ToolSpec;
+	call: ToolCall;
+	context: AdapterContext;
+}) => Promise<'pass' | 'ask' | 'error'>;
+
+export type ActionApprovalConfig = {
+	autoReviewEnabled: boolean;
+	rules?: readonly ActionApprovalRule[];
+	checker?: ActionApprovalChecker;
+};
 
 /** Testo e/o immagini, più un flag d'errore che INSEGNA. */
 export type ToolResultContent =
@@ -111,6 +130,7 @@ export interface RunRequest {
 	system: string;
 	messages: Array<{ role: 'user' | 'assistant' | 'tool'; content: unknown }>;
 	tools: ToolSpec[];
+	approval?: ActionApprovalConfig;
 	model: ModelRef;
 	limits: { maxSteps: number; tokenBudget: number; deadlineMs: number };
 }

--- a/src/lib/agent/plugins/analyst.ts
+++ b/src/lib/agent/plugins/analyst.ts
@@ -11,34 +11,40 @@ export interface AnalystPluginDeps {
 	locale?: 'en' | 'it';
 }
 
-const MAP: Record<string, { source: string; description: string }> = {
+const MAP: Record<string, { source: string; description: string; consequential: boolean }> = {
 	analyst_read_strategy: {
 		source: 'read_strategy',
+		consequential: false,
 		description:
 			'Read the brand strategy in one call: competitive research report, positioning, the active editorial plan (voice, cadence, platform mix, weeks) and the active GTM plan (horizon, objective, current phase). This is the plan every recommendation must be compared against — read it before proposing a change to it.'
 	},
 	analyst_list_posts: {
 		source: 'read_posts',
+		consequential: false,
 		description:
 			'List brand posts as real rows — status, platform, caption, scheduled slot, media_origin, and the media_review verdict (ship/fix/kill) when one exists. This is the grounded source for anything said about what the brand published: never quote a post, a title or a count that did not come back from here.'
 	},
 	analyst_post_patterns: {
 		source: 'analyze_post_people',
+		consequential: false,
 		description:
 			'Analyze the synced post history (up to 200 published posts) for recurring people, best posting times, top formats and engagement patterns. Needs synced social history — with none it returns an error naming that, which is the honest answer, not a retry.'
 	},
 	analyst_read_leads: {
 		source: 'read_leads',
+		consequential: false,
 		description:
 			'Read leads: real online conversations (Reddit/Threads/X) where the product or category is discussed, with the drafted comment/DM suggestions. Use them for the audience language, questions and objections behind a recommendation.'
 	},
 	analyst_run_review: {
 		source: 'run_analytics_review',
+		consequential: true,
 		description:
 			'Run the analytics review: it reads social/blog/SEO performance and proposes GTM + editorial plan revisions for owner approval. Runs in the BACKGROUND — this call returns a job id immediately and the result lands later as a new message. Say one line and end the turn; never report the review as finished from this call.'
 	},
 	analyst_update_gtm_plan: {
 		source: 'update_gtm_plan',
+		consequential: true,
 		description:
 			'Update the active GTM plan: objective, a phase name/objective, platform weights, or pillars. Refused when the brand has no active GTM plan. This is the only write in this trade — you do not create posts, you brief the other specialists through the plan.'
 	}
@@ -59,6 +65,7 @@ export function createAnalystPlugin(deps: AnalystPluginDeps): ToolPlugin {
 	const tools: ToolSpec[] = Object.entries(MAP).map(([name, m]) => ({
 		name,
 		description: m.description,
+		consequential: m.consequential,
 		inputSchema: jsonSchemaOf(chatTools[m.source])
 	}));
 

--- a/src/lib/agent/plugins/content.ts
+++ b/src/lib/agent/plugins/content.ts
@@ -29,13 +29,20 @@ export interface ContentPluginDeps {
 }
 
 /** Nome nel kit → tool reale in `createChatTools` (stesso schema, stessa execute, stessi gate). */
-type ContentSource = { source: string; description: string; requiresMode?: ToolSpec['requiresMode']; effectful?: boolean };
+type ContentSource = {
+	source: string;
+	description: string;
+	requiresMode?: ToolSpec['requiresMode'];
+	effectful?: boolean;
+	consequential: boolean;
+};
 
 const MAP: Record<string, ContentSource> = {
 	content_create_post: {
 		source: 'create_post',
 		requiresMode: 'agent',
 		effectful: true,
+		consequential: true,
 		description:
 			'Create a social post (caption + visual) as a pending_user draft — image, carousel, or video. MEDIA FIRST: pass media_ids to reuse a library asset instead of minting a new AI image (free). content_type "video" submits the clip in the BACKGROUND and ships the QC\'d cover as a stand-in — the result carries video_render_status/video_note honestly, never claims a finished video that has not landed. Real people in people_ids without recorded consent are silently DROPPED from the visual (server-logged, not refused) — content_generate_image refuses instead. Runs out of AI credits or monthly post quota → an error naming which, not a retry loop. Naming a `platform` the brand has NOT connected is REFUSED before any generation (error platform_not_connected, nothing spent) — tell the user to connect it, or pass allow_unconnected if they want a draft anyway.'
 	},
@@ -43,6 +50,7 @@ const MAP: Record<string, ContentSource> = {
 		source: 'design_graphic',
 		requiresMode: 'agent',
 		effectful: true,
+		consequential: true,
 		description:
 			"Compose or revise a post's typographic graphic (words on a brand-coloured canvas, optional embedded photos) as HTML/TSX, via the same composer + render gate the post editor uses. Needs an existing post_id — create the post first. Real people without recorded consent are silently dropped from the canvas (same as content_create_post, not a refusal)."
 	},
@@ -50,6 +58,7 @@ const MAP: Record<string, ContentSource> = {
 		source: 'generate_image',
 		requiresMode: 'agent',
 		effectful: true,
+		consequential: true,
 		description:
 			'Mint or edit an AI photo (Nano Banana). Standalone (no post_id): returns image_url, does not touch a post. With post_id on an ai_generated post: regenerates that image using the prompt as feedback. Real people in people_ids/talent_ids without recorded consent make this REFUSE outright (AI Act gate, error names who is blocked) — unlike content_create_post. Reference images are capped by the renderer\'s real input limit; past it, extras are dropped oldest-priority-last, never an error.'
 	},
@@ -57,29 +66,34 @@ const MAP: Record<string, ContentSource> = {
 		source: 'approve_post',
 		requiresMode: 'agent',
 		effectful: true,
+		consequential: true,
 		description:
 			"Approve a pending_user draft and schedule it for publishing (Zernio). The prepublish gate REFUSES a post with no image/video — a visual post cannot go out empty — and refuses while a video render for it is still in flight. Only approved/pending_user posts qualify; omit scheduled_for to keep the post's existing slot. With no connected account for the post's platform the result is success:false + noAccount:true: the post stays approved and does NOT go out — say so, never call it scheduled."
 	},
 	content_update_post: {
 		source: 'update_post',
 		effectful: true,
+		consequential: true,
 		description:
 			"Edit an existing post in place: caption, first comment, platform(s), pillar, slot. Only the fields passed change. On an already-scheduled post the old Zernio schedule is cancelled and the post re-sent, so the published copy stays in sync with the row — the result says so with rescheduled: true. To move the time use content_reschedule_post; to add a platform use content_cross_post."
 	},
 	content_reschedule_post: {
 		source: 'reschedule_post',
 		effectful: true,
+		consequential: true,
 		description:
 			"Move an approved or scheduled post to a new time (brand timezone). REFUSED on a pending_user draft — rescheduling one would publish it without approval; approve it with content_schedule instead. The old Zernio schedule is cancelled before the new one is sent, so a moved post never goes out twice."
 	},
 	content_cross_post: {
 		source: 'cross_post',
 		effectful: true,
+		consequential: true,
 		description:
 			"Add platforms to an existing post. pending_user: the platform list is widened on the draft. scheduled: the schedule is cancelled and re-sent with the wider list. published: a CLONE is created for the new platforms only — the live post is never touched. Refused when the post already covers every platform asked for."
 	},
 	content_list_posts: {
 		source: 'read_posts',
+		consequential: false,
 		description:
 			'List brand posts, optionally filtered by status (pending_user/approved/scheduled/published/failed). Each post carries media_origin (typographic_graphic/ai_generated/user_uploaded/video/none) and, when reviewed, a media_review verdict (ship/fix/kill) — honor fix/kill, do not approve as-is.'
 	}
@@ -104,6 +118,7 @@ export function createContentPlugin(deps: ContentPluginDeps): ToolPlugin {
 		description: m.description,
 		requiresMode: m.requiresMode,
 		effectful: m.effectful,
+		consequential: m.consequential,
 		inputSchema: jsonSchemaOf(chatTools[m.source])
 	}));
 

--- a/src/lib/agent/plugins/delegation.ts
+++ b/src/lib/agent/plugins/delegation.ts
@@ -30,6 +30,7 @@ export function createDelegationPlugin(deps: DelegationPluginDeps): ToolPlugin {
 		name,
 		description: String(delegation[name]?.description ?? ''),
 		requiresMode: 'agent',
+		consequential: true,
 		inputSchema: jsonSchemaOf(delegation[name])
 	}));
 

--- a/src/lib/agent/plugins/goal.ts
+++ b/src/lib/agent/plugins/goal.ts
@@ -46,6 +46,7 @@ export function createGoalPlugin(deps: GoalPluginDeps): ToolPlugin {
 		name,
 		description: withKitToolNames(String(goalTools[name]?.description ?? name)),
 		requiresMode: 'plan',
+		consequential: true,
 		inputSchema: jsonSchemaOf(goalTools[name])
 	}));
 

--- a/src/lib/agent/plugins/grounding.ts
+++ b/src/lib/agent/plugins/grounding.ts
@@ -34,6 +34,7 @@ export function createGroundingPlugin(deps: GroundingPluginDeps): ToolPlugin {
 	const tools: ToolSpec[] = [
 		{
 			name: SOURCE,
+			consequential: false,
 			description: String(chatTools[SOURCE]?.description ?? SOURCE),
 			inputSchema: jsonSchemaOf(chatTools[SOURCE])
 		}

--- a/src/lib/agent/plugins/motion.ts
+++ b/src/lib/agent/plugins/motion.ts
@@ -98,6 +98,7 @@ export const MOTION_PLUGIN_TOOLS: ToolSpec[] = [
 	{
 		name: 'motion_write',
 		requiresMode: 'agent',
+		consequential: true,
 		description: [
 			'Build a kinetic motion video from a brief in prose. You do NOT write Remotion source: the motion agent does, and it is the one that carries the craft — the transition recipes, the easing rules, the reference wall, and the gates that refuse a composition written in one shot.',
 			'Say what the video must do: the angle, the beats, the copy that matters, the proof, the CTA. Name products, people and features by their real names — vague in, vague out.',
@@ -118,6 +119,7 @@ export const MOTION_PLUGIN_TOOLS: ToolSpec[] = [
 	{
 		name: 'motion_check',
 		requiresMode: 'agent',
+		consequential: false,
 		description: [
 			'Where a queued motion build got to: its status, the tools it is running now, and what it has said so far.',
 			'Do NOT poll it in a loop — check, then do other work or tell the user where it is, and come back later. A composition is still not a video when the build is done: motion_render makes the MP4.'
@@ -131,6 +133,7 @@ export const MOTION_PLUGIN_TOOLS: ToolSpec[] = [
 	{
 		name: 'motion_edit',
 		requiresMode: 'agent',
+		consequential: true,
 		description: [
 			'The PREFERRED way to change an existing composition: targeted search-and-replace on the saved source instead of resending it whole — full motion_write with id+force stays for total rewrites only.',
 			"op 'grep' lists every saved-source line containing pattern as numbered lines (plain text, case-insensitive) — run it first to find exact text.",
@@ -152,6 +155,7 @@ export const MOTION_PLUGIN_TOOLS: ToolSpec[] = [
 	{
 		name: 'motion_render',
 		requiresMode: 'agent',
+		consequential: true,
 		description: [
 			'Render the REAL MP4 in a VM from the saved source, and attach it to the gallery as its preview.',
 			'This is the only way to produce a file someone can actually watch — motion_write only saves code. Costs VM time.',
@@ -169,6 +173,7 @@ export const MOTION_PLUGIN_TOOLS: ToolSpec[] = [
 	{
 		name: 'motion_stills',
 		requiresMode: 'agent',
+		consequential: true,
 		description:
 			'Render a few real frames of the saved source — cheap, no audio, no MP4 — so you can look at the composition before spending a full render. Frames come back attached as images FOR YOU, and are ALSO published as chat artifacts so the user sees them in the conversation. Do not re-publish or show_media the same frames.',
 		inputSchema: {
@@ -186,6 +191,7 @@ export const MOTION_PLUGIN_TOOLS: ToolSpec[] = [
 	},
 	{
 		name: 'motion_list',
+		consequential: false,
 		description: [
 			'List this brand’s motion videos — id, title, created_at/updated_at, status (rendered or source only), preview_url when it exists, and source_path. Use it to find the one to keep editing (“the one from the 4th” is a date, and the date is here), or to check what already exists before making something new.',
 			'source_path is artifacts/motion/<id>.md: brand_read opens it and gives you the whole TSX plus its meta. That file is a projection of the row, so it exists the moment motion_write saves — there is no extra step. It is NOT writable: to change the code, call motion_edit (targeted search-and-replace) or motion_write with that id and a brief of what must change.'
@@ -194,19 +200,22 @@ export const MOTION_PLUGIN_TOOLS: ToolSpec[] = [
 	}
 ];
 
-export const MOTION_AUDIO_MAP: Record<string, { source: string; description: string }> = {
+export const MOTION_AUDIO_MAP: Record<string, { source: string; description: string; consequential: boolean }> = {
 	motion_voiceover: {
 		source: 'generate_voiceover',
+		consequential: true,
 		description:
 			'Record the spoken voice-over for the video: ONE take of the whole script, cut afterwards into one clip per line with motion_cut_voiceover. It is a single recording on purpose — a clip per beat gives a slightly different voice in every beat. Returns one https URL with its real duration in seconds and in frames, plus the pauses to cut at. Bills AI credits. Does NOT change the TSX.'
 	},
 	motion_cut_voiceover: {
 		source: 'cut_voiceover',
+		consequential: true,
 		description:
 			'Cut the take from motion_voiceover into one clip per line, at timestamps taken from its `pauses` list — never guessed. N cuts give N+1 clips, each with its real duration in seconds and frames; put each inside the <Sequence> of the beat that speaks it. Free: it slices a file that already exists. Cuts falling outside the take come back in dropped_cuts instead of silently shifting the labels.'
 	},
 	motion_music: {
 		source: 'generate_music',
+		consequential: true,
 		description:
 			'Generate an instrumental music bed and get back an https URL. Describe the music, not the video: tempo, instruments, mood, energy. It is a bed — it sits under the voice, it does not compete with it. The clip always comes back short: a longer composition repeats it with `loop` on the <Audio>. Bills AI credits. Does NOT change the TSX.'
 	}
@@ -238,6 +247,7 @@ export function createMotionPlugin(deps: MotionPluginDeps): ToolPlugin {
 	const audioTools: ToolSpec[] = Object.entries(MOTION_AUDIO_MAP).map(([name, m]) => ({
 		name,
 		description: m.description,
+		consequential: m.consequential,
 		inputSchema: jsonSchemaOf(chatTools[m.source])
 	}));
 

--- a/src/lib/agent/plugins/notify.ts
+++ b/src/lib/agent/plugins/notify.ts
@@ -41,6 +41,7 @@ export function createNotifyPlugin(deps: NotifyPluginDeps): ToolPlugin {
 		{
 			name: SOURCE,
 			requiresMode: 'agent',
+			consequential: true,
 			description: String(chatTools[SOURCE]?.description ?? SOURCE),
 			inputSchema: jsonSchemaOf(chatTools[SOURCE])
 		}

--- a/src/lib/agent/plugins/team.ts
+++ b/src/lib/agent/plugins/team.ts
@@ -51,11 +51,13 @@ export function createTeamPlugin(deps: TeamPluginDeps): ToolPlugin {
 	const tools: ToolSpec[] = [
 		{
 			name: 'message_agent',
+			consequential: true,
 			description: String(dm.message_agent?.description ?? ''),
 			inputSchema: jsonSchemaOf(dm.message_agent)
 		},
 		{
 			name: 'open_session_with_user',
+			consequential: true,
 			description: String(session.open_session_with_user?.description ?? ''),
 			inputSchema: jsonSchemaOf(session.open_session_with_user)
 		}

--- a/src/lib/agent/plugins/ugc.ts
+++ b/src/lib/agent/plugins/ugc.ts
@@ -48,19 +48,22 @@ const VIDEO_FIELDS = [
 	'image_urls'
 ];
 
-const PASSTHROUGH: Record<string, { source: string; description: string; requiresMode?: ToolSpec['requiresMode'] }> = {
+const PASSTHROUGH: Record<string, { source: string; description: string; requiresMode?: ToolSpec['requiresMode']; consequential: boolean }> = {
 	ugc_list_people: {
 		source: 'read_people',
+		consequential: false,
 		description:
 			'List brand people (real team + AI personas) with ids and signed preview URLs. Pass ids into ugc_generate_video.people_ids as face references. Real people need recorded consent (Studio → People) before their face can appear in a generated clip — this list does not show consent status, ugc_generate_video applies the gate.'
 	},
 	ugc_list_talents: {
 		source: 'read_talents',
+		consequential: false,
 		description: 'List the AI talent library (global synthetic models — no consent needed, they depict nobody). Pass ids into ugc_generate_video.talent_ids as face/body references.'
 	},
 	ugc_review_video: {
 		source: 'review_video',
 		requiresMode: 'plan',
+		consequential: false,
 		description:
 			'Review a FINISHED video against organic UGC or paid-ads standards (Gemini watches the clip): hook, doomscroll stop, sound-off, hold, authenticity, CTA. Use before calling a post ready, or on a competitor URL for research. Bills credits only, never the monthly video budget.'
 	}
@@ -86,6 +89,7 @@ export function createUgcPlugin(deps: UgcPluginDeps): ToolPlugin {
 		{
 			name: 'ugc_generate_video',
 			requiresMode: 'agent',
+			consequential: true,
 			description:
 				'Generate an AI video clip as a new post draft (UGC-style, product shot, or talking-head — the real submission path create_post uses for content_type "video"). Renders in the BACKGROUND: the result carries video_render_status ("rendering" while the clip is in flight) and video_note — call ugc_check_video with the returned post_id later, do not claim a finished video from this call alone. ugc defaults to true (handheld UGC genre, no burned-in captions) unless set false for silent/cinematic b-roll. Real people in people_ids without recorded consent are silently dropped from the reference set (server-logged), not refused.',
 			inputSchema: pickJsonSchema(chatTools['create_post'], VIDEO_FIELDS, ['brief'])
@@ -94,10 +98,12 @@ export function createUgcPlugin(deps: UgcPluginDeps): ToolPlugin {
 			name,
 			description: m.description,
 			requiresMode: m.requiresMode,
+			consequential: m.consequential,
 			inputSchema: jsonSchemaOf(chatTools[m.source])
 		})),
 		{
 			name: 'ugc_check_video',
+			consequential: false,
 			description:
 				"Check a post's real video state — the honest status ugc_generate_video points you back to. video_render_status \"rendering\" means the clip has NOT landed yet (media_url/video_thumbnail_url is still the cover frame); null/absent means the clip either finished or was never in flight — check content_type (\"generated_video\" = done) and media_url.",
 			inputSchema: {

--- a/src/lib/agent/plugins/web.ts
+++ b/src/lib/agent/plugins/web.ts
@@ -28,56 +28,66 @@ export interface WebPluginDeps {
 	locale?: 'en' | 'it';
 }
 
-const BLOG_MAP: Record<string, { source: string; description: string; requiresMode?: ToolSpec['requiresMode'] }> = {
+const BLOG_MAP: Record<string, { source: string; description: string; requiresMode?: ToolSpec['requiresMode']; consequential: boolean }> = {
 	web_list_articles: {
 		source: 'list_articles',
+		consequential: false,
 		description:
 			'List the brand\'s blog articles with status and schedule. draft = written, awaiting review. planned = title-only placeholder, body not written (write with web_write_planned_article). approved = scheduled, auto-publishes at scheduled_for. published = live.'
 	},
 	web_read_article: {
 		source: 'read_article',
+		consequential: false,
 		description: 'Read a blog article in full: title, meta title/description, markdown body, status, schedule, cover image. Read before editing or optimizing.'
 	},
 	web_update_article: {
 		source: 'update_article',
 		requiresMode: 'agent',
+		consequential: true,
 		description: 'Edit a blog article: title, meta title, meta description, and/or the full markdown body (a full replacement, not a diff). Never touches status or schedule — use web_schedule_article for that.'
 	},
 	web_schedule_article: {
 		source: 'schedule_article',
 		requiresMode: 'agent',
+		consequential: true,
 		description:
 			'Schedule, reschedule, or unschedule a blog article. With a datetime: sets scheduled_for and marks it "approved" — ONLY "approved" ever auto-publishes, this tool never sets status to "published" directly. Without a datetime: clears the schedule back to a plain draft (refused on a "planned" placeholder — those need a slot). Refuses on an already-published article.'
 	},
 	web_optimize_article: {
 		source: 'optimize_article',
 		requiresMode: 'agent',
+		consequential: true,
 		description:
 			'Run the quality-optimization pass on a blog article: web-grounds real sources/statistics, weaves in internal links, tightens structure and meta, adds on-brand images. Takes 1-2 min. No-op if the article already scores >= 90.'
 	},
 	web_generate_article_cover: {
 		source: 'generate_article_cover',
 		requiresMode: 'agent',
+		consequential: true,
 		description: "Generate a new on-brand AI cover image for a blog article and set it as the article's cover. ~30s."
 	},
 	web_generate_article_images: {
 		source: 'generate_article_images',
 		requiresMode: 'agent',
+		consequential: true,
 		description: "Generate a few on-brand images and splice them into a blog article's body as in-article illustrations. ~1 min."
 	},
 	web_write_planned_article: {
 		source: 'write_planned_article',
 		requiresMode: 'agent',
+		consequential: true,
 		description: 'Write the full article for a "planned" placeholder (title-only slot from the month plan), keeping its calendar slot. ~1-2 min. Result is a draft — schedule or edit it after.'
 	},
 	web_seo_audit: {
 		source: 'run_seo_geo_audit',
 		requiresMode: 'plan',
+		consequential: true,
 		description:
 			'Run a fresh SEO & GEO audit of the brand website (technical crawl + on-page content + AI citation share-of-voice). Runs in the BACKGROUND — this call returns a job id immediately, NOT the audit; the result lands later. Call web_read_seo_audit after to read the numbers, do not assume this call finished the work.'
 	},
 	web_read_seo_audit: {
 		source: 'read_seo_geo_audit',
+		consequential: false,
 		description: 'Read the latest SEO & GEO audit: technical score, top issues, on-page summary, AI share-of-voice, and category questions where the brand is NOT cited (with which competitors ARE). Call web_seo_audit first if none exists yet.'
 	}
 };
@@ -100,7 +110,7 @@ export function createWebPlugin(deps: WebPluginDeps): ToolPlugin {
 	for (const [name, m] of Object.entries(BLOG_MAP)) {
 		if (!chatTools[m.source]) continue; // richiede estrazione? no: assente solo se createChatTools cambia forma
 		map[name] = m.source;
-		tools.push({ name, description: m.description, requiresMode: m.requiresMode, inputSchema: jsonSchemaOf(chatTools[m.source]) });
+		tools.push({ name, description: m.description, requiresMode: m.requiresMode, consequential: m.consequential, inputSchema: jsonSchemaOf(chatTools[m.source]) });
 	}
 
 	// I 7 dfs_* diventano web_dfs_* — stesso schema, stessa description, stessa execute.
@@ -109,7 +119,7 @@ export function createWebPlugin(deps: WebPluginDeps): ToolPlugin {
 		if (!t) continue; // dataforseoConfigured() false in questo env: createDataForSeoTools torna {}
 		const name = `web_${key}`;
 		map[name] = key;
-		tools.push({ name, description: String(t.description ?? key), inputSchema: jsonSchemaOf(t) });
+		tools.push({ name, description: String(t.description ?? key), consequential: false, inputSchema: jsonSchemaOf(t) });
 	}
 
 	return {

--- a/src/lib/content/changelog/2026-08-29-hitl-judge.ts
+++ b/src/lib/content/changelog/2026-08-29-hitl-judge.ts
@@ -1,0 +1,10 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-08-29',
+  title: 'Safer action approvals',
+  items: [
+    'Read-only work continues without an approval prompt, while consequential actions can now be checked automatically before they run.',
+    'If an automatic check fails, the action waits for your approval instead of running on an uncertain verdict.'
+  ]
+} satisfies ChangelogEntry;


### PR DESCRIPTION
## What?

Adds the HITL action gate with ask, allow and judge paths for agent tools. Consequential tools can be checked automatically before execution; uncertain checks wait for human approval.

Task: Notion #102 — Estendere il gate di approvazione HITL con il giudice.

## Why?

Read-only work continues without unnecessary prompts while consequential actions remain fail-closed when automatic review cannot decide safely.

## How?

- Adds one centralized consequential-tool classification beside tool definitions.
- Resolves explicit tool, connector and category rules by specificity.
- Selects judge only for default consequential actions when auto-review and a checker are configured.
- Maps checker pass to allow and checker ask/error to human approval.
- Applies the same gate to the runtime executor and exposes approval metadata to the model adapter.

## Testing?

- 107 targeted Vitest tests passed across 13 files.
- `git diff --check` passed.
- Runtime typecheck is being verified separately; it ignores the repository’s known non-fatal TypeScript mismatches and fails on runtime-name errors.

## Evidence

Not applicable: this is an agent-runtime change with no UI surface.

## Anything Else?

The approval configuration is optional, preserving current behavior when no checker is configured.