### PR TITLE
Localize onboarding analysis errors

### DIFF
--- a/changelog/2026-08-29-localize-onboarding-analysis-errors.md
+++ b/changelog/2026-08-29-localize-onboarding-analysis-errors.md
@@ -1,0 +1,3 @@
+# Localize onboarding analysis errors
+
+Onboarding analysis failures displayed the server exception directly, so an Italian user could see technical English such as `Could not fetch URL`. The existing localized analysis-failure message is now used for the UI while the original detail remains available to error reporting.

--- a/src/lib/content/changelog/2026-08-29-localize-onboarding-analysis-errors.ts
+++ b/src/lib/content/changelog/2026-08-29-localize-onboarding-analysis-errors.ts
@@ -1,0 +1,9 @@
+import type { ChangelogEntry } from './index';
+
+const entry: ChangelogEntry = {
+  date: 'August 29, 2026',
+  title: 'Onboarding errors use your language',
+  items: ['Website analysis failures now show a clear localized message instead of technical fetch details.']
+};
+
+export default entry;

--- a/src/routes/app/onboarding/components/EntryInput.svelte
+++ b/src/routes/app/onboarding/components/EntryInput.svelte
@@ -155,7 +155,7 @@
           onanalyzed();
         } else if (msg.type === 'error') {
           onerror?.('analyze', msg.message);
-          error = msg.message as string;
+          error = $_('onboarding.status.analysisFailed');
         }
       });
     } catch (e) {

--- a/src/routes/app/onboarding/components/EntryInput.test.ts
+++ b/src/routes/app/onboarding/components/EntryInput.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(new URL('./EntryInput.svelte', import.meta.url), 'utf8');
+const streamErrorStart = source.indexOf("else if (msg.type === 'error') {");
+const streamErrorEnd = source.indexOf('\n        }', streamErrorStart);
+const streamErrorBranch = source.slice(streamErrorStart, streamErrorEnd);
+
+describe('onboarding analysis errors', () => {
+  it('shows the localized failure while retaining server detail for diagnostics', () => {
+    expect(streamErrorBranch).toContain("onerror?.('analyze', msg.message)");
+    expect(streamErrorBranch).toContain("error = $_('onboarding.status.analysisFailed')");
+    expect(streamErrorBranch).not.toContain('error = msg.message');
+  });
+});


### PR DESCRIPTION
Bug: onboarding streamed raw analysis exceptions into the visible error field, so Italian users could see technical English such as Could not fetch URL. Fix: keep the raw message in error telemetry and show the existing localized analysis-failure message in the UI; add regression coverage and both changelogs. Tests: focused EntryInput Vitest passed; git diff check passed; locale consistency test has pre-existing es/fr missing chat.attach.processing failures; npm run check and tsc --noEmit were inconclusive after remaining silent for several minutes and were stopped.