### PR TITLE
Separate stable tool call identity

### DIFF
--- a/changelog/2026-08-29-stable-tool-call-identity.md
+++ b/changelog/2026-08-29-stable-tool-call-identity.md
@@ -1,0 +1,23 @@
+# Identità stabile per le chiamate tool
+
+Il ledger introdotto dalla PR #70 usava tool e argomenti come identità. Questo proteggeva i resume,
+ma impediva due richieste legittime con lo stesso payload.
+
+Ora l'executor usa il `toolCallId` del runtime come identità stabile: il runtime lo persiste nella
+storia e nei partial, mentre `agent_kit_effects.invocation_id` lo rende unico per brand. Gli
+argomenti restano il payload registrato e vengono confrontati per rifiutare il riuso della stessa
+identità con dati diversi.
+
+Il claim è atomico nel database. Un solo worker può eseguire; un claim già `completed`, `ambiguous`
+o `reconciled` non riparte; un `failed` può essere reclamato. Le righe vecchie restano leggibili:
+la vecchia chiave vale solo per il run che le aveva create, così un run nuovo non collassa con un
+effetto legacy.
+
+`invocation_id` non dipende da `run_id`, sequenza degli eventi, lease, fence o attempt: questi
+restano metadati di orchestrazione e possono evolvere senza cambiare l'identità della chiamata.
+
+La migration `20260829180000_agent_kit_effect_identity.sql` va applicata manualmente: i deploy del
+repo non eseguono le migration.
+
+Le righe legacy senza `run_id` o senza un `toolCallId` rigiocabile non sono correlabili a una nuova
+identità; richiedono riconciliazione manuale prima di un retry.

--- a/packages/agent-adapters/src/runtime/harness-runtime.test.ts
+++ b/packages/agent-adapters/src/runtime/harness-runtime.test.ts
@@ -96,6 +96,7 @@ describe('HarnessRuntime', () => {
 		expect(events.some((e) => e.type === 'text' && e.text === 'ciao')).toBe(true);
 		const call = events.find((e) => e.type === 'tool_call');
 		expect(call && call.type === 'tool_call' && call.call.name).toBe('publish_post');
+		expect(call && call.type === 'tool_call' && call.call.id).toBe('t1');
 		const done = events.at(-1);
 		expect(done).toMatchObject({ type: 'done', reason: 'completed' });
 		expect(seen.sessionId).toBe('r1');

--- a/packages/agent-adapters/src/runtime/harness-runtime.ts
+++ b/packages/agent-adapters/src/runtime/harness-runtime.ts
@@ -100,7 +100,11 @@ function toRunEvent(part: StreamPart): RunEvent | null {
 			return {
 				type: 'tool_call',
 				id: part.toolCallId ?? '',
-				call: { name: part.toolName ?? '', args: (part.input ?? {}) as Record<string, unknown> }
+				call: {
+					name: part.toolName ?? '',
+					args: (part.input ?? {}) as Record<string, unknown>,
+					...(part.toolCallId ? { id: part.toolCallId } : {})
+				}
 			};
 		case 'tool-result':
 			return {

--- a/packages/agent-core/src/effects-store.test.ts
+++ b/packages/agent-core/src/effects-store.test.ts
@@ -4,152 +4,195 @@ import { createEffectsLedger, effectKey } from './effects-store';
 
 type Row = Record<string, unknown>;
 
-/** Il finto client parla con una tabella in memoria, applicando i filtri `eq` per davvero. */
 function fakeDb(seed: Row[] = []) {
-	const rows: Row[] = seed.map((r) => ({ ...r }));
+	const rows: Row[] = seed.map((row) => ({ ...row }));
 
 	function from(_table: string) {
 		let op: 'select' | 'insert' | 'update' = 'select';
 		let payload: Row | undefined;
-		const eqFilters: Array<[string, unknown]> = [];
-		let insertId = `e-${rows.length + 1}`;
+		const filters: Array<[string, unknown]> = [];
+		const nullFilters: Array<[string, unknown]> = [];
 
-		function apply(): { data: Row[] | null; error: { message: string } | null } {
-			let matched = rows;
-			for (const [col, val] of eqFilters) matched = matched.filter((r) => r[col] === val);
+		function apply(): { data: Row[] | null; error: { code?: string; message: string } | null } {
+			let matched = rows.filter((row) => filters.every(([column, value]) => row[column] === value));
+			matched = matched.filter((row) => nullFilters.every(([column, value]) => (row[column] ?? null) === value));
 			if (op === 'insert' && payload) {
+				if (
+					payload.invocation_id != null &&
+					rows.some((row) => row.brand_id === payload?.brand_id && row.invocation_id === payload?.invocation_id)
+				) {
+					return { data: null, error: { code: '23505', message: 'duplicate key' } };
+				}
 				const row: Row = {
-					...payload,
-					id: insertId,
+					id: `e-${rows.length + 1}`,
 					created_at: '2026-08-29T00:00:00.000Z',
-					updated_at: '2026-08-01T00:00:00.000Z'
+					updated_at: '2026-08-29T00:00:00.000Z',
+					...payload
 				};
 				rows.push(row);
 				return { data: [row], error: null };
 			}
 			if (op === 'update' && payload) {
-				for (const r of matched) Object.assign(r, payload);
+				for (const row of matched) Object.assign(row, payload);
 				return { data: matched, error: null };
 			}
 			return { data: matched, error: null };
 		}
 
-		const b: Record<string, unknown> = {
-			insert(p: Row) {
+		const builder: Record<string, unknown> = {
+			insert(value: Row) {
 				op = 'insert';
-				payload = p;
-				return b;
+				payload = value;
+				return builder;
 			},
-			update(p: Row) {
+			update(value: Row) {
 				op = 'update';
-				payload = p;
-				return b;
+				payload = value;
+				return builder;
 			},
-			select(_cols?: string) {
-				return b;
+			select() {
+				return builder;
 			},
-			eq(col: string, val: unknown) {
-				eqFilters.push([col, val]);
-				return b;
+			eq(column: string, value: unknown) {
+				filters.push([column, value]);
+				return builder;
 			},
-			single() {
-				const { data, error } = apply();
-				if (error) return Promise.resolve({ data: null, error });
-				if (!data || data.length !== 1) return Promise.resolve({ data: null, error: { message: 'not exactly one row' } });
-				return Promise.resolve({ data: data[0], error: null });
+			is(column: string, value: unknown) {
+				nullFilters.push([column, value]);
+				return builder;
 			},
 			maybeSingle() {
-				const { data, error } = apply();
-				return Promise.resolve({ data: data?.[0] ?? null, error });
+				const result = apply();
+				return Promise.resolve({ data: result.data?.[0] ?? null, error: result.error });
 			},
-			then(resolve: (v: unknown) => void, reject?: (e: unknown) => void) {
+			then(resolve: (value: unknown) => void, reject?: (error: unknown) => void) {
 				return Promise.resolve(apply()).then(resolve, reject);
 			}
 		};
-		return b;
+		return builder;
 	}
 
 	return { db: { from } as unknown as SupabaseClient, rows };
 }
+
+const RECORD = {
+	brandId: 'b1',
+	runId: 'r1',
+	invocationId: 'call-1',
+	toolName: 'content_schedule',
+	request: { post_id: 'p1' }
+};
 
 const ROW = (over: Row = {}): Row => ({
 	id: 'e-1',
 	brand_id: 'b1',
 	run_id: 'r1',
 	tool_name: 'content_schedule',
-	idempotency_key: 'k1',
+	invocation_id: 'call-1',
+	idempotency_key: null,
 	status: 'intended',
+	request: { post_id: 'p1' },
+	result: null,
 	created_at: '2026-08-29T00:00:00.000Z',
 	updated_at: '2026-08-29T00:00:00.000Z',
 	...over
 });
 
-describe('createEffectsLedger — intend', () => {
-	it('registra intended col request e mappa la riga nel ToolEffect', async () => {
+describe('createEffectsLedger — claim', () => {
+	it('registra l’identità stabile e il payload prima dell’esecuzione', async () => {
+		const { db } = fakeDb();
+		const claim = await createEffectsLedger(db).claim(RECORD);
+
+		expect(claim.kind).toBe('claimed');
+		expect(claim.effect.invocationId).toBe('call-1');
+		expect(claim.effect.request).toEqual({ post_id: 'p1' });
+	});
+
+	it('due claim concorrenti della stessa identità ne autorizzano uno solo', async () => {
 		const { db } = fakeDb();
 		const ledger = createEffectsLedger(db);
-		const effect = await ledger.intend({ brandId: 'b1', runId: 'r1', toolName: 'content_schedule', key: 'k1', request: { post_id: 'p1' } });
-		expect(effect.status).toBe('intended');
-		expect(effect.brandId).toBe('b1');
-		expect(effect.runId).toBe('r1');
-		expect(effect.idempotencyKey).toBe('k1');
-		expect(effect.request).toEqual({ post_id: 'p1' });
-	});
-});
+		const claims = await Promise.all([ledger.claim(RECORD), ledger.claim({ ...RECORD, runId: 'r2' })]);
 
-describe('createEffectsLedger — find', () => {
-	it('la stessa chiave di brand torna la riga esistente', async () => {
-		const { db } = fakeDb([ROW({ idempotency_key: 'k1', status: 'completed', result: { ok: true } })]);
-		const effect = await createEffectsLedger(db).find('b1', 'k1');
-		expect(effect?.status).toBe('completed');
-		expect(effect?.result).toEqual({ ok: true });
+		expect(claims.filter((claim) => claim.kind === 'claimed')).toHaveLength(1);
+		expect(claims.filter((claim) => claim.kind === 'existing')).toHaveLength(1);
 	});
 
-	it('una chiave diversa torna null', async () => {
-		const { db } = fakeDb([ROW({ idempotency_key: 'k1' })]);
-		const effect = await createEffectsLedger(db).find('b1', 'k2');
-		expect(effect).toBeNull();
+	it('due identità nuove con args identici hanno due righe', async () => {
+		const { db, rows } = fakeDb();
+		const ledger = createEffectsLedger(db);
+		await ledger.claim(RECORD);
+		await ledger.claim({ ...RECORD, invocationId: 'call-2', runId: 'r2' });
+
+		expect(rows).toHaveLength(2);
 	});
 
-	it('un altro brand non condivide la chiave (lo scoping è per brand)', async () => {
-		const { db } = fakeDb([ROW({ brand_id: 'b1', idempotency_key: 'k1' })]);
-		const effect = await createEffectsLedger(db).find('b2', 'k1');
-		expect(effect).toBeNull();
-	});
-});
+	it('la stessa identità con payload diverso è un mismatch', async () => {
+		const { db } = fakeDb();
+		const ledger = createEffectsLedger(db);
+		await ledger.claim(RECORD);
 
-describe('createEffectsLedger — resolve', () => {
-	it('sposta intended → completed col result', async () => {
-		const { db, rows } = fakeDb([ROW({ idempotency_key: 'k1', status: 'intended' })]);
-		await createEffectsLedger(db).resolve('e-1', 'completed', { post_id: 'p1' });
-		expect(rows[0].status).toBe('completed');
-		expect(rows[0].result).toEqual({ post_id: 'p1' });
+		const claim = await ledger.claim({ ...RECORD, request: { post_id: 'p2' } });
+
+		expect(claim.kind).toBe('mismatch');
 	});
 
-	it('sposta intended → failed in caso di errore', async () => {
-		const { db, rows } = fakeDb([ROW({ idempotency_key: 'k1', status: 'intended' })]);
-		await createEffectsLedger(db).resolve('e-1', 'failed', { message: 'net' });
-		expect(rows[0].status).toBe('failed');
-	});
-});
-
-describe('createEffectsLedger — reconcileRun', () => {
-	it('tira verso ambiguous solo gli intended del run, mai i completed', async () => {
+	it('il resume di un run legacy continua a riconoscere la riga congelata', async () => {
 		const { db, rows } = fakeDb([
-			ROW({ id: 'e-1', run_id: 'r1', status: 'intended' }),
-			ROW({ id: 'e-2', run_id: 'r1', status: 'completed' }),
-			ROW({ id: 'e-3', run_id: 'r2', status: 'intended' })
+			ROW({ invocation_id: null, idempotency_key: effectKey(RECORD.toolName, RECORD.request), status: 'completed' })
 		]);
-		const n = await createEffectsLedger(db).reconcileRun('r1');
-		expect(n).toBe(1);
-		expect(rows.find((r) => r.id === 'e-1')?.status).toBe('ambiguous');
-		expect(rows.find((r) => r.id === 'e-2')?.status).toBe('completed');
-		expect(rows.find((r) => r.id === 'e-3')?.status).toBe('intended');
+		const ledger = createEffectsLedger(db);
+
+		const claim = await ledger.claim({ ...RECORD, invocationId: 'call-new', legacyKey: effectKey(RECORD.toolName, RECORD.request) });
+
+		expect(claim.kind).toBe('existing');
+		expect(rows).toHaveLength(1);
+	});
+
+	it('una riga legacy di un run diverso non blocca una nuova identità', async () => {
+		const { db, rows } = fakeDb([
+			ROW({
+				run_id: 'run-old',
+				invocation_id: null,
+				idempotency_key: effectKey(RECORD.toolName, RECORD.request),
+				status: 'completed'
+			})
+		]);
+		const ledger = createEffectsLedger(db);
+
+		const claim = await ledger.claim({ ...RECORD, runId: 'run-new', invocationId: 'call-new', legacyKey: effectKey(RECORD.toolName, RECORD.request) });
+
+		expect(claim.kind).toBe('claimed');
+		expect(rows).toHaveLength(2);
 	});
 });
 
-describe('effectKey — solo il contratto del key non cambia', () => {
-	it('produce una chiave che contiene il nome del tool', () => {
+describe('createEffectsLedger — lifecycle', () => {
+	it('un worker tardivo non sovrascrive ambiguous', async () => {
+		const { db, rows } = fakeDb();
+		const ledger = createEffectsLedger(db);
+		const claim = await ledger.claim(RECORD);
+
+		await ledger.reconcileRun(RECORD.runId);
+		const resolved = await ledger.resolve(claim.effect.id, 'completed', { ok: true });
+
+		expect(resolved).toBe(false);
+		expect(rows[0].status).toBe('ambiguous');
+	});
+
+	it('un failed può essere reclamato di nuovo dalla stessa identità', async () => {
+		const { db } = fakeDb();
+		const ledger = createEffectsLedger(db);
+		const first = await ledger.claim(RECORD);
+		await ledger.resolve(first.effect.id, 'failed', { message: 'network' });
+
+		const retry = await ledger.claim({ ...RECORD, runId: 'r2' });
+
+		expect(retry.kind).toBe('claimed');
+	});
+});
+
+describe('effectKey — compatibilità legacy', () => {
+	it('conserva la forma della vecchia chiave per le righe esistenti', () => {
 		expect(effectKey('content_schedule', { post_id: 'p1' })).toContain('content_schedule');
 	});
 });

--- a/packages/agent-core/src/effects-store.ts
+++ b/packages/agent-core/src/effects-store.ts
@@ -1,19 +1,19 @@
-/**
- * IL LEDGER SU POSTGRES. L'unico punto che scrive `agent_kit_effects`: `intend` prima di eseguire,
- * `resolve` dopo, `reconcileRun` quando un segmento muore. Il resto (decidere congelare) sta in
- * `effects.ts`, la logica pura.
- */
 import type { SupabaseClient } from '@supabase/supabase-js';
-import type { EffectsLedger, ToolEffect } from '@anomalia/agent-kit';
+import type { EffectClaim, EffectsLedger, ToolEffect } from '@anomalia/agent-kit';
+import { legacyEffectKey, sameEffectPayload } from './effects';
 
 const TABLE = 'agent_kit_effects';
+const UNIQUE_VIOLATION = '23505';
+const INTENDED_STATUS: ToolEffect['status'] = 'intended';
+const FAILED_STATUS: ToolEffect['status'] = 'failed';
 
 type Row = {
 	id: string;
 	brand_id: string;
 	run_id: string | null;
 	tool_name: string;
-	idempotency_key: string;
+	invocation_id: string | null;
+	idempotency_key: string | null;
 	status: ToolEffect['status'];
 	request?: unknown;
 	result?: unknown;
@@ -27,7 +27,7 @@ function toEffect(r: Row): ToolEffect {
 		brandId: r.brand_id,
 		runId: r.run_id ?? null,
 		toolName: r.tool_name,
-		idempotencyKey: r.idempotency_key,
+		invocationId: r.invocation_id ?? null,
 		status: r.status,
 		request: r.request,
 		result: r.result,
@@ -36,82 +36,144 @@ function toEffect(r: Row): ToolEffect {
 	};
 }
 
-/**
- * Chiave deterministica dell'effetto: brand + tool + args canonicalizzati. NON contiene il run_id:
- * l'idempotenza deve riconoscere la stessa intenzione attraverso un resume (che riparte da zero) e
- * un takeover. Due args che coincidono in fondo = stessa intenzione = stesso effetto.
- */
-export function effectKey(toolName: string, args: Record<string, unknown>): string {
-	const canonical = stableSerialize(args);
-	const bytes = new TextEncoder().encode(`${toolName}\n${canonical}`);
-	// FNV-1a 64-bit, esadecimale — niente crypto asincrona: il key è un indice, non un segreto.
-	let hash = 0x811c9dc5;
-	for (const b of bytes) {
-		hash ^= b;
-		hash = Math.imul(hash, 0x01000193);
-	}
-	return `${toolName}:${(hash >>> 0).toString(36)}:${canonical.length}`;
+function uniqueViolation(error: { code?: string; message?: string }): boolean {
+	return error.code === UNIQUE_VIOLATION || /duplicate key|unique constraint/i.test(error.message ?? '');
 }
 
-function stableSerialize(value: unknown): string {
-	if (Array.isArray(value)) return `[${value.map(stableSerialize).join(',')}]`;
-	if (value && typeof value === 'object') {
-		return `{${Object.keys(value)
-			.sort()
-			.map((k) => `${JSON.stringify(k)}:${stableSerialize((value as Record<string, unknown>)[k])}`)
-			.join(',')}}`;
+function samePayload(effect: ToolEffect, record: { toolName: string; request: unknown }): boolean {
+	return effect.toolName === record.toolName && sameEffectPayload(effect.request, record.request);
+}
+
+async function findInvocation(
+	db: SupabaseClient,
+	brandId: string,
+	invocationId: string
+): Promise<ToolEffect | null> {
+	const { data, error } = await db
+		.from(TABLE)
+		.select()
+		.eq('brand_id', brandId)
+		.eq('invocation_id', invocationId)
+		.maybeSingle();
+	if (error) {
+		throw new Error(`effects: lettura claim fallita — ${error.message}`);
 	}
-	return JSON.stringify(value);
+	return data ? toEffect(data as Row) : null;
 }
 
 export function createEffectsLedger(db: SupabaseClient): EffectsLedger {
 	return {
-		async intend(record): Promise<ToolEffect> {
+		async claim(record): Promise<EffectClaim> {
+			if (record.legacyKey) {
+				const { data, error } = await db
+					.from(TABLE)
+					.select()
+					.eq('brand_id', record.brandId)
+					.eq('idempotency_key', record.legacyKey)
+					.is('invocation_id', null)
+					.maybeSingle();
+				if (error) {
+					throw new Error(`effects: lettura legacy fallita — ${error.message}`);
+				}
+				if (data) {
+					const effect = toEffect(data as Row);
+					if (effect.runId === record.runId) {
+						if (!samePayload(effect, record)) {
+							return { kind: 'mismatch', effect };
+						}
+						if (effect.status !== FAILED_STATUS) {
+							return { kind: 'existing', effect };
+						}
+					}
+				}
+			}
+
 			const { data, error } = await db
 				.from(TABLE)
 				.insert({
 					brand_id: record.brandId,
 					run_id: record.runId,
 					tool_name: record.toolName,
-					idempotency_key: record.key,
-					status: 'intended',
+					invocation_id: record.invocationId,
+					idempotency_key: null,
+					status: INTENDED_STATUS,
 					request: record.request
 				})
 				.select()
-				.single();
-			if (error) throw new Error(`effects: intend fallito — ${error.message}`);
-			return toEffect(data as Row);
-		},
+				.maybeSingle();
+			if (!error && data) {
+				return { kind: 'claimed', effect: toEffect(data as Row) };
+		}
+		if (error && !uniqueViolation(error)) {
+			throw new Error(`effects: claim fallito — ${error.message}`);
+		}
 
-		async resolve(id, status, result): Promise<void> {
-			const { error } = await db
+			const existing = await findInvocation(db, record.brandId, record.invocationId);
+			if (!existing) {
+				throw new Error('effects: claim concorrente senza riga proprietaria');
+			}
+			if (!samePayload(existing, record)) {
+				return { kind: 'mismatch', effect: existing };
+			}
+			if (existing.status !== FAILED_STATUS) {
+				return { kind: 'existing', effect: existing };
+			}
+
+			const retried = await db
 				.from(TABLE)
-				.update({ status, result, updated_at: new Date().toISOString() })
-				.eq('id', id);
-			if (error) throw new Error(`effects: resolve fallito — ${error.message}`);
+				.update({
+					run_id: record.runId,
+					status: INTENDED_STATUS,
+					result: null,
+					updated_at: new Date().toISOString()
+				})
+				.eq('id', existing.id)
+				.eq('status', 'failed')
+				.select()
+				.maybeSingle();
+			if (retried.error) {
+				throw new Error(`effects: retry fallito — ${retried.error.message}`);
+			}
+			if (retried.data) {
+				return { kind: 'claimed', effect: toEffect(retried.data as Row) };
+			}
+
+			const current = await findInvocation(db, record.brandId, record.invocationId);
+			if (!current) {
+				throw new Error('effects: retry concorrente senza riga proprietaria');
+			}
+			return samePayload(current, record)
+				? { kind: 'existing', effect: current }
+				: { kind: 'mismatch', effect: current };
 		},
 
-		async find(brandId, key): Promise<ToolEffect | null> {
+		async resolve(id, status, result): Promise<boolean> {
 			const { data, error } = await db
 				.from(TABLE)
-				.select()
-				.eq('brand_id', brandId)
-				.eq('idempotency_key', key)
+				.update({ status, result, updated_at: new Date().toISOString() })
+				.eq('id', id)
+				.eq('status', 'intended')
+				.select('id')
 				.maybeSingle();
-			if (error) throw new Error(`effects: find fallito — ${error.message}`);
-			return data ? toEffect(data as Row) : null;
+			if (error) {
+				throw new Error(`effects: resolve fallito — ${error.message}`);
+			}
+			return !!data;
 		},
 
 		async reconcileRun(runId): Promise<number> {
-			// Solo le righe ancora `intended`: un `completed` è un esito vero, non va toccato.
 			const { data, error } = await db
 				.from(TABLE)
 				.update({ status: 'ambiguous', updated_at: new Date().toISOString() })
 				.eq('run_id', runId)
 				.eq('status', 'intended')
 				.select('id');
-			if (error) throw new Error(`effects: reconcile fallito — ${error.message}`);
+			if (error) {
+				throw new Error(`effects: reconcile fallito — ${error.message}`);
+			}
 			return data?.length ?? 0;
 		}
 	};
 }
+
+export const effectKey = legacyEffectKey;

--- a/packages/agent-core/src/effects.test.ts
+++ b/packages/agent-core/src/effects.test.ts
@@ -9,7 +9,7 @@ function effect(status: ToolEffect['status'], result?: unknown, over: Partial<To
 		brandId: 'b1',
 		runId: 'r1',
 		toolName: 'content_schedule',
-		idempotencyKey: 'k',
+		invocationId: 'call-1',
 		status,
 		result,
 		createdAt: '2026-08-29T00:00:00.000Z',

--- a/packages/agent-core/src/effects.ts
+++ b/packages/agent-core/src/effects.ts
@@ -2,8 +2,8 @@
  * LA LOGICA PURA del gate degli effetti — niente db, niente framework. Decide se un tool con un
  * effetto collaterale va rieseguito o se è già stato (o è stato avviato e lasciato in dubbio) e
  * quindi va congelato. La macchina a stati: `intended -> completed|failed`, con i ripieghi
- * `ambiguous` (il segmento è morto a metà) e `reconciled` (confermato fuori). Prima di rieseguire
- * l'executor legge per chiave: se esiste già un esito non-rieseguibile, NON riesegue.
+ * `ambiguous` (il segmento è morto a metà) e `reconciled` (confermato fuori). Il claim atomico per
+ * identità vive nel port `EffectsLedger`; questo modulo conserva la logica pura.
  */
 import type { EffectStatus, ToolEffect, ToolResult } from '@anomalia/agent-kit';
 
@@ -12,13 +12,13 @@ export const EFFECT_LID_NOTE = 'questo effetto è già stato registrato: non rie
 /** Stati a cui l'effetto è già avvenuto (o è avviato ma di esito ignoto): NON vanno rieseguiti. */
 const FROZEN_STATUSES: ReadonlySet<EffectStatus> = new Set(['completed', 'ambiguous', 'reconciled']);
 
-/** C'è già un esito non-rieseguibile per questa chiave? */
+/** C'è già un esito non-rieseguibile per questo effetto? */
 export function isFrozen(status: EffectStatus): boolean {
 	return FROZEN_STATUSES.has(status);
 }
 
 /**
- * Decide se eseguire o congelare. `intended` NON congela: è un ripiego di sicurezza, ma corrisponde
+ * Decide se eseguire o congelare per il percorso legacy. `intended` NON congela: è un ripiego di sicurezza, ma corrisponde
  * a un segmento ancora vivo o appena morto — a differenza di `ambiguous` (morto confermato), il
  * run corrente è il primo e solo autore, quindi può riprovare.
  */
@@ -32,4 +32,34 @@ export function decide(effect: ToolEffect | null): { run: boolean; note: string 
 export function frozenResult(effect: ToolEffect): ToolResult | null {
 	if (!isFrozen(effect.status)) return null;
 	return (effect.result as ToolResult | null) ?? null;
+}
+
+export function sameEffectPayload(left: unknown, right: unknown): boolean {
+	return stableSerialize(left) === stableSerialize(right);
+}
+
+export function legacyEffectKey(toolName: string, args: Record<string, unknown>): string {
+	const canonical = stableSerialize(args);
+	const bytes = new TextEncoder().encode(`${toolName}\n${canonical}`);
+	let hash = 0x811c9dc5;
+	for (const b of bytes) {
+		hash ^= b;
+		hash = Math.imul(hash, 0x01000193);
+	}
+	return `${toolName}:${(hash >>> 0).toString(36)}:${canonical.length}`;
+}
+
+export const effectKey = legacyEffectKey;
+
+function stableSerialize(value: unknown): string {
+	if (Array.isArray(value)) {
+		return `[${value.map(stableSerialize).join(',')}]`;
+	}
+	if (value && typeof value === 'object') {
+		return `{${Object.keys(value)
+			.sort()
+			.map((key) => `${JSON.stringify(key)}:${stableSerialize((value as Record<string, unknown>)[key])}`)
+			.join(',')}}`;
+	}
+	return JSON.stringify(value);
 }

--- a/packages/agent-core/src/executor.test.ts
+++ b/packages/agent-core/src/executor.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { createApplyTool, buildSystemPrompt, type ApplyToolDeps } from './executor';
 import { BUILTIN_TOOLS } from './tools/builtin';
-import { effectKey } from './effects-store';
 import { SYSTEM_PROMPT_MAX_CHARS, type AgentSpec } from '@anomalia/agent-contracts/contracts';
 import { SandboxEmulator } from '@anomalia/agent-adapters/sandbox-emulator';
 import {
@@ -273,9 +272,9 @@ describe('createApplyTool — il gate sugli effetti', () => {
 		};
 	}
 
-	const CALL = { name: 'content_schedule', args: { post_id: 'p1' } };
+	const CALL = { name: 'content_schedule', id: 'call-1', args: { post_id: 'p1' } };
 
-	it('intend PRIMA di eseguire, resolve completed dopo', async () => {
+	it('claim PRIMA di eseguire, resolve completed dopo', async () => {
 		const counter = { calls: 0 };
 		const ledger = createMemoryEffectsLedger();
 		const apply = createApplyTool(baseDeps({ plugins: [effectfulPlugin(counter)], effects: ledger }));
@@ -286,47 +285,112 @@ describe('createApplyTool — il gate sugli effetti', () => {
 		expect(counter.calls).toBe(1);
 	});
 
-	it('abort → resume: la SECONDA chiamata con la stessa intenzione congelate invece di rieseguire', async () => {
+	it('resume della stessa intenzione esegue una sola volta', async () => {
 		const counter = { calls: 0 };
 		const ledger = createMemoryEffectsLedger();
 		const apply = createApplyTool(baseDeps({ plugins: [effectfulPlugin(counter)], effects: ledger }));
 
-		// primo turno: esegue e registra completed
 		await apply(CALL, fakeContext({ runId: 'run-1' }));
 		expect(counter.calls).toBe(1);
 
-		// il segmento muore a metà e si riprende: il run è DIVERSO (run-2) ma la chiave è la stessa
 		const out = await apply(CALL, fakeContext({ runId: 'run-2' }));
-		expect(counter.calls).toBe(1); // non riesegue: un solo post
+		expect(counter.calls).toBe(1);
 		expect(out.isError).toBeFalsy();
 		expect((out.content[0] as { text: string }).text).toContain('post 1');
 	});
 
-	it('un effect ambiguous NON viene rieseguito, nemmeno su un run nuovo', async () => {
+	it('due intenzioni nuove con args identici eseguono due volte', async () => {
 		const counter = { calls: 0 };
-		const { brandId } = fakeContext();
-		const injected = createMemoryEffectsLedger();
-		await injected.intend({ brandId, runId: 'run-dead', toolName: 'content_schedule', key: effectKey('content_schedule', { post_id: 'p1' }), request: { post_id: 'p1' } });
-		await injected.reconcileRun('run-dead');
-		const apply = createApplyTool(baseDeps({ plugins: [effectfulPlugin(counter)], effects: injected }));
+		const ledger = createMemoryEffectsLedger();
+		const apply = createApplyTool(baseDeps({ plugins: [effectfulPlugin(counter)], effects: ledger }));
 
-		const out = await apply({ name: 'content_schedule', args: { post_id: 'p1' } }, fakeContext({ runId: 'run-new' }));
+		await apply(CALL, fakeContext({ runId: 'run-1' }));
+		await apply({ ...CALL, id: 'call-2' }, fakeContext({ runId: 'run-2' }));
+
+		expect(counter.calls).toBe(2);
+		expect(ledger.rows).toHaveLength(2);
+	});
+
+	it('un tool effectful senza identità stabile non viene eseguito', async () => {
+		const counter = { calls: 0 };
+		const ledger = createMemoryEffectsLedger();
+		const apply = createApplyTool(baseDeps({ plugins: [effectfulPlugin(counter)], effects: ledger }));
+
+		const out = await apply({ name: 'content_schedule', args: { post_id: 'p1' } }, fakeContext());
+
 		expect(counter.calls).toBe(0);
 		expect(out.isError).toBe(true);
-		expect((out.content[0] as { text: string }).text).toMatch(/già stato registrato/);
+		expect(out.content[0]).toMatchObject({ type: 'text' });
+	});
+
+	it('due worker concorrenti ottengono un solo claim', async () => {
+		const counter = { calls: 0 };
+		const ledger = createMemoryEffectsLedger();
+		const apply = createApplyTool(baseDeps({ plugins: [effectfulPlugin(counter)], effects: ledger }));
+
+		const [first, second] = await Promise.all([
+			apply(CALL, fakeContext({ runId: 'run-1' })),
+			apply(CALL, fakeContext({ runId: 'run-2' }))
+		]);
+
+		expect(counter.calls).toBe(1);
+		expect([first, second].filter((result) => !result.isError)).toHaveLength(1);
+		expect(ledger.rows).toHaveLength(1);
+	});
+
+	it('un worker tardivo non risolve un effetto già riconciliato', async () => {
+		const counter = { calls: 0 };
+		const ledger = createMemoryEffectsLedger();
+		const claim = await ledger.claim({
+			brandId: 'brand-test',
+			runId: 'run-dead',
+			invocationId: CALL.id,
+			toolName: CALL.name,
+			request: CALL.args
+		});
+		await ledger.reconcileRun('run-dead');
+		await ledger.resolve(claim.effect.id, 'completed', { content: [{ type: 'text', text: 'late' }] });
+		const apply = createApplyTool(baseDeps({ plugins: [effectfulPlugin(counter)], effects: ledger }));
+
+		const out = await apply(CALL, fakeContext({ runId: 'run-new' }));
+		expect(counter.calls).toBe(0);
+		expect(out.isError).toBe(true);
+		expect((out.content[0] as { text: string }).text).toMatch(/già registrato/);
+		expect(ledger.rows[0].status).toBe('ambiguous');
 	});
 
 	it('failed lascia rieseguire (l\'effetto non è avvenuto, non è un doppione)', async () => {
 		const counter = { calls: 0 };
-		const { brandId } = fakeContext();
 		const injected = createMemoryEffectsLedger();
-		await injected.intend({ brandId, runId: 'r0', toolName: 'content_schedule', key: effectKey('content_schedule', { post_id: 'p1' }), request: { post_id: 'p1' } });
-		await injected.resolve(injected.rows[0].id, 'failed', { message: 'net' });
+		const claim = await injected.claim({
+			brandId: 'brand-test',
+			runId: 'r0',
+			invocationId: CALL.id,
+			toolName: CALL.name,
+			request: CALL.args
+		});
+		await injected.resolve(claim.effect.id, 'failed', { message: 'net' });
 		const apply = createApplyTool(baseDeps({ plugins: [effectfulPlugin(counter)], effects: injected }));
 
-		const out = await apply({ name: 'content_schedule', args: { post_id: 'p1' } }, fakeContext());
+		const out = await apply(CALL, fakeContext());
 		expect(counter.calls).toBe(1);
 		expect((out.content[0] as { text: string }).text).toBe('post 1');
+	});
+
+	it('la stessa identità con payload diverso viene rifiutata', async () => {
+		const counter = { calls: 0 };
+		const ledger = createMemoryEffectsLedger();
+		const apply = createApplyTool(baseDeps({ plugins: [effectfulPlugin(counter)], effects: ledger }));
+
+		await apply(CALL, fakeContext({ runId: 'run-1' }));
+		const out = await apply(
+			{ ...CALL, args: { post_id: 'p2' } },
+			fakeContext({ runId: 'run-2' })
+		);
+
+		expect(counter.calls).toBe(1);
+		expect(out.isError).toBe(true);
+		expect((out.content[0] as { text: string }).text).toMatch(/payload|identità|identity/i);
 	});
 
 	it('solo i tool marcat effectful passano dal gate; gli altri no', async () => {

--- a/packages/agent-core/src/executor.ts
+++ b/packages/agent-core/src/executor.ts
@@ -7,8 +7,7 @@ import type { AdapterContext, EffectsLedger, ToolCall, ToolResult } from '@anoma
 import type { BrandFs, CheckpointStore, MemoryStore, SandboxProvider, SandboxRef, ToolPlugin } from '@anomalia/agent-kit';
 import { SYSTEM_PROMPT_MAX_CHARS, type AgentSpec } from '@anomalia/agent-contracts/contracts';
 import { BUILTIN_TOOLS, TERMINAL_TOOL_NAMES } from './tools/builtin';
-import { decide, frozenResult } from './effects';
-import { effectKey } from './effects-store';
+import { frozenResult, legacyEffectKey } from './effects';
 import { ensureComputer, touchComputer } from './computer';
 import {
 	ensureGraphicalMode,
@@ -78,8 +77,8 @@ export interface ApplyToolDeps {
 	/** Senza, `observe`/`act` rispondono con l'errore-che-insegna invece di esplodere. */
 	graphicalBootstrap?: GraphicalBootstrapDeps;
 	/**
-	 * Presente: i tool con `effectful: true` passano dal ledger degli effetti — `intend` prima di
-	 * eseguire, `resolve` dopo, e su un resume che rivede la stessa chiave congelano invece di
+	 * Presente: i tool con `effectful: true` passano dal ledger degli effetti — claim prima di
+	 * eseguire, resolve dopo, e su un resume che rivede la stessa identità congelano invece di
 	 * rieseguire (un doppio post/schedulazione è un danno, non un errore da riprovare).
 	 * Assente: nessun gate, si esegue e basta (il lab, i test, le superfici senza righe).
 	 */
@@ -228,28 +227,40 @@ export function createApplyTool(deps: ApplyToolDeps): ApplyTool {
 	return async (call: ToolCall, ctx: AdapterContext): Promise<ToolResult> => {
 		const name = LEGACY_TOOL_ALIASES[call.name] ?? call.name;
 
-		if (!deps.effects || !isEffectful(name, deps.plugins)) return execute(call, ctx);
-
-		// GATE: una stessa chiave (brand + tool + args) che ha già un esito non-rieseguibile NON va
-		// rieseguita. `intended` è un ripiego di sicurezza (il segmento è vivo, è il primo autore),
-		// quindi decide() lo lascia riprovare; `ambiguous`/`completed`/`reconciled` congelano.
-		const key = effectKey(name, call.args);
-		const existing = await deps.effects.find(ctx.brandId, key);
-		const decision = decide(existing);
-		if (!decision.run) {
-			const frozen = frozenResult(existing!);
-			if (frozen) return frozen;
-			return err(`${decision.note}. Esito registrato: ${existing!.status}`);
+		if (!deps.effects || !isEffectful(name, deps.plugins)) {
+			return execute(call, ctx);
 		}
 
-		const effect = await deps.effects.intend({ brandId: ctx.brandId, runId: ctx.runId, toolName: name, key, request: call.args });
+		const invocationId = call.id?.trim();
+		if (!invocationId) {
+			return err(`tool '${name}' senza identità stabile della chiamata`);
+		}
+
+		const claim = await deps.effects.claim({
+			brandId: ctx.brandId,
+			runId: ctx.runId,
+			invocationId,
+			toolName: name,
+			request: call.args,
+			legacyKey: legacyEffectKey(name, call.args)
+		});
+		if (claim.kind === 'mismatch') {
+			return err(`tool '${name}' rifiutato: payload diverso per la stessa identità di chiamata`);
+		}
+		if (claim.kind === 'existing') {
+			const frozen = frozenResult(claim.effect);
+			if (frozen) {
+				return frozen;
+			}
+			return err(`tool '${name}' non eseguito: effetto già registrato (${claim.effect.status})`);
+		}
+
+		const effect = claim.effect;
 		try {
 			const result = await execute(call, ctx);
 			await deps.effects.resolve(effect.id, result.isError ? 'failed' : 'completed', result);
 			return result;
 		} catch (err) {
-			// L'effetto resta `intended`: sarà `reconcileRun` (morte del segmento) a tirarlo verso
-			// `ambiguous`. Espongo l'errore vero, mai un esito finto.
 			await deps.effects.resolve(effect.id, 'failed', { message: err instanceof Error ? err.message : String(err) });
 			throw err;
 		}

--- a/packages/agent-kit/src/interfaces.ts
+++ b/packages/agent-kit/src/interfaces.ts
@@ -11,6 +11,7 @@ import type {
 	AdapterDescriptor,
 	CommandRequest,
 	EffectStatus,
+	EffectClaim,
 	FileEntry,
 	MemoryCapabilities,
 	MemoryEntry,
@@ -32,12 +33,23 @@ import type {
  * contratto: l'executor non sa dove viva la riga, la superficie gliela passa come implementazione.
  */
 export interface EffectsLedger {
-	/** Registra `intended` PRIMA di eseguire. Se esiste già la chiave, la restituisce senza toccare. */
-	intend(record: { brandId: string; runId: string; toolName: string; key: string; request: unknown }): Promise<ToolEffect>;
-	/** Risolve dopo l'esecuzione: completed (con result) o failed. */
-	resolve(id: string, status: 'completed' | 'failed', result: unknown): Promise<void>;
-	/** Legge per chiave: la riga esistente, o null. */
-	find(brandId: string, key: string): Promise<ToolEffect | null>;
+	/**
+	 * Claim atomico per (brand, invocationId). L'identità è indipendente da run, lease, fence e
+	 * attempt; il payload serve solo a rilevare un riuso errato. Solo `claimed` autorizza l'esecuzione.
+	 */
+	claim(record: {
+		brandId: string;
+		/** Il run che detiene il claim, usato per audit e riconciliazione. */
+		runId: string;
+		/** L'identità persistita della singola chiamata, non derivata da `request`. */
+		invocationId: string;
+		toolName: string;
+		request: unknown;
+		/** Chiave della versione precedente, usata solo per righe legacy dello stesso run. */
+		legacyKey?: string;
+	}): Promise<EffectClaim>;
+	/** Risolve solo un claim ancora `intended`; un worker riconciliato non può sovrascriverlo. */
+	resolve(id: string, status: 'completed' | 'failed', result: unknown): Promise<boolean>;
 	/** Attira gli `intended` orfani di un run morto verso `ambiguous` — il ripiego che non duplica. */
 	reconcileRun(runId: string): Promise<number>;
 }

--- a/packages/agent-kit/src/testkit.ts
+++ b/packages/agent-kit/src/testkit.ts
@@ -19,6 +19,9 @@ import type {
 } from './index';
 import type { BrandFs, MemoryStore, SandboxProvider, ToolPlugin } from './index';
 
+const INTENDED_STATUS: ToolEffect['status'] = 'intended';
+const FAILED_STATUS: ToolEffect['status'] = 'failed';
+
 export function fakeContext(overrides: Partial<AdapterContext> = {}): AdapterContext {
 	return {
 		brandId: 'brand-test',
@@ -137,9 +140,8 @@ export function fakePlugin(name: string, reply: ToolResult): ToolPlugin {
 }
 
 /**
- * IL LEDGER IN MEMORIA per i test del gate: `intend`/`resolve`/`find`/`reconcileRun` su una mappa
- * per (brand, chiave). Così il gate dell'executor si verifica col suo comportamento vero — decidere
- * se rieseguire o congelare — senza montare un database.
+ * IL LEDGER IN MEMORIA per i test del gate: claim/resolve/reconcileRun su una mappa per
+ * (brand, invocationId). Così il gate dell'executor si verifica senza montare un database.
  */
 export function createMemoryEffectsLedger(seed: { [key: string]: unknown } = {}): EffectsLedger & { rows: ToolEffect[] } {
 	const rows: ToolEffect[] = [];
@@ -150,7 +152,7 @@ export function createMemoryEffectsLedger(seed: { [key: string]: unknown } = {})
 			brandId: 'brand-test',
 			runId: 'run-test',
 			toolName: 'content_schedule',
-			idempotencyKey: 'seed',
+			invocationId: 'seed',
 			status: status as ToolEffect['status'],
 			request: request as unknown,
 			result: null,
@@ -161,34 +163,44 @@ export function createMemoryEffectsLedger(seed: { [key: string]: unknown } = {})
 
 	return {
 		rows,
-		async intend(record) {
-			const existing = rows.find((r) => r.brandId === record.brandId && r.idempotencyKey === record.key);
-			if (existing) return existing;
+		async claim(record) {
+			const existing = rows.find((r) => r.brandId === record.brandId && r.invocationId === record.invocationId);
+			if (existing) {
+				if (existing.toolName !== record.toolName || stableSerialize(existing.request) !== stableSerialize(record.request)) {
+					return { kind: 'mismatch', effect: existing };
+				}
+				if (existing.status === FAILED_STATUS) {
+					existing.runId = record.runId;
+					existing.status = 'intended';
+					existing.result = null;
+					return { kind: 'claimed', effect: existing };
+				}
+				return { kind: 'existing', effect: existing };
+			}
 			const effect: ToolEffect = {
 				id: `e-${rows.length + 1}`,
 				brandId: record.brandId,
 				runId: record.runId,
 				toolName: record.toolName,
-				idempotencyKey: record.key,
-				status: 'intended',
+				invocationId: record.invocationId,
+				status: INTENDED_STATUS,
 				request: record.request,
 				result: null,
 				createdAt: '2026-08-29T00:00:00.000Z',
 				updatedAt: '2026-08-29T00:00:00.000Z'
 			};
 			rows.push(effect);
-			return effect;
+			return { kind: 'claimed', effect };
 		},
 		async resolve(id, status, result) {
 			const effect = rows.find((r) => r.id === id);
-			if (effect) {
+			if (effect?.status === INTENDED_STATUS) {
 				effect.status = status;
 				effect.result = result;
 				effect.updatedAt = '2026-08-29T00:00:00.000Z';
+				return true;
 			}
-		},
-		async find(brandId, key) {
-			return rows.find((r) => r.brandId === brandId && r.idempotencyKey === key) ?? null;
+			return false;
 		},
 		async reconcileRun(runId) {
 			let n = 0;
@@ -201,4 +213,17 @@ export function createMemoryEffectsLedger(seed: { [key: string]: unknown } = {})
 			return n;
 		}
 	};
+}
+
+function stableSerialize(value: unknown): string {
+	if (Array.isArray(value)) {
+		return `[${value.map(stableSerialize).join(',')}]`;
+	}
+	if (value && typeof value === 'object') {
+		return `{${Object.keys(value)
+			.sort()
+			.map((key) => `${JSON.stringify(key)}:${stableSerialize((value as Record<string, unknown>)[key])}`)
+			.join(',')}}`;
+	}
+	return JSON.stringify(value);
 }

--- a/packages/agent-kit/src/types.ts
+++ b/packages/agent-kit/src/types.ts
@@ -80,13 +80,20 @@ export interface ToolResult {
 /** Lo stato di un effetto collaterale nel ledger — la macchina a stati di `agent_kit_effects`. */
 export type EffectStatus = 'intended' | 'completed' | 'failed' | 'ambiguous' | 'reconciled';
 
-/** Una riga del ledger degli effetti: chi, cosa, con quale chiave, in che stato. */
+/** Risultato atomico del claim: solo `claimed` può eseguire il payload. */
+export type EffectClaim =
+	| { kind: 'claimed'; effect: ToolEffect }
+	| { kind: 'existing'; effect: ToolEffect }
+	| { kind: 'mismatch'; effect: ToolEffect };
+
+/** Una riga del ledger: identità della chiamata e payload sono dati distinti. */
 export interface ToolEffect {
 	id: string;
 	brandId: string;
 	runId: string | null;
 	toolName: string;
-	idempotencyKey: string;
+	/** SDK `toolCallId`, persistito nella storia e stabile tra resume e takeover. */
+	invocationId: string | null;
 	status: EffectStatus;
 	request?: unknown;
 	result?: unknown;
@@ -97,7 +104,7 @@ export interface ToolEffect {
 export interface ToolCall {
 	name: string;
 	args: Record<string, unknown>;
-	/** Id della chiamata sul filo (SDK `toolCallId`). Ancora un artefatto alla chip giusta. */
+	/** Identità della chiamata sul filo (SDK `toolCallId`), non derivata dagli argomenti. */
 	id?: string;
 }
 
@@ -110,6 +117,7 @@ export interface RunTokenUsage {
 export type RunEvent =
 	| { type: 'text'; text: string }
 	| { type: 'reasoning'; text: string }
+	/** `id` è il `toolCallId` persistito e rigiocato dai runtime durante resume e takeover. */
 	| { type: 'tool_call'; call: ToolCall; id: string }
 	| { type: 'tool_result'; id: string; result: ToolResult }
 	| { type: 'done'; reason: RunStopReason; usage?: RunTokenUsage }

--- a/src/lib/content/changelog/2026-08-29-stable-tool-call-identity.ts
+++ b/src/lib/content/changelog/2026-08-29-stable-tool-call-identity.ts
@@ -1,0 +1,10 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-08-29',
+  title: 'Identical tool requests can run independently',
+  items: [
+    'Resumed tool calls keep their original identity, preventing duplicate effects.',
+    'Separate requests with identical arguments are tracked and executed independently.'
+  ]
+} satisfies ChangelogEntry;

--- a/supabase/migrations/20260829180000_agent_kit_effect_identity.sql
+++ b/supabase/migrations/20260829180000_agent_kit_effect_identity.sql
@@ -1,0 +1,15 @@
+alter table public.agent_kit_effects
+  add column if not exists invocation_id text;
+
+alter table public.agent_kit_effects
+  alter column idempotency_key drop not null;
+
+drop index if exists public.agent_kit_effects_brand_key_idx;
+
+create unique index if not exists agent_kit_effects_brand_invocation_idx
+  on public.agent_kit_effects (brand_id, invocation_id)
+  where invocation_id is not null;
+
+create index if not exists agent_kit_effects_legacy_key_idx
+  on public.agent_kit_effects (brand_id, idempotency_key)
+  where invocation_id is null;


### PR DESCRIPTION
## Summary

- Separate the stable runtime tool-call identity from the effect payload.
- Claim effects atomically on `(brand_id, invocation_id)` before execution.
- Preserve completed and ambiguous outcomes, allow failed retries, and reject payload mismatches.

## Decisions

- `toolCallId` is the invocation identity. It is carried by the AI runtime and persisted in replayable tool-call history and partial state.
- New effects use the partial unique index on `(brand_id, invocation_id)`; payload is stored and compared, never used as identity.
- Legacy rows keep `idempotency_key`. They are consulted only for the original `run_id`, avoiding a legacy row from collapsing a new identical request.
- No in-memory lock is used. Database uniqueness and compare-and-swap resolve/claim races.
- Applied remotely through Supabase MCP: `agent_kit_effects`, then `agent_kit_effect_identity`.

## Files

- Agent-kit contract and testkit: `packages/agent-kit/`
- Ledger and executor: `packages/agent-core/`
- Runtime identity mapping: `packages/agent-adapters/src/runtime/`
- Compatibility migration: `supabase/migrations/20260829180000_agent_kit_effect_identity.sql`
- Internal and public changelogs.

## Verification

- Targeted tests: 115 passed.
- Full unit suite: 5752 passed, 4 pre-existing failures.
- `npm run typecheck:runtime`: passed earlier; the final rerun was interrupted after exceeding ten minutes without output.
- `npm run check`: pre-existing baseline failures only.
- `git diff --check`: passed.
- Remote drift check no longer reports either ledger migration; two unrelated pre-existing column-name divergences remain.

## Risks

- Legacy rows without `run_id`, or replayed calls that lose their persisted `toolCallId`, cannot be correlated safely and require manual reconciliation before retry.
- The concurrent-claim test uses the adapter fake; the production guarantee relies on the remote unique index and PostgreSQL `23505` handling.