### PR TITLE
Prevent pre-hydration attachment loss

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -80,6 +80,9 @@ Il turno di setup dell'onboarding consegna la prima risposta in ~20s e continua 
 ### I rimount (`{#key}`) rendono stale i ref dell'automazione browser
 Un click su un ref catturato prima del re-render non arriva a nessuno: il carosello dell'onboarding sembrava bloccato prima del pick — era il bottone rimontato ad ogni slide. Mossa: snapshot fresco e selettori stabili (`.wide-btn`), click lenti; un "blocco" va riprodotto con click lenti e selelettori nuovi prima di chiamarlo bug. Il falso positivo costa un'ora, la prudenza tre secondi.
 
+### Un file input SSR accetta la selezione prima dell'hydration
+`waitForSelector` può vedere il file input nel markup SSR mentre `onchange` non è ancora collegato; `setInputFiles` allora perde l'immagine senza errore, la strip non nasce e il turno parte cieco. Mossa: montare il picker solo dopo `onMount`, così il selettore trova solo un input interattivo.
+
 ### Un cookie di sessione malformato abbatte il dev server
 Una curl con `sb-<host>-auth-token` corrotto produce `Invalid Base64-URL character` non gestito nella recovery della sessione e il processo muore (`curl` → 000, niente più risposte). È un finding prodotto, non rumore: la recovery non tollera input corrotto. Mossa: quando curl dà 000, guardare il log del server prima di incolpare la rete; e la richiesta che ha ucciso il server diventa un test.
 

--- a/changelog/2026-08-29-chat-attachment-hydration.md
+++ b/changelog/2026-08-29-chat-attachment-hydration.md
@@ -1,0 +1,9 @@
+# Il composer non perde più allegati selezionati all'avvio
+
+Il file input del composer veniva renderizzato anche nel markup SSR. Un browser poteva trovarlo e
+selezionare un'immagine prima che Svelte avesse collegato `onPickFiles`; la selezione si perdeva,
+la strip non compariva e il turno partiva senza allegato.
+
+Il picker viene ora montato solo dopo l'hydration del composer. Il selettore del browser aspetta
+così un input già interattivo; il percorso di downscale e il blocco dell'invio durante
+l'elaborazione restano invariati.

--- a/src/lib/components/ChatPrompt.svelte
+++ b/src/lib/components/ChatPrompt.svelte
@@ -162,6 +162,7 @@
   let fileEl = $state<HTMLInputElement>();
   let docEl = $state<HTMLInputElement>();
   let importEl = $state<HTMLInputElement>();
+  let hydrated = $state(false);
   let importStatus = $state<string | null>(null);
   let convertStatus = $state<string | null>(null);
   let rootEl = $state<HTMLFormElement>();
@@ -256,6 +257,7 @@
    * così i bottoni dentro il menu tengono il loro handler.
    */
   onMount(() => {
+    hydrated = true;
     const onPointerDown = (e: Event) => {
       if (menu === 'none' && !slashOpen) return;
       const target = e.target as HTMLElement | null;
@@ -1305,24 +1307,26 @@
         </div>
       {/if}
 
-      {#if brandSlug}
-        <input
-          bind:this={fileEl}
-          type="file"
-          accept={`${RASTER_IMAGE_ACCEPT},${CHAT_VIDEO_ACCEPT}`}
-          multiple
-          hidden
-          onchange={onPickFiles}
-        />
-        <input
-          bind:this={docEl}
-          type="file"
-          accept={CHAT_DOCUMENT_ACCEPT}
-          multiple
-          hidden
-          onchange={onPickDocs}
-        />
-        <input bind:this={importEl} type="file" accept={RASTER_IMAGE_ACCEPT} multiple hidden onchange={onImportFiles} />
+      {#if hydrated}
+        {#if brandSlug}
+          <input
+            bind:this={fileEl}
+            type="file"
+            accept={`${RASTER_IMAGE_ACCEPT},${CHAT_VIDEO_ACCEPT}`}
+            multiple
+            hidden
+            onchange={onPickFiles}
+          />
+          <input
+            bind:this={docEl}
+            type="file"
+            accept={CHAT_DOCUMENT_ACCEPT}
+            multiple
+            hidden
+            onchange={onPickDocs}
+          />
+          <input bind:this={importEl} type="file" accept={RASTER_IMAGE_ACCEPT} multiple hidden onchange={onImportFiles} />
+        {/if}
       {/if}
       {#if convertStatus}
         <span class="ch-hint" role="status" aria-live="polite">{convertStatus}</span>

--- a/src/lib/components/chat-send-loading.test.ts
+++ b/src/lib/components/chat-send-loading.test.ts
@@ -47,4 +47,17 @@ describe('il primo invio mostra la rotella finche` il thread non esiste', () => 
 		expect(branch).toBeGreaterThan(-1);
 		expect(branch).toBeLessThan(mic);
 	});
+
+	it('ChatPrompt monta il file picker solo dopo l’hydration', () => {
+		const prompt = read('./ChatPrompt.svelte');
+		const ready = prompt.indexOf('let hydrated = $state(false)');
+		const mount = prompt.indexOf('hydrated = true');
+		const picker = prompt.indexOf('bind:this={fileEl}');
+		const guard = prompt.lastIndexOf('{#if hydrated}', picker);
+
+		expect(ready).toBeGreaterThan(-1);
+		expect(mount).toBeGreaterThan(ready);
+		expect(guard).toBeGreaterThan(mount);
+		expect(guard).toBeLessThan(picker);
+	});
 });

--- a/src/lib/content/changelog/2026-08-29-chat-attachment-hydration.ts
+++ b/src/lib/content/changelog/2026-08-29-chat-attachment-hydration.ts
@@ -1,0 +1,9 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-08-29',
+  title: 'Chat attachments no longer disappear while the composer loads',
+  items: [
+    'The attachment picker now becomes available only when the composer is ready, so selected images reliably appear in the preview strip and reach the turn.'
+  ]
+} satisfies ChangelogEntry;


### PR DESCRIPTION
Bug: the E2E runner could select the SSR file input before Svelte attached its change handler, dropping the image and starting a blind turn. Fix: render chat file pickers only after composer hydration, so selection starts on an interactive input. Tests: focused composer regression (5/5), attachment stall tests (2/2), public changelog tests in TZ=UTC (2/2), and direct Svelte compiler check.