### PR TITLE
Flag OAuth exchange failures

### DIFF
--- a/changelog/2026-08-29-oauth-code-exchange-error.md
+++ b/changelog/2026-08-29-oauth-code-exchange-error.md
@@ -1,0 +1,10 @@
+# OAuth code-exchange error recovery
+
+What happened: `/auth/callback` redirected a failed Supabase code exchange to bare `/login`,
+losing the error marker used by the other authentication-link failure path.
+
+What changes: a failed exchange now redirects to `/login?error=link`, matching `/auth/confirm`.
+Callbacks without a code still redirect to `/login`.
+
+Decision: reuse the existing generic `link` flag so OAuth failures do not expose provider error
+details and both callback paths keep the same recovery contract.

--- a/src/lib/content/changelog/2026-08-29-oauth-code-exchange-error.ts
+++ b/src/lib/content/changelog/2026-08-29-oauth-code-exchange-error.ts
@@ -1,0 +1,9 @@
+import type { ChangelogEntry } from './index';
+
+const entry: ChangelogEntry = {
+  date: '2026-08-29',
+  title: 'Clearer OAuth recovery',
+  items: ['Failed OAuth sign-ins now return to login with the same error signal used by authentication links.']
+};
+
+export default entry;

--- a/src/routes/auth/callback/+server.ts
+++ b/src/routes/auth/callback/+server.ts
@@ -42,6 +42,8 @@ export const GET: RequestHandler = async ({ url, cookies, locals: { supabase } }
       }
       throw redirect(303, '/app');
     }
+
+    throw redirect(303, '/login?error=link');
   }
 
   throw redirect(303, '/login');

--- a/src/routes/auth/callback/server.test.ts
+++ b/src/routes/auth/callback/server.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest';
+import { isRedirect } from '@sveltejs/kit';
+
+const exchangeCodeForSession = vi.fn();
+
+vi.mock('$lib/server/access', () => ({ canEnter: vi.fn() }));
+vi.mock('$lib/server/feature-flags', () => ({ isPlanGoEnabled: () => true }));
+vi.mock('$lib/server/oauth', () => ({ takeOAuthReturn: () => null }));
+
+const { GET } = await import('./+server');
+
+async function redirectFor(code: string) {
+  const event = {
+    url: new URL(`https://anomalia.so/auth/callback?code=${code}`),
+    cookies: {},
+    locals: { supabase: { auth: { exchangeCodeForSession } } }
+  };
+
+  try {
+    await (GET as unknown as (event: unknown) => Promise<never>)(event);
+  } catch (error) {
+    if (isRedirect(error)) return { status: error.status, location: error.location };
+    throw error;
+  }
+
+  throw new Error('Expected callback to redirect');
+}
+
+describe('OAuth callback', () => {
+  it('returns to login with an error when code exchange fails', async () => {
+    exchangeCodeForSession.mockResolvedValue({ error: new Error('code expired') });
+
+    await expect(redirectFor('expired')).resolves.toEqual({
+      status: 303,
+      location: '/login?error=link'
+    });
+  });
+});


### PR DESCRIPTION
## Bug
Failed OAuth code exchanges redirected to bare `/login`, dropping the existing `error=link` recovery signal.

## Fix
Failed exchanges now redirect to `/login?error=link`, matching `/auth/confirm`. A route regression test covers the failure path, with internal and public changelogs.

## Tests
- `npx --no-install vitest run src/routes/auth/callback/server.test.ts src/routes/[[lang=locale]]/page.server.test.ts`: 15 passed
- `git diff --cached --check`: passed
- `src/lib/content/changelog/index.test.ts`: pre-existing failure caused by mixed ISO and textual date formats in existing entries
- `npm run check`, `npx --no-install tsc --noEmit`, and `npm run typecheck:runtime`: attempted, but produced no result in the environment and were stopped after extended waits