### PR TITLE
Stop inventing platform mix shares

### DIFF
--- a/changelog/2026-08-29-editorial-plan-empty-share.md
+++ b/changelog/2026-08-29-editorial-plan-empty-share.md
@@ -1,0 +1,3 @@
+# Editorial plan platform mix
+
+The platform-mix chart filled missing `share` values with an equal split, so a plan with four platforms displayed `25%` for each one. The chart now keeps missing shares unknown and renders a percentage only when the plan provides one or a complete cadence share can be normalized. Explicit percentages and complete cadence shares keep their existing behavior.

--- a/src/lib/components/PlatformMixBars.svelte
+++ b/src/lib/components/PlatformMixBars.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
   import { siInstagram, siTiktok, siFacebook, siX, siThreads, siYoutube, siBluesky, siReddit } from 'simple-icons';
+  import { platformMixRows, type PlatformMixItem } from '$lib/platform-mix';
 
   // Horizontal platform-mix chart: one row per platform — social logo + name on the left, a
   // %-proportional bar in the platform's colour, the percentage on the right. Shared by the
   // onboarding manifesto, the editorial-plan cards and the GTM phase panel so a "mix" always
   // looks the same everywhere (brief §8: consistent per-platform colours).
-  type MixItem = { platform: string; percent?: number; share?: string; role?: string };
-  let { mix = [] }: { mix: MixItem[] } = $props();
+  let { mix = [] }: { mix: PlatformMixItem[] } = $props();
 
   const META: Record<string, { l: string; c: string; g: string }> = {
     instagram: { l: 'Instagram', c: '#dd2a7b', g: 'IG' },
@@ -30,33 +30,7 @@
     reddit: siReddit
   };
 
-  // Resolve a percentage per row. Sources, in order: an explicit `percent` (GTM weights), a
-  // share string containing '%' ("40%"), else the first number in the share normalised across
-  // rows ("2/week" style), else an equal split. Always clamped to 0–100.
-  const rows = $derived.by(() => {
-    const parsed = mix
-      .filter((m) => m?.platform)
-      .map((m) => {
-        const key = String(m.platform).toLowerCase().trim();
-        let p: number | null = typeof m.percent === 'number' && Number.isFinite(m.percent) ? m.percent : null;
-        if (p == null && m.share) {
-          const pm = String(m.share).match(/(\d+(?:[.,]\d+)?)\s*%/);
-          if (pm) p = parseFloat(pm[1].replace(',', '.'));
-        }
-        return { key, role: m.role ?? '', share: m.share ?? '', p };
-      });
-    if (parsed.some((r) => r.p == null)) {
-      const nums = parsed.map((r) => {
-        const nm = String(r.share).match(/(\d+(?:[.,]\d+)?)/);
-        return nm ? parseFloat(nm[1].replace(',', '.')) : 1;
-      });
-      const tot = nums.reduce((a, b) => a + b, 0) || 1;
-      parsed.forEach((r, i) => {
-        if (r.p == null) r.p = Math.round((nums[i] / tot) * 100);
-      });
-    }
-    return parsed.map((r) => ({ ...r, p: Math.max(0, Math.min(100, Math.round(r.p ?? 0))) }));
-  });
+  const rows = $derived(platformMixRows(mix));
 </script>
 
 {#if rows.length}
@@ -72,8 +46,8 @@
           {META[r.key]?.l ?? r.key}
           {#if r.role}<small>{r.role}</small>{/if}
         </span>
-        <span class="pm-track"><span class="pm-fill" style={`width:${r.p}%`}></span></span>
-        <span class="pm-pct">{r.p}%</span>
+        <span class="pm-track">{#if r.percent != null}<span class="pm-fill" style={`width:${r.percent}%`}></span>{/if}</span>
+        <span class="pm-pct">{r.percent == null ? '' : `${r.percent}%`}</span>
       </div>
     {/each}
   </div>

--- a/src/lib/content/changelog/2026-08-29-editorial-plan-empty-share.ts
+++ b/src/lib/content/changelog/2026-08-29-editorial-plan-empty-share.ts
@@ -1,0 +1,7 @@
+const entry = {
+  date: '2026-08-29',
+  title: 'Platform mix shows only known shares',
+  items: ['Editorial plans no longer show made-up percentages when a platform share is missing.']
+};
+
+export default entry;

--- a/src/lib/platform-mix.test.ts
+++ b/src/lib/platform-mix.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { render } from 'svelte/server';
+import PlatformMixBars from './components/PlatformMixBars.svelte';
+import { platformMixRows } from './platform-mix';
+
+describe('platformMixRows', () => {
+  it('keeps empty shares unknown instead of inventing equal percentages', () => {
+    expect(
+      platformMixRows([
+        { platform: 'instagram', share: '', role: '' },
+        { platform: 'tiktok', share: '', role: '' },
+        { platform: 'linkedin', share: '', role: '' },
+        { platform: 'x', share: '', role: '' }
+      ])
+    ).toEqual([
+      { key: 'instagram', role: '', share: '', percent: null },
+      { key: 'tiktok', role: '', share: '', percent: null },
+      { key: 'linkedin', role: '', share: '', percent: null },
+      { key: 'x', role: '', share: '', percent: null }
+    ]);
+  });
+
+  it('does not render an invented percentage for empty shares', () => {
+    const { body } = render(PlatformMixBars, {
+      props: {
+        mix: [
+          { platform: 'instagram', share: '', role: '' },
+          { platform: 'tiktok', share: '', role: '' },
+          { platform: 'linkedin', share: '', role: '' },
+          { platform: 'x', share: '', role: '' }
+        ]
+      }
+    });
+
+    expect(body).not.toContain('25%');
+  });
+
+  it('normalizes complete cadence shares', () => {
+    expect(
+      platformMixRows([
+        { platform: 'instagram', share: '2/week', role: '' },
+        { platform: 'tiktok', share: '1/week', role: '' }
+      ]).map((row) => row.percent)
+    ).toEqual([67, 33]);
+  });
+});

--- a/src/lib/platform-mix.ts
+++ b/src/lib/platform-mix.ts
@@ -1,0 +1,58 @@
+export type PlatformMixItem = {
+  platform?: string | null;
+  percent?: number;
+  share?: string | null;
+  role?: string | null;
+};
+
+export type PlatformMixRow = {
+  key: string;
+  role: string;
+  share: string;
+  percent: number | null;
+};
+
+const PERCENT = /(\d+(?:[.,]\d+)?)\s*%/;
+const NUMBER = /(\d+(?:[.,]\d+)?)/;
+
+function numberIn(value: string): number | null {
+  const match = value.match(NUMBER);
+  return match ? parseFloat(match[1].replace(',', '.')) : null;
+}
+
+function percentIn(item: PlatformMixItem, share: string): number | null {
+  if (typeof item.percent === 'number' && Number.isFinite(item.percent)) return item.percent;
+  const match = share.match(PERCENT);
+  return match ? parseFloat(match[1].replace(',', '.')) : null;
+}
+
+function clamp(value: number): number {
+  return Math.max(0, Math.min(100, Math.round(value)));
+}
+
+export function platformMixRows(mix: readonly PlatformMixItem[]): PlatformMixRow[] {
+  const rows = mix
+    .filter((item) => item?.platform)
+    .map((item) => {
+      const share = String(item.share ?? '');
+      return {
+        key: String(item.platform).toLowerCase().trim(),
+        role: item.role ?? '',
+        share,
+        percent: percentIn(item, share)
+      };
+    });
+
+  const numbers = rows.map((row) => numberIn(row.share));
+  const canNormalize =
+    rows.some((row) => row.percent == null) &&
+    rows.every((row, index) => row.percent != null || numbers[index] != null);
+  if (canNormalize) {
+    const total = numbers.reduce<number>((sum, value) => sum + (value ?? 0), 0) || 1;
+    rows.forEach((row, index) => {
+      if (row.percent == null) row.percent = ((numbers[index] ?? 0) / total) * 100;
+    });
+  }
+
+  return rows.map((row) => ({ ...row, percent: row.percent == null ? null : clamp(row.percent) }));
+}


### PR DESCRIPTION
## Bug
The editorial-plan platform chart displayed 25% for every platform when each `share` field was empty.

## Fix
Keep missing shares unknown and render no percentage or fill for them. Preserve explicit percentages and complete cadence-share normalization in the shared formatter.

## Tests
- `npx --no-install vitest run src/lib/platform-mix.test.ts`
- `TZ=UTC npx --no-install vitest run src/lib/platform-mix.test.ts src/lib/server/editorial-plan.test.ts src/lib/content/changelog/index.test.ts` (27 passed)
- `npx --no-install tsc --noEmit --skipLibCheck --target ES2022 --module ESNext --moduleResolution bundler src/lib/platform-mix.ts`
- `npm run check` started but was stopped after about five minutes without diagnostics.