### PR TITLE
Preserve website onboarding destination

### DIFF
--- a/changelog/2026-08-29-login-website-onboarding.md
+++ b/changelog/2026-08-29-login-website-onboarding.md
@@ -1,0 +1,5 @@
+# Conserva il sito nel login autenticato
+
+Un utente già autenticato che apriva `/login?website=...` finiva su `/app` e perdeva il sito da analizzare.
+
+Il `load` del login ora tratta un `website` valido come intenzione di onboarding e riusa la sanitizzazione esistente. Non serve un cookie aggiuntivo: il valore è già nella query.

--- a/src/lib/content/changelog/2026-08-29-login-website-onboarding.ts
+++ b/src/lib/content/changelog/2026-08-29-login-website-onboarding.ts
@@ -1,0 +1,7 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-08-29',
+  title: 'Website links keep their onboarding destination',
+  items: ['Already signed-in users keep the website when a login link takes them to setup.']
+} satisfies ChangelogEntry;

--- a/src/routes/login/+page.server.ts
+++ b/src/routes/login/+page.server.ts
@@ -57,6 +57,7 @@ export const load: PageServerLoad = async ({ url, cookies, locals: { safeGetSess
     if (cliPort) throw redirect(303, `/cli/callback?cli_port=${cliPort}&cli_state=${cliState}`);
     if (
       url.searchParams.get('next') === 'onboarding' ||
+      sanitizeWebsiteParam(url.searchParams.get('website')) ||
       hasGuestOnboardingCookie(cookies.get(GUEST_ONBOARDING_COOKIE))
     ) {
       const qs = onboardingQs(url.searchParams);

--- a/src/routes/login/page.server.test.ts
+++ b/src/routes/login/page.server.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { isRedirect } from '@sveltejs/kit';
+import { load } from './+page.server';
+
+const ORIGIN = 'https://anomalia.so';
+const SIGNED_IN = { session: { access_token: 'jwt' }, user: { id: 'u1' } };
+
+function run(path: string) {
+  const url = new URL(`${ORIGIN}${path}`);
+  const event = {
+    url,
+    cookies: {
+      get: () => undefined,
+      delete: () => undefined
+    },
+    locals: { safeGetSession: async () => SIGNED_IN }
+  };
+
+  return Promise.resolve((load as any)(event)).then(
+    () => null,
+    (error) => {
+      if (isRedirect(error)) return { status: error.status, location: error.location };
+      throw error;
+    }
+  );
+}
+
+describe('login page load', () => {
+  it('keeps a website URL for an authenticated user', async () => {
+    await expect(run('/login?website=acme.example')).resolves.toEqual({
+      status: 303,
+      location: '/app/onboarding?website=acme.example'
+    });
+  });
+});


### PR DESCRIPTION
## Bug
Authenticated users visiting `/login?website=...` without `next` or the guest cookie were redirected to `/app`, losing the website to analyze.

## Fix
Treat a valid `website` parameter as onboarding intent in the authenticated login load and preserve it in the onboarding redirect. Added the required internal and public changelog entries.

## Tests
- `npx --no-install vitest run src/routes/login/page.server.test.ts src/lib/website-param.test.ts src/lib/guest-onboarding.test.ts --reporter=verbose`
- `TZ=UTC npx --no-install vitest run src/lib/content/changelog/index.test.ts --reporter=verbose`
- `npm run check` attempted; it did not finish after several minutes.
- Targeted TypeScript check reached pre-existing errors outside the changed files; none were reported for the route, test, or changelog entry.