### PR TITLE
Prevent post deletion 404 flash

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -100,6 +100,12 @@ aspettare `document.body.innerText.includes(marker)` conferma anche il messaggio
 
 ## Codice
 
+### Un dettaglio eliminato non si invalida prima di uscire
+Il reject del post cancellava la riga, poi aggiornava la pagina `/posts/:id`: il layout trovava
+correttamente un 404 prima che il callback portasse al calendario. Segnale: la pagina 404 lampeggia
+solo dopo una cancellazione dal dettaglio. Mossa: sul successo distruttivo navigare subito e lasciare
+che la nuova pagina carichi i dati; `update()` resta per errori e modifiche non distruttive.
+
 ### Markdown venduto: file veri + `?raw`, non template literal
 Skill e guide upstream restano file `.md` diffabili contro upstream, inlineati con `import x from './x.md?raw'` (pattern di `agent-files.ts`). 43KB di markdown in un template literal sono mine: backtick e `${` nel testo upstream rompono la compilazione in modo opaco.
 

--- a/changelog/2026-08-29-post-delete-404.md
+++ b/changelog/2026-08-29-post-delete-404.md
@@ -1,0 +1,7 @@
+# Post rejection no longer flashes 404
+
+The post editor refreshed the deleted detail route before navigating away, so its valid 404 state
+briefly appeared after a successful rejection.
+
+Successful rejection now navigates straight to the calendar. Failed actions still refresh the
+current page and show their error.

--- a/src/lib/components/PostEditor.svelte
+++ b/src/lib/components/PostEditor.svelte
@@ -852,12 +852,16 @@
   const runAction = (name: string): SubmitFunction => () => {
     submitting = name;
     return async ({ result, update }) => {
+      if (result.type === 'success' && name === 'reject') {
+        submitting = null;
+        close();
+        return;
+      }
+
       await update();
       submitting = null;
       if (result.type === 'success') {
-        // Reject deletes the row — leave the dashboard. Other saves stay put and refresh.
-        if (name === 'reject') close();
-        else if (embedded) await invalidateAll();
+        if (embedded) await invalidateAll();
         else close();
       } else if (result.type === 'failure') {
         saveError = (result.data?.error as string) ?? get(_)('posteditor.errGeneric');

--- a/src/lib/components/post-editor-delete.test.ts
+++ b/src/lib/components/post-editor-delete.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const read = (rel: string) => readFileSync(fileURLToPath(new URL(rel, import.meta.url)), 'utf8');
+
+describe('la cancellazione dal post editor non passa dal 404 del post eliminato', () => {
+  it('chiude il post prima di aggiornare la pagina eliminata', () => {
+    const source = read('./PostEditor.svelte');
+    const action = source.slice(source.indexOf('const runAction'), source.indexOf('const repostEnhance'));
+
+    const reject = action.indexOf("name === 'reject'");
+    const close = action.indexOf('close();', reject);
+    const update = action.indexOf('await update();');
+
+    expect(reject).toBeGreaterThan(-1);
+    expect(close).toBeGreaterThan(-1);
+    expect(update).toBeGreaterThan(-1);
+    expect(close).toBeLessThan(update);
+  });
+
+  it.each([
+    '../../routes/app/[brand]/posts/[id]/edit/+page.svelte',
+    '../../routes/app/[brand]/posts/[id]/chat/+page.svelte'
+  ])('naviga al calendario senza invalidare il dettaglio eliminato: %s', (path) => {
+    const source = read(path);
+    const leave = source.slice(source.indexOf('async function onLeave'), source.indexOf('</script>'));
+
+    expect(leave).toContain('await goto(`/app/${brand.slug}/calendar`)');
+    expect(leave).not.toContain('invalidateAll');
+  });
+});

--- a/src/lib/content/changelog/2026-08-29-post-delete-404.ts
+++ b/src/lib/content/changelog/2026-08-29-post-delete-404.ts
@@ -1,0 +1,7 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-08-29',
+  title: 'Smoother post deletion',
+  items: ['Deleting a post now returns you to the calendar without a temporary 404 page.']
+} satisfies ChangelogEntry;

--- a/src/routes/app/[brand]/posts/[id]/chat/+page.svelte
+++ b/src/routes/app/[brand]/posts/[id]/chat/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
-  import { invalidateAll } from '$app/navigation';
   import PostEditor from '$lib/components/PostEditor.svelte';
   import { _ } from 'svelte-i18n';
 
@@ -10,7 +9,6 @@
   const studioOn = $derived(!!data.flags?.studio);
 
   async function onLeave() {
-    await invalidateAll();
     await goto(`/app/${brand.slug}/calendar`);
   }
 </script>

--- a/src/routes/app/[brand]/posts/[id]/edit/+page.svelte
+++ b/src/routes/app/[brand]/posts/[id]/edit/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
-  import { invalidateAll } from '$app/navigation';
   import PostEditor from '$lib/components/PostEditor.svelte';
 
   let { data } = $props();
@@ -8,7 +7,6 @@
   const post = $derived(data.post);
 
   async function onLeave() {
-    await invalidateAll();
     await goto(`/app/${brand.slug}/calendar`);
   }
 </script>


### PR DESCRIPTION
## Bug
Rejecting a post from the detail editor refreshed the deleted `/posts/:id` route before navigating away, so its expected 404 page flashed briefly.

## Fix
Successful reject actions now leave the detail page before any refresh. The edit and chat close handlers navigate directly to the calendar, which loads fresh data. Added a focused regression test and the required internal and public changelogs.

## Tests
- `./node_modules/.bin/vitest run src/lib/components/post-editor-delete.test.ts src/lib/server/post-editing.test.ts 'src/routes/app/[brand]/calendar/page.server.delete.test.ts' --reporter=verbose` — 17 passed\n- `TZ=UTC ./node_modules/.bin/vitest run src/lib/content/changelog/index.test.ts --reporter=verbose` — 2 passed\n- `npm run typecheck:runtime` — passed; repository reports 252 known non-fatal type errors\n- `npm run check` was attempted and stopped after about 10 minutes while concurrent worktrees were running checks; the valid narrowed Svelte check found only existing baseline errors and none on changed lines.