### PR TITLE
Fix agent_sessions insert losing every subagent trace

### DIFF
--- a/changelog/2026-08-29-agent-session-row-id.md
+++ b/changelog/2026-08-29-agent-session-row-id.md
@@ -1,0 +1,30 @@
+# La scatola nera dei sotto-agenti si scriveva a vuoto
+
+## Perché
+
+Ogni insert di `saveAgentSession` moriva in produzione con
+`null value in column "id" of relation "agent_sessions" violates not-null
+constraint` (23502): `agentSessionRow` non produceva `id`, e la migration
+0205 definisce la colonna senza default. Gli errori vengono ingoiati di
+proposito (la diagnostica non può rompere il turno), quindi il difetto è
+stato silenzioso: l'altro writer, `harness/persist.ts`, include `id` nel
+proprio snapshot ed è l'unico motivo per cui la tabella non è vuota.
+L'intera traccia dei turni delegati dalla chat (comandi sandbox, pagine,
+report) non è mai arrivata al database.
+
+## Decisione
+
+- `agentSessionRow` genera il proprio `id` con `crypto.randomUUID()`,
+  come già fa il percorso harness. Fix nel codice e non un
+  `alter column id set default gen_random_uuid()`: le deploys non girano
+  migration, quindi la default sul database avrebbe lasciato il difetto
+  in produzione fino a un apply manuale — e il contratto «chi scrive
+  porta il suo id» è già il pattern stabilito dall'altro writer.
+- Test di regressione sul seam puro (`agentSessionRow`): la riga deve
+  portare un uuid valido. Guarda sia la rimozione del campo sia un
+  futuro writer che riusa la funzione senza id.
+
+## Scartato
+
+Migration con default sulla colonna: rimanda il fix a un passaggio
+manuale su produzione e maschera il contratto invece di dichiararlo.

--- a/src/lib/content/changelog/2026-08-29-agent-session-row-id.ts
+++ b/src/lib/content/changelog/2026-08-29-agent-session-row-id.ts
@@ -1,0 +1,9 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-08-29',
+  title: 'Delegated agent work is now recorded',
+  items: [
+    'When a main agent delegates a task to a specialist, the full run — commands executed, pages visited, final report — is now saved again. A technical failure was silently discarding these traces.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/agent-sessions.test.ts
+++ b/src/lib/server/agent-sessions.test.ts
@@ -1,12 +1,33 @@
 import { describe, expect, it } from 'vitest';
-import { clipEventData, createRecorder } from './agent-sessions';
+import { agentSessionRow, clipEventData, createRecorder } from './agent-sessions';
 import { noteSecret } from './redact';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function minimalInsert() {
+  return {
+    brandId: 'b-1',
+    agent: 'web',
+    mode: 'sandbox',
+    surface: 'chat',
+    status: 'ok' as const,
+    transcript: '',
+    recorder: createRecorder()
+  };
+}
 
 /** Un orologio finto: `new Date()` dentro un test rende gli assert dipendenti da quando girano. */
 function clock() {
   let t = 1_700_000_000_000;
   return () => (t += 1000);
 }
+
+describe('agentSessionRow', () => {
+  it('la riga porta il suo id: la colonna non ha default e senza uuid la insert muore con 23502', () => {
+    const row = agentSessionRow(minimalInsert());
+    expect(row.id).toMatch(UUID_RE);
+  });
+});
 
 describe('createRecorder', () => {
   it('tiene ordine, tipo ed esito di ogni evento', () => {

--- a/src/lib/server/agent-sessions.ts
+++ b/src/lib/server/agent-sessions.ts
@@ -200,6 +200,7 @@ export type AgentSessionInsert = {
 export function agentSessionRow(s: AgentSessionInsert, events = s.recorder.events()) {
   const b = s.brandId;
   return {
+    id: crypto.randomUUID(),
     brand_id: s.brandId,
     user_id: s.userId ?? null,
     thread_id: s.threadId ?? null,


### PR DESCRIPTION
## What?
`saveAgentSession` inserted rows into `agent_sessions` without `id`, but the column (migration 0205) has no default: every insert died with 23502 (`null value in column "id" ... violates not-null constraint`). The error was swallowed by design, so the delegated-run traces never reached the database. `agentSessionRow` now generates its uuid (`crypto.randomUUID()`), matching `harness/persist.ts`, which already carried its own `id` — and is the only reason the table isn't empty. Adds a regression test on the pure row seam.

## Why?
The sub-agent black box (sandbox commands, pages visited, final report) for chat-delegated work was silently never persisted — the diagnostic path this table exists for was dead on one of its two writers.

## How?
- Fix lives in the row builder, not a migration `set default gen_random_uuid()`: deploys don't run migrations, so a DB default would leave prod broken until a manual apply. "The writer carries its id" is already the pattern of the other writer.
- Regression test asserts `agentSessionRow(...)` returns a valid uuid — catches both a removed field and a future writer reusing the row without one.

## Testing?
- Red first: `npx vitest run src/lib/server/agent-sessions.test.ts` → `row.id` undefined (reproduces 23502 input). After fix: 11/11 green.
- `redact.test.ts` + `subagents.test.ts` re-run: 78/78 green.
- Not tested: a live insert against the production schema (unit seam only, per repo test convention for this module — no DB in these tests).

## Evidence (screenshots/videos)
Backend only; no UI change.

<details>
<summary>Red run (pre-fix)</summary>

```
× agentSessionRow > la riga porta il suo id: ...
  → .toMatch() expects to receive a string, but got undefined
Tests  1 failed | 10 passed (11)
```
</details>

<details>
<summary>Green run (post-fix)</summary>

```
✓ src/lib/server/agent-sessions.test.ts (11 tests) 21ms
✓ src/lib/server/redact.test.ts + subagents.test.ts (78 tests)
```
</details>

## Anything Else?
Task #67. The same log line also appears in task #73 (subagent reliability bundle) — the data-loss half of that incident is closed here; the queue/visibility halves remain in their own tasks.