### PR TITLE
Close delegate chips that outlive their stream

### DIFF
--- a/changelog/2026-08-29-delegate-chip-dangling-close.md
+++ b/changelog/2026-08-29-delegate-chip-dangling-close.md
@@ -1,0 +1,42 @@
+# La chip di un tool non sopravvive al proprio stream
+
+## Perché
+
+Il 27/8 (riga di produzione `7bc0f716` di `agent_kit_runs`) la sessione è
+morta a metà di un `delegate_task`. Il turno è ripreso con una sessione
+fresca, che non riemette il risultato del call precedente: il partial del
+run ha quindi conservato la chip `running` senza output per tutto il resto
+del turno — loading perpetuo in UI, refresh per sbloccare.
+
+Due buchi si sommavano:
+
+1. **Server (mirror).** `mirrorSseToRun` scrive il partial con lo stato
+   piegato dallo stream; a stream finito una chip ancora `running` non
+   riceverà più nulla, ma restava tale nel partial servito dal poll.
+2. **Client (poll).** `applyLiveSnapshot` Mergeava i tool solo quando il
+   loro numero cresceva: una transizione di stato (running→done) senza
+   aggiunte non veniva mai riparata, quindi nemmeno un partial vero
+   avrebbe chiuso la chip.
+
+## Decisione
+
+- Nuovo `closeDanglingToolCalls` in `chat-stream-events.ts` (il modulo
+  condiviso server/client): a stream terminato per cosa sua (evento
+  `finish` o `error` visto) ogni chip ancora aperta diventa `error` con
+  un testo onesto. Se invece il mirror si ghiaccia per un client andato
+  via, lo stato resta com'è: le chip aperte possono essere legittime,
+  il turno continua senza di noi.
+- `applyLiveSnapshot` mergea anche a lunghezza invariata (ma mai con
+  meno tool di quelli che la tab conosce: lo snapshot non rimpicciolisce
+  la lista).
+- Scelti i dati prima della teoria: la query su `agent_kit_runs` dei 7
+  giorni mostra un run con `open_delegate: 1` nel partial finale e tutti
+  gli altri chiusi — conferma che il difetto è nel lifecycle del mirror,
+  non nell'emissione generale dei risultati.
+
+## Scartato
+
+Riscrivere il partial alla chiusura del run dalla verità degli `steps`:
+dopo `closeRunSaving` il run esce dagli stati working e il poll risponde
+204 — il partial riconciliato non verrebbe mai letto. La riparazione sta
+nel mirror, dove il partial vive ancora.

--- a/src/lib/agent/bridge/live.ts
+++ b/src/lib/agent/bridge/live.ts
@@ -43,7 +43,7 @@ import { assistantContentFromPartial, type ChatPartialSnapshot } from '$lib/serv
 import { createQueryTool, type QueryToolDeps } from '$lib/server/chat/query-tool';
 import { CHAT_USER_ERROR } from '$lib/server/chat/report-error';
 import { enqueueTurnContinuation, kickChatQueueWork } from '$lib/server/chat/queue';
-import { applyChatStreamEvent, emptyStreamState, readSseEvents, toolsForMirror } from '$lib/chat-stream-events';
+import { applyChatStreamEvent, closeDanglingToolCalls, emptyStreamState, readSseEvents, toolsForMirror } from '$lib/chat-stream-events';
 import { isChatMode, modeBlock, toolsForMode, type ChatMode } from '$lib/chat-modes';
 import { broadcastToBrand } from '$lib/server/realtime';
 import { specById } from '../specs';
@@ -1301,6 +1301,8 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
 				const decoder = new TextDecoder();
 				let sseBuf = '';
 				let lastWrite = 0;
+				/** Lo stream è finito per cosa sua (finish/error), non per un client andato via. */
+				let sawTerminal = false;
 				/** Un evento di ciclo di vita di una tool call: si scrive comunque, vedi PARTIAL_FLUSH_EVENTS. */
 				let mustWrite = false;
 				/** La scrittura in volo: una alla volta, e MAI attesa dal ciclo di lettura (v1). */
@@ -1345,6 +1347,7 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
 							const at = { text: state.text.length, reasoning: state.reasoning.length };
 							applyChatStreamEvent(state, evt);
 							signOfLife();
+							if (String((evt as { type?: unknown }).type ?? '') === 'finish' || state.failed) sawTerminal = true;
 							if (PARTIAL_FLUSH_EVENTS.has(String((evt as { type?: unknown }).type ?? ''))) mustWrite = true;
 							const raw = JSON.stringify(evt);
 							void broadcastToBrand(brand.id, {
@@ -1381,6 +1384,13 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
 							});
 						}
 					}
+				// STREAM FINITO, CHIP ANCORA APERTA = BUGIA NEL PARTIAL (27/8: `delegate_task` in
+					// loading perenne — la sessione morta a metà tool non riemette il risultato e la
+					// chip sopravviveva nel mirror per tutto il turno). Se lo stream è terminato per
+					// cosa sua, ogni chip rimasta aperta non riceverà più nulla: diventa un errore
+					// dichiarato. Se invece il client è solo andato via, il mirror si ghiaccia com'era:
+					// le chip aperte possono essere legittime, il turno continua senza di noi.
+					if (sawTerminal && closeDanglingToolCalls(state)) mustWrite = true;
 					// L'ULTIMA scrittura è INCONDIZIONATA e ATTESA (stesso motivo di chat/+server.ts:
 					// un client che pollasse in questo preciso istante deve trovare il testo intero,
 					// non quello di un attimo fa) — un turno più corto della soglia non avrebbe MAI

--- a/src/lib/chat-live-join.test.ts
+++ b/src/lib/chat-live-join.test.ts
@@ -113,4 +113,54 @@ describe('chat live join — due sorgenti, una sola posizione', () => {
 
 		expect(pending.length).toBeLessThanOrEqual(1000);
 	});
+
+	/**
+	 * L'incidente del 27/8 (task 66): la chip di un `delegate_task` restò «in corso» per tutto il
+	 * resto del turno — il chunk di chiusura era finito con lo stream morto, e lo snapshot del poll
+	 * non la riparava perché il numero di tool non era cambiato. Una transizione di stato è pur
+	 * sempre una notizia: lo snapshot la consegna anche a lunghezza invariata.
+	 */
+	it('lo snapshot chiude una chip rimasta aperta che il canale non ha mai chiuso', () => {
+		const state = emptyStreamState();
+		const pending: PendingChunk[] = [];
+		applyLiveChunk(
+			state,
+			pending,
+			{ type: 'tool-input-available', toolCallId: 'd1', toolName: 'delegate_task', input: { role: 'sandbox' } },
+			{ text: 0, reasoning: 0 }
+		);
+		expect(state.tools[0].status).toBe('running');
+
+		applyLiveSnapshot(state, pending, {
+			text: 'sto lavorando',
+			tools: [{ toolCallId: 'd1', toolName: 'delegate_task', status: 'done', input: { role: 'sandbox' }, output: 'report' }]
+		});
+
+		expect(state.tools[0].status).toBe('done');
+		expect(state.tools[0].output).toBe('report');
+	});
+
+	it('lo snapshot non butta via le chip che la tab conosce e lui no', () => {
+		const state = emptyStreamState();
+		const pending: PendingChunk[] = [];
+		applyLiveChunk(
+			state,
+			pending,
+			{ type: 'tool-input-available', toolCallId: 't1', toolName: 'shell', input: { cmd: 'ls' } },
+			{ text: 0, reasoning: 0 }
+		);
+		applyLiveChunk(
+			state,
+			pending,
+			{ type: 'tool-input-available', toolCallId: 't2', toolName: 'shell', input: { cmd: 'pwd' } },
+			{ text: 2, reasoning: 0 }
+		);
+
+		applyLiveSnapshot(state, pending, {
+			text: 'sto lavorando',
+			tools: [{ toolCallId: 't1', toolName: 'shell', status: 'done' }]
+		});
+
+		expect(state.tools.map((t) => t.toolCallId)).toEqual(['t1', 't2']);
+	});
 });

--- a/src/lib/chat-live-join.ts
+++ b/src/lib/chat-live-join.ts
@@ -86,7 +86,10 @@ export function applyLiveSnapshot(
       changed = true;
     }
     const tools = Array.isArray(snapshot.tools) ? snapshot.tools : [];
-    if (tools.length > state.tools.length) {
+    // Anche a lunghezza invariata lo snapshot può dire qualcosa di nuovo: la chiusura di una chip
+    // persa dal canale (realtime best-effort, stream morto a metà tool) è una transizione di
+    // stato, non un'aggiunta. Il merge tiene i payload interi che il canale ha già portato.
+    if (tools.length > 0 && tools.length >= state.tools.length) {
       // Lo snapshot ha payload troncati: il merge tiene quelli interi che il canale ha già portato.
       state.tools = mergeStreamToolCalls(state.tools, tools);
       changed = true;

--- a/src/lib/chat-stream-events.test.ts
+++ b/src/lib/chat-stream-events.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   applyChatStreamEvent,
+  closeDanglingToolCalls,
   emptyStreamState,
   mergeStreamToolCalls,
   readSseEvents,
@@ -127,6 +128,41 @@ describe('the resumable snapshot', () => {
   it('takes the snapshot as truth for a call this tab never saw', () => {
     const merged = mergeStreamToolCalls([], [{ toolCallId: 't9', toolName: 'y', status: 'running' }]);
     expect(merged).toEqual([{ toolCallId: 't9', toolName: 'y', status: 'running' }]);
+  });
+});
+
+describe('closeDanglingToolCalls', () => {
+  /**
+   * L'incidente del 27/8 (riga di produzione `7bc0f716`): la sessione è morta a metà di un
+   * `delegate_task`, il turno è ripreso con una sessione fresca che non riemetteva il risultato
+   * del call precedente, e il partial finale ha mantenuto la chip «running» per sempre — loading
+   * perpetuo in UI fino al refresh. Lo stream che avrebbe consegnato la chiusura è finito: una
+   * chip ancora aperta a fine stream è una bugia, e va dichiarata come errore onesto.
+   */
+  it('a fine stream una chip ancora running diventa un errore dichiarato', () => {
+    const state = feed([
+      { type: 'tool-input-available', toolCallId: 'd1', toolName: 'delegate_task', input: { role: 'sandbox' } },
+      { type: 'text-delta', delta: 'continuo oltre' },
+      { type: 'finish', finishReason: 'stop' }
+    ]);
+    expect(state.tools[0].status).toBe('running');
+
+    const changed = closeDanglingToolCalls(state);
+
+    expect(changed).toBe(true);
+    expect(state.tools[0].status).toBe('error');
+    expect(state.tools[0].errorText).toBeTruthy();
+  });
+
+  it('una chip già chiusa non si tocca, e uno stream senza perdite non cambia nulla', () => {
+    const state = feed([
+      { type: 'tool-input-available', toolCallId: 't1', toolName: 'shell', input: { cmd: 'ls' } },
+      { type: 'tool-output-available', toolCallId: 't1', output: 'ok' },
+      { type: 'finish', finishReason: 'stop' }
+    ]);
+
+    expect(closeDanglingToolCalls(state)).toBe(false);
+    expect(state.tools[0]).toMatchObject({ status: 'done', output: 'ok' });
   });
 });
 

--- a/src/lib/chat-stream-events.ts
+++ b/src/lib/chat-stream-events.ts
@@ -181,6 +181,22 @@ export function toolsForMirror(tools: StreamToolCallState[]): StreamToolCallStat
 }
 
 /**
+ * A stream finito non esiste una chip «running»: o il risultato è arrivato, o non arriverà mai.
+ * La sessione può morire a metà di un tool (il turno ripreso con una sessione fresca non
+ * riemette il risultato del call precedente) — senza questo gesto il partial conserva il loading
+ * perpetuo che l'utente ha visto il 27/8. `true` se qualcosa è cambiato.
+ */
+export function closeDanglingToolCalls(state: ChatStreamState): boolean {
+  let changed = false;
+  state.tools = state.tools.map((t) => {
+    if (t.status !== 'running' && t.status !== undefined) return t;
+    changed = true;
+    return { ...t, status: 'error' as const, errorText: t.errorText ?? 'the turn ended before this result arrived' };
+  });
+  return changed;
+}
+
+/**
  * Piega la lista di tool di uno snapshot su quella che questa scheda ha già, tenendo i payload che
  * lo snapshot ha buttato: senza, il primo poll dopo una disconnessione chiuderebbe ogni chip aperta.
  */

--- a/src/lib/content/changelog/2026-08-29-delegate-chip-dangling-close.ts
+++ b/src/lib/content/changelog/2026-08-29-delegate-chip-dangling-close.ts
@@ -1,0 +1,9 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-08-29',
+  title: 'Sub-agent task indicators can no longer hang',
+  items: [
+    'When a turn recovers from a mid-task failure, a delegated task no longer stays stuck as "running" forever — it is now marked honestly as failed, and the page picks up the correction without a refresh.'
+  ]
+} satisfies ChangelogEntry;


### PR DESCRIPTION
## What?
A kit turn whose session died mid-tool (e.g. during a long `delegate_task`) left the tool chip in `running` forever: the resumed fresh session never re-emits the previous call's result, so the run's final `partial` kept an open chip with no output (production evidence: `agent_kit_runs` row `7bc0f716`, 27/8 — `open_delegate: 1` in the final partial; all other recent runs close normally). Two-layer fix: the server mirror now closes dangling chips as honest errors when its stream ends on its own, and the client snapshot poll can now repair status transitions (previously only additions). Tests first, red → green.

## Why?
Task #66: the user watched a delegate chip load forever while the agent kept working and even replied; only a refresh closed it. The stuck chip is one visible face of the session-death incident (#73/#74 are the reliability halves).

## How?
- `closeDanglingToolCalls` (shared reducer `chat-stream-events.ts`): at stream end with a terminal event seen (`finish` or `error`), any still-`running` chip becomes `error` with an honest message. If the mirror froze because a client went away (no terminal event), state is untouched — open chips may be legitimate, the turn continues server-side.
- `applyLiveSnapshot` now merges tools when `tools.length >= state.tools.length`, so a lost close chunk is repaired by the 350 ms poll; snapshots with fewer tools than the tab knows are still skipped (the list never shrinks).
- Evidence-first diagnosis: production `partial` rows distinguished "mirror never closed the chip" (one run) from "harness never emits results" (all others close) — so the fix targets the mirror lifecycle, not result emission.

## Testing?
- Red first: 3 new tests (dangling close on terminal stream; untouched closed chips; snapshot repairs equal-length status flip; snapshot never drops chips the tab knows). All green after fix.
- Suites re-run: chat-stream-events + chat-live-join (30), delegation, subagent-async, surface-turn (52), thread shell (16) — all green.
- `npm run check`: 292 errors before and after (identical baseline lines in touched files; the known #49 debt).
- NOT tested live: a real kit turn with a killed session (needs the eval harness or a browser e2e). Recommend `npm run eval` before merge per the chat-path rule.

## Evidence (screenshots/videos)
Backend/client logic; no UI surface change beyond chip states. Production query in the changelog file (`changelog/2026-08-29-delegate-chip-dangling-close.md`) shows the stuck row vs closed ones.

## Anything Else?
The stuck-LIVE-tab case (composer blocked until refresh) additionally needs the SSE re-attach repair — that is #68's territory; this PR makes every snapshot-driven surface honest. Companion PR: #81 (same incident family: the lost sub-agent trace writes).