### PR TITLE
Skip Chromium first-run in sandbox

### DIFF
--- a/changelog/2026-08-29-sandbox-browser-first-run.md
+++ b/changelog/2026-08-29-sandbox-browser-first-run.md
@@ -1,0 +1,7 @@
+# Skip Chromium's first-run screen in sandbox browsing
+
+Agents using sandbox browsing could land on Chromium's first-run sign-in screen because the
+shared launch arguments omitted `--no-first-run`.
+
+The flag now belongs to the browser sandbox's shared arguments, covering both visible and
+headless launches. The graphical desktop launcher already had the flag, so it was left unchanged.

--- a/src/lib/content/changelog/2026-08-29-sandbox-browser-first-run.ts
+++ b/src/lib/content/changelog/2026-08-29-sandbox-browser-first-run.ts
@@ -1,0 +1,7 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-08-29',
+  title: "Sandbox browsing skips Chromium's first-run screen",
+  items: ['Sandbox browsing now opens Chromium without the first-run sign-in screen.']
+} satisfies ChangelogEntry;

--- a/src/lib/server/sandbox.test.ts
+++ b/src/lib/server/sandbox.test.ts
@@ -182,6 +182,12 @@ describe('BROWSE_SCRIPT', () => {
     expect(BROWSE_SCRIPT).toContain('browser.close()');
   });
 
+  it('passa --no-first-run agli avvii effettivi di Chromium', () => {
+    expect(BROWSE_SCRIPT).toContain(
+      "const args = ['--no-sandbox', '--disable-dev-shm-usage', '--no-first-run'];"
+    );
+  });
+
   /**
    * Un delegato apriva Chromium in headless mentre l'utente guardava lo schermo della stessa VM:
    * il desktop restava vuoto per tutta la ricerca. Se il display c'è, si naviga a vista.

--- a/src/lib/server/sandbox.ts
+++ b/src/lib/server/sandbox.ts
@@ -307,7 +307,7 @@ const [url, ...rest] = process.argv.slice(2);
 const opts = Object.fromEntries(rest.map((a) => { const i = a.indexOf('='); return i < 0 ? [a, 'true'] : [a.slice(0, i), a.slice(i + 1)]; }));
 if (!url) { console.error('usage: browse.mjs <url> [wait=selector] [screenshot=path] [maxChars=20000]'); process.exit(2); }
 
-const args = ['--no-sandbox', '--disable-dev-shm-usage'];
+const args = ['--no-sandbox', '--disable-dev-shm-usage', '--no-first-run'];
 const onScreen = existsSync('${X_SOCKET}');
 const browser = onScreen
   ? await chromium


### PR DESCRIPTION
## Bug
Agents using sandbox browsing could land on Chromium’s first-run sign-in screen because the browser launch arguments omitted `--no-first-run`.

## Fix
Add `--no-first-run` to the shared `BROWSE_SCRIPT` arguments used by headed and headless Chromium launches. Add a regression assertion against the effective launch arguments and the required internal and public changelogs.

## Tests
- `npx --no-install vitest run src/lib/server/sandbox.test.ts --reporter=verbose` — 43 passed; the new test failed before the fix and passed after it.
- `npx --no-install vitest run packages/agent-adapters/src/graphical-bootstrap.test.ts src/lib/server/sandbox.test.ts src/lib/content/changelog/index.test.ts --reporter=verbose` — 65 passed, 1 known baseline failure in changelog ordering because `2026-08-29-market-collection-paused.ts` uses a local-date string among ISO dates.
- `npm run typecheck:runtime` — passed; the repository reports 252 ignored non-fatal type errors.