### PR TITLE
Show social disconnect progress

### DIFF
--- a/changelog/2026-08-29-social-disconnect-feedback.md
+++ b/changelog/2026-08-29-social-disconnect-feedback.md
@@ -1,0 +1,3 @@
+# Social disconnect feedback
+
+The confirmation form used enhanced submission without an in-flight state, so a slow disconnect looked stuck and could be submitted again. The page now tracks the selected account, disables both confirmation actions, shows the existing localized deletion label, and clears the state even when the action fails. A focused page contract test guards the affordance.

--- a/src/lib/content/changelog/2026-08-29-social-disconnect-feedback.ts
+++ b/src/lib/content/changelog/2026-08-29-social-disconnect-feedback.ts
@@ -1,0 +1,9 @@
+import type { ChangelogEntry } from './index';
+
+const entry: ChangelogEntry = {
+  date: '2026-08-29',
+  title: 'Clearer social account removal',
+  items: ['Removing a social account now shows progress and disables duplicate actions']
+};
+
+export default entry;

--- a/src/routes/app/[brand]/settings/connected-accounts/+page.svelte
+++ b/src/routes/app/[brand]/settings/connected-accounts/+page.svelte
@@ -19,6 +19,7 @@
   let syncForm = $state<HTMLFormElement | null>(null);
   let pendingConnect = $state(false);
   let confirmingDisconnect = $state<string | null>(null);
+  let disconnecting = $state<string | null>(null);
   let syncing = $state(false);
 
   // Coming back from the OAuth tab, the sync runs for a few seconds — say so instead of showing
@@ -28,6 +29,17 @@
     return async ({ update }: { update: () => Promise<void> }) => {
       await update();
       syncing = false;
+    };
+  };
+
+  const withDisconnectSpinner = (id: string) => () => {
+    disconnecting = id;
+    return async ({ update }: { update: () => Promise<void> }) => {
+      try {
+        await update();
+      } finally {
+        disconnecting = null;
+      }
     };
   };
 
@@ -72,10 +84,12 @@
         </div>
         <div class="nm"><div class="h">{a.display_name ?? a.username ?? a.platform}</div><div class="s">{a.platform}{a.username ? ` · @${a.username}` : ''}</div></div>
         {#if confirmingDisconnect === a.id}
-          <form method="POST" action="?/disconnect" use:enhance class="disc-confirm">
+          <form method="POST" action="?/disconnect" use:enhance={withDisconnectSpinner(a.id)} class="disc-confirm" aria-busy={disconnecting === a.id}>
             <input type="hidden" name="id" value={a.id} />
-            <button class="mini danger" type="submit">{$_('app.settings.remove')}</button>
-            <button class="mini ghost" type="button" onclick={() => (confirmingDisconnect = null)}>{$_('app.settings.keep')}</button>
+            <button class="mini danger" type="submit" disabled={disconnecting === a.id}>
+              {disconnecting === a.id ? $_('app.settings.del.deleting') : $_('app.settings.remove')}
+            </button>
+            <button class="mini ghost" type="button" disabled={disconnecting === a.id} onclick={() => (confirmingDisconnect = null)}>{$_('app.settings.keep')}</button>
           </form>
         {:else}
           <span class="status"><span class="d"></span>{$_('app.settings.active')}</span>

--- a/src/routes/app/[brand]/settings/connected-accounts/disconnect-feedback.test.ts
+++ b/src/routes/app/[brand]/settings/connected-accounts/disconnect-feedback.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const page = readFileSync(new URL('./+page.svelte', import.meta.url), 'utf8');
+const disconnectFormStart = page.indexOf('<form method="POST" action="?/disconnect"');
+const disconnectForm = page.slice(disconnectFormStart, page.indexOf('</form>', disconnectFormStart));
+
+describe('connected accounts disconnect feedback', () => {
+  it('keeps the selected removal action visibly pending until the form update completes', () => {
+    expect(page).toContain('let disconnecting = $state<string | null>(null);');
+    expect(disconnectForm).toContain('use:enhance={withDisconnectSpinner(a.id)}');
+    expect(disconnectForm).toContain('disabled={disconnecting === a.id}');
+    expect(disconnectForm).toContain("$_('app.settings.del.deleting')");
+    expect(page).toMatch(
+      /const withDisconnectSpinner = \(id: string\) => \(\) => \{[\s\S]*?disconnecting = id;[\s\S]*?finally \{[\s\S]*?disconnecting = null;/
+    );
+  });
+});


### PR DESCRIPTION
## Bug
Disconnecting a social account gave no progress signal, so the Remove button looked stuck during a slow request.

## Fix
Track the selected account while its enhanced disconnect form is pending. Disable Remove and Keep, mark the form busy, show the localized “Deleting…” label, and clear the state in `finally`. Add the required internal and public changelogs plus a focused regression test.

## Tests
- `npx --no-install vitest run 'src/routes/app/[brand]/settings/connected-accounts/disconnect-feedback.test.ts' --reporter=verbose` — red before the fix, green after\n- Focused UI, connector, changelog, and locale selection — 4 passed, 1 skipped\n- `npm run check` — repository baseline failure: 292 pre-existing errors and 245 warnings in 166 files; no diagnostics reported for the changed page\n- `git diff --check` — passed