### PR TITLE
Recover from malformed session cookies

### DIFF
--- a/changelog/2026-08-29-malformed-session-cookie-recovery.md
+++ b/changelog/2026-08-29-malformed-session-cookie-recovery.md
@@ -1,0 +1,7 @@
+# Recupero dai cookie di sessione corrotti
+
+Prima, un cookie auth con Base64-URL non valido faceva fallire la recovery Supabase e poteva
+terminare il dev server.
+
+Ora il cookie auth corrotto viene ignorato insieme ai suoi chunk e la richiesta prosegue come
+anonima. I cookie validi restano invariati.

--- a/src/hooks.server.test.ts
+++ b/src/hooks.server.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('$env/static/public', () => ({
+	PUBLIC_SUPABASE_URL: 'http://localhost:8000',
+	PUBLIC_SUPABASE_ANON_KEY: 'anon-key'
+}));
+
+vi.mock('$env/dynamic/private', () => ({ env: {} }));
+
+vi.mock('@sentry/sveltekit', () => ({
+	sentryHandle: () => ({ event, resolve }: { event: unknown; resolve: (event: unknown) => unknown }) =>
+		resolve(event),
+	handleErrorWithSentry: () => () => undefined
+}));
+
+vi.mock('@sveltejs/kit/hooks', () => ({
+	sequence: (...handlers: Array<(input: { event: any; resolve: any }) => any>) =>
+		({ event, resolve }: { event: any; resolve: any }) => {
+			const run = (index: number, nextEvent: any): any => {
+				if (index === handlers.length) return resolve(nextEvent);
+				return handlers[index]({
+					event: nextEvent,
+					resolve: (resolvedEvent: any) => run(index + 1, resolvedEvent)
+				});
+			};
+
+			return run(0, event);
+		}
+}));
+
+const { handle } = await import('./hooks.server');
+
+describe('server session recovery', () => {
+	it('serves the request when the session cookie is invalid Base64-URL', async () => {
+		const response = await handle({
+			event: {
+				request: new Request('http://localhost/status'),
+				url: new URL('http://localhost/status'),
+				route: { id: '/status' },
+				params: {},
+				cookies: {
+					getAll: () => [{ name: 'sb-localhost-auth-token', value: 'base64-*' }],
+					get: () => undefined,
+					set: vi.fn()
+				},
+				locals: {}
+			},
+			resolve: async (event: any) => {
+				expect(await event.locals.safeGetSession()).toEqual({ session: null, user: null });
+				return new Response('ok');
+			}
+		} as any);
+
+		expect(response.status).toBe(200);
+	});
+});

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -13,6 +13,25 @@ import { marketingShellTarget } from '$lib/server/marketing-shell';
 
 type CookieToSet = { name: string; value: string; options: CookieOptions };
 
+const SESSION_COOKIE_NAME = `sb-${new URL(PUBLIC_SUPABASE_URL).hostname.split('.')[0]}-auth-token`;
+const SESSION_COOKIE_PREFIX = `${SESSION_COOKIE_NAME}.`;
+const BASE64_COOKIE_PREFIX = 'base64-';
+const BASE64_URL = /^[A-Za-z0-9_-]*$/;
+
+function isSessionCookie(name: string): boolean {
+  return name === SESSION_COOKIE_NAME || name.startsWith(SESSION_COOKIE_PREFIX);
+}
+
+function isValidSessionCookie(cookie: { name: string; value: string }): boolean {
+  if (!isSessionCookie(cookie.name) || !cookie.value.startsWith(BASE64_COOKIE_PREFIX)) return true;
+  return BASE64_URL.test(cookie.value.slice(BASE64_COOKIE_PREFIX.length));
+}
+
+function validSessionCookies(cookies: { name: string; value: string }[]) {
+  if (cookies.every(isValidSessionCookie)) return cookies;
+  return cookies.filter(({ name }) => !isSessionCookie(name));
+}
+
 // slug → brand id for the AI-credits brand context. Slugs are stable, so a per-instance cache
 // with a 10-min TTL amortises the lookup to ~once per brand per instance.
 // ponytail: in-memory Map; move to Redis only if instance churn ever makes the hit rate matter.
@@ -48,7 +67,7 @@ export const handle: Handle = sequence(csrf, Sentry.sentryHandle(), async ({ eve
   // Per-request Supabase client bound to the request cookies (SSR auth).
   event.locals.supabase = createServerClient(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY, {
     cookies: {
-      getAll: () => event.cookies.getAll(),
+      getAll: () => validSessionCookies(event.cookies.getAll()),
       setAll: (cookiesToSet: CookieToSet[]) => {
         cookiesToSet.forEach(({ name, value, options }) => {
           try {

--- a/src/lib/content/changelog/2026-08-29-malformed-session-cookie-recovery.ts
+++ b/src/lib/content/changelog/2026-08-29-malformed-session-cookie-recovery.ts
@@ -1,0 +1,7 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-08-29',
+  title: 'Corrupted sessions no longer stop the app',
+  items: ['A malformed session cookie now falls back to a signed-out state instead of taking down the server.']
+} satisfies ChangelogEntry;


### PR DESCRIPTION
## Bug
A corrupted Supabase session cookie containing an invalid Base64-URL character could trigger an unhandled rejection during session recovery and terminate the dev server.

## Fix
Validate Base64-URL session cookies at the SSR boundary and discard invalid auth cookies with their chunks. Requests continue as signed out; valid cookies are unchanged. Added a focused request-level regression test and both changelog entries.

## Tests
- `npx --no-install vitest run src/hooks.server.test.ts --reporter=verbose` — passed; the pre-fix regression test failed with `Invalid Base64-URL character` and unhandled rejections.
- `npm run typecheck:runtime` — passed; 273 known non-fatal type errors ignored.
- `npm run check` — failed on the repository baseline (313 errors, including unrelated files; the worktree lacked `.env`).
- `src/lib/content/changelog/index.test.ts` — failed on a pre-existing mixed date-format ordering defect (`market-collection-paused` before `llm-only-chat`).