### PR TITLE
Guard Motion reference video input

### DIFF
--- a/changelog/2026-08-29-motion-reference-video-capability.md
+++ b/changelog/2026-08-29-motion-reference-video-capability.md
@@ -1,0 +1,9 @@
+# Motion reference video capability
+
+Motion reference study always forwarded a prepared MP4 to the configured reviewer model. An explicit
+reviewer setting could point to a text-only model, which rejected the request after the video had
+already crossed the model boundary.
+
+The study now sends the MP4 only to Google Gemini models. Other models receive the extracted stills
+and an explicit prompt that timing must not be inferred from unseen video. A hard failure was
+rejected because stills still provide a useful structural study.

--- a/src/lib/content/changelog/2026-08-29-motion-reference-video-capability.ts
+++ b/src/lib/content/changelog/2026-08-29-motion-reference-video-capability.ts
@@ -1,0 +1,9 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-08-29',
+  title: 'Motion references respect video support',
+  items: [
+    'Motion reference studies send full clips only to models that support video; other models receive extracted stills with a clear limitation.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/motion-references.ts
+++ b/src/lib/server/motion-references.ts
@@ -30,7 +30,7 @@
 import { swallow } from '$lib/server/swallow';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { getBrandContext } from '$lib/server/ai-log';
-import { llmConfigured, llmStructured, llmVideoReviewerModel } from '$lib/server/llm';
+import { isGoogleGeminiModel, llmConfigured, llmStructured, llmVideoReviewerModel } from '$lib/server/llm';
 import { createAdminClient } from '$lib/server/supabase-admin';
 import { fetchVideoBytes, prepareReviewMedia } from '$lib/server/video-fetch';
 import {
@@ -309,6 +309,7 @@ const SPEC_SCHEMA = {
 
 function studyPrompt(opts: {
   medium: 'video' | 'still';
+  videoAttached: boolean;
   brandName?: string | null;
   language?: string | null;
   ref: MotionReferenceCard;
@@ -320,7 +321,9 @@ function studyPrompt(opts: {
     : 'The engineer reading this is about to build a different piece for another brand.';
   const watch =
     opts.medium === 'video'
-      ? `MEDIA: stills from the scene changes plus the clip itself (~${opts.duration.toFixed(1)}s). Watch it in order and time the beats.`
+      ? opts.videoAttached
+        ? `MEDIA: stills from the scene changes plus the clip itself (~${opts.duration.toFixed(1)}s). Watch it in order and time the beats.`
+        : 'MEDIA: extracted stills only — the selected model cannot receive video input. Describe the visible structure without inventing unseen timing.'
       : 'MEDIA: a single still — this post does not move. Describe the composition as one beat and say what a motion version of it would animate.';
 
   return `You are a motion-design director breaking down a reference so someone else can build their own piece with the same STRUCTURE.
@@ -601,6 +604,9 @@ export async function studyMotionReference(opts: {
   if (opts.abortSignal?.aborted) return { ok: false, error: 'aborted' };
   if (!media) return { ok: false, error: 'media_unavailable' };
 
+  const reviewerModel = llmVideoReviewerModel();
+  const videoAttached = !!media.clipMp4 && isGoogleGeminiModel(reviewerModel);
+
   const frameNote = media.frames.map((f, i) => `${i + 1}. ${f.label || `frame ${i + 1}`}`).join('\n');
 
   try {
@@ -608,6 +614,7 @@ export async function studyMotionReference(opts: {
     const prompt = [
       studyPrompt({
         medium: media.medium,
+        videoAttached,
         brandName: opts.brandName,
         language: opts.language,
         ref,
@@ -622,8 +629,8 @@ export async function studyMotionReference(opts: {
       prompt,
       schema: SPEC_SCHEMA,
       images: media.frames.map((f) => ({ mediaType: f.mimeType, data: f.data })),
-      file: media.clipMp4 ? { mediaType: 'video/mp4', data: media.clipMp4 } : undefined,
-      model: llmVideoReviewerModel(),
+      ...(videoAttached ? { file: { mediaType: 'video/mp4', data: media.clipMp4! } } : {}),
+      model: reviewerModel,
       label: 'motion.reference_study'
     })) as AnyRec | null;
     if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return { ok: false, error: 'model_parse_failed' };

--- a/src/lib/server/motion-references.video.test.ts
+++ b/src/lib/server/motion-references.video.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const M = vi.hoisted(() => ({
+	llmStructured: vi.fn(async () => ({
+		format: 'launch clip',
+		duration_s: 4,
+		beats: [],
+		transitions: [],
+		easing: '',
+		type_density: '',
+		palette: '',
+		logo_role: '',
+		ui_elements: [],
+		sound_off: '',
+		adapt: [],
+		summary: 'A launch clip.'
+	})),
+	llmVideoReviewerModel: vi.fn(() => 'anthropic/claude-sonnet-4'),
+	fetchVideoBytes: vi.fn(async () => Buffer.from('source-video')),
+	prepareReviewMedia: vi.fn(async () => ({
+		duration: 4,
+		videoMp4: Buffer.from('compact-video'),
+		frames: [{ mimeType: 'image/jpeg', data: 'frame', label: 'frame 1' }]
+	})),
+	loadPostsDesignIndex: vi.fn(async () => [ENTRY]),
+	loadPostsDesignDetail: vi.fn(async () => DETAIL)
+}));
+
+const ENTRY = {
+	id: 'video-reference',
+	slug: 'video-reference',
+	url: 'https://posts.design/video-reference',
+	platform: 'x',
+	handleSlug: null,
+	externalId: null,
+	capturedAt: null,
+	words: 'video reference'
+};
+
+const DETAIL = {
+	...ENTRY,
+	title: 'Video reference',
+	brand: 'Reference brand',
+	handle: null,
+	category: 'launch',
+	styleTags: [],
+	hasVideo: true,
+	text: null,
+	sourceUrl: null,
+	videoUrl: 'https://cdn.example.com/reference.mp4',
+	imageUrl: null
+};
+
+vi.mock('$lib/server/ai-log', () => ({ getBrandContext: () => null }));
+vi.mock('$lib/server/llm', () => ({
+	llmConfigured: () => true,
+	llmStructured: M.llmStructured,
+	llmVideoReviewerModel: M.llmVideoReviewerModel,
+	isGoogleGeminiModel: (id: string | undefined) => /^google\/gemini-/.test(id ?? '')
+}));
+vi.mock('$lib/server/posts-design', () => ({
+	isPostsDesignEnabled: () => true,
+	loadPostsDesignIndex: M.loadPostsDesignIndex,
+	loadPostsDesignDetail: M.loadPostsDesignDetail
+}));
+vi.mock('$lib/server/video-fetch', () => ({
+	fetchVideoBytes: M.fetchVideoBytes,
+	prepareReviewMedia: M.prepareReviewMedia
+}));
+vi.mock('$lib/server/supabase-admin', () => ({
+	createAdminClient: () => {
+		throw new Error('no database in unit test');
+	}
+}));
+
+const { studyMotionReference } = await import('./motion-references');
+
+describe('studyMotionReference video capability', () => {
+	beforeEach(() => {
+		M.llmStructured.mockClear();
+		M.llmVideoReviewerModel.mockReset();
+		M.llmVideoReviewerModel.mockReturnValue('anthropic/claude-sonnet-4');
+	});
+
+	it('keeps the MP4 out of a reviewer model without video input', async () => {
+		const result = await studyMotionReference({ idOrSlug: ENTRY.id });
+		const call = M.llmStructured.mock.calls[0]?.[0];
+
+		expect(result.ok).toBe(true);
+		expect(call).toMatchObject({
+			model: 'anthropic/claude-sonnet-4',
+			images: [{ mediaType: 'image/jpeg', data: 'frame' }]
+		});
+		expect(call.file).toBeUndefined();
+		expect(call.prompt).toContain('stills only');
+	});
+
+	it('passes the MP4 to a Gemini reviewer that supports video input', async () => {
+		M.llmVideoReviewerModel.mockReturnValue('google/gemini-2.5-flash');
+
+		await studyMotionReference({ idOrSlug: ENTRY.id });
+		const call = M.llmStructured.mock.calls[0]?.[0];
+
+		expect(call).toMatchObject({
+			model: 'google/gemini-2.5-flash',
+			file: { mediaType: 'video/mp4', data: Buffer.from('compact-video').toString('base64') }
+		});
+		expect(call.prompt).toContain('FULL CLIP is attached');
+	});
+});


### PR DESCRIPTION
## Bug
Motion reference study sent a prepared MP4 to any explicit reviewer model, including text-only models.

## Fix
Gate the MP4 on the existing Google Gemini video-capability check. Models without video input receive extracted stills and an explicit prompt not to infer unseen timing; Gemini reviewers retain the full clip. Added the required internal and public changelog entries.

## Tests
- `npx --no-install vitest run src/lib/server/motion-references.video.test.ts src/lib/server/motion-references.test.ts src/lib/server/motion-video/reference-tools.test.ts src/lib/server/motion-video/reference-tools.watch.test.ts src/lib/server/llm.test.ts --reporter=verbose` — 5 files, 42 passed
- `npm run typecheck:runtime` — passed; 257 baseline type errors ignored
- `npm run check` — pre-existing baseline failure: 297 errors and 245 warnings in 167 files; none reported in the changed Motion files
- Public changelog test — existing mixed-date ordering failure; entry-shape test passed