### PR TITLE
Wire agent chat durability guards

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,6 +70,7 @@ LLM_MODELS=google/gemini-2.5-flash,google/gemini-2.5-pro
 EMBEDDING_MODEL=google/gemini-embedding-001
 # AGENT_KIT è sperimentale e SPENTO di default (accendilo con AGENT_KIT=on). La chat, col kit
 # o senza, parla solo col centralino LLM_*; KIE_API_KEY serve a immagini, clip, voce e probe GEO.
+# CHAT_ACTION_JUDGE=off          # auto-review consequential kit actions before execution
 # Quanto ragionano i giudici Gemini (video review, QC immagini, caption panel, prepublish, motion):
 # low | medium | high. Default high. Dalla 3.x Gemini prende un LIVELLO, non un tetto di token —
 # GEMINI_JUDGE_THINKING_BUDGET e PREPUBLISH_THINKING_BUDGET non arrivano più all'API.

--- a/changelog/2026-08-29-hitl-judge.md
+++ b/changelog/2026-08-29-hitl-judge.md
@@ -12,5 +12,7 @@ dalla stessa decisione binaria e non c'era un punto comune per l'auto-review.
 - Il percorso di default diventa `judge` solo per azioni conseguenziali con auto-review e checker.
 - Un checker che fallisce restituisce `ask` per un'azione conseguenziale; l'executor non viene
   chiamato.
+- Il bridge live e il worker in coda costruiscono il checker sullo stesso transcript; il flag
+  `CHAT_ACTION_JUDGE=on` abilita il controllo senza duplicare la classificazione.
 - Il gate vive nel kit e la traduzione verso l'AI SDK resta nell'adapter, senza una seconda
   classificazione nei plugin.

--- a/changelog/2026-08-29-ledger-effects-idempotent.md
+++ b/changelog/2026-08-29-ledger-effects-idempotent.md
@@ -18,29 +18,33 @@ promuoveva il partial salvato, ma nessuno dei due sapeva dire "questo effetto è
 ## La decisione
 
 Portare il pattern `ExternalEffect` di Rakazo: una tabella `agent_kit_effects` (migration
-`20260829130000`) con una riga per effetto, `idempotency_key` deterministica e una macchina a
-stati `intended -> completed|failed`, coi ripieghi `ambiguous` (segmento morto a metà) e
-`reconciled` (confermato fuori). Le scelte che contano:
+`20260829130000`) con una riga per effetto e una macchina a stati
+`intended -> completed|failed`, coi ripieghi `ambiguous` (segmento morto a metà) e
+`reconciled` (confermato fuori). La PR successiva sull’identità stabile ha sostituito la chiave
+`tool+args` con `invocation_id` (`toolCallId`): due richieste distinte con lo stesso payload restano
+distinte, mentre il resume deve conservare lo stesso id.
 
-- **La chiave contiene brand + nome tool + args canonicalizzati, NON il run_id.** Così
-  l'idempotenza riconosce la stessa intenzione attraverso un resume (che riparte da zero) e un
-  takeover, non solo alla ripresa dello stesso run. Order-insensitive (chiavi ordinate), e la
-  lunghezza del payload è codificata nella chiave per evitare collisioni da troncamento. L'hash
-  è FNV-1a a 64 bit: la chiave è un indice, non un segreto, e niente `crypto` asincrona.
+- **L’identità di una chiamata è il `toolCallId`, NON il `run_id`.** Così il claim atomico
+  protegge la stessa chiamata se il run cambia, senza bloccare due richieste legittime con lo
+  stesso payload. La vecchia `idempotency_key` resta solo per leggere le righe create dalla PR
+  precedente; se un resume produce un nuovo `toolCallId`, il ledger non può riconoscerlo.
 - **Il gate vive in `createApplyTool`, non nei singoli plugin.** È l'unico punto che esegue i
   tool; un tool dichiara `effectful: true` nel proprio `ToolSpec` e il gate lo avvolge — `intend`
   prima di eseguire, `resolve` dopo. I plugin (content, motion, ugc) non riscrivono la regola:
   la marcano. `buildTools` non cambia: il gate è sotto l'executor, il modello vede solo il
   catalogo di sempre.
+- Le eccezioni catturate dal bridge dei tool diventano `ambiguous`, così un possibile side effect
+  non torna automaticamente rieseguibile come un semplice fallimento dichiarato dal tool.
 - **`decide()` è puro e testato.** `null` e `failed` rieseguono (nessun esito, o esito negativo:
-  non è un doppione); `completed`/`ambiguous`/`reconciled` congelano. `intended` è il caso "il
-  run corrente è il primo autore" (il segmento è vivo): decide() lo lascia riprovare, perché
-  congelarlo bloccherebbe l'unico tentativo vero.
+  non è un doppione); `intended`/`completed`/`ambiguous`/`reconciled` congelano. Un `intended`
+  viene sbloccato solo da un esito esplicito o da `reconcileRun`: senza lease non si può sapere
+  se un secondo worker sia il proprietario vivo del claim, quindi il default è fail-closed.
 - **`reconcileRun` tira gli orfani a `ambiguous`.** Chiamato dallo sweep alla morte di un run:
-  gli `intended` rimasti soli diventano `ambiguous`, e il gate li congelatile. Solo `intended` è
+  gli `intended` rimasti soli diventano `ambiguous`, e il gate li congela. Solo `intended` è
   toccato: un `completed` è un esito vero.
-- **Il port è nel contratto (`EffectsLedger`), l'implementazione in `effects-store.ts`, la logica
-  in `effects.ts`.** L'executor dipende dall'interfaccia, la superficie (`live.ts`) passa
+- **Il port è nel contratto (`EffectsLedger`), l'implementazione nell'adapter app
+  `agent-kit-effects-store.ts`, la logica in `effects.ts`.** L'executor dipende dall'interfaccia,
+  la superficie (`live.ts`) passa
   l'implementazione col client admin. Il lab e i test senza ledger non cambiano comportamento.
 
 Scartato: chiave per-run (non sopravvive a resume/takeover, che è il caso che il spec nomina);
@@ -49,9 +53,9 @@ sapere se l'effetto è davvero avvenuto, che è dominio del tool — oggi resta 
 
 ## Cosa guarda il test
 
-- `effects.test.ts`: la macchina a stati di `decide`, e che `effectKey` è deterministica e
+- `effects.test.ts`: la chiave legacy è deterministica e
   order-insensitive e non collida tra intenzioni diverse.
-- `effects-store.test.ts`: `intend`/`find`/`resolve`/`reconcileRun` su un finto client che
+- `agent-kit-effects-store.test.ts`: claim/resolve/reconcile su un finto client che
   applica i filtri per davvero (il compare-and-swap si verifica col codice di produzione).
 - `executor.test.ts`: il gate — abort → resume con la stessa intenzione esegue UNA volta;
   un `ambiguous` non viene rieseguito nemmeno su un run nuovo; `failed` riesegue; solo i tool

--- a/changelog/2026-08-29-stable-tool-call-identity.md
+++ b/changelog/2026-08-29-stable-tool-call-identity.md
@@ -1,0 +1,23 @@
+# Identità stabile per le chiamate tool
+
+Il ledger introdotto dalla PR #70 usava tool e argomenti come identità. Questo proteggeva i resume,
+ma impediva due richieste legittime con lo stesso payload.
+
+Ora l'executor usa il `toolCallId` del runtime come identità stabile: il runtime lo persiste nella
+storia e nei partial, mentre `agent_kit_effects.invocation_id` lo rende unico per brand. Gli
+argomenti restano il payload registrato e vengono confrontati per rifiutare il riuso della stessa
+identità con dati diversi.
+
+Il claim è atomico nel database. Un solo worker può eseguire; un claim già `completed`, `ambiguous`
+o `reconciled` non riparte; un `failed` può essere reclamato. Le righe vecchie restano leggibili:
+la vecchia chiave vale solo per il run che le aveva create, così un run nuovo non collassa con un
+effetto legacy.
+
+`invocation_id` non dipende da `run_id`, sequenza degli eventi, lease, fence o attempt: questi
+restano metadati di orchestrazione e possono evolvere senza cambiare l'identità della chiamata.
+
+La migration `20260829180000_agent_kit_effect_identity.sql` va applicata manualmente: i deploy del
+repo non eseguono le migration.
+
+Le righe legacy senza `run_id` o senza un `toolCallId` rigiocabile non sono correlabili a una nuova
+identità; richiedono riconciliazione manuale prima di un retry.

--- a/changelog/2026-08-30-durable-chat-resume.md
+++ b/changelog/2026-08-30-durable-chat-resume.md
@@ -1,0 +1,19 @@
+# Durable chat resume
+
+## Perché
+
+Un refresh o la chiusura della tab potevano lasciare il transcript e lo stato del turno su
+percorsi separati. Le nuove feature dovevano essere verificabili nella chat reale, non solo nel
+runtime isolato.
+
+## Decisioni
+
+- `thread_events` è append-only, sequenziato per thread e idempotente per `source_key`.
+- I messaggi finali entrano nel log tramite trigger nella stessa transazione dell'inserimento; il
+  reader usa un reducer unico e torna al percorso legacy se trova un log incompleto.
+- Le richieste HITL `ask` salvano input redatto per la UI, continuation state e messaggio assistant
+  in una sola RPC.
+- Il resume verifica run, approval id e tool call id; una seconda decisione identica non rilancia
+  un turno già ripreso.
+- Il judge può autorizzare automaticamente il default consequential; `ask` e gli errori restano
+  fail-closed e attendono una persona.

--- a/packages/agent-adapters/src/runtime/ai-runtime.approval.test.ts
+++ b/packages/agent-adapters/src/runtime/ai-runtime.approval.test.ts
@@ -7,6 +7,7 @@ const context: AdapterContext = { brandId: 'b1', userId: 'u1', runId: 'r1', loca
 const CONSEQUENT: ToolSpec = {
 	name: 'publish',
 	description: 'publish',
+	effectful: true,
 	inputSchema: { type: 'object' },
 	consequential: true
 };
@@ -14,6 +15,7 @@ const CONSEQUENT: ToolSpec = {
 const READ: ToolSpec = {
 	name: 'read',
 	description: 'read',
+	effectful: false,
 	consequential: false,
 	inputSchema: { type: 'object' }
 };
@@ -26,6 +28,19 @@ describe('buildTools — action approval', () => {
 		const tools = buildTools([CONSEQUENT], execute, context, {
 			autoReviewEnabled: true,
 			checker: async () => 'error'
+		});
+
+		const result = await (tools.publish.execute as (input: Record<string, unknown>) => Promise<ToolResult>)({});
+
+		expect(execute).not.toHaveBeenCalled();
+		expect(result.isError).toBe(true);
+	});
+
+	it('fails closed when the judge asks for a person before a consequential tool executes', async () => {
+		const execute = vi.fn(async () => ok);
+		const tools = buildTools([CONSEQUENT], execute, context, {
+			autoReviewEnabled: true,
+			checker: async () => 'ask'
 		});
 
 		const result = await (tools.publish.execute as (input: Record<string, unknown>) => Promise<ToolResult>)({});

--- a/packages/agent-adapters/src/runtime/ai-runtime.approval.test.ts
+++ b/packages/agent-adapters/src/runtime/ai-runtime.approval.test.ts
@@ -81,5 +81,16 @@ describe('buildTools — action approval', () => {
 
 		expect(tools.publish.needsApproval).toBeTypeOf('function');
 		expect(tools.read.needsApproval).toBeTypeOf('function');
-});
+	});
+
+	it('does not rerun the judge for a tool approved by the native harness flow', async () => {
+		const execute = vi.fn(async () => ok);
+		const checker = vi.fn(async () => 'error' as const);
+		const tools = buildTools([CONSEQUENT], execute, context, { autoReviewEnabled: true, checker }, new Set(['publish-1']));
+
+		await (tools.publish.execute as (input: Record<string, unknown>, options: { toolCallId: string }) => Promise<ToolResult>)({}, { toolCallId: 'publish-1' });
+
+		expect(checker).not.toHaveBeenCalled();
+		expect(execute).toHaveBeenCalledOnce();
+	});
 });

--- a/packages/agent-adapters/src/runtime/ai-runtime.test.ts
+++ b/packages/agent-adapters/src/runtime/ai-runtime.test.ts
@@ -7,6 +7,7 @@ const ctx: AdapterContext = { brandId: 'b1', userId: 'u1', runId: 'run-1', local
 const BURN_TOOL: ToolSpec = {
 	name: 'burn',
 	description: 'brucia token',
+	effectful: false,
 	consequential: false,
 	inputSchema: { type: 'object', properties: {}, additionalProperties: false }
 };
@@ -14,6 +15,7 @@ const BURN_TOOL: ToolSpec = {
 const REPLY_TOOL: ToolSpec = {
 	name: 'reply',
 	description: 'chiude il turno',
+	effectful: false,
 	consequential: false,
 	inputSchema: { type: 'object', properties: { message: { type: 'string' } }, required: ['message'] },
 	terminal: true

--- a/packages/agent-adapters/src/runtime/ai-runtime.ts
+++ b/packages/agent-adapters/src/runtime/ai-runtime.ts
@@ -33,7 +33,8 @@ export function buildTools(
 	specs: ToolSpec[],
 	execToolCall: ExecToolCall,
 	context: AdapterContext,
-	approval?: ActionApprovalConfig
+	approval?: ActionApprovalConfig,
+	approvedToolCallIds: ReadonlySet<string> = new Set()
 ): ToolSet {
 	const tools: ToolSet = {};
 	for (const spec of specs) {
@@ -55,7 +56,7 @@ export function buildTools(
 				args: input ?? {},
 				...(options?.toolCallId ? { id: options.toolCallId } : {})
 			};
-			if (approval) {
+			if (approval && !approvedToolCallIds.has(call.id ?? '')) {
 				const cached = options?.toolCallId ? approvalResults.get(options.toolCallId) : undefined;
 				if (options?.toolCallId) approvalResults.delete(options.toolCallId);
 				const gate = cached ?? (await gateAction({ spec, call, context, config: approval }));

--- a/packages/agent-adapters/src/runtime/harness-runtime.test.ts
+++ b/packages/agent-adapters/src/runtime/harness-runtime.test.ts
@@ -96,6 +96,7 @@ describe('HarnessRuntime', () => {
 		expect(events.some((e) => e.type === 'text' && e.text === 'ciao')).toBe(true);
 		const call = events.find((e) => e.type === 'tool_call');
 		expect(call && call.type === 'tool_call' && call.call.name).toBe('publish_post');
+		expect(call && call.type === 'tool_call' && call.call.id).toBe('t1');
 		const done = events.at(-1);
 		expect(done).toMatchObject({ type: 'done', reason: 'completed' });
 		expect(seen.sessionId).toBe('r1');

--- a/packages/agent-adapters/src/runtime/harness-runtime.test.ts
+++ b/packages/agent-adapters/src/runtime/harness-runtime.test.ts
@@ -7,6 +7,7 @@ const ctx: AdapterContext = { brandId: 'b1', userId: 'u1', runId: 'r1', locale: 
 const spec: ToolSpec = {
 	name: 'publish_post',
 	description: 'publish',
+	effectful: true,
 	consequential: true,
 	inputSchema: { type: 'object', properties: {} }
 };

--- a/packages/agent-adapters/src/runtime/harness-runtime.ts
+++ b/packages/agent-adapters/src/runtime/harness-runtime.ts
@@ -100,7 +100,11 @@ function toRunEvent(part: StreamPart): RunEvent | null {
 			return {
 				type: 'tool_call',
 				id: part.toolCallId ?? '',
-				call: { name: part.toolName ?? '', args: (part.input ?? {}) as Record<string, unknown> }
+				call: {
+					name: part.toolName ?? '',
+					args: (part.input ?? {}) as Record<string, unknown>,
+					...(part.toolCallId ? { id: part.toolCallId } : {})
+				}
 			};
 		case 'tool-result':
 			return {

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -10,7 +10,6 @@
     "./computer": "./src/computer.ts",
     "./memory-context": "./src/memory-context.ts",
     "./effects": "./src/effects.ts",
-    "./effects-store": "./src/effects-store.ts",
     "./tools/builtin": "./src/tools/builtin.ts"
   },
   "dependencies": {

--- a/packages/agent-core/src/effects-store.test.ts
+++ b/packages/agent-core/src/effects-store.test.ts
@@ -4,152 +4,195 @@ import { createEffectsLedger, effectKey } from './effects-store';
 
 type Row = Record<string, unknown>;
 
-/** Il finto client parla con una tabella in memoria, applicando i filtri `eq` per davvero. */
 function fakeDb(seed: Row[] = []) {
-	const rows: Row[] = seed.map((r) => ({ ...r }));
+	const rows: Row[] = seed.map((row) => ({ ...row }));
 
 	function from(_table: string) {
 		let op: 'select' | 'insert' | 'update' = 'select';
 		let payload: Row | undefined;
-		const eqFilters: Array<[string, unknown]> = [];
-		let insertId = `e-${rows.length + 1}`;
+		const filters: Array<[string, unknown]> = [];
+		const nullFilters: Array<[string, unknown]> = [];
 
-		function apply(): { data: Row[] | null; error: { message: string } | null } {
-			let matched = rows;
-			for (const [col, val] of eqFilters) matched = matched.filter((r) => r[col] === val);
+		function apply(): { data: Row[] | null; error: { code?: string; message: string } | null } {
+			let matched = rows.filter((row) => filters.every(([column, value]) => row[column] === value));
+			matched = matched.filter((row) => nullFilters.every(([column, value]) => (row[column] ?? null) === value));
 			if (op === 'insert' && payload) {
+				if (
+					payload.invocation_id != null &&
+					rows.some((row) => row.brand_id === payload?.brand_id && row.invocation_id === payload?.invocation_id)
+				) {
+					return { data: null, error: { code: '23505', message: 'duplicate key' } };
+				}
 				const row: Row = {
-					...payload,
-					id: insertId,
+					id: `e-${rows.length + 1}`,
 					created_at: '2026-08-29T00:00:00.000Z',
-					updated_at: '2026-08-01T00:00:00.000Z'
+					updated_at: '2026-08-29T00:00:00.000Z',
+					...payload
 				};
 				rows.push(row);
 				return { data: [row], error: null };
 			}
 			if (op === 'update' && payload) {
-				for (const r of matched) Object.assign(r, payload);
+				for (const row of matched) Object.assign(row, payload);
 				return { data: matched, error: null };
 			}
 			return { data: matched, error: null };
 		}
 
-		const b: Record<string, unknown> = {
-			insert(p: Row) {
+		const builder: Record<string, unknown> = {
+			insert(value: Row) {
 				op = 'insert';
-				payload = p;
-				return b;
+				payload = value;
+				return builder;
 			},
-			update(p: Row) {
+			update(value: Row) {
 				op = 'update';
-				payload = p;
-				return b;
+				payload = value;
+				return builder;
 			},
-			select(_cols?: string) {
-				return b;
+			select() {
+				return builder;
 			},
-			eq(col: string, val: unknown) {
-				eqFilters.push([col, val]);
-				return b;
+			eq(column: string, value: unknown) {
+				filters.push([column, value]);
+				return builder;
 			},
-			single() {
-				const { data, error } = apply();
-				if (error) return Promise.resolve({ data: null, error });
-				if (!data || data.length !== 1) return Promise.resolve({ data: null, error: { message: 'not exactly one row' } });
-				return Promise.resolve({ data: data[0], error: null });
+			is(column: string, value: unknown) {
+				nullFilters.push([column, value]);
+				return builder;
 			},
 			maybeSingle() {
-				const { data, error } = apply();
-				return Promise.resolve({ data: data?.[0] ?? null, error });
+				const result = apply();
+				return Promise.resolve({ data: result.data?.[0] ?? null, error: result.error });
 			},
-			then(resolve: (v: unknown) => void, reject?: (e: unknown) => void) {
+			then(resolve: (value: unknown) => void, reject?: (error: unknown) => void) {
 				return Promise.resolve(apply()).then(resolve, reject);
 			}
 		};
-		return b;
+		return builder;
 	}
 
 	return { db: { from } as unknown as SupabaseClient, rows };
 }
+
+const RECORD = {
+	brandId: 'b1',
+	runId: 'r1',
+	invocationId: 'call-1',
+	toolName: 'content_schedule',
+	request: { post_id: 'p1' }
+};
 
 const ROW = (over: Row = {}): Row => ({
 	id: 'e-1',
 	brand_id: 'b1',
 	run_id: 'r1',
 	tool_name: 'content_schedule',
-	idempotency_key: 'k1',
+	invocation_id: 'call-1',
+	idempotency_key: null,
 	status: 'intended',
+	request: { post_id: 'p1' },
+	result: null,
 	created_at: '2026-08-29T00:00:00.000Z',
 	updated_at: '2026-08-29T00:00:00.000Z',
 	...over
 });
 
-describe('createEffectsLedger — intend', () => {
-	it('registra intended col request e mappa la riga nel ToolEffect', async () => {
+describe('createEffectsLedger — claim', () => {
+	it('registra l’identità stabile e il payload prima dell’esecuzione', async () => {
+		const { db } = fakeDb();
+		const claim = await createEffectsLedger(db).claim(RECORD);
+
+		expect(claim.kind).toBe('claimed');
+		expect(claim.effect.invocationId).toBe('call-1');
+		expect(claim.effect.request).toEqual({ post_id: 'p1' });
+	});
+
+	it('due claim concorrenti della stessa identità ne autorizzano uno solo', async () => {
 		const { db } = fakeDb();
 		const ledger = createEffectsLedger(db);
-		const effect = await ledger.intend({ brandId: 'b1', runId: 'r1', toolName: 'content_schedule', key: 'k1', request: { post_id: 'p1' } });
-		expect(effect.status).toBe('intended');
-		expect(effect.brandId).toBe('b1');
-		expect(effect.runId).toBe('r1');
-		expect(effect.idempotencyKey).toBe('k1');
-		expect(effect.request).toEqual({ post_id: 'p1' });
-	});
-});
+		const claims = await Promise.all([ledger.claim(RECORD), ledger.claim({ ...RECORD, runId: 'r2' })]);
 
-describe('createEffectsLedger — find', () => {
-	it('la stessa chiave di brand torna la riga esistente', async () => {
-		const { db } = fakeDb([ROW({ idempotency_key: 'k1', status: 'completed', result: { ok: true } })]);
-		const effect = await createEffectsLedger(db).find('b1', 'k1');
-		expect(effect?.status).toBe('completed');
-		expect(effect?.result).toEqual({ ok: true });
+		expect(claims.filter((claim) => claim.kind === 'claimed')).toHaveLength(1);
+		expect(claims.filter((claim) => claim.kind === 'existing')).toHaveLength(1);
 	});
 
-	it('una chiave diversa torna null', async () => {
-		const { db } = fakeDb([ROW({ idempotency_key: 'k1' })]);
-		const effect = await createEffectsLedger(db).find('b1', 'k2');
-		expect(effect).toBeNull();
+	it('due identità nuove con args identici hanno due righe', async () => {
+		const { db, rows } = fakeDb();
+		const ledger = createEffectsLedger(db);
+		await ledger.claim(RECORD);
+		await ledger.claim({ ...RECORD, invocationId: 'call-2', runId: 'r2' });
+
+		expect(rows).toHaveLength(2);
 	});
 
-	it('un altro brand non condivide la chiave (lo scoping è per brand)', async () => {
-		const { db } = fakeDb([ROW({ brand_id: 'b1', idempotency_key: 'k1' })]);
-		const effect = await createEffectsLedger(db).find('b2', 'k1');
-		expect(effect).toBeNull();
-	});
-});
+	it('la stessa identità con payload diverso è un mismatch', async () => {
+		const { db } = fakeDb();
+		const ledger = createEffectsLedger(db);
+		await ledger.claim(RECORD);
 
-describe('createEffectsLedger — resolve', () => {
-	it('sposta intended → completed col result', async () => {
-		const { db, rows } = fakeDb([ROW({ idempotency_key: 'k1', status: 'intended' })]);
-		await createEffectsLedger(db).resolve('e-1', 'completed', { post_id: 'p1' });
-		expect(rows[0].status).toBe('completed');
-		expect(rows[0].result).toEqual({ post_id: 'p1' });
+		const claim = await ledger.claim({ ...RECORD, request: { post_id: 'p2' } });
+
+		expect(claim.kind).toBe('mismatch');
 	});
 
-	it('sposta intended → failed in caso di errore', async () => {
-		const { db, rows } = fakeDb([ROW({ idempotency_key: 'k1', status: 'intended' })]);
-		await createEffectsLedger(db).resolve('e-1', 'failed', { message: 'net' });
-		expect(rows[0].status).toBe('failed');
-	});
-});
-
-describe('createEffectsLedger — reconcileRun', () => {
-	it('tira verso ambiguous solo gli intended del run, mai i completed', async () => {
+	it('il resume di un run legacy continua a riconoscere la riga congelata', async () => {
 		const { db, rows } = fakeDb([
-			ROW({ id: 'e-1', run_id: 'r1', status: 'intended' }),
-			ROW({ id: 'e-2', run_id: 'r1', status: 'completed' }),
-			ROW({ id: 'e-3', run_id: 'r2', status: 'intended' })
+			ROW({ invocation_id: null, idempotency_key: effectKey(RECORD.toolName, RECORD.request), status: 'completed' })
 		]);
-		const n = await createEffectsLedger(db).reconcileRun('r1');
-		expect(n).toBe(1);
-		expect(rows.find((r) => r.id === 'e-1')?.status).toBe('ambiguous');
-		expect(rows.find((r) => r.id === 'e-2')?.status).toBe('completed');
-		expect(rows.find((r) => r.id === 'e-3')?.status).toBe('intended');
+		const ledger = createEffectsLedger(db);
+
+		const claim = await ledger.claim({ ...RECORD, invocationId: 'call-new', legacyKey: effectKey(RECORD.toolName, RECORD.request) });
+
+		expect(claim.kind).toBe('existing');
+		expect(rows).toHaveLength(1);
+	});
+
+	it('una riga legacy di un run diverso non blocca una nuova identità', async () => {
+		const { db, rows } = fakeDb([
+			ROW({
+				run_id: 'run-old',
+				invocation_id: null,
+				idempotency_key: effectKey(RECORD.toolName, RECORD.request),
+				status: 'completed'
+			})
+		]);
+		const ledger = createEffectsLedger(db);
+
+		const claim = await ledger.claim({ ...RECORD, runId: 'run-new', invocationId: 'call-new', legacyKey: effectKey(RECORD.toolName, RECORD.request) });
+
+		expect(claim.kind).toBe('claimed');
+		expect(rows).toHaveLength(2);
 	});
 });
 
-describe('effectKey — solo il contratto del key non cambia', () => {
-	it('produce una chiave che contiene il nome del tool', () => {
+describe('createEffectsLedger — lifecycle', () => {
+	it('un worker tardivo non sovrascrive ambiguous', async () => {
+		const { db, rows } = fakeDb();
+		const ledger = createEffectsLedger(db);
+		const claim = await ledger.claim(RECORD);
+
+		await ledger.reconcileRun(RECORD.runId);
+		const resolved = await ledger.resolve(claim.effect.id, 'completed', { ok: true });
+
+		expect(resolved).toBe(false);
+		expect(rows[0].status).toBe('ambiguous');
+	});
+
+	it('un failed può essere reclamato di nuovo dalla stessa identità', async () => {
+		const { db } = fakeDb();
+		const ledger = createEffectsLedger(db);
+		const first = await ledger.claim(RECORD);
+		await ledger.resolve(first.effect.id, 'failed', { message: 'network' });
+
+		const retry = await ledger.claim({ ...RECORD, runId: 'r2' });
+
+		expect(retry.kind).toBe('claimed');
+	});
+});
+
+describe('effectKey — compatibilità legacy', () => {
+	it('conserva la forma della vecchia chiave per le righe esistenti', () => {
 		expect(effectKey('content_schedule', { post_id: 'p1' })).toContain('content_schedule');
 	});
 });

--- a/packages/agent-core/src/effects-store.ts
+++ b/packages/agent-core/src/effects-store.ts
@@ -1,19 +1,19 @@
-/**
- * IL LEDGER SU POSTGRES. L'unico punto che scrive `agent_kit_effects`: `intend` prima di eseguire,
- * `resolve` dopo, `reconcileRun` quando un segmento muore. Il resto (decidere congelare) sta in
- * `effects.ts`, la logica pura.
- */
 import type { SupabaseClient } from '@supabase/supabase-js';
-import type { EffectsLedger, ToolEffect } from '@anomalia/agent-kit';
+import type { EffectClaim, EffectsLedger, ToolEffect } from '@anomalia/agent-kit';
+import { legacyEffectKey, sameEffectPayload } from './effects';
 
 const TABLE = 'agent_kit_effects';
+const UNIQUE_VIOLATION = '23505';
+const INTENDED_STATUS: ToolEffect['status'] = 'intended';
+const FAILED_STATUS: ToolEffect['status'] = 'failed';
 
 type Row = {
 	id: string;
 	brand_id: string;
 	run_id: string | null;
 	tool_name: string;
-	idempotency_key: string;
+	invocation_id: string | null;
+	idempotency_key: string | null;
 	status: ToolEffect['status'];
 	request?: unknown;
 	result?: unknown;
@@ -27,7 +27,7 @@ function toEffect(r: Row): ToolEffect {
 		brandId: r.brand_id,
 		runId: r.run_id ?? null,
 		toolName: r.tool_name,
-		idempotencyKey: r.idempotency_key,
+		invocationId: r.invocation_id ?? null,
 		status: r.status,
 		request: r.request,
 		result: r.result,
@@ -36,82 +36,144 @@ function toEffect(r: Row): ToolEffect {
 	};
 }
 
-/**
- * Chiave deterministica dell'effetto: brand + tool + args canonicalizzati. NON contiene il run_id:
- * l'idempotenza deve riconoscere la stessa intenzione attraverso un resume (che riparte da zero) e
- * un takeover. Due args che coincidono in fondo = stessa intenzione = stesso effetto.
- */
-export function effectKey(toolName: string, args: Record<string, unknown>): string {
-	const canonical = stableSerialize(args);
-	const bytes = new TextEncoder().encode(`${toolName}\n${canonical}`);
-	// FNV-1a 64-bit, esadecimale — niente crypto asincrona: il key è un indice, non un segreto.
-	let hash = 0x811c9dc5;
-	for (const b of bytes) {
-		hash ^= b;
-		hash = Math.imul(hash, 0x01000193);
-	}
-	return `${toolName}:${(hash >>> 0).toString(36)}:${canonical.length}`;
+function uniqueViolation(error: { code?: string; message?: string }): boolean {
+	return error.code === UNIQUE_VIOLATION || /duplicate key|unique constraint/i.test(error.message ?? '');
 }
 
-function stableSerialize(value: unknown): string {
-	if (Array.isArray(value)) return `[${value.map(stableSerialize).join(',')}]`;
-	if (value && typeof value === 'object') {
-		return `{${Object.keys(value)
-			.sort()
-			.map((k) => `${JSON.stringify(k)}:${stableSerialize((value as Record<string, unknown>)[k])}`)
-			.join(',')}}`;
+function samePayload(effect: ToolEffect, record: { toolName: string; request: unknown }): boolean {
+	return effect.toolName === record.toolName && sameEffectPayload(effect.request, record.request);
+}
+
+async function findInvocation(
+	db: SupabaseClient,
+	brandId: string,
+	invocationId: string
+): Promise<ToolEffect | null> {
+	const { data, error } = await db
+		.from(TABLE)
+		.select()
+		.eq('brand_id', brandId)
+		.eq('invocation_id', invocationId)
+		.maybeSingle();
+	if (error) {
+		throw new Error(`effects: lettura claim fallita — ${error.message}`);
 	}
-	return JSON.stringify(value);
+	return data ? toEffect(data as Row) : null;
 }
 
 export function createEffectsLedger(db: SupabaseClient): EffectsLedger {
 	return {
-		async intend(record): Promise<ToolEffect> {
+		async claim(record): Promise<EffectClaim> {
+			if (record.legacyKey) {
+				const { data, error } = await db
+					.from(TABLE)
+					.select()
+					.eq('brand_id', record.brandId)
+					.eq('idempotency_key', record.legacyKey)
+					.is('invocation_id', null)
+					.maybeSingle();
+				if (error) {
+					throw new Error(`effects: lettura legacy fallita — ${error.message}`);
+				}
+				if (data) {
+					const effect = toEffect(data as Row);
+					if (effect.runId === record.runId) {
+						if (!samePayload(effect, record)) {
+							return { kind: 'mismatch', effect };
+						}
+						if (effect.status !== FAILED_STATUS) {
+							return { kind: 'existing', effect };
+						}
+					}
+				}
+			}
+
 			const { data, error } = await db
 				.from(TABLE)
 				.insert({
 					brand_id: record.brandId,
 					run_id: record.runId,
 					tool_name: record.toolName,
-					idempotency_key: record.key,
-					status: 'intended',
+					invocation_id: record.invocationId,
+					idempotency_key: null,
+					status: INTENDED_STATUS,
 					request: record.request
 				})
 				.select()
-				.single();
-			if (error) throw new Error(`effects: intend fallito — ${error.message}`);
-			return toEffect(data as Row);
-		},
+				.maybeSingle();
+			if (!error && data) {
+				return { kind: 'claimed', effect: toEffect(data as Row) };
+		}
+		if (error && !uniqueViolation(error)) {
+			throw new Error(`effects: claim fallito — ${error.message}`);
+		}
 
-		async resolve(id, status, result): Promise<void> {
-			const { error } = await db
+			const existing = await findInvocation(db, record.brandId, record.invocationId);
+			if (!existing) {
+				throw new Error('effects: claim concorrente senza riga proprietaria');
+			}
+			if (!samePayload(existing, record)) {
+				return { kind: 'mismatch', effect: existing };
+			}
+			if (existing.status !== FAILED_STATUS) {
+				return { kind: 'existing', effect: existing };
+			}
+
+			const retried = await db
 				.from(TABLE)
-				.update({ status, result, updated_at: new Date().toISOString() })
-				.eq('id', id);
-			if (error) throw new Error(`effects: resolve fallito — ${error.message}`);
+				.update({
+					run_id: record.runId,
+					status: INTENDED_STATUS,
+					result: null,
+					updated_at: new Date().toISOString()
+				})
+				.eq('id', existing.id)
+				.eq('status', 'failed')
+				.select()
+				.maybeSingle();
+			if (retried.error) {
+				throw new Error(`effects: retry fallito — ${retried.error.message}`);
+			}
+			if (retried.data) {
+				return { kind: 'claimed', effect: toEffect(retried.data as Row) };
+			}
+
+			const current = await findInvocation(db, record.brandId, record.invocationId);
+			if (!current) {
+				throw new Error('effects: retry concorrente senza riga proprietaria');
+			}
+			return samePayload(current, record)
+				? { kind: 'existing', effect: current }
+				: { kind: 'mismatch', effect: current };
 		},
 
-		async find(brandId, key): Promise<ToolEffect | null> {
+		async resolve(id, status, result): Promise<boolean> {
 			const { data, error } = await db
 				.from(TABLE)
-				.select()
-				.eq('brand_id', brandId)
-				.eq('idempotency_key', key)
+				.update({ status, result, updated_at: new Date().toISOString() })
+				.eq('id', id)
+				.eq('status', 'intended')
+				.select('id')
 				.maybeSingle();
-			if (error) throw new Error(`effects: find fallito — ${error.message}`);
-			return data ? toEffect(data as Row) : null;
+			if (error) {
+				throw new Error(`effects: resolve fallito — ${error.message}`);
+			}
+			return !!data;
 		},
 
 		async reconcileRun(runId): Promise<number> {
-			// Solo le righe ancora `intended`: un `completed` è un esito vero, non va toccato.
 			const { data, error } = await db
 				.from(TABLE)
 				.update({ status: 'ambiguous', updated_at: new Date().toISOString() })
 				.eq('run_id', runId)
 				.eq('status', 'intended')
 				.select('id');
-			if (error) throw new Error(`effects: reconcile fallito — ${error.message}`);
+			if (error) {
+				throw new Error(`effects: reconcile fallito — ${error.message}`);
+			}
 			return data?.length ?? 0;
 		}
 	};
 }
+
+export const effectKey = legacyEffectKey;

--- a/packages/agent-core/src/effects.test.ts
+++ b/packages/agent-core/src/effects.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { decide, frozenResult, isFrozen, EFFECT_LID_NOTE } from './effects';
-import { effectKey } from './effects-store';
+import { decide, effectKey, frozenResult, isFrozen, EFFECT_LID_NOTE } from './effects';
 import type { ToolEffect } from '@anomalia/agent-kit';
 
 function effect(status: ToolEffect['status'], result?: unknown, over: Partial<ToolEffect> = {}): ToolEffect {

--- a/packages/agent-core/src/effects.test.ts
+++ b/packages/agent-core/src/effects.test.ts
@@ -9,7 +9,7 @@ function effect(status: ToolEffect['status'], result?: unknown, over: Partial<To
 		brandId: 'b1',
 		runId: 'r1',
 		toolName: 'content_schedule',
-		idempotencyKey: 'k',
+		invocationId: 'call-1',
 		status,
 		result,
 		createdAt: '2026-08-29T00:00:00.000Z',

--- a/packages/agent-core/src/effects.ts
+++ b/packages/agent-core/src/effects.ts
@@ -2,8 +2,8 @@
  * LA LOGICA PURA del gate degli effetti — niente db, niente framework. Decide se un tool con un
  * effetto collaterale va rieseguito o se è già stato (o è stato avviato e lasciato in dubbio) e
  * quindi va congelato. La macchina a stati: `intended -> completed|failed`, con i ripieghi
- * `ambiguous` (il segmento è morto a metà) e `reconciled` (confermato fuori). Prima di rieseguire
- * l'executor legge per chiave: se esiste già un esito non-rieseguibile, NON riesegue.
+ * `ambiguous` (il segmento è morto a metà) e `reconciled` (confermato fuori). Il claim atomico per
+ * identità vive nel port `EffectsLedger`; questo modulo conserva la logica pura.
  */
 import type { EffectStatus, ToolEffect, ToolResult } from '@anomalia/agent-kit';
 
@@ -12,13 +12,13 @@ export const EFFECT_LID_NOTE = 'questo effetto è già stato registrato: non rie
 /** Stati a cui l'effetto è già avvenuto (o è avviato ma di esito ignoto): NON vanno rieseguiti. */
 const FROZEN_STATUSES: ReadonlySet<EffectStatus> = new Set(['completed', 'ambiguous', 'reconciled']);
 
-/** C'è già un esito non-rieseguibile per questa chiave? */
+/** C'è già un esito non-rieseguibile per questo effetto? */
 export function isFrozen(status: EffectStatus): boolean {
 	return FROZEN_STATUSES.has(status);
 }
 
 /**
- * Decide se eseguire o congelare. `intended` NON congela: è un ripiego di sicurezza, ma corrisponde
+ * Decide se eseguire o congelare per il percorso legacy. `intended` NON congela: è un ripiego di sicurezza, ma corrisponde
  * a un segmento ancora vivo o appena morto — a differenza di `ambiguous` (morto confermato), il
  * run corrente è il primo e solo autore, quindi può riprovare.
  */
@@ -32,4 +32,34 @@ export function decide(effect: ToolEffect | null): { run: boolean; note: string 
 export function frozenResult(effect: ToolEffect): ToolResult | null {
 	if (!isFrozen(effect.status)) return null;
 	return (effect.result as ToolResult | null) ?? null;
+}
+
+export function sameEffectPayload(left: unknown, right: unknown): boolean {
+	return stableSerialize(left) === stableSerialize(right);
+}
+
+export function legacyEffectKey(toolName: string, args: Record<string, unknown>): string {
+	const canonical = stableSerialize(args);
+	const bytes = new TextEncoder().encode(`${toolName}\n${canonical}`);
+	let hash = 0x811c9dc5;
+	for (const b of bytes) {
+		hash ^= b;
+		hash = Math.imul(hash, 0x01000193);
+	}
+	return `${toolName}:${(hash >>> 0).toString(36)}:${canonical.length}`;
+}
+
+export const effectKey = legacyEffectKey;
+
+function stableSerialize(value: unknown): string {
+	if (Array.isArray(value)) {
+		return `[${value.map(stableSerialize).join(',')}]`;
+	}
+	if (value && typeof value === 'object') {
+		return `{${Object.keys(value)
+			.sort()
+			.map((key) => `${JSON.stringify(key)}:${stableSerialize((value as Record<string, unknown>)[key])}`)
+			.join(',')}}`;
+	}
+	return JSON.stringify(value);
 }

--- a/packages/agent-core/src/effects.ts
+++ b/packages/agent-core/src/effects.ts
@@ -17,11 +17,7 @@ export function isFrozen(status: EffectStatus): boolean {
 	return FROZEN_STATUSES.has(status);
 }
 
-/**
- * Decide se eseguire o congelare per il percorso legacy. `intended` NON congela: è un ripiego di sicurezza, ma corrisponde
- * a un segmento ancora vivo o appena morto — a differenza di `ambiguous` (morto confermato), il
- * run corrente è il primo e solo autore, quindi può riprovare.
- */
+/** Decide se un claim già presente può essere ritentato. Solo failed è ritentabile. */
 export function decide(effect: ToolEffect | null): { run: boolean; note: string } {
 	if (!effect) return { run: true, note: '' };
 	if (effect.status === 'failed') return { run: true, note: '' };
@@ -41,10 +37,12 @@ export function sameEffectPayload(left: unknown, right: unknown): boolean {
 export function legacyEffectKey(toolName: string, args: Record<string, unknown>): string {
 	const canonical = stableSerialize(args);
 	const bytes = new TextEncoder().encode(`${toolName}\n${canonical}`);
-	let hash = 0x811c9dc5;
+	const FNV_OFFSET = 0x811c9dc5;
+	const FNV_PRIME = 0x01000193;
+	let hash = FNV_OFFSET;
 	for (const b of bytes) {
 		hash ^= b;
-		hash = Math.imul(hash, 0x01000193);
+		hash = Math.imul(hash, FNV_PRIME);
 	}
 	return `${toolName}:${(hash >>> 0).toString(36)}:${canonical.length}`;
 }

--- a/packages/agent-core/src/executor.test.ts
+++ b/packages/agent-core/src/executor.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { createApplyTool, buildSystemPrompt, type ApplyToolDeps } from './executor';
 import { BUILTIN_TOOLS } from './tools/builtin';
-import { effectKey } from './effects-store';
 import { SYSTEM_PROMPT_MAX_CHARS, type AgentSpec } from '@anomalia/agent-contracts/contracts';
 import { SandboxEmulator } from '@anomalia/agent-adapters/sandbox-emulator';
 import {
@@ -273,9 +272,9 @@ describe('createApplyTool — il gate sugli effetti', () => {
 		};
 	}
 
-	const CALL = { name: 'content_schedule', args: { post_id: 'p1' } };
+	const CALL = { name: 'content_schedule', id: 'call-1', args: { post_id: 'p1' } };
 
-	it('intend PRIMA di eseguire, resolve completed dopo', async () => {
+	it('claim PRIMA di eseguire, resolve completed dopo', async () => {
 		const counter = { calls: 0 };
 		const ledger = createMemoryEffectsLedger();
 		const apply = createApplyTool(baseDeps({ plugins: [effectfulPlugin(counter)], effects: ledger }));
@@ -286,47 +285,112 @@ describe('createApplyTool — il gate sugli effetti', () => {
 		expect(counter.calls).toBe(1);
 	});
 
-	it('abort → resume: la SECONDA chiamata con la stessa intenzione congelate invece di rieseguire', async () => {
+	it('resume della stessa intenzione esegue una sola volta', async () => {
 		const counter = { calls: 0 };
 		const ledger = createMemoryEffectsLedger();
 		const apply = createApplyTool(baseDeps({ plugins: [effectfulPlugin(counter)], effects: ledger }));
 
-		// primo turno: esegue e registra completed
 		await apply(CALL, fakeContext({ runId: 'run-1' }));
 		expect(counter.calls).toBe(1);
 
-		// il segmento muore a metà e si riprende: il run è DIVERSO (run-2) ma la chiave è la stessa
 		const out = await apply(CALL, fakeContext({ runId: 'run-2' }));
-		expect(counter.calls).toBe(1); // non riesegue: un solo post
+		expect(counter.calls).toBe(1);
 		expect(out.isError).toBeFalsy();
 		expect((out.content[0] as { text: string }).text).toContain('post 1');
 	});
 
-	it('un effect ambiguous NON viene rieseguito, nemmeno su un run nuovo', async () => {
+	it('due intenzioni nuove con args identici eseguono due volte', async () => {
 		const counter = { calls: 0 };
-		const { brandId } = fakeContext();
-		const injected = createMemoryEffectsLedger();
-		await injected.intend({ brandId, runId: 'run-dead', toolName: 'content_schedule', key: effectKey('content_schedule', { post_id: 'p1' }), request: { post_id: 'p1' } });
-		await injected.reconcileRun('run-dead');
-		const apply = createApplyTool(baseDeps({ plugins: [effectfulPlugin(counter)], effects: injected }));
+		const ledger = createMemoryEffectsLedger();
+		const apply = createApplyTool(baseDeps({ plugins: [effectfulPlugin(counter)], effects: ledger }));
 
-		const out = await apply({ name: 'content_schedule', args: { post_id: 'p1' } }, fakeContext({ runId: 'run-new' }));
+		await apply(CALL, fakeContext({ runId: 'run-1' }));
+		await apply({ ...CALL, id: 'call-2' }, fakeContext({ runId: 'run-2' }));
+
+		expect(counter.calls).toBe(2);
+		expect(ledger.rows).toHaveLength(2);
+	});
+
+	it('un tool effectful senza identità stabile non viene eseguito', async () => {
+		const counter = { calls: 0 };
+		const ledger = createMemoryEffectsLedger();
+		const apply = createApplyTool(baseDeps({ plugins: [effectfulPlugin(counter)], effects: ledger }));
+
+		const out = await apply({ name: 'content_schedule', args: { post_id: 'p1' } }, fakeContext());
+
 		expect(counter.calls).toBe(0);
 		expect(out.isError).toBe(true);
-		expect((out.content[0] as { text: string }).text).toMatch(/già stato registrato/);
+		expect(out.content[0]).toMatchObject({ type: 'text' });
+	});
+
+	it('due worker concorrenti ottengono un solo claim', async () => {
+		const counter = { calls: 0 };
+		const ledger = createMemoryEffectsLedger();
+		const apply = createApplyTool(baseDeps({ plugins: [effectfulPlugin(counter)], effects: ledger }));
+
+		const [first, second] = await Promise.all([
+			apply(CALL, fakeContext({ runId: 'run-1' })),
+			apply(CALL, fakeContext({ runId: 'run-2' }))
+		]);
+
+		expect(counter.calls).toBe(1);
+		expect([first, second].filter((result) => !result.isError)).toHaveLength(1);
+		expect(ledger.rows).toHaveLength(1);
+	});
+
+	it('un worker tardivo non risolve un effetto già riconciliato', async () => {
+		const counter = { calls: 0 };
+		const ledger = createMemoryEffectsLedger();
+		const claim = await ledger.claim({
+			brandId: 'brand-test',
+			runId: 'run-dead',
+			invocationId: CALL.id,
+			toolName: CALL.name,
+			request: CALL.args
+		});
+		await ledger.reconcileRun('run-dead');
+		await ledger.resolve(claim.effect.id, 'completed', { content: [{ type: 'text', text: 'late' }] });
+		const apply = createApplyTool(baseDeps({ plugins: [effectfulPlugin(counter)], effects: ledger }));
+
+		const out = await apply(CALL, fakeContext({ runId: 'run-new' }));
+		expect(counter.calls).toBe(0);
+		expect(out.isError).toBe(true);
+		expect((out.content[0] as { text: string }).text).toMatch(/già registrato/);
+		expect(ledger.rows[0].status).toBe('ambiguous');
 	});
 
 	it('failed lascia rieseguire (l\'effetto non è avvenuto, non è un doppione)', async () => {
 		const counter = { calls: 0 };
-		const { brandId } = fakeContext();
 		const injected = createMemoryEffectsLedger();
-		await injected.intend({ brandId, runId: 'r0', toolName: 'content_schedule', key: effectKey('content_schedule', { post_id: 'p1' }), request: { post_id: 'p1' } });
-		await injected.resolve(injected.rows[0].id, 'failed', { message: 'net' });
+		const claim = await injected.claim({
+			brandId: 'brand-test',
+			runId: 'r0',
+			invocationId: CALL.id,
+			toolName: CALL.name,
+			request: CALL.args
+		});
+		await injected.resolve(claim.effect.id, 'failed', { message: 'net' });
 		const apply = createApplyTool(baseDeps({ plugins: [effectfulPlugin(counter)], effects: injected }));
 
-		const out = await apply({ name: 'content_schedule', args: { post_id: 'p1' } }, fakeContext());
+		const out = await apply(CALL, fakeContext());
 		expect(counter.calls).toBe(1);
 		expect((out.content[0] as { text: string }).text).toBe('post 1');
+	});
+
+	it('la stessa identità con payload diverso viene rifiutata', async () => {
+		const counter = { calls: 0 };
+		const ledger = createMemoryEffectsLedger();
+		const apply = createApplyTool(baseDeps({ plugins: [effectfulPlugin(counter)], effects: ledger }));
+
+		await apply(CALL, fakeContext({ runId: 'run-1' }));
+		const out = await apply(
+			{ ...CALL, args: { post_id: 'p2' } },
+			fakeContext({ runId: 'run-2' })
+		);
+
+		expect(counter.calls).toBe(1);
+		expect(out.isError).toBe(true);
+		expect((out.content[0] as { text: string }).text).toMatch(/payload|identità|identity/i);
 	});
 
 	it('solo i tool marcat effectful passano dal gate; gli altri no', async () => {

--- a/packages/agent-core/src/executor.test.ts
+++ b/packages/agent-core/src/executor.test.ts
@@ -377,6 +377,47 @@ describe('createApplyTool — il gate sugli effetti', () => {
 		expect((out.content[0] as { text: string }).text).toBe('post 1');
 	});
 
+	it('un risultato ambiguo resta congelato anche se il tool lo segnala come errore', async () => {
+		const counter = { calls: 0 };
+		const ledger = createMemoryEffectsLedger();
+		const plugin = {
+			...effectfulPlugin(counter),
+			async execute() {
+				counter.calls += 1;
+				return { content: [{ type: 'text' as const, text: 'esito incerto' }], isError: true, effectStatus: 'ambiguous' as const };
+			}
+		};
+		const apply = createApplyTool(baseDeps({ plugins: [plugin], effects: ledger }));
+
+		const first = await apply(CALL, fakeContext({ runId: 'run-1' }));
+		const second = await apply(CALL, fakeContext({ runId: 'run-2' }));
+
+		expect(first.effectStatus).toBe('ambiguous');
+		expect(second).toEqual(first);
+		expect(counter.calls).toBe(1);
+		expect(ledger.rows[0]?.status).toBe('ambiguous');
+	});
+
+	it('un eccezione durante un effetto diventa ambiguous, non un retry cieco', async () => {
+		const counter = { calls: 0 };
+		const ledger = createMemoryEffectsLedger();
+		const plugin = {
+			...effectfulPlugin(counter),
+			async execute() {
+				counter.calls += 1;
+				throw new Error('connessione interrotta dopo la scrittura');
+			}
+		};
+		const apply = createApplyTool(baseDeps({ plugins: [plugin], effects: ledger }));
+
+		await expect(apply(CALL, fakeContext({ runId: 'run-1' }))).rejects.toThrow('connessione interrotta');
+		const second = await apply(CALL, fakeContext({ runId: 'run-2' }));
+
+		expect(second.isError).toBe(true);
+		expect(counter.calls).toBe(1);
+		expect(ledger.rows[0]?.status).toBe('ambiguous');
+	});
+
 	it('la stessa identità con payload diverso viene rifiutata', async () => {
 		const counter = { calls: 0 };
 		const ledger = createMemoryEffectsLedger();
@@ -396,7 +437,7 @@ describe('createApplyTool — il gate sugli effetti', () => {
 	it('solo i tool marcat effectful passano dal gate; gli altri no', async () => {
 		const counter = { calls: 0 };
 		const ledger = createMemoryEffectsLedger();
-		const plugin = { ...effectfulPlugin(counter), tools: [{ name: 'content_read', description: 'legge', inputSchema: { type: 'object' }, consequential: false }] };
+		const plugin = { ...effectfulPlugin(counter), tools: [{ name: 'content_read', description: 'legge', inputSchema: { type: 'object' }, effectful: false, consequential: false }] };
 		const apply = createApplyTool(baseDeps({ plugins: [plugin], effects: ledger }));
 		const out = await apply({ name: 'content_read', args: {} }, fakeContext());
 		expect(out.isError).toBeFalsy();

--- a/packages/agent-core/src/executor.ts
+++ b/packages/agent-core/src/executor.ts
@@ -258,11 +258,13 @@ export function createApplyTool(deps: ApplyToolDeps): ApplyTool {
 		const effect = claim.effect;
 		try {
 			const result = await execute(call, ctx);
-			await deps.effects.resolve(effect.id, result.isError ? 'failed' : 'completed', result);
+			const status = result.effectStatus ?? (result.isError ? 'failed' : 'completed');
+			await deps.effects.resolve(effect.id, status, result);
 			return result;
-		} catch (err) {
-			await deps.effects.resolve(effect.id, 'failed', { message: err instanceof Error ? err.message : String(err) });
-			throw err;
+		} catch (cause) {
+			const message = cause instanceof Error ? cause.message : String(cause);
+			await deps.effects.resolve(effect.id, 'ambiguous', err(message));
+			throw cause;
 		}
 	};
 }

--- a/packages/agent-core/src/executor.ts
+++ b/packages/agent-core/src/executor.ts
@@ -7,8 +7,7 @@ import type { AdapterContext, EffectsLedger, ToolCall, ToolResult } from '@anoma
 import type { BrandFs, CheckpointStore, MemoryStore, SandboxProvider, SandboxRef, ToolPlugin } from '@anomalia/agent-kit';
 import { SYSTEM_PROMPT_MAX_CHARS, type AgentSpec } from '@anomalia/agent-contracts/contracts';
 import { BUILTIN_TOOLS, TERMINAL_TOOL_NAMES } from './tools/builtin';
-import { decide, frozenResult } from './effects';
-import { effectKey } from './effects-store';
+import { frozenResult, legacyEffectKey } from './effects';
 import { ensureComputer, touchComputer } from './computer';
 import {
 	ensureGraphicalMode,
@@ -78,8 +77,8 @@ export interface ApplyToolDeps {
 	/** Senza, `observe`/`act` rispondono con l'errore-che-insegna invece di esplodere. */
 	graphicalBootstrap?: GraphicalBootstrapDeps;
 	/**
-	 * Presente: i tool con `effectful: true` passano dal ledger degli effetti — `intend` prima di
-	 * eseguire, `resolve` dopo, e su un resume che rivede la stessa chiave congelano invece di
+	 * Presente: i tool con `effectful: true` passano dal ledger degli effetti — claim prima di
+	 * eseguire, resolve dopo, e su un resume che rivede la stessa identità congelano invece di
 	 * rieseguire (un doppio post/schedulazione è un danno, non un errore da riprovare).
 	 * Assente: nessun gate, si esegue e basta (il lab, i test, le superfici senza righe).
 	 */
@@ -228,28 +227,40 @@ export function createApplyTool(deps: ApplyToolDeps): ApplyTool {
 	return async (call: ToolCall, ctx: AdapterContext): Promise<ToolResult> => {
 		const name = LEGACY_TOOL_ALIASES[call.name] ?? call.name;
 
-		if (!deps.effects || !isEffectful(name, deps.plugins)) return execute(call, ctx);
-
-		// GATE: una stessa chiave (brand + tool + args) che ha già un esito non-rieseguibile NON va
-		// rieseguita. `intended` è un ripiego di sicurezza (il segmento è vivo, è il primo autore),
-		// quindi decide() lo lascia riprovare; `ambiguous`/`completed`/`reconciled` congelano.
-		const key = effectKey(name, call.args);
-		const existing = await deps.effects.find(ctx.brandId, key);
-		const decision = decide(existing);
-		if (!decision.run) {
-			const frozen = frozenResult(existing!);
-			if (frozen) return frozen;
-			return err(`${decision.note}. Esito registrato: ${existing!.status}`);
+		if (!deps.effects || !isEffectful(name, deps.plugins)) {
+			return execute(call, ctx);
 		}
 
-		const effect = await deps.effects.intend({ brandId: ctx.brandId, runId: ctx.runId, toolName: name, key, request: call.args });
+		const invocationId = call.id?.trim();
+		if (!invocationId) {
+			return err(`tool '${name}' senza identità stabile della chiamata`);
+		}
+
+		const claim = await deps.effects.claim({
+			brandId: ctx.brandId,
+			runId: ctx.runId,
+			invocationId,
+			toolName: name,
+			request: call.args,
+			legacyKey: legacyEffectKey(name, call.args)
+		});
+		if (claim.kind === 'mismatch') {
+			return err(`tool '${name}' rifiutato: payload diverso per la stessa identità di chiamata`);
+		}
+		if (claim.kind === 'existing') {
+			const frozen = frozenResult(claim.effect);
+			if (frozen) {
+				return frozen;
+			}
+			return err(`tool '${name}' non eseguito: effetto già registrato (${claim.effect.status})`);
+		}
+
+		const effect = claim.effect;
 		try {
 			const result = await execute(call, ctx);
 			await deps.effects.resolve(effect.id, result.isError ? 'failed' : 'completed', result);
 			return result;
 		} catch (err) {
-			// L'effetto resta `intended`: sarà `reconcileRun` (morte del segmento) a tirarlo verso
-			// `ambiguous`. Espongo l'errore vero, mai un esito finto.
 			await deps.effects.resolve(effect.id, 'failed', { message: err instanceof Error ? err.message : String(err) });
 			throw err;
 		}

--- a/packages/agent-core/src/run-store.ts
+++ b/packages/agent-core/src/run-store.ts
@@ -21,6 +21,7 @@ export type RunRow = {
 	question: unknown | null;
 	lease_until: string | null;
 	heartbeat_at: string | null;
+	harness_continue_state?: unknown;
 	created_at: string;
 	updated_at: string;
 };
@@ -152,6 +153,7 @@ export type CloseMessage = {
 	reasoning?: string;
 	toolCalls?: unknown;
 	attachments?: string[];
+	speaker?: string;
 };
 
 /**
@@ -179,7 +181,8 @@ export async function closeRunSaving(
 					content: message.content,
 					reasoning: message.reasoning ?? null,
 					tool_calls: message.toolCalls ?? null,
-					attachments: message.attachments ?? null
+					attachments: message.attachments ?? null,
+					name: message.speaker ?? null
 				}
 			: null
 	});

--- a/packages/agent-core/src/tools/builtin.ts
+++ b/packages/agent-core/src/tools/builtin.ts
@@ -14,6 +14,7 @@ import type { ToolSpec } from '@anomalia/agent-kit';
 export const BUILTIN_TOOLS: ToolSpec[] = [
 	{
 		name: 'brand_ls',
+		effectful: false,
 		consequential: false,
 		description:
 			"Elenca i file dell'albero del brand (studio, piano, post, artefatti) a un path — NON il filesystem della macchina, per quello c'è `shell`. Usalo per orientarti prima di leggere; recursive:true per l'albero intero.",
@@ -27,6 +28,7 @@ export const BUILTIN_TOOLS: ToolSpec[] = [
 	},
 	{
 		name: 'brand_read',
+		effectful: false,
 		consequential: false,
 		description:
 			"Legge per intero un file dell'albero del brand (studio, piano, post, artefatti) — NON il filesystem della macchina, per quello c'è `shell`. Non indovinare il contenuto: leggilo.",
@@ -38,6 +40,7 @@ export const BUILTIN_TOOLS: ToolSpec[] = [
 	},
 	{
 		name: 'brand_grep',
+		effectful: false,
 		consequential: false,
 		description:
 			"Cerca un pattern nei file dell'albero del brand (studio, piano, post, artefatti) — NON il filesystem della macchina, per quello c'è `shell`. Più economico di leggere tutto quando cerchi una cosa sola; path limita la ricerca a un sottoalbero.",
@@ -65,6 +68,7 @@ export const BUILTIN_TOOLS: ToolSpec[] = [
 	},
 	{
 		name: 'query',
+		effectful: false,
 		consequential: false,
 		description: "Legge dal database coi permessi dell'utente corrente. Usalo per dati strutturati (post, metriche); per file usa brand_ls/brand_read/brand_grep.",
 		inputSchema: {
@@ -117,6 +121,7 @@ export const BUILTIN_TOOLS: ToolSpec[] = [
 	},
 	{
 		name: 'reply',
+		effectful: false,
 		consequential: false,
 		description: "L'atto esplicito di parlare all'utente: cosa esiste adesso (con gli id), cosa non è riuscito, cosa serve da lui. Il turno finisce SOLO qui o con ask_user — mai in silenzio dopo un tool.",
 		terminal: true,
@@ -131,6 +136,7 @@ export const BUILTIN_TOOLS: ToolSpec[] = [
 	},
 	{
 		name: 'ask_user',
+		effectful: false,
 		consequential: false,
 		description: "Domanda bloccante: il run va in waiting_input e RESTA VIVO in attesa della risposta. Usalo solo quando non puoi procedere senza saperlo, non per confermare l'ovvio.",
 		terminal: true,
@@ -145,6 +151,7 @@ export const BUILTIN_TOOLS: ToolSpec[] = [
 	},
 	{
 		name: 'plan',
+		effectful: false,
 		consequential: false,
 		description: 'Dichiara il piano del turno per la UI. Facoltativo: non serve per turni di un solo passo.',
 		inputSchema: {
@@ -155,6 +162,7 @@ export const BUILTIN_TOOLS: ToolSpec[] = [
 	},
 	{
 		name: 'observe',
+		effectful: false,
 		consequential: false,
 		description: "Scatta uno screenshot dello schermo grafico della VM del brand (desktop reale, non un'immagine finta). Accende il modo grafico da solo se non è già attivo — la primissima volta può volerci qualche minuto, e il risultato lo dice. Usalo prima di 'act' per vedere dove cliccare.",
 		inputSchema: { type: 'object', properties: {} }

--- a/packages/agent-kit/src/index.ts
+++ b/packages/agent-kit/src/index.ts
@@ -2,3 +2,4 @@ export * from './types';
 export * from './interfaces';
 export * from './registry';
 export * from './action-approval';
+export * from './thread-events';

--- a/packages/agent-kit/src/interfaces.ts
+++ b/packages/agent-kit/src/interfaces.ts
@@ -11,6 +11,7 @@ import type {
 	AdapterDescriptor,
 	CommandRequest,
 	EffectStatus,
+	EffectClaim,
 	FileEntry,
 	MemoryCapabilities,
 	MemoryEntry,
@@ -32,12 +33,23 @@ import type {
  * contratto: l'executor non sa dove viva la riga, la superficie gliela passa come implementazione.
  */
 export interface EffectsLedger {
-	/** Registra `intended` PRIMA di eseguire. Se esiste già la chiave, la restituisce senza toccare. */
-	intend(record: { brandId: string; runId: string; toolName: string; key: string; request: unknown }): Promise<ToolEffect>;
-	/** Risolve dopo l'esecuzione: completed (con result) o failed. */
-	resolve(id: string, status: 'completed' | 'failed', result: unknown): Promise<void>;
-	/** Legge per chiave: la riga esistente, o null. */
-	find(brandId: string, key: string): Promise<ToolEffect | null>;
+	/**
+	 * Claim atomico per (brand, invocationId). L'identità è indipendente da run, lease, fence e
+	 * attempt; il payload serve solo a rilevare un riuso errato. Solo `claimed` autorizza l'esecuzione.
+	 */
+	claim(record: {
+		brandId: string;
+		/** Il run che detiene il claim, usato per audit e riconciliazione. */
+		runId: string;
+		/** L'identità persistita della singola chiamata, non derivata da `request`. */
+		invocationId: string;
+		toolName: string;
+		request: unknown;
+		/** Chiave della versione precedente, usata solo per righe legacy dello stesso run. */
+		legacyKey?: string;
+	}): Promise<EffectClaim>;
+	/** Risolve solo un claim ancora `intended`; un worker riconciliato non può sovrascriverlo. */
+	resolve(id: string, status: 'completed' | 'failed', result: unknown): Promise<boolean>;
 	/** Attira gli `intended` orfani di un run morto verso `ambiguous` — il ripiego che non duplica. */
 	reconcileRun(runId: string): Promise<number>;
 }

--- a/packages/agent-kit/src/interfaces.ts
+++ b/packages/agent-kit/src/interfaces.ts
@@ -49,7 +49,7 @@ export interface EffectsLedger {
 		legacyKey?: string;
 	}): Promise<EffectClaim>;
 	/** Risolve solo un claim ancora `intended`; un worker riconciliato non può sovrascriverlo. */
-	resolve(id: string, status: 'completed' | 'failed', result: unknown): Promise<boolean>;
+	resolve(id: string, status: 'completed' | 'failed' | 'ambiguous', result: unknown): Promise<boolean>;
 	/** Attira gli `intended` orfani di un run morto verso `ambiguous` — il ripiego che non duplica. */
 	reconcileRun(runId: string): Promise<number>;
 }

--- a/packages/agent-kit/src/testkit.ts
+++ b/packages/agent-kit/src/testkit.ts
@@ -19,6 +19,9 @@ import type {
 } from './index';
 import type { BrandFs, MemoryStore, SandboxProvider, ToolPlugin } from './index';
 
+const INTENDED_STATUS: ToolEffect['status'] = 'intended';
+const FAILED_STATUS: ToolEffect['status'] = 'failed';
+
 export function fakeContext(overrides: Partial<AdapterContext> = {}): AdapterContext {
 	return {
 		brandId: 'brand-test',
@@ -137,9 +140,8 @@ export function fakePlugin(name: string, reply: ToolResult): ToolPlugin {
 }
 
 /**
- * IL LEDGER IN MEMORIA per i test del gate: `intend`/`resolve`/`find`/`reconcileRun` su una mappa
- * per (brand, chiave). Così il gate dell'executor si verifica col suo comportamento vero — decidere
- * se rieseguire o congelare — senza montare un database.
+ * IL LEDGER IN MEMORIA per i test del gate: claim/resolve/reconcileRun su una mappa per
+ * (brand, invocationId). Così il gate dell'executor si verifica senza montare un database.
  */
 export function createMemoryEffectsLedger(seed: { [key: string]: unknown } = {}): EffectsLedger & { rows: ToolEffect[] } {
 	const rows: ToolEffect[] = [];
@@ -150,7 +152,7 @@ export function createMemoryEffectsLedger(seed: { [key: string]: unknown } = {})
 			brandId: 'brand-test',
 			runId: 'run-test',
 			toolName: 'content_schedule',
-			idempotencyKey: 'seed',
+			invocationId: 'seed',
 			status: status as ToolEffect['status'],
 			request: request as unknown,
 			result: null,
@@ -161,34 +163,44 @@ export function createMemoryEffectsLedger(seed: { [key: string]: unknown } = {})
 
 	return {
 		rows,
-		async intend(record) {
-			const existing = rows.find((r) => r.brandId === record.brandId && r.idempotencyKey === record.key);
-			if (existing) return existing;
+		async claim(record) {
+			const existing = rows.find((r) => r.brandId === record.brandId && r.invocationId === record.invocationId);
+			if (existing) {
+				if (existing.toolName !== record.toolName || stableSerialize(existing.request) !== stableSerialize(record.request)) {
+					return { kind: 'mismatch', effect: existing };
+				}
+				if (existing.status === FAILED_STATUS) {
+					existing.runId = record.runId;
+					existing.status = 'intended';
+					existing.result = null;
+					return { kind: 'claimed', effect: existing };
+				}
+				return { kind: 'existing', effect: existing };
+			}
 			const effect: ToolEffect = {
 				id: `e-${rows.length + 1}`,
 				brandId: record.brandId,
 				runId: record.runId,
 				toolName: record.toolName,
-				idempotencyKey: record.key,
-				status: 'intended',
+				invocationId: record.invocationId,
+				status: INTENDED_STATUS,
 				request: record.request,
 				result: null,
 				createdAt: '2026-08-29T00:00:00.000Z',
 				updatedAt: '2026-08-29T00:00:00.000Z'
 			};
 			rows.push(effect);
-			return effect;
+			return { kind: 'claimed', effect };
 		},
 		async resolve(id, status, result) {
 			const effect = rows.find((r) => r.id === id);
-			if (effect) {
+			if (effect?.status === INTENDED_STATUS) {
 				effect.status = status;
 				effect.result = result;
 				effect.updatedAt = '2026-08-29T00:00:00.000Z';
+				return true;
 			}
-		},
-		async find(brandId, key) {
-			return rows.find((r) => r.brandId === brandId && r.idempotencyKey === key) ?? null;
+			return false;
 		},
 		async reconcileRun(runId) {
 			let n = 0;
@@ -201,4 +213,17 @@ export function createMemoryEffectsLedger(seed: { [key: string]: unknown } = {})
 			return n;
 		}
 	};
+}
+
+function stableSerialize(value: unknown): string {
+	if (Array.isArray(value)) {
+		return `[${value.map(stableSerialize).join(',')}]`;
+	}
+	if (value && typeof value === 'object') {
+		return `{${Object.keys(value)
+			.sort()
+			.map((key) => `${JSON.stringify(key)}:${stableSerialize((value as Record<string, unknown>)[key])}`)
+			.join(',')}}`;
+	}
+	return JSON.stringify(value);
 }

--- a/packages/agent-kit/src/testkit.ts
+++ b/packages/agent-kit/src/testkit.ts
@@ -132,7 +132,7 @@ export function createMemoryStore(): MemoryStore & { entries: MemoryEntry[] } {
 export function fakePlugin(name: string, reply: ToolResult): ToolPlugin {
 	return {
 		name: `plugin-${name}`,
-		tools: [{ name, description: `tool di test per ${name}`, consequential: false, inputSchema: { type: 'object' } }],
+		tools: [{ name, description: `tool di test per ${name}`, effectful: false, consequential: false, inputSchema: { type: 'object' } }],
 		async execute(_call: ToolCall) {
 			return reply;
 		}

--- a/packages/agent-kit/src/thread-events.test.ts
+++ b/packages/agent-kit/src/thread-events.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+import { emptyThreadProjection, reduceThreadEvents, type ThreadEvent } from './index';
+
+const message = (seq: number, id: string, content: string): ThreadEvent => ({
+	seq,
+	sourceKey: `message:${id}`,
+	kind: 'message',
+	message: { id, role: 'assistant', content }
+});
+
+const progress = (seq: number, runId: string, status: string): ThreadEvent => ({
+	seq,
+	sourceKey: `progress:${runId}:${status}`,
+	kind: 'progress',
+	progress: { runId, status }
+});
+
+describe('thread event reducer', () => {
+	it('orders events and projects messages and latest progress', () => {
+		const result = reduceThreadEvents(emptyThreadProjection(), [
+			progress(3, 'run-1', 'completed'),
+			message(2, 'message-1', 'done'),
+			progress(1, 'run-1', 'running')
+		]);
+
+		expect(result.gap).toBeNull();
+		expect(result.conflict).toBeNull();
+		expect(result.projection.cursor).toBe(3);
+		expect(result.projection.messages).toEqual([
+			{ id: 'message-1', role: 'assistant', content: 'done' }
+		]);
+		expect(result.projection.progress).toEqual({
+			'run-1': { runId: 'run-1', status: 'completed' }
+		});
+		expect(Object.keys(result.projection.sourceEvents)).toEqual([
+			'progress:run-1:running',
+			'message:message-1',
+			'progress:run-1:completed'
+		]);
+	});
+
+	it('ignores events already applied and duplicates in the same batch', () => {
+		const existing = {
+			cursor: 1,
+			messages: [{ id: 'message-1', role: 'user', content: 'hello' }],
+			progress: { 'run-1': { runId: 'run-1', status: 'running' } },
+			sourceEvents: {}
+		};
+		const next = message(2, 'message-2', 'world');
+
+		const result = reduceThreadEvents(existing, [next, message(1, 'message-1', 'changed'), next]);
+
+		expect(result.gap).toBeNull();
+		expect(result.conflict).toBeNull();
+		expect(result.applied).toEqual([next]);
+		expect(result.projection).toEqual({
+			cursor: 2,
+			messages: [
+				{ id: 'message-1', role: 'user', content: 'hello' },
+				{ id: 'message-2', role: 'assistant', content: 'world' }
+			],
+			progress: { 'run-1': { runId: 'run-1', status: 'running' } },
+			sourceEvents: { [next.sourceKey]: next }
+		});
+	});
+
+	it('reports a missing sequence without skipping later events', () => {
+		const result = reduceThreadEvents(emptyThreadProjection(), [
+			message(1, 'message-1', 'first'),
+			message(3, 'message-3', 'third'),
+			message(4, 'message-4', 'fourth')
+		]);
+
+		expect(result.gap).toEqual({ from: 2, to: 2 });
+		expect(result.conflict).toBeNull();
+		expect(result.applied).toEqual([message(1, 'message-1', 'first')]);
+		expect(result.projection.cursor).toBe(1);
+		expect(result.projection.messages).toEqual([
+			{ id: 'message-1', role: 'assistant', content: 'first' }
+		]);
+	});
+
+	it('does not mutate the input projection', () => {
+		const initial = emptyThreadProjection();
+
+		reduceThreadEvents(initial, [message(1, 'message-1', 'hello')]);
+
+		expect(initial).toEqual(emptyThreadProjection());
+	});
+
+	it('reports a source-key conflict instead of applying a different payload', () => {
+		const first = message(1, 'message-1', 'hello');
+		const result = reduceThreadEvents(emptyThreadProjection(), [
+			first,
+			{ ...message(2, 'message-2', 'changed'), sourceKey: first.sourceKey }
+		]);
+
+		expect(result.conflict).toMatchObject({ sourceKey: first.sourceKey });
+		expect(result.projection.cursor).toBe(1);
+		expect(result.projection.messages).toEqual([first.message]);
+	});
+
+	it('deduplicates the same payload even when a repeated event has another sequence', () => {
+		const first = message(1, 'message-1', 'hello');
+		const result = reduceThreadEvents(emptyThreadProjection(), [first, { ...first, seq: 2 }]);
+
+		expect(result.conflict).toBeNull();
+		expect(result.projection.cursor).toBe(1);
+		expect(result.projection.messages).toEqual([first.message]);
+	});
+});

--- a/packages/agent-kit/src/thread-events.test.ts
+++ b/packages/agent-kit/src/thread-events.test.ts
@@ -15,6 +15,13 @@ const progress = (seq: number, runId: string, status: string): ThreadEvent => ({
 	progress: { runId, status }
 });
 
+const superseded = (seq: number, ids: string[]): ThreadEvent => ({
+	seq,
+	sourceKey: `superseded:${seq}`,
+	kind: 'messages_superseded',
+	messageIds: ids
+});
+
 describe('thread event reducer', () => {
 	it('orders events and projects messages and latest progress', () => {
 		const result = reduceThreadEvents(emptyThreadProjection(), [
@@ -107,5 +114,18 @@ describe('thread event reducer', () => {
 		expect(result.conflict).toBeNull();
 		expect(result.projection.cursor).toBe(1);
 		expect(result.projection.messages).toEqual([first.message]);
+	});
+
+	it('hides messages through an ordered supersede event', () => {
+		const result = reduceThreadEvents(emptyThreadProjection(), [
+			message(1, 'message-1', 'old'),
+			message(2, 'message-2', 'new'),
+			superseded(3, ['message-1'])
+		]);
+
+		expect(result.gap).toBeNull();
+		expect(result.projection.messages).toEqual([
+			{ id: 'message-2', role: 'assistant', content: 'new' }
+		]);
 	});
 });

--- a/packages/agent-kit/src/thread-events.ts
+++ b/packages/agent-kit/src/thread-events.ts
@@ -1,0 +1,126 @@
+export interface ThreadMessage {
+	id: string;
+	role: string;
+	content: unknown;
+}
+
+export interface ThreadProgress {
+	runId: string;
+	status: string;
+	[key: string]: unknown;
+}
+
+type ThreadEventBase = {
+	seq: number;
+	sourceKey: string;
+};
+
+export type ThreadEvent =
+	| (ThreadEventBase & {
+			kind: 'message';
+			message: ThreadMessage;
+		})
+	| (ThreadEventBase & {
+			kind: 'progress';
+			progress: ThreadProgress;
+		});
+
+export interface ThreadProjection {
+	cursor: number;
+	messages: readonly ThreadMessage[];
+	progress: Readonly<Record<string, ThreadProgress>>;
+	sourceEvents: Readonly<Record<string, ThreadEvent>>;
+}
+
+export interface ThreadEventGap {
+	from: number;
+	to: number;
+}
+
+export interface ThreadEventReduction {
+	projection: ThreadProjection;
+	applied: readonly ThreadEvent[];
+	gap: ThreadEventGap | null;
+	conflict: ThreadEventConflict | null;
+}
+
+export interface ThreadEventConflict {
+	sourceKey: string;
+	existing: ThreadEvent;
+	incoming: ThreadEvent;
+}
+
+export function emptyThreadProjection(): ThreadProjection {
+	return { cursor: 0, messages: [], progress: {}, sourceEvents: {} };
+}
+
+export function reduceThreadEvents(
+	projection: ThreadProjection,
+	events: readonly ThreadEvent[]
+): ThreadEventReduction {
+	const ordered = [...events].sort((left, right) => left.seq - right.seq);
+	const messages = [...projection.messages];
+	const progress = { ...projection.progress };
+	const sourceEvents = { ...projection.sourceEvents };
+	const applied: ThreadEvent[] = [];
+	let cursor = projection.cursor;
+	let gap: ThreadEventGap | null = null;
+	let conflict: ThreadEventConflict | null = null;
+
+	for (const event of ordered) {
+		const existing = sourceEvents[event.sourceKey];
+		if (existing) {
+			if (stableSerialize(eventPayload(existing)) !== stableSerialize(eventPayload(event))) {
+				conflict = { sourceKey: event.sourceKey, existing, incoming: event };
+				break;
+			}
+			continue;
+		}
+
+		if (event.seq <= cursor) {
+			continue;
+		}
+
+		const expected = cursor + 1;
+		if (event.seq > expected) {
+			gap = { from: expected, to: event.seq - 1 };
+			break;
+		}
+
+		if (event.kind === 'message') {
+			messages.push(event.message);
+		}
+
+		if (event.kind === 'progress') {
+			progress[event.progress.runId] = event.progress;
+		}
+
+		sourceEvents[event.sourceKey] = event;
+		applied.push(event);
+		cursor = event.seq;
+	}
+
+	return {
+		projection: { cursor, messages, progress, sourceEvents },
+		applied,
+		gap,
+		conflict
+	};
+}
+
+function eventPayload(event: ThreadEvent): unknown {
+	return event.kind === 'message'
+		? { kind: event.kind, message: event.message }
+		: { kind: event.kind, progress: event.progress };
+}
+
+function stableSerialize(value: unknown): string {
+	if (Array.isArray(value)) return `[${value.map(stableSerialize).join(',')}]`;
+	if (value && typeof value === 'object') {
+		return `{${Object.keys(value as Record<string, unknown>)
+			.sort()
+			.map((key) => `${JSON.stringify(key)}:${stableSerialize((value as Record<string, unknown>)[key])}`)
+			.join(',')}}`;
+	}
+	return JSON.stringify(value);
+}

--- a/packages/agent-kit/src/thread-events.ts
+++ b/packages/agent-kit/src/thread-events.ts
@@ -2,6 +2,7 @@ export interface ThreadMessage {
 	id: string;
 	role: string;
 	content: unknown;
+	[key: string]: unknown;
 }
 
 export interface ThreadProgress {
@@ -23,6 +24,10 @@ export type ThreadEvent =
 	| (ThreadEventBase & {
 			kind: 'progress';
 			progress: ThreadProgress;
+		})
+	| (ThreadEventBase & {
+			kind: 'messages_superseded';
+			messageIds: readonly string[];
 		});
 
 export interface ThreadProjection {
@@ -59,7 +64,12 @@ export function reduceThreadEvents(
 	events: readonly ThreadEvent[]
 ): ThreadEventReduction {
 	const ordered = [...events].sort((left, right) => left.seq - right.seq);
-	const messages = [...projection.messages];
+	const supersededIds = new Set(
+		Object.values(projection.sourceEvents)
+			.filter((event): event is Extract<ThreadEvent, { kind: 'messages_superseded' }> => event.kind === 'messages_superseded')
+			.flatMap((event) => event.messageIds)
+	);
+	const messages = projection.messages.filter((message) => !supersededIds.has(message.id));
 	const progress = { ...projection.progress };
 	const sourceEvents = { ...projection.sourceEvents };
 	const applied: ThreadEvent[] = [];
@@ -95,6 +105,13 @@ export function reduceThreadEvents(
 			progress[event.progress.runId] = event.progress;
 		}
 
+		if (event.kind === 'messages_superseded') {
+			for (const id of event.messageIds) supersededIds.add(id);
+			for (let index = messages.length - 1; index >= 0; index--) {
+				if (supersededIds.has(messages[index].id)) messages.splice(index, 1);
+			}
+		}
+
 		sourceEvents[event.sourceKey] = event;
 		applied.push(event);
 		cursor = event.seq;
@@ -109,9 +126,9 @@ export function reduceThreadEvents(
 }
 
 function eventPayload(event: ThreadEvent): unknown {
-	return event.kind === 'message'
-		? { kind: event.kind, message: event.message }
-		: { kind: event.kind, progress: event.progress };
+	if (event.kind === 'message') return { kind: event.kind, message: event.message };
+	if (event.kind === 'progress') return { kind: event.kind, progress: event.progress };
+	return { kind: event.kind, messageIds: event.messageIds };
 }
 
 function stableSerialize(value: unknown): string {

--- a/packages/agent-kit/src/types.ts
+++ b/packages/agent-kit/src/types.ts
@@ -80,13 +80,20 @@ export interface ToolResult {
 /** Lo stato di un effetto collaterale nel ledger — la macchina a stati di `agent_kit_effects`. */
 export type EffectStatus = 'intended' | 'completed' | 'failed' | 'ambiguous' | 'reconciled';
 
-/** Una riga del ledger degli effetti: chi, cosa, con quale chiave, in che stato. */
+/** Risultato atomico del claim: solo `claimed` può eseguire il payload. */
+export type EffectClaim =
+	| { kind: 'claimed'; effect: ToolEffect }
+	| { kind: 'existing'; effect: ToolEffect }
+	| { kind: 'mismatch'; effect: ToolEffect };
+
+/** Una riga del ledger: identità della chiamata e payload sono dati distinti. */
 export interface ToolEffect {
 	id: string;
 	brandId: string;
 	runId: string | null;
 	toolName: string;
-	idempotencyKey: string;
+	/** SDK `toolCallId`, persistito nella storia e stabile tra resume e takeover. */
+	invocationId: string | null;
 	status: EffectStatus;
 	request?: unknown;
 	result?: unknown;
@@ -97,7 +104,7 @@ export interface ToolEffect {
 export interface ToolCall {
 	name: string;
 	args: Record<string, unknown>;
-	/** Id della chiamata sul filo (SDK `toolCallId`). Ancora un artefatto alla chip giusta. */
+	/** Identità della chiamata sul filo (SDK `toolCallId`), non derivata dagli argomenti. */
 	id?: string;
 }
 
@@ -110,6 +117,7 @@ export interface RunTokenUsage {
 export type RunEvent =
 	| { type: 'text'; text: string }
 	| { type: 'reasoning'; text: string }
+	/** `id` è il `toolCallId` persistito e rigiocato dai runtime durante resume e takeover. */
 	| { type: 'tool_call'; call: ToolCall; id: string }
 	| { type: 'tool_result'; id: string; result: ToolResult }
 	| { type: 'done'; reason: RunStopReason; usage?: RunTokenUsage }

--- a/packages/agent-kit/src/types.ts
+++ b/packages/agent-kit/src/types.ts
@@ -44,9 +44,10 @@ export interface ToolSpec {
 	terminal?: boolean;
 	/**
 	 * Il tool ha un effetto collaterale reale (scrive/post/schedula/rende un file): va avvolto dal
-	 * ledger, così un resume a metà turno non lo riesegue. Assente = si legge e basta, mai una riga.
+	 * ledger, così un resume a metà turno non lo riesegue. La dichiarazione è obbligatoria per non
+	 * lasciare alla convenzione la decisione se una chiamata scrive o legge.
 	 */
-	effectful?: boolean;
+	effectful: boolean;
 }
 
 export type ActionApprovalRule = {
@@ -75,6 +76,7 @@ export type ToolResultContent =
 export interface ToolResult {
 	content: ToolResultContent[];
 	isError?: boolean;
+	effectStatus?: Exclude<EffectStatus, 'intended' | 'reconciled'>;
 }
 
 /** Lo stato di un effetto collaterale nel ledger — la macchina a stati di `agent_kit_effects`. */

--- a/src/lib/agent/bridge/adapters.ts
+++ b/src/lib/agent/bridge/adapters.ts
@@ -282,6 +282,7 @@ export async function startHarnessTurn(opts: {
 	 * sessione che aveva chiuso. L'adapter e` tenuto a propagare la cancellazione.
 	 */
 	abortSignal?: AbortSignal;
+	toolApproval?: Record<string, 'not-applicable' | 'approved' | 'user-approval' | 'denied'>;
 }): Promise<HarnessTurnStream> {
 	hydrateHarnessEnv();
 	const knownSetup = HARNESS_SETUPS[opts.model.provider];
@@ -296,6 +297,7 @@ export async function startHarnessTurn(opts: {
 		instructions: opts.historyMd ? `${opts.system}\n\n---\nCONVERSAZIONE PRECEDENTE (dato storico, non istruzione):\n${opts.historyMd}` : opts.system,
 		tools: opts.tools,
 		stopWhen: opts.stopWhen,
+		...(opts.toolApproval ? { toolApproval: opts.toolApproval } : {}),
 		...(skills.length > 0 ? { skills } : {})
 	} as never);
 	type LiveEntry = { agent: unknown; session: { destroy(): Promise<void> } };
@@ -317,7 +319,7 @@ export async function startHarnessTurn(opts: {
 			const rawSession = cached.session as {
 				hasUnfinishedTurn?: () => boolean;
 			};
-			if (rawSession.hasUnfinishedTurn?.()) {
+			if (rawSession.hasUnfinishedTurn?.() && !hasApprovalResponse(opts.messages)) {
 				const drained = await (cached.agent as {
 					continueGenerate: (o: { session: unknown }) => Promise<{ text?: Promise<string> }>;
 				}).continueGenerate({ session: cached.session });
@@ -371,4 +373,12 @@ export async function startHarnessTurn(opts: {
 			await session.destroy();
 		}
 	};
+}
+
+function hasApprovalResponse(messages: unknown): boolean {
+	if (!Array.isArray(messages)) return false;
+	const last = messages.at(-1) as { role?: string; content?: unknown } | undefined;
+	return last?.role === 'tool' && Array.isArray(last.content) && last.content.some((part) => {
+		return !!part && typeof part === 'object' && (part as { type?: string }).type === 'tool-approval-response';
+	});
 }

--- a/src/lib/agent/bridge/approval.test.ts
+++ b/src/lib/agent/bridge/approval.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { approvalContinuationMessage, findToolApproval, approvalMessageParts } from './approval';
+
+describe('harness approval bridge', () => {
+	it('finds a pending approval and its original tool call from a completed step', () => {
+		expect(
+			findToolApproval([
+				{
+					content: [
+						{ type: 'tool-call', toolCallId: 'call-1', toolName: 'publish_post', input: { post_id: 'p1' } },
+						{ type: 'tool-approval-request', approvalId: 'approval-1', toolCallId: 'call-1' }
+					]
+				}
+			])
+		).toEqual({
+			approvalId: 'approval-1',
+			toolCallId: 'call-1',
+			toolName: 'publish_post',
+			input: { post_id: 'p1' }
+		});
+	});
+
+	it('serializes the original call and approval request for model history', () => {
+		expect(approvalMessageParts({ approvalId: 'a1', toolCallId: 'c1', toolName: 'send_email', input: { to: 'a@b.test' } })).toEqual([
+			{ type: 'tool-call', toolCallId: 'c1', toolName: 'send_email', input: { to: 'a@b.test' } },
+			{ type: 'tool-approval-request', approvalId: 'a1', toolCallId: 'c1' }
+		]);
+	});
+
+	it('creates the native continuation response without adding a user turn', () => {
+		expect(approvalContinuationMessage({ approvalId: 'a1', approved: false, reason: 'Not now' })).toEqual({
+			role: 'tool',
+			content: [{ type: 'tool-approval-response', approvalId: 'a1', approved: false, reason: 'Not now' }]
+		});
+	});
+});

--- a/src/lib/agent/bridge/approval.ts
+++ b/src/lib/agent/bridge/approval.ts
@@ -1,0 +1,72 @@
+import type { ModelMessage } from 'ai';
+
+export type ToolApproval = {
+	approvalId: string;
+	toolCallId: string;
+	toolName: string;
+	input: unknown;
+	reason?: string;
+};
+
+export function findToolApproval(steps: readonly unknown[]): ToolApproval | null {
+	const calls = new Map<string, { toolName: string; input: unknown }>();
+	for (const step of steps) {
+		const value = step as { content?: unknown; toolCalls?: unknown };
+		for (const part of partsOf(value.content)) {
+			if (part.type === 'tool-call' && typeof part.toolCallId === 'string' && typeof part.toolName === 'string') {
+				calls.set(part.toolCallId, { toolName: part.toolName, input: part.input });
+			}
+		}
+		for (const call of Array.isArray(value.toolCalls) ? value.toolCalls : []) {
+			const part = call as Record<string, unknown>;
+			if (typeof part.toolCallId === 'string' && typeof part.toolName === 'string') {
+				calls.set(part.toolCallId, { toolName: part.toolName, input: part.input });
+			}
+		}
+	}
+
+	for (const step of steps) {
+		for (const part of partsOf((step as { content?: unknown }).content)) {
+			if (part.type !== 'tool-approval-request' || typeof part.approvalId !== 'string' || typeof part.toolCallId !== 'string') continue;
+			const call = calls.get(part.toolCallId);
+			if (!call) continue;
+			return {
+				approvalId: part.approvalId,
+				toolCallId: part.toolCallId,
+				toolName: call.toolName,
+				input: call.input,
+				...(typeof part.reason === 'string' ? { reason: part.reason } : {})
+			};
+		}
+	}
+	return null;
+}
+
+export function approvalMessageParts(approval: ToolApproval): unknown[] {
+	return [
+		{ type: 'tool-call', toolCallId: approval.toolCallId, toolName: approval.toolName, input: approval.input },
+		{ type: 'tool-approval-request', approvalId: approval.approvalId, toolCallId: approval.toolCallId }
+	];
+}
+
+export function approvalContinuationMessage(input: {
+	approvalId: string;
+	approved: boolean;
+	reason?: string;
+}): ModelMessage {
+	return {
+		role: 'tool',
+		content: [
+			{
+				type: 'tool-approval-response',
+				approvalId: input.approvalId,
+				approved: input.approved,
+				...(input.reason ? { reason: input.reason } : {})
+			} as never
+		]
+	};
+}
+
+function partsOf(value: unknown): Array<Record<string, unknown>> {
+	return Array.isArray(value) ? value.filter((part): part is Record<string, unknown> => !!part && typeof part === 'object') : [];
+}

--- a/src/lib/agent/bridge/live.test.ts
+++ b/src/lib/agent/bridge/live.test.ts
@@ -3,6 +3,7 @@ import { MockLanguageModelV3 } from 'ai/test';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { applyChatStreamEvent, emptyStreamState, readSseEvents } from '$lib/chat-stream-events';
 import { judgeTranscript, type TranscriptEvent } from '$lib/server/eval/transcript-judge';
+import type { ActionApprovalConfig } from '@anomalia/agent-kit/types';
 
 /**
  * COME `ai-runtime.test.ts` E `run-store.test.ts`: il turno arriva scripted sull'harness finto
@@ -503,7 +504,7 @@ const spec = specById('content')!;
 // turno (brand_memory per l'iniezione della memoria): righe vuote, catena PostgREST minima.
 function emptyReadChain(): Record<string, unknown> {
 	const chain: Record<string, unknown> = {};
-	for (const m of ['select', 'eq', 'is', 'or', 'not', 'neq', 'order', 'limit', 'in']) {
+	for (const m of ['select', 'insert', 'update', 'delete', 'eq', 'is', 'or', 'not', 'neq', 'order', 'limit', 'in']) {
 		chain[m] = () => chain;
 	}
 	chain.then = (resolve: (v: unknown) => void) => resolve({ data: [], error: null });
@@ -614,6 +615,30 @@ describe('la squadra: message_agent è montato per OGNI mestiere', () => {
 		expect(prompt.text).toContain("language of the user's latest message");
 		expect(prompt.text).toContain('an English message gets an English reply');
 		expect(prompt.text).not.toMatch(/^Sei /m);
+	});
+});
+
+describe('runKitTurn — action approval', () => {
+	it('applica il judge al tool del turno prima di arrivare al plugin', async () => {
+		const checker = vi.fn(async () => 'error' as const);
+		const approval: ActionApprovalConfig = { autoReviewEnabled: true, checker };
+		toolCallModel('content_update_post', { post_id: 'p1', caption: 'nuova caption' });
+		const { db } = fakeDb();
+
+		const res = await runKitTurn({
+			supabase: fakeSupabase,
+			admin: db,
+			brand: { id: 'b1' },
+			user: { id: 'u1' },
+			threadId: 't-approval',
+			spec,
+			messages: [{ role: 'user', content: 'aggiorna il post' }],
+			locale: 'it',
+			approval
+		});
+		await res.text();
+
+		expect(checker).toHaveBeenCalledOnce();
 	});
 });
 

--- a/src/lib/agent/bridge/live.test.ts
+++ b/src/lib/agent/bridge/live.test.ts
@@ -134,6 +134,7 @@ type FakeCall = { toolCallId: string; toolName: string; input: Record<string, un
 type FakeTurn = {
 	texts?: string[];
 	calls?: FakeCall[];
+	nativeApproval?: boolean;
 	totalUsage?: Record<string, unknown>;
 	onStreamStart?: () => void;
 	/** Non produce MAI il primo evento: la sessione riusata che non parte (incidente reale). */
@@ -171,7 +172,10 @@ function teeText(payload: string): [ReadableStream<Uint8Array>, ReadableStream<U
 	return src.tee();
 }
 
-function buildFakeHarnessResult(turn: FakeTurn, opts: { tools: Record<string, { execute?: (input: unknown, options: unknown) => Promise<unknown> }> }) {
+function buildFakeHarnessResult(turn: FakeTurn, opts: {
+	tools: Record<string, { execute?: (input: unknown, options: unknown) => Promise<unknown> }>;
+	toolApproval?: Record<string, string>;
+}) {
 	const stepParts: Array<Record<string, unknown>> = [];
 	const stepToolCalls: Array<{ toolCallId: string; toolName: string; input: unknown }> = [];
 	const stepToolResults: Array<{ toolCallId: string; toolName: string; input: unknown; output: unknown }> = [];
@@ -193,6 +197,12 @@ function buildFakeHarnessResult(turn: FakeTurn, opts: { tools: Record<string, { 
 		}
 		await new Promise((r) => setTimeout(r, 8));
 		for (const call of turn.calls ?? []) {
+			if (turn.nativeApproval && opts.toolApproval?.[call.toolName] === 'user-approval') {
+				const approvalId = `approval-${call.toolCallId}`;
+				uiChunks.push({ type: 'tool-approval-request', approvalId, toolCallId: call.toolCallId, toolName: call.toolName, input: call.input });
+				stepParts.push({ type: 'tool-approval-request', approvalId, toolCallId: call.toolCallId });
+				continue;
+			}
 			const t = opts.tools?.[call.toolName];
 			if (t && typeof t.execute === 'function') {
 				let output: unknown;
@@ -277,6 +287,7 @@ vi.mock('./adapters', async (importOriginal) => {
 			tools: Record<string, { execute?: (input: unknown, options: unknown) => Promise<unknown> }>;
 			stopWhen: unknown[];
 			sessionKey?: string;
+			toolApproval?: Record<string, string>;
 		}) => {
 			const idx = Math.min(harnessServed, harnessQueue.length - 1);
 			harnessServed += 1;
@@ -298,7 +309,11 @@ vi.mock('./adapters', async (importOriginal) => {
 			}
 			harnessTurnOpts.push(opts);
 			turn.capture?.({ system: opts.system, messages: opts.messages, tools, stopWhen: opts.stopWhen });
-			return { result: buildFakeHarnessResult(turn, { ...opts, tools }), destroy: async () => {} };
+			return {
+				result: buildFakeHarnessResult(turn, { ...opts, tools }),
+				detach: async () => ({ checkpoint: 'approval' }),
+				destroy: async () => {}
+			};
 		}
 	};
 });
@@ -321,15 +336,17 @@ type Row = Record<string, unknown>;
 	function fakeDb(seed: Row[] = []) {
 	const rows: Row[] = seed.map((r) => ({ ...r }));
 	let seq = rows.length;
+	const approvals: Row[] = [];
 	// L'emulazione di `agent_kit_close_run` (migration 0222): CAS su state='running', inserimento
 	// del messaggio e stato finale nella STESSA chiamata — la stessa semantica della funzione SQL.
 	const chatMessages: Row[] = [];
 
 	function from(_table: string) {
-		const store = _table === 'chat_messages' ? chatMessages : rows;
+		const store = _table === 'chat_messages' ? chatMessages : _table === 'agent_kit_approval_requests' ? approvals : rows;
 		let op: 'select' | 'insert' | 'update' = 'select';
 		let payload: Row | undefined;
 		const eqFilters: Array<[string, unknown]> = [];
+		const inFilters: Array<[string, unknown[]]> = [];
 		let limitN: number | undefined;
 		let orderCol: string | undefined;
 		let orderAscending = true;
@@ -337,6 +354,7 @@ type Row = Record<string, unknown>;
 		function matchedRows(): Row[] {
 			let matched = store;
 			for (const [col, val] of eqFilters) matched = matched.filter((r) => r[col] === val);
+			for (const [col, values] of inFilters) matched = matched.filter((r) => values.includes(r[col]));
 			if (orderCol) {
 				const col = orderCol;
 				matched = [...matched].sort((a, b) => {
@@ -377,6 +395,10 @@ type Row = Record<string, unknown>;
 			order(col: string, opts?: { ascending?: boolean }) {
 				orderCol = col;
 				orderAscending = opts?.ascending ?? true;
+				return b;
+			},
+			in(col: string, values: unknown[]) {
+				inFilters.push([col, values]);
 				return b;
 			},
 			limit(n: number) {
@@ -437,6 +459,42 @@ type Row = Record<string, unknown>;
 	// del messaggio e stato finale nella STESSA chiamata — la stessa semantica della funzione SQL.
 	// `chatMessages` vive in testa a `fakeDb`: `from('chat_messages')` ci opera sopra.
 	function rpc(fn: string, params: Record<string, unknown>) {
+		if (fn === 'agent_kit_wait_for_approval') {
+			const run = rows.find((r) => r.id === params.p_run_id && r.state === 'running');
+			if (!run) return Promise.resolve({ data: { closed: false }, error: null });
+			run.state = 'waiting_takeover';
+			run.harness_continue_state = params.p_continue_state;
+			const approval = {
+				id: `approval-row-${approvals.length + 1}`,
+				run_id: run.id,
+				thread_id: run.thread_id,
+				status: 'pending',
+				harness_approval_id: params.p_harness_approval_id,
+				tool_call_id: params.p_tool_call_id,
+				tool_name: params.p_tool_name,
+				tool_input: params.p_tool_input
+			};
+			approvals.push(approval);
+			const message = params.p_message as Row | null;
+			if (message) {
+				const toolCalls = Array.isArray(message.tool_calls)
+					? message.tool_calls.map((part) =>
+							(part as Row).type === 'tool-approval-request' && (part as Row).approvalId === params.p_harness_approval_id
+								? { ...(part as Row), approvalId: approval.id }
+								: part
+						)
+					: message.tool_calls;
+				const id = `msg-${chatMessages.length + 1}`;
+				chatMessages.push({ id, thread_id: run.thread_id, role: 'assistant', ...message, tool_calls: toolCalls });
+				run.partial_saved_msg_id = id;
+				savedMessages.push({
+					threadId: run.thread_id as string,
+					content: (toolCalls as unknown[]) ?? [],
+					attachments: (message.attachments as string[] | null) ?? undefined
+				});
+			}
+			return Promise.resolve({ data: { closed: true, approval_id: approval.id, harness_approval_id: approval.harness_approval_id }, error: null });
+		}
 		if (fn !== 'agent_kit_close_run') {
 			return Promise.resolve({ data: null, error: { message: `rpc sconosciuta: ${fn}` } });
 		}
@@ -461,7 +519,7 @@ type Row = Record<string, unknown>;
 		return Promise.resolve({ data: { closed: true, message_id: msgId }, error: null });
 	}
 
-	return { db: { from, rpc } as unknown as SupabaseClient, rows, chatMessages };
+	return { db: { from, rpc } as unknown as SupabaseClient, rows, chatMessages, approvals };
 }
 
 /** Un turno che chiama UN tool (e unico) e basta. */
@@ -639,6 +697,126 @@ describe('runKitTurn — action approval', () => {
 		await res.text();
 
 		expect(checker).toHaveBeenCalledOnce();
+	});
+
+	it('un judge pass riprende il turno senza chiedere all’utente', async () => {
+		scriptTurns(
+			{
+				nativeApproval: true,
+				calls: [{ toolCallId: 'c1', toolName: 'content_update_post', input: { post_id: 'p1' } }]
+			},
+			{ calls: [replyCall('aggiornato')] }
+		);
+		const checker = vi.fn(async () => 'pass' as const);
+		const { db, rows, approvals } = fakeDb();
+
+		const res = await runKitTurn({
+			supabase: fakeSupabase,
+			admin: db,
+			brand: { id: 'b1' },
+			user: { id: 'u1' },
+			threadId: 't-approval-pass',
+			spec,
+			messages: [{ role: 'user', content: 'aggiorna il post' }],
+			locale: 'it',
+			approval: { autoReviewEnabled: true, checker }
+		});
+		await res.text();
+		await new Promise((resolve) => setTimeout(resolve, 40));
+
+		expect(checker).toHaveBeenCalledOnce();
+		expect(harnessTurnOpts).toHaveLength(2);
+		expect(approvals).toHaveLength(0);
+		expect(rows[0].state).toBe('done');
+	});
+
+	it('un judge ask salva richiesta, card e continuation state prima di uscire', async () => {
+		scriptTurns({
+			nativeApproval: true,
+			calls: [{ toolCallId: 'c1', toolName: 'content_update_post', input: { post_id: 'p1' } }]
+		});
+		const checker = vi.fn(async () => 'error' as const);
+		const { db, rows, approvals } = fakeDb();
+
+		const res = await runKitTurn({
+			supabase: fakeSupabase,
+			admin: db,
+			brand: { id: 'b1' },
+			user: { id: 'u1' },
+			threadId: 't-approval-ask',
+			spec,
+			messages: [{ role: 'user', content: 'aggiorna il post' }],
+			locale: 'it',
+			approval: { autoReviewEnabled: true, checker }
+		});
+		await res.text();
+		await new Promise((resolve) => setTimeout(resolve, 40));
+
+		expect(checker).toHaveBeenCalledOnce();
+		expect(rows[0].state).toBe('waiting_takeover');
+		expect(rows[0].harness_continue_state).toEqual({ checkpoint: 'approval' });
+		expect(approvals[0]?.status).toBe('pending');
+		expect(JSON.stringify(savedMessages.at(-1)?.content)).toContain('tool-approval-request');
+		expect(JSON.stringify(savedMessages.at(-1)?.content)).toContain('approval-row-1');
+	});
+
+	it('riprende dopo un reload quando l utente approva la richiesta persistita', async () => {
+		const checker = vi.fn(async () => 'error' as const);
+		scriptTurns(
+			{
+				nativeApproval: true,
+				calls: [{ toolCallId: 'c1', toolName: 'content_update_post', input: { post_id: 'p1' } }]
+			},
+			{ calls: [replyCall('aggiornato')] }
+		);
+		const { db, rows, approvals } = fakeDb();
+		const approval = { autoReviewEnabled: true, checker };
+		const first = await runKitTurn({
+			supabase: fakeSupabase,
+			admin: db,
+			brand: { id: 'b1' },
+			user: { id: 'u1' },
+			threadId: 't-approval-reload',
+			spec,
+			messages: [{ role: 'user', content: 'aggiorna il post' }],
+			locale: 'it',
+			approval
+		});
+		await first.text();
+		await new Promise((resolve) => setTimeout(resolve, 40));
+
+		approvals[0].status = 'approved';
+		const resumed = await runKitTurn({
+			supabase: fakeSupabase,
+			admin: db,
+			brand: { id: 'b1' },
+			user: { id: 'u1' },
+			threadId: 't-approval-reload',
+			spec,
+			messages: [
+				{ role: 'user', content: 'aggiorna il post' },
+				{
+					role: 'assistant',
+					content: [
+						{ type: 'tool-call', toolCallId: 'c1', toolName: 'content_update_post', input: { post_id: 'p1' } },
+						{ type: 'tool-approval-request', approvalId: 'approval-row-1', toolCallId: 'c1' }
+					]
+				},
+				{
+					role: 'tool',
+					content: [{ type: 'tool-approval-response', approvalId: 'approval-c1', approved: true }]
+				}
+			],
+			locale: 'it',
+			approval,
+			approvalResponse: { approvalId: 'approval-c1', approved: true, toolCallId: 'c1' }
+		});
+		await resumed.text();
+		await new Promise((resolve) => setTimeout(resolve, 40));
+
+		expect(rows[0].state).toBe('done');
+		expect(approvals[0]?.status).toBe('approved');
+		expect(harnessTurnOpts).toHaveLength(2);
 	});
 });
 

--- a/src/lib/agent/bridge/live.ts
+++ b/src/lib/agent/bridge/live.ts
@@ -118,6 +118,7 @@ import { resolveChatModel } from '$lib/server/chat/model';
 import { createGoalPlugin, withKitToolNames } from '../plugins/goal';
 import { kitPluginsFor } from '../plugins/registry';
 import { GOAL_TOOL_KEYS } from '$lib/server/chat/goal-tools';
+import { gateAction, planActionGate, resolveActionApprovalDetail } from '@anomalia/agent-kit/action-approval';
 import { CHAT_MAX_CONTINUATIONS } from '$lib/server/chat/turn-limits';
 import {
 	goalBriefing,
@@ -128,6 +129,8 @@ import {
 	trackGoalSettlement,
 	type ChatGoal
 } from '$lib/server/chat/goal';
+import { approvalContinuationMessage, approvalMessageParts, findToolApproval, type ToolApproval } from './approval';
+import { waitForApproval } from '$lib/server/chat/agent-kit-approvals';
 
 /**
  * La condizione pura che il ramo nel motore esistente valuta: flag ON *E* uno specialista
@@ -204,6 +207,7 @@ export interface RunKitTurnInput {
 	 */
 	dm?: { speaker: string; meName: string; otherName: string };
 	approval?: ActionApprovalConfig;
+	approvalResponse?: { approvalId: string; approved: boolean; reason?: string; toolCallId?: string };
 }
 
 /**
@@ -225,6 +229,20 @@ function lastToolCall(steps: readonly StepLike[]): { toolName: string; input?: u
 	return null;
 }
 
+function nativeToolApproval(
+	specs: Array<{ name: string; consequential: boolean }>,
+	config?: ActionApprovalConfig
+): Record<string, 'not-applicable' | 'approved' | 'user-approval' | 'denied'> | undefined {
+	if (!config) return undefined;
+	return Object.fromEntries(
+		specs.map((spec) => {
+			const resolved = resolveActionApprovalDetail({ toolName: spec.name, rules: config.rules ?? [] });
+			if (resolved.source === 'always_allow') return [spec.name, 'approved'];
+			return [spec.name, resolved.decision === 'ask' || spec.consequential ? 'user-approval' : 'not-applicable'];
+		})
+	);
+}
+
 /**
  * Un chunk UI message per lo specchio Realtime: piccolo così com'è (text-delta è già solo un
  * delta). L'unico caso grasso è un tool-output-available con un risultato voluminoso — lì si
@@ -244,16 +262,18 @@ function shrinkChunkForBroadcast(chunk: unknown): unknown {
  */
 function closeMessageFields(
 	content: Array<{ type: string; text?: string }>,
-	attachments: string[]
+	attachments: string[],
+	speaker?: string
 ): CloseMessage {
 	const text = content.filter((p) => p.type === 'text').map((p) => p.text ?? '').join('\n\n');
 	const reasoning = content.filter((p) => p.type === 'reasoning').map((p) => p.text ?? '').join('\n');
-	const hasToolCalls = content.some((p) => p.type === 'tool-call');
+	const hasToolCalls = content.some((p) => p.type === 'tool-call' || p.type === 'tool-approval-request');
 	return {
 		content: text,
 		reasoning: reasoning || undefined,
-		toolCalls: hasToolCalls ? content.filter((p) => p.type === 'tool-call' || p.type === 'text') : undefined,
-		attachments: attachments.length ? [...attachments] : undefined
+		toolCalls: hasToolCalls ? content.filter((p) => p.type === 'tool-call' || p.type === 'tool-approval-request' || p.type === 'text') : undefined,
+		attachments: attachments.length ? [...attachments] : undefined,
+		speaker
 	};
 }
 
@@ -265,7 +285,8 @@ function queryToolAdapter(deps: QueryToolDeps) {
 		const out = (await query.execute!(args as any, {
 			toolCallId: `query:${ctx.runId}`,
 			messages: [],
-			abortSignal: ctx.signal
+			abortSignal: ctx.signal,
+			context: undefined as never
 		})) as Record<string, unknown>;
 		return { content: [{ type: 'text', text: JSON.stringify(out) }], isError: 'error' in out };
 	};
@@ -323,16 +344,16 @@ function lastAssistantText(messages: ModelMessage[]): string {
 }
 
 /** Un run `waiting_input` per questo thread, se c'è — il turno corrente ne è la risposta. */
-async function currentWaitingRun(db: SupabaseClient, threadId: string): Promise<string | null> {
+async function currentWaitingRun(db: SupabaseClient, threadId: string): Promise<{ id: string; state: string } | null> {
 	const { data } = await db
 		.from('agent_kit_runs')
-		.select('id')
+		.select('id, state')
 		.eq('thread_id', threadId)
-		.eq('state', 'waiting_input')
+		.in('state', ['waiting_input', 'waiting_takeover'])
 		.order('created_at', { ascending: false })
 		.limit(1)
 		.maybeSingle();
-	return (data as { id: string } | null)?.id ?? null;
+	return (data as { id: string; state: string } | null) ?? null;
 }
 
 /** Fa girare UN turno sul sistema nuovo e restituisce la `Response` che il client già sa leggere. */
@@ -342,15 +363,42 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
 	const isDm = !!input.dm;
 
 	let run: RunRow;
-	const waitingId = await currentWaitingRun(admin, threadId);
-	if (waitingId) {
+	const waiting = await currentWaitingRun(admin, threadId);
+	if (waiting) {
+		if (waiting.state === 'waiting_takeover') {
+			const response = input.approvalResponse;
+			if (!response) {
+				return new Response(JSON.stringify({ error: 'approval_required' }), {
+					status: 409,
+					headers: { 'Content-Type': 'application/json' }
+				});
+			}
+			const { data: approval } = await admin
+				.from('agent_kit_approval_requests')
+				.select('status, tool_call_id')
+				.eq('run_id', waiting.id)
+				.eq('harness_approval_id', response.approvalId)
+				.maybeSingle();
+			if (!approval || !['approved', 'denied'].includes(String(approval.status))) {
+				return new Response(JSON.stringify({ error: 'approval_not_decided' }), {
+					status: 409,
+					headers: { 'Content-Type': 'application/json' }
+				});
+			}
+			if (response.toolCallId && response.toolCallId !== approval.tool_call_id) {
+				return new Response(JSON.stringify({ error: 'approval_tool_mismatch' }), {
+					status: 409,
+					headers: { 'Content-Type': 'application/json' }
+				});
+			}
+		}
 		// DOPPIO RESUME: due dispositivi rispondono insieme a una `waiting_input`. Il primo vince
 		// il compare-and-swap di `resume()`; il secondo lo trova già spostato e riceverebbe il
 		// 500 grezzo di `run: stato cambiato sotto le mani` — un'azione legittima (ha solo perso
 		// la corsa), non un errore di sistema. Risposta pulita, stesso 409 ritentabile del busy
 		// qui sotto, con un messaggio che l'utente capisce.
 		try {
-			({ run } = await resume(admin, waitingId));
+			({ run } = await resume(admin, waiting.id));
 		} catch (e) {
 			if (e instanceof Error && e.message.includes('stato cambiato sotto le mani')) {
 			// API payload, non chat: nessuna persona la legge in un fumetto. In inglese comunque,
@@ -737,7 +785,11 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
 				)
 			: turnTools;
 		const toolNames = turnToolsFinal.map((t) => t.name);
-		const toolSet = buildTools(turnToolsFinal, applyTool, ctx, input.approval);
+		const approvedToolCallIds = new Set<string>();
+		if (input.approvalResponse?.approved && input.approvalResponse.toolCallId) {
+			approvedToolCallIds.add(input.approvalResponse.toolCallId);
+		}
+		const toolSet = buildTools(turnToolsFinal, applyTool, ctx, input.approval, approvedToolCallIds);
 
 		// Il set che i worker di delega ricevono: gli STESSI oggetti tool dell'orchestratore, quindi
 		// ogni chiamata di un worker passa dall'applyTool qui sopra — battito, Stop e
@@ -745,7 +797,8 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
 		Object.assign(scopedTools, toolSet);
 		kitHubKeys.push(...toolNames.filter((n) => !(SUBAGENT_TOOL_KEYS as readonly string[]).includes(n)));
 
-		let savedResume: unknown = null;
+		let savedResume: unknown = run.harness_continue_state ?? null;
+		let turnMessages = messages;
 		// `process.env` e non il globale di Vite: questo file lo impacchetta anche il worker, che
 		// gira su Node puro dove quel globale non esiste — leggerne un campo era un TypeError che
 		// uccideva il turno prima di cominciare. Vedi `no-vite-globals.test.ts`.
@@ -756,7 +809,7 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
 				.select('harness_resume')
 				.eq('id', threadId)
 				.maybeSingle();
-			savedResume = (th as { harness_resume?: unknown } | null)?.harness_resume ?? null;
+			if (!savedResume) savedResume = (th as { harness_resume?: unknown } | null)?.harness_resume ?? null;
 		} catch {
 			savedResume = null;
 		}
@@ -777,8 +830,9 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
                             .join('\n')
                             .slice(-8_000),
 				resumeFrom: savedResume ?? undefined,
-			messages: stripProviderRefs(messages),
-			tools: toolSet,
+			messages: stripProviderRefs(turnMessages),
+				tools: toolSet as never,
+			toolApproval: nativeToolApproval(turnToolsFinal, input.approval),
 			abortSignal: turnAbort.signal,
 			// Un DM è un consulto fra colleghi, non una produzione: il tetto tiene il suo costo lì,
 			// come DM_REPLY_STEP_CAP fa sul motore classico.
@@ -865,6 +919,76 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
 				settled = true;
 				if (stoppedByUser) {
 					kickQueue();
+					return;
+				}
+				const pendingApproval = findToolApproval(steps);
+				if (pendingApproval) {
+					const content = assistantContentFromSteps(steps);
+					const approvalParts = approvalMessageParts(pendingApproval);
+					const hasCall = content.some(
+						(part) => part.type === 'tool-call' && part.toolCallId === pendingApproval.toolCallId
+					);
+					if (!hasCall) content.push(approvalParts[0]);
+					content.push(approvalParts[1]);
+					const specForApproval = turnToolsFinal.find((candidate) => candidate.name === pendingApproval.toolName);
+					const plan = input.approval && specForApproval
+						? planActionGate({
+								resolved: resolveActionApprovalDetail({ toolName: specForApproval.name, rules: input.approval.rules ?? [] }),
+								consequential: specForApproval.consequential === true,
+								autoReviewEnabled: input.approval.autoReviewEnabled,
+								checkerConfigured: input.approval.checker != null
+							})
+						: 'ask';
+					if (plan === 'judge' && specForApproval && input.approval?.checker) {
+						const gate = await gateAction({
+							spec: specForApproval,
+							call: {
+								name: pendingApproval.toolName,
+								args: (pendingApproval.input ?? {}) as Record<string, unknown>,
+								id: pendingApproval.toolCallId
+							},
+							context: ctx,
+							config: input.approval
+						});
+						if (gate.decision === 'allow') {
+							const continuationState = await turn.detach();
+							approvedToolCallIds.add(pendingApproval.toolCallId);
+							savedResume = continuationState;
+							turnMessages = [
+								...messages,
+								{ role: 'assistant', content },
+								approvalContinuationMessage({ approvalId: pendingApproval.approvalId, approved: true })
+							];
+							settled = false;
+							turn = await startTurnOnce(true);
+							const resumedResult = turn.result;
+							await resumedResult.consumeStream({
+								onError: (e) => console.error(`[AGENT_KIT] run ${run.id} judge resume error`, e)
+							});
+							await handleFinish({ steps: await resumedResult.steps, text: await resumedResult.text });
+							return;
+						}
+						if (gate.reason) pendingApproval.reason = gate.reason;
+					}
+					const continuationState = await turn.detach();
+					const waited = await waitForApproval(admin, {
+						runId: run.id,
+						harnessApprovalId: pendingApproval.approvalId,
+						toolCallId: pendingApproval.toolCallId,
+						toolName: pendingApproval.toolName,
+						toolInput: pendingApproval.input,
+						reason: pendingApproval.reason,
+						continueState: continuationState,
+						message: closeMessageFields(content, turnAttachments, input.dm?.speaker)
+					});
+					if (!waited.closed) {
+						kickQueue();
+						return;
+					}
+					try {
+						await touchThread(supabase, threadId);
+						void broadcastToBrand(brand.id, { event: 'thread-changed', payload: { threadId } });
+					} catch {}
 					return;
 				}
 				const last = lastToolCall(steps);
@@ -1217,7 +1341,7 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
 					userId: user.id,
 					threadId,
 					tier: String(input.tier ?? ''),
-					provider: modelRef.provider,
+					provider: modelRef.provider as Parameters<typeof logAiCall>[0]['provider'],
 					model: modelRef.label,
 					kind: 'agent_kit_stream',
 					detail: `run ${run.id} · agente ${spec.id}`
@@ -1239,7 +1363,7 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
 						model: modelRef ?? undefined,
 						system,
 						messages: stripProviderRefs([...messages, { role: 'user', content: corrective } as ModelMessage]),
-						tools: toolSet,
+							tools: toolSet as never,
 						stopWhen: [isStepCount(TURN_MAX_STEPS)],
 						sandboxSession: brandSandbox?.session,
 						sessionKey: threadId
@@ -1261,7 +1385,7 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
 				const usage = extractSdkUsage(await result.totalUsage);
 				logAiCall({
 					label: 'chat',
-					provider: modelRef.provider,
+					provider: modelRef.provider as Parameters<typeof logAiCall>[0]['provider'],
 					model: modelRef.id,
 					ms: Date.now() - turnT0,
 					ok: true,
@@ -1391,7 +1515,7 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
 						if (mustWrite) {
 							mustWrite = false;
 							lastWrite = now;
-							const prev = inFlight ?? Promise.resolve();
+							const prev: Promise<void> = inFlight ?? Promise.resolve();
 							inFlight = prev.then(writePartial).finally(() => {
 								inFlight = null;
 							});

--- a/src/lib/agent/bridge/live.ts
+++ b/src/lib/agent/bridge/live.ts
@@ -91,7 +91,7 @@ import { attachForChat } from './attach';
 import { buildTools } from '@anomalia/agent-adapters/runtime/ai-runtime';
 import { createCheckpointStorage } from '@anomalia/agent-adapters/checkpoint-storage';
 import { markComputerRunning, touchComputer } from '@anomalia/agent-core/computer';
-import { createEffectsLedger } from '@anomalia/agent-core/effects-store';
+import { createEffectsLedger } from '$lib/server/agent-kit-effects-store';
 import {
 	createServerBrandFs,
 	createPostgresMemoryStore,
@@ -106,7 +106,7 @@ import {
 import { reportChatError } from '$lib/server/chat/report-error';
 import { BUILTIN_TOOLS } from '../tools/builtin';
 import { createRun, transition, finish, resume, closeRunSaving, type CloseMessage, type CloseOutcome, type RunRow } from '../run-store';
-import type { AdapterContext, RunStopReason, ToolResult } from '../kit/types';
+import type { ActionApprovalConfig, AdapterContext, RunStopReason, ToolResult } from '../kit/types';
 import { createMotionPlugin } from '../plugins/motion';
 import { createContentPlugin } from '../plugins/content';
 import { createUgcPlugin } from '../plugins/ugc';
@@ -203,6 +203,7 @@ export interface RunKitTurnInput {
 	 * automatica. Senza, è un normale turno kit.
 	 */
 	dm?: { speaker: string; meName: string; otherName: string };
+	approval?: ActionApprovalConfig;
 }
 
 /**
@@ -736,7 +737,7 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
 				)
 			: turnTools;
 		const toolNames = turnToolsFinal.map((t) => t.name);
-		const toolSet = buildTools(turnToolsFinal, applyTool, ctx);
+		const toolSet = buildTools(turnToolsFinal, applyTool, ctx, input.approval);
 
 		// Il set che i worker di delega ricevono: gli STESSI oggetti tool dell'orchestratore, quindi
 		// ogni chiamata di un worker passa dall'applyTool qui sopra — battito, Stop e

--- a/src/lib/agent/plugins/analyst.ts
+++ b/src/lib/agent/plugins/analyst.ts
@@ -11,39 +11,45 @@ export interface AnalystPluginDeps {
 	locale?: 'en' | 'it';
 }
 
-const MAP: Record<string, { source: string; description: string; consequential: boolean }> = {
+const MAP: Record<string, { source: string; description: string; effectful: boolean; consequential: boolean }> = {
 	analyst_read_strategy: {
 		source: 'read_strategy',
+		effectful: false,
 		consequential: false,
 		description:
 			'Read the brand strategy in one call: competitive research report, positioning, the active editorial plan (voice, cadence, platform mix, weeks) and the active GTM plan (horizon, objective, current phase). This is the plan every recommendation must be compared against — read it before proposing a change to it.'
 	},
 	analyst_list_posts: {
 		source: 'read_posts',
+		effectful: false,
 		consequential: false,
 		description:
 			'List brand posts as real rows — status, platform, caption, scheduled slot, media_origin, and the media_review verdict (ship/fix/kill) when one exists. This is the grounded source for anything said about what the brand published: never quote a post, a title or a count that did not come back from here.'
 	},
 	analyst_post_patterns: {
 		source: 'analyze_post_people',
+		effectful: false,
 		consequential: false,
 		description:
 			'Analyze the synced post history (up to 200 published posts) for recurring people, best posting times, top formats and engagement patterns. Needs synced social history — with none it returns an error naming that, which is the honest answer, not a retry.'
 	},
 	analyst_read_leads: {
 		source: 'read_leads',
+		effectful: false,
 		consequential: false,
 		description:
 			'Read leads: real online conversations (Reddit/Threads/X) where the product or category is discussed, with the drafted comment/DM suggestions. Use them for the audience language, questions and objections behind a recommendation.'
 	},
 	analyst_run_review: {
 		source: 'run_analytics_review',
+		effectful: true,
 		consequential: true,
 		description:
 			'Run the analytics review: it reads social/blog/SEO performance and proposes GTM + editorial plan revisions for owner approval. Runs in the BACKGROUND — this call returns a job id immediately and the result lands later as a new message. Say one line and end the turn; never report the review as finished from this call.'
 	},
 	analyst_update_gtm_plan: {
 		source: 'update_gtm_plan',
+		effectful: true,
 		consequential: true,
 		description:
 			'Update the active GTM plan: objective, a phase name/objective, platform weights, or pillars. Refused when the brand has no active GTM plan. This is the only write in this trade — you do not create posts, you brief the other specialists through the plan.'
@@ -65,6 +71,7 @@ export function createAnalystPlugin(deps: AnalystPluginDeps): ToolPlugin {
 	const tools: ToolSpec[] = Object.entries(MAP).map(([name, m]) => ({
 		name,
 		description: m.description,
+		effectful: m.effectful,
 		consequential: m.consequential,
 		inputSchema: jsonSchemaOf(chatTools[m.source])
 	}));

--- a/src/lib/agent/plugins/chat-bridge.test.ts
+++ b/src/lib/agent/plugins/chat-bridge.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { execChatTool } from './chat-bridge';
+
+describe('execChatTool', () => {
+	it('marca ambiguous una eccezione del tool reale', async () => {
+		const tool = {
+			execute: async () => {
+				throw new Error('connessione interrotta dopo la scrittura');
+			}
+		};
+
+		const result = await execChatTool(tool as never, 'content_update_post', {}, 'run-1');
+
+		expect(result.isError).toBe(true);
+		expect(result.effectStatus).toBe('ambiguous');
+	});
+});

--- a/src/lib/agent/plugins/chat-bridge.ts
+++ b/src/lib/agent/plugins/chat-bridge.ts
@@ -68,6 +68,6 @@ export async function execChatTool(
 			isError: !!out && typeof out === 'object' && 'error' in out
 		};
 	} catch (e) {
-		return { content: [{ type: 'text', text: errMsg(e) }], isError: true };
+		return { content: [{ type: 'text', text: errMsg(e) }], isError: true, effectStatus: 'ambiguous' };
 	}
 }

--- a/src/lib/agent/plugins/content.ts
+++ b/src/lib/agent/plugins/content.ts
@@ -33,7 +33,7 @@ type ContentSource = {
 	source: string;
 	description: string;
 	requiresMode?: ToolSpec['requiresMode'];
-	effectful?: boolean;
+	effectful: boolean;
 	consequential: boolean;
 };
 
@@ -93,6 +93,7 @@ const MAP: Record<string, ContentSource> = {
 	},
 	content_list_posts: {
 		source: 'read_posts',
+		effectful: false,
 		consequential: false,
 		description:
 			'List brand posts, optionally filtered by status (pending_user/approved/scheduled/published/failed). Each post carries media_origin (typographic_graphic/ai_generated/user_uploaded/video/none) and, when reviewed, a media_review verdict (ship/fix/kill) — honor fix/kill, do not approve as-is.'

--- a/src/lib/agent/plugins/delegation.ts
+++ b/src/lib/agent/plugins/delegation.ts
@@ -30,6 +30,7 @@ export function createDelegationPlugin(deps: DelegationPluginDeps): ToolPlugin {
 		name,
 		description: String(delegation[name]?.description ?? ''),
 		requiresMode: 'agent',
+		effectful: true,
 		consequential: true,
 		inputSchema: jsonSchemaOf(delegation[name])
 	}));

--- a/src/lib/agent/plugins/goal.ts
+++ b/src/lib/agent/plugins/goal.ts
@@ -46,6 +46,7 @@ export function createGoalPlugin(deps: GoalPluginDeps): ToolPlugin {
 		name,
 		description: withKitToolNames(String(goalTools[name]?.description ?? name)),
 		requiresMode: 'plan',
+		effectful: true,
 		consequential: true,
 		inputSchema: jsonSchemaOf(goalTools[name])
 	}));

--- a/src/lib/agent/plugins/grounding.ts
+++ b/src/lib/agent/plugins/grounding.ts
@@ -34,6 +34,7 @@ export function createGroundingPlugin(deps: GroundingPluginDeps): ToolPlugin {
 	const tools: ToolSpec[] = [
 		{
 			name: SOURCE,
+			effectful: false,
 			consequential: false,
 			description: String(chatTools[SOURCE]?.description ?? SOURCE),
 			inputSchema: jsonSchemaOf(chatTools[SOURCE])

--- a/src/lib/agent/plugins/motion.ts
+++ b/src/lib/agent/plugins/motion.ts
@@ -97,6 +97,7 @@ function staticGateViolation(source: string): string | null {
 export const MOTION_PLUGIN_TOOLS: ToolSpec[] = [
 	{
 		name: 'motion_write',
+		effectful: true,
 		requiresMode: 'agent',
 		consequential: true,
 		description: [
@@ -118,6 +119,7 @@ export const MOTION_PLUGIN_TOOLS: ToolSpec[] = [
 	},
 	{
 		name: 'motion_check',
+		effectful: false,
 		requiresMode: 'agent',
 		consequential: false,
 		description: [
@@ -132,6 +134,7 @@ export const MOTION_PLUGIN_TOOLS: ToolSpec[] = [
 	},
 	{
 		name: 'motion_edit',
+		effectful: true,
 		requiresMode: 'agent',
 		consequential: true,
 		description: [
@@ -154,6 +157,7 @@ export const MOTION_PLUGIN_TOOLS: ToolSpec[] = [
 	},
 	{
 		name: 'motion_render',
+		effectful: true,
 		requiresMode: 'agent',
 		consequential: true,
 		description: [
@@ -172,6 +176,7 @@ export const MOTION_PLUGIN_TOOLS: ToolSpec[] = [
 	},
 	{
 		name: 'motion_stills',
+		effectful: true,
 		requiresMode: 'agent',
 		consequential: true,
 		description:
@@ -191,6 +196,7 @@ export const MOTION_PLUGIN_TOOLS: ToolSpec[] = [
 	},
 	{
 		name: 'motion_list',
+		effectful: false,
 		consequential: false,
 		description: [
 			'List this brand’s motion videos — id, title, created_at/updated_at, status (rendered or source only), preview_url when it exists, and source_path. Use it to find the one to keep editing (“the one from the 4th” is a date, and the date is here), or to check what already exists before making something new.',
@@ -200,21 +206,24 @@ export const MOTION_PLUGIN_TOOLS: ToolSpec[] = [
 	}
 ];
 
-export const MOTION_AUDIO_MAP: Record<string, { source: string; description: string; consequential: boolean }> = {
+export const MOTION_AUDIO_MAP: Record<string, { source: string; description: string; effectful: boolean; consequential: boolean }> = {
 	motion_voiceover: {
 		source: 'generate_voiceover',
+		effectful: true,
 		consequential: true,
 		description:
 			'Record the spoken voice-over for the video: ONE take of the whole script, cut afterwards into one clip per line with motion_cut_voiceover. It is a single recording on purpose — a clip per beat gives a slightly different voice in every beat. Returns one https URL with its real duration in seconds and in frames, plus the pauses to cut at. Bills AI credits. Does NOT change the TSX.'
 	},
 	motion_cut_voiceover: {
 		source: 'cut_voiceover',
+		effectful: true,
 		consequential: true,
 		description:
 			'Cut the take from motion_voiceover into one clip per line, at timestamps taken from its `pauses` list — never guessed. N cuts give N+1 clips, each with its real duration in seconds and frames; put each inside the <Sequence> of the beat that speaks it. Free: it slices a file that already exists. Cuts falling outside the take come back in dropped_cuts instead of silently shifting the labels.'
 	},
 	motion_music: {
 		source: 'generate_music',
+		effectful: true,
 		consequential: true,
 		description:
 			'Generate an instrumental music bed and get back an https URL. Describe the music, not the video: tempo, instruments, mood, energy. It is a bed — it sits under the voice, it does not compete with it. The clip always comes back short: a longer composition repeats it with `loop` on the <Audio>. Bills AI credits. Does NOT change the TSX.'
@@ -247,6 +256,7 @@ export function createMotionPlugin(deps: MotionPluginDeps): ToolPlugin {
 	const audioTools: ToolSpec[] = Object.entries(MOTION_AUDIO_MAP).map(([name, m]) => ({
 		name,
 		description: m.description,
+		effectful: m.effectful,
 		consequential: m.consequential,
 		inputSchema: jsonSchemaOf(chatTools[m.source])
 	}));

--- a/src/lib/agent/plugins/notify.ts
+++ b/src/lib/agent/plugins/notify.ts
@@ -41,6 +41,7 @@ export function createNotifyPlugin(deps: NotifyPluginDeps): ToolPlugin {
 		{
 			name: SOURCE,
 			requiresMode: 'agent',
+			effectful: true,
 			consequential: true,
 			description: String(chatTools[SOURCE]?.description ?? SOURCE),
 			inputSchema: jsonSchemaOf(chatTools[SOURCE])

--- a/src/lib/agent/plugins/team.ts
+++ b/src/lib/agent/plugins/team.ts
@@ -51,12 +51,14 @@ export function createTeamPlugin(deps: TeamPluginDeps): ToolPlugin {
 	const tools: ToolSpec[] = [
 		{
 			name: 'message_agent',
+			effectful: true,
 			consequential: true,
 			description: String(dm.message_agent?.description ?? ''),
 			inputSchema: jsonSchemaOf(dm.message_agent)
 		},
 		{
 			name: 'open_session_with_user',
+			effectful: true,
 			consequential: true,
 			description: String(session.open_session_with_user?.description ?? ''),
 			inputSchema: jsonSchemaOf(session.open_session_with_user)

--- a/src/lib/agent/plugins/ugc.ts
+++ b/src/lib/agent/plugins/ugc.ts
@@ -48,20 +48,23 @@ const VIDEO_FIELDS = [
 	'image_urls'
 ];
 
-const PASSTHROUGH: Record<string, { source: string; description: string; requiresMode?: ToolSpec['requiresMode']; consequential: boolean }> = {
+const PASSTHROUGH: Record<string, { source: string; description: string; requiresMode?: ToolSpec['requiresMode']; effectful: boolean; consequential: boolean }> = {
 	ugc_list_people: {
 		source: 'read_people',
+		effectful: false,
 		consequential: false,
 		description:
 			'List brand people (real team + AI personas) with ids and signed preview URLs. Pass ids into ugc_generate_video.people_ids as face references. Real people need recorded consent (Studio → People) before their face can appear in a generated clip — this list does not show consent status, ugc_generate_video applies the gate.'
 	},
 	ugc_list_talents: {
 		source: 'read_talents',
+		effectful: false,
 		consequential: false,
 		description: 'List the AI talent library (global synthetic models — no consent needed, they depict nobody). Pass ids into ugc_generate_video.talent_ids as face/body references.'
 	},
 	ugc_review_video: {
 		source: 'review_video',
+		effectful: true,
 		requiresMode: 'plan',
 		consequential: false,
 		description:
@@ -86,8 +89,9 @@ export function createUgcPlugin(deps: UgcPluginDeps): ToolPlugin {
 	) as ChatToolsRecord;
 
 	const tools: ToolSpec[] = [
-		{
+	{
 			name: 'ugc_generate_video',
+			effectful: true,
 			requiresMode: 'agent',
 			consequential: true,
 			description:
@@ -98,11 +102,13 @@ export function createUgcPlugin(deps: UgcPluginDeps): ToolPlugin {
 			name,
 			description: m.description,
 			requiresMode: m.requiresMode,
+			effectful: m.effectful,
 			consequential: m.consequential,
 			inputSchema: jsonSchemaOf(chatTools[m.source])
 		})),
 		{
 			name: 'ugc_check_video',
+			effectful: false,
 			consequential: false,
 			description:
 				"Check a post's real video state — the honest status ugc_generate_video points you back to. video_render_status \"rendering\" means the clip has NOT landed yet (media_url/video_thumbnail_url is still the cover frame); null/absent means the clip either finished or was never in flight — check content_type (\"generated_video\" = done) and media_url.",

--- a/src/lib/agent/plugins/web.ts
+++ b/src/lib/agent/plugins/web.ts
@@ -28,26 +28,30 @@ export interface WebPluginDeps {
 	locale?: 'en' | 'it';
 }
 
-const BLOG_MAP: Record<string, { source: string; description: string; requiresMode?: ToolSpec['requiresMode']; consequential: boolean }> = {
+const BLOG_MAP: Record<string, { source: string; description: string; requiresMode?: ToolSpec['requiresMode']; effectful: boolean; consequential: boolean }> = {
 	web_list_articles: {
 		source: 'list_articles',
+		effectful: false,
 		consequential: false,
 		description:
 			'List the brand\'s blog articles with status and schedule. draft = written, awaiting review. planned = title-only placeholder, body not written (write with web_write_planned_article). approved = scheduled, auto-publishes at scheduled_for. published = live.'
 	},
 	web_read_article: {
 		source: 'read_article',
+		effectful: false,
 		consequential: false,
 		description: 'Read a blog article in full: title, meta title/description, markdown body, status, schedule, cover image. Read before editing or optimizing.'
 	},
 	web_update_article: {
 		source: 'update_article',
+		effectful: true,
 		requiresMode: 'agent',
 		consequential: true,
 		description: 'Edit a blog article: title, meta title, meta description, and/or the full markdown body (a full replacement, not a diff). Never touches status or schedule — use web_schedule_article for that.'
 	},
 	web_schedule_article: {
 		source: 'schedule_article',
+		effectful: true,
 		requiresMode: 'agent',
 		consequential: true,
 		description:
@@ -55,6 +59,7 @@ const BLOG_MAP: Record<string, { source: string; description: string; requiresMo
 	},
 	web_optimize_article: {
 		source: 'optimize_article',
+		effectful: true,
 		requiresMode: 'agent',
 		consequential: true,
 		description:
@@ -62,24 +67,28 @@ const BLOG_MAP: Record<string, { source: string; description: string; requiresMo
 	},
 	web_generate_article_cover: {
 		source: 'generate_article_cover',
+		effectful: true,
 		requiresMode: 'agent',
 		consequential: true,
 		description: "Generate a new on-brand AI cover image for a blog article and set it as the article's cover. ~30s."
 	},
 	web_generate_article_images: {
 		source: 'generate_article_images',
+		effectful: true,
 		requiresMode: 'agent',
 		consequential: true,
 		description: "Generate a few on-brand images and splice them into a blog article's body as in-article illustrations. ~1 min."
 	},
 	web_write_planned_article: {
 		source: 'write_planned_article',
+		effectful: true,
 		requiresMode: 'agent',
 		consequential: true,
 		description: 'Write the full article for a "planned" placeholder (title-only slot from the month plan), keeping its calendar slot. ~1-2 min. Result is a draft — schedule or edit it after.'
 	},
 	web_seo_audit: {
 		source: 'run_seo_geo_audit',
+		effectful: true,
 		requiresMode: 'plan',
 		consequential: true,
 		description:
@@ -87,6 +96,7 @@ const BLOG_MAP: Record<string, { source: string; description: string; requiresMo
 	},
 	web_read_seo_audit: {
 		source: 'read_seo_geo_audit',
+		effectful: false,
 		consequential: false,
 		description: 'Read the latest SEO & GEO audit: technical score, top issues, on-page summary, AI share-of-voice, and category questions where the brand is NOT cited (with which competitors ARE). Call web_seo_audit first if none exists yet.'
 	}
@@ -110,7 +120,7 @@ export function createWebPlugin(deps: WebPluginDeps): ToolPlugin {
 	for (const [name, m] of Object.entries(BLOG_MAP)) {
 		if (!chatTools[m.source]) continue; // richiede estrazione? no: assente solo se createChatTools cambia forma
 		map[name] = m.source;
-		tools.push({ name, description: m.description, requiresMode: m.requiresMode, consequential: m.consequential, inputSchema: jsonSchemaOf(chatTools[m.source]) });
+		tools.push({ name, description: m.description, requiresMode: m.requiresMode, effectful: m.effectful, consequential: m.consequential, inputSchema: jsonSchemaOf(chatTools[m.source]) });
 	}
 
 	// I 7 dfs_* diventano web_dfs_* — stesso schema, stessa description, stessa execute.
@@ -119,7 +129,7 @@ export function createWebPlugin(deps: WebPluginDeps): ToolPlugin {
 		if (!t) continue; // dataforseoConfigured() false in questo env: createDataForSeoTools torna {}
 		const name = `web_${key}`;
 		map[name] = key;
-		tools.push({ name, description: String(t.description ?? key), consequential: false, inputSchema: jsonSchemaOf(t) });
+		tools.push({ name, description: String(t.description ?? key), effectful: false, consequential: false, inputSchema: jsonSchemaOf(t) });
 	}
 
 	return {

--- a/src/lib/chat-parts.test.ts
+++ b/src/lib/chat-parts.test.ts
@@ -50,6 +50,17 @@ describe('messageBlocks', () => {
     expect(toolCallsOf('[{"type":"tool-call","toolName":"x"},{"type":"text","text":"hi"}]')).toHaveLength(1);
   });
 
+  it('attaches a native approval request to its tool call', () => {
+    const calls = toolCallsOf([
+      { type: 'tool-call', toolCallId: 'call-1', toolName: 'publish_post', input: { post_id: 'p1' } },
+      { type: 'tool-approval-request', approvalId: 'approval-1', toolCallId: 'call-1' }
+    ]);
+    expect(calls[0]).toMatchObject({
+      toolName: 'publish_post',
+      approval: { approvalId: 'approval-1' }
+    });
+  });
+
   it('does not dump a persisted tool output into the bubble — chips stay chips', () => {
     const parts = [
       {

--- a/src/lib/chat-parts.ts
+++ b/src/lib/chat-parts.ts
@@ -16,6 +16,7 @@ export type ChatToolPart = {
   toolCallId?: string;
   toolName: string;
   input?: unknown;
+  approval?: { approvalId: string };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [k: string]: any;
 };
@@ -160,9 +161,25 @@ const isReasoning = (p: ChatPart): p is ChatReasoningPart => p.type === 'reasoni
 
 /** Just the tool calls of a turn (no text parts) — for chips, plan pointers, previews, … */
 export function toolCallsOf(raw: unknown): ChatToolPart[] {
-  return parseToolCalls(raw).filter(
+  const parts = parseToolCalls(raw);
+  const calls = parts.filter(
     (p): p is ChatToolPart => !isText(p) && !isReasoning(p) && !!(p as ChatToolPart).toolName
   );
+  const approvals = new Map(
+    parts
+      .filter((p) => {
+        const part = p as ChatToolPart & { approvalId?: unknown; toolCallId?: unknown };
+        return part.type === 'tool-approval-request' && typeof part.toolCallId === 'string' && typeof part.approvalId === 'string';
+      })
+      .map((p) => {
+        const part = p as ChatToolPart & { approvalId: string; toolCallId: string };
+        return [part.toolCallId, part.approvalId] as const;
+      })
+  );
+  return calls.map((call) => {
+    const approvalId = call.toolCallId ? approvals.get(call.toolCallId) : undefined;
+    return approvalId ? { ...call, approval: { approvalId } } : call;
+  });
 }
 
 /**

--- a/src/lib/components/ChatApprovalCard.svelte
+++ b/src/lib/components/ChatApprovalCard.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+  let {
+    approvalId,
+    toolName,
+    input,
+    status = 'pending',
+    disabled = false,
+    ondecision
+  }: {
+    approvalId: string;
+    toolName: string;
+    input: unknown;
+    status?: string;
+    disabled?: boolean;
+    ondecision: (approved: boolean) => Promise<void> | void;
+  } = $props();
+
+  let busy = $state(false);
+
+  function redact(value: unknown, key = ''): unknown {
+    if (/api.?key|authorization|credential|password|secret|token/i.test(key)) return '[redacted]';
+    if (Array.isArray(value)) return value.map((item) => redact(item));
+    if (!value || typeof value !== 'object') return value;
+    return Object.fromEntries(Object.entries(value).map(([name, item]) => [name, redact(item, name)]));
+  }
+
+  async function decide(approved: boolean) {
+    if (busy || disabled) return;
+    busy = true;
+    try {
+      await ondecision(approved);
+    } finally {
+      busy = false;
+    }
+  }
+</script>
+
+<section class="approval-card" aria-label="Tool approval">
+  <div class="approval-title">{status === 'approved' ? 'Approved' : status === 'denied' ? 'Denied' : 'Approval required'}</div>
+  <div class="approval-tool">{toolName.replace(/_/g, ' ')}</div>
+  <pre>{JSON.stringify(redact(input), null, 2)}</pre>
+  {#if status === 'pending'}
+    <div class="approval-actions">
+      <button type="button" class="approval-deny" disabled={disabled || busy} onclick={() => decide(false)}>Deny</button>
+      <button type="button" class="approval-allow" disabled={disabled || busy} onclick={() => decide(true)}>Allow</button>
+    </div>
+  {/if}
+</section>
+
+<style>
+  .approval-card {
+    margin: 0.65rem 0 0.9rem 2.35rem;
+    max-width: 34rem;
+    border: 1px solid var(--line, #d7d7d7);
+    border-radius: 0.75rem;
+    padding: 0.85rem;
+    background: var(--paper-1, #fff);
+  }
+
+  .approval-title { font-weight: 650; }
+  .approval-tool { margin-top: 0.2rem; color: var(--muted, #666); font-size: 0.85rem; }
+  pre { max-height: 12rem; overflow: auto; margin: 0.7rem 0; white-space: pre-wrap; font-size: 0.75rem; }
+  .approval-actions { display: flex; justify-content: flex-end; gap: 0.5rem; }
+  button { border: 0; border-radius: 0.5rem; padding: 0.45rem 0.75rem; cursor: pointer; }
+  button:disabled { cursor: wait; opacity: 0.55; }
+  .approval-deny { background: var(--paper-3, #eee); }
+  .approval-allow { color: white; background: var(--accent, #2563eb); }
+</style>

--- a/src/lib/content/changelog/2026-08-29-hitl-judge.ts
+++ b/src/lib/content/changelog/2026-08-29-hitl-judge.ts
@@ -5,6 +5,6 @@ export default {
   title: 'Safer action approvals',
   items: [
     'Read-only work continues without an approval prompt, while consequential actions can now be checked automatically before they run.',
-    'If an automatic check fails, the action waits for your approval instead of running on an uncertain verdict.'
+    'If an automatic check asks or fails, the action is blocked instead of running on an uncertain verdict.'
   ]
 } satisfies ChangelogEntry;

--- a/src/lib/content/changelog/2026-08-29-stable-tool-call-identity.ts
+++ b/src/lib/content/changelog/2026-08-29-stable-tool-call-identity.ts
@@ -1,0 +1,10 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-08-29',
+  title: 'Identical tool requests can run independently',
+  items: [
+    'Resumed tool calls keep their original identity, preventing duplicate effects.',
+    'Separate requests with identical arguments are tracked and executed independently.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/content/changelog/2026-08-30-durable-chat-resume.ts
+++ b/src/lib/content/changelog/2026-08-30-durable-chat-resume.ts
@@ -1,0 +1,7 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-08-30',
+  title: 'Chat work survives refreshes',
+  items: ['Long-running replies and agent approvals now survive a refresh and resume safely.']
+} satisfies ChangelogEntry;

--- a/src/lib/server/agent-kit-effects-store.test.ts
+++ b/src/lib/server/agent-kit-effects-store.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { SupabaseClient } from '@supabase/supabase-js';
-import { createEffectsLedger, effectKey } from './effects-store';
+import { createEffectsLedger, effectKey } from './agent-kit-effects-store';
 
 type Row = Record<string, unknown>;
 

--- a/src/lib/server/agent-kit-effects-store.ts
+++ b/src/lib/server/agent-kit-effects-store.ts
@@ -1,6 +1,6 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { EffectClaim, EffectsLedger, ToolEffect } from '@anomalia/agent-kit';
-import { legacyEffectKey, sameEffectPayload } from './effects';
+import { legacyEffectKey, sameEffectPayload } from '@anomalia/agent-core/effects';
 
 const TABLE = 'agent_kit_effects';
 const UNIQUE_VIOLATION = '23505';
@@ -21,18 +21,18 @@ type Row = {
 	updated_at: string;
 };
 
-function toEffect(r: Row): ToolEffect {
+function toEffect(row: Row): ToolEffect {
 	return {
-		id: r.id,
-		brandId: r.brand_id,
-		runId: r.run_id ?? null,
-		toolName: r.tool_name,
-		invocationId: r.invocation_id ?? null,
-		status: r.status,
-		request: r.request,
-		result: r.result,
-		createdAt: r.created_at,
-		updatedAt: r.updated_at
+		id: row.id,
+		brandId: row.brand_id,
+		runId: row.run_id ?? null,
+		toolName: row.tool_name,
+		invocationId: row.invocation_id ?? null,
+		status: row.status,
+		request: row.request,
+		result: row.result,
+		createdAt: row.created_at,
+		updatedAt: row.updated_at
 	};
 }
 
@@ -44,20 +44,14 @@ function samePayload(effect: ToolEffect, record: { toolName: string; request: un
 	return effect.toolName === record.toolName && sameEffectPayload(effect.request, record.request);
 }
 
-async function findInvocation(
-	db: SupabaseClient,
-	brandId: string,
-	invocationId: string
-): Promise<ToolEffect | null> {
+async function findInvocation(db: SupabaseClient, brandId: string, invocationId: string): Promise<ToolEffect | null> {
 	const { data, error } = await db
 		.from(TABLE)
 		.select()
 		.eq('brand_id', brandId)
 		.eq('invocation_id', invocationId)
 		.maybeSingle();
-	if (error) {
-		throw new Error(`effects: lettura claim fallita — ${error.message}`);
-	}
+	if (error) throw new Error(`effects: lettura claim fallita — ${error.message}`);
 	return data ? toEffect(data as Row) : null;
 }
 
@@ -72,18 +66,12 @@ export function createEffectsLedger(db: SupabaseClient): EffectsLedger {
 					.eq('idempotency_key', record.legacyKey)
 					.is('invocation_id', null)
 					.maybeSingle();
-				if (error) {
-					throw new Error(`effects: lettura legacy fallita — ${error.message}`);
-				}
+				if (error) throw new Error(`effects: lettura legacy fallita — ${error.message}`);
 				if (data) {
 					const effect = toEffect(data as Row);
 					if (effect.runId === record.runId) {
-						if (!samePayload(effect, record)) {
-							return { kind: 'mismatch', effect };
-						}
-						if (effect.status !== FAILED_STATUS) {
-							return { kind: 'existing', effect };
-						}
+						if (!samePayload(effect, record)) return { kind: 'mismatch', effect };
+						if (effect.status !== FAILED_STATUS) return { kind: 'existing', effect };
 					}
 				}
 			}
@@ -101,23 +89,13 @@ export function createEffectsLedger(db: SupabaseClient): EffectsLedger {
 				})
 				.select()
 				.maybeSingle();
-			if (!error && data) {
-				return { kind: 'claimed', effect: toEffect(data as Row) };
-		}
-		if (error && !uniqueViolation(error)) {
-			throw new Error(`effects: claim fallito — ${error.message}`);
-		}
+			if (!error && data) return { kind: 'claimed', effect: toEffect(data as Row) };
+			if (error && !uniqueViolation(error)) throw new Error(`effects: claim fallito — ${error.message}`);
 
 			const existing = await findInvocation(db, record.brandId, record.invocationId);
-			if (!existing) {
-				throw new Error('effects: claim concorrente senza riga proprietaria');
-			}
-			if (!samePayload(existing, record)) {
-				return { kind: 'mismatch', effect: existing };
-			}
-			if (existing.status !== FAILED_STATUS) {
-				return { kind: 'existing', effect: existing };
-			}
+			if (!existing) throw new Error('effects: claim concorrente senza riga proprietaria');
+			if (!samePayload(existing, record)) return { kind: 'mismatch', effect: existing };
+			if (existing.status !== FAILED_STATUS) return { kind: 'existing', effect: existing };
 
 			const retried = await db
 				.from(TABLE)
@@ -128,20 +106,14 @@ export function createEffectsLedger(db: SupabaseClient): EffectsLedger {
 					updated_at: new Date().toISOString()
 				})
 				.eq('id', existing.id)
-				.eq('status', 'failed')
+				.eq('status', FAILED_STATUS)
 				.select()
 				.maybeSingle();
-			if (retried.error) {
-				throw new Error(`effects: retry fallito — ${retried.error.message}`);
-			}
-			if (retried.data) {
-				return { kind: 'claimed', effect: toEffect(retried.data as Row) };
-			}
+			if (retried.error) throw new Error(`effects: retry fallito — ${retried.error.message}`);
+			if (retried.data) return { kind: 'claimed', effect: toEffect(retried.data as Row) };
 
 			const current = await findInvocation(db, record.brandId, record.invocationId);
-			if (!current) {
-				throw new Error('effects: retry concorrente senza riga proprietaria');
-			}
+			if (!current) throw new Error('effects: retry concorrente senza riga proprietaria');
 			return samePayload(current, record)
 				? { kind: 'existing', effect: current }
 				: { kind: 'mismatch', effect: current };
@@ -152,12 +124,10 @@ export function createEffectsLedger(db: SupabaseClient): EffectsLedger {
 				.from(TABLE)
 				.update({ status, result, updated_at: new Date().toISOString() })
 				.eq('id', id)
-				.eq('status', 'intended')
+				.eq('status', INTENDED_STATUS)
 				.select('id')
 				.maybeSingle();
-			if (error) {
-				throw new Error(`effects: resolve fallito — ${error.message}`);
-			}
+			if (error) throw new Error(`effects: resolve fallito — ${error.message}`);
 			return !!data;
 		},
 
@@ -166,11 +136,9 @@ export function createEffectsLedger(db: SupabaseClient): EffectsLedger {
 				.from(TABLE)
 				.update({ status: 'ambiguous', updated_at: new Date().toISOString() })
 				.eq('run_id', runId)
-				.eq('status', 'intended')
+				.eq('status', INTENDED_STATUS)
 				.select('id');
-			if (error) {
-				throw new Error(`effects: reconcile fallito — ${error.message}`);
-			}
+			if (error) throw new Error(`effects: reconcile fallito — ${error.message}`);
 			return data?.length ?? 0;
 		}
 	};

--- a/src/lib/server/agent-kit-recover.ts
+++ b/src/lib/server/agent-kit-recover.ts
@@ -7,7 +7,7 @@ import {
 } from '$lib/server/chat/turn-limits';
 import { ChatTurnDeadError } from '$lib/server/chat/job-cancel';
 import { assistantContentFromPartial, type ChatPartialSnapshot } from '$lib/server/chat/partial-persist';
-import { createEffectsLedger } from '@anomalia/agent-core/effects-store';
+import { createEffectsLedger } from '$lib/server/agent-kit-effects-store';
 
 /**
  * IL RECUPERO DEL LAVORO MORTO, per una riga sola — estratto dal loop del cron perché `sweep.test.ts`

--- a/src/lib/server/chat/action-approval.test.ts
+++ b/src/lib/server/chat/action-approval.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const generateText = vi.fn();
+const logged: Array<Record<string, unknown>> = [];
+const envHolder: Record<string, string | undefined> = {};
+
+vi.mock('ai', async (original) => ({
+	...((await original()) as object),
+	generateText: (...args: unknown[]) => generateText(...args)
+}));
+vi.mock('$env/dynamic/private', () => ({ env: envHolder }));
+vi.mock('$lib/server/chat/model', () => ({
+	compactionModel: () => ({ model: {}, modelId: 'judge', provider: 'test' })
+}));
+vi.mock('$lib/server/ai-log', () => ({
+	logAiCall: (row: Record<string, unknown>) => logged.push(row)
+}));
+
+const { createChatActionApproval } = await import('./action-approval');
+
+function verdict(...answers: boolean[]) {
+	return {
+		text: JSON.stringify(answers.map((answer) => ({ question: 'q', answer, reason: 'r' }))),
+		usage: { inputTokens: 10, outputTokens: 4 }
+	};
+}
+
+const context = { brandId: 'b1', userId: 'u1', runId: 'r1', locale: 'it' as const };
+
+beforeEach(() => {
+	generateText.mockReset();
+	logged.length = 0;
+	delete envHolder.CHAT_ACTION_JUDGE;
+});
+
+describe('createChatActionApproval', () => {
+	it('resta spento se il judge non è abilitato', () => {
+		expect(createChatActionApproval({ messages: [], brandId: 'b1', userId: 'u1', threadId: 't1' })).toBeUndefined();
+	});
+
+	it('promuove il consenso del transcript a pass', async () => {
+		envHolder.CHAT_ACTION_JUDGE = 'on';
+		generateText.mockResolvedValue(verdict(false, false));
+		const approval = createChatActionApproval({
+			messages: [{ role: 'user', content: 'aggiorna il post p1' }],
+			brandId: 'b1',
+			userId: 'u1',
+			threadId: 't1'
+		});
+
+		const decision = await approval!.checker!({
+			spec: { name: 'content_update_post', description: '', inputSchema: {}, consequential: true, effectful: true },
+			call: { name: 'content_update_post', args: { post_id: 'p1' }, id: 'c1' },
+			context
+		});
+
+		expect(decision).toBe('pass');
+		expect(generateText).toHaveBeenCalledOnce();
+		expect(logged[0]).toMatchObject({ label: 'chatActionJudge', ok: true, threadId: 't1' });
+	});
+
+	it('chiede approvazione se il transcript segnala un’azione non autorizzata', async () => {
+		envHolder.CHAT_ACTION_JUDGE = 'on';
+		generateText.mockResolvedValue(verdict(true, false));
+		const approval = createChatActionApproval({ messages: [], brandId: 'b1', userId: 'u1', threadId: 't1' });
+
+		const decision = await approval!.checker!({
+			spec: { name: 'content_schedule', description: '', inputSchema: {}, consequential: true, effectful: true },
+			call: { name: 'content_schedule', args: {}, id: 'c1' },
+			context
+		});
+
+		expect(decision).toBe('ask');
+	});
+
+	it('fallisce chiuso se il giudice non restituisce un verdetto valido', async () => {
+		envHolder.CHAT_ACTION_JUDGE = 'on';
+		generateText.mockResolvedValue({ text: 'no' });
+		const approval = createChatActionApproval({ messages: [], brandId: 'b1', userId: 'u1', threadId: 't1' });
+
+		const decision = await approval!.checker!({
+			spec: { name: 'content_schedule', description: '', inputSchema: {}, consequential: true, effectful: true },
+			call: { name: 'content_schedule', args: {}, id: 'c1' },
+			context
+		});
+
+		expect(decision).toBe('error');
+		expect(logged[0]).toMatchObject({ label: 'chatActionJudge', ok: false });
+	});
+});

--- a/src/lib/server/chat/action-approval.ts
+++ b/src/lib/server/chat/action-approval.ts
@@ -1,0 +1,89 @@
+import { env } from '$env/dynamic/private';
+import { type ModelMessage } from 'ai';
+import type { ActionApprovalConfig } from '@anomalia/agent-kit/types';
+import { logAiCall } from '$lib/server/ai-log';
+import { compactionModel } from './model';
+import { judgeTranscript } from '$lib/server/eval/transcript-judge';
+
+const QUESTIONS = [
+	'Answer true ONLY if the user did not ask for this exact action anywhere in the conversation.',
+	'Answer true ONLY if the action target or scope is wider or different from what the user asked for.'
+];
+const MAX_TRANSCRIPT_CHARS = 6_000;
+
+type ActionApprovalInput = {
+	messages: readonly ModelMessage[];
+	brandId: string;
+	userId: string;
+	threadId: string;
+};
+
+function transcriptOf(messages: readonly ModelMessage[], toolName: string, args: Record<string, unknown>): string {
+	const history = messages
+		.slice(-12)
+		.map((message) => `${message.role}: ${typeof message.content === 'string' ? message.content : JSON.stringify(message.content)}`)
+		.join('\n');
+	return `${history}\n[proposed tool] ${toolName} input=${JSON.stringify(args)}`.slice(-MAX_TRANSCRIPT_CHARS);
+}
+
+export function createChatActionApproval(input: ActionApprovalInput): ActionApprovalConfig | undefined {
+	if (env.CHAT_ACTION_JUDGE !== 'on') return undefined;
+
+	const model = compactionModel();
+	return {
+		autoReviewEnabled: true,
+		checker: async ({ spec, call, context }) => {
+			const startedAt = Date.now();
+			if (!model) {
+				logAiCall({
+					label: 'chatActionJudge',
+					provider: 'none',
+					model: 'none',
+					ms: Date.now() - startedAt,
+					ok: false,
+					brandId: input.brandId,
+					userId: input.userId,
+					threadId: input.threadId,
+					context: `tool=${spec.name}:no-model`
+				});
+				return 'error';
+			}
+
+			try {
+				const result = await judgeTranscript({
+					model: model.model,
+					transcript: transcriptOf(input.messages, call.name, call.args),
+					questions: QUESTIONS
+				});
+				const decision = result.answers.some((answer) => answer.answer) ? 'ask' : 'pass';
+				logAiCall({
+					label: 'chatActionJudge',
+					provider: model.provider,
+					model: model.modelId,
+					ms: Date.now() - startedAt,
+					ok: true,
+					inputTokens: result.usage?.inputTokens,
+					outputTokens: result.usage?.outputTokens,
+					brandId: context.brandId,
+					userId: context.userId ?? input.userId,
+					threadId: input.threadId,
+					context: `tool=${spec.name}:${decision}`
+				});
+				return decision;
+			} catch {
+				logAiCall({
+					label: 'chatActionJudge',
+					provider: model.provider,
+					model: model.modelId,
+					ms: Date.now() - startedAt,
+					ok: false,
+					brandId: context.brandId,
+					userId: context.userId ?? input.userId,
+					threadId: input.threadId,
+					context: `tool=${spec.name}:error`
+				});
+				return 'error';
+			}
+		}
+	};
+}

--- a/src/lib/server/chat/agent-kit-approvals.test.ts
+++ b/src/lib/server/chat/agent-kit-approvals.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { approvalInputHash, displayApprovalInput, isApprovalDecision, waitForApproval } from './agent-kit-approvals';
+
+describe('agent kit approvals', () => {
+	it('hashes the same input independently of object key order', () => {
+		expect(approvalInputHash({ post_id: 'p1', caption: 'new' })).toBe(
+			approvalInputHash({ caption: 'new', post_id: 'p1' })
+		);
+	});
+
+	it('redacts credentials before approval input reaches the UI', () => {
+		expect(displayApprovalInput({ channel: 'instagram', api_key: 'secret', nested: { token: 'x' } })).toEqual({
+			channel: 'instagram',
+			api_key: '[redacted]',
+			nested: { token: '[redacted]' }
+		});
+	});
+
+	it('accepts only terminal approval decisions', () => {
+		expect(isApprovalDecision('approved')).toBe(true);
+		expect(isApprovalDecision('denied')).toBe(true);
+		expect(isApprovalDecision('pending')).toBe(false);
+	});
+
+	it('persists the continuation and the visible request in one RPC call', async () => {
+		let args: Record<string, unknown> | undefined;
+		const db = {
+			rpc: async (_name: string, next: Record<string, unknown>) => {
+				args = next;
+				return { data: { closed: true }, error: null };
+			}
+		} as never;
+
+		await waitForApproval(db, {
+			runId: 'run-1',
+			harnessApprovalId: 'harness-1',
+			toolCallId: 'call-1',
+			toolName: 'publish_post',
+			toolInput: { post_id: 'post-1' },
+			continueState: { cursor: 3 },
+			message: { content: '', toolCalls: [{ type: 'tool-approval-request', approvalId: 'harness-1' }] }
+		});
+
+		expect(args).toMatchObject({
+			p_run_id: 'run-1',
+			p_continue_state: { cursor: 3 },
+			p_message: { content: '', tool_calls: [{ type: 'tool-approval-request', approvalId: 'harness-1' }] }
+		});
+		expect(args?.p_input_hash).toBe(approvalInputHash({ post_id: 'post-1' }));
+	});
+});

--- a/src/lib/server/chat/agent-kit-approvals.ts
+++ b/src/lib/server/chat/agent-kit-approvals.ts
@@ -1,0 +1,126 @@
+import { createHash } from 'node:crypto';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+const SECRET_KEY = /api.?key|authorization|credential|password|secret|token/i;
+
+export type ApprovalDecision = 'approved' | 'denied';
+
+export type AgentKitApproval = {
+	id: string;
+	brand_id: string;
+	thread_id: string;
+	run_id: string;
+	user_id: string;
+	harness_approval_id: string;
+	tool_call_id: string;
+	tool_name: string;
+	tool_input: unknown;
+	input_hash: string;
+	reason: string | null;
+	status: string;
+	decision_reason: string | null;
+	created_at: string;
+	updated_at: string;
+};
+
+export function isApprovalDecision(value: unknown): value is ApprovalDecision {
+	return value === 'approved' || value === 'denied';
+}
+
+export function approvalInputHash(input: unknown): string {
+	return createHash('sha256').update(stableSerialize(input)).digest('hex');
+}
+
+export function displayApprovalInput(input: unknown): unknown {
+	if (Array.isArray(input)) return input.map(displayApprovalInput);
+	if (!input || typeof input !== 'object') return input;
+	return Object.fromEntries(
+		Object.entries(input as Record<string, unknown>).map(([key, value]) => [
+			key,
+			SECRET_KEY.test(key) ? '[redacted]' : displayApprovalInput(value)
+		])
+	);
+}
+
+export async function waitForApproval(
+	db: SupabaseClient,
+	input: {
+		runId: string;
+		harnessApprovalId: string;
+		toolCallId: string;
+		toolName: string;
+		toolInput: unknown;
+		reason?: string;
+		continueState: unknown;
+		message?: {
+			content: string;
+			reasoning?: string;
+			toolCalls?: unknown;
+			attachments?: string[];
+			speaker?: string;
+		};
+	}
+): Promise<{ closed: boolean; approvalId?: string; harnessApprovalId?: string; messageId?: string }> {
+	const { data, error } = await db.rpc('agent_kit_wait_for_approval', {
+		p_run_id: input.runId,
+		p_harness_approval_id: input.harnessApprovalId,
+		p_tool_call_id: input.toolCallId,
+		p_tool_name: input.toolName,
+		p_tool_input: input.toolInput,
+		p_input_hash: approvalInputHash(input.toolInput),
+		p_reason: input.reason ?? null,
+		p_continue_state: input.continueState,
+		p_message: input.message
+			? {
+					content: input.message.content,
+					reasoning: input.message.reasoning ?? null,
+					tool_calls: input.message.toolCalls ?? null,
+					attachments: input.message.attachments ?? null,
+					name: input.message.speaker ?? null
+				}
+			: null
+	});
+	if (error) throw new Error(`approval wait failed: ${error.message}`);
+	return data as { closed: boolean; approvalId?: string; harnessApprovalId?: string };
+}
+
+export async function decideApproval(
+	db: SupabaseClient,
+	approvalId: string,
+	decision: ApprovalDecision,
+	reason?: string
+): Promise<AgentKitApproval> {
+	const { data, error } = await db.rpc('decide_agent_kit_approval', {
+		p_approval_id: approvalId,
+		p_status: decision,
+		p_reason: reason ?? null
+	});
+	if (error) throw new Error(`approval decision failed: ${error.message}`);
+	return data as AgentKitApproval;
+}
+
+export async function pendingApproval(
+	db: SupabaseClient,
+	threadId: string
+): Promise<AgentKitApproval | null> {
+	const { data } = await db
+		.from('agent_kit_approval_requests')
+		.select('*')
+		.eq('thread_id', threadId)
+		.eq('status', 'pending')
+		.order('created_at', { ascending: false })
+		.limit(1)
+		.maybeSingle();
+	return (data as AgentKitApproval | null) ?? null;
+}
+
+function stableSerialize(value: unknown): string {
+	if (Array.isArray(value)) return `[${value.map(stableSerialize).join(',')}]`;
+	if (value && typeof value === 'object') {
+		return `{${Object.keys(value as Record<string, unknown>)
+			.sort()
+			.map((key) => `${JSON.stringify(key)}:${stableSerialize((value as Record<string, unknown>)[key])}`)
+			.join(',')}}`;
+	}
+	return JSON.stringify(value);
+}

--- a/src/lib/server/chat/persistence.test.ts
+++ b/src/lib/server/chat/persistence.test.ts
@@ -684,6 +684,27 @@ describe('messagesFromRow', () => {
     expect(result.output.value).not.toContain('outcome unknown');
   });
 
+  it('reconstructs a native approval request without manufacturing a tool result', () => {
+    const msgs = messagesFromRow({
+      role: 'assistant',
+      content: '',
+      tool_calls: [
+        { type: 'tool-call', toolCallId: 'a1', toolName: 'publish_post', input: { post_id: 'p1' } },
+        { type: 'tool-approval-request', approvalId: 'approval-1', toolCallId: 'a1' }
+      ]
+    });
+
+    expect(msgs).toEqual([
+      {
+        role: 'assistant',
+        content: [
+          { type: 'tool-call', toolCallId: 'a1', toolName: 'publish_post', input: { post_id: 'p1' } },
+          { type: 'tool-approval-request', approvalId: 'approval-1', toolCallId: 'a1' }
+        ]
+      }
+    ]);
+  });
+
   it('keeps history text-only by default — a model that cannot see must not be handed parts', () => {
     expect(messagesFromRow({ role: 'user', content: 'guarda', attachments: ['https://cdn/a.png'] })).toEqual([
       { role: 'user', content: 'guarda\n[attached urls: https://cdn/a.png]' }

--- a/src/lib/server/chat/persistence.ts
+++ b/src/lib/server/chat/persistence.ts
@@ -1,5 +1,5 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
-import type { ModelMessage, TextPart, ToolCallPart, ToolResultPart } from 'ai';
+import type { ModelMessage, TextPart, ToolApprovalRequest, ToolCallPart, ToolResultPart } from 'ai';
 import { TERMINAL_TOOL_NAMES } from '@anomalia/agent-core/tools/builtin';
 import { normalizeQuestionsPayload } from '$lib/chat-questions';
 import { normalizeAgentProposal } from '$lib/chat-agent-proposal';
@@ -20,6 +20,7 @@ import {
 } from '$lib/media-parts';
 import { summaryBlock } from './compaction';
 import { markThreadRead } from './unread';
+import { loadThreadEvents, threadMessageRows } from './thread-events';
 
 type ChatMessageRow = {
   id: string;
@@ -667,9 +668,16 @@ export function messagesFromRow(
   }
 
   const out: ModelMessage[] = [];
-  let assistantParts: Array<TextPart | ToolCallPart> = [];
+  let assistantParts: Array<TextPart | ToolApprovalRequest | ToolCallPart> = [];
   let resultParts: ToolResultPart[] = [];
   let partsHaveText = false;
+  const approvalCallIds = new Set(
+    parts
+      .filter((part): part is { type: 'tool-approval-request'; toolCallId: string } => {
+        return !!part && typeof part === 'object' && (part as { type?: string }).type === 'tool-approval-request' && typeof (part as { toolCallId?: unknown }).toolCallId === 'string';
+      })
+      .map((part) => part.toolCallId)
+  );
 
   const flush = () => {
     if (assistantParts.length) {
@@ -691,6 +699,11 @@ export function messagesFromRow(
       partsHaveText = true;
       continue;
     }
+    if (p && typeof p === 'object' && (p as { type?: string }).type === 'tool-approval-request') {
+      if (resultParts.length) flush();
+      assistantParts.push(p as ToolApprovalRequest);
+      continue;
+    }
     if (!isStoredToolCall(p) || !p.toolCallId) continue;
     if (TERMINAL_TOOL_NAMES.includes(p.toolName)) continue;
     assistantParts.push({
@@ -699,16 +712,18 @@ export function messagesFromRow(
       toolName: p.toolName,
       input: p.input ?? {}
     });
-    resultParts.push(
-      p.output === undefined
-        ? interruptedToolResult({ toolCallId: p.toolCallId, toolName: p.toolName, status: p.status })
-        : {
-            type: 'tool-result',
-            toolCallId: p.toolCallId,
-            toolName: p.toolName,
-            output: toToolResultOutput(p.output)
-          }
-    );
+    if (!approvalCallIds.has(p.toolCallId)) {
+      resultParts.push(
+        p.output === undefined
+          ? interruptedToolResult({ toolCallId: p.toolCallId, toolName: p.toolName, status: p.status })
+          : {
+              type: 'tool-result',
+              toolCallId: p.toolCallId,
+              toolName: p.toolName,
+              output: toToolResultOutput(p.output)
+            }
+      );
+    }
   }
 
   flush();
@@ -914,7 +929,7 @@ export async function saveMessages(
   const { data: inserted, error } = await supabase
     .from('chat_messages')
     .insert(rows)
-    .select('id');
+    .select('*');
   if (error) throw new Error(`[saveMessages] insert failed: ${error.message}`);
 
   // Da qui in giù è tutto accessorio e va dentro un catch proprio: la riga c'è già, e un'eccezione
@@ -1048,6 +1063,31 @@ export async function loadHistory(
     .eq('user_id', userId)
     .maybeSingle();
 
+  const summary: ModelMessage[] = thread?.summary
+    ? [
+        {
+          role: 'system',
+          content: summaryBlock(thread.summary, thread.summary_message_count ?? 0)
+        }
+      ]
+    : [];
+
+  const eventRows = await loadThreadEvents(supabase, threadId);
+  const eventMessages = eventRows?.length
+    ? threadMessageRows(eventRows)?.filter((row) => row.role !== 'system' && row.role !== 'tool') ?? null
+    : null;
+  if (eventMessages) {
+    const filtered = thread?.summary_upto
+      ? eventMessages.filter((row) => String(row.created_at ?? '') > thread.summary_upto)
+      : eventMessages;
+    const messages: ModelMessage[] = [];
+    for (const row of chronologicalTail(filtered, limit)) {
+      messages.push(...messagesFromRow(row as Parameters<typeof messagesFromRow>[0], media));
+    }
+    if (media !== 'none') await pruneUnreachableMedia(messages);
+    return [...summary, ...dropLeadingAssistant(messages)];
+  }
+
   let query = supabase
     .from('chat_messages')
     .select('role, content, tool_calls, tool_call_id, name, created_at, attachments')
@@ -1069,15 +1109,6 @@ export async function loadHistory(
 
     // Un errore inghiottito qui si legge come «l'AI ha dimenticato tutto», senza traccia.
   if (error) console.error('[loadHistory]', error.message);
-
-  const summary: ModelMessage[] = thread?.summary
-    ? [
-        {
-          role: 'system',
-          content: summaryBlock(thread.summary, thread.summary_message_count ?? 0)
-        }
-      ]
-    : [];
 
   if (!data?.length) return summary;
 
@@ -1104,6 +1135,14 @@ export async function loadHistoryForUI(
   threadId: string,
   limit: number = 100
 ): Promise<ChatMessageUiRow[]> {
+  const eventRows = await loadThreadEvents(supabase, threadId);
+  if (eventRows?.length) {
+    const eventMessages = threadMessageRows(eventRows);
+    if (eventMessages) {
+      return chronologicalTail(eventMessages.filter((row) => row.role !== 'system' && row.role !== 'tool'), limit) as ChatMessageUiRow[];
+    }
+  }
+
   const { data, error } = await supabase
     .from('chat_messages')
     .select(

--- a/src/lib/server/chat/queue-kit-heartbeat.test.ts
+++ b/src/lib/server/chat/queue-kit-heartbeat.test.ts
@@ -13,6 +13,9 @@ type Row = Record<string, any>;
 
 let enteredKitTurn = false;
 let releaseKitTurn: (() => void) | null = null;
+const kitTurnInputs: Array<Record<string, unknown>> = [];
+
+const actionApproval = { autoReviewEnabled: true, checker: async () => 'pass' as const };
 
 // La compattazione parla con tabelle che questo finto database non conosce (scrive il riassunto):
 // qui si misura il BATTITO, non lei. Che venga chiamata nel punto giusto lo pinna kit-parity.test.
@@ -21,12 +24,17 @@ vi.mock('$env/dynamic/private', () => ({ env: { AGENT_KIT: 'on' } }));
 vi.mock('$lib/agent/bridge/live', () => ({
 	shouldUseKit: () => ({ id: 'content' }),
 	runKitTurn: vi.fn(
-		() =>
-			new Promise((resolve) => {
+		(input: Record<string, unknown>) => {
+			kitTurnInputs.push(input);
+			return new Promise((resolve) => {
 				enteredKitTurn = true;
 				releaseKitTurn = () => resolve(new Response(null, { status: 200 }));
-			})
+			});
+		}
 	)
+}));
+vi.mock('$lib/server/chat/action-approval', () => ({
+	createChatActionApproval: vi.fn(() => actionApproval)
 }));
 vi.mock('./persistence', () => ({
 	getThread: vi.fn(async () => ({
@@ -123,6 +131,7 @@ describe('il ramo kit del drain batte mentre lavora', () => {
 			const drain = processNextQueuedChatJob(db.client as never, 'https://app.example');
 			await until(() => enteredKitTurn);
 			expect(enteredKitTurn).toBe(true);
+			expect(kitTurnInputs[0]?.approval).toBe(actionApproval);
 
 			const claimedAt = Number(db.tables.chat_jobs[0].partial?.at);
 			expect(claimedAt).toBeGreaterThan(0);

--- a/src/lib/server/chat/queue.ts
+++ b/src/lib/server/chat/queue.ts
@@ -93,6 +93,7 @@ import { DM_REPLY_STEP_CAP, dmAgents, dmBrief, dmNames } from '$lib/chat-dm';
 import { parseRoomAgents, stripRoomPeerTools } from '$lib/server/chat/room';
 import { bilingualNoticeLocale } from '$lib/i18n/locale';
 import { carryImagesToContinuation } from '$lib/agent/bridge/provider-refs';
+import { createChatActionApproval } from '$lib/server/chat/action-approval';
 
 export function kickChatQueueWork(origin: string): Promise<void> {
 	const headers: Record<string, string> = {};
@@ -776,6 +777,14 @@ await maybeCompactThread(admin, {
 						// La scalata Auto→Pro segue la richiesta di una PERSONA: un turno schedulato, un
 						// DM fra agenti o una ripresa scritta dal sistema restano sul default.
 						escalationText: params.scheduled === true || replay || isDm ? undefined : userMessageContent,
+						approval: isDm
+							? undefined
+							: createChatActionApproval({
+									messages: kitMessages,
+									brandId: brand.id,
+									userId: job.user_id as string,
+									threadId
+							  }),
 						// Il contesto del DM: chi parla, per chi. Il turno kit nasce DM (blocco in testa
 						// al prompt, firma della risposta, niente riprese) come lo nasceva quello classico.
 						dm:

--- a/src/lib/server/chat/thread-events.test.ts
+++ b/src/lib/server/chat/thread-events.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import {
+	appendThreadEvent,
+	messageEvent,
+	progressEvent,
+	supersedeEvent,
+	threadMessageRows
+} from './thread-events';
+
+const row = {
+	id: 'message-1',
+	role: 'assistant',
+	content: 'done',
+	tool_calls: null,
+	created_at: '2026-08-30T10:00:00.000Z'
+};
+
+describe('thread event writer', () => {
+	it('builds a complete idempotent message event', () => {
+		expect(messageEvent('thread-1', row, 'run-1:assistant')).toEqual({
+			threadId: 'thread-1',
+			sourceKey: 'run-1:assistant',
+			kind: 'message',
+			payload: row
+		});
+	});
+
+	it('builds absolute progress and branch events', () => {
+    expect(progressEvent('thread-1', 'run-1:progress:2', { runId: 'run-1', status: 'running', text: 'half' })).toEqual({
+		threadId: 'thread-1',
+		sourceKey: 'run-1:progress:2',
+		kind: 'progress',
+    payload: { runId: 'run-1', status: 'running', text: 'half' }
+		});
+		expect(supersedeEvent('thread-1', 'redo-1', ['message-1'])).toEqual({
+		threadId: 'thread-1',
+		sourceKey: 'redo-1',
+		kind: 'messages_superseded',
+		payload: { messageIds: ['message-1'] }
+		});
+	});
+
+	it('calls the serialized database append primitive', async () => {
+		const rpc = vi.fn(async () => ({
+			data: [{ thread_id: 'thread-1', seq: 4, source_key: 'run-1:assistant', kind: 'message', payload: row }],
+			error: null
+		}));
+
+		await appendThreadEvent({ rpc } as unknown as SupabaseClient, messageEvent('thread-1', row, 'run-1:assistant'));
+
+		expect(rpc).toHaveBeenCalledWith('append_thread_event', {
+			p_thread_id: 'thread-1',
+			p_source_key: 'run-1:assistant',
+			p_kind: 'message',
+			p_payload: row
+		});
+	});
+
+	it('projects message events and removes superseded rows', () => {
+		const projected = threadMessageRows([
+			{ thread_id: 'thread-1', seq: 1, source_key: 'm-1', kind: 'message', payload: row },
+			{
+				thread_id: 'thread-1',
+				seq: 2,
+				source_key: 'm-2',
+				kind: 'message',
+				payload: { ...row, id: 'message-2', content: 'new' }
+			},
+			{
+				thread_id: 'thread-1',
+				seq: 3,
+				source_key: 'redo-1',
+				kind: 'messages_superseded',
+				payload: { messageIds: ['message-1'] }
+			}
+		]);
+
+		expect(projected).toEqual([{ ...row, id: 'message-2', content: 'new' }]);
+	});
+
+	it('refuses to project an incomplete event page', () => {
+		expect(
+			threadMessageRows([
+				{ thread_id: 'thread-1', seq: 1, source_key: 'm-1', kind: 'message', payload: row },
+				{ thread_id: 'thread-1', seq: 3, source_key: 'm-3', kind: 'message', payload: { ...row, id: 'message-3' } }
+			])
+		).toBeNull();
+	});
+});

--- a/src/lib/server/chat/thread-events.ts
+++ b/src/lib/server/chat/thread-events.ts
@@ -1,0 +1,122 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import {
+	emptyThreadProjection,
+	reduceThreadEvents,
+	type ThreadEvent,
+	type ThreadMessage,
+	type ThreadProgress
+} from '@anomalia/agent-kit';
+
+export type ThreadEventInput = {
+	threadId: string;
+	sourceKey: string;
+	kind: ThreadEvent['kind'];
+	payload: ThreadMessage | ThreadProgress | { messageIds: readonly string[] };
+};
+
+export type StoredThreadEvent = {
+	thread_id: string;
+	seq: number;
+	source_key: string;
+	kind: ThreadEvent['kind'];
+	payload: unknown;
+};
+
+export async function loadThreadEvents(
+	db: SupabaseClient,
+	threadId: string,
+	afterSeq = 0,
+	limit = 100_000
+): Promise<StoredThreadEvent[] | null> {
+	try {
+		const pageSize = 2_000;
+		const events: StoredThreadEvent[] = [];
+		let cursor = afterSeq;
+		for (;;) {
+			const { data, error } = await db
+				.from('thread_events')
+				.select('thread_id, seq, source_key, kind, payload')
+				.eq('thread_id', threadId)
+				.gt('seq', cursor)
+				.order('seq', { ascending: true })
+				.limit(Math.min(pageSize, limit - events.length));
+			if (error) return null;
+			const page = (data ?? []) as StoredThreadEvent[];
+			events.push(...page);
+			if (page.length < pageSize || events.length >= limit) return events.length >= limit ? null : events;
+			cursor = page[page.length - 1].seq;
+		}
+	} catch {
+		return null;
+	}
+}
+
+export function messageEvent(
+	threadId: string,
+	message: ThreadMessage,
+	sourceKey: string
+): ThreadEventInput {
+	return { threadId, sourceKey, kind: 'message', payload: message };
+}
+
+export function progressEvent(
+	threadId: string,
+	sourceKey: string,
+	progress: ThreadProgress
+): ThreadEventInput {
+	return { threadId, sourceKey, kind: 'progress', payload: progress };
+}
+
+export function supersedeEvent(
+	threadId: string,
+	sourceKey: string,
+	messageIds: readonly string[]
+): ThreadEventInput {
+	return { threadId, sourceKey, kind: 'messages_superseded', payload: { messageIds } };
+}
+
+export async function appendThreadEvent(
+	db: SupabaseClient,
+	event: ThreadEventInput
+): Promise<StoredThreadEvent> {
+	const { data, error } = await db.rpc('append_thread_event', {
+		p_thread_id: event.threadId,
+		p_source_key: event.sourceKey,
+		p_kind: event.kind,
+		p_payload: event.payload
+	});
+	if (error) throw new Error(`thread event append failed: ${error.message}`);
+	const row = Array.isArray(data) ? data[0] : data;
+	if (!row) throw new Error('thread event append returned no row');
+	return row as StoredThreadEvent;
+}
+
+export function threadMessageRows(events: readonly StoredThreadEvent[]): Record<string, unknown>[] | null {
+	const converted: ThreadEvent[] = events.map((event) => {
+		if (event.kind === 'message') {
+			return {
+				seq: event.seq,
+				sourceKey: event.source_key,
+				kind: event.kind,
+				message: event.payload as ThreadMessage
+			};
+		}
+		if (event.kind === 'progress') {
+			return {
+				seq: event.seq,
+				sourceKey: event.source_key,
+				kind: event.kind,
+				progress: event.payload as ThreadProgress
+			};
+		}
+		return {
+			seq: event.seq,
+			sourceKey: event.source_key,
+			kind: event.kind,
+			messageIds: ((event.payload as { messageIds?: unknown }).messageIds ?? []) as string[]
+		};
+	});
+	const result = reduceThreadEvents(emptyThreadProjection(), converted);
+	if (result.gap || result.conflict) return null;
+	return result.projection.messages.filter((message) => message.superseded !== true) as Record<string, unknown>[];
+}

--- a/src/lib/server/chat/turn-limits.ts
+++ b/src/lib/server/chat/turn-limits.ts
@@ -167,7 +167,7 @@ export function classifyChatJob(
 	return createdAge > CHAT_RUNNING_HARD_STALE_MS ? { dead: true, reason: 'wall' } : ALIVE;
 }
 
-export const KIT_RUN_WORKING_STATES = ['queued', 'running'] as const;
+export const KIT_RUN_WORKING_STATES = ['queued', 'running', 'waiting_input', 'waiting_takeover'] as const;
 
 /**
  * Lo stato in cui lo Stop dell'utente mette il run — dichiarato QUI, dove vive il resto del
@@ -186,7 +186,8 @@ export type KitRunLiveness = {
 };
 
 export function classifyKitRun(run: KitRunLiveness, now: number = Date.now()): ChatJobLiveness {
-	const working = (KIT_RUN_WORKING_STATES as readonly string[]).includes(run.state ?? '');
+  if (run.state === 'waiting_input' || run.state === 'waiting_takeover') return ALIVE;
+  const working = run.state === 'queued' || run.state === 'running';
 	const lastSignOfLife = run.heartbeat_at ?? run.created_at;
 	return classifyChatJob(
 		{

--- a/src/lib/stores/chat-session.ts
+++ b/src/lib/stores/chat-session.ts
@@ -530,6 +530,7 @@ export async function startChatSession(opts: {
    * Resend / edit: supersede this message (+ later rows) before saving the new user turn.
    */
   truncateFromMessageId?: string;
+  approval?: { approvalId: string; approved: boolean; reason?: string };
 }): Promise<'ok' | 'busy' | 'busy_saved' | 'error' | 'cancelled'> {
   const displayPending = opts.pendingUserText ?? opts.userText;
   const existing = sessions.get(opts.threadId);
@@ -579,7 +580,14 @@ export async function startChatSession(opts: {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        ...(opts.redoMessageId
+        ...(opts.approval
+          ? {
+              action: 'approval_response',
+              approval_id: opts.approval.approvalId,
+              approval_decision: opts.approval.approved ? 'approved' : 'denied',
+              ...(opts.approval.reason ? { approval_reason: opts.approval.reason } : {})
+            }
+          : opts.redoMessageId
           ? { action: 'redo', message_id: opts.redoMessageId }
           : { messages: [{ role: 'user', content: opts.userText }] }),
         thread_id: opts.threadId,
@@ -1359,4 +1367,3 @@ async function tickToolWatch(threadId: string): Promise<void> {
     /* best-effort */
   }
 }
-

--- a/src/routes/app/[brand]/chat/+server.ts
+++ b/src/routes/app/[brand]/chat/+server.ts
@@ -49,6 +49,7 @@ import { handlePostAction } from './lib/post-actions';
 import { applyGoalCommand, applyTurnBriefings, buildTurnContext, buildTurnMessages, type DeadlineRef } from './lib/turn-prep';
 import { finishSuccessfulTurn } from './lib/turn-finish';
 import { createChatActionApproval } from '$lib/server/chat/action-approval';
+import { decideApproval, isApprovalDecision } from '$lib/server/chat/agent-kit-approvals';
 
 // Vercel extended max duration (Pro/Enterprise, nodejs22.x). Must stay in sync with
 // CHAT_MAX_DURATION_MS — every budget in turn-limits.ts is carved out of this number.
@@ -74,6 +75,7 @@ export const POST: RequestHandler = async ({ request, params, locals: { supabase
   const webHubEnabled = hasWebHub(brand.plan);
   const body = await request.json();
   const action = body.action as string | undefined;
+  const isApprovalResponse = action === 'approval_response';
   let threadId: string;
   // Specialized agent bound to this thread scopes prompt + tools (multi-agent chat).
   let threadAgent: string | null = null;
@@ -110,6 +112,43 @@ export const POST: RequestHandler = async ({ request, params, locals: { supabase
     threadCustomAgentId = thread.custom_agent_id ?? null;
   }
 
+  type ApprovalRecord = { id: string; run_id: string; status: string; tool_call_id: string; harness_approval_id: string };
+  let approvalRecord: ApprovalRecord | null = null;
+  if (isApprovalResponse) {
+    const approvalId = typeof body.approval_id === 'string' ? body.approval_id : '';
+    const decision = body.approval_decision;
+    if (!approvalId || !isApprovalDecision(decision)) {
+      return json({ error: 'invalid_approval_decision' }, { status: 400 });
+    }
+    const { data } = await supabase
+      .from('agent_kit_approval_requests')
+      .select('id, run_id, status, tool_call_id, harness_approval_id')
+      .eq('id', approvalId)
+      .eq('thread_id', threadId)
+      .maybeSingle();
+    approvalRecord = data as unknown as ApprovalRecord | null;
+    if (!approvalRecord) return json({ error: 'approval_not_found' }, { status: 404 });
+    if (approvalRecord.status !== 'pending') {
+      if (approvalRecord.status !== decision) return json({ error: 'approval_already_decided' }, { status: 409 });
+
+      const { data: waitingRun } = await supabase
+        .from('agent_kit_runs')
+        .select('id')
+        .eq('id', approvalRecord.run_id)
+        .eq('state', 'waiting_takeover')
+        .maybeSingle();
+      if (!waitingRun) return json({ approval_id: approvalRecord.id, status: approvalRecord.status });
+    }
+    if (approvalRecord.status === 'pending') {
+      try {
+        approvalRecord = await decideApproval(supabase, approvalId, decision, typeof body.approval_reason === 'string' ? body.approval_reason : undefined);
+      } catch (e) {
+        return json({ error: 'approval_already_decided', message: e instanceof Error ? e.message : String(e) }, { status: 409 });
+      }
+    }
+    body.approval_harness_id = approvalRecord.harness_approval_id;
+  }
+
   const handledAction = await handlePostAction({
     supabase,
     brand: brand as { id: string; plan: string | null },
@@ -127,7 +166,7 @@ export const POST: RequestHandler = async ({ request, params, locals: { supabase
 
   const isRedo = action === 'redo';
   const userMessages = body.messages as ModelMessage[] | undefined;
-  if (!isRedo && !userMessages?.length) return new Response('No messages', { status: 400 });
+  if (!isRedo && !isApprovalResponse && !userMessages?.length) return new Response('No messages', { status: 400 });
 
   // Rolling chat windows (5h / week) — monthly credits still apply separately via tools / metering.
   {
@@ -147,10 +186,10 @@ export const POST: RequestHandler = async ({ request, params, locals: { supabase
   // già da solo (enqueueChatMessage). Prima di saveMessages, così il retry non lascia doppioni.
   {
     const { createAdminClient } = await import('$lib/server/supabase-admin');
-    if (
+    if (!isApprovalResponse && (
       (await threadHasActiveChatResponse(supabase, { userId: user.id, threadId })) ||
       (await threadHasActiveKitRun(createAdminClient(), threadId))
-    ) {
+    )) {
       return json({ error: 'busy' }, { status: 409 });
     }
   }
@@ -275,6 +314,16 @@ export const POST: RequestHandler = async ({ request, params, locals: { supabase
         userId: user.id,
         threadId
       }),
+      ...(isApprovalResponse
+        ? {
+            approvalResponse: {
+              approvalId: approvalRecord?.harness_approval_id ?? String(body.approval_id ?? ''),
+              approved: body.approval_decision === 'approved',
+              toolCallId: approvalRecord?.tool_call_id,
+              ...(typeof body.approval_reason === 'string' ? { reason: body.approval_reason } : {})
+            }
+          }
+        : {}),
       waitUntil: (platform as Platform)?.context?.waitUntil
     });
   }

--- a/src/routes/app/[brand]/chat/+server.ts
+++ b/src/routes/app/[brand]/chat/+server.ts
@@ -48,6 +48,7 @@ import { loadThreadState } from './lib/thread-load';
 import { handlePostAction } from './lib/post-actions';
 import { applyGoalCommand, applyTurnBriefings, buildTurnContext, buildTurnMessages, type DeadlineRef } from './lib/turn-prep';
 import { finishSuccessfulTurn } from './lib/turn-finish';
+import { createChatActionApproval } from '$lib/server/chat/action-approval';
 
 // Vercel extended max duration (Pro/Enterprise, nodejs22.x). Must stay in sync with
 // CHAT_MAX_DURATION_MS — every budget in turn-limits.ts is carved out of this number.
@@ -268,6 +269,12 @@ export const POST: RequestHandler = async ({ request, params, locals: { supabase
       // senza, un follow-up accodato su un thread kit resta fermo fino al cron (2 minuti) e poi
       // viene risposto dal motore CLASSICO invece che dallo specialista.
       origin,
+      approval: createChatActionApproval({
+        messages,
+        brandId: brand.id,
+        userId: user.id,
+        threadId
+      }),
       waitUntil: (platform as Platform)?.context?.waitUntil
     });
   }

--- a/src/routes/app/[brand]/chat/[thread]/+page.server.ts
+++ b/src/routes/app/[brand]/chat/[thread]/+page.server.ts
@@ -159,7 +159,7 @@ export const load: PageServerLoad = async ({ params, locals: { supabase, safeGet
   // Close out dead rows before asking what is in flight, so a thread unblocks itself on open.
   await reapStaleChatJobs(supabase, { userId: user.id, threadId: params.thread, limit: 10 });
 
-  const [thread, messages, artifacts, activeJobResult, failedJobResult, pendingToolsResult, sessionMemoryResult, lastReads] = await Promise.all([
+  const [thread, messages, artifacts, activeJobResult, failedJobResult, pendingToolsResult, approvalRowsResult, sessionMemoryResult, lastReads] = await Promise.all([
     getThread(supabase, params.thread, brand.id, user.id),
     loadHistoryForUI(supabase, brand.id, user.id, params.thread),
     // Stessa consegna di GET /chat?thread=: i fotogrammi di motion_stills / render_stills
@@ -205,6 +205,10 @@ export const load: PageServerLoad = async ({ params, locals: { supabase, safeGet
       .order('created_at', { ascending: false })
       .limit(10),
     supabase
+      .from('agent_kit_approval_requests')
+      .select('id, harness_approval_id, status')
+      .eq('thread_id', params.thread),
+    supabase
       .from('brand_memory')
       .select('id, key, value, category')
       .eq('brand_id', brand.id)
@@ -220,6 +224,13 @@ export const load: PageServerLoad = async ({ params, locals: { supabase, safeGet
   ]);
   if (!thread) throw error(404, 'Thread not found');
 
+  const approvalStatuses = Object.fromEntries(
+    ((approvalRowsResult.data ?? []) as Array<{ id: string; harness_approval_id?: string | null; status: string }>).flatMap((row) => [
+      [row.id, row.status],
+      ...(row.harness_approval_id ? [[row.harness_approval_id, row.status]] : [])
+    ])
+  );
+
   // Dopo il 404: il pannello dipende da agent/custom_agent_id del thread risolto.
   const agentPanel = await loadAgentPanel(supabase, brand, thread);
 
@@ -228,6 +239,7 @@ export const load: PageServerLoad = async ({ params, locals: { supabase, safeGet
     agentPanel,
     agentDesktopEnabled: agentDesktopEnabled(),
     messages,
+    approvalStatuses,
     artifacts,
     brandSlug: brand.slug,
     brandId: brand.id,

--- a/src/routes/app/[brand]/chat/[thread]/+page.svelte
+++ b/src/routes/app/[brand]/chat/[thread]/+page.svelte
@@ -75,6 +75,7 @@
   });
 
   let messages = $state<ChatMessage[]>([]);
+  let approvalStatuses = $state<Record<string, string>>(data.approvalStatuses ?? {});
   let artifacts = $state<ChatArtifactUi[]>([]);
   let agentSel = $state(DEFAULT_AGENT_ID);
   // `agentSel` in coda: Anomalia non è più fra le scelte ma va rimessa in lista se è l'agente
@@ -102,6 +103,7 @@
     // ri-sottoscrive l'effect e fa scattare effect_update_depth_exceeded.
     const next = consolidateMessages((data.messages ?? []).map(mapMsg));
     messages = next;
+    approvalStatuses = { ...(data.approvalStatuses ?? {}) };
     artifacts = (data.artifacts ?? []) as ChatArtifactUi[];
     // I piani già nel thread sono cronologia, non una proposta da aprire.
     autoOpenedPlans = new Set(planIdsIn(next));
@@ -600,6 +602,24 @@
     await setThreadAgent(data.brandSlug, data.thread.id, id);
   }
 
+  async function decideApproval(approvalId: string, approved: boolean) {
+    const result = await startChatSession({
+      brandSlug: data.brandSlug,
+      threadId: data.thread.id,
+      userText: '',
+      pendingUserText: '',
+      mode: chatMode,
+      tier: chatTier,
+      reasoning: chatReasoning,
+      agent: agentSel,
+      approval: { approvalId, approved }
+    });
+    if (result === 'ok') {
+      approvalStatuses = { ...approvalStatuses, [approvalId]: approved ? 'approved' : 'denied' };
+    }
+    if (result === 'error') staleError = 'chat.error';
+  }
+
   async function send(
     text?: string,
     meta?: {
@@ -927,6 +947,8 @@
       onredo={(index) => life.redoAssistant(index)}
       onfeedback={(id, value, note) => void life.sendFeedback(id, value, note)}
       onsend={(text) => send(text)}
+      {approvalStatuses}
+      onapproval={decideApproval}
     />
   </div>
 

--- a/src/routes/app/[brand]/chat/components/ChatTurn.svelte
+++ b/src/routes/app/[brand]/chat/components/ChatTurn.svelte
@@ -17,6 +17,7 @@
   import ChatConnectCard from '$lib/components/ChatConnectCard.svelte';
   import ChatDeviceLoginCard from '$lib/components/ChatDeviceLoginCard.svelte';
   import ChatQuestionsCard from '$lib/components/ChatQuestionsCard.svelte';
+  import ChatApprovalCard from '$lib/components/ChatApprovalCard.svelte';
   import ChatTeamCard from '$lib/components/ChatTeamCard.svelte';
   import ChatMessageActions from '$lib/components/ChatMessageActions.svelte';
   import ChatSources from '$lib/components/ChatSources.svelte';
@@ -56,7 +57,9 @@
     onredo,
     onfeedback,
     onsend,
-    onpreview
+    onpreview,
+    approvalStatuses,
+    onapproval
   }: {
     msg: ChatMessage;
     index: number;
@@ -75,6 +78,8 @@
     onfeedback: (messageId: string | undefined, value: 1 | -1 | null, note?: string) => void;
     onsend: (text: string) => void;
     onpreview: (p: PostPreview) => void;
+    approvalStatuses: Record<string, string>;
+    onapproval: (approvalId: string, approved: boolean) => void;
   } = $props();
 
   const blocks = $derived(messageBlocks(msg.content, msg.tool_calls));
@@ -170,6 +175,16 @@
 <!-- Quali tool restino muti lo decide `chipCalls` dentro ChatToolChips: mai un elenco
      copiato a mano qui, o una chip nuda compare al posto di una card. -->
 <ChatToolChips {calls} />
+{#each calls.filter((tc) => tc.approval) as tc (tc.toolCallId)}
+  <ChatApprovalCard
+    approvalId={tc.approval!.approvalId}
+    toolName={tc.toolName}
+    input={tc.input}
+    status={approvalStatuses[tc.approval!.approvalId] ?? 'pending'}
+    disabled={loading}
+    ondecision={(approved) => onapproval(tc.approval!.approvalId, approved)}
+  />
+{/each}
 <ChatExpressionStickers {calls} />
 <ChatDmChip {calls} {brandSlug} />
 {@const arts = calls.flatMap((tc) => {

--- a/src/routes/app/[brand]/chat/components/TranscriptList.svelte
+++ b/src/routes/app/[brand]/chat/components/TranscriptList.svelte
@@ -17,7 +17,7 @@
   import ChatTurn from './ChatTurn.svelte';
   import ChatArtifactCard from '$lib/components/ChatArtifactCard.svelte';
   import type { AgentAvatarFace } from '$lib/agent-avatars';
-  import type { ChatArtifactUi, ChatMessage, PostPreview } from './transcript';
+  import { parseToolCalls, type ChatArtifactUi, type ChatMessage, type PostPreview } from './transcript';
   import type { KitRun } from './kit-run';
 
   let {
@@ -47,7 +47,9 @@
     onresend,
     onredo,
     onfeedback,
-    onsend
+    onsend,
+    approvalStatuses,
+    onapproval
   }: {
     messages: ChatMessage[];
     artifacts?: ChatArtifactUi[];
@@ -84,6 +86,8 @@
     onredo: (index: number) => void;
     onfeedback: (messageId: string | undefined, value: 1 | -1 | null, note?: string) => void;
     onsend: (text: string) => void;
+    approvalStatuses: Record<string, string>;
+    onapproval: (approvalId: string, approved: boolean) => void;
   } = $props();
 
   // La riga in store porta anche gli avatar dei custom agent; thread copre il primo paint.
@@ -150,8 +154,8 @@
       // Il checkpoint vivo è saltato nel transcript (lo disegna la bolla): i suoi toolCallId
       // non contano come "già mostrati", o i fotogrammi sparirebbero per tutta la durata del turno.
       if (m.id && m.id === liveCheckpointId) continue;
-      for (const part of m.tool_calls ?? []) {
-        const id = (part as { toolCallId?: string }).toolCallId;
+      for (const part of parseToolCalls(m.tool_calls)) {
+        const id = part.toolCallId;
         if (id) ids.add(id);
       }
     }
@@ -240,6 +244,8 @@
         onfeedback={onfeedback}
         onsend={onsend}
         onpreview={onzoompost}
+        {approvalStatuses}
+        onapproval={onapproval}
       />
     </div>
   {/if}

--- a/src/routes/app/[brand]/chat/components/transcript.ts
+++ b/src/routes/app/[brand]/chat/components/transcript.ts
@@ -67,6 +67,7 @@ export type ToolCallUi = {
   team?: unknown;
   routineEvent?: unknown;
   plan?: PlanProposal;
+  approval?: { approvalId: string };
 };
 
 /** Solo i tool call: i segmenti di testo vivono nello stesso JSON (chat-parts.ts). */

--- a/src/routes/app/[brand]/chat/lib/turn-prep.ts
+++ b/src/routes/app/[brand]/chat/lib/turn-prep.ts
@@ -43,6 +43,7 @@ import { aiActTurnBriefing, screenForProhibitedPractice, type PracticeHit } from
 import { goalCommandInstruction, parseGoalCommand } from '$lib/goal-command';
 import { lastUserText } from './jobs';
 import { persistChatAttachments, resolveChatAttachments } from './attachments';
+import { approvalContinuationMessage } from '$lib/agent/bridge/approval';
 
 export type DeadlineRef = { current: { remainingMs: () => number } | null };
 
@@ -84,7 +85,7 @@ export async function buildTurnContext(input: {
   // arriva molto più sotto, dopo la history, e allo smistatore serve adesso.
   // ponytail: sul `redo` la stanza non si rismista — si rigenera con l'agente del thread. Redo su
   // una room è raro e reinterrogare il router costerebbe un giro per cambiare voce a metà.
-  const roomPlan = isRedo
+  const roomPlan = isRedo || body.action === 'approval_response'
     ? null
     : await roomBeat(supabase, {
         thread: { id: threadId, room_agents: threadRoomAgents },
@@ -349,6 +350,8 @@ export async function buildTurnMessages(input: {
   let messages: ModelMessage[];
   let textContent: string;
 
+  const isApprovalResponse = body.action === 'approval_response';
+
   if (isRedo) {
     const messageId = typeof body.message_id === 'string' ? body.message_id : '';
     if (!messageId) return { response: new Response('message_id required', { status: 400 }) };
@@ -376,6 +379,25 @@ export async function buildTurnMessages(input: {
             .join('');
     // History already ends at the user turn — do not append or re-save it.
     messages = history;
+  } else if (isApprovalResponse) {
+    const approvalId = typeof body.approval_id === 'string' ? body.approval_id : '';
+    const approved = body.approval_decision === 'approved';
+    if (!approvalId || !['approved', 'denied'].includes(String(body.approval_decision))) {
+      return { response: new Response('approval_id and approval_decision are required', { status: 400 }) };
+    }
+
+    history = await loadHistory(supabase, brand.id, userId, threadId, 50, historyMedia);
+    const priorUser = [...history].reverse().find((m) => m.role === 'user');
+    if (!priorUser) return { response: new Response('No user message to resume', { status: 400 }) };
+    lastUserMsg = priorUser;
+    textContent = '';
+    messages = [...history, approvalContinuationMessage({
+      approvalId: typeof body.approval_harness_id === 'string' ? body.approval_harness_id : approvalId,
+      approved,
+      ...(typeof body.approval_reason === 'string' && body.approval_reason.trim()
+        ? { reason: body.approval_reason.trim() }
+        : {})
+    })];
   } else {
     const truncateFrom =
       typeof body.truncate_from_message_id === 'string' ? body.truncate_from_message_id : '';
@@ -436,7 +458,7 @@ export async function buildTurnMessages(input: {
     if (!isRetryOfDeadTurn) {
       const attachments = refUrls.length ? await persistChatAttachments(supabase, userId, refUrls) : [];
       await saveMessages(supabase, brand.id, userId, [persistMsg], threadId, {
-        ...(attachments.length ? { attachments } : {})
+        ...(attachments.length ? { attachments } : {}),
       });
     }
   }

--- a/supabase/migrations/0226_durable_thread_events.sql
+++ b/supabase/migrations/0226_durable_thread_events.sql
@@ -1,0 +1,162 @@
+alter table public.chat_threads
+  add column if not exists event_head_seq bigint not null default 0;
+
+create table if not exists public.thread_events (
+  thread_id uuid not null references public.chat_threads(id) on delete cascade,
+  seq bigint not null,
+  source_key text not null,
+  kind text not null check (kind in ('message', 'progress', 'messages_superseded')),
+  payload jsonb not null,
+  created_at timestamptz not null default now(),
+  primary key (thread_id, seq),
+  unique (thread_id, source_key)
+);
+
+create index if not exists idx_thread_events_source
+  on public.thread_events(thread_id, source_key);
+
+create index if not exists idx_thread_events_kind
+  on public.thread_events(thread_id, kind, seq);
+
+alter table public.thread_events enable row level security;
+
+drop policy if exists thread_events_select on public.thread_events;
+create policy thread_events_select on public.thread_events for select
+  using (
+    thread_id in (
+      select id
+      from public.chat_threads
+      where brand_id in (select public.auth_brand_ids())
+        and user_id = auth.uid()
+    )
+  );
+
+revoke all on public.thread_events from anon, authenticated;
+grant select on public.thread_events to authenticated;
+
+insert into public.thread_events (thread_id, seq, source_key, kind, payload, created_at)
+select
+  m.thread_id,
+  row_number() over (partition by m.thread_id order by m.created_at, m.id),
+  'backfill:message:' || m.id,
+  'message',
+  to_jsonb(m),
+  m.created_at
+from public.chat_messages m
+on conflict (thread_id, source_key) do nothing;
+
+update public.chat_threads t
+set event_head_seq = coalesce(
+  (select max(e.seq) from public.thread_events e where e.thread_id = t.id),
+  0
+);
+
+create or replace function public.append_thread_event(
+  p_thread_id uuid,
+  p_source_key text,
+  p_kind text,
+  p_payload jsonb
+) returns public.thread_events
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_thread public.chat_threads%rowtype;
+  v_event public.thread_events%rowtype;
+begin
+  if p_kind not in ('message', 'progress', 'messages_superseded') then
+    raise exception 'thread event kind is not supported';
+  end if;
+
+  select * into v_thread
+  from public.chat_threads
+  where id = p_thread_id
+  for update;
+
+  if v_thread.id is null then
+    raise exception 'thread not found';
+  end if;
+
+  if auth.role() <> 'service_role' and v_thread.user_id <> auth.uid() then
+    raise exception 'thread access denied';
+  end if;
+
+  select * into v_event
+  from public.thread_events
+  where thread_id = p_thread_id and source_key = p_source_key;
+
+  if v_event.thread_id is not null then
+    if v_event.kind <> p_kind or v_event.payload is distinct from p_payload then
+      raise exception 'thread event source key conflict';
+    end if;
+    return v_event;
+  end if;
+
+  insert into public.thread_events (thread_id, seq, source_key, kind, payload)
+  values (p_thread_id, v_thread.event_head_seq + 1, p_source_key, p_kind, p_payload)
+  returning * into v_event;
+
+  update public.chat_threads
+  set event_head_seq = v_event.seq
+  where id = p_thread_id;
+
+  return v_event;
+end;
+$$;
+
+revoke all on function public.append_thread_event(uuid, text, text, jsonb) from public, anon;
+grant execute on function public.append_thread_event(uuid, text, text, jsonb) to authenticated, service_role;
+
+create or replace function public.capture_chat_message_event()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if new.thread_id is null then
+    return new;
+  end if;
+
+  perform public.append_thread_event(
+    new.thread_id,
+    'message:' || new.id,
+    'message',
+    to_jsonb(new)
+  );
+  return new;
+end;
+$$;
+
+create or replace function public.capture_chat_message_supersede_event()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if old.superseded is false and new.superseded is true and new.thread_id is not null then
+    perform public.append_thread_event(
+      new.thread_id,
+      'supersede:' || new.id,
+      'messages_superseded',
+      jsonb_build_object('messageIds', jsonb_build_array(new.id))
+    );
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists chat_messages_capture_event on public.chat_messages;
+create trigger chat_messages_capture_event
+after insert on public.chat_messages
+for each row execute function public.capture_chat_message_event();
+
+drop trigger if exists chat_messages_capture_supersede on public.chat_messages;
+create trigger chat_messages_capture_supersede
+after update of superseded on public.chat_messages
+for each row execute function public.capture_chat_message_supersede_event();
+
+revoke all on function public.capture_chat_message_event() from public, anon, authenticated;
+revoke all on function public.capture_chat_message_supersede_event() from public, anon, authenticated;

--- a/supabase/migrations/0227_resumable_tool_approvals.sql
+++ b/supabase/migrations/0227_resumable_tool_approvals.sql
@@ -1,0 +1,199 @@
+alter table public.agent_kit_runs
+  add column if not exists harness_continue_state jsonb;
+
+create table if not exists public.agent_kit_approval_requests (
+  id uuid primary key default gen_random_uuid(),
+  brand_id uuid not null references public.brands(id) on delete cascade,
+  thread_id uuid not null references public.chat_threads(id) on delete cascade,
+  run_id uuid not null references public.agent_kit_runs(id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  harness_approval_id text not null,
+  tool_call_id text not null,
+  tool_name text not null,
+  tool_input jsonb not null,
+  input_hash text not null,
+  reason text,
+  status text not null default 'pending' check (status in ('pending', 'approved', 'denied', 'expired', 'cancelled', 'consumed')),
+  decided_by uuid references auth.users(id) on delete set null,
+  decision_reason text,
+  decided_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (run_id, harness_approval_id)
+);
+
+create index if not exists idx_agent_kit_approvals_thread
+  on public.agent_kit_approval_requests(thread_id, status, created_at desc);
+
+alter table public.agent_kit_approval_requests enable row level security;
+
+drop policy if exists agent_kit_approvals_select on public.agent_kit_approval_requests;
+create policy agent_kit_approvals_select on public.agent_kit_approval_requests for select
+  using (
+    user_id = auth.uid()
+    and brand_id in (select public.auth_brand_ids())
+  );
+
+revoke all on public.agent_kit_approval_requests from anon, authenticated;
+grant select on public.agent_kit_approval_requests to authenticated;
+
+create or replace function public.agent_kit_wait_for_approval(
+  p_run_id uuid,
+  p_harness_approval_id text,
+  p_tool_call_id text,
+  p_tool_name text,
+  p_tool_input jsonb,
+  p_input_hash text,
+  p_reason text,
+  p_continue_state jsonb,
+  p_message jsonb default null
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_run public.agent_kit_runs%rowtype;
+  v_approval public.agent_kit_approval_requests%rowtype;
+  v_message public.chat_messages%rowtype;
+  v_message_payload jsonb;
+begin
+  update public.agent_kit_runs
+  set state = 'waiting_takeover',
+      harness_continue_state = p_continue_state,
+      question = null,
+      updated_at = now()
+  where id = p_run_id and state = 'running'
+  returning * into v_run;
+
+  if v_run.id is null then
+    return jsonb_build_object('closed', false);
+  end if;
+
+  insert into public.agent_kit_approval_requests (
+    brand_id, thread_id, run_id, user_id, harness_approval_id,
+    tool_call_id, tool_name, tool_input, input_hash, reason
+  ) values (
+    v_run.brand_id, v_run.thread_id, v_run.id, v_run.user_id, p_harness_approval_id,
+    p_tool_call_id, p_tool_name, p_tool_input, p_input_hash, p_reason
+  )
+  returning * into v_approval;
+
+  if p_message is not null then
+    v_message_payload := p_message;
+    if jsonb_typeof(p_message->'tool_calls') = 'array' then
+      v_message_payload := jsonb_set(
+        v_message_payload,
+        '{tool_calls}',
+        (
+          select coalesce(
+            jsonb_agg(
+              case
+                when part->>'type' = 'tool-approval-request'
+                  and part->>'approvalId' = p_harness_approval_id
+                then part || jsonb_build_object('approvalId', v_approval.id::text)
+                else part
+              end
+              order by item.ord
+            ),
+            '[]'::jsonb
+          )
+          from jsonb_array_elements(p_message->'tool_calls') with ordinality as item(part, ord)
+        )
+      );
+    end if;
+
+    insert into public.chat_messages (brand_id, user_id, thread_id, role, content, reasoning, tool_calls, attachments, name)
+    values (
+      v_run.brand_id,
+      v_run.user_id,
+      v_run.thread_id,
+      'assistant',
+      coalesce(v_message_payload->>'content', ''),
+      v_message_payload->>'reasoning',
+      v_message_payload->'tool_calls',
+      v_message_payload->'attachments',
+      v_message_payload->>'name'
+    )
+    returning * into v_message;
+
+    update public.agent_kit_runs
+    set partial_saved_msg_id = v_message.id
+    where id = p_run_id;
+  end if;
+
+  if v_run.thread_id is not null then
+    perform public.append_thread_event(
+      v_run.thread_id,
+      'run:' || p_run_id || ':state:waiting_takeover',
+      'progress',
+      jsonb_build_object(
+        'runId', p_run_id,
+        'status', 'waiting_takeover',
+        'approvalId', v_approval.id
+      )
+    );
+  end if;
+
+  return jsonb_build_object(
+    'closed', true,
+    'approval_id', v_approval.id,
+    'harness_approval_id', v_approval.harness_approval_id,
+    'message_id', v_message.id
+  );
+end;
+$$;
+
+create or replace function public.decide_agent_kit_approval(
+  p_approval_id uuid,
+  p_status text,
+  p_reason text default null
+) returns public.agent_kit_approval_requests
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_approval public.agent_kit_approval_requests%rowtype;
+  v_status text;
+begin
+  if p_status not in ('approved', 'denied') then
+    raise exception 'approval status is not supported';
+  end if;
+
+  select a.* into v_approval
+  from public.agent_kit_approval_requests a
+  where a.id = p_approval_id
+    and a.user_id = auth.uid()
+    and a.brand_id in (select public.auth_brand_ids())
+  for update;
+
+  if v_approval.id is null then
+    raise exception 'approval not found';
+  end if;
+
+  if v_approval.status <> 'pending' then
+    if v_approval.status = p_status then
+      return v_approval;
+    end if;
+    raise exception 'approval already decided';
+  end if;
+
+  update public.agent_kit_approval_requests
+  set status = p_status,
+      decided_by = auth.uid(),
+      decision_reason = p_reason,
+      decided_at = now(),
+      updated_at = now()
+  where id = p_approval_id and status = 'pending'
+  returning * into v_approval;
+
+  return v_approval;
+end;
+$$;
+
+revoke all on function public.agent_kit_wait_for_approval(uuid, text, text, text, jsonb, text, text, jsonb, jsonb) from public, anon, authenticated;
+grant execute on function public.agent_kit_wait_for_approval(uuid, text, text, text, jsonb, text, text, jsonb, jsonb) to service_role;
+
+revoke all on function public.decide_agent_kit_approval(uuid, text, text) from public, anon;
+grant execute on function public.decide_agent_kit_approval(uuid, text, text) to authenticated;

--- a/supabase/migrations/0228_agent_kit_event_close.sql
+++ b/supabase/migrations/0228_agent_kit_event_close.sql
@@ -1,0 +1,73 @@
+create or replace function public.agent_kit_close_run(
+  p_run_id uuid,
+  p_to_state text,
+  p_reason text default null,
+  p_question jsonb default null,
+  p_message jsonb default null
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_run public.agent_kit_runs%rowtype;
+  v_message public.chat_messages%rowtype;
+begin
+  if p_to_state not in ('waiting_input', 'done', 'failed', 'aborted') then
+    raise exception 'agent_kit_close_run: state is not allowed';
+  end if;
+
+  update public.agent_kit_runs
+  set state = p_to_state,
+      reason = coalesce(p_reason, reason),
+      question = coalesce(p_question, question),
+      harness_continue_state = null,
+      updated_at = now()
+  where id = p_run_id and state = 'running'
+  returning * into v_run;
+
+  if v_run.id is null then
+    return jsonb_build_object('closed', false);
+  end if;
+
+  if p_message is not null then
+    insert into public.chat_messages (brand_id, user_id, thread_id, role, content, reasoning, tool_calls, attachments, name)
+    values (
+      v_run.brand_id,
+      v_run.user_id,
+      v_run.thread_id,
+      'assistant',
+      coalesce(p_message->>'content', ''),
+      p_message->>'reasoning',
+      p_message->'tool_calls',
+      p_message->'attachments',
+      p_message->>'name'
+    )
+    returning * into v_message;
+
+    update public.agent_kit_runs
+    set partial_saved_msg_id = v_message.id
+    where id = p_run_id;
+
+  end if;
+
+  if v_run.thread_id is not null then
+    perform public.append_thread_event(
+      v_run.thread_id,
+      'run:' || p_run_id || ':state:' || p_to_state,
+      'progress',
+      jsonb_build_object(
+        'runId', p_run_id,
+        'status', p_to_state,
+        'reason', p_reason,
+        'question', p_question
+      )
+    );
+  end if;
+
+  return jsonb_build_object('closed', true, 'message_id', v_message.id);
+end;
+$$;
+
+revoke all on function public.agent_kit_close_run(uuid, text, text, jsonb, jsonb) from public, anon, authenticated;
+grant execute on function public.agent_kit_close_run(uuid, text, text, jsonb, jsonb) to service_role;

--- a/supabase/migrations/20260829180000_agent_kit_effect_identity.sql
+++ b/supabase/migrations/20260829180000_agent_kit_effect_identity.sql
@@ -1,0 +1,15 @@
+alter table public.agent_kit_effects
+  add column if not exists invocation_id text;
+
+alter table public.agent_kit_effects
+  alter column idempotency_key drop not null;
+
+drop index if exists public.agent_kit_effects_brand_key_idx;
+
+create unique index if not exists agent_kit_effects_brand_invocation_idx
+  on public.agent_kit_effects (brand_id, invocation_id)
+  where invocation_id is not null;
+
+create index if not exists agent_kit_effects_legacy_key_idx
+  on public.agent_kit_effects (brand_id, idempotency_key)
+  where invocation_id is null;


### PR DESCRIPTION
## Summary

Harden the Agent Kit chat around idempotent effects, durable replay, and human approval.

## Changes

### Idempotent effects

- Route effectful tools through the persisted effects ledger.
- Claim each effect before execution and record completed, failed, ambiguous, or reconciled outcomes.
- Keep the ledger adapter outside the Agent Kit core package.

### Durable thread events

- Add an append-only `thread_events` log with per-thread monotonic sequences and idempotent source keys.
- Capture message inserts and supersedes atomically.
- Rebuild model and UI history through one pure reducer.
- Fall back to legacy message reads if the event log is missing, incomplete, or inconsistent.

### HITL approvals

- Add persisted `ask` requests with redacted input, input hashes, continuation state, and a visible chat card.
- Resume after refresh or tab closure with an atomic, idempotent decision.
- Apply the automatic judge before consequential Harness actions.
- Resume immediately on `allow`; keep `ask` and checker errors fail-closed.
- Prevent duplicate execution when two devices decide at the same time.

### Tests and docs

- Add coverage for reducer gaps/conflicts, approval persistence, judge pass/ask, reload resume, and runtime approval bypass.
- Update internal and public changelogs.

## Guarantees

- A run cannot persist its final message after another worker has closed it.
- A refresh cannot lose a completed message or a pending approval.
- A retry cannot execute the same claimed effect twice.
- A denied approval never reaches the tool executor.

## Verification

- Targeted Vitest: 186 tests passed across 11 files after conflict resolution.
- `npm run typecheck:runtime`: passed; 253 known non-fatal type errors ignored.
- `git diff --check`: passed.
- `npm run check`: prior baseline remains 287 errors and 246 warnings in 165 files; no errors were reported in the changed chat files.
- Schema drift check is read-only and reports the new migrations are not applied remotely yet.
- Real-model evaluation was not run: this checkout has no generic `npm run eval` script, and `eval:ux` requires a live server, database, and paid model calls.

## Remaining parity work

This closes the main durability gap, but three bounded follow-ups remain:

- Replace the existing stream and partial mirrors with a realtime `{ threadId, headSeq }` poke protocol.
- Add distributed lease, fence, and attempt ownership for worker takeover.
- Add real-model quality scenarios and browser durability scenarios for reconnect, tab closure, and network loss.

The three new migrations must be applied before enabling these paths in production.
