### PR TITLE
Fix post-merge chat CI checks

### DIFF
--- a/src/lib/components/ChatApprovalCard.svelte
+++ b/src/lib/components/ChatApprovalCard.svelte
@@ -54,11 +54,11 @@
     border: 1px solid var(--line, #d7d7d7);
     border-radius: 0.75rem;
     padding: 0.85rem;
-    background: var(--paper-1, #fff);
+    background: var(--paper, #fff);
   }
 
   .approval-title { font-weight: 650; }
-  .approval-tool { margin-top: 0.2rem; color: var(--muted, #666); font-size: 0.85rem; }
+  .approval-tool { margin-top: 0.2rem; color: var(--ink-faint, #666); font-size: 0.85rem; }
   pre { max-height: 12rem; overflow: auto; margin: 0.7rem 0; white-space: pre-wrap; font-size: 0.75rem; }
   .approval-actions { display: flex; justify-content: flex-end; gap: 0.5rem; }
   button { border: 0; border-radius: 0.5rem; padding: 0.45rem 0.75rem; cursor: pointer; }

--- a/src/lib/content/changelog/2026-08-29-localize-onboarding-analysis-errors.ts
+++ b/src/lib/content/changelog/2026-08-29-localize-onboarding-analysis-errors.ts
@@ -1,7 +1,7 @@
 import type { ChangelogEntry } from './index';
 
 const entry: ChangelogEntry = {
-  date: 'August 29, 2026',
+  date: '2026-08-29',
   title: 'Onboarding errors use your language',
   items: ['Website analysis failures now show a clear localized message instead of technical fetch details.']
 };


### PR DESCRIPTION
## Summary

Fix the two failures reported by the full CI run after the chat durability merge.

## Fixes

- Use UI tokens that are defined by the application in `ChatApprovalCard`.
- Keep the public changelog date format consistent with the loader ordering check.

## Verification

- Full Vitest suite: 5,824 tests passed across 515 files.
- Focused changelog test: 2 tests passed.
- Runtime typecheck: passed; known non-fatal type errors remain ignored by the repository script.
- `git diff --check`: passed.
