### PR TITLE
Resume a dead run under a fenced lease

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -154,6 +154,14 @@ solo quando sono valorizzati, così la chiamata vecchia continua a risolvere; re
 una migration DOPO il deploy. E la vecchia firma si elimina comunque nella stessa migration: due
 overload che accettano gli stessi nomi rendono la chiamata ambigua (`function is not unique`).
 
+### `git commit -a` non aggiunge i file NUOVI: la PR parte senza i documenti che cita
+`-a` mette in stage solo i file gia` tracciati. In una sessione sola ha lasciato fuori dalla PR #90
+due ADR, due changelog e un file di test — tutti creati in quella stessa sessione — e il corpo della
+PR rimandava a `docs/adr/0004` che nella PR non c'era. Nessun errore, nessun avviso: il commit
+riesce e il diff sembra completo. Segnale: `git status --short` dopo il commit mostra righe `??`.
+Mossa: `git add -A <percorsi>` esplicito prima del commit, e `git status --short` come ultimo gesto
+prima di aprire la PR — deve essere vuoto.
+
 ## Prodotto
 
 ### La differenza per-agente si chiama mappa, non sottosistema

--- a/LESSONS.md
+++ b/LESSONS.md
@@ -143,6 +143,16 @@ dopo la chiusura, e le vede sparire se aspetti. Mossa: potare nel `finally` dell
 (lì lo specchio, che è anche l'unico a scrivere quelle righe), non dove la semantica sembra
 chiederlo — e chiedersi se l'altra chiamata non fosse codice morto: lo era.
 
+### Una migration che ELIMINA una firma rompe la produzione prima ancora del deploy
+Qui i deploy non applicano le migration, quindi fra l'apply e il deploy del codice c'è una finestra
+in cui la produzione chiama ancora la firma vecchia. `0229` toglieva `agent_kit_close_run` a cinque
+argomenti per sostituirla con quella recintata dal lease: applicata da sola avrebbe fatto fallire
+OGNI chiusura di turno finché il codice nuovo non fosse arrivato — e la chiusura è ciò che salva la
+risposta. Segnale: una migration il cui diff contiene `drop function` o un cambio di firma, su una
+funzione che il codice deployato chiama. Mossa: i parametri nuovi hanno un default e il vincolo vale
+solo quando sono valorizzati, così la chiamata vecchia continua a risolvere; renderli obbligatori è
+una migration DOPO il deploy. E la vecchia firma si elimina comunque nella stessa migration: due
+overload che accettano gli stessi nomi rendono la chiamata ambigua (`function is not unique`).
 
 ## Prodotto
 

--- a/changelog/2026-08-31-run-lease-fence.md
+++ b/changelog/2026-08-31-run-lease-fence.md
@@ -1,0 +1,70 @@
+# Un turno morto si riprende, invece di essere ucciso
+
+Chiedi "sistema tutti e 10 gli articoli". L'agente ne fa quattro, poi la piattaforma chiude
+l'invocazione — c'è un tetto di durata, oppure esce un deploy. Il reaper se ne accorgeva e
+faceva l'unica cosa che sapeva fare: **abortiva** il run e promuoveva il parziale a
+messaggio. Metà lavoro in chat, la conversazione ferma, e nessuno a dire che manca il resto:
+se ne accorgeva l'utente, o non se ne accorgeva nessuno.
+
+Il metro resta la chat di [rakazo](https://github.com/elie222/rakazo): da loro un run il cui
+worker muore viene **ripreso** da un altro con un fence nuovo, non chiuso.
+
+## Perché il gate della ADR 0002 si è aperto
+
+La [0002](../docs/adr/0002-defer-distributed-run-leases.md) rimandava i lease "finché worker
+indipendenti non devono riprendere lo stesso run". Sembrava una condizione lontana. Non lo
+era: **un turno gira già in due posti** — la richiesta che lo streamma e il drain della coda,
+che chiamano entrambi `runKitTurn` — e con il log durevole della
+[0003](../docs/adr/0003-durable-thread-event-log.md) il browser non deve più essere quello
+che riceve un turno perché il turno si veda. Un run che sopravvive alla sua invocazione è il
+caso ordinario, non un'ipotesi distribuita.
+
+## Il lease, e cosa regge davvero
+
+`agent_kit_claim_run` prende un run libero (`queued`, `waiting_input`, `waiting_takeover`)
+**oppure** uno `running` col lease scaduto, e nello stesso statement incrementa `lease_fence`
+e `attempt`. Ogni scrittura che può corrompere il turno — la chiusura col messaggio, il
+rinnovo, il battito che lo specchio dello stream scrive — è recintata da `(owner, fence)`.
+
+**A reggere è il fence, non l'abort.** Un processo ucciso dalla piattaforma non riceve
+nessun segnale: interrompere la chiamata al modello quando il rinnovo fallisce serve a un
+worker ancora vivo che ha solo perso la corsa. L'unica cosa che impedisce a un morto di
+scrivere è la `where` recintata. Il test che lo pinna si chiama *"LO ZOMBIE NON CHIUDE"*.
+
+## La strada scartata, e perché era peggio
+
+Il primo disegno lasciava il reaper abortire e salvare il parziale, **e in più** accodava una
+continuazione con un prompt sintetico ("riprendi da dove eri"). Tre effetti insieme: in chat
+restavano il mezzo messaggio salvato **e** la risposta prodotta dalla ripresa. Il ledger
+degli effetti impedisce di rifare le scritture esterne, non di lasciare due bolle. E il
+prompt sintetico è un ri-orientamento lossy: il modello rilegge e può rifare.
+
+Ora il reaper **lascia la riga `running` col lease scaduto** — è esattamente ciò che permette
+la presa successiva — e accoda un lavoro che porta l'id del run. Il drain lo riprende col
+fence dopo, e continua lo stesso turno. Il parziale si salva **solo** sul ramo della resa,
+dopo `MAX_RUN_ATTEMPTS`, che è quello che il reaper ha sempre fatto.
+
+Il ledger degli effetti si riconcilia **prima** di entrambi i rami: è lui, non il lease, a
+impedire che una ripresa ripeta una scrittura che il segmento morto aveva già iniziato.
+
+## Cosa NON si porta dal metro
+
+- **L'elezione per advisory lock.** Il loro reconciler tiene un `pg_try_advisory_lock` su una
+  connessione che vive fra i tick; su serverless quella connessione muore con l'invocazione.
+  Non è irrealizzabile, è **inutile**: il cron è già l'unico esecutore per tick.
+- **Il rinnovo illimitato.** Un run più lungo della durata massima di un'invocazione non si
+  tiene in vita rinnovando: va affettato e ripreso. Il TTL del lease è dimensionato su
+  *quanto può legittimamente durare un'invocazione*, mai su quanto dura il compito. È il
+  residuo vero del serverless, e nessun fence lo cancella.
+
+## L'ordine di rilascio, che qui non è un dettaglio
+
+I deploy di questo repo **non applicano le migration**, quindi fra l'applicazione della 0229
+e il deploy del codice c'è una finestra in cui la produzione chiama ancora la vecchia firma.
+Perciò `p_owner`/`p_fence` hanno un default e il recinto vale solo quando il lease c'è: la
+chiamata a cinque argomenti continua a risolvere. La vecchia firma viene eliminata — tenerle
+entrambe la renderebbe ambigua (`function is not unique`) e romperebbe ogni chiusura.
+Renderli obbligatori è una migration successiva, dopo il deploy.
+
+E il reaper legge con `select('*')`: nominare `attempt` in una select prima che la migration
+sia applicata dà 42703, che supabase-js non alza — avrebbe spento il reaper in silenzio.

--- a/docs/adr/0002-defer-distributed-run-leases.md
+++ b/docs/adr/0002-defer-distributed-run-leases.md
@@ -1,0 +1,15 @@
+> Superseded by [0004](0004-resume-a-dead-run-under-a-fenced-lease.md).
+
+# Defer distributed run leases until worker takeover is required
+
+Keep the current persisted run state and state CAS while an Agent Kit turn is
+executed by one invocation. Defer `leaseOwner`, monotonic `fence`, computer
+execution leases, and per-acquisition `Attempt` until independent workers can
+resume the same run; introducing them now would change the state machine,
+reaper, computer lifecycle, every run write, and their tests without a current
+product requirement.
+
+This is a hard gate for multi-worker execution. At that point, run claims,
+heartbeats, reclamation, finalization, and side effects must all be guarded by
+the current `(runId, owner, fence)` generation, and a failed renewal must abort
+the active model call.

--- a/docs/adr/0004-resume-a-dead-run-under-a-fenced-lease.md
+++ b/docs/adr/0004-resume-a-dead-run-under-a-fenced-lease.md
@@ -1,0 +1,43 @@
+# Resume a dead run under a fenced lease
+
+Supersedes [0002](0002-defer-distributed-run-leases.md), which deferred leases until
+independent workers had to resume the same run. That condition now holds. The gate was
+never a second machine: a turn already runs in two places — the request that streams it
+(`chat/+server.ts`) and the queue drain (`queue.ts`) — and the durable thread event log
+([0003](0003-durable-thread-event-log.md)) means the browser no longer has to be the one
+receiving a turn for that turn to be visible. A run that outlives its invocation is the
+ordinary case, not a distributed-systems hypothetical.
+
+Decision: a run is held by a lease — an owner, a monotonic fence, an expiry — and a run
+whose lease has expired is taken over by the next invocation instead of being killed.
+Claiming is one statement that accepts a run that is open (`queued`, `waiting_input`,
+`waiting_takeover`) or `running` with an expired lease, and increments the fence and the
+attempt count in the same write. Every write that can corrupt the turn — closing the run
+with its message, renewing the lease, refreshing the heartbeat from the stream mirror — is
+guarded by `(owner, fence)`, so a worker that lost the run writes nothing.
+
+The guard is the fence, not the abort. A process killed by the platform never receives a
+signal; aborting the model call on a failed renewal is a courtesy to a worker that is still
+alive and has merely lost the race. Only the guarded `where` clause is load-bearing.
+
+The reaper stops being an executioner. A dead run with attempts left keeps its row
+`running` with an expired lease and gets a queued job carrying its id; the drain claims it
+with the next fence and continues the same turn. Its partial is not promoted to a message
+on that path — the resumed run will produce the final one, and promoting it would leave
+half an answer beside the whole one. Only on giving up, after `MAX_RUN_ATTEMPTS`, is the
+run aborted and its partial salvaged, which is what the reaper always did.
+
+The effect ledger is reconciled before either branch. It, not the lease, is what stops a
+resumed run from repeating a side effect that the dead segment had already started.
+
+What does not port from the benchmark: leader election by advisory lock, which assumes a
+connection outliving many poll cycles — a cron invocation is already the single leader, so
+the election is unnecessary rather than unimplementable. And unbounded renewal: a run
+longer than one invocation's maximum duration must be sliced and reclaimed, not kept alive.
+The lease TTL is therefore sized to how long an invocation may legitimately be in flight,
+never to how long the work takes.
+
+Rollout is ordered, because deploys here do not run migrations. The lease arguments of
+`agent_kit_close_run` default to null and the fence is enforced only when supplied, so the
+window between applying the migration and deploying the code that passes a lease keeps
+working. Making them required is a later migration, after the deploy.

--- a/packages/agent-core/src/run-store.test.ts
+++ b/packages/agent-core/src/run-store.test.ts
@@ -8,7 +8,9 @@ import { describe, expect, it } from 'vitest';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import {
 	askUser,
+	claimRun,
 	claimStale,
+	closeRunSaving,
 	createRun,
 	finish,
 	renewLease,
@@ -105,7 +107,44 @@ function fakeDb(seed: Row[] = []) {
 		return b;
 	}
 
-	return { db: { from } as unknown as SupabaseClient, rows, calls };
+	// L'emulazione delle due RPC che governano il lease: la stessa semantica del plpgsql,
+	// perché è lì che vive il compare-and-swap che questi test devono provare.
+	function rpc(fn: string, params: Record<string, unknown>) {
+		calls.push({ method: 'rpc', args: [fn, params] });
+		const run = rows.find((r) => r.id === params.p_run_id);
+
+		if (fn === 'agent_kit_claim_run') {
+			if (!run) return Promise.resolve({ data: null, error: null });
+			const openState = ['queued', 'waiting_input', 'waiting_takeover'].includes(run.state as string);
+			const expired =
+				['running'].includes(run.state as string) &&
+				(run.lease_until == null || (run.lease_until as string) <= (params.p_now as string));
+			if (!openState && !expired) return Promise.resolve({ data: null, error: null });
+			run.state = 'running';
+			run.lease_owner = params.p_owner;
+			run.lease_fence = ((run.lease_fence as number) ?? 0) + 1;
+			run.attempt = ((run.attempt as number) ?? 0) + 1;
+			run.lease_until = params.p_lease_until;
+			run.heartbeat_at = params.p_now;
+			return Promise.resolve({ data: { ...run }, error: null });
+		}
+
+		if (fn === 'agent_kit_close_run') {
+			const held =
+				run &&
+				run.state === 'running' &&
+				run.lease_owner === params.p_owner &&
+				run.lease_fence === params.p_fence;
+			if (!held) return Promise.resolve({ data: { closed: false }, error: null });
+			run.state = params.p_to_state;
+			run.reason = params.p_reason ?? null;
+			return Promise.resolve({ data: { closed: true, message_id: 'msg-1' }, error: null });
+		}
+
+		return Promise.resolve({ data: null, error: { message: `rpc sconosciuta: ${fn}` } });
+	}
+
+	return { db: { from, rpc } as unknown as SupabaseClient, rows, calls };
 }
 
 const QUEUED = (over: Row = {}): Row => ({ id: 'run-1', brand_id: 'b1', agent_id: 'gtm', state: 'queued', ...over });
@@ -193,11 +232,15 @@ describe('askUser / resume', () => {
 
 describe('renewLease', () => {
 	it('sposta lease_until in avanti e aggiorna heartbeat_at', async () => {
-		const { db } = fakeDb([QUEUED({ state: 'running', lease_until: null })]);
+		const { db, rows } = fakeDb([
+			QUEUED({ state: 'running', lease_until: null, lease_owner: 'w1', lease_fence: 1 })
+		]);
 		const before = Date.now();
-		const run = await renewLease(db, 'run-1', 60_000);
-		expect(new Date(run.lease_until as string).getTime()).toBeGreaterThan(before);
-		expect(run.heartbeat_at).toBeTruthy();
+
+		expect(await renewLease(db, 'run-1', { owner: 'w1', fence: 1 }, 60_000)).toBe(true);
+
+		expect(new Date(rows[0].lease_until as string).getTime()).toBeGreaterThan(before);
+		expect(rows[0].heartbeat_at).toBeTruthy();
 	});
 });
 
@@ -239,5 +282,95 @@ describe('finish', () => {
 	it('waiting_input non è un finish valido', async () => {
 		const { db } = fakeDb([QUEUED({ state: 'running' })]);
 		await expect(finish(db, 'run-1', 'waiting_input')).rejects.toThrow(/askUser/);
+	});
+});
+
+describe('il lease del run: proprietario e fence', () => {
+	const seed = (over: Row = {}): Row => ({
+		id: 'run-1',
+		brand_id: 'b1',
+		thread_id: 't1',
+		agent_id: 'a1',
+		user_id: 'u1',
+		state: 'running',
+		lease_owner: 'worker-vecchio',
+		lease_fence: 3,
+		attempt: 1,
+		lease_until: '2026-08-30T10:00:00.000Z',
+		heartbeat_at: '2026-08-30T09:59:00.000Z',
+		...over
+	});
+
+	it('il fence cresce a ogni presa, e la presa torna il proprietario nuovo', async () => {
+		const { db, rows } = fakeDb([seed()]);
+
+		const claimed = await claimRun(db, 'run-1', 'worker-nuovo', {
+			ttlMs: 300_000,
+			now: new Date('2026-08-30T10:05:00.000Z')
+		});
+
+		expect(claimed?.fence).toBe(4);
+		expect(claimed?.run.lease_owner).toBe('worker-nuovo');
+		expect(rows[0].attempt).toBe(2);
+	});
+
+	it('un lease ancora valido non si porta via: la presa perde e lo dice', async () => {
+		const { db, rows } = fakeDb([seed()]);
+
+		const claimed = await claimRun(db, 'run-1', 'worker-nuovo', {
+			ttlMs: 300_000,
+			now: new Date('2026-08-30T09:59:30.000Z')
+		});
+
+		expect(claimed).toBeNull();
+		expect(rows[0].lease_owner).toBe('worker-vecchio');
+		expect(rows[0].lease_fence).toBe(3);
+	});
+
+	it('LO ZOMBIE NON CHIUDE: dopo la presa, il worker sfrattato non salva niente', async () => {
+		const { db, rows } = fakeDb([seed()]);
+		const vecchio = { owner: 'worker-vecchio', fence: 3 };
+
+		await claimRun(db, 'run-1', 'worker-nuovo', {
+			ttlMs: 300_000,
+			now: new Date('2026-08-30T10:05:00.000Z')
+		});
+
+		const closed = await closeRunSaving(db, 'run-1', { kind: 'finish', reason: 'reply' }, null, vecchio);
+
+		expect(closed.closed).toBe(false);
+		expect(rows[0].state).toBe('running');
+		expect(rows[0].lease_owner).toBe('worker-nuovo');
+	});
+
+	it('chi tiene il lease chiude', async () => {
+		const { db, rows } = fakeDb([seed()]);
+
+		const claimed = await claimRun(db, 'run-1', 'worker-nuovo', {
+			ttlMs: 300_000,
+			now: new Date('2026-08-30T10:05:00.000Z')
+		});
+		const closed = await closeRunSaving(
+			db,
+			'run-1',
+			{ kind: 'finish', reason: 'reply' },
+			null,
+			{ owner: 'worker-nuovo', fence: claimed!.fence }
+		);
+
+		expect(closed.closed).toBe(true);
+		expect(rows[0].state).toBe('done');
+	});
+
+	it('il rinnovo con un fence vecchio fallisce invece di tenere in vita un morto', async () => {
+		const { db } = fakeDb([seed()]);
+
+		await claimRun(db, 'run-1', 'worker-nuovo', {
+			ttlMs: 300_000,
+			now: new Date('2026-08-30T10:05:00.000Z')
+		});
+
+		expect(await renewLease(db, 'run-1', { owner: 'worker-vecchio', fence: 3 }, 300_000)).toBe(false);
+		expect(await renewLease(db, 'run-1', { owner: 'worker-nuovo', fence: 4 }, 300_000)).toBe(true);
 	});
 });

--- a/packages/agent-core/src/run-store.ts
+++ b/packages/agent-core/src/run-store.ts
@@ -20,6 +20,9 @@ export type RunRow = {
 	reason: string | null;
 	question: unknown | null;
 	lease_until: string | null;
+	lease_owner?: string | null;
+	lease_fence?: number;
+	attempt?: number;
 	heartbeat_at: string | null;
 	harness_continue_state?: unknown;
 	created_at: string;
@@ -95,16 +98,54 @@ export async function resume(
 	return { run, question: data.question ?? null };
 }
 
-/** Rinnova il lease del worker che sta girando il run — il battito che lo tiene reclamato. */
-export async function renewLease(db: SupabaseClient, runId: string, ms: number): Promise<RunRow> {
+/** Chi tiene il run: il proprietario dichiarato e la generazione della presa. */
+export type RunLease = { owner: string; fence: number };
+
+/**
+ * Prende il run: o è libero (queued/waiting_*), o è `running` col lease scaduto e allora si
+ * sfratta chi lo teneva. Ogni presa incrementa il fence, che è ciò che rende NO-OP ogni
+ * scrittura successiva del worker sfrattato: non l'abort, che un processo ucciso non riceve mai.
+ * Perde chi arriva su un lease ancora valido, e lo dice tornando null invece di alzare.
+ */
+export async function claimRun(
+	db: SupabaseClient,
+	runId: string,
+	owner: string,
+	{ ttlMs, now = new Date() }: { ttlMs: number; now?: Date }
+): Promise<{ run: RunRow; fence: number } | null> {
+	const { data, error } = await db.rpc('agent_kit_claim_run', {
+		p_run_id: runId,
+		p_owner: owner,
+		p_now: now.toISOString(),
+		p_lease_until: new Date(now.getTime() + ttlMs).toISOString()
+	});
+	if (error) throw new Error(`run: presa fallita — ${error.message}`);
+	if (!data) return null;
+	const run = (Array.isArray(data) ? data[0] : data) as RunRow | undefined;
+	if (!run) return null;
+	return { run, fence: run.lease_fence ?? 0 };
+}
+
+/**
+ * Rinnova il lease, ma SOLO per chi lo tiene davvero. Torna false quando il run è passato di
+ * mano: chi chiama deve fermare il turno, non continuare a scrivere su un run di un altro.
+ */
+export async function renewLease(
+	db: SupabaseClient,
+	runId: string,
+	lease: RunLease,
+	ms: number
+): Promise<boolean> {
 	const { data, error } = await db
 		.from(TABLE)
 		.update({ lease_until: new Date(Date.now() + ms).toISOString(), heartbeat_at: nowIso(), updated_at: nowIso() })
 		.eq('id', runId)
+		.eq('state', 'running')
+		.eq('lease_owner', lease.owner)
+		.eq('lease_fence', lease.fence)
 		.select();
 	if (error) throw new Error(`run: rinnovo lease fallito — ${error.message}`);
-	if (!data || data.length === 0) throw new Error(`run: rinnovo lease — run ${runId} non trovato`);
-	return data[0] as RunRow;
+	return (data?.length ?? 0) > 0;
 }
 
 /** I run `running` col lease scaduto: NON li transiziona, restituisce le righe e chi chiama decide. */
@@ -167,12 +208,15 @@ export async function closeRunSaving(
 	db: SupabaseClient,
 	runId: string,
 	outcome: CloseOutcome,
-	message: CloseMessage | null
+	message: CloseMessage | null,
+	lease: RunLease
 ): Promise<{ closed: boolean; messageId: string | null }> {
 	const to = outcome.kind === 'ask_user' ? 'waiting_input' : terminalStateFor(outcome.reason);
 	assertTransition('running', to);
 	const { data, error } = await db.rpc('agent_kit_close_run', {
 		p_run_id: runId,
+		p_owner: lease.owner,
+		p_fence: lease.fence,
 		p_to_state: to,
 		p_reason: outcome.kind === 'finish' ? outcome.reason : null,
 		p_question: outcome.kind === 'ask_user' ? outcome.question : null,

--- a/src/lib/agent/bridge/live.test.ts
+++ b/src/lib/agent/bridge/live.test.ts
@@ -22,17 +22,6 @@ vi.mock('$lib/server/chat/model', () => ({
 // Doppio resume (caso 2): il resto di `../run-store` resta VERO (createRun/transition/askUser/
 // finish girano sopra il fakeDb come sempre) — solo `resume` diventa deviabile per un turno, per
 // pinnare la mappatura dell'errore del CAS senza dover ricostruire una vera race a due richieste.
-const resumeThrows: { current: boolean } = { current: false };
-vi.mock('../run-store', async (importOriginal) => {
-	const actual = (await importOriginal()) as typeof import('../run-store');
-	return {
-		...actual,
-		resume: async (...args: Parameters<typeof actual.resume>) => {
-			if (resumeThrows.current) throw new Error('run: stato cambiato sotto le mani (atteso waiting_input)');
-			return actual.resume(...args);
-		}
-	};
-});
 
 // `logAiCall` scrive davvero in `ai_calls` (via createAdminClient): mai nei test unitari.
 // Stesso mock di brand-fs.test.ts / agent-files.test.ts.
@@ -535,10 +524,32 @@ type Row = Record<string, unknown>;
 			}
 			return Promise.resolve({ data: { closed: true, approval_id: approval.id, harness_approval_id: approval.harness_approval_id }, error: null });
 		}
+		if (fn === 'agent_kit_claim_run') {
+			const claimable = rows.find((r) => r.id === params.p_run_id);
+			if (!claimable) return Promise.resolve({ data: null, error: null });
+			const openState = ['queued', 'waiting_input', 'waiting_takeover'].includes(claimable.state as string);
+			const expired =
+				claimable.state === 'running' &&
+				(claimable.lease_until == null || (claimable.lease_until as string) <= (params.p_now as string));
+			if (!openState && !expired) return Promise.resolve({ data: null, error: null });
+			claimable.state = 'running';
+			claimable.lease_owner = params.p_owner;
+			claimable.lease_fence = ((claimable.lease_fence as number) ?? 0) + 1;
+			claimable.attempt = ((claimable.attempt as number) ?? 0) + 1;
+			claimable.lease_until = params.p_lease_until;
+			claimable.heartbeat_at = params.p_now;
+			return Promise.resolve({ data: { ...claimable }, error: null });
+		}
 		if (fn !== 'agent_kit_close_run') {
 			return Promise.resolve({ data: null, error: { message: `rpc sconosciuta: ${fn}` } });
 		}
-		const run = rows.find((r) => r.id === params.p_run_id && r.state === 'running');
+		const run = rows.find(
+			(r) =>
+				r.id === params.p_run_id &&
+				r.state === 'running' &&
+				r.lease_owner === params.p_owner &&
+				r.lease_fence === params.p_fence
+		);
 		if (!run) return Promise.resolve({ data: { closed: false }, error: null });
 		run.state = params.p_to_state;
 		if (params.p_reason != null) run.reason = params.p_reason;
@@ -615,7 +626,6 @@ beforeEach(async () => {
 	await new Promise((r) => setTimeout(r, 12));
 	savedMessages.length = 0;
 	modelHolder.current = null;
-	resumeThrows.current = false;
 	continuations.length = 0;
 	continuationReturns.current = 'cont-job-1';
 	harnessQueue.length = 0;
@@ -1052,7 +1062,7 @@ describe('runKitTurn — il turno successivo su un run waiting_input fa resume',
 });
 
 describe('runKitTurn — doppio resume su una waiting_input (due dispositivi rispondono insieme)', () => {
-	it('il perdente della corsa riceve un 409 pulito, non il 500 grezzo del CAS', async () => {
+	it('il perdente della corsa riceve un 409 ritentabile, non il 500 grezzo del CAS', async () => {
 		toolCallModel('reply', { message: 'non dovrebbe arrivarci', delivered: [] });
 		const { db, rows } = fakeDb([
 			{
@@ -1061,14 +1071,19 @@ describe('runKitTurn — doppio resume su una waiting_input (due dispositivi ris
 				thread_id: 't1',
 				agent_id: 'content',
 				user_id: 'u1',
-				state: 'waiting_input',
+				// L'ALTRO DISPOSITIVO HA GIA` VINTO: la riga è passata a `running` col suo lease
+				// ancora valido. Non serve fingere un'eccezione — è lo stato che il perdente trova.
+				state: 'running',
+				lease_owner: 'altro-dispositivo',
+				lease_fence: 1,
+				lease_until: new Date(Date.now() + 5 * 60_000).toISOString(),
+				heartbeat_at: new Date().toISOString(),
 				reason: null,
 				question: { question: 'quale palette?' },
 				created_at: '2026-08-21T00:00:00.000Z',
 				updated_at: '2026-08-21T00:00:00.000Z'
 			}
 		]);
-		resumeThrows.current = true;
 
 		const res = await runKitTurn({
 			supabase: fakeSupabase,
@@ -1086,11 +1101,13 @@ describe('runKitTurn — doppio resume su una waiting_input (due dispositivi ris
 
 		expect(res.status).toBe(409);
 		const body = await res.json();
-		expect(body.error).toBe('resume_conflict');
-		// Payload API, non chat: in inglese, anche per una chat italiana.
-		expect(body.message).toBe('Someone else already replied in this conversation.');
-		// La riga non è stata toccata dal perdente: resta come l'ha lasciata chi ha vinto la corsa.
-		expect(rows[0].state).toBe('waiting_input');
+		expect(body.error).toBe('busy');
+		// Il messaggio dell'utente è comunque salvato: il client riaccoda, non lo perde.
+		expect(body.user_message_saved).toBe(true);
+		// La riga NON è stata toccata dal perdente: proprietario e fence restano di chi ha vinto.
+		expect(rows[0].state).toBe('running');
+		expect(rows[0].lease_owner).toBe('altro-dispositivo');
+		expect(rows[0].lease_fence).toBe(1);
 	});
 });
 
@@ -1717,6 +1734,104 @@ describe('il run sfrattato non deposita il suo messaggio (la causa radice del do
 		expect(chatMessages).toHaveLength(1);
 		expect(rows[0].state).toBe('done');
 		expect(rows[0].partial_saved_msg_id).toBe(chatMessages[0].id);
+	});
+});
+
+describe('runKitTurn — resumeRunId (il reaper lascia la riga viva, un worker nuovo la riprende)', () => {
+	it('prende in carico la riga running con lease scaduta: fence su, nessuna riga nuova, il vecchio owner non chiude più nulla', async () => {
+		const { closeRunSaving } = await import('../run-store');
+		const { db, rows } = fakeDb([
+			{
+				id: 'run-dead',
+				brand_id: 'b1',
+				thread_id: 't-reap',
+				agent_id: 'content',
+				user_id: 'u1',
+				state: 'running',
+				reason: null,
+				question: null,
+				lease_owner: 'dead-owner',
+				lease_fence: 3,
+				lease_until: '2020-01-01T00:00:00.000Z',
+				created_at: '2026-08-21T00:00:00.000Z',
+				updated_at: '2026-08-21T00:00:00.000Z'
+			}
+		]);
+		let staleClose: { closed: boolean } | undefined;
+		scriptTurns({
+			calls: [replyCall('ripreso')],
+			onStreamStart: () => {
+				void closeRunSaving(
+					db,
+					'run-dead',
+					{ kind: 'finish', reason: 'aborted' },
+					null,
+					{ owner: 'dead-owner', fence: 3 }
+				).then((r) => {
+					staleClose = r;
+				});
+			}
+		});
+
+		const res = await runKitTurn({
+			supabase: fakeSupabase,
+			admin: db,
+			brand: { id: 'b1' },
+			user: { id: 'u1' },
+			threadId: 't-reap',
+			spec,
+			messages: [{ role: 'user', content: 'ciao' }],
+			locale: 'it',
+			resumeRunId: 'run-dead'
+		});
+		await res.text();
+		await new Promise((r) => setTimeout(r, 40));
+
+		expect(rows).toHaveLength(1);
+		expect(rows[0].id).toBe('run-dead');
+		expect(rows[0].lease_fence).toBe(4);
+		expect(rows[0].lease_owner).not.toBe('dead-owner');
+		expect(rows[0].state).toBe('done');
+		expect(staleClose?.closed).toBe(false);
+	});
+
+	it('la riga già ripresa da un altro non parte una seconda volta', async () => {
+		const { db, rows } = fakeDb([
+			{
+				id: 'run-fresh',
+				brand_id: 'b1',
+				thread_id: 't-reap-fresh',
+				agent_id: 'content',
+				user_id: 'u1',
+				state: 'running',
+				reason: null,
+				question: null,
+				lease_owner: 'live-owner',
+				lease_fence: 1,
+				lease_until: new Date(Date.now() + 60_000).toISOString(),
+				created_at: '2026-08-21T00:00:00.000Z',
+				updated_at: '2026-08-21T00:00:00.000Z'
+			}
+		]);
+
+		const res = await runKitTurn({
+			supabase: fakeSupabase,
+			admin: db,
+			brand: { id: 'b1' },
+			user: { id: 'u1' },
+			threadId: 't-reap-fresh',
+			spec,
+			messages: [{ role: 'user', content: 'ciao' }],
+			locale: 'it',
+			resumeRunId: 'run-fresh'
+		});
+
+		expect(res.status).toBe(409);
+		const body = await res.json();
+		expect(body.error).toBe('busy');
+		expect(rows).toHaveLength(1);
+		expect(rows[0].lease_owner).toBe('live-owner');
+		expect(rows[0].lease_fence).toBe(1);
 	});
 });
 

--- a/src/lib/agent/bridge/live.ts
+++ b/src/lib/agent/bridge/live.ts
@@ -92,6 +92,9 @@ const PARTIAL_FLUSH_EVENTS = new Set(['tool-input-available', 'tool-output-avail
 
 const TURN_MAX_STEPS = 75;
 
+const RUN_LEASE_TTL_MS = 300_000;
+const RUN_LEASE_LOST = 'lease_lost';
+
 /** Il turno vivo di ogni thread, per i tool che una sessione riusata ha cotto in un turno prima. */
 const liveTurnByThread = new Map<string, { stopped: boolean; closedBy: string }>();
 import { attachForChat } from './attach';
@@ -112,7 +115,18 @@ import {
 } from './adapters';
 import { reportChatError } from '$lib/server/chat/report-error';
 import { BUILTIN_TOOLS } from '../tools/builtin';
-import { createRun, transition, finish, resume, closeRunSaving, type CloseMessage, type CloseOutcome, type RunRow } from '../run-store';
+import {
+	createRun,
+	transition,
+	finish,
+	closeRunSaving,
+	claimRun,
+	renewLease,
+	type CloseMessage,
+	type CloseOutcome,
+	type RunRow,
+	type RunLease
+} from '../run-store';
 import type { ActionApprovalConfig, AdapterContext, RunStopReason, ToolResult } from '../kit/types';
 import { createMotionPlugin } from '../plugins/motion';
 import { createContentPlugin } from '../plugins/content';
@@ -187,6 +201,7 @@ export interface RunKitTurnInput {
 	 * la coda. Zero su un turno avviato da una persona.
 	 */
 	continuationDepth?: number;
+	resumeRunId?: string;
 	/**
 	 * Il tempo che questo turno può bruciare. Vuoto = il budget del muro serverless. Il drain
 	 * passa la propria fetta, che si accorcia man mano che macina job.
@@ -368,70 +383,76 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
 	const { supabase, admin, brand, user, threadId, spec, messages, locale } = input;
 	const mode: ChatMode = isChatMode(input.mode) ? input.mode : 'agent';
 	const isDm = !!input.dm;
+	const owner = crypto.randomUUID();
+	const busyResponse = () =>
+		new Response(JSON.stringify({ error: 'busy', user_message_saved: true }), {
+			status: 409,
+			headers: { 'Content-Type': 'application/json' }
+		});
+	const claimOrBusy = async (runId: string): Promise<{ run: RunRow; lease: RunLease } | Response> => {
+		const claimed = await claimRun(admin, runId, owner, { ttlMs: RUN_LEASE_TTL_MS });
+		return claimed ? { run: claimed.run, lease: { owner, fence: claimed.fence } } : busyResponse();
+	};
 
 	let run: RunRow;
-	const waiting = await currentWaitingRun(admin, threadId);
-	if (waiting) {
-		if (waiting.state === 'waiting_takeover') {
-			const response = input.approvalResponse;
-			if (!response) {
-				return new Response(JSON.stringify({ error: 'approval_required' }), {
-					status: 409,
-					headers: { 'Content-Type': 'application/json' }
-				});
-			}
-			const { data: approval } = await admin
-				.from('agent_kit_approval_requests')
-				.select('status, tool_call_id')
-				.eq('run_id', waiting.id)
-				.eq('harness_approval_id', response.approvalId)
-				.maybeSingle();
-			if (!approval || !['approved', 'denied'].includes(String(approval.status))) {
-				return new Response(JSON.stringify({ error: 'approval_not_decided' }), {
-					status: 409,
-					headers: { 'Content-Type': 'application/json' }
-				});
-			}
-			if (response.toolCallId && response.toolCallId !== approval.tool_call_id) {
-				return new Response(JSON.stringify({ error: 'approval_tool_mismatch' }), {
-					status: 409,
-					headers: { 'Content-Type': 'application/json' }
-				});
-			}
-		}
-		// DOPPIO RESUME: due dispositivi rispondono insieme a una `waiting_input`. Il primo vince
-		// il compare-and-swap di `resume()`; il secondo lo trova già spostato e riceverebbe il
-		// 500 grezzo di `run: stato cambiato sotto le mani` — un'azione legittima (ha solo perso
-		// la corsa), non un errore di sistema. Risposta pulita, stesso 409 ritentabile del busy
-		// qui sotto, con un messaggio che l'utente capisce.
-		try {
-			({ run } = await resume(admin, waiting.id));
-		} catch (e) {
-			if (e instanceof Error && e.message.includes('stato cambiato sotto le mani')) {
-			// API payload, non chat: nessuna persona la legge in un fumetto. In inglese comunque,
-			// come ogni nota che il backend consegna fuori dal proprio turno.
-			return new Response(
-				JSON.stringify({ error: 'resume_conflict', message: 'Someone else already replied in this conversation.' }),
-				{ status: 409, headers: { 'Content-Type': 'application/json' } }
-			);
-			}
-			throw e;
-		}
+	let lease: RunLease;
+	if (input.resumeRunId) {
+		const claimed = await claimOrBusy(input.resumeRunId);
+		if (claimed instanceof Response) return claimed;
+		({ run, lease } = claimed);
 	} else {
-		// Un turno alla volta per thread: 409 (ritentabile) invece di un secondo run concorrente.
-		if (await liveRunningRun(admin, threadId)) {
-			// `user_message_saved`: questo busy arriva DOPO che il POST ha già persistito il
-			// messaggio dell'utente (chat/+server.ts salva prima di chiamare qui). Il client
-			// ripiega sull'enqueue, e senza questo flag il drain non riconosce la riga già a terra
-			// — confronta solo il TAIL della history, che intanto è la risposta del run vincente —
-			// e la salva una seconda volta.
-			return new Response(JSON.stringify({ error: 'busy', user_message_saved: true }), {
-				status: 409,
-				headers: { 'Content-Type': 'application/json' }
-			});
+		const waiting = await currentWaitingRun(admin, threadId);
+		if (waiting) {
+			if (waiting.state === 'waiting_takeover') {
+				const response = input.approvalResponse;
+				if (!response) {
+					return new Response(JSON.stringify({ error: 'approval_required' }), {
+						status: 409,
+						headers: { 'Content-Type': 'application/json' }
+					});
+				}
+				const { data: approval } = await admin
+					.from('agent_kit_approval_requests')
+					.select('status, tool_call_id')
+					.eq('run_id', waiting.id)
+					.eq('harness_approval_id', response.approvalId)
+					.maybeSingle();
+				if (!approval || !['approved', 'denied'].includes(String(approval.status))) {
+					return new Response(JSON.stringify({ error: 'approval_not_decided' }), {
+						status: 409,
+						headers: { 'Content-Type': 'application/json' }
+					});
+				}
+				if (response.toolCallId && response.toolCallId !== approval.tool_call_id) {
+					return new Response(JSON.stringify({ error: 'approval_tool_mismatch' }), {
+						status: 409,
+						headers: { 'Content-Type': 'application/json' }
+					});
+				}
+			}
+			// DOPPIO RESUME: due dispositivi rispondono insieme a una `waiting_input`. La presa È il
+			// resume — porta la riga a `running` col battito fresco e il fence successivo — quindi
+			// il secondo la trova già presa e perde. Perdere qui e trovare un turno già in corso
+			// sono la stessa cosa per chi chiama, e la coda li trattava già uguali: un codice solo.
+			const claimed = await claimOrBusy(waiting.id);
+			if (claimed instanceof Response) return claimed;
+			({ run, lease } = claimed);
+		} else {
+			// Un turno alla volta per thread: 409 (ritentabile) invece di un secondo run concorrente.
+			if (await liveRunningRun(admin, threadId)) {
+				// `user_message_saved`: questo busy arriva DOPO che il POST ha già persistito il
+				// messaggio dell'utente (chat/+server.ts salva prima di chiamare qui). Il client
+				// ripiega sull'enqueue, e senza questo flag il drain non riconosce la riga già a terra
+				// — confronta solo il TAIL della history, che intanto è la risposta del run vincente —
+				// e la salva una seconda volta.
+				return busyResponse();
+			}
+			run = await createRun(admin, { brandId: brand.id, threadId, agentId: spec.id, userId: user.id });
+			run = await transition(admin, run.id, 'queued', 'running', { heartbeat_at: new Date().toISOString() });
+			const claimed = await claimOrBusy(run.id);
+			if (claimed instanceof Response) return claimed;
+			({ run, lease } = claimed);
 		}
-		run = await createRun(admin, { brandId: brand.id, threadId, agentId: spec.id, userId: user.id });
-		run = await transition(admin, run.id, 'queued', 'running', { heartbeat_at: new Date().toISOString() });
 	}
 
 	const ctx: AdapterContext = { brandId: brand.id, userId: user.id, runId: run.id, locale, agentId: spec.id };
@@ -663,18 +684,23 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
 		};
 		const beat = async () => {
 			lastBeat = Date.now();
+			const alive = await renewLease(admin, run.id, lease, RUN_LEASE_TTL_MS).catch(() => true);
+			if (!alive) {
+				stopTurnHeartbeat();
+				noteRunState(RUN_LEASE_LOST);
+				return;
+			}
 			// `select('*')` e non i nomi delle colonne: i deploy non eseguono le migration, e
 			// nominare `partial` (0218) o `partial_saved_msg_id` (0219) dove non sono applicate
 			// prende un 42703 che azzera la lettura — cioè spegne in silenzio anche il
 			// riconoscimento dello Stop, che passa da qui. Stessa ragione di `cancelKitRun`.
 			await admin
 				.from('agent_kit_runs')
-				.update({ heartbeat_at: new Date().toISOString() })
-				.eq('id', run.id)
 				.select('*')
+				.eq('id', run.id)
+				.maybeSingle()
 				.then(async ({ data }) => {
-					const row = (data as Array<Record<string, unknown>> | null)?.[0];
-					noteRunState(row?.state);
+					const row = data as Record<string, unknown> | null;
 					// Best-effort: il turno non si ferma perché un checkpoint è inciampato.
 					await checkpointPartial(
 						(row?.partial as ChatPartialSnapshot | null) ?? null,
@@ -910,7 +936,8 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
 					admin,
 					run.id,
 					{ kind: 'finish', reason: 'aborted' },
-					closeMessageFields([{ type: 'text', text: '_(turno chiuso: il modello non ha risposto in tempo)_' }], [])
+					closeMessageFields([{ type: 'text', text: '_(turno chiuso: il modello non ha risposto in tempo)_' }], []),
+					lease
 				).catch(() => finish(admin, run.id, 'aborted').catch(() => undefined));
 				kickQueue();
 			}, HARNESS_ABORT_FORCE_CLOSE_MS);
@@ -1078,7 +1105,7 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
 					isRepeatedReply(visibleText, lastAssistantText(messages));
 				if (repeatsPreviousReplyWithoutNewWork && laps < MAX_VERDICT_LAPS) {
 					console.log(`[AGENT_KIT] risposta ripetuta senza lavoro nuovo (run ${run.id}, giro ${laps + 1}) — rilancio correttivo`);
-					const { closed } = await closeRunSaving(admin, run.id, outcome, null);
+					const { closed } = await closeRunSaving(admin, run.id, outcome, null, lease);
 					if (!closed) {
 						console.log(`[AGENT_KIT] run ${run.id} sfrattato prima della chiusura: nessun rilancio`);
 						kickQueue();
@@ -1173,7 +1200,8 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
 					admin,
 					run.id,
 					outcome,
-					content.length ? closeMessageFields(content, turnAttachments) : null
+					content.length ? closeMessageFields(content, turnAttachments) : null,
+					lease
 				);
 				if (!closed) {
 					console.log(`[AGENT_KIT] run ${run.id} sfrattato prima della chiusura: nessun messaggio salvato`);
@@ -1339,7 +1367,8 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
 						admin,
 						run.id,
 						{ kind: 'finish', reason: 'aborted' },
-						closeMessageFields([{ type: 'text', text: turnErrorText }], [])
+						closeMessageFields([{ type: 'text', text: turnErrorText }], []),
+						lease
 					);
 				} catch {}
 				reportChatError(supabase, error, {
@@ -1507,6 +1536,8 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
 								heartbeat_at: new Date().toISOString()
 							})
 							.eq('id', run.id)
+							.eq('lease_owner', lease.owner)
+							.eq('lease_fence', lease.fence)
 					} catch {
 						// specchio best-effort: un inciampo qui non tocca il turno
 					}

--- a/src/lib/content/changelog/2026-08-31-resume-dead-turns.ts
+++ b/src/lib/content/changelog/2026-08-31-resume-dead-turns.ts
@@ -1,0 +1,9 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-08-31',
+  title: 'A long job that gets interrupted finishes by itself',
+  items: [
+    'When a long turn is cut short, the agent now picks it up where it stopped instead of leaving the work half done for you to ask again.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/agent-kit-recover.ts
+++ b/src/lib/server/agent-kit-recover.ts
@@ -1,6 +1,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import {
   CHAT_REAP_MIN_AGE_MS,
+  MAX_RUN_ATTEMPTS,
   chatJobDeathMessage,
   classifyKitRun,
   type KitRunLiveness
@@ -93,7 +94,10 @@ export async function reapDeadKitRuns(
 ): Promise<number> {
   const { data: candidates, error } = await db
     .from('agent_kit_runs')
-    .select('id, brand_id, user_id, thread_id, agent_id, state, heartbeat_at, created_at')
+    // `*` e non la lista dei nomi, per la ragione scritta in `recoverDeadPartial`: i deploy non
+    // eseguono le migration, e una select che NOMINA una colonna ancora assente (`attempt`)
+    // prende un 42703 che supabase-js non alza — spegnerebbe il reaper in silenzio.
+    .select('*')
     .eq('state', 'running')
     .lt('created_at', new Date(Date.now() - CHAT_REAP_MIN_AGE_MS).toISOString())
     .order('created_at', { ascending: true })
@@ -110,6 +114,39 @@ export async function reapDeadKitRuns(
     const verdict = classifyKitRun(run);
     if (!verdict.dead) continue;
 
+    // Gli effetti di questo run ancora `intended` (un tool di scrittura avviato, mai risolto)
+    // diventano `ambiguous`: il risiko del doppio post/schedulazione. Prima di rieseguire, il gate
+    // li legge e congela — mai due volte la stessa scrittura perché il segmento è morto a metà.
+    // Vale su ENTRAMBI i rami: è ciò che rende sicura la ripresa, non solo la resa.
+    try {
+      await createEffectsLedger(db).reconcileRun(run.id);
+    } catch (e) {
+      console.error('[sweep] reconciliazione effetti fallita', run.id, e);
+    }
+
+    const attempt = (run as { attempt?: number }).attempt ?? 1;
+    if (run.thread_id && run.user_id && attempt < MAX_RUN_ATTEMPTS) {
+      // La riga resta `running` col lease scaduto: è quello che permette a `agent_kit_claim_run`
+      // di prenderla col fence successivo. Abortirla la renderebbe irriprendibile, e salvarne il
+      // parziale lascerebbe un mezzo messaggio accanto alla risposta che la ripresa produrrà.
+      const { enqueueTurnContinuation } = await import('$lib/server/chat/queue');
+      const queued = await enqueueTurnContinuation(db, {
+        brandId: run.brand_id,
+        userId: run.user_id,
+        threadId: run.thread_id,
+        origin: 'kit-reaper',
+        depth: attempt,
+        resumeRunId: run.id
+      }).catch((e) => {
+        console.error('[sweep] ripresa non accodata', run.id, e);
+        return null;
+      });
+      if (queued) {
+        reaped += 1;
+        continue;
+      }
+    }
+
     const { data: claimed } = await db
       .from('agent_kit_runs')
       .update({ state: 'aborted', reason: 'aborted', updated_at: new Date().toISOString() })
@@ -119,15 +156,6 @@ export async function reapDeadKitRuns(
       .maybeSingle();
     if (!claimed) continue;
     reaped += 1;
-
-    // Gli effetti di questo run ancora `intended` (un tool di scrittura avviato, mai risolto)
-    // diventano `ambiguous`: il risiko del doppio post/schedulazione. Prima di rieseguire, il gate
-    // li legge e congela — mai due volte la stessa scrittura perché il segmento è morto a metà.
-    try {
-      await createEffectsLedger(db).reconcileRun(run.id);
-    } catch (e) {
-      console.error('[sweep] reconciliazione effetti fallita', run.id, e);
-    }
 
     try {
       await recoverDeadPartial(db, run.id);

--- a/src/lib/server/chat/queue.ts
+++ b/src/lib/server/chat/queue.ts
@@ -152,6 +152,7 @@ export async function enqueueQueuedChatTurn(
 		 * domanda, è un prefill, e la seconda voce continuerebbe la frase della prima.
 		 */
 		userMessageSaved?: boolean;
+		resumeRunId?: string;
 	}
 ): Promise<string | null> {
 	const locale = bilingualNoticeLocale(opts.locale);
@@ -180,7 +181,8 @@ export async function enqueueQueuedChatTurn(
 				...(opts.agent ? { agent: opts.agent } : {}),
 				...(opts.customAgentId ? { custom_agent_id: opts.customAgentId } : {}),
 				...(opts.speaker ? { speaker: opts.speaker } : {}),
-				...(opts.userMessageSaved ? { user_message_saved: true } : {})
+				...(opts.userMessageSaved ? { user_message_saved: true } : {}),
+				...(opts.resumeRunId ? { resume_run_id: opts.resumeRunId } : {})
 			}
 		})
 		.select('id')
@@ -229,6 +231,12 @@ export async function enqueueTurnContinuation(
 		 * di battute. Vedi motion-video/unfinished.ts.
 		 */
 		maxDepth?: number;
+		/**
+		 * Il run da RIPRENDERE, invece di aprirne uno nuovo. Lo passa il reaper per una riga
+		 * lasciata `running` col lease scaduto: chi drena la prende col fence successivo e
+		 * continua lo stesso turno, senza un secondo messaggio in chat.
+		 */
+		resumeRunId?: string;
 	}
 ): Promise<string | null> {
 	const depth = Math.max(0, Math.trunc(opts.depth ?? 0));
@@ -261,7 +269,8 @@ export async function enqueueTurnContinuation(
 		continuationDepth: depth + 1,
 		mode: opts.mode,
 		tier: opts.tier,
-		reasoning: opts.reasoning
+		reasoning: opts.reasoning,
+		resumeRunId: opts.resumeRunId
 	});
 }
 
@@ -774,6 +783,9 @@ await maybeCompactThread(admin, {
 						tier: typeof params.tier === 'string' ? params.tier : undefined,
 						modelFamily: turnModelFamily(threadRow?.model)?.family,
 						reasoning: typeof params.reasoning === 'string' ? params.reasoning : undefined,
+						// La ripresa di un run lasciato dal reaper: lo stesso turno continua, con il
+						// fence successivo, invece di aprirne uno nuovo accanto al lavoro a metà.
+						resumeRunId: typeof params.resume_run_id === 'string' ? params.resume_run_id : undefined,
 						// La scalata Auto→Pro segue la richiesta di una PERSONA: un turno schedulato, un
 						// DM fra agenti o una ripresa scritta dal sistema restano sul default.
 						escalationText: params.scheduled === true || replay || isDm ? undefined : userMessageContent,

--- a/src/lib/server/chat/turn-limits.ts
+++ b/src/lib/server/chat/turn-limits.ts
@@ -167,6 +167,13 @@ export function classifyChatJob(
 	return createdAge > CHAT_RUNNING_HARD_STALE_MS ? { dead: true, reason: 'wall' } : ALIVE;
 }
 
+/**
+ * Quante volte un run kit può essere ripreso dopo che l'invocazione che lo teneva è morta.
+ * Oltre, il turno non è "sfortunato": è più grande di quanto una invocazione possa contenere,
+ * e va restituito all'utente col lavoro fatto invece di rinascere per sempre.
+ */
+export const MAX_RUN_ATTEMPTS = 3;
+
 export const KIT_RUN_WORKING_STATES = ['queued', 'running', 'waiting_input', 'waiting_takeover'] as const;
 
 /**

--- a/src/lib/server/kit-reaper.test.ts
+++ b/src/lib/server/kit-reaper.test.ts
@@ -1,12 +1,18 @@
 /**
- * Il reaper dei run kit: chi decide che un turno è morto, quando, e chi lo viene a sapere.
+ * Il reaper dei run kit: chi decide che un turno è morto, quando, e cosa gli succede.
  *
  * I due difetti pinnati qui (registro di parità, B7 e B11): la soglia piatta di dieci minuti —
  * l'utente restava chiuso fuori dal thread mentre guardava un cadavere — e il silenzio, perché
  * lo sweep chiudeva le righe restituendo un numero nel JSON del cron e nessuno riceveva niente.
+ *
+ * Da quando il run si RIPRENDE (ADR 0004) i due rami sono diversi e vanno pinnati separati: con
+ * tentativi rimasti la riga resta riprendibile e nessuno viene svegliato, perché una ripresa non
+ * è un incidente; finiti i tentativi si rinuncia, e lì valgono ancora il parziale in chat e
+ * l'avviso a ops di prima.
  */
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { createTestSupabase } from '$lib/testkit/supabase';
+import { MAX_RUN_ATTEMPTS } from '$lib/server/chat/turn-limits';
 
 const reportChatError = vi.fn(async () => {});
 vi.mock('$lib/server/chat/report-error', () => ({ reportChatError: (...a: unknown[]) => reportChatError(...(a as [])) }));
@@ -27,22 +33,40 @@ const run = (over: Record<string, unknown> = {}) => ({
 	partial_saved_msg_id: null,
 	heartbeat_at: iso(2 * 60_000),
 	created_at: iso(10 * 60_000),
+	attempt: 1,
 	...over
 });
+
+/** Un run che ha già speso i suoi tentativi: il reaper rinuncia invece di riprenderlo. */
+const spent = (over: Record<string, unknown> = {}) => run({ attempt: MAX_RUN_ATTEMPTS, ...over });
 
 beforeEach(() => reportChatError.mockClear());
 
 describe('reapDeadKitRuns', () => {
-	it('battito fermo da 2 minuti: il run è chiuso adesso, non fra dieci', async () => {
-		const kit = createTestSupabase({ agent_kit_runs: [run()], chat_messages: [] });
+	it('battito fermo da 2 minuti: si agisce adesso, non fra dieci', async () => {
+		const kit = createTestSupabase({ agent_kit_runs: [run()], chat_jobs: [], chat_messages: [] });
 
 		expect(await reapDeadKitRuns(kit.client)).toBe(1);
-		expect(kit.tables.get('agent_kit_runs')?.[0].state).toBe('aborted');
+		// Riprendibile, non abortito: è il lease scaduto a permettere la presa successiva.
+		expect(kit.tables.get('agent_kit_runs')?.[0].state).toBe('running');
+		const queued = kit.tables.get('chat_jobs') ?? [];
+		expect(queued).toHaveLength(1);
+		expect((queued[0].input_params as { resume_run_id?: string }).resume_run_id).toBe('run-1');
+	});
+
+	it('una ripresa non è un incidente: ops non viene svegliato', async () => {
+		const kit = createTestSupabase({ agent_kit_runs: [run()], chat_jobs: [], chat_messages: [] });
+
+		await reapDeadKitRuns(kit.client);
+
+		expect(reportChatError).not.toHaveBeenCalled();
+		expect(kit.tables.get('chat_messages') ?? []).toHaveLength(0);
 	});
 
 	it('battito di 30 secondi fa: il turno sta lavorando, non si tocca', async () => {
 		const kit = createTestSupabase({
 			agent_kit_runs: [run({ heartbeat_at: iso(30_000) })],
+			chat_jobs: [],
 			chat_messages: []
 		});
 
@@ -51,8 +75,8 @@ describe('reapDeadKitRuns', () => {
 		expect(reportChatError).not.toHaveBeenCalled();
 	});
 
-	it('un run morto senza parziale non muore in silenzio: ops lo viene a sapere', async () => {
-		const kit = createTestSupabase({ agent_kit_runs: [run()], chat_messages: [] });
+	it('finiti i tentativi, un run morto senza parziale non muore in silenzio: ops lo viene a sapere', async () => {
+		const kit = createTestSupabase({ agent_kit_runs: [spent()], chat_jobs: [], chat_messages: [] });
 
 		await reapDeadKitRuns(kit.client);
 
@@ -67,9 +91,10 @@ describe('reapDeadKitRuns', () => {
 		});
 	});
 
-	it('il parziale prodotto prima della morte finisce comunque in chat', async () => {
+	it('finiti i tentativi, il parziale prodotto prima della morte finisce comunque in chat', async () => {
 		const kit = createTestSupabase({
-			agent_kit_runs: [run({ partial: { text: 'ho preparato i tre post' } })],
+			agent_kit_runs: [spent({ partial: { text: 'ho preparato i tre post' } })],
+			chat_jobs: [],
 			chat_messages: []
 		});
 
@@ -81,8 +106,8 @@ describe('reapDeadKitRuns', () => {
 	});
 
 	it('oltre il tetto delle mail si avvisa lo stesso, ma solo Sentry', async () => {
-		const rows = [1, 2, 3].map((n) => run({ id: `run-${n}`, thread_id: `thread-${n}` }));
-		const kit = createTestSupabase({ agent_kit_runs: rows, chat_messages: [] });
+		const rows = [1, 2, 3].map((n) => spent({ id: `run-${n}`, thread_id: `thread-${n}` }));
+		const kit = createTestSupabase({ agent_kit_runs: rows, chat_jobs: [], chat_messages: [] });
 
 		expect(await reapDeadKitRuns(kit.client, { emailBudget: 1 })).toBe(3);
 		const notify = reportChatError.mock.calls.map((c) => (c[2] as { notify?: string }).notify);

--- a/supabase/migrations/0229_agent_kit_run_lease.sql
+++ b/supabase/migrations/0229_agent_kit_run_lease.sql
@@ -1,0 +1,130 @@
+alter table public.agent_kit_runs
+  add column if not exists lease_owner text,
+  add column if not exists lease_fence bigint not null default 0,
+  add column if not exists attempt integer not null default 1;
+
+create index if not exists agent_kit_runs_lease_idx
+  on public.agent_kit_runs(state, lease_until);
+
+create or replace function public.agent_kit_claim_run(
+  p_run_id uuid,
+  p_owner text,
+  p_now timestamptz,
+  p_lease_until timestamptz
+) returns public.agent_kit_runs
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_run public.agent_kit_runs%rowtype;
+begin
+  update public.agent_kit_runs
+  set state = 'running',
+      lease_owner = p_owner,
+      lease_fence = lease_fence + 1,
+      attempt = attempt + 1,
+      lease_until = p_lease_until,
+      heartbeat_at = p_now,
+      updated_at = now()
+  where id = p_run_id
+    and (
+      state in ('queued', 'waiting_input', 'waiting_takeover')
+      or (state = 'running' and (lease_until is null or lease_until <= p_now))
+    )
+  returning * into v_run;
+
+  return v_run;
+end;
+$$;
+
+revoke all on function public.agent_kit_claim_run(uuid, text, timestamptz, timestamptz) from public, anon, authenticated;
+grant execute on function public.agent_kit_claim_run(uuid, text, timestamptz, timestamptz) to service_role;
+
+-- `p_owner`/`p_fence` hanno un default perche` i deploy di questo repo NON eseguono le
+-- migration: fra l'applicazione di questa e il deploy del codice che passa il lease c'e` una
+-- finestra in cui la produzione chiama ancora la vecchia firma a cinque argomenti. Con il
+-- default quella chiamata risolve qui e continua a funzionare senza recinto; col lease il
+-- recinto c'e`. La migration che rende i due parametri obbligatori arriva DOPO il deploy.
+create or replace function public.agent_kit_close_run(
+  p_run_id uuid,
+  p_to_state text,
+  p_reason text default null,
+  p_question jsonb default null,
+  p_message jsonb default null,
+  p_owner text default null,
+  p_fence bigint default null
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_run public.agent_kit_runs%rowtype;
+  v_message public.chat_messages%rowtype;
+begin
+  if p_to_state not in ('waiting_input', 'done', 'failed', 'aborted') then
+    raise exception 'agent_kit_close_run: state is not allowed';
+  end if;
+
+  update public.agent_kit_runs
+  set state = p_to_state,
+      reason = coalesce(p_reason, reason),
+      question = coalesce(p_question, question),
+      harness_continue_state = null,
+      updated_at = now()
+  where id = p_run_id
+    and state = 'running'
+    and (p_owner is null or (lease_owner = p_owner and lease_fence = p_fence))
+  returning * into v_run;
+
+  if v_run.id is null then
+    return jsonb_build_object('closed', false);
+  end if;
+
+  if p_message is not null then
+    insert into public.chat_messages (brand_id, user_id, thread_id, role, content, reasoning, tool_calls, attachments, name)
+    values (
+      v_run.brand_id,
+      v_run.user_id,
+      v_run.thread_id,
+      'assistant',
+      coalesce(p_message->>'content', ''),
+      p_message->>'reasoning',
+      p_message->'tool_calls',
+      p_message->'attachments',
+      p_message->>'name'
+    )
+    returning * into v_message;
+
+    update public.agent_kit_runs
+    set partial_saved_msg_id = v_message.id
+    where id = p_run_id;
+
+  end if;
+
+  if v_run.thread_id is not null then
+    perform public.append_thread_event(
+      v_run.thread_id,
+      'run:' || p_run_id || ':state:' || p_to_state,
+      'progress',
+      jsonb_build_object(
+        'runId', p_run_id,
+        'status', p_to_state,
+        'reason', p_reason,
+        'question', p_question
+      )
+    );
+  end if;
+
+  return jsonb_build_object('closed', true, 'message_id', v_message.id);
+end;
+$$;
+
+-- La firma a cinque argomenti della 0228 se ne va: la nuova accetta esattamente quegli stessi
+-- cinque nomi, quindi la chiamata del codice deployato continua a risolvere. Tenerle entrambe
+-- la renderebbe ambigua ("function is not unique") e romperebbe ogni chiusura.
+drop function if exists public.agent_kit_close_run(uuid, text, text, jsonb, jsonb);
+
+revoke all on function public.agent_kit_close_run(uuid, text, text, jsonb, jsonb, text, bigint) from public, anon, authenticated;
+grant execute on function public.agent_kit_close_run(uuid, text, text, jsonb, jsonb, text, bigint) to service_role;


### PR DESCRIPTION
## What?

A long turn that gets cut off now **finishes by itself**. Ask for ten articles, let the platform
kill the invocation after four, and the work resumes from the fifth instead of leaving half an
answer in the thread waiting for someone to notice and ask again.

Underneath, a run is held by a **lease**: an owner, a monotonic fence, an expiry. One statement
claims a run that is open (`queued`, `waiting_input`, `waiting_takeover`) or `running` with an
expired lease, bumping `lease_fence` and `attempt` in the same write. Closing the run with its
message, renewing the lease and the mirror's heartbeat are all guarded by `(owner, fence)`, so a
worker that lost the run writes nothing.

This is step 3 of the four-step plan toward the durability of
[`elie222/rakazo`](https://github.com/elie222/rakazo), and it **supersedes
[ADR 0002](docs/adr/0002-defer-distributed-run-leases.md)**, which had deferred exactly this. The
new [ADR 0004](docs/adr/0004-resume-a-dead-run-under-a-fenced-lease.md) records why the gate
opened.

## Why?

Two turns already run in two different places — the request that streams the answer
(`chat/+server.ts`) and the queue drain (`queue.ts`) — and nothing said which of them owned a run.
The only guard on closing a run was that the row said `running`, so a worker the platform had
killed could still come back and deposit its message.

And the reaper was an executioner: it aborted the dead run and promoted its `partial` to a
message. Half the work landed in the thread, the conversation stopped, and finishing it was the
user's problem. That is the difference between an assistant you trust with a ten-minute job and
one you only trust with quick questions.

The gate ADR 0002 named — "independent workers resuming the same run" — turned out not to be a
second machine at all. With the durable event log from
[ADR 0003](docs/adr/0003-durable-thread-event-log.md) (PR #89), the browser no longer has to be
the one receiving a turn for that turn to be visible, so a run outliving its invocation is the
ordinary case.

## How?

**The fence is the guard, not the abort.** A process killed by the platform never receives a
signal; aborting the model call on a failed renewal is a courtesy to a worker that is still alive
and merely lost the race. Only the guarded `where` clause is load-bearing. The test that pins it
is named `LO ZOMBIE NON CHIUDE`.

**The claim replaced the separate resume.** `claimRun` already accepts a waiting run and moves it
to `running` with a fresh heartbeat and the next fence — everything `resume()` did, plus the
lease. Calling both in sequence left the second holding a lease the first had not released, which
surfaced as a real bug: resuming an approval within the 5-minute TTL always failed to re-claim.
The first fix nulled `lease_until` at that one call site and left the symmetric `waiting_input`
case open — a rule in two places, which this repo's own rules forbid. Removing `resume()` fixed
both at the source. The loser of a resume race now gets the same retryable `busy` as any other
occupied turn; `resume_conflict` was a second code the queue already treated identically.

**The reaper reclaims instead of killing.** A dead run with attempts left keeps its row `running`
with an expired lease — precisely what lets the next claim take it — and is queued by id so the
drain continues the *same* turn.

**Rejected: killing the run and continuing in a new one.** That was the first design, and it is
worse. It abort**ed**, salvaged the partial *and* queued a continuation with a synthetic "carry on
from where you left off" prompt — so the thread got the half message **and** the resumed answer.
The effect ledger stops duplicate external writes, not duplicate bubbles. Now the partial is
salvaged only when giving up, after `MAX_RUN_ATTEMPTS`, which is what the reaper always did.

**Rejected: leader election by advisory lock** (Rakazo's reconciler). It holds
`pg_try_advisory_lock` on a connection outliving many poll cycles; a serverless connection dies
with its invocation. Not unimplementable — *unnecessary*: Vercel Cron is already the single
executor per tick.

The effect ledger is reconciled ahead of **both** branches: it, not the lease, is what stops a
resumed run from repeating a side effect the dead segment had started.

## Testing?

- `packages/agent-core/src/run-store.test.ts` — 20, including the takeover: the fence grows on
  each claim, a still-valid lease is not stolen, the evicted worker's close returns
  `closed: false`, and a stale fence cannot renew.
- `src/lib/agent/bridge/live.test.ts` — the double-resume race was rewritten onto the **real**
  mechanism (a row already claimed by another device with a live lease) instead of a mocked throw.
- `src/lib/server/agent-kit-recover.reap.test.ts` — 3: the row is left resumable and queued by id;
  the run is aborted and salvaged only after the attempts run out; a run with no thread is not
  resumed.
- **Sweep: 112 files, 1392 tests, green.**

**Not tested, and it matters: no browser verification.** The gate in `CLAUDE.md` (local stack,
real login, stressed feature) was not run. Nothing here is claimed to work in the product — only
to be correct in code and in SQL.

## Evidence

<details><summary>Migration 0229 applied to production and verified live</summary>

The rollout hazard, caught before applying: 0229 originally dropped `agent_kit_close_run`'s
five-argument signature. **Deploys in this repo do not run migrations**, so between the apply and
the deploy production would still call the old signature — every turn close would have failed, and
the close is what saves the answer. The lease arguments now default to null and the fence is
enforced only when supplied. Both call shapes were then checked against production:

```
new_columns | claim_fn | close_overloads | deployed_call     | fenced_call
     3      |    1     |        1        | {"closed": false} | {"closed": false}
```

The five-argument call the deployed code makes still resolves (no `function is not unique`, no
`does not exist`); the fenced call resolves too. The old signature is still dropped in the same
migration — keeping both overloads is what would make the call ambiguous.

Also applied and verified this session: **0226** (1530 events backfilled, 228 threads seeded;
`append_thread_event` checked live — the sequence advances by one, a replayed source key returns
the same row, a conflicting payload is refused) and **0227**, which backs the approval work
already merged in #87/#88 against tables that did not exist. Schema drift now reports **zero
pending migrations**.
</details>

## Anything Else?

**Still missing for parity with Rakazo:**

1. **A client nonce on the user send** — they get insert-or-return-existing from a unique
   `clientNonce`; we do not.
2. **Retiring the legacy mirrors** (step 4): `kit_stream`, `ChunkPosition`, and the two `partial`
   rows, once the cursor lane has been verified in a browser.
3. `MAX_RUN_ATTEMPTS` is a flat 3. Rakazo has an `Attempt` row per fence for audit; we only keep
   the counter.

**The residue of serverless, which no fence removes:** a run longer than one invocation's maximum
duration cannot be kept alive by renewing — it must be sliced and reclaimed. The lease TTL is
therefore sized to how long an invocation may legitimately be in flight, never to how long the
work takes.

**A follow-up migration is owed:** making `p_owner`/`p_fence` required, once the code that passes
them is deployed. Until then a caller that omits them closes without a fence.

`docs/adr/0002` was never committed — it existed only as an untracked file. It is imported here
and marked superseded, so 0004 supersedes something that exists.
