### PR TITLE
Prove the work survives, against the real database

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,17 +197,29 @@ single quality defect, because they run on a fake model and a fake database: bra
 arrived empty, attachments were rejected by a constraint, the model resolved to the wrong one,
 and a read crossed every brand of the user — **green suite for everyone**.
 
-The evaluation (`scripts/eval/`, plan in [`docs/EVAL_PLAN.md`](docs/EVAL_PLAN.md)) is the only
-thing that verifies **the product works**: it puts the real agents to work on a disposable trial
-brand, with real requests, and judges FACTS before tastes — does the artifact exist? is the
-number right? how many text blocks? what did it cost?
+The evaluation (`scripts/eval/`) is the only thing that verifies **the product works**: it puts
+the real agents to work on a disposable trial brand, with real requests, and judges FACTS before
+tastes — does the artifact exist? is the number right? how many text blocks? what did it cost?
+
+**What exists today. Only these two commands are real:**
 
 ```bash
-npm run eval                                  # phase 1: the cheap scenarios (~$0.001)
-npm run eval -- --only <scenario>             # just one
-npm run eval -- --all --budget 0.50 --jobs 1  # everything, with the spending cap
-npm run eval -- --compare eval-results/<run>  # free: what got WORSE than before
+npm run eval:ux           # the onboarding walk: a real browser, 6 deterministic gates + 4 judged criteria
+npm run eval:durability   # the work does not vanish: 3 scenarios against the real database and the real plpgsql
+npm run eval:durability -- --only=<scenario>
 ```
+
+`eval:ux` measures whether the product is *good*. `eval:durability` measures whether it *keeps
+what it produced* — a turn killed mid-work, the salvage when it gives up, and a taken-over run
+that must not deposit a second message. Those run against real SQL, which is the whole point:
+the two defects that slipped through in one session were a changed function signature and a
+reaper whose contract had moved under its own tests, and a fake client cannot see either.
+
+**What does NOT exist, so nobody writes it in a report as if it had run:** `npm run eval`, the
+`--all` / `--budget` / `--jobs` / `--compare` flags, cost read from `ai_calls`, `docs/EVAL_PLAN.md`,
+and the browser engine with a throttled network. The richer scenario catalogue described in the
+frozen `CHANGELOG.md` (`brand-nudo`, `conteggio-secco`, …) was designed and never merged. Reading
+about a command here is not evidence that it runs — check `package.json`.
 
 **When to run it** — not on every commit (it costs real money), but always:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,17 +199,29 @@ single quality defect, because they run on a fake model and a fake database: bra
 arrived empty, attachments were rejected by a constraint, the model resolved to the wrong one,
 and a read crossed every brand of the user — **green suite for everyone**.
 
-The evaluation (`scripts/eval/`, plan in [`docs/EVAL_PLAN.md`](docs/EVAL_PLAN.md)) is the only
-thing that verifies **the product works**: it puts the real agents to work on a disposable trial
-brand, with real requests, and judges FACTS before tastes — does the artifact exist? is the
-number right? how many text blocks? what did it cost?
+The evaluation (`scripts/eval/`) is the only thing that verifies **the product works**: it puts
+the real agents to work on a disposable trial brand, with real requests, and judges FACTS before
+tastes — does the artifact exist? is the number right? how many text blocks? what did it cost?
+
+**What exists today. Only these two commands are real:**
 
 ```bash
-npm run eval                                  # phase 1: the cheap scenarios (~$0.001)
-npm run eval -- --only <scenario>             # just one
-npm run eval -- --all --budget 0.50 --jobs 1  # everything, with the spending cap
-npm run eval -- --compare eval-results/<run>  # free: what got WORSE than before
+npm run eval:ux           # the onboarding walk: a real browser, 6 deterministic gates + 4 judged criteria
+npm run eval:durability   # the work does not vanish: 3 scenarios against the real database and the real plpgsql
+npm run eval:durability -- --only=<scenario>
 ```
+
+`eval:ux` measures whether the product is *good*. `eval:durability` measures whether it *keeps
+what it produced* — a turn killed mid-work, the salvage when it gives up, and a taken-over run
+that must not deposit a second message. Those run against real SQL, which is the whole point:
+the two defects that slipped through in one session were a changed function signature and a
+reaper whose contract had moved under its own tests, and a fake client cannot see either.
+
+**What does NOT exist, so nobody writes it in a report as if it had run:** `npm run eval`, the
+`--all` / `--budget` / `--jobs` / `--compare` flags, cost read from `ai_calls`, `docs/EVAL_PLAN.md`,
+and the browser engine with a throttled network. The richer scenario catalogue described in the
+frozen `CHANGELOG.md` (`brand-nudo`, `conteggio-secco`, …) was designed and never merged. Reading
+about a command here is not evidence that it runs — check `package.json`.
 
 **When to run it** — not on every commit (it costs real money), but always:
 

--- a/LESSONS.md
+++ b/LESSONS.md
@@ -162,6 +162,16 @@ riesce e il diff sembra completo. Segnale: `git status --short` dopo il commit m
 Mossa: `git add -A <percorsi>` esplicito prima del commit, e `git status --short` come ultimo gesto
 prima di aprire la PR — deve essere vuoto.
 
+### Cancellare l'utente NON distrugge il brand di prova: gli eval perdono un brand per giro
+La regola dice che il brand di prova va distrutto sempre, e `deleteEvalUser` sembrava bastare. Non
+basta: il brand pende dall'ORGANIZZAZIONE, non dall'utente, e resta a terra. In produzione ci sono
+4 brand `eval-mt*` dai giri di `eval:ux` fra il 24 e il 26 agosto, ognuno con la sua organizzazione.
+Segnale: `select count(*) from brands where slug like 'eval-%'` maggiore di zero a eval fermo.
+Mossa: nel `finally` si cancella l'ORGANIZZAZIONE per prima (il brand se ne va in cascata) e poi
+l'utente. E il caso che perde davvero è la creazione fallita a METÀ — utente già creato, nessun
+fixture restituito, `destroyFixture(null)` che esce subito: la creazione ripulisce da sola prima
+di rilanciare.
+
 ## Prodotto
 
 ### La differenza per-agente si chiama mappa, non sottosistema

--- a/changelog/2026-08-31-durability-evals.md
+++ b/changelog/2026-08-31-durability-evals.md
@@ -1,0 +1,50 @@
+# Gli eval di durabilità, e la documentazione che mentiva
+
+CLAUDE.md dice *«un eval che mente è peggio di un agente che promette e non consegna»*. In questa
+sessione a mentire era la documentazione: descriveva `npm run eval`, i flag `--only`/`--all`/
+`--budget`/`--compare`, il costo letto da `ai_calls` e un `docs/EVAL_PLAN.md`. **Niente di tutto
+questo esiste.** `package.json` aveva anche `test:durability → eval:durability`, con
+`eval:durability` mai definito su nessun branch. L'unica cosa reale era `eval:ux`.
+
+Il catalogo più ricco che il CHANGELOG archivia (`brand-nudo`, `conteggio-secco`, `pins`, `unrun`)
+è stato progettato e mai mergiato. Lavoro di design perso, segnalato qui perché qualcuno decida.
+
+## I tre scenari
+
+Girano contro il database vero e contro il **plpgsql vero** — la presa del lease, il fence, la
+chiusura recintata. È precisamente ciò che un finto client non può verificare, ed è da lì che in
+questa sessione sono passati due difetti: una firma di funzione cambiata sotto al codice
+deployato, e un reaper il cui contratto era cambiato sotto ai propri test.
+
+- **`turno-ucciso-si-riprende`** — la riga resta riprendibile, viene riaccodata col suo id, e in
+  chat non compare nessun mezzo messaggio.
+- **`finiti-i-tentativi-il-lavoro-non-sparisce`** — alla resa il parziale diventa un messaggio col
+  testo davvero prodotto. È il difetto che in una settimana ha perso 25 turni veri: 73 run
+  abortiti con lavoro dentro, solo 48 recuperati.
+- **`lo-zombie-non-deposita-un-doppione`** — il fence cresce, il worker sfrattato chiude a vuoto,
+  chi tiene il lease chiude, e in chat resta **un** messaggio.
+
+`--only=<scenario>` c'è. E il campo `unrun` è reale: se la migration 0229 non è applicata su quel
+database gli scenari escono `UNRUN` col motivo, **prima** del giro, e l'uscita è rossa. Un eval
+che non gira non è verde.
+
+## Il brand di prova non veniva distrutto
+
+Scoperto costruendo questo: `deleteEvalUser` non basta, perché il brand pende
+dall'organizzazione. In produzione ci sono 4 brand `eval-mt*` lasciati da `eval:ux` fra il 24 e il
+26 agosto — uno per giro. Il `finally` ora cancella l'organizzazione per prima; e la creazione
+fallita a metà (utente già creato, nessun fixture da distruggere) ripulisce da sola prima di
+rilanciare. Gli avanzi di `eval:ux` restano lì: non sono di questo lavoro e li decide chi lo
+possiede.
+
+## Il reaper si può recintare a un brand
+
+`reapDeadKitRuns` mieteva tutto ciò che trovava — giusto per il cron, inaccettabile per un eval
+che gira su un database condiviso, dove significherebbe toccare il lavoro vero di altre persone.
+Ora accetta un `brandId` che recinta la passata.
+
+## Cosa NON è coperto
+
+**La ricarica a metà stream** — il caso "chiudo il portatile mentre l'agente scrive" — richiede il
+motore col browser e la rete strozzata, che non esiste. Non lo fingo con un test che ricarica dopo
+la fine del turno: proverebbe un'altra cosa. Resta scoperto, e dichiarato.

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "eval:ux": "vite-node --config scripts/vite-node.config.ts scripts/eval/ux.ts",
     "oss:export": "node scripts/export-oss.mjs",
     "test:durability": "npm run eval:durability",
-    "postinstall": "patch-package"
+    "postinstall": "patch-package",
+    "eval:durability": "vite-node --config scripts/vite-node.config.ts scripts/eval/durability.ts"
   },
   "devDependencies": {
     "@internationalized/date": "^3.12.0",

--- a/scripts/eval/durability.ts
+++ b/scripts/eval/durability.ts
@@ -1,0 +1,208 @@
+/**
+ * Gli scenari di DURABILITÀ: non "l'agente risponde bene", ma "il lavoro non sparisce".
+ *
+ * Girano contro il database vero e contro il plpgsql vero — la presa del lease, il fence, la
+ * chiusura recintata — che è precisamente ciò che nessun test con un finto client può verificare.
+ * In questa sessione due difetti sono passati proprio di lì: una firma di funzione cambiata e un
+ * reaper il cui contratto era cambiato sotto ai suoi test.
+ *
+ * Ogni scenario lavora su un brand usa e getta e lo distrugge nel `finally`. Uno scenario che non
+ * gira NON è verde: esce con `unrun` e il motivo, stampato prima del giro.
+ */
+import { createAdminClient } from '$lib/server/supabase-admin';
+import { claimRun, closeRunSaving } from '$lib/agent/run-store';
+import { reapDeadKitRuns } from '$lib/server/agent-kit-recover';
+// Il reaper importa la coda DINAMICAMENTE per non chiudere un ciclo. Sotto vite-node quel primo
+// import ricarica il grafo a metà scenario e fa esplodere il giro: importarla qui la mette nel
+// grafo prima che il giro cominci. Serve all'harness, non al prodotto.
+import '$lib/server/chat/queue';
+import { MAX_RUN_ATTEMPTS } from '$lib/server/chat/turn-limits';
+import { createFixture, destroyFixture, type Fixture } from './durability/fixture';
+
+type Fact = { id: string; ok: boolean; detail: string };
+type Scenario = { id: string; what: string; run: (fixture: Fixture) => Promise<Fact[]> };
+
+const DEAD_HEARTBEAT_MS = 30 * 60_000;
+const PARTIAL_TEXT = 'ho sistemato quattro articoli su dieci';
+
+const SCENARIOS: Scenario[] = [
+	{
+		id: 'turno-ucciso-si-riprende',
+		what: 'un turno morto col lavoro dentro resta riprendibile e viene riaccodato, non sepolto',
+		async run(fixture) {
+			const admin = createAdminClient();
+			const run = await seedDeadRun(fixture, 1);
+
+			await reapDeadKitRuns(admin, { brandId: fixture.brandId });
+
+			const after = await readRun(run.id);
+			const jobs = await readJobs(fixture);
+			const messages = await readAssistantMessages(fixture);
+			return [
+				fact('riga-riprendibile', after?.state === 'running', `stato ${after?.state}`),
+				fact(
+					'riaccodato-per-id',
+					jobs.some((j) => j.input_params?.resume_run_id === run.id),
+					`${jobs.length} lavori in coda`
+				),
+				fact('nessun-mezzo-messaggio', messages.length === 0, `${messages.length} messaggi assistant`)
+			];
+		}
+	},
+	{
+		id: 'finiti-i-tentativi-il-lavoro-non-sparisce',
+		what: 'alla resa il parziale diventa un messaggio — il difetto che ha perso 25 turni veri',
+		async run(fixture) {
+			const admin = createAdminClient();
+			const run = await seedDeadRun(fixture, MAX_RUN_ATTEMPTS);
+
+			await reapDeadKitRuns(admin, { brandId: fixture.brandId });
+
+			const after = await readRun(run.id);
+			const messages = await readAssistantMessages(fixture);
+			return [
+				fact('run-chiuso', after?.state === 'aborted', `stato ${after?.state}`),
+				fact('parziale-salvato', messages.length === 1, `${messages.length} messaggi assistant`),
+				fact(
+					'il-testo-e-quello-prodotto',
+					JSON.stringify(messages[0] ?? {}).includes(PARTIAL_TEXT),
+					'il messaggio porta il testo del parziale'
+				)
+			];
+		}
+	},
+	{
+		id: 'lo-zombie-non-deposita-un-doppione',
+		what: 'dopo la presa, il worker sfrattato non scrive né messaggio né stato',
+		async run(fixture) {
+			const admin = createAdminClient();
+			const run = await seedDeadRun(fixture, 1, { lease_owner: 'worker-vecchio', lease_fence: 7 });
+			const stale = { owner: 'worker-vecchio', fence: 7 };
+
+			const taken = await claimRun(admin, run.id, 'worker-nuovo', { ttlMs: 300_000 });
+			const zombie = await closeRunSaving(
+				admin,
+				run.id,
+				{ kind: 'finish', reason: 'reply' },
+				{ content: 'risposta dello zombie' },
+				stale
+			);
+			const owner = await closeRunSaving(
+				admin,
+				run.id,
+				{ kind: 'finish', reason: 'reply' },
+				{ content: 'risposta di chi tiene il lease' },
+				{ owner: 'worker-nuovo', fence: taken?.fence ?? -1 }
+			);
+
+			const messages = await readAssistantMessages(fixture);
+			return [
+				fact('il-fence-cresce', taken?.fence === 8, `fence ${taken?.fence}`),
+				fact('lo-zombie-non-chiude', zombie.closed === false, `closed ${zombie.closed}`),
+				fact('chi-tiene-il-lease-chiude', owner.closed === true, `closed ${owner.closed}`),
+				fact('un-solo-messaggio', messages.length === 1, `${messages.length} messaggi assistant`)
+			];
+		}
+	}
+];
+
+async function seedDeadRun(fixture: Fixture, attempt: number, extra: Record<string, unknown> = {}) {
+	const admin = createAdminClient();
+	const { data, error } = await admin
+		.from('agent_kit_runs')
+		.insert({
+			brand_id: fixture.brandId,
+			thread_id: fixture.threadId,
+			user_id: fixture.userId,
+			agent_id: 'content',
+			state: 'running',
+			attempt,
+			partial: { text: PARTIAL_TEXT, tools: [], updatedAt: new Date().toISOString() },
+			heartbeat_at: new Date(Date.now() - DEAD_HEARTBEAT_MS).toISOString(),
+			created_at: new Date(Date.now() - 2 * DEAD_HEARTBEAT_MS).toISOString(),
+			lease_until: new Date(Date.now() - DEAD_HEARTBEAT_MS).toISOString(),
+			...extra
+		})
+		.select('id')
+		.single();
+	if (error) throw new Error(`seed del run morto fallito — ${error.message}`);
+	return data as { id: string };
+}
+
+async function readRun(id: string) {
+	const { data } = await createAdminClient().from('agent_kit_runs').select('*').eq('id', id).maybeSingle();
+	return data as { state?: string } | null;
+}
+
+async function readJobs(fixture: Fixture) {
+	const { data } = await createAdminClient()
+		.from('chat_jobs')
+		.select('id, input_params')
+		.eq('thread_id', fixture.threadId);
+	return (data ?? []) as { id: string; input_params?: { resume_run_id?: string } }[];
+}
+
+async function readAssistantMessages(fixture: Fixture) {
+	const { data } = await createAdminClient()
+		.from('chat_messages')
+		.select('*')
+		.eq('thread_id', fixture.threadId)
+		.eq('role', 'assistant');
+	return (data ?? []) as Record<string, unknown>[];
+}
+
+function fact(id: string, ok: boolean, detail: string): Fact {
+	return { id, ok, detail };
+}
+
+/** Il motivo per cui uno scenario NON è stato eseguito. Un eval che tace è peggio di uno rosso. */
+async function unrunReason(): Promise<string | null> {
+	const admin = createAdminClient();
+	const { error } = await admin.rpc('agent_kit_claim_run', {
+		p_run_id: '00000000-0000-0000-0000-000000000000',
+		p_owner: 'probe',
+		p_now: new Date().toISOString(),
+		p_lease_until: new Date().toISOString()
+	});
+	if (error) return `migration 0229 non applicata su questo database (${error.message})`;
+	return null;
+}
+
+async function main(): Promise<number> {
+	const only = process.argv.find((a) => a.startsWith('--only='))?.split('=')[1];
+	const chosen = only ? SCENARIOS.filter((s) => s.id === only) : SCENARIOS;
+	if (!chosen.length) {
+		console.error(`nessuno scenario chiamato ${only}. Disponibili: ${SCENARIOS.map((s) => s.id).join(', ')}`);
+		return 1;
+	}
+
+	const unrun = await unrunReason();
+	if (unrun) {
+		for (const s of chosen) console.log(`  UNRUN  ${s.id} — ${unrun}`);
+		console.error(`\n${chosen.length} scenari NON eseguiti. Un eval che non gira non è verde.`);
+		return 1;
+	}
+
+	let failed = 0;
+	for (const scenario of chosen) {
+		let fixture: Fixture | null = null;
+		try {
+			fixture = await createFixture(scenario.id.slice(0, 20));
+			const facts = await scenario.run(fixture);
+			const ok = facts.every((f) => f.ok);
+			if (!ok) failed += 1;
+			console.log(`\n${ok ? '  OK   ' : '  FAIL '} ${scenario.id} — ${scenario.what}`);
+			for (const f of facts) console.log(`         ${f.ok ? '✓' : '✗'} ${f.id}: ${f.detail}`);
+		} catch (e) {
+			failed += 1;
+			console.log(`\n  FAIL  ${scenario.id} — esploso: ${e instanceof Error ? e.message : String(e)}`);
+		} finally {
+			await destroyFixture(fixture).catch((e) => console.error('  teardown fallito', e));
+		}
+	}
+
+	console.log(`\n${chosen.length - failed}/${chosen.length} scenari verdi.`);
+	return failed === 0 ? 0 : 1;
+}
+
+main().then((code) => process.exit(code));

--- a/scripts/eval/durability/fixture.ts
+++ b/scripts/eval/durability/fixture.ts
@@ -8,6 +8,7 @@ import { createEvalUser, deleteEvalUser } from '../ux/user';
 
 export type Fixture = {
   userId: string;
+  orgId: string;
   brandId: string;
   threadId: string;
 };
@@ -17,22 +18,48 @@ export async function createFixture(tag: string): Promise<Fixture> {
   const stamp = `${Date.now()}-${tag}`;
   const user = await createEvalUser(`eval-durability-${stamp}@anomalia.so`, `pw-${stamp}`);
 
-  const org = await insert(admin, 'organizations', { name: `Eval ${stamp}`, owner_id: user.id });
-  await insert(admin, 'org_members', { org_id: org.id, user_id: user.id });
-  const brand = await insert(admin, 'brands', {
-    org_id: org.id,
-    slug: `eval-${stamp}`.slice(0, 60),
-    name: `Eval ${stamp}`
-  });
-  await insert(admin, 'brand_members', { brand_id: brand.id, user_id: user.id });
-  const thread = await insert(admin, 'chat_threads', { brand_id: brand.id, user_id: user.id });
+  // La creazione che fallisce a METÀ è il caso che perde davvero: l'utente esiste già e chi
+  // chiama non riceve un fixture da distruggere. Qui si ripulisce da soli prima di rilanciare.
+  try {
+    const org = await insert(admin, 'organizations', { name: `Eval ${stamp}`, owner_id: user.id });
+    await link(admin, 'org_members', { org_id: org.id, user_id: user.id });
+    const brand = await insert(admin, 'brands', {
+      org_id: org.id,
+      slug: `eval-${stamp}`.slice(0, 60),
+      name: `Eval ${stamp}`
+    });
+    await link(admin, 'brand_members', { brand_id: brand.id, user_id: user.id });
+    const thread = await insert(admin, 'chat_threads', { brand_id: brand.id, user_id: user.id });
 
-  return { userId: user.id, brandId: brand.id, threadId: thread.id };
+    return { userId: user.id, orgId: org.id, brandId: brand.id, threadId: thread.id };
+  } catch (e) {
+    await admin.from('organizations').delete().eq('owner_id', user.id);
+    await deleteEvalUser(user.id).catch(() => undefined);
+    throw e;
+  }
 }
 
+/**
+ * Cancellare l'utente NON basta: il brand pende dall'organizzazione, non da lui, e resta a
+ * terra. Gli avanzi di `eval:ux` in produzione — un brand per giro dal 24 agosto — sono
+ * esattamente questo. L'organizzazione se ne va per prima e porta via il brand in cascata.
+ */
 export async function destroyFixture(fixture: Fixture | null): Promise<void> {
   if (!fixture) return;
+  const admin = createAdminClient();
+  const { error } = await admin.from('organizations').delete().eq('id', fixture.orgId);
+  if (error) throw new Error(`fixture: teardown organizzazione fallito — ${error.message}`);
   await deleteEvalUser(fixture.userId);
+}
+
+/** Le tabelle di collegamento non hanno `id`: si inserisce e basta, senza chiedere una chiave. */
+async function link(
+  admin: ReturnType<typeof createAdminClient>,
+  table: string,
+  row: Record<string, unknown>
+): Promise<void> {
+  const { error } = await admin.from(table).insert(row);
+  if (error) throw new Error(`fixture: collegamento su ${table} fallito — ${error.message}`);
 }
 
 async function insert(

--- a/scripts/eval/durability/fixture.ts
+++ b/scripts/eval/durability/fixture.ts
@@ -1,0 +1,46 @@
+/**
+ * Il brand usa e getta su cui girano gli scenari di durabilità. Tutto appeso all'utente:
+ * cancellare lui porta via organizzazione, brand, thread, run e messaggi in cascata, ed è
+ * l'unica garanzia che regge anche quando lo scenario muore a metà.
+ */
+import { createAdminClient } from '$lib/server/supabase-admin';
+import { createEvalUser, deleteEvalUser } from '../ux/user';
+
+export type Fixture = {
+  userId: string;
+  brandId: string;
+  threadId: string;
+};
+
+export async function createFixture(tag: string): Promise<Fixture> {
+  const admin = createAdminClient();
+  const stamp = `${Date.now()}-${tag}`;
+  const user = await createEvalUser(`eval-durability-${stamp}@anomalia.so`, `pw-${stamp}`);
+
+  const org = await insert(admin, 'organizations', { name: `Eval ${stamp}`, owner_id: user.id });
+  await insert(admin, 'org_members', { org_id: org.id, user_id: user.id });
+  const brand = await insert(admin, 'brands', {
+    org_id: org.id,
+    slug: `eval-${stamp}`.slice(0, 60),
+    name: `Eval ${stamp}`
+  });
+  await insert(admin, 'brand_members', { brand_id: brand.id, user_id: user.id });
+  const thread = await insert(admin, 'chat_threads', { brand_id: brand.id, user_id: user.id });
+
+  return { userId: user.id, brandId: brand.id, threadId: thread.id };
+}
+
+export async function destroyFixture(fixture: Fixture | null): Promise<void> {
+  if (!fixture) return;
+  await deleteEvalUser(fixture.userId);
+}
+
+async function insert(
+  admin: ReturnType<typeof createAdminClient>,
+  table: string,
+  row: Record<string, unknown>
+): Promise<{ id: string }> {
+  const { data, error } = await admin.from(table).insert(row).select('id').single();
+  if (error) throw new Error(`fixture: insert su ${table} fallito — ${error.message}`);
+  return data as { id: string };
+}

--- a/src/lib/content/changelog/2026-08-31-durability-evals.ts
+++ b/src/lib/content/changelog/2026-08-31-durability-evals.ts
@@ -1,0 +1,9 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-08-31',
+  title: 'Checks that a long job never loses your work',
+  items: [
+    'Automated checks now prove that an interrupted job either resumes or hands back what it had already produced, instead of losing it.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/agent-kit-recover.ts
+++ b/src/lib/server/agent-kit-recover.ts
@@ -90,7 +90,7 @@ type DeadKitRun = KitRunLiveness & {
  */
 export async function reapDeadKitRuns(
   db: SupabaseClient,
-  opts: { limit?: number; emailBudget?: number } = {}
+  opts: { limit?: number; emailBudget?: number; brandId?: string } = {}
 ): Promise<number> {
   const { data: candidates, error } = await db
     .from('agent_kit_runs')
@@ -102,6 +102,12 @@ export async function reapDeadKitRuns(
     .lt('created_at', new Date(Date.now() - CHAT_REAP_MIN_AGE_MS).toISOString())
     .order('created_at', { ascending: true })
     .limit(opts.limit ?? 200);
+  // Il cron mieteva tutto ciò che trovava, e va bene per il cron. Per chiunque altro — un eval
+  // che gira su un database condiviso — significa toccare il lavoro vero di altre persone:
+  // `brandId` recinta la passata al brand usa e getta.
+  const scoped = opts.brandId
+    ? ((candidates ?? []) as DeadKitRun[]).filter((r) => r.brand_id === opts.brandId)
+    : ((candidates ?? []) as DeadKitRun[]);
   if (error) {
     console.error('[sweep] lettura dei run da chiudere fallita', error.message);
     return 0;
@@ -110,7 +116,7 @@ export async function reapDeadKitRuns(
   let emailsLeft = opts.emailBudget ?? 3;
   let reaped = 0;
 
-  for (const run of (candidates ?? []) as DeadKitRun[]) {
+  for (const run of scoped) {
     const verdict = classifyKitRun(run);
     if (!verdict.dead) continue;
 


### PR DESCRIPTION
> **Stacked on #90.** Base is `feat/run-lease-fence`, so the diff shows only this work. Merge #90 first.

## What?

Three durability scenarios that run against the **real database and the real plpgsql** — the lease
claim, the fence, the guarded close — plus the correction of documentation that described an eval
harness which does not exist.

```bash
npm run eval:durability
npm run eval:durability -- --only=lo-zombie-non-deposita-un-doppione
```

- **`turno-ucciso-si-riprende`** — a dead turn keeps its row resumable, is queued by its own id,
  and leaves no half message in the thread.
- **`finiti-i-tentativi-il-lavoro-non-sparisce`** — on giving up, the partial becomes a message
  carrying the text that was actually produced.
- **`lo-zombie-non-deposita-un-doppione`** — the fence grows, the evicted worker's close returns
  false, the lease holder's returns true, and exactly one message exists.

All three pass. `package.json` already had `test:durability → eval:durability`; `eval:durability`
was never defined, on any branch. Now it is.

## Why?

Unit tests run on a fake client, and twice in one session that was not enough — both times in SQL,
where a fake cannot look:

1. Migration 0229 dropped `agent_kit_close_run`'s five-argument signature while the deployed code
   still called it. Caught by reading, not by a test.
2. The reaper's contract moved under its own tests (`kit-reaper.test.ts`), which my local sweep
   did not run because it globbed `src/lib/server/chat`, not `src/lib/server`. Caught by CI.

Scenario 2 has a number behind it. In production, between 23 and 30 August: **91 runs ended
aborted, 73 of them holding partial work, and only 48 had it salvaged.** Twenty-five turns
produced work nobody ever saw. (Honest caveat: `reason='aborted'` is also what a user cancel
writes, so some of those 91 are people pressing stop.)

## How?

**FACTS, not tastes.** Every assertion is a row in the database: the run's state, a queued job
carrying `resume_run_id`, the count of assistant messages, the fence value. No judge model, no
prose.

**`unrun` is real here.** If migration 0229 is not applied on the target database, the scenarios
print `UNRUN` with the reason **before** the round and the run exits red. A scenario that did not
execute is not green — the rule was written in CLAUDE.md and had nothing implementing it.

**The reaper can be fenced to one brand.** `reapDeadKitRuns` reaped everything it found, which is
right for the cron and unacceptable for an eval on a shared database: it would touch other
people's real work. It now takes an optional `brandId`.

**Rejected: faking the third scenario.** "Reload mid-stream and the partial answer is still there"
needs a real browser with a throttled network, an engine that does not exist. `docs/e2e-testing.md`
only reload-checks *after* a turn closes, which proves something else. It is left uncovered and
said so, rather than covered by a test that would pass for the wrong reason.

## Testing?

The eval itself is the test; it was run repeatedly while being built, and the final run is 3/3.
The unit suite is unchanged and green (`kit-reaper.test.ts` 6/6 with the scoped reaper).

<details><summary>Output</summary>

```
  OK    turno-ucciso-si-riprende
         ✓ riga-riprendibile: stato running
         ✓ riaccodato-per-id: 1 lavori in coda
         ✓ nessun-mezzo-messaggio: 0 messaggi assistant

  OK    finiti-i-tentativi-il-lavoro-non-sparisce
         ✓ run-chiuso: stato aborted
         ✓ parziale-salvato: 1 messaggi assistant
         ✓ il-testo-e-quello-prodotto: il messaggio porta il testo del parziale

  OK    lo-zombie-non-deposita-un-doppione
         ✓ il-fence-cresce: fence 8
         ✓ lo-zombie-non-chiude: closed false
         ✓ chi-tiene-il-lease-chiude: closed true
         ✓ un-solo-messaggio: 1 messaggi assistant

3/3 scenari verdi.
```
</details>

## Anything Else?

**The docs were the thing lying.** CLAUDE.md and AGENTS.md described `npm run eval`, `--all`,
`--budget`, `--jobs`, `--compare`, cost read from `ai_calls`, and `docs/EVAL_PLAN.md`. None of it
exists — the plan doc was never created, in any branch, in any commit. They now list the two
commands that run and name explicitly what does not, because a document that describes absent
tooling is the same failure the document itself warns about.

**Lost design work, for you to decide on.** The frozen `CHANGELOG.md` (2026-08-25) documents a
much richer catalogue — `brand-nudo`, `mucchio-di-bozze`, `conteggio-secco`, `pins`, `unrun`,
`--jobs`/`--budget` — with no corresponding commit anywhere. It was designed, logged, and never
merged.

**Four leftover brands in production, not mine.** `eval-mt7fo7hz`, `eval-mt8eyo9w`, `eval-mt8fw0j8`,
`eval-mtabgbn7`, from `eval:ux` runs between 24 and 26 August, one per run, each with its own
organisation. The cause is fixed here — the disposable brand hangs off the **organisation**, not
the user, so deleting the user never removed it — but the existing rows are someone else's data
and are left for their owner to clear. Everything this PR created was cleaned up, verified by
query.

**Still uncovered:** the mid-stream reload, which needs the browser engine; and the browser gate in
`CLAUDE.md` (local stack, real login, stressed feature) has not been run for any of this work.
