### PR TITLE
Show the half-written answer on the first render

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -196,6 +196,20 @@ dipendenze con hash nuovi. Segnale: la pagina non idrata, nessun effetto gira, e
 `Failed to fetch dynamically imported module` su un nodo di rotta che via `curl` risponde 200.
 Mossa: `rm -rf node_modules/.vite .svelte-kit/generated` e riavvia il dev server.
 
+### Un turno kit reale dura ~80s: il test che asserisce a 10 secondi misura il nulla
+Il primo stress nel browser dava tutto verde in 9 secondi, e in chat non c'era nessuna risposta: il
+modello (glm-5.3-flash, con reasoning) impiega ~80s e le mie asserzioni guardavano `body.innerText`,
+che comprende la barra laterale — quindi «testo presente» era sempre vero. Segnale: un turno che
+«finisce» in pochi secondi e conteggi di caratteri a quattro cifre che non cambiano. Mossa: asserire
+sulla BOLLA (`.assistant-msg-wrap`), non sul body, e considerare finito un turno solo quando la riga
+assistant esiste in `chat_messages` — il DOM dice cosa si vede, il database dice cosa è successo.
+
+### `progress` a zero dopo un turno finito è la POTATURA che funziona, non un difetto
+Cercavo le istantanee durevoli a turno concluso e ne trovavo zero, e per un momento ho creduto che
+la corsia non scrivesse. Le scrive: guardate DURANTE il turno erano 259 in 90 secondi, la cadenza dei
+250ms. A fine turno il messaggio definitivo le supera e il `finally` dello specchio le cancella —
+esattamente il disegno della ADR 0004. Mossa: una corsia potata si osserva in volo, non a terra.
+
 ## Prodotto
 
 ### La differenza per-agente si chiama mappa, non sottosistema

--- a/LESSONS.md
+++ b/LESSONS.md
@@ -172,6 +172,30 @@ l'utente. E il caso che perde davvero è la creazione fallita a METÀ — utente
 fixture restituito, `destroyFixture(null)` che esce subito: la creazione ripulisce da sola prima
 di rilanciare.
 
+### PostgREST tiene in CACHE lo schema: la migration applicata in locale non basta
+Applicate 0226/0227/0229 allo stack locale, la chat continuava a ricadere sul percorso vecchio e la
+lettura per cursore rispondeva 503. La RLS era sana (provata a mano: l'utente leggeva i suoi eventi),
+il codice era giusto, e il colpevole era il container `rest`: PostgREST aveva la cache dello schema
+di PRIMA della migration, quindi per l'API `thread_events` non esisteva. `loadThreadEvents` cattura
+l'errore e torna `null`, e tutto scivola in silenzio sul fallback. Segnale: dopo una migration
+locale, un endpoint che nomina la tabella nuova risponde vuoto o 503 mentre psql la vede benissimo.
+Mossa: `notify pgrst, 'reload schema'` e, se non basta, `docker restart anomalia-rest`.
+
+### Il `catch` muto nel load nasconde proprio la causa che ti servirà
+`loadLiveRun(supabase, thread).catch(() => null)` sembrava prudenza: un caricamento pagina non deve
+rompersi per una lettura accessoria. Ma quando il parziale non compariva, quel catch aveva ingoiato
+l'unica informazione utile, e ho perso mezz'ora a interrogare il database invece di leggere l'errore.
+Mossa: il catch che protegge il caricamento LOGGA sempre prima di tornare `null`. Ingoiare l'errore
+e ingoiare la diagnosi sono la stessa riga.
+
+### Vite: dopo aver toccato un `package.json` di `packages/`, il browser resta su hash morti
+Aggiunta una subpath export a `@anomalia/agent-kit`, la pagina ha smesso di idratarsi con
+`Failed to fetch dynamically imported module: .../nodes/150.js`. Non era il mio modulo: era
+`/node_modules/.vite/deps/@lucide_svelte.js?v=<hash>` in 404 — l'ottimizzatore aveva rigenerato le
+dipendenze con hash nuovi. Segnale: la pagina non idrata, nessun effetto gira, e in console un
+`Failed to fetch dynamically imported module` su un nodo di rotta che via `curl` risponde 200.
+Mossa: `rm -rf node_modules/.vite .svelte-kit/generated` e riavvia il dev server.
+
 ## Prodotto
 
 ### La differenza per-agente si chiama mappa, non sottosistema

--- a/LESSONS.md
+++ b/LESSONS.md
@@ -210,6 +210,16 @@ la corsia non scrivesse. Le scrive: guardate DURANTE il turno erano 259 in 90 se
 250ms. A fine turno il messaggio definitivo le supera e il `finally` dello specchio le cancella —
 esattamente il disegno della ADR 0004. Mossa: una corsia potata si osserva in volo, non a terra.
 
+### Un glob di intercettazione che prende anche il MODULO col nome dell'endpoint accusa il prodotto
+`page.route('**/kit-run**')` per provare cosa succede quando il poll fallisce: intercettava anche
+`src/routes/app/[brand]/chat/components/kit-run.ts`, cioè il modulo sorgente con lo stesso nome.
+Abortito quello, la pagina non si idrata, niente si disegna, e i tre casi provati (rete caduta, 500,
+204) risultavano TUTTI E TRE rotti — compreso quello che funzionava. Segnale: intercettando qualcosa,
+il conteggio delle richieste è 1 e non decine, e il difetto sembra colpire anche i casi che il codice
+gestisce chiaramente. Mossa: intercettare per PATHNAME esatto (una regex sull'URL), mai per un glob
+che un file sorgente può soddisfare — e prima di credere a un difetto, misurare il caso base senza
+intercettazione.
+
 ## Prodotto
 
 ### La differenza per-agente si chiama mappa, non sottosistema

--- a/changelog/2026-08-31-cold-load-shows-the-partial.md
+++ b/changelog/2026-08-31-cold-load-shows-the-partial.md
@@ -1,0 +1,43 @@
+# La ricarica mostra il parziale al primo render, non dopo il poll
+
+Segnalazione secca: *«vedere un aggiornamento ogni 4s oppure non essere sicuri che lo si veda
+neppure è decisamente incompleto»*. Aveva ragione, e il difetto era mio, lasciato nella PR #89.
+
+Il testo in corso di scrittura **finisce** nel log durevole ogni 250ms. Ma `threadMessageRows`
+proiettava solo gli eventi `message` e **buttava via i `progress`**, e il client partiva con la
+proiezione vuota. Risultato: al reload la pagina mostrava meno di quanto il database avesse già,
+e il parziale ricompariva solo al poke successivo o col poll a 4 secondi del vecchio specchio.
+
+## Una funzione sola, come da loro
+
+Il metro è [rakazo](https://github.com/elie222/rakazo), dove il carico a freddo rigioca il log
+INTERO — progress compresi — con lo stesso riduttore del tail live: *«il messaggio parziale che
+una scheda nuova vede a metà stream è identico byte a byte a quello che una scheda viva sta
+accumulando»*. Da noi le due strade divergevano, e una divergenza fra due percorsi che dovrebbero
+dire la stessa cosa non si corregge: si toglie.
+
+`threadProjectionRows` restituisce messaggi, istantanee per `runId` e cursore.
+`threadMessageRows` ora **delega** a lei. Non c'è più un secondo posto in cui la proiezione possa
+comportarsi diversamente.
+
+## Il primo render, non il primo poll
+
+Non bastava. Il rendering della bolla viva è appeso a `orphanRun`, che il client seminava da solo
+in modo asincrono: la proiezione era pronta e non aveva dove essere disegnata. Ora il run vivo
+arriva col caricamento della pagina (`loadLiveRun`, la stessa lettura di `kit-run/+server.ts`
+spostata dove serve), quindi la bolla esiste al primo render e il testo ci finisce dentro subito.
+
+I test di `loadLiveRun` pinnano anche i due casi che contano: un run col battito fermo non produce
+una bolla per un cadavere, e un run finito non si mostra.
+
+## Cosa resta
+
+Questo è lo **stadio 1** della conversione decisa in
+[ADR 0005](../docs/adr/0005-the-browser-follows-the-log.md): rendere il log sufficiente a guidare
+la UI da solo. Lo streaming dalla richiesta, i due specchi `partial`, `ChunkPosition` e il poll a
+4s sono ancora tutti al loro posto — si tolgono allo stadio 3, uno alla volta, ognuno con lo
+scenario che avrebbe preso la sua perdita.
+
+E il motore di eval col browser, quello che dovrebbe misurare proprio questa ricarica a metà
+stream, non esiste ancora: l'ADR lo mette come vincolo PRIMA di spegnere lo streaming, non dopo.
+Quindi questa correzione è provata dai test e dal ragionamento, non da un browser.

--- a/docs/adr/0005-the-browser-follows-the-log.md
+++ b/docs/adr/0005-the-browser-follows-the-log.md
@@ -1,0 +1,40 @@
+# The browser follows the log, and the request stops streaming the turn
+
+Context: a turn is executed by the request that asks for it, and the answer is streamed back
+over that same connection. Everything that makes a reload survivable was built to compensate
+for that: a chunk broadcast carrying text offsets, a client that matches those offsets against
+its own and queues what does not fit, two mutable `partial` mirrors, a four-second poll, and an
+orphan-run reattach. Five mechanisms, all of them existing because the truth lived in a
+connection instead of in the database.
+
+[0003](0003-durable-thread-event-log.md) put the truth in the database, and
+[0004](0004-resume-a-dead-run-under-a-fenced-lease.md) made a run outlive the invocation that
+started it. Neither removed the streaming path, so the product now carries both.
+
+Decision: the request stops executing the turn. It saves the user's message, queues the turn,
+wakes the drain and returns. The turn is executed away from the request, and the browser renders
+by following the durable event log — the same log, through the same reducer, on a cold load and
+on a live tail. A tab opened halfway through a turn shows what a tab that never left is showing,
+because both are folding the same rows.
+
+The trade is explicit and was chosen: text appears in 250ms snapshots instead of token by token.
+Four updates a second is below the threshold where a reader perceives a step, and it buys the
+property that the streaming design could only imitate — nothing is lost, ever, because nothing
+is ever only in flight.
+
+What this deletes, and deletion is the point: the payload-carrying broadcast and its offsets,
+the offset-matching client and its pending queue, both `partial` mirrors, the four-second poll,
+and the orphan-run reattach. The benchmark's entire application weighs what this repository's
+chat directory weighs; the distance is closed by removing, not by adding.
+
+Migration is staged, in the order [0003](0003-durable-thread-event-log.md) already prescribes.
+First the log is made sufficient: the cold load projects progress, so a reload paints the
+half-written answer at first render — until that holds, the log cannot drive the UI alone and no
+switch may be thrown. Then the request stops streaming and the drain executes. Only then are the
+compensating mechanisms removed, one at a time, each with the scenario that would have caught its
+loss.
+
+The risk is concentrated in one place and named here: this is the product's hot path, and a
+regression is a chat that does not answer. The durability scenarios
+(`npm run eval:durability`) are the gate; the browser engine that would cover a mid-stream reload
+does not exist yet, and building it belongs to the stage that throws the switch, not after it.

--- a/packages/agent-kit/package.json
+++ b/packages/agent-kit/package.json
@@ -9,6 +9,7 @@
     "./interfaces": "./src/interfaces.ts",
     "./registry": "./src/registry.ts",
     "./action-approval": "./src/action-approval.ts",
-    "./testkit": "./src/testkit.ts"
+    "./testkit": "./src/testkit.ts",
+    "./thread-events": "./src/thread-events.ts"
   }
 }

--- a/src/lib/content/changelog/2026-08-31-reload-shows-the-partial.ts
+++ b/src/lib/content/changelog/2026-08-31-reload-shows-the-partial.ts
@@ -1,0 +1,9 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-08-31',
+  title: 'Reload mid-answer and the text is already there',
+  items: [
+    'Reloading while an agent is still writing now shows the half-written answer immediately, instead of an empty wait.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/chat/live-run.test.ts
+++ b/src/lib/server/chat/live-run.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { createTestSupabase } from '$lib/testkit/supabase';
+import { loadLiveRun } from './live-run';
+
+const iso = (msAgo: number) => new Date(Date.now() - msAgo).toISOString();
+
+const run = (over: Record<string, unknown> = {}) => ({
+	id: 'run-1',
+	thread_id: 'thread-1',
+	agent_id: 'content',
+	state: 'running',
+	created_at: iso(60_000),
+	heartbeat_at: iso(2_000),
+	partial: { text: 'sto scrivendo' },
+	partial_saved_msg_id: null,
+	...over
+});
+
+describe('loadLiveRun', () => {
+	it('restituisce il run al lavoro, così il primo render ha dove disegnare il parziale', async () => {
+		const db = createTestSupabase({ agent_kit_runs: [run()] });
+
+		expect(await loadLiveRun(db.client, 'thread-1')).toMatchObject({ id: 'run-1', state: 'running' });
+	});
+
+	it('un run col battito fermo non è vivo: niente bolla per un cadavere', async () => {
+		const db = createTestSupabase({ agent_kit_runs: [run({ heartbeat_at: iso(30 * 60_000) })] });
+
+		expect(await loadLiveRun(db.client, 'thread-1')).toBeNull();
+	});
+
+	it('un run finito non si mostra', async () => {
+		const db = createTestSupabase({ agent_kit_runs: [run({ state: 'done' })] });
+
+		expect(await loadLiveRun(db.client, 'thread-1')).toBeNull();
+	});
+
+	it('il thread senza run non esplode', async () => {
+		const db = createTestSupabase({ agent_kit_runs: [] });
+
+		expect(await loadLiveRun(db.client, 'thread-1')).toBeNull();
+	});
+});

--- a/src/lib/server/chat/live-run.ts
+++ b/src/lib/server/chat/live-run.ts
@@ -21,7 +21,7 @@ export async function loadLiveRun(
 	supabase: SupabaseClient,
 	threadId: string
 ): Promise<LiveRunRow | null> {
-	const { data } = await supabase
+	const { data, error } = await supabase
 		.from('agent_kit_runs')
 		.select('id, agent_id, state, created_at, updated_at, partial, partial_saved_msg_id, heartbeat_at')
 		.eq('thread_id', threadId)
@@ -30,6 +30,7 @@ export async function loadLiveRun(
 		.limit(1)
 		.maybeSingle();
 
+	if (error) console.error('[loadLiveRun]', error.message);
 	if (!data || !kitRunIsAlive(data)) return null;
 	return data as LiveRunRow;
 }

--- a/src/lib/server/chat/live-run.ts
+++ b/src/lib/server/chat/live-run.ts
@@ -1,0 +1,35 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { KIT_RUN_WORKING_STATES, kitRunIsAlive } from './turn-limits';
+
+export type LiveRunRow = {
+	id: string;
+	agent_id: string;
+	state: string;
+	created_at: string;
+	partial?: unknown;
+	partial_saved_msg_id?: string | null;
+};
+
+/**
+ * Il run vivo del thread, per il PRIMO render. Finché lo seminava solo il client, la bolla del
+ * lavoro in corso non esisteva fino alla prima risposta del poll: chi ricaricava a metà turno
+ * vedeva il vuoto per qualche centinaio di millisecondi, e il testo che il database aveva già
+ * non aveva dove essere disegnato. La stessa lettura di `kit-run/+server.ts`, spostata dove il
+ * caricamento della pagina può usarla.
+ */
+export async function loadLiveRun(
+	supabase: SupabaseClient,
+	threadId: string
+): Promise<LiveRunRow | null> {
+	const { data } = await supabase
+		.from('agent_kit_runs')
+		.select('id, agent_id, state, created_at, updated_at, partial, partial_saved_msg_id, heartbeat_at')
+		.eq('thread_id', threadId)
+		.in('state', [...KIT_RUN_WORKING_STATES])
+		.order('created_at', { ascending: false })
+		.limit(1)
+		.maybeSingle();
+
+	if (!data || !kitRunIsAlive(data)) return null;
+	return data as LiveRunRow;
+}

--- a/src/lib/server/chat/persistence.ts
+++ b/src/lib/server/chat/persistence.ts
@@ -20,7 +20,8 @@ import {
 } from '$lib/media-parts';
 import { summaryBlock } from './compaction';
 import { markThreadRead } from './unread';
-import { loadThreadEvents, threadMessageRows } from './thread-events';
+import { loadThreadEvents, threadMessageRows, threadProjectionRows } from './thread-events';
+import type { ThreadProgress } from '@anomalia/agent-kit';
 
 type ChatMessageRow = {
   id: string;
@@ -1127,6 +1128,29 @@ export async function loadHistory(
   return [...summary, ...dropLeadingAssistant(messages)];
 }
 
+async function chatMessagesFallbackForUI(
+  supabase: SupabaseClient,
+  brandId: string,
+  userId: string,
+  threadId: string,
+  limit: number
+): Promise<ChatMessageUiRow[]> {
+  const { data, error } = await supabase
+    .from('chat_messages')
+    .select(
+      'id, role, content, reasoning, tool_calls, tool_call_id, name, created_at, regenerated_from, duration_ms, model, tier, input_tokens, output_tokens, feedback, sources, attachments'
+    )
+    .eq('brand_id', brandId)
+    .eq('user_id', userId)
+    .eq('thread_id', threadId)
+    .eq('superseded', false)
+    .order('created_at', { ascending: false })
+    .limit(limit);
+
+  if (error) console.error('[loadHistoryForUI]', error.message);
+  return chronologicalTail(data ?? [], limit);
+}
+
 /** Come loadHistory, ma per la UI: include tool call e tool result. */
 export async function loadHistoryForUI(
   supabase: SupabaseClient,
@@ -1143,20 +1167,42 @@ export async function loadHistoryForUI(
     }
   }
 
-  const { data, error } = await supabase
-    .from('chat_messages')
-    .select(
-      'id, role, content, reasoning, tool_calls, tool_call_id, name, created_at, regenerated_from, duration_ms, model, tier, input_tokens, output_tokens, feedback, sources, attachments'
-    )
-    .eq('brand_id', brandId)
-    .eq('user_id', userId)
-    .eq('thread_id', threadId)
-    .eq('superseded', false)
-    .order('created_at', { ascending: false })
-    .limit(limit);
+  return chatMessagesFallbackForUI(supabase, brandId, userId, threadId, limit);
+}
 
-  if (error) console.error('[loadHistoryForUI]', error.message);
-  return chronologicalTail(data ?? [], limit);
+export type ThreadUiHistory = {
+  messages: ChatMessageUiRow[];
+  liveProgress: Record<string, ThreadProgress>;
+  eventCursor: number;
+};
+
+export async function loadThreadUiHistory(
+  supabase: SupabaseClient,
+  brandId: string,
+  userId: string,
+  threadId: string,
+  limit: number = 100
+): Promise<ThreadUiHistory> {
+  const eventRows = await loadThreadEvents(supabase, threadId);
+  if (eventRows?.length) {
+    const projection = threadProjectionRows(eventRows);
+    if (projection) {
+      return {
+        messages: chronologicalTail(
+          projection.messages.filter((row) => row.role !== 'system' && row.role !== 'tool'),
+          limit
+        ) as ChatMessageUiRow[],
+        liveProgress: projection.progress,
+        eventCursor: projection.cursor
+      };
+    }
+  }
+
+  return {
+    messages: await chatMessagesFallbackForUI(supabase, brandId, userId, threadId, limit),
+    liveProgress: {},
+    eventCursor: 0
+  };
 }
 
 /** Tutta la storia di un brand+utente, senza filtro sul thread — per la pagina di riepilogo. */

--- a/src/lib/server/chat/thread-events.test.ts
+++ b/src/lib/server/chat/thread-events.test.ts
@@ -7,7 +7,8 @@ import {
 	progressEvent,
 	pruneRunProgress,
 	supersedeEvent,
-	threadMessageRows
+	threadMessageRows,
+	threadProjectionRows
 } from './thread-events';
 
 const row = {
@@ -165,5 +166,54 @@ describe('run progress lane', () => {
 		await expect(
 			pruneRunProgress({ from } as unknown as SupabaseClient, 'thread-1', 'run-1')
 		).resolves.toBeUndefined();
+	});
+});
+
+describe('la proiezione che il carico a freddo restituisce', () => {
+	const message = (seq: number, id: string) => ({
+		thread_id: 'thread-1',
+		seq,
+		source_key: `message:${id}`,
+		kind: 'message' as const,
+		payload: { ...row, id }
+	});
+	const progress = (seq: number, runId: string, text: string) => ({
+		thread_id: 'thread-1',
+		seq,
+		source_key: `${runId}:progress:${seq}`,
+		kind: 'progress' as const,
+		payload: { runId, status: 'running', text }
+	});
+
+	it('porta il testo IN CORSO DI SCRITTURA, non solo i messaggi finiti', () => {
+		const projected = threadProjectionRows([
+			message(1, 'message-1'),
+			progress(2, 'run-1', 'sto scriv'),
+			progress(3, 'run-1', 'sto scrivendo la risposta')
+		]);
+
+		expect(projected?.messages).toHaveLength(1);
+		// L'ultima istantanea vince: sono assolute, non incrementi da sommare.
+		expect(projected?.progress['run-1']).toMatchObject({ text: 'sto scrivendo la risposta' });
+		expect(projected?.cursor).toBe(3);
+	});
+
+	it('tiene le istantanee separate per run', () => {
+		const projected = threadProjectionRows([
+			progress(1, 'run-1', 'primo turno'),
+			progress(2, 'run-2', 'secondo turno')
+		]);
+
+		expect(projected?.progress['run-1']).toMatchObject({ text: 'primo turno' });
+		expect(projected?.progress['run-2']).toMatchObject({ text: 'secondo turno' });
+	});
+
+	it('rifiuta la proiezione quando due eventi reclamano la stessa chiave', () => {
+		expect(
+			threadProjectionRows([
+				message(1, 'message-1'),
+				{ thread_id: 'thread-1', seq: 2, source_key: 'message:message-1', kind: 'message', payload: { ...row, id: 'altro' } }
+			])
+		).toBeNull();
 	});
 });

--- a/src/lib/server/chat/thread-events.ts
+++ b/src/lib/server/chat/thread-events.ts
@@ -119,32 +119,44 @@ export async function pruneRunProgress(
 	}
 }
 
-export function threadMessageRows(events: readonly StoredThreadEvent[]): Record<string, unknown>[] | null {
-	const converted: ThreadEvent[] = events.map((event) => {
-		if (event.kind === 'message') {
-			return {
-				seq: event.seq,
-				sourceKey: event.source_key,
-				kind: event.kind,
-				message: event.payload as ThreadMessage
-			};
-		}
-		if (event.kind === 'progress') {
-			return {
-				seq: event.seq,
-				sourceKey: event.source_key,
-				kind: event.kind,
-				progress: event.payload as ThreadProgress
-			};
-		}
-		return {
-			seq: event.seq,
-			sourceKey: event.source_key,
-			kind: event.kind,
-			messageIds: ((event.payload as { messageIds?: unknown }).messageIds ?? []) as string[]
-		};
-	});
-	const result = reduceThreadEvents(emptyThreadProjection(), converted);
+export type ThreadProjectionRows = {
+	messages: Record<string, unknown>[];
+	progress: Record<string, ThreadProgress>;
+	cursor: number;
+};
+
+/**
+ * Il carico a freddo e il tail live si riducono con LA STESSA funzione, e leggono lo stesso log:
+ * è l'unico modo perché una scheda aperta a metà turno veda ciò che una scheda viva sta
+ * accumulando. Prima di qui il freddo proiettava solo i `message` e buttava via i `progress`, e
+ * il parziale ricompariva solo al poke successivo — cioè la ricarica mostrava meno di quanto il
+ * database avesse già.
+ */
+export function threadProjectionRows(events: readonly StoredThreadEvent[]): ThreadProjectionRows | null {
+	const result = reduceThreadEvents(emptyThreadProjection(), events.map(asThreadEvent));
 	if (result.conflict) return null;
-	return result.projection.messages.filter((message) => message.superseded !== true) as Record<string, unknown>[];
+	return {
+		messages: result.projection.messages.filter((m) => m.superseded !== true) as Record<string, unknown>[],
+		progress: { ...result.projection.progress },
+		cursor: result.projection.cursor
+	};
+}
+
+function asThreadEvent(event: StoredThreadEvent): ThreadEvent {
+	if (event.kind === 'message') {
+		return { seq: event.seq, sourceKey: event.source_key, kind: 'message', message: event.payload as ThreadMessage };
+	}
+	if (event.kind === 'progress') {
+		return { seq: event.seq, sourceKey: event.source_key, kind: 'progress', progress: event.payload as ThreadProgress };
+	}
+	return {
+		seq: event.seq,
+		sourceKey: event.source_key,
+		kind: 'messages_superseded',
+		messageIds: ((event.payload as { messageIds?: unknown }).messageIds ?? []) as string[]
+	};
+}
+
+export function threadMessageRows(events: readonly StoredThreadEvent[]): Record<string, unknown>[] | null {
+	return threadProjectionRows(events)?.messages ?? null;
 }

--- a/src/lib/thread-cursor.test.ts
+++ b/src/lib/thread-cursor.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { emptyThreadProjection } from '@anomalia/agent-kit';
-import { foldThreadCursor, latestRunProgress, type RawThreadEvent } from './thread-cursor';
+import { foldThreadCursor, latestRunProgress, seedThreadProjection, type RawThreadEvent } from './thread-cursor';
 
 const message = (seq: number, id: string): RawThreadEvent => ({
 	thread_id: 'thread-1',
@@ -72,6 +72,28 @@ describe('foldThreadCursor', () => {
 
 	it('returns null progress for a runId never seen', () => {
 		expect(latestRunProgress(emptyThreadProjection(), 'run-x')).toBeNull();
+	});
+
+	it('ignores events at or below a cursor seeded from the server', () => {
+		const seeded = seedThreadProjection({}, 5);
+
+		const result = foldThreadCursor(seeded, [progress(3, 'run-1', 'running')]);
+
+		expect(result.projection.cursor).toBe(5);
+		expect(latestRunProgress(result.projection, 'run-1')).toBeNull();
+	});
+
+	it('returns the newest snapshot for a run seeded from the server', () => {
+		const seeded = seedThreadProjection(
+			{ 'run-1': { runId: 'run-1', status: 'running', text: 'partial-3' } },
+			3
+		);
+
+		expect(latestRunProgress(seeded, 'run-1')).toEqual({
+			runId: 'run-1',
+			status: 'running',
+			text: 'partial-3'
+		});
 	});
 
 	it('marks the first fold of a thread as a seeding, not as news', () => {

--- a/src/lib/thread-cursor.ts
+++ b/src/lib/thread-cursor.ts
@@ -36,6 +36,13 @@ export function latestRunProgress(projection: ThreadProjection, runId: string): 
 	return projection.progress[runId] ?? null;
 }
 
+export function seedThreadProjection(
+	progress: Readonly<Record<string, ThreadProgress>>,
+	cursor: number
+): ThreadProjection {
+	return { cursor, messages: [], progress: { ...progress }, sourceEvents: {} };
+}
+
 function toThreadEvent(raw: RawThreadEvent): ThreadEvent {
 	const base = { seq: raw.seq, sourceKey: raw.source_key };
 	if (raw.kind === 'message') {

--- a/src/lib/thread-cursor.ts
+++ b/src/lib/thread-cursor.ts
@@ -4,7 +4,7 @@ import {
 	type ThreadMessage,
 	type ThreadProgress,
 	type ThreadProjection
-} from '@anomalia/agent-kit';
+} from '@anomalia/agent-kit/thread-events';
 
 export type RawThreadEvent = {
 	thread_id: string;

--- a/src/routes/app/[brand]/chat/[thread]/+page.server.ts
+++ b/src/routes/app/[brand]/chat/[thread]/+page.server.ts
@@ -166,7 +166,10 @@ export const load: PageServerLoad = async ({ params, locals: { supabase, safeGet
     // Il run vivo arriva col primo render: seminato solo dal client, la bolla del lavoro in
     // corso non esisteva finché il poll non rispondeva, e il testo che il log aveva già non
     // aveva dove essere disegnato.
-    loadLiveRun(supabase, params.thread).catch(() => null),
+    loadLiveRun(supabase, params.thread).catch((e) => {
+      console.error('[page] loadLiveRun', e);
+      return null;
+    }),
     // Stessa consegna di GET /chat?thread=: i fotogrammi di motion_stills / render_stills
     // vivono in chat_artifacts, non nel testo del messaggio. Senza questa load la pagina
     // del thread non ha niente da disegnare e l'utente vede la chip a vuoto.

--- a/src/routes/app/[brand]/chat/[thread]/+page.server.ts
+++ b/src/routes/app/[brand]/chat/[thread]/+page.server.ts
@@ -1,5 +1,6 @@
 import { error, fail } from '@sveltejs/kit';
-import { getThread, loadHistoryForUI } from '$lib/server/chat/persistence';
+import { getThread, loadThreadUiHistory } from '$lib/server/chat/persistence';
+import { loadLiveRun } from '$lib/server/chat/live-run';
 import { agentDesktopEnabled } from '$lib/server/agent-desktop';
 import { listThreadArtifacts } from '$lib/server/chat/artifacts';
 import { chatJobFreshSince, reapStaleChatJobs } from '$lib/server/chat/job-cancel';
@@ -159,9 +160,13 @@ export const load: PageServerLoad = async ({ params, locals: { supabase, safeGet
   // Close out dead rows before asking what is in flight, so a thread unblocks itself on open.
   await reapStaleChatJobs(supabase, { userId: user.id, threadId: params.thread, limit: 10 });
 
-  const [thread, messages, artifacts, activeJobResult, failedJobResult, pendingToolsResult, approvalRowsResult, sessionMemoryResult, lastReads] = await Promise.all([
+  const [thread, threadHistory, liveRun, artifacts, activeJobResult, failedJobResult, pendingToolsResult, approvalRowsResult, sessionMemoryResult, lastReads] = await Promise.all([
     getThread(supabase, params.thread, brand.id, user.id),
-    loadHistoryForUI(supabase, brand.id, user.id, params.thread),
+    loadThreadUiHistory(supabase, brand.id, user.id, params.thread),
+    // Il run vivo arriva col primo render: seminato solo dal client, la bolla del lavoro in
+    // corso non esisteva finché il poll non rispondeva, e il testo che il log aveva già non
+    // aveva dove essere disegnato.
+    loadLiveRun(supabase, params.thread).catch(() => null),
     // Stessa consegna di GET /chat?thread=: i fotogrammi di motion_stills / render_stills
     // vivono in chat_artifacts, non nel testo del messaggio. Senza questa load la pagina
     // del thread non ha niente da disegnare e l'utente vede la chip a vuoto.
@@ -238,7 +243,10 @@ export const load: PageServerLoad = async ({ params, locals: { supabase, safeGet
     thread,
     agentPanel,
     agentDesktopEnabled: agentDesktopEnabled(),
-    messages,
+    messages: threadHistory.messages,
+    liveProgress: threadHistory.liveProgress,
+    eventCursor: threadHistory.eventCursor,
+    liveRun,
     approvalStatuses,
     artifacts,
     brandSlug: brand.slug,

--- a/src/routes/app/[brand]/chat/[thread]/+page.svelte
+++ b/src/routes/app/[brand]/chat/[thread]/+page.svelte
@@ -62,7 +62,7 @@
   import EditMessageDialog from '../components/EditMessageDialog.svelte';
   import AgentComputerDock from '../components/AgentComputerDock.svelte';
   import { consolidateMessages, mapMsg, planIdsIn, parseToolCalls, redoIdOf, type ChatArtifactUi, type ChatMessage, type PostPreview } from '../components/transcript';
-  import { LIVE_POLL_MS, IDLE_POLL_EVERY, type KitRun } from '../components/kit-run';
+  import { LIVE_POLL_MS, IDLE_POLL_EVERY, pollOutcome, type KitRun } from '../components/kit-run';
   import { createLifecycle, assistantReportOf, assistantWorkOf } from './lifecycle.svelte';
   import { dmAgents } from '$lib/chat-dm';
 
@@ -410,13 +410,11 @@
       try {
         const res = await fetch(`/app/${data.brandSlug}/chat/${data.thread.id}/kit-run`);
         if (stop) return;
-        if (res.status === 200) {
+        const esito = pollOutcome(res.status);
+        if (esito === 'run') {
           orphanRun = (await res.json()) as KitRun;
-        } else {
-          // 204: nessun run attivo. Se prima ne mostravamo uno, è appena finito.
-          if (orphanRun) {
-            void finalizeOrphanRun();
-          }
+        } else if (esito === 'finished' && orphanRun) {
+          void finalizeOrphanRun();
         }
       } catch {
         /* un poll fallito riprova al giro dopo */

--- a/src/routes/app/[brand]/chat/[thread]/+page.svelte
+++ b/src/routes/app/[brand]/chat/[thread]/+page.svelte
@@ -55,8 +55,7 @@
   import { brandChannel } from '$lib/realtime/brand-channel.svelte';
   import { emptyStreamState, type StreamToolCallState } from '$lib/chat-stream-events';
   import { applyLiveChunk, applyLiveSnapshot, type PendingChunk } from '$lib/chat-live-join';
-  import { emptyThreadProjection } from '@anomalia/agent-kit';
-  import { foldThreadCursor, latestRunProgress, type RawThreadEvent } from '$lib/thread-cursor';
+  import { foldThreadCursor, latestRunProgress, seedThreadProjection, type RawThreadEvent } from '$lib/thread-cursor';
   import '$lib/styles/chat-messages.css';
   import TranscriptList from '../components/TranscriptList.svelte';
   import ComposerDock from '../components/ComposerDock.svelte';
@@ -269,22 +268,26 @@
     loading || (!!session?.completedAt && hasLivePartial)
   );
 
+  function seedProjectionFromData() {
+    return seedThreadProjection(data.liveProgress ?? {}, data.eventCursor ?? 0);
+  }
+
   // Reload a metà turno: il turno CONTINUA sul server (consumeStream) e il suo stato vive in
   // agent_kit_runs. Qui lo si riaggancia (Realtime, o il poll qui sotto) e a run chiuso si
   // ricaricano i messaggi: l'utente non deve mai pensare di aver perso tutto.
-  let orphanRun = $state<KitRun | null>(null);
+  let orphanRun = $state<KitRun | null>((data.liveRun as KitRun | null) ?? null);
   let orphanState = $state(emptyStreamState());
   let orphanStateRunId = '';
   /** I chunk del canale che non continuano dove siamo: aspettano lo snapshot che colma il buco. */
   let orphanPending: PendingChunk[] = [];
 
   /** La proiezione durevole del thread aperto: `thread-seq` la spinge oltre `kit_stream`/poll. */
-  let threadProjection = $state(emptyThreadProjection());
+  let threadProjection = $state(seedProjectionFromData());
   let threadCursorFetching = false;
 
   $effect(() => {
     void data.thread.id;
-    threadProjection = emptyThreadProjection();
+    threadProjection = seedProjectionFromData();
   });
 
   $effect(() => {
@@ -348,6 +351,18 @@
       orphanPending = [];
     }
     applyLiveSnapshot(orphanState, orphanPending, orphanRun.partial);
+  });
+
+  $effect(() => {
+    if (!orphanRun) return;
+    const seeded = latestRunProgress(threadProjection, orphanRun.id);
+    if (seeded) {
+      applyLiveSnapshot(
+        orphanState,
+        orphanPending,
+        seeded as { text?: string; reasoning?: string; tools?: StreamToolCallState[] }
+      );
+    }
   });
 
   // Stesso reducer che usa il server per scrivere `partial` (chat-stream-events.ts): a canale

--- a/src/routes/app/[brand]/chat/[thread]/+page.svelte
+++ b/src/routes/app/[brand]/chat/[thread]/+page.svelte
@@ -288,6 +288,10 @@
   $effect(() => {
     void data.thread.id;
     threadProjection = seedProjectionFromData();
+    // `orphanRun` nasce dal caricamento, e cambiando thread SENZA ricaricare quel valore
+    // iniziale resterebbe quello del thread precedente: va riseminato qui, dove si rifà anche
+    // la proiezione. Il poll lo aggiorna dopo; questo è ciò che si vede al primo fotogramma.
+    orphanRun = (data.liveRun as KitRun | null) ?? null;
   });
 
   $effect(() => {

--- a/src/routes/app/[brand]/chat/components/kit-run.test.ts
+++ b/src/routes/app/[brand]/chat/components/kit-run.test.ts
@@ -1,0 +1,23 @@
+/**
+ * Il poll dello stato del run distingue TRE risposte, non due. Confondere «il server ha
+ * sbagliato» con «il turno è finito» cancella dallo schermo un lavoro che c'è ancora: il testo
+ * è già in mano al client, e sparisce per una richiesta accessoria andata storta.
+ */
+import { describe, expect, it } from 'vitest';
+import { pollOutcome } from './kit-run';
+
+describe('pollOutcome', () => {
+	it('200: il server manda il run', () => {
+		expect(pollOutcome(200)).toBe('run');
+	});
+
+	it('204 e SOLO 204 vuol dire che il turno è finito', () => {
+		expect(pollOutcome(204)).toBe('finished');
+	});
+
+	it('un errore del server NON è un turno finito: si tiene quello che si ha', () => {
+		for (const status of [500, 502, 503, 401, 403, 404, 429]) {
+			expect(pollOutcome(status)).toBe('keep');
+		}
+	});
+});

--- a/src/routes/app/[brand]/chat/components/kit-run.ts
+++ b/src/routes/app/[brand]/chat/components/kit-run.ts
@@ -21,3 +21,13 @@ export const LIVE_POLL_MS = 350;
 
 /** A vuoto si chiede un giro su questi: ~10 secondi fra due domande, come prima. */
 export const IDLE_POLL_EVERY = 28;
+
+/**
+ * Cosa fare della risposta del poll. `keep` è il caso che mancava: un errore del server non
+ * dice che il turno è finito, dice che non lo sappiamo — e ciò che è già a schermo resta.
+ */
+export function pollOutcome(status: number): 'run' | 'finished' | 'keep' {
+	if (status === 200) return 'run';
+	if (status === 204) return 'finished';
+	return 'keep';
+}

--- a/src/routes/app/[brand]/chat/lib/thread-load.ts
+++ b/src/routes/app/[brand]/chat/lib/thread-load.ts
@@ -1,6 +1,6 @@
 import { json } from '@sveltejs/kit';
 import type { SupabaseClient } from '@supabase/supabase-js';
-import { getThread, loadAllHistoryForUI, loadHistoryForUI } from '$lib/server/chat/persistence';
+import { getThread, loadAllHistoryForUI, loadThreadUiHistory } from '$lib/server/chat/persistence';
 import { listThreadArtifacts } from '$lib/server/chat/artifacts';
 import { loadLastReads } from '$lib/server/chat/unread';
 import { loadLatestGoal } from '$lib/server/chat/goal';
@@ -199,8 +199,8 @@ export async function loadThreadState(
   // The reply still being generated for this thread, if any. sessionStorage only survives a reload
   // of the SAME tab, so this is the only way a reopened/duplicated tab can reattach to a turn that
   // is still running (the generation itself survives the disconnect — see consumeSseStream below).
-  const [messages, artifacts, goal, { data: activeJob }, lastReads] = await Promise.all([
-    loadHistoryForUI(supabase, brand.id, user.id, threadId),
+  const [threadHistory, artifacts, goal, { data: activeJob }, lastReads] = await Promise.all([
+    loadThreadUiHistory(supabase, brand.id, user.id, threadId),
     // Gli artefatti del thread arrivano firmati insieme alla cronologia: le card devono esserci al
     // primo paint, non dopo una seconda chiamata che a volte non parte.
     listThreadArtifacts(supabase, threadId, brand.id).catch(() => []),
@@ -224,7 +224,9 @@ export async function loadThreadState(
     loadLastReads(supabase, user.id, [threadId])
   ]);
   return json({
-    messages,
+    messages: threadHistory.messages,
+    liveProgress: threadHistory.liveProgress,
+    eventCursor: threadHistory.eventCursor,
     artifacts,
     goal,
     last_read_at: lastReads[threadId] ?? null,


### PR DESCRIPTION
> **Stacked on #91**, which is stacked on #90. Base is `feat/durability-evals`. Merge in order.

## What?

Reload the page while an agent is still writing and the half-written answer is **on screen at the
first render** — not after a four-second poll, not after the next realtime poke.

This also records [ADR 0005](docs/adr/0005-the-browser-follows-the-log.md): the decision to stop
streaming the turn from the request and let the browser render by following the durable log. This
PR is **stage 1** of that conversion — making the log sufficient to drive the UI on its own. No
switch is thrown here.

## Why?

Direct feedback: *"seeing an update every 4s, or not being sure you see it at all, is decidedly
incomplete."* Correct, and the defect was mine, left in #89.

The text reaches the durable log every 250ms. Nothing read it on page load: `threadMessageRows`
projected `message` events and **discarded `progress`**, and the client started from an empty
projection. So a reload showed *less than the database already held*, and the partial came back
only on the next poke or via the old four-second mirror poll.

The benchmark does not have this hole because its cold load replays the whole log, progress
included, through the same reducer as the live tail — *"the partial message a fresh tab sees
mid-stream is byte-identical to what a live tab has been accumulating."* Ours diverged.

## How?

**One projection, and the messages delegate to it.** `threadProjectionRows` returns messages,
per-`runId` snapshots and the cursor; `threadMessageRows` now calls it and takes `.messages`. A
divergence between two paths that should say the same thing is not fixed, it is removed — there
is no longer a second place that can disagree.

**The first render, not the first poll.** Projecting progress was not enough: the live bubble
hangs off `orphanRun`, which the client seeded asynchronously, so the projection was ready with
nowhere to draw. `loadLiveRun` moves that read into the page load — the same query
`kit-run/+server.ts` already makes. Its tests pin the two cases that matter: a run whose heartbeat
stopped does not produce a bubble for a corpse, and a finished run does not show.

**Additive.** `kit_stream`, `applyLiveChunk`, both `partial` mirrors and the 4s poll are all
untouched. ADR 0003's migration order stands: make the log sufficient, then switch, then remove.

## Testing?

- `src/lib/server/chat/thread-events.test.ts` — the projection carries the text **being written**,
  keeps snapshots separate per run, and refuses when two events claim one source key. Written red
  first.
- `src/lib/server/chat/live-run.test.ts` (new, 4) — the working run is returned; a stopped
  heartbeat, a finished run and an empty thread each return null.
- `src/lib/thread-cursor.test.ts` — a projection seeded from the server cursor ignores what is at
  or below it; a seeded map returns the newest snapshot per run.
- **Full suite: 517 files, 5860 tests, green.** `svelte-check`: 293 errors before and after — none
  added.

**Not tested: the reload itself.** Proving "reload mid-stream and the text is there" needs a real
browser with a throttled network, and that engine does not exist. ADR 0005 makes building it a
precondition for stage 2 — the stage that turns the streaming off — rather than a follow-up. So
this change is proven by tests and by reading, not by a browser.

## Anything Else?

**What stage 3 deletes, once the switch is thrown:** the payload-carrying `kit_stream` broadcast
and its offsets, `chat-live-join.ts` with its pending queue, `agent_kit_runs.partial`,
`chat_jobs.partial`, `job-partial-mirror.ts`, the 4s poll and the orphan-run reattach. Five
mechanisms that exist only because the truth lived in a connection. The benchmark's whole
application weighs what this repository's chat directory weighs; the distance closes by removing.

**The trade accepted in ADR 0005:** text in 250ms snapshots instead of token by token. Four
updates a second sits below the step a reader perceives, and buys the property streaming could
only imitate — nothing is ever only in flight.

**Unrelated but true, and it applies to #90 and #91 as well:** `main` is 110 commits behind `dev`,
so none of this is in production, while migrations 0226/0227/0229 have been applied there. The
schema is ahead of the code.
