### PR TITLE
Stop bundling simple-icons into the node server chunk

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -144,6 +144,11 @@ dopo la chiusura, e le vede sparire se aspetti. Mossa: potare nel `finally` dell
 chiederlo — e chiedersi se l'altra chiamata non fosse codice morto: lo era.
 
 
+## Build e bundle
+
+### Un chunk sovradimensionato non è il colpevole del build che muore per memoria
+`index3.js` (5,4 MB, dieci volte il secondo chunk) era `simple-icons` intero, bundlato via `ssr.noExternal` per un motivo Vercel-only (nft duplica il pacchetto per funzione) che non vale per `DEPLOY_TARGET=node`. Rimuoverlo lo porta a 295 KB (-94,5%) — ma bisecando `--max-old-space-size` (4096/4608/5120) il build muore e riesce agli stessi tetti prima e dopo: zero spostamento. Strumentando `adapter-node`'s `adapt()` (scritture sincrone `appendFileSync`, non `console.error` — l'OOM abort salta il flush dei buffer stdio e perde l'ultimo log) l'heap è già a ~3,4 GB PRIMA che `adapt()` faccia alcunché di suo, durante la sola copia/compressione asset. Segnale: bisecare il tetto di memoria prima e dopo un fix e vedere la stessa soglia di crash — il chunk grande era un difetto reale (fix corretto, va tenuto) ma non la causa del crash. Mossa: non fidarsi della dimensione di un chunk come proxy del picco di memoria; misurare il picco stesso, e quando serve isolare DOVE cresce, strumentare con scritture sincrone perché un OOM non flush-a l'output normale.
+
 ## Prodotto
 
 ### La differenza per-agente si chiama mappa, non sottosistema

--- a/changelog/2026-08-30-server-bundle-memory.md
+++ b/changelog/2026-08-30-server-bundle-memory.md
@@ -19,6 +19,11 @@ build; the node build leaves it as a normal `require`, already satisfied by
 `node_modules` at runtime. `index3.js` drops from 5,382.78 kB to 295.52 kB
 (-94.5%) and the SSR build phase runs measurably faster.
 
+The node target still bundles `@anomalia/*`: the Dockerfile's final stage
+runs `npm ci --omit=dev` without `packages/`, so the workspaces are not on
+disk at runtime and Rollup has to inline them, same as it always did before
+this change — only `simple-icons` moved.
+
 This does **not** by itself fix the OOM: bisecting `--max-old-space-size`
 shows both the old and new build fail at 4096 MB and succeed at 4608/5120 MB —
 unchanged. Instrumenting `adapter-node`'s own `adapt()` (temporary, not

--- a/changelog/2026-08-30-server-bundle-memory.md
+++ b/changelog/2026-08-30-server-bundle-memory.md
@@ -1,0 +1,33 @@
+# Stop bundling simple-icons into the node SSR chunk
+
+`npm run build:node` OOMs building the self-host Docker image. `vite.config.ts`
+forced `ssr.noExternal: ['simple-icons']` unconditionally, to keep Vercel's nft
+tracer from copying the package's twin 5 MB entries (index.js + index.mjs) into
+every serverless function. That reasoning is Vercel-specific: it does not apply
+to `DEPLOY_TARGET=node`, whose Dockerfile (`infra/app/Dockerfile`) runs
+`npm ci --omit=dev` and ships the whole `node_modules` once, with no
+per-function tracing at all.
+
+Because `graphic-icons.ts` does `import * as SimpleIcons from 'simple-icons'`
+and resolves slugs dynamically, forcing the bundle defeats tree-shaking
+entirely: the full 5.2 MB module lands verbatim in
+`.svelte-kit/output/server/chunks/index3.js`, ten times any other chunk.
+
+`noExternal` is now decided by `scripts/ssr-no-external.ts`
+(`ssrNoExternalForDeploy`), which only bundles `simple-icons` for the Vercel
+build; the node build leaves it as a normal `require`, already satisfied by
+`node_modules` at runtime. `index3.js` drops from 5,382.78 kB to 295.52 kB
+(-94.5%) and the SSR build phase runs measurably faster.
+
+This does **not** by itself fix the OOM: bisecting `--max-old-space-size`
+shows both the old and new build fail at 4096 MB and succeed at 4608/5120 MB —
+unchanged. Instrumenting `adapter-node`'s own `adapt()` (temporary, not
+committed) shows the Node heap is already ~3.4 GB used by the time its own
+asset-copy/compress phase starts, before it does any bundling of its own — the
+dominant cost is memory Vite/Rollup's SSR build never releases across the
+~1,378 emitted server chunks, not one bloated import. That is a
+Vite/Rollup/adapter-node build-time retention issue, not application code;
+left for the next attempt, with `nodeAdapter({ precompress: false })`
+identified and explicitly rejected as a lever — it would serve every static
+asset uncompressed in production, a real user-facing regression traded for a
+build-time convenience.

--- a/scripts/ssr-no-external.test.ts
+++ b/scripts/ssr-no-external.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { ssrNoExternalForDeploy } from './ssr-no-external';
+
+describe('ssrNoExternalForDeploy', () => {
+  it('does not bundle simple-icons for DEPLOY_TARGET=node', () => {
+    expect(ssrNoExternalForDeploy('node')).not.toContain('simple-icons');
+  });
+
+  it('bundles simple-icons for the Vercel build', () => {
+    expect(ssrNoExternalForDeploy('')).toContain('simple-icons');
+  });
+});

--- a/scripts/ssr-no-external.test.ts
+++ b/scripts/ssr-no-external.test.ts
@@ -2,11 +2,19 @@ import { describe, expect, it } from 'vitest';
 import { ssrNoExternalForDeploy } from './ssr-no-external';
 
 describe('ssrNoExternalForDeploy', () => {
-  it('does not bundle simple-icons for DEPLOY_TARGET=node', () => {
+  it('bundles @anomalia/* for node, whose Docker final stage installs without packages/', () => {
+    expect(ssrNoExternalForDeploy('node')).toContainEqual(/^@anomalia\//);
+  });
+
+  it('leaves simple-icons external for node, which ships full node_modules and needs no dead copy inlined', () => {
     expect(ssrNoExternalForDeploy('node')).not.toContain('simple-icons');
   });
 
-  it('bundles simple-icons for the Vercel build', () => {
+  it('bundles simple-icons for Vercel, whose nft tracer would otherwise duplicate it per function', () => {
     expect(ssrNoExternalForDeploy('')).toContain('simple-icons');
+  });
+
+  it('does not bundle @anomalia/* for Vercel, which installs packages/ workspaces normally', () => {
+    expect(ssrNoExternalForDeploy('')).not.toContainEqual(/^@anomalia\//);
   });
 });

--- a/scripts/ssr-no-external.ts
+++ b/scripts/ssr-no-external.ts
@@ -1,0 +1,3 @@
+export function ssrNoExternalForDeploy(deployTarget: string): string[] {
+  return deployTarget === 'node' ? [] : ['simple-icons'];
+}

--- a/scripts/ssr-no-external.ts
+++ b/scripts/ssr-no-external.ts
@@ -1,3 +1,3 @@
-export function ssrNoExternalForDeploy(deployTarget: string): string[] {
-  return deployTarget === 'node' ? [] : ['simple-icons'];
+export function ssrNoExternalForDeploy(deployTarget: string): (string | RegExp)[] {
+  return deployTarget === 'node' ? [/^@anomalia\//] : ['simple-icons'];
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -75,10 +75,6 @@ export default defineConfig({
     // Bundling it into the server chunks keeps one copy per function instead. Tree-shaking cannot
     // slim it further — graphic-icons.ts resolves arbitrary model-emitted slugs via a namespace
     // scan, and that full-catalogue lookup is the contract (unknown slug → null, any brand works).
-    // The node build ships full node_modules in the Docker image (no per-function tracing), so
-    // it leaves simple-icons external instead of inlining a dead 5 MB copy into every SSR chunk
-    // Rollup has to parse and minify. See changelog/2026-08-30-server-bundle-memory.md for what
-    // this alone does and doesn't fix in `npm run build:node`'s memory use.
     noExternal: ssrNoExternalForDeploy(process.env.DEPLOY_TARGET ?? '')
   },
     test: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import { sentrySvelteKit } from "@sentry/sveltekit";
 import { sveltekit } from '@sveltejs/kit/vite';
 import tailwindcss from '@tailwindcss/vite';
 import { defineConfig } from 'vitest/config';
+import { ssrNoExternalForDeploy } from './scripts/ssr-no-external';
 
 /** Worktree `node_modules` is often a symlink into another checkout; Vite resolves it and
  *  rejects the real path unless it is on the allow list. */
@@ -74,7 +75,11 @@ export default defineConfig({
     // Bundling it into the server chunks keeps one copy per function instead. Tree-shaking cannot
     // slim it further — graphic-icons.ts resolves arbitrary model-emitted slugs via a namespace
     // scan, and that full-catalogue lookup is the contract (unknown slug → null, any brand works).
-    noExternal: ['simple-icons']
+    // The node build ships full node_modules in the Docker image (no per-function tracing), so
+    // it leaves simple-icons external instead of inlining a dead 5 MB copy into every SSR chunk
+    // Rollup has to parse and minify. See changelog/2026-08-30-server-bundle-memory.md for what
+    // this alone does and doesn't fix in `npm run build:node`'s memory use.
+    noExternal: ssrNoExternalForDeploy(process.env.DEPLOY_TARGET ?? '')
   },
     test: {
     testTimeout: TEST_TIMEOUT_MS,


### PR DESCRIPTION
## What?

The node SSR build stops inlining `simple-icons` into the server bundle. The largest server
chunk (`index3.js`) drops from **5,382 kB to 296 kB — 94.5% smaller**. The rule that decides
what each deploy target bundles now lives in one named function, `ssrNoExternalForDeploy`,
instead of an unconditional array in `vite.config.ts`.

## Why?

`ssr.noExternal: ['simple-icons']` was a Vercel-specific workaround: it stops the nft tracer
from duplicating the package's twin 5 MB entries into every serverless function. It was applied
unconditionally, so the node target paid for it too — and there it is pure cost, because
`infra/app/Dockerfile` runs `npm ci --omit=dev` and ships one full `node_modules`, with no
per-function tracing to defeat.

`src/lib/design/graphic-icons.ts` does `import * as SimpleIcons from 'simple-icons'` and resolves
slugs dynamically, so forcing the bundle defeats tree-shaking completely: the whole 5.23 MB module
landed in the server chunk verbatim, for Rollup to parse and minify on every build.

## How?

The decision is a two-row table in one place, which is the point — a rule written in several
places diverges at the first change:

- `node` → `[/^@anomalia\//]`: bundle the workspace packages (the final Docker stage has no
  `packages/`, so they are not resolvable at runtime), leave `simple-icons` external.
- Vercel → `['simple-icons']`: unchanged.

Rejected: `nodeAdapter({ precompress: false })`. It would cut build memory, but `sirv`'s
`gzip`/`brotli` options are wired straight to that flag, so the self-hosted server would stop
serving compressed assets — a real bandwidth regression for users, traded for build convenience.

## Testing?

Red test first, then the fix. `scripts/ssr-no-external.test.ts` asserts all four corners: node
bundles the workspaces, node excludes `simple-icons`, Vercel bundles `simple-icons`, Vercel
excludes the workspaces. The first version of this test only checked `simple-icons` and would
never have caught the missing workspace half — that gap was found by trying to compose this
branch with `fix/task-39` and is why the test now covers both targets.

- `npx vitest run scripts/ssr-no-external.test.ts src/lib/design/graphic-icons.test.ts` — 11/11
- `npm run build:node` succeeds; the app boots (`node build`, HTTP 200)
- `node scripts/typecheck-runtime.mjs` unchanged (254 pre-existing non-fatal errors, none new)

Not tested: the Docker image build with this fix combined with `fix/task-39`. Attempted twice;
both runs were killed by the environment before finishing. That measurement is still missing.

## Evidence (screenshots/videos)

No UI change. Numbers, measured on this host, `NODE_OPTIONS=--max-old-space-size=8192`:

<details>
<summary>Chunk size and peak RSS, before and after</summary>

```
index3.js   before: 5,382.78 kB     after: 295.52 kB     (-94.5%)
next chunk  agent-files.js 666 kB   (unchanged)

peak RSS    before: 3,680 / 3,556 MB          (median ~3.62 GB)
            after:  4,294 / 3,325 / 3,371 MB  (median ~3.37 GB)
```
</details>

## Anything Else?

**This does not fix the OOM that blocks the self-host image**, and the numbers say so plainly.
Bisecting `--max-old-space-size` gives the same pass/fail threshold before and after: both fail
at 4096, both pass at 4608 and 5120. The RSS improvement is ~7-8% and noisy.

Instrumenting `adapter-node`'s `adapt()` (synchronous `appendFileSync` — a hard OOM abort skips
stdio flush, so `console.error` traces are silently lost) showed the heap already at ~3.4 GB
*before* `adapt()` does any work of its own. The dominant cost is memory that Vite/Rollup's SSR
build retains across ~1,378 emitted chunks / 19 MB, not one bloated import. That is the next
thing to attack; the method is recorded in LESSONS.md for whoever picks it up.

Conflicts with `fix/task-39` on `vite.config.ts`. The resolution is not a free choice: node must
keep `@anomalia/*` bundled (that branch needs it) **and** `simple-icons` external (this branch's
gain). The version here already expresses both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0195CeHJYyE5XyF9ueWU6UuV
