### PR TITLE
Notify users of replies in other chats

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,18 +45,19 @@ You need Node.js 22+, Docker with Compose, and openssl.
 ```sh
 cp infra/compose/.env.example infra/compose/.env   # fill POSTGRES_PASSWORD, DASHBOARD_PASSWORD, SECRET_KEY_BASE
 cp .env.example .env                               # set PUBLIC_SUPABASE_URL=http://localhost:8000 and copy ANON_KEY / SERVICE_ROLE_KEY from infra/compose/.env into PUBLIC_SUPABASE_ANON_KEY / SUPABASE_SERVICE_ROLE_KEY
-(cd infra/compose && docker compose up -d --wait)
+(cd infra/compose && docker compose up -d --wait db kong auth rest realtime storage)
 npm install
 
 export DATABASE_URL="postgres://postgres:<POSTGRES_PASSWORD>@localhost:5432/postgres"
 npm run db:migrate
+(cd infra/compose && docker compose --profile init run --rm realtime-policies)
 npm run db:seed
 npm run dev          # http://localhost:5173 — login with the seeded demo@example.com / change-me-now-12345
 ```
 
 `--wait` is required: migrate needs tables that storage and realtime create on
-startup. If it stops on a missing `storage.buckets` relation, run
-`npm run db:migrate` again.
+startup. The `realtime-policies` init runs after Realtime health and is safe to
+repeat; it records 0226 only after both policies exist.
 
 `db:seed` prints the `TENANT_BRAND_ID` line to paste into `.env` for a
 single-brand install. The demo login comes from `SEED_DEMO_EMAIL` /

--- a/changelog/2026-08-30-chat-reply-notifications.md
+++ b/changelog/2026-08-30-chat-reply-notifications.md
@@ -1,0 +1,29 @@
+# Avvisi per le risposte nelle altre chat
+
+Prima una risposta dell'agente aggiornava solo la chat aperta e il pallino della
+sidebar. Se l'utente lavorava in un'altra pagina, non aveva un modo immediato
+per sapere quale conversazione era cambiata.
+
+Ora il guscio dell'app ascolta lo stesso evento reale che salva la risposta,
+ignora i messaggi dell'utente e la chat attiva, mostra una notifica per ogni
+thread non letto e la rimuove quando il thread viene aperto. Il conteggio resta
+quello persistito dal server, quindi refresh e riconnessione riallineano lo
+stato invece di inventare dati nel browser.
+
+La notifica è un unico avviso per thread, in alto a destra su desktop e a tutta
+larghezza in alto su mobile. Il clic apre il thread corretto e registra la
+lettura sul server.
+
+Sullo stack self-hosted il canale Realtime non consegnava nulla: `kong.yml`
+puntava al vecchio hostname del tenant Supabase (`realtime-dev.supabase-realtime`,
+mai esistito su questo compose, i container sono `anomalia-*`), e la migration
+`0137` che apre `realtime.messages` in RLS è un `do $$ if to_regclass(...) is not
+null then ... end if$$`: su un DB dove Realtime non ha ancora creato il proprio
+schema, il blocco non fa nulla ma la migration viene comunque segnata applicata
+— le policy non nascono mai più, in silenzio. Corretto instradando Kong al
+container reale (con l'header `Host: realtime-dev` che il tenant si aspetta) e
+sostituendo il guard silenzioso con `0226_realtime_brand_channel_policies.sql`
+(niente `if`, fallisce se `realtime.messages` non c'è) più un hook
+(`realtime-policies.sh`, servizio compose `realtime-policies`) che la riapplica
+dopo l'healthcheck di Realtime; `db-migrate.mjs` riconosce quel fallimento
+specifico e la lascia `deferred` invece di bloccare le migration successive.

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -115,7 +115,7 @@ cp .env.example .env
 # 3. Supabase stack: Postgres + Auth + REST + Storage + Realtime + the API gateway
 #    --wait is not optional: step 5 needs tables that the storage and realtime containers
 #    create during their own startup.
-(cd infra/compose && docker compose up -d --wait)
+(cd infra/compose && docker compose up -d --wait db kong auth rest realtime storage)
 
 # 4. App dependencies
 npm install
@@ -125,10 +125,14 @@ npm install
 DATABASE_URL="postgres://postgres:<POSTGRES_PASSWORD from infra/compose/.env>@localhost:5432/postgres" \
   npm run db:migrate
 
-# 6. One demo user + org + brand to log in with
+# 6. Realtime's policies depend on a table created by the Realtime service, so
+#    apply this idempotent hook after the service is healthy.
+(cd infra/compose && docker compose --profile init run --rm realtime-policies)
+
+# 7. One demo user + org + brand to log in with
 DATABASE_URL="postgres://postgres:<same password>@localhost:5432/postgres" npm run db:seed
 
-# 7. The app
+# 8. The app
 npm run dev
 
 #    `npm run dev` is the local-trial path. For a real deployment use the production build:
@@ -140,8 +144,10 @@ npm run dev
 and `SUPABASE_SERVICE_ROLE_KEY` (the `SERVICE_ROLE_KEY` from `infra/compose/.env`): it creates the
 demo user through GoTrue's admin API, not with a hand-written insert.
 
-`npm run db:migrate` and `npm run db:seed` are idempotent — re-run either any time (after pulling
-new migrations, for instance) without duplicating anything.
+`npm run db:migrate`, the Realtime policy hook and `npm run db:seed` are idempotent — re-run any of
+them after pulling new migrations, for instance, without duplicating anything. If migration runs
+before Realtime has created `realtime.messages`, it defers 0226 without recording it; the hook
+applies and records it after the Realtime healthcheck.
 
 If `db:migrate` stops on `0004` with `relation "storage.buckets" does not exist`, the storage
 container hadn't finished creating its own tables yet (this is what `--wait` above prevents). Just

--- a/infra/compose/docker-compose.yml
+++ b/infra/compose/docker-compose.yml
@@ -218,6 +218,25 @@ services:
       RUN_JANITOR: 'true'
       DISABLE_HEALTHCHECK_LOGGING: 'true'
 
+  realtime-policies:
+    profiles: ['init']
+    container_name: anomalia-realtime-policies
+    image: supabase/postgres:17.6.1.136
+    restart: 'no'
+    depends_on:
+      realtime:
+        condition: service_healthy
+    environment:
+      PGHOST: db
+      PGPORT: ${POSTGRES_PORT:-5432}
+      PGUSER: postgres
+      PGPASSWORD: ${POSTGRES_PASSWORD}
+      PGDATABASE: ${POSTGRES_DB:-postgres}
+    volumes:
+      - ../../supabase/migrations/0226_realtime_brand_channel_policies.sql:/0226_realtime_brand_channel_policies.sql:ro
+      - ./volumes/db/realtime-policies.sh:/realtime-policies.sh:ro
+    entrypoint: ['/bin/sh', '/realtime-policies.sh']
+
   storage:
     container_name: anomalia-storage
     image: supabase/storage-api:v1.60.4

--- a/infra/compose/volumes/api/kong.yml
+++ b/infra/compose/volumes/api/kong.yml
@@ -221,7 +221,7 @@ services:
   ## Secure Realtime routes
   - name: realtime-v1-ws
     _comment: 'Realtime: /realtime/v1/* -> ws://realtime:4000/socket/*'
-    url: http://realtime-dev.supabase-realtime:4000/socket
+    url: http://realtime-dev.anomalia-realtime:4000/socket
     protocol: ws
     routes:
       - name: realtime-v1-ws
@@ -239,6 +239,8 @@ services:
             headers:
               - "x-api-key:$LUA_RT_WS_EXPR"
           replace:
+            headers:
+              - "Host: realtime-dev"
             querystring:
               - "apikey:$LUA_RT_WS_EXPR"
       - name: acl
@@ -251,7 +253,7 @@ services:
   # Block access to /realtime/v1/api/openapi
   - name: realtime-v1-rest-openapi
     _comment: 'Realtime: /realtime/v1/api/openapi/* -> http://realtime:4000/api/openapi/* (blocked)'
-    url: http://realtime-dev.supabase-realtime:4000/api/openapi
+    url: http://realtime-dev.anomalia-realtime:4000/api/openapi
     protocol: http
     routes:
       - name: realtime-v1-rest-openapi
@@ -267,7 +269,7 @@ services:
   # Block access to /realtime/v1/api/tenants
   - name: realtime-v1-rest-tenants
     _comment: 'Realtime: /realtime/v1/api/tenants/* -> http://realtime:4000/api/tenants/* (blocked)'
-    url: http://realtime-dev.supabase-realtime:4000/api/tenants
+    url: http://realtime-dev.anomalia-realtime:4000/api/tenants
     protocol: http
     routes:
       - name: realtime-v1-rest-tenants
@@ -282,7 +284,7 @@ services:
 
   - name: realtime-v1-rest
     _comment: 'Realtime: /realtime/v1/api/* -> http://realtime:4000/api/*'
-    url: http://realtime-dev.supabase-realtime:4000/api
+    url: http://realtime-dev.anomalia-realtime:4000/api
     protocol: http
     routes:
       - name: realtime-v1-rest
@@ -302,6 +304,7 @@ services:
           replace:
             headers:
               - "Authorization: $LUA_AUTH_EXPR"
+              - "Host: realtime-dev"
       - name: acl
         config:
           hide_groups_header: true

--- a/infra/compose/volumes/db/realtime-policies.sh
+++ b/infra/compose/volumes/db/realtime-policies.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+set -eu
+
+attempt=0
+while [ "$attempt" -lt 60 ]; do
+  if [ "$(psql --no-psqlrc --tuples-only --no-align --command "select to_regclass('realtime.messages')")" = 'realtime.messages' ]; then
+    psql --no-psqlrc --set ON_ERROR_STOP=on \
+      --command 'begin' \
+      --command 'create table if not exists app_schema_migrations (filename text primary key, applied_at timestamptz not null default now())' \
+      --file /0226_realtime_brand_channel_policies.sql \
+      --command "insert into app_schema_migrations (filename) values ('0226_realtime_brand_channel_policies.sql') on conflict (filename) do nothing" \
+      --command 'commit'
+    exit 0
+  fi
+
+  attempt=$((attempt + 1))
+  sleep 1
+done
+
+echo 'realtime.messages did not become available' >&2
+exit 1

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "worker:build": "node scripts/build-worker.mjs",
     "bake:motion-library": "vite-node --config scripts/vite-node.config.ts scripts/bake-motion-library.ts",
     "db:migrate": "node --env-file-if-exists=.env scripts/db-migrate.mjs",
+    "test:realtime-policies": "node scripts/realtime-policy-harness.mjs",
     "db:seed": "node --env-file-if-exists=.env scripts/db-seed.mjs",
     "tool-e2e": "vite-node --config scripts/vite-node.config.ts scripts/tool-e2e/run.ts",
     "eval:ux": "vite-node --config scripts/vite-node.config.ts scripts/eval/ux.ts",

--- a/scripts/db-migrate.mjs
+++ b/scripts/db-migrate.mjs
@@ -56,6 +56,10 @@ export function lineForPosition(sql, position) {
  *  failure halfway leaves it unrecorded and partially applied — the price of VACUUM. */
 const OUTSIDE_TRANSACTION = /^[ \t]*(vacuum|reindex|create\s+index\s+concurrently|drop\s+index\s+concurrently)\b/im;
 
+const DEFERRED_PREREQUISITES = new Map([
+  ['0226_realtime_brand_channel_policies.sql', 'realtime.messages']
+]);
+
 export function runsInTransaction(sql) {
   return !OUTSIDE_TRANSACTION.test(stripComments(sql));
 }
@@ -94,6 +98,13 @@ function stripComments(sql) {
   return sql.replace(/--[^\n]*/g, '').replace(/\/\*[\s\S]*?\*\//g, '');
 }
 
+function missingPrerequisite(file, error) {
+  const prerequisite = DEFERRED_PREREQUISITES.get(file);
+  if (!prerequisite || error?.code !== '42P01') return null;
+  if (!String(error.message).includes(`"${prerequisite}"`)) return null;
+  return prerequisite;
+}
+
 export async function applyOne(client, file, dir = MIGRATIONS_DIR) {
   const sql = readFileSync(join(dir, file), 'utf8');
   const transactional = runsInTransaction(sql);
@@ -106,9 +117,15 @@ export async function applyOne(client, file, dir = MIGRATIONS_DIR) {
     if (transactional) await client.query('commit');
   } catch (err) {
     if (transactional) await client.query('rollback').catch(() => {});
+
+    const prerequisite = missingPrerequisite(file, err);
+    if (prerequisite) return { status: 'deferred', prerequisite };
+
     const line = lineForPosition(sql, err.position);
     throw new Error(`${file}${line ? `:${line}` : ''} — ${err.message}`);
   }
+
+  return { status: 'applied' };
 }
 
 async function main() {
@@ -147,12 +164,19 @@ async function main() {
     console.log(`${pending.length} pending migration(s):`);
     for (const file of pending) console.log(`  ${file}`);
 
+    let applied = 0;
     for (const file of pending) {
-      await applyOne(client, file);
+      const result = await applyOne(client, file);
+      if (result.status === 'deferred') {
+        console.log(`deferred ${file} — waiting for ${result.prerequisite}`);
+        continue;
+      }
+
       console.log(`applied ${file}`);
+      applied += 1;
     }
 
-    console.log(`Applied ${pending.length} migration(s).`);
+    console.log(`Applied ${applied} migration(s).`);
   } catch (err) {
     console.error(`FAILED: ${err.message}`);
     process.exitCode = 1;

--- a/scripts/db-migrate.test.ts
+++ b/scripts/db-migrate.test.ts
@@ -40,6 +40,20 @@ class FakeClient {
   }
 }
 
+class MissingRealtimeClient extends FakeClient {
+  async query(sql: string, params: unknown[] = []) {
+    if (sql.includes('on realtime.messages')) {
+      const error = Object.assign(new Error('relation "realtime.messages" does not exist'), {
+        code: '42P01',
+        position: sql.indexOf('realtime.messages') + 1
+      });
+      throw error;
+    }
+
+    return super.query(sql, params);
+  }
+}
+
 describe('listMigrationFiles', () => {
   it('lists .sql files in lexicographic (= numeric, zero-padded) order', () => {
     const dir = makeMigrationsDir({
@@ -114,6 +128,23 @@ describe('statementChunks', () => {
 });
 
 describe('applyOne', () => {
+  it('defers Realtime policies without recording the migration when Realtime is not ready', async () => {
+    const dir = makeMigrationsDir({
+      '0226_realtime_brand_channel_policies.sql':
+        'create policy "brand channel" on realtime.messages for select using (true);'
+    });
+    const client = new MissingRealtimeClient();
+    try {
+      expect(await applyOne(client, '0226_realtime_brand_channel_policies.sql', dir)).toEqual({
+        status: 'deferred',
+        prerequisite: 'realtime.messages'
+      });
+      expect(client.calls).not.toContainEqual(expect.stringContaining('insert into app_schema_migrations'));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('runs a vacuum migration outside a transaction, one statement per query', async () => {
     const dir = makeMigrationsDir({
       '0003_vac.sql': 'create index i on t (a);\nvacuum (analyze) public.posts;'

--- a/scripts/realtime-policy-harness.mjs
+++ b/scripts/realtime-policy-harness.mjs
@@ -1,0 +1,228 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { createHmac } from 'node:crypto';
+import { Client } from 'pg';
+import { applyOne } from './db-migrate.mjs';
+
+const ROOT = fileURLToPath(new URL('..', import.meta.url));
+const JWT_SECRET = 'task59-jwt-secret';
+const JWT_PART = (value) => Buffer.from(JSON.stringify(value)).toString('base64url');
+const JWT_HEADER = JWT_PART({ alg: 'HS256', typ: 'JWT' });
+const JWT_PAYLOAD = JWT_PART({
+  role: 'anon',
+  iss: 'supabase',
+  iat: Math.floor(Date.now() / 1000),
+  exp: Math.floor(Date.now() / 1000) + 3600
+});
+const ANON_KEY = `${JWT_HEADER}.${JWT_PAYLOAD}.${createHmac('sha256', JWT_SECRET).update(`${JWT_HEADER}.${JWT_PAYLOAD}`).digest('base64url')}`;
+const MIGRATION = join(ROOT, 'supabase/migrations/0226_realtime_brand_channel_policies.sql');
+const REALTIME_SCHEMA = join(ROOT, 'infra/compose/volumes/db/realtime.sql');
+const POLICY_INIT = join(ROOT, 'infra/compose/volumes/db/realtime-policies.sh');
+const MIGRATION_NAME = '0226_realtime_brand_channel_policies.sql';
+const PROJECT = `anomalia-task59-${process.pid}-${Date.now()}`;
+const TEMP = mkdtempSync(join(tmpdir(), 'anomalia-task59-'));
+const COMPOSE = join(TEMP, 'compose.yml');
+const INIT = join(TEMP, 'init.sql');
+
+const compose = `
+services:
+  db:
+    image: supabase/postgres:17.6.1.136
+    environment:
+      POSTGRES_PASSWORD: task59-postgres
+      POSTGRES_DB: postgres
+      PGPORT: 5432
+    volumes:
+      - db-data:/var/lib/postgresql/data
+      - ${INIT}:/docker-entrypoint-initdb.d/99-task59.sql:ro
+      - ${REALTIME_SCHEMA}:/docker-entrypoint-initdb.d/migrations/99-realtime.sql:ro
+    ports:
+      - '127.0.0.1::5432'
+    healthcheck:
+      test: ['CMD', 'pg_isready', '-U', 'postgres', '-h', 'localhost']
+      interval: 2s
+      timeout: 2s
+      retries: 30
+
+  realtime:
+    image: supabase/realtime:v2.102.3
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      PORT: 4000
+      DB_HOST: db
+      DB_PORT: 5432
+      DB_USER: supabase_admin
+      DB_PASSWORD: task59-postgres
+      DB_NAME: postgres
+      DB_AFTER_CONNECT_QUERY: SET search_path TO _realtime
+      DB_ENC_KEY: supabaserealtime
+      API_JWT_SECRET: ${JWT_SECRET}
+      SECRET_KEY_BASE: task59-secret-key-base-that-is-long-enough-for-realtime
+      METRICS_JWT_SECRET: task59-jwt-secret
+      ERL_AFLAGS: -proto_dist inet_tcp
+      DNS_NODES: "''"
+      RLIMIT_NOFILE: '10000'
+      APP_NAME: realtime
+      SEED_SELF_HOST: 'true'
+      RUN_JANITOR: 'true'
+      DISABLE_HEALTHCHECK_LOGGING: 'true'
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          'curl -sSfL --head -o /dev/null -H "Authorization: Bearer ${ANON_KEY}" http://localhost:4000/api/tenants/realtime-dev/health'
+        ]
+      interval: 2s
+      timeout: 2s
+      retries: 30
+      start_period: 5s
+
+  realtime-policies:
+    image: supabase/postgres:17.6.1.136
+    depends_on:
+      realtime:
+        condition: service_healthy
+    environment:
+      PGHOST: db
+      PGPORT: 5432
+      PGUSER: postgres
+      PGPASSWORD: task59-postgres
+      PGDATABASE: postgres
+    volumes:
+      - ${MIGRATION}:/0226_realtime_brand_channel_policies.sql:ro
+      - ${POLICY_INIT}:/realtime-policies.sh:ro
+    entrypoint: ['/bin/sh', '/realtime-policies.sh']
+
+volumes:
+  db-data:
+`;
+
+const init = `
+create schema if not exists _realtime;
+grant usage, create on schema _realtime to public;
+create schema if not exists realtime;
+
+create or replace function public.auth_brand_ids()
+returns setof uuid
+language sql
+stable
+as $$
+  select null::uuid where false;
+$$;
+`;
+
+writeFileSync(COMPOSE, compose);
+writeFileSync(INIT, init);
+
+function composeRun(args, allowFailure = false) {
+  const result = spawnSync(
+    'docker',
+    ['compose', '--project-name', PROJECT, '--file', COMPOSE, ...args],
+    { cwd: ROOT, encoding: 'utf8', maxBuffer: 10 * 1024 * 1024 }
+  );
+  if (result.status !== 0 && !allowFailure) {
+    throw new Error(`${args.join(' ')}\n${result.stdout}${result.stderr}`);
+  }
+  return `${result.stdout}${result.stderr}`;
+}
+
+function sql(query) {
+  return composeRun([
+    'exec',
+    '-T',
+    'db',
+    'psql',
+    '-U',
+    'postgres',
+    '-d',
+    'postgres',
+    '--no-psqlrc',
+    '--set',
+    'ON_ERROR_STOP=on',
+    '--tuples-only',
+    '--no-align',
+    '--command',
+    query
+  ]).trim();
+}
+
+function expect(value, expected, label) {
+  if (value !== expected) throw new Error(`${label}: expected ${expected}, received ${value}`);
+}
+
+async function applyMigration(dbPort) {
+  const client = new Client({
+    connectionString: `postgres://postgres:task59-postgres@127.0.0.1:${dbPort}/postgres`
+  });
+  await client.connect();
+  try {
+    await client.query(
+      'create table if not exists app_schema_migrations (filename text primary key, applied_at timestamptz not null default now())'
+    );
+    return await applyOne(client, MIGRATION_NAME);
+  } finally {
+    await client.end();
+  }
+}
+
+try {
+  composeRun(['up', '--detach', '--wait', 'db']);
+  sql('grant usage, create on schema realtime to postgres');
+  const dbPort = Number(composeRun(['port', 'db', '5432']).trim().split(':').pop());
+  const first = await applyMigration(dbPort);
+  expect(
+    JSON.stringify(first),
+    JSON.stringify({ status: 'deferred', prerequisite: 'realtime.messages' }),
+    'clean replay result'
+  );
+  expect(sql("select coalesce(to_regclass('realtime.messages')::text, 'missing')"), 'missing', 'clean replay table');
+  expect(
+    sql("select count(*)::text from pg_policies where schemaname = 'realtime' and tablename = 'messages'"),
+    '0',
+    'clean replay policies'
+  );
+  expect(
+    sql("select count(*)::text from app_schema_migrations where filename = '0226_realtime_brand_channel_policies.sql'"),
+    '0',
+    'clean replay migration record'
+  );
+
+  composeRun(['up', '--detach', '--wait', 'realtime']);
+  composeRun(['run', '--rm', 'realtime-policies']);
+  expect(sql("select coalesce(to_regclass('realtime.messages')::text, 'missing')"), 'realtime.messages', 'post-health table');
+  expect(
+    sql("select count(*)::text from pg_policies where schemaname = 'realtime' and tablename = 'messages'"),
+    '2',
+    'post-health policies'
+  );
+  expect(
+    sql("select count(*)::text from app_schema_migrations where filename = '0226_realtime_brand_channel_policies.sql'"),
+    '1',
+    'post-health migration record'
+  );
+
+  composeRun(['run', '--rm', '--no-deps', 'realtime-policies']);
+  expect(
+    sql("select count(*)::text from pg_policies where schemaname = 'realtime' and tablename = 'messages'"),
+    '2',
+    'repeated hook policies'
+  );
+  expect(
+    sql("select count(*)::text from app_schema_migrations where filename = '0226_realtime_brand_channel_policies.sql'"),
+    '1',
+    'repeated hook migration record'
+  );
+
+  console.log('Realtime policy lifecycle passed: clean replay, post-health init, repeated init.');
+} catch (error) {
+  console.error(composeRun(['logs', '--no-color', 'db', 'realtime', 'realtime-policies'], true));
+  throw error;
+} finally {
+  composeRun(['down', '--volumes', '--remove-orphans'], true);
+  rmSync(TEMP, { recursive: true, force: true });
+}

--- a/src/lib/agent/bridge/live.ts
+++ b/src/lib/agent/bridge/live.ts
@@ -1079,7 +1079,10 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
 					// aperte. La riga è già a terra — un inciampo qui non vale una seconda risposta.
 					try {
 						await touchThread(supabase, threadId);
-						void broadcastToBrand(brand.id, { event: 'thread-changed', payload: { threadId } });
+						void broadcastToBrand(brand.id, {
+							event: 'thread-changed',
+							payload: { threadId, hasAssistantReply: true }
+						});
 					} catch (e) {
 						console.warn(`[AGENT_KIT] run ${run.id} post-save best-effort failed`, e);
 					}

--- a/src/lib/chat-reply-notifications.test.ts
+++ b/src/lib/chat-reply-notifications.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { getReplyNotices, type ReplyNoticeThread } from './chat-reply-notifications';
+
+const thread = (id: string): ReplyNoticeThread => ({
+	id,
+	title: id,
+	agent: 'analyst',
+	preview: `reply from ${id}`
+});
+
+describe('getReplyNotices', () => {
+	it('shows each unread reply once, except the active chat', () => {
+		const threads = [thread('active'), thread('other'), thread('third'), thread('other')];
+		const unread = new Map([
+			['active', 4],
+			['other', 2],
+			['third', 1]
+		]);
+
+		expect(getReplyNotices(threads, unread, 'active')).toEqual([
+			{ thread: threads[1], unreadCount: 2 },
+			{ thread: threads[2], unreadCount: 1 }
+		]);
+	});
+
+	it('does not create notices for read threads', () => {
+		expect(getReplyNotices([thread('read')], new Map(), null)).toEqual([]);
+	});
+});

--- a/src/lib/chat-reply-notifications.ts
+++ b/src/lib/chat-reply-notifications.ts
@@ -1,0 +1,31 @@
+export type ReplyNoticeThread = {
+	id: string;
+	title: string;
+	agent?: string | null;
+	custom_agent_id?: string | null;
+	agents?: Array<{ id: string; name: string; face: string; color: string }>;
+	room_agents?: unknown;
+	preview?: string | null;
+};
+
+export type ReplyNotice = {
+	thread: ReplyNoticeThread;
+	unreadCount: number;
+};
+
+export function getReplyNotices(
+	threads: ReplyNoticeThread[],
+	unread: Map<string, number>,
+	activeThreadId: string | null
+): ReplyNotice[] {
+	const seen = new Set<string>();
+	const notices: ReplyNotice[] = [];
+
+	for (const thread of threads) {
+		if (thread.id === activeThreadId || !unread.has(thread.id) || seen.has(thread.id)) continue;
+		seen.add(thread.id);
+		notices.push({ thread, unreadCount: Math.max(1, unread.get(thread.id) ?? 0) });
+	}
+
+	return notices;
+}

--- a/src/lib/components/ChatReplyNotifications.svelte
+++ b/src/lib/components/ChatReplyNotifications.svelte
@@ -1,0 +1,175 @@
+<script lang="ts">
+  import { goto } from '$app/navigation';
+  import { _ } from 'svelte-i18n';
+  import AgentAvatar from '$lib/components/AgentAvatar.svelte';
+  import { getReplyNotices } from '$lib/chat-reply-notifications';
+  import { SHELL_MOBILE_BREAKPOINT, IsMobile } from '$lib/hooks/is-mobile.svelte';
+  import { brandChannel } from '$lib/realtime/brand-channel.svelte';
+  import {
+    chatThreadId,
+    chatThreads,
+    markThreadRead,
+    refreshThreads,
+    unreadThreadIds
+  } from '$lib/stores/chat';
+  import { threadIdentity } from '$lib/thread-identity';
+
+  let { brandSlug }: { brandSlug: string } = $props();
+
+  const isMobile = new IsMobile(SHELL_MOBILE_BREAKPOINT);
+  const notices = $derived(getReplyNotices($chatThreads, $unreadThreadIds, $chatThreadId));
+
+  $effect(() => {
+    const slug = brandSlug;
+    if (!slug) return;
+
+    let active = true;
+    const refresh = () => {
+      if (active) void refreshThreads(slug);
+    };
+
+    refresh();
+    const stop = brandChannel.onConnected(refresh);
+    return () => {
+      active = false;
+      stop();
+    };
+  });
+
+  function openNotice(threadId: string) {
+    markThreadRead(brandSlug, threadId);
+    chatThreadId.set(threadId);
+    void goto(`/app/${brandSlug}/chat/${threadId}`, { noScroll: true, keepFocus: true });
+  }
+</script>
+
+{#if notices.length}
+  <div
+    class="reply-notifications"
+    class:mobile={isMobile.current}
+    aria-label={$_('chat.replyNotification.region')}
+    aria-live="polite"
+    data-testid="chat-reply-notifications"
+  >
+    {#each notices as notice (notice.thread.id)}
+      {@const who = threadIdentity(notice.thread, (key) => $_(key))}
+      <a
+        class="reply-notice"
+        href={`/app/${brandSlug}/chat/${notice.thread.id}`}
+        data-testid={`chat-reply-notification-${notice.thread.id}`}
+        aria-label={$_('chat.replyNotification.open', { values: { name: who.name } })}
+        onclick={(event) => {
+          event.preventDefault();
+          openNotice(notice.thread.id);
+        }}
+      >
+        <AgentAvatar face={who.face} color={who.color} size={34} />
+        <span class="reply-notice-copy">
+          <span class="reply-notice-label">{$_('chat.replyNotification.label')}</span>
+          <strong>{who.name}</strong>
+          <span class="reply-notice-preview">
+            {notice.thread.preview || $_('chat.replyNotification.message')}
+          </span>
+        </span>
+        <span
+          class="reply-notice-count"
+          aria-label={$_('chat.replyNotification.count', { values: { count: notice.unreadCount } })}
+        >{notice.unreadCount > 9 ? '9+' : notice.unreadCount}</span>
+      </a>
+    {/each}
+  </div>
+{/if}
+
+<style>
+  .reply-notifications {
+    position: fixed;
+    top: calc(var(--shell-top-h, 56px) + 12px);
+    right: 20px;
+    z-index: 35;
+    display: grid;
+    gap: 8px;
+    width: min(360px, calc(100vw - 40px));
+    pointer-events: none;
+  }
+
+  .reply-notice {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-height: 62px;
+    padding: 10px 12px;
+    border: 1px solid var(--line);
+    border-radius: 14px;
+    background: color-mix(in srgb, var(--paper) 96%, transparent);
+    box-shadow: 0 12px 30px color-mix(in srgb, var(--ink) 13%, transparent);
+    color: var(--ink);
+    text-decoration: none;
+    pointer-events: auto;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+  }
+
+  .reply-notice:hover {
+    border-color: var(--ink-faint);
+  }
+
+  .reply-notice-copy {
+    display: grid;
+    min-width: 0;
+    flex: 1 1 auto;
+    gap: 2px;
+  }
+
+  .reply-notice-label {
+    color: var(--ink-faint);
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    line-height: 1.1;
+    text-transform: uppercase;
+  }
+
+  .reply-notice-copy strong,
+  .reply-notice-preview {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .reply-notice-copy strong {
+    font-size: 13px;
+    line-height: 1.2;
+  }
+
+  .reply-notice-preview {
+    color: var(--ink-soft);
+    font-size: 12px;
+    line-height: 1.25;
+  }
+
+  .reply-notice-count {
+    display: inline-flex;
+    flex: 0 0 auto;
+    align-items: center;
+    justify-content: center;
+    min-width: 20px;
+    height: 20px;
+    padding: 0 5px;
+    border-radius: 999px;
+    background: var(--accent-solid, #7c5cff);
+    color: #fff;
+    font-size: 11px;
+    font-weight: 700;
+    line-height: 1;
+  }
+
+  @media (max-width: 1023px) {
+    .reply-notifications,
+    .reply-notifications.mobile {
+      top: calc(var(--shell-top-h, 56px) + 8px);
+      right: 12px;
+      left: 12px;
+      width: auto;
+    }
+  }
+</style>

--- a/src/lib/content/changelog/2026-08-30-chat-reply-notifications.ts
+++ b/src/lib/content/changelog/2026-08-30-chat-reply-notifications.ts
@@ -1,0 +1,9 @@
+import type { ChangelogEntry } from './index';
+
+const entry: ChangelogEntry = {
+  date: '2026-08-30',
+  title: 'See replies from every chat',
+  items: ['A notice now points you to new agent replies in other chats, on desktop and mobile.']
+};
+
+export default entry;

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -9503,6 +9503,13 @@
     },
     "unread": "Unread messages",
     "unreadCount": "{count, plural, one {# unread message} other {# unread messages}}",
+    "replyNotification": {
+      "region": "New chat replies",
+      "label": "New reply",
+      "message": "Open the chat to read it",
+      "open": "Open {name}'s chat",
+      "count": "{count, plural, one {# unread reply} other {# unread replies}}"
+    },
     "docPanel": {
       "subtitle": "From the knowledge base",
       "openInKnowledge": "Open in Knowledge",

--- a/src/lib/i18n/locales/es.json
+++ b/src/lib/i18n/locales/es.json
@@ -9386,6 +9386,13 @@
     },
     "unread": "Mensajes sin leer",
     "unreadCount": "{count, plural, one {# mensaje sin leer} other {# mensajes sin leer}}",
+    "replyNotification": {
+      "region": "Nuevas respuestas de chat",
+      "label": "Nueva respuesta",
+      "message": "Abre el chat para leerla",
+      "open": "Abrir el chat de {name}",
+      "count": "{count, plural, one {# respuesta sin leer} other {# respuestas sin leer}}"
+    },
     "docPanel": {
       "subtitle": "Desde la base de conocimiento",
       "openInKnowledge": "Abrir en Knowledge",

--- a/src/lib/i18n/locales/fr.json
+++ b/src/lib/i18n/locales/fr.json
@@ -9386,6 +9386,13 @@
     },
     "unread": "Messages non lus",
     "unreadCount": "{count, plural, one {# message non lu} other {# messages non lus}}",
+    "replyNotification": {
+      "region": "Nouvelles réponses de chat",
+      "label": "Nouvelle réponse",
+      "message": "Ouvrez le chat pour la lire",
+      "open": "Ouvrir le chat de {name}",
+      "count": "{count, plural, one {# réponse non lue} other {# réponses non lues}}"
+    },
     "docPanel": {
       "subtitle": "Depuis la base de connaissances",
       "openInKnowledge": "Ouvrir dans Knowledge",

--- a/src/lib/i18n/locales/it.json
+++ b/src/lib/i18n/locales/it.json
@@ -9504,6 +9504,13 @@
     },
     "unread": "Messaggi non letti",
     "unreadCount": "{count, plural, one {# messaggio non letto} other {# messaggi non letti}}",
+    "replyNotification": {
+      "region": "Nuove risposte in chat",
+      "label": "Nuova risposta",
+      "message": "Apri la chat per leggerla",
+      "open": "Apri la chat di {name}",
+      "count": "{count, plural, one {# risposta non letta} other {# risposte non lette}}"
+    },
     "docPanel": {
       "subtitle": "Dalla knowledge base",
       "openInKnowledge": "Apri in Knowledge",

--- a/src/lib/realtime/brand-channel.svelte.ts
+++ b/src/lib/realtime/brand-channel.svelte.ts
@@ -53,7 +53,8 @@ class BrandChannel {
 	#brandId: string | null = null;
 	#slug: string | null = null;
 	#me: Me | null = null;
-	#threadListeners = new Set<(threadId: string) => void>();
+	#threadListeners = new Set<(threadId: string, hasAssistantReply: boolean) => void>();
+	#connectedListeners = new Set<() => void>();
 	#turnListeners = new Set<TurnListener>();
 	#kitStreamListeners = new Set<(payload: KitStreamChunk) => void>();
 	#kitStreamDoneListeners = new Set<(payload: { runId: string; threadId: string }) => void>();
@@ -108,10 +109,17 @@ class BrandChannel {
 	}
 
 	/** Returns an unsubscribe function. */
-	onThreadChanged(fn: (threadId: string) => void): () => void {
+	onThreadChanged(fn: (threadId: string, hasAssistantReply: boolean) => void): () => void {
 		this.#threadListeners.add(fn);
 		return () => {
 			this.#threadListeners.delete(fn);
+		};
+	}
+
+	onConnected(fn: () => void): () => void {
+		this.#connectedListeners.add(fn);
+		return () => {
+			this.#connectedListeners.delete(fn);
 		};
 	}
 
@@ -182,9 +190,11 @@ class BrandChannel {
 
 		channel.on('presence', { event: 'sync' }, () => this.#readPresence());
 		channel.on('broadcast', { event: 'thread-changed' }, ({ payload }) => {
-			const id = (payload as { threadId?: unknown } | null)?.threadId;
+			const event = payload as { threadId?: unknown; hasAssistantReply?: unknown } | null;
+			const id = event?.threadId;
 			if (typeof id === 'string' && id) {
-				for (const fn of this.#threadListeners) fn(id);
+				const hasAssistantReply = event?.hasAssistantReply === true;
+				for (const fn of this.#threadListeners) fn(id, hasAssistantReply);
 			}
 		});
 
@@ -217,6 +227,7 @@ class BrandChannel {
 			if (status === 'SUBSCRIBED') {
 				void this.#track();
 				void this.#hydrateRuns();
+				for (const fn of this.#connectedListeners) fn();
 			}
 		});
 	}

--- a/src/lib/server/chat/persistence.ts
+++ b/src/lib/server/chat/persistence.ts
@@ -934,7 +934,10 @@ export async function saveMessages(
     // senza browser attaccato arriva comunque in ogni tab aperta.
     if (inserted?.length) {
       const { broadcastToBrand } = await import('$lib/server/realtime');
-      void broadcastToBrand(brandId, { event: 'thread-changed', payload: { threadId } });
+      void broadcastToBrand(brandId, {
+        event: 'thread-changed',
+        payload: { threadId, hasAssistantReply: messages.some((m) => m.role === 'assistant') }
+      });
     }
   } catch (e) {
     console.warn('[saveMessages] post-insert best-effort failed:', e instanceof Error ? e.message : e);

--- a/src/lib/server/chat/unread.test.ts
+++ b/src/lib/server/chat/unread.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
 import { isUnread, loadLastReads, loadUnreadCounts, markThreadRead } from './unread';
 import { saveMessages } from './persistence';
+import { broadcastToBrand } from '$lib/server/realtime';
+
+vi.mock('$lib/server/realtime', () => ({ broadcastToBrand: vi.fn() }));
 
 /** Client finto: `select(...).eq(...).in(...)` risolve con quello che gli si passa. */
 function selectClient(result: { data?: unknown; error?: { message: string } } | Error) {
@@ -216,5 +219,22 @@ describe('saveMessages ↔ read state', () => {
       't1'
     );
     expect(reads).toHaveLength(0);
+  });
+
+  it('announces whether the saved batch contains an agent reply', async () => {
+    const announced = vi.mocked(broadcastToBrand);
+    announced.mockClear();
+
+    await saveMessages(client([]), 'b1', 'u1', [{ role: 'user', content: 'ciao' }], 't1');
+    await saveMessages(client([]), 'b1', 'u1', [{ role: 'assistant', content: 'fatto' }], 't1');
+
+    expect(announced).toHaveBeenNthCalledWith(1, 'b1', {
+      event: 'thread-changed',
+      payload: { threadId: 't1', hasAssistantReply: false }
+    });
+    expect(announced).toHaveBeenNthCalledWith(2, 'b1', {
+      event: 'thread-changed',
+      payload: { threadId: 't1', hasAssistantReply: true }
+    });
   });
 });

--- a/src/lib/server/realtime-config.test.ts
+++ b/src/lib/server/realtime-config.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const KONG_CONFIG = fileURLToPath(
+  new URL('../../../infra/compose/volumes/api/kong.yml', import.meta.url)
+);
+
+describe('local Realtime routing', () => {
+  it('uses the compose Realtime service for HTTP and WebSocket traffic', () => {
+    const config = readFileSync(KONG_CONFIG, 'utf8');
+
+    expect(config).toContain('url: http://realtime-dev.anomalia-realtime:4000/socket');
+    expect(config).toContain('url: http://realtime-dev.anomalia-realtime:4000/api');
+    expect(config).not.toContain('host_header:');
+    expect(config.match(/"Host: realtime-dev"/g)).toHaveLength(2);
+    expect(config).not.toContain('realtime-dev.supabase-realtime');
+  });
+});

--- a/src/lib/server/realtime-migration.test.ts
+++ b/src/lib/server/realtime-migration.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { listMigrationFiles, MIGRATIONS_DIR } from '../../../scripts/db-migrate.mjs';
+
+const REPLAY = fileURLToPath(
+  new URL('../../../supabase/migrations/0226_realtime_brand_channel_policies.sql', import.meta.url)
+);
+const COMPOSE = fileURLToPath(
+  new URL('../../../infra/compose/docker-compose.yml', import.meta.url)
+);
+const INIT = fileURLToPath(
+  new URL('../../../infra/compose/volumes/db/realtime-policies.sh', import.meta.url)
+);
+
+describe('Realtime policy replay', () => {
+  it('replays safely before Realtime and installs policies after its healthcheck', () => {
+    const files = listMigrationFiles(MIGRATIONS_DIR);
+    const original = files.indexOf('0137_realtime_brand_channel.sql');
+    const replay = files.indexOf('0226_realtime_brand_channel_policies.sql');
+    const sql = readFileSync(REPLAY, 'utf8');
+    const compose = readFileSync(COMPOSE, 'utf8');
+    const init = readFileSync(INIT, 'utf8');
+
+    expect(original).toBeGreaterThanOrEqual(0);
+    expect(replay).toBeGreaterThan(original);
+    expect(sql).not.toMatch(/to_regclass\s*\(\s*'realtime\.messages'\s*\)/i);
+    expect(sql).not.toMatch(/do\s*\$\$/i);
+    expect(sql).toContain('public.auth_brand_ids()');
+    expect(compose).toMatch(
+      /realtime-policies:[\s\S]*?profiles: \['init'\][\s\S]*?condition: service_healthy[\s\S]*?realtime-policies\.sh[\s\S]*?entrypoint/i
+    );
+    expect(compose).not.toMatch(/app:[\s\S]*?realtime-policies:/i);
+    expect(init).toMatch(/to_regclass\('realtime\.messages'\)/i);
+    expect(init).toMatch(/0226_realtime_brand_channel_policies\.sql/);
+    expect(init).toMatch(/insert into app_schema_migrations[\s\S]*?on conflict/i);
+
+    for (const name of [
+      'brand members receive brand channel',
+      'brand members publish presence on brand channel'
+    ]) {
+      const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      expect(sql).toMatch(
+        new RegExp(
+          `drop policy if exists "${escaped}" on realtime\\.messages[\\s\\S]*create policy "${escaped}"`,
+          'i'
+        )
+      );
+    }
+  });
+});

--- a/src/lib/server/realtime.ts
+++ b/src/lib/server/realtime.ts
@@ -18,7 +18,10 @@ export function brandChannelTopic(brandId: string): string {
 /** Payloads the shell knows how to react to. Keep names stable — clients match on them. */
 export type BrandBroadcast =
   /** A message row was written to this thread by anyone (live turn, queue worker, salvage). */
-  | { event: 'thread-changed'; payload: { threadId: string } }
+  | {
+      event: 'thread-changed';
+      payload: { threadId: string; hasAssistantReply: boolean };
+    }
   /**
    * One `ai` v6 UI message chunk from a live agent-kit turn (live.ts), mirrored so a client that
    * reloads mid-turn can reattach instead of only seeing "still working". `chunk` is normally the

--- a/src/routes/app/[brand]/+layout.svelte
+++ b/src/routes/app/[brand]/+layout.svelte
@@ -7,6 +7,7 @@
   import PageModal from '$lib/components/PageModal.svelte';
   import PageRailDrawer from '$lib/components/PageRailDrawer.svelte';
   import CommandPalette from '$lib/components/CommandPalette.svelte';
+  import ChatReplyNotifications from '$lib/components/ChatReplyNotifications.svelte';
   import Send from '@lucide/svelte/icons/send';
   import Layers from '@lucide/svelte/icons/layers';
   import Globe from '@lucide/svelte/icons/globe';
@@ -46,7 +47,7 @@
   import { onDestroy } from 'svelte';
   import { brandChannel } from '$lib/realtime/brand-channel.svelte';
   import { get } from 'svelte/store';
-  import { chatThreadId, chatThreads, markThreadUnread, unreadThreadIds } from '$lib/stores/chat';
+  import { chatThreadId, chatThreads, markThreadUnread, refreshThreads, unreadThreadIds } from '$lib/stores/chat';
   import { roomMemberKeys, threadIdentity, type ThreadIdentitySource } from '$lib/thread-identity';
   import { hasAds, hasWebHub } from '$lib/plans';
   let { data, children } = $props();
@@ -285,8 +286,10 @@
   // aperto lo segna letto ChatColumn.
   $effect(() => {
     if (!browser) return;
-    return brandChannel.onThreadChanged((threadId) => {
-      if (threadId !== get(chatThreadId)) markThreadUnread(threadId);
+    return brandChannel.onThreadChanged((threadId, hasAssistantReply) => {
+      if (!hasAssistantReply || threadId === get(chatThreadId)) return;
+      markThreadUnread(threadId);
+      void refreshThreads(data.brand.slug);
     });
   });
 
@@ -766,6 +769,8 @@
 <!-- Montata una volta per tutto il brand, fuori dai rami settings/full-width: le scorciatoie
      devono valere ovunque. -->
 <CommandPalette {base} brandSlug={data.brand.slug} navGroups={sidebarGroups} />
+
+<ChatReplyNotifications brandSlug={data.brand.slug} />
 
 </div>
 

--- a/supabase/migrations/0226_realtime_brand_channel_policies.sql
+++ b/supabase/migrations/0226_realtime_brand_channel_policies.sql
@@ -1,0 +1,31 @@
+drop policy if exists "brand members receive brand channel" on realtime.messages;
+
+create policy "brand members receive brand channel"
+on realtime.messages
+for select
+to authenticated
+using (
+  extension in ('broadcast', 'presence')
+  and case
+        when (select realtime.topic()) ~
+             '^brand:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+          then substring((select realtime.topic()) from 7)::uuid in (select public.auth_brand_ids())
+        else false
+      end
+);
+
+drop policy if exists "brand members publish presence on brand channel" on realtime.messages;
+
+create policy "brand members publish presence on brand channel"
+on realtime.messages
+for insert
+to authenticated
+with check (
+  extension in ('broadcast', 'presence')
+  and case
+        when (select realtime.topic()) ~
+             '^brand:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+          then substring((select realtime.topic()) from 7)::uuid in (select public.auth_brand_ids())
+        else false
+      end
+);

--- a/tests/e2e/chat-reply-notifications.real.spec.ts
+++ b/tests/e2e/chat-reply-notifications.real.spec.ts
@@ -1,0 +1,353 @@
+import { expect, test, type BrowserContext, type Page } from '@playwright/test';
+
+const REAL_E2E = process.env.REAL_E2E === '1';
+const BRAND = 'demo';
+const EMAIL = process.env.E2E_EMAIL ?? 'test@anomalia.so';
+const PASSWORD = process.env.E2E_PASSWORD ?? '123456';
+const AUTH_TIMEOUT = 2 * 60_000;
+const REALTIME_TIMEOUT = 30_000;
+const RESPONSE_TIMEOUT = 4 * 60_000;
+const TEST_TIMEOUT = 15 * 60_000;
+
+type BrowserTrace = {
+  consoleErrors: string[];
+  pageErrors: string[];
+  failedRequests: string[];
+  realtimeConnections: number;
+  realtimeJoins: number;
+  realtimePrivateJoins: number;
+  realtimeJoinStatuses: string[];
+};
+
+test.describe('real chat reply notifications', () => {
+  test.skip(!REAL_E2E, 'Set REAL_E2E=1 against the local seeded app');
+  test.describe.configure({ timeout: TEST_TIMEOUT });
+
+  async function signIn(page: Page) {
+    await page.goto('/login');
+    const form = page.locator('form[action="?/login"]');
+    await form.locator('input[name="email"]').fill(EMAIL);
+    await form.locator('input[name="password"]').fill(PASSWORD);
+    await Promise.all([
+      page.waitForURL((url) => url.pathname.startsWith('/app'), { timeout: AUTH_TIMEOUT }),
+      form.locator('button[type="submit"]').click()
+    ]);
+  }
+
+  async function markExistingThreadsRead(page: Page) {
+    await page.evaluate(async (brand) => {
+      const response = await fetch(`/app/${brand}/chat/threads`, { cache: 'no-store' });
+      if (!response.ok) throw new Error(`Cannot load threads: ${response.status}`);
+      const body = (await response.json()) as { threads?: Array<{ id: string; unread?: boolean }> };
+      await Promise.all(
+        (body.threads ?? [])
+          .filter((thread) => thread.unread)
+          .map((thread) =>
+            fetch(`/app/${brand}/chat/threads`, {
+              method: 'PATCH',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ thread_id: thread.id, read: true })
+            })
+          )
+      );
+    }, BRAND);
+  }
+
+  async function createThread(page: Page, title: string): Promise<string> {
+    return page.evaluate(async ({ brand, threadTitle }) => {
+      const response = await fetch(`/app/${brand}/chat/threads`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: threadTitle })
+      });
+      if (!response.ok) throw new Error(`Cannot create thread: ${response.status}`);
+      const body = (await response.json()) as { thread?: { id?: string } };
+      if (!body.thread?.id) throw new Error('Thread creation returned no id');
+      return body.thread.id;
+    }, { brand: BRAND, threadTitle: title });
+  }
+
+  async function deleteThreads(page: Page, threadIds: string[]) {
+    await page.evaluate(async ({ brand, ids }) => {
+      for (const threadId of ids) {
+        const response = await fetch(`/app/${brand}/chat/threads`, {
+          method: 'DELETE',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ thread_id: threadId })
+        });
+        if (!response.ok) throw new Error(`Cannot delete thread: ${response.status}`);
+      }
+    }, { brand: BRAND, ids: threadIds });
+  }
+
+  async function persistedAssistantCount(page: Page, threadId: string): Promise<number> {
+    return page.evaluate(async ({ brand, thread }) => {
+      const response = await fetch(`/app/${brand}/chat?thread=${thread}`, { cache: 'no-store' });
+      if (!response.ok) return -1;
+      const body = (await response.json()) as { messages?: Array<{ role?: string; superseded?: boolean }> };
+      return (body.messages ?? []).filter((message) => message.role === 'assistant' && !message.superseded).length;
+    }, { brand: BRAND, thread: threadId });
+  }
+
+  async function sendRealReply(page: Page, threadId: string, marker: string) {
+    const repliesBefore = await persistedAssistantCount(page, threadId);
+    const userMessage = `Reply with a concise sentence containing ${marker}.`;
+
+    await expect(page.locator('textarea.ch-input')).toBeVisible({ timeout: 30_000 });
+    await page.locator('textarea.ch-input').fill(userMessage);
+    await page.locator('button.ch-send[type="submit"]').click();
+    await expect(page.locator('.chat-msg-cell-user').last()).toContainText(marker);
+    await expect
+      .poll(() => persistedAssistantCount(page, threadId), {
+        timeout: RESPONSE_TIMEOUT,
+        message: 'The real agent did not persist an assistant reply'
+      })
+      .toBeGreaterThan(repliesBefore);
+  }
+
+  async function saveScreenshot(page: Page, name: string) {
+    await page.screenshot({ path: test.info().outputPath(name), fullPage: false });
+  }
+
+  async function traceBrowser(page: Page): Promise<BrowserTrace> {
+    const trace: BrowserTrace = {
+      consoleErrors: [],
+      pageErrors: [],
+      failedRequests: [],
+      realtimeConnections: 0,
+      realtimeJoins: 0,
+      realtimePrivateJoins: 0,
+      realtimeJoinStatuses: []
+    };
+
+    await page.addInitScript(() => {
+      const NativeWebSocket = window.WebSocket;
+      const frames: Array<{ direction: 'in' | 'out'; data: string }> = [];
+      const stateKey = '__task59RealtimeState';
+      const state = JSON.parse(sessionStorage.getItem(stateKey) ?? '{}') as {
+        privateJoins?: number;
+        successfulJoins?: number;
+      };
+
+      const record = (direction: 'in' | 'out', data: string) => {
+        frames.push({ direction, data });
+        try {
+          const message = JSON.parse(data) as unknown[];
+          if (direction === 'out' && message[3] === 'phx_join') {
+            const payload = message[4] as { config?: { private?: unknown } } | undefined;
+            if (payload?.config?.private === true) state.privateJoins = (state.privateJoins ?? 0) + 1;
+          }
+          if (direction === 'in' && message[3] === 'phx_reply') {
+            const payload = message[4] as { status?: unknown } | undefined;
+            if (payload?.status === 'ok') state.successfulJoins = (state.successfulJoins ?? 0) + 1;
+          }
+          sessionStorage.setItem(stateKey, JSON.stringify(state));
+        } catch {
+          return;
+        }
+      };
+
+      Object.defineProperty(window, '__task59RealtimeFrames', { value: frames });
+
+      window.WebSocket = new Proxy(NativeWebSocket, {
+        construct(target, args, newTarget) {
+          const socket = Reflect.construct(target, args, newTarget);
+          const url = String(args[0]);
+          if (!url.includes('/realtime/v1/websocket')) return socket;
+
+          const send = socket.send.bind(socket);
+          socket.send = (data: string | ArrayBufferLike | Blob | ArrayBufferView) => {
+            record('out', typeof data === 'string' ? data : '');
+            return send(data);
+          };
+          socket.addEventListener('message', (event: MessageEvent) => {
+            record('in', typeof event.data === 'string' ? event.data : '');
+          });
+          return socket;
+        }
+      });
+    });
+
+    page.on('console', (message) => {
+      if (message.type() === 'error') trace.consoleErrors.push(message.text());
+    });
+    page.on('pageerror', (error) => trace.pageErrors.push(error.message));
+    page.on('requestfailed', (request) => {
+      trace.failedRequests.push(`${request.method()} ${new URL(request.url()).pathname}`);
+    });
+    page.on('websocket', (socket) => {
+      if (!socket.url().includes('/realtime/v1/websocket')) return;
+      trace.realtimeConnections += 1;
+    });
+
+    return trace;
+  }
+
+  async function readRealtimeState(
+    page: Page
+  ): Promise<{ statuses: string[]; privateJoins: number; successfulJoins: number }> {
+    return page.evaluate(() => {
+      const frames = (
+        window as unknown as { __task59RealtimeFrames?: Array<{ data?: unknown }> }
+      ).__task59RealtimeFrames;
+      const state = JSON.parse(sessionStorage.getItem('__task59RealtimeState') ?? '{}') as {
+        privateJoins?: number;
+        successfulJoins?: number;
+      };
+      const statuses: string[] = [];
+
+      for (const frame of frames ?? []) {
+        if (typeof frame.data !== 'string') continue;
+        try {
+          const message = JSON.parse(frame.data) as unknown[];
+          if (message[3] !== 'phx_reply') continue;
+          const payload = message[4] as { status?: unknown } | undefined;
+          if (typeof payload?.status === 'string') statuses.push(payload.status);
+        } catch {
+          continue;
+        }
+      }
+
+      return {
+        statuses,
+        privateJoins: state.privateJoins ?? 0,
+        successfulJoins: state.successfulJoins ?? 0
+      };
+    });
+  }
+
+  async function waitForRealtime(page: Page, trace: BrowserTrace, connections: number, joins: number) {
+    await expect
+      .poll(() => trace.realtimeConnections, {
+        timeout: REALTIME_TIMEOUT,
+        message: 'The browser did not open the local Realtime WebSocket'
+      })
+      .toBeGreaterThanOrEqual(connections);
+    await expect
+      .poll(async () => {
+        const state = await readRealtimeState(page);
+        trace.realtimeJoinStatuses = state.statuses;
+        trace.realtimePrivateJoins = state.privateJoins;
+        trace.realtimeJoins = state.successfulJoins;
+        return trace.realtimeJoins;
+      }, {
+        timeout: REALTIME_TIMEOUT,
+        message: `The browser did not receive a successful Realtime channel join (statuses: ${trace.realtimeJoinStatuses.join(', ') || 'none'})`
+      })
+      .toBeGreaterThanOrEqual(joins);
+    expect(trace.realtimePrivateJoins).toBeGreaterThanOrEqual(joins);
+  }
+
+  test('shows, persists, deduplicates, and opens real replies on desktop and mobile', async ({
+    browser,
+    page
+  }) => {
+    test.setTimeout(TEST_TIMEOUT);
+    const observerTrace = await traceBrowser(page);
+    const createdThreadIds: string[] = [];
+    let writer: Page | null = null;
+    let reconnectContext: BrowserContext | null = null;
+    let reconnectWriter: Page | null = null;
+    let testError: unknown = null;
+
+    try {
+      await signIn(page);
+      await page.goto(`/app/${BRAND}`);
+      await markExistingThreadsRead(page);
+      await page.reload();
+      const observerId = await createThread(page, `E2E observer ${Date.now()}`);
+      createdThreadIds.push(observerId);
+      const targetId = await createThread(page, `E2E target ${Date.now()}`);
+      createdThreadIds.push(targetId);
+      const observerHref = `/app/${BRAND}/chat/${observerId}`;
+      const targetHref = `/app/${BRAND}/chat/${targetId}`;
+
+      await page.goto(observerHref);
+      await waitForRealtime(page, observerTrace, 1, 1);
+      writer = await page.context().newPage();
+      await writer.goto(targetHref);
+      await expect(writer.locator('textarea.ch-input')).toBeVisible({ timeout: 30_000 });
+
+      const notice = () => page.locator(`[data-testid="chat-reply-notification-${targetId}"]`);
+      const region = () => page.locator('[data-testid="chat-reply-notifications"]');
+
+      await page.setViewportSize({ width: 1440, height: 900 });
+      await sendRealReply(writer, targetId, `REAL-E2E-DESKTOP-${Date.now()}`);
+      await expect(notice()).toBeVisible({ timeout: 30_000 });
+      await expect(page.locator('[data-testid^="chat-reply-notification-"]')).toHaveCount(1);
+
+      const desktopBox = await region().boundingBox();
+      expect(desktopBox).not.toBeNull();
+      expect((desktopBox?.x ?? 0) + (desktopBox?.width ?? 0)).toBeGreaterThan(1400);
+      await saveScreenshot(page, 'chat-reply-notification-desktop.png');
+
+      await notice().click();
+      await expect(page).toHaveURL(new RegExp(`/app/${BRAND}/chat/${targetId}$`));
+      await expect(notice()).toHaveCount(0);
+
+      await page.setViewportSize({ width: 390, height: 844 });
+      await page.goto(observerHref);
+      await sendRealReply(writer, targetId, `REAL-E2E-MOBILE-${Date.now()}`);
+      await expect(notice()).toBeVisible({ timeout: 30_000 });
+      await expect(page.locator('[data-testid^="chat-reply-notification-"]')).toHaveCount(1);
+
+      const mobileBox = await region().boundingBox();
+      expect(mobileBox).not.toBeNull();
+      expect(mobileBox?.x ?? 99).toBeLessThan(16);
+      expect(mobileBox?.width ?? 0).toBeGreaterThan(358);
+      await saveScreenshot(page, 'chat-reply-notification-mobile.png');
+
+      await page.reload();
+      await expect(notice()).toBeVisible({ timeout: 30_000 });
+      await notice().click();
+      await expect(page).toHaveURL(new RegExp(`/app/${BRAND}/chat/${targetId}$`));
+      await expect(notice()).toHaveCount(0);
+      await page.reload();
+      await expect(notice()).toHaveCount(0);
+
+      await writer.close();
+      writer = null;
+      reconnectContext = await browser.newContext();
+      reconnectWriter = await reconnectContext.newPage();
+      await signIn(reconnectWriter);
+      await reconnectWriter.goto(targetHref);
+      await expect(reconnectWriter.locator('textarea.ch-input')).toBeVisible({ timeout: 30_000 });
+
+      await page.goto(observerHref);
+      await page.context().setOffline(true);
+      await sendRealReply(reconnectWriter, targetId, `REAL-E2E-RECONNECT-${Date.now()}`);
+      await expect(notice()).toHaveCount(0);
+      const connectionsBeforeReconnect = observerTrace.realtimeConnections;
+      const joinsBeforeReconnect = observerTrace.realtimeJoins;
+      await page.context().setOffline(false);
+      await waitForRealtime(page, observerTrace, connectionsBeforeReconnect + 1, joinsBeforeReconnect);
+      await expect(notice()).toBeVisible({ timeout: 60_000 });
+      await notice().click();
+      await expect(page).toHaveURL(new RegExp(`/app/${BRAND}/chat/${targetId}$`));
+
+      expect(observerTrace.consoleErrors).toEqual([]);
+      expect(observerTrace.pageErrors).toEqual([]);
+      expect(observerTrace.failedRequests).toEqual([]);
+      await test.info().attach('browser-trace.json', {
+        body: JSON.stringify(observerTrace, null, 2),
+        contentType: 'application/json'
+      });
+    } catch (error) {
+      testError = error;
+      throw error;
+    } finally {
+      await page.context().setOffline(false);
+      await writer?.close();
+      await reconnectContext?.close();
+      if (createdThreadIds.length) {
+        try {
+          await page.goto(`/app/${BRAND}`, { waitUntil: 'domcontentloaded' });
+          await deleteThreads(page, createdThreadIds);
+        } catch (error) {
+          if (!testError) throw error;
+          console.error(`E2E cleanup failed: ${String(error)}`);
+        }
+      }
+    }
+  });
+});


### PR DESCRIPTION
## What?

A reply that lands in another chat now reaches you where you are: a notice appears live, clicking
it opens that thread and marks it read, and it survives a reload. Underneath, the self-hosted
Realtime service is repaired — on a fresh install it was delivering nothing at all.

## Why?

Two failures, one visible and one silent.

The visible one: with several threads open, an agent finishing work in thread B left no trace in
thread A. You had to go looking.

The silent one is worse. `0137_realtime_brand_channel.sql` opens the RLS on `realtime.messages`
inside `do $$ if to_regclass(...) is not null`. On a fresh self-host the table does not exist
yet, so the block does nothing — and the migration is still recorded as applied. The policies
were never created, on any install, ever, and Realtime silently delivered nothing forever. Kong
compounded it by pointing at `realtime-dev.supabase-realtime`, a hostname that has never been a
container in this compose.

## How?

Root cause, not a patch on the one caller that reported it:

- `0226_realtime_brand_channel_policies.sql` recreates the policies **unconditionally**. If the
  prerequisite is missing it fails loudly instead of skipping in silence.
- `scripts/db-migrate.mjs` defers exactly that known prerequisite through a single
  `DEFERRED_PREREQUISITES` entry — one place that governs the one real exception, so the next one
  is a row and not a fifth scattered `if`.
- A compose `realtime-policies` init service replays it after Realtime's healthcheck.
- Kong points at the container that actually exists.

The policies use `(select realtime.topic())` and `(select public.auth_brand_ids())` — the
initplan-safe form, so they do not add to the 57 `auth_rls_initplan` advisories already on
production.

## Testing?

Each fix was reverted one at a time and the matching test watched fail with the predicted
symptom — including the raw `relation "realtime.messages" does not exist` that a naive
unconditional fix would hard-fail on — then pass again once restored.

`scripts/realtime-policy-harness.mjs` runs a from-scratch isolated stack and proves the
mechanism rather than one lucky run: a clean replay defers without recording, the post-health
hook applies and records, a repeated hook is a no-op.

`node scripts/schema-drift-check.mjs` against production: 2 pre-existing unrelated drifts
(`chat_messages.speaker`, `talents.body`), nothing introduced here.

## Evidence (screenshots/videos)

Exercised in a real browser against a disposable stack (db :55459, kong :58059, seeded brand
`demo`, real login) — no headless shortcuts:

<details>
<summary>What was actually done in the browser</summary>

- Two tabs, same user, two different threads. A real message sent on thread B produced a live
  notice on thread A over the real WebSocket — proving both the Kong host fix and the RLS
  policies end to end.
- The two policies were confirmed to exist by querying the database after startup, not by
  trusting that the script ran.
- The notice survived a hard reload (server-side unread state, not a browser flag), the click
  opened the right thread and marked it read, and a reload after that showed nothing — dedup is
  real, not a one-shot UI toggle.
- Repeated twice more from a non-chat route: the notice fired every time, always exactly one
  banner even as the sidebar badge incremented.
- Double-Enter on the composer produced exactly one message.
- No console errors and no failed requests across the session.
</details>

## Anything Else?

The mobile viewport screenshot could not be forced: the window resize reported success but the
tab kept rendering at desktop width. Stopped after two attempts rather than cycling. The mobile
CSS was reviewed and `tests/e2e/chat-reply-notifications.real.spec.ts` asserts the mobile layout,
but it drives real paid agent turns and was not run here — worth running in CI for a photographic
check.

Conflicts with `fix/task-39` on `infra/compose/volumes/api/kong.yml`: both branches edit the
self-host compose. Small and mechanical — this branch fixes the dead Realtime hostname, that one
touches the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0195CeHJYyE5XyF9ueWU6UuV
