### PR TITLE
Name the two columns the code was getting wrong

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -255,6 +255,16 @@ piu` povero. Mossa: consenso ESPLICITO come per gli altri test di integrazione d
 (`E2E_REAL_STACK=1`, come `SANDBOX_HOLDER_INTEGRATION=1`), e poi provare che con lo stack vero il
 test passa davvero — una guardia che nasconde un test rotto non vale niente.
 
+### Un finto client che IGNORA la select regala colonne che il database non ha
+`team_activity` chiedeva `speaker` a `chat_messages`, dove la colonna si chiama `name`: PostgREST
+risponde 42703, supabase-js torna `data: null` SENZA alzare, e lo strumento restituiva vuoto in
+silenzio. I test passavano perché il loro `fakeClient` restituiva l'array seminato tale e quale,
+select o no — quindi il campo inventato c'era sempre. Segnale: `schema-drift-check` che segna una
+colonna «che il codice nomina e non esiste» mentre la suite e` verde. Mossa: il finto PROIETTA le
+colonne chieste e applica gli alias `alias:colonna`, come fa PostgREST; con quello i test sono
+diventati rossi da soli, e solo dopo si corregge la query. Un finto piu` generoso del database non
+e` un finto, e` una benda.
+
 ## Prodotto
 
 ### La differenza per-agente si chiama mappa, non sottosistema

--- a/scripts/talent/save-valeria.mjs
+++ b/scripts/talent/save-valeria.mjs
@@ -171,7 +171,7 @@ async function main() {
         name: MODEL.name,
         gender: MODEL.gender,
         age: MODEL.age,
-        body: MODEL.body,
+        body_type: MODEL.body,
         ethnicity: MODEL.ethnicity,
         summary: MODEL.summary,
         traits: MODEL.traits,

--- a/src/lib/server/chat/team-activity-tools.test.ts
+++ b/src/lib/server/chat/team-activity-tools.test.ts
@@ -18,8 +18,12 @@ function fakeClient(): any {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	const from = (_table: string) => {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		let cols: string[] = [];
 		const self: any = {
-			select: () => self,
+			select: (c?: string) => {
+				cols = (c ?? '').split(',').map((x) => x.trim()).filter(Boolean);
+				return self;
+			},
 			eq: () => self,
 			in: () => self,
 			not: () => self,
@@ -27,9 +31,24 @@ function fakeClient(): any {
 			order: () => self,
 			limit: () => self,
 			async then(resolve: (v: unknown) => unknown) {
-				if (_table === 'chat_threads') return resolve({ data: threads, error: null });
-				if (_table === 'chat_messages') return resolve({ data: messages, error: null });
-				return resolve({ data: customs, error: null });
+				// PostgREST restituisce SOLO le colonne chieste, e `alias:colonna` le rinomina. Senza
+				// questa proiezione il finto regalava campi che il database non ha — ed è così che
+				// `speaker` (colonna inesistente: si chiama `name`) passava i test e tornava vuoto
+				// in produzione, dove un 42703 diventa `data: null` senza alzare.
+				const proietta = (righe: Record<string, unknown>[]) =>
+					cols.length
+						? righe.map((r) =>
+								Object.fromEntries(
+									cols.map((c) => {
+										const [alias, vera] = c.includes(':') ? c.split(':') : [c, c];
+										return [alias, r[vera]];
+									})
+								)
+							)
+						: righe;
+				if (_table === 'chat_threads') return resolve({ data: proietta(threads), error: null });
+				if (_table === 'chat_messages') return resolve({ data: proietta(messages), error: null });
+				return resolve({ data: proietta(customs), error: null });
 			},
 			async maybeSingle() {
 				return { data: null, error: null };
@@ -88,7 +107,7 @@ describe('team_activity', () => {
 			}
 		];
 		messages = [
-			{ thread_id: 'dm1', role: 'assistant', speaker: 'analyst', content: 'Numbers look off — check before publishing.', created_at: '2026-08-26T09:00:00Z' }
+			{ thread_id: 'dm1', role: 'assistant', name: 'analyst', content: 'Numbers look off — check before publishing.', created_at: '2026-08-26T09:00:00Z' }
 		];
 		const out = await run('motion');
 		expect(out.waiting_on_me).toHaveLength(1);
@@ -106,7 +125,7 @@ describe('team_activity', () => {
 			}
 		];
 		messages = [
-			{ thread_id: 'dm2', role: 'user', speaker: 'motion', content: 'Sending you the draft brief.', created_at: '2026-08-26T09:00:00Z' }
+			{ thread_id: 'dm2', role: 'user', name: 'motion', content: 'Sending you the draft brief.', created_at: '2026-08-26T09:00:00Z' }
 		];
 		const out = await run('motion');
 		expect(out.waiting_on_me).toHaveLength(0);

--- a/src/lib/server/chat/team-activity-tools.ts
+++ b/src/lib/server/chat/team-activity-tools.ts
@@ -74,7 +74,7 @@ export function createTeamActivityTools(ctx: {
 		if (threadIds.length) {
 			const msgs = await supabase
 				.from('chat_messages')
-				.select('thread_id, role, speaker, content, created_at')
+				.select('thread_id, role, speaker:name, content, created_at')
 				.in('thread_id', threadIds)
 				.order('created_at', { ascending: false })
 				.limit(threadIds.length * 5);


### PR DESCRIPTION
## What?

Ships the one commit that landed on `dev` after #97 was cut: two columns the code had been naming
wrong, and the reason no test could see either.

## Why?

**`team_activity` has been returning nothing at all, silently, for as long as it has existed.** It
asked `chat_messages` for a `speaker` column; the column is `name`. PostgREST answers 42703,
supabase-js turns that into `data: null` **without throwing**, so the tool's read came back empty and
the agent was told there was no team activity — no error anywhere, in the logs or on screen.

The second is narrower: the talent save script wrote `body` where the column is `body_type`.

`node scripts/schema-drift-check.mjs` had been reporting both. It now ends **green** — *"ogni nome
che il codice pronuncia esiste nel database"* — for the first time.

## How?

**The tool** takes an alias, `speaker:name`, so the query names the real column while everything
downstream keeps reading `speaker`. One line, no ripple.

**The test could not have caught it, and that is the part worth reading.** Its `fakeClient` returned
the seeded rows whatever the select asked for, so an invented column was always present. A fake more
generous than the database is not a fake, it is a blindfold.

The fake now projects the requested columns and applies `alias:column` the way PostgREST does. With
that in place the existing tests went **red on their own**, reproducing the production behaviour
exactly — `speaker` undefined, the tool returning empty — and only then was the query corrected.
Red first, and the red came from the harness telling the truth rather than from a new assertion.

## Testing?

- Full suite: **5897 passed, 4 skipped.**
- `schema-drift-check`: **green**, no pending migrations and no unknown column names.
- The two tool tests now fail without the fix and pass with it, which is the property that was
  missing before.

Not verified in a browser: `team_activity` is an agent-facing tool, and exercising it end to end
means driving an agent into a cross-thread question. The drift check plus the now-faithful fake are
what stand behind this one.

## Anything Else?

**Still owed, after this deploys:** making `agent_kit_close_run`'s `p_owner` / `p_fence` required.
They default to null so the window between applying 0229 and shipping the code that passes a lease
kept working; with #97 now in production that window is closed and the parameters can be tightened.

**A class of defect worth naming**, since this is the third instance today: a test harness more
permissive than the real thing hides exactly the failures that only production shows. All three are
in `LESSONS.md` with the signal that identifies each.
