### PR TITLE
Build production with the lockfile, like CI does

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -265,6 +265,19 @@ colonne chieste e applica gli alias `alias:colonna`, come fa PostgREST; con quel
 diventati rossi da soli, e solo dopo si corregge la query. Un finto piu` generoso del database non
 e` un finto, e` una benda.
 
+### La CI verde non dice che la produzione si COSTRUISCE: `npm ci` contro `npm install`
+Due deploy di produzione di fila in ERROR su `patch-package cannot apply`, con la CI verde sugli
+stessi commit. La CI usa `npm ci`, che CANCELLA `node_modules` prima di installare; Vercel usava
+`npm install`, che riusa l'albero ripristinato dalla cache — e su un albero gia` patchato
+patch-package si rifiuta, dicendolo esplicitamente («Try removing node_modules and trying again»).
+Segnale: build di produzione rossa su patch-package mentre `npm ci` in locale e in CI passa, e
+nessun file di patch e` cambiato nel commit incriminato. Mossa: `installCommand: "npm ci"` in
+`vercel.json`, cosi` la produzione costruisce con lo stesso comando che i test hanno provato — e un
+test che lo pinna, perche` la prossima volta il sintomo sara` di nuovo «ma la CI e` verde».
+
+E la lezione dietro la lezione: un merge in `main` che passa i check NON e` un rilascio. Il
+deployment va guardato (`state`), o si festeggia una consegna che non e` avvenuta.
+
 ## Prodotto
 
 ### La differenza per-agente si chiama mappa, non sottosistema

--- a/scripts/vercel-install.test.ts
+++ b/scripts/vercel-install.test.ts
@@ -1,0 +1,20 @@
+/**
+ * Il deploy di produzione è fallito due volte di fila su `patch-package cannot apply`, mentre la
+ * CI restava verde: la CI usa `npm ci`, che CANCELLA `node_modules` prima di installare, e Vercel
+ * usava `npm install`, che riusa l'albero ripristinato dalla cache. Su un albero già patchato (o
+ * patchato per un'altra versione) patch-package si rifiuta — lo dice il suo stesso messaggio,
+ * «Try removing node_modules and trying again».
+ *
+ * Che la produzione costruisca con lo stesso comando che la CI ha provato non è un dettaglio di
+ * configurazione: è la differenza fra «i test passano» e «il prodotto si costruisce».
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const vercel = JSON.parse(readFileSync('vercel.json', 'utf8')) as { installCommand?: string };
+
+describe('vercel.json', () => {
+	it('installa col lockfile, come la CI, non con npm install', () => {
+		expect(vercel.installCommand).toBe('npm ci');
+	});
+});

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "installCommand": "npm ci",
   "headers": [
     {
       "source": "/fonts/(.*)",


### PR DESCRIPTION
## What?

**The release did not ship.** Both production deployments today — #97 and #98 — ended in `ERROR`,
so `main` has the code and production is still serving what it served this morning. This makes
production build with `npm ci`, the command CI already uses.

## Why?

The failure is `patch-package cannot apply` on two patches, during `npm install`:

```
Failed to apply patch for package @ai-sdk/harness-pi
  patches/@ai-sdk+harness-pi+1.0.89.patch
Failed to apply patch for package @earendil-works/pi-ai
  patches/@earendil-works+pi-ai+0.74.2.patch
Try removing node_modules and trying again.
```

CI was green on the same commits, which is the whole trap: **CI runs `npm ci`, which deletes
`node_modules` before installing. Vercel ran `npm install`, which reuses the tree Vercel restores
from cache** — and patch-package refuses to apply onto an already-patched or mismatched tree. Its
own message says so.

Checked before blaming the release: **neither patch file changed** in the merge that preceded the
failures — they are byte-identical on `main`, on `dev`, and on `dev` before it. A first theory that
`^1.0.88` was floating to the published 1.0.96 was **wrong**, and discarded: `npm install --dry-run`
locally keeps 1.0.89 and 0.74.2, because the lockfile is honoured. The cache is what differs.

This is not new breakage. It has been waiting for whichever deploy first ran against a cache holding
a patched tree — today's release was simply the first production deploy in four days.

## How?

`"installCommand": "npm ci"` in `vercel.json`. Production now installs exactly what the tests ran
against, and the class of failure disappears rather than being timed away: `npm ci` starts from a
deleted `node_modules` every time.

A test pins it, because the next occurrence will present the same way — a red production build under
a green CI — and the configuration line is the last place anyone will look.

## Testing?

- `scripts/vercel-install.test.ts` — written red first, asserting the install command, with the
  reasoning in the file rather than in a commit message nobody re-reads.
- The real proof is the deployment this PR produces. **It is not verified until a production
  deployment reaches `READY`** — a green check here would only repeat the mistake this PR is about.

## Anything Else?

**Two things I got wrong today, both worth stating.** I reported the release as shipped on the
strength of the merge; a merge is not a deploy, and the deployment state is the only thing that says
otherwise. And I proposed a version-drift explanation before testing it — the dry run refuted it in
one command.

**Still owed, and still blocked:** making `agent_kit_close_run`'s `p_owner` / `p_fence` required.
That waits on the lease-passing code actually running in production, which is precisely what has not
happened yet.
