### PR TITLE
Carry the production install fix to main

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -265,6 +265,19 @@ colonne chieste e applica gli alias `alias:colonna`, come fa PostgREST; con quel
 diventati rossi da soli, e solo dopo si corregge la query. Un finto piu` generoso del database non
 e` un finto, e` una benda.
 
+### La CI verde non dice che la produzione si COSTRUISCE: `npm ci` contro `npm install`
+Due deploy di produzione di fila in ERROR su `patch-package cannot apply`, con la CI verde sugli
+stessi commit. La CI usa `npm ci`, che CANCELLA `node_modules` prima di installare; Vercel usava
+`npm install`, che riusa l'albero ripristinato dalla cache — e su un albero gia` patchato
+patch-package si rifiuta, dicendolo esplicitamente («Try removing node_modules and trying again»).
+Segnale: build di produzione rossa su patch-package mentre `npm ci` in locale e in CI passa, e
+nessun file di patch e` cambiato nel commit incriminato. Mossa: `installCommand: "npm ci"` in
+`vercel.json`, cosi` la produzione costruisce con lo stesso comando che i test hanno provato — e un
+test che lo pinna, perche` la prossima volta il sintomo sara` di nuovo «ma la CI e` verde».
+
+E la lezione dietro la lezione: un merge in `main` che passa i check NON e` un rilascio. Il
+deployment va guardato (`state`), o si festeggia una consegna che non e` avvenuta.
+
 ## Prodotto
 
 ### La differenza per-agente si chiama mappa, non sottosistema

--- a/scripts/vercel-install.test.ts
+++ b/scripts/vercel-install.test.ts
@@ -1,0 +1,20 @@
+/**
+ * Il deploy di produzione è fallito due volte di fila su `patch-package cannot apply`, mentre la
+ * CI restava verde: la CI usa `npm ci`, che CANCELLA `node_modules` prima di installare, e Vercel
+ * usava `npm install`, che riusa l'albero ripristinato dalla cache. Su un albero già patchato (o
+ * patchato per un'altra versione) patch-package si rifiuta — lo dice il suo stesso messaggio,
+ * «Try removing node_modules and trying again».
+ *
+ * Che la produzione costruisca con lo stesso comando che la CI ha provato non è un dettaglio di
+ * configurazione: è la differenza fra «i test passano» e «il prodotto si costruisce».
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const vercel = JSON.parse(readFileSync('vercel.json', 'utf8')) as { installCommand?: string };
+
+describe('vercel.json', () => {
+	it('installa col lockfile, come la CI, non con npm install', () => {
+		expect(vercel.installCommand).toBe('npm ci');
+	});
+});

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "installCommand": "npm ci",
   "headers": [
     {
       "source": "/fonts/(.*)",


### PR DESCRIPTION
## What?

Carries #99 to production: `vercel.json` gains `"installCommand": "npm ci"`.

## Why?

**Production has not built successfully today.** Both deployments — #97's release and #98's
follow-up — ended in `ERROR` on `patch-package cannot apply`, so `main` holds four days of work that
users are not running. #99 fixed the cause, but it landed on `dev`, and production builds from
`main`: until this merges, the next deployment fails exactly like the last two.

The cause, in one line: CI runs `npm ci`, which deletes `node_modules` before installing; Vercel ran
`npm install`, which reuses the tree restored from cache, and patch-package refuses to apply onto an
already-patched one.

## How?

One key in `vercel.json`, plus the test that pins it. Nothing else changes.

## Testing?

The unit suite covers the assertion; it cannot cover the thing that matters. **This is verified only
when a production deployment reaches `READY`** — a green check here would repeat precisely the
mistake that let two failed releases be reported as shipped.

## Anything Else?

**Do not treat this merge as the release.** Watch the deployment state; the previous two merged
cleanly, passed their checks, and never reached users.

**Blocked behind this, and only this:** making `agent_kit_close_run`'s `p_owner` / `p_fence`
required. That migration is safe only once the code that passes a lease is actually running in
production, which is what this unblocks. Applying it before that would fail every turn close — the
moment the answer is saved.
