### PR TITLE
Require the lease when a run is closed

### DIFF
--- a/changelog/2026-08-30-require-run-lease.md
+++ b/changelog/2026-08-30-require-run-lease.md
@@ -1,0 +1,28 @@
+# Il recinto del lease smette di essere facoltativo
+
+La 0229 aveva dato un default a `p_owner`/`p_fence` di `agent_kit_close_run` per una ragione sola,
+e temporanea: i deploy di questo repo non applicano le migration, quindi fra l'applicazione della
+0229 e il rilascio del codice che passa il lease c'era una finestra in cui la produzione chiamava
+ancora la firma a cinque argomenti. Senza default, in quella finestra ogni chiusura di turno
+sarebbe fallita — cioè il momento esatto in cui la risposta viene salvata.
+
+Quella finestra è chiusa: il deployment di produzione è `READY` e il codice che passa proprietario
+e fence gira. Da qui una chiamata senza lease è un **errore**, non una chiusura senza recinto.
+
+## L'ordine dei parametri, che non è un dettaglio
+
+In PostgreSQL i parametri con default devono stare in fondo, quindi `p_owner`/`p_fence` passano
+davanti a `p_reason`/`p_question`/`p_message`. Non tocca nessuno: supabase-js manda un oggetto e la
+chiamata è per nome. Ma la firma vecchia **va eliminata nella stessa migration** — due overload che
+accettano gli stessi nomi rendono ogni chiamata ambigua (`function is not unique`) e romperebbero
+tutte le chiusure. È la stessa trappola della 0229, presa dal verso opposto.
+
+## Verificata dal vivo, in due metà
+
+Applicata alla produzione con **zero run in esecuzione** — l'unico aperto era un `waiting_input`
+senza proprietario, che non è a rischio perché `claimRun` gliene assegna uno quando riprende.
+
+- una chiusura **col** lease risolve;
+- una chiusura **senza** lease non esiste più: `undefined_function`.
+
+Una stretta che non si prova in entrambi i sensi non è una stretta: è una speranza.

--- a/supabase/migrations/0230_require_run_lease_on_close.sql
+++ b/supabase/migrations/0230_require_run_lease_on_close.sql
@@ -1,0 +1,93 @@
+-- Il recinto del lease smette di essere facoltativo.
+--
+-- La 0229 aveva dato un default a `p_owner`/`p_fence` per una ragione sola: fra l'applicazione
+-- della migration e il deploy del codice che passa il lease, la produzione chiamava ancora la
+-- firma a cinque argomenti, e senza default ogni chiusura di turno sarebbe fallita — cioè il
+-- momento in cui la risposta viene salvata. Quella finestra è chiusa: il codice in produzione
+-- passa proprietario e fence (run-store.ts). Da qui una chiamata senza lease è un errore, non
+-- una chiusura senza recinto.
+
+create or replace function public.agent_kit_close_run(
+  p_run_id uuid,
+  p_to_state text,
+  -- I parametri col default DEVONO stare in fondo, quindi il lease passa davanti. Chi chiama usa
+  -- i nomi (supabase-js manda un oggetto), perciò l'ordine non tocca nessuno.
+  p_owner text,
+  p_fence bigint,
+  p_reason text default null,
+  p_question jsonb default null,
+  p_message jsonb default null
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_run public.agent_kit_runs%rowtype;
+  v_message public.chat_messages%rowtype;
+begin
+  if p_to_state not in ('waiting_input', 'done', 'failed', 'aborted') then
+    raise exception 'agent_kit_close_run: state is not allowed';
+  end if;
+
+  update public.agent_kit_runs
+  set state = p_to_state,
+      reason = coalesce(p_reason, reason),
+      question = coalesce(p_question, question),
+      harness_continue_state = null,
+      updated_at = now()
+  where id = p_run_id
+    and state = 'running'
+    and lease_owner = p_owner
+    and lease_fence = p_fence
+  returning * into v_run;
+
+  if v_run.id is null then
+    return jsonb_build_object('closed', false);
+  end if;
+
+  if p_message is not null then
+    insert into public.chat_messages (brand_id, user_id, thread_id, role, content, reasoning, tool_calls, attachments, name)
+    values (
+      v_run.brand_id,
+      v_run.user_id,
+      v_run.thread_id,
+      'assistant',
+      coalesce(p_message->>'content', ''),
+      p_message->>'reasoning',
+      p_message->'tool_calls',
+      p_message->'attachments',
+      p_message->>'name'
+    )
+    returning * into v_message;
+
+    update public.agent_kit_runs
+    set partial_saved_msg_id = v_message.id
+    where id = p_run_id;
+
+  end if;
+
+  if v_run.thread_id is not null then
+    perform public.append_thread_event(
+      v_run.thread_id,
+      'run:' || p_run_id || ':state:' || p_to_state,
+      'progress',
+      jsonb_build_object(
+        'runId', p_run_id,
+        'status', p_to_state,
+        'reason', p_reason,
+        'question', p_question
+      )
+    );
+  end if;
+
+  return jsonb_build_object('closed', true, 'message_id', v_message.id);
+end;
+$$;
+
+-- La firma vecchia se ne va: quella nuova ha un ordine di tipi diverso, e tenerle entrambe
+-- renderebbe ambigua ogni chiamata per nome.
+drop function if exists public.agent_kit_close_run(uuid, text, text, jsonb, jsonb, text, bigint);
+
+revoke all on function public.agent_kit_close_run(uuid, text, text, bigint, text, jsonb, jsonb) from public, anon, authenticated;
+grant execute on function public.agent_kit_close_run(uuid, text, text, bigint, text, jsonb, jsonb) to service_role;


### PR DESCRIPTION
> **Already applied to production.** The migration file is recorded here for the repository; the
> database was changed first, once the precondition held. Details below.

## What?

`agent_kit_close_run`'s `p_owner` / `p_fence` stop being optional. A close without a lease is now an
error rather than a close without a fence.

## Why?

The defaults existed for one temporary reason. Deploys here do not run migrations, so between
applying 0229 and shipping the code that passes a lease there was a window where production still
called the five-argument form — and without the defaults every turn close in that window would have
failed, at the exact moment the answer is saved.

**That window is now closed, and only now.** The production deployment reached `READY` — the first
one today; the two before it ended in `ERROR` and never reached users. Until that happened this
migration would have broken every close in production, which is why it waited.

## How?

**The parameter order changed, and it is not cosmetic.** PostgreSQL requires defaulted parameters
last, so `p_owner` / `p_fence` move ahead of `p_reason` / `p_question` / `p_message`. No caller
notices — supabase-js sends an object, so calls are by name. But the old signature **must be dropped
in the same migration**: two overloads accepting the same names make every call ambiguous
(`function is not unique`) and would break every close. The same trap as 0229, from the other side.

## Testing?

**Applied with no runs in flight**, checked first: the only open run was a `waiting_input` with no
owner, and that one is not at risk — `claimRun` assigns it an owner when it resumes.

Verified live, in both halves, because a tightening that is not tested both ways is a hope:

```
close WITH the lease     → resolves ({"closed": false} on a non-existent run, no exception)
close WITHOUT the lease  → undefined_function — the signature is gone
one signature remains    → no ambiguity
```

`schema-drift-check`: **green**. Unit suite for the lease path: 101 passed.

## Anything Else?

This closes the last item owed from [ADR 0004](docs/adr/0004-resume-a-dead-run-under-a-fenced-lease.md).

**The sequence this took is the point**, and is worth keeping: the migration was blocked not by
work but by a precondition — the code had to be *running*, not merged. Two releases were reported as
shipped today on the strength of a clean merge and a green check, and neither reached users. The
deployment state is the only thing that says otherwise.
