### PR TITLE
Stop the suite from paging ops

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -278,6 +278,16 @@ test che lo pinna, perche` la prossima volta il sintomo sara` di nuovo «ma la C
 E la lezione dietro la lezione: un merge in `main` che passa i check NON e` un rilascio. Il
 deployment va guardato (`state`), o si festeggia una consegna che non e` avvenuta.
 
+### La suite spediva DAVVERO: un test non sveglia nessuno
+Ops riceveva segnalazioni `agent_kit_stream` con dentro `thread: t-retry-no-sandbox`, `brand b1`,
+`user u1` e uno stack che punta a `live.test.ts`: la suite gira col `.env` di chi la lancia — chiavi
+vere di Sentry, PostHog e Resend — e `reportChatError` partiva sul serio. Segnale: una segnalazione
+il cui `detail` nomina entita` che esistono solo nei fixture. Mossa: la guardia sta nella SORGENTE
+(`reportChatError` e `sendEmail` escono subito sotto `process.env.VITEST`), mai nei mock dei singoli
+file — `live.test.ts` non mockava `report-error`, e bastera` un altro file distratto perche' ricominci.
+Il `console.error` resta: serve a chi guarda la suite. Il danno peggiore non e` il rumore, e` che una
+segnalazione finta rende sospette anche quelle vere.
+
 ## Prodotto
 
 ### La differenza per-agente si chiama mappa, non sottosistema

--- a/src/lib/server/chat/report-error.test.ts
+++ b/src/lib/server/chat/report-error.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Un test non sveglia nessuno. La suite gira con il `.env` di chi la lancia — chiavi vere di
+ * Sentry, PostHog e posta — e `reportChatError` spediva davvero: ops ha ricevuto segnalazioni con
+ * dentro `thread: t-retry-no-sandbox` e uno stack che punta a un file di test. Il rumore non è il
+ * danno peggiore: è che una segnalazione finta rende sospette anche quelle vere.
+ *
+ * La guardia sta nella sorgente e non nei mock dei singoli file, o il prossimo test che scorda il
+ * mock ricomincia a spedire — ed è esattamente com'è successo.
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const captureException = vi.fn();
+vi.mock('@sentry/sveltekit', () => ({ captureException: (...a: unknown[]) => captureException(...a) }));
+const sendEmail = vi.fn(async () => undefined);
+vi.mock('$lib/server/email', () => ({ sendEmail: (...a: unknown[]) => sendEmail(...a) }));
+
+const { reportChatError } = await import('./report-error');
+
+describe('reportChatError sotto test', () => {
+	beforeEach(() => {
+		captureException.mockClear();
+		sendEmail.mockClear();
+		vi.restoreAllMocks();
+	});
+
+	it('non sveglia Sentry', async () => {
+		await reportChatError(null, new Error('boom'), { kind: 'agent_kit_stream', notify: 'all' });
+		expect(captureException).not.toHaveBeenCalled();
+	});
+
+	it('non manda la mail a ops', async () => {
+		await reportChatError(null, new Error('boom'), { kind: 'agent_kit_stream', notify: 'all' });
+		expect(sendEmail).not.toHaveBeenCalled();
+	});
+
+	it('non chiama nessun servizio esterno', async () => {
+		const fetchSpy = vi.spyOn(globalThis, 'fetch');
+		await reportChatError(null, new Error('boom'), { kind: 'agent_kit_stream', notify: 'all' });
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+});

--- a/src/lib/server/chat/report-error.ts
+++ b/src/lib/server/chat/report-error.ts
@@ -62,6 +62,12 @@ export async function reportChatError(
 
   console.error(`[chat:${kind}]`, message, context);
 
+  // Un test non sveglia nessuno. La suite gira col `.env` di chi la lancia — chiavi vere — e da
+  // qui partivano segnalazioni con dentro thread e run finti. Il log resta (serve a chi guarda la
+  // suite), tutto ciò che ESCE si ferma. La guardia sta qui e non nei mock dei singoli file: uno
+  // che si dimentica il mock e ops riceve di nuovo un incidente che non esiste.
+  if (process.env.VITEST) return;
+
   Sentry.captureException(error instanceof Error ? error : new Error(message), {
     tags: {
       chat_error: kind,

--- a/src/lib/server/email.test.ts
+++ b/src/lib/server/email.test.ts
@@ -1,0 +1,19 @@
+/**
+ * La posta è l'unica cosa che arriva a una persona: un test che la manda non fa rumore in un log,
+ * squilla nella casella di qualcuno. E rende sospette anche le segnalazioni vere.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { sendEmail } from './email';
+
+describe('sendEmail sotto test', () => {
+	it('non parte, e non esplode per una chiave mancante', async () => {
+		const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+		await expect(
+			sendEmail({ to: 'ops@anomalia.so', subject: 'prova', html: '<p>prova</p>' })
+		).resolves.toBeUndefined();
+
+		expect(fetchSpy).not.toHaveBeenCalled();
+		fetchSpy.mockRestore();
+	});
+});

--- a/src/lib/server/email.ts
+++ b/src/lib/server/email.ts
@@ -17,6 +17,11 @@ const ACCENT = '#7c5cff';
 // Always send a plain-text part alongside the HTML: a missing text/plain alternative is a strong
 // spam signal, so this materially improves inbox placement (and degrades gracefully everywhere).
 export async function sendEmail(opts: { to: string; subject: string; html: string; text?: string; headers?: Record<string, string> }): Promise<void> {
+  // La posta è l'unica cosa che arriva a una PERSONA. La suite gira col `.env` di chi la lancia,
+  // quindi da qui partivano davvero: ops ha ricevuto incidenti con dentro thread e run finti. Si
+  // ferma qui e non nei mock dei singoli file, perché basta un file che se ne dimentica.
+  if (process.env.VITEST) return;
+
   const key = env.RESEND_API_KEY;
   if (!key) throw new Error('RESEND_API_KEY not configured');
 


### PR DESCRIPTION
## What?

Running the test suite was sending **real** incident reports — to Sentry, to PostHog, and to the ops
inbox. This stops it at the source.

## Why?

The reports name entities that exist only in fixtures:

```
Kind: agent_kit_stream
Detail: run run-1 · agente content
Brand: — (b1)   User: u1   Thread: t-retry-no-sandbox
Stack: Error: boom
    at src/lib/agent/bridge/live.test.ts:263:31
```

The suite runs with whatever `.env` the machine has, and those are real keys. `live.test.ts` never
mocked `report-error`, so every run of it paged a human.

**The noise is not the worst of it: a fake incident makes the real ones suspect.** If ops sees an
`agent_kit_stream` tomorrow, it should mean something happened.

## How?

Two guards, both at a **chokepoint**, deliberately not in the test files:

- **`reportChatError`** returns before Sentry, PostHog and mail under `process.env.VITEST`. The
  `console.error` stays — that line is what makes a failing suite readable.
- **`sendEmail`** returns immediately, which covers the four other callers that reach an inbox
  (radar, onboarding, brand notifications, settings) instead of chasing each one.

Guarding the test file instead would have fixed today and broken again with the next file that
forgets the mock — which is precisely how this happened.

## Testing?

Written red first, and they fail without the guards:

- `report-error.test.ts` — Sentry not called, ops mail not sent, no outbound `fetch`.
- `email.test.ts` — no `fetch`, and it resolves rather than throwing on the missing key, so a test
  that reaches this path does not fail for the wrong reason.

Full suite: **5902 passed, 4 skipped.**

## Anything Else?

**Still unguarded, and declared rather than assumed:** direct `Sentry.captureException` calls in
`market-errors.ts`, `onboarding-errors.ts` and `swallow.ts`. A test can reach those. They do not
reach an inbox, but they do dirty Sentry. Left alone because I have no evidence they fired — the
reported symptom came through `reportChatError` — and guarding paths on suspicion is how a small fix
turns into a sweep. Worth doing the moment one of them shows up in a report.
