### PR TITLE
Keep the market study a killed attempt paid for

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -347,3 +347,16 @@ dieci secondi dice in un colpo se il problema è che non parte niente o che part
 effetti Svelte non vengono eseguiti (`$effect.root` + `flushSync` conta zero esecuzioni del corpo):
 un test lì passa identico con e senza il fix. Lasciarlo è peggio che non averlo — è una guardia
 finta che il prossimo leggerà come copertura. Va tolto e il buco va scritto qui.
+
+### In locale non gira nessun cron: il wizard che «pensa» per sempre non è un difetto del prodotto
+L'onboarding resta a *«Drafting your editorial plan…»* all'infinito sullo stack locale, e sembra un
+hang del piano editoriale. Non lo è: i job di `onboarding_step_jobs` vengono ripresi dal cron
+`*/2 * * * *` su `/api/v1/onboarding/steps/work`, che in locale **non esiste**. Il job stalla dopo
+`STALL_MS` (6 minuti), nessuno lo rimette in coda, e la pagina continua a pollare una riga
+`running` che non avanzerà più. Il `[swallowed] fetch failed` nel log è il kick fire-and-forget del
+worker che non ha risposto entro il timeout di undici — sintomo, non causa.
+Mossa: fai il cron a mano prima di diagnosticare, e tienilo acceso per tutta la camminata:
+`for i in $(seq 1 45); do curl -s --max-time 4 -X POST -H "x-autopilot-secret: $AUTOPILOT_SECRET" \
+http://localhost:5220/api/v1/onboarding/steps/work; sleep 60; done`.
+Vale per ogni `*/N` in `vercel.json` (radar, knowledge, chat queue, designer, webhooks): in locale
+nessuno di quei lavori parte da solo, e ciò che sembra un blocco è una coda che nessuno drena.

--- a/changelog/2026-08-31-onboarding-study-resume.md
+++ b/changelog/2026-08-31-onboarding-study-resume.md
@@ -1,0 +1,53 @@
+# Il piano editoriale non ricomincia da capo ogni volta
+
+`onboarding_step_jobs` in produzione: cinque job `research`, quattro `done`, uno **failed con
+`Job timed out after 3 attempts`**. Dopo di quello, due soli utenti sono arrivati a `plan_posts` e
+uno a `preview_images`. Il criterio della task — *ti iscrivi da zero e arrivi in fondo vedendo i
+tre post* — moriva qui.
+
+## Il muro
+
+Il worker `/api/v1/onboarding/steps/work` ha `maxDuration = 300`. Il job `research` fa, in
+sequenza: handle dei concorrenti, scraping dei loro post, benchmark, analisi qualitativa, report
+di strategia, e infine il piano editoriale. Misurato sullo stack locale (dove nessuno lo uccide a
+300s), su un brand con cinque concorrenti:
+
+| fase | tempo osservato |
+| --- | --- |
+| due chiamate strutturate iniziali | 12s + 12s |
+| `strategy_report` | 39s al primo giro, **127s** al secondo |
+| `upcomingTimelyHooks` | 56s, 74s |
+| lo studio completo, prima che il piano cominci | **8–10 minuti** |
+
+Il piano non veniva quasi mai raggiunto dentro una singola invocazione. Fin qui è fisiologico: il
+reaper (`STALL_MS`, sei minuti) rimette il job in coda e il cron `*/2` lo ripesca.
+
+**Il difetto è cosa succedeva al secondo tentativo: ricominciava da `handles`.** In
+`runResearchJob` non c'era una sola lettura di `job.result`: i risultati parziali venivano
+salvati (`mergeResult`) e mai riletti. Quindi ogni tentativo ripagava scraping, benchmark,
+personas e report — e moriva contro lo stesso muro, tre volte, poi `failed`. Verificato dal vivo:
+tre tentativi consecutivi hanno riscritto `handles>scraping>benchmark>analysis>strategy` da zero.
+
+## Cosa cambia
+
+Le fasi 1-4 stanno in `runMarketStudy()`, che alla fine deposita anche `planInputs` — quello che
+al piano serve dello studio quando lo studio non c'è più: `aiContext`, `visualStyle`, i `topPosts`
+del brand e `zeroToOne`. `resumableStudy(job.result)` decide, e restituisce lo studio **solo se
+ogni pezzo è sopravvissuto**: uno studio a metà non serve, il piano girerebbe senza i propri
+input.
+
+E il budget dei tentativi si azzera quando lo studio è depositato. Senza, i tentativi spesi per
+arrivarci restavano addebitati al piano — che da lì in poi riparte in pochi secondi — e un job
+che aveva finalmente fatto progresso durevole veniva comunque fallito.
+
+## Il limite che resta
+
+La ripresa ha una sola giuntura, dove cade il muro dei 300s: studio → piano. Un tentativo che
+muore *dentro* lo studio (per esempio nello scraping) lo rifà tutto. Frammentarlo di più
+significa persistere lo stato intermedio di ogni fase, e non serve finché il punto in cui si muore
+è quello misurato qui.
+
+## Nota per chi verifica in locale
+
+In locale non gira nessun cron: un job che stalla non riparte più e il wizard resta a *«Drafting
+your editorial plan…»* per sempre. Non è il difetto — è l'ambiente. Sta in [`LESSONS.md`](../LESSONS.md).

--- a/src/lib/content/changelog/2026-08-31-onboarding-study-resume.ts
+++ b/src/lib/content/changelog/2026-08-31-onboarding-study-resume.ts
@@ -1,0 +1,12 @@
+import type { ChangelogEntry } from './index';
+
+const entry: ChangelogEntry = {
+  date: '2026-08-31',
+  title: 'Setting up a brand reaches the editorial plan',
+  items: [
+    'The market study behind your first editorial plan is no longer thrown away when a step takes too long: the setup picks up where it left off instead of starting the research over.',
+    'Long setups that used to stop with a timeout now finish and hand you the plan.'
+  ]
+};
+
+export default entry;

--- a/src/lib/server/onboarding-steps.test.ts
+++ b/src/lib/server/onboarding-steps.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { resumableStudy } from './onboarding-steps';
+
+const study = () => ({
+  report: { headline: 'white space is short-form teardown' },
+  buyerPersonas: [{ name: 'Ops lead' }],
+  researchData: { competitors: [], report: {}, benchmark: {}, positioning: '', personas: [] },
+  planInputs: { aiContext: 'brand context', visualStyle: null, topPosts: [], zeroToOne: true }
+});
+
+describe('resumableStudy', () => {
+  it('hands back the market study a killed attempt already paid for', () => {
+    const saved = study();
+
+    expect(resumableStudy(saved)).toEqual({
+      report: saved.report,
+      buyerPersonas: saved.buyerPersonas,
+      researchData: saved.researchData,
+      planInputs: saved.planInputs
+    });
+  });
+
+  it('re-runs the study when the attempt died before it was whole', () => {
+    const { planInputs, ...halfway } = study();
+
+    expect(resumableStudy(halfway)).toBeNull();
+    expect(resumableStudy({ ...study(), researchData: null })).toBeNull();
+    expect(resumableStudy({ steps: [] })).toBeNull();
+    expect(resumableStudy(null)).toBeNull();
+  });
+});

--- a/src/lib/server/onboarding-steps.ts
+++ b/src/lib/server/onboarding-steps.ts
@@ -69,6 +69,44 @@ const STALL_MS = 6 * 60 * 1000;
 
 const TABLE = 'onboarding_step_jobs';
 
+/**
+ * What one attempt of the market study costs, kept so the next attempt does not pay it again.
+ * `planInputs` is what the editorial plan needs from the study once the study itself is gone.
+ */
+export type MarketStudy = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  report: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  buyerPersonas: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  researchData: any;
+  planInputs: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    aiContext: any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    visualStyle: any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    topPosts: any;
+    zeroToOne: boolean;
+  };
+};
+
+/**
+ * A re-queued attempt starts the pipeline over from `handles`. Scraping, benchmark, personas and
+ * the strategy report cost minutes and real money, and the platform kills the invocation at 300s:
+ * without this, an attempt that dies inside the editorial plan pays for the whole study again, and
+ * dies at the same wall — three times, then `failed`, and the user never sees a post.
+ *
+ * Returns the study only when every piece the plan needs survived. A half-written one is worth
+ * nothing: the plan would run on a study missing its own inputs.
+ */
+export function resumableStudy(prior: unknown): MarketStudy | null {
+  if (!prior || typeof prior !== 'object') return null;
+  const { report, buyerPersonas, researchData, planInputs } = prior as Record<string, unknown>;
+  if (!report || !researchData || !buyerPersonas || !planInputs) return null;
+  return { report, buyerPersonas, researchData, planInputs } as MarketStudy;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function parseHandles(raw: any): ScrapeTarget[] {
   if (!Array.isArray(raw)) return [];
@@ -557,165 +595,192 @@ async function processResearch(
     try {
       const ai = genaiClient();
 
-      // Phase 1 (parallel): scrape the brand's own posts while resolving competitor social handles.
-      await pushProgress('handles', 'Finding competitor profiles…');
-      const [brandScrape, handleMap] = await Promise.all([
-        brandHandles.length
-          ? scrapeForOnboarding(brandHandles).catch((error) => { swallow('scrape onboarding profile', error); return ({ posts: [], errors: [] }); })
-          : Promise.resolve({ posts: [], errors: [] }),
-        competitors.length
-          ? resolveCompetitorHandles(ai, competitors, platforms)
-          : Promise.resolve(new Map<string, ScrapeTarget[]>())
-      ]);
-      const brandPosts = brandScrape.posts;
-      if (competitors.length) {
-        await attachStepResult('handles', {
-          competitors: competitors.map((c) => ({
-            name: c.name,
-            handles: (handleMap.get(c.name) ?? []).map((h) => ({
-              platform: h.platform,
-              username: h.username
-            }))
-          }))
-        });
-      }
-      if (brandPosts.length) {
-        await pushProgress(
-          'brandHistory',
-          `Retrieved ${brandPosts.length} of your posts with their stats — saved to your brand…`
-        );
-      }
-
-      // Phase 2: scrape competitor posts WHILE brand-only LLM work runs.
-      await pushProgress('scraping', 'Reading your competitors’ posts…');
-      const topThumbs = [...brandPosts]
-        .sort(
-          (a, b) =>
-            (b.metrics?.likes ?? 0) +
-            (b.metrics?.comments ?? 0) -
-            ((a.metrics?.likes ?? 0) + (a.metrics?.comments ?? 0))
-        )
-        .map((p) => p.thumbnailUrl)
-        .filter((u): u is string => !!u);
-
-      const brandWork = Promise.all([
-        brandPosts.length
-          ? synthesizeBrandContext(ai, {
-              name: profile?.name ?? '',
-              kit: {
-                about: profile?.about,
-                category: profile?.category,
-                target_audience: profile?.target_audience
-              },
-              documents: [],
-              posts: brandPosts.map((p) => ({
-                content: p.content,
-                platform: p.platform,
-                metrics: p.metrics
+      const runMarketStudy = async (): Promise<MarketStudy> => {
+        // Phase 1 (parallel): scrape the brand's own posts while resolving competitor social handles.
+        await pushProgress('handles', 'Finding competitor profiles…');
+        const [brandScrape, handleMap] = await Promise.all([
+          brandHandles.length
+            ? scrapeForOnboarding(brandHandles).catch((error) => { swallow('scrape onboarding profile', error); return ({ posts: [], errors: [] }); })
+            : Promise.resolve({ posts: [], errors: [] }),
+          competitors.length
+            ? resolveCompetitorHandles(ai, competitors, platforms)
+            : Promise.resolve(new Map<string, ScrapeTarget[]>())
+        ]);
+        const brandPosts = brandScrape.posts;
+        if (competitors.length) {
+          await attachStepResult('handles', {
+            competitors: competitors.map((c) => ({
+              name: c.name,
+              handles: (handleMap.get(c.name) ?? []).map((h) => ({
+                platform: h.platform,
+                username: h.username
               }))
-            }).catch((error) => { swallow('brandPosts.map failed', error); return ''; })
-          : Promise.resolve(''),
-        brandPosts.length ? synthesizeVisualStyle(ai, topThumbs).catch((error) => { swallow('synthesize visual style', error); return ''; }) : Promise.resolve(''),
-        brandPosts.length
-          ? synthesizeVisualPlaybook(ai, topThumbs).catch((error) => { swallow('synthesize visual playbook', error); return ''; })
-          : Promise.resolve(''),
-        generateBuyerPersonas(ai, profile, competitors, platforms, outputLanguage).catch((error) => { swallow('generate buyer personas', error); return [] as BuyerPersona[]; })
-      ]);
+            }))
+          });
+        }
+        if (brandPosts.length) {
+          await pushProgress(
+            'brandHistory',
+            `Retrieved ${brandPosts.length} of your posts with their stats — saved to your brand…`
+          );
+        }
 
-      const [competitorPosts, [brandCtx, brandStyle, visualPlaybook, buyerPersonas]] =
-        await Promise.all([scrapeCompetitors(handleMap), brandWork]);
+        // Phase 2: scrape competitor posts WHILE brand-only LLM work runs.
+        await pushProgress('scraping', 'Reading your competitors’ posts…');
+        const topThumbs = [...brandPosts]
+          .sort(
+            (a, b) =>
+              (b.metrics?.likes ?? 0) +
+              (b.metrics?.comments ?? 0) -
+              ((a.metrics?.likes ?? 0) + (a.metrics?.comments ?? 0))
+          )
+          .map((p) => p.thumbnailUrl)
+          .filter((u): u is string => !!u);
 
-      if (competitorPosts.size) {
-        await attachStepResult('scraping', {
-          counts: [...competitorPosts.entries()].map(([name, posts]) => ({
-            name,
-            posts: posts.length
+        const brandWork = Promise.all([
+          brandPosts.length
+            ? synthesizeBrandContext(ai, {
+                name: profile?.name ?? '',
+                kit: {
+                  about: profile?.about,
+                  category: profile?.category,
+                  target_audience: profile?.target_audience
+                },
+                documents: [],
+                posts: brandPosts.map((p) => ({
+                  content: p.content,
+                  platform: p.platform,
+                  metrics: p.metrics
+                }))
+              }).catch((error) => { swallow('brandPosts.map failed', error); return ''; })
+            : Promise.resolve(''),
+          brandPosts.length ? synthesizeVisualStyle(ai, topThumbs).catch((error) => { swallow('synthesize visual style', error); return ''; }) : Promise.resolve(''),
+          brandPosts.length
+            ? synthesizeVisualPlaybook(ai, topThumbs).catch((error) => { swallow('synthesize visual playbook', error); return ''; })
+            : Promise.resolve(''),
+          generateBuyerPersonas(ai, profile, competitors, platforms, outputLanguage).catch((error) => { swallow('generate buyer personas', error); return [] as BuyerPersona[]; })
+        ]);
+
+        const [competitorPosts, [brandCtx, brandStyle, visualPlaybook, buyerPersonas]] =
+          await Promise.all([scrapeCompetitors(handleMap), brandWork]);
+
+        if (competitorPosts.size) {
+          await attachStepResult('scraping', {
+            counts: [...competitorPosts.entries()].map(([name, posts]) => ({
+              name,
+              posts: posts.length
+            }))
+          });
+        }
+        if (brandStyle) profile.visual_style = brandStyle;
+
+        // Phase 3: quantitative benchmark + qualitative field read.
+        await pushProgress('benchmark', 'Comparing engagement across the field…');
+        const benchmark = benchmarkCompetitors(brandPosts, competitorPosts);
+        await attachStepResult('benchmark', {
+          market: benchmark.market,
+          brand: benchmark.brand
+            ? {
+                count: benchmark.brand.count,
+                medianEngagement: benchmark.brand.medianEngagement,
+                postsPerWeek: benchmark.brand.postsPerWeek
+              }
+            : null,
+          competitors: benchmark.competitors.map((c) => ({
+            name: c.name,
+            count: c.stats.count,
+            medianEngagement: c.stats.medianEngagement,
+            postsPerWeek: c.stats.postsPerWeek
           }))
         });
-      }
-      if (brandStyle) profile.visual_style = brandStyle;
 
-      // Phase 3: quantitative benchmark + qualitative field read.
-      await pushProgress('benchmark', 'Comparing engagement across the field…');
-      const benchmark = benchmarkCompetitors(brandPosts, competitorPosts);
-      await attachStepResult('benchmark', {
-        market: benchmark.market,
-        brand: benchmark.brand
-          ? {
-              count: benchmark.brand.count,
-              medianEngagement: benchmark.brand.medianEngagement,
-              postsPerWeek: benchmark.brand.postsPerWeek
-            }
-          : null,
-        competitors: benchmark.competitors.map((c) => ({
-          name: c.name,
-          count: c.stats.count,
-          medianEngagement: c.stats.medianEngagement,
-          postsPerWeek: c.stats.postsPerWeek
-        }))
-      });
+        await pushProgress('analysis', 'Studying what wins in your category…');
+        const qualitative = await analyzeCompetitorContent(ai, benchmark, outputLanguage);
+        if (qualitative) {
+          await attachStepResult('analysis', { text: qualitative });
+        }
 
-      await pushProgress('analysis', 'Studying what wins in your category…');
-      const qualitative = await analyzeCompetitorContent(ai, benchmark, outputLanguage);
-      if (qualitative) {
-        await attachStepResult('analysis', { text: qualitative });
-      }
+        // Phase 4: strategy report — onboarding uses ultraspeed + a single variant so this doesn't stall.
+        await pushProgress('strategy', 'Mapping your white space…');
+        let baseContext = brandCtx || profile?.ai_context || '';
+        if (additionalContext) {
+          baseContext = [baseContext, `ADDITIONAL CONTEXT FROM USER:\n${additionalContext}`]
+            .filter(Boolean)
+            .join('\n\n');
+        }
+        const histDigest = historyInsightsDigest(analyzePostHistory(brandPosts));
+        if (histDigest) baseContext = [baseContext, histDigest].filter(Boolean).join('\n\n');
+        if (visualPlaybook) baseContext = [baseContext, visualPlaybook].filter(Boolean).join('\n\n');
+        profile.ai_context = baseContext;
 
-      // Phase 4: strategy report — onboarding uses ultraspeed + a single variant so this doesn't stall.
-      await pushProgress('strategy', 'Mapping your white space…');
-      let baseContext = brandCtx || profile?.ai_context || '';
-      if (additionalContext) {
-        baseContext = [baseContext, `ADDITIONAL CONTEXT FROM USER:\n${additionalContext}`]
-          .filter(Boolean)
-          .join('\n\n');
-      }
-      const histDigest = historyInsightsDigest(analyzePostHistory(brandPosts));
-      if (histDigest) baseContext = [baseContext, histDigest].filter(Boolean).join('\n\n');
-      if (visualPlaybook) baseContext = [baseContext, visualPlaybook].filter(Boolean).join('\n\n');
-      profile.ai_context = baseContext;
+        const { XIAOMI_ULTRASPEED_MODEL, AI_PROVIDER } = await import('$lib/server/xiaomi');
+        const fastModel = AI_PROVIDER === 'xiaomi' ? XIAOMI_ULTRASPEED_MODEL : undefined;
 
-      const { XIAOMI_ULTRASPEED_MODEL, AI_PROVIDER } = await import('$lib/server/xiaomi');
-      const fastModel = AI_PROVIDER === 'xiaomi' ? XIAOMI_ULTRASPEED_MODEL : undefined;
+        const report = await synthesizeStrategyReport(
+          ai,
+          profile,
+          benchmark,
+          qualitative,
+          platforms,
+          outputLanguage,
+          { model: fastModel, variants: 1 }
+        );
 
-      const report = await synthesizeStrategyReport(
-        ai,
-        profile,
-        benchmark,
-        qualitative,
-        platforms,
-        outputLanguage,
-        { model: fastModel, variants: 1 }
-      );
+        profile.ai_context = buildCompetitiveContext(baseContext, report);
+        const strategyBrief = strategyBriefFromReport(report);
 
-      profile.ai_context = buildCompetitiveContext(baseContext, report);
-      const strategyBrief = strategyBriefFromReport(report);
+        await mergeResult({ report, buyerPersonas });
 
-      await mergeResult({ report, buyerPersonas });
-
-      const resolvedCompetitors = competitors.map((c) => {
-        const cb = benchmark.competitors.find((b) => b.name === c.name);
-        return {
-          ...c,
-          handles: handleMap.get(c.name) ?? [],
-          top_posts: cb?.stats.topPosts ?? [],
-          benchmark: cb?.stats ?? null
+        const resolvedCompetitors = competitors.map((c) => {
+          const cb = benchmark.competitors.find((b) => b.name === c.name);
+          return {
+            ...c,
+            handles: handleMap.get(c.name) ?? [],
+            top_posts: cb?.stats.topPosts ?? [],
+            benchmark: cb?.stats ?? null
+          };
+        });
+        const researchData = {
+          competitors: resolvedCompetitors,
+          report,
+          benchmark,
+          positioning: qualitative,
+          personas: buyerPersonas
         };
-      });
-      const researchData = {
-        competitors: resolvedCompetitors,
-        report,
-        benchmark,
-        positioning: qualitative,
-        personas: buyerPersonas
+        const planInputs = {
+          aiContext: profile.ai_context ?? null,
+          visualStyle: profile.visual_style ?? null,
+          topPosts: brandPosts.map((p) => ({
+            content: p.content,
+            platform: p.platform,
+            metrics: p.metrics
+          })) as PastWinner[],
+          zeroToOne: brandPosts.length < 10
+        };
+        await mergeResult({ researchData, planInputs });
+        // Durable progress refunds the retry budget: the attempts spent reaching the study must not
+        // be charged against the plan, which now restarts cheap.
+        await patchJob(admin, jobId, { attempts: 0 });
+
+        return { report, buyerPersonas, researchData, planInputs };
       };
-      await mergeResult({ researchData });
+
+      // A resumed attempt inherits the timeline it already earned, or the wizard would redraw
+      // itself as if the market study had never happened.
+      const resumed = resumableStudy(job.result);
+      const priorSteps = (job.result as { steps?: unknown } | null)?.steps;
+      if (resumed && Array.isArray(priorSteps)) steps.push(...(priorSteps as typeof steps));
+      const study = resumed ?? (await runMarketStudy());
+      const { report, buyerPersonas, researchData, planInputs } = study;
+      profile.ai_context = planInputs.aiContext ?? profile.ai_context;
+      if (planInputs.visualStyle) profile.visual_style = planInputs.visualStyle;
+      const strategyBrief = strategyBriefFromReport(report);
+      const benchmark = researchData?.benchmark ?? null;
+      const { XIAOMI_ULTRASPEED_MODEL: ULTRASPEED, AI_PROVIDER: PROVIDER } = await import('$lib/server/xiaomi');
+      const planModel = PROVIDER === 'xiaomi' ? ULTRASPEED : undefined;
 
       await pushProgress('editorialPlan', 'Drafting your editorial plan…');
-      const topPosts: PastWinner[] = brandPosts.map((p) => ({
-        content: p.content,
-        platform: p.platform,
-        metrics: p.metrics
-      }));
+      const topPosts = planInputs.topPosts;
       const calendarHooks = await upcomingTimelyHooks({
         category: profile?.category,
         archetype: profile?.site_type,
@@ -729,9 +794,9 @@ async function processResearch(
         strategyBrief,
         benchmark,
         topPosts,
-        zeroToOne: brandPosts.length < 10,
+        zeroToOne: planInputs.zeroToOne,
         calendarHooks,
-        model: fastModel,
+        model: planModel,
         variants: 1,
         supabase: admin,
         brandId: brandId ?? undefined,


### PR DESCRIPTION
## What?

The onboarding research job — the one that studies the market and then drafts the first editorial
plan — no longer throws away everything it paid for when an attempt is killed. The market study
(competitor handles, scraping, benchmark, personas, strategy report) is banked when it completes,
and a re-queued attempt resumes at the editorial plan instead of starting over from the first
scrape.

Four files: the job pipeline, its first unit test, `LESSONS.md`, and the two changelogs.

## Why?

Task 106 (*Riaprire l'onboarding: da 6 settimane nessuno arriva ai post*) is done when a user
signs up and reaches the three posts. #106 removed the two walls at the entrance — the brand that
could not be created, the site that became an error page. This is the wall behind them.

**The numbers, measured on the local stack where nothing kills the job:**

| | observed |
| --- | --- |
| the market study, before the plan starts | 8–10 minutes |
| `strategy_report`, same brand, three runs | 39s · 127s · **668s** |
| one editorial-plan call | 256s · **424s** |
| the worker's `maxDuration` | **300s** |

So the plan is rarely reached inside one invocation. That alone is survivable: the reaper
re-queues a stalled job (`STALL_MS`, six minutes) and the `*/2` cron picks it up.

**What was not survivable is that the retry started over from `handles`.** `runResearchJob` never
read `job.result` back — partial results were written by `mergeResult` and never used. Every
attempt repaid scraping, benchmark, personas and the report, and died at the same wall. Three
times, then `failed`.

Production says the same thing: of five `research` jobs, one is dead with
`Job timed out after 3 attempts` — and only two users ever reached `plan_posts`, one
`preview_images`. Reproduced locally before touching anything: three consecutive attempts
rewriting `handles>scraping>benchmark>analysis>strategy` from zero, then the identical error.

## How?

Phases 1–4 moved into `runMarketStudy()` — a pure extraction, the body is unchanged (read the diff
with `-w`). At the end it banks `planInputs`: what the plan needs from the study once the study
itself is gone (`aiContext`, `visualStyle`, the brand's `topPosts`, `zeroToOne`). `report`,
`buyerPersonas` and `researchData` were already being persisted.

`resumableStudy(job.result)` decides, and it is the whole rule in one pure function: it returns
the study **only when every piece survived**. A half-written study is worth nothing — the plan
would run on inputs it never got. That is what the test pins.

**Durable progress refunds the retry budget.** When the study is banked, `attempts` goes back to
zero. Without it, the attempts spent reaching the study stay charged against a plan that now
restarts cheap, and a job that finally made real progress is failed anyway.

Rejected: making every phase resumable. That means persisting intermediate state for each of them,
and it buys nothing while the wall falls at the study→plan boundary, which is where it was
measured. The limit is written down in the changelog rather than papered over.

## Testing?

**Unit.** `src/lib/server/onboarding-steps.test.ts` — the file did not exist, which is part of why
this rotted. Two cases, written first and watched fail: a banked study comes back whole; a study
missing any piece (or missing entirely) returns null so the pipeline re-runs it.

**The resume, end to end, against the real database and the real worker.** The local job that had
just died with `Job timed out after 3 attempts` was put in the state the new code produces (study
banked), re-queued, and the worker kicked:

- the attempt started **directly at `editorialPlan`** — no handles, no scraping, no strategy report
  in the log, only the plan's own calls;
- the job finished **`done` with `attempts 1`**, after three full-pipeline attempts had killed it;
- the wizard timeline still showed the whole road (the resumed attempt inherits the steps it
  already earned), instead of redrawing itself as if the study never happened;
- on the next run, `attempts` was observed back at `0` at the `editorialPlan` step — the refund.

**Not covered.** An attempt that dies *inside* the study still repays it; only the study→plan
seam resumes. And the walk to the three posts in the preview step is a separate leg — the plan
lands, but the six preview images were not exercised in this PR.

## Evidence (screenshots/videos)

<details>
<summary>The defect, live: three attempts, same road, then dead</summary>

```
steps this attempt: handles>scraping>benchmark>analysis>strategy   (attempt 1)
steps this attempt: handles>scraping>benchmark>analysis>strategy   (attempt 2)
steps this attempt: handles>scraping>benchmark>analysis>strategy   (attempt 3)
[onboarding:research] Job timed out after 3 attempts
```

</details>

<details>
<summary>Production, read-only</summary>

```
onboarding_step_jobs, all of them:
  competitors     done   5
  plan_posts      done   2
  preview_images  done   1
  research        done   4
  research        failed 1   → "Job timed out after 3 attempts"
```

</details>

<details>
<summary>After the fix: the resumed attempt</summary>

```
kick → the only AI call is the plan's own 20s text call; no scrape, no report
status: running | attempts: 1 | progress: { step: editorialPlan }
steps: handles>scraping>benchmark>analysis>strategy>editorialPlan   (inherited + new)
…
research done attempts 1
```

</details>

## Anything Else?

- **A local walk needs a hand-made cron.** No `*/N` job in `vercel.json` runs on a laptop, so a
  stalled onboarding job is never re-queued and the wizard sits on *«Drafting your editorial
  plan…»* forever. It looks exactly like a hang in the plan. The loop that fixes it is in
  `LESSONS.md`, along with the `[swallowed] fetch failed` line that is its symptom, not its cause.
- **The strategy agent never produced a plan in this environment** — every run logged
  *«strategy agent failed, falling back to legacy: Strategy agent finished without a plan»* and the
  legacy pipeline carried it. The degradation works, which is why nobody noticed. Worth its own
  look.
- Task 106 stays open after this: the criterion is the three posts, and this PR gets the road as
  far as the plan.
