### PR TITLE
Honor a model family only when the gateway serves it

### DIFF
--- a/changelog/2026-09-01-family-wireid-gateway.md
+++ b/changelog/2026-09-01-family-wireid-gateway.md
@@ -1,0 +1,28 @@
+# Una famiglia scelta nel picker non uccide più il turno
+
+Il catalogo (`src/lib/models/catalog.ts`) tiene per ogni famiglia il suo nome **nativo**:
+`luna` → `gpt-5-6-luna`, `grok` → `grok-4-6`. Sono i nomi di kie, di quando ogni provider
+parlava il suo vocabolario. Da quando la chat passa tutta dal centralino
+(`LLM_BASE_URL`, OpenRouter), il vocabolario è un altro: `openai/gpt-5-6-luna`, `x-ai/grok-4-6`.
+
+`resolveHarnessModelRef` prendeva il `wireId` del catalogo e lo passava al gateway così com'è.
+Il gateway non conosce `gpt-5-6-luna`, e il turno moriva prima di cominciare: lo stream chiudeva
+senza `finish_reason`, il reaper trovava un turno senza output, l'utente vedeva un errore rosso.
+Il test che stava a guardia (`adapters.test.ts`) fotografava proprio il difetto: pretendeva
+`llm/grok-4-6`, cioè l'id che il gateway rifiuta.
+
+Non era teoria in attesa di un caso raro: `policyForChoice` scrive la famiglia su
+`chat_threads.model` **al primo click sul picker** — chiunque scegliesse Fast si comprava un
+thread che non risponde più. Il 2026-09-01 nessuna riga in `chat_threads.model` né in
+`custom_agents.model` era ancora popolata: la mina era armata e non ancora pestata.
+
+Ora la famiglia vale solo se la lista dichiarata (`LLM_MODELS`) serve davvero quel modello —
+per id esatto o per ultimo segmento, così `x-ai/grok-4-6` copre la famiglia `grok`. Se non lo
+serve, `servableWireId` torna `null` e decide il tier, che passa da `llmModelForPicker` ed è
+sempre un id che il gateway ha.
+
+**Scartato:** riscrivere i `wireId` del catalogo con gli id del centralino. Il catalogo non
+descrive solo la chat — descrive anche i gradini di thinking e le capacità di ogni famiglia, e
+il nome nativo è ciò che serve a `toNativeThinking`. Fare del catalogo un elenco di id
+OpenRouter avrebbe legato la tassonomia dei modelli al gateway di oggi: la traduzione sta in un
+posto solo, dove il gateway viene interrogato.

--- a/src/lib/agent/bridge/adapters.test.ts
+++ b/src/lib/agent/bridge/adapters.test.ts
@@ -107,11 +107,20 @@ describe('resolveHarnessModelRef — la catena preferenza → tier → lista, tu
 		expect(resolveHarnessModelRef({ tier: 'pro' })).toBeNull();
 	});
 
-	it('la preferenza famiglia mappa il wireId del catalogo attraverso il centralino', () => {
+	it('la preferenza famiglia vale quando il centralino serve quel modello', () => {
 		env.LLM_API_KEY = 'k';
 		env.LLM_DEFAULT_MODEL = 'z-ai/glm-5.3-flash';
+		env.LLM_MODELS = 'z-ai/glm-5.3-flash,x-ai/grok-4-6';
 		const ref = resolveHarnessModelRef({ family: 'grok', tier: 'fast' });
-		expect(ref).toEqual({ provider: 'llm', id: 'llm/grok-4-6', label: 'grok-4-6' });
+		expect(ref).toEqual({ provider: 'llm', id: 'llm/x-ai/grok-4-6', label: 'grok-4-6' });
+	});
+
+	it('una famiglia che il centralino non serve degrada sul tier, mai sul wireId nudo', () => {
+		env.LLM_API_KEY = 'k';
+		env.LLM_DEFAULT_MODEL = 'z-ai/glm-5.3-flash';
+		env.LLM_MODELS = 'z-ai/glm-5.3-flash,openai/gpt-5.6-sol';
+		expect(resolveHarnessModelRef({ family: 'luna', tier: 'fast' })?.id).toBe('llm/z-ai/glm-5.3-flash');
+		expect(resolveHarnessModelRef({ family: 'luna', tier: 'pro' })?.id).toBe('llm/openai/gpt-5.6-sol');
 	});
 
 	it('una famiglia che non esiste degrada sul tier del picker', () => {

--- a/src/lib/agent/bridge/adapters.ts
+++ b/src/lib/agent/bridge/adapters.ts
@@ -126,11 +126,17 @@ export interface HarnessModelPreference {
 	tier?: unknown;
 }
 
+/**
+ * Il `wireId` del catalogo e` il nome NATIVO del modello (`gpt-5-6-luna`), non un id del
+ * centralino (`openai/gpt-5-6-luna`): passarlo cosi` com'e` chiede al gateway un modello che
+ * non esiste, e il turno muore senza mai cominciare — «Stream ended without finish_reason».
+ * Vale solo se la lista dichiarata lo serve davvero; altrimenti null, e decide il tier.
+ */
 function servableWireId(family: unknown): string | null {
 	if (typeof family !== 'string') return null;
 	if (!(MODEL_FAMILY_IDS as readonly string[]).includes(family)) return null;
-	const def = MODEL_FAMILIES[family as keyof typeof MODEL_FAMILIES];
-	return def.wireId;
+	const wire = MODEL_FAMILIES[family as keyof typeof MODEL_FAMILIES].wireId;
+	return llmModels().find((id) => id === wire || id.endsWith(`/${wire}`)) ?? null;
 }
 
 export function resolveHarnessModelRef(pref?: HarnessModelPreference | string | null): HarnessModelRef | null {

--- a/src/lib/content/changelog/2026-09-01-model-picker-thread.ts
+++ b/src/lib/content/changelog/2026-09-01-model-picker-thread.ts
@@ -1,0 +1,9 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-01',
+  title: 'Picking a model no longer breaks the thread',
+  items: [
+    'Choosing a model for a chat used to leave that thread unable to answer. The choice is now applied only when the model is actually available, and the chat falls back to its usual model instead of failing.'
+  ]
+} satisfies ChangelogEntry;


### PR DESCRIPTION
## What?

`resolveHarnessModelRef` handed the model catalog's **native** model name straight to the LLM
gateway. The catalog stores `luna → gpt-5-6-luna` and `grok → grok-4-6`, names left over from
when each provider spoke its own dialect; the gateway's vocabulary is `openai/gpt-5-6-luna`,
`x-ai/grok-4-6`. Asking it for `gpt-5-6-luna` asks for a model that does not exist there, and the
turn died before its first step — the stream closed with no `finish_reason`, the reaper found a
turn with no output, the user saw a red error.

A model family is now honored only when `LLM_MODELS` actually lists that model (exact id, or last
segment, so `x-ai/grok-4-6` serves the `grok` family). When it does not, `servableWireId` returns
`null` and the tier decides, which goes through `llmModelForPicker` and always yields an id the
gateway has.

## Why?

This was armed, not hypothetical. `policyForChoice` writes the family onto `chat_threads.model`
**on the first click in the model picker**, so anyone choosing Fast bought a thread that stopped
answering. As of 2026-09-01 no row in `chat_threads.model` or `custom_agents.model` had a family
stored yet, so nobody had stepped on it — the picker was one click away from breaking a thread
per user.

## How?

One place changed, because there is only one consumer of `wireId` outside the catalog itself
(`grep -rn wireId src/ packages/*/src` → `adapters.ts:133`). The translation lives where the
gateway is already interrogated:

```ts
const wire = MODEL_FAMILIES[family as keyof typeof MODEL_FAMILIES].wireId;
return llmModels().find((id) => id === wire || id.endsWith(`/${wire}`)) ?? null;
```

**Rejected: rewriting the catalog's `wireId`s as gateway ids.** The catalog does not only describe
chat — it also carries each family's thinking steps and capabilities, and `toNativeThinking` needs
the *native* name. Turning the catalog into a list of OpenRouter ids would bind the model taxonomy
to today's gateway.

The guard test enshrined the defect (it asserted `llm/grok-4-6`, the id the gateway rejects), so
it was rewritten to state the real contract, and a second test pins the fallback.

## Testing?

Test first, watched fail, then fixed:

<details>
<summary>Red — before the fix</summary>

```
AssertionError: expected 'llm/gpt-5-6-luna' to be 'llm/z-ai/glm-5.3-flash'
Expected: "llm/z-ai/glm-5.3-flash"
Received: "llm/gpt-5-6-luna"
 ❯ src/lib/agent/bridge/adapters.test.ts:122
 Tests  2 failed | 5 passed | 14 skipped (21)
```
</details>

<details>
<summary>Green — after the fix</summary>

```
✓ src/lib/agent/bridge/adapters.test.ts (21 tests)
 Test Files  1 passed (1)
      Tests  21 passed (21)
```

Neighbours (bridge, catalog, chat model, model policy, changelog loader):

```
 Test Files  12 passed (12)
      Tests  188 passed (188)
```
</details>

<details>
<summary>Production state that made this urgent (read-only, 2026-09-01)</summary>

```sql
select model::text, count(*) from chat_threads  where model is not null group by 1;  -- []
select model::text, count(*) from custom_agents where model is not null group by 1;  -- []
```

No family stored anywhere yet: the defect was reachable by the next picker click, not by
existing data.
</details>

**Not tested:** the browser gate (local stack → login → pick Fast in the picker → send a turn).
Backend-only change with no UI surface, but the user-visible symptom is in the browser, so the
risk left uncovered is that some other layer also passes a bare family through.

## Evidence (screenshots/videos)

No UI change — no screenshots. CLI evidence in the collapsible blocks above.

## Anything Else?

The `Provider: kie · Model: gpt-5-6-luna` errors that started this investigation are **not** this
bug: that thread has `model = null`. They come from the Render worker
(`srv-da6ih4on74is73f86t4g`), whose live deploy is commit `1ea26f79` of 2026-08-27 from the
**old** repo `andreabuttarelli/021-app` — code that predates the LLM-gateway merge and still has
`activeProvider() = ['kie','openrouter','opencode']` with a `KIE_LUNA_MODEL` fallback. Repointing
that service is separate work: its build/start commands (`bun ci && bun run worker:build`,
`bun run worker:start`) do not match this repo either — there is no `worker:start` script here,
and `bun ci` fails on a `package-lock.json` it has to migrate.
