### PR TITLE
Say which provider actually serves the text

### DIFF
--- a/changelog/2026-09-01-honest-provider-boot-log.md
+++ b/changelog/2026-09-01-honest-provider-boot-log.md
@@ -1,0 +1,41 @@
+# La riga di boot dice chi serve il testo, o tace
+
+Due `console.log` al livello del modulo — `xiaomi.ts` e `gtm.ts` — annunciavano a ogni avvio:
+
+```
+[AI] provider: gemini (gemini-3.7-flash)
+[GTM] provider: gemini (gemini-3.7-flash)
+```
+
+Nessuna delle due era vera. `AI_PROVIDER` viene dal registro delle rotte, il cui default è
+`gemini`, ma da quando ogni testo passa dal centralino quel ramo non chiama più Google:
+`aiStructured` con `AI_PROVIDER === 'gemini'` va a `llmStructured`, cioè al gateway, col modello
+di `LLM_DEFAULT_MODEL`. `gemini-3.7-flash` era `geminiFlash()`, un id che quel percorso non
+chiede a nessuno. `'gemini'` lì dentro ha smesso di essere una famiglia ed è diventato il nome
+del ramo "gateway".
+
+Il costo non è estetico: è la PRIMA riga che si legge quando qualcosa non torna, e manda la
+diagnosi dalla parte sbagliata prima ancora che cominci — è successo, cercando su Gemini un
+turno che moriva altrove. È il commento scaduto della CLAUDE.md, in forma di log.
+
+Ora la traduzione sta in una funzione sola, `textRouteLabel()`, accanto a `AI_PROVIDER` che la
+governa, e dice il provider che serve DAVVERO il testo:
+
+```
+openrouter.ai (z-ai/glm-5.3-flash)      il gateway, con la lista dichiarata
+kie (grok-4-5)                          rotta deviata a mano su kie
+xiaomi (mimo-v2.5-pro)                  idem su MiMo
+not configured (LLM_API_KEY missing)    il guasto, invece di un modello inventato
+```
+
+La stampa una volta sola, e nel punto dove un boot esiste davvero: la riga `[worker] started`,
+che già dice origin, batch e poll. Un `console.log` in cima a un modulo di servizio non è il
+boot di niente — gira quando qualcuno importa il file, e in un test.
+
+**Scartato: rimetterne uno in `hooks.server.ts`.** L'app non ha un boot solo, ne ha uno per cold
+start, e per stampare quella riga dovrebbe importare il grafo di `xiaomi.ts` dentro il modulo più
+caldo che ha. Chi lavora davvero lo dice già dove serve, a chiamata avvenuta:
+`[AI] structured call → …` e `[AI] llm responded in Nms`.
+
+**Scartato anche: metterla in `/api/status`.** Quell'endpoint è pubblico e nasconde i vendor
+apposta ("role, not vendor"): il nome del provider non ci va.

--- a/src/lib/server/gtm.ts
+++ b/src/lib/server/gtm.ts
@@ -11,8 +11,6 @@ import { clampFunnelSpec, funnelBrief, stampFunnelGoals, ratesLabel, DEFAULT_RAT
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyRec = Record<string, any>;
 
-console.log(`[GTM] provider: ${AI_PROVIDER} (${AI_PROVIDER === 'xiaomi' ? XIAOMI_MODEL : AI_PROVIDER === 'kie' ? (env.KIE_MODEL || 'grok-4-5') : geminiFlash()})`);
-
 // The GTM (go-to-market) engine — the TIME-AXIS strategy layer above the editorial plan. It
 // decides where the brand is going phase by phase: platform weights that evolve over time,
 // pillars/CTAs to anchor, and honest targets calibrated on the brand's real starting data.

--- a/src/lib/server/xiaomi.test.ts
+++ b/src/lib/server/xiaomi.test.ts
@@ -79,7 +79,8 @@ const M = vi.hoisted(() => ({
 }));
 const env = M.env;
 vi.mock('$env/dynamic/private', () => ({ env: M.env }));
-vi.mock('$lib/server/llm', () => ({
+vi.mock('$lib/server/llm', async () => ({
+  ...(await vi.importActual<typeof import('$lib/server/llm')>('$lib/server/llm')),
   llmStructured: M.llmStructured,
   llmText: M.llmText,
   llmImagesFromInline: M.llmImagesFromInline
@@ -201,5 +202,35 @@ describe('satisfiesSchema (xiaomi/kie fall-through guard)', () => {
         brandProfile
       )
     ).toBe(false);
+  });
+});
+
+
+/**
+ * La riga stampata al boot è la prima cosa che si legge quando qualcosa non torna, e per mesi ha
+ * detto `gemini (gemini-3.7-flash)` mentre la chiamata andava al gateway: manda la diagnosi dalla
+ * parte sbagliata prima ancora che cominci. Dica chi serve il testo DAVVERO, o taccia.
+ */
+describe('textRouteLabel — chi serve il testo, per il log di boot', () => {
+  beforeEach(() => {
+    for (const k of Object.keys(env)) delete env[k];
+    vi.resetModules();
+  });
+
+  it('senza rotte forzate nomina il gateway e i suoi modelli, mai un id Gemini', async () => {
+    Object.assign(env, { LLM_API_KEY: 'k', LLM_DEFAULT_MODEL: 'z-ai/glm-5.3-flash' });
+    const { textRouteLabel } = await import('./xiaomi');
+    expect(textRouteLabel()).toBe('openrouter.ai (z-ai/glm-5.3-flash)');
+  });
+
+  it('una rotta deviata su kie lo dice, col modello che kie riceverà', async () => {
+    Object.assign(env, { LLM_API_KEY: 'k', AI_ROUTE_TEXT: 'grok@kie', KIE_API_KEY: 'k' });
+    const { textRouteLabel } = await import('./xiaomi');
+    expect(textRouteLabel()).toBe('kie (grok-4-5)');
+  });
+
+  it('senza la chiave del centralino annuncia il guasto, non un modello', async () => {
+    const { textRouteLabel } = await import('./xiaomi');
+    expect(textRouteLabel()).toBe('not configured (LLM_API_KEY missing)');
   });
 });

--- a/src/lib/server/xiaomi.ts
+++ b/src/lib/server/xiaomi.ts
@@ -5,7 +5,7 @@ import { logAiCall, extractXiaomiUsage, requireBrandContext } from '$lib/server/
 import { geminiFlash, type GeminiThinkingLevel } from '$lib/server/gemini';
 import { env } from '$env/dynamic/private';
 import { route } from '$lib/server/model-routing';
-import { llmImagesFromInline, llmStructured, llmText } from '$lib/server/llm';
+import { llmBaseUrl, llmConfigured, llmImagesFromInline, llmModels, llmStructured, llmText } from '$lib/server/llm';
 
 // ── Xiaomi MiMo structured output via tool calling ──────────────────────────
 // Shared module used by GTM engine, strategy report, editorial plan, etc.
@@ -51,9 +51,19 @@ export const AI_PROVIDER =
     : TEXT_ROUTE.provider === 'kie' && TEXT_ROUTE.family !== 'gemini'
       ? 'kie'
       : 'gemini';
-const providerModel =
-  AI_PROVIDER === 'xiaomi' ? XIAOMI_MODEL : AI_PROVIDER === 'kie' ? (env.KIE_MODEL || 'grok-4-5') : geminiFlash();
-console.log(`[AI] provider: ${AI_PROVIDER} (${providerModel})`);
+/**
+ * Chi serve il testo DAVVERO, per la riga di boot. Non è la famiglia richiesta: da quando ogni
+ * testo passa dal centralino, `AI_PROVIDER === 'gemini'` vuol dire "gateway", e la riga di prima
+ * annunciava `gemini (gemini-3.7-flash)` — un modello che quel percorso non chiama — mandando la
+ * diagnosi dalla parte sbagliata prima ancora di cominciare.
+ */
+export function textRouteLabel(): string {
+  if (AI_PROVIDER === 'xiaomi') return `xiaomi (${XIAOMI_MODEL})`;
+  if (AI_PROVIDER === 'kie') return `kie (${env.KIE_MODEL || 'grok-4-5'})`;
+  if (!llmConfigured()) return 'not configured (LLM_API_KEY missing)';
+  const host = llmBaseUrl().replace(/^https?:\/\//, '').split('/')[0];
+  return `${host} (${llmModels().join(', ') || 'no model declared'})`;
+}
 
 // Tutta la generazione di testo — strategia GTM, piano editoriale, articoli del blog — resta su
 // Gemini Flash: mai MiMo, mai Kie, qualunque cosa dica GTM_PROVIDER.

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -11,6 +11,7 @@
  * which is what makes this safe to roll out and safe to turn off again.
  */
 import { drainChatQueue } from '$lib/server/chat/queue';
+import { textRouteLabel } from '$lib/server/xiaomi';
 
 /** Nothing to do → wait this long before asking again. The queue is a table, not a firehose. */
 const IDLE_POLL_MS = Number(process.env.WORKER_IDLE_POLL_MS ?? 2_000);
@@ -57,7 +58,9 @@ async function main() {
 		process.exit(1);
 	}
 
-	console.log(`[worker] started — origin=${ORIGIN}, batch=${BATCH}, idlePoll=${IDLE_POLL_MS}ms`);
+	console.log(
+		`[worker] started — origin=${ORIGIN}, batch=${BATCH}, idlePoll=${IDLE_POLL_MS}ms, text=${textRouteLabel()}`
+	);
 	let lastReapAt = 0;
 
 	while (!stopping) {


### PR DESCRIPTION
## What?

Two module-level `console.log`s — one in `xiaomi.ts`, one in `gtm.ts` — announced on every import:

```
[AI] provider: gemini (gemini-3.7-flash)
[GTM] provider: gemini (gemini-3.7-flash)
```

Neither was true. `AI_PROVIDER` comes from the route registry, whose default is `gemini`, but
since all text moved to the gateway that branch does not call Google: `aiStructured` with
`AI_PROVIDER === 'gemini'` goes to `llmStructured`, i.e. the gateway, with `LLM_DEFAULT_MODEL`.
The printed `gemini-3.7-flash` was `geminiFlash()`, an id that path never asks anyone for.

Both lines are gone. One function, `textRouteLabel()`, now names the transport that really serves
the text, and it is printed once on the existing `[worker] started` line.

## Why?

It is the first line you read when something looks wrong, and it sends the diagnosis the wrong
way before it starts — that is exactly how this was found: hunting Gemini for turns that were
dying on another provider entirely. An expired log is worse than no log, for the same reason an
expired comment is: it describes a decision already reversed, and it is believed.

## How?

```ts
export function textRouteLabel(): string {
  if (AI_PROVIDER === 'xiaomi') return `xiaomi (${XIAOMI_MODEL})`;
  if (AI_PROVIDER === 'kie') return `kie (${env.KIE_MODEL || 'grok-4-5'})`;
  if (!llmConfigured()) return 'not configured (LLM_API_KEY missing)';
  const host = llmBaseUrl().replace(/^https?:\/\//, '').split('/')[0];
  return `${host} (${llmModels().join(', ') || 'no model declared'})`;
}
```

It lives next to the `AI_PROVIDER` that governs it (moving it to `model-routing.ts` would need
`XIAOMI_MODEL` and close a cycle). The host is taken by string, not `new URL()`, so a malformed
`LLM_BASE_URL` cannot crash a boot over a banner.

**Rejected: a replacement banner in `hooks.server.ts`.** The app has no single boot — it has one
per cold start — and printing that line would drag the `xiaomi.ts` graph into the hottest module
it owns. What actually works already says so where it matters, once the call happened:
`[AI] structured call → …`, `[AI] llm responded in Nms`.

**Rejected: exposing it on `/api/status`.** That endpoint is public and hides vendors on purpose
("Service names are deliberately generic (role, not vendor)").

## Testing?

Test first, watched fail (`TypeError: textRouteLabel is not a function`), then written. Three
cases: gateway default, a route diverted to kie, and no gateway key.

<details>
<summary>Green</summary>

```
 Test Files  3 passed (3)      xiaomi, gtm, model-routing
      Tests  43 passed (43)

typecheck-runtime: ok
[build-worker] → build-worker/index.js
```
</details>

**Not tested:** the line as printed by a live worker boot. Starting the bundle here would drain the
real chat queue, so the string is pinned by unit test and the banner is a template around it.

## Evidence (screenshots/videos)

No UI change. Before, on every app and worker start:

```
[AI] provider: gemini (gemini-3.7-flash)
[GTM] provider: gemini (gemini-3.7-flash)
```

After, once, at worker boot:

```
[worker] started — origin=…, batch=3, idlePoll=2000ms, text=openrouter.ai (z-ai/glm-5.3-flash)
```

## Anything Else?

The route registry's own warning (`[AI] AI_ROUTE_TEXT chiede …: ripiego su …`) is left alone: it
fires at call time, only when a route was set explicitly and its key is missing, and it speaks the
registry's vocabulary rather than claiming a transport.

Internal changelog only — a log line is invisible from outside the product.
