### PR TITLE
Let the editorial plan finish, and stop the resumed attempt from killing the wizard

### DIFF
--- a/changelog/2026-09-01-research-timeline-registry.md
+++ b/changelog/2026-09-01-research-timeline-registry.md
@@ -1,0 +1,26 @@
+# La timeline della ricerca è un registro, non un log
+
+`StrategyStep.svelte` disegna la timeline con `{#each researchSteps as s (s.step)}`: la chiave è il
+nome dello step. Un tentativo ripreso ereditava gli step già guadagnati (#109) e poi annunciava
+quello da cui riparte, quindi `steps.push` aggiungeva un secondo `editorialPlan`. Svelte lancia
+`each_key_duplicate` e smonta l'intero step: il piano atterrava dietro uno spinner che non se ne
+andava più.
+
+Un job reale sullo stack locale lo portava quattro volte, uno per tentativo:
+
+```
+["handles","scraping","benchmark","analysis","strategy","editorialPlan","editorialPlan","editorialPlan","editorialPlan"]
+```
+
+Il secondo è già fatale — e da quando #109 rende la ripresa la strada normale, lo è anche il crash.
+
+`putStep` fa l'upsert: uno step che esiste resta al suo posto e tiene il `result` che si era già
+guadagnato, cambia solo il messaggio. Le righe scritte prima esistono ancora e ucciderebbero il
+wizard lo stesso, quindi `applyResearchResult` ripiega i duplicati anche in lettura.
+
+Scartato: **togliere la chiave dall'`{#each}`**. Nasconde il duplicato invece di impedirlo, e la
+chiave serve — le righe della timeline si aprono e si chiudono, l'identità conta.
+
+Scartato: **deduplicare solo nel client.** La regola sarebbe finita in due posti che divergono al
+primo cambiamento. Chi produce la timeline è il server: l'invariante sta lì, e il client si
+difende solo dalle righe già scritte.

--- a/changelog/2026-09-01-strategy-agent-invocation-budget.md
+++ b/changelog/2026-09-01-strategy-agent-invocation-budget.md
@@ -1,0 +1,28 @@
+# Lo strategy agent non si prende più tutta l'invocazione
+
+`runStrategyAgent` chiedeva 280s di wall clock — `deadlineMs ?? 280_000` — e nessun chiamante
+gliene passava un altro. Dentro il worker dell'onboarding quella cifra è una pretesa: lo studio di
+mercato è già girato prima, e se l'agente finisce senza piano la pipeline legacy deve ancora
+starci dentro i 300s di `maxDuration`.
+
+I numeri di produzione dicevano che il tetto era già toccato:
+
+| | |
+| --- | --- |
+| research job completati | 299s · 278s · 225s · 224s |
+| `maxDuration` del worker | 300s |
+| l'unico research fallito | `Job timed out after 3 attempts`, step `editorialPlan` |
+| `strategy-agent`, 17 chiamate | media 108s, massimo 272s |
+| `return_editorial_plan`, 206 chiamate | mediana 16,6s, massimo 87s |
+
+Il passo del piano ora riceve `remainingMs` — quanto resta dell'invocazione — e `agentPlanBudget`
+decide: all'agente va ciò che avanza dopo aver messo da parte i 90s della pipeline legacy, mai più
+del suo tetto da solo. Se quel che resta non tiene entrambi, **l'agente non parte**: avviarlo
+comprerebbe un'invocazione uccisa al posto di un piano.
+
+Scartato: alzare `maxDuration`. Il tetto della piattaforma è 300s e il problema non è che serve
+più tempo, è che due cose si contendevano lo stesso tempo senza saperlo.
+
+Scartato anche: rendere l'agente più veloce (meno step, meno tool). È una cura per un sintomo —
+finché il budget non è dichiarato, qualunque agente più veloce ricomincerà a sforare appena lo
+studio davanti a lui rallenta.

--- a/src/lib/content/changelog/2026-09-01-editorial-plan-budget.ts
+++ b/src/lib/content/changelog/2026-09-01-editorial-plan-budget.ts
@@ -1,0 +1,9 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-01',
+  title: 'The editorial plan arrives instead of timing out',
+  items: [
+    'Onboarding no longer runs out of time while drafting the editorial plan: the strategist now works within the time the step actually has, and hands over to the faster planner when there is not enough left for both.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/content/changelog/2026-09-01-onboarding-timeline.ts
+++ b/src/lib/content/changelog/2026-09-01-onboarding-timeline.ts
@@ -1,0 +1,9 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-01',
+  title: 'Onboarding no longer stalls on the research screen',
+  items: [
+    'When the market study was picked up again after an interruption, the setup screen could freeze on the spinner with the plan already finished behind it. The progress list is now written once per step, and the wizard carries on to your first posts.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/editorial-plan.test.ts
+++ b/src/lib/server/editorial-plan.test.ts
@@ -10,6 +10,10 @@ import {
   weekStrategyBrief,
   postsForWeek,
   normalizePlan,
+  agentPlanBudget,
+  AGENT_PLAN_MAX_MS,
+  LEGACY_PLAN_RESERVE_MS,
+  MIN_AGENT_PLAN_MS,
   PLAN_WEEKS,
   type EditorialPlan,
   type PlanWeek
@@ -247,5 +251,25 @@ describe('profileBlock (the brand half of every plan prompt)', () => {
     const block = profileBlock({ name: 'Nuovo', about: 'Solo questo' });
     expect(block).toContain('Nuovo');
     expect(block).not.toContain('undefined');
+  });
+});
+
+describe('agentPlanBudget', () => {
+  it('leaves the legacy pipeline its own time, and gives the agent the rest', () => {
+    expect(agentPlanBudget(300_000)).toBe(300_000 - LEGACY_PLAN_RESERVE_MS);
+  });
+
+  it('never claims more than the standalone budget, however much is left', () => {
+    expect(agentPlanBudget(3_600_000)).toBe(AGENT_PLAN_MAX_MS);
+  });
+
+  it('gives up the agent when what is left cannot hold it and the fallback too', () => {
+    expect(agentPlanBudget(LEGACY_PLAN_RESERVE_MS + MIN_AGENT_PLAN_MS - 1)).toBeNull();
+    expect(agentPlanBudget(LEGACY_PLAN_RESERVE_MS)).toBeNull();
+    expect(agentPlanBudget(0)).toBeNull();
+  });
+
+  it('keeps the agent when what is left holds both', () => {
+    expect(agentPlanBudget(LEGACY_PLAN_RESERVE_MS + MIN_AGENT_PLAN_MS)).toBe(MIN_AGENT_PLAN_MS);
   });
 });

--- a/src/lib/server/editorial-plan.ts
+++ b/src/lib/server/editorial-plan.ts
@@ -422,6 +422,8 @@ export type ProposePlanOpts = {
   timezone?: string;
   /** Log each agent step to stdout (scripts / debugging). */
   agentVerbose?: boolean;
+  /** Wall clock left in the caller's invocation. Absent → the caller owns its own time. */
+  remainingMs?: number;
 };
 
 /** Exported for tests: the brand half of every plan prompt, pure over the profile. */
@@ -529,6 +531,29 @@ export function buildNextCycleSeedBrief(opts: ProposePlanOpts): string {
     .join('\n\n');
 }
 
+/**
+ * Wall clock the strategy agent may spend, from what is left of the caller's invocation.
+ *
+ * `AGENT_PLAN_MAX_MS` is what the agent takes when it runs alone in its own request. Inside the
+ * onboarding worker it does not: the market study ran first, and the legacy pipeline still has to
+ * fit afterwards if the agent ends without a plan. Production said the ceiling was already being
+ * touched — research jobs finishing at 299s, 278s, 225s against a 300s cap, and the one that died
+ * died at `editorialPlan`.
+ *
+ * `null` → do not start the agent: what is left cannot hold it AND the pipeline it must degrade
+ * into, so starting it buys a killed invocation instead of a plan.
+ */
+export const AGENT_PLAN_MAX_MS = 280_000;
+/** `return_editorial_plan` took at most 87s over 206 production calls; round up. */
+export const LEGACY_PLAN_RESERVE_MS = 90_000;
+/** Under this the agent cannot close a loop — its fastest production run was 28s, its median 52s. */
+export const MIN_AGENT_PLAN_MS = 60_000;
+
+export function agentPlanBudget(remainingMs: number): number | null {
+  const forAgent = Math.min(remainingMs - LEGACY_PLAN_RESERVE_MS, AGENT_PLAN_MAX_MS);
+  return forAgent >= MIN_AGENT_PLAN_MS ? forAgent : null;
+}
+
 async function invokeEditorialAgent(
   profile: BrandProfile,
   opts: ProposePlanOpts,
@@ -539,6 +564,13 @@ async function invokeEditorialAgent(
 ): Promise<EditorialPlan | null> {
   const { strategyAgentEnabled, runStrategyAgent } = await import('$lib/server/strategy-agent');
   if (!strategyAgentEnabled() || !opts.supabase || !opts.brandId) return null;
+  const deadlineMs = opts.remainingMs == null ? undefined : agentPlanBudget(opts.remainingMs);
+  if (deadlineMs === null) {
+    console.warn(
+      `[editorial-plan] ${Math.round(opts.remainingMs! / 1000)}s left: too little for the agent and the fallback, going legacy`
+    );
+    return null;
+  }
   // null → the caller falls through to the legacy pipeline. The guard lives HERE, in the one place
   // all four call sites (propose / revise / replan_week / next_cycle) route through: an agent that
   // ends without a plan must degrade to the pipeline that still works, never take onboarding down.
@@ -560,7 +592,8 @@ async function invokeEditorialAgent(
       weekIndex,
       outputLanguage: opts.outputLanguage,
       planOpts: opts,
-      verbose: opts.agentVerbose
+      verbose: opts.agentVerbose,
+      deadlineMs
     });
     return result.plan;
   } catch (e) {

--- a/src/lib/server/onboarding-steps.test.ts
+++ b/src/lib/server/onboarding-steps.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { resumableStudy } from './onboarding-steps';
+import { putStep, resumableStudy } from './onboarding-steps';
 
 const study = () => ({
   report: { headline: 'white space is short-form teardown' },
@@ -27,5 +27,40 @@ describe('resumableStudy', () => {
     expect(resumableStudy({ ...study(), researchData: null })).toBeNull();
     expect(resumableStudy({ steps: [] })).toBeNull();
     expect(resumableStudy(null)).toBeNull();
+  });
+});
+
+describe('putStep', () => {
+  it('does not repeat a step a resumed attempt already earned', () => {
+    const earned = ['handles', 'scraping', 'benchmark', 'analysis', 'strategy', 'editorialPlan'].map(
+      (step) => ({ step, message: `${step} done` })
+    );
+
+    const timeline = putStep(earned, { step: 'editorialPlan', message: 'Drafting your editorial plan…' });
+
+    expect(timeline.map((s) => s.step)).toEqual([
+      'handles',
+      'scraping',
+      'benchmark',
+      'analysis',
+      'strategy',
+      'editorialPlan'
+    ]);
+    expect(timeline.at(-1)?.message).toBe('Drafting your editorial plan…');
+  });
+
+  it('keeps the result the step already carried when only the message moves on', () => {
+    const earned = [{ step: 'benchmark', message: 'Comparing…', result: { medianEngagement: 42 } }];
+
+    expect(putStep(earned, { step: 'benchmark', message: 'Compared' })).toEqual([
+      { step: 'benchmark', message: 'Compared', result: { medianEngagement: 42 } }
+    ]);
+  });
+
+  it('appends a step the timeline has never seen', () => {
+    expect(putStep([{ step: 'handles', message: 'Finding…' }], { step: 'scraping', message: 'Reading…' })).toEqual([
+      { step: 'handles', message: 'Finding…' },
+      { step: 'scraping', message: 'Reading…' }
+    ]);
   });
 });

--- a/src/lib/server/onboarding-steps.ts
+++ b/src/lib/server/onboarding-steps.ts
@@ -66,6 +66,12 @@ const MAX_ATTEMPTS = 3;
  * waiting after a kill. 300s + 60s of slack for clock skew and the final status write.
  */
 const STALL_MS = 6 * 60 * 1000;
+/**
+ * The worker's `maxDuration` (api/v1/onboarding/steps/work). The study runs first and the plan
+ * runs on what is left, so the plan step is told how much of this is already gone instead of
+ * assuming it owns a fresh request.
+ */
+const INVOCATION_BUDGET_MS = 300_000;
 
 const TABLE = 'onboarding_step_jobs';
 
@@ -556,6 +562,7 @@ async function processResearch(
 
   const brandId = (job.brand_id as string | null) ?? null;
   const userId = job.user_id as string;
+  const startedAt = Date.now();
   let lastStep = 'start';
 
   // Accumulate timeline steps + partial payloads so the poll UI can render progress live.
@@ -800,7 +807,8 @@ async function processResearch(
         variants: 1,
         supabase: admin,
         brandId: brandId ?? undefined,
-        planTier
+        planTier,
+        remainingMs: INVOCATION_BUDGET_MS - (Date.now() - startedAt)
       });
       const planVisualStyle = profile?.visual_style ?? null;
       await mergeResult({

--- a/src/lib/server/onboarding-steps.ts
+++ b/src/lib/server/onboarding-steps.ts
@@ -73,6 +73,24 @@ const STALL_MS = 6 * 60 * 1000;
  */
 const INVOCATION_BUDGET_MS = 300_000;
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type ResearchStep = { step: string; message: string; result?: any };
+
+/**
+ * The wizard's timeline is a registry keyed by step, not a log. It is rendered with a keyed
+ * `{#each ... (s.step)}`, so a repeated key is not a cosmetic duplicate: Svelte throws
+ * `each_key_duplicate` and tears the whole step down — the user stays on the spinner while the
+ * plan lands behind it. A resumed attempt inherits the timeline it already earned and then
+ * announces the step it restarts at, which is exactly where the two meet.
+ */
+export function putStep(steps: ResearchStep[], entry: ResearchStep): ResearchStep[] {
+  const at = steps.findIndex((s) => s.step === entry.step);
+  if (at < 0) return [...steps, entry];
+  const merged = steps.slice();
+  merged[at] = { ...steps[at], ...entry };
+  return merged;
+}
+
 const TABLE = 'onboarding_step_jobs';
 
 /**
@@ -566,14 +584,13 @@ async function processResearch(
   let lastStep = 'start';
 
   // Accumulate timeline steps + partial payloads so the poll UI can render progress live.
+  let steps: ResearchStep[] = [];
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const steps: Array<{ step: string; message: string; result?: any }> = [];
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let accumulated: Record<string, any> = { steps };
+  let accumulated: Record<string, any> = { steps: [...steps] };
 
   const pushProgress = async (step: string, message: string) => {
     lastStep = step;
-    steps.push({ step, message });
+    steps = putStep(steps, { step, message });
     accumulated = { ...accumulated, steps: [...steps] };
     await note(admin, jobId, step, message);
     await patchPartialResult(admin, jobId, { steps: [...steps] });
@@ -776,7 +793,9 @@ async function processResearch(
       // itself as if the market study had never happened.
       const resumed = resumableStudy(job.result);
       const priorSteps = (job.result as { steps?: unknown } | null)?.steps;
-      if (resumed && Array.isArray(priorSteps)) steps.push(...(priorSteps as typeof steps));
+      if (resumed && Array.isArray(priorSteps)) {
+        for (const prior of priorSteps as ResearchStep[]) steps = putStep(steps, prior);
+      }
       const study = resumed ?? (await runMarketStudy());
       const { report, buyerPersonas, researchData, planInputs } = study;
       profile.ai_context = planInputs.aiContext ?? profile.ai_context;

--- a/src/routes/app/onboarding/+page.svelte
+++ b/src/routes/app/onboarding/+page.svelte
@@ -175,12 +175,15 @@ import EntryInput from './components/EntryInput.svelte';
   function applyResearchResult(result: Record<string, any> | null | undefined) {
     if (!result) return;
     if (Array.isArray(result.steps)) {
+      // Rows written before the timeline became a registry can repeat a step, and the timeline is
+      // rendered keyed by it: one duplicate and the whole strategy step is torn down.
+      const byStep = new Map<string, { step: string; message: string; result?: unknown }>();
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      researchSteps = result.steps.map((s: any) => ({
-        step: String(s.step ?? ''),
-        message: String(s.message ?? ''),
-        result: s.result
-      }));
+      for (const s of result.steps as any[]) {
+        const step = String(s.step ?? '');
+        byStep.set(step, { ...byStep.get(step), step, message: String(s.message ?? ''), result: s.result });
+      }
+      researchSteps = [...byStep.values()];
     }
     if (result.report) report = result.report;
     if (result.researchData) researchData = result.researchData;


### PR DESCRIPTION
## What?

Two defects on the last leg of onboarding — the stretch between the market study and the three
posts.

1. **The strategy agent asked for 280s of a 300s invocation it did not own.** The plan step now
   receives what is left of the invocation and reserves the legacy pipeline's own time; when what
   is left cannot hold both, the agent is not started at all.
2. **A resumed attempt killed the wizard.** The research timeline is rendered with a keyed
   `{#each}`; a resumed attempt inherited the steps it had earned and then announced the step it
   restarts at, appending a second `editorialPlan`. Svelte threw `each_key_duplicate` and tore the
   strategy step down — the plan landed behind a spinner nobody would ever leave.

Four source files, two test files, four changelogs.

## Why?

Task 106 (*Riaprire l'onboarding: da 6 settimane nessuno arriva ai post*) is done when a user signs
up and reaches the three posts. #106 removed the two walls at the entrance; #109 stopped the market
study from being repaid on every retry. These are the two behind them.

### The budget, measured on production

| | observed |
| --- | --- |
| research jobs that completed | 299s · 278s · 225s · 224s |
| the worker's `maxDuration` | **300s** |
| the one research job that died | `Job timed out after 3 attempts`, step **`editorialPlan`** |
| `strategy-agent`, 17 calls | avg 108s, max 272s |
| `return_editorial_plan`, 206 calls | median 16.6s, max 87s |

Every job that finished did so within a hair of the cap, and the one that did not died exactly at
the plan. `runStrategyAgent` defaults to `deadlineMs ?? 280_000` and **no caller ever passed one**:
the market study had already run, and the legacy pipeline the agent must degrade into still had to
fit in what was left. It could not.

### The crash is not hypothetical either

A real research job on the local stack, stuck `running`, carried this timeline:

```
["handles","scraping","benchmark","analysis","strategy","editorialPlan","editorialPlan","editorialPlan","editorialPlan"]
```

One `editorialPlan` per attempt. The second is already fatal — and since #109 made resume the
normal path, so is the crash.

## How?

**`agentPlanBudget(remainingMs)`** lives in `editorial-plan.ts`, beside the call site that already
owns both paths. It hands the agent what is left minus `LEGACY_PLAN_RESERVE_MS` (90s — the legacy
call's worst observed run was 87s), never more than the 280s it takes when it runs alone, and
returns `null` when what is left cannot hold the agent *plus* the fallback. `invokeEditorialAgent`
reads `null` as "go legacy now": starting the agent there buys a killed invocation instead of a
plan. `processResearch` is the only caller passing `remainingMs` today, because it is the only one
that shares its invocation with something else.

- **Rejected: raising `maxDuration`.** The platform ceiling is 300s, and the problem is not that
  more time is needed — it is that two things were spending the same time without knowing about
  each other.
- **Rejected: making the agent faster** (fewer steps, fewer tools). A cure for the symptom: until
  the budget is declared, any faster agent starts overrunning again the moment the study in front
  of it slows down.

**`putStep(steps, entry)`** in `onboarding-steps.ts` makes the timeline what it always was — a
registry keyed by step, not a log. An existing step keeps its place and the `result` it already
earned; only the message moves on.

- **Rejected: dropping the key from the `{#each}`.** That hides the duplicate instead of preventing
  it, and the key earns its place — timeline rows open and close, identity matters.
- **Rejected: deduplicating only in the client.** The rule would live in two places and diverge at
  the first change. The server produces the timeline, so the invariant belongs there; the client
  only defends itself against rows already written, which is why `applyResearchResult` folds
  duplicates on read.

## Testing?

**Unit, written first and watched fail.**

- `editorial-plan.test.ts` — the budget leaves the fallback its time, never exceeds the standalone
  cap, and returns `null` at the boundary where the two stop fitting. First run: *`agentPlanBudget`
  is not a function*.
- `onboarding-steps.test.ts` — a resumed attempt that re-announces `editorialPlan` yields one entry,
  not two, and the step keeps the result it already carried.

**The whole suite**, from this branch after merging `dev`: `532 files, 6038 passed, 4 skipped` in 43s.

**In the browser, on the local stack.** Self-hosted Supabase in Docker, the dev server on :5199
against it (never the hosted project), signed in as `test@anomalia.so`, plus a hand-made cron loop
standing in for the `*/2` job that does not exist locally.

- *Before:* the wizard sat on the loading screen forever while the plan finished behind it.
- *After:* the timeline renders — six steps, one `editorialPlan` — and the wizard walks Website →
  People → Competitors → Strategy → Plan → Preview, reaching *Your first posts* and starting the
  last leg.

**Not covered, and why.** The three posts and six preview images did not land, so that leg is still
unexercised end to end. The blocker is the local LLM transport, not this code: one structured call
took **577s** and another **failed after 1,476s**, where production serves the same calls in 17–60s.
`plan_posts` died against `STALL_MS`, not against the step. Worth its own ticket — a local stack
this slow means nobody can walk onboarding locally.

## Evidence (screenshots/videos)

<details>
<summary>The crash, in the browser console</summary>

```
Svelte error: each_key_duplicate
Keyed each block has duplicate key `editorialPlan` at indexes 5 and 6
  in StrategyStep.svelte
  in WizardChrome.svelte
  at src/routes/app/onboarding/components/StrategyStep.svelte:233
```

The UI said nothing: a spinner, indefinitely.
</details>

<details>
<summary>The poisoned row that produced it (local stack, read-only)</summary>

```
 kind     | status  | attempts | steps
----------+---------+----------+------------------------------------------------------------
 research | running | 3        | handles, scraping, benchmark, analysis, strategy,
          |         |          | editorialPlan, editorialPlan, editorialPlan, editorialPlan
```

Under the cron loop it then exhausted its attempts — `[onboarding:research] Job timed out after 3
attempts` — reproducing the production failure locally.
</details>

<details>
<summary>Production, read-only: where the invocation goes</summary>

```
onboarding_step_jobs, research:
  done    299s   done    278s   done    225s   done    224s
  failed  480s   "Job timed out after 3 attempts"   progress.step = editorialPlan

ai_calls:
  strategy-agent          n=17   avg 108s   max 272s
  return_editorial_plan   n=206  p50 16.6s  max  87s
```
</details>

<details>
<summary>After the fix: the timeline renders and the wizard walks</summary>

Six steps, each ticked once — `Finding competitor profiles… / Reading your competitors' posts… /
Comparing engagement across the field… / Studying what wins in your category… / Mapping your white
space… / Drafting your editorial plan…` — then *Your editorial plan*, then *Your first posts* with
its three stages starting. No console exception.
</details>

## Merged with `dev`

`dev` moved under this branch while it was open (#111, #112 — the plan reworked around the budget).
One file conflicted, `editorial-plan.test.ts`, and both sides were additive: the import line and two
adjacent `describe` blocks. Both are kept — 36 cases in that file, `dev`'s 32 and this branch's 4.
`git diff origin/dev HEAD` is exactly the nine files of this PR; nothing of `dev`'s was dropped.

Worth naming, because it lands next to this work: `dev` added `LLM_TIMEOUT_MS` (240s,
`AbortSignal.timeout`) on the gateway calls. The two are complementary — that one bounds a single
call, this one declares the step's budget and decides whether the agent may start at all. It also
directly attacks the local hangs described above.

## Anything Else?

- **The same 280s pretense lives in five other agents** (`image-agent`, `produce-agent`,
  `analytics-review-agent`, `week-planner-agent`, `seo-agent`). Each runs in its own route today, so
  it is harmless there — but it is the same pretense, and the day one of them is called from inside
  another's invocation it fails the same way. Not changed here: no evidence yet that it bites.
- **The claim that the strategy agent never produces a plan is local, not production.** Of 12
  production runs: 8 `finished`, 3 `fallback`, 1 `failed` (DeepSeek *Insufficient Balance*, a
  provider now out of the path). Locally it fails every time because a single call outlives the
  agent's whole deadline — which this PR now makes it give up on cleanly, degrading to legacy.
- **`.env` in the checkout points at production Supabase** (task 78). This walk ran against a
  separate env aimed at the local stack; nothing was written to production.
- The local `demo` brand was left with `onboarding_completed_at = NULL` to reopen the wizard.
