### PR TITLE
Derive the test's future date from the clock

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -366,3 +366,21 @@ Mossa: fai il cron a mano prima di diagnosticare, e tienilo acceso per tutta la 
 http://localhost:5220/api/v1/onboarding/steps/work; sleep 60; done`.
 Vale per ogni `*/N` in `vercel.json` (radar, knowledge, chat queue, designer, webhooks): in locale
 nessuno di quei lavori parte da solo, e ciò che sembra un blocco è una coda che nessuno drena.
+
+### Una data «futura» scritta a mano in un test è una bomba a orologeria
+`web_schedule_article` e `content_reschedule_post` passavano `scheduled_for: '2026-09-01T10:00'`, e
+il test la chiamava «una data futura». L'1/9/2026 alle 10:00 quella data è diventata passato: i due
+tool l'hanno rifiutata, giustamente, e i test sono diventati rossi **su ogni branch nello stesso
+istante**, per sempre. La suite completa era verde alle 08:43 e alle 08:59 dello stesso giorno.
+
+Il danno peggiore non è il rosso, è il verde che c'era prima: `content_reschedule_post` asserisce
+`isError === true`, quindi ha continuato a "passare" mentre l'errore arrivava da un'altra causa —
+un test che non verificava più la regola che dichiara di verificare, e che senza l'asserzione sul
+messaggio non avrebbe mai detto niente.
+
+Segnale: **«era verde stamattina e non ho toccato niente»**, con i file rossi lontanissimi dal tuo
+diff. Prima di cercare il colpevole nel codice, guarda l'orologio e cerca date scritte a mano.
+Mossa: la data si deriva da `Date.now()`, mai si scrive — `aDateInTheFuture()` in
+`packages/agent-kit/src/testkit.ts`. Restano della stessa forma quattro `periodEnd: new
+Date('2026-09-01')` (credit-warning, tool-policy, brand-studio-tools, content/ugc plugins): oggi
+innocui perché nessuno li confronta con l'orologio, domani no.

--- a/changelog/2026-09-01-test-dates-derive-from-now.md
+++ b/changelog/2026-09-01-test-dates-derive-from-now.md
@@ -1,0 +1,18 @@
+# Le date dei test si derivano dall'orologio, non si scrivono
+
+Due test passavano `scheduled_for: '2026-09-01T10:00'` chiamandola «una data futura». Alle 10:00
+dell'1/9/2026 è diventata passato, i tool l'hanno rifiutata — correttamente — e la suite è
+diventata rossa su ogni branch del repository nello stesso minuto, senza che nessuno avesse
+toccato una riga.
+
+`aDateInTheFuture()` vive nel testkit che entrambi i file già importano: la data si calcola da
+`Date.now()`, così non può invecchiare.
+
+Scartato: **spostare la data più in là** (2027, 2030). È lo stesso difetto con la miccia più
+lunga, e la prossima volta esplode addosso a qualcun altro senza il contesto per riconoscerlo.
+
+Scartato: **congelare l'orologio nei due test** con i fake timer. Avrebbe funzionato, ma questi
+test non parlano del tempo: chiedono «una data futura», e il modo onesto di dirlo è calcolarla.
+
+La lezione sta in `LESSONS.md`, insieme al segnale che la fa riconoscere — «era verde stamattina e
+non ho cambiato niente», con i file rossi lontani dal proprio diff.

--- a/packages/agent-kit/src/testkit.ts
+++ b/packages/agent-kit/src/testkit.ts
@@ -227,3 +227,8 @@ function stableSerialize(value: unknown): string {
 	}
 	return JSON.stringify(value);
 }
+
+/** Sempre avanti rispetto all'orologio: una data scritta a mano invecchia e diventa passato. */
+export function aDateInTheFuture(): string {
+	return new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString().slice(0, 16);
+}

--- a/src/lib/agent/plugins/content.test.ts
+++ b/src/lib/agent/plugins/content.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { createTestSupabase } from '$lib/testkit/supabase';
-import { fakeContext } from '../testkit';
+import { aDateInTheFuture, fakeContext } from '../testkit';
 
 // `content_create_post` avvolge `create_post` di chat/tools.ts, che a sua volta chiama
 // `createSingleContent` (rendering AI vero) e `remaining`/`addUsage` (crediti/quota, dietro
@@ -319,7 +319,7 @@ describe('le scritture di dominio che il kit non aveva', () => {
 		});
 		const plugin = createContentPlugin({ supabase: kit.client, brandId: BRAND_ID, userId: USER_ID });
 		const res = await plugin.execute(
-			{ name: 'content_reschedule_post', args: { post_id: 'post-10', scheduled_for: '2026-09-01T10:00' } },
+			{ name: 'content_reschedule_post', args: { post_id: 'post-10', scheduled_for: aDateInTheFuture() } },
 			fakeContext()
 		);
 		expect(res.isError).toBe(true);

--- a/src/lib/agent/plugins/web.test.ts
+++ b/src/lib/agent/plugins/web.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { createTestSupabase } from '$lib/testkit/supabase';
-import { fakeContext } from '../testkit';
+import { aDateInTheFuture, fakeContext } from '../testkit';
 
 // Ogni tool sugli articoli passa da `blogAdmin()` (chat/tools.ts), che apre l'admin client VERO:
 // senza mockarlo ogni test colpirebbe Supabase di produzione (stesso motivo di
@@ -74,7 +74,7 @@ describe('web_schedule_article — solo "approved" pubblica (regola non riscritt
 		const rls = seed([{ id: 'art-1', brand_id: BRAND_ID, title: 'Guida', status: 'draft' }]);
 		const plugin = createWebPlugin({ supabase: rls.client, brandId: BRAND_ID, userId: USER_ID });
 		const res = await plugin.execute(
-			{ name: 'web_schedule_article', args: { article_id: 'art-1', scheduled_for: '2026-09-01T10:00' } },
+			{ name: 'web_schedule_article', args: { article_id: 'art-1', scheduled_for: aDateInTheFuture() } },
 			fakeContext()
 		);
 		expect(res.isError).toBeFalsy();
@@ -89,7 +89,7 @@ describe('web_schedule_article — solo "approved" pubblica (regola non riscritt
 		const rls = seed([{ id: 'art-2', brand_id: BRAND_ID, title: 'Vecchio', status: 'published' }]);
 		const plugin = createWebPlugin({ supabase: rls.client, brandId: BRAND_ID, userId: USER_ID });
 		const res = await plugin.execute(
-			{ name: 'web_schedule_article', args: { article_id: 'art-2', scheduled_for: '2026-09-01T10:00' } },
+			{ name: 'web_schedule_article', args: { article_id: 'art-2', scheduled_for: aDateInTheFuture() } },
 			fakeContext()
 		);
 		expect(res.isError).toBe(true);


### PR DESCRIPTION
## What?

Two tests passed `scheduled_for: '2026-09-01T10:00'` and called it *«una data futura»*. At 10:00 on
2026-09-01 that date became the past, both tools rejected it — correctly — and the suite turned red
**on every branch of this repository in the same minute**, with nobody having touched a line.

The date now comes from the clock: `aDateInTheFuture()` in the testkit both files already import.

Three files, plus `LESSONS.md` and the internal changelog.

## Why?

This is blocking, not cosmetic: **every PR opened from now on fails CI** on these two tests until
this lands. Three branches are in flight right now that will hit it.

The worse half is the green that came before the red. `content_reschedule_post` asserts
`isError === true` — it wants the tool to refuse a `pending_user` draft. From 10:00 the tool refused
for an entirely different reason (a date in the past), so the test **stopped verifying the rule it
names** while still looking like it worked. Only its second assertion, the one on the error message,
turned it red. Without that line it would have gone on lying.

Measured, not argued: the full suite on this same repo was green at **08:43** and **08:59** today,
red from **10:00**. No commit in between.

## How?

```ts
export function aDateInTheFuture(): string {
	return new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString().slice(0, 16);
}
```

It lives in `packages/agent-kit/src/testkit.ts`, reached through the `src/lib/agent/testkit.ts`
re-export that both test files already use — one place, not one per file.

- **Rejected: moving the date further out** (2027, 2030). The same defect with a longer fuse, and
  next time it goes off in someone else's hands without the context to recognise it.
- **Rejected: freezing the clock** with fake timers in the two tests. It would work, but these tests
  are not about time: they ask for *a future date*, and the honest way to say that is to compute it.

## Testing?

- The two files, before: `2 failed | 22 passed`. After: `24 passed`.
- Full suite on this branch: **531 files green, 6037 tests passed, zero failed assertions.**
- One file, `src/hooks.server.test.ts`, fails in a bare worktree with `TypeError: Invalid URL` —
  `new URL(publicEnv.PUBLIC_SUPABASE_URL)` on an empty variable. It is a missing `.env` in the
  worktree, not a defect: given `PUBLIC_SUPABASE_URL` and `PUBLIC_SUPABASE_ANON_KEY` (local Docker
  stack, no production values) the file passes. CI has both.

## Evidence (screenshots/videos)

<details>
<summary>The failure, before the fix</summary>

```
× web_schedule_article — solo "approved" pubblica > con una data futura … 
  AssertionError: expected true to be falsy
  ❯ src/lib/agent/plugins/web.test.ts:80  expect(res.isError).toBeFalsy();

× content_reschedule_post RIFIUTA una bozza pending_user …
```

Wall clock at the time of the run: `2026-09-01T10:57`. The hardcoded date: `2026-09-01T10:00`.
</details>

<details>
<summary>Same two files, after</summary>

```
Test Files  2 passed (2)
     Tests  24 passed (24)
```
</details>

## Anything Else?

- **Four more of the same shape**, left alone deliberately: `periodEnd: new Date('2026-09-01')` in
  `credit-warning.test.ts`, `chat/tool-policy.test.ts`, `chat/brand-studio-tools.test.ts` and the
  `content`/`ugc` plugin tests. They pass today because nothing compares them to the clock. The day
  something does, they go off the same way. Naming them here rather than widening this PR.
- The lesson is in `LESSONS.md` with the signal that makes it recognisable: *«it was green this
  morning and I changed nothing»*, with the red files far away from your own diff. Look at the
  clock before you look for a culprit in the code.
