### PR TITLE
Mount the live answer once, not once per source

### DIFF
--- a/changelog/2026-09-01-live-bubble-one-mount.md
+++ b/changelog/2026-09-01-live-bubble-one-mount.md
@@ -1,0 +1,29 @@
+# La bolla viva è una sola, e non si rimonta più
+
+Il sintomo era vecchio: la pagina chat «ogni tanto si riaggiorna e perde lo stream, riprendendolo
+subito dopo», intanto saltando su e giù. Sette PR di durabilità — event log con `seq` monotono,
+cursore, lease con fence, parziale al primo render, poll una volta per tick — hanno reso durevoli
+i **dati** e non lo hanno tolto. Non lo toglievano perché il difetto non era nei dati.
+
+La bolla viva stava in **due blocchi `{#if}` mutuamente esclusivi**, uno per il run orfano e uno
+per lo stream della sessione, ciascuno con il proprio `<ChatLiveStatus>` dentro il proprio
+wrapper. Passare dall'uno all'altro non cambia delle prop: smonta un componente e ne monta un
+altro. Il salto della pagina era quel rimontaggio.
+
+E il passaggio non è raro, è la norma. `chat-session.ts` dismette di proposito la sessione su
+qualunque disconnessione benigna di un turno kit che abbia già ricevuto stream — il commento lo
+dichiara — e il poll riaggancia il run entro `LIVE_POLL_MS`. Da quando il Kit serve la chat
+utente, quel percorso è quello di tutti i giorni. I turni con `jobId` non ce l'hanno: lì la stessa
+disconnessione lascia `loading: true` e basta.
+
+Ora la scelta della sorgente — sessione o run orfano — si fa **in un posto solo**, un `$derived`,
+e il componente montato è uno. Il dismiss resta dov'era, il poll riaggancia come prima, ma il DOM
+non si ricostruisce.
+
+Scartato: **togliere il `sessions.delete` sui turni kit**. Quel dismiss è deliberato e il commento
+racconta cosa succedeva prima: `markSessionError` piegava il parziale in una bolla assistant e il
+poll faceva ricrescere lo stesso testo accanto — doppione, con una barra rossa su un turno vivo.
+Rimuoverlo riapre quel difetto per chiuderne un altro.
+
+Scartato: **ripetere `showLivePartial ? … : …` su ogni prop**. Sei condizioni identiche in sei
+punti sono un registro non scritto: alla prima prop nuova una delle sei si dimentica.

--- a/src/lib/content/changelog/2026-09-01-live-answer-stays-put.ts
+++ b/src/lib/content/changelog/2026-09-01-live-answer-stays-put.ts
@@ -1,0 +1,9 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-01',
+  title: 'The answer being written no longer jumps',
+  items: [
+    'A reply in progress used to blink away and come back a moment later, moving the page under you. It now stays in place from the first word to the last.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/routes/app/[brand]/chat/[thread]/shell.test.ts
+++ b/src/routes/app/[brand]/chat/[thread]/shell.test.ts
@@ -147,3 +147,23 @@ describe('thread page: il turno orfano non mescola canale e poll', () => {
 		expect(src).toMatch(/orphanState = emptyStreamState\(\);\s*\n\s*orphanPending = \[\];/);
 	});
 });
+
+/**
+ * Il difetto dell'1/9: la bolla viva stava in DUE blocchi `{#if}` distinti — uno per il run
+ * orfano, uno per lo stream della sessione — ciascuno con il suo `<ChatLiveStatus>`. Su una
+ * disconnessione benigna di un turno kit la sessione viene dismessa di proposito
+ * (`chat-session.ts`) e il poll riaggancia il run entro `LIVE_POLL_MS`: il passaggio fra i due
+ * rami SMONTAVA il componente e ne montava un altro, e l'utente vedeva lo stream sparire e la
+ * pagina saltare. I dati erano già durevoli: a rompersi era il montaggio.
+ */
+describe('thread page: la bolla viva non si smonta passando da sessione a orfano', () => {
+	const src = readFileSync(new URL('../components/TranscriptList.svelte', import.meta.url), 'utf8');
+
+	it('monta un solo ChatLiveStatus: due istanze in rami esclusivi si rimontano a vicenda', () => {
+		expect(src.match(/<ChatLiveStatus\b/g) ?? []).toHaveLength(1);
+	});
+
+	it('sceglie la sorgente in un posto solo, non ripetendo la condizione su ogni prop', () => {
+		expect(src.match(/showLivePartial\s*\?/g) ?? []).not.toHaveLength(6);
+	});
+});

--- a/src/routes/app/[brand]/chat/components/TranscriptList.svelte
+++ b/src/routes/app/[brand]/chat/components/TranscriptList.svelte
@@ -91,6 +91,26 @@
   } = $props();
 
   // La riga in store porta anche gli avatar dei custom agent; thread copre il primo paint.
+  const live = $derived(
+    showLivePartial
+      ? {
+          loading,
+          text: streamBuf,
+          tools: streamToolCalls,
+          reasoning: streamReasoning,
+          reasoningSegments: streamReasoningSegments
+        }
+      : orphanRun
+        ? {
+            loading: true,
+            text: orphanState.text,
+            tools: orphanState.tools,
+            reasoning: orphanState.reasoning,
+            reasoningSegments: [] as ChatReasoningSegment[]
+          }
+        : null
+  );
+
   const threadWho = $derived(
     threadIdentity($chatThreads.find((t) => t.id === thread.id) ?? thread, (k) => $_(k))
   );
@@ -267,27 +287,14 @@
      bolla viva, nello stesso punto. `ChatLiveStatus` a buffer vuoto mostra gia' «sta pensando»,
      quindi non serve nessuna riga di stato accanto — e un pulsante da solo, senza il testo che
      sta arrivando, era peggio del silenzio: diceva che c'era un turno senza mostrarlo. -->
-{#if orphanRun && !showLivePartial}
+{#if live}
   <div class="assistant-msg-wrap chat-turn">
     <ChatLiveStatus
-      loading
-      streamBuf={orphanState.text}
-      streamToolCalls={orphanState.tools}
-      streamReasoning={orphanState.reasoning}
-      {brandSlug}
-      face={liveWho.face}
-      color={liveWho.color}
-    />
-  </div>
-{/if}
-{#if showLivePartial}
-  <div class="assistant-msg-wrap chat-turn">
-    <ChatLiveStatus
-      {loading}
-      {streamBuf}
-      {streamToolCalls}
-      {streamReasoning}
-      {streamReasoningSegments}
+      loading={live.loading}
+      streamBuf={live.text}
+      streamToolCalls={live.tools}
+      streamReasoning={live.reasoning}
+      streamReasoningSegments={live.reasoningSegments}
       {brandSlug}
       face={liveWho.face}
       color={liveWho.color}


### PR DESCRIPTION
## What?

The live answer no longer blinks away and comes back a moment later, moving the page under the
reader. The bubble is now **one component**, with its source — the session stream or the orphan run
— chosen in a single derived value.

Two files: `TranscriptList.svelte` and the shell test that pins the invariant.

## Why?

Task #68: *«la pagina chat sembra ogni tot riaggiornarsi e perdere lo stream (riprendendolo subito
dopo), ma intanto fa casini a livello UI con il riposizionamento»*.

Seven PRs had already gone after this — #89 (durable turn progress, monotonic `seq`), #90 (fenced
lease), #92 (partial on first render), #105 (read forward, poll once per tick), and three commits
around them. They made the **data** durable and the symptom stayed, because the defect was never in
the data.

The live bubble lived in two mutually exclusive blocks, each with its own `<ChatLiveStatus>` inside
its own wrapper:

```svelte
{#if orphanRun && !showLivePartial}   → one bubble
{#if showLivePartial}                 → another bubble
```

Moving between them does not update props. It **unmounts one component and mounts another** — and
that remount is the jump.

**The move is the common case, not an edge one.** `chat-session.ts:793-807` dismisses the session on
purpose on any benign disconnect of a *kit* turn that already received stream — the comment says so
— and the page's poll re-attaches the run within `LIVE_POLL_MS` (350ms). Since the Kit serves user
chat, that is the everyday path. Turns carrying a `jobId` never had the problem: the same
disconnect leaves them `loading: true` (`chat-session.ts:776-783`). The protection existed and was
never extended.

## How?

One `$derived` picks the source; one component is mounted.

- **Rejected: removing the `sessions.delete` for kit turns.** That dismiss is deliberate, and its
  comment records what happened before it: `markSessionError` folded the partial into an assistant
  bubble *and* the poll regrew the same text beside it — a duplicate, with a red bar on a live turn.
  Removing it reopens that defect to close this one.
- **Rejected: repeating `showLivePartial ? … : …` on every prop.** Six identical conditions in six
  places are a registry nobody wrote down; the first prop added later forgets one of the six.

## Testing?

**Unit, written first and watched fail** — `expected length 1, got 2`, two `<ChatLiveStatus>` in the
file. The test pins both halves of the rule: one mount, and the condition written once.

**In the browser**, on the local stack (self-hosted Supabase in Docker, dev server on :5201 against
it, signed in as `test@anomalia.so`):

- **Session source** — a turn sent from the page streamed through the loading state, the
  *Thinking…* phase and the text, then finalized with its actions. No regression: this is the half
  the rewrite could have broken outright.
- **Orphan source** — the same thread opened in a second tab *during* a live turn, where the turn
  was never that tab's own. It rendered the stream and kept advancing: **54 → 163** between two
  screenshots.

**Not covered, and I am not going to imply otherwise.** I did not force the in-page transition
itself — session dismissed, orphan takes over, same page life. It needs a benign disconnect
mid-stream, and I have no network control from the browser tools; killing the dev server is a
different case, because with no `waitUntil` locally the turn actually dies and the poll has nothing
to re-attach. The absence of the remount is carried by construction — one mount, pinned by the test
— and by both sources rendering correctly, not by a video of the transition.

## Evidence (screenshots/videos)

<details>
<summary>The defect, in the console (before)</summary>

```
Svelte error: each_key_duplicate
Keyed each block has duplicate key `editorialPlan` at indexes 5 and 6
```

— that one is the sibling defect fixed in #113, on the same page family. For this one the console
said nothing at all: the remount is legal Svelte. It is visible only as movement.
</details>

<details>
<summary>The orphan bubble, live in a second tab</summary>

Two screenshots of the same tab seconds apart: the counter reads **54**, then **163**, in a tab
that never owned the turn. One mount, props advancing.
</details>

## Anything Else?

- A comment in `+page.svelte:424` says the poll re-attaches in «1,2s e non 4», while `LIVE_POLL_MS`
  is 350ms (`kit-run.ts:20`). Drift between a comment and the constant it describes — left alone
  here to keep the diff honest, but it is the exact kind of expired comment this repo bans.
- No test asserts the DOM identity of the bubble across the transition; the pin here is on the
  source shape instead. A real one needs a component harness this repo does not have.
