### PR TITLE
Use a solid marketing logo

### DIFF
--- a/changelog/2026-09-01-filled-logo.md
+++ b/changelog/2026-09-01-filled-logo.md
@@ -1,0 +1,8 @@
+# Logo marketing a tinta unica
+
+Il logo della navigazione marketing usava un gradiente, mentre il contesto richiedeva un segno
+più netto e leggibile.
+
+La variante negativa usa un solo `currentColor`, così il logo si adatta al contrasto del fondo:
+scuro nella navigazione chiara e bianco nel footer scuro. Il default gradientato resta disponibile
+per app e docs, che hanno già i propri trattamenti cromatici.

--- a/src/lib/components/BrandMark.svelte
+++ b/src/lib/components/BrandMark.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
-  // The Anomalia logo mark — sits next to the "Anomalia" wordmark in the navbar, footer and
-  // app sidebar. Inline SVG so it scales crisply and ships with no extra request. Keeps its
-  // brand colour (#9D86FF = --accent-2), which reads on both the light marketing chrome and
-  // the app sidebar.
-  let { size = 24 }: { size?: number } = $props();
+  let {
+    size = 24,
+    tone = 'gradient'
+  }: {
+    size?: number;
+    tone?: 'gradient' | 'negative';
+  } = $props();
 </script>
 
 <svg
@@ -15,17 +17,19 @@
   xmlns="http://www.w3.org/2000/svg"
   aria-hidden="true"
 >
-  <defs>
-    <linearGradient id="brandmark-gradient" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" style="stop-color:var(--accent);stop-opacity:1" />
-      <stop offset="100%" style="stop-color:var(--accent-2);stop-opacity:1" />
-    </linearGradient>
-  </defs>
+  {#if tone === 'gradient'}
+    <defs>
+      <linearGradient id="brandmark-gradient" x1="0%" y1="0%" x2="0%" y2="100%">
+        <stop offset="0%" style="stop-color:var(--accent);stop-opacity:1" />
+        <stop offset="100%" style="stop-color:var(--accent-2);stop-opacity:1" />
+      </linearGradient>
+    </defs>
+  {/if}
   <path
     fill-rule="evenodd"
     clip-rule="evenodd"
     d="M473.158 226.577C473.158 226.577 390.618 226.577 365.909 226.577C341.199 226.577 314.629 213.958 327.005 169.75C342.293 115.155 415.443 78.2267 473.158 78.2267C530.873 78.2267 604.023 115.155 619.311 169.75C631.697 213.958 605.116 226.577 580.407 226.577C555.698 226.577 473.158 226.577 473.158 226.577ZM49.0507 231.406C32.6058 231.301 16.1084 230.999 0 230.999V231.406V240.896V254.13H946.316V240.906V231.395V230.988C930.207 230.988 913.71 231.291 897.265 231.395H879.401C847.026 231.155 815.472 229.361 788.113 221.999C722.512 204.343 714.878 171.106 681.852 123.759C643.358 68.6113 577.505 0 473.158 0C368.811 0 302.958 68.6009 264.464 123.769C231.437 171.106 223.804 204.343 158.203 222.009C130.844 229.372 99.2896 231.166 66.915 231.406H49.0507ZM617.355 281.693H682.388C682.388 324.848 632.517 464 473.158 464C313.798 464 263.927 324.848 263.927 281.693H328.96C328.96 308.777 363.333 402.418 473.158 402.418C582.983 402.418 617.355 308.777 617.355 281.693Z"
-    fill="url(#brandmark-gradient)"
+    fill={tone === 'negative' ? 'currentColor' : 'url(#brandmark-gradient)'}
   />
 </svg>
 

--- a/src/lib/components/BrandMark.test.ts
+++ b/src/lib/components/BrandMark.test.ts
@@ -1,0 +1,21 @@
+import { render } from 'svelte/server';
+import { describe, expect, it } from 'vitest';
+import BrandMark from './BrandMark.svelte';
+
+describe('BrandMark', () => {
+	it('renders a negative mark as one current color', () => {
+		const { body } = render(BrandMark, { props: { tone: 'negative', size: 28 } });
+
+		expect(body).toContain('fill="currentColor"');
+		expect(body).not.toContain('<linearGradient');
+	});
+
+	it('keeps the gradient default and accessible SVG shape', () => {
+		const { body } = render(BrandMark);
+
+		expect(body).toContain('<linearGradient');
+		expect(body).toContain('fill="url(#brandmark-gradient)"');
+		expect(body).toContain('viewBox="0 0 947 464"');
+		expect(body).toContain('aria-hidden="true"');
+	});
+});

--- a/src/lib/components/SiteFooter.svelte
+++ b/src/lib/components/SiteFooter.svelte
@@ -56,7 +56,7 @@
     <!-- Left: brand + description -->
     <div class="foot-brand">
       <div class="foot-logo" role="img" aria-label={$_('landing.nav.brandAria')}>
-        <BrandMark size={36} />
+        <BrandMark size={36} tone="negative" />
         <span class="foot-logo-text" aria-hidden="true">Anomalia</span>
       </div>
       <p class="foot-desc">{$_('marketing.footer.tagline')}</p>
@@ -167,7 +167,7 @@
     </div>
   </div>
   <div class="foot-brand-big" aria-hidden="true">
-    <BrandMark size="clamp(4.5rem, 14vw, 12rem)" />
+    <BrandMark size="clamp(4.5rem, 14vw, 12rem)" tone="negative" />
     <span>anomalia</span>
   </div>
 </footer>
@@ -234,6 +234,7 @@
     align-items: center;
     gap: 10px;
     margin-bottom: 14px;
+    color: #fff;
   }
   .foot-logo-text {
     font-size: 20px;

--- a/src/lib/components/SiteNav.svelte
+++ b/src/lib/components/SiteNav.svelte
@@ -122,7 +122,7 @@
     <!-- Left: brand -->
     <div class="nav-left">
       <a href={lp('/')} class="brand" aria-label={$_('landing.nav.brandAria')}>
-        <BrandMark size={28} />
+        <BrandMark size={28} tone="negative" />
         <span class="logo logo-text" aria-hidden="true">Anomalia</span>
       </a>
     </div>

--- a/src/lib/content/changelog/2026-09-01-filled-logo.ts
+++ b/src/lib/content/changelog/2026-09-01-filled-logo.ts
@@ -1,0 +1,7 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-01',
+  title: 'A single-color Anomalia mark',
+  items: ['Marketing pages now show the Anomalia mark as a solid color that contrasts with its background.']
+} satisfies ChangelogEntry;


### PR DESCRIPTION
## Summary

- Add a single-color negative treatment for marketing navigation and footer marks.
- Preserve the gradient default for app and docs.
- Keep the existing mark shape and accessible labeling.
- Add internal and public changelog entries.

Task: Notion #10

## Tests

- `npx --no-install vitest run src/lib/components/BrandMark.test.ts src/lib/content/changelog/index.test.ts --reporter=verbose` — 4 passed
- `git diff --check` — passed
- `npm run check` — interrupted after about two minutes without output or errors; focused SSR tests pass.

Not merged.