### PR TITLE
Refine Agent panel topbar button

### DIFF
--- a/changelog/2026-09-01-agent-panel-button.md
+++ b/changelog/2026-09-01-agent-panel-button.md
@@ -1,0 +1,5 @@
+# Neutral Agent panel control
+
+The Agent panel toggle used the shared ghost CTA, which made it look like an accent-colored action in the chat top bar.
+
+It now uses a dedicated neutral variant with tighter spacing, a quieter border, no shadow, and no accent color. The shared primary and ghost CTA variants remain unchanged, including their behavior and responsive handling.

--- a/src/lib/components/PageTopBar.svelte
+++ b/src/lib/components/PageTopBar.svelte
@@ -736,6 +736,39 @@
     pointer-events: none;
     transform: none;
   }
+  .page-topbar-actions :global(.topbar-cta.neutral) {
+    gap: 6px;
+    border: 1px solid var(--line);
+    padding: 7px 10px;
+    font-size: 12px;
+    font-weight: 550;
+    color: var(--ink-soft);
+    background: transparent;
+    box-shadow: none;
+    transform: none;
+  }
+  .page-topbar-actions :global(.topbar-cta.neutral:hover:not(:disabled)) {
+    color: var(--ink);
+    background: var(--paper-2);
+    border-color: var(--line-2);
+    box-shadow: none;
+    transform: none;
+  }
+  .page-topbar-actions :global(.topbar-cta.neutral:active:not(:disabled)) {
+    background: var(--paper-3);
+    box-shadow: none;
+    transform: none;
+  }
+  .page-topbar-actions :global(.topbar-cta.neutral:focus-visible) {
+    outline: 2px solid var(--ink);
+    outline-offset: 2px;
+  }
+  .page-topbar-actions :global(.topbar-cta.neutral:disabled) {
+    opacity: 0.72;
+    cursor: not-allowed;
+    pointer-events: none;
+    transform: none;
+  }
   .page-topbar-actions :global(.topbar-cta-spin),
   .page-topbar-actions :global(.spin) {
     width: 14px;

--- a/src/lib/components/TopbarCta.svelte
+++ b/src/lib/components/TopbarCta.svelte
@@ -17,7 +17,7 @@
     disabled?: boolean;
     type?: 'submit' | 'button';
     title?: string;
-    variant?: 'primary' | 'ghost';
+    variant?: 'primary' | 'ghost' | 'neutral';
     /** Lucide (or compatible) icon — shown when not busy; spinner replaces it while loading. */
     Icon?: Component<{ class?: string; strokeWidth?: number | string; 'aria-hidden'?: boolean | 'true' | 'false' }>;
     class?: string;
@@ -32,6 +32,7 @@
   class="topbar-cta {className}"
   class:is-busy={busy}
   class:ghost={variant === 'ghost'}
+  class:neutral={variant === 'neutral'}
   {type}
   disabled={locked}
   aria-busy={busy}
@@ -89,6 +90,17 @@
     box-shadow: none;
   }
 
+  .topbar-cta.neutral {
+    gap: 6px;
+    padding: 7px 10px;
+    font-size: 12px;
+    font-weight: 550;
+    color: var(--ink-soft);
+    background: transparent;
+    border: 1px solid var(--line);
+    box-shadow: none;
+  }
+
   .topbar-cta:hover:not(:disabled):not(.is-busy) {
     transform: translateY(-1px);
     background: color-mix(in srgb, var(--accent) 88%, #000);
@@ -99,6 +111,14 @@
 
   .topbar-cta.ghost:hover:not(:disabled):not(.is-busy) {
     background: color-mix(in srgb, var(--accent) 14%, var(--paper));
+    box-shadow: none;
+  }
+
+  .topbar-cta.neutral:hover:not(:disabled):not(.is-busy) {
+    transform: none;
+    color: var(--ink);
+    background: var(--paper-2);
+    border-color: var(--line-2);
     box-shadow: none;
   }
 
@@ -115,9 +135,19 @@
     box-shadow: none;
   }
 
+  .topbar-cta.neutral:active:not(:disabled):not(.is-busy) {
+    transform: none;
+    background: var(--paper-3);
+    box-shadow: none;
+  }
+
   .topbar-cta:focus-visible {
     outline: 2px solid color-mix(in srgb, var(--accent) 55%, #fff);
     outline-offset: 2px;
+  }
+
+  .topbar-cta.neutral:focus-visible {
+    outline-color: var(--ink);
   }
 
   .topbar-cta:disabled,
@@ -154,6 +184,11 @@
   .topbar-cta.ghost .topbar-cta-spin {
     border-color: color-mix(in srgb, var(--accent) 30%, transparent);
     border-top-color: var(--accent);
+  }
+
+  .topbar-cta.neutral .topbar-cta-spin {
+    border-color: color-mix(in srgb, var(--ink) 22%, transparent);
+    border-top-color: var(--ink);
   }
 
   @keyframes topbar-cta-spin {

--- a/src/lib/components/topbar-cta.test.ts
+++ b/src/lib/components/topbar-cta.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const read = (rel: string) => readFileSync(fileURLToPath(new URL(rel, import.meta.url)), 'utf8');
+
+describe('agent panel topbar action', () => {
+	const page = read('../../routes/app/[brand]/chat/[thread]/+page.svelte');
+	const cta = read('./TopbarCta.svelte');
+	const topbar = read('./PageTopBar.svelte');
+
+	it('uses a compact neutral variant without accent styling', () => {
+		expect(page).toMatch(/variant="neutral"/);
+		expect(cta).toMatch(/variant\?: 'primary' \| 'ghost' \| 'neutral'/);
+		expect(cta).toMatch(/class:neutral=\{variant === 'neutral'\}/);
+		expect(cta).toMatch(/\.topbar-cta\.neutral/);
+		expect(topbar).toMatch(/:global\(\.topbar-cta\.neutral\)/);
+	});
+
+	it('keeps the accessible button toggle contract', () => {
+		expect(page).toMatch(/type="button"/);
+		expect(page).toMatch(/title=\{\$_\('chat\.computer\.toggle'\)\}/);
+		expect(page).toMatch(/onclick=\{\(\) => \(agentPanelOpen = !agentPanelOpen\)\}/);
+	});
+});

--- a/src/lib/content/changelog/2026-09-01-agent-panel-button.ts
+++ b/src/lib/content/changelog/2026-09-01-agent-panel-button.ts
@@ -1,0 +1,9 @@
+import type { ChangelogEntry } from './index';
+
+const entry: ChangelogEntry = {
+  date: '2026-09-01',
+  title: 'A quieter Agent panel control',
+  items: ['The Agent panel button is now smaller, neutral, and less distracting while you chat.']
+};
+
+export default entry;

--- a/src/routes/app/[brand]/chat/[thread]/+page.svelte
+++ b/src/routes/app/[brand]/chat/[thread]/+page.svelte
@@ -939,7 +939,7 @@
 {#snippet agentPanelTopAction()}
   <TopbarCta
     type="button"
-    variant="ghost"
+    variant="neutral"
     Icon={Monitor}
     title={$_('chat.computer.toggle')}
     onclick={() => (agentPanelOpen = !agentPanelOpen)}


### PR DESCRIPTION
## What

Make the chat Agent panel control more minimal, neutral, and less visually invasive.

## Changes

- Add a dedicated neutral TopbarCta variant without accent color or shadow.
- Use it only for the Agent panel toggle.
- Preserve button semantics, toggle behavior, and mobile actions-menu layout.
- Add internal and public changelogs.

## Tests

- `npx --no-install vitest run src/lib/components/topbar-cta.test.ts src/lib/chat-agent-panel-pref.test.ts src/lib/content/changelog/index.test.ts --reporter=verbose` — 9 passed.
- `git diff --check` — passed.
- `npm run check` — repository baseline failure: 346 errors and 247 warnings in 171 files; no reported errors in changed files.

## Evidence

Not applicable: UI-only styling change; behavior remains covered by focused tests.