### PR TITLE
Name a new custom-agent chat after its agent

### DIFF
--- a/changelog/2026-09-01-custom-agent-thread-name.md
+++ b/changelog/2026-09-01-custom-agent-thread-name.md
@@ -1,0 +1,38 @@
+# Il thread di un agente custom nasce già col suo nome
+
+Aprendo una chat nuova con un agente custom dal composer, per tutto il primo turno
+l'intestazione e la riga in sidebar mostravano lo **specialista sottostante** («Content
+Creator») invece dell'agente scelto. Dopo un reload il nome giusto compariva.
+
+Il perché: il thread nasceva senza legame. `POST /chat/threads` non guardava
+`custom_agent_id`; il composer creava il thread e poi mandava una PATCH per legarlo.
+La riga ottimistica nello store arrivava dalla risposta della POST — `custom_agent_id`
+valorizzato dopo la PATCH, `agents` vuoto — e `threadIdentity`, non trovando l'agente
+in `agents`, ricadeva sull'avatar fisso dello specialista.
+
+`agents` si popolava solo dai **run**: `listThreadAgentAvatars` leggeva
+`custom_agent_thread_runs`, e la riga di run nasce quando il turno parte
+(`touchThreadAgentRun`). Da qui il reload che «aggiusta»: a turno avviato il run c'è.
+
+**Il fix sta dove il server sa già la risposta.** La POST accetta `custom_agent_id`,
+lega il thread subito e restituisce la riga con `custom_agent_id` **e** `agents` già
+risolti: sidebar, topbar e composer leggono tutti quella riga dallo store, quindi si
+sistemano insieme invece di uno alla volta. La PATCH successiva dal composer sparisce
+(un giro in meno).
+
+E `listThreadAgentAvatars` non è più «chi ha girato qui»: è **chi identifica il thread**
+— l'agente legato per primo, poi i run. Una query in più non c'è: gli id legati entrano
+nella stessa `getCustomAgentsByIds`. Questo copre anche il fratello mai segnalato: un
+thread già esistente a cui si cambia agente custom dalla PATCH non ha ancora un run col
+nuovo agente, e dopo un reload mostrava il **vecchio**.
+
+**Il guardrail in `threadIdentity`.** La regola vive in un posto solo, e ora dice che un
+thread con `custom_agent_id` valorizzato non può essere nominato da nessun altro: se
+l'agente legato non è in `agents`, non si ripiega né su `agents[0]` né sull'etichetta
+dello specialista — resta «Anomalia» neutro. Meglio generico che sbagliato: il nome di
+un altro agente è indistinguibile da un difetto di routing.
+
+**Scartato:** far aggiornare `agents` al client dentro `setThreadCustomAgent` dello
+store. Il composer ha nome, faccia e colore dell'agente scelto e sarebbe stato più
+corto, ma avrebbe scritto la regola dell'identità in un secondo posto — e la seconda
+copia diverge alla prima modifica.

--- a/src/lib/chat-recipients.test.ts
+++ b/src/lib/chat-recipients.test.ts
@@ -61,6 +61,10 @@ describe('il composer usa QUESTA regola, non una copia', () => {
   });
 
   it('il thread nasce con l’agente selezionato, non con una costante', () => {
-    expect(src).toMatch(/createThread\(brandSlug, undefined, agentSel, roomSel\)/);
+    expect(src).toMatch(/createThread\(brandSlug, undefined, agentSel, roomSel, /);
+  });
+
+  it('l’agente custom scelto viaggia con la CREAZIONE del thread, non con una PATCH dopo', () => {
+    expect(src).toMatch(/createThread\(brandSlug, undefined, agentSel, roomSel, roomSel\.length \? null : customAgentSel\)/);
   });
 });

--- a/src/lib/components/ChatColumn.svelte
+++ b/src/lib/components/ChatColumn.svelte
@@ -849,7 +849,7 @@
     if (liveSendThreadId) return liveSendThreadId;
     // Chat di gruppo: la stanza scelta nel picker nasce insieme al thread, al primo messaggio.
     // Se il server la rifiuta (feature spenta, meno di due membri) resta un thread normale.
-    const id = await createThread(brandSlug, undefined, agentSel, roomSel);
+    const id = await createThread(brandSlug, undefined, agentSel, roomSel, roomSel.length ? null : customAgentSel);
     if (id) {
       liveSendThreadId = id;
       // Da qui in poi la stanza è il thread: la memoria del campo "A" copre solo l'attesa fra
@@ -861,7 +861,6 @@
       // `createThread` ha già inserito la riga in `chatThreads`: il refetch è solo allineamento
       // e non deve trattenere il primo turno.
       void refreshThreads(brandSlug);
-      if (!roomSel.length && customAgentSel) await setThreadCustomAgent(brandSlug, id, customAgentSel);
     }
     return id;
   }

--- a/src/lib/content/changelog/2026-09-01-custom-agent-thread-name.ts
+++ b/src/lib/content/changelog/2026-09-01-custom-agent-thread-name.ts
@@ -1,0 +1,9 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-01',
+  title: 'A chat with your agent carries its name from the first word',
+  items: [
+    'Starting a chat with one of your agents used to show the built-in specialist behind it — name and face — until the page was reloaded. The chat now carries your agent from the very first message, in the sidebar and at the top of the page.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/custom-agents.ts
+++ b/src/lib/server/custom-agents.ts
@@ -705,32 +705,40 @@ export type ThreadAgentAvatar = {
 };
 
 /**
- * Avatars of the custom agents that ran in each of `threadIds`, newest run first.
+ * Avatars of the custom agents that identify each thread: the one the thread is BOUND to first,
+ * then whoever ran in it, newest run first. A thread bound before its first turn has no run row
+ * yet, and without the binding it would borrow the name of the specialist underneath.
  * Threads no agent touched are simply absent from the map.
  */
 export async function listThreadAgentAvatars(
   supabase: SupabaseClient,
   brandId: string,
-  threadIds: string[]
+  threads: Array<{ id: string; custom_agent_id?: string | null }>
 ): Promise<Record<string, ThreadAgentAvatar[]>> {
   const out: Record<string, ThreadAgentAvatar[]> = {};
-  if (!threadIds.length) return out;
+  if (!threads.length) return out;
 
   const { data: runs } = await supabase
     .from('custom_agent_thread_runs')
     .select('thread_id, schedule_id, last_run_at')
     .eq('brand_id', brandId)
-    .in('thread_id', threadIds)
+    .in(
+      'thread_id',
+      threads.map((t) => t.id)
+    )
     .order('last_run_at', { ascending: false });
-  if (!runs?.length) return out;
+
+  const bound = threads
+    .filter((t) => t.custom_agent_id)
+    .map((t) => [t.id, t.custom_agent_id as string] as const);
+  const wanted = [
+    ...new Set([...(runs ?? []).map((r) => r.schedule_id as string), ...bound.map(([, a]) => a)])
+  ];
+  if (!wanted.length) return out;
 
   // La faccia è dell'AGENTE, non della routine che l'ha fatto lavorare: due routine dello stesso
   // agente devono impilare un avatar solo.
-  const agents = await getCustomAgentsByIds(
-    supabase,
-    brandId,
-    [...new Set(runs.map((r) => r.schedule_id as string))]
-  );
+  const agents = await getCustomAgentsByIds(supabase, brandId, wanted);
 
   const byId = new Map(
     agents.map((s) => [
@@ -744,12 +752,15 @@ export async function listThreadAgentAvatars(
     ])
   );
 
-  for (const run of runs) {
-    const avatar = byId.get(run.schedule_id as string);
-    if (!avatar) continue;
-    const list = (out[run.thread_id as string] ??= []);
+  const stack = (threadId: string, agentId: string) => {
+    const avatar = byId.get(agentId);
+    if (!avatar) return;
+    const list = (out[threadId] ??= []);
     if (!list.some((a) => a.id === avatar.id)) list.push(avatar);
-  }
+  };
+
+  for (const [threadId, agentId] of bound) stack(threadId, agentId);
+  for (const run of runs ?? []) stack(run.thread_id as string, run.schedule_id as string);
   return out;
 }
 

--- a/src/lib/stores/chat.ts
+++ b/src/lib/stores/chat.ts
@@ -153,7 +153,8 @@ export async function createThread(
   brandSlug: string,
   title?: string,
   agent?: string,
-  agents?: string[]
+  agents?: string[],
+  customAgentId?: string | null
 ): Promise<string | null> {
   try {
     console.log('[createThread] Creating thread for:', brandSlug);
@@ -163,6 +164,7 @@ export async function createThread(
       body: JSON.stringify({
         title: title ?? undefined,
         agent: agent ?? undefined,
+        custom_agent_id: customAgentId ?? undefined,
         ...(agents && agents.length >= 2 ? { agents } : {})
       })
     });

--- a/src/lib/thread-identity.test.ts
+++ b/src/lib/thread-identity.test.ts
@@ -50,6 +50,27 @@ describe('threadIdentity', () => {
     expect(who.color).toBe('#2563eb');
   });
 
+  it('custom agent non ancora risolto → mai il nome dello specialista sotto', () => {
+    const who = threadIdentity(
+      { title: 'Nuova chat', agent: 'content', custom_agent_id: 'b', agents: [] },
+      t
+    );
+    expect(who.name).toBe('Anomalia');
+  });
+
+  it('custom agent legato → mai il nome di un altro agente passato per la stessa chat', () => {
+    const who = threadIdentity(
+      {
+        title: 'Nuova chat',
+        agent: 'content',
+        custom_agent_id: 'b',
+        agents: [{ id: 'a', name: 'Primo', face: 'dot', color: '#ef4444' }]
+      },
+      t
+    );
+    expect(who.name).toBe('Anomalia');
+  });
+
   it('specialista builtin → etichetta e avatar dell’hub, mai il titolo', () => {
     const who = threadIdentity({ title: 'Riassunto', agent: 'content' }, t);
     expect(who.name).toBe('Content Creator');

--- a/src/lib/thread-identity.ts
+++ b/src/lib/thread-identity.ts
@@ -82,7 +82,8 @@ export function roomMemberAvatar(
  * Risolve nome + avatar di un thread. Il nome è SEMPRE l'agente, mai il titolo/riassunto: come in
  * una lista di messaggi l'identità è il contatto.
  * - `agent = 'job:<key>'` (LEGACY) → nome della routine con la faccia dell'agente PROPRIETARIO.
- * - thread con custom agent → il suo nome e il suo avatar salvati.
+ * - thread con custom agent → il suo nome e il suo avatar salvati; finché non è risolto resta
+ *   "Anomalia", mai l'etichetta dello specialista che gli sta sotto.
  * - specialista builtin → la sua etichetta i18n e il suo avatar fisso.
  * - thread semplice → "Anomalia" con l'avatar neutro a tema. Il nome è un letterale, non una
  *   chiave i18n: non si traduce.
@@ -128,10 +129,9 @@ export function threadIdentity(
     };
   }
 
-  const custom =
-    (thread.custom_agent_id
-      ? thread.agents?.find((a) => a.id === thread.custom_agent_id)
-      : null) ?? (thread.agents?.length ? thread.agents[0] : null);
+  const custom = thread.custom_agent_id
+    ? (thread.agents?.find((a) => a.id === thread.custom_agent_id) ?? null)
+    : (thread.agents?.[0] ?? null);
   if (custom) {
     return {
       name: custom.name || title || 'Anomalia',
@@ -141,7 +141,7 @@ export function threadIdentity(
     };
   }
 
-  if (agent && agent !== 'auto' && BUILTIN_AGENT_AVATARS[agent]) {
+  if (!thread.custom_agent_id && agent && agent !== 'auto' && BUILTIN_AGENT_AVATARS[agent]) {
     const builtin = BUILTIN_AGENT_AVATARS[agent];
     // `.label`, non la chiave nuda: `chat.agents.<id>` è un OGGETTO {label, desc}, e svelte-i18n su
     // una chiave-oggetto restituisce l'oggetto → "[object Object]" in sidebar.

--- a/src/routes/app/[brand]/chat/threads/+server.ts
+++ b/src/routes/app/[brand]/chat/threads/+server.ts
@@ -21,7 +21,7 @@ import {
   roomRoster,
   setThreadRoomAgents
 } from '$lib/server/chat/room';
-import { listThreadAgentAvatars } from '$lib/server/custom-agents';
+import { listThreadAgentAvatars, type ThreadAgentAvatar } from '$lib/server/custom-agents';
 import { isUnread, loadLastReads, loadUnreadCounts, markThreadRead } from '$lib/server/chat/unread';
 import { hasWebHub } from '$lib/server/plans';
 import { bilingualNoticeLocale } from '$lib/i18n/locale';
@@ -42,8 +42,8 @@ export const GET: RequestHandler = async ({ params, locals: { supabase, safeGetS
     (t) => !dmAgents((t as { room_agents?: unknown }).room_agents)
   );
   const ids = threads.map((t) => t.id);
-  // Custom agents that ran in each thread — the sidebar stacks their avatars.
-  const avatars = await listThreadAgentAvatars(supabase, brand.id, ids);
+  // Custom agents that identify each thread — the sidebar stacks their avatars.
+  const avatars = await listThreadAgentAvatars(supabase, brand.id, threads);
 
   // Chat di gruppo: per una stanza la pila di avatar è LA STANZA — i membri, nell'ordine in cui
   // sono stati scelti — non chi ci ha girato dentro. Stessa forma di `listThreadAgentAvatars`,
@@ -111,6 +111,17 @@ export const POST: RequestHandler = async ({ request, params, locals: { supabase
 
   const thread = await createThread(supabase, brand.id, user.id, title, null, agent);
 
+  const customAgentId =
+    typeof body.custom_agent_id === 'string' && body.custom_agent_id ? body.custom_agent_id : null;
+  let agents: ThreadAgentAvatar[] = [];
+  if (thread && customAgentId) {
+    await setThreadCustomAgent(supabase, thread.id, brand.id, user.id, customAgentId);
+    const avatars = await listThreadAgentAvatars(supabase, brand.id, [
+      { id: thread.id, custom_agent_id: customAgentId }
+    ]);
+    agents = avatars[thread.id] ?? [];
+  }
+
   // Chat di gruppo: `agents` è la stanza, `agent` resta chi risponde se la stanza non regge
   // (feature spenta, migration non applicata, meno di due membri validi). Un update a parte e non
   // un parametro di createThread apposta: se fallisce, il thread è già nato ed è un thread normale.
@@ -118,7 +129,19 @@ export const POST: RequestHandler = async ({ request, params, locals: { supabase
   if (thread && groupChatsEnabled() && Array.isArray(body.agents)) {
     room = await setThreadRoomAgents(supabase, thread.id, brand.id, user.id, body.agents);
   }
-  return json({ thread: thread ? { ...thread, room_agents: room.length ? room : null } : thread }, { status: 201 });
+  return json(
+    {
+      thread: thread
+        ? {
+            ...thread,
+            custom_agent_id: customAgentId,
+            room_agents: room.length ? room : null,
+            agents
+          }
+        : thread
+    },
+    { status: 201 }
+  );
 };
 
 // PATCH: rename a thread and/or set its specialized agent

--- a/src/routes/app/[brand]/chat/threads/create-custom-agent.test.ts
+++ b/src/routes/app/[brand]/chat/threads/create-custom-agent.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { threadIdentity } from '$lib/thread-identity';
+
+const CUSTOM_AGENT_ID = '11111111-2222-3333-4444-555555555555';
+
+const createThread = vi.fn(async () => ({
+  id: 'thread-1',
+  agent: 'content',
+  custom_agent_id: null,
+  created_at: 'now'
+}));
+const setThreadCustomAgent = vi.fn(async () => {});
+
+vi.mock('$lib/server/chat/persistence', () => ({
+  createThread: (...a: unknown[]) => createThread(...(a as [])),
+  getThread: async () => null,
+  listThreads: async () => [],
+  listThreadSnippets: async () => ({}),
+  renameThread: vi.fn(),
+  deleteThread: vi.fn(),
+  setThreadAgent: vi.fn(),
+  setThreadCustomAgent: (...a: unknown[]) => setThreadCustomAgent(...(a as [])),
+  setThreadModel: vi.fn()
+}));
+
+vi.mock('$lib/server/custom-agents-read', () => ({
+  listCustomAgents: async () => [],
+  getCustomAgent: async () => null,
+  getCustomAgentsByIds: async (_c: unknown, _b: string, ids: string[]) =>
+    ids.includes(CUSTOM_AGENT_ID)
+      ? [{ id: CUSTOM_AGENT_ID, name: 'Scriba Fischietto', avatar_face: 'wink', avatar_color: '#2563eb' }]
+      : []
+}));
+
+const { POST } = await import('./+server');
+
+const t = (k: string) => ({ 'chat.agents.content.label': 'Content Creator' })[k] ?? k;
+
+/** Fake Supabase: solo le catene che POST percorre (il brand, e i run dei custom agent). */
+function makeSupabase() {
+  const chain: Record<string, unknown> = {
+    maybeSingle: async () => ({ data: { id: 'brand-1', plan: 'pro' } }),
+    then: (resolve: (v: { data: unknown[] }) => unknown) => resolve({ data: [] })
+  };
+  chain.select = () => chain;
+  chain.eq = () => chain;
+  chain.in = () => chain;
+  chain.order = () => chain;
+  return { from: () => chain };
+}
+
+function post(body: unknown) {
+  const event = {
+    request: { json: async () => body },
+    params: { brand: 'demo' },
+    locals: {
+      supabase: makeSupabase(),
+      safeGetSession: async () => ({ user: { id: 'u1' }, session: {} })
+    }
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (POST as any)(event) as Promise<Response>;
+}
+
+describe('POST /app/[brand]/chat/threads con un agente custom', () => {
+  beforeEach(() => {
+    createThread.mockClear();
+    setThreadCustomAgent.mockClear();
+  });
+
+  it('il thread nasce già legato: la risposta lo dice', async () => {
+    const res = await post({ agent: 'content', custom_agent_id: CUSTOM_AGENT_ID });
+    const { thread } = await res.json();
+    expect(setThreadCustomAgent).toHaveBeenCalled();
+    expect(thread.custom_agent_id).toBe(CUSTOM_AGENT_ID);
+  });
+
+  it('la risposta porta già il nome e il volto dell’agente, non quelli dello specialista sotto', async () => {
+    const res = await post({ agent: 'content', custom_agent_id: CUSTOM_AGENT_ID });
+    const { thread } = await res.json();
+    const who = threadIdentity(thread, t);
+    expect(who.name).toBe('Scriba Fischietto');
+    expect(who.face).toBe('wink');
+    expect(who.color).toBe('#2563eb');
+  });
+
+  it('senza agente custom resta un thread normale: nessun legame, nessun avatar', async () => {
+    const res = await post({ agent: 'content' });
+    const { thread } = await res.json();
+    expect(setThreadCustomAgent).not.toHaveBeenCalled();
+    expect(thread.agents).toEqual([]);
+    expect(threadIdentity(thread, t).name).toBe('Content Creator');
+  });
+});


### PR DESCRIPTION
## What?

Opening a new chat with one of your **custom agents** from the composer used to name the thread after the *built-in specialist underneath it* — "Content Creator", with its face — in the chat topbar and in the sidebar, for the whole first turn. Reloading the page fixed the name. This PR makes the thread carry its agent from the first word: `POST /chat/threads` binds the custom agent at creation and answers with its name and avatar already resolved, and `threadIdentity` now refuses to name a bound thread after the specialist under it.

## Why?

The first turn is exactly when the user is checking they are talking to the agent they picked. Being told they are talking to "Content Creator" is indistinguishable from a routing bug, and the only remedy was a reload nobody thinks to do. The same hole also hit a thread whose custom agent was *changed*: with no run of the new agent yet, a reload showed the previous one.

## How?

Three moves, one rule each:

1. **The creation endpoint binds and answers with the identity.** `POST /app/[brand]/chat/threads` accepts `custom_agent_id`, calls `setThreadCustomAgent`, and returns the row with `custom_agent_id` **and** `agents` already resolved. Sidebar, topbar and composer all read that one row from the store, so they fix together instead of one call site at a time. The composer's follow-up `PATCH` disappears — one round-trip less.
2. **`listThreadAgentAvatars` is no longer "who ran here": it is "who identifies this thread".** It takes the thread rows instead of ids and puts the **bound** agent first, then the runs. Same number of queries — the bound ids join the existing `getCustomAgentsByIds`. This is what covers the never-reported sibling: `custom_agent_thread_runs` only gets a row when a turn starts (`touchThreadAgentRun`), which is why a reload "fixed" the original bug and why changing a thread's agent showed the old one.
3. **The rule lives in one place.** `threadIdentity`: a thread with `custom_agent_id` can only be named by *that* agent. If it isn't in `agents`, it falls back to neutral "Anomalia" — never `agents[0]`, never the specialist's i18n label. Generic beats wrong: another agent's name reads as a routing defect.

**Rejected:** having the store's `setThreadCustomAgent` patch `agents` on the client. The composer knows the picked agent's name, face and colour, so it would have been the shorter diff — but it writes the identity rule in a second place, and the second copy diverges at the first change (`CLAUDE.md`, scattered conditions).

## Testing?

Red first, then green — the failing tests were watched fail before the fix:

- `src/lib/thread-identity.test.ts` — a bound thread with an unresolved (or stale) `agents` list is never named "Content Creator". Before the fix: `expected 'Content Creator' to be 'Anomalia'` and `expected 'Primo' to be 'Anomalia'`.
- `src/routes/app/[brand]/chat/threads/create-custom-agent.test.ts` (new) — the POST response, fed straight into `threadIdentity`, yields "Scriba Fischietto" with its face and colour; without a custom agent the thread stays a normal one named after its specialist. Before the fix: `expected 'Content Creator' to be 'Scriba Fischietto'`.
- `src/lib/chat-recipients.test.ts` — the existing source-level guard on the composer, extended: the picked custom agent must ride along with the **creation**, not a later PATCH.

Full suite on this branch, rebased onto `dev`: **6069 passed, 1 failed, 4 skipped (542 files)**. The single failure is `src/lib/content/changelog/index.test.ts` and is **pre-existing on `dev`**: `src/lib/content/changelog/2026-09-01-homepage-agent-panel.ts` (from #122) declares `date: 'September 1, 2026'` instead of the ISO form, which parses two hours off and breaks the newest-first ordering. Reproduced identically on the main checkout, untouched by this PR.

**Verified in the browser** — yes, against the local Docker stack (`localhost:8000`), a dev server from this worktree on port 5179 (env overlay, never the hosted project), logged in as `test@anomalia.so` on brand `demo`, identity confirmed through the DB (`chat_threads.user_id` → `auth.users.email`), with the existing custom agent "Scriba Fischietto" (spec `content`):

- Composer → chip TO → YOUR AGENTS → only "Scriba Fischietto" selected → message sent. **During the whole first turn** the topbar and the new sidebar row read "Scriba Fischietto" with its avatar. That is exactly where "Content Creator" used to be.
- Then the harder case: the thread's `custom_agent_thread_runs` row was deleted by hand and the page hard-reloaded. Still "Scriba Fischietto" — the identity now comes from the binding, not from a past run.
- `GET /chat/threads` returns `agents: [{id, name: 'Scriba Fischietto', face: 'wink', color: '#fdba74'}]` with `custom_agent_id` set.

**Not tested:** the persona's *content*. In one turn on that thread the model introduced itself as "Content Creator" despite the custom brief; the persona branch did run (the run row is written by `touchThreadAgentRun` only inside it, and it reappeared on the next turn), the thread row is identical in shape to threads created before this change, and nothing here touches `turn-prep` or the system prompt. It is worth its own look, but it is not this diff.

## Evidence

Screenshots taken on the local stack (not hosted), saved locally — GitHub cannot receive them from the CLI:

- `first-turn.jpg` — during the first turn, before any reply: topbar "Scriba Fischietto" + its face, sidebar row "Scriba Fischi… / Nuova chat". Before this PR both said "Content Creator".
- `after-reload-no-run-row.jpg` — same thread after a hard reload with the run row deleted: still "Scriba Fischietto", proving the name comes from the binding.

## Anything Else?

- `createThread` in `src/lib/stores/chat.ts` now takes a fifth positional argument. Five positionals is one too many; it becomes an options object the next time that signature is touched, not in a fix.
- The `date: 'September 1, 2026'` entry noted above should be corrected to `2026-09-01` on `dev` — it is a one-line fix and it is not in this branch's scope.
