### PR TITLE
Give the image path the design execution floor

### DIFF
--- a/changelog/2026-09-01-design-floor-in-image-path.md
+++ b/changelog/2026-09-01-design-floor-in-image-path.md
@@ -1,0 +1,84 @@
+# Il pavimento di esecuzione del design arriva ai render dei post
+
+## Cosa c'era prima
+
+Il wall di `/design` fa giudicare ogni pezzo da un modello vision (`design-judge.ts`:
+`design_score`, `design_note`, `design_tags`, punteggi per asse) e `wall-digest.ts` ne
+distilla un testo compatto — `designWallDigestSection()` — che dice, con istruzioni
+osservabili, cosa fa il lavoro forte in questo momento: struttura del layout, densità e
+gerarchia tipografica, ruoli della palette, mosse compositive, uso del vuoto.
+
+Quel testo aveva **un solo consumatore**: `content-preview/caption-quality.ts`, cioè la
+qualità della *didascalia*. Il percorso che genera davvero la grafica —
+`content-preview/images.ts` — non importava nulla da `wall-digest`. L'unico contatto fra
+le immagini dei concorrenti e la generazione era un divieto in `plan-pipeline.ts`, per
+giunta su thumbnail scelte per *performance*, non per qualità di design.
+
+Risultato osservato dal proprietario: in `/design` l'AI riconosce benissimo cosa è fatto
+bene; i produttori dentro l'app continuano a consegnare grafiche brutte.
+
+## Cosa cambia
+
+`RenderImageOpts` porta un campo `craftFloor`, e `buildImageRequest` lo concatena
+**subito dopo `HOUSE_LOOK`**, prima dello stile del brand. È il posto giusto per una
+ragione sola: `HOUSE_LOOK` è già il pavimento di esecuzione statico ("IMAGE QUALITY
+BAR"), e il digest è il suo gemello dinamico. La regola sta scritta in **un posto solo**;
+tutto il resto è approvvigionamento.
+
+Ad approvvigionarlo sono `renderWithQC` e `renderCarouselSlide`, i due ingressi dei
+produttori di grafica: da lì passano il batch settimanale (`weekly-planner.ts`), la
+creazione del post singolo e del carosello (`creation.ts`) e le immagini degli articoli
+(`articles.ts`).
+
+## Perché non `renderPostImage`, che sarebbe stato un punto solo
+
+`renderPostImage` è il chokepoint di *ogni* render, UGC compreso: `ugc-batch.ts` ci passa
+ritratti, still e frame di copertina. Un pavimento pensato per il design da feed
+("un titolo sovradimensionato, 3-5 parole, 60% dell'altezza") su un frame UGC candid è un
+peggioramento, non un miglioramento — e il percorso video/UGC ha già il suo pavimento, il
+digest *trending*. Due righe di approvvigionamento invece di una sono il prezzo di non
+toccare quel percorso.
+
+## Perché non nei 5 punti dove si costruiscono i `renderOpts`
+
+`creation.ts` li costruisce tre volte, `weekly-planner.ts` una (dentro il ciclo per post),
+`articles.ts` una. Cinque copie della stessa riga divergono alla prima modifica.
+
+## I due assi, tenuti separati
+
+L'anti-moodboard confondeva due cose diverse: differenziarsi nel **soggetto** e rifiutare
+l'**artigianato**. La frase «NEVER imitate or echo these images' style, layouts or ideas»
+governa i *seed*, che portano anche `art_direction` (medium, grammatica di pagina,
+palette): cioè diceva allo stratega di eseguire diversamente dal campo, non solo di
+mostrare altro. Ora dice che il soggetto va differenziato e che l'esecuzione deve
+pareggiare o battere il campo.
+
+La separazione vera però è di **stadio**, ed è quella che regge: il soggetto si decide
+nel prompt di strategia (`planStrategy`), il pavimento di esecuzione entra nel prompt di
+render. Sono due chiamate diverse: nessuna delle due contiene l'istruzione dell'altra.
+
+## Costo
+
+`designWallDigestSection()` scaricava il JSON dal bucket a ogni chiamata. Con l'aggancio
+in `renderWithQC` + `renderCarouselSlide` sarebbe diventato un download per post e per
+slide, dentro il ciclo del batch. `digestSection` ora memoizza la *lettura* per processo
+(non la sezione): la freschezza resta valutata a ogni chiamata, quindi un digest che
+supera i 30 giorni degrada comunque a stringa vuota. Il digest è globale e oggi non ha
+nemmeno un rigeneratore, quindi una lettura per processo è esatta.
+
+## Scartato
+
+- **Rendere `buildImageRequest` async** per leggere da sé il digest: è pura apposta
+  (`articles.ts` la usa per costruire richieste Batch identiche byte per byte), e la
+  purezza è ciò che rende il prompt testabile senza rete.
+- **Una cache con TTL**: il TTL sarebbe stato una seconda nozione di freschezza accanto a
+  `DIGEST_MAX_AGE_DAYS`, che già esiste e già decade correttamente perché memoizziamo il
+  record, non la sezione.
+- **Agganciare anche `image-agent.ts`**: il loop agentico scrive i propri prompt e ha già
+  un giro di ispezione e QC. È un altro lavoro, non questo.
+
+## Cosa questo NON dimostra
+
+Che le immagini diventino più belle. Il test prova che il pavimento arriva al prompt e che
+senza digest il prompt resta identico byte per byte. La differenza di qualità si misura
+solo guardando immagini prodotte prima e dopo, e non è stata misurata.

--- a/src/lib/content/changelog/2026-09-01-design-craft-floor.ts
+++ b/src/lib/content/changelog/2026-09-01-design-craft-floor.ts
@@ -1,0 +1,9 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-01',
+  title: 'Post images now build on the best design around',
+  items: [
+    'The craft standard distilled from the strongest design in your field — layout, type hierarchy, palette roles, composition — now reaches the generator for every post image and every carousel slide, not just the captions. Your subject stays deliberately different from your competitors; only the execution bar goes up.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/content-preview/craft-floor.test.ts
+++ b/src/lib/server/content-preview/craft-floor.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const digest = { section: '' };
+
+vi.mock('$lib/server/wall-digest', () => ({
+  designWallDigestSection: () => Promise.resolve(digest.section)
+}));
+
+const generateContent = vi.fn();
+
+vi.mock('$lib/server/gemini', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('$lib/server/gemini')>()),
+  googleGenaiClient: () => ({ models: { generateContent } })
+}));
+
+vi.mock('$lib/server/model-routing', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('$lib/server/model-routing')>()),
+  route: () => ({ endpoint: 'google' })
+}));
+
+vi.mock('$lib/server/research', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('$lib/server/research')>()),
+  structured: vi.fn(async () => ({ pass: true, score: 9, issues: [], fixHint: '', brandStyleMatch: true }))
+}));
+
+const { buildImageRequest, renderWithQC, renderCarouselSlide } = await import('./images');
+
+const RENDERED = {
+  candidates: [{ content: { parts: [{ inlineData: { data: 'AAAA', mimeType: 'image/png' } }] } }]
+};
+
+const DESIGN_FLOOR =
+  '\n\nAMBIENT DESIGN FLOOR (distilled 2026-08-20 from the strongest current feed design):\none oversized headline, 3-5 words, 60% of canvas height\n';
+
+const PROMPT = 'A jar of honey on a linen cloth';
+const RENDER_OPTS = { visualStyle: 'warm editorial', aspectRatio: '1:1' as const };
+
+const promptsSentToModel = () =>
+  generateContent.mock.calls.map((c) => c[0].contents[0].parts[0].text as string);
+
+const failingStorage = {
+  storage: { from: () => ({ upload: async () => ({ error: { message: 'no bucket' } }) }) }
+};
+
+beforeEach(() => {
+  digest.section = '';
+  generateContent.mockReset();
+  generateContent.mockResolvedValue(RENDERED);
+});
+
+describe('il pavimento di esecuzione del design arriva al percorso immagine', () => {
+  it('renderWithQC lo inietta quando il digest esiste', async () => {
+    digest.section = DESIGN_FLOOR;
+
+    await renderWithQC(null as never, PROMPT, RENDER_OPTS, {}, false);
+
+    expect(promptsSentToModel()[0]).toContain('AMBIENT DESIGN FLOOR');
+  });
+
+  it('renderCarouselSlide lo inietta su ogni slide', async () => {
+    digest.section = DESIGN_FLOOR;
+
+    await renderCarouselSlide(
+      null as never,
+      failingStorage as never,
+      'user-1',
+      'slide two: the mechanic',
+      1,
+      3,
+      RENDER_OPTS,
+      undefined,
+      {}
+    );
+
+    expect(promptsSentToModel()[0]).toContain('AMBIENT DESIGN FLOOR');
+  });
+
+  it('senza digest il prompt resta identico a prima', async () => {
+    await renderWithQC(null as never, PROMPT, RENDER_OPTS, {}, false);
+
+    expect(promptsSentToModel()[0]).toBe(buildImageRequest(PROMPT, RENDER_OPTS).contents[0].parts[0].text);
+  });
+
+  it('il pavimento non tocca il soggetto: entra come blocco a sé, prima dello stile del brand', async () => {
+    digest.section = DESIGN_FLOOR;
+
+    await renderWithQC(null as never, PROMPT, RENDER_OPTS, {}, false);
+
+    const text = promptsSentToModel()[0];
+    expect(text).toContain('AMBIENT DESIGN FLOOR');
+    expect(text.indexOf('AMBIENT DESIGN FLOOR')).toBeLessThan(text.indexOf('BRAND VISUAL STYLE'));
+    expect(text.slice(0, PROMPT.length)).toBe(PROMPT);
+  });
+});

--- a/src/lib/server/content-preview/images.ts
+++ b/src/lib/server/content-preview/images.ts
@@ -17,6 +17,7 @@ import { signPaths } from '$lib/server/people';
 import { svgToPng } from '$lib/server/brand-analysis';
 import { normalizeContentFormat } from '$lib/content-formats';
 import { firstLogoUrl } from '$lib/server/blog-site';
+import { designWallDigestSection } from '$lib/server/wall-digest';
 
 
 // Image MIME types Gemini ingests directly (SVG is rasterised via svgToPng).
@@ -143,6 +144,7 @@ export type RenderImageOpts = {
   baseImage?: ImagePart;
   aspectRatio?: AspectRatio;
   model?: string;
+  craftFloor?: string;
 };
 
 /**
@@ -203,7 +205,7 @@ export function buildImageRequest(imagePrompt: string, opts: RenderImageOpts = {
   const userRefSuffix = opts.userRefImages?.length
     ? '\n\nThe user attached the following image(s) as REFERENCES for this specific edit — use them to guide the change described above: match the look, composition, colours or subject they show, as the feedback implies. Let the user\'s instruction decide exactly what to take from them.'
     : '';
-  const text = `${cleanPrompt}\n\n${ASPECT_LABEL[aspectRatio]}, high quality, social-media ready. No text overlays unless natural.\n\n${HOUSE_LOOK}${styleSuffix}${brandSuffix}${playbookSuffix}${baseSuffix}${logoSuffix}${personSuffix}${refSuffix}${userRefSuffix}${moodSuffix}`;
+  const text = `${cleanPrompt}\n\n${ASPECT_LABEL[aspectRatio]}, high quality, social-media ready. No text overlays unless natural.\n\n${HOUSE_LOOK}${opts.craftFloor ?? ''}${styleSuffix}${brandSuffix}${playbookSuffix}${baseSuffix}${logoSuffix}${personSuffix}${refSuffix}${userRefSuffix}${moodSuffix}`;
   // L'immagine base va per PRIMA: il prompt la chiama "the FIRST attached image". I mood per ultimi.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const parts: any[] = [{ text }, ...(opts.baseImage ? [opts.baseImage] : []), ...(opts.logoImage ? [opts.logoImage] : []), ...(opts.personImages ?? []), ...(opts.referenceImages ?? []), ...(opts.userRefImages ?? []), ...(opts.moodImages ?? [])];
@@ -422,8 +424,9 @@ export async function renderWithQC(
 ): Promise<{ dataUrl: string | undefined; qc?: QcVerdict }> {
   // Alto rischio → N candidati in parallelo e il critico sceglie; altrimenti un render solo.
   const wanted = highStakes ? HIGH_STAKES_CANDIDATES : 1;
+  const opts = { ...renderOpts, craftFloor: await designWallDigestSection() };
   const settled = await Promise.allSettled(
-    Array.from({ length: wanted }, () => renderPostImage(ai, imagePrompt, renderOpts))
+    Array.from({ length: wanted }, () => renderPostImage(ai, imagePrompt, opts))
   );
   const candidates = settled
     .filter((r): r is PromiseFulfilledResult<string | undefined> => r.status === 'fulfilled')
@@ -461,7 +464,7 @@ export async function renderWithQC(
     const retryPrompt = `${imagePrompt}\n\nCORRECTIONS (previous attempt(s) failed QC — fix ALL of these):${hints.map((h) => `\n- ${h}`).join('')}`;
     console.warn(`[renderWithQC] QC failed (${best.critique.score}/10, ${nCandidates} candidate(s))${critiqueOpts.productName ? ` for "${critiqueOpts.productName}"` : ''}: ${best.critique.issues.join('; ')} → retry ${attempt + 1}/${MAX_QC_RETRIES}`);
     // Un ritentativo che non torna con un'immagine chiude il ciclo: resta il migliore finora.
-    const retry = await renderPostImage(ai, retryPrompt, renderOpts).catch((error) => { swallow('render qc retry', error); return undefined; });
+    const retry = await renderPostImage(ai, retryPrompt, opts).catch((error) => { swallow('render qc retry', error); return undefined; });
     if (!retry) break;
     attempts += 1;
     retried = true;
@@ -519,7 +522,7 @@ export async function renderCarouselSlide(
 ): Promise<string | undefined> {
   const seriesDirective = carouselSeriesDirective(slideIndex, totalSlides);
   // La slide 1 precede i mood del brand, così domina l'ancoraggio estetico.
-  const opts = { ...renderOpts, moodImages: [...(slideOneAnchor ? [slideOneAnchor] : []), ...(renderOpts.moodImages ?? [])] };
+  const opts = { ...renderOpts, craftFloor: await designWallDigestSection(), moodImages: [...(slideOneAnchor ? [slideOneAnchor] : []), ...(renderOpts.moodImages ?? [])] };
   try {
     let dataUrl = await renderPostImage(ai, slidePrompt + seriesDirective, opts);
     if (dataUrl && critiqueOpts.referenceImages?.length) {

--- a/src/lib/server/content-preview/plan-pipeline.ts
+++ b/src/lib/server/content-preview/plan-pipeline.ts
@@ -283,7 +283,7 @@ ${STORY_FAILURE_MODES}`
     ? ((await Promise.all(competitorThumbUrls.slice(0, MAX_COMPETITOR_MOOD_IMAGES).map(fetchImagePart))).filter(Boolean) as ImagePart[])
     : [];
   const competitorBlock = competitorParts.length
-    ? `\nCOMPETITOR VISUAL FIELD (the ${competitorParts.length} attached image(s) are top-performing posts from this brand's COMPETITORS — an ANTI-moodboard): read the visual clichés this field repeats (subjects, compositions, backdrops, styling, on-image text) and make every seed's SUBJECT/SETTING deliberately DIFFERENT from them — claim the visual white space. NEVER imitate or echo these images' style, layouts or ideas.\n`
+    ? `\nCOMPETITOR VISUAL FIELD (the ${competitorParts.length} attached image(s) are top-performing posts from this brand's COMPETITORS — an ANTI-moodboard): read the visual clichés this field repeats (subjects, compositions, backdrops, styling, on-image text) and make every seed's SUBJECT/SETTING deliberately DIFFERENT from them — claim the visual white space. NEVER reuse their subjects, ideas or on-image copy. This is about WHAT a post shows, never about how well it is made: differentiating never licenses executing below this field — composition, type hierarchy, light, colour and finish must match or beat it.\n`
     : '';
 
   const marketBlock = marketBrief.trim() ? `\n${marketBrief.trim()}\n` : '';

--- a/src/lib/server/wall-digest-read.test.ts
+++ b/src/lib/server/wall-digest-read.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from 'vitest';
+import { WALL_DIGEST_VERSION } from './wall-digest';
+
+const downloads = { count: 0 };
+
+vi.mock('$lib/server/supabase-admin', () => ({
+  createAdminClient: () => ({
+    storage: {
+      from: () => ({
+        download: async () => {
+          downloads.count += 1;
+          return {
+            data: {
+              text: async () =>
+                JSON.stringify({
+                  kind: 'design',
+                  version: WALL_DIGEST_VERSION,
+                  generatedAt: new Date().toISOString(),
+                  itemCount: 12,
+                  text: 'one oversized headline, 3-5 words'
+                })
+            },
+            error: null
+          };
+        }
+      })
+    }
+  })
+}));
+
+const { designWallDigestSection } = await import('./wall-digest');
+
+describe('il pavimento del design si scarica una volta per processo', () => {
+  it('non ripete il download a ogni post del batch', async () => {
+    const sections = await Promise.all(Array.from({ length: 8 }, () => designWallDigestSection()));
+
+    expect(downloads.count).toBe(1);
+    for (const section of sections) {
+      expect(section).toContain('AMBIENT DESIGN FLOOR');
+    }
+  });
+});

--- a/src/lib/server/wall-digest.ts
+++ b/src/lib/server/wall-digest.ts
@@ -316,9 +316,16 @@ export function wallDigestSection(digest: WallDigest | null, now = Date.now()): 
   return `\n\nCURRENT VIRAL MECHANICS (distilled ${dated} from clips that beat their own account's median — ambient floor; the brief and any studied reference stay the ceiling):\n${digest.text}\n`;
 }
 
+const digestReadOncePerProcess = new Map<WallDigestKind, Promise<WallDigest | null>>();
+
 async function digestSection(kind: WallDigestKind): Promise<string> {
   try {
-    return wallDigestSection(await readWallDigest(createAdminClient(), kind));
+    let read = digestReadOncePerProcess.get(kind);
+    if (!read) {
+      read = readWallDigest(createAdminClient(), kind);
+      digestReadOncePerProcess.set(kind, read);
+    }
+    return wallDigestSection(await read);
   } catch {
     return '';
   }


### PR DESCRIPTION
## What?

The design digest that `/design` produces — the craft standard distilled from the strongest
graded posts in the field: layout structure, type density and hierarchy, palette roles,
composition moves, what the best pieces avoid — now reaches the prompt that renders post
images and carousel slides. It did not before.

`RenderImageOpts` gains `craftFloor`; `buildImageRequest` concatenates it immediately after
`HOUSE_LOOK`, before the brand style. `renderWithQC` and `renderCarouselSlide` source it from
`designWallDigestSection()`. The rule is written in exactly one place; the two other lines only
fetch it.

Two smaller changes ride along because they are the same defect:

- The anti-moodboard in `planStrategy` conflated two axes. It now says the SUBJECT must differ
  from the competitor field and that differentiating never licenses executing below it.
- `digestSection` memoizes the storage read per process. The new hook lives inside the batch's
  per-post loop, and one download per post and per slide buys nothing.

## Why?

Verified on the code before touching anything, and the diagnosis holds:

- `design-judge.ts` grades competitor posters (`design_score`, `design_note`, `design_tags`,
  per-axis scores) and writes them to `market_posts`.
- `wall-digest.ts` builds two digests from that. `trendingWallDigestSection()` has three
  consumers — `motion-video/agent.ts`, `media-generator/ugc-plan-agent.ts`,
  `media-generator/ugc-batch.ts`.
- **`designWallDigestSection()` had exactly one consumer: `content-preview/caption-quality.ts`.**
  The caption. Not the graphic.
- `content-preview/images.ts` imported nothing from `wall-digest`: zero references to
  `design_score`, `design_note` or the digest.
- The only contact between competitor imagery and generation was a prohibition in
  `plan-pipeline.ts:286` — *"NEVER imitate or echo these images' style, layouts or ideas"* — on
  thumbnails selected by **performance** (`competitorThumbUrls`), not by design quality.

So the product knew what good design looks like and never told the thing that draws.

## How?

**Where the floor is injected, and why there.** `HOUSE_LOOK` is already the execution floor of
every render — a static "IMAGE QUALITY BAR" that raises the bar and leaves palette, mood and
subject to `visualStyle` + `brandLook`. The design digest is its dynamic twin: same register,
same job, sourced from what actually scores well right now instead of from a constant. So it
goes immediately after it, and before `styleSuffix`, so the brand style still reads as the
thing that overrides.

**Where it is sourced, and what was rejected.**

- *Rejected: `renderPostImage`.* It is the single chokepoint of every render, one line would
  have done it — and that is exactly the problem. `media-generator/ugc-batch.ts` renders
  portraits, stills and cover frames through it. A feed-design floor ("one oversized headline,
  3-5 words, 60% of canvas height") on a candid UGC frame is a regression, and the UGC path
  already has its own floor in the trending digest. Two sourcing lines is the price of not
  touching it.
- *Rejected: the five `renderOpts` construction sites* (`creation.ts` ×3, `weekly-planner.ts`,
  `articles.ts`). Five copies of one line diverge at the first edit.
- *Rejected: making `buildImageRequest` async.* It is pure on purpose — `articles.ts` uses it to
  build Batch requests byte-identical to the synchronous path — and that purity is what makes
  the prompt testable without the network.
- *Rejected: hooking `image-agent.ts`.* The agentic loop writes its own prompts and runs its own
  inspect/QC cycle. Different problem, different PR.

`renderWithQC` and `renderCarouselSlide` are the two entry points of the graphic producers:
through them go the weekly batch (`weekly-planner.ts`), single post and carousel creation
(`creation.ts`) and article images (`articles.ts`).

**The two axes, kept apart.** The real separation is by **stage**, not by wording: the subject
is decided in the strategy prompt (`planStrategy`, which emits SUBJECT / SETTING / PROPS), the
execution floor enters the render prompt. Two different model calls; neither carries the other's
instruction. The wording change in `plan-pipeline.ts` exists because seeds also carry
`art_direction` (medium, page grammar, palette) — so the old sentence was telling the strategist
to execute differently from the field, not just to show something else.

**Cost.** `designWallDigestSection()` downloaded a JSON from the private bucket on every call.
Hooked where it now is, that would be one download per post and per slide inside the batch loop.
`digestSection` memoizes the *record*, not the section, so `isDigestFresh` is still evaluated on
every call and a digest past `DIGEST_MAX_AGE_DAYS` (30) still degrades to an empty string. The
digest is global and currently has no regenerator, so one read per process is exact. A TTL was
rejected: it would be a second notion of freshness beside one that already works.

## Testing?

**Written first, watched fail.** `src/lib/server/content-preview/craft-floor.test.ts` drives the
real `renderWithQC` / `renderCarouselSlide` with a fake Google client and asserts on the prompt
text that actually reaches the model. Before the fix: 3 failed / 1 passed. After: 4 passed. The
one that passed on both sides is the invariance test, and it is meant to.

- `renderWithQC` injects the floor when the digest exists.
- `renderCarouselSlide` injects it on every slide.
- **With no digest the prompt is byte-identical** to `buildImageRequest(prompt, opts)` without a
  floor — a brand with no field data changes nothing.
- The floor lands as its own block, before `BRAND VISUAL STYLE`, and the seed's own prompt still
  opens the text.

`src/lib/server/wall-digest-read.test.ts` counts storage downloads: 8 concurrent
`designWallDigestSection()` calls, 1 download.

**Full suite** (`npx vitest run`, worktree with its own `npm ci` and a copied `.env`):
`5992 tests — 5944 passed, 41 skipped, 7 failed` across `534 files — 524 passed, 1 skipped,
9 failed`.

Every failure was chased down, none is mine:

- **7 of 9 files pass when rerun isolated.** They are the documented full-suite noise: 120s and
  60s test timeouts, `[vitest-worker]: Timeout calling "fetch"` on module transforms, and
  `redact` "under 1s on 1 MB" measuring 1137ms. `tsc` was running concurrently on the same
  machine; transform time alone was 794s.
- **The 2 that survive isolation — `agent/plugins/content.test.ts` and
  `agent/plugins/web.test.ts` — fail identically on the base.** Proven by parking the diff
  (`git diff > patch` + `git checkout --`, never `git stash`), rerunning both files on the
  pristine tree, and getting the same two assertions (`expected 'requested time is in the past'
  to contain 'approve_post'`, `expected true to be falsy`). They look date-dependent. Patch
  reapplied and re-verified afterwards.

`npx tsc --noEmit`: 20 errors, all in `scripts/db-migrate.mjs`, all pre-existing implicit-`any`
in an untouched `.mjs`. Zero in `src/`.

**What I did NOT verify, and cannot.**

- **I cannot show that the images come out better.** No image was rendered. What is proven is
  that the floor reaches the prompt, and that without a digest the prompt is unchanged byte for
  byte. Read the two as exactly that and nothing more.
- **No browser gate.** This change has no UI surface, and exercising it end to end means paying
  for real renders on a local stack against a bucket that would have to be seeded with a digest.
  Not done.
- **No eval run.** `npm run eval:ux` and `npm run eval:durability` measure the onboarding walk
  and durability; neither judges image craft, so neither would have said anything about this.
- **The wording change in `plan-pipeline.ts` has no test.** It is prompt text inside a large
  async function with heavy dependencies; a test asserting the string is present would only
  restate the diff. Its risk is real and stated: it slightly relaxes an instruction that was
  tuned for subject differentiation.
- **Empty-digest behaviour in production is the likely case.** `distillWallDigests` has had no
  caller since the public wall was switched off. If the bucket holds nothing, or something older
  than 30 days, this PR is a no-op by construction — which is the point of the invariance test,
  but also means the win depends on a digest existing.

## Evidence (screenshots/videos)

No UI change, so no screenshots.

<details>
<summary>The test, red before the fix</summary>

```
FAIL  craft-floor.test.ts > renderWithQC lo inietta quando il digest esiste
AssertionError: expected 'A jar of honey on a linen cloth\n\nSq…' to contain 'AMBIENT DESIGN FLOOR'

FAIL  craft-floor.test.ts > renderCarouselSlide lo inietta su ogni slide
AssertionError: expected 'slide two: the mechanic\n\nCAROUSEL S…' to contain 'AMBIENT DESIGN FLOOR'

 Test Files  1 failed (1)
      Tests  3 failed | 1 passed (4)
```
</details>

<details>
<summary>Green after</summary>

```
 ✓ src/lib/server/content-preview/craft-floor.test.ts (4 tests)
 ✓ src/lib/server/wall-digest-read.test.ts (1 test)
 Test Files  2 passed (2)
      Tests  5 passed (5)
```
</details>

<details>
<summary>The two survivors, failing the same way on the base (diff parked)</summary>

```
$ git diff > /tmp/patch && git checkout -- <3 files>
$ npx vitest run src/lib/agent/plugins/content.test.ts src/lib/agent/plugins/web.test.ts

FAIL  content.test.ts > content_reschedule_post RIFIUTA una bozza pending_user
AssertionError: expected 'requested time is in the past' to contain 'approve_post'
FAIL  web.test.ts > con una data futura: scheduled_for + status approved, MAI published
AssertionError: expected true to be falsy

 Test Files  2 failed (2)
      Tests  2 failed | 22 passed (24)
```
</details>

## Anything Else?

**An honest way to measure whether this actually works, since I cannot claim it does.** The
cheapest one that would not lie: render the same N seeds twice — once with the floor, once with
`craftFloor` forced empty — and send both sets to `design-judge.ts`, the same vision judge that
grades the wall, comparing per-axis scores (typography, composition, colour, craft) pairwise.
The judge is already written, already calibrated on this exact question, and never sees which
arm is which. It costs real renders, so it belongs in an eval scenario, not in CI. Without
something like that, "the images got better" stays an opinion.

**Known debt.**

- `image-agent.ts` (default ON, backs standalone image generation and article images) does not
  get the floor. Its render tool builds opts inline and the agent writes its own prompts; giving
  it the floor is a design question about where an agentic loop's constraints live, not a line
  of plumbing.
- `distillWallDigests` still has no scheduled caller. Whatever sits in the bucket is what every
  brand gets, until it crosses 30 days and everyone silently gets nothing. That expiry is the
  right default, but nothing today refills it.
- The digest is global. Per-brand nuance happens only because the rest of the prompt carries the
  brand's category — which is the existing design, not something this PR changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHzdoJhyXfnkX6mWWJkduX
