### PR TITLE
Make the changelog date the one in the filename

### DIFF
--- a/changelog/2026-09-01-changelog-dates-iso.md
+++ b/changelog/2026-09-01-changelog-dates-iso.md
@@ -1,0 +1,21 @@
+# Le date del changelog pubblico si scrivono come il nome del file
+
+Il changelog pubblico ordina le entry con `Date.parse(entry.date)`, e il tipo diceva `date: string`.
+Due formati convivevano: 61 voci in ISO (`'2026-09-01'`) e 14 in prosa (`'September 1, 2026'`).
+
+Finché i due formati cadevano in giorni diversi non se ne accorgeva nessuno. Il 1° settembre 2026
+sono atterrate dodici voci nello stesso giorno e una era in prosa: `Date.parse` legge la prosa come
+mezzanotte **locale** e l'ISO come mezzanotte **UTC**, quindi la voce in prosa risultava due ore più
+vecchia delle sue coetanee, l'ordinamento newest-first si rovesciava e il test diventava rosso —
+su `dev`, per tutti, senza che nessuno avesse toccato il changelog.
+
+Ora il nome del file è la verità e il tipo la impone: `ChangelogDate` accetta solo `YYYY-MM-DD`,
+e un test verifica che ogni entry dichiari esattamente la data del proprio file. Le 13 voci
+disallineate sono state normalizzate leggendo il loro stesso nome, non a mano.
+
+Scartato: **correggere solo la voce che aveva rotto la build**. Avrebbe rimesso il verde lasciando
+in piedi le altre tredici e il tipo che le permette: la prossima collisione era questione di
+giorni, e sarebbe arrivata addosso a qualcun altro senza il contesto per riconoscerla.
+
+Scartato: **ordinare per nome del file invece che per il campo `date`**. Toglie il sintomo e lascia
+due fonti di verità che possono dire cose diverse; meglio che possano dirne una sola.

--- a/src/lib/content/changelog/2026-08-27-llm-gateway.ts
+++ b/src/lib/content/changelog/2026-08-27-llm-gateway.ts
@@ -1,6 +1,6 @@
 // Il formato lo definisce ./index.ts: qui solo i dati.
 const entry = {
-  date: 'August 27, 2026',
+  date: '2026-08-27',
   title: 'One pipe for text',
   items: [
     'Chat, embeddings, video and audio reviews and music prompts now run through a single AI gateway — one place decides what powers the product, and model swaps are configuration, not code.',

--- a/src/lib/content/changelog/2026-08-28-agent-specific-skills.ts
+++ b/src/lib/content/changelog/2026-08-28-agent-specific-skills.ts
@@ -1,6 +1,6 @@
 // Il formato lo definisce ./index.ts (PR changelog-entry-files): qui solo i dati.
 const entry = {
-  date: 'August 28, 2026',
+  date: '2026-08-28',
   title: 'A skill kit of their own',
   items: [
     'Each agent of your team now carries its own set of skills instead of one shared bundle — starting with the Motion specialist, who picks up the Remotion playbook nobody else needs.',

--- a/src/lib/content/changelog/2026-08-28-brand-writing-skills.ts
+++ b/src/lib/content/changelog/2026-08-28-brand-writing-skills.ts
@@ -1,6 +1,6 @@
 // Il formato lo definisce ./index.ts (PR changelog-entry-files): qui solo i dati.
 const entry = {
-  date: 'August 28, 2026',
+  date: '2026-08-28',
   title: 'Copy that never reads like a chatbot',
   items: [
     'Every text your agents write now passes through two writing disciplines — one governs how it is drafted, the other reviews it — so posts and captions stop carrying the usual AI tells.',

--- a/src/lib/content/changelog/2026-08-28-chat-images-reach-the-agent.ts
+++ b/src/lib/content/changelog/2026-08-28-chat-images-reach-the-agent.ts
@@ -1,6 +1,6 @@
 // Il formato lo definisce ./index.ts: qui solo i dati.
 const entry = {
-  date: 'August 28, 2026',
+  date: '2026-08-28',
   title: 'Attached images reach the chat agent',
   items: [
     'Attaching a photo to a chat no longer fails the turn: the agent now sees the image natively and can work with it.',

--- a/src/lib/content/changelog/2026-08-28-chat-underscore-italic.ts
+++ b/src/lib/content/changelog/2026-08-28-chat-underscore-italic.ts
@@ -1,7 +1,7 @@
 import type { ChangelogEntry } from './index';
 
 const entry: ChangelogEntry = {
-  date: 'August 28, 2026',
+  date: '2026-08-28',
   title: 'System notices read as italic, not raw underscores',
   items: [
     'Short system notices in chat — like the one telling you a background task did not start — now show in italic instead of displaying raw underscores around the text.'

--- a/src/lib/content/changelog/2026-08-28-kit-onboarding-ignite.ts
+++ b/src/lib/content/changelog/2026-08-28-kit-onboarding-ignite.ts
@@ -1,7 +1,7 @@
 import type { ChangelogEntry } from './index';
 
 const entry: ChangelogEntry = {
-  date: 'August 28, 2026',
+  date: '2026-08-28',
   title: 'Your whole team greets you on day one',
   items: [
     'The specialists matched to your plan now reach out in their own conversations after setup on every engine, not just one — no matter which one handled your first conversation.'

--- a/src/lib/content/changelog/2026-08-28-onboarding-team-contact.ts
+++ b/src/lib/content/changelog/2026-08-28-onboarding-team-contact.ts
@@ -1,7 +1,7 @@
 import type { ChangelogEntry } from './index';
 
 const entry: ChangelogEntry = {
-  date: 'August 28, 2026',
+  date: '2026-08-28',
   title: 'Your whole team greets you on day one',
   items: [
     'When you create a brand, the specialists relevant to your plan now reach out to you in their own conversations right after the setup starts — declaring who they are and beginning their first concrete piece of work, not just saying hello.'

--- a/src/lib/content/changelog/2026-08-28-one-repo-for-everything-anomalia.ts
+++ b/src/lib/content/changelog/2026-08-28-one-repo-for-everything-anomalia.ts
@@ -1,7 +1,7 @@
 // Il formato lo definisce ./index.ts (PR changelog-entry-files): qui solo i dati.
 // Finché il loader non è merged il file è inerte — nessun conflitto in arrivo.
 const entry = {
-  date: 'August 28, 2026',
+  date: '2026-08-28',
   title: 'One repository for everything Anomalia',
   items: [
     'The CLI, the MCP server and the agent skills now live in this repository — releases, installs and updates all come from here.',

--- a/src/lib/content/changelog/2026-08-28-openrouter-stream-finish.ts
+++ b/src/lib/content/changelog/2026-08-28-openrouter-stream-finish.ts
@@ -1,7 +1,7 @@
 import type { ChangelogEntry } from './index';
 
 const entry: ChangelogEntry = {
-  date: 'August 28, 2026',
+  date: '2026-08-28',
   title: 'OpenRouter chat streams no longer fail silently',
   items: ['Chat turns now complete when OpenRouter omits a finish signal after delivering a response.']
 };

--- a/src/lib/content/changelog/2026-08-28-proactive-delegation.ts
+++ b/src/lib/content/changelog/2026-08-28-proactive-delegation.ts
@@ -1,7 +1,7 @@
 import type { ChangelogEntry } from './index';
 
 const entry: ChangelogEntry = {
-  date: 'August 28, 2026',
+  date: '2026-08-28',
   title: 'Agents hand cross-craft work over without being asked',
   items: [
     'Agents now delegate by default: when your request contains work that belongs to another specialist, they hand it over immediately instead of doing it badly themselves or waiting for you to say who should do it.',

--- a/src/lib/content/changelog/2026-08-28-tool-schema-literal-true.ts
+++ b/src/lib/content/changelog/2026-08-28-tool-schema-literal-true.ts
@@ -1,7 +1,7 @@
 import type { ChangelogEntry } from './index';
 
 const entry: ChangelogEntry = {
-  date: 'August 28, 2026',
+  date: '2026-08-28',
   title: 'Fewer silent chat failures',
   items: [
     'Fixed a bug that made every Content Creator turn fail before generating anything — a malformed tool description that the model provider rejected as a whole.'

--- a/src/lib/content/changelog/2026-08-28-version-tags-releases.ts
+++ b/src/lib/content/changelog/2026-08-28-version-tags-releases.ts
@@ -1,5 +1,5 @@
 const entry = {
-  date: 'August 28, 2026',
+  date: '2026-08-28',
   title: 'Versions, tags and releases — automatic',
   items: [
     'Every release now carries a version and a build identity: merging to main tags `v0.3.0`-style versions and publishes GitHub release notes on its own.',

--- a/src/lib/content/changelog/2026-09-01-homepage-agent-panel.ts
+++ b/src/lib/content/changelog/2026-09-01-homepage-agent-panel.ts
@@ -1,7 +1,7 @@
 import type { ChangelogEntry } from './index';
 
 const entry: ChangelogEntry = {
-  date: 'September 1, 2026',
+  date: '2026-09-01',
   title: 'See your agent at work',
   items: ['The homepage now shows the agent panel and a remote-computer preview on desktop; mobile keeps the focused chat view.']
 };

--- a/src/lib/content/changelog/index.test.ts
+++ b/src/lib/content/changelog/index.test.ts
@@ -9,6 +9,20 @@ describe('changelog pubblico', () => {
     }
   });
 
+  // Il nome del file è la verità: `YYYY-MM-DD-slug.ts`. Una data scritta a mano che non lo
+  // rispecchia sposta la entry nel tempo senza che nessuno se ne accorga — e se cade nello stesso
+  // giorno di una ISO, l'ordine si rovescia.
+  test('ogni data è ISO e coincide con quella del nome del file', () => {
+    const files = import.meta.glob('./2*.ts', { eager: true }) as Record<
+      string,
+      { default: { date: string } }
+    >;
+    for (const [path, mod] of Object.entries(files)) {
+      if (path.endsWith('.test.ts')) continue;
+      expect(mod.default.date, path).toBe(path.slice('./'.length, './'.length + 10));
+    }
+  });
+
   test('ogni entry ha un titolo e almeno una riga', () => {
     for (const entry of changelogEntries) {
       expect(entry.title.trim().length).toBeGreaterThan(0);

--- a/src/lib/content/changelog/index.ts
+++ b/src/lib/content/changelog/index.ts
@@ -1,5 +1,10 @@
+/** `YYYY-MM-DD`, come il nome del file. Una data in prosa e una ISO nello stesso giorno si
+ *  ordinano al contrario: `Date.parse` legge la prima come mezzanotte locale e la seconda come
+ *  mezzanotte UTC. */
+export type ChangelogDate = `${number}-${number}-${number}`;
+
 export type ChangelogEntry = {
-  date: string;
+  date: ChangelogDate;
   title: string;
   items: string[];
 };


### PR DESCRIPTION
## What?

`dev` is red right now, and this makes it green.

The public changelog sorts its entries on `Date.parse(entry.date)`, and the type said `date: string`.
Two formats had been coexisting for weeks: **61 entries in ISO** (`'2026-09-01'`) and **14 in prose**
(`'September 1, 2026'`). The date is now the one in the filename, and the type refuses anything else.

Sixteen files: the type, the test, the 13 entries that disagreed with their own name, and the two
changelogs.

## Why?

While the two formats landed on different days, nobody noticed. On 2026-09-01 twelve entries landed
on the same day and one of them was prose: `Date.parse` reads prose as **local** midnight and ISO as
**UTC** midnight, so the prose entry sorted two hours older than its own day-mates, the newest-first
ordering broke, and `src/lib/content/changelog/index.test.ts` went red — on `dev`, for everybody,
with nobody having touched the changelog.

Verified on `origin/dev` at `e79d479`:

```
FAIL  src/lib/content/changelog/index.test.ts
  le entry arrivano dalla più recente
```

**This blocks the release**: `dev` is 24 commits ahead of `main` and cannot ship with a red suite.

## How?

The filename already carried the truth (`YYYY-MM-DD-slug.ts`), so it became the rule:

```ts
export type ChangelogDate = `${number}-${number}-${number}`;
```

and a test asserts every entry's `date` equals the ten characters at the head of its own filename —
which also catches an ISO date that is simply *wrong*, not only one in prose. The 13 stragglers were
rewritten from their own names by a script, never by hand.

- **Rejected: fixing only the entry that broke the build.** Green again, thirteen more still there
  and a type that still permits them. The next collision was days away and would have landed on
  someone without the context to recognise it.
- **Rejected: sorting by filename instead of by the `date` field.** It removes the symptom and
  leaves two sources of truth free to disagree. Better that there is only one.

## Testing?

- Before, on `dev`: `index.test.ts` → **1 failed | 1 passed**.
- After: **3 passed** (the new filename invariant included).
- Full suite on this branch: **540 files, 6065 passed, 4 skipped, zero failures.**

## Evidence (screenshots/videos)

<details>
<summary>The two formats, and the day they collided</summary>

```
voci totali: 74 | in prosa: 14 | ISO: 61

2026-09-01: dodici entry, una sola in prosa
  date: '2026-09-01'      × 11
  date: 'September 1, 2026'
```
</details>

<details>
<summary>The 13 normalizations, each read from its own filename</summary>

```
'August 27, 2026'    -> 2026-08-27   2026-08-27-llm-gateway.ts
'August 28, 2026'    -> 2026-08-28   … (11 entries)
'September 1, 2026'  -> 2026-09-01   2026-09-01-homepage-agent-panel.ts
```
</details>

## Anything Else?

- The entry that triggered it arrived with #122; the format it used was the majority style until a
  few weeks ago, so this is not that PR's mistake — it is a type that allowed both.
- `legacy.ts` is untouched: it is the frozen archive and is merged after the per-entry files.
