### PR TITLE
Put the custom agent brief at the head of the prompt

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -126,6 +126,18 @@ aspettare `document.body.innerText.includes(marker)` conferma anche il messaggio
 
 ## Codice
 
+### Un blocco che dichiara CHI è l'agente va in TESTA, o perde contro il prompt che lo precede
+Il brief del DM lo aveva già pagato — in coda il modello salutava l'utente per nome — e per questo
+sta in testa in `live.ts` e in `queue.ts`. Il blocco del custom agent, che è la stessa cosa (una
+dichiarazione d'identità, non un compito in più), è rimasto in coda: dopo
+`You are Content Creator (…), an Anomalia agent.`, le istruzioni del mestiere, fino a 32 KB di
+memoria e l'indice dei file. Segnale: un agente custom con una voce molto caratterizzata che **a
+volte** si presenta col nome dello specialista sottostante — intermittente, perché fra le due
+identità ci sono decine di migliaia di caratteri e vince chi capita. Mossa: ogni blocco che
+dichiara identità o cornice va prima di `buildSystemPrompt`, non appeso in fondo; e quando ne
+sposti uno, chiediti quali ALTRI blocchi hanno la stessa natura e sono rimasti indietro. Il
+motore classico ha ancora la stessa forma in due punti (`chat/queue.ts`, `chat/lib/turn-prep.ts`).
+
 ### Una regola chiusa su una superficie sola resta aperta su tutte le altre
 La migration `0187` dichiarava chiuso il buco del consenso all'immagine, e sul browser lo era:
 `addPersonReal` rifiuta senza la spunta e timbra `consent_at`/`consent_source`. L'endpoint gemello

--- a/changelog/2026-09-01-custom-agent-brief-first.md
+++ b/changelog/2026-09-01-custom-agent-brief-first.md
@@ -1,0 +1,32 @@
+# La consegna del custom agent apre il prompt, non lo chiude
+
+Su `dev` dopo la #118 un agente custom con un brief molto caratterizzato — «Scriba Fischietto, un
+notaio teatrale» — a volte si presentava come «Content Creator»: l'identità dello specialista
+sottostante invece della propria. Non sistematico: un turno con la voce giusta, il successivo no.
+
+Un agente custom non ha un `AgentSpec` suo. È il mestiere del thread con la consegna dell'utente
+sopra — e «sopra» va preso alla lettera, perché `customAgentSystemBlock` non aggiunge un compito:
+dichiara *chi è* l'agente. In `runKitTurn` quella dichiarazione stava **in coda** a tutto il
+prompt dello specialista, che si apre con `You are Content Creator (…), an Anomalia agent.` e
+prosegue con le sue istruzioni, la memoria (fino a 32 KB) e l'indice dei file del brand. Fra la
+prima identità e la seconda ci passano decine di migliaia di caratteri: quale delle due vinca il
+turno diventa una questione di fortuna.
+
+La stessa trappola era già stata pagata dal DM fra agenti, tre righe più su, e il commento che la
+racconta è ancora lì: in coda il brief perdeva contro l'intero prompt di brand e il modello
+salutava l'utente per nome. La persona è rimasta dov'era.
+
+Ora la consegna sta in testa, subito **dopo** il brief del DM e prima di `buildSystemPrompt`.
+L'ordine fra i due non è arbitrario: il brief del DM è la cornice della conversazione (con chi
+stai parlando, e che non è una persona) e ha guadagnato la prima posizione con un incidente vero;
+la consegna è l'identità di chi parla, e le basta precedere il mestiere che indossa — il pezzo
+contro cui perdeva. Il resto dell'ordine — lingua, squadra, modalità, obiettivo — non si muove.
+
+**Il limite, dichiarato.** Il test prova che il blocco arriva in testa, non che il modello smetta
+di sbagliare identità: quello lo direbbe solo una eval, che non è stata eseguita. Il difetto è
+intermittente, quindi nessun singolo turno andato bene vale come prova del contrario.
+
+**Non toccato:** il motore classico ha la stessa forma in due punti (`chat/queue.ts`,
+`chat/lib/turn-prep.ts`: `systemPrompt += customAgentSystemBlock(...)`). Il difetto segnalato sta
+sul percorso kit e il fix resta lì; i due siti classici sono candidati alla stessa mossa, con la
+loro eval.

--- a/src/lib/agent/bridge/live.test.ts
+++ b/src/lib/agent/bridge/live.test.ts
@@ -2779,3 +2779,49 @@ describe('runKitTurn — DM fra agenti', () => {
 		expect(continuations).toHaveLength(0);
 	});
 });
+
+/**
+ * Un agente custom non ha uno spec suo: indossa il mestiere del thread con la sua consegna
+ * sopra. «Sopra» è letterale — la consegna dichiara CHI è, e una dichiarazione d'identità in
+ * coda ha già perso una volta contro l'intero prompt del mestiere (il DM, `chat-dm.ts`). Fra
+ * `You are Content Creator` e la coda del prompt ci stanno la memoria (fino a 32 KB) e l'indice
+ * dei file: la persona letta là in fondo è la seconda voce che il modello sente, non la prima.
+ */
+describe('runKitTurn — la consegna del custom agent', () => {
+	const SCRIBA = '## Agente custom — "Scriba Fischietto"\nSei un notaio teatrale.';
+
+	function personaTurnInput(extra: Record<string, unknown> = {}) {
+		return {
+			supabase: fakeSupabase,
+			admin: fakeDb().db,
+			brand: { id: 'b1' },
+			user: { id: 'u1' },
+			threadId: 't-persona',
+			spec: specById('content')!,
+			messages: [{ role: 'user' as const, content: 'presentati' }],
+			locale: 'it' as const,
+			persona: { id: 'ca-1', memoryKey: 'custom:ca-1', systemBlock: `\n\n${SCRIBA}` },
+			...extra
+		};
+	}
+
+	it('apre il prompt, davanti al mestiere che indossa', async () => {
+		const prompt = { text: '' };
+		toolCatalogModel([], prompt);
+		const { db } = fakeDb();
+		const res = await runKitTurn({ ...personaTurnInput(), admin: db });
+		await res.text();
+		expect(prompt.text).toContain(SCRIBA);
+		expect(prompt.text.indexOf(SCRIBA)).toBeLessThan(prompt.text.indexOf('You are Content Creator'));
+	});
+
+	it('in un DM il brief resta in testa e la consegna lo segue, sempre prima del mestiere', async () => {
+		const prompt = { text: '' };
+		toolCatalogModel([], prompt);
+		const { db } = fakeDb();
+		const res = await runKitTurn({ ...personaTurnInput({ dm: dmContext }), admin: db });
+		await res.text();
+		expect(prompt.text.startsWith('## CHAT PRIVATA TRA AGENTI')).toBe(true);
+		expect(prompt.text.indexOf(SCRIBA)).toBeLessThan(prompt.text.indexOf('You are Content Creator'));
+	});
+});

--- a/src/lib/agent/bridge/live.ts
+++ b/src/lib/agent/bridge/live.ts
@@ -798,8 +798,8 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
 		// l'intero prompt di brand (il modello salutava l'utente per nome).
 		let system =
 			(input.dm ? `${dmBrief(input.dm.meName, input.dm.otherName, locale)}\n\n` : '') +
+			(input.persona ? `${input.persona.systemBlock.trim()}\n\n` : '') +
 			buildSystemPrompt(spec, { memoryMd, fileIndex: filesIndexFor(spec.id) }) +
-			(input.persona ? input.persona.systemBlock : '') +
 			`\n\n${chatReplyLanguageBlock(locale)}` +
 			(peer ? `\n\n${teamBlock(peer)}` : '') +
 			`\n\n${modeBlock(mode)}`;

--- a/src/lib/content/changelog/2026-09-01-custom-agent-brief-first.ts
+++ b/src/lib/content/changelog/2026-09-01-custom-agent-brief-first.ts
@@ -1,0 +1,9 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-01',
+  title: 'Custom agents stay in character',
+  items: [
+    'A custom agent now answers with the identity you gave it, instead of slipping back into the name of the built-in specialist it is built on.'
+  ]
+} satisfies ChangelogEntry;


### PR DESCRIPTION
## What?

In a kit turn worn by a custom agent, the agent's own brief now sits at the **head** of the
system prompt instead of at its tail. One line moved in `src/lib/agent/bridge/live.ts`, plus two
tests that pin the new order.

Reported on `dev` after #118: a custom agent with a strongly characterised brief — «Scriba
Fischietto, un notaio teatrale» — sometimes introduced itself as **«Content Creator»**, the
identity of the specialist underneath instead of its own. Intermittent: correct voice in one
turn, wrong in the next.

## Why?

A custom agent has no `AgentSpec` of its own. It is the thread's craft with the user's brief worn
on top — and `customAgentSystemBlock` does not add a task, it declares *who the agent is*:

> «L'utente sta parlando con un agente custom che ha configurato lui. Questa è la sua consegna
> permanente: …»

That declaration was appended **after** the entire specialist prompt, which opens with
`You are Content Creator (…), an Anomalia agent.` and then runs through the craft instructions
(~2 000 chars), the injected memory (**up to 32 KB**) and the brand file index. Two competing
identity statements, tens of thousands of characters apart, and which one governs the turn is
left to luck — which is exactly the shape of an intermittent defect.

The same trap had already been paid for three lines above, and the comment that records it is
still in the file:

> «In un DM il blocco sta IN TESTA, davanti a tutto: in coda ha già perso una volta contro
> l'intero prompt di brand (il modello salutava l'utente per nome).»

The DM brief was moved to the head for precisely this reason. The persona was left where it was.

## How?

```diff
 let system =
 	(input.dm ? `${dmBrief(input.dm.meName, input.dm.otherName, locale)}\n\n` : '') +
+	(input.persona ? `${input.persona.systemBlock.trim()}\n\n` : '') +
 	buildSystemPrompt(spec, { memoryMd, fileIndex: filesIndexFor(spec.id) }) +
-	(input.persona ? input.persona.systemBlock : '') +
 	`\n\n${chatReplyLanguageBlock(locale)}` +
 	(peer ? `\n\n${teamBlock(peer)}` : '') +
 	`\n\n${modeBlock(mode)}`;
```

**Order between DM brief and persona: DM first, persona second.** Both are at the head, so both
win against the craft prompt; the question is only which of the two leads. The DM brief is the
*frame of the conversation* — who you are talking to, and that it is not a person — and it earned
first place with a real incident (the model greeting the user by name). The persona is the
*identity of the speaker*, and all it needed was to precede the craft prompt it was losing to.
Keeping the DM brief first also keeps the existing comment literally true, so a lesson already
paid for is not quietly weakened by this change. No third behaviour was invented: the rest of the
order — reply language, team, mode, goal — is untouched.

`.trim()` on the block because `customAgentSystemBlock` returns a string that starts with `\n\n`
(it was written to be appended); at the head that would open the prompt with blank lines.

**Rejected: extracting the composition into a pure function.** It is a good candidate — CLAUDE.md
is right that a thing hard to test is badly built — but `live.test.ts` already drives a real
`runKitTurn` with a mocked `startHarnessTurn` that captures the real `system` string
(`toolCatalogModel(seen, prompt)`), and the DM head-position test at line 2724 is exactly the
template needed. The behavioural test was already available without moving code, and the
extraction would have had to carry the paid-lesson DM comment out of `live.ts`. Not worth it in
this PR.

## Testing?

Two new tests in `src/lib/agent/bridge/live.test.ts`, written first and **watched fail** against
the unfixed composition:

```
AssertionError: expected 4534 to be less than 0      ← persona at 4534, `You are Content Creator` at 0
AssertionError: expected 5748 to be less than 1214   ← same, with a DM brief in front
```

- `apre il prompt, davanti al mestiere che indossa` — a turn with a persona: the block's index is
  lower than the index of `You are Content Creator`.
- `in un DM il brief resta in testa e la consegna lo segue, sempre prima del mestiere` — with
  both `dm` and `persona`, the prompt still *starts* with `## CHAT PRIVATA TRA AGENTI` and the
  persona still precedes the craft. This is the test that pins the order decision above.

Both green after the fix.

**Full suite** (`npm ci`, then `npx vitest run`, `.env` copied from the main checkout so
`src/hooks.server.test.ts` runs):

```
Test Files  543 passed | 1 skipped (544)
     Tests  6078 passed | 4 skipped (6082)
  Duration  45.72s
```

### What was NOT tested, and the risk

**The eval is due and was not run.** This changes the system prompt of **every custom-agent
turn**. CLAUDE.md requires `npm run eval:ux` before a merge that touches the chat path or the
prompts, and it costs real money — it was not run, and no approval to spend was given. **This PR
should not be merged on the evidence in it alone.**

**No manual verification on the local stack either.** The Docker Supabase stack is up, but the
repo `.env` points at the hosted project (the trap in LESSONS.md), so a real walk would need a
separate local env overlay, a seeded brand, a seeded custom agent and real model spend. And it
would prove very little: **the defect is intermittent**, so no bounded number of good turns is a
demonstration. Reported as not done rather than dressed up.

**What the test can and cannot say.** It proves the block *arrives first*. It cannot prove the
model stops mistaking its identity — that is a claim only an eval can make. The mechanism is the
one the DM incident already demonstrated on this same prompt, which is the argument for the fix,
not proof of the outcome.

## Evidence (screenshots/videos)

No UI change. Backend evidence:

<details>
<summary>Red before the fix</summary>

```
FAIL  src/lib/agent/bridge/live.test.ts > runKitTurn — la consegna del custom agent > apre il prompt, davanti al mestiere che indossa
AssertionError: expected 4534 to be less than 0

FAIL  src/lib/agent/bridge/live.test.ts > runKitTurn — la consegna del custom agent > in un DM il brief resta in testa e la consegna lo segue, sempre prima del mestiere
AssertionError: expected 5748 to be less than 1214

Test Files  1 failed (1)
     Tests  2 failed | 81 skipped (83)
```

The persona block sat 4 534 characters *after* the specialist's identity line — the whole point
of the change, in a number.
</details>

<details>
<summary>Green after the fix, file then suite</summary>

```
✓ src/lib/agent/bridge/live.test.ts (83 tests) 7205ms
Test Files  1 passed (1)
     Tests  83 passed (83)
```

```
Test Files  543 passed | 1 skipped (544)
     Tests  6078 passed | 4 skipped (6082)
```
</details>

## Anything Else?

**The classic engine has the same shape, in two places, and is not touched here:**

- `src/lib/server/chat/queue.ts:887` — `if (persona) systemPrompt += customAgentSystemBlock(persona, locale);`
- `src/routes/app/[brand]/chat/lib/turn-prep.ts:138` — `systemPrompt += customAgentSystemBlock(persona, locale);`

Both append the identity declaration after a full `buildSystemPrompt`, and `queue.ts` even moves
its DM brief to the head two lines earlier for the same documented reason. The reported defect is
on the kit path, so the fix stays there; the two classic sites are candidates for the same move,
with their own eval. Flagging them rather than fixing three prompt paths in one unevaluated PR.

**No shared seam exists between the three.** They are three independent string concatenations,
not three callers of one composer. If the classic sites get the same treatment, extracting one
composition function is the moment to do it.
