### PR TITLE
Teach the image agent how to write a prompt

### DIFF
--- a/changelog/2026-09-01-image-prompt-guide.md
+++ b/changelog/2026-09-01-image-prompt-guide.md
@@ -1,0 +1,67 @@
+# Una guida ai prompt immagine, dove il prompt si scrive davvero
+
+Il prompt di sistema dell'image agent sapeva **giudicare** un'immagine e non sapeva
+**scriverne** una. Sei righe di workflow, sei punti di QC — e il punto 5 boccia il render
+generico («over-saturated HDR glow, waxy skin, sterile posing, un'immagine che potrebbe
+stare nel feed di chiunque») senza dire da nessuna parte come lo si evita. Il parametro era
+`prompt: z.string().describe('Image generation prompt')`. Punto.
+
+Adesso `how/WRITE-IMAGE-PROMPTS.md` è inline nel suo prompt di sistema, e nell'indice dei
+file dei tre mestieri che possono mintare una still.
+
+## Da dove viene, e cosa è stato buttato
+
+È condensata dal guide di Nano Banana di `NikiforovAll/claude-code-rules` (Apache-2.0), che
+gira come skill `nano-banana-prompting`. **La skill così com'è non poteva entrare**: è
+interattiva — `AskUserQuestion` a raffica, «vuoi che la generi adesso?», handoff a una
+seconda skill — e le domande che fa a un umano qui hanno già una risposta in
+`ImageAgentOpts`. Output type sta in `productKind` e `referenceMode`; soggetto in
+`productName`/`personName`; era, camera e luce in `visualStyle`/`brandLook`/`visualPlaybook`;
+aspect ratio in `aspectRatioFor(platform)`; ruoli dei riferimenti in `refs`; editing in
+`baseImageUrl`; iterazione in `feedback`. Un secondo agente non le avrebbe risposte, le
+avrebbe inventate partendo dallo stesso contesto del primo.
+
+Quindi è stato preso il contenuto e buttato il workflow. Delle sedici tecniche ne restano
+nove, e **quattro sono escluse perché qui sono difetti**:
+
+- **Tecniche 5, 7, 16** (typography, infografiche etichettate, traduzione in-image) chiedono
+  tutte al diffusore di scrivere lettere. È il difetto più frequente che abbiamo sui
+  visuali: «Social growts», «Scopa menu». Il testo si disegna in codice sopra l'immagine.
+- **Tecnica 11** (aspect ratio dentro il prompt) contraddice il renderer: il rapporto lo
+  decide `aspectRatioFor(platform)` e `render_image` lo porta come argomento suo. Copiarla
+  avrebbe creato esattamente la regola scritta in due posti che diverge al primo cambio —
+  `caption-quality.ts:291` già dice il contrario.
+- **Tecniche 9, 14, 15** (multi-pannello, blending, upscaling) non hanno un aggancio: i
+  caroselli qui sono N render separati (`renderSlides`), non un pannello unico, e un
+  percorso di upscale non esiste.
+
+Ci sono invece quattro regole che upstream non può conoscere, e ognuna è un difetto già
+pagato: niente testo leggibile, niente aspect ratio, niente descrizione fisica di una
+persona con nome (l'identità si blocca dalle foto di riferimento, una descrizione ci
+compete e il render deriva), e il medium deve essere quello del brand — un brand illustrato
+non diventa una foto «per varietà».
+
+## Perché nessun cancello
+
+La guida video ha `unlocks: ['create_post']`: chi scrive un reel deve averla letta. Quel
+cancello se l'era guadagnato con una misura — 131 prompt su 340 chiedevano testo nel frame,
+il 16,8% delle review lo ritrovava corrotto. Sulle immagini quella misura non c'è. Un
+`unlocks` su `generate_image` costerebbe un giro di tool in più a ogni still per un difetto
+di cui non conosciamo la frequenza, ed è il tipo di costo che si accende dopo aver contato,
+non prima. Sta nell'indice, si legge, e diventa cancello quando un numero lo chiede.
+Precedente identico: `how/DISRUPTIVE-IDEAS.md`.
+
+## Il file è uno, i lettori sono due
+
+L'image agent non ha `read_file`, quindi la guida gli sta inline nel prompt di sistema
+(`IMAGE_PROMPT_GUIDE`, ~1,2k token per passo, sopra un prompt che porta già immagini a
+768px). L'agente in chat la legge come file. Stesso markdown, due import `?raw`: se cambia,
+cambia per entrambi.
+
+## Quello che non è stato toccato
+
+Le istruzioni sui prompt immagine vivono anche in `caption-quality.ts:291-302`,
+`produce-agent.ts:259`, `content-preview/creation.ts:232` e `articles.ts:356` — quattro
+posti, ognuno col suo paragrafo inline. Sono la stessa regola scritta cinque volte, e vanno
+ricondotte a questo file. Non qui: sarebbe un refactor del percorso batch mescolato a un
+cambio di comportamento, e i due si separano.

--- a/src/lib/agent-docs/how/WRITE-IMAGE-PROMPTS.md
+++ b/src/lib/agent-docs/how/WRITE-IMAGE-PROMPTS.md
@@ -1,0 +1,121 @@
+# How to write an image prompt
+
+For whoever hands a prompt to Nano Banana — the image agent's `render_image`, and the
+`generate_image` brief that seeds it. Not for video (that is `how/WRITE-VIDEO-PROMPTS.md`)
+and not for typographic graphics, which are drawn in HTML/TSX and never diffused.
+
+Source: the Nano Banana prompting guide from `NikiforovAll/claude-code-rules`
+(Apache-2.0), condensed. Four of its sixteen techniques are **deliberately not here** —
+they teach things that are defects in this pipeline. The last section says which, and why.
+
+---
+
+## The shape
+
+**Default to narrative.** One paragraph of prose: subject, what it is doing, where, then a
+closing line that anchors the aesthetic. The model reads intent, not tag soup — a comma
+list of adjectives is the single most common way to get a generic render.
+
+> A young woman stands almost sideways, slightly bent forward, during the final preparation
+> for the show. Makeup artists apply lipstick to her. The main emphasis is on her face and
+> the details of her costume.
+
+**Switch to structured (YAML) only when precision is the point** — a product whose finish
+must survive, a scene with several distinct subjects that keep bleeding into each other.
+Structure buys control at the cost of life; a structured prompt for a candid photo reads
+like a spec sheet and renders like one.
+
+```yaml
+subject:
+  girl: { hair: "long, wavy brown", expression: "puckering toward the camera" }
+  puppy: { type: "small white puppy", eyes: "light blue" }
+photography:
+  camera_style: "early-2000s digital camera aesthetic"
+  lighting: "harsh super-flash, blown-out highlights, subject still visible"
+```
+
+---
+
+## What separates a good prompt from a lucky one
+
+**Photography terminology, not adjectives.** This is the largest single win, and it is the
+antidote to the QC failure we hit most (*"technically correct but generic"*). Name the
+gear, the light and the texture and the render stops looking like an AI render:
+
+- *Gear* — "shot on a Sony A7III with an 85mm f/1.4 lens, flattering portrait compression".
+- *Light, by name* — "classic three-point setup, key light casting soft defining shadows,
+  a subtle rim light separating the shoulders from the dark background". Or by clock:
+  golden hour, blue hour, harsh noon, overcast diffusion, night on artificial light.
+- *Texture, asked for explicitly* — "natural skin texture with visible pores", "subtle wool
+  in the suit". Waxy skin is what you get when nobody asks.
+- *Focus and grade* — "exquisite focus on the eyes"; "clean, bright cinematic grade with
+  subtle warmth".
+
+**A vibe is a list of signature details, not a mood word.** "2000s bedroom" renders as
+nothing; *CD player, beaded door curtain, cluttered vanity of lip glosses, pop-icon posters*
+renders as 2003. Same for film noir (venetian-blind shadows, smoke, rain on the window),
+Wes Anderson (symmetry, pastels, centred framing), Blade Runner (neon rain, steam, cramped
+frames). Find the props that only that era owns, and name them.
+
+**Candid beats posed.** "Looking slightly away from the camera, holding a coffee cup,
+relaxed" outperforms any amount of "authentic, natural, genuine".
+
+**Give every reference a job.** When more than one image is attached, say what each is for
+— upstream calls it role assignment and it is the difference between a composite and a
+mush: *"pose from image 1, colour palette from image 2, the environment from image 3."*
+The usual roles are subject, style, palette, environment, branding.
+
+**To edit, use task verbs.** Editing an attached base frame is a list of operations, not a
+new description: *"identify the main product, cleanly extract it, recreate it as a premium
+e-commerce shot on pure white, removing any fingers, hands or clutter."* Say what leaves
+the frame as explicitly as what stays.
+
+**Exclusions are cheap and specific.** "no date stamp", "not rustic", "no neon". Reach for
+them when a render keeps volunteering the same unwanted thing — a negative is how you stop
+a repeat, not how you set a style.
+
+**Ask for a viewpoint when the subject is a concept.** "How engineers see the Bay Bridge"
+gets you blueprints, stress lines and structure without you having to invent the shot.
+
+---
+
+## The four rules this pipeline adds
+
+Upstream is written for one person generating one image. These four are ours, and each one
+is a defect we have already paid for.
+
+1. **Never ask for readable text.** No headline, no label, no caption, no number, no
+   barcode, no arrow diagram — a diffusion model cannot be trusted to draw letters, and it
+   returns "Social growts" and "Scopa menu" burned into the frame. Type is drawn in code
+   over the image (`design_graphic`, the typographic graphic path), never asked for inside
+   the prompt. This kills upstream's magazine covers, its infographics and its in-image
+   translation outright.
+2. **Never state an aspect ratio, a resolution or a crop.** `aspectRatioFor(platform)`
+   decides the canvas and `render_image` carries it as its own `aspect` argument. A prompt
+   that says "9:16 vertical poster" fights the renderer and loses — or worse, wins, and
+   draws a poster inside the photo.
+3. **Never describe the appearance of a named person.** No gender, age, body, face, hair,
+   skin or ethnicity. Identity is locked from the attached reference photos; a description
+   competes with them and the render drifts off the real person. Describe only pose energy,
+   expression, wardrobe, lighting, camera and environment.
+4. **Match the brand's medium.** If the brand's visual style is illustrated, editorial or
+   collage, the prompt describes an image *in that medium* — never a photograph, and never
+   "a photo for variety". Photorealism is the default only when the brand's style is
+   photographic or when there is no style at all.
+
+And one that is not a rule but a habit: the brand's official logo is attached on every
+render when it exists. Reproduce **that** mark when branding appears; never invent one, and
+on a candid photo with no branding leave it out.
+
+---
+
+## Before you send it
+
+- Subject, action and setting present, in prose.
+- At least one photographic specific: lens, named light, or texture.
+- Era or style carried by props, not by an adjective.
+- A job assigned to every attached reference.
+- No readable text requested anywhere.
+- No aspect ratio, no resolution, no crop.
+- No physical description of a named person.
+- The medium matches the brand's visual style.

--- a/src/lib/content/changelog/2026-09-01-image-prompt-guide.ts
+++ b/src/lib/content/changelog/2026-09-01-image-prompt-guide.ts
@@ -1,0 +1,14 @@
+import type { ChangelogEntry } from './index';
+
+const entry: ChangelogEntry = {
+  date: '2026-09-01',
+  title: 'Photos that stop looking like AI photos',
+  items: [
+    'Generated images now get real photographic direction — lens, named lighting setup, texture — instead of mood words, so they read as photographs rather than generic AI renders.',
+    'A period or a look is built from the props that define it, not from adjectives: ask for a 2000s bedroom and you get the CD player and the beaded curtain.',
+    'When you attach more than one reference, each one is given a job — pose from this, palette from that, background from the third.',
+    'Images stay in your brand’s medium: an illustrated brand no longer drifts into stock photography.'
+  ]
+};
+
+export default entry;

--- a/src/lib/server/chat/agent-files.test.ts
+++ b/src/lib/server/chat/agent-files.test.ts
@@ -737,3 +737,28 @@ describe('artifacts/motion/<id>.md è il sorgente, non una promessa', () => {
     expect(out.content).toContain(SOURCE);
   });
 });
+
+/**
+ * LA GUIDA AI PROMPT IMMAGINE STA DOVE SI MINTA UN'IMMAGINE, e da nessun'altra parte.
+ *
+ * `generate_image` prende un `prompt` scritto dall'agente in chat (post-editor-tools.ts): quel
+ * testo diventa il brief dell'image agent, e sul percorso legacy — `isImageAgentEnabled()` falso —
+ * arriva al renderer così com'è. Chi ha quel tool deve vedere la guida; chi non ce l'ha no, perché
+ * un indice si paga a ogni passo.
+ */
+describe('how/WRITE-IMAGE-PROMPTS.md', () => {
+  const PATH = 'how/WRITE-IMAGE-PROMPTS.md';
+
+  it('la vedono tutti e soli i mestieri che possono mintare un\'immagine', () => {
+    const minters = AGENT_IDS.filter((id) => 'generate_image' in pickTools(ALL, id));
+    expect(minters.length).toBeGreaterThan(0);
+    for (const id of AGENT_IDS) {
+      expect(filePathsFor(id).includes(PATH), `${id}`).toBe(minters.includes(id));
+    }
+  });
+
+  it('non è un cancello: nessun numero lo giustifica ancora', () => {
+    expect(AGENT_FILES[PATH].unlocks).toEqual([]);
+    expect(Object.values(REQUIRED_READS)).not.toContain(PATH);
+  });
+});

--- a/src/lib/server/chat/agent-files.ts
+++ b/src/lib/server/chat/agent-files.ts
@@ -29,6 +29,7 @@ import { disruptiveSystemSection } from '$lib/disruptive';
 import { renderBrandStudioFile, renderBrandStrategyFile } from '$lib/server/chat/brand-file';
 import { DEFAULT_SKILLS } from '$lib/server/default-skills';
 import VIDEO_PROMPTS_GUIDE from '$lib/agent-docs/how/WRITE-VIDEO-PROMPTS.md?raw';
+import IMAGE_PROMPTS_GUIDE from '$lib/agent-docs/how/WRITE-IMAGE-PROMPTS.md?raw';
 import { AGENTS, type AgentId } from '$lib/server/chat/agents';
 import { logAiCall } from '$lib/server/ai-log';
 import type { SupabaseClient } from '@supabase/supabase-js';
@@ -64,6 +65,9 @@ export type AgentFile = {
   /** Pigro: il corpo si compone solo quando qualcuno legge davvero. */
   body: () => string;
 };
+
+/** I mestieri che possono mintare una still con `generate_image`. */
+const IMAGE_MINTERS = ['content', 'motion', 'ugc'] as const satisfies readonly AgentId[];
 
 /** Gli unici due mestieri che scrivono TSX Remotion — gli stessi di `MOTION_WRITERS`. */
 const MOTION_WRITERS = ['motion', 'content'] as const satisfies readonly AgentId[];
@@ -123,6 +127,25 @@ export const AGENT_FILES: Record<string, AgentFile> = {
     summary:
       'come si scrive un prompt per Seedance 2.5: struttura, i lock numerici, le note per genere — e perché il testo non si chiede MAI dentro il prompt',
     body: () => VIDEO_PROMPTS_GUIDE
+  },
+  /**
+   * NESSUN CANCELLO QUI, e la differenza con la guida video sta nei numeri, non nel gusto.
+   *
+   * Là il cancello se lo è guadagnato con una misura: 131 prompt su 340 chiedevano testo dentro il
+   * frame, il 16,8% delle review lo ritrovava corrotto. Sulle immagini quella misura non l'abbiamo
+   * ancora, e `unlocks` su `generate_image` costerebbe un giro di tool in più a ogni still per un
+   * difetto di cui non conosciamo la frequenza. Si legge perché è nell'indice; diventa cancello
+   * quando un numero lo chiede.
+   *
+   * L'image agent NON passa di qui — non ha `read_file` — e la stessa guida ce l'ha inline nel suo
+   * prompt di sistema (`IMAGE_PROMPT_GUIDE`). Il file markdown è uno solo: due lettori, una fonte.
+   */
+  'how/WRITE-IMAGE-PROMPTS.md': {
+    agents: IMAGE_MINTERS,
+    unlocks: [],
+    summary:
+      'come si scrive un prompt per Nano Banana: la forma, la terminologia fotografica che toglie il look da render generico, e le quattro regole che qui non si violano (niente testo, niente aspect ratio, niente descrizione fisica di una persona, il medium del brand)',
+    body: () => IMAGE_PROMPTS_GUIDE
   },
     /**
      * `agents: null` e nessun `unlocks`: vale per tutti (anche l'Analyst propone angoli) e non blocca

--- a/src/lib/server/image-agent.test.ts
+++ b/src/lib/server/image-agent.test.ts
@@ -80,7 +80,8 @@ import {
   NANO_BANANA_PRO_LIST_RENDER_USD,
   PER_RUN_USD_CAP,
   STALL_STEP_THRESHOLD,
-  estimatedRenderCostUsd
+  estimatedRenderCostUsd,
+  IMAGE_PROMPT_GUIDE
 } from './image-agent';
 import { llmDefaultModel } from './llm';
 
@@ -257,5 +258,43 @@ describe('image-agent inspect budget', () => {
     expect(consumeInspectBudget(budget).ok).toBe(true);
     expect(consumeInspectBudget(budget).ok).toBe(true);
     expect(consumeInspectBudget(budget).ok).toBe(false);
+  });
+});
+
+/**
+ * LA GUIDA AI PROMPT IMMAGINE, e le due regole che upstream non può conoscere.
+ *
+ * Il guide di Nano Banana da cui è condensata (NikiforovAll/claude-code-rules, Apache-2.0) insegna
+ * a chiedere il testo dentro l'immagine (Tecnica 5, 7, 16) e a dichiarare l'aspect ratio nel prompt
+ * (Tecnica 11). Qui sono due difetti misurati, non due tecniche: il diffusore scrive «Social
+ * growts», e il rapporto lo decide `aspectRatioFor(platform)`, non la frase. Se qualcuno ricopia
+ * quelle tecniche dall'originale, questo test cade.
+ */
+describe('la guida ai prompt immagine', () => {
+  it('vieta il testo leggibile e l\'aspect ratio dentro il prompt', () => {
+    expect(IMAGE_PROMPT_GUIDE).toContain('Never ask for readable text');
+    expect(IMAGE_PROMPT_GUIDE).toContain('Never state an aspect ratio');
+  });
+
+  it('arriva al modello a ogni passo, non solo alla prima chiamata', async () => {
+    let stepSystem = '';
+    generateText.mockImplementation(async ({ prepareStep, tools }) => {
+      stepSystem = prepareStep?.({ stepNumber: 3, steps: [] })?.system ?? '';
+      await tools.finish.execute({ imagePrompt: 'x', notes: 'n', imageUrl: 'https://cdn.example/img.png' });
+      return { text: '', totalUsage: { inputTokens: 10, outputTokens: 5 } };
+    });
+
+    await runImageAgent({
+      supabase: stubSupabase,
+      userId: 'u1',
+      brandId: 'b1',
+      brief: 'Product hero shot',
+      platform: 'instagram',
+      budget: { renders: 1, inspects: 0 },
+      deadlineMs: 30_000
+    });
+
+    expect(stepSystem).toContain('How to write an image prompt');
+    expect(stepSystem).toContain('PRODUCT FIDELITY');
   });
 });

--- a/src/lib/server/image-agent.ts
+++ b/src/lib/server/image-agent.ts
@@ -1,3 +1,4 @@
+import IMAGE_PROMPTS_GUIDE from '$lib/agent-docs/how/WRITE-IMAGE-PROMPTS.md?raw';
 import { GEMINI_MAX_OUTPUT_TOKENS } from '$lib/server/ai-output-limits';
 import type { GoogleGenAI } from '@google/genai';
 import { tool, stepCountIs, hasToolCall, type StopCondition } from 'ai';
@@ -279,6 +280,14 @@ function modelOutputWithImages(text: string, dataUrls: string[]) {
   };
 }
 
+/**
+ * IL PEZZO CHE MANCAVA: il prompt di sistema sapeva GIUDICARE un'immagine e non sapeva SCRIVERNE
+ * una. La checklist di QC qui sotto boccia il render generico (punto 5) senza dire da nessuna
+ * parte come si evita — e la si evita con la terminologia fotografica, che è quello che la guida
+ * porta. Sta inline e non dietro un `read_file` perché questo loop non ha file da leggere.
+ */
+export const IMAGE_PROMPT_GUIDE = IMAGE_PROMPTS_GUIDE.trim();
+
 // critiqueImage checklist — copied verbatim from content-preview.ts (do not paraphrase).
 const CRITIQUE_CHECKLIST = `1. PRODUCT FIDELITY: does the generated product match the REAL product reference (shape, TRUE colours, materials, finish, branding)? It must NOT be desaturated to greyscale, recoloured, redesigned, or swapped for a similar object.
 2. PERSON FIDELITY: if a person should appear, they must look like the attached person REFERENCE photo(s) — same face, gender presentation, approximate age, hair. FAIL if the generated person clearly contradicts the references (e.g. wrong gender presentation vs the photos). Place them NATURALLY in the scene (not pasted into a reflection, not floating, not duplicated).
@@ -313,7 +322,9 @@ Rules:
 - Prefer a real library asset when it clearly fits the brief.
 - The brand's official LOGO is attached on every render_image when available — reproduce THAT mark whenever branding/wordmark appears; never invent a different logo. On a candid photo with no branding, you may omit it.
 - imagePrompt in finish must be non-empty when source is "generated".
-- notes in finish: explain what you tried and what you changed.`;
+- notes in finish: explain what you tried and what you changed.
+
+${IMAGE_PROMPT_GUIDE}`;
 }
 
 async function loadAssetCatalog(


### PR DESCRIPTION
## What?

The image agent's system prompt could **judge** an image and could not **write** one. It carries six QC points, one of which fails a render for looking like "a generic AI render — over-saturated HDR glow, waxy skin, sterile posing, an image that could belong to any brand's feed", and nowhere does it say how to avoid producing one. The tool underneath it is `render_image({ prompt: z.string().describe('Image generation prompt') })`. That was the entire guidance.

This adds `src/lib/agent-docs/how/WRITE-IMAGE-PROMPTS.md` and wires it to the two places that write a Nano Banana prompt: inline in the image agent's system prompt, and as a readable file in the index of the three trades that can mint a still (`content`, `motion`, `ugc`).

It is condensed from the Nano Banana prompting guide in [`NikiforovAll/claude-code-rules`](https://github.com/NikiforovAll/claude-code-rules/blob/main/plugins/handbook-nano-banana/skills/nano-banana-prompting/references/guide.md) (Apache-2.0), which ships as the `nano-banana-prompting` skill.

## Why?

Nine of the sixteen upstream techniques have a hook in this codebase and were not written down anywhere. The largest one is photography terminology — naming the lens, the light setup and the texture — and it is the direct antidote to the QC failure we reject most often. "Technically correct but generic" is a defect the agent was told to detect and never told to prevent.

## How?

**The skill could not be installed as-is, and a second agent would not have fixed that.** Upstream is interactive: `AskUserQuestion` in batches, "would you like me to generate the image now?", a handoff to a separate `nano-banana` skill. Routing those questions to a second agent was considered and rejected — every question it asks already has an answer in `ImageAgentOpts`, in the same context window the first agent holds:

| Upstream question | Field that already answers it |
|---|---|
| Output type (photo / product / UI) | `productKind`, `referenceMode: 'product' \| 'ui'` |
| Subject | `productName`, `personName` |
| Era, camera, lighting | `visualStyle`, `brandLook`, `visualPlaybook` |
| Aspect ratio | `aspectRatioFor(platform)` — resolved before the agent runs |
| Reference images and their roles | `userRefUrls`, `pinnedLibraryMediaIds`, `moodImageUrls`, `refs` |
| Preserve character identity | `personName` + `signPersonImages` |
| Edit an existing image | `baseImageUrl` |
| Iterate | `feedback` |

A second agent would not have answered them, it would have invented them, at four extra LLM round-trips per post (`MAX_AGENT_RENDERS = 4`) against a `PER_RUN_USD_CAP` that counts real money. So the content was taken and the workflow was dropped.

**Four upstream techniques are deliberately excluded**, because here they are defects rather than techniques:

- **5, 7 and 16** (typography, labelled infographics, in-image translation) all ask a diffusion model to draw letters. That is the most frequent defect we have on visuals — "Social growts", "Scopa menu". Type is drawn in code over the image, never requested inside the prompt.
- **11** (aspect ratio in the prompt) contradicts the renderer: `aspectRatioFor(platform)` decides the canvas and `render_image` carries it as its own argument. Copying it would have created the same rule in two places, and `caption-quality.ts:291` already says the opposite.
- **9, 14, 15** (multi-panel, blending, upscaling) have no hook: carousels here are N separate renders (`renderSlides`), and no upscale path exists.

**Four rules were added that upstream cannot know**, each one a defect already paid for: no readable text, no aspect ratio, no physical description of a named person (identity is locked from reference photos and a description competes with them), and the medium must be the brand's — an illustrated brand does not become a photograph "for variety".

**Two readers, one markdown.** The image agent has no `read_file`, so it carries the guide inline in its system prompt (~1.2k tokens per step, above a prompt that already ships 768px images). The chat agents read it as a file. Both import the same `.md?raw`: if it changes, it changes for both.

**It is not a gate.** The video guide has `unlocks: ['create_post']` and earned it with a measurement — 131 prompts out of 340 asked for text in the frame, 16.8% of reviews found it corrupted. We have no equivalent number for images, and `unlocks` on `generate_image` would cost a tool round-trip per still for a defect of unknown frequency. It sits in the index and becomes a gate when a number asks for one. Same precedent as `how/DISRUPTIVE-IDEAS.md`.

## Testing?

Test-first, both halves watched fail before the fix existed:

- `image-agent.test.ts` — the guide reaches the model on **every** step, not just the first call (asserted through `prepareStep`, alongside the existing QC checklist), and it carries the two rules that make this an adaptation rather than a copy. If someone re-imports upstream's Technique 5 or 11, this test falls.
- `agent-files.test.ts` — the file is in the index of exactly the trades that have `generate_image`, and of no others; and it is not in `REQUIRED_READS`.

Full suite after rebase onto `dev@59888a5`: **6081 passed, 0 failed, 4 skipped** (544 files).

**Not tested, and it matters:** the browser gate did not run. The local Supabase stack is up (`localhost:8000`, 147 tables, 14 brands), but every `.env` in the checkouts points `PUBLIC_SUPABASE_URL` at the hosted project, and the local stack's anon/service keys are not in the repo — per `LESSONS.md` the local run needs `PUBLIC_SUPABASE_URL=http://localhost:8000`. So no image was actually generated through this prompt, and the claim here is "the guide reaches the model", not "the renders got better".

Worth knowing while reviewing: `IMAGE_AGENT_ENABLED=false` in the local `.env`. `isImageAgentEnabled()` defaults ON when unset, so on that path the inline half is live; with the flag off, `generateStandaloneImage` falls back to `renderWithQC` and the chat agent's prompt reaches the renderer verbatim — which is exactly why the file half of this change is not redundant.

## Evidence (screenshots/videos)

No UI surface changes — this is prompt and agent-file material.

<details>
<summary>Red before green: both new tests failing against the unmodified prompt</summary>

```
 ❯ src/lib/server/image-agent.test.ts:297:24
    297|     expect(stepSystem).toContain('How to write an image prompt');
       |                        ^
 Test Files  1 failed (1)
      Tests  2 failed | 12 passed (14)
```

```
 × how/WRITE-IMAGE-PROMPTS.md > la vedono tutti e soli i mestieri che possono mintare un'immagine
 × how/WRITE-IMAGE-PROMPTS.md > non è un cancello: nessun numero lo giustifica ancora
 Test Files  1 failed (1)
      Tests  2 failed | 48 passed (50)
```

</details>

<details>
<summary>Green after, and the full suite</summary>

```
 ✓ src/lib/server/image-agent.test.ts (14 tests)
 ✓ src/lib/server/chat/agent-files.test.ts (50 tests)

 Test Files  542 passed | 1 skipped
      Tests  6081 passed | 4 skipped (6085)
```

The one file reported as failed in that run was `src/hooks.server.test.ts` with `TypeError: Invalid URL` at `new URL(publicEnv.PUBLIC_SUPABASE_URL)` — a fresh worktree with no `.env`, the lesson already written in `LESSONS.md`. Green after `cp ../anomalia/.env .`, and untouched by this diff.

</details>

<details>
<summary>Size, against its sibling</summary>

```
1048 words   6467 bytes   src/lib/agent-docs/how/WRITE-IMAGE-PROMPTS.md
1038 words   6235 bytes   src/lib/agent-docs/how/WRITE-VIDEO-PROMPTS.md
```

</details>

## Anything Else?

**The debt this does not pay.** Image-prompt instructions also live inline in `caption-quality.ts:291-302`, `produce-agent.ts:259`, `content-preview/creation.ts:232` and `articles.ts:356` — four more places, each with its own paragraph. That is the same rule written in five places, which diverges at the first change; they should be pulled back to this file. Not in this PR: it would mix a refactor of the batch path with a behaviour change, and those two get separate commits.

**The number that should decide the next step.** Before either gating this file or adding a prompt-crafting pass, the honest move is to measure — how often image QC fails, and on what. `npm run eval:ux` is the instrument; a scenario that reproduces the generic-render failure would turn both questions from taste into arithmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HxD8BrmkFMWEpGf5wwpCKt
