### PR TITLE
Stop pinning motion videos to five beats

### DIFF
--- a/changelog/2026-09-01-motion-beat-count-is-not-five.md
+++ b/changelog/2026-09-01-motion-beat-count-is-not-five.md
@@ -1,0 +1,18 @@
+# Il motion non ha più cinque beat per default
+
+`MOTION_CRAFT_SPECS` apriva la sezione STORYLINE con l'arco scritto come una lista
+di cinque: «hook → tension → demonstration → proof → resolution. Not five statements
+in a row». L'ultima frase vietava le cinque frasi in fila, non i cinque beat — e
+l'agente leggeva l'elenco come il conto: su un 8s e su un 45s costruiva comunque
+cinque scene, e si giustificava con «5 beats is the established pattern».
+
+Ora l'arco è dichiarato come MESTIERI e non come conto: un beat può portarne due,
+un mestiere che il brief non chiede si toglie, uno che vale dieci secondi diventa
+tre beat. Il numero segue durata, copione e reference.
+
+Restano invariati i vincoli che non sono un conto: 2.5–4s per beat (leggibilità) e
+il cancello QC sui 4+ beat, che riguarda i meccanismi di transizione, non quante
+scene ci sono.
+
+Il test in `craft.test.ts` guarda le due frasi nuove e vieta il ritorno di «Not five
+statements»: la regola vecchia non rientra da sola.

--- a/src/lib/content/changelog/2026-09-01-motion-beat-count-is-not-five.ts
+++ b/src/lib/content/changelog/2026-09-01-motion-beat-count-is-not-five.ts
@@ -1,0 +1,9 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-01',
+  title: 'Motion videos pick their own number of scenes',
+  items: [
+    'Motion videos no longer default to five scenes: the count follows the length, the script and the reference, so a short cut stays short and a long one gets the room it needs.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/motion-video/craft.test.ts
+++ b/src/lib/motion-video/craft.test.ts
@@ -19,6 +19,14 @@ describe('MOTION_CRAFT_SPECS', () => {
 		expect(MOTION_CRAFT_SPECS).toContain('<Img src=');
 	});
 
+	it('non fissa il numero di beat: l’arco sono i mestieri, il conto lo decide chi scrive', () => {
+		// «5 beats è il pattern stabilito» era una regola letta dall’elenco dei cinque mestieri:
+		// l’agente ci si ancorava anche su un 8s e su un 45s.
+		expect(MOTION_CRAFT_SPECS).toMatch(/JOBS, not a fixed count/);
+		expect(MOTION_CRAFT_SPECS).toMatch(/never from a template/);
+		expect(MOTION_CRAFT_SPECS).not.toMatch(/Not five statements/);
+	});
+
 	it('mandates expo in-out and names the trap that actually ships linear motion', () => {
 		// La regola "mai linear" c'era già e non bastava: il modo comune di scrivere movimento
 		// lineare è OMETTERE l'easing, che in Remotion è lineare per default.

--- a/src/lib/motion-video/craft.ts
+++ b/src/lib/motion-video/craft.ts
@@ -14,7 +14,7 @@ TYPE
 - If no brand font is listed, use a minimal clean sans-serif (${MOTION_FALLBACK_SANS}) for every headline, UI label, and CTA. Never invent a serif, script, or decorative family.
 
 STORYLINE (a kinetic ad is a story, not a slide deck)
-- Beats form an arc: hook → tension (the problem, the before) → demonstration (the product doing the thing) → proof (a number, a result, a name) → resolution (the CTA). Not five statements in a row.
+- Beats form an arc, and the arc is JOBS, not a fixed count: hook, tension (the problem, the before), demonstration (the product doing the thing), proof (a number, a result, a name), resolution (the CTA). One beat can carry two jobs, a job the brief does not need is dropped, and a job worth ten seconds gets three beats. How many beats there are follows from the length, the script and the reference — never from a template.
 - Every beat must earn its seconds and hand something to the next one. If two beats say the same thing in different words, cut one and give its time to the demonstration.
 - Give each beat room to be read: 2.5–4s. Six beats crammed into eight seconds is unreadable at any easing.
 

--- a/src/lib/server/motion-video/refinement.test.ts
+++ b/src/lib/server/motion-video/refinement.test.ts
@@ -55,8 +55,9 @@ describe('length comes from the beats', () => {
 describe('the craft specs ask for an arc', () => {
 	it('names the shape of the story, not just the polish', () => {
 		expect(MOTION_CRAFT_SPECS).toContain('STORYLINE');
-		expect(MOTION_CRAFT_SPECS).toMatch(/hook → tension/);
-		expect(MOTION_CRAFT_SPECS).toMatch(/not five statements in a row/i);
+		expect(MOTION_CRAFT_SPECS).toMatch(/hook, tension/);
+		// L'arco nomina i mestieri; il CONTO lo decide chi scrive (craft.test.ts).
+		expect(MOTION_CRAFT_SPECS).toMatch(/JOBS, not a fixed count/);
 	});
 
 	it('gives each beat room, which is what "too fast" actually meant', () => {


### PR DESCRIPTION
## What?

The Motion Specialist's craft brief (`MOTION_CRAFT_SPECS`) opened STORYLINE with the arc written as a list of five — *hook → tension → demonstration → proof → resolution* — closing with "Not five statements in a row". That last sentence bans five flat sentences, not five scenes, so the list read as the count. The agent anchored on it and said so out loud: *"But 5 beats is the established pattern"*, building five scenes for an 8s cut and for a 45s one alike.

The arc is now stated as **jobs, not a count**: one beat can carry two jobs, a job the brief does not need is dropped, a job worth ten seconds gets three beats. How many beats there are follows from the length, the script and the reference — never from a template.

## Why?

The beat count is a creative decision that belongs to whoever writes the composition, informed by duration and by the reference it studied. A prompt that hands it a default number gets that number back regardless of the brief, which is exactly what was happening.

## How?

One rewritten bullet in `src/lib/motion-video/craft.ts`. Nothing else moves.

Deliberately **not** touched, because neither is a count rule:

- `2.5–4s per beat` — a readability floor. It already constrains how many beats fit in a given length, and it does so from the duration instead of from a template.
- The QC gate on `4+ beat` compositions — it demands match-cut and full-canvas mechanisms, it does not demand four beats.

## Testing?

Test first, watched fail: `craft.test.ts` gains *"non fissa il numero di beat: l'arco sono i mestieri, il conto lo decide chi scrive"*, asserting the two new phrases and forbidding the return of `Not five statements`. Red against the old prompt, green after the rewrite.

```
$ npx vitest run src/lib/motion-video/craft.test.ts        # red before, 28 passed after
$ npx vitest run src/lib/server/chat/brand-context-tools.test.ts
$ npx vitest run src/lib/content/changelog/index.test.ts
```

**Not tested:** whether the agent actually varies the count now — that is a prompt-behaviour change, and the honest verdict comes from a motion run, not from a unit test. No browser gate here: nothing renders differently, the change is a string in a system prompt.

## Evidence (screenshots/videos)

No UI surface changes. The diff is the evidence:

<details><summary>Before / after, the STORYLINE bullet</summary>

Before:
> Beats form an arc: hook → tension (the problem, the before) → demonstration (the product doing the thing) → proof (a number, a result, a name) → resolution (the CTA). Not five statements in a row.

After:
> Beats form an arc, and the arc is JOBS, not a fixed count: hook, tension (the problem, the before), demonstration (the product doing the thing), proof (a number, a result, a name), resolution (the CTA). One beat can carry two jobs, a job the brief does not need is dropped, and a job worth ten seconds gets three beats. How many beats there are follows from the length, the script and the reference — never from a template.

</details>

## Anything Else?

Same prompt file still carries other numbers the agent can over-read (`2.5–4s`, `4+ beats`). Those are checked in code, so they earn their place — but if the same anchoring shows up on pacing, that is where to look next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CPHcJKUNRK7z8dLF4jq9NU