### PR TITLE
Record the user's verdict on a post, and the activation event

### DIFF
--- a/changelog/2026-09-01-post-verdict-and-activation.md
+++ b/changelog/2026-09-01-post-verdict-and-activation.md
@@ -1,0 +1,88 @@
+# Il verdetto dell'utente sul post, e l'evento di attivazione
+
+Misura di produzione dell'1/9/2026, su 500 post: 243 `pending_user` (49%), 176 `published`,
+61 `scheduled`, 14 `approved`, 6 `failed`, e **zero scartati da giugno** — lo stato non esiste.
+Un post che il cliente ha odiato e uno che non ha mai aperto erano la stessa riga, e non c'era
+nessuna definizione di «attivato» con cui giudicare un cambiamento del flusso d'ingresso.
+
+## La forma scelta: una tabella di eventi
+
+`post_verdicts` (post_id, brand_id, user_id, verdict, caption_before, caption_after, created_at).
+Le altre due forme sono state scartate per un motivo ciascuna:
+
+- **Un nuovo stato su `posts.status`.** Buttare un post ne CANCELLA la riga (`deletePostCancellingZernio`,
+  `reject_post`, il bulk della CLI): uno stato `discarded` richiederebbe la cancellazione morbida,
+  cioè un filtro in ogni lettura di `posts` del prodotto. È la migration più invasiva possibile per
+  il segnale più raro.
+- **Una colonna dedicata su `posts`.** Stesso problema per «buttato», più due: «modificato» succede
+  più volte e una colonna tiene solo l'ultima, e `posts` non ha nessuna colonna che dica CHI ha
+  deciso — il verdetto è di una persona, non di un brand.
+
+`post_id` è deliberatamente **senza foreign key**: il verdetto `discarded` deve sopravvivere alla
+riga che descrive, o «buttato» resta immisurabile come oggi.
+
+**«Modificato» conserva la differenza**, perché costava zero: `applyPostEdits` legge già la caption
+precedente per insegnarla a `brand_memory`. Le due colonne `caption_before` / `caption_after`
+riusano quella lettura. Restano fuori le modifiche non testuali (media, orario): il verdetto
+«modificato» qui vuol dire *l'utente ha riscritto quello che avevamo scritto noi*.
+
+## La regola in un posto solo
+
+`recordPostVerdict` (`src/lib/server/post-verdict.ts`) è l'unico posto che sa che forma ha un
+verdetto. Le superfici dichiarano soltanto CHI ha deciso, perché è l'unica cosa che solo loro
+sanno. Il verdetto viene emesso dalle tre strozzature che già esistevano:
+
+- `publishApprovedPost` → `approved`, ma **solo** se lo stato memorizzato era `pending_user` e la
+  chiamata porta un `by`. Le due condizioni servono entrambe: senza la prima una riprogrammazione
+  o un repost conterebbero come approvazione, senza la seconda l'agente di analytics
+  (`reschedule_pending_post`, che può pubblicare un `pending_user`) gonfierebbe l'attivazione con
+  decisioni che nessun umano ha preso.
+- `applyPostEdits` → `edited`, quando la caption cambia davvero.
+- `deletePostCancellingZernio` → `discarded`.
+
+Tre superfici scavalcavano una strozzatura e sono state ricondotte, non duplicate: la
+`updateCaption` del calendario e quella di Content scrivevano `posts.caption` a mano (quindi non
+insegnavano nemmeno la voce al brand), e `DELETE /api/v1/brands/:slug/posts/:id` cancellava la riga
+senza passare dalla revoca Zernio. Il `update_post` e il `reject_post` della chat e il bulk-delete
+della CLI restano con una chiamata esplicita: le loro scritture non sono le stesse.
+
+L'approvazione via email non ha una sessione: `brandOwnerId` risolve brand → organizzazione →
+proprietario, così anche quel percorso ha una persona dietro invece di un buco.
+
+**Non registra un verdetto** `createManualPost`: un post che l'utente ha scritto lui non è un
+giudizio su quello che abbiamo scritto noi, e contarlo come attivazione misurerebbe il prodotto
+sbagliato.
+
+## L'evento di attivazione
+
+Non è una riga in più: è `min(created_at)` per `(user_id, brand_id)` sui verdetti `approved`.
+L'indice parziale `post_verdicts_activation_idx` serve esattamente quella query. Nessun cruscotto,
+nessuna colonna materializzata, nessuna pagina.
+
+```sql
+-- Attivazione per coorte di iscrizione: quanti utenti approvano il primo post, e dopo quanto.
+with activation as (
+  select user_id, brand_id, min(created_at) as activated_at
+  from post_verdicts
+  where verdict = 'approved'
+  group by user_id, brand_id
+)
+select
+  date_trunc('week', u.created_at)::date                                as signup_week,
+  count(distinct u.id)                                                  as signed_up,
+  count(distinct a.user_id)                                             as activated,
+  round(100.0 * count(distinct a.user_id) / nullif(count(distinct u.id), 0), 1) as activation_pct,
+  round(avg(extract(epoch from (a.activated_at - u.created_at)) / 3600) filter (where a.user_id is not null)::numeric, 1) as avg_hours_to_activate
+from auth.users u
+left join activation a on a.user_id = u.id
+group by 1
+order by 1 desc;
+```
+
+## La migration va applicata a mano
+
+I deploy di questo repo non applicano le migration. `20260901140000_post_verdicts.sql` va applicata
+PRIMA che il codice arrivi in produzione: senza la tabella ogni `recordPostVerdict` fallisce, e
+fallisce in silenzio per costruzione (logga e prosegue — un verdetto non deve mai far fallire
+un'approvazione). Il risultato sarebbe una feature che non registra niente senza che nessuno se ne
+accorga.

--- a/src/lib/content/changelog/2026-09-01-post-verdict-and-activation.ts
+++ b/src/lib/content/changelog/2026-09-01-post-verdict-and-activation.ts
@@ -1,0 +1,10 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-01',
+  title: 'Every edit you make teaches the writer',
+  items: [
+    'Rewriting a caption straight from the calendar or the content list now teaches your brand voice, the same way editing it in the post editor always did.',
+    'Deleting a post from the CLI now cancels its live schedule first, so it cannot go out after you removed it.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/chat/tools/brand-write-tools.ts
+++ b/src/lib/server/chat/tools/brand-write-tools.ts
@@ -11,12 +11,13 @@ import { APPROVABLE_STATUSES, type CrossPostResult, RESCHEDULABLE_STATUSES, appr
 import type { ChatToolCtx } from './shared';
 import { startLongToolJob, type AnyRec } from './shared';
 import { requireFreshRead } from '../read-guards';
+import { recordPostVerdict } from '$lib/server/post-verdict';
 import { refreshPostReceipt } from '../post-editor-tools';
 
 // ── WRITE tools ─────────────────────────────────────────────────────────
 
 export function brandWriteTools(ctx: ChatToolCtx) {
-  const { supabase, brandId, tz } = ctx;
+  const { supabase, brandId, tz, userId } = ctx;
   return {
     update_brand_kit: tool({
       description:
@@ -355,13 +356,24 @@ export function brandWriteTools(ctx: ChatToolCtx) {
         if (Object.keys(clean).length === 0) return { error: 'No changes specified' };
 
         // Check current status before updating
-        const { data: current } = await supabase.from('posts').select('status, updated_at').eq('id', post_id).eq('brand_id', brandId).maybeSingle();
+        const { data: current } = await supabase.from('posts').select('status, updated_at, caption').eq('id', post_id).eq('brand_id', brandId).maybeSingle();
         if (!current) return { error: 'Post not found' };
         const stale = requireFreshRead('post', String(post_id), current.updated_at, 'This post', 'read_posts (find this id in the list)');
         if (stale) return stale;
 
         const { error } = await supabase.from('posts').update(clean).eq('id', post_id).eq('brand_id', brandId);
         if (error) return { error: error.message };
+
+        if (typeof clean.caption === 'string' && String(current.caption ?? '') !== clean.caption) {
+          await recordPostVerdict(supabase, {
+            postId: String(post_id),
+            brandId,
+            actorId: userId,
+            verdict: 'edited',
+            captionBefore: current.caption as string | null,
+            captionAfter: clean.caption
+          });
+        }
         await refreshPostReceipt(supabase, brandId, String(post_id));
 
         // For scheduled posts: cancel old Zernio schedule and re-publish to keep 1:1 sync
@@ -461,7 +473,7 @@ export function brandWriteTools(ctx: ChatToolCtx) {
           };
         }
         try {
-          const res = await publishApprovedPost(supabase, post as ApprovablePost, tz);
+          const res = await publishApprovedPost(supabase, post as ApprovablePost, tz, { by: userId });
           if (res.scheduled === 0 && res.failed > 0) {
             return { error: res.error ?? 'Could not schedule — the post did not meet platform requirements.' };
           }
@@ -506,6 +518,14 @@ export function brandWriteTools(ctx: ChatToolCtx) {
         }
         const { error } = await supabase.from('posts').delete().eq('id', post_id).eq('brand_id', brandId);
         if (error) return { error: error.message };
+
+        await recordPostVerdict(supabase, {
+          postId: String(post_id),
+          brandId,
+          actorId: userId,
+          verdict: 'discarded'
+        });
+
         return { success: true, deleted: post_id };
     }),
 

--- a/src/lib/server/cli-queries.ts
+++ b/src/lib/server/cli-queries.ts
@@ -526,7 +526,7 @@ function localeForLanguage(language: string | null): string {
 
 // ── Approve ─────────────────────────────────────────────────────────────
 
-export async function approvePost(supabase: SupabaseClient, brandId: string, postId: string, brandTimezone: string) {
+export async function approvePost(supabase: SupabaseClient, brandId: string, postId: string, brandTimezone: string, actorId?: string) {
   const { data: post, error } = await supabase
     .from('posts').select('*').eq('id', postId).eq('brand_id', brandId).maybeSingle();
   if (error || !post) return { error: 'Post not found' };
@@ -536,7 +536,7 @@ export async function approvePost(supabase: SupabaseClient, brandId: string, pos
   // Import publish logic dynamically
   const { publishApprovedPost } = await import('$lib/server/publish');
   try {
-    const res = await publishApprovedPost(supabase, post, brandTimezone);
+    const res = await publishApprovedPost(supabase, post, brandTimezone, { by: actorId });
     // Nothing scheduled but something failed → over-limit caption or Zernio rejection. Surface the
     // reason instead of a false "published" so the CLI/AI don't think it worked.
     if (res.scheduled === 0 && res.failed > 0) {
@@ -554,7 +554,7 @@ export async function approvePost(supabase: SupabaseClient, brandId: string, pos
   }
 }
 
-export async function approveAllPosts(supabase: SupabaseClient, brandId: string, brandTimezone: string) {
+export async function approveAllPosts(supabase: SupabaseClient, brandId: string, brandTimezone: string, actorId?: string) {
   // Never bulk-publish Director-flagged posts (needs_attention) — same rule as the token page.
   const { data: pending } = await supabase
     .from('posts').select('*').eq('brand_id', brandId).eq('status', 'pending_user')
@@ -568,7 +568,7 @@ export async function approveAllPosts(supabase: SupabaseClient, brandId: string,
 
   for (const post of pending) {
     try {
-      const res = await publishApprovedPost(supabase, post, brandTimezone);
+      const res = await publishApprovedPost(supabase, post, brandTimezone, { by: actorId });
       if (res.scheduled === 0 && res.failed > 0) {
         results.push({ id: post.id, ok: false, error: res.error ?? 'Did not meet platform requirements' });
       } else {

--- a/src/lib/server/post-editing.ts
+++ b/src/lib/server/post-editing.ts
@@ -6,6 +6,7 @@ import { deletePost, getPostStatus } from '$lib/server/zernio';
 import { nextOccurrence, wallClockToUtc, startOfWeek } from '$lib/server/schedule';
 import { learnFromCaptionEdit } from '$lib/server/brand-memory';
 import { ALT_CAPTION_PLATFORMS, ensureShortNetworkCuts } from '$lib/platform-limits';
+import { recordPostVerdict } from '$lib/server/post-verdict';
 
 // Columns the shared post editor (caption + scheduling + status actions) needs.
 // Intentionally omits video_task_id / video_resolution — those are publish-only (see
@@ -180,7 +181,7 @@ export async function applyPostEdits(
   id: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   patch: Record<string, any>,
-  opts?: { origin?: string }
+  opts?: { origin?: string; by?: string }
 ) {
   const wantsCaptionLearn = typeof patch.caption === 'string' && patch.caption.trim();
   let before: {
@@ -211,6 +212,18 @@ export async function applyPostEdits(
     void captureCaptionEditPair(before.brand_id, String(before.caption), String(patch.caption)).catch(swallow('String failed'));
   }
   const result = await supabase.from('posts').update(patch).eq('id', id);
+
+  if (opts?.by && before && String(before.caption ?? '') !== String(patch.caption ?? '')) {
+    await recordPostVerdict(supabase, {
+      postId: id,
+      brandId: before.brand_id,
+      actorId: opts.by,
+      verdict: 'edited',
+      captionBefore: before.caption,
+      captionAfter: patch.caption
+    });
+  }
+
   return result;
 }
 
@@ -355,7 +368,8 @@ export type PostDeletionResult =
 export async function deletePostCancellingZernio(
   supabase: App.Locals['supabase'],
   postId: string,
-  brandId?: string
+  brandId?: string,
+  by?: string
 ): Promise<PostDeletionResult> {
   let query = supabase.from('posts').select('id, brand_id, platform, status').eq('id', postId);
   if (brandId) query = query.eq('brand_id', brandId);
@@ -391,6 +405,16 @@ export async function deletePostCancellingZernio(
   }
   const { error } = await supabase.from('posts').delete().eq('id', postId);
   if (error) return { ok: false, status: 500, message: error.message };
+
+  if (by) {
+    await recordPostVerdict(supabase, {
+      postId,
+      brandId: post.brand_id,
+      actorId: by,
+      verdict: 'discarded'
+    });
+  }
+
   return { ok: true, wasScheduled };
 }
 
@@ -398,20 +422,20 @@ export async function deletePostCancellingZernio(
 // `export const actions`. Both pages render the same <PostEditor> whose forms POST to these.
 export const editorActions: Actions = {
   // Edit caption and/or schedule (exact day+time). RLS scopes by brand.
-  updatePost: async ({ request, params, url, locals: { supabase } }) => {
+  updatePost: async ({ request, params, url, locals: { supabase, user } }) => {
     const data = await request.formData();
     const id = String(data.get('id') ?? '');
     if (!id) return fail(400, { error: 'Missing post' });
 
     const patch = editPatchFrom(data, await brandTz(supabase, params.brand));
     if (patch === null) return fail(400, { error: 'Pick a time at least 2 minutes from now.' });
-    const { error } = await applyPostEdits(supabase, id, patch, { origin: url.origin });
+    const { error } = await applyPostEdits(supabase, id, patch, { origin: url.origin, by: user?.id });
     if (error) return fail(500, { error: error.message });
     return { saved: true };
   },
 
   // Reschedule an already-scheduled post: apply edits, cancel the live Zernio post, re-publish.
-  reschedule: async ({ request, params, url, locals: { supabase } }) => {
+  reschedule: async ({ request, params, url, locals: { supabase, user } }) => {
     const data = await request.formData();
     const id = String(data.get('id') ?? '');
     if (!id) return fail(400, { error: 'Missing post' });
@@ -423,7 +447,7 @@ export const editorActions: Actions = {
     const cancellationError = zernioCancellationError(cancellation);
     if (cancellationError) return fail(502, { error: cancellationError });
 
-    if (Object.keys(patch).length) await applyPostEdits(supabase, id, patch, { origin: url.origin });
+    if (Object.keys(patch).length) await applyPostEdits(supabase, id, patch, { origin: url.origin, by: user?.id });
 
     const { data: post } = await supabase.from('posts').select(EDITOR_POST_COLS).eq('id', id).maybeSingle();
     if (!post) return fail(404, { error: 'Post not found' });
@@ -475,17 +499,17 @@ export const editorActions: Actions = {
   // Reject a draft → delete it (the user chose not to publish this one).
   // Prima cancellava la riga e basta: su un post scheduled/approved la schedulazione Zernio
   // restava viva e il post usciva comunque (classe incidente scheduling luglio 2026).
-  reject: async ({ request, locals: { supabase } }) => {
+  reject: async ({ request, locals: { supabase, user } }) => {
     const data = await request.formData();
     const id = String(data.get('id') ?? '');
     if (!id) return fail(400, { error: 'Missing post' });
-    const res = await deletePostCancellingZernio(supabase, id);
+    const res = await deletePostCancellingZernio(supabase, id, undefined, user?.id);
     if (!res.ok) return fail(res.status, { error: res.message });
     return { rejected: true };
   },
 
   // Approve = apply edits, then send to Zernio scheduled at the chosen instant.
-  approve: async ({ request, params, url, locals: { supabase } }) => {
+  approve: async ({ request, params, url, locals: { supabase, user } }) => {
     const data = await request.formData();
     const id = String(data.get('id') ?? '');
     if (!id) return {};
@@ -493,26 +517,26 @@ export const editorActions: Actions = {
     const tz = await brandTz(supabase, params.brand);
     const patch = editPatchFrom(data, tz);
     if (patch === null) return fail(400, { error: 'Pick a time at least 2 minutes from now.' });
-    if (Object.keys(patch).length) await applyPostEdits(supabase, id, patch, { origin: url.origin });
+    if (Object.keys(patch).length) await applyPostEdits(supabase, id, patch, { origin: url.origin, by: user?.id });
 
     const { data: post } = await supabase.from('posts').select(EDITOR_POST_COLS).eq('id', id).maybeSingle();
     if (!post || post.status !== 'pending_user') return {};
 
-    const res = await publishApprovedPost(supabase, post as ApprovablePost, tz);
+    const res = await publishApprovedPost(supabase, post as ApprovablePost, tz, { by: user?.id });
     return { ok: true, noAccount: res.noAccount };
   },
 
   // Publish immediately. Cancels any existing scheduled Zernio copy FIRST (so Zernio's 24h
   // same-content-same-account dedupe guard doesn't reject the new send), then publishes now.
   // Works from any editable state (pending / scheduled / failed) and applies pending edits.
-  publishNow: async ({ request, params, url, locals: { supabase } }) => {
+  publishNow: async ({ request, params, url, locals: { supabase, user } }) => {
     const data = await request.formData();
     const id = String(data.get('id') ?? '');
     if (!id) return fail(400, { error: 'Missing post' });
 
     const tz = await brandTz(supabase, params.brand);
     const patch = editPatchFrom(data, tz, { ignoreSchedule: true }) ?? {};
-    if (Object.keys(patch).length) await applyPostEdits(supabase, id, patch, { origin: url.origin });
+    if (Object.keys(patch).length) await applyPostEdits(supabase, id, patch, { origin: url.origin, by: user?.id });
 
     // Remove the live/scheduled Zernio post (and mark its logs canceled) before re-sending.
     const cancellation = await cancelZernioForPost(supabase, id);
@@ -522,7 +546,7 @@ export const editorActions: Actions = {
     const { data: post } = await supabase.from('posts').select(EDITOR_POST_COLS).eq('id', id).maybeSingle();
     if (!post) return fail(404, { error: 'Post not found' });
 
-    const res = await publishApprovedPost(supabase, post as ApprovablePost, tz, { now: true });
+    const res = await publishApprovedPost(supabase, post as ApprovablePost, tz, { now: true, by: user?.id });
     return { ok: true, noAccount: res.noAccount };
   }
 };

--- a/src/lib/server/post-verdict.test.ts
+++ b/src/lib/server/post-verdict.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+vi.mock('$lib/server/zernio', () => ({ deletePost: vi.fn(), getPostStatus: vi.fn() }));
+vi.mock('$lib/server/brand-memory', () => ({ learnFromCaptionEdit: vi.fn(async () => {}) }));
+vi.mock('$lib/server/supabase-admin', () => ({ createAdminClient: () => ({ from: () => ({ select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: null }) }) }), update: () => ({ eq: async () => ({ error: null }) }) }) }) }));
+
+import { applyPostEdits, deletePostCancellingZernio } from '$lib/server/post-editing';
+import { publishApprovedPost, type ApprovablePost } from '$lib/server/publish';
+import { brandOwnerId, recordPostVerdict } from '$lib/server/post-verdict';
+
+type Row = Record<string, unknown>;
+
+/**
+ * Finto supabase che risponde con la riga chiesta e RACCOGLIE gli insert: il verdetto è una riga
+ * nuova, quindi è l'insert — non l'update — a dire se il segnale è stato registrato.
+ */
+function fakeSupabase(rows: Record<string, Row | null> = {}) {
+  const inserted: Array<{ table: string; payload: Row }> = [];
+  const builder = (table: string) => {
+    const b: Record<string, unknown> = {};
+    for (const m of ['select', 'eq', 'in', 'is', 'not', 'or', 'order', 'limit', 'update', 'delete']) {
+      b[m] = () => b;
+    }
+    b.insert = (payload: Row | Row[]) => {
+      for (const row of Array.isArray(payload) ? payload : [payload]) inserted.push({ table, payload: row });
+      return { then: (resolve: (v: { error: null }) => unknown) => resolve({ error: null }) };
+    };
+    b.maybeSingle = async () => ({ data: rows[table] ?? null, error: null });
+    b.single = async () => ({ data: rows[table] ?? null, error: null });
+    b.then = (resolve: (v: { data: unknown[]; error: null }) => unknown) => resolve({ data: [], error: null });
+    return b;
+  };
+  return { client: { from: builder } as unknown as SupabaseClient, inserted };
+}
+
+const verdicts = (inserted: Array<{ table: string; payload: Row }>) =>
+  inserted.filter((i) => i.table === 'post_verdicts').map((i) => i.payload);
+
+const approvable = (over: Partial<ApprovablePost> = {}): ApprovablePost => ({
+  id: 'p1',
+  brand_id: 'b1',
+  platform: 'instagram',
+  caption: 'Una caption vera che non è un segnaposto.',
+  media_url: 'https://cdn.test/img.jpg',
+  slot: 'monday-09:00',
+  scheduled_for: null,
+  content_type: 'image',
+  ...over
+});
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('recordPostVerdict', () => {
+  it('writes one row naming the post, the brand, the person and the verdict', async () => {
+    const { client, inserted } = fakeSupabase();
+
+    await recordPostVerdict(client, {
+      postId: 'p1',
+      brandId: 'b1',
+      actorId: 'u1',
+      verdict: 'approved'
+    });
+
+    expect(verdicts(inserted)).toEqual([
+      {
+        post_id: 'p1',
+        brand_id: 'b1',
+        user_id: 'u1',
+        verdict: 'approved',
+        caption_before: null,
+        caption_after: null
+      }
+    ]);
+  });
+
+  it('keeps the before→after pair of an edit — the difference is the signal', async () => {
+    const { client, inserted } = fakeSupabase();
+
+    await recordPostVerdict(client, {
+      postId: 'p1',
+      brandId: 'b1',
+      actorId: 'u1',
+      verdict: 'edited',
+      captionBefore: 'Quello che abbiamo scritto noi.',
+      captionAfter: 'Quello che pubblica lui.'
+    });
+
+    expect(verdicts(inserted)[0]).toMatchObject({
+      verdict: 'edited',
+      caption_before: 'Quello che abbiamo scritto noi.',
+      caption_after: 'Quello che pubblica lui.'
+    });
+  });
+});
+
+describe('brandOwnerId', () => {
+  it('resolves brand → org → owner, so an email approval has a person behind it', async () => {
+    const { client } = fakeSupabase({ brands: { org_id: 'o1' }, organizations: { owner_id: 'u9' } });
+
+    await expect(brandOwnerId(client, 'b1')).resolves.toBe('u9');
+  });
+
+  it('returns null when the brand has no organisation', async () => {
+    const { client } = fakeSupabase({ brands: null });
+
+    await expect(brandOwnerId(client, 'b1')).resolves.toBeNull();
+  });
+});
+
+describe('il verdetto passa dalle strozzature condivise', () => {
+  it('approving a draft records "approved" for that person', async () => {
+    const { client, inserted } = fakeSupabase({ posts: { video_render_status: null, status: 'pending_user', brand_id: 'b1' } });
+
+    await publishApprovedPost(client, approvable(), 'Europe/Rome', { by: 'u1' });
+
+    expect(verdicts(inserted)).toEqual([
+      expect.objectContaining({ post_id: 'p1', brand_id: 'b1', user_id: 'u1', verdict: 'approved' })
+    ]);
+  });
+
+  it('records nothing when the autopilot publishes: no person, no verdict', async () => {
+    const { client, inserted } = fakeSupabase({ posts: { video_render_status: null, status: 'pending_user', brand_id: 'b1' } });
+
+    await publishApprovedPost(client, approvable(), 'Europe/Rome');
+
+    expect(verdicts(inserted)).toEqual([]);
+  });
+
+  it('records nothing when the post was not a draft: a reschedule is not an approval', async () => {
+    const { client, inserted } = fakeSupabase({ posts: { video_render_status: null, status: 'scheduled', brand_id: 'b1' } });
+
+    await publishApprovedPost(client, approvable(), 'Europe/Rome', { by: 'u1' });
+
+    expect(verdicts(inserted)).toEqual([]);
+  });
+
+  it('editing the caption records "edited" with what we wrote and what the user wrote', async () => {
+    const { client, inserted } = fakeSupabase({
+      posts: { brand_id: 'b1', caption: 'Quello che abbiamo scritto noi.', source: 'plan', media_url: null, media_urls: null }
+    });
+
+    await applyPostEdits(client, 'p1', { caption: 'Quello che pubblica lui.' }, { by: 'u1' });
+
+    expect(verdicts(inserted)).toEqual([
+      expect.objectContaining({
+        verdict: 'edited',
+        caption_before: 'Quello che abbiamo scritto noi.',
+        caption_after: 'Quello che pubblica lui.'
+      })
+    ]);
+  });
+
+  it('records nothing when the edit leaves the caption alone', async () => {
+    const { client, inserted } = fakeSupabase({
+      posts: { brand_id: 'b1', caption: 'Identica.', source: 'plan', media_url: null, media_urls: null }
+    });
+
+    await applyPostEdits(client, 'p1', { caption: 'Identica.' }, { by: 'u1' });
+
+    expect(verdicts(inserted)).toEqual([]);
+  });
+
+  it('discarding a draft records "discarded" — the row dies, the verdict does not', async () => {
+    const { client, inserted } = fakeSupabase({
+      posts: { id: 'p1', brand_id: 'b1', platform: 'instagram', status: 'pending_user' }
+    });
+
+    const res = await deletePostCancellingZernio(client, 'p1', undefined, 'u1');
+
+    expect(res).toEqual({ ok: true, wasScheduled: false });
+    expect(verdicts(inserted)).toEqual([
+      expect.objectContaining({ post_id: 'p1', brand_id: 'b1', user_id: 'u1', verdict: 'discarded' })
+    ]);
+  });
+});

--- a/src/lib/server/post-verdict.ts
+++ b/src/lib/server/post-verdict.ts
@@ -1,0 +1,62 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export const POST_VERDICTS = ['approved', 'edited', 'discarded'] as const;
+
+export type PostVerdict = (typeof POST_VERDICTS)[number];
+
+export type PostVerdictInput = {
+  postId: string;
+  brandId: string;
+  actorId: string;
+  verdict: PostVerdict;
+  captionBefore?: string | null;
+  captionAfter?: string | null;
+};
+
+const CAPTION_KEPT_CHARS = 2200;
+
+function trimmedCaption(caption: string | null | undefined): string | null {
+  const text = String(caption ?? '');
+  return text ? text.slice(0, CAPTION_KEPT_CHARS) : null;
+}
+
+export async function recordPostVerdicts(
+  client: Pick<SupabaseClient, 'from'>,
+  inputs: PostVerdictInput[]
+): Promise<void> {
+  if (!inputs.length) return;
+
+  try {
+    const { error } = await client.from('post_verdicts').insert(
+      inputs.map((input) => ({
+        post_id: input.postId,
+        brand_id: input.brandId,
+        user_id: input.actorId,
+        verdict: input.verdict,
+        caption_before: trimmedCaption(input.captionBefore),
+        caption_after: trimmedCaption(input.captionAfter)
+      }))
+    );
+    if (error) console.warn('[post-verdict] not recorded:', error.message);
+  } catch (e) {
+    console.warn('[post-verdict] not recorded:', e instanceof Error ? e.message : e);
+  }
+}
+
+export async function recordPostVerdict(
+  client: Pick<SupabaseClient, 'from'>,
+  input: PostVerdictInput
+): Promise<void> {
+  return recordPostVerdicts(client, [input]);
+}
+
+export async function brandOwnerId(
+  client: Pick<SupabaseClient, 'from'>,
+  brandId: string
+): Promise<string | null> {
+  const { data: brand } = await client.from('brands').select('org_id').eq('id', brandId).maybeSingle();
+  const orgId = (brand as { org_id?: string } | null)?.org_id;
+  if (!orgId) return null;
+  const { data: org } = await client.from('organizations').select('owner_id').eq('id', orgId).maybeSingle();
+  return (org as { owner_id?: string } | null)?.owner_id ?? null;
+}

--- a/src/lib/server/publish.ts
+++ b/src/lib/server/publish.ts
@@ -7,6 +7,7 @@ import { withBrandContext } from './ai-log';
 import { platformLimit, platformLabel, captionFor, ensureShortNetworkCuts, mediaUrlsForPublish, VIDEO_ONLY_PLATFORMS, youtubeTitleFrom, type PlatformCaptions } from '$lib/platform-limits';
 import { isVideoUrl } from '$lib/content-formats';
 import { mediaUrlsForCheck, requiresVisualMedia } from './prepublish-check';
+import { recordPostVerdict } from './post-verdict';
 
 const PROVIDER_REFUSAL = 'No social publishing provider is configured on this instance.';
 
@@ -180,7 +181,7 @@ export async function publishApprovedPost(
   supabase: SupabaseClient,
   post: ApprovablePost,
   timezone: string,
-  opts: { now?: boolean } = {}
+  opts: { now?: boolean; by?: string } = {}
 ): Promise<PublishResult> {
   // A clip rendering out-of-band leaves the cover frame in media_url, so publishing now would ship
   // a photo where a video was promised. The guard belongs HERE, not only in the chat's
@@ -190,9 +191,10 @@ export async function publishApprovedPost(
   // whose migration may be pending, and a failure here must not block ordinary publishing.
   const { data: renderState } = await supabase
     .from('posts')
-    .select('video_render_status')
+    .select('video_render_status, status')
     .eq('id', post.id)
     .maybeSingle();
+  const wasDraft = (renderState as { status?: string | null } | null)?.status === 'pending_user';
   if ((renderState as { video_render_status?: string | null } | null)?.video_render_status === 'rendering') {
     return {
       scheduled: 0,
@@ -219,6 +221,15 @@ export async function publishApprovedPost(
       error:
         'This post has no image or video. Give it a visual (or make it a text post) before approving — a visual post with no media publishes as an empty post.'
     };
+  }
+
+  if (opts.by && wasDraft) {
+    await recordPostVerdict(supabase, {
+      postId: post.id,
+      brandId: post.brand_id,
+      actorId: opts.by,
+      verdict: 'approved'
+    });
   }
 
   const targets = (post.platforms && post.platforms.length ? post.platforms : [post.platform])

--- a/src/routes/api/radar/approve/[token]/+server.ts
+++ b/src/routes/api/radar/approve/[token]/+server.ts
@@ -2,6 +2,7 @@ import type { RequestHandler } from './$types';
 import { createAdminClient } from '$lib/server/supabase-admin';
 import { publishApprovedPost, type ApprovablePost } from '$lib/server/publish';
 import { EDITOR_POST_COLS } from '$lib/server/post-editing';
+import { brandOwnerId } from '$lib/server/post-verdict';
 
 // One-click approve from the Radar digest email. The token is single-use and expiring — it can
 // ONLY approve this one post (never edit, never reach anything else), so a leaked link's blast
@@ -27,8 +28,11 @@ export const GET: RequestHandler = async ({ params }) => {
   // Invalidate the token FIRST (single use), then publish/schedule via the normal approval path.
   await admin.from('posts').update({ approval_token: null, approval_token_expires_at: null }).eq('id', post.id);
   const { data: brand } = await admin.from('brands').select('timezone').eq('id', post.brand_id).maybeSingle();
+  const owner = await brandOwnerId(admin, post.brand_id as string);
   try {
-    const res = await publishApprovedPost(admin, post as unknown as ApprovablePost, brand?.timezone ?? 'Europe/Rome');
+    const res = await publishApprovedPost(admin, post as unknown as ApprovablePost, brand?.timezone ?? 'Europe/Rome', {
+      by: owner ?? undefined
+    });
     if (res.noAccount) return page('Approvato ✓', 'Nessun account social collegato: il post resta in coda, collega un account per pubblicarlo.');
     return page('Approvato ✓', 'Il post è stato messo in pubblicazione.');
   } catch {

--- a/src/routes/api/radar/reject/[token]/+server.ts
+++ b/src/routes/api/radar/reject/[token]/+server.ts
@@ -1,5 +1,6 @@
 import type { RequestHandler } from './$types';
 import { createAdminClient } from '$lib/server/supabase-admin';
+import { brandOwnerId, recordPostVerdict } from '$lib/server/post-verdict';
 
 // One-click reject from the Radar digest email: deletes the proposed post (same semantics as the
 // editor's "reject"). Single-use, expiring token; deleting a proposal is the worst it can do.
@@ -13,7 +14,7 @@ export const GET: RequestHandler = async ({ params }) => {
   const admin = createAdminClient();
   const { data: post } = await admin
     .from('posts')
-    .select('id, status, approval_token_expires_at')
+    .select('id, brand_id, status, approval_token_expires_at')
     .eq('approval_token', params.token)
     .maybeSingle();
   if (!post) return page('Link non valido', 'Questo link è già stato usato o non esiste.');
@@ -22,5 +23,16 @@ export const GET: RequestHandler = async ({ params }) => {
   }
   if (post.status !== 'pending_user') return page('Non più in bozza', 'Il post è già stato gestito dall’app.');
   await admin.from('posts').delete().eq('id', post.id);
+
+  const owner = await brandOwnerId(admin, post.brand_id as string);
+  if (owner) {
+    await recordPostVerdict(admin, {
+      postId: post.id as string,
+      brandId: post.brand_id as string,
+      actorId: owner,
+      verdict: 'discarded'
+    });
+  }
+
   return page('Scartato', 'La proposta è stata eliminata.');
 };

--- a/src/routes/api/v1/brands/[slug]/posts/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/posts/+server.ts
@@ -3,6 +3,7 @@ import type { RequestHandler } from './$types';
 import { authenticate, loadBrandForUser, checkApiKeyWriteAccess } from '$lib/server/cli-auth';
 import { getPosts } from '$lib/server/cli-queries';
 import { deletePostCancellingZernio } from '$lib/server/post-editing';
+import { recordPostVerdicts } from '$lib/server/post-verdict';
 
 export const GET: RequestHandler = async ({ request, params, url }) => {
   const { supabase, error, apiKey } = await authenticate(request);
@@ -19,7 +20,7 @@ export const GET: RequestHandler = async ({ request, params, url }) => {
 // Bulk-delete posts by status (default: pending_user). Lets the CLI clear a stale queue without
 // rejecting posts one by one. Refuses to bulk-delete published posts.
 export const DELETE: RequestHandler = async ({ request, params, url }) => {
-  const { supabase, error, apiKey } = await authenticate(request);
+  const { supabase, user, error, apiKey } = await authenticate(request);
   if (error) return error;
 
   const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
@@ -42,7 +43,7 @@ export const DELETE: RequestHandler = async ({ request, params, url }) => {
     let deleted = 0;
     const failed: { id: string; error: string }[] = [];
     for (const row of rows ?? []) {
-      const res = await deletePostCancellingZernio(supabase, row.id, brand.id);
+      const res = await deletePostCancellingZernio(supabase, row.id, brand.id, user.id);
       if (res.ok) deleted++;
       else failed.push({ id: row.id, error: res.message });
     }
@@ -58,5 +59,10 @@ export const DELETE: RequestHandler = async ({ request, params, url }) => {
     .select('id');
 
   if (delErr) return json({ error: delErr.message }, { status: 500 });
+
+  await recordPostVerdicts(
+    supabase,
+    (deleted ?? []).map((row) => ({ postId: row.id, brandId: brand.id, actorId: user.id, verdict: 'discarded' as const }))
+  );
   return json({ ok: true, deleted: deleted?.length ?? 0 });
 };

--- a/src/routes/api/v1/brands/[slug]/posts/[id]/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/posts/[id]/+server.ts
@@ -1,7 +1,7 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { authenticate, loadBrandForUser, checkApiKeyWriteAccess } from '$lib/server/cli-auth';
-import { applyPostEdits } from '$lib/server/post-editing';
+import { applyPostEdits, deletePostCancellingZernio } from '$lib/server/post-editing';
 import { reschedIfNeeded } from '$lib/server/chat/post-editor-tools';
 import { isContentFormat } from '$lib/content-formats';
 
@@ -14,7 +14,7 @@ const FIELDS = [
 ] as const;
 
 export const PUT: RequestHandler = async ({ request, params }) => {
-  const { supabase, error, apiKey } = await authenticate(request);
+  const { supabase, user, error, apiKey } = await authenticate(request);
   if (error) return error;
 
   const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
@@ -43,7 +43,8 @@ export const PUT: RequestHandler = async ({ request, params }) => {
 
   // Shared with the web editor: learns the brand's voice from a caption diff before overwriting.
   const { error: updateError } = await applyPostEdits(supabase, params.id, updates, {
-    origin: new URL(request.url).origin
+    origin: new URL(request.url).origin,
+    by: user.id
   });
   if (updateError) return json({ error: updateError.message }, { status: 500 });
 
@@ -54,7 +55,7 @@ export const PUT: RequestHandler = async ({ request, params }) => {
 };
 
 export const DELETE: RequestHandler = async ({ request, params }) => {
-  const { supabase, error, apiKey } = await authenticate(request);
+  const { supabase, user, error, apiKey } = await authenticate(request);
   if (error) return error;
 
   const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
@@ -71,9 +72,7 @@ export const DELETE: RequestHandler = async ({ request, params }) => {
     return json({ error: 'Can only delete pending posts' }, { status: 400 });
   }
 
-  const { error: deleteError } = await supabase
-    .from('posts').delete().eq('id', params.id);
-
-  if (deleteError) return json({ error: deleteError.message }, { status: 500 });
+  const res = await deletePostCancellingZernio(supabase, params.id, brand.id, user.id);
+  if (!res.ok) return json({ error: res.message }, { status: res.status });
   return json({ ok: true });
 };

--- a/src/routes/api/v1/brands/[slug]/posts/[id]/approve/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/posts/[id]/approve/+server.ts
@@ -4,7 +4,7 @@ import { authenticate, loadBrandForUser, checkApiKeyWriteAccess } from '$lib/ser
 import { approvePost } from '$lib/server/cli-queries';
 
 export const POST: RequestHandler = async ({ request, params }) => {
-  const { supabase, error, apiKey } = await authenticate(request);
+  const { supabase, user, error, apiKey } = await authenticate(request);
   if (error) return error;
 
   const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
@@ -12,7 +12,7 @@ export const POST: RequestHandler = async ({ request, params }) => {
   const writeDenied = checkApiKeyWriteAccess(apiKey);
   if (writeDenied) return writeDenied;
 
-  const result = await approvePost(supabase, brand.id, params.id, brand.timezone as string);
+  const result = await approvePost(supabase, brand.id, params.id, brand.timezone as string, user.id);
   if (result.error) return json(result, { status: 400 });
   return json(result);
 };

--- a/src/routes/api/v1/brands/[slug]/posts/[id]/publish/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/posts/[id]/publish/+server.ts
@@ -3,7 +3,7 @@ import type { RequestHandler } from './$types';
 import { authenticate, loadBrandForUser, checkApiKeyWriteAccess } from '$lib/server/cli-auth';
 
 export const POST: RequestHandler = async ({ request, params }) => {
-  const { supabase, error, apiKey } = await authenticate(request);
+  const { supabase, user, error, apiKey } = await authenticate(request);
   if (error) return error;
 
   const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
@@ -19,7 +19,7 @@ export const POST: RequestHandler = async ({ request, params }) => {
   if (!post) return json({ error: 'Post not found' }, { status: 404 });
 
   try {
-    await publishApprovedPost(supabase, post, brand.timezone as string);
+    await publishApprovedPost(supabase, post, brand.timezone as string, { by: user.id });
     return json({ ok: true, status: 'published' });
   } catch (e) {
     return json({ error: `Publish failed: ${String(e)}` }, { status: 500 });

--- a/src/routes/api/v1/brands/[slug]/posts/approve-all/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/posts/approve-all/+server.ts
@@ -4,7 +4,7 @@ import { authenticate, loadBrandForUser, checkApiKeyWriteAccess } from '$lib/ser
 import { approveAllPosts } from '$lib/server/cli-queries';
 
 export const POST: RequestHandler = async ({ request, params }) => {
-  const { supabase, error, apiKey } = await authenticate(request);
+  const { supabase, user, error, apiKey } = await authenticate(request);
   if (error) return error;
 
   const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
@@ -12,6 +12,6 @@ export const POST: RequestHandler = async ({ request, params }) => {
   const writeDenied = checkApiKeyWriteAccess(apiKey);
   if (writeDenied) return writeDenied;
 
-  const result = await approveAllPosts(supabase, brand.id, brand.timezone as string);
+  const result = await approveAllPosts(supabase, brand.id, brand.timezone as string, user.id);
   return json(result);
 };

--- a/src/routes/api/v1/brands/[slug]/posts/server.delete.test.ts
+++ b/src/routes/api/v1/brands/[slug]/posts/server.delete.test.ts
@@ -21,7 +21,7 @@ vi.mock('$lib/server/post-editing', () => ({
 import { DELETE } from './+server';
 import { authenticate, loadBrandForUser } from '$lib/server/cli-auth';
 
-type Op = { table: string; kind: string };
+type Op = { table: string; kind: string; payload?: unknown };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function fakeSupabase(rows: Record<string, unknown[]>): { client: any; ops: Op[] } {
@@ -33,6 +33,7 @@ function fakeSupabase(rows: Record<string, unknown[]>): { client: any; ops: Op[]
       const q: any = {
         select: () => q,
         delete: () => { kind = 'delete'; ops.push({ table, kind }); return q; },
+        insert: (payload: unknown) => { ops.push({ table, kind: 'insert', payload }); return { then: (resolve: (v: unknown) => void) => resolve({ error: null }) }; },
         eq: () => q,
         then(resolve: (v: unknown) => void) {
           return Promise.resolve(resolve({ data: rows[table] ?? [], error: null }));
@@ -49,7 +50,7 @@ beforeEach(() => vi.clearAllMocks());
 describe('DELETE /api/v1/brands/:slug/posts?status=scheduled', () => {
   it('cancels Zernio per post, keeps the uncancellable ones and answers 502 with the survivors', async () => {
     const { client, ops } = fakeSupabase({ posts: [{ id: 'p1' }, { id: 'p2' }] });
-    vi.mocked(authenticate).mockResolvedValue({ supabase: client, apiKey: null, error: null } as never);
+    vi.mocked(authenticate).mockResolvedValue({ supabase: client, user: { id: 'u1' }, apiKey: null, error: null } as never);
     vi.mocked(loadBrandForUser).mockResolvedValue({ brand: { id: 'brand-1' }, error: null } as never);
     deletePostCancellingZernio
       .mockResolvedValueOnce({ ok: true, wasScheduled: true })
@@ -63,7 +64,7 @@ describe('DELETE /api/v1/brands/:slug/posts?status=scheduled', () => {
     const body = await res.json();
 
     expect(deletePostCancellingZernio).toHaveBeenCalledTimes(2);
-    expect(deletePostCancellingZernio).toHaveBeenNthCalledWith(1, client, 'p1', 'brand-1');
+    expect(deletePostCancellingZernio).toHaveBeenNthCalledWith(1, client, 'p1', 'brand-1', 'u1');
     expect(res.status).toBe(502);
     expect(body.deleted).toBe(1);
     expect(body.failed).toEqual([{ id: 'p2', error: expect.stringContaining('NOT deleted') }]);
@@ -73,7 +74,7 @@ describe('DELETE /api/v1/brands/:slug/posts?status=scheduled', () => {
 
   it('still bulk-deletes pending_user directly (draft-only, no live schedule to revoke)', async () => {
     const { client, ops } = fakeSupabase({ posts: [{ id: 'p1' }] });
-    vi.mocked(authenticate).mockResolvedValue({ supabase: client, apiKey: null, error: null } as never);
+    vi.mocked(authenticate).mockResolvedValue({ supabase: client, user: { id: 'u1' }, apiKey: null, error: null } as never);
     vi.mocked(loadBrandForUser).mockResolvedValue({ brand: { id: 'brand-1' }, error: null } as never);
 
     const res = await (DELETE as (event: unknown) => Promise<Response>)({
@@ -85,6 +86,9 @@ describe('DELETE /api/v1/brands/:slug/posts?status=scheduled', () => {
 
     expect(deletePostCancellingZernio).not.toHaveBeenCalled();
     expect(ops.filter((o) => o.kind === 'delete')).toEqual([{ table: 'posts', kind: 'delete' }]);
+    expect(ops.find((o) => o.table === 'post_verdicts')?.payload).toEqual([
+      { post_id: 'p1', brand_id: 'brand-1', user_id: 'u1', verdict: 'discarded', caption_before: null, caption_after: null }
+    ]);
     expect(body).toEqual({ ok: true, deleted: 1 });
   });
 });

--- a/src/routes/app/[brand]/approvals/+page.server.ts
+++ b/src/routes/app/[brand]/approvals/+page.server.ts
@@ -15,7 +15,7 @@ export const actions: Actions = {
   // Shared editor actions: updatePost, reschedule, cancelSchedule, repost, reject, approve.
   ...editorActions,
 
-  approveAll: async ({ params, locals: { supabase } }) => {
+  approveAll: async ({ params, locals: { supabase, user } }) => {
     const { data: brand } = await supabase
       .from('brands')
       .select('id, timezone')
@@ -31,7 +31,7 @@ export const actions: Actions = {
 
     let noAccount = false;
     for (const post of pending ?? []) {
-      const res = await publishApprovedPost(supabase, post as ApprovablePost, brand.timezone ?? 'Europe/Rome');
+      const res = await publishApprovedPost(supabase, post as ApprovablePost, brand.timezone ?? 'Europe/Rome', { by: user?.id });
       if (res.noAccount) noAccount = true;
     }
     return { ok: true, noAccount };

--- a/src/routes/app/[brand]/calendar/+page.server.ts
+++ b/src/routes/app/[brand]/calendar/+page.server.ts
@@ -10,6 +10,7 @@ import {
   EDITOR_POST_COLS,
   decoratePosts,
   buildBusyDays,
+  applyPostEdits,
   deletePostCancellingZernio,
   editorActions
 } from '$lib/server/post-editing';
@@ -317,13 +318,13 @@ export const load: PageServerLoad = async (event) => {
 };
 
 export const actions: Actions = {
-  updateCaption: async ({ request, locals: { supabase } }) => {
+  updateCaption: async ({ request, locals: { supabase, user } }) => {
     const data = await request.formData();
     const id = String(data.get('id') ?? '');
     const caption = String(data.get('caption') ?? '').trim();
     if (!id) return fail(400, { error: 'Missing post' });
     if (!caption) return fail(400, { error: 'Caption cannot be empty' });
-    const { error } = await supabase.from('posts').update({ caption }).eq('id', id);
+    const { error } = await applyPostEdits(supabase, id, { caption }, { by: user?.id });
     if (error) return fail(500, { error: error.message });
     return { updated: id };
   },
@@ -331,16 +332,16 @@ export const actions: Actions = {
   // Prima scriveva un publish_log 'canceled' e cancellava la riga SENZA mai revocare Zernio:
   // il log dichiarava una cancellazione inesistente e il post usciva comunque (classe incidente
   // scheduling luglio 2026). Ora la revoca viene prima; se fallisce, il post resta visibile.
-  deletePost: async ({ request, locals: { supabase } }) => {
+  deletePost: async ({ request, locals: { supabase, user } }) => {
     const data = await request.formData();
     const id = String(data.get('id') ?? '');
     if (!id) return fail(400, { error: 'Missing post' });
-    const res = await deletePostCancellingZernio(supabase, id);
+    const res = await deletePostCancellingZernio(supabase, id, undefined, user?.id);
     if (!res.ok) return fail(res.status, { error: res.message });
     return { deleted: id, wasScheduled: res.wasScheduled };
   },
 
-  approveWeek: async ({ request, params, locals: { supabase } }) => {
+  approveWeek: async ({ request, params, locals: { supabase, user } }) => {
     const form = await request.formData();
     const ids = parseIds(form);
     if (!ids.length) return {};
@@ -361,7 +362,8 @@ export const actions: Actions = {
       const res = await publishApprovedPost(
         supabase,
         post as ApprovablePost,
-        brand.timezone ?? 'Europe/Rome'
+        brand.timezone ?? 'Europe/Rome',
+        { by: user?.id }
       );
       if (res.noAccount) noAccount = true;
     }
@@ -369,7 +371,7 @@ export const actions: Actions = {
   },
 
   /** Bulk-delete selected social posts (same-type multi-select). */
-  deleteSelected: async ({ request, params, locals: { supabase } }) => {
+  deleteSelected: async ({ request, params, locals: { supabase, user } }) => {
     const ids = parseIds(await request.formData());
     if (!ids.length) return fail(400, { error: 'No posts selected' });
     const { data: brand } = await supabase
@@ -392,7 +394,7 @@ export const actions: Actions = {
     let deleted = 0;
     const failures: string[] = [];
     for (const post of posts) {
-      const res = await deletePostCancellingZernio(supabase, post.id, brand.id);
+      const res = await deletePostCancellingZernio(supabase, post.id, brand.id, user?.id);
       if (res.ok) deleted++;
       else failures.push(res.message);
     }
@@ -457,7 +459,7 @@ export const actions: Actions = {
   },
 
 
-  approveAll: async ({ params, locals: { supabase } }) => {
+  approveAll: async ({ params, locals: { supabase, user } }) => {
     const { data: brand } = await supabase
       .from('brands')
       .select('id, timezone')
@@ -474,7 +476,8 @@ export const actions: Actions = {
       const res = await publishApprovedPost(
         supabase,
         post as ApprovablePost,
-        brand.timezone ?? 'Europe/Rome'
+        brand.timezone ?? 'Europe/Rome',
+        { by: user?.id }
       );
       if (res.noAccount) noAccount = true;
     }

--- a/src/routes/app/[brand]/calendar/page.server.delete.test.ts
+++ b/src/routes/app/[brand]/calendar/page.server.delete.test.ts
@@ -53,7 +53,7 @@ function post(action: unknown, fields: Record<string, string>, supabase: unknown
   return (action as (event: unknown) => Promise<unknown>)({
     request: new Request('https://example.test/app/b/calendar', { method: 'POST', body: form }),
     params: { brand: 'b' },
-    locals: { supabase }
+    locals: { supabase, user: { id: 'u1' } }
   });
 }
 
@@ -68,7 +68,7 @@ describe('calendar deletePost', () => {
     const res = await post(actions.deletePost, { id: 'post-1' }, fakeSupabase({})) as
       { status: number; data: { error: string } };
 
-    expect(deletePostCancellingZernio).toHaveBeenCalledWith(expect.anything(), 'post-1');
+    expect(deletePostCancellingZernio).toHaveBeenCalledWith(expect.anything(), 'post-1', undefined, 'u1');
     expect(res.status).toBe(502);
     expect(res.data.error).toContain('NOT deleted');
   });
@@ -88,7 +88,7 @@ describe('calendar deleteSelected', () => {
       { status: number; data: { error: string; deletedSelected: number } };
 
     expect(deletePostCancellingZernio).toHaveBeenCalledTimes(2);
-    expect(deletePostCancellingZernio).toHaveBeenNthCalledWith(1, expect.anything(), 'p1', 'brand-1');
+    expect(deletePostCancellingZernio).toHaveBeenNthCalledWith(1, expect.anything(), 'p1', 'brand-1', 'u1');
     expect(res.status).toBe(502);
     expect(res.data.deletedSelected).toBe(1);
     expect(res.data.error).toContain('NOT deleted');

--- a/src/routes/app/[brand]/content/+page.server.ts
+++ b/src/routes/app/[brand]/content/+page.server.ts
@@ -4,7 +4,7 @@ import { fail } from '@sveltejs/kit';
 import { publishApprovedPost, type ApprovablePost } from '$lib/server/publish';
 import { signApproveToken } from '$lib/server/token';
 import { sendEmail, approvalEmailHtml, approvalEmailText, approvalEmailSubject } from '$lib/server/email';
-import { EDITOR_POST_COLS, deletePostCancellingZernio, editorActions } from '$lib/server/post-editing';
+import { EDITOR_POST_COLS, applyPostEdits, deletePostCancellingZernio, editorActions } from '$lib/server/post-editing';
 
 /**
  * Queue UI merged into Calendar. Keep this route as a redirect so old links
@@ -17,13 +17,13 @@ export const load: PageServerLoad = async ({ params, url }) => {
 };
 
 export const actions: Actions = {
-  updateCaption: async ({ request, locals: { supabase } }) => {
+  updateCaption: async ({ request, locals: { supabase, user } }) => {
     const data = await request.formData();
     const id = String(data.get('id') ?? '');
     const caption = String(data.get('caption') ?? '').trim();
     if (!id) return fail(400, { error: 'Missing post' });
     if (!caption) return fail(400, { error: 'Caption cannot be empty' });
-    const { error } = await supabase.from('posts').update({ caption }).eq('id', id);
+    const { error } = await applyPostEdits(supabase, id, { caption }, { by: user?.id });
     if (error) return fail(500, { error: error.message });
     return { updated: id };
   },
@@ -31,16 +31,16 @@ export const actions: Actions = {
   // Prima scriveva un publish_log 'canceled' e cancellava la riga SENZA mai revocare Zernio:
   // il log dichiarava una cancellazione inesistente e il post usciva comunque (classe incidente
   // scheduling luglio 2026). Ora la revoca viene prima; se fallisce, il post resta visibile.
-  deletePost: async ({ request, locals: { supabase } }) => {
+  deletePost: async ({ request, locals: { supabase, user } }) => {
     const data = await request.formData();
     const id = String(data.get('id') ?? '');
     if (!id) return fail(400, { error: 'Missing post' });
-    const res = await deletePostCancellingZernio(supabase, id);
+    const res = await deletePostCancellingZernio(supabase, id, undefined, user?.id);
     if (!res.ok) return fail(res.status, { error: res.message });
     return { deleted: id, wasScheduled: res.wasScheduled };
   },
 
-  approveWeek: async ({ request, params, locals: { supabase } }) => {
+  approveWeek: async ({ request, params, locals: { supabase, user } }) => {
     const form = await request.formData();
     const ids = String(form.get('ids') ?? '')
       .split(',')
@@ -64,14 +64,15 @@ export const actions: Actions = {
       const res = await publishApprovedPost(
         supabase,
         post as ApprovablePost,
-        brand.timezone ?? 'Europe/Rome'
+        brand.timezone ?? 'Europe/Rome',
+        { by: user?.id }
       );
       if (res.noAccount) noAccount = true;
     }
     return { ok: true, noAccount };
   },
 
-  approveAll: async ({ params, locals: { supabase } }) => {
+  approveAll: async ({ params, locals: { supabase, user } }) => {
     const { data: brand } = await supabase
       .from('brands')
       .select('id, timezone')
@@ -88,7 +89,8 @@ export const actions: Actions = {
       const res = await publishApprovedPost(
         supabase,
         post as ApprovablePost,
-        brand.timezone ?? 'Europe/Rome'
+        brand.timezone ?? 'Europe/Rome',
+        { by: user?.id }
       );
       if (res.noAccount) noAccount = true;
     }

--- a/src/routes/app/[brand]/plan/+page.server.ts
+++ b/src/routes/app/[brand]/plan/+page.server.ts
@@ -419,11 +419,11 @@ export const actions: Actions = {
   // publish_logs.post_id è ON DELETE SET NULL, quindi la riga di audit sopravvive.
   // La REVOCA su Zernio viene PRIMA della cancellazione: senza, un post scheduled/approved usciva
   // lo stesso. Se la revoca fallisce, il post resta.
-  deletePost: async ({ request, params, locals: { supabase } }) => {
+  deletePost: async ({ request, params, locals: { supabase, user } }) => {
     const brand = await requireBrand(supabase, params.brand);
     const id = String((await request.formData()).get('id') ?? '');
     if (!id) return fail(400, { error: 'missing_id' });
-    const res = await deletePostCancellingZernio(supabase, id, brand.id);
+    const res = await deletePostCancellingZernio(supabase, id, brand.id, user?.id);
     if (!res.ok) return fail(res.status, { error: res.message });
     return { deleted: true };
   },

--- a/src/routes/approve/[token]/+page.server.ts
+++ b/src/routes/approve/[token]/+page.server.ts
@@ -4,6 +4,7 @@ import { createAdminClient } from '$lib/server/supabase-admin';
 import { publishApprovedPost, type ApprovablePost } from '$lib/server/publish';
 import { EDITOR_POST_COLS } from '$lib/server/post-editing';
 import { nextOccurrence } from '$lib/server/schedule';
+import { brandOwnerId } from '$lib/server/post-verdict';
 
 // One-tap email approval — no session. The signed token IS the authorization;
 // we use the service-role client to approve + schedule the brand's pending posts.
@@ -80,6 +81,7 @@ export const actions: Actions = {
       .eq('status', 'pending_user')
       .eq('needs_attention', true);
 
+    const owner = await brandOwnerId(admin, brand.id);
     let approved = 0;
     let noAccount = false;
 
@@ -99,7 +101,7 @@ export const actions: Actions = {
         await admin.from('posts').update({ scheduled_for: when }).eq('id', p.id);
         p.scheduled_for = when;
       }
-      const r = await publishApprovedPost(admin, p, tz);
+      const r = await publishApprovedPost(admin, p, tz, { by: owner ?? undefined });
       approved++;
       if (r.noAccount) noAccount = true;
     }

--- a/supabase/migrations/20260901140000_post_verdicts.sql
+++ b/supabase/migrations/20260901140000_post_verdicts.sql
@@ -1,0 +1,39 @@
+-- Il verdetto umano su un post: approvato, modificato, buttato.
+--
+-- Perché una TABELLA e non una colonna su `posts`: buttare un post ne CANCELLA la riga, quindi una
+-- colonna sparirebbe insieme al verdetto più informativo di tutti — e infatti al 1/9/2026 «scartato»
+-- non esiste da giugno. Un post odiato e uno mai aperto sono la stessa riga. Inoltre un post si
+-- modifica più volte, e `posts` non ha nessuna colonna che dica CHI ha deciso: il verdetto è di una
+-- persona, non di un brand.
+--
+-- `post_id` non ha foreign key APPOSTA: il verdetto 'discarded' deve sopravvivere alla riga che
+-- descrive. È l'unico modo perché «buttato» resti misurabile.
+create table if not exists public.post_verdicts (
+  id uuid primary key default gen_random_uuid(),
+  post_id uuid not null,
+  brand_id uuid not null references public.brands (id) on delete cascade,
+  user_id uuid not null references auth.users (id) on delete cascade,
+  verdict text not null check (verdict in ('approved', 'edited', 'discarded')),
+  caption_before text,
+  caption_after text,
+  created_at timestamptz not null default now()
+);
+
+-- L'evento di attivazione si legge da qui: min(created_at) per (user_id, brand_id) con verdict
+-- 'approved'. L'indice serve esattamente quella query.
+create index if not exists post_verdicts_activation_idx
+  on public.post_verdicts (user_id, brand_id, created_at)
+  where verdict = 'approved';
+
+create index if not exists post_verdicts_brand_idx on public.post_verdicts (brand_id, created_at);
+create index if not exists post_verdicts_post_idx on public.post_verdicts (post_id);
+
+alter table public.post_verdicts enable row level security;
+
+-- Il brand decide chi legge; scrive chiunque possa già agire sul brand (la stessa sessione che
+-- approva il post) oltre al service role.
+drop policy if exists "post_verdicts via brand" on public.post_verdicts;
+create policy "post_verdicts via brand" on public.post_verdicts
+  for all
+  using (brand_id in (select public.auth_brand_ids()))
+  with check (brand_id in (select public.auth_brand_ids()));


### PR DESCRIPTION
## What?

Records the human verdict on a post — **approved / edited / discarded** — in a new table
`post_verdicts`, and defines the activation event ("approved the first post", per user and per
brand, with the date) as a one-query read over it. No dashboard, no analytics page, no automatic
scoring: the event and its query.

The rule that decides what a verdict is lives in exactly one module
(`src/lib/server/post-verdict.ts`); the surfaces only declare **who** decided, which is the one
thing only they know.

## Why?

Measured in production on 1/9/2026, over 500 posts: 243 `pending_user` (49%), 176 `published`,
61 `scheduled`, 14 `approved`, 6 `failed`, and **zero discarded since June** — the state does not
exist. A post the customer hated and one they never opened are the same row. There is no quality
column on `posts` at all, while `market_posts` (the COMPETITORS' posts), `content_quality_samples`
and `brand_pages` all carry one: we grade everything except what we deliver.

The consequence is the one that blocks work already underway: there is no definition of
"activated", so the entry flow is about to change with no way to tell whether it improved.

## How?

### The shape: an events table, and why not the other two

`post_verdicts (post_id, brand_id, user_id, verdict, caption_before, caption_after, created_at)`.

- **A new `posts.status`** — rejected. Discarding a post **DELETES its row** today
  (`deletePostCancellingZernio`, the chat's `reject_post`, the CLI bulk delete). A `discarded`
  status implies soft deletion, i.e. a filter in every read of `posts` in the product: the most
  invasive migration possible, for the rarest signal.
- **A dedicated column on `posts`** — rejected, for the same reason plus two more: "edited" happens
  more than once and a column keeps only the last one, and `posts` has **no column saying who
  decided**. The verdict belongs to a person, not to a brand.
- **An events table** — chosen. `post_id` deliberately carries **no foreign key**: the `discarded`
  verdict has to outlive the row it describes, or "discarded" stays as unmeasurable as it is today.

**"Edited" keeps the difference, because it cost nothing.** `applyPostEdits` already reads the
previous caption to teach `brand_memory`; `caption_before` / `caption_after` reuse that read. What
is deliberately left out is non-textual editing (media, schedule): "edited" here means *the user
rewrote what we wrote*, which is the signal the ticket calls the most valuable. Extending it to
media swaps would need a second read on a path that does not have one — a separate ticket if it
ever matters.

### The write points — 22, across 5 surfaces

The verdict is emitted from the three chokepoints that already existed, so a new approval surface
records itself:

| chokepoint | verdict | condition |
|---|---|---|
| `publishApprovedPost` | `approved` | stored status was `pending_user` **and** the call names a person (`opts.by`) |
| `applyPostEdits` | `edited` | the caption actually changed **and** the call names a person |
| `deletePostCancellingZernio` | `discarded` | the delete succeeded **and** the call names a person |

Both conditions on approval are load-bearing. Without the status check, a reschedule or a repost
would count as an approval. Without the actor, the analytics agent's `reschedule_pending_post` —
which can publish a `pending_user` post — would inflate activation with a decision no human took.

Surfaces now naming the person:

- **Editor** (`editorActions`, shared by Approvals and Content): `updatePost`, `reschedule`,
  `approve`, `publishNow`, `reject`.
- **Calendar**: `updateCaption`, `deletePost`, `approveWeek`, `deleteSelected`, `approveAll`.
- **Content**: `updateCaption`, `deletePost`, `approveWeek`, `approveAll`.
- **Plan**: `deletePost`. **Approvals**: `approveAll`.
- **API / CLI**: `PUT` and `DELETE /posts/:id`, `DELETE /posts` (bulk), `POST /posts/:id/publish`,
  `POST /posts/:id/approve`, `POST /posts/approve-all` (the last two through
  `approvePost` / `approveAllPosts` in `cli-queries`).
- **Chat tools**: `approve_post`, `update_post`, `reject_post` (`ctx.userId`).
- **Email, no session**: `/approve/:token`, `/api/radar/approve/:token`,
  `/api/radar/reject/:token` — `brandOwnerId` resolves brand → organisation → owner, so those paths
  have a person behind them instead of a hole.

**Three surfaces bypassed a chokepoint and were routed back through it rather than duplicated** —
the divergence class LESSONS already names ("a rule closed on one surface stays open on all the
others"). Two of them were live defects in their own right:

- `updateCaption` on **Calendar** and on **Content** wrote `posts.caption` by hand, so a caption
  rewritten from those two screens **never taught the brand voice** and never landed in
  `captionEditPairs`. Now they call `applyPostEdits` like everything else.
- `DELETE /api/v1/brands/:slug/posts/:id` deleted the row without revoking the Zernio schedule.
  Guarded to `pending_user` so no schedule was live in practice, but it was the only delete path
  left outside the shared helper. Now it calls `deletePostCancellingZernio`.

The chat's `update_post` / `reject_post` and the CLI bulk delete keep an explicit
`recordPostVerdict` call: their writes are genuinely not the same write, and folding them in would
have changed behaviour beyond this ticket.

**What deliberately records nothing:** `createManualPost`. A post the user wrote themselves is not
a judgement on what we wrote, and counting it as activation would measure the wrong product.

### Failure mode

`recordPostVerdict` logs and returns on any error. A verdict must never fail an approval — which is
also exactly why the migration has to be applied first (see Testing).

## Testing?

`npx vitest run` — **544 files passed, 1 skipped; 6088 tests passed, 4 skipped**. Green, including
`src/hooks.server.test.ts` (the worktree has a `.env`).

New: `src/lib/server/post-verdict.test.ts`, 10 tests, **written first and watched fail** (3 red on
the chokepoints before the wiring existed):

- the row names post, brand, person, verdict; the before→after pair survives on an edit
- `brandOwnerId` resolves brand → org → owner, and returns null with no organisation
- approving a draft records `approved`; **the autopilot records nothing** (no person); **a
  reschedule records nothing** (not a draft)
- a caption edit records `edited` with both sides; an edit that leaves the caption alone records
  nothing
- discarding records `discarded` after the row is gone

Two existing tests were updated because their fakes had aged, not because behaviour regressed:
`server.delete.test.ts` mocked `authenticate` without the `user` it always returns (it now also
asserts the verdict rows), and `page.server.delete.test.ts` pinned the exact argument list of
`deletePostCancellingZernio`.

**Schema drift check** — `node scripts/schema-drift-check.mjs`: **RED, 1 divergence, and it is the
expected one**:

```
MIGRATION SCRITTE MA NON APPLICATE (1) — le applica una persona, non questo script
  supabase/migrations/20260901140000_post_verdicts.sql
    assenti nel database: post_verdicts
    → APPLICA LA MIGRATION
```

Nothing else moved (the 13 manual CHECK items and the 272 unverifiable points are pre-existing).

> [!IMPORTANT]
> **This repo's deploys do not run migrations.**
> `supabase/migrations/20260901140000_post_verdicts.sql` **must be applied by hand before this code
> reaches production.** Without the table every `recordPostVerdict` fails — and it fails silently by
> construction — so the feature would record nothing with nobody noticing. After applying it on a
> local stack, `notify pgrst, 'reload schema'` (LESSONS: PostgREST caches the schema).

**Not tested:** no browser gate. The change is a write-side signal with no UI; the surfaces it
touches are covered by the suite, and the one visible difference (Calendar/Content caption edits
now feeding brand memory) rides on the already-tested `applyPostEdits`. The migration itself has not
been applied anywhere, so nothing has yet written a real row: **the first person to apply it should
check that one approval produces one row before trusting the counts.**

## Evidence (screenshots/videos)

No UI change, so no screenshots.

<details>
<summary>The migration</summary>

```sql
create table if not exists public.post_verdicts (
  id uuid primary key default gen_random_uuid(),
  post_id uuid not null,
  brand_id uuid not null references public.brands (id) on delete cascade,
  user_id uuid not null references auth.users (id) on delete cascade,
  verdict text not null check (verdict in ('approved', 'edited', 'discarded')),
  caption_before text,
  caption_after text,
  created_at timestamptz not null default now()
);

create index if not exists post_verdicts_activation_idx
  on public.post_verdicts (user_id, brand_id, created_at)
  where verdict = 'approved';
```

RLS is on, with the repo's standard `auth_brand_ids()` policy.
</details>

<details>
<summary>Test run</summary>

```
 Test Files  544 passed | 1 skipped (545)
      Tests  6088 passed | 4 skipped (6092)
   Duration  225.12s
```
</details>

## The activation query — paste and run

Activation is **not** a stored row: it is `min(created_at)` per `(user_id, brand_id)` over the
`approved` verdicts. `post_verdicts_activation_idx` is the partial index for exactly this.

**By signup cohort — how many activate, and how fast:**

```sql
with activation as (
  select user_id, brand_id, min(created_at) as activated_at
  from post_verdicts
  where verdict = 'approved'
  group by user_id, brand_id
)
select
  date_trunc('week', u.created_at)::date                                as signup_week,
  count(distinct u.id)                                                  as signed_up,
  count(distinct a.user_id)                                             as activated,
  round(100.0 * count(distinct a.user_id) / nullif(count(distinct u.id), 0), 1) as activation_pct,
  round(avg(extract(epoch from (a.activated_at - u.created_at)) / 3600)
        filter (where a.user_id is not null)::numeric, 1)               as avg_hours_to_activate
from auth.users u
left join activation a on a.user_id = u.id
group by 1
order by 1 desc;
```

**The raw event, one row per activated (user, brand):**

```sql
select user_id, brand_id, min(created_at) as activated_at
from post_verdicts
where verdict = 'approved'
group by user_id, brand_id
order by activated_at desc;
```

**And the reason the table exists — what the verdicts actually say:**

```sql
select verdict, count(*), count(distinct user_id) as people
from post_verdicts
group by verdict
order by 2 desc;
```

## Anything Else?

- **The counts start at zero and only look forward.** Nothing backfills history: past approvals left
  no trace to reconstruct, which is the whole problem. The first cohort with meaningful numbers is
  the one that signs up after the migration is applied.
- **"Edited" covers the caption only.** Media swaps, reschedules and regenerations record nothing.
  Deliberate — see How. The `before`/`after` columns are there if a later ticket widens it.
- **The email paths attribute to the brand owner**, not to whoever actually clicked. A forwarded
  digest link approved by a teammate is recorded as the owner's decision. For cohort analysis, where
  the owner is the unit, this is the right answer; for per-person attribution it is an approximation
  worth knowing about.
- **`post_id` has no FK**, so nothing stops a verdict pointing at an id that no longer exists. That
  is the point for `discarded`, and it means the table is not a place to join back to `posts`
  expecting a hit.
- **Not in this PR, on purpose:** the quality eval, onboarding (another agent is working there), and
  any automatic scoring of posts. Only the human verdict, recorded, and the activation event you can
  query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHzdoJhyXfnkX6mWWJkduX
