### PR TITLE
Resolve the host before fetching it for a stranger

### DIFF
--- a/src/lib/server/tool-guard.ts
+++ b/src/lib/server/tool-guard.ts
@@ -165,8 +165,13 @@ export function isPrivateAddress(ip: string): boolean {
   return false;
 }
 
-/** Reject anything that isn't a public http(s) host. Throws with a user-safe message. */
-async function assertPublicUrl(url: URL): Promise<void> {
+/**
+ * Reject anything that isn't a public http(s) host. Throws with a user-safe message.
+ *
+ * Exported because /start/preview is the same shape of caller as the tools above — an
+ * anonymous stranger's URL — and must not fall back to the hostname-pattern check.
+ */
+export async function assertPublicUrl(url: URL): Promise<void> {
   if (url.protocol !== 'http:' && url.protocol !== 'https:') throw new Error('Only http(s) URLs are supported');
   const host = url.hostname.toLowerCase();
   if (host === 'localhost' || host.endsWith('.localhost') || host.endsWith('.local') || host.endsWith('.internal')) {

--- a/src/routes/start/preview/+server.ts
+++ b/src/routes/start/preview/+server.ts
@@ -1,7 +1,7 @@
 import type { RequestHandler } from './$types';
 import { isGuestPreviewEnabled } from '$lib/server/feature-flags';
-import { guardTool } from '$lib/server/tool-guard';
-import { isUrlSafe, runBrandAnalysis } from '$lib/server/brand-analysis';
+import { assertPublicUrl, guardTool } from '$lib/server/tool-guard';
+import { runBrandAnalysis } from '$lib/server/brand-analysis';
 import { planPreviewPosts, renderPreviewImages } from '$lib/server/content-preview/weekly-planner';
 import { createAdminClient } from '$lib/server/supabase-admin';
 import { NANO_BANANA_2_LITE } from '$lib/server/gemini';
@@ -25,8 +25,14 @@ import { localeLanguageName } from '$lib/i18n/locale';
  *
  * This is the only unauthenticated endpoint that spends real money, and no credit gate stands
  * behind it — `renderPostImage` gates on a brand context a guest does not have. The three guards
- * at the top (kill switch, per-IP cap, SSRF) ARE the spending limit, in that order: refuse before
- * counting, count before generating.
+ * at the top (kill switch, per-IP cap, resolve-then-check SSRF) ARE the spending limit, in that
+ * order: refuse before counting, count before generating.
+ *
+ * Known gap, deliberately not widened here: runBrandAnalysis still fetches internally behind
+ * brand-analysis.ts's pattern-only isUrlSafe (:788), which fetchPage (:813) applies at :815 and
+ * re-checks on each redirect hop at :846 — all string comparisons, so a hostname resolving to a
+ * private address passes. Fine while every caller was authenticated; now that an anonymous one
+ * exists, it is real debt, tracked in the PR rather than widened here.
  */
 export const config = { maxDuration: 300 };
 
@@ -56,9 +62,16 @@ export const POST: RequestHandler = async ({ request, getClientAddress, locals: 
   }
   if (!/^[a-z0-9-]+(\.[a-z0-9-]+)+$/i.test(host)) return new Response('Invalid URL', { status: 400 });
 
-  // The guard that makes an open endpoint stop being a request forger. It already runs inside
-  // fetchPage; it runs HERE too because this is the boundary that made it necessary.
-  if (!isUrlSafe(url)) return new Response('Invalid URL', { status: 400 });
+  // The guard that makes an open endpoint stop being a request forger — and it has to be the
+  // RESOLVING one. brand-analysis's isUrlSafe compares hostname patterns, which is enough for a
+  // URL we already trust (a brand's own site) but blind to a perfectly public hostname whose DNS
+  // record points at 127.0.0.1. This caller is an anonymous stranger, so it gets the same
+  // resolve-then-check the public /api/tools endpoints get.
+  try {
+    await assertPublicUrl(new URL(url));
+  } catch {
+    return new Response('Invalid URL', { status: 400 });
+  }
 
   const enc = new TextEncoder();
   const stream = new ReadableStream({

--- a/src/routes/start/preview/server.test.ts
+++ b/src/routes/start/preview/server.test.ts
@@ -1,7 +1,18 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('$lib/server/feature-flags', () => ({ isGuestPreviewEnabled: vi.fn(() => true) }));
-vi.mock('$lib/server/tool-guard', () => ({ guardTool: vi.fn(async () => ({ ok: true })) }));
+vi.mock('$lib/server/tool-guard', async (orig) => ({
+  ...(await orig<Record<string, unknown>>()),
+  guardTool: vi.fn(async () => ({ ok: true }))
+}));
+// Resolve-then-check is the whole point of the boundary guard, so DNS is the thing to fake:
+// an address literal resolves to itself, every other host to a public address unless a test says
+// otherwise.
+const lookupMock = vi.fn(async (host: string) => {
+  if (/^\d+\.\d+\.\d+\.\d+$/.test(host)) return [{ address: host, family: 4 }];
+  return [{ address: '93.184.216.34', family: 4 }];
+});
+vi.mock('node:dns/promises', () => ({ lookup: (host: string) => lookupMock(host) }));
 vi.mock('$lib/server/supabase-admin', () => ({ createAdminClient: vi.fn(() => ({})) }));
 vi.mock('$lib/server/gemini', async (orig) => ({
   ...(await orig<Record<string, unknown>>()),
@@ -26,6 +37,7 @@ import { POST } from './+server';
 import { isGuestPreviewEnabled } from '$lib/server/feature-flags';
 import { guardTool } from '$lib/server/tool-guard';
 import { planPreviewPosts, renderPreviewImages } from '$lib/server/content-preview/weekly-planner';
+import { runBrandAnalysis } from '$lib/server/brand-analysis';
 
 function call(url: unknown, ip = '203.0.113.9') {
   return (POST as (e: unknown) => Promise<Response>)({
@@ -78,6 +90,25 @@ describe('POST /start/preview', () => {
       expect(res.status).toBe(400);
     }
     expect(planPreviewPosts).not.toHaveBeenCalled();
+  });
+
+  it('refuses a public hostname whose DNS points inside the network', async () => {
+    // The attack the hostname-pattern guard cannot see: nothing about "rebind.example.com" looks
+    // private until you resolve it.
+    lookupMock.mockResolvedValueOnce([{ address: '127.0.0.1', family: 4 }]);
+
+    const res = await call('rebind.example.com');
+
+    expect(res.status).toBe(400);
+    expect(planPreviewPosts).not.toHaveBeenCalled();
+    expect(runBrandAnalysis).not.toHaveBeenCalled();
+  });
+
+  it('refuses a host that does not resolve at all', async () => {
+    lookupMock.mockResolvedValueOnce([]);
+
+    expect((await call('nowhere.example.com')).status).toBe(400);
+    expect(runBrandAnalysis).not.toHaveBeenCalled();
   });
 
   it('refuses a missing url', async () => {


### PR DESCRIPTION
## What?

`POST /start/preview` — the public, unauthenticated endpoint merged in #129 — validated its URL with `isUrlSafe()` from `brand-analysis.ts`, which compares hostname **patterns**. This swaps it for the **resolve-then-check** guard that already serves every public `/api/tools` route.

> ⚠️ **This is a follow-up to #129, which was merged while this fix was being written.** The hole is on `dev` right now.

## Why?

`tool-guard.ts` documents this exact trap, immediately above its own implementation:

> brand-analysis.ts has its own `isUrlSafe`, kept deliberately separate. That one matches hostname PATTERNS only, which is fine for URLs we already trust (a brand's own site). These tools take a URL from an anonymous stranger, so the check has to survive a public hostname whose DNS record points at 127.0.0.1 — hence the resolve-then-check below.

`/start/preview` is precisely "a URL from an anonymous stranger", and it was using the guard that note warns against. `rebind.example.com` is syntactically a perfectly ordinary public hostname; nothing about the string is private. If its A record points at `127.0.0.1` — or at `169.254.169.254`, the cloud metadata endpoint — the pattern check passes and `runBrandAnalysis` goes and fetches it. That is server-side request forgery reachable by anyone on the internet, with no account.

## How?

`assertPublicUrl()` in `tool-guard.ts` already did the right thing and was already the guard for every public tool route. It was private to the module. **It is now exported** — the fix is a keyword plus a call site.

That was deliberate over the alternative: inlining `lookup()` + `isPrivateAddress()` into the endpoint would have produced a third SSRF guard saying a third slightly different thing. The repo still has exactly two, and the public boundary now uses the strong one. `isPrivateAddress` and `safeFetchUrl` are untouched.

```ts
try {
  await assertPublicUrl(new URL(url));
} catch {
  return new Response('Invalid URL', { status: 400 });
}
```

`assertPublicUrl` resolves the host and rejects if **any** returned address is private (IPv4 private/loopback/link-local/CGNAT/multicast, IPv6 loopback/unique-local/link-local), plus the `localhost` / `.local` / `.internal` suffix rules.

## Testing?

**Both new tests were watched fail with `200` before the fix**, on the merged code:

```
FAIL  refuses a public hostname whose DNS points inside the network
  expected 200 to be 400
FAIL  refuses a host that does not resolve at all
  expected 200 to be 400
```

DNS is faked so the check itself is what is under test: an address literal resolves to itself, every other host to a public address unless a test overrides it. That also means the pre-existing literal-IP cases (`169.254.169.254`, `127.0.0.1`, `10.0.0.5`) are now exercised through the **strong** guard rather than the pattern one.

- `src/routes/start/preview/server.test.ts` → **8 passed**
- Full suite → **544 files passed, 1 skipped; 6090 passed, 4 skipped**, exit 0 (2 more than #129's 6088 — these two)
- `node scripts/typecheck-runtime.mjs` (the CI gate) → ok, exit 0
- `svelte-check` → zero diagnostics in any touched file (the repo's 377 errors are pre-existing and not gated in CI)

**Not tested:** no browser walk, same as #129. The guard is covered by unit tests with faked DNS; it has not been exercised against a real resolver.

## Evidence (screenshots/videos)

Backend-only change; no UI.

<details>
<summary>The gap, before and after</summary>

Before — pattern comparison only, blind to what the name resolves to:

```ts
if (!isUrlSafe(url)) return new Response('Invalid URL', { status: 400 });
```

After — the same resolve-then-check every public `/api/tools` route gets:

```ts
try {
  await assertPublicUrl(new URL(url));
} catch {
  return new Response('Invalid URL', { status: 400 });
}
```
</details>

## Anything Else?

**Remaining debt, deliberately not widened here.** The *boundary* is now closed, but `runBrandAnalysis` still fetches internally behind the pattern-only guard: `src/lib/server/brand-analysis.ts:788` defines `isUrlSafe`; `fetchPage` (`:813`) applies it at `:815` and re-checks each redirect hop at `:846` — all string comparisons, so a hostname resolving to a private address passes all three. That was acceptable while every caller was authenticated; #129 gave it an anonymous caller.

Closing it properly means moving the analysis pipeline onto `safeFetchUrl` (which re-validates every redirect hop after resolving, and adds byte and time budgets). That touches every brand-analysis path and deserves its own PR and its own tests, rather than riding along here. It is also recorded in the endpoint's own docstring so the next reader finds it at the code, not only in a PR.

**Order of guards at the endpoint is unchanged** and still: kill switch → per-IP cap → URL validation + SSRF → any spending. Refuse before counting, count before generating.
