### PR TITLE
Apply the likeness consent gate to the media-refs door

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -262,6 +262,18 @@ gestisce chiaramente. Mossa: intercettare per PATHNAME esatto (una regex sull'UR
 che un file sorgente può soddisfare — e prima di credere a un difetto, misurare il caso base senza
 intercettazione.
 
+### Un cancello messo un livello sopra il chokepoint non è un cancello: è una delle porte
+Il consenso alla likeness era controllato in `resolvePeopleVisualRefsDetailed` — un livello sopra
+`signPersonImages`, che è il punto dove la foto di una persona reale diventa davvero un URL
+firmato. Otto chiamanti firmano quelle foto; uno solo passava dal cancello. `media-refs` non
+selezionava nemmeno la colonna `consent`, e il workbench renderizzava una persona che la chat
+rifiutava per nome: stessa regola, due risposte secondo la porta. Segnale: una regola che vale su
+un percorso e non su un altro, e un `select` che non nomina la colonna su cui la regola decide —
+la regola non è stata aggirata, non è mai stata chiamata. Mossa: il cancello sta **sul
+chokepoint**, cioè sulla funzione che tutti devono attraversare per ottenere la cosa pericolosa,
+e prende la riga intera invece del campo già estratto; se sta più in alto, prima di dirlo chiuso
+conta i chiamanti del chokepoint e verifica ciascuno.
+
 ## Build e bundle
 
 ### Un chunk sovradimensionato non è il colpevole del build che muore per memoria

--- a/changelog/2026-09-01-media-refs-likeness-gate.md
+++ b/changelog/2026-09-01-media-refs-likeness-gate.md
@@ -1,0 +1,52 @@
+# Il consenso vale anche dalla porta del workbench
+
+La #117 ha chiuso la **scrittura** del consenso: da API e CLI non si crea più una persona reale
+senza attestare, e le righe importate dall'onboarding nascono `consent_source =
+'import_unattested'`. Restava aperta la **lettura**.
+
+`GET /app/:brand/media-refs` selezionava `id, name, role, images` — `consent` non c'era proprio.
+Firmava le foto di *ogni* persona del brand e le restituiva al workbench, che le mette in
+`referenceUrls`; `media-generator/+server.ts` accetta quegli URL come stringhe grezze e li passa
+al job UGC. Il cancello — `resolvePeopleVisualRefsDetailed` — su quel percorso non veniva mai
+chiamato. Risultato: una persona importata, che per costruzione non ha attestato nulla, era
+selezionabile e renderizzabile dal workbench mentre la chat la rifiutava per nome. La stessa
+regola diceva due cose diverse secondo la porta.
+
+**Strada scelta: il cancello si applica dove i riferimenti nascono.** `media-refs` seleziona
+`kind, consent` e trattiene chi non ha attestato: chi non esce non può essere rimandato indietro.
+
+**Scartata: far ri-risolvere gli id al generatore.** È più robusta in astratto — non si fida del
+client — ma `referenceUrls` è un campo generico che porta anche mood board, thumbnail di post e
+foto prodotto, tutte cose senza id lato server. Renderlo fidato voleva dire un secondo canale
+`people: [{id}]` piombato nel workbench, nel Motion Composer e nei parametri del job UGC: molto
+più diff, e comunque inutile finché le altre porte firmano URL ungated (sotto). La difesa vera è
+il chokepoint, non questo endpoint.
+
+**La regola sta in un posto solo.** La condizione era scritta dentro
+`resolvePeopleVisualRefsDetailed`; ora è `likenessConsented(subject)` in
+`design-visual-refs.ts`, e la funzione di prima la chiama come la chiama `media-refs`. Nessuna
+riscrittura del `kind === 'ai' || consent === true` altrove.
+
+## Le altre porte, che restano aperte
+
+Un giro su chi legge `people` e ne firma le immagini ha trovato **otto** bypass, sette oltre
+questo. Sei arrivano davvero a un modello generativo:
+
+1. `people.ts` `attachBrandPeople` — la pipeline di contenuto automatica (scheduler, radar,
+   plan, generate, onboarding). Blast radius più grande di tutti: nessun umano nel giro.
+2. `image-agent.ts:380` — catalogo asset dell'image agent → `resolveRefParts` → `generate`.
+3. `ads-remix.ts:602` — remix di ad UGC, quindi **video**. L'unico filtro è `onlyOwnMediaUrls`,
+   che è un cancello sui CDN esterni, non sul consenso.
+4. `chat/lib/attachments.ts:106` — il picker "allega persone" della chat: `mintStandaloneImage`
+   fa passare `people_ids` dal cancello e poi riceve `referenceUrls` ungated dalla porta di
+   servizio.
+5. `agent-urls.ts:107` e `chat/tools/read-tools.ts:683` — URL etichettati `reference` messi nel
+   contesto del modello, che può rilanciarli in `create_post.image_urls` o
+   `generate_image.reference_image_urls`.
+6. `people.ts:283` `inferMissingPersonAttributes` — non è una reference di generazione, ma manda
+   il volto reale a Gemini vision per dedurre genere ed età.
+
+Il chokepoint vero è `signPersonImages`: otto chiamanti, uno solo controlla il consenso. Il
+cancello vive un livello troppo in alto. Chiuderlo lì — la funzione prende la riga, non un
+`PersonImage[]` nudo — è meno diff che rattoppare sei call site, ed è il seguito naturale di
+questa PR. Qui si chiude solo `media-refs`, perché è quella che qualcuno ha notato.

--- a/src/lib/content/changelog/2026-09-01-media-refs-likeness-gate.ts
+++ b/src/lib/content/changelog/2026-09-01-media-refs-likeness-gate.ts
@@ -1,0 +1,10 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-01',
+  title: 'Real people appear as references only once you have confirmed consent',
+  items: [
+    'The media workbench now offers a real person as a photo reference only after you have confirmed you have their consent to use their likeness — the same rule the chat already applied.',
+    'People imported automatically during onboarding stay hidden until you confirm consent for them in Studio. AI personas are never affected.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/design-visual-refs.ts
+++ b/src/lib/server/design-visual-refs.ts
@@ -19,15 +19,23 @@ const SOCIAL_THUMB_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 const SOCIAL_THUMB_SIGN_TTL_S = 7 * 24 * 60 * 60;
 const MAX_SOCIAL_THUMBS = 8;
 
+export type LikenessSubject = { kind?: string | null; consent?: unknown };
+
 /**
- * Brand people (real + AI persona) → signed photo URLs, labeled for the composer.
+ * THE LIKENESS RULE. The single place that decides whether a person's photograph may become a
+ * reference an image or video model can act on. A `kind='real'` person without an attested
+ * `consent` never qualifies — a UGC clip of a real face speaking a synthetic script is a deepfake
+ * under Art. 3(60) AI Act, and image rights and the GDPR apply to it whatever the brand intends.
+ * AI personas depict nobody, so they are never gated.
  *
- * THE LIKENESS GATE LIVES HERE. This is the one place a real person's photograph turns into a
- * reference an image or video model can act on, so it is where consent is checked. A `kind='real'`
- * person without `consent` is dropped and named in `blocked` — a UGC clip of a real face speaking
- * a synthetic script is a deepfake under Art. 3(60) AI Act, and image rights and the GDPR apply to
- * it whatever the brand intends. AI personas depict nobody, so they are never gated.
+ * Every surface that signs a person's photos calls this. Re-stating the condition anywhere else
+ * is how the rule diverges.
  */
+export function likenessConsented(subject: LikenessSubject): boolean {
+  return subject.kind === 'ai' || subject.consent === true;
+}
+
+/** Brand people (real + AI persona) → signed photo URLs, labeled for the composer. */
 export async function resolvePeopleVisualRefsDetailed(
   supabase: SupabaseClient,
   brandId: string,
@@ -44,7 +52,7 @@ export async function resolvePeopleVisualRefsDetailed(
   const refs: VisualRef[] = [];
   const blocked: string[] = [];
   for (const row of data ?? []) {
-    if (row.kind !== 'ai' && row.consent !== true) {
+    if (!likenessConsented(row)) {
       blocked.push(String(row.name ?? row.id));
       continue;
     }

--- a/src/routes/app/[brand]/media-refs/+server.ts
+++ b/src/routes/app/[brand]/media-refs/+server.ts
@@ -1,6 +1,7 @@
 import { swallow } from '$lib/server/swallow';
 import { json } from '@sveltejs/kit';
 import { signKnowledgePaths } from '$lib/server/media-archive';
+import { likenessConsented } from '$lib/server/design-visual-refs';
 import { signPersonImages, type PersonImage } from '$lib/server/people';
 import { createAdminClient } from '$lib/server/supabase-admin';
 import { listTalents } from '$lib/server/talent';
@@ -10,7 +11,7 @@ import type { RequestHandler } from './$types';
 // Lists reusable reference images for post editor + brand chat composer + media generator:
 //  - brandImages: Studio mood refs (brand_documents kind='image') + Media library images
 //  - postThumbs:  recent own-post thumbnails (social_post_history)
-//  - people:      brand people from Studio (all signed reference photos)
+//  - people:      brand people from Studio whose likeness may be used (see likenessConsented)
 //  - talents:     global AI talents from /talents (all signed views)
 //  - products:    brand catalog products with image URLs
 //  - ads:         already-harvested Meta Ad Library creatives (no live pull)
@@ -50,7 +51,7 @@ export const GET: RequestHandler = async ({ params, locals: { supabase, safeGetS
       .limit(36),
     supabase
       .from('people')
-      .select('id, name, role, images')
+      .select('id, name, role, kind, consent, images')
       .eq('brand_id', brand.id)
       .order('created_at', { ascending: true })
       .limit(24),
@@ -96,6 +97,9 @@ export const GET: RequestHandler = async ({ params, locals: { supabase, safeGetS
 
   const people: Array<{ id: string; name: string; role: string | null; url: string; urls: string[] }> = [];
   for (const row of peopleRows ?? []) {
+    if (!likenessConsented(row)) {
+      continue;
+    }
     const urls = await signPersonImages(supabase, (row.images ?? []) as PersonImage[]);
     if (!urls.length) continue;
     people.push({

--- a/src/routes/app/[brand]/media-refs/server.consent.test.ts
+++ b/src/routes/app/[brand]/media-refs/server.consent.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('$lib/server/people', () => ({
+  signPersonImages: async (_s: unknown, imgs: Array<{ path: string }>) =>
+    imgs.map((i) => `https://signed.example/${i.path}`)
+}));
+vi.mock('$lib/server/media-archive', () => ({
+  signKnowledgePaths: async () => new Map<string, string>()
+}));
+vi.mock('$lib/server/supabase-admin', () => ({ createAdminClient: () => ({}) }));
+vi.mock('$lib/server/talent', () => ({ listTalents: async () => [] }));
+vi.mock('$lib/server/stored-ads', () => ({ listStoredAdRefs: async () => [] }));
+
+import { GET } from './+server';
+
+type PersonRow = {
+  id: string;
+  name: string;
+  role: string | null;
+  kind: string;
+  consent: unknown;
+  images: Array<{ path: string }>;
+};
+
+function fakeSupabase(people: PersonRow[]) {
+  return {
+    from(table: string) {
+      const rows = table === 'people' ? people : [];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const q: any = {
+        select: () => q,
+        eq: () => q,
+        order: () => q,
+        limit: () => q,
+        maybeSingle: async () => ({ data: table === 'brands' ? { id: 'brand-1' } : null }),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        then: (ok: any, ko: any) => Promise.resolve({ data: rows }).then(ok, ko)
+      };
+      return q;
+    }
+  };
+}
+
+const person = (over: Partial<PersonRow> = {}): PersonRow => ({
+  id: 'p1',
+  name: 'Marta',
+  role: null,
+  kind: 'real',
+  consent: true,
+  images: [{ path: 'a.jpg' }],
+  ...over
+});
+
+async function listPeople(people: PersonRow[]) {
+  const res = await (GET as (event: unknown) => Promise<Response>)({
+    params: { brand: 'demo' },
+    locals: {
+      supabase: fakeSupabase(people),
+      safeGetSession: async () => ({ user: { id: 'u1' } })
+    }
+  });
+  return (await res.json()).people as Array<{ id: string; name: string; urls: string[] }>;
+}
+
+describe('GET /app/:brand/media-refs — the likeness gate on the workbench door', () => {
+  it('offers a real person once consent is attested', async () => {
+    const people = await listPeople([person()]);
+
+    expect(people.map((p) => p.name)).toEqual(['Marta']);
+    expect(people[0].urls).toEqual(['https://signed.example/a.jpg']);
+  });
+
+  it('withholds a real person imported without attestation', async () => {
+    const people = await listPeople([person({ consent: false })]);
+
+    expect(people).toEqual([]);
+  });
+
+  it('treats a missing or malformed consent value as no consent', async () => {
+    for (const bad of [undefined, null, 'true', 1]) {
+      const people = await listPeople([person({ consent: bad })]);
+
+      expect(people, `consent=${String(bad)} must not pass`).toEqual([]);
+    }
+  });
+
+  it('never gates an AI persona — there is no real person to consent', async () => {
+    const people = await listPeople([person({ kind: 'ai', name: 'Nova', consent: false })]);
+
+    expect(people.map((p) => p.name)).toEqual(['Nova']);
+  });
+
+  it('withholds only the unattested person in a mixed set', async () => {
+    const people = await listPeople([
+      person({ id: 'p1', name: 'Marta', consent: true }),
+      person({ id: 'p2', name: 'Luca', consent: false }),
+      person({ id: 'p3', name: 'Nova', kind: 'ai', consent: false })
+    ]);
+
+    expect(people.map((p) => p.name)).toEqual(['Marta', 'Nova']);
+  });
+});


### PR DESCRIPTION
## What?

`GET /app/:brand/media-refs` selected `id, name, role, images` from `people`. **`consent` was not
in the query at all.** The endpoint signed and returned the reference photos of *every* person in
the brand. The media workbench puts those URLs into `referenceUrls`, and
`media-generator/+server.ts` accepts them as raw strings and passes them straight to the UGC job.
The likeness gate — `resolvePeopleVisualRefsDetailed` in `src/lib/server/design-visual-refs.ts` —
was never called on this path.

So a person with `consent_source = 'import_unattested'` — created by the onboarding import, which
by construction attests nothing — was selectable and renderable from the workbench, while the chat
refused her by name. The same rule gave two different answers depending on which door you came in.

This is the read side of the same defect [#117](https://github.com/anomaliaso/anomalia/pull/117)
closed on the write side: that one stopped API and CLI from *creating* a real person without an
attestation; this one stops us from *handing out* her photos.

Two commits: one extracts the rule (no behavior change), one applies it.

## Why?

This is consent to the use of a real person's image, not a cosmetic defect.

Concretely, with the hole open: a brand owner runs onboarding, we scrape the team page and write
those people into `people` with `consent = false, consent_source = 'import_unattested'`. Nobody in
those photos has been asked anything — several may not know the brand has their picture at all.
The owner then opens the media workbench, sees them in the people picker like any other reference,
selects one, and generates a UGC clip: a real face, recognisable, speaking a script it never
spoke. That is a deepfake under Art. 3(60) AI Act, and image rights plus the GDPR apply to the
output whatever the brand intended. The person has no way of knowing it happened.

The gate exists precisely to make that impossible and it was doing its job everywhere except
here — which is the worse failure mode of the two, because the team believed the rule was enforced
product-wide.

Not dramatising it: no evidence any brand actually did this, and the owner who does it is the one
who bears most of the liability. But we built the button, and we built the gate, and the gate was
not on the button.

## How?

**The rule now lives in one named function.** The condition was written inline inside
`resolvePeopleVisualRefsDetailed`. It is now `likenessConsented(subject)` in
`design-visual-refs.ts` — `kind === 'ai' || consent === true` — and the gate function calls it
exactly as `media-refs` calls it. No second copy of the condition anywhere, which is the failure
mode this class of bug keeps repeating.

**Chosen: the gate applies where the references are born.** `media-refs` selects `kind, consent`
and skips anyone who has not attested. What does not leave cannot be sent back.

**Rejected: have the generator re-resolve person ids server-side.** More robust in the abstract —
it stops trusting the client — but `referenceUrls` is a generic field that also carries Studio mood
boards, own-post thumbnails and product catalogue photos, none of which have a server-side id to
re-resolve. Making it trusted means a second `people: [{ id }]` channel plumbed through
`MediaGeneratorWorkbench`, `MotionVideoComposer` and the UGC job parameters: several times the
diff, and it buys nothing while the other doors below still hand out ungated signed URLs. The real
defence is the chokepoint, not this endpoint. Doing both would have duplicated the rule, which the
brief explicitly ruled out.

**No migration.** `people.kind` (0028) and `people.consent` (0028, semantics fixed in 0187) both
already exist. `node scripts/schema-drift-check.mjs` → **VERDE**, exit 0.

## The other doors — this PR closes one of eight

An audit of everything that reads `people` and signs its photos found **eight** paths that bypass
the gate. Seven are still open after this PR; six of those reach a generation model. Ranked by
blast radius:

| # | Where | Surface | Reaches a model? |
|---|---|---|---|
| 1 | `src/lib/server/people.ts:224` `attachBrandPeople` | The whole automated content pipeline — `scheduler.ts:323` (recurring auto-posting, **no human in the loop**), `radar.ts:1350`, `chat/async-jobs.ts:45`, `plan/+page.server.ts:291`, `content/generate/+server.ts:143`, `onboarding/render-content/+server.ts:54` | Yes — `personImageMap` → `personReference` → ImageParts |
| 2 | `src/lib/server/ads-remix.ts:602` | Paid UGC ad remix → **video**. Its only filter, `onlyOwnMediaUrls`, gates foreign CDNs, not consent | Yes — deepfake-grade (real face + synthetic speech) |
| 3 | `src/lib/server/image-agent.ts:380` | Image agent asset catalogue → `resolveRefParts` → `generate` | Yes |
| 4 | `src/routes/app/[brand]/chat/lib/attachments.ts:106` | Chat "attach people" picker. `mintStandaloneGraphicAsset` gates `people_ids` and then receives ungated faces via `referenceUrls` — the gated tool fed through the side door | Yes |
| 5 | `src/lib/server/agent-urls.ts:107` | `read_market_references` chat tool, labelled `use=reference` | Yes, via model relay into `create_post.image_urls` / `generate_image.reference_image_urls` |
| 6 | `src/lib/server/chat/tools/read-tools.ts:683` `read_people` | Selects `kind` but never branches on it; `consent` not selected. Returns 3 signed URLs per person into model context | Yes, same relay |
| 7 | `src/lib/server/people.ts:283` `inferMissingPersonAttributes` | Sends the real face to Gemini vision to infer gender/age-range | No — but it is unconsented profiling of a real person, written back to `people.attributes` |
| 8 | `src/routes/app/[brand]/media-refs/+server.ts` | **Closed by this PR** | — |

Clean, checked, no action needed: `studio-deferred.ts` (returns `consent`, thumb only),
`cli-queries.ts:389` (emits `imageCount`, no URLs), `brand-design-doc.ts` and `chat/brand-file.ts`
(storage paths, not signed URLs — with a regression test holding that invariant), and every path
that already goes through `resolvePeopleVisualRefs*`.

**The root cause is one layer down.** `signPersonImages` in `people.ts:58` is the actual
chokepoint: eight callers, one of which checks consent. The gate lives one level too high, so any
caller that queries `people` itself walks around it. Moving the guard *into* `signPersonImages` —
taking the row rather than a bare `PersonImage[]` — is a smaller diff than patching six call
sites, and is the natural follow-up. Deliberately not done here: it is a signature change across
eight callers and belongs in its own reviewable PR, not smuggled into this one. Filing it.

## Testing?

**Written first, watched fail.** `src/routes/app/[brand]/media-refs/server.consent.test.ts`, 5
cases, against the real `GET` handler with a faked Supabase. Before the fix: **3 failed, 2
passed** — an unattested person came back with a usable signed URL
(`expected [ 'Marta', 'Luca', 'Nova' ] to deeply equal [ 'Marta', 'Nova' ]`). After: 5 passed. The
cases are consent attested → offered; `consent: false` → withheld; `undefined | null | 'true' | 1`
→ withheld (a truthy non-`true` must not slip through); AI persona → never gated; mixed set → only
the unattested one disappears.

The pre-existing `design-visual-refs.consent.test.ts` (7 cases) still passes unchanged, which is
what makes the extraction commit a refactor rather than a rewrite.

**Full suite:** `npx vitest run` → **546 test files passed, 1 skipped (547); 6107 tests passed, 4 skipped (6111)**, exit 0. Zero failures.

`src/hooks.server.test.ts` and the rest of the env-dependent files ran normally: `.env` was copied
from the main checkout per `LESSONS.md`.

**Not tested, and why.** No browser verification. The local Supabase stack and dev server were not
brought up for this worktree, so the CLAUDE.md browser gate was **not** run — I am not claiming the
workbench was exercised by hand. The risk that leaves: the endpoint's contract is unchanged (same
shape, fewer rows) and the workbench already renders an empty `people` array for a brand with no
people, so a regression would have to be in the client's handling of a *shrunk* list. Worth ten
minutes with the stack up before merge.

No eval run: this touches neither prompts, tools, nor the model.

## Evidence

Backend change, no UI diff to screenshot beyond "an unattested person is no longer in the picker",
which is exactly what the tests assert.

<details>
<summary>The test, red before the fix</summary>

```
FAIL  src/routes/app/[brand]/media-refs/server.consent.test.ts > withholds only the unattested person in a mixed set
AssertionError: expected [ 'Marta', 'Luca', 'Nova' ] to deeply equal [ 'Marta', 'Nova' ]

  Array [
    "Marta",
+   "Luca",
    "Nova",
  ]

 Test Files  1 failed (1)
      Tests  3 failed | 2 passed (5)
```
</details>

<details>
<summary>Green after</summary>

```
 ✓ src/lib/server/design-visual-refs.consent.test.ts (7 tests) 158ms
 ✓ src/routes/app/[brand]/media-refs/server.consent.test.ts (5 tests) 192ms

 Test Files  2 passed (2)
      Tests  12 passed (12)
```
</details>

<details>
<summary>schema-drift-check — no migration needed</summary>

```
VERDE — ogni nome che il codice pronuncia esiste nel database.
EXIT=0
```

Worth restating since deploys here do not run migrations: this PR adds none. `people.kind` and
`people.consent` have existed since 0028 and are present in production.
</details>

## Anything Else?

- **Seven doors stay open.** They are in the table above and in the changelog. The owner should
  know the count is seven, not one, before this PR reads as "consent is handled".
- **The follow-up that actually fixes the class:** move the guard into `signPersonImages`. Until
  then every new caller that queries `people` and signs its photos is a new bypass, and nothing in
  the codebase will tell the author.
- **Rows already imported stay hidden until attested.** That is the intended behavior, and the
  public changelog says why in the user's own terms rather than reading as a lost feature. There is
  no backfill and there should not be one: attestation is an act, not a default.
- `attachBrandPeople` (#1) is the one I would fix next regardless of the chokepoint work — it runs
  on a schedule with nobody watching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHzdoJhyXfnkX6mWWJkduX
