### PR TITLE
Extract the lead-finding core into @anomalia/leads-core

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -417,3 +417,28 @@ Mossa: la data si deriva da `Date.now()`, mai si scrive — `aDateInTheFuture()`
 `packages/agent-kit/src/testkit.ts`. Restano della stessa forma quattro `periodEnd: new
 Date('2026-09-01')` (credit-warning, tool-policy, brand-studio-tools, content/ugc plugins): oggi
 innocui perché nessuno li confronta con l'orologio, domani no.
+
+### `npm run check` esce 0 con centinaia di errori: il verde è finto, conta la DIFFERENZA
+Il typecheck di questo repo non è pulito — 346 errori su 171 file, tutti pre-esistenti — e
+`svelte-check` **esce comunque 0**. Quindi «il check passa» non significa niente: né in locale né
+in CI, dove un gate costruito sull'exit code sarebbe cieco per definizione.
+
+È già costato un difetto vero, sfuggito a una suite di 6102 test verdi. Estraendo i fetcher in
+`@anomalia/leads-core/feed` il factory era stato legato a `const sources = createSources(...)` a
+livello di modulo, ma `sources` è già il nome delle righe di `brand_news_sources` lette dal
+database in TRE funzioni di `radar.ts`: ognuna lo ombreggiava, e `sources.fetchSourceFeed(...)`
+risolveva sull'array del database. I test non l'hanno visto perché quei percorsi
+(`buildRadarFeedCache`, `radarDiagnose`, `radarScan`) toccano il DB e non hanno unit test — cioè
+proprio la forma di guasto che i commenti di quel file raccontano: una sorgente che smette di
+funzionare in silenzio e riporta «0 item».
+
+Segnale: nessuno. Non c'è un rosso da cercare — la suite è verde e l'exit code è 0. L'unico
+segnale è il **conteggio**: `COMPLETED <n> FILES <m> ERRORS` nell'ultima riga dell'output.
+Mossa: prima di dire che il typecheck regge, confronta `m` con quello della base e cerca i tuoi
+file per nome fra le righe `ERROR` (`grep ERROR out.txt | grep <i tuoi file>`). E l'output va
+rediretto su un file tuo: quello del task in background viene troncato alla coda, quindi ci leggi
+gli ultimi 40 errori e concludi il falso.
+
+Corollario di progettazione: legando in un modulo grande le funzioni che arrivano da un factory,
+**destrutturale** invece di tenere l'oggetto. Un oggetto con un nome generico (`sources`, `items`,
+`data`) prima o poi lo ombreggia una locale, e TypeScript è l'unica cosa che te lo dice.

--- a/changelog/2026-09-01-leads-core-package.md
+++ b/changelog/2026-09-01-leads-core-package.md
@@ -61,8 +61,16 @@ fa fallire un test invece di spegnere una sorgente in silenzio.
 
 ## Difetti visti e non toccati
 
-Due difetti trovati leggendo, non toccati per non mescolare spostamento e comportamento:
-`radar.ts` importava `suppressAuthor` senza chiamarlo mai (rimosso, era import morto), e il
-tipo di ritorno di `pendingOutcomeChecks` omette `author_handle`/`author_platform` che il
-mapper restituisce davvero — quindi il ramo opt-out di `checkLeadOutcome` non parte mai da
-`runOutcomeChecks`. Quello è un difetto vero e vuole il suo test, prima del suo fix.
+`radar.ts` importava `suppressAuthor` senza chiamarlo mai: import morto, rimosso.
+
+Il tipo di ritorno di `pendingOutcomeChecks` ometteva `author_handle`/`author_platform` che il
+mapper restituisce davvero. Leggendolo sembrava un difetto vivo — il ramo opt-out di
+`checkLeadOutcome` che non parte mai — e invece **il test ha detto di no**: a runtime i campi
+ci sono e la soppressione scatta. Il difetto era solo il tipo che mente, e vale comunque,
+perché chi avesse rimosso quelle due righe dal mapper avrebbe spento la soppressione senza un
+solo errore di compilazione. Ora il tipo li dichiara e due test coprono il giro completo
+(`runOutcomeChecks` → thread con ritiro del consenso → riga in `lead_suppressions`), che prima
+non aveva copertura alcuna.
+
+Vale la pena registrare l'ordine: la diagnosi a vista era sbagliata, e a correggerla è stato il
+test scritto prima del fix — non una rilettura più attenta.

--- a/changelog/2026-09-01-leads-core-package.md
+++ b/changelog/2026-09-01-leads-core-package.md
@@ -6,7 +6,7 @@ hunting reggerebbero un SaaS verticale a sé? La risposta onesta era "sì, ma no
 director, scheduler ed email. Quello che ha valore fuori da Anomalia era dentro, ma non
 separabile a vista.
 
-Ora quattro moduli stanno in `packages/leads-core/`, e il guardiano che già esisteva
+Ora cinque moduli stanno in `packages/leads-core/`, e il guardiano che già esisteva
 (`packages/no-app-imports.test.ts`) li tiene puliti: al primo `$lib` o `$env` fallisce.
 
 - `intent` — le bande di intento d'acquisto e il loro ordine in coda. Zero dipendenze.
@@ -17,6 +17,9 @@ Ora quattro moduli stanno in `packages/leads-core/`, e il guardiano che già esi
   risponde alla stessa domanda di `platformOf`: dove si raggiunge questa persona.
 - `prompts` — il drafter del commento e del DM, con i guard-rail nati dai modi in cui le
   bozze fallivano davvero, e la selezione degli N migliori del giorno.
+- `feed` — dove si trovano le conversazioni: RSS, Google News, subreddit in rising, e le
+  ricerche su Reddit, Threads, X Communities e LinkedIn. Più il parsing, le finestre di
+  freschezza e il round-robin a quote eque.
 
 ## Le due dipendenze invertite, e le due lasciate stare
 
@@ -33,12 +36,30 @@ fuori anche `radarScan`, `radarProduce`, `radarArticles`, il digest e il tick: s
 orchestrazione, e tirarli dentro avrebbe voluto dire una `Deps` con quindici campi per
 guadagnare niente.
 
-## Cosa NON è stato fatto
+## I fetcher: un factory, non quindici parametri
 
-I fetcher delle sorgenti (Reddit, Threads, X Communities, LinkedIn, RSS) sono la parte più
-riusabile di tutte e sono ancora in `radar.ts`: dipendono da `scrapeCreatorsGet`, da quattro
-variabili d'ambiente e dal fallback Browserless. Sono il prossimo lotto, e sono ~350 righe:
-tenerlo separato lascia questo diff verificabile invece che enorme.
+I fetcher sono la parte più riusabile di tutte, e l'unica con dipendenze vere: il gateway di
+scraping, il token del feed personale di Reddit, e Chrome vero per i feed che bloccano i
+client HTTP da server. Non basta un `deps` per funzione, perché `radarScan` li passa come
+callback per le query dinamiche e `radarEngage` usa `fetchRedditText` da solo — quindi
+`createSources(deps)` restituisce le funzioni già legate, e i call site restano puliti.
+
+`redditAuth` è una **funzione** e non un oggetto: il codice originale leggeva `env` a ogni
+chiamata, e congelare le credenziali alla costruzione del factory avrebbe voluto dire che un
+cambio d'ambiente non arriva mai. C'è un test che lo pinna, perché è esattamente il tipo di
+regressione che nessuno nota finché non serve.
+
+Lo script di pagina di Browserless resta nell'app: il package riceve "una funzione che dato un
+URL torna il testo" e non sa che dietro c'è un browser.
+
+È stato aggiunto un test che non esisteva, sull'instradamento di ogni `kind` verso il suo
+endpoint. È la classe di bug che i commenti del file raccontano — `linkedin_query` che cadeva
+su `fetchFeed` e scaricava le parole chiave come se fossero un URL RSS, e X chiamata con `id=`
+dove l'endpoint vuole `url=`. Entrambi si presentavano come "0 item": un successo pulito e
+vuoto, indistinguibile da "nessuna conversazione degna oggi". Ora un'inversione di quel tipo
+fa fallire un test invece di spegnere una sorgente in silenzio.
+
+## Difetti visti e non toccati
 
 Due difetti trovati leggendo, non toccati per non mescolare spostamento e comportamento:
 `radar.ts` importava `suppressAuthor` senza chiamarlo mai (rimosso, era import morto), e il

--- a/changelog/2026-09-01-leads-core-package.md
+++ b/changelog/2026-09-01-leads-core-package.md
@@ -1,0 +1,47 @@
+# Il nucleo del lead finding esce dall'app: `@anomalia/leads-core`
+
+La domanda che ha aperto il lavoro era commerciale, non tecnica: le feature di lead
+hunting reggerebbero un SaaS verticale a sé? La risposta onesta era "sì, ma non copiando
+`radar.ts`": 1782 righe con trenta import, di cui env SvelteKit, piani, editorial plan,
+director, scheduler ed email. Quello che ha valore fuori da Anomalia era dentro, ma non
+separabile a vista.
+
+Ora quattro moduli stanno in `packages/leads-core/`, e il guardiano che già esisteva
+(`packages/no-app-imports.test.ts`) li tiene puliti: al primo `$lib` o `$env` fallisce.
+
+- `intent` — le bande di intento d'acquisto e il loro ordine in coda. Zero dipendenze.
+- `match` — ritrovare la nostra bozza in un thread che ha pubblicato un umano, con il suo
+  account. Shingle di tre parole e contenimento, non Jaccard.
+- `contact` — "una persona, un tocco": il gate globale, la soppressione, il setaccio
+  dell'opt-out, le scadenze di retention. E `authorProfileUrl`, che stava in `radar.ts` ma
+  risponde alla stessa domanda di `platformOf`: dove si raggiunge questa persona.
+- `prompts` — il drafter del commento e del DM, con i guard-rail nati dai modi in cui le
+  bozze fallivano davvero, e la selezione degli N migliori del giorno.
+
+## Le due dipendenze invertite, e le due lasciate stare
+
+Il client Supabase era **già** un parametro ovunque in `radar.ts` e `lead-contact.ts`: non
+c'era niente da invertire, solo da non aggiungere. L'unica inversione vera è `swallow`, che
+riporta a Sentry via `@sentry/sveltekit`: diventa un `report` iniettato, con default in
+console. Ogni call site dell'app passa `swallow`, quindi Sentry continua a vedere tutto, e
+un test lo pinna — una scadenza fallita deve arrivare al reporter iniettato.
+
+Non è stato invertito niente per simmetria. Il gating per piano (`radarPrefsOf`,
+`radarPlatformEnabled`, `radarSourceLimit`) resta nell'app: è il pricing di Anomalia, e un
+verticale ne avrebbe un altro — il package riceve limiti e sorgenti come parametri. Restano
+fuori anche `radarScan`, `radarProduce`, `radarArticles`, il digest e il tick: sono
+orchestrazione, e tirarli dentro avrebbe voluto dire una `Deps` con quindici campi per
+guadagnare niente.
+
+## Cosa NON è stato fatto
+
+I fetcher delle sorgenti (Reddit, Threads, X Communities, LinkedIn, RSS) sono la parte più
+riusabile di tutte e sono ancora in `radar.ts`: dipendono da `scrapeCreatorsGet`, da quattro
+variabili d'ambiente e dal fallback Browserless. Sono il prossimo lotto, e sono ~350 righe:
+tenerlo separato lascia questo diff verificabile invece che enorme.
+
+Due difetti trovati leggendo, non toccati per non mescolare spostamento e comportamento:
+`radar.ts` importava `suppressAuthor` senza chiamarlo mai (rimosso, era import morto), e il
+tipo di ritorno di `pendingOutcomeChecks` omette `author_handle`/`author_platform` che il
+mapper restituisce davvero — quindi il ramo opt-out di `checkLeadOutcome` non parte mai da
+`runOutcomeChecks`. Quello è un difetto vero e vuole il suo test, prima del suo fix.

--- a/package-lock.json
+++ b/package-lock.json
@@ -307,6 +307,10 @@
       "resolved": "packages/agent-kit",
       "link": true
     },
+    "node_modules/@anomalia/leads-core": {
+      "resolved": "packages/leads-core",
+      "link": true
+    },
     "node_modules/@anthropic-ai/sdk": {
       "version": "0.91.1",
       "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
@@ -16299,6 +16303,13 @@
     "packages/agent-kit": {
       "name": "@anomalia/agent-kit",
       "version": "0.0.0"
+    },
+    "packages/leads-core": {
+      "name": "@anomalia/leads-core",
+      "version": "0.0.0",
+      "dependencies": {
+        "@supabase/supabase-js": "^2.46.1"
+      }
     }
   }
 }

--- a/packages/leads-core/README.md
+++ b/packages/leads-core/README.md
@@ -1,0 +1,51 @@
+# @anomalia/leads-core
+
+Trovare conversazioni in cui un brand ha davvero qualcosa da dire, giudicarle, scriverne la bozza,
+e non disturbare mai due volte la stessa persona. È la parte del prodotto che non dipende da
+Anomalia: niente piani, niente `$env`, niente SvelteKit.
+
+Il confine lo tiene un test, non la buona volontà: `packages/no-app-imports.test.ts` fallisce al
+primo `$lib` o `$env` che entra qui dentro.
+
+## Moduli
+
+| Import | Cosa contiene | Dipendenze |
+|---|---|---|
+| `@anomalia/leads-core/intent` | Le bande di intento d'acquisto (`seeking_now` → `none`), il loro ordine in coda, la normalizzazione di quello che risponde il modello | nessuna |
+| `@anomalia/leads-core/match` | Ritrovare la nostra bozza in un thread pubblicato da un umano: shingle di tre parole, contenimento, soglia | nessuna |
+| `@anomalia/leads-core/contact` | "Una persona, un tocco": gate globale, soppressione, setaccio dell'opt-out, riga di opt-out nel DM, scadenze di retention | client Supabase iniettato |
+| `@anomalia/leads-core/prompts` | Il drafter (commento pubblico + DM) e la selezione degli N lead migliori del giorno | `./intent` |
+
+## Le due dipendenze invertite
+
+Il package non conosce né il database né il reporter dell'app: entrambi entrano dall'esterno.
+
+```ts
+// Il client Supabase è un parametro, mai un import: il package non legge env e non crea client.
+await contactGate(admin, 'reddit', 'pippo');
+
+// L'errore va dove decide l'app. Il default stampa in console; Anomalia passa `swallow`,
+// che aggiunge Sentry.
+await sweepLeadRetention(admin, swallow);
+```
+
+## Contratto di schema
+
+`contact` e le query che lo circondano si aspettano queste tabelle. Sono l'unica cosa da
+replicare per usare il package altrove:
+
+- **`lead_suppressions`** — `platform`, `handle`, `source`, `reason`, con `unique (platform, handle)`.
+  **Non ha `brand_id`, ed è deliberato**: il frequency cap è globale all'istanza. Chi lo scopa per
+  brand rompe la promessa che rende difendibile l'outreach.
+- **`brand_news_items`** — il lead: `url`, `title`, `status`, `author_platform`/`author_handle`
+  (l'indice che serve al gate), `done_at`, `suggestion`, `dm_draft`, `gist`, `intent`.
+- **`lead_outcomes`** — l'esito osservato, in append: `lead_id`, `found`, `method`, `match_score`,
+  `upvotes`, `replies`, `removed`.
+- **`radar_searches`** — telemetria di scansione, solo perché la retention la scade.
+
+## Cosa è rimasto fuori, e perché
+
+L'orchestrazione resta nell'app (`src/lib/server/radar.ts`): il giro sulle sorgenti, le scritture,
+la produzione dei post, le email, il tick. Dipende da piani, cron, editorial plan e director —
+cose di Anomalia, non del dominio lead. Fuori anche il gating per piano (`radarPrefsOf`,
+`radarPlatformEnabled`): il package riceve limiti e sorgenti come parametri, non li decide.

--- a/packages/leads-core/README.md
+++ b/packages/leads-core/README.md
@@ -15,10 +15,12 @@ primo `$lib` o `$env` che entra qui dentro.
 | `@anomalia/leads-core/match` | Ritrovare la nostra bozza in un thread pubblicato da un umano: shingle di tre parole, contenimento, soglia | nessuna |
 | `@anomalia/leads-core/contact` | "Una persona, un tocco": gate globale, soppressione, setaccio dell'opt-out, riga di opt-out nel DM, scadenze di retention | client Supabase iniettato |
 | `@anomalia/leads-core/prompts` | Il drafter (commento pubblico + DM) e la selezione degli N lead migliori del giorno | `./intent` |
+| `@anomalia/leads-core/feed` | Dove si trovano le conversazioni: RSS, Google News, subreddit in rising, ricerche su Reddit/Threads/X Communities/LinkedIn. Più parsing, finestre di freschezza e round-robin | gateway di scraping iniettato |
 
-## Le due dipendenze invertite
+## Le dipendenze invertite
 
-Il package non conosce né il database né il reporter dell'app: entrambi entrano dall'esterno.
+Il package non conosce il database, il reporter dell'app, il gateway di scraping né le
+credenziali: entrano tutti dall'esterno.
 
 ```ts
 // Il client Supabase è un parametro, mai un import: il package non legge env e non crea client.
@@ -27,7 +29,24 @@ await contactGate(admin, 'reddit', 'pippo');
 // L'errore va dove decide l'app. Il default stampa in console; Anomalia passa `swallow`,
 // che aggiunge Sentry.
 await sweepLeadRetention(admin, swallow);
+
+const sources = createSources({
+  scrape,                                // il gateway di scraping
+  redditAuth: () => ({ token, user }),   // funzione, NON oggetto — v. sotto
+  fetchViaBrowser                        // Chrome vero, per i feed che bloccano i client da server
+});
+await sources.fetchSourceFeed({ kind: 'subreddit', value: 'saas' });
 ```
+
+`redditAuth` è una **funzione** perché le credenziali vanno lette al momento della chiamata:
+congelarle quando si costruisce il factory vorrebbe dire che un cambio d'ambiente non arriva mai.
+C'è un test che lo pinna.
+
+`scrape` deve lanciare errori nella forma `scrapecreators <status> <body>`: `isNoMatch404` ci
+riconosce il "nessun risultato" di LinkedIn, che arriva come 404 ma è un insieme vuoto, non un
+guasto. Le ricerche di conversazioni **propagano** gli errori di proposito — prima li
+inghiottivano, e una chiave scaduta finiva nei log come "0 item", indistinguibile da "nessuna
+conversazione degna oggi".
 
 ## Contratto di schema
 

--- a/packages/leads-core/package.json
+++ b/packages/leads-core/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "exports": {
+    "./contact": "./src/contact.ts",
     "./intent": "./src/intent.ts",
     "./match": "./src/match.ts"
   },

--- a/packages/leads-core/package.json
+++ b/packages/leads-core/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "exports": {
     "./contact": "./src/contact.ts",
+    "./feed": "./src/feed.ts",
     "./intent": "./src/intent.ts",
     "./match": "./src/match.ts",
     "./prompts": "./src/prompts.ts"

--- a/packages/leads-core/package.json
+++ b/packages/leads-core/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@anomalia/leads-core",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "exports": {
+    "./intent": "./src/intent.ts",
+    "./match": "./src/match.ts"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.46.1"
+  }
+}

--- a/packages/leads-core/package.json
+++ b/packages/leads-core/package.json
@@ -6,7 +6,8 @@
   "exports": {
     "./contact": "./src/contact.ts",
     "./intent": "./src/intent.ts",
-    "./match": "./src/match.ts"
+    "./match": "./src/match.ts",
+    "./prompts": "./src/prompts.ts"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.46.1"

--- a/packages/leads-core/src/contact.test.ts
+++ b/packages/leads-core/src/contact.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { SupabaseClient } from '@supabase/supabase-js';
-import { platformOf, isOptOutSignal, dmWithOptOut, gateVerdict, contactGate, suppressAuthor, sweepLeadRetention } from './contact';
+import { platformOf, authorProfileUrl, isOptOutSignal, dmWithOptOut, gateVerdict, contactGate, suppressAuthor, sweepLeadRetention } from './contact';
 
 describe('platformOf (una sola fonte di verità per la piattaforma di un lead)', () => {
   it('riconosce le quattro piattaforme di engage e manda il resto a web', () => {
@@ -10,6 +10,23 @@ describe('platformOf (una sola fonte di verità per la piattaforma di un lead)',
     expect(platformOf('https://twitter.com/pippo/status/1')).toBe('x');
     expect(platformOf('https://www.linkedin.com/posts/pippo-123')).toBe('linkedin');
     expect(platformOf('https://news.google.com/rss/articolo')).toBe('web');
+  });
+});
+
+describe('authorProfileUrl (dove l\'umano apre il DM, per piattaforma)', () => {
+  it('deriva il profilo dall\'handle su reddit, threads e x', () => {
+    expect(authorProfileUrl('https://www.reddit.com/r/SaaS/comments/a/b/', 'u/pippo')).toBe('https://www.reddit.com/user/pippo');
+    expect(authorProfileUrl('https://www.threads.net/@tizio/post/1', '@tizio')).toBe('https://www.threads.net/@tizio');
+    expect(authorProfileUrl('https://x.com/caio/status/1', '@caio')).toBe('https://x.com/caio');
+  });
+
+  it('su LinkedIn l\'autore è un nome, non un handle: si apre il post', () => {
+    const post = 'https://www.linkedin.com/posts/abc';
+    expect(authorProfileUrl(post, 'Mario Rossi')).toBe(post);
+  });
+
+  it('senza autore non inventa un URL', () => {
+    expect(authorProfileUrl('https://www.reddit.com/r/SaaS/comments/a/b/', '')).toBe('');
   });
 });
 

--- a/packages/leads-core/src/contact.test.ts
+++ b/packages/leads-core/src/contact.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { SupabaseClient } from '@supabase/supabase-js';
-import { platformOf, isOptOutSignal, dmWithOptOut, gateVerdict, contactGate, suppressAuthor, sweepLeadRetention } from './lead-contact';
+import { platformOf, isOptOutSignal, dmWithOptOut, gateVerdict, contactGate, suppressAuthor, sweepLeadRetention } from './contact';
 
 describe('platformOf (una sola fonte di verità per la piattaforma di un lead)', () => {
   it('riconosce le quattro piattaforme di engage e manda il resto a web', () => {
@@ -164,5 +164,17 @@ describe('sweepLeadRetention (il contenuto scade, la riga minima e gli esiti no)
       from: () => { throw new Error('boom'); }
     } as unknown as SupabaseClient;
     await expect(sweepLeadRetention(client)).resolves.toBeUndefined();
+  });
+
+  it('consegna ogni scadenza fallita al reporter iniettato: è così che l\'app ci mette Sentry', async () => {
+    const client = { from: () => { throw new Error('boom'); } } as unknown as SupabaseClient;
+    const seen: string[] = [];
+    await sweepLeadRetention(client, (reason) => seen.push(reason));
+    expect(seen).toEqual([
+      'lead retention: gist purge',
+      'lead retention: unconverted rows',
+      'lead retention: outcomes',
+      'lead retention: scan telemetry'
+    ]);
   });
 });

--- a/packages/leads-core/src/contact.ts
+++ b/packages/leads-core/src/contact.ts
@@ -74,6 +74,16 @@ export async function suppressAuthor(
   }
 }
 
+/** Dove si raggiunge l'autore, per piattaforma: l'umano apre l'URL e manda il DM a mano. */
+export function authorProfileUrl(url: string, author: string): string {
+  if (!author) return '';
+  if (url.includes('threads.net')) return `https://www.threads.net/@${author.replace(/^@/, '')}`;
+  if (url.includes('x.com') || url.includes('twitter.com')) return `https://x.com/${author.replace(/^@/, '')}`;
+  // LinkedIn authors are display names, not handles → no derivable profile URL; open the post itself.
+  if (url.includes('linkedin.com')) return url;
+  return `https://www.reddit.com/user/${author.replace(/^u\//, '')}`;
+}
+
 export function platformOf(url: string): LeadPlatform {
   const u = (url ?? '').toLowerCase();
   if (u.includes('reddit.com')) return 'reddit';

--- a/packages/leads-core/src/contact.ts
+++ b/packages/leads-core/src/contact.ts
@@ -1,5 +1,14 @@
+/**
+ * Una persona, un tocco.
+ *
+ * Il frequency cap è GLOBALE per istanza, non per brand: il prospect che ha già ricevuto un
+ * messaggio da UN cliente non viene mai più proposto a nessun altro. È la ragione per cui
+ * `lead_suppressions` non ha `brand_id` — chi lo aggiunge rompe la promessa.
+ *
+ * L'errore non si riporta da qui: il package non conosce il reporter dell'app, quindi `report`
+ * entra come dipendenza e di default finisce solo in console.
+ */
 import type { SupabaseClient } from '@supabase/supabase-js';
-import { swallow } from './swallow';
 
 export type LeadPlatform = 'reddit' | 'threads' | 'x' | 'linkedin' | 'web';
 
@@ -7,8 +16,12 @@ export type ContactGate = { suppressed: boolean; contacted: boolean };
 
 export type SuppressSource = 'reply' | 'manual' | 'thread_scan';
 
-// Una persona, un tocco: il frequency cap è globale per istanza, non per brand. Il prospect che
-// ha già ricevuto un messaggio da UN cliente non viene mai più proposto a nessun altro.
+export type ReportError = (reason: string, err: unknown) => void;
+
+const reportToConsole: ReportError = (reason, err) => {
+  console.error(`[swallowed] ${reason}:`, err instanceof Error ? err.message : String(err));
+};
+
 export async function contactGate(
   admin: SupabaseClient,
   platform: string,
@@ -40,7 +53,8 @@ export function gateVerdict(gate: ContactGate): 'suppressed' | 'contacted' | 'ok
 
 export async function suppressAuthor(
   admin: SupabaseClient,
-  input: { platform: string; handle: string; source: SuppressSource; reason?: string }
+  input: { platform: string; handle: string; source: SuppressSource; reason?: string },
+  report: ReportError = reportToConsole
 ): Promise<boolean> {
   try {
     const { error } = await admin
@@ -55,7 +69,7 @@ export async function suppressAuthor(
     }
     return true;
   } catch (e) {
-    swallow('suppress author', e);
+    report('suppress author', e);
     return false;
   }
 }
@@ -69,7 +83,7 @@ export function platformOf(url: string): LeadPlatform {
   return 'web';
 }
 
-// Setaccio stretto di proposito: "stop" da solocompare in mezzo a frasi normali ("stop wasting
+// Setaccio stretto di proposito: "stop" da solo compare in mezzo a frasi normali ("stop wasting
 // time"), quindi ogni regola vuole il verbo di contatto accanto al segnale.
 const OPT_OUT_RULES: RegExp[] = [
   /\b(?:do\s?not|don'?t)\s+(?:contact|message|dm|write|email)\b/i,
@@ -103,14 +117,17 @@ const OUTCOME_RETENTION_DAYS = 365;
 const SCAN_TELEMETRY_DAYS = 90;
 const UNCONVERTED_STATUSES = ['proposed', 'suggested', 'skipped', 'dismissed'];
 
-export async function sweepLeadRetention(admin: SupabaseClient): Promise<void> {
+export async function sweepLeadRetention(
+  admin: SupabaseClient,
+  report: ReportError = reportToConsole
+): Promise<void> {
   const daysAgo = (days: number) => new Date(Date.now() - days * 24 * 3600 * 1000).toISOString();
   // I builder Supabase sono thenable ma non promesse: niente .catch — il try sta qua.
   const quiet = async (what: string, run: () => unknown) => {
     try {
       await run();
     } catch (e) {
-      swallow(`lead retention: ${what}`, e);
+      report(`lead retention: ${what}`, e);
     }
   };
 

--- a/packages/leads-core/src/feed.test.ts
+++ b/packages/leads-core/src/feed.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseFeed,
+  roundRobin,
+  normalizeRedditUrl,
+  xCommunityUrl,
+  maxAgeHoursFor,
+  withinWindow,
+  isNoMatch404,
+  googleNewsRssUrl,
+  createSources
+} from './feed';
+
+describe('roundRobin (fair share across sources)', () => {
+  it('gives every source a slot before any takes a second — no starvation by a high-volume source', () => {
+    // news has 100 items but the two subs must still appear in the first passes.
+    const byOrigin = new Map<string, string[]>([
+      ['news', Array.from({ length: 100 }, (_, i) => `n${i}`)],
+      ['r/saas', ['s0', 's1']],
+      ['r/founder', ['f0', 'f1']]
+    ]);
+    const out = roundRobin(byOrigin, 6);
+    expect(out).toEqual(['n0', 's0', 'f0', 'n1', 's1', 'f1']);
+    // Both subs are represented — the old slice(0,N) in fetch order would have returned only news.
+    expect(out).toContain('s0');
+    expect(out).toContain('f0');
+  });
+
+  it('respects the cap and drains remaining sources when others empty', () => {
+    const byOrigin = new Map<string, number[]>([['a', [1, 2, 3]], ['b', [4]]]);
+    expect(roundRobin(byOrigin, 10)).toEqual([1, 4, 2, 3]); // b empties, a keeps going
+    expect(roundRobin(new Map(), 5)).toEqual([]);
+  });
+});
+
+describe('parseFeed', () => {
+  it('parses RSS 2.0 items (Google News shape)', () => {
+    const xml = `<?xml version="1.0"?><rss><channel>
+      <item><title><![CDATA[Il Kansas approva la legge X]]></title><link>https://news.google.com/rss/articles/abc</link>
+        <pubDate>Wed, 02 Jul 2026 10:00:00 GMT</pubDate><description>Snippet &amp; testo</description>
+        <source url="https://ilpost.it">Il Post</source></item>
+      <item><title>Seconda notizia</title><link>https://example.com/2</link></item>
+    </channel></rss>`;
+    const items = parseFeed(xml);
+    expect(items).toHaveLength(2);
+    expect(items[0].title).toBe('Il Kansas approva la legge X');
+    expect(items[0].url).toContain('news.google.com');
+    expect(items[0].sourceName).toBe('Il Post');
+    expect(items[0].snippet).toContain('Snippet & testo');
+    expect(items[0].publishedAt).toMatch(/^2026-07-02/);
+  });
+
+  it('parses Atom entries (Reddit shape)', () => {
+    const xml = `<feed xmlns="http://www.w3.org/2005/Atom">
+      <entry><title>Post dal subreddit</title><link href="https://reddit.com/r/x/comments/1"/>
+        <updated>2026-07-01T08:00:00Z</updated><content type="html">&lt;p&gt;body&lt;/p&gt;</content></entry>
+    </feed>`;
+    const items = parseFeed(xml);
+    expect(items).toHaveLength(1);
+    expect(items[0].url).toBe('https://www.reddit.com/r/x/comments/1');
+    expect(items[0].snippet).toContain('body');
+  });
+
+  it('rewrites old.reddit.com permalinks from rising RSS to www', () => {
+    const xml = `<feed xmlns="http://www.w3.org/2005/Atom">
+      <entry><title>Rising</title><link href="https://old.reddit.com/r/saas/comments/abc/title/"/>
+        <updated>2026-07-01T08:00:00Z</updated></entry>
+    </feed>`;
+    expect(parseFeed(xml)[0].url).toBe('https://www.reddit.com/r/saas/comments/abc/title/');
+  });
+
+  it('skips malformed blocks without throwing', () => {
+    expect(parseFeed('<rss><item><title>no link</title></item></rss>')).toHaveLength(0);
+    expect(parseFeed('garbage')).toHaveLength(0);
+  });
+});
+
+describe('normalizeRedditUrl', () => {
+  it('maps old/new/bare/relative hosts onto www.reddit.com', () => {
+    expect(normalizeRedditUrl('https://old.reddit.com/r/x/comments/1')).toBe('https://www.reddit.com/r/x/comments/1');
+    expect(normalizeRedditUrl('https://new.reddit.com/r/x/comments/1')).toBe('https://www.reddit.com/r/x/comments/1');
+    expect(normalizeRedditUrl('https://reddit.com/r/x/comments/1')).toBe('https://www.reddit.com/r/x/comments/1');
+    expect(normalizeRedditUrl('https://www.reddit.com/r/x/comments/1')).toBe('https://www.reddit.com/r/x/comments/1');
+    expect(normalizeRedditUrl('/r/x/comments/1')).toBe('https://www.reddit.com/r/x/comments/1');
+  });
+});
+
+describe('xCommunityUrl', () => {
+  // The endpoint takes `url`, not `id`. Passing the bare id errored, the fetcher swallowed it, and
+  // every scan logged "0 items" — X looked configured and simply never produced a lead.
+  it('builds the community URL from a bare id', () => {
+    expect(xCommunityUrl('1926186499399139650')).toBe('https://x.com/i/communities/1926186499399139650');
+  });
+
+  it('accepts a pasted community URL', () => {
+    expect(xCommunityUrl('https://x.com/i/communities/1926186499399139650')).toBe(
+      'https://x.com/i/communities/1926186499399139650'
+    );
+    expect(xCommunityUrl(' twitter.com/i/communities/42/ ')).toBe('https://x.com/i/communities/42');
+  });
+
+  it('returns empty when there is no id to find, so the caller can say why', () => {
+    expect(xCommunityUrl('marketing')).toBe('');
+    expect(xCommunityUrl('')).toBe('');
+  });
+});
+
+describe('freshness windows', () => {
+  const item = (hoursAgo: number) => ({
+    title: 't', url: 'u', snippet: '', sourceName: 's', publishedAt: null,
+    createdUtc: Date.now() / 1000 - hoursAgo * 3600
+  });
+
+  it('keeps Reddit tight (rising = now) and gives the slower platforms 48h', () => {
+    expect(maxAgeHoursFor('subreddit')).toBe(12);
+    expect(maxAgeHoursFor('reddit_query')).toBe(12);
+    expect(maxAgeHoursFor('threads_query')).toBe(48);
+    expect(maxAgeHoursFor('linkedin_query')).toBe(48);
+    expect(maxAgeHoursFor('x_community')).toBe(48);
+  });
+
+  it('drops what is outside the window and keeps what is inside', () => {
+    const items = [item(1), item(24), item(60)];
+    expect(withinWindow('subreddit', items)).toHaveLength(1);
+    // A Threads search ranks by relevance, not recency: the 12h cut used to leave nothing.
+    expect(withinWindow('threads_query', items)).toHaveLength(2);
+  });
+});
+
+describe('isNoMatch404 (LinkedIn: nessun risultato vestito da errore)', () => {
+  // Verificato in produzione: 404 + not_found + credits_charged 0, mentre lo stesso endpoint
+  // riempiva il catalogo globale quella mattina. È un insieme vuoto, non un guasto.
+  const noMatch = new Error(
+    'scrapecreators 404: {"success":false,"credits_remaining":12651,"credits_charged":0,"error":"not_found","errorStatus":404}'
+  );
+
+  it('riconosce il no-match documentato', () => {
+    expect(isNoMatch404(noMatch)).toBe(true);
+  });
+
+  it('NON inghiotte gli altri errori: un path rotto deve restare rumoroso', () => {
+    expect(isNoMatch404(new Error('scrapecreators 404: {"error":"route_not_found"}'))).toBe(false);
+    expect(isNoMatch404(new Error('scrapecreators 401: {"error":"not_found"}'))).toBe(false);
+    expect(isNoMatch404(new Error('scrapecreators 500: server error'))).toBe(false);
+    expect(isNoMatch404(new Error('fetch failed'))).toBe(false);
+  });
+
+  it('guarda il corpo del messaggio, non il tipo di quello che è stato lanciato', () => {
+    // Il client lancia sempre un Error, ma la verità sta nel corpo: se un giorno arrivasse come
+    // stringa la risposta non cambierebbe di significato.
+    expect(isNoMatch404('scrapecreators 404: {"error":"not_found"}')).toBe(true);
+  });
+});
+
+describe('googleNewsRssUrl', () => {
+  it("senza lingua non impone un locale: decide Google dalla query", () => {
+    expect(googleNewsRssUrl('pizza al taglio')).toBe('https://news.google.com/rss/search?q=pizza%20al%20taglio');
+  });
+
+  it('mappa la lingua su hl/gl/ceid, e ripiega su en-US per una sconosciuta', () => {
+    expect(googleNewsRssUrl('x', 'it')).toContain('hl=it&gl=IT&ceid=IT:it');
+    expect(googleNewsRssUrl('x', 'klingon')).toContain('hl=en-US&gl=US&ceid=US:en');
+  });
+});
+
+describe('createSources — instradamento delle sorgenti', () => {
+  // È QUI che sono nati i due difetti raccontati nei commenti: linkedin_query cadeva su fetchFeed
+  // e scaricava le parole chiave come fossero un URL RSS, e X veniva chiamata con `id=` dove
+  // l'endpoint vuole `url=`. Entrambi si presentavano come "0 item", non come errori.
+  function spy() {
+    const paths: string[] = [];
+    const sources = createSources({
+      scrape: async (path: string) => { paths.push(path); return { posts: [], tweets: [] }; }
+    });
+    return { sources, paths };
+  }
+
+  it('manda ogni kind al suo endpoint, e X con url= non con id=', async () => {
+    const { sources, paths } = spy();
+    await sources.fetchSourceFeed({ kind: 'threads_query', value: 'seo' });
+    await sources.fetchSourceFeed({ kind: 'reddit_query', value: 'seo' });
+    await sources.fetchSourceFeed({ kind: 'linkedin_query', value: 'seo' });
+    await sources.fetchSourceFeed({ kind: 'x_community', value: '42' });
+
+    expect(paths[0]).toContain('/v1/threads/search?query=seo');
+    expect(paths[1]).toContain('/v1/reddit/search?query=seo');
+    // linkedin_query DEVE colpire la ricerca LinkedIn: se ricade su fetchFeed torna vuoto per sempre.
+    expect(paths[2]).toContain('/v1/linkedin/search/posts?query=seo');
+    expect(paths[3]).toContain('/v1/twitter/community/tweets?url=');
+    expect(paths[3]).not.toContain('?id=');
+  });
+
+  it('una community X senza id non parte in silenzio: lancia', async () => {
+    const { sources } = spy();
+    await expect(sources.fetchSourceFeed({ kind: 'x_community', value: 'marketing' })).rejects.toThrow('no community id');
+  });
+});
+
+describe('sorgenti Reddit (solo ScrapeCreators e RSS: niente OAuth ufficiale)', () => {
+  it('non resta alcun riferimento al client OAuth Reddit', async () => {
+    const { readFile } = await import('node:fs/promises');
+    const src = await readFile(new URL('./feed.ts', import.meta.url), 'utf8');
+    expect(src).not.toMatch(/oauth\.reddit\.com|REDDIT_CLIENT_(ID|SECRET)|redditAccessToken|redditGet/);
+  });
+});
+
+describe('createSources — auth del feed Reddit', () => {
+  it('aggiunge token e utente quando ci sono, e lascia stare l\'URL quando mancano', () => {
+    const withAuth = createSources({ scrape: async () => null, redditAuth: () => ({ token: 't/1', user: 'me' }) });
+    expect(withAuth.redditRssAuth('https://www.reddit.com/r/x/.rss')).toBe(
+      'https://www.reddit.com/r/x/.rss?feed=t%2F1&user=me'
+    );
+    expect(withAuth.redditRssAuth('https://www.reddit.com/r/x/.rss?a=1')).toContain('?a=1&feed=');
+
+    const anonymous = createSources({ scrape: async () => null });
+    expect(anonymous.redditRssAuth('https://www.reddit.com/r/x/.rss')).toBe('https://www.reddit.com/r/x/.rss');
+  });
+
+  it('legge le credenziali a ogni chiamata, non quando si costruisce', () => {
+    // Congelarle alla costruzione significherebbe che un cambio d'ambiente non arriva mai.
+    let token: string | undefined;
+    const sources = createSources({ scrape: async () => null, redditAuth: () => ({ token, user: 'me' }) });
+    expect(sources.redditRssAuth('https://r.example/.rss')).toBe('https://r.example/.rss');
+    token = 'arrivato';
+    expect(sources.redditRssAuth('https://r.example/.rss')).toContain('feed=arrivato');
+  });
+});

--- a/packages/leads-core/src/feed.ts
+++ b/packages/leads-core/src/feed.ts
@@ -1,0 +1,365 @@
+/**
+ * Dove si trovano le conversazioni: RSS, Google News, subreddit in rising, e le ricerche per
+ * parola chiave su Reddit, Threads, X Communities e LinkedIn.
+ *
+ * READ-ONLY per costruzione: da qui non si pubblica e non si commenta niente, si legge soltanto.
+ *
+ * Il modulo non conosce né il gateway di scraping né le credenziali: entrano da `createSources`.
+ * La parte pura — parsing, finestre di freschezza, round-robin — sta fuori dal factory, perché
+ * non ha bisogno di niente e si prova da sola.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyRec = Record<string, any>;
+
+export type FeedItem = { title: string; url: string; snippet: string; sourceName: string; publishedAt: string | null };
+export type RedditItem = FeedItem & { createdUtc: number };
+export type SourceRef = { kind: string; value: string; lang?: string | null };
+
+const FEED_TIMEOUT_MS = 10_000;
+const ITEMS_PER_FEED = 15;
+
+// Un buon commento arriva su un thread che sta SALENDO adesso.
+const ENGAGE_MAX_AGE_HOURS = 12;
+// Threads / X / LinkedIn hanno un altro orologio. Le loro ricerche ordinano per rilevanza, non per
+// recenza (Threads non ha proprio un filtro data), e un post lì resta vivo per giorni invece di
+// cadere da una lista rising in ore. Tagliarli a 12h buttava via quasi ogni risultato — la
+// scansione registrava "0 item" e sembrava un feed vuoto invece di una finestra troppo stretta.
+const CONVERSATION_MAX_AGE_HOURS = 48;
+
+const REDDIT_UA = 'AnomaliaRadar/1.0 (read-only; instant-marketing suggestions)';
+
+/** Una sorgente è brand-AGNOSTICA da scaricare: r/marketing è lo stesso per ogni brand che la guarda. */
+export const sourceKey = (s: SourceRef): string => `${s.kind}|${s.value}|${s.lang ?? ''}`;
+
+const strip = (s: string) =>
+  s
+    .replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, '$1')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&quot;/g, '"').replace(/&#39;|&apos;/g, "'").replace(/&nbsp;/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+const tag = (xml: string, name: string) => {
+  const m = xml.match(new RegExp(`<${name}[^>]*>([\\s\\S]*?)<\\/${name}>`, 'i'));
+  return m ? strip(m[1]) : '';
+};
+
+// Il rising RSS di Reddit si scarica da old.reddit.com (meno bloccato dal fingerprint), ma quei
+// feed emettono permalink old.reddit.com. Si riscrivono sempre a www, così /leads e le email
+// aprono l'interfaccia attuale — mai la skin classica.
+export function normalizeRedditUrl(url: string): string {
+  const u = (url ?? '').trim();
+  if (!u) return u;
+  if (u.startsWith('/r/') || u.startsWith('/user/') || u.startsWith('/u/')) return `https://www.reddit.com${u}`;
+  return u.replace(/^https?:\/\/(old\.|new\.|www\.)?reddit\.com/i, 'https://www.reddit.com');
+}
+
+// Parser RSS 2.0 + Atom tollerante: basta per Google News, RSS standard e i feed Atom di Reddit.
+// ponytail: parsing XML a regex — va bene per feed ben formati; si passa a un parser vero se una
+// sorgente che serve lo rompe.
+export function parseFeed(xml: string): FeedItem[] {
+  const out: FeedItem[] = [];
+  const blocks = [...xml.matchAll(/<item[\s>][\s\S]*?<\/item>/gi), ...xml.matchAll(/<entry[\s>][\s\S]*?<\/entry>/gi)].map((m) => m[0]);
+  for (const b of blocks) {
+    const title = tag(b, 'title');
+    // RSS: <link>url</link>. Atom/Reddit: <link href="url"/>.
+    let url = tag(b, 'link');
+    if (!url) url = b.match(/<link[^>]+href=["']([^"']+)["']/i)?.[1] ?? '';
+    if (!title || !url) continue;
+    const snippet = (tag(b, 'description') || tag(b, 'summary') || tag(b, 'content')).slice(0, 1000);
+    const sourceName = tag(b, 'source') || tag(b, 'author') || '';
+    const dateRaw = tag(b, 'pubDate') || tag(b, 'published') || tag(b, 'updated');
+    const t = dateRaw ? Date.parse(dateRaw) : NaN;
+    const cleaned = strip(url);
+    out.push({
+      title,
+      url: /reddit\.com/i.test(cleaned) || cleaned.startsWith('/r/') ? normalizeRedditUrl(cleaned) : cleaned,
+      snippet,
+      sourceName,
+      publishedAt: Number.isNaN(t) ? null : new Date(t).toISOString()
+    });
+  }
+  return out;
+}
+
+// Selezione a quote eque: un item per origine a giro, fino a `cap`. Garantisce che ogni sorgente
+// con contenuto fresco contribuisca prima che una qualsiasi prenda un secondo posto — così una
+// sorgente ad alto volume non affama le altre.
+export function roundRobin<T>(byOrigin: Map<string, T[]>, cap: number): T[] {
+  const qList = [...byOrigin.values()];
+  const out: T[] = [];
+  while (out.length < cap && qList.some((q) => q.length)) {
+    for (const q of qList) {
+      if (!q.length) continue;
+      out.push(q.shift()!);
+      if (out.length >= cap) break;
+    }
+  }
+  return out;
+}
+
+/** Quanto può essere vecchia una conversazione, per piattaforma. */
+export function maxAgeHoursFor(kind: string): number {
+  return kind === 'subreddit' || kind === 'reddit_query' ? ENGAGE_MAX_AGE_HOURS : CONVERSATION_MAX_AGE_HOURS;
+}
+
+/** Scarta le conversazioni oltre la finestra della loro piattaforma. */
+export function withinWindow(kind: string, items: RedditItem[]): RedditItem[] {
+  const cutoff = Date.now() / 1000 - maxAgeHoursFor(kind) * 3600;
+  return items.filter((i) => i.createdUtc >= cutoff);
+}
+
+/**
+ * La ricerca di LinkedIn dice "nessun post corrisponde" con un **404 `not_found`** e non addebita
+ * credito — un risultato vuoto vestito da errore.
+ *
+ * Il riconoscimento è volutamente stretto — solo il corpo documentato del no-match — perché ogni
+ * altro 404 (path sbagliato, endpoint rimosso) resta un errore vero e deve continuare a urlare.
+ */
+export function isNoMatch404(e: unknown): boolean {
+  const m = e instanceof Error ? e.message : String(e);
+  return m.startsWith('scrapecreators 404') && m.includes('"not_found"');
+}
+
+// Le impostazioni chiedono l'ID della community X, ma la gente incolla l'URL intero — si accettano
+// entrambi e all'endpoint si passa l'URL che documenta davvero.
+export function xCommunityUrl(value: string): string {
+  const v = String(value ?? '').trim();
+  const id = v.match(/communities\/(\d+)/)?.[1] ?? v.replace(/\D/g, '');
+  return id ? `https://x.com/i/communities/${id}` : '';
+}
+
+const GNEWS_LANG_MAP: Record<string, [string, string, string]> = {
+  en: ['en-US', 'US', 'US:en'], it: ['it', 'IT', 'IT:it'], es: ['es', 'ES', 'ES:es'],
+  fr: ['fr', 'FR', 'FR:fr'], de: ['de', 'DE', 'DE:de'], pt: ['pt-BR', 'BR', 'BR:pt'],
+  nl: ['nl', 'NL', 'NL:nl'], pl: ['pl', 'PL', 'PL:pl'], ro: ['ro', 'RO', 'RO:ro'],
+  sv: ['sv', 'SE', 'SE:sv'], no: ['no', 'NO', 'NO:no'], da: ['da', 'DK', 'DK:da'],
+  fi: ['fi', 'FI', 'FI:fi'], cs: ['cs', 'CZ', 'CZ:cs'], sk: ['sk', 'SK', 'SK:sk'],
+  hu: ['hu', 'HU', 'HU:hu'], hr: ['hr', 'HR', 'HR:hr'], sr: ['sr', 'RS', 'RS:sr'],
+  sl: ['sl', 'SI', 'SI:sl'], bg: ['bg', 'BG', 'BG:bg'], uk: ['uk', 'UA', 'UA:uk'],
+  ru: ['ru', 'RU', 'RU:ru'], tr: ['tr', 'TR', 'TR:tr'], el: ['el', 'GR', 'GR:el'],
+  ar: ['ar', 'SA', 'SA:ar'], he: ['he', 'IL', 'IL:he'], fa: ['fa', 'IR', 'IR:fa'],
+  hi: ['hi', 'IN', 'IN:hi'], th: ['th', 'TH', 'TH:th'], vi: ['vi', 'VN', 'VN:vi'],
+  id: ['id', 'ID', 'ID:id'], ms: ['ms', 'MY', 'MY:ms'], zh: ['zh-CN', 'CN', 'CN:zh'],
+  ja: ['ja', 'JP', 'JP:ja'], ko: ['ko', 'KR', 'KR:ko'],
+};
+
+/** L'URL RSS di Google News per una query. `auto` = nessun parametro di locale, decide Google. */
+export function googleNewsRssUrl(query: string, lang?: string | null): string {
+  const code = (lang ?? 'auto').toLowerCase();
+  if (code === 'auto') return `https://news.google.com/rss/search?q=${encodeURIComponent(query)}`;
+  const [hl, gl, ceid] = GNEWS_LANG_MAP[code] ?? ['en-US', 'US', 'US:en'];
+  return `https://news.google.com/rss/search?q=${encodeURIComponent(query)}&hl=${hl}&gl=${gl}&ceid=${ceid}`;
+}
+
+/**
+ * Quello che il package non può procurarsi da solo.
+ *
+ * `redditAuth` è una funzione e non un oggetto di proposito: le credenziali vanno lette al momento
+ * della chiamata, come faceva il codice originale, non congelate quando si costruisce il factory.
+ */
+export type SourceDeps = {
+  /** Il gateway di scraping. Deve lanciare `scrapecreators <status> <body>` sugli errori. */
+  scrape: (path: string) => Promise<AnyRec | null>;
+  /** Feed token personale di Reddit (reddit.com/prefs/feeds). Senza, gli RSS restano anonimi. */
+  redditAuth?: () => { token?: string; user?: string };
+  /** Chrome vero, per i feed che bloccano i client HTTP da server. Senza, si salta il ripiego. */
+  fetchViaBrowser?: (url: string) => Promise<string | null>;
+};
+
+export function createSources(deps: SourceDeps) {
+  // Auth del feed personale: dal 2026 i feed anonimi sono bloccati per fingerprint dai server, ma
+  // ogni account ha un token privato — aggiungere ?feed=TOKEN&user=USERNAME rende la richiesta il
+  // feed autenticato dell'utente e passa. Più semplice di OAuth e read-only per costruzione.
+  const redditRssAuth = (url: string): string => {
+    const { token, user } = deps.redditAuth?.() ?? {};
+    if (!token || !user) return url;
+    return `${url}${url.includes('?') ? '&' : '?'}feed=${encodeURIComponent(token)}&user=${encodeURIComponent(user)}`;
+  };
+
+  const feedUrlFor = (source: SourceRef): string => {
+    if (source.kind === 'gnews_query') return googleNewsRssUrl(source.value, source.lang);
+    if (source.kind === 'subreddit') return redditRssAuth(`https://www.reddit.com/r/${source.value.replace(/^r\//, '')}/.rss`);
+    return source.value; // plain RSS url
+  };
+
+  const fetchFeed = async (source: SourceRef): Promise<FeedItem[]> => {
+    try {
+      const res = await fetch(feedUrlFor(source), {
+        signal: AbortSignal.timeout(FEED_TIMEOUT_MS),
+        headers: { 'User-Agent': 'Mozilla/5.0 (compatible; AnomaliaRadar/1.0)', Accept: 'application/rss+xml, application/atom+xml, application/xml, text/xml' }
+      });
+      if (!res.ok) return [];
+      return parseFeed(await res.text()).slice(0, ITEMS_PER_FEED);
+    } catch {
+      return []; // un feed morto non rompe mai la scansione
+    }
+  };
+
+  // Scarica il corpo grezzo di un URL Reddit schivando il muro del fingerprint TLS: Reddit dà 403
+  // ai client HTTP da server (Node/undici) anche con auth valida, mentre i browser veri passano.
+  // Catena: fetch normale → browser vero. null quando falliscono entrambi.
+  const fetchRedditText = async (url: string): Promise<string | null> => {
+    try {
+      const res = await fetch(url, { signal: AbortSignal.timeout(FEED_TIMEOUT_MS), headers: { 'User-Agent': REDDIT_UA } });
+      if (res.ok) return await res.text();
+    } catch { /* si passa al browser */ }
+    if (!deps.fetchViaBrowser) return null;
+    try {
+      const out = await deps.fetchViaBrowser(url);
+      return typeof out === 'string' && out.trim() ? out : null;
+    } catch {
+      return null;
+    }
+  };
+
+  const fetchSubredditRising = async (sub: string): Promise<RedditItem[]> => {
+    const clean = sub.replace(/^r\//, '').replace(/\/+$/, '');
+    try {
+      const data = await deps.scrape(`/v1/reddit/subreddit?subreddit=${encodeURIComponent(clean)}&sort=rising&trim=true`);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const raw: AnyRec[] = Array.isArray(data?.posts) ? data.posts : Array.isArray(data?.data?.children) ? data.data.children.map((c: any) => c?.data ?? c) : [];
+      const mapped = raw
+        .map((d) => ({
+          title: String(d?.title ?? ''),
+          url: d?.permalink ? `https://www.reddit.com${String(d.permalink).startsWith('/') ? d.permalink : `/${d.permalink}`}` : String(d?.url ?? ''),
+          snippet: String(d?.selftext ?? '').slice(0, 1000),
+          sourceName: `r/${clean}`,
+          publishedAt: d?.created_utc ? new Date(Number(d.created_utc) * 1000).toISOString() : null,
+          createdUtc: Number(d?.created_utc) || 0
+        }))
+        .filter((i) => i.title && i.url.includes('/comments/'));
+      if (mapped.length) return mapped;
+    } catch (e) {
+      console.warn(`[radar] scrapecreators reddit r/${clean} failed:`, e instanceof Error ? e.message.slice(0, 120) : e);
+    }
+    // Ripiego: l'endpoint RSS, che funziona da alcune reti ma è bloccato per fingerprint da molti server.
+    const xml = await fetchRedditText(redditRssAuth(`https://old.reddit.com/r/${encodeURIComponent(clean)}/rising/.rss`));
+    if (!xml) {
+      console.warn(`[radar] reddit r/${clean} unavailable — set the reddit feed token (prefs/feeds)`);
+      return [];
+    }
+    return parseFeed(xml)
+      .filter((i) => i.url.includes('/comments/'))
+      .map((i) => ({ ...i, sourceName: `r/${clean}`, createdUtc: i.publishedAt ? Date.parse(i.publishedAt) / 1000 : 0 }));
+  };
+
+  // Le ricerche di conversazioni PROPAGANO gli errori di proposito. Prima facevano
+  // `catch { return [] }`, quindi un parametro sbagliato o una chiave scaduta finivano nel log
+  // come "0 item" — indistinguibile da "nessuna conversazione degna oggi". È così che la sorgente
+  // X è rimasta morta in silenzio: veniva chiamata con `id=` dove l'endpoint vuole `url=`, e ogni
+  // scansione riportava un successo pulito e vuoto.
+
+  const fetchThreadsSearch = async (query: string): Promise<RedditItem[]> => {
+    // NB: il filtro start_date dell'endpoint restituisce 0 risultati (verificato dal vivo) —
+    // si scarica senza filtro e il taglio di freschezza lo fa il chiamante con createdUtc.
+    const data = await deps.scrape(`/v1/threads/search?query=${encodeURIComponent(query)}&trim=true`);
+    return ((data?.posts ?? []) as AnyRec[])
+      .map((post) => ({
+        title: String(post?.caption?.text ?? '').replace(/\s+/g, ' ').slice(0, 200),
+        url: post?.code && post?.user?.username ? `https://www.threads.net/@${post.user.username}/post/${post.code}` : '',
+        snippet: String(post?.caption?.text ?? '').slice(0, 1000),
+        sourceName: `threads${post?.user?.username ? ` · @${post.user.username}` : ''}`,
+        publishedAt: post?.taken_at ? new Date(Number(post.taken_at) * 1000).toISOString() : null,
+        createdUtc: Number(post?.taken_at) || 0
+      }))
+      .filter((i) => i.title && i.url);
+  };
+
+  const fetchRedditSearch = async (query: string): Promise<RedditItem[]> => {
+    const data = await deps.scrape(`/v1/reddit/search?query=${encodeURIComponent(query)}&sort=new&timeframe=day&trim=true`);
+    return ((data?.posts ?? []) as AnyRec[])
+      .map((post) => ({
+        title: String(post?.title ?? ''),
+        url: post?.permalink ? `https://www.reddit.com${String(post.permalink).startsWith('/') ? post.permalink : `/${post.permalink}`}` : String(post?.url ?? ''),
+        snippet: String(post?.selftext ?? '').slice(0, 1000),
+        // Il prefisso `r/` resta: il prompt del verdetto e la UI lo usano per trattare questi item
+        // come quelli dei subreddit.
+        sourceName: `r/${post?.subreddit ?? ''}`,
+        publishedAt: post?.created_utc ? new Date(Number(post.created_utc) * 1000).toISOString() : null,
+        createdUtc: Number(post?.created_utc) || 0
+      }))
+      .filter((i) => i.title && i.url.includes('/comments/'));
+  };
+
+  const fetchLinkedInSearch = async (query: string): Promise<RedditItem[]> => {
+    let data: AnyRec | null;
+    try {
+      data = await deps.scrape(`/v1/linkedin/search/posts?query=${encodeURIComponent(query)}&date_posted=last-day`);
+    } catch (e) {
+      // "Nessun post" non è un guasto: segnarlo rosso sarebbe l'errore opposto a quello appena
+      // tolto — gridare al lupo invece di tacere. Resta nei log.
+      if (isNoMatch404(e)) {
+        console.warn(`[radar] linkedin search: nessun risultato per "${query.slice(0, 60)}"`);
+        return [];
+      }
+      throw e;
+    }
+    return ((data?.posts ?? []) as AnyRec[])
+      .map((post) => {
+        const text = String(post?.description ?? '').replace(/\s+/g, ' ').trim();
+        const ts = post?.datePublished ? Date.parse(String(post.datePublished)) : NaN;
+        return {
+          title: text.slice(0, 200),
+          url: String(post?.url ?? ''),
+          snippet: text.slice(0, 1000),
+          sourceName: `linkedin${post?.author?.name ? ` · ${post.author.name}` : ''}`,
+          publishedAt: Number.isNaN(ts) ? null : new Date(ts).toISOString(),
+          createdUtc: Number.isNaN(ts) ? 0 : ts / 1000
+        };
+      })
+      .filter((i) => i.title && i.url);
+  };
+
+  // X vende la ricerca per parola chiave solo con l'API a pagamento — le community di nicchia sono
+  // la superficie di engage lì. Value = l'id della community dal suo URL.
+  const fetchXCommunityTweets = async (communityId: string): Promise<RedditItem[]> => {
+    const url = xCommunityUrl(communityId);
+    if (!url) throw new Error(`x_community: "${communityId}" has no community id in it`);
+    // L'endpoint vuole `url`, NON `id` — v. docs.scrapecreators.com/v1/twitter/community/tweets.
+    const data = await deps.scrape(`/v1/twitter/community/tweets?url=${encodeURIComponent(url)}&trim=true`);
+    const raw: AnyRec[] = Array.isArray(data?.tweets) ? data.tweets : Array.isArray(data?.data) ? data.data : [];
+    return raw
+      .map((t) => {
+        const ts = t?.created_at ? Date.parse(String(t.created_at)) : NaN;
+        const id = String(t?.id_str ?? t?.rest_id ?? t?.id ?? '');
+        return {
+          title: String(t?.full_text ?? t?.text ?? '').replace(/\s+/g, ' ').slice(0, 200),
+          url: id ? `https://x.com/i/status/${id}` : '',
+          snippet: String(t?.full_text ?? t?.text ?? '').slice(0, 1000),
+          sourceName: 'x community',
+          publishedAt: Number.isNaN(ts) ? null : new Date(ts).toISOString(),
+          createdUtc: Number.isNaN(ts) ? 0 : ts / 1000
+        };
+      })
+      .filter((i) => i.title && i.url);
+  };
+
+  /** Una sorgente, già filtrata nel tempo dove il tempo conta. L'unità della cache condivisa. */
+  const fetchSourceFeed = async (s: SourceRef): Promise<FeedItem[]> => {
+    if (s.kind === 'threads_query') return withinWindow(s.kind, await fetchThreadsSearch(s.value));
+    if (s.kind === 'x_community') return withinWindow(s.kind, await fetchXCommunityTweets(s.value));
+    // linkedin_query mancava qui: la sorgente cadeva su fetchFeed(), che scaricava le PAROLE CHIAVE
+    // come se fossero un url RSS. Ogni sorgente LinkedIn restituiva niente, per sempre.
+    if (s.kind === 'linkedin_query') return withinWindow(s.kind, await fetchLinkedInSearch(s.value));
+    if (s.kind === 'reddit_query') return withinWindow(s.kind, await fetchRedditSearch(s.value));
+    if (s.kind !== 'subreddit') return fetchFeed(s);
+    // TIMING: solo RISING (momentum adesso), taglio netto — un commento su un thread stantio è
+    // fiato sprecato.
+    return withinWindow(s.kind, await fetchSubredditRising(s.value));
+  };
+
+  return {
+    redditRssAuth,
+    fetchRedditText,
+    fetchSubredditRising,
+    fetchThreadsSearch,
+    fetchRedditSearch,
+    fetchLinkedInSearch,
+    fetchXCommunityTweets,
+    fetchSourceFeed
+  };
+}
+
+export type Sources = ReturnType<typeof createSources>;

--- a/packages/leads-core/src/intent.test.ts
+++ b/packages/leads-core/src/intent.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeIntent, INTENT_RANK } from './intent';
+
+describe('intent', () => {
+  it('normalises anything the model returns to a known band', () => {
+    expect(normalizeIntent('seeking_now')).toBe('seeking_now');
+    expect(normalizeIntent('SEEKING_NOW')).toBe('seeking_now');
+    expect(normalizeIntent('ready to buy')).toBe('none');
+    expect(normalizeIntent(undefined)).toBe('none');
+  });
+
+  it('ranks someone asking now above someone venting', () => {
+    expect(INTENT_RANK.seeking_now).toBeGreaterThan(INTENT_RANK.comparing);
+    expect(INTENT_RANK.comparing).toBeGreaterThan(INTENT_RANK.researching);
+    expect(INTENT_RANK.researching).toBeGreaterThan(INTENT_RANK.venting);
+    expect(INTENT_RANK.venting).toBeGreaterThan(INTENT_RANK.none);
+  });
+});

--- a/packages/leads-core/src/intent.ts
+++ b/packages/leads-core/src/intent.ts
@@ -5,9 +5,8 @@
  * shopping". They diverge constantly: a thread asking *which tool do you use for X* and one ranting
  * about X earn the same relevance and are not the same lead.
  *
- * Client-safe on purpose (same split as `$lib/plans`): the Leads page ranks and labels by it
- * without pulling the whole Radar server module — and `$lib/server/radar` re-exports it, so there
- * is one ladder, not two.
+ * Zero dependencies on purpose: it ranks the queue in the browser and scores the verdict on the
+ * server, so it may never reach for a client, an env var or a plan.
  */
 export const LEAD_INTENTS = ['seeking_now', 'comparing', 'researching', 'venting', 'none'] as const;
 export type LeadIntent = (typeof LEAD_INTENTS)[number];

--- a/packages/leads-core/src/match.test.ts
+++ b/packages/leads-core/src/match.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { matchScore, pickMatch, shingles, normalizeForMatch, isCheckable, MATCH_THRESHOLD } from './lead-outcomes';
+import { matchScore, pickMatch, shingles, normalizeForMatch, isCheckable, MATCH_THRESHOLD } from './match';
 
 const draft =
   'Most founders overcomplicate this. Forget paid ads when you have zero traction. For the first ten users it is pure unscalable grind, search for people complaining about the exact bottleneck you solve and reply with actual help.';

--- a/packages/leads-core/src/match.ts
+++ b/packages/leads-core/src/match.ts
@@ -1,0 +1,103 @@
+/**
+ * Ritrovare il nostro commento in un thread che non abbiamo pubblicato noi.
+ *
+ * IL PROBLEMA DI FONDO: il commento lo incolla l'umano, con il suo account, che noi non
+ * conosciamo — ed è la scelta giusta, è la ragione per cui gli account sopravvivono. Quindi il
+ * commento va RITROVATO nel thread, e l'unico appiglio è il testo che avevamo scritto.
+ *
+ * Il matcher lavora su shingle di tre parole, non su parole singole: "social media marketing"
+ * compare in metà dei commenti di r/SaaS, "before it turns into another" no. E misura il
+ * CONTENIMENTO delle shingle della bozza dentro il candidato, non la somiglianza simmetrica —
+ * perché chi incolla taglia, aggiunge una riga sua, corregge un refuso: il testo cresce o si
+ * accorcia, ma i pezzi che restano sono i nostri.
+ */
+
+/** Prima di 48h il punteggio di un commento non si è assestato: guardarlo prima è rumore. */
+export const CHECK_AFTER_HOURS = 48;
+/** Oltre questa età non si controlla più: il thread è morto e il dato non cambierebbe. */
+export const CHECK_BEFORE_DAYS = 14;
+/** Lead controllati per run (ogni controllo è una chiamata al lettore di thread). */
+export const MAX_CHECKS_PER_RUN = 25;
+
+/**
+ * Soglia di contenimento per dire "questo è il nostro commento".
+ *
+ * 0.35 è basso di proposito: chi incolla riscrive. Il rischio di un falso positivo è basso perché
+ * le shingle di tre parole sono specifiche — perché un altro commento ne condivida un terzo con la
+ * nostra bozza dovrebbe averla praticamente copiata.
+ */
+export const MATCH_THRESHOLD = 0.35;
+
+/** Testo confrontabile: via URL, punteggiatura e maiuscole, che l'editing tocca per primi. */
+export function normalizeForMatch(text: string): string {
+  return String(text ?? '')
+    .toLowerCase()
+    .replace(/https?:\/\/\S+/g, ' ')
+    .replace(/[^\p{L}\p{N}\s]/gu, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/** Shingle di N parole. Tre è il punto in cui una frase smette di essere generica. */
+export function shingles(text: string, n = 3): Set<string> {
+  const words = normalizeForMatch(text).split(' ').filter(Boolean);
+  const out = new Set<string>();
+  if (words.length < n) {
+    if (words.length) out.add(words.join(' '));
+    return out;
+  }
+  for (let i = 0; i <= words.length - n; i++) out.add(words.slice(i, i + n).join(' '));
+  return out;
+}
+
+/**
+ * Quanta parte della bozza sopravvive nel candidato, da 0 a 1.
+ *
+ * Contenimento e non Jaccard: un commento in cui l'umano ha aggiunto tre righe sue resta il nostro
+ * commento, e Jaccard lo punirebbe per la lunghezza in più.
+ */
+export function matchScore(draft: string, candidate: string): number {
+  const a = shingles(draft);
+  if (!a.size) return 0;
+  const b = shingles(candidate);
+  if (!b.size) return 0;
+  let hit = 0;
+  for (const s of a) if (b.has(s)) hit++;
+  return hit / a.size;
+}
+
+export type CommentLike = { body: string; author?: string | null; ups?: number | null; replies?: number | null; permalink?: string | null };
+
+/** Il commento più simile alla bozza, se supera la soglia. Nessun match = null, mai un ripiego. */
+export function pickMatch(
+  draft: string,
+  comments: CommentLike[],
+  opts: { handle?: string | null; threshold?: number } = {}
+): { comment: CommentLike; score: number; method: 'text' | 'handle' } | null {
+  const threshold = opts.threshold ?? MATCH_THRESHOLD;
+  const handle = String(opts.handle ?? '').replace(/^u\//, '').trim().toLowerCase();
+
+  // Se il brand ha dichiarato il proprio handle, quello vince sul testo: è un'identità, non una
+  // somiglianza. Il testo resta come ripiego per chi non l'ha configurato.
+  if (handle) {
+    const mine = comments.filter((c) => String(c.author ?? '').toLowerCase() === handle);
+    if (mine.length) {
+      const best = mine
+        .map((c) => ({ comment: c, score: matchScore(draft, c.body) }))
+        .sort((x, y) => y.score - x.score)[0];
+      return { comment: best.comment, score: best.score, method: 'handle' };
+    }
+  }
+
+  const scored = comments
+    .map((c) => ({ comment: c, score: matchScore(draft, c.body) }))
+    .sort((x, y) => y.score - x.score);
+  const best = scored[0];
+  if (!best || best.score < threshold) return null;
+  return { comment: best.comment, score: best.score, method: 'text' };
+}
+
+/** Solo Reddit: è l'unica superficie da cui possiamo rileggere i commenti di un thread. */
+export function isCheckable(url: string): boolean {
+  return /reddit\.com\//i.test(String(url ?? ''));
+}

--- a/packages/leads-core/src/prompts.test.ts
+++ b/packages/leads-core/src/prompts.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { buildEngagePrompt, selectTopComments, COMMENT_MIN_RELEVANCE } from './prompts';
+
+describe('buildEngagePrompt (la lingua è quella del THREAD, non del brand)', () => {
+  // Brand italiano, thread inglese: il caso reale che produceva bozze in italiano su Reddit EN.
+  const base = {
+    brandName: 'Trattoria Bio',
+    about: 'Prodotti biologici italiani, spedizione in tutta Europa.',
+    siteUrl: 'https://trattoriabio.it',
+    aiContext: 'Voce: diretta, concreta, italiana.',
+    sourceName: 'r/organicfarming',
+    title: 'What should I look for when buying organic olive oil?',
+    body: 'I keep seeing conflicting labels at the store. My budget is limited. How do I know the oil is actually organic?',
+    topComments: '- Look for the EU organic leaf logo',
+    author: 'oliveguy',
+    intent: 'researching' as const,
+    profileBlock: '',
+    toneHint: '\nTONE: Write in a friendly tone.',
+    styleHint: '\nSTYLE INSTRUCTIONS (PRIORITY — override any conflicting rules below): Sii cinico. No emoji.'
+  };
+
+  it('pins the reply language to the thread and carries the thread text the model detects it from', () => {
+    const p = buildEngagePrompt(base);
+    expect(p).toContain('REPLY LANGUAGE — ABSOLUTE RULE');
+    expect(p).toContain('language of the THREAD');
+    // le istruzioni di stile (spesso in italiano) governano lo stile, mai la lingua
+    expect(p).toContain('Style instructions shape style, never language');
+    // il testo su cui rilevare la lingua è nel prompt: titolo e corpo del thread
+    expect(p).toContain(base.title);
+    expect(p).toContain('conflicting labels');
+  });
+
+  it('guards the known failure modes: filler openers, title-only answers, echoing the thread, unsolicited pitch', () => {
+    const p = buildEngagePrompt(base);
+    expect(p).toContain('NO FILLER OPENERS');
+    expect(p).toContain('ANSWER THE ACTUAL QUESTION');
+    expect(p).toContain('ADD VALUE BEYOND THE THREAD');
+    expect(p).toContain('NO UNSOLICITED PITCH');
+    // i commenti già presenti arrivano al drafter come "già detto", non come suggerimento
+    expect(p).toContain('EU organic leaf logo');
+    expect(p).toContain('never restate it');
+  });
+
+  it("includes the owner's recent before→after edits, and omits the block when there are none", () => {
+    const withPairs = buildEngagePrompt({
+      ...base,
+      editPairs: [{ before: 'Bozza lunga e promozionale', after: 'Corta e utile', feedback: 'meno pitch' }]
+    });
+    expect(withPairs).toContain('HOW THE OWNER REWRITES YOUR DRAFTS');
+    expect(withPairs).toContain('BEFORE: Bozza lunga e promozionale');
+    expect(withPairs).toContain('AFTER: Corta e utile');
+    expect(withPairs).toContain('meno pitch');
+    // senza riscritture il drafter lavora come prima: nessun blocco vuoto nel prompt
+    expect(buildEngagePrompt(base)).not.toContain('HOW THE OWNER REWRITES');
+  });
+});
+
+describe('selectTopComments (il cap è "gli N migliori", non "i primi N")', () => {
+  const c = (id: string, relevance: number, intent: 'seeking_now' | 'none') =>
+    ({ id, action: 'comment', relevance, intent });
+
+  it('picks by intent then relevance, regardless of arrival order', () => {
+    const picked = [c('a', 72, 'none'), c('b', 90, 'none'), c('c', 71, 'seeking_now'), c('d', 99, 'none')];
+    // 'c' compra adesso (batte tutti), poi 'd' per rilevanza — 'a' arrivato primo NON entra.
+    expect(selectTopComments(picked, 2).map((x) => x.id)).toEqual(['c', 'd']);
+  });
+
+  it('drops below-floor comments and non-comment actions, and honours a zero budget', () => {
+    const picked = [
+      { id: 'p', action: 'post', relevance: 99, intent: 'none' as const },
+      c('low', COMMENT_MIN_RELEVANCE - 1, 'seeking_now'),
+      c('ok', 80, 'none')
+    ];
+    expect(selectTopComments(picked, 5).map((x) => x.id)).toEqual(['ok']);
+    expect(selectTopComments(picked, 0)).toEqual([]);
+  });
+});

--- a/packages/leads-core/src/prompts.ts
+++ b/packages/leads-core/src/prompts.ts
@@ -1,0 +1,94 @@
+/**
+ * Il drafter: da una conversazione trovata alla bozza che l'umano incollerà.
+ *
+ * I guard-rail qui dentro rispondono ai modi in cui le bozze fallivano DAVVERO nell'uso reale:
+ * risposta nella lingua del brand invece che del thread, aperture di cortesia vuote, risposta al
+ * titolo invece che alla domanda nel corpo, pitch non richiesto, e commenti che ripetevano quello
+ * che i top comment avevano già detto.
+ */
+import { INTENT_RANK, type LeadIntent } from './intent';
+
+// "Pochi ma buoni": il proprietario non riusciva a stare dietro a 6-8 bozze di commento al
+// giorno. Due leve: una soglia di rilevanza più alta dei post (sotto, un commento consuma
+// attenzione senza rendere) e un budget giornaliero. Il cap significa "gli N MIGLIORI del
+// giorno": prima si ordina per punteggio, poi si taglia — mai first-come.
+export const COMMENT_MIN_RELEVANCE = 70;
+
+/** I migliori N commenti: soglia, poi ordine per intent e rilevanza, poi taglio al budget. */
+export function selectTopComments<T extends { action: string; relevance: number; intent: LeadIntent }>(
+  picked: T[],
+  budget: number
+): T[] {
+  return picked
+    .filter((p) => p.action === 'comment' && p.relevance >= COMMENT_MIN_RELEVANCE)
+    // Riordinato qui dentro (anche se il chiamante già ordina): la semantica "i migliori, non i
+    // primi" non deve dipendere dall'ordine di arrivo.
+    .sort((a, b) => INTENT_RANK[b.intent] - INTENT_RANK[a.intent] || b.relevance - a.relevance)
+    .slice(0, Math.max(0, budget));
+}
+
+export const COMMENT_SCHEMA = {
+  type: 'object' as const,
+  properties: {
+    worth_it: { type: 'boolean' as const, description: 'false if, seeing the full thread, a brand comment would NOT genuinely help — better silence than noise.' },
+    comment: { type: 'string' as const, description: "The ready-to-paste comment, in the thread's language and Reddit's register." },
+    dm: { type: 'string' as const, description: "A short, PERSONAL 1:1 direct message to the POST AUTHOR — ONLY when there is genuine 1:1 value (they're explicitly seeking a solution the brand actually offers). Softer and warmer than the public comment: open by referencing THEIR specific post, be helpful first, never a hard sell or a pitch. Bring in the brand either as an insider (with a light affiliation disclosure) or as a neutral tip ('you could check e.g. https://domain.com') — no need to declare you're the founder. When you point to the site, use the full https:// URL. Empty string when a DM would feel intrusive or spammy (default to empty unless the fit is obvious). Same language as the thread. 30-90 words." }
+  },
+  required: ['worth_it', 'comment', 'dm']
+};
+
+export type EngagePromptArgs = {
+  brandName: string;
+  about: string;
+  siteUrl: string;
+  aiContext: string;
+  sourceName: string;
+  title: string;
+  body: string;
+  topComments: string;
+  author: string;
+  intent: LeadIntent;
+  profileBlock: string;
+  toneHint: string;
+  styleHint: string;
+  // Ultime riscritture dell'utente (prima→dopo): il segnale più onesto su cosa correggere.
+  editPairs?: Array<{ before: string; after: string; feedback?: string }>;
+};
+
+export function buildEngagePrompt(a: EngagePromptArgs): string {
+  const editBlock = a.editPairs?.length
+    ? `\nHOW THE OWNER REWRITES YOUR DRAFTS (real before → after edits on this brand's recent drafts — absorb the DIFFERENCE: what they cut, the length, the tone. Apply the same taste to THIS draft; never reuse their wording, it belongs to other threads):\n${a.editPairs
+        .map((p, i) => `${i + 1}. BEFORE: ${p.before}\n   AFTER: ${p.after}${p.feedback ? `\n   (owner's note: ${p.feedback})` : ''}`)
+        .join('\n')}\n`
+    : '';
+  return `A conversation on ${a.sourceName} is rising and this brand's expertise is relevant. Draft the ONE reply the brand should post — as a knowledgeable community member, not a marketer.
+
+REPLY LANGUAGE — ABSOLUTE RULE: write the comment AND the DM in the language of the THREAD (detect it from the thread's title and body below). The brand's language, the language of these instructions and of any style or voice material are IRRELEVANT to this choice: an English thread gets an English reply even when the brand writes its posts in Italian, and vice versa. Style instructions shape style, never language.
+
+Brand: ${a.brandName} — ${a.about}
+${a.siteUrl ? `Brand site (link it with the FULL URL exactly like this, never just the name or a bare domain): ${a.siteUrl}\n` : ''}${a.aiContext ? `Voice & expertise:\n${a.aiContext}\n` : ''}
+THREAD "${a.title}":
+${a.body || '(no body — title only)'}
+${a.topComments ? `\nTOP COMMENTS ALREADY THERE (this is what the thread ALREADY has — never restate it):\n${a.topComments}` : ''}
+${a.author ? `\nPOST AUTHOR: ${a.author} (the person you would DM 1:1).` : ''}
+BUYER INTENT: ${a.intent} — 'seeking_now'/'comparing' means they asked for a solution, so naming one is welcome; 'researching' wants the explanation, not a product; 'venting' wants to be heard, so help without pointing anywhere and leave the DM empty.
+${a.profileBlock ? `\n${a.profileBlock}\n` : ''}${a.toneHint}${a.styleHint}
+${editBlock}
+Produce TWO things: (1) the public COMMENT for the thread, and (2) a private DM to the post author — but ONLY draft a DM when there's a clear 1:1 fit (they explicitly want a solution the brand offers). If a DM would be intrusive, return an empty dm.
+
+HARD RULES (survival + Italian hidden-advertising law):
+- ANSWER THE ACTUAL QUESTION: the title is a headline; the real ask (their constraints, budget, what they already tried) lives in the body. When body and title diverge, answer the body.
+- NO FILLER OPENERS: never start with "Great question", "Interesting point", or a restatement of their post. The first sentence already carries the substance.
+- ADD VALUE BEYOND THE THREAD: when a top comment above already gives the core advice, do not repeat it — acknowledge it in passing ("someone already mentioned X") and contribute the piece it misses: a nuance, a trade-off, a concrete next step. If you have nothing beyond what's already there, set worth_it=false — better silence than an echo.
+- WRITE FOR THE ROOM: when a COMMUNITY PROFILE is above, it wins over generic instinct — use the exact words from its vocabulary line, respect its rules line (what gets removed), and match the shape its tone line describes. Do not repeat advice its "already tried" line says they were burned by.
+- VALUE FIRST: actually answer the thread with the brand's real expertise.
+- NO UNSOLICITED PITCH: mention the brand ONLY when the buyer intent above says they asked for a solution (seeking_now/comparing) or the thread explicitly asks for recommendations. For 'researching' and 'venting', help without pointing anywhere.
+- NEVER PROMISE WHAT IS NOT THERE: describe only what the brand context above actually says the product does. If the thread needs something it does not do, say so plainly or say nothing — an overpromise in public costs more than a missed lead.
+- TWO WAYS to bring in the brand — pick whichever fits the thread naturally:
+  (a) INSIDER: speak as someone who works on it, with an explicit disclosure ("Disclosure: I work on X" / "Trasparenza: ci lavoro io"). Use when a first-person "we built this" is the honest framing.
+  (b) NEUTRAL TIP: recommend it as ONE example/resource among options, third person, no founder claim ("you could check e.g. ${a.siteUrl || 'the site'}"). Use for broadly-useful advice where naming yourself would feel heavy. Never pose as an unaffiliated fan hyping it — a neutral pointer is fine, a disguised hard sell is not.
+  You do NOT have to say "I'm the founder" every time; mention the brand ONLY when it genuinely answers the question.
+- When you DO point to the brand, write the WEBSITE as the full URL${a.siteUrl ? ` (${a.siteUrl})` : ''} — never just the name, never a bare domain without https://.
+- PLATFORM REGISTER: Reddit → plain, first person, no hashtags; Threads → conversational, like talking to a friend; X → ONE sharp reply under 280 characters. Never marketing phrasing or emoji spam.
+- COMMENT: 60-150 words. DM: 30-90 words, warmer and personal, opens by referencing THEIR post, helpful-not-salesy — empty when a cold DM would feel spammy.`;
+}

--- a/packages/leads-core/tsconfig.json
+++ b/packages/leads-core/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/src/lib/server/lead-outcomes.test.ts
+++ b/src/lib/server/lead-outcomes.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+const scrapeCreatorsGet = vi.fn();
+vi.mock('$lib/server/scrapecreators', () => ({ scrapeCreatorsGet: (path: string) => scrapeCreatorsGet(path) }));
+
+const { runOutcomeChecks, pendingOutcomeChecks } = await import('./lead-outcomes');
+
+const LEAD = {
+  id: 'lead-1',
+  brand_id: 'brand-1',
+  url: 'https://www.reddit.com/r/SaaS/comments/abc/def/',
+  suggestion: 'Forget paid ads with zero traction, go talk to the people complaining about the bottleneck you solve.',
+  done_at: new Date(Date.now() - 3 * 24 * 3600 * 1000).toISOString(),
+  author_handle: 'u/pippo',
+  author_platform: 'reddit'
+};
+
+type Op = { table: string; op: string; payload?: unknown };
+
+/** Un admin finto che registra ogni scrittura: è su quelle che si giudica, non sui ritorni. */
+function fakeAdmin(leads: Array<Record<string, unknown>> = [LEAD]) {
+  const ops: Op[] = [];
+  const rows: Record<string, unknown[]> = { brand_news_items: leads, lead_outcomes: [] };
+
+  const client = {
+    from: (table: string) => {
+      const op: Op = { table, op: 'select' };
+      const b: Record<string, unknown> = {};
+      const self = () => b;
+      for (const m of ['select', 'eq', 'not', 'gte', 'lte', 'order', 'limit', 'in']) b[m] = self;
+      b.upsert = (payload: unknown) => { ops.push({ table, op: 'upsert', payload }); return Promise.resolve({ error: null }); };
+      b.insert = (payload: unknown) => { ops.push({ table, op: 'insert', payload }); return Promise.resolve({ error: null }); };
+      b.then = (resolve: (v: { data: unknown[]; error: null }) => void) => {
+        ops.push(op);
+        return resolve({ data: rows[table] ?? [], error: null });
+      };
+      return b;
+    }
+  } as unknown as SupabaseClient;
+
+  return { client, ops };
+}
+
+beforeEach(() => scrapeCreatorsGet.mockReset());
+
+describe('runOutcomeChecks — il ramo opt-out arriva davvero fino alla soppressione', () => {
+  it('un "non contattarmi" nel thread sopprime l\'autore a livello globale', async () => {
+    // Il thread viene comunque riletto per cercare il nostro commento: se dentro c'è un ritiro del
+    // consenso, quella persona non va mai più proposta a nessun brand dell'istanza.
+    scrapeCreatorsGet.mockResolvedValue({
+      comments: [
+        { body: 'Please stop contacting me about this, I mean it.', author: 'pippo', ups: 2 },
+        { body: 'Unrelated chatter that is long enough to be considered.', author: 'altro', ups: 1 }
+      ]
+    });
+
+    const { client, ops } = fakeAdmin();
+    await runOutcomeChecks(client, 5);
+
+    const suppression = ops.find((o) => o.table === 'lead_suppressions' && o.op === 'upsert');
+    expect(suppression, 'nessuna soppressione scritta: il ramo opt-out non è stato raggiunto').toBeDefined();
+    expect(suppression?.payload).toMatchObject({
+      platform: 'reddit',
+      handle: 'u/pippo',
+      source: 'thread_scan'
+    });
+  });
+
+  it('un thread senza segnali non sopprime nessuno', async () => {
+    scrapeCreatorsGet.mockResolvedValue({
+      comments: [{ body: 'Great thread, this was genuinely useful to read.', author: 'tizio', ups: 5 }]
+    });
+
+    const { client, ops } = fakeAdmin();
+    await runOutcomeChecks(client, 5);
+
+    expect(ops.find((o) => o.table === 'lead_suppressions')).toBeUndefined();
+    // L'esito viene comunque registrato: non ritrovato, non "rimosso" per finta.
+    expect(ops.find((o) => o.table === 'lead_outcomes' && o.op === 'insert')).toBeDefined();
+  });
+});
+
+describe('pendingOutcomeChecks — i campi autore fanno parte del contratto', () => {
+  it('porta author_handle e author_platform, che sono ciò che rende possibile la soppressione', async () => {
+    const { client } = fakeAdmin();
+    const [lead] = await pendingOutcomeChecks(client, 5);
+    // Il tipo dichiarato li ometteva pur restituendoli: chi rimuovesse queste due righe dal mapper
+    // spegnerebbe il ramo opt-out senza un solo errore di compilazione.
+    expect(lead.author_handle).toBe('u/pippo');
+    expect(lead.author_platform).toBe('reddit');
+  });
+});

--- a/src/lib/server/lead-outcomes.ts
+++ b/src/lib/server/lead-outcomes.ts
@@ -2,6 +2,14 @@ import { swallow } from '$lib/server/swallow';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { scrapeCreatorsGet } from '$lib/server/scrapecreators';
 import { isOptOutSignal, platformOf, suppressAuthor } from './lead-contact';
+import {
+  CHECK_AFTER_HOURS,
+  CHECK_BEFORE_DAYS,
+  MAX_CHECKS_PER_RUN,
+  isCheckable,
+  pickMatch,
+  type CommentLike
+} from '@anomalia/leads-core/match';
 
 // ── L'esito di un lead: cosa è successo al commento dopo che l'hai incollato ─────────────────────
 //
@@ -10,16 +18,9 @@ import { isOptOutSignal, platformOf, suppressAuthor } from './lead-contact';
 // ottenuto una risposta o si sia presa una rimozione non lo sapeva nessuno, quindi ogni giudizio
 // sulla qualità ("le bozze sembrano migliori") era un'opinione con l'accento di un dato.
 //
-// IL PROBLEMA DI FONDO: il commento non lo pubblichiamo noi. Lo incolla l'umano, con il suo
-// account, che noi non conosciamo — ed è la scelta giusta, è la ragione per cui gli account
-// sopravvivono. Quindi il commento va RITROVATO nel thread, e l'unico appiglio è il testo che
-// avevamo scritto.
-//
-// Il matcher lavora su shingle di tre parole, non su parole singole: "social media marketing"
-// compare in metà dei commenti di r/SaaS, "before it turns into another" no. E misura il
-// CONTENIMENTO delle shingle della bozza dentro il candidato, non la somiglianza simmetrica —
-// perché chi incolla taglia, aggiunge una riga sua, corregge un refuso: il testo cresce o si
-// accorcia, ma i pezzi che restano sono i nostri.
+// Il commento non lo pubblichiamo noi: va RITROVATO nel thread, e come si ritrova sta in
+// `@anomalia/leads-core/match`. Qui c'è il giro attorno — chi controllare, quando, e cosa
+// registrare.
 //
 // Oggi solo Reddit: è dove stanno i lead veri, ed è l'unica delle nostre superfici da cui possiamo
 // rileggere i commenti di un thread. Threads/X/LinkedIn passano ma restano non verificabili, e
@@ -27,96 +28,6 @@ import { isOptOutSignal, platformOf, suppressAuthor } from './lead-contact';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyRec = Record<string, any>;
-
-/** Prima di 48h il punteggio di un commento non si è assestato: guardarlo prima è rumore. */
-export const CHECK_AFTER_HOURS = 48;
-/** Oltre questa età non si controlla più: il thread è morto e il dato non cambierebbe. */
-export const CHECK_BEFORE_DAYS = 14;
-/** Lead controllati per run (ogni controllo è una chiamata a ScrapeCreators). */
-export const MAX_CHECKS_PER_RUN = 25;
-
-/**
- * Soglia di contenimento per dire "questo è il nostro commento".
- *
- * 0.35 è basso di proposito: chi incolla riscrive. Il rischio di un falso positivo è basso perché
- * le shingle di tre parole sono specifiche — perché un altro commento ne condivida un terzo con la
- * nostra bozza dovrebbe averla praticamente copiata.
- */
-export const MATCH_THRESHOLD = 0.35;
-
-/** Testo confrontabile: via URL, punteggiatura e maiuscole, che l'editing tocca per primi. */
-export function normalizeForMatch(text: string): string {
-  return String(text ?? '')
-    .toLowerCase()
-    .replace(/https?:\/\/\S+/g, ' ')
-    .replace(/[^\p{L}\p{N}\s]/gu, ' ')
-    .replace(/\s+/g, ' ')
-    .trim();
-}
-
-/** Shingle di N parole. Tre è il punto in cui una frase smette di essere generica. */
-export function shingles(text: string, n = 3): Set<string> {
-  const words = normalizeForMatch(text).split(' ').filter(Boolean);
-  const out = new Set<string>();
-  if (words.length < n) {
-    if (words.length) out.add(words.join(' '));
-    return out;
-  }
-  for (let i = 0; i <= words.length - n; i++) out.add(words.slice(i, i + n).join(' '));
-  return out;
-}
-
-/**
- * Quanta parte della bozza sopravvive nel candidato, da 0 a 1.
- *
- * Contenimento e non Jaccard: un commento in cui l'umano ha aggiunto tre righe sue resta il nostro
- * commento, e Jaccard lo punirebbe per la lunghezza in più.
- */
-export function matchScore(draft: string, candidate: string): number {
-  const a = shingles(draft);
-  if (!a.size) return 0;
-  const b = shingles(candidate);
-  if (!b.size) return 0;
-  let hit = 0;
-  for (const s of a) if (b.has(s)) hit++;
-  return hit / a.size;
-}
-
-export type CommentLike = { body: string; author?: string | null; ups?: number | null; replies?: number | null; permalink?: string | null };
-
-/** Il commento più simile alla bozza, se supera la soglia. Nessun match = null, mai un ripiego. */
-export function pickMatch(
-  draft: string,
-  comments: CommentLike[],
-  opts: { handle?: string | null; threshold?: number } = {}
-): { comment: CommentLike; score: number; method: 'text' | 'handle' } | null {
-  const threshold = opts.threshold ?? MATCH_THRESHOLD;
-  const handle = String(opts.handle ?? '').replace(/^u\//, '').trim().toLowerCase();
-
-  // Se il brand ha dichiarato il proprio handle, quello vince sul testo: è un'identità, non una
-  // somiglianza. Il testo resta come ripiego per chi non l'ha configurato.
-  if (handle) {
-    const mine = comments.filter((c) => String(c.author ?? '').toLowerCase() === handle);
-    if (mine.length) {
-      const best = mine
-        .map((c) => ({ comment: c, score: matchScore(draft, c.body) }))
-        .sort((x, y) => y.score - x.score)[0];
-      return { comment: best.comment, score: best.score, method: 'handle' };
-    }
-  }
-
-  const scored = comments
-    .map((c) => ({ comment: c, score: matchScore(draft, c.body) }))
-    .sort((x, y) => y.score - x.score);
-  const best = scored[0];
-  if (!best || best.score < threshold) return null;
-  return { comment: best.comment, score: best.score, method: 'text' };
-}
-
-/** Solo Reddit: è l'unica superficie da cui possiamo rileggere i commenti di un thread. */
-export function isCheckable(url: string): boolean {
-  return /reddit\.com\//i.test(String(url ?? ''));
-}
 
 const num = (v: unknown): number | null => {
   const n = Number(v);

--- a/src/lib/server/lead-outcomes.ts
+++ b/src/lib/server/lead-outcomes.ts
@@ -125,11 +125,24 @@ export async function checkLeadOutcome(
   };
 }
 
-/** I lead maturi e mai controllati. */
+/**
+ * I lead maturi e mai controllati.
+ *
+ * I campi autore fanno parte del contratto, non sono un extra: sono l'unica cosa che permette a
+ * `checkLeadOutcome` di sopprimere chi ha chiesto di non essere ricontattato. Il tipo li ometteva
+ * pur restituendoli, quindi rimuoverli dal mapper non avrebbe rotto niente in compilazione.
+ */
 export async function pendingOutcomeChecks(
   admin: SupabaseClient,
   limit = MAX_CHECKS_PER_RUN
-): Promise<Array<{ id: string; brand_id: string; url: string; suggestion: string | null }>> {
+): Promise<Array<{
+  id: string;
+  brand_id: string;
+  url: string;
+  suggestion: string | null;
+  author_handle: string | null;
+  author_platform: string | null;
+}>> {
   const from = new Date(Date.now() - CHECK_BEFORE_DAYS * 24 * 3600 * 1000).toISOString();
   const to = new Date(Date.now() - CHECK_AFTER_HOURS * 3600 * 1000).toISOString();
 

--- a/src/lib/server/lead-outcomes.ts
+++ b/src/lib/server/lead-outcomes.ts
@@ -1,7 +1,7 @@
 import { swallow } from '$lib/server/swallow';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { scrapeCreatorsGet } from '$lib/server/scrapecreators';
-import { isOptOutSignal, platformOf, suppressAuthor } from './lead-contact';
+import { isOptOutSignal, platformOf, suppressAuthor } from '@anomalia/leads-core/contact';
 import {
   CHECK_AFTER_HOURS,
   CHECK_BEFORE_DAYS,
@@ -100,7 +100,7 @@ export async function checkLeadOutcome(
       handle: lead.author_handle,
       source: 'thread_scan',
       reason: 'opt-out signal in the thread'
-    });
+    }, swallow);
   }
 
   const hit = pickMatch(lead.suggestion, comments, { handle });

--- a/src/lib/server/radar.test.ts
+++ b/src/lib/server/radar.test.ts
@@ -1,95 +1,14 @@
 import { describe, it, expect } from 'vitest';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import {
-  parseFeed,
   radarPrefsOf,
-  roundRobin,
-  normalizeRedditUrl,
   radarPlatformEnabled,
   sourceKindPlatform,
   radarBacklogExceeded,
   RADAR_PENDING_BACKLOG_CAP,
-  xCommunityUrl,
-  withinWindow,
-  maxAgeHoursFor,
-  isNoMatch404,
   radarDigestHtml
 } from './radar';
 import { communityKeyOf, renderCommunityProfile, renderVocabularyDigest } from './community-profile';
-
-describe('roundRobin (fair share across sources)', () => {
-  it('gives every source a slot before any takes a second — no starvation by a high-volume source', () => {
-    // news has 100 items but the two subs must still appear in the first passes.
-    const byOrigin = new Map<string, string[]>([
-      ['news', Array.from({ length: 100 }, (_, i) => `n${i}`)],
-      ['r/saas', ['s0', 's1']],
-      ['r/founder', ['f0', 'f1']]
-    ]);
-    const out = roundRobin(byOrigin, 6);
-    expect(out).toEqual(['n0', 's0', 'f0', 'n1', 's1', 'f1']);
-    // Both subs are represented — the old slice(0,N) in fetch order would have returned only news.
-    expect(out).toContain('s0');
-    expect(out).toContain('f0');
-  });
-
-  it('respects the cap and drains remaining sources when others empty', () => {
-    const byOrigin = new Map<string, number[]>([['a', [1, 2, 3]], ['b', [4]]]);
-    expect(roundRobin(byOrigin, 10)).toEqual([1, 4, 2, 3]); // b empties, a keeps going
-    expect(roundRobin(new Map(), 5)).toEqual([]);
-  });
-});
-
-describe('parseFeed', () => {
-  it('parses RSS 2.0 items (Google News shape)', () => {
-    const xml = `<?xml version="1.0"?><rss><channel>
-      <item><title><![CDATA[Il Kansas approva la legge X]]></title><link>https://news.google.com/rss/articles/abc</link>
-        <pubDate>Wed, 02 Jul 2026 10:00:00 GMT</pubDate><description>Snippet &amp; testo</description>
-        <source url="https://ilpost.it">Il Post</source></item>
-      <item><title>Seconda notizia</title><link>https://example.com/2</link></item>
-    </channel></rss>`;
-    const items = parseFeed(xml);
-    expect(items).toHaveLength(2);
-    expect(items[0].title).toBe('Il Kansas approva la legge X');
-    expect(items[0].url).toContain('news.google.com');
-    expect(items[0].sourceName).toBe('Il Post');
-    expect(items[0].snippet).toContain('Snippet & testo');
-    expect(items[0].publishedAt).toMatch(/^2026-07-02/);
-  });
-
-  it('parses Atom entries (Reddit shape)', () => {
-    const xml = `<feed xmlns="http://www.w3.org/2005/Atom">
-      <entry><title>Post dal subreddit</title><link href="https://reddit.com/r/x/comments/1"/>
-        <updated>2026-07-01T08:00:00Z</updated><content type="html">&lt;p&gt;body&lt;/p&gt;</content></entry>
-    </feed>`;
-    const items = parseFeed(xml);
-    expect(items).toHaveLength(1);
-    expect(items[0].url).toBe('https://www.reddit.com/r/x/comments/1');
-    expect(items[0].snippet).toContain('body');
-  });
-
-  it('rewrites old.reddit.com permalinks from rising RSS to www', () => {
-    const xml = `<feed xmlns="http://www.w3.org/2005/Atom">
-      <entry><title>Rising</title><link href="https://old.reddit.com/r/saas/comments/abc/title/"/>
-        <updated>2026-07-01T08:00:00Z</updated></entry>
-    </feed>`;
-    expect(parseFeed(xml)[0].url).toBe('https://www.reddit.com/r/saas/comments/abc/title/');
-  });
-
-  it('skips malformed blocks without throwing', () => {
-    expect(parseFeed('<rss><item><title>no link</title></item></rss>')).toHaveLength(0);
-    expect(parseFeed('garbage')).toHaveLength(0);
-  });
-});
-
-describe('normalizeRedditUrl', () => {
-  it('maps old/new/bare/relative hosts onto www.reddit.com', () => {
-    expect(normalizeRedditUrl('https://old.reddit.com/r/x/comments/1')).toBe('https://www.reddit.com/r/x/comments/1');
-    expect(normalizeRedditUrl('https://new.reddit.com/r/x/comments/1')).toBe('https://www.reddit.com/r/x/comments/1');
-    expect(normalizeRedditUrl('https://reddit.com/r/x/comments/1')).toBe('https://www.reddit.com/r/x/comments/1');
-    expect(normalizeRedditUrl('https://www.reddit.com/r/x/comments/1')).toBe('https://www.reddit.com/r/x/comments/1');
-    expect(normalizeRedditUrl('/r/x/comments/1')).toBe('https://www.reddit.com/r/x/comments/1');
-  });
-});
 
 describe('radarPrefsOf', () => {
   it('defaults to disabled digest with cap 1', () => {
@@ -231,48 +150,6 @@ describe('radarBacklogExceeded (pending-user queue cap)', () => {
   });
 });
 
-describe('xCommunityUrl', () => {
-  // The endpoint takes `url`, not `id`. Passing the bare id errored, the fetcher swallowed it, and
-  // every scan logged "0 items" — X looked configured and simply never produced a lead.
-  it('builds the community URL from a bare id', () => {
-    expect(xCommunityUrl('1926186499399139650')).toBe('https://x.com/i/communities/1926186499399139650');
-  });
-
-  it('accepts a pasted community URL', () => {
-    expect(xCommunityUrl('https://x.com/i/communities/1926186499399139650')).toBe(
-      'https://x.com/i/communities/1926186499399139650'
-    );
-    expect(xCommunityUrl(' twitter.com/i/communities/42/ ')).toBe('https://x.com/i/communities/42');
-  });
-
-  it('returns empty when there is no id to find, so the caller can say why', () => {
-    expect(xCommunityUrl('marketing')).toBe('');
-    expect(xCommunityUrl('')).toBe('');
-  });
-});
-
-describe('freshness windows', () => {
-  const item = (hoursAgo: number) => ({
-    title: 't', url: 'u', snippet: '', sourceName: 's', publishedAt: null,
-    createdUtc: Date.now() / 1000 - hoursAgo * 3600
-  });
-
-  it('keeps Reddit tight (rising = now) and gives the slower platforms 48h', () => {
-    expect(maxAgeHoursFor('subreddit')).toBe(12);
-    expect(maxAgeHoursFor('reddit_query')).toBe(12);
-    expect(maxAgeHoursFor('threads_query')).toBe(48);
-    expect(maxAgeHoursFor('linkedin_query')).toBe(48);
-    expect(maxAgeHoursFor('x_community')).toBe(48);
-  });
-
-  it('drops what is outside the window and keeps what is inside', () => {
-    const items = [item(1), item(24), item(60)];
-    expect(withinWindow('subreddit', items)).toHaveLength(1);
-    // A Threads search ranks by relevance, not recency: the 12h cut used to leave nothing.
-    expect(withinWindow('threads_query', items)).toHaveLength(2);
-  });
-});
-
 describe('communityKeyOf', () => {
   it('keys Reddit per subreddit — two subs on one topic are two different rooms', () => {
     expect(communityKeyOf('r/smallbusiness', 'https://www.reddit.com/r/smallbusiness/comments/x/y/')).toEqual({
@@ -329,31 +206,6 @@ describe('renderVocabularyDigest', () => {
   });
 });
 
-describe('isNoMatch404 (LinkedIn: nessun risultato vestito da errore)', () => {
-  // Verificato in produzione: 404 + not_found + credits_charged 0, mentre lo stesso endpoint
-  // riempiva il catalogo globale quella mattina. È un insieme vuoto, non un guasto.
-  const noMatch = new Error(
-    'scrapecreators 404: {"success":false,"credits_remaining":12651,"credits_charged":0,"error":"not_found","errorStatus":404}'
-  );
-
-  it('riconosce il no-match documentato', () => {
-    expect(isNoMatch404(noMatch)).toBe(true);
-  });
-
-  it('NON inghiotte gli altri errori: un path rotto deve restare rumoroso', () => {
-    expect(isNoMatch404(new Error('scrapecreators 404: {"error":"route_not_found"}'))).toBe(false);
-    expect(isNoMatch404(new Error('scrapecreators 401: {"error":"not_found"}'))).toBe(false);
-    expect(isNoMatch404(new Error('scrapecreators 500: server error'))).toBe(false);
-    expect(isNoMatch404(new Error('fetch failed'))).toBe(false);
-  });
-
-  it('guarda il corpo del messaggio, non il tipo di quello che è stato lanciato', () => {
-    // Il client lancia sempre un Error, ma la verità sta nel corpo: se un giorno arrivasse come
-    // stringa la risposta non cambierebbe di significato.
-    expect(isNoMatch404('scrapecreators 404: {"error":"not_found"}')).toBe(true);
-  });
-});
-
 describe('radarDigestHtml (la mail porta la merce: testo pronto + link diretto)', () => {
   it('con radarUrl porta il link di disiscrizione nel corpo, non solo negli header', () => {
     const html = radarDigestHtml(false, 'https://app.example.com', [], [], [], 'https://app.example.com/app/acme/radar');
@@ -393,10 +245,3 @@ describe('radarDigestHtml (la mail porta la merce: testo pronto + link diretto)'
   });
 });
 
-describe('sorgenti Reddit (solo ScrapeCreators e RSS: niente OAuth ufficiale)', () => {
-  it('non resta alcun riferimento al client OAuth Reddit nel radar', async () => {
-    const { readFile } = await import('node:fs/promises');
-    const src = await readFile(new URL('./radar.ts', import.meta.url), 'utf8');
-    expect(src).not.toMatch(/oauth\.reddit\.com|REDDIT_CLIENT_(ID|SECRET)|redditAccessToken|redditGet/);
-  });
-});

--- a/src/lib/server/radar.test.ts
+++ b/src/lib/server/radar.test.ts
@@ -13,9 +13,6 @@ import {
   withinWindow,
   maxAgeHoursFor,
   isNoMatch404,
-  buildEngagePrompt,
-  selectTopComments,
-  COMMENT_MIN_RELEVANCE,
   radarDigestHtml
 } from './radar';
 import { communityKeyOf, renderCommunityProfile, renderVocabularyDigest } from './community-profile';
@@ -354,81 +351,6 @@ describe('isNoMatch404 (LinkedIn: nessun risultato vestito da errore)', () => {
     // Il client lancia sempre un Error, ma la verità sta nel corpo: se un giorno arrivasse come
     // stringa la risposta non cambierebbe di significato.
     expect(isNoMatch404('scrapecreators 404: {"error":"not_found"}')).toBe(true);
-  });
-});
-
-describe('buildEngagePrompt (la lingua è quella del THREAD, non del brand)', () => {
-  // Brand italiano, thread inglese: il caso reale che produceva bozze in italiano su Reddit EN.
-  const base = {
-    brandName: 'Trattoria Bio',
-    about: 'Prodotti biologici italiani, spedizione in tutta Europa.',
-    siteUrl: 'https://trattoriabio.it',
-    aiContext: 'Voce: diretta, concreta, italiana.',
-    sourceName: 'r/organicfarming',
-    title: 'What should I look for when buying organic olive oil?',
-    body: 'I keep seeing conflicting labels at the store. My budget is limited. How do I know the oil is actually organic?',
-    topComments: '- Look for the EU organic leaf logo',
-    author: 'oliveguy',
-    intent: 'researching' as const,
-    profileBlock: '',
-    toneHint: '\nTONE: Write in a friendly tone.',
-    styleHint: '\nSTYLE INSTRUCTIONS (PRIORITY — override any conflicting rules below): Sii cinico. No emoji.'
-  };
-
-  it('pins the reply language to the thread and carries the thread text the model detects it from', () => {
-    const p = buildEngagePrompt(base);
-    expect(p).toContain('REPLY LANGUAGE — ABSOLUTE RULE');
-    expect(p).toContain('language of the THREAD');
-    // le istruzioni di stile (spesso in italiano) governano lo stile, mai la lingua
-    expect(p).toContain('Style instructions shape style, never language');
-    // il testo su cui rilevare la lingua è nel prompt: titolo e corpo del thread
-    expect(p).toContain(base.title);
-    expect(p).toContain('conflicting labels');
-  });
-
-  it('guards the known failure modes: filler openers, title-only answers, echoing the thread, unsolicited pitch', () => {
-    const p = buildEngagePrompt(base);
-    expect(p).toContain('NO FILLER OPENERS');
-    expect(p).toContain('ANSWER THE ACTUAL QUESTION');
-    expect(p).toContain('ADD VALUE BEYOND THE THREAD');
-    expect(p).toContain('NO UNSOLICITED PITCH');
-    // i commenti già presenti arrivano al drafter come "già detto", non come suggerimento
-    expect(p).toContain('EU organic leaf logo');
-    expect(p).toContain('never restate it');
-  });
-
-  it("includes the owner's recent before→after edits, and omits the block when there are none", () => {
-    const withPairs = buildEngagePrompt({
-      ...base,
-      editPairs: [{ before: 'Bozza lunga e promozionale', after: 'Corta e utile', feedback: 'meno pitch' }]
-    });
-    expect(withPairs).toContain('HOW THE OWNER REWRITES YOUR DRAFTS');
-    expect(withPairs).toContain('BEFORE: Bozza lunga e promozionale');
-    expect(withPairs).toContain('AFTER: Corta e utile');
-    expect(withPairs).toContain('meno pitch');
-    // senza riscritture il drafter lavora come prima: nessun blocco vuoto nel prompt
-    expect(buildEngagePrompt(base)).not.toContain('HOW THE OWNER REWRITES');
-  });
-});
-
-describe('selectTopComments (il cap è "gli N migliori", non "i primi N")', () => {
-  const c = (id: string, relevance: number, intent: 'seeking_now' | 'none') =>
-    ({ id, action: 'comment', relevance, intent });
-
-  it('picks by intent then relevance, regardless of arrival order', () => {
-    const picked = [c('a', 72, 'none'), c('b', 90, 'none'), c('c', 71, 'seeking_now'), c('d', 99, 'none')];
-    // 'c' compra adesso (batte tutti), poi 'd' per rilevanza — 'a' arrivato primo NON entra.
-    expect(selectTopComments(picked, 2).map((x) => x.id)).toEqual(['c', 'd']);
-  });
-
-  it('drops below-floor comments and non-comment actions, and honours a zero budget', () => {
-    const picked = [
-      { id: 'p', action: 'post', relevance: 99, intent: 'none' as const },
-      c('low', COMMENT_MIN_RELEVANCE - 1, 'seeking_now'),
-      c('ok', 80, 'none')
-    ];
-    expect(selectTopComments(picked, 5).map((x) => x.id)).toEqual(['ok']);
-    expect(selectTopComments(picked, 0)).toEqual([]);
   });
 });
 

--- a/src/lib/server/radar.test.ts
+++ b/src/lib/server/radar.test.ts
@@ -18,7 +18,6 @@ import {
   COMMENT_MIN_RELEVANCE,
   radarDigestHtml
 } from './radar';
-import { normalizeIntent, INTENT_RANK } from '$lib/leads-intent';
 import { communityKeyOf, renderCommunityProfile, renderVocabularyDigest } from './community-profile';
 
 describe('roundRobin (fair share across sources)', () => {
@@ -274,22 +273,6 @@ describe('freshness windows', () => {
     expect(withinWindow('subreddit', items)).toHaveLength(1);
     // A Threads search ranks by relevance, not recency: the 12h cut used to leave nothing.
     expect(withinWindow('threads_query', items)).toHaveLength(2);
-  });
-});
-
-describe('intent', () => {
-  it('normalises anything the model returns to a known band', () => {
-    expect(normalizeIntent('seeking_now')).toBe('seeking_now');
-    expect(normalizeIntent('SEEKING_NOW')).toBe('seeking_now');
-    expect(normalizeIntent('ready to buy')).toBe('none');
-    expect(normalizeIntent(undefined)).toBe('none');
-  });
-
-  it('ranks someone asking now above someone venting', () => {
-    expect(INTENT_RANK.seeking_now).toBeGreaterThan(INTENT_RANK.comparing);
-    expect(INTENT_RANK.comparing).toBeGreaterThan(INTENT_RANK.researching);
-    expect(INTENT_RANK.researching).toBeGreaterThan(INTENT_RANK.venting);
-    expect(INTENT_RANK.venting).toBeGreaterThan(INTENT_RANK.none);
   });
 });
 

--- a/src/lib/server/radar.ts
+++ b/src/lib/server/radar.ts
@@ -29,7 +29,7 @@ import { brandContacts } from './scheduler';
 import { generateBlogFromNews } from './blog-generate';
 import { hasProRadarLeads, isRadarKindAllowed, leadEngagePlatforms, radarSourceLimit, type RadarPlatformKey, RADAR_PLATFORM_KEYS } from './plans';
 import { ALT_CAPTION_PLATFORMS, ensureShortNetworkCuts } from '$lib/platform-limits';
-import { contactGate, dmWithOptOut, gateVerdict, platformOf, suppressAuthor } from './lead-contact';
+import { contactGate, dmWithOptOut, gateVerdict, platformOf } from '@anomalia/leads-core/contact';
 // Re-exported: Settings → Radar imports the type from here, next to the functions that use it.
 export type { RadarPlatformKey } from './plans';
 import { INTENT_RANK, normalizeIntent, type LeadIntent } from '@anomalia/leads-core/intent';

--- a/src/lib/server/radar.ts
+++ b/src/lib/server/radar.ts
@@ -32,7 +32,7 @@ import { ALT_CAPTION_PLATFORMS, ensureShortNetworkCuts } from '$lib/platform-lim
 import { contactGate, dmWithOptOut, gateVerdict, platformOf, suppressAuthor } from './lead-contact';
 // Re-exported: Settings → Radar imports the type from here, next to the functions that use it.
 export type { RadarPlatformKey } from './plans';
-import { INTENT_RANK, normalizeIntent, type LeadIntent } from '$lib/leads-intent';
+import { INTENT_RANK, normalizeIntent, type LeadIntent } from '@anomalia/leads-core/intent';
 import {
   communityKeyOf,
   loadCommunityProfiles,
@@ -581,11 +581,6 @@ export type RadarVerdictItem = {
   // How close this person is to buying — see LEAD_INTENTS. Feed items are always 'none'.
   intent: LeadIntent;
 };
-
-// Intent lives in `$lib/leads-intent` so the Leads page can rank and label without importing the
-// server-side Radar module; re-exported here because every server caller reaches for it via radar.
-export { LEAD_INTENTS, INTENT_RANK, normalizeIntent } from '$lib/leads-intent';
-export type { LeadIntent } from '$lib/leads-intent';
 
 const VERDICT_SCHEMA = {
   type: 'object' as const,

--- a/src/lib/server/radar.ts
+++ b/src/lib/server/radar.ts
@@ -197,7 +197,17 @@ const fetchViaBrowser = async (url: string): Promise<string | null> => {
 
 // Le credenziali si leggono a OGNI chiamata, non qui: `$env/dynamic/private` è vivo, e congelarlo
 // alla costruzione vorrebbe dire che un cambio d'ambiente non arriva mai.
-const sources = createSources({
+// Destrutturate e non tenute come oggetto: `sources` qui dentro è già il nome delle righe di
+// `brand_news_sources` lette dal database, in tre funzioni diverse — un oggetto con quel nome
+// verrebbe ombreggiato da ognuna, in silenzio.
+const {
+  fetchSourceFeed,
+  fetchRedditSearch,
+  fetchThreadsSearch,
+  fetchLinkedInSearch,
+  fetchRedditText,
+  redditRssAuth
+} = createSources({
   scrape: scrapeCreatorsGet,
   redditAuth: () => ({ token: env.REDDIT_FEED_TOKEN, user: env.REDDIT_FEED_USER }),
   fetchViaBrowser
@@ -350,7 +360,7 @@ export async function buildRadarFeedCache(admin: SupabaseClient, brandIds: strin
   const fetched = await Promise.all(
     [...uniq.entries()].map(async ([key, s]) => {
       try {
-        return { source_key: key, items: await sources.fetchSourceFeed(s), fetched_at: now };
+        return { source_key: key, items: await fetchSourceFeed(s), fetched_at: now };
       } catch (e) {
         // A FAILED fetch is never cached. Caching it as an empty list would hand the per-brand
         // scan a clean cache hit with zero items, and the error would vanish exactly the way the
@@ -395,7 +405,7 @@ export async function radarDiagnose(
       };
     }
     try {
-      const items = await sources.fetchSourceFeed({ kind, value: String(s.value), lang: s.lang ?? null });
+      const items = await fetchSourceFeed({ kind, value: String(s.value), lang: s.lang ?? null });
       return { ...base, items: items.length, windowHours: maxAgeHoursFor(kind), sample: items.slice(0, 3).map((i) => ({ title: i.title.slice(0, 120), url: i.url })) };
     } catch (e) {
       return { ...base, items: 0, error: e instanceof Error ? e.message.slice(0, 300) : String(e) };
@@ -498,7 +508,7 @@ export async function radarScan(
         return tag(hit);
       }
       try {
-        const items = await sources.fetchSourceFeed(s);
+        const items = await fetchSourceFeed(s);
         searchLog.push({ kind: s.kind, value: s.value, items: items.length, fromCache: false, ok: true });
         return tag(items);
       } catch (e) {
@@ -526,13 +536,13 @@ export async function radarScan(
     if (ctx.length > 10) {
       const searchers: Array<{ kind: 'reddit_query' | 'threads_query' | 'linkedin_query'; prefix: string; run: (q: string) => Promise<RedditItem[]> }> = [];
       if (radarPlatformEnabled(prefs, 'reddit', brand.plan)) {
-        searchers.push({ kind: 'reddit_query', prefix: 'rq', run: sources.fetchRedditSearch });
+        searchers.push({ kind: 'reddit_query', prefix: 'rq', run: fetchRedditSearch });
       }
       if (radarPlatformEnabled(prefs, 'threads', brand.plan)) {
-        searchers.push({ kind: 'threads_query', prefix: 'tq', run: sources.fetchThreadsSearch });
+        searchers.push({ kind: 'threads_query', prefix: 'tq', run: fetchThreadsSearch });
       }
       if (radarPlatformEnabled(prefs, 'linkedin', brand.plan)) {
-        searchers.push({ kind: 'linkedin_query', prefix: 'lq', run: sources.fetchLinkedInSearch });
+        searchers.push({ kind: 'linkedin_query', prefix: 'lq', run: fetchLinkedInSearch });
       }
       if (searchers.length) {
         const platformsLabel = searchers.map((s) => (s.kind === 'reddit_query' ? 'Reddit' : s.kind === 'threads_query' ? 'Threads' : 'LinkedIn')).join(', ');
@@ -798,7 +808,7 @@ export async function radarEngage(
       // <threads|x|linkedin url>/.rss, got nothing back, and then overwrote the body and the top
       // comments ScrapeCreators had just returned with the empty result.
       if (isReddit && !postBody) {
-        const xml = await sources.fetchRedditText(sources.redditRssAuth(`${it.url.replace(/\/$/, '').replace('://www.', '://old.')}/.rss`));
+        const xml = await fetchRedditText(redditRssAuth(`${it.url.replace(/\/$/, '').replace('://www.', '://old.')}/.rss`));
         const entries = xml ? parseFeed(xml) : [];
         postBody = entries[0]?.snippet ?? '';
         topComments = entries.slice(1, 6)

--- a/src/lib/server/radar.ts
+++ b/src/lib/server/radar.ts
@@ -31,6 +31,18 @@ import { hasProRadarLeads, isRadarKindAllowed, leadEngagePlatforms, radarSourceL
 import { ALT_CAPTION_PLATFORMS, ensureShortNetworkCuts } from '$lib/platform-limits';
 import { authorProfileUrl, contactGate, dmWithOptOut, gateVerdict, platformOf } from '@anomalia/leads-core/contact';
 import { COMMENT_MIN_RELEVANCE, COMMENT_SCHEMA, buildEngagePrompt, selectTopComments } from '@anomalia/leads-core/prompts';
+import {
+  createSources,
+  maxAgeHoursFor,
+  normalizeRedditUrl,
+  parseFeed,
+  roundRobin,
+  sourceKey,
+  withinWindow,
+  type FeedItem,
+  type RedditItem,
+  type SourceRef
+} from '@anomalia/leads-core/feed';
 // Re-exported: Settings → Radar imports the type from here, next to the functions that use it.
 export type { RadarPlatformKey } from './plans';
 import { INTENT_RANK, normalizeIntent, type LeadIntent } from '@anomalia/leads-core/intent';
@@ -162,334 +174,34 @@ export function radarPrefsOf(contentPrefs: AnyRec | null | undefined): RadarPref
   };
 }
 
-// ── Feed fetching (zero dependencies) ───────────────────────────────────────────────────────────
 
-export type FeedItem = { title: string; url: string; snippet: string; sourceName: string; publishedAt: string | null };
-
-const strip = (s: string) =>
-  s
-    .replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, '$1')
-    .replace(/<[^>]+>/g, ' ')
-    .replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&quot;/g, '"').replace(/&#39;|&apos;/g, "'").replace(/&nbsp;/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim();
-
-const tag = (xml: string, name: string) => {
-  const m = xml.match(new RegExp(`<${name}[^>]*>([\\s\\S]*?)<\\/${name}>`, 'i'));
-  return m ? strip(m[1]) : '';
+// ── Le sorgenti, con dentro quello che il package non può procurarsi ────────────────────────────
+//
+// Reddit dà 403 ai client HTTP da server (Node/undici) anche con auth valida, mentre i browser
+// veri passano: il ripiego è Chrome vero via Browserless. Il package non lo sa — riceve solo "una
+// funzione che dato un URL torna il testo", e qui dentro c'è l'unico posto che conosce lo script
+// di pagina. ~1 unità Browserless a chiamata; il traffico reddit è una manciata di richieste al giorno.
+const fetchViaBrowser = async (url: string): Promise<string | null> => {
+  const { isBrowserlessConfigured, browserlessFunction } = await import('./browserless');
+  if (!isBrowserlessConfigured()) return null;
+  const out = await browserlessFunction(
+    `export default async ({ page, context }) => {
+      const res = await page.goto(context.url, { waitUntil: 'domcontentloaded', timeout: 20000 });
+      if (!res || res.status() >= 400) return null;
+      return await res.text();
+    }`,
+    { url }
+  );
+  return typeof out === 'string' && out.trim() ? out : null;
 };
 
-// Reddit's rising RSS is fetched from old.reddit.com (less fingerprint-blocked), but those feeds
-// emit old.reddit.com permalinks. Always rewrite to www so /leads and digest emails open the
-// current Reddit UI — never the classic old.reddit skin.
-export function normalizeRedditUrl(url: string): string {
-  const u = (url ?? '').trim();
-  if (!u) return u;
-  if (u.startsWith('/r/') || u.startsWith('/user/') || u.startsWith('/u/')) return `https://www.reddit.com${u}`;
-  return u.replace(/^https?:\/\/(old\.|new\.|www\.)?reddit\.com/i, 'https://www.reddit.com');
-}
-
-// Tolerant RSS 2.0 + Atom parser: enough for Google News, standard RSS and Reddit's Atom feeds.
-// ponytail: regex XML parsing — fine for well-formed feeds; swap for a real parser if a needed
-// source ever breaks it.
-export function parseFeed(xml: string): FeedItem[] {
-  const out: FeedItem[] = [];
-  const blocks = [...xml.matchAll(/<item[\s>][\s\S]*?<\/item>/gi), ...xml.matchAll(/<entry[\s>][\s\S]*?<\/entry>/gi)].map((m) => m[0]);
-  for (const b of blocks) {
-    const title = tag(b, 'title');
-    // RSS: <link>url</link>. Atom/Reddit: <link href="url"/>.
-    let url = tag(b, 'link');
-    if (!url) url = b.match(/<link[^>]+href=["']([^"']+)["']/i)?.[1] ?? '';
-    if (!title || !url) continue;
-    const snippet = (tag(b, 'description') || tag(b, 'summary') || tag(b, 'content')).slice(0, 1000);
-    const sourceName = tag(b, 'source') || tag(b, 'author') || '';
-    const dateRaw = tag(b, 'pubDate') || tag(b, 'published') || tag(b, 'updated');
-    const t = dateRaw ? Date.parse(dateRaw) : NaN;
-    const cleaned = strip(url);
-    out.push({
-      title,
-      url: /reddit\.com/i.test(cleaned) || cleaned.startsWith('/r/') ? normalizeRedditUrl(cleaned) : cleaned,
-      snippet,
-      sourceName,
-      publishedAt: Number.isNaN(t) ? null : new Date(t).toISOString()
-    });
-  }
-  return out;
-}
-
-const FEED_TIMEOUT_MS = 10_000;
-const ITEMS_PER_FEED = 15;
-
-function feedUrlFor(source: { kind: string; value: string; lang?: string | null }): string {
-  if (source.kind === 'gnews_query') {
-    const lang = (source.lang ?? 'auto').toLowerCase();
-    if (lang === 'auto') {
-      // Auto: no locale params — Google decides based on query
-      return `https://news.google.com/rss/search?q=${encodeURIComponent(source.value)}`;
-    }
-    // Map language code → Google News hl/gl/ceid
-    const LANG_MAP: Record<string, [string, string, string]> = {
-      en: ['en-US', 'US', 'US:en'], it: ['it', 'IT', 'IT:it'], es: ['es', 'ES', 'ES:es'],
-      fr: ['fr', 'FR', 'FR:fr'], de: ['de', 'DE', 'DE:de'], pt: ['pt-BR', 'BR', 'BR:pt'],
-      nl: ['nl', 'NL', 'NL:nl'], pl: ['pl', 'PL', 'PL:pl'], ro: ['ro', 'RO', 'RO:ro'],
-      sv: ['sv', 'SE', 'SE:sv'], no: ['no', 'NO', 'NO:no'], da: ['da', 'DK', 'DK:da'],
-      fi: ['fi', 'FI', 'FI:fi'], cs: ['cs', 'CZ', 'CZ:cs'], sk: ['sk', 'SK', 'SK:sk'],
-      hu: ['hu', 'HU', 'HU:hu'], hr: ['hr', 'HR', 'HR:hr'], sr: ['sr', 'RS', 'RS:sr'],
-      sl: ['sl', 'SI', 'SI:sl'], bg: ['bg', 'BG', 'BG:bg'], uk: ['uk', 'UA', 'UA:uk'],
-      ru: ['ru', 'RU', 'RU:ru'], tr: ['tr', 'TR', 'TR:tr'], el: ['el', 'GR', 'GR:el'],
-      ar: ['ar', 'SA', 'SA:ar'], he: ['he', 'IL', 'IL:he'], fa: ['fa', 'IR', 'IR:fa'],
-      hi: ['hi', 'IN', 'IN:hi'], th: ['th', 'TH', 'TH:th'], vi: ['vi', 'VN', 'VN:vi'],
-      id: ['id', 'ID', 'ID:id'], ms: ['ms', 'MY', 'MY:ms'], zh: ['zh-CN', 'CN', 'CN:zh'],
-      ja: ['ja', 'JP', 'JP:ja'], ko: ['ko', 'KR', 'KR:ko'],
-    };
-    const [hl, gl, ceid] = LANG_MAP[lang] ?? ['en-US', 'US', 'US:en'];
-    return `https://news.google.com/rss/search?q=${encodeURIComponent(source.value)}&hl=${hl}&gl=${gl}&ceid=${ceid}`;
-  }
-  if (source.kind === 'subreddit') return redditRssAuth(`https://www.reddit.com/r/${source.value.replace(/^r\//, '')}/.rss`);
-  return source.value; // plain RSS url
-}
-
-async function fetchFeed(source: { kind: string; value: string; lang?: string | null; name?: string }): Promise<FeedItem[]> {
-  try {
-    const res = await fetch(feedUrlFor(source), {
-      signal: AbortSignal.timeout(FEED_TIMEOUT_MS),
-      headers: { 'User-Agent': 'Mozilla/5.0 (compatible; AnomaliaRadar/1.0)', Accept: 'application/rss+xml, application/atom+xml, application/xml, text/xml' }
-    });
-    if (!res.ok) return [];
-    return parseFeed(await res.text()).slice(0, ITEMS_PER_FEED);
-  } catch {
-    return []; // a dead feed never breaks the scan
-  }
-}
-
-// ── Reddit engage sources (timing-aware) ────────────────────────────────────────────────────────
-// A good comment lands on a thread that's RISING right now. Reddit's unauthenticated JSON API is
-// gone (403), but the RSS endpoints still serve: /r/{sub}/rising/.rss for the timing signal and
-// {permalink}/.rss for a thread's body + comments. READ-ONLY by design: Anomalia never posts or
-// comments; it only drafts a suggestion for the human. ponytail: on a 429 the catch returns [].
-const ENGAGE_MAX_AGE_HOURS = 12;
-// Threads / X / LinkedIn are a different clock. Their search endpoints rank by relevance, not
-// recency (Threads has no date filter at all), and a post there stays live for days instead of
-// falling off a rising list in hours. Cutting them at 12h threw away nearly every result — the
-// scan logged "0 items" and looked like an empty feed rather than a window that was too narrow.
-const CONVERSATION_MAX_AGE_HOURS = 48;
-type RedditItem = FeedItem & { createdUtc: number };
-
-const REDDIT_UA = 'AnomaliaRadar/1.0 (read-only; instant-marketing suggestions)';
-
-// Personal-feed auth for Reddit RSS: since 2026 the anonymous feeds are fingerprint-blocked from
-// servers, but every account has a private feed token (reddit.com/prefs/feeds) — appending
-// ?feed=TOKEN&user=USERNAME turns the request into the user's own authenticated feed and passes.
-// Simpler than OAuth and read-only by construction. '' when the env isn't set.
-function redditRssAuth(url: string): string {
-  const feed = env.REDDIT_FEED_TOKEN;
-  const user = env.REDDIT_FEED_USER;
-  if (!feed || !user) return url;
-  return `${url}${url.includes('?') ? '&' : '?'}feed=${encodeURIComponent(feed)}&user=${encodeURIComponent(user)}`;
-}
-
-// Fetch a Reddit URL's raw body, dodging the TLS-fingerprint wall: Reddit 403s server HTTP clients
-// (Node/undici) even with valid feed auth, while real browsers pass. Chain: plain fetch (in case
-// this network passes) → Browserless (REAL Chrome, real fingerprint — verified: curl/browser 200
-// where Node 403). null when both fail. ~1 Browserless unit per call; reddit traffic is a handful
-// of requests per day.
-async function fetchRedditText(url: string): Promise<string | null> {
-  try {
-    const res = await fetch(url, { signal: AbortSignal.timeout(FEED_TIMEOUT_MS), headers: { 'User-Agent': REDDIT_UA } });
-    if (res.ok) return await res.text();
-  } catch { /* fall through to browserless */ }
-  try {
-    const { isBrowserlessConfigured, browserlessFunction } = await import('./browserless');
-    if (!isBrowserlessConfigured()) return null;
-    const out = await browserlessFunction(
-      `export default async ({ page, context }) => {
-        const res = await page.goto(context.url, { waitUntil: 'domcontentloaded', timeout: 20000 });
-        if (!res || res.status() >= 400) return null;
-        return await res.text();
-      }`,
-      { url }
-    );
-    return typeof out === 'string' && out.trim() ? out : null;
-  } catch {
-    return null;
-  }
-}
-
-// NOTE (verified live 2026-07-03): Exa (exa.ai) is NOT an option for Reddit — the API rejects
-// includeDomains:['reddit.com'] ("domain not available") and its index contains zero reddit URLs
-// (Reddit's data is exclusively licensed). For server-side Reddit reads the paths are
-// ScrapeCreators and the RSS feeds.
-// Fair-share selection: round-robin one item per origin per pass, up to `cap`. Guarantees every
-// source with fresh content contributes before any single source takes a second slot — so a
-// high-volume source can't starve the others (see radarScan). Pure + exported for tests.
-export function roundRobin<T>(byOrigin: Map<string, T[]>, cap: number): T[] {
-  const qList = [...byOrigin.values()];
-  const out: T[] = [];
-  while (out.length < cap && qList.some((q) => q.length)) {
-    for (const q of qList) {
-      if (!q.length) continue;
-      out.push(q.shift()!);
-      if (out.length >= cap) break;
-    }
-  }
-  return out;
-}
-
-async function fetchSubredditRising(sub: string): Promise<RedditItem[]> {
-  const clean = sub.replace(/^r\//, '').replace(/\/+$/, '');
-  // PRIMARY: ScrapeCreators' Reddit endpoint — same key/gateway the whole app already uses for
-  // IG/TikTok/etc., with real `rising` sort and full post fields. The RSS chain below stays as
-  // fallback.
-  try {
-    const data = await scrapeCreatorsGet(`/v1/reddit/subreddit?subreddit=${encodeURIComponent(clean)}&sort=rising&trim=true`);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const raw: AnyRec[] = Array.isArray(data?.posts) ? data.posts : Array.isArray(data?.data?.children) ? data.data.children.map((c: any) => c?.data ?? c) : [];
-    const mapped = raw
-      .map((d) => ({
-        title: String(d?.title ?? ''),
-        url: d?.permalink ? `https://www.reddit.com${String(d.permalink).startsWith('/') ? d.permalink : `/${d.permalink}`}` : String(d?.url ?? ''),
-        snippet: String(d?.selftext ?? '').slice(0, 1000),
-        sourceName: `r/${clean}`,
-        publishedAt: d?.created_utc ? new Date(Number(d.created_utc) * 1000).toISOString() : null,
-        createdUtc: Number(d?.created_utc) || 0
-      }))
-      .filter((i) => i.title && i.url.includes('/comments/'));
-    if (mapped.length) return mapped;
-  } catch (e) {
-    console.warn(`[radar] scrapecreators reddit r/${clean} failed:`, e instanceof Error ? e.message.slice(0, 120) : e);
-  }
-  // Fallback: the RSS endpoint, which works from some networks (curl-like clients) but is
-  // fingerprint-blocked from most servers.
-  const xml = await fetchRedditText(redditRssAuth(`https://old.reddit.com/r/${encodeURIComponent(clean)}/rising/.rss`));
-  if (!xml) {
-    console.warn(`[radar] reddit r/${clean} unavailable — set REDDIT_FEED_TOKEN/USER (prefs/feeds)`);
-    return [];
-  }
-  return parseFeed(xml)
-    .filter((i) => i.url.includes('/comments/'))
-    .map((i) => ({ ...i, sourceName: `r/${clean}`, createdUtc: i.publishedAt ? Date.parse(i.publishedAt) / 1000 : 0 }));
-}
-
-// Conversation searches (Threads / Reddit / LinkedIn / X) all go through ScrapeCreators.
-//
-// Errors PROPAGATE on purpose. These used to `catch { return [] }`, so a wrong parameter or an
-// expired key was logged in radar_searches as "0 items" — indistinguishable from "no conversation
-// worth joining today". That is how the X source stayed silently dead: it was called with `id=`
-// where the endpoint wants `url=`, and every scan reported a clean, empty success.
-
-// Threads keyword search (/v1/threads/search): up to 10 posts per query (Threads' own ceiling),
-// with engagement counts and taken_at for the freshness cut.
-async function fetchThreadsSearch(query: string): Promise<RedditItem[]> {
-  // NB: the endpoint's start_date filter returns 0 results (verified live) — fetch unfiltered
-  // and let the caller's createdUtc cutoff do the freshness cut.
-  const data = await scrapeCreatorsGet(`/v1/threads/search?query=${encodeURIComponent(query)}&trim=true`);
-  return ((data?.posts ?? []) as AnyRec[])
-    .map((post) => ({
-      title: String(post?.caption?.text ?? '').replace(/\s+/g, ' ').slice(0, 200),
-      url: post?.code && post?.user?.username ? `https://www.threads.net/@${post.user.username}/post/${post.code}` : '',
-      snippet: String(post?.caption?.text ?? '').slice(0, 1000),
-      sourceName: `threads${post?.user?.username ? ` · @${post.user.username}` : ''}`,
-      publishedAt: post?.taken_at ? new Date(Number(post.taken_at) * 1000).toISOString() : null,
-      createdUtc: Number(post?.taken_at) || 0
-    }))
-    .filter((i) => i.title && i.url);
-}
-
-// Global Reddit keyword search (/v1/reddit/search): finds conversations across ALL of Reddit,
-// not just the brand's own subreddits — same shape as fetchThreadsSearch.
-async function fetchRedditSearch(query: string): Promise<RedditItem[]> {
-  const data = await scrapeCreatorsGet(`/v1/reddit/search?query=${encodeURIComponent(query)}&sort=new&timeframe=day&trim=true`);
-  return ((data?.posts ?? []) as AnyRec[])
-    .map((post) => ({
-      title: String(post?.title ?? ''),
-      url: post?.permalink ? `https://www.reddit.com${String(post.permalink).startsWith('/') ? post.permalink : `/${post.permalink}`}` : String(post?.url ?? ''),
-      snippet: String(post?.selftext ?? '').slice(0, 1000),
-      // Keep the `r/` prefix: the verdict prompt's Reddit conversation ruler and the UI both key
-      // off it to treat these like subreddit items.
-      sourceName: `r/${post?.subreddit ?? ''}`,
-      publishedAt: post?.created_utc ? new Date(Number(post.created_utc) * 1000).toISOString() : null,
-      createdUtc: Number(post?.created_utc) || 0
-    }))
-    .filter((i) => i.title && i.url.includes('/comments/'));
-}
-
-/**
- * LinkedIn's search says "nessun post corrisponde" with a **404 `not_found`** and charges zero
- * credits — un risultato vuoto vestito da errore. Verificato in produzione: due query hanno preso
- * 404 mentre il catalogo globale aveva 15 post LinkedIn presi dallo stesso endpoint quel mattino,
- * e il giorno prima la stessa query dinamica ne aveva restituiti 2.
- *
- * Il riconoscimento è volutamente stretto — solo il corpo documentato del no-match — perché ogni
- * altro 404 (path sbagliato, endpoint rimosso) resta un errore vero e deve continuare a urlare.
- */
-export function isNoMatch404(e: unknown): boolean {
-  const m = e instanceof Error ? e.message : String(e);
-  return m.startsWith('scrapecreators 404') && m.includes('"not_found"');
-}
-
-// Global LinkedIn keyword search (/v1/linkedin/search/posts): the B2B lead surface.
-// `date_posted=last-day` keeps it fresh; the post's full text rides in `snippet`, so the comment
-// drafter can work off it without a second fetch (LinkedIn has no comments endpoint here).
-async function fetchLinkedInSearch(query: string): Promise<RedditItem[]> {
-  let data: AnyRec | null;
-  try {
-    data = await scrapeCreatorsGet(`/v1/linkedin/search/posts?query=${encodeURIComponent(query)}&date_posted=last-day`);
-  } catch (e) {
-    // "Nessun post" non è un guasto: segnarlo rosso nella cronologia scan sarebbe l'errore opposto
-    // a quello che abbiamo appena tolto — gridare al lupo invece di tacere. Resta nei log.
-    if (isNoMatch404(e)) {
-      console.warn(`[radar] linkedin search: nessun risultato per "${query.slice(0, 60)}"`);
-      return [];
-    }
-    throw e;
-  }
-  return ((data?.posts ?? []) as AnyRec[])
-    .map((post) => {
-      const text = String(post?.description ?? '').replace(/\s+/g, ' ').trim();
-      const ts = post?.datePublished ? Date.parse(String(post.datePublished)) : NaN;
-      return {
-        title: text.slice(0, 200),
-        url: String(post?.url ?? ''),
-        snippet: text.slice(0, 1000),
-        sourceName: `linkedin${post?.author?.name ? ` · ${post.author.name}` : ''}`,
-        publishedAt: Number.isNaN(ts) ? null : new Date(ts).toISOString(),
-        createdUtc: Number.isNaN(ts) ? 0 : ts / 1000
-      };
-    })
-    .filter((i) => i.title && i.url);
-}
-
-// Settings asks for the X community ID, but people paste the whole URL — accept either and hand
-// the endpoint the URL it actually documents.
-export function xCommunityUrl(value: string): string {
-  const v = String(value ?? '').trim();
-  const id = v.match(/communities\/(\d+)/)?.[1] ?? v.replace(/\D/g, '');
-  return id ? `https://x.com/i/communities/${id}` : '';
-}
-
-// X Community tweets (X sells keyword search only via its paid API — niche communities are the
-// engage surface there). Value = the community id from its URL.
-async function fetchXCommunityTweets(communityId: string): Promise<RedditItem[]> {
-  const url = xCommunityUrl(communityId);
-  if (!url) throw new Error(`x_community: "${communityId}" has no community id in it`);
-  // The endpoint takes `url`, NOT `id` — see docs.scrapecreators.com/v1/twitter/community/tweets.
-  const data = await scrapeCreatorsGet(`/v1/twitter/community/tweets?url=${encodeURIComponent(url)}&trim=true`);
-  const raw: AnyRec[] = Array.isArray(data?.tweets) ? data.tweets : Array.isArray(data?.data) ? data.data : [];
-  return raw
-    .map((t) => {
-      const ts = t?.created_at ? Date.parse(String(t.created_at)) : NaN;
-      const id = String(t?.id_str ?? t?.rest_id ?? t?.id ?? '');
-      return {
-        title: String(t?.full_text ?? t?.text ?? '').replace(/\s+/g, ' ').slice(0, 200),
-        url: id ? `https://x.com/i/status/${id}` : '',
-        snippet: String(t?.full_text ?? t?.text ?? '').slice(0, 1000),
-        sourceName: 'x community',
-        publishedAt: Number.isNaN(ts) ? null : new Date(ts).toISOString(),
-        createdUtc: Number.isNaN(ts) ? 0 : ts / 1000
-      };
-    })
-    .filter((i) => i.title && i.url);
-}
+// Le credenziali si leggono a OGNI chiamata, non qui: `$env/dynamic/private` è vivo, e congelarlo
+// alla costruzione vorrebbe dire che un cambio d'ambiente non arriva mai.
+const sources = createSources({
+  scrape: scrapeCreatorsGet,
+  redditAuth: () => ({ token: env.REDDIT_FEED_TOKEN, user: env.REDDIT_FEED_USER }),
+  fetchViaBrowser
+});
 
 // ── Source seeding (once, at onboarding — user-editable in the Studio) ──────────────────────────
 
@@ -611,35 +323,6 @@ const VERDICT_SCHEMA = {
 
 const MAX_ITEMS_PER_SCAN = 40;
 
-// A source is brand-AGNOSTIC to fetch: r/marketing's rising threads are the same for every brand
-// watching it. Key by (kind, value, lang) so identical sources across brands dedup to ONE fetch.
-type SourceRef = { kind: string; value: string; lang?: string | null };
-export const sourceKey = (s: SourceRef): string => `${s.kind}|${s.value}|${s.lang ?? ''}`;
-
-/** How old a conversation may be, per platform. Reddit rising = now; the rest = a couple of days. */
-export function maxAgeHoursFor(kind: string): number {
-  return kind === 'subreddit' || kind === 'reddit_query' ? ENGAGE_MAX_AGE_HOURS : CONVERSATION_MAX_AGE_HOURS;
-}
-
-/** Drop conversations older than their platform's window. Applied to stored AND dynamic searches. */
-export function withinWindow(kind: string, items: RedditItem[]): RedditItem[] {
-  const cutoff = Date.now() / 1000 - maxAgeHoursFor(kind) * 3600;
-  return items.filter((i) => i.createdUtc >= cutoff);
-}
-
-// Fetch ONE source's feed (already time-filtered where timing matters). The unit of the shared cache.
-async function fetchSourceFeed(s: SourceRef): Promise<FeedItem[]> {
-  if (s.kind === 'threads_query') return withinWindow(s.kind, await fetchThreadsSearch(s.value));
-  if (s.kind === 'x_community') return withinWindow(s.kind, await fetchXCommunityTweets(s.value));
-  // linkedin_query was missing here: the source fell through to fetchFeed(), which fetched the
-  // KEYWORDS as if they were an RSS url. Every LinkedIn source returned nothing, forever.
-  if (s.kind === 'linkedin_query') return withinWindow(s.kind, await fetchLinkedInSearch(s.value));
-  if (s.kind === 'reddit_query') return withinWindow(s.kind, await fetchRedditSearch(s.value));
-  if (s.kind !== 'subreddit') return fetchFeed(s);
-  // TIMING: only RISING (momentum right now), hard-cut at ENGAGE_MAX_AGE_HOURS — a comment on a
-  // stale thread is wasted breath.
-  return withinWindow(s.kind, await fetchSubredditRising(s.value));
-}
 
 // How long a cached feed is considered fresh. Ticks run every ~4h; 3h TTL covers the gap so
 // workers processing brands minutes after the orchestrator always read valid data.
@@ -667,7 +350,7 @@ export async function buildRadarFeedCache(admin: SupabaseClient, brandIds: strin
   const fetched = await Promise.all(
     [...uniq.entries()].map(async ([key, s]) => {
       try {
-        return { source_key: key, items: await fetchSourceFeed(s), fetched_at: now };
+        return { source_key: key, items: await sources.fetchSourceFeed(s), fetched_at: now };
       } catch (e) {
         // A FAILED fetch is never cached. Caching it as an empty list would hand the per-brand
         // scan a clean cache hit with zero items, and the error would vanish exactly the way the
@@ -712,7 +395,7 @@ export async function radarDiagnose(
       };
     }
     try {
-      const items = await fetchSourceFeed({ kind, value: String(s.value), lang: s.lang ?? null });
+      const items = await sources.fetchSourceFeed({ kind, value: String(s.value), lang: s.lang ?? null });
       return { ...base, items: items.length, windowHours: maxAgeHoursFor(kind), sample: items.slice(0, 3).map((i) => ({ title: i.title.slice(0, 120), url: i.url })) };
     } catch (e) {
       return { ...base, items: 0, error: e instanceof Error ? e.message.slice(0, 300) : String(e) };
@@ -815,7 +498,7 @@ export async function radarScan(
         return tag(hit);
       }
       try {
-        const items = await fetchSourceFeed(s);
+        const items = await sources.fetchSourceFeed(s);
         searchLog.push({ kind: s.kind, value: s.value, items: items.length, fromCache: false, ok: true });
         return tag(items);
       } catch (e) {
@@ -843,13 +526,13 @@ export async function radarScan(
     if (ctx.length > 10) {
       const searchers: Array<{ kind: 'reddit_query' | 'threads_query' | 'linkedin_query'; prefix: string; run: (q: string) => Promise<RedditItem[]> }> = [];
       if (radarPlatformEnabled(prefs, 'reddit', brand.plan)) {
-        searchers.push({ kind: 'reddit_query', prefix: 'rq', run: fetchRedditSearch });
+        searchers.push({ kind: 'reddit_query', prefix: 'rq', run: sources.fetchRedditSearch });
       }
       if (radarPlatformEnabled(prefs, 'threads', brand.plan)) {
-        searchers.push({ kind: 'threads_query', prefix: 'tq', run: fetchThreadsSearch });
+        searchers.push({ kind: 'threads_query', prefix: 'tq', run: sources.fetchThreadsSearch });
       }
       if (radarPlatformEnabled(prefs, 'linkedin', brand.plan)) {
-        searchers.push({ kind: 'linkedin_query', prefix: 'lq', run: fetchLinkedInSearch });
+        searchers.push({ kind: 'linkedin_query', prefix: 'lq', run: sources.fetchLinkedInSearch });
       }
       if (searchers.length) {
         const platformsLabel = searchers.map((s) => (s.kind === 'reddit_query' ? 'Reddit' : s.kind === 'threads_query' ? 'Threads' : 'LinkedIn')).join(', ');
@@ -1115,7 +798,7 @@ export async function radarEngage(
       // <threads|x|linkedin url>/.rss, got nothing back, and then overwrote the body and the top
       // comments ScrapeCreators had just returned with the empty result.
       if (isReddit && !postBody) {
-        const xml = await fetchRedditText(redditRssAuth(`${it.url.replace(/\/$/, '').replace('://www.', '://old.')}/.rss`));
+        const xml = await sources.fetchRedditText(sources.redditRssAuth(`${it.url.replace(/\/$/, '').replace('://www.', '://old.')}/.rss`));
         const entries = xml ? parseFeed(xml) : [];
         postBody = entries[0]?.snippet ?? '';
         topComments = entries.slice(1, 6)

--- a/src/lib/server/radar.ts
+++ b/src/lib/server/radar.ts
@@ -29,7 +29,8 @@ import { brandContacts } from './scheduler';
 import { generateBlogFromNews } from './blog-generate';
 import { hasProRadarLeads, isRadarKindAllowed, leadEngagePlatforms, radarSourceLimit, type RadarPlatformKey, RADAR_PLATFORM_KEYS } from './plans';
 import { ALT_CAPTION_PLATFORMS, ensureShortNetworkCuts } from '$lib/platform-limits';
-import { contactGate, dmWithOptOut, gateVerdict, platformOf } from '@anomalia/leads-core/contact';
+import { authorProfileUrl, contactGate, dmWithOptOut, gateVerdict, platformOf } from '@anomalia/leads-core/contact';
+import { COMMENT_MIN_RELEVANCE, COMMENT_SCHEMA, buildEngagePrompt, selectTopComments } from '@anomalia/leads-core/prompts';
 // Re-exported: Settings → Radar imports the type from here, next to the functions that use it.
 export type { RadarPlatformKey } from './plans';
 import { INTENT_RANK, normalizeIntent, type LeadIntent } from '@anomalia/leads-core/intent';
@@ -1019,99 +1020,8 @@ Duplicated stories: keep the best one, skip the rest ("duplicate"). Never invent
 
 // ── Engage: draft a Reddit comment for the human to post (Anomalia NEVER touches Reddit) ────────────
 
-// "Pochi ma buoni": il proprietario non riusciva a stare dietro a 6-8 bozze di commento al
-// giorno. Due leve: una soglia di rilevanza più alta dei post (sotto, un commento consuma
-// attenzione senza rendere) e un budget giornaliero pari a maxPerDay (stesso numero 1-3 di
-// content_prefs.radar). Il cap significa "gli N MIGLIORI del giorno": prima si ordina per
-// punteggio, poi si taglia — mai first-come.
-export const COMMENT_MIN_RELEVANCE = 70;
-
-/** I migliori N commenti: soglia, poi ordine per intent e rilevanza, poi taglio al budget. */
-export function selectTopComments<T extends { action: string; relevance: number; intent: LeadIntent }>(
-  picked: T[],
-  budget: number
-): T[] {
-  return picked
-    .filter((p) => p.action === 'comment' && p.relevance >= COMMENT_MIN_RELEVANCE)
-    // Riordinato qui dentro (anche se il chiamante già ordina): la semantica "i migliori, non i
-    // primi" non deve dipendere dall'ordine di arrivo.
-    .sort((a, b) => INTENT_RANK[b.intent] - INTENT_RANK[a.intent] || b.relevance - a.relevance)
-    .slice(0, Math.max(0, budget));
-}
-
 // Daily cap on radar-generated blog articles. Long-form takes AI time + owner review attention.
 const ARTICLES_PER_DAY = 1;
-
-const COMMENT_SCHEMA = {
-  type: 'object' as const,
-  properties: {
-    worth_it: { type: 'boolean' as const, description: 'false if, seeing the full thread, a brand comment would NOT genuinely help — better silence than noise.' },
-    comment: { type: 'string' as const, description: "The ready-to-paste comment, in the thread's language and Reddit's register." },
-    dm: { type: 'string' as const, description: "A short, PERSONAL 1:1 direct message to the POST AUTHOR — ONLY when there is genuine 1:1 value (they're explicitly seeking a solution the brand actually offers). Softer and warmer than the public comment: open by referencing THEIR specific post, be helpful first, never a hard sell or a pitch. Bring in the brand either as an insider (with a light affiliation disclosure) or as a neutral tip ('you could check e.g. https://domain.com') — no need to declare you're the founder. When you point to the site, use the full https:// URL. Empty string when a DM would feel intrusive or spammy (default to empty unless the fit is obvious). Same language as the thread. 30-90 words." }
-  },
-  required: ['worth_it', 'comment', 'dm']
-};
-
-// ── Il prompt del drafter, estratto in funzione pura per i test ────────────────────────────────
-// I guard-rail qui dentro rispondono ai modi in cui le bozze fallivano DAVVERO nell'uso reale:
-// risposta nella lingua del brand invece che del thread, aperture di cortesia vuote, risposta al
-// titolo invece che alla domanda nel corpo, pitch non richiesto, e commenti che ripetevano quello
-// che i top comment avevano già detto.
-export type EngagePromptArgs = {
-  brandName: string;
-  about: string;
-  siteUrl: string;
-  aiContext: string;
-  sourceName: string;
-  title: string;
-  body: string;
-  topComments: string;
-  author: string;
-  intent: LeadIntent;
-  profileBlock: string;
-  toneHint: string;
-  styleHint: string;
-  // Ultime riscritture dell'utente (prima→dopo): il segnale più onesto su cosa correggere.
-  editPairs?: Array<{ before: string; after: string; feedback?: string }>;
-};
-
-export function buildEngagePrompt(a: EngagePromptArgs): string {
-  const editBlock = a.editPairs?.length
-    ? `\nHOW THE OWNER REWRITES YOUR DRAFTS (real before → after edits on this brand's recent drafts — absorb the DIFFERENCE: what they cut, the length, the tone. Apply the same taste to THIS draft; never reuse their wording, it belongs to other threads):\n${a.editPairs
-        .map((p, i) => `${i + 1}. BEFORE: ${p.before}\n   AFTER: ${p.after}${p.feedback ? `\n   (owner's note: ${p.feedback})` : ''}`)
-        .join('\n')}\n`
-    : '';
-  return `A conversation on ${a.sourceName} is rising and this brand's expertise is relevant. Draft the ONE reply the brand should post — as a knowledgeable community member, not a marketer.
-
-REPLY LANGUAGE — ABSOLUTE RULE: write the comment AND the DM in the language of the THREAD (detect it from the thread's title and body below). The brand's language, the language of these instructions and of any style or voice material are IRRELEVANT to this choice: an English thread gets an English reply even when the brand writes its posts in Italian, and vice versa. Style instructions shape style, never language.
-
-Brand: ${a.brandName} — ${a.about}
-${a.siteUrl ? `Brand site (link it with the FULL URL exactly like this, never just the name or a bare domain): ${a.siteUrl}\n` : ''}${a.aiContext ? `Voice & expertise:\n${a.aiContext}\n` : ''}
-THREAD "${a.title}":
-${a.body || '(no body — title only)'}
-${a.topComments ? `\nTOP COMMENTS ALREADY THERE (this is what the thread ALREADY has — never restate it):\n${a.topComments}` : ''}
-${a.author ? `\nPOST AUTHOR: ${a.author} (the person you would DM 1:1).` : ''}
-BUYER INTENT: ${a.intent} — 'seeking_now'/'comparing' means they asked for a solution, so naming one is welcome; 'researching' wants the explanation, not a product; 'venting' wants to be heard, so help without pointing anywhere and leave the DM empty.
-${a.profileBlock ? `\n${a.profileBlock}\n` : ''}${a.toneHint}${a.styleHint}
-${editBlock}
-Produce TWO things: (1) the public COMMENT for the thread, and (2) a private DM to the post author — but ONLY draft a DM when there's a clear 1:1 fit (they explicitly want a solution the brand offers). If a DM would be intrusive, return an empty dm.
-
-HARD RULES (survival + Italian hidden-advertising law):
-- ANSWER THE ACTUAL QUESTION: the title is a headline; the real ask (their constraints, budget, what they already tried) lives in the body. When body and title diverge, answer the body.
-- NO FILLER OPENERS: never start with "Great question", "Interesting point", or a restatement of their post. The first sentence already carries the substance.
-- ADD VALUE BEYOND THE THREAD: when a top comment above already gives the core advice, do not repeat it — acknowledge it in passing ("someone already mentioned X") and contribute the piece it misses: a nuance, a trade-off, a concrete next step. If you have nothing beyond what's already there, set worth_it=false — better silence than an echo.
-- WRITE FOR THE ROOM: when a COMMUNITY PROFILE is above, it wins over generic instinct — use the exact words from its vocabulary line, respect its rules line (what gets removed), and match the shape its tone line describes. Do not repeat advice its "already tried" line says they were burned by.
-- VALUE FIRST: actually answer the thread with the brand's real expertise.
-- NO UNSOLICITED PITCH: mention the brand ONLY when the buyer intent above says they asked for a solution (seeking_now/comparing) or the thread explicitly asks for recommendations. For 'researching' and 'venting', help without pointing anywhere.
-- NEVER PROMISE WHAT IS NOT THERE: describe only what the brand context above actually says the product does. If the thread needs something it does not do, say so plainly or say nothing — an overpromise in public costs more than a missed lead.
-- TWO WAYS to bring in the brand — pick whichever fits the thread naturally:
-  (a) INSIDER: speak as someone who works on it, with an explicit disclosure ("Disclosure: I work on X" / "Trasparenza: ci lavoro io"). Use when a first-person "we built this" is the honest framing.
-  (b) NEUTRAL TIP: recommend it as ONE example/resource among options, third person, no founder claim ("you could check e.g. ${a.siteUrl || 'the site'}"). Use for broadly-useful advice where naming yourself would feel heavy. Never pose as an unaffiliated fan hyping it — a neutral pointer is fine, a disguised hard sell is not.
-  You do NOT have to say "I'm the founder" every time; mention the brand ONLY when it genuinely answers the question.
-- When you DO point to the brand, write the WEBSITE as the full URL${a.siteUrl ? ` (${a.siteUrl})` : ''} — never just the name, never a bare domain without https://.
-- PLATFORM REGISTER: Reddit → plain, first person, no hashtags; Threads → conversational, like talking to a friend; X → ONE sharp reply under 280 characters. Never marketing phrasing or emoji spam.
-- COMMENT: 60-150 words. DM: 30-90 words, warmer and personal, opens by referencing THEIR post, helpful-not-salesy — empty when a cold DM would feel spammy.`;
-}
 
 export type RadarEngageRow = { title: string; url: string; sourceName: string; comment: string; dm: string; dmTarget: string; dmProfileUrl: string };
 
@@ -1125,16 +1035,6 @@ function normalizeSiteUrl(raw: unknown): string {
   } catch {
     return '';
   }
-}
-
-// Build the author's profile/DM URL per platform (the human opens it to send the DM manually).
-function authorProfileUrl(url: string, author: string): string {
-  if (!author) return '';
-  if (url.includes('threads.net')) return `https://www.threads.net/@${author.replace(/^@/, '')}`;
-  if (url.includes('x.com') || url.includes('twitter.com')) return `https://x.com/${author.replace(/^@/, '')}`;
-  // LinkedIn authors are display names, not handles → no derivable profile URL; open the post itself.
-  if (url.includes('linkedin.com')) return url;
-  return `https://www.reddit.com/user/${author.replace(/^u\//, '')}`;
 }
 
 // For each picked Reddit thread: fetch the FULL thread (public read-only .json — post body + top

--- a/src/routes/api/v1/leads/outcomes/+server.ts
+++ b/src/routes/api/v1/leads/outcomes/+server.ts
@@ -1,7 +1,8 @@
 import type { RequestHandler } from './$types';
 import { createAdminClient } from '$lib/server/supabase-admin';
 import { cronAuthorized } from '$lib/server/cron-auth';
-import { runOutcomeChecks, CHECK_AFTER_HOURS, MAX_CHECKS_PER_RUN } from '$lib/server/lead-outcomes';
+import { runOutcomeChecks } from '$lib/server/lead-outcomes';
+import { CHECK_AFTER_HOURS, MAX_CHECKS_PER_RUN } from '@anomalia/leads-core/match';
 
 // Esiti dei lead — torna a guardare i commenti segnati come "fatto" e registra com'è andata.
 //

--- a/src/routes/api/v1/radar/tick/+server.ts
+++ b/src/routes/api/v1/radar/tick/+server.ts
@@ -2,7 +2,8 @@ import type { RequestHandler } from './$types';
 import { createAdminClient } from '$lib/server/supabase-admin';
 import { cronAuthorized } from '$lib/server/cron-auth';
 import { radarPrefsOf, buildRadarFeedCache, kickRadarWork } from '$lib/server/radar';
-import { sweepLeadRetention } from '$lib/server/lead-contact';
+import { sweepLeadRetention } from '@anomalia/leads-core/contact';
+import { swallow } from '$lib/server/swallow';
 
 // Radar ORCHESTRATOR: fetch every distinct source ONCE → DB cache → create one job per brand →
 // fan out N workers (calculated from brand count) so the fleet drains in parallel chains, not one
@@ -37,7 +38,7 @@ async function run(request: Request, platform: Platform): Promise<Response> {
     admin.from('radar_jobs').delete().lt('created_at', old),
     admin.from('radar_feed_cache').delete().lt('fetched_at', old)
   ]);
-  await sweepLeadRetention(admin);
+  await sweepLeadRetention(admin, swallow);
 
   let q = admin
     .from('brands')

--- a/src/routes/app/[brand]/leads/+page.server.ts
+++ b/src/routes/app/[brand]/leads/+page.server.ts
@@ -2,7 +2,7 @@ import { fail } from '@sveltejs/kit';
 import type { PageServerLoad, Actions } from './$types';
 import { withBrandContext } from '$lib/server/ai-log';
 import { hasProRadarLeads } from '$lib/server/plans';
-import { INTENT_RANK, normalizeIntent } from '$lib/leads-intent';
+import { INTENT_RANK, normalizeIntent } from '@anomalia/leads-core/intent';
 import { cachedBrandPage } from '$lib/server/page-cache';
 
 // Leads — the AI-drafted reply suggestions (Reddit/Threads/X conversations worth joining), split

--- a/src/routes/app/[brand]/leads/+page.server.ts
+++ b/src/routes/app/[brand]/leads/+page.server.ts
@@ -153,13 +153,14 @@ async function suppressLead(
     .maybeSingle();
   const handle = lead?.author_handle || lead?.dm_target;
   if (lead && handle) {
-    const { suppressAuthor, platformOf } = await import('$lib/server/lead-contact');
+    const { suppressAuthor, platformOf } = await import('@anomalia/leads-core/contact');
+    const { swallow } = await import('$lib/server/swallow');
     await suppressAuthor(admin, {
       platform: lead.author_platform ?? platformOf(String(lead.url ?? '')),
       handle: String(handle),
       source: 'manual',
       reason: 'marked by the brand in /leads'
-    });
+    }, swallow);
   }
   const { error } = await admin.from('brand_news_items').update({ status: 'dismissed' }).eq('id', id).eq('brand_id', brand.id);
   if (error) return fail(500, { error: error.message });


### PR DESCRIPTION
## What?

Il nucleo del lead finding esce dall'app e diventa `@anomalia/leads-core`, un package in
`packages/` con cinque moduli: `intent` (bande di intento d'acquisto), `match` (ritrovare la
nostra bozza in un thread pubblicato da un umano), `contact` ("una persona, un tocco", opt-out,
retention), `prompts` (il drafter di commento e DM, la selezione degli N migliori) e `feed` (dove
si trovano le conversazioni: RSS, Google News, subreddit in rising, ricerche su Reddit, Threads,
X Communities e LinkedIn).

`src/lib/server/radar.ts` scende da 1782 a ~1320 righe. Nessun cambiamento di comportamento: gli
stessi test, spostati accanto al codice che provano, più tre test nuovi sui punti che
l'estrazione ha reso espliciti.

## Why?

La domanda che ha aperto il lavoro era commerciale: le feature di lead hunting reggerebbero un
SaaS verticale a sé? La risposta onesta era "sì, ma non copiando `radar.ts`". Quello che ha
valore fuori da Anomalia — trovare conversazioni, giudicarle, scriverne la bozza, non disturbare
due volte la stessa persona — era dentro un modulo con trenta import, fra cui env di SvelteKit,
piani, editorial plan, director, scheduler ed email. Separabile in teoria, non a vista.

Ora la separazione è una proprietà del repo e non una buona intenzione: `packages/no-app-imports.test.ts`
esisteva già e ora sorveglia anche questi file — al primo `$lib` o `$env` che rientra, fallisce.

## How?

**Il confine.** Dentro il package va ciò che è plan-free, env-free e framework-free. Restano
fuori l'orchestrazione (`radarScan`, `radarProduce`, `radarArticles`, digest, tick, recap) e tutto
ciò che è plan-shaped (`radarPrefsOf`, `radarPlatformEnabled`, `radarSourceLimit`): è il pricing
di Anomalia, e un verticale ne avrebbe un altro — il package riceve limiti e sorgenti come
parametri anziché deciderli.

**Le inversioni, tre, e nessuna per simmetria.** Il client Supabase era **già** un parametro
ovunque: non c'era niente da invertire, solo da non aggiungere. Quelle vere sono:

1. `swallow` (che riporta a Sentry via `@sentry/sveltekit`) → un `report` iniettato, default in
   console. Ogni call site dell'app passa `swallow`, quindi Sentry continua a vedere tutto.
2. Il gateway di scraping e le credenziali del feed Reddit → `createSources(deps)`. Un factory e
   non un `deps` per funzione, perché `radarScan` passa i searcher come callback e `radarEngage`
   usa `fetchRedditText` da solo: le funzioni già legate lasciano i call site puliti.
3. Il fallback Browserless → una `fetchViaBrowser` iniettata. Lo script di pagina resta nell'app:
   il package riceve "una funzione che dato un URL torna il testo" e non sa che dietro c'è Chrome.

`redditAuth` è una **funzione** e non un oggetto perché il codice originale leggeva `env` a ogni
chiamata: congelare le credenziali alla costruzione del factory vorrebbe dire che un cambio
d'ambiente non arriva mai. C'è un test che lo pinna.

**Alternative scartate.** Tirare dentro anche l'orchestrazione avrebbe voluto dire una `Deps` con
quindici campi per guadagnare niente. Lasciare `$lib/leads-intent` come ri-export ponte avrebbe
lasciato due scale per la stessa cosa: i tre import site sono stati aggiornati e il file è sparito.
`SOURCES_SCHEMA` e `VERDICT_SCHEMA` restano in `radar.ts` di proposito — i loro prompt sono
costruiti inline dentro `radarScan`, e spostare uno schema lontano dal prompt che lo riempie
sarebbe mezzo contratto.

## Testing?

- **Suite completa**: 547 file, 6105 test, zero falliti. I test spostati sono gli stessi di prima,
  accanto al codice che provano. Il guardiano del confine copre ora 63 file.
- **Typecheck contro la baseline di `dev`**: 376 errori / 247 warning / 172 file con problemi su
  entrambi — identici. Zero errori aggiunti, nessuno nei file toccati. Il confronto è col
  **conteggio** e non con l'esito, perché `npm run check` esce 0 anche con 376 errori dentro.
- **Il package compila da solo**: `tsc --noEmit` in strict mode, exit 0 — il controllo che conta
  davvero per qualcosa destinato a essere riusato fuori da qui.
- **Tre test nuovi**, tutti su punti che l'estrazione ha reso espliciti:
  - una scadenza di retention fallita deve arrivare al reporter iniettato (è così che l'app ci
    mette Sentry);
  - le credenziali Reddit si leggono a ogni chiamata, non alla costruzione;
  - ogni `kind` di sorgente va al suo endpoint. Questa è la classe di bug che i commenti del file
    raccontano — `linkedin_query` che cadeva su `fetchFeed` e scaricava le parole chiave come se
    fossero un URL RSS, e X chiamata con `id=` dove l'endpoint vuole `url=`. Entrambi si
    presentavano come "0 item": un successo pulito e vuoto, indistinguibile da "nessuna
    conversazione degna oggi".

### Due difetti trovati DALLA verifica, non dalla lettura

Meritano di stare qui perché dicono quanto vale ciascuno strumento su questo repo.

**Il primo era vero e la suite non lo vedeva.** Il factory era legato a un `const sources` di
modulo, ma `sources` è già il nome delle righe di `brand_news_sources` lette dal database in TRE
funzioni di `radar.ts`: ognuna lo ombreggiava, e `sources.fetchSourceFeed(...)` risolveva
sull'array del database. 6102 test verdi con il difetto dentro, perché quei tre percorsi
(`buildRadarFeedCache`, `radarDiagnose`, `radarScan`) toccano il DB e non hanno unit test — cioè
esattamente la forma di guasto contro cui quel file mette in guardia nei suoi commenti: una
sorgente che muore in silenzio e riporta "0 item". L'ha preso il typecheck, e solo contando: 386
errori contro 376 di base. Corretto destrutturando il factory, il che riporta ogni call site alla
forma identica a prima dell'estrazione. La lezione sta in `LESSONS.md`.

**Il secondo era presunto e il test l'ha smentito.** Vedi *Anything Else*.

**Non testato, e perché.** Nessuna verifica nel browser: è un refactor a comportamento invariato
coperto da test, e non ho esercitato Radar e /leads su architettura locale con login reale. Il
rischio residuo sta tutto nei percorsi che i test non toccano — in particolare `radarEngage` e
`radarProduce`, che restano nell'app ma ora chiamano il package. **Prima del merge andrebbe fatto
un tick reale su un brand di prova.**

## Evidence

Refactor senza superficie visibile: nessuno screenshot da mostrare. Il numero che conta è la
riduzione di `radar.ts` e il guardiano che regge.

## Anything Else?

**Una diagnosi sbagliata, corretta dal test.** Leggendo `pendingOutcomeChecks` sembrava esserci un
difetto vivo: il tipo di ritorno omette `author_handle`/`author_platform` che il mapper
restituisce, e da lì pareva che il ramo opt-out di `checkLeadOutcome` non partisse mai da
`runOutcomeChecks`. Il test scritto prima del fix ha detto di no — a runtime i campi ci sono e la
soppressione scatta. Il difetto era solo il tipo che mente, ed è stato comunque sistemato: chi
avesse rimosso quelle due righe dal mapper avrebbe spento la soppressione senza un errore di
compilazione. Quel giro ora ha due test e prima non ne aveva nessuno.

`radar.ts` importava anche `suppressAuthor` senza chiamarlo mai — import morto, rimosso.

**Debito ereditato, non introdotto**: il typecheck del repo non è pulito (346 errori su 171 file,
tutti pre-esistenti, nessuno nei file toccati). `npm run check` esce **0 lo stesso**, quindi oggi
non è un gate. Se il verticale nasce da questo package, quello è debito che eredita.

**Il passo successivo** per un verticale non è altro codice da spostare, ma lo schema: il README
del package elenca le quattro tabelle che il core si aspetta. `lead_suppressions` non ha
`brand_id` ed è deliberato — il frequency cap è globale all'istanza. Chi lo scopa per brand rompe
la promessa che rende difendibile l'outreach.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GXcLdTcRKysdpC9bHoteXW
