### PR TITLE
Drop the per-turn cap on voice-over and music

### DIFF
--- a/changelog/2026-09-01-audio-senza-tetto.md
+++ b/changelog/2026-09-01-audio-senza-tetto.md
@@ -1,0 +1,20 @@
+# Voce e musica: via il tetto per turno
+
+`MAX_VOICEOVERS_PER_TURN = 2` e `MAX_MUSIC_PER_TURN = 2` limitavano i tentativi
+audio dell'agente motion. Peggio del tetto era la contabilità: lo slot si
+prendeva PRIMA della chiamata e non tornava indietro se la generazione falliva.
+Una generazione fallita non addebita crediti (`gemini-audio.ts` logga `ok:false`
+e non passa da `credits`), quindi il turno pagava in tentativi una cosa che non
+era costata niente — e dopo un fallimento passeggero all'agente ne restava uno
+solo. Nello stesso file `render_motion_video` il rimborso c'era già: il render
+rifiutato dal voice-gate restituisce lo slot «perché non ha speso niente».
+
+Ora non c'è tetto. Provare una voce, riascoltarla, rifarla con un'altra
+inflessione è il mestiere, e la spesa la governano i crediti: il turno si ferma
+su `credits_exhausted`, che è il freno vero.
+
+Resta UN freno, e non è un tetto: un fallimento permanente della musica (modello
+ritirato, chiave assente — `permanentMusicFailure`) spegne la musica per il resto
+del turno. Nessun prompt diverso ripara un 404, e senza contatore quel caso
+girerebbe all'infinito. L'errore ora si chiama `music_unavailable`: dice cosa è
+successo invece di dire che il budget è finito.

--- a/src/lib/content/changelog/2026-09-01-audio-senza-tetto.ts
+++ b/src/lib/content/changelog/2026-09-01-audio-senza-tetto.ts
@@ -1,0 +1,10 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-01',
+  title: 'Voice-over and music can be retried freely',
+  items: [
+    'Motion videos are no longer limited to two voice-over takes and two music beds per turn: the agent can try a line again, or a different bed, until it sounds right.',
+    'A generation that fails no longer counts as a try — a failed take costs nothing and takes nothing away.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/motion-video/output-tools.test.ts
+++ b/src/lib/server/motion-video/output-tools.test.ts
@@ -26,7 +26,6 @@ vi.mock('./render-tools', async () => {
 // il percorso sbagliato.
 vi.mock('$lib/server/sandbox', () => ({ isSandboxConfigured: () => true }));
 import {
-	MAX_MUSIC_PER_TURN,
 	MAX_VIDEO_RENDERS_PER_DAY,
 	MAX_VIDEO_RENDERS_PER_TURN,
 	createMotionOutputTools,
@@ -269,8 +268,68 @@ describe('cut_voiceover attraverso le slice', () => {
 	});
 });
 
-describe('generate_music — permanente chiude il budget, passeggero no', () => {
-	it('dopo un 404 il secondo slot non si spende su un retry condannato', async () => {
+describe('audio senza tetto — provare non si paga a slot', () => {
+	it('voce e musica si generano quante volte servono', async () => {
+		vi.doMock(import('$lib/server/gemini-audio'), async (importOriginal) => ({
+			...(await importOriginal()),
+			generateVoiceOver: (async () => ({
+				voice: 'calm',
+				fullUrl: 'https://cdn.test/voiceover/take.wav',
+				fullDurationSeconds: 4,
+				gaps: []
+			})) as never,
+			generateMusicBed: (async () => ({ url: 'https://cdn.test/music/bed.wav', durationSeconds: 30 })) as never
+		}));
+		vi.resetModules();
+		const { createMotionOutputTools: make } = await import('./output-tools');
+		const tools = make({ supabase: {} as never, brandId: 'b1', fps: () => 30 });
+
+		for (let attempt = 1; attempt <= 3; attempt++) {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const voice = await (tools.generate_voiceover as any).execute(
+				{ lines: [`riga ${attempt}`] },
+				{ toolCallId: 't', messages: [] }
+			);
+			expect(voice.error, `voce ${attempt}`).toBeUndefined();
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const music = await (tools.generate_music as any).execute(
+				{ prompt: `pads ${attempt}`, seconds: 10 },
+				{ toolCallId: 't', messages: [] }
+			);
+			expect(music.error, `musica ${attempt}`).toBeUndefined();
+		}
+
+		vi.doUnmock('$lib/server/gemini-audio');
+		vi.resetModules();
+	});
+
+	it('un fallimento passeggero non toglie niente: il tentativo dopo parte', async () => {
+		let calls = 0;
+		vi.doMock(import('$lib/server/gemini-audio'), async (importOriginal) => ({
+			...(await importOriginal()),
+			generateVoiceOver: (async () => {
+				calls += 1;
+				if (calls < 3) throw new Error('kie timed out');
+				return { voice: 'calm', fullUrl: 'https://cdn.test/voiceover/take.wav', fullDurationSeconds: 4, gaps: [] };
+			}) as never
+		}));
+		vi.resetModules();
+		const { createMotionOutputTools: make } = await import('./output-tools');
+		const tools = make({ supabase: {} as never, brandId: 'b1', fps: () => 30 });
+
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const run = () => (tools.generate_voiceover as any).execute({ lines: ['ciao'] }, { toolCallId: 't', messages: [] });
+		expect((await run()).error).toBe('voiceover_failed');
+		expect((await run()).error).toBe('voiceover_failed');
+		expect((await run()).url).toBe('https://cdn.test/voiceover/take.wav');
+
+		vi.doUnmock('$lib/server/gemini-audio');
+		vi.resetModules();
+	});
+});
+
+describe('generate_music — il permanente spegne la musica, il passeggero no', () => {
+	it('dopo un 404 il tentativo successivo non ricompra lo stesso errore', async () => {
 		vi.doMock(import('$lib/server/gemini-audio'), async (importOriginal) => ({
 			...(await importOriginal()),
 			generateMusicBed: (async () => {
@@ -293,8 +352,7 @@ describe('generate_music — permanente chiude il budget, passeggero no', () => 
 			{ prompt: 'different pads', seconds: 10 },
 			{ toolCallId: 't', messages: [] }
 		);
-		expect(second.error).toBe('music_budget_spent');
-		expect(MAX_MUSIC_PER_TURN).toBeGreaterThan(1); // il blocco è la chiusura, non il tetto normale
+		expect(second.error).toBe('music_unavailable');
 		vi.doUnmock('$lib/server/gemini-audio');
 		vi.resetModules();
 	});

--- a/src/lib/server/motion-video/output-tools.ts
+++ b/src/lib/server/motion-video/output-tools.ts
@@ -55,9 +55,6 @@ import {
 	type VoiceOverVoice
 } from '$lib/server/gemini-audio';
 
-/** Voce e musica per turno. Oltre, non è una correzione: è un agente che prova a orecchio. */
-export const MAX_VOICEOVERS_PER_TURN = 2;
-export const MAX_MUSIC_PER_TURN = 2;
 /** Render finiti per turno. Ognuno è una VM accesa e crediti spesi: non è una cosa da riprovare a caso. */
 export const MAX_VIDEO_RENDERS_PER_TURN = 2;
 /**
@@ -151,9 +148,13 @@ export function createMotionOutputTools(opts: {
 	abortSignal?: AbortSignal;
 	locale?: string;
 }) {
-	let voiceovers = 0;
-	let musics = 0;
 	let renders = 0;
+	/**
+	 * Un modello ritirato o una chiave assente non si riparano riprovando: la musica si spegne per
+	 * il resto del turno. È l'UNICO freno rimasto sull'audio — i tentativi non hanno un tetto,
+	 * perché provare una voce e un letto è il mestiere, e la spesa la governano i crediti.
+	 */
+	let musicUnavailable = false;
 	/** Lo storyboard di questo turno: chi l'ha già visto, e quante volte si può ancora rimandare. */
 	const storyboard = createStoryboardGate();
 	/** I PNG dello storyboard, consegnati al modello da `toModelOutput` (vedi render-tools.ts). */
@@ -405,13 +406,6 @@ export function createMotionOutputTools(opts: {
 				style?: string;
 				language_code?: string;
 			}) => {
-				if (voiceovers >= MAX_VOICEOVERS_PER_TURN) {
-					return {
-						error: 'voiceover_budget_spent',
-						hint: `Already recorded ${MAX_VOICEOVERS_PER_TURN} takes this turn. Build with what you have.`
-					};
-				}
-				voiceovers += 1;
 				try {
 					const res = await generateVoiceOver({
 						supabase: opts.supabase,
@@ -601,10 +595,12 @@ export function createMotionOutputTools(opts: {
 					.describe('clip (default, ~30s, loop if longer) or pro (real duration, higher cost).')
 			}),
 			execute: async (input: { prompt: string; seconds: number; tier?: 'clip' | 'pro' }) => {
-				if (musics >= MAX_MUSIC_PER_TURN) {
-					return { error: 'music_budget_spent', hint: `Already generated ${MAX_MUSIC_PER_TURN} beds this turn.` };
+				if (musicUnavailable) {
+					return {
+						error: 'music_unavailable',
+						hint: 'Music generation is down for this turn (a configuration failure, not a bad prompt). Build the video without a bed and say so.'
+					};
 				}
-				musics += 1;
 				try {
 					const res = await generateMusicBed({
 						supabase: opts.supabase,
@@ -630,18 +626,18 @@ export function createMotionOutputTools(opts: {
 					};
 				} catch (e) {
 					const detail = errorMessage(e);
-					// Permanente vs passeggero, detto nel risultato: un 404/modello ritirato riproposto
-					// identico bruciava il secondo slot di budget per comprare lo stesso errore. Sul
-					// permanente il budget si CHIUDE: nessun prompt diverso ripara un modello sbagliato.
+					// Permanente vs passeggero, detto nel risultato: sul permanente la musica si SPEGNE
+					// per il turno — nessun prompt diverso ripara un modello ritirato. Sul passeggero
+					// si riprova quante volte serve.
 					const permanent = permanentMusicFailure(detail);
-					if (permanent) musics = MAX_MUSIC_PER_TURN;
+					if (permanent) musicUnavailable = true;
 					return {
 						error: 'music_failed',
 						retryable: !permanent,
 						detail,
 						hint: permanent
 							? 'This failure is an environment/configuration problem (wrong or retired model id, missing key) — retrying cannot fix it. Carry on without music, say so, and do not invent an audio URL.'
-							: 'Transient failure — one more try is reasonable if the bed matters; otherwise carry on without music and say so. Do not invent an audio URL.'
+							: 'Transient failure — try again if the bed matters; otherwise carry on without music and say so. Do not invent an audio URL.'
 					};
 				}
 			}


### PR DESCRIPTION
## What?

`generate_voiceover` and `generate_music` had a per-turn budget of two each (`MAX_VOICEOVERS_PER_TURN`, `MAX_MUSIC_PER_TURN`). Both are gone. The agent can now record a take, listen to it, and do it again with a different delivery as many times as the work needs.

The cap was not the whole problem — the accounting was. The slot was taken **before** the call and never returned when the generation failed, so a turn paid a tentative for something that cost nothing. That is why the agent behaved as if it had a single generation: one transient failure left it exactly one attempt.

## Why?

Trying a voice and a bed until they sit right is the craft, not waste. And the spend is already governed where spend belongs: a turn stops on `credits_exhausted`, and a failed generation bills nothing (`gemini-audio.ts` logs `ok:false` without charging). A second, cruder counter on top of the credit gate bought nothing and cost the agent its ability to iterate.

The refund pattern was already in the same file, one tool over: a render the voice gate refuses gives its slot back, on the grounds that *"nessun credito speso, quindi il tentativo non conta"*. Audio never got that treatment.

## How?

Removed both constants and both counters. One brake stays and it is deliberately not a cap: a **permanent** music failure — a retired model id, a missing key, matched by `permanentMusicFailure` — turns music off for the rest of the turn. No different prompt repairs a 404, and with no counter left that case would loop forever. Its error is now `music_unavailable` instead of `music_budget_spent`: it says what happened rather than claiming a budget ran out.

Rejected: keeping a higher cap. A bigger number is the same design with a later wall, and the number would have been guessed rather than measured.

## Testing?

Two tests written first and watched fail (`output-tools.test.ts`):

- *"voce e musica si generano quante volte servono"* — three voice-overs and three beds in one turn, none returns an error.
- *"un fallimento passeggero non toglie niente: il tentativo dopo parte"* — two transient failures then a success; the third call still runs.

The existing permanent-failure test stays, retargeted to `music_unavailable`.

```
$ npx vitest run src/lib/server/motion-video/output-tools.test.ts   # red before, 18 passed after
$ npx vitest run src/lib/server/motion-video/ src/lib/server/chat/  # 100 files, 1183 passed
```

**Not tested:** the real cost profile of an agent that iterates without a cap. Credits are the guard, but nobody has measured how many takes a typical motion turn now records. Worth watching in `ai_calls` on the first days.

## Evidence (screenshots/videos)

No UI. The defect is in the accounting, and this is it:

<details><summary>Before — the slot was taken before the call, never returned</summary>

```ts
if (voiceovers >= MAX_VOICEOVERS_PER_TURN) return { error: 'voiceover_budget_spent', … };
voiceovers += 1;
try { … } catch (e) { return { error: 'voiceover_failed', … }; }   // no decrement
```

Compare `render_motion_video` in the same file, which does refund:

```ts
// Rifiutato PRIMA di aprire la VM: nessun credito speso, quindi il tentativo non conta
renders = Math.max(0, renders - 1);
```

</details>

## Anything Else?

`permanentMusicFailure` matches `\b(400|401|403|404|422)\b` anywhere in a free-text error message, so an unrelated message containing one of those numbers turns music off for the turn. It was worth a slot before and it is worth the whole turn's music now — narrowing it to the status field is a follow-up, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CPHcJKUNRK7z8dLF4jq9NU