### PR TITLE
Let a rewritten message reach the thread event log

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -262,6 +262,25 @@ gestisce chiaramente. Mossa: intercettare per PATHNAME esatto (una regex sull'UR
 che un file sorgente può soddisfare — e prima di credere a un difetto, misurare il caso base senza
 intercettazione.
 
+### Un trigger `after insert` su una riga che poi viene AGGIORNATA perde tutto ciò che viene dopo
+`thread_events` — il log da cui la UI della chat proietta il thread — si riempiva da
+`chat_messages_capture_event`, un trigger `after insert`. Ma il checkpoint del battito
+(`bridge/live.ts`) INSERISCE la riga dell'assistente vuota e poi la AGGIORNA a ogni battito: nel log
+restava la fotografia del primo istante. Un thread reale in produzione aveva 60.700 caratteri di
+reasoning e 10.236 di tool_calls nella riga di `chat_messages`, e `0` e `0` nell'evento — con
+`loadThreadUiHistory` che ricade su `chat_messages` solo quando gli eventi sono ZERO, quindi non ci
+ricadeva mai. Per l'utente il turno era sparito; nel database non mancava niente.
+
+Segnale: un turno che «è scomparso» ma di cui il modello ha memoria, o due messaggi identici di
+salvataggio in coda a un lavoro lungo. Confronto che chiude la diagnosi in una query:
+`length(payload->>'content')` dell'evento contro `length(content)` della riga, sullo stesso id.
+
+Mossa, e vale oltre questo caso: **prima di scrivere un trigger `after insert`, chiedi se qualcuno
+aggiorna quella riga.** Se sì, o il trigger copre anche l'UPDATE, o il log è una bugia dal secondo
+battito in poi. Qui l'evento resta immutabile (`append_thread_event` solleva sul payload diverso, ed
+è giusto): l'aggiornamento entra come evento NUOVO con la sua `source_key`, di cui se ne tiene UNA
+sola, e il reducer sostituisce il messaggio con lo stesso id invece di accodarlo.
+
 ## Build e bundle
 
 ### Un chunk sovradimensionato non è il colpevole del build che muore per memoria

--- a/changelog/2026-09-01-thread-event-revisions.md
+++ b/changelog/2026-09-01-thread-event-revisions.md
@@ -1,0 +1,41 @@
+# Il turno riscritto non sparisce più dal thread
+
+`thread_events` è il log da cui la UI proietta la chat, e si riempiva da un solo trigger:
+`chat_messages_capture_event`, `after insert`. Il checkpoint del battito (`bridge/live.ts:663`)
+però inserisce la riga dell'assistente VUOTA e poi la aggiorna a ogni battito — quindi nel log
+restava la fotografia del primo istante, per sempre.
+
+Misurato sul thread `cc6854d2` in produzione, messaggio `cce28fda`:
+
+| | riga `chat_messages` | evento letto dalla UI |
+|---|---|---|
+| content | 531 | 0 |
+| tool_calls | 10.236 | 0 |
+| reasoning | 60.700 | 0 |
+
+`loadThreadUiHistory` preferisce sempre la proiezione degli eventi e ricade su `chat_messages`
+solo quando di eventi non ce n'è NESSUNO: con 230 eventi nel thread non ci ricadeva mai. Il turno
+risultava scomparso a chi guardava, mentre nel database non mancava una virgola.
+
+Non bastava un trigger in più sull'UPDATE: `append_thread_event` solleva
+`thread event source key conflict` se il payload cambia sotto la stessa `source_key`, e
+l'eccezione avrebbe fatto abortire anche la scrittura del contenuto. E `reduceThreadEvents` faceva
+`messages.push()`, quindi un secondo evento sullo stesso messaggio avrebbe prodotto una bolla
+doppia invece di un aggiornamento.
+
+Quindi due pezzi, uno per lato:
+
+- **L'evento resta immutabile.** La revisione è un evento NUOVO, `message:<id>:r<seq>`, scritto da
+  `append_thread_message_revision` sotto lo stesso lock di thread che alloca il seq — così la
+  chiave è unica per costruzione. Se ne tiene UNA: il payload è la riga intera, e un turno lungo
+  produce decine di checkpoint. Una riscrittura identica non costa niente (il confronto
+  `is not distinct from` sta nel trigger, perché `update of` scatta anche a valore uguale).
+- **Il reducer sostituisce al suo posto** il messaggio con lo stesso id, invece di accodarlo: la
+  bolla resta dov'era nel thread e porta il contenuto ultimo. Un messaggio già superato non torna
+  in vita per via di una revisione tardiva.
+
+Lo scenario di durabilità `il-turno-riscritto-non-sparisce` è il guardiano: inserisce vuoto,
+riscrive due volte, e pretende una bolla sola col testo finale e una sola revisione in log.
+
+I thread già colpiti NON si riparano da soli: l'evento vecchio resta quello che è. Il riallineamento
+dei payload esistenti è un intervento a parte.

--- a/packages/agent-kit/src/thread-events.test.ts
+++ b/packages/agent-kit/src/thread-events.test.ts
@@ -22,7 +22,56 @@ const superseded = (seq: number, ids: string[]): ThreadEvent => ({
 	messageIds: ids
 });
 
+const revision = (seq: number, id: string, content: string): ThreadEvent => ({
+	seq,
+	sourceKey: `message:${id}:r${seq}`,
+	kind: 'message',
+	message: { id, role: 'assistant', content }
+});
+
 describe('thread event reducer', () => {
+	/**
+	 * Il checkpoint del battito INSERISCE la riga vuota e poi la AGGIORNA: senza revisione il log
+	 * teneva la fotografia iniziale e la UI mostrava un turno vuoto con 60k di reasoning nel
+	 * database. Una revisione SOSTITUISCE il messaggio, non ne aggiunge un secondo.
+	 */
+	it('una revisione sostituisce il messaggio con lo stesso id, al suo posto', () => {
+		const result = reduceThreadEvents(emptyThreadProjection(), [
+			message(1, 'message-1', ''),
+			message(2, 'message-2', 'la domanda dopo'),
+			revision(3, 'message-1', 'il turno intero')
+		]);
+
+		expect(result.conflict).toBeNull();
+		expect(result.projection.messages).toEqual([
+			{ id: 'message-1', role: 'assistant', content: 'il turno intero' },
+			{ id: 'message-2', role: 'assistant', content: 'la domanda dopo' }
+		]);
+	});
+
+	it('l’ultima revisione vince, e il cursore avanza', () => {
+		const result = reduceThreadEvents(emptyThreadProjection(), [
+			message(1, 'message-1', ''),
+			revision(2, 'message-1', 'a metà'),
+			revision(5, 'message-1', 'finito')
+		]);
+
+		expect(result.projection.messages).toEqual([
+			{ id: 'message-1', role: 'assistant', content: 'finito' }
+		]);
+		expect(result.projection.cursor).toBe(5);
+	});
+
+	it('una revisione su un messaggio già superato non lo riporta in vita', () => {
+		const first = reduceThreadEvents(emptyThreadProjection(), [
+			message(1, 'message-1', 'da rifare'),
+			superseded(2, ['message-1'])
+		]);
+		const second = reduceThreadEvents(first.projection, [revision(3, 'message-1', 'tardi')]);
+
+		expect(second.projection.messages).toEqual([]);
+	});
+
 	it('orders events and projects messages and latest progress', () => {
 		const result = reduceThreadEvents(emptyThreadProjection(), [
 			progress(3, 'run-1', 'completed'),

--- a/packages/agent-kit/src/thread-events.ts
+++ b/packages/agent-kit/src/thread-events.ts
@@ -63,7 +63,7 @@ export function reduceThreadEvents(
 			.filter((event): event is Extract<ThreadEvent, { kind: 'messages_superseded' }> => event.kind === 'messages_superseded')
 			.flatMap((event) => event.messageIds)
 	);
-	const messages = projection.messages.filter((message) => !supersededIds.has(message.id));
+	const messages = [...projection.messages.filter((message) => !supersededIds.has(message.id))];
 	const progress = { ...projection.progress };
 	const sourceEvents = { ...projection.sourceEvents };
 	const applied: ThreadEvent[] = [];
@@ -85,7 +85,7 @@ export function reduceThreadEvents(
 		}
 
 		if (event.kind === 'message') {
-			messages.push(event.message);
+			putMessage(messages, event.message, supersededIds);
 		}
 
 		if (event.kind === 'progress') {
@@ -109,6 +109,27 @@ export function reduceThreadEvents(
 		applied,
 		conflict
 	};
+}
+
+/**
+ * Il messaggio si SOSTITUISCE al suo posto, non si accoda: la riga dell'assistente nasce vuota e
+ * viene riscritta a ogni checkpoint del battito, quindi un secondo evento sullo stesso id è la
+ * stessa bolla più avanti nel lavoro — non una bolla nuova, e non una bolla in fondo al thread.
+ */
+function putMessage(
+	messages: ThreadMessage[],
+	message: ThreadMessage,
+	supersededIds: ReadonlySet<string>
+): void {
+	if (supersededIds.has(message.id)) return;
+
+	const at = messages.findIndex((existing) => existing.id === message.id);
+	if (at < 0) {
+		messages.push(message);
+		return;
+	}
+
+	messages[at] = message;
 }
 
 function eventPayload(event: ThreadEvent): unknown {

--- a/scripts/eval/durability.ts
+++ b/scripts/eval/durability.ts
@@ -17,6 +17,7 @@ import { reapDeadKitRuns } from '$lib/server/agent-kit-recover';
 // grafo prima che il giro cominci. Serve all'harness, non al prodotto.
 import '$lib/server/chat/queue';
 import { MAX_RUN_ATTEMPTS } from '$lib/server/chat/turn-limits';
+import { loadThreadEvents, threadProjectionRows } from '$lib/server/chat/thread-events';
 import { createFixture, destroyFixture, type Fixture } from './durability/fixture';
 
 type Fact = { id: string; ok: boolean; detail: string };
@@ -24,6 +25,7 @@ type Scenario = { id: string; what: string; run: (fixture: Fixture) => Promise<F
 
 const DEAD_HEARTBEAT_MS = 30 * 60_000;
 const PARTIAL_TEXT = 'ho sistemato quattro articoli su dieci';
+const REWRITTEN_TEXT = 'il turno intero, come lo vede chi riapre il thread';
 
 const SCENARIOS: Scenario[] = [
 	{
@@ -101,6 +103,52 @@ const SCENARIOS: Scenario[] = [
 				fact('lo-zombie-non-chiude', zombie.closed === false, `closed ${zombie.closed}`),
 				fact('chi-tiene-il-lease-chiude', owner.closed === true, `closed ${owner.closed}`),
 				fact('un-solo-messaggio', messages.length === 1, `${messages.length} messaggi assistant`)
+			];
+		}
+	},
+	{
+		id: 'il-turno-riscritto-non-sparisce',
+		what: 'la riga dell’assistente nasce vuota e viene riscritta: il thread deve mostrare il turno intero',
+		async run(fixture) {
+			const admin = createAdminClient();
+			const { data, error } = await admin
+				.from('chat_messages')
+				.insert({
+					brand_id: fixture.brandId,
+					user_id: fixture.userId,
+					thread_id: fixture.threadId,
+					role: 'assistant',
+					content: ''
+				})
+				.select('id')
+				.single();
+			if (error) throw new Error(`seed del messaggio fallito — ${error.message}`);
+			const messageId = (data as { id: string }).id;
+
+			// Il battito riscrive la STESSA riga a ogni checkpoint: due giri, come in produzione.
+			for (const text of ['a metà del lavoro', REWRITTEN_TEXT]) {
+				const { error: patch } = await admin
+					.from('chat_messages')
+					.update({ content: text, reasoning: `${text} — pensiero`, tool_calls: [{ toolName: 'read_posts' }] })
+					.eq('id', messageId);
+				if (patch) throw new Error(`riscrittura fallita — ${patch.message}`);
+			}
+
+			const events = (await loadThreadEvents(admin, fixture.threadId)) ?? [];
+			const projection = threadProjectionRows(events);
+			const shown = (projection?.messages ?? []).find((m) => m.id === messageId) as
+				| { content?: string; reasoning?: string }
+				| undefined;
+
+			return [
+				fact('una-bolla-sola', (projection?.messages ?? []).filter((m) => m.id === messageId).length === 1, `${(projection?.messages ?? []).length} messaggi proiettati`),
+				fact('il-testo-e-l-ultimo', shown?.content === REWRITTEN_TEXT, `contenuto proiettato: ${JSON.stringify(shown?.content ?? null)}`),
+				fact('il-pensiero-arriva', Boolean(shown?.reasoning), `reasoning proiettato: ${shown?.reasoning ? 'sì' : 'no'}`),
+				fact(
+					'una-revisione-sola',
+					events.filter((e) => e.source_key.startsWith(`message:${messageId}:r`)).length === 1,
+					`${events.filter((e) => e.source_key.startsWith(`message:${messageId}:r`)).length} revisioni in log`
+				)
 			];
 		}
 	}

--- a/src/lib/content/changelog/2026-09-01-thread-event-revisions.ts
+++ b/src/lib/content/changelog/2026-09-01-thread-event-revisions.ts
@@ -1,0 +1,9 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-01',
+  title: 'Long turns stay visible in the thread',
+  items: [
+    'A turn that takes a while no longer looks empty when you reopen it: the reply, the thinking and the tools it used stay in the thread as they are written, instead of showing the moment the turn started.'
+  ]
+} satisfies ChangelogEntry;

--- a/supabase/migrations/20260901150000_thread_message_revisions.sql
+++ b/supabase/migrations/20260901150000_thread_message_revisions.sql
@@ -1,0 +1,97 @@
+-- Il log degli eventi vedeva solo l'INSERT di chat_messages. Il checkpoint del battito
+-- (bridge/live.ts) inserisce la riga dell'assistente VUOTA e poi la aggiorna a ogni battito, quindi
+-- il log teneva la fotografia iniziale: un thread reale aveva 60.700 caratteri di reasoning e 10.236
+-- di tool_calls nella riga, e zero nell'evento che la UI legge. Il turno risultava scomparso.
+--
+-- Un evento non si riscrive (append_thread_event solleva sul payload diverso, ed è giusto: il log è
+-- immutabile). La revisione è un evento NUOVO, con la sua source_key, e il reducer sostituisce il
+-- messaggio con lo stesso id invece di accodarlo. Della revisione se ne tiene UNA: il payload è la
+-- riga intera, e un turno lungo ne produce decine.
+
+create or replace function public.append_thread_message_revision(
+  p_thread_id uuid,
+  p_message_id uuid,
+  p_payload jsonb
+)
+returns public.thread_events
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_thread public.chat_threads%rowtype;
+  v_event public.thread_events%rowtype;
+  v_origin text := 'message:' || p_message_id;
+begin
+  select * into v_thread
+  from public.chat_threads
+  where id = p_thread_id
+  for update;
+
+  if v_thread.id is null then
+    raise exception 'thread not found';
+  end if;
+
+  -- Nessuna revisione prima dell'originale: senza l'evento di INSERT il messaggio non esiste per
+  -- il reducer, e una revisione da sola lo farebbe comparire fuori dal suo posto.
+  if not exists (
+    select 1 from public.thread_events
+    where thread_id = p_thread_id and source_key = v_origin
+  ) then
+    return null;
+  end if;
+
+  delete from public.thread_events
+  where thread_id = p_thread_id and source_key like v_origin || ':r%';
+
+  insert into public.thread_events (thread_id, seq, source_key, kind, payload)
+  values (
+    p_thread_id,
+    v_thread.event_head_seq + 1,
+    v_origin || ':r' || (v_thread.event_head_seq + 1),
+    'message',
+    p_payload
+  )
+  returning * into v_event;
+
+  update public.chat_threads
+  set event_head_seq = v_event.seq
+  where id = p_thread_id;
+
+  return v_event;
+end;
+$$;
+
+revoke all on function public.append_thread_message_revision(uuid, uuid, jsonb) from public, anon;
+grant execute on function public.append_thread_message_revision(uuid, uuid, jsonb) to authenticated, service_role;
+
+create or replace function public.capture_chat_message_revision()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if new.thread_id is null then
+    return new;
+  end if;
+
+  -- `update of` scatta anche quando il valore riscritto è identico: un checkpoint che non ha
+  -- aggiunto niente non deve costare un evento da 60 kB.
+  if new.content is not distinct from old.content
+     and new.reasoning is not distinct from old.reasoning
+     and new.tool_calls is not distinct from old.tool_calls then
+    return new;
+  end if;
+
+  perform public.append_thread_message_revision(new.thread_id, new.id, to_jsonb(new));
+  return new;
+end;
+$$;
+
+drop trigger if exists chat_messages_capture_revision on public.chat_messages;
+create trigger chat_messages_capture_revision
+after update of content, reasoning, tool_calls on public.chat_messages
+for each row execute function public.capture_chat_message_revision();
+
+revoke all on function public.capture_chat_message_revision() from public, anon, authenticated;


### PR DESCRIPTION
## What?

A long turn could vanish from the chat. The reply, the thinking and the tool calls were all in the database and none of it reached the screen.

`thread_events` — the log the chat UI projects from — was fed by one trigger, `chat_messages_capture_event`, `AFTER INSERT`. But the heartbeat checkpoint (`bridge/live.ts:663`) **inserts the assistant row empty and then updates it** on every beat. The log kept the snapshot of the first instant, forever.

Measured on production thread `cc6854d2`, message `cce28fda`:

| | row in `chat_messages` | event the UI reads |
|---|---|---|
| content | 531 | **0** |
| tool_calls | 10,236 | **0** |
| reasoning | 60,700 | **0** |

`loadThreadUiHistory` prefers the event projection and falls back to `chat_messages` only when there are **zero** events. That thread had 230, so it never fell back. Same thread, seq 500: another 4,986 chars of reasoning already invisible.

An update now reaches the log as a revision, and the projection shows it.

## Why?

This is silent data loss as the user experiences it — work that took twelve minutes reads as a thread that ends at their own message. It is also the worst possible shape of bug: nothing is actually lost, so no alarm fires, and the only symptom is a user saying a turn disappeared.

## How?

The event log stays append-only. `append_thread_event` raises `thread event source key conflict` when a payload changes under an existing `source_key`, and that guarantee is worth keeping — an `AFTER UPDATE` trigger calling it would have raised inside the trigger and aborted the write of the content too.

So the update arrives as a **new** event:

- `append_thread_message_revision` writes `message:<id>:r<seq>`, allocating the seq under the same `chat_threads` row lock the original RPC uses — the key is unique by construction, no counter to race on.
- **One revision is kept.** The payload is the entire row; a twelve-minute turn checkpoints dozens of times, and at 60 kB of reasoning each that log would cost megabytes per turn. The new revision deletes the previous one; the original INSERT event is never touched.
- The trigger is column-scoped (`after update of content, reasoning, tool_calls`) and additionally compares `is not distinct from`, because `update of` fires even when the rewritten value is identical.
- `reduceThreadEvents` now **replaces** the message with the same id in place instead of `messages.push()`. In place matters: the bubble keeps its position in the thread instead of jumping to the end. A revision for an already-superseded message is dropped rather than resurrecting it.

Rejected — the UI overlaying `chat_messages` on the projection: smaller, no migration, but it leaves the log saying something untrue and the next person to read it falls into the same hole.

Rejected — never updating in place (supersede + insert a fresh row per checkpoint): coherent, but multiplies rows per turn and rewrites the write path for a projection problem.

## Testing?

Reducer, three tests written first and watched fail (`packages/agent-kit/src/thread-events.test.ts`): a revision replaces in place and does not duplicate; the last revision wins and the cursor advances; a revision cannot revive a superseded message.

The plpgsql cannot be tested by a fake client, so it was exercised against the **local self-hosted stack** (`anomalia-db`), inside a transaction rolled back at the end — insert empty, two rewrites, one identical rewrite:

<details><summary>psql probe output</summary>

```
 seq |                   source_key                    |     content     | reasoning
-----+-------------------------------------------------+-----------------+------------
   1 | message:b4cbdaa0-…                              |                 |
   3 | message:b4cbdaa0-…:r3                           | il turno intero | pensiero 2
```

The original event untouched at seq 1; the first revision (seq 2) replaced by the second; the identical rewrite wrote nothing.

</details>

```
$ npx vitest run          # 543 files, 6081 passed, 1 skipped
```

Durability scenario `il-turno-riscritto-non-sparisce` added to `npm run eval:durability`: insert empty, rewrite twice, demand one bubble with the final text and exactly one revision in the log. **It has not been run**, because the eval points at the hosted database and the migration is not applied there yet — it is the guardian for after the migration lands, not evidence collected before it.

**Not tested:** the event-count growth on a very long real turn. One revision is kept per message, so the ceiling is one extra event per message, but nobody has watched it under a real twelve-minute motion job yet.

## Evidence (screenshots/videos)

No UI change — the fix is that the existing UI receives the data it was already asking for. The measurement is the table at the top, taken with a read-only query against production.

## Anything Else?

**This does not repair threads already hit.** The stale events stay stale: the original event keeps the empty payload and no update will ever come for it again. Realigning existing payloads to the current `chat_messages` rows is a separate, one-shot operation — worth doing for `cc6854d2` at least, and worth a query first to see how many threads carry the same gap.

**The migration must be applied by hand** (deploys here do not run migrations). Until it is, the trigger does not exist and the reducer change alone changes nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CPHcJKUNRK7z8dLF4jq9NU