### PR TITLE
Stop re-sending the whole chat history every three seconds

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -79,6 +79,17 @@ Il mock scritto nell'era della PR non dichiara gli export nuovi di dev (`createS
 ### Il websocket Realtime non si collega dalla stack locale: quello che arriva per broadcast non lo verifichi qui
 Il broadcast HTTP del server risponde 202 e il container lo logga, ma il browser non apre mai il canale: `channel(...).subscribe()` non risolve, e in `read_network_requests` non c'è una sola richiesta verso `localhost:8000`. Tutto quello che il prodotto consegna via `thread-changed` / `turn-state` / `kit_stream` — il turno scritto dal worker che deve comparire da solo, il pallino in sidebar, il riaggancio a uno stream partito altrove — nella stack locale non si vede, e la tentazione è di dichiararlo rotto nel codice. Segnale: il POST `/api/broadcast/...` esce 202, i log di `realtime-dev.anomalia-realtime` non mostrano nessun join di canale, e la UI resta ferma. Mossa: verifica quel percorso dal lato che NON dipende dal socket — scrivi la riga in `chat_messages` mentre la scheda è nascosta e torna sulla scheda: se il ricontrollo al focus la porta a schermo, il difetto non è lì. E dillo nel PR invece di far passare per verificato ciò che la macchina non poteva provare.
 
+### Due dev server su localhost si rubano la sessione: il 404 «Brand not found» non è un bug tuo
+Per un confronto prima/dopo viene naturale tenere due porte accese insieme (dev su 5201, branch su
+5200). I cookie però stanno sull'HOST, non sulla porta: entrambi i server ruotano lo stesso refresh
+token di GoTrue, e chi arriva secondo se lo trova già speso. Da lì la pagina risponde 404 con
+`{"error":"Brand not found"}`, oppure ti sbatte su `/app/onboarding` come se l'utente non avesse
+brand — e sembra un difetto del codice appena scritto. Segnale: la stessa URL rende su una porta e
+404 sull'altra, con lo stesso `.env` e lo stesso `PUBLIC_SUPABASE_URL=http://localhost:8000`; un
+`fetch` all'endpoint dice «Brand not found» invece di «Unauthorized». Mossa: **un dev server alla
+volta** per qualunque verifica nel browser. Il confronto prima/dopo si fa in sequenza — misuri il
+branch, spegni, accendi il baseline, misuri — non in parallelo.
+
 ### Il worker locale è un build vecchio che compete per la stessa coda
 La stack Docker porta un'app pronta (`anomalia-app`, immagine `anomalia-selfhost-app`) che prosciuga `chat_jobs` dallo stesso DB del dev server: il cron chiama `app:3000`, non la tua porta. Con l'immagine più vecchia del checkout, il codice nuovo **non gira mai** (il team contact post-onboarding non parte) e i due reaper si contendono i turni: `chat turn died mid-flight (heartbeat lost)` su turni vivi, `Failed to load url credits.ts` da moduli che nel checkout esistono. Segnale: `chat_jobs` failed con errori che il codice attuale non può produrre. Mossa: identificare chi prosciuga la coda prima di giudicare il flusso — `docker logs anomalia-app`, data dell'immagine (`docker images`) contro `git log -1` — e fermare o ricostruire il container stantio (ricordarsi di riaccenderlo).
 

--- a/changelog/2026-09-02-chat-poll-delta.md
+++ b/changelog/2026-09-02-chat-poll-delta.md
@@ -43,11 +43,6 @@ sola; finita quella, la successiva riparte davvero. E i tre `console.log` non ci
 **Le due scansioni spariscono.** `lastUserIndex` si calcola una volta; `followingUserTexts` passa
 come getter, quindi il giro quadratico avviene solo per il turno raro che mostra la card domande.
 
-**`content-visibility: auto` su ogni turno.** Cento turni sono renderizzati, dieci stanno sullo
-schermo, e il browser non aveva modo di sapere che poteva saltare gli altri novanta.
-`contain-intrinsic-size: auto 180px` è l'altezza dichiarata finché il turno resta fuori campo, così
-la barra di scorrimento non salta quando entra.
-
 ## Quello che NON si è fatto, e perché
 
 **Chiavare la lista sull'id del messaggio.** Sembra l'ovvio miglioramento e invece spegne la lista:
@@ -64,4 +59,9 @@ dieci `{#await}` dentro il file che non si deve rompere. Non paga.
 
 **La barra azioni al hover.** Quattro bottoni e quattro icone per turno sono ~800 nodi su cento
 turni, ma senza hover — cioè su ogni schermo tattile — quelle azioni diventano irraggiungibili.
-`content-visibility` prende gran parte dello stesso beneficio senza togliere niente a nessuno.
+
+**`content-visibility: auto` sui turni.** Scritto, misurato, tolto. Su cento turni di testo il
+benchmark di scroll a schermo visibile dà lo stesso p95 con e senza (9,4 ms contro 9,5 ms, su un
+budget di 8,33 ms a 120 Hz), e il costo di un re-layout forzato resta 0,05–0,1 ms in entrambi i
+casi. Zero misurato, quindi zero righe: se un giorno un thread pieno di immagini e card mostrerà
+un costo di layout vero, si riapre con quel numero in mano.

--- a/changelog/2026-09-02-chat-poll-delta.md
+++ b/changelog/2026-09-02-chat-poll-delta.md
@@ -1,0 +1,67 @@
+# La chat smette di rispedirsi la cronologia ogni tre secondi
+
+Misurato su un thread da 200 messaggi (100 renderizzati, il tetto di `loadThreadUiHistory`), stack
+locale, browser vero. Non un sospetto: numeri.
+
+## Cosa costava
+
+**Il poll dei lavori in background.** Mentre un job gira, `tickToolWatch` rifaceva l'INTERO
+transcript a ogni tick: **202 KB e 176 ms** per cento messaggi, venti volte al minuto, per un testo
+quasi sempre identico a sé stesso. Poi riassegnava `messages`, quindi ogni turno riceveva oggetti
+nuovi e la cronologia si ridisegnava tutta.
+
+**Il markdown.** `renderMd` è puro e non ricordava niente: **~40 ms per cento turni, uguali a ogni
+passata**. Quel costo si pagava a ogni ridisegno, cioè a ogni tick del poll.
+
+**La lista dei thread.** `refreshThreads` non sa degli altri sei chiamanti: all'apertura di un
+thread partivano **tre `/chat/threads` identiche nello stesso secondo** — novantaquattro thread,
+63 KB, sei query lato server ciascuna — più tre `console.log` per chiamata spediti in produzione.
+
+**Due scansioni quadratiche in `TranscriptList`.** `isLastUser` e `followingUserTexts` scorrevano
+la coda della lista per OGNI riga: su cento turni cinquemila passi e cento array nuovi a ogni
+ridisegno. `followingUserTexts` serve solo alla card domande, che quasi nessun turno ha.
+
+## Cosa cambia
+
+**Il tick chiede il delta, non la storia.** Il thread ha già un registro durevole con cursore —
+`thread_events`, e a scriverlo è un trigger su ogni insert di `chat_messages`, quindi copre ogni
+percorso: stream, worker, CLI. La pagina lo legge già per `thread-seq` (`syncThreadCursor`), che
+ricarica il transcript SOLO quando un messaggio è davvero atterrato. Il watcher ora si limita a
+battere: `onMessages` diventa `onTick`, e la pagina avanza il proprio cursore.
+
+Misurato nel browser con un job vivo: due tick producono quattro richieste per **0,41 KB in tutto**
+— `pending_tools` 0,19 KB, `events_after` 0,015 KB — e **zero** chiamate al transcript. Da ~202 KB
+a ~0,2 KB per tick.
+
+**`renderMd` ricorda per testo.** Mappa limitata a 400 voci (una cronologia intera ne porta 100),
+sfratto del più vecchio con l'ordine di inserimento della Map. Misurato: rifare cento turni già
+visti passa da **~40 ms a 0,1 ms**.
+
+**`refreshThreads` restituisce la promessa in volo.** Tre chiamate concorrenti fanno una fetch
+sola; finita quella, la successiva riparte davvero. E i tre `console.log` non ci sono più.
+
+**Le due scansioni spariscono.** `lastUserIndex` si calcola una volta; `followingUserTexts` passa
+come getter, quindi il giro quadratico avviene solo per il turno raro che mostra la card domande.
+
+**`content-visibility: auto` su ogni turno.** Cento turni sono renderizzati, dieci stanno sullo
+schermo, e il browser non aveva modo di sapere che poteva saltare gli altri novanta.
+`contain-intrinsic-size: auto 180px` è l'altezza dichiarata finché il turno resta fuori campo, così
+la barra di scorrimento non salta quando entra.
+
+## Quello che NON si è fatto, e perché
+
+**Chiavare la lista sull'id del messaggio.** Sembra l'ovvio miglioramento e invece spegne la lista:
+il carico del thread può contenere due righe con lo stesso id (un checkpoint parziale e la sua
+versione finale — osservato su una cronologia vera: stesso id, stesso testo, due tool contro
+dieci), e Svelte su una chiave duplicata non disegna il blocco. Transcript vuoto, nessun errore a
+schermo. Verificato nel browser cambiando la sola riga della chiave, avanti e indietro. Si potrà
+fare quando `consolidateMessages` produrrà una chiave sua, unica per riga; fino ad allora la chiave
+resta la posizione e `transcript-key.test.ts` lo tiene fermo.
+
+**Import dinamico per le venti card di `ChatTurn`.** Il nodo della rotta pesa 91 KB non compressi
+su una base condivisa di ~1 MB decodificati: la resa massima è intorno all'1% del critico, contro
+dieci `{#await}` dentro il file che non si deve rompere. Non paga.
+
+**La barra azioni al hover.** Quattro bottoni e quattro icone per turno sono ~800 nodi su cento
+turni, ma senza hover — cioè su ogni schermo tattile — quelle azioni diventano irraggiungibili.
+`content-visibility` prende gran parte dello stesso beneficio senza togliere niente a nessuno.

--- a/src/lib/chat-markdown.test.ts
+++ b/src/lib/chat-markdown.test.ts
@@ -96,3 +96,37 @@ describe('renderMd images', () => {
     }
   });
 });
+
+/**
+ * Misurato l'1/9 su un thread da 100 turni: rifare il markdown dell'intera cronologia costa ~40 ms
+ * di main thread, identici a ogni passata, perché niente veniva ricordato. E la cronologia si
+ * ridisegna a ogni poll mentre un lavoro gira in background: lo stesso testo, immutato, macinato
+ * di nuovo venti volte al minuto.
+ */
+describe('renderMd non rimacina lo stesso testo', () => {
+  const sample = '## Titolo\n\n' + 'Testo con **grassetto** e `codice`. '.repeat(40) + '\n\n- uno\n- due\n';
+
+  it('lo stesso testo torna identico senza ricalcolo', () => {
+    const first = renderMd(sample);
+    const second = renderMd(sample);
+    expect(second).toBe(first);
+
+    const corpus = Array.from({ length: 100 }, (_, i) => `Risposta ${i}\n\n${sample}`);
+    for (const t of corpus) renderMd(t);
+    const cold = process.hrtime.bigint();
+    for (const t of corpus) renderMd(t);
+    const warmNs = Number(process.hrtime.bigint() - cold);
+
+    const fresh = corpus.map((t) => `${t}\n\nnuovo`);
+    const start = cold && process.hrtime.bigint();
+    for (const t of fresh) renderMd(t);
+    const freshNs = Number(process.hrtime.bigint() - start);
+
+    // Una seconda passata sullo stesso corpus deve costare una frazione della prima.
+    expect(warmNs).toBeLessThan(freshNs / 2);
+  });
+
+  it('un testo diverso resta diverso: la cache è sul contenuto, non sulla posizione', () => {
+    expect(renderMd('**a**')).not.toBe(renderMd('**b**'));
+  });
+});

--- a/src/lib/chat-markdown.ts
+++ b/src/lib/chat-markdown.ts
@@ -111,7 +111,7 @@ export function escapeChatText(text: string): string {
 // modello che può averlo copiato dalla pagina appena letta: incorporarlo significa consegnare a
 // un terzo l'IP e il referrer di chi guarda. Quindi si incorpora solo ciò che è NOSTRO (stessa
 // regola di `show_media`), e tutto il resto resta un link — visibile, cliccabile, non caricato.
-export function renderMd(text: string): string {
+function renderMarkdown(text: string): string {
   const esc = (s: string) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
   const inline = (s: string) =>
     esc(s)
@@ -265,4 +265,28 @@ export function renderMd(text: string): string {
   flushTable();
   if (inCode) out.push(esc(codeBuf.join('\n')) + '</code></pre>');
   return decorateColorCodes(out.join(''));
+}
+
+/**
+ * Il markdown di un messaggio già reso non si rifà.
+ *
+ * Un turno immutato veniva rimacinato a ogni ridisegno della cronologia: misurato l'1/9, 40 ms di
+ * main thread per 100 turni, ripetuti a ogni poll mentre un lavoro gira in background. La funzione
+ * è pura — stesso testo, stesso HTML — quindi il testo È la chiave.
+ *
+ * Il tetto tiene la mappa più larga di una cronologia intera (il caricamento ne porta 100) senza
+ * crescere per sempre in una scheda lasciata aperta: superato, si butta l'ingresso più vecchio,
+ * che l'ordine di inserimento della Map rende gratis.
+ */
+const RENDERED_LIMIT = 400;
+const rendered = new Map<string, string>();
+
+export function renderMd(text: string): string {
+  const hit = rendered.get(text);
+  if (hit !== undefined) return hit;
+
+  const html = renderMarkdown(text);
+  if (rendered.size >= RENDERED_LIMIT) rendered.delete(rendered.keys().next().value as string);
+  rendered.set(text, html);
+  return html;
 }

--- a/src/lib/content/changelog/2026-09-02-chat-lighter.ts
+++ b/src/lib/content/changelog/2026-09-02-chat-lighter.ts
@@ -5,7 +5,7 @@ export default {
   title: 'Long conversations feel lighter',
   items: [
     'While a job runs in the background, the chat now asks the server only for what changed instead of re-downloading the whole conversation every few seconds.',
-    'Long histories redraw faster: text already on screen is no longer re-rendered from scratch, and the browser skips the turns you have scrolled past.',
+    'Long histories redraw faster: text already on screen is no longer re-rendered from scratch.',
     'Opening a conversation no longer loads your thread list three times over.'
   ]
 } satisfies ChangelogEntry;

--- a/src/lib/content/changelog/2026-09-02-chat-lighter.ts
+++ b/src/lib/content/changelog/2026-09-02-chat-lighter.ts
@@ -1,0 +1,11 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-02',
+  title: 'Long conversations feel lighter',
+  items: [
+    'While a job runs in the background, the chat now asks the server only for what changed instead of re-downloading the whole conversation every few seconds.',
+    'Long histories redraw faster: text already on screen is no longer re-rendered from scratch, and the browser skips the turns you have scrolled past.',
+    'Opening a conversation no longer loads your thread list three times over.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/stores/chat-session.test.ts
+++ b/src/lib/stores/chat-session.test.ts
@@ -9,7 +9,7 @@ import {
   hydrateSessionFromStorage,
   readPersistedSession,
   watchToolJobs,
-  detachToolJobMessages,
+  detachToolJobCallbacks,
   stopWatchingToolJobs,
   isWatchingToolJobs,
   getSession,
@@ -470,7 +470,7 @@ describe('chat-session store', () => {
   it('watchToolJobs keeps sidebar busy after detach and clears when jobs finish', async () => {
     const fetchMock = vi.mocked(fetch);
     let pending = [{ id: 'j1', tool_name: 'produce_week', status: 'running' }];
-    const onMessages = vi.fn();
+    const onTick = vi.fn();
     const onIdle = vi.fn();
 
     fetchMock.mockImplementation((url) => {
@@ -478,33 +478,23 @@ describe('chat-session store', () => {
       if (u.includes('pending_tools=1')) {
         return Promise.resolve(new Response(JSON.stringify({ jobs: pending }), { status: 200 }));
       }
-      if (u.includes('/chat?thread=')) {
-        return Promise.resolve(
-          new Response(
-            JSON.stringify({
-              messages: [{ role: 'assistant', content: 'ancora in corso…' }]
-            }),
-            { status: 200 }
-          )
-        );
-      }
       return Promise.reject(new Error(u));
     });
 
     watchToolJobs({
       brandSlug: 'acme',
       threadId: 'thread-4',
-      onMessages,
+      onTick,
       onIdle
     });
 
     await vi.runOnlyPendingTimersAsync();
     expect(isWatchingToolJobs('thread-4')).toBe(true);
     expect(get(backgroundToolThreads).has('thread-4')).toBe(true);
-    expect(onMessages).toHaveBeenCalled();
+    expect(onTick).toHaveBeenCalled();
 
     // User leaves the page — detach callbacks but keep watcher
-    detachToolJobMessages('thread-4');
+    detachToolJobCallbacks('thread-4');
     expect(isWatchingToolJobs('thread-4')).toBe(true);
     expect(get(backgroundToolThreads).has('thread-4')).toBe(true);
 
@@ -795,5 +785,53 @@ describe('chat-session — turni kit e race del client (23-24/8)', () => {
     await vi.advanceTimersByTimeAsync(91_000);
     expect(await p).toBe('ok');
     expect(getSession('th-stall')).toBeNull();
+  });
+});
+
+/**
+ * Misurato l'1/9: mentre un lavoro gira in background il watcher rifaceva l'INTERO transcript
+ * ogni tre secondi — 202 KB e 176 ms per un thread da 100 messaggi, cioè ~4 MB al minuto di
+ * cronologia identica. Il thread ha già un registro durevole con cursore (`thread_events`, scritto
+ * da un trigger su ogni insert di `chat_messages`) e la pagina lo legge già per `thread-seq`: il
+ * tick deve chiedere il DELTA, non la storia.
+ */
+describe('watchToolJobs non riscarica la cronologia a ogni tick', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    __resetChatSessionForTests();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: unknown) => {
+        const u = String(url);
+        if (u.includes('pending_tools=1')) {
+          return new Response(JSON.stringify({ jobs: [{ id: 'j1', tool_name: 'motion_video', status: 'running' }] }), { status: 200 });
+        }
+        return new Response(JSON.stringify({ messages: [] }), { status: 200 });
+      })
+    );
+  });
+
+  it('il tick chiede i lavori, non il transcript', async () => {
+    watchToolJobs({ brandSlug: 'acme', threadId: 'thread-delta', onTick: vi.fn() });
+    await vi.runOnlyPendingTimersAsync();
+    await vi.advanceTimersByTimeAsync(3000);
+    await vi.runOnlyPendingTimersAsync();
+
+    const urls = vi.mocked(fetch).mock.calls.map((c) => String(c[0]));
+    expect(urls.some((u) => u.includes('pending_tools=1'))).toBe(true);
+    expect(urls.filter((u) => /\/chat\?thread=[^&]+$/.test(u))).toEqual([]);
+    vi.useRealTimers();
+  });
+
+  it('a ogni tick avvisa la pagina, che sincronizza il suo cursore', async () => {
+    const onTick = vi.fn();
+    watchToolJobs({ brandSlug: 'acme', threadId: 'thread-delta2', onTick });
+    await vi.runOnlyPendingTimersAsync();
+    expect(onTick).toHaveBeenCalled();
+
+    const before = onTick.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(3000);
+    await vi.runOnlyPendingTimersAsync();
+    expect(onTick.mock.calls.length).toBeGreaterThan(before);
   });
 });

--- a/src/lib/stores/chat-session.ts
+++ b/src/lib/stores/chat-session.ts
@@ -1256,8 +1256,12 @@ type ToolWatch = {
   brandSlug: string;
   threadId: string;
   timer: ReturnType<typeof setInterval>;
-  /** Page-mounted callback to fold fresh messages into the UI. */
-  onMessages: ((msgs: unknown[]) => void) | null;
+  /**
+   * Il battito passato alla pagina, che da lì avanza il proprio cursore sul registro del thread.
+   * Prima qui c'era `onMessages` e il tick si portava dietro l'intera cronologia a ogni giro:
+   * 202 KB e 176 ms per cento messaggi, venti volte al minuto, per un testo quasi sempre identico.
+   */
+  onTick: (() => void) | null;
   /** Fired once when no pending tool jobs remain (sidebar / list refresh). */
   onIdle: (() => void) | null;
 };
@@ -1284,13 +1288,13 @@ export function isWatchingToolJobs(threadId: string): boolean {
 export function watchToolJobs(opts: {
   brandSlug: string;
   threadId: string;
-  onMessages?: (msgs: unknown[]) => void;
+  onTick?: () => void;
   onIdle?: () => void;
 }): void {
   const existing = toolWatches.get(opts.threadId);
   if (existing) {
     existing.brandSlug = opts.brandSlug;
-    if (opts.onMessages) existing.onMessages = opts.onMessages;
+    if (opts.onTick) existing.onTick = opts.onTick;
     if (opts.onIdle) existing.onIdle = opts.onIdle;
     setThreadToolBackground(opts.threadId, true);
     return;
@@ -1300,7 +1304,7 @@ export function watchToolJobs(opts: {
   const watch: ToolWatch = {
     brandSlug: opts.brandSlug,
     threadId: opts.threadId,
-    onMessages: opts.onMessages ?? null,
+    onTick: opts.onTick ?? null,
     onIdle: opts.onIdle ?? null,
     timer: setInterval(() => {
       void tickToolWatch(opts.threadId);
@@ -1311,11 +1315,11 @@ export function watchToolJobs(opts: {
   void tickToolWatch(opts.threadId);
 }
 
-/** Detach the page callback without stopping the watcher (user left the chat). */
-export function detachToolJobMessages(threadId: string): void {
+/** Detach the page callbacks without stopping the watcher (user left the chat). */
+export function detachToolJobCallbacks(threadId: string): void {
   const w = toolWatches.get(threadId);
   if (w) {
-    w.onMessages = null;
+    w.onTick = null;
     w.onIdle = null;
   }
 }
@@ -1344,17 +1348,15 @@ async function tickToolWatch(threadId: string): Promise<void> {
   if (!w) return;
 
   try {
-    const [jobsRes, msgRes] = await Promise.all([
-      fetch(`/app/${w.brandSlug}/chat?thread=${threadId}&pending_tools=1`),
-      w.onMessages
-        ? fetch(`/app/${w.brandSlug}/chat?thread=${threadId}`)
-        : Promise.resolve(null)
-    ]);
-
-    if (msgRes?.ok && w.onMessages) {
-      const body = await msgRes.json();
-      if (Array.isArray(body.messages)) w.onMessages(body.messages);
+    // Il battito arriva alla pagina PRIMA della risposta: chi sincronizza il cursore non deve
+    // aspettare la lista dei lavori per accorgersi che è atterrato un messaggio.
+    try {
+      w.onTick?.();
+    } catch {
+      /* una pagina che inciampa non spegne il watcher */
     }
+
+    const jobsRes = await fetch(`/app/${w.brandSlug}/chat?thread=${threadId}&pending_tools=1`);
 
     if (jobsRes.ok) {
       const { jobs } = await jobsRes.json();

--- a/src/lib/stores/chat.test.ts
+++ b/src/lib/stores/chat.test.ts
@@ -81,3 +81,37 @@ describe('unread threads', () => {
     expect(unreadCount(get(unreadThreadIds), 't1')).toBe(2);
   });
 });
+
+/**
+ * Misurato l'1/9: aprendo un thread la lista completa (`/chat/threads`, 94 thread, 63 KB e sei
+ * query lato server) veniva chiesta TRE volte nello stesso secondo — sette chiamanti, nessuno
+ * che sappia degli altri. Chi arriva mentre una richiesta è già in volo deve aspettare quella,
+ * non aprirne un'altra.
+ */
+describe('refreshThreads non chiede la stessa lista più volte insieme', () => {
+  beforeEach(() => {
+    unreadThreadIds.set(new Map());
+    chatThreadId.set(null);
+  });
+
+  it('tre chiamate concorrenti fanno una fetch sola', async () => {
+    let resolve!: (v: Response) => void;
+    const fetchMock = vi.fn(() => new Promise<Response>((r) => (resolve = r)));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const all = Promise.all([refreshThreads('acme'), refreshThreads('acme'), refreshThreads('acme')]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    resolve(new Response(JSON.stringify({ threads: [] }), { status: 200 }));
+    await all;
+  });
+
+  it('finita la prima, una chiamata successiva riparte davvero', async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ threads: [] }), { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await refreshThreads('acme');
+    await refreshThreads('acme');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lib/stores/chat.ts
+++ b/src/lib/stores/chat.ts
@@ -115,16 +115,29 @@ export function markThreadRead(brandSlug: string, threadId: string): void {
 }
 
 /**
- * Refresh the thread list from the server.
+ * La lista dei thread, chiesta UNA volta anche quando la chiedono in sette.
+ *
+ * `/chat/threads` non è una lettura leggera: elenca tutti i thread del brand e ci monta sopra
+ * avatar, anteprime, soglie di lettura e conteggi — sei query. Sette chiamanti indipendenti la
+ * facevano partire tre volte nello stesso secondo all'apertura di un thread. Chi arriva mentre
+ * una è in volo aspetta quella; la prossima, dopo, riparte davvero.
  */
-export async function refreshThreads(brandSlug: string): Promise<void> {
+const threadsInFlight = new Map<string, Promise<void>>();
+
+export function refreshThreads(brandSlug: string): Promise<void> {
+  const running = threadsInFlight.get(brandSlug);
+  if (running) return running;
+
+  const call = fetchThreads(brandSlug).finally(() => threadsInFlight.delete(brandSlug));
+  threadsInFlight.set(brandSlug, call);
+  return call;
+}
+
+async function fetchThreads(brandSlug: string): Promise<void> {
   try {
-    console.log('[refreshThreads] Fetching:', `/app/${brandSlug}/chat/threads`);
     const res = await fetch(`/app/${brandSlug}/chat/threads`);
-    console.log('[refreshThreads] Status:', res.status);
     if (res.ok) {
       const data = await res.json();
-      console.log('[refreshThreads] Threads:', data.threads?.length ?? 0);
       const threads: ChatThread[] = data.threads ?? [];
       chatThreads.set(threads);
       // Il thread aperto non è mai non letto: il server può averlo marcato tale per il messaggio

--- a/src/lib/styles/chat-messages.css
+++ b/src/lib/styles/chat-messages.css
@@ -22,12 +22,6 @@
 .chat-turn {
   --chat-gutter: 38px;
   position: relative;
-  /* Una cronologia aperta ne porta cento e sullo schermo ne stanno dieci: il browser rifaceva
-     layout e disegno anche dei novanta fuori campo, perché nessuno gli aveva detto che poteva
-     saltarli. `contain-intrinsic-size` è l'altezza che il turno DICHIARA finché resta fuori:
-     la barra di scorrimento non salta quando entra, e la misura vera prende il posto della stima. */
-  content-visibility: auto;
-  contain-intrinsic-size: auto 180px;
 }
 
 /* La riga di UNA bolla di testo. Ci vive quello che appartiene alla risposta parlata e non

--- a/src/lib/styles/chat-messages.css
+++ b/src/lib/styles/chat-messages.css
@@ -22,6 +22,12 @@
 .chat-turn {
   --chat-gutter: 38px;
   position: relative;
+  /* Una cronologia aperta ne porta cento e sullo schermo ne stanno dieci: il browser rifaceva
+     layout e disegno anche dei novanta fuori campo, perché nessuno gli aveva detto che poteva
+     saltarli. `contain-intrinsic-size` è l'altezza che il turno DICHIARA finché resta fuori:
+     la barra di scorrimento non salta quando entra, e la misura vera prende il posto della stima. */
+  content-visibility: auto;
+  contain-intrinsic-size: auto 180px;
 }
 
 /* La riga di UNA bolla di testo. Ci vive quello che appartiene alla risposta parlata e non

--- a/src/routes/app/[brand]/chat/[thread]/+page.svelte
+++ b/src/routes/app/[brand]/chat/[thread]/+page.svelte
@@ -32,7 +32,7 @@
     readPersistedSession,
     hydrateSessionFromStorage,
     watchToolJobs,
-    detachToolJobMessages,
+    detachToolJobCallbacks,
     isWatchingToolJobs,
     type QueuedChatItem
   } from '$lib/stores/chat-session';
@@ -98,6 +98,7 @@
     handled: () => handledCompletionAt,
     touchHandled: (at) => (handledCompletionAt = at),
     finalize: (at) => finalizeCompletedSession(at),
+    syncCursor: () => void syncThreadCursor(data.thread.id),
     send
   });
 
@@ -648,7 +649,7 @@
   onDestroy(() => {
     // SSE e watcher restano vivi nello store di modulo (il pulse in sidebar deve spegnersi anche
     // dopo aver lasciato la pagina): si stacca solo la callback che tocca questo componente.
-    detachToolJobMessages(data.thread.id);
+    detachToolJobCallbacks(data.thread.id);
   });
 
   /** Incollati in fondo solo finché l'utente ci sta: chi ha scrollato indietro sta LEGGENDO, e

--- a/src/routes/app/[brand]/chat/[thread]/lifecycle.svelte.ts
+++ b/src/routes/app/[brand]/chat/[thread]/lifecycle.svelte.ts
@@ -1,16 +1,6 @@
 import { readPersistedSession, hydrateSessionFromStorage, beginJobPolling, watchToolJobs, isWatchingToolJobs, getSession } from '$lib/stores/chat-session';
 import { refreshThreads } from '$lib/stores/chat';
-import { consolidateMessages, parseToolCalls, redoIdOf, type ChatMessage } from '../components/transcript';
-
-type FreshRow = {
-  id?: string;
-  role: string;
-  content: string;
-  reasoning?: string | null;
-  tool_calls?: unknown;
-  tool_call_id?: string | null;
-  name?: string | null;
-};
+import { parseToolCalls, redoIdOf, type ChatMessage } from '../components/transcript';
 
 /**
  * Il ciclo di vita del turno visto dalla pagina: riaggancio dopo un refresh, poll dei job di
@@ -27,55 +17,22 @@ export function createLifecycle(io: {
   handled: () => number | null;
   touchHandled: (at: number) => void;
   finalize: (completedAt: number) => Promise<void>;
+  /** Avanza il cursore del thread sul registro degli eventi e, se serve, rilegge il transcript. */
+  syncCursor: () => void;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   send: (text?: string, meta?: any, opts?: { resend?: boolean; redoMessageId?: string; truncateFromMessageId?: string }) => Promise<void>;
 }) {
-  function applyFreshToolMessages(
-    fresh: Array<{
-      id?: string;
-      role: string;
-      content: string;
-      reasoning?: string | null;
-      tool_calls?: unknown;
-      tool_call_id?: string | null;
-      name?: string | null;
-    }>
-  ) {
-    if (!fresh?.length) return;
-    const consolidated = consolidateMessages(
-      fresh.map((m) => ({
-        // Senza l'id, redo/edit ricadono in silenzio sul percorso che non tronca.
-        id: m.id,
-        role: m.role,
-        content: typeof m.content === 'string' ? m.content : '',
-        reasoning: m.reasoning,
-        tool_calls: m.tool_calls,
-        tool_call_id: m.tool_call_id,
-        name: m.name
-      }))
-    );
-    // Si rimpiazza solo se è arrivato qualcosa di nuovo: mai cancellare la UI ottimistica.
-    if (!io.loading() && consolidated.length >= io.messages().length) {
-      io.setMessages(consolidated);
-    }
-  }
-
+  /**
+   * Il battito del watcher non porta più la cronologia: la chiede la pagina al proprio cursore
+   * sul registro del thread, che risponde con il solo delta e ricarica il transcript unicamente
+   * quando un messaggio è davvero atterrato. Prima il tick si tirava dietro tutto — 202 KB e
+   * 176 ms per cento messaggi, ogni tre secondi, quasi sempre identici a sé stessi.
+   */
   function startToolPolling() {
     watchToolJobs({
       brandSlug: io.brandSlug(),
       threadId: io.threadId(),
-      onMessages: (fresh) =>
-        applyFreshToolMessages(
-          fresh as Array<{
-            id?: string;
-            role: string;
-            content: string;
-            reasoning?: string | null;
-            tool_calls?: unknown;
-            tool_call_id?: string | null;
-            name?: string | null;
-          }>
-        ),
+      onTick: () => io.syncCursor(),
       onIdle: () => refreshThreads(io.brandSlug())
     });
   }
@@ -222,7 +179,7 @@ export function createLifecycle(io: {
     }
   }
 
-  return { applyFreshToolMessages, startToolPolling, maybeStartToolPolling, checkPendingTools, resumeActiveGeneration, retryLast, resendAt, redoAssistant, sendFeedback };
+  return { startToolPolling, maybeStartToolPolling, checkPendingTools, resumeActiveGeneration, retryLast, resendAt, redoAssistant, sendFeedback };
 }
 
 // VERBATIM: i report dei job sono già deterministici lato server, niente parser da inventare.

--- a/src/routes/app/[brand]/chat/components/ChatTurn.svelte
+++ b/src/routes/app/[brand]/chat/components/ChatTurn.svelte
@@ -72,7 +72,8 @@
     speakerLabel: (name: string | null | undefined) => string;
     speakerAvatar: (name: string | null | undefined) => SpeakerWho;
     artifactsByCall: Map<string, ChatArtifactUi[]>;
-    followingUserTexts: string[];
+    /** Getter, non lista: la calcola solo una card domande, che quasi nessun turno ha. */
+    followingUserTexts: () => string[];
     oncopy: (content: string) => void;
     onredo: (index: number) => void;
     onfeedback: (messageId: string | undefined, value: 1 | -1 | null, note?: string) => void;
@@ -308,7 +309,7 @@
     questions={tc.questions!}
     toolCallId={tc.toolCallId ?? `qq-${i}-${bi}-${ti}`}
     {threadId}
-    followingUserTexts={followingUserTexts}
+    followingUserTexts={followingUserTexts()}
     disabled={loading}
     onanswer={(text) => onsend(text)}
   />

--- a/src/routes/app/[brand]/chat/components/TranscriptList.svelte
+++ b/src/routes/app/[brand]/chat/components/TranscriptList.svelte
@@ -184,6 +184,20 @@
   const looseArtifacts = $derived(
     artifacts.filter((a) => !a.tool_call_id || !renderedCallIds.has(a.tool_call_id))
   );
+
+  /**
+   * L'ultimo messaggio dell'utente, cercato UNA volta.
+   *
+   * Ogni riga se lo chiedeva scorrendo la coda della lista (`messages.slice(i + 1).some(...)`):
+   * su cento turni sono cinquemila passi e cento array nuovi a ogni ridisegno, per un indice che
+   * è lo stesso per tutti.
+   */
+  const lastUserIndex = $derived.by(() => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].role === 'user') return i;
+    }
+    return -1;
+  });
 </script>
 
 <div class="chat-column">
@@ -195,6 +209,10 @@
   </div>
 {/if}
 
+<!-- La chiave resta la POSIZIONE, e non è una svista. `consolidateMessages` può emettere due
+     righe con lo stesso `id` (misurato l'1/9: 100 righe, un id ripetuto su una cronologia vera),
+     e Svelte su una chiave duplicata non disegna la lista: transcript vuoto, nessun errore a
+     schermo. Chiavare sull'id si può solo dopo che il consolidamento produce una chiave sua. -->
 {#each messages as msg, i (i)}
   {#if msg.role === 'user' && isDmReplyBackMessage(msg.content)}
     <!-- La risposta di un DM non sta in questa chat: vive nel thread privato (chip). -->
@@ -220,9 +238,7 @@
   {#if dayLines[i]}<ChatDivider label={dayLines[i]} />{/if}
   {#if i === unreadIndex}<ChatDivider label={$_('chat.newMessages')} tone="accent" />{/if}
   {#if msg.role === 'user'}
-    {@const isLastUser =
-      i === messages.length - 1 ||
-      !messages.slice(i + 1).some((m) => m.role === 'user')}
+    {@const isLastUser = i === lastUserIndex}
     <div class="self-end flex flex-col gap-1.5 items-end w-[80%] max-w-[80%] min-w-0 box-border">
       {#if msg.attachments?.length || msg.documents?.length}
         <ChatAttStrip urls={msg.attachments} docs={msg.documents} />
@@ -258,7 +274,11 @@
         {speakerLabel}
         {speakerAvatar}
         {artifactsByCall}
-        followingUserTexts={messages.slice(i + 1).filter((m) => m.role === 'user' && !isDmReplyBackMessage(m.content)).map((m) => m.content)}
+        followingUserTexts={() =>
+          messages
+            .slice(i + 1)
+            .filter((m) => m.role === 'user' && !isDmReplyBackMessage(m.content))
+            .map((m) => m.content)}
         oncopy={oncopy}
         onredo={onredo}
         onfeedback={onfeedback}

--- a/src/routes/app/[brand]/chat/components/transcript-key.test.ts
+++ b/src/routes/app/[brand]/chat/components/transcript-key.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { consolidateMessages } from './transcript';
+
+/**
+ * Il difetto dell'1/9, pagato due volte in un'ora: chiavare il transcript sull'id del messaggio
+ * sembra l'ovvio miglioramento — con la chiave posizionale Svelte riusa il componente di un turno
+ * per un turno diverso — e invece SPEGNE la lista.
+ *
+ * Il carico del thread può contenere due righe con lo STESSO id: un checkpoint parziale e la sua
+ * versione finale arrivano entrambi nella proiezione (osservato su una cronologia vera: stesso id,
+ * stesso testo, due tool contro dieci). Su una chiave duplicata Svelte non disegna il blocco: il
+ * transcript resta vuoto, senza un errore a schermo — verificato nel browser, stessa pagina, la
+ * sola riga della chiave cambiata.
+ *
+ * Si potrà chiavare sull'identità quando il consolidamento produrrà una chiave sua, unica per
+ * riga. Fino ad allora questa riga resta com'è, e questo test lo ricorda.
+ */
+describe('transcript: la chiave della lista', () => {
+	const src = readFileSync(new URL('./TranscriptList.svelte', import.meta.url), 'utf8');
+
+	it('è la posizione, non l`id del messaggio', () => {
+		expect(src).toContain('{#each messages as msg, i (i)}');
+		expect(src).not.toMatch(/\{#each messages as msg, i \(msg\.id/);
+	});
+
+	it('il consolidamento non promette id unici: due righe possono condividerlo', () => {
+		const same = 'msg-1';
+		const rows = consolidateMessages([
+			{ id: same, role: 'assistant', content: 'Capisco la richiesta', tool_calls: [] },
+			{ id: same, role: 'assistant', content: 'Capisco la richiesta', tool_calls: [] }
+		] as Parameters<typeof consolidateMessages>[0]);
+
+		const ids = rows.map((r) => r.id);
+		expect(new Set(ids).size).toBeLessThan(ids.length);
+	});
+});


### PR DESCRIPTION
## What?

The chat stops re-sending itself. While a background job runs, the tool watcher no longer refetches the whole transcript on every tick — it tells the page to advance the cursor it already keeps on the thread's durable event log, and the transcript is reloaded only when a message really landed. Three smaller cuts ride along: `renderMd` remembers what it has already parsed, `refreshThreads` returns the request already in flight instead of starting an identical one (and stops logging three lines per call to the production console), and two quadratic scans in `TranscriptList` are gone.

Nothing about the rendered conversation changes — same turns, same markdown, same node count. What changes is what the page transfers while you use it, and how much main thread it burns redrawing text that has not moved.

## Why?

"The chat feels heavy." Measured on a 200-message thread (100 rendered — the `loadThreadUiHistory` cap), local stack, real browser:

- **The poll.** `tickToolWatch` refetched the entire transcript every 3 s: **202 KB and 176 ms** for a hundred messages, twenty times a minute, for text that was almost always identical. Then it reassigned `messages`, so every turn got new objects and the whole history redrew.
- **The markdown.** `renderMd` is pure and remembered nothing: **~40 ms per hundred turns, the same on every pass** — paid on every redraw, so on every tick.
- **The thread list.** `refreshThreads` has seven callers and none of them know about the others: opening a thread fired **three identical `/chat/threads` in the same second** (94 threads, 63 KB, six server-side queries each).
- **Two O(n²) walks.** `isLastUser` and `followingUserTexts` scanned the tail of the list for every row: five thousand steps and a hundred fresh arrays per redraw on a hundred turns. `followingUserTexts` feeds only the questions card, which almost no turn has.

Idle is already clean — zero requests in 50 s with no job running. The weight was concentrated in the seconds when something is actually working, which is exactly when the chat is being watched.

## How?

The thread already has a durable event log with a cursor (`thread_events`), and a **trigger on every `chat_messages` insert** writes into it — so it covers every path: stream, queue worker, CLI. The page already reads it for `thread-seq` (`syncThreadCursor`), which reloads the transcript only when the fold reports a new message. So the watcher goes back to being a heartbeat: `onMessages` becomes `onTick`, and the page advances its own cursor. `applyFreshToolMessages` is deleted rather than adapted.

`renderMd` gets a text-keyed `Map` capped at 400 entries (a full history carries 100), evicting the oldest via Map insertion order. `refreshThreads` keeps one in-flight promise per brand. `lastUserIndex` is computed once; `followingUserTexts` is passed as a getter so the quadratic walk only runs for the rare turn that renders a questions card.

**Three things were written and then removed, each with the number that killed it:**

- **Keying the list by message id.** It blanks the transcript. The thread payload can carry two rows with the same id (a partial checkpoint and its final version — observed on a real history: same id, same text, two tools against ten), and Svelte draws nothing for a duplicate key, with no error on screen. Verified in the browser by flipping that single line back and forth: 101 rows → 0 → 101. Pinned by `transcript-key.test.ts` so nobody pays for it twice.
- **`content-visibility: auto` on each turn.** Benchmarked with the tab genuinely in the foreground: scroll p95 **9.4 ms with, 9.5 ms without** (8.33 ms budget at 120 Hz), forced re-layout 0.05–0.1 ms either way. Zero measured, so zero lines.
- **Dynamic imports for ChatTurn's twenty cards.** The route's own code is 91 KB uncompressed against a ~1 MB shared baseline: at best ~1% of the critical path, in exchange for ten `{#await}` blocks inside the file that must not break.

Also rejected: the hover-only action bar (~800 nodes saved on a hundred turns, but with no hover — every touch screen — those actions become unreachable).

## Testing?

**Unit** — 87 green across the touched areas. Four new behaviour tests written red first: the tick asks for jobs and never for the transcript, and it beats to the page each time (`chat-session.test.ts`); the same text is not re-parsed (`chat-markdown.test.ts`); three concurrent `refreshThreads` make one fetch, and a later one starts for real (`chat.test.ts`). Two pins on the transcript key.

Full suite: 9 failures out of 5,711, **none in the touched files** — `oauth.test` reads `PUBLIC_APP_URL` from the local `.env` (a known sensitivity, in LESSONS), the rest pass in isolation and are the load-flaky class.

**Browser**, local Docker Supabase, `test@anomalia.so` on brand `demo`, same 200-message fixture on both sides:

| | dev | this branch |
| --- | --- | --- |
| rows in the column | 101 | 101 |
| assistant turns / user bubbles | 51 / 49 | 51 / 49 |
| DOM nodes | 8,935 | 8,929 |
| SVG / buttons | 570 / 414 | 570 / 414 |
| JS heap | 72 MB | 72 MB |
| markdown rendered | strong 1890, code 1880, li 147, h2 47 | identical |

**What it buys:**

| | before | after |
| --- | --- | --- |
| bytes per poll tick | 202 KB (transcript) | **0.2 KB** (`pending_tools` 0.19 + `events_after` 0.015), zero transcript calls |
| at the unchanged 3 s cadence | ~4 MB/min | ~4 KB/min |
| redraw a 100-turn history | ~40 ms every pass | **0.1 ms** warm (19 ms cold, 201 ms for 100 unseen texts) |
| `/chat/threads` on open | 3 identical calls | 1 |

**Bundle** — total client JS is byte-identical (37,908 KB over 2,418 files before and after). The two chunks carrying the chat page are 132 KB + 68 KB on both sides; gzipped they go from 64,919 B to 64,665 B (−254 B, the dead code and the three `console.log`). **The download size of the chat page does not change, and was never the lever** — this PR is about bytes at runtime and main-thread work.

**Not measured, and why:** the sustained foreground rate over a full minute. A hidden tab suspends the 3 s timer entirely (measured: 0 requests in 33 s), and holding the window in the foreground from this session proved unreliable; the per-tick payload is measured, the cadence is unchanged, so the per-minute figure above is arithmetic on a measured tick, not an observation.

## Evidence (screenshots/videos)

Local stack only. The numbers above are the evidence for a change with no visual surface: the before/after table is two settled loads of the same fixture on the same machine, and the traffic figures come from `performance.getEntriesByType('resource')` in the page during a live `chat_jobs` row.

## Anything Else?

- `LESSONS.md` gains the trap that cost the most time here: two dev servers on `localhost` share one cookie jar and rotate the same GoTrue refresh token, so the second one answers 404 `Brand not found` and it looks like the code under test. Before/after browser comparisons must run one server at a time.
- The transcript is still 100 turns rendered at once, ~90 nodes and 5.6 icons each. Virtualising it is the next real lever, and it is a real piece of work — worth opening only against a measurement that says scrolling actually hurts, which on a text-only history it currently does not.
- `consolidateMessages` handing back rows that share an id is a wart of its own. Giving each row a key of its own would unlock the id-keyed list and is a small, separate change.
