### PR TITLE
Serve six image models, one dialect table

### DIFF
--- a/changelog/2026-09-02-image-model-choice.md
+++ b/changelog/2026-09-02-image-model-choice.md
@@ -3,41 +3,64 @@
 Il modello video il brand lo sceglieva da mesi (Settings → Video, `content_prefs.videoModel`);
 quello delle immagini no: era deciso dentro `buildImageRequest`, con una regola ragionevole
 (riferimenti da riprodurre ⇒ Lite, altrimenti `IMAGE_MODEL_NO_REF || BLOG_IMAGE_MODEL`) che
-nessuno poteva scavalcare senza un deploy. Chi voleva Nano Banana Pro su tutto il brand non aveva
-un posto dove dirlo.
+nessuno poteva scavalcare senza un deploy.
 
 Ora c'è `content_prefs.imageModel`, la riga accanto a quella del video, e la regola di prima resta
 il default: **vuoto significa "decidi tu"**, non "Lite". Un brand che non tocca nulla renderizza
 esattamente come ieri.
 
-**Gli id sono quelli di Gemini, non quelli di kie**, ed è voluto: sono ciò che
-`RenderImageOpts.model` già parla, `kieImageModel()` li traduce per kie (`nano-banana-pro`,
-`nano-banana-2`, `nano-banana-2-lite`, verificati vivi su `POST /jobs/createTask` — pro accettato,
-18 crediti) e senza chiave kie la stessa stringa è ancora un modello valido su Google. Un id kie
-salvato sul brand sarebbe diventato un 400 il giorno del ripiego.
+## Il catalogo è una tabella, perché su kie ogni modello è un dialetto
 
-I tre id vivevano in tre file (`gemini.ts`, `content-preview/images.ts`) e ora vengono da
-`$lib/image-models.ts`, client-safe come `video-models.ts`: il picker e il renderer non possono
-più divergere.
+Sei modelli, tre famiglie nuove oltre ai Nano Banana, e **nessuno di loro chiama le cose allo
+stesso modo** sullo stesso `POST /jobs/createTask`:
 
-**Dove la preferenza entra.** Nei tre `renderOpts` di `creation.ts` (post singolo, carosello,
-immagine standalone) e nel render del media generator. La copertina UGC **non** la segue: quel
-modello è scelto per essere scadente e costare metà, ed è una decisione estetica, non un default
-da sovrascrivere.
+| modello | riferimenti | rapporto | dimensione | id separati t2i/i2i |
+|---|---|---|---|---|
+| nano-banana-pro / -2 | `image_input` (8) | `aspect_ratio` | `resolution` | no |
+| nano-banana-2-lite | `image_urls` (10) | `aspect_ratio` | — | no |
+| seedream/5-pro | `image_urls` (10) | `aspect_ratio` | `quality` basic/high | **sì** |
+| gpt-image-2 | `input_urls` (16) | `aspect_ratio` | `resolution` | **sì** |
+| qwen3/pro | `image_urls` (3) | **`image_size`** | `resolution` | **sì** |
 
-`generateStandaloneImage` legge le prefs da sé — una `select` in più nel `Promise.all` che già
-carica il brand kit — invece di farsi passare il modello dai cinque chiamanti: cinque posti da
-ricordare sono cinque posti da dimenticare.
+Le differenze stanno tutte in `$lib/image-models.ts`, una riga per modello, e `buildKieImageInput`
+compone il payload da lì invece che da una catena di `if`. Una famiglia nuova è una riga.
 
-**Scartato:** un endpoint nuovo e un picker duplicato dentro il `+` della chat. La voce nel menu è
-un `<a>` alla pagina di Settings, come Connettori: la PageModal la apre in overlay su desktop, e
-la preferenza resta scritta in un posto solo.
+## Le due cose che i documenti non dicono e la misura sì
 
-**Non fatto, e perché.** Le altre famiglie che kie serve (Seedream 5, GPT Image 2, Qwen3, Flux-2,
-Z-Image, Grok Imagine Image 2) non sono nell'elenco: ognuna è un dialetto diverso su
-`/jobs/createTask` — Seedream vuole `image_urls` + `quality`, noi mandiamo `image_input` +
-`resolution` — e nessuna esiste su Google, quindi il ripiego senza chiave kie non c'è. Aggiungerne
-una è una riga in una tabella di dialetti che oggi non esiste, più una resa vera per misurarla.
+**GPT Image 2 rifiuta 4:5 a 2K.** `createTask` risponde `500 "aspect_ratio is not within the range
+of allowed options"`; lo stesso 4:5 a 1K passa, e 9:16 a 2K passa. In produzione
+`KIE_IMAGE_RESOLUTION=2K`, quindi senza la riga `ratios1KOnly` **ogni post Instagram** su quel
+modello sarebbe fallito. Il formato è una decisione di prodotto e la risoluzione una manopola:
+si abbassa la manopola, l'inquadratura resta.
 
-`IMAGE_CREDITS` in `content-cost.ts` resta la mediana misurata sul default: un brand che pinna Pro
-costa di più di quanto il planner crede. Va rimisurato quando qualcuno lo userà davvero.
+**4:5 non esiste affatto su Seedream né su Qwen.** Ripiegare sul default `1:1` avrebbe cambiato in
+silenzio l'inquadratura di ogni post verticale del brand, quindi `kieAspectRatio` sceglie il
+rapporto servito più vicino in proporzione — 4:5 → 3:4, mai un quadrato.
+
+Verificati vivi su kie, non dedotti dal listino: t2i e i2i di tutte e tre le famiglie accettati e
+renderizzati (seedream 14 crediti, qwen3 12, gpt-image-2 6 a 1K e 10 a 2K, nano-banana-pro 18).
+
+## Dove la preferenza entra, e dove no
+
+Nei tre `renderOpts` di `creation.ts`, nel render del media generator e — il buco trovato
+rileggendo, non scrivendo — dentro `renderPreviewImages`, che è **la produzione della settimana**:
+sette chiamanti, nessuno passava un modello. Si legge lì una volta sola, come in
+`generateStandaloneImage`, invece che in sette punti da ricordare.
+
+La copertina UGC **non** la segue: quel modello è scelto per essere scadente e costare metà, ed è
+una decisione estetica. E un `imageModel` esplicito (l'anteprima ospite) vince sempre sulla
+preferenza del brand.
+
+## Il ripiego su Google, che senza guardia era un 400
+
+`route('image')` ripiega su Google quando la chiave kie manca. `seedream/5-pro-…` su Google non è
+un modello: sarebbe stato un 400 su ogni immagine, proprio nel momento in cui kie non risponde.
+`googleImageModel()` riporta al modello di casa e lo dice; solo i Nano Banana hanno un id Gemini
+vero, ed è per questo che lo spec ha il campo `google` con `null` dentro per tutti gli altri.
+
+**Scartato:** un endpoint nuovo e un picker duplicato nel `+` della chat. La voce è un `<a>` alla
+pagina di Settings, come Connettori: una sola fonte della verità.
+
+**Rimasto aperto.** `IMAGE_CREDITS` in `content-cost.ts` è la mediana misurata sul default: un
+brand che pinna Pro (18 crediti) o Seedream (14) costa più di quanto il planner crede. E non c'è
+gate di piano sulla scelta: se il modello deve diventare un upsell, è una decisione a parte.

--- a/src/lib/content/changelog/2026-09-02-image-model-choice.ts
+++ b/src/lib/content/changelog/2026-09-02-image-model-choice.ts
@@ -4,8 +4,9 @@ export default {
   date: '2026-09-02',
   title: 'Pick the model that renders your images',
   items: [
-    'Settings → Video now has an Image model choice: Nano Banana 2 Lite, Nano Banana 2 or Nano Banana Pro. Leave it on Platform default and each image keeps being rendered by whichever model fits it.',
-    'The choice applies to posts, carousels, chat-generated visuals and the Media generator.',
+    'Settings → Images & video now has an Image model choice: Nano Banana 2 Lite, Nano Banana 2, Nano Banana Pro, Seedream 5 Pro, GPT Image 2 and Qwen3 Pro. Leave it on Platform default and each image keeps being rendered by whichever model fits it.',
+    'The choice applies everywhere images are produced: the weekly batch, single posts, carousels, chat-generated visuals and the Media generator.',
+    'Seedream and Qwen3 do not support the 4:5 Instagram frame — on those models portrait posts are rendered at 3:4.',
     'The + menu in chat now links straight to the image and video model settings.'
   ]
 } satisfies ChangelogEntry;

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -5342,9 +5342,9 @@
         "reload": "Reload properties"
       },
       "video": {
-        "title": "Video",
+        "title": "Images & video",
         "imageModel": "Image model",
-        "imageModelDesc": "Which AI model renders your images. Platform default lets the renderer pick per image (a cheaper model when there is nothing to reproduce, a faithful one with product or person references). Nano Banana Pro is the most faithful and the most expensive.",
+        "imageModelDesc": "Which AI model renders your images. Platform default lets the renderer pick per image (a cheaper model when there is nothing to reproduce, a faithful one with product or person references). Models outside the Nano Banana family run only on kie and frame Instagram posts at 3:4 instead of 4:5.",
         "model": "Video model",
         "modelDesc": "Which AI model generates your clips. Clip length options follow the model you pick — Seedance 2.5 can go up to 30 seconds.",
         "modelDefault": "Platform default",

--- a/src/lib/i18n/locales/es.json
+++ b/src/lib/i18n/locales/es.json
@@ -4992,9 +4992,9 @@
         "reload": "Recargar properties"
       },
       "video": {
-        "title": "Vídeo",
+        "title": "Imágenes y vídeo",
         "imageModel": "Modelo de imagen",
-        "imageModelDesc": "Qué modelo de IA genera tus imágenes. Con el valor predeterminado, el renderizador elige imagen por imagen (uno más barato cuando no hay nada que reproducir, uno fiel con referencias de producto o persona). Nano Banana Pro es el más fiel y el más caro.",
+        "imageModelDesc": "Qué modelo de IA genera tus imágenes. Con el valor predeterminado, el renderizador elige imagen por imagen (uno más barato cuando no hay nada que reproducir, uno fiel con referencias de producto o persona). Los modelos fuera de la familia Nano Banana solo funcionan en kie y encuadran las publicaciones de Instagram en 3:4 en lugar de 4:5.",
         "model": "Modelo de vídeo",
         "modelDesc": "Qué modelo de IA genera tus clips. Las duraciones disponibles siguen el modelo elegido — Seedance 2.5 llega hasta 30 segundos.",
         "modelDefault": "Predeterminado de la plataforma",

--- a/src/lib/i18n/locales/fr.json
+++ b/src/lib/i18n/locales/fr.json
@@ -4992,9 +4992,9 @@
         "reload": "Recharger les propriétés"
       },
       "video": {
-        "title": "Vidéo",
+        "title": "Images et vidéo",
         "imageModel": "Modèle d'image",
-        "imageModelDesc": "Quel modèle d'IA génère vos images. Par défaut, le moteur de rendu choisit image par image (un modèle moins cher quand il n'y a rien à reproduire, un modèle fidèle avec des références de produit ou de personne). Nano Banana Pro est le plus fidèle et le plus cher.",
+        "imageModelDesc": "Quel modèle d'IA génère vos images. Par défaut, le moteur de rendu choisit image par image (un modèle moins cher quand il n'y a rien à reproduire, un modèle fidèle avec des références de produit ou de personne). Les modèles hors famille Nano Banana ne tournent que sur kie et cadrent les posts Instagram en 3:4 au lieu de 4:5.",
         "model": "Modèle vidéo",
         "modelDesc": "Quel modèle IA génère vos clips. Les durées proposées suivent le modèle choisi — Seedance 2.5 va jusqu’à 30 secondes.",
         "modelDefault": "Défaut de la plateforme",

--- a/src/lib/i18n/locales/it.json
+++ b/src/lib/i18n/locales/it.json
@@ -5343,9 +5343,9 @@
         "reload": "Ricarica le property"
       },
       "video": {
-        "title": "Video",
+        "title": "Immagini e video",
         "imageModel": "Modello immagini",
-        "imageModelDesc": "Quale modello AI genera le tue immagini. Con il predefinito sceglie il renderer immagine per immagine (uno più economico quando non c'è nulla da riprodurre, uno fedele con riferimenti di prodotto o persona). Nano Banana Pro è il più fedele e il più caro.",
+        "imageModelDesc": "Quale modello AI genera le tue immagini. Con il predefinito sceglie il renderer immagine per immagine (uno più economico quando non c'è nulla da riprodurre, uno fedele con riferimenti di prodotto o persona). I modelli fuori dalla famiglia Nano Banana girano solo su kie e inquadrano i post Instagram in 3:4 invece che 4:5.",
         "model": "Modello video",
         "modelDesc": "Quale modello AI genera le clip. Le durate disponibili seguono il modello scelto — Seedance 2.5 arriva fino a 30 secondi.",
         "modelDefault": "Default della piattaforma",

--- a/src/lib/image-models.test.ts
+++ b/src/lib/image-models.test.ts
@@ -1,9 +1,15 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   IMAGE_MODEL_CHOICES,
   NANO_BANANA_PRO_MODEL,
+  SEEDREAM_5_PRO_MODEL,
+  GPT_IMAGE_2_MODEL,
+  QWEN3_PRO_MODEL,
+  imageModelSpec,
   isKnownImageModelId,
-  imageModelFor
+  imageModelFor,
+  kieAspectRatio,
+  googleImageModel
 } from './image-models';
 
 describe('image models', () => {
@@ -14,18 +20,78 @@ describe('image models', () => {
   });
 
   it('un id sconosciuto non passa', () => {
-    expect(isKnownImageModelId('gpt-image-2')).toBe(false);
+    expect(isKnownImageModelId('gpt-image-9')).toBe(false);
     expect(isKnownImageModelId('')).toBe(false);
     expect(isKnownImageModelId(undefined)).toBe(false);
   });
 
   it('la preferenza del brand vince quando è nota', () => {
-    expect(imageModelFor({ imageModel: NANO_BANANA_PRO_MODEL })).toBe(NANO_BANANA_PRO_MODEL);
+    expect(imageModelFor({ imageModel: SEEDREAM_5_PRO_MODEL })).toBe(SEEDREAM_5_PRO_MODEL);
   });
 
   it('senza preferenza il renderer resta libero di scegliere', () => {
     expect(imageModelFor({})).toBeUndefined();
     expect(imageModelFor(null)).toBeUndefined();
     expect(imageModelFor({ imageModel: 'un-modello-che-non-esiste' })).toBeUndefined();
+  });
+
+  it('un id Gemini scritto a mano da un call site resta uno spec valido', () => {
+    expect(imageModelSpec('gemini-3-pro-image-preview')?.id).toBe(NANO_BANANA_PRO_MODEL);
+  });
+
+  it('solo i nano-banana esistono anche su Google', () => {
+    expect(imageModelSpec(NANO_BANANA_PRO_MODEL)?.google).toBe('gemini-3-pro-image-preview');
+    expect(imageModelSpec(SEEDREAM_5_PRO_MODEL)?.google).toBeNull();
+    expect(imageModelSpec(GPT_IMAGE_2_MODEL)?.google).toBeNull();
+    expect(imageModelSpec(QWEN3_PRO_MODEL)?.google).toBeNull();
+  });
+
+  it('con riferimenti kie vuole un id diverso, dove la famiglia li separa', () => {
+    const seedream = imageModelSpec(SEEDREAM_5_PRO_MODEL)!;
+    expect(seedream.kie.text).toBe('seedream/5-pro-text-to-image');
+    expect(seedream.kie.refs).toBe('seedream/5-pro-image-to-image');
+    const nano = imageModelSpec(NANO_BANANA_PRO_MODEL)!;
+    expect(nano.kie.text).toBe('nano-banana-pro');
+    expect(nano.kie.refs).toBe('nano-banana-pro');
+  });
+
+  // 4:5 è il formato di un post Instagram. Seedream e Qwen non lo servono: ripiegare su 1:1
+  // cambierebbe di nascosto l'inquadratura di ogni post verticale del brand.
+  it('un rapporto che il modello non serve diventa il verticale più vicino, non un quadrato', () => {
+    expect(kieAspectRatio(imageModelSpec(SEEDREAM_5_PRO_MODEL)!, '4:5')).toBe('3:4');
+    expect(kieAspectRatio(imageModelSpec(QWEN3_PRO_MODEL)!, '4:5')).toBe('3:4');
+    expect(kieAspectRatio(imageModelSpec(GPT_IMAGE_2_MODEL)!, '4:5')).toBe('4:5');
+    expect(kieAspectRatio(imageModelSpec(NANO_BANANA_PRO_MODEL)!, '4:5')).toBe('4:5');
+  });
+
+  it('9:16 e 1:1 li serve chiunque', () => {
+    for (const choice of IMAGE_MODEL_CHOICES) {
+      const spec = imageModelSpec(choice.id)!;
+      expect(kieAspectRatio(spec, '9:16')).toBe('9:16');
+      expect(kieAspectRatio(spec, '1:1')).toBe('1:1');
+    }
+  });
+
+  // Senza chiave kie il render va su Google, dove "seedream/5-pro-…" non è un modello: sarebbe un
+  // 400 su OGNI immagine del brand, e proprio nel momento in cui kie non risponde.
+  it('un modello che vive solo su kie non arriva mai a Google', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(googleImageModel(SEEDREAM_5_PRO_MODEL, 'gemini-3.1-flash-image')).toBe('gemini-3.1-flash-image');
+    expect(googleImageModel(QWEN3_PRO_MODEL, 'gemini-3.1-flash-image')).toBe('gemini-3.1-flash-image');
+    expect(warn).toHaveBeenCalledTimes(2);
+    warn.mockRestore();
+  });
+
+  it('su Google i nano-banana passano con il loro id Gemini', () => {
+    expect(googleImageModel(NANO_BANANA_PRO_MODEL, 'x')).toBe('gemini-3-pro-image-preview');
+    expect(googleImageModel('gemini-3.1-flash-image', 'x')).toBe('gemini-3.1-flash-image');
+    // Un id che il catalogo non conosce resta quello che il call site ha chiesto.
+    expect(googleImageModel('gemini-4-whatever', 'x')).toBe('gemini-4-whatever');
+  });
+
+  it('il tetto dei riferimenti è quello del modello, non uno globale', () => {
+    expect(imageModelSpec(QWEN3_PRO_MODEL)!.maxRefs).toBe(3);
+    expect(imageModelSpec(GPT_IMAGE_2_MODEL)!.maxRefs).toBe(16);
+    expect(imageModelSpec(NANO_BANANA_PRO_MODEL)!.maxRefs).toBe(8);
   });
 });

--- a/src/lib/image-models.ts
+++ b/src/lib/image-models.ts
@@ -1,33 +1,203 @@
-/** Shared image-model ids safe for client + server (no $env), like video-models.ts. */
-
-export const NANO_BANANA_PRO_MODEL = 'gemini-3-pro-image-preview';
-export const NANO_BANANA_2_MODEL = 'gemini-3.1-flash-image';
-export const NANO_BANANA_2_LITE_MODEL = 'gemini-3.1-flash-lite-image';
-
 /**
- * Models a brand can pin for its renders. Ids are the Gemini ones because that is what
- * `RenderImageOpts.model` speaks; `kieImageModel()` translates them for kie.
+ * I modelli che possono disegnare per un brand, e COME ciascuno vuole essere chiamato.
+ *
+ * Su kie ogni modello è un dialetto diverso dello stesso `POST /jobs/createTask`: i riferimenti si
+ * chiamano `image_input` su Nano Banana, `image_urls` su Seedream e Qwen, `input_urls` su GPT
+ * Image; il rapporto d'aspetto è `aspect_ratio` per tutti tranne Qwen, che lo chiama `image_size`;
+ * la dimensione è `resolution` per alcuni e `quality` (basic|high) per Seedream. Metà di queste
+ * famiglie separa il modello testo-a-immagine da quello con riferimenti.
+ *
+ * Le differenze stanno TUTTE qui, in una riga per modello, perché una famiglia nuova sia una riga
+ * e non una caccia a cinque `if` sparsi. Le assenze sono la parte che conta: `4:5` — il formato di
+ * un post Instagram — non esiste su Seedream né su Qwen, e `google` è null per tutto ciò che kie
+ * serve in esclusiva.
+ *
+ * Fonti: docs.kie.ai, una pagina per modello, lette il 2026-09-02.
  */
-export const IMAGE_MODEL_CHOICES = [
-  { id: NANO_BANANA_2_LITE_MODEL, label: 'Nano Banana 2 Lite' },
-  { id: NANO_BANANA_2_MODEL, label: 'Nano Banana 2' },
-  { id: NANO_BANANA_PRO_MODEL, label: 'Nano Banana Pro' }
-] as const;
 
-export type ImageModelChoiceId = (typeof IMAGE_MODEL_CHOICES)[number]['id'];
+export const NANO_BANANA_PRO_MODEL = 'nano-banana-pro';
+export const NANO_BANANA_2_MODEL = 'nano-banana-2';
+export const NANO_BANANA_2_LITE_MODEL = 'nano-banana-2-lite';
+export const SEEDREAM_5_PRO_MODEL = 'seedream-5-pro';
+export const GPT_IMAGE_2_MODEL = 'gpt-image-2';
+export const QWEN3_PRO_MODEL = 'qwen3-pro';
 
-export function isKnownImageModelId(value: unknown): value is ImageModelChoiceId {
-  const v = String(value ?? '').trim();
-  return IMAGE_MODEL_CHOICES.some((c) => c.id === v);
+/** Gli id Gemini che i call site scrivono a mano da prima che questo registro esistesse. */
+export const GEMINI_NANO_BANANA_PRO = 'gemini-3-pro-image-preview';
+export const GEMINI_NANO_BANANA_2 = 'gemini-3.1-flash-image';
+export const GEMINI_NANO_BANANA_2_LITE = 'gemini-3.1-flash-lite-image';
+
+export type ImageModelSpec = {
+  id: string;
+  label: string;
+  /** L'id su Google, quando lo stesso modello esiste anche lì. null = solo kie. */
+  google: string | null;
+  /** Gli id kie: `text` senza riferimenti, `refs` con. Uguali dove la famiglia non li separa. */
+  kie: { text: string; refs: string };
+  /** Come si chiama il campo dei riferimenti nel payload kie. */
+  refField: 'image_input' | 'image_urls' | 'input_urls';
+  /** Quanti riferimenti il modello inoltra davvero. */
+  maxRefs: number;
+  /** Come si chiama il rapporto d'aspetto. Qwen è l'unico a chiamarlo `image_size`. */
+  aspectField: 'aspect_ratio' | 'image_size';
+  /** I rapporti che il modello accetta. Fuori da qui il provider risponde 500 dopo un giro di rete. */
+  aspectRatios: string[];
+  /** Come si chiede la dimensione: `resolution` (1K|2K|4K), `quality` (basic|high), o niente. */
+  sizeField: 'resolution' | 'quality' | null;
+  /**
+   * Rapporti che il modello serve SOLO a 1K. Misurato su kie: `gpt-image-2` a 4:5 e 2K risponde
+   * 500 "aspect_ratio is not within the range of allowed options", lo stesso 4:5 a 1K passa. Con
+   * KIE_IMAGE_RESOLUTION=2K in produzione sarebbe ogni post Instagram del brand.
+   */
+  ratios1KOnly?: string[];
+  /** `output_format` accettato. Lite non lo prende. */
+  outputFormat: 'png' | 'jpeg' | null;
+};
+
+const NANO_ASPECTS = ['1:1', '2:3', '3:2', '3:4', '4:3', '4:5', '5:4', '9:16', '16:9', '21:9'];
+
+const SPECS: ImageModelSpec[] = [
+  {
+    id: NANO_BANANA_2_LITE_MODEL,
+    label: 'Nano Banana 2 Lite',
+    google: GEMINI_NANO_BANANA_2_LITE,
+    kie: { text: 'nano-banana-2-lite', refs: 'nano-banana-2-lite' },
+    refField: 'image_urls',
+    maxRefs: 10,
+    aspectField: 'aspect_ratio',
+    aspectRatios: NANO_ASPECTS,
+    sizeField: null,
+    outputFormat: null
+  },
+  {
+    id: NANO_BANANA_2_MODEL,
+    label: 'Nano Banana 2',
+    google: GEMINI_NANO_BANANA_2,
+    kie: { text: 'nano-banana-2', refs: 'nano-banana-2' },
+    refField: 'image_input',
+    // kie ne documenta 14; 8 è il tetto che il prodotto ha sempre imposto e che i prompt assumono.
+    maxRefs: 8,
+    aspectField: 'aspect_ratio',
+    aspectRatios: NANO_ASPECTS,
+    sizeField: 'resolution',
+    outputFormat: 'png'
+  },
+  {
+    id: NANO_BANANA_PRO_MODEL,
+    label: 'Nano Banana Pro',
+    google: GEMINI_NANO_BANANA_PRO,
+    kie: { text: 'nano-banana-pro', refs: 'nano-banana-pro' },
+    refField: 'image_input',
+    maxRefs: 8,
+    aspectField: 'aspect_ratio',
+    aspectRatios: NANO_ASPECTS,
+    sizeField: 'resolution',
+    outputFormat: 'png'
+  },
+  {
+    id: SEEDREAM_5_PRO_MODEL,
+    label: 'Seedream 5 Pro',
+    google: null,
+    kie: { text: 'seedream/5-pro-text-to-image', refs: 'seedream/5-pro-image-to-image' },
+    refField: 'image_urls',
+    maxRefs: 10,
+    aspectField: 'aspect_ratio',
+    aspectRatios: ['1:1', '4:3', '3:4', '16:9', '9:16', '2:3', '3:2', '21:9'],
+    sizeField: 'quality',
+    outputFormat: 'png'
+  },
+  {
+    id: GPT_IMAGE_2_MODEL,
+    label: 'GPT Image 2',
+    google: null,
+    kie: { text: 'gpt-image-2-text-to-image', refs: 'gpt-image-2-image-to-image' },
+    refField: 'input_urls',
+    maxRefs: 16,
+    aspectField: 'aspect_ratio',
+    aspectRatios: ['1:1', '3:2', '2:3', '4:3', '3:4', '5:4', '4:5', '16:9', '9:16', '21:9'],
+    sizeField: 'resolution',
+    ratios1KOnly: ['4:5', '5:4'],
+    outputFormat: null
+  },
+  {
+    id: QWEN3_PRO_MODEL,
+    label: 'Qwen3 Pro',
+    google: null,
+    kie: { text: 'qwen3/pro-text-to-image', refs: 'qwen3/pro-image-to-image' },
+    refField: 'image_urls',
+    maxRefs: 3,
+    aspectField: 'image_size',
+    aspectRatios: ['1:1', '3:2', '2:3', '4:3', '3:4', '16:9', '9:16', '21:9'],
+    sizeField: 'resolution',
+    outputFormat: 'png'
+  }
+];
+
+export const IMAGE_MODEL_CHOICES = SPECS.map((s) => ({ id: s.id, label: s.label }));
+
+export function isKnownImageModelId(value: unknown): value is string {
+  return !!imageModelSpec(value);
 }
 
 /**
- * Undefined means "no preference": the renderer keeps deciding per call (fidelity refs, UGC
- * covers), which is the behaviour every brand had before the picker existed.
+ * Lo spec di un modello, da qualunque nome quel modello abbia: il nostro id, l'id Gemini scritto in
+ * un vecchio call site, o uno dei due id kie. Riconoscerli tutti è ciò che impedisce a un
+ * `seedream/5-pro-image-to-image` di ripresentarsi come modello sconosciuto e finire nel dialetto
+ * sbagliato.
  */
-export function imageModelFor(
-  prefs: { imageModel?: unknown } | null | undefined
-): ImageModelChoiceId | undefined {
+export function imageModelSpec(value: unknown): ImageModelSpec | undefined {
+  const v = String(value ?? '').trim();
+  if (!v) return undefined;
+  return SPECS.find((s) => s.id === v || s.google === v || s.kie.text === v || s.kie.refs === v);
+}
+
+/**
+ * Undefined vuol dire "nessuna preferenza": il renderer continua a decidere per ogni immagine,
+ * che è il comportamento che ogni brand aveva prima che il selettore esistesse.
+ */
+export function imageModelFor(prefs: { imageModel?: unknown } | null | undefined): string | undefined {
   const v = String(prefs?.imageModel ?? '').trim();
   return isKnownImageModelId(v) ? v : undefined;
+}
+
+/**
+ * L'id da mandare a Google. Un modello che kie serve in esclusiva NON esiste lì: mandarcelo è un
+ * 400 su ogni immagine del brand, e succederebbe proprio nel momento peggiore — quando la chiave
+ * kie manca o il suo endpoint è giù. Meglio un render col modello di casa e un avviso rumoroso.
+ */
+export function googleImageModel(model: string | undefined, fallback: string): string {
+  const spec = imageModelSpec(model);
+  if (!spec) return model ?? fallback;
+  if (spec.google) return spec.google;
+  console.warn(
+    `[AI] ${spec.id} esiste solo su kie e questo render sta andando su Google: uso ${fallback}. ` +
+      `La preferenza del brand non è stata applicata.`
+  );
+  return fallback;
+}
+
+/**
+ * Il rapporto d'aspetto più vicino fra quelli che il modello serve davvero.
+ *
+ * Un post Instagram è 4:5, e Seedream e Qwen non lo hanno: ripiegare sul default 1:1 cambierebbe
+ * in silenzio l'inquadratura di ogni post verticale del brand, quindi si sceglie il rapporto con
+ * la proporzione più vicina — 4:5 → 3:4, non un quadrato.
+ */
+export function kieAspectRatio(spec: ImageModelSpec, aspectRatio: string | undefined): string {
+  const wanted = String(aspectRatio ?? '').trim() || '1:1';
+  if (spec.aspectRatios.includes(wanted)) return wanted;
+  const target = ratioValue(wanted);
+  if (!target) return '1:1';
+  return spec.aspectRatios.reduce((best, candidate) => {
+    const b = ratioValue(best);
+    const c = ratioValue(candidate);
+    if (!c) return best;
+    if (!b) return candidate;
+    return Math.abs(Math.log(c / target)) < Math.abs(Math.log(b / target)) ? candidate : best;
+  }, spec.aspectRatios[0]);
+}
+
+function ratioValue(ratio: string): number | undefined {
+  const [w, h] = ratio.split(':').map(Number);
+  return w > 0 && h > 0 ? w / h : undefined;
 }

--- a/src/lib/server/content-preview/images.ts
+++ b/src/lib/server/content-preview/images.ts
@@ -9,7 +9,7 @@ import { env } from '$env/dynamic/private';
 import { fetchImagePart } from '$lib/server/brand-context';
 import { getBrandContext } from '$lib/server/ai-log';
 import { googleGenaiClient, judgeThinkingLevel, NANO_BANANA_2_LITE } from '$lib/server/gemini';
-import { NANO_BANANA_2_MODEL } from '$lib/image-models';
+import { GEMINI_NANO_BANANA_2, googleImageModel } from '$lib/image-models';
 import { structured } from '$lib/server/research';
 import { signKnowledgePaths } from '$lib/server/media-archive';
 import { generateImageOnKie } from '$lib/server/kie-jobs';
@@ -80,7 +80,7 @@ export type AspectRatio = '1:1' | '4:5' | '9:16' | '16:9';
 
 // Metà del prezzo di output immagine di Pro, e un articolo rende 3 immagini contro 1 di un post.
 // I post social usano lo stesso id quando non c'è nulla da riprodurre; con riferimenti, Lite.
-export const BLOG_IMAGE_MODEL = NANO_BANANA_2_MODEL;
+export const BLOG_IMAGE_MODEL = GEMINI_NANO_BANANA_2;
 
 const ASPECT_LABEL: Record<AspectRatio, string> = {
   '1:1': 'Square 1:1',
@@ -261,6 +261,9 @@ export async function renderPostImage(
     throw new Error(`No image returned from kie (${imageModel}) after 2 attempts`);
   }
   // Pixel Google: il client si costruisce QUI, non nei chiamanti (testo/QC non devono toccare Google).
+  // Un modello che vive solo su kie non è un modello per Google: `googleImageModel` lo riporta a
+  // quello di casa e lo dice, invece di far fallire ogni immagine con un 400.
+  req.model = googleImageModel(req.model, NANO_BANANA_2_LITE);
   const googleAi = googleGenaiClient();
   void ai;
   // genWithRetry ritenta gli ERRORI, ma il modello risponde spesso 200 SENZA parte immagine — un
@@ -269,7 +272,7 @@ export async function renderPostImage(
   const MAX_IMAGE_ATTEMPTS = 3;
   let lastInfo = '';
   for (let attempt = 1; attempt <= MAX_IMAGE_ATTEMPTS; attempt++) {
-    const res = await genWithRetry(() => googleAi.models.generateContent(req), 'renderPostImage', { model: imageModel });
+    const res = await genWithRetry(() => googleAi.models.generateContent(req), 'renderPostImage', { model: req.model });
     const found = imageFromResponse(res);
     if (found) return found;
     const out = res.candidates?.[0]?.content?.parts ?? [];

--- a/src/lib/server/content-preview/weekly-planner.ts
+++ b/src/lib/server/content-preview/weekly-planner.ts
@@ -73,9 +73,10 @@ type RenderPreviewOpts = {
   supabase: SupabaseClient;
   userId: string;
   brandId?: string;
-  // Force one image model for the whole batch. Absent → buildImageRequest picks as it always has.
-  // The guest preview passes the cheapest model here; a UGC cover still overrides it, because its
-  // look is the point of that format.
+  // Force one image model for the whole batch, ahead of the brand's own preference. Absent → the
+  // brand's Settings choice, and absent that too, buildImageRequest picks as it always has. The
+  // guest preview passes the cheapest model here; a UGC cover still overrides everything, because
+  // its look is the point of that format.
   imageModel?: string;
   onProgress?: Progress;
   onPost: (post: PreviewPost) => void;
@@ -374,12 +375,27 @@ export async function planPreviewPosts(
 // post (imageUrl set when rendering succeeds) via onPost. Builds the shared render context (offerings,
 // people, visual style, brand look, logo) once per batch from the profile, so this is a faithful,
 // stateless continuation of planPreviewPosts — runnable in a separate request.
+async function brandPreferredImageModel(opts: RenderPreviewOpts): Promise<string | undefined> {
+  if (!opts.brandId) return undefined;
+  const { data } = await opts.supabase
+    .from('brands')
+    .select('content_prefs')
+    .eq('id', opts.brandId)
+    .maybeSingle();
+  const { imageModelFor } = await import('$lib/image-models');
+  return imageModelFor((data?.content_prefs ?? {}) as { imageModel?: unknown });
+}
+
 export async function renderPreviewImages(
   profile: BrandProfile,
   posts: PreviewPost[],
   opts: RenderPreviewOpts
 ): Promise<void> {
   const ai = client();
+  // La preferenza del brand si legge QUI e non nei sette chiamanti: è la produzione della
+  // settimana, e sette posti da ricordare sono sette posti da dimenticare. Un `imageModel`
+  // esplicito (l'anteprima ospite) vince comunque.
+  const brandImageModel = opts.imageModel ?? (await brandPreferredImageModel(opts));
 
   opts.onProgress?.('generating', `Generating images for ${posts.length} posts…`);
 
@@ -502,7 +518,7 @@ export async function renderPreviewImages(
           const isUgc = post.format === 'video' && post.ugc !== false;
           const { UGC_VISUAL_STYLE, UGC_COVER_MODEL } = await import('$lib/server/ugc');
           const effectiveStyle = isUgc ? UGC_VISUAL_STYLE : visualStyle;
-          const forcedModel = isUgc ? UGC_COVER_MODEL : opts.imageModel;
+          const forcedModel = isUgc ? UGC_COVER_MODEL : brandImageModel;
           const renderOpts = {
             referenceImages,
             personImages: personRefs,

--- a/src/lib/server/gemini.ts
+++ b/src/lib/server/gemini.ts
@@ -1,7 +1,7 @@
 import { env } from '$env/dynamic/private';
 import { GoogleGenAI, type ThinkingLevel } from '@google/genai';
 import { route } from '$lib/server/model-routing';
-import { NANO_BANANA_2_LITE_MODEL, NANO_BANANA_PRO_MODEL } from '$lib/image-models';
+import { GEMINI_NANO_BANANA_2_LITE, GEMINI_NANO_BANANA_PRO } from '$lib/image-models';
 
 /** Default Gemini Flash text/vision model when `GEMINI_FLASH` is unset. */
 export const GEMINI_FLASH = 'gemini-3.7-flash';
@@ -23,14 +23,14 @@ export function isGeminiFlashId(model: string | undefined): boolean {
 }
 
 /** Nano Banana Pro — reachable only via an explicit model at a call site. */
-export const NANO_BANANA_PRO = NANO_BANANA_PRO_MODEL;
+export const NANO_BANANA_PRO = GEMINI_NANO_BANANA_PRO;
 
 export function isNanoBananaProId(model: string | undefined): boolean {
   return model === NANO_BANANA_PRO;
 }
 
 /** Nano Banana 2 Lite — the default render model everywhere (Gemini 3.1 Flash-Lite Image). */
-export const NANO_BANANA_2_LITE = NANO_BANANA_2_LITE_MODEL;
+export const NANO_BANANA_2_LITE = GEMINI_NANO_BANANA_2_LITE;
 
 /**
  * Share of *list* written to `ai_calls.cost_usd` for Gemini Flash / Nano Banana Pro: always 1,

--- a/src/lib/server/kie-jobs.test.ts
+++ b/src/lib/server/kie-jobs.test.ts
@@ -21,16 +21,20 @@ function geminiRequest(parts: Array<Record<string, unknown>>, aspectRatio = '4:5
 }
 
 describe('buildKieImageInput', () => {
-  it('accetta solo i rapporti d\'aspetto dell\'enum di kie, e ripiega su 1:1', async () => {
+  it('non esce mai un rapporto che il modello non serve', async () => {
     const { buildKieImageInput } = await import('./kie-jobs');
+    const { imageModelSpec, NANO_BANANA_2_MODEL } = await import('$lib/image-models');
+    const spec = imageModelSpec(NANO_BANANA_2_MODEL)!;
     // I quattro che il prodotto usa davvero passano intatti.
     for (const ar of ['1:1', '4:5', '9:16', '16:9']) {
       expect(buildKieImageInput({ prompt: 'x', aspectRatio: ar }).aspect_ratio).toBe(ar);
     }
-    // 99:1 su kie è un 500 alla submit: qui diventa un render valido invece di un render perso.
+    // 99:1 su kie è un 500 alla submit: qui diventa il rapporto servito più vicino, cioè un render
+    // valido invece di un render perso.
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    expect(buildKieImageInput({ prompt: 'x', aspectRatio: '99:1' }).aspect_ratio).toBe('1:1');
-    expect(buildKieImageInput({ prompt: 'x', aspectRatio: '3:1' }).aspect_ratio).toBe('1:1');
+    for (const junk of ['99:1', '3:1', 'banana']) {
+      expect(spec.aspectRatios).toContain(buildKieImageInput({ prompt: 'x', aspectRatio: junk }).aspect_ratio);
+    }
     expect(warn).toHaveBeenCalled();
     warn.mockRestore();
   });
@@ -301,5 +305,94 @@ describe('generateSpeechOnKie', () => {
     expect(out?.credits).toBe(0.62);
     expect(out?.wav.equals(wav)).toBe(true);
     vi.unstubAllGlobals();
+  });
+});
+
+// Ogni famiglia su kie è un dialetto diverso dello stesso endpoint. Questi test sono la copia
+// eseguibile di docs.kie.ai: se un campo cambia nome, qui si rompe prima che si rompa un render.
+describe('buildKieImageInput, un dialetto per famiglia', () => {
+  it('Seedream vuole image_urls e quality, mai image_input né resolution', async () => {
+    const { buildKieImageInput } = await import('./kie-jobs');
+    const input = buildKieImageInput({
+      model: 'seedream-5-pro',
+      prompt: 'x',
+      aspectRatio: '4:5',
+      refUrls: ['https://a/1.png'],
+      resolution: '2K'
+    });
+    expect(input.image_urls).toEqual(['https://a/1.png']);
+    expect(input.image_input).toBeUndefined();
+    expect(input.resolution).toBeUndefined();
+    expect(input.quality).toBe('high');
+    // 4:5 non esiste su Seedream: diventa il verticale più vicino, non un quadrato.
+    expect(input.aspect_ratio).toBe('3:4');
+  });
+
+  it('GPT Image 2 vuole input_urls, e 4:5 lo serve davvero', async () => {
+    const { buildKieImageInput } = await import('./kie-jobs');
+    const input = buildKieImageInput({
+      model: 'gpt-image-2',
+      prompt: 'x',
+      aspectRatio: '4:5',
+      refUrls: ['https://a/1.png']
+    });
+    expect(input.input_urls).toEqual(['https://a/1.png']);
+    expect(input.aspect_ratio).toBe('4:5');
+    expect(input.output_format).toBeUndefined();
+  });
+
+  it('Qwen3 chiama image_size il rapporto d\'aspetto e prende 3 riferimenti', async () => {
+    const { buildKieImageInput } = await import('./kie-jobs');
+    const refs = ['1', '2', '3', '4', '5'].map((n) => `https://a/${n}.png`);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const input = buildKieImageInput({ model: 'qwen3-pro', prompt: 'x', aspectRatio: '4:5', refUrls: refs });
+    expect(input.image_size).toBe('3:4');
+    expect(input.aspect_ratio).toBeUndefined();
+    expect(input.image_urls).toHaveLength(3);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  // MISURATO su kie, non dedotto: 4:5 a 2K → 500 "aspect_ratio is not within the range of allowed
+  // options"; lo stesso 4:5 a 1K passa, e 9:16 a 2K passa. Con KIE_IMAGE_RESOLUTION=2K in
+  // produzione, senza questa regola OGNI post Instagram su GPT Image 2 fallirebbe.
+  it('GPT Image 2: un rapporto che esiste solo a 1K abbassa la risoluzione, non perde il formato', async () => {
+    const { buildKieImageInput } = await import('./kie-jobs');
+    const portrait = buildKieImageInput({ model: 'gpt-image-2', prompt: 'x', aspectRatio: '4:5', resolution: '2K' });
+    expect(portrait.aspect_ratio).toBe('4:5');
+    expect(portrait.resolution).toBe('1K');
+    const story = buildKieImageInput({ model: 'gpt-image-2', prompt: 'x', aspectRatio: '9:16', resolution: '2K' });
+    expect(story.resolution).toBe('2K');
+  });
+
+  it('Nano Banana Pro resta com\'era: image_input, resolution, output_format', async () => {
+    const { buildKieImageInput } = await import('./kie-jobs');
+    const input = buildKieImageInput({
+      model: 'nano-banana-pro',
+      prompt: 'x',
+      aspectRatio: '4:5',
+      refUrls: ['https://a/1.png'],
+      resolution: '2K'
+    });
+    expect(input.image_input).toEqual(['https://a/1.png']);
+    expect(input.aspect_ratio).toBe('4:5');
+    expect(input.resolution).toBe('2K');
+    expect(input.output_format).toBe('png');
+  });
+});
+
+describe('kieImageModel', () => {
+  it('con riferimenti sceglie l\'id image-to-image, dove la famiglia lo separa', async () => {
+    const { kieImageModel } = await import('./kie-jobs');
+    expect(kieImageModel('seedream-5-pro', 0)).toBe('seedream/5-pro-text-to-image');
+    expect(kieImageModel('seedream-5-pro', 2)).toBe('seedream/5-pro-image-to-image');
+    expect(kieImageModel('nano-banana-pro', 2)).toBe('nano-banana-pro');
+  });
+
+  it('un id Gemini di un vecchio call site resta tradotto', async () => {
+    const { kieImageModel } = await import('./kie-jobs');
+    expect(kieImageModel('gemini-3-pro-image-preview', 0)).toBe('nano-banana-pro');
+    expect(kieImageModel('gemini-3.1-flash-lite-image', 0)).toBe('nano-banana-2-lite');
+    expect(kieImageModel(undefined, 0)).toBe('nano-banana-2');
   });
 });

--- a/src/lib/server/kie-jobs.ts
+++ b/src/lib/server/kie-jobs.ts
@@ -40,6 +40,7 @@
  * nostra. Un URL di kie in una riga che dura più di un giorno è un'immagine che sparisce da sola.
  */
 import { env } from '$env/dynamic/private';
+import { NANO_BANANA_2_LITE_MODEL, NANO_BANANA_2_MODEL, imageModelSpec, kieAspectRatio } from '$lib/image-models';
 import { logAiCall } from '$lib/server/ai-log';
 import { KIE_CREDIT_USD } from '$lib/server/kie';
 
@@ -185,19 +186,6 @@ export function kieFlatCostUsd(credits?: number): number | undefined {
 // ── Immagini ────────────────────────────────────────────────────────────────────────────────
 
 /** Gli unici rapporti d'aspetto che kie accetta. Fuori elenco è un 500 alla submit. */
-export const KIE_ASPECT_RATIOS = new Set([
-  '1:1',
-  '2:3',
-  '3:2',
-  '3:4',
-  '4:3',
-  '4:5',
-  '5:4',
-  '9:16',
-  '16:9',
-  '21:9',
-  'auto'
-]);
 
 /** `1K|2K|4K`, e le maiuscole contano: `"2k"` è un 500. */
 export type KieResolution = '1K' | '2K' | '4K';
@@ -223,34 +211,36 @@ const MAX_IMAGE_BYTES = 20 * 1024 * 1024;
 export const KIE_IMAGE_INPUT_MAX = 8;
 
 /**
- * Da id Gemini a id kie.
+ * Da id del catalogo (o da un vecchio id Gemini scritto in un call site) a id kie.
  *
- * Sono gli stessi modelli con due nomi: `gemini-3-pro-image-preview` è Nano Banana Pro,
- * `gemini-3.1-flash-image` è Nano Banana 2, `gemini-3.1-flash-lite-image` è Nano Banana 2 Lite.
- * La regola è una sola riga apposta — un elenco di corrispondenze invecchia al primo id nuovo,
- * mentre "pro nel nome ⇒ pro", "lite nel nome ⇒ lite" reggono anche allora.
+ * `refCount` non è un dettaglio: metà delle famiglie su kie separa il modello testo-a-immagine da
+ * quello che accetta riferimenti — `seedream/5-pro-text-to-image` rifiuta `image_urls`, e il suo
+ * gemello li PRETENDE. Nano Banana usa lo stesso id in entrambi i casi, e per questo la differenza
+ * non si vedeva finché c'era solo lui.
  */
-export type KieImageModel = 'nano-banana-pro' | 'nano-banana-2' | 'nano-banana-2-lite';
-
-export function kieImageModel(geminiModel: string | undefined): KieImageModel {
-  if (/pro/i.test(geminiModel ?? '')) return 'nano-banana-pro';
-  if (/lite/i.test(geminiModel ?? '')) return 'nano-banana-2-lite';
+export function kieImageModel(model: string | undefined, refCount = 0): string {
+  const spec = imageModelSpec(model);
+  if (spec) return refCount > 0 ? spec.kie.refs : spec.kie.text;
+  // Un id che il catalogo non conosce è un id Gemini di prima del registro: la regola vale ancora.
+  if (/pro/i.test(model ?? '')) return 'nano-banana-pro';
+  if (/lite/i.test(model ?? '')) return 'nano-banana-2-lite';
   return 'nano-banana-2';
 }
 
-/** Nano Banana 2 Lite: solo prompt + image_urls + aspect_ratio, e al massimo 10 riferimenti. */
-const KIE_LITE_IMAGE_MAX = 10;
-
-export function isKieLiteImageModel(model: string): model is 'nano-banana-2-lite' {
-  return model === 'nano-banana-2-lite';
+export function isKieLiteImageModel(model: string): boolean {
+  return imageModelSpec(model)?.id === NANO_BANANA_2_LITE_MODEL;
 }
 
 /**
  * L'input del job, dai pezzi che `buildImageRequest` produce già. Puro, quindi testabile.
  *
+ * Ogni campo qui sotto viene dallo spec del modello e non da un `if`: i nomi cambiano davvero da
+ * una famiglia all'altra (`image_input` / `image_urls` / `input_urls`, `aspect_ratio` /
+ * `image_size`, `resolution` / `quality`), e un campo sbagliato non è un errore — è un render che
+ * riesce ignorando i riferimenti del brand.
+ *
  * Il rapporto d'aspetto lo validiamo NOI anche se kie lo rifiuta: il suo rifiuto arriva come un 500
- * generico dopo un giro di rete, e a quel punto il render è perso. Qui invece un valore fuori
- * elenco diventa 1:1 con un avviso, e il post l'immagine ce l'ha.
+ * generico dopo un giro di rete, e a quel punto il render è perso.
  */
 export function buildKieImageInput(opts: {
   prompt: string;
@@ -259,44 +249,37 @@ export function buildKieImageInput(opts: {
   resolution?: KieResolution;
   model?: string;
 }): Record<string, unknown> {
-  const aspect = opts.aspectRatio && KIE_ASPECT_RATIOS.has(opts.aspectRatio) ? opts.aspectRatio : '1:1';
+  const spec = imageModelSpec(opts.model) ?? imageModelSpec(NANO_BANANA_2_MODEL)!;
+  const aspect = kieAspectRatio(spec, opts.aspectRatio);
   if (opts.aspectRatio && aspect !== opts.aspectRatio) {
-    console.warn(`[kie-image] aspect_ratio "${opts.aspectRatio}" non è fra quelli accettati — uso 1:1`);
+    console.warn(`[kie-image] ${spec.id} non serve aspect_ratio "${opts.aspectRatio}" — uso ${aspect}`);
   }
-  // Il taglio qui sotto era muto, e mentiva anche il commento che lo accompagnava ("buildImageRequest
-  // ne attacca al massimo 6": ne può attaccare 13 — base 1 + logo 1 + prodotto 4 + allegati 4 + mood 3).
-  // Un riferimento perso è già trattato come un guasto poche righe più giù, quando l'upload fallisce;
-  // perderlo per aritmetica non è meno grave, ed è più difficile da vedere perché non lascia traccia.
+
   const refUrls = opts.refUrls ?? [];
-  if (refUrls.length > KIE_IMAGE_INPUT_MAX) {
+  if (refUrls.length > spec.maxRefs) {
     console.warn(
-      `[kie-image] ${refUrls.length} riferimenti ma kie ne inoltra ${KIE_IMAGE_INPUT_MAX}: ` +
-        `${refUrls.length - KIE_IMAGE_INPUT_MAX} scartati. Il tetto va imposto A MONTE, dove si sa che cosa sono.`
+      `[kie-image] ${refUrls.length} riferimenti ma ${spec.id} ne inoltra ${spec.maxRefs}: ` +
+        `${refUrls.length - spec.maxRefs} scartati. Il tetto va imposto A MONTE, dove si sa che cosa sono.`
     );
   }
 
-  // La forma Lite è un DIALETTO, non un sottoinsieme: il campo riferimenti si chiama image_urls,
-  // la cap è 10, e resolution/output_format NON esistono (il "2K" inviato a un modello che li
-  // scarta è un payload sbagliato che funziona per sbaglio).
-  if (isKieLiteImageModel(opts.model ?? '')) {
-    return {
-      prompt: opts.prompt.slice(0, 10_000),
-      aspect_ratio: aspect,
-      ...(refUrls.length ? { image_urls: refUrls.slice(0, KIE_LITE_IMAGE_MAX) } : {})
-    };
+  const asked =
+    opts.resolution ?? (isKieResolution(env.KIE_IMAGE_RESOLUTION) ? env.KIE_IMAGE_RESOLUTION : '1K');
+  // Il formato è una decisione di prodotto, la risoluzione una manopola: quando il modello serve
+  // quel rapporto solo a 1K, si abbassa la manopola e si tiene l'inquadratura.
+  const resolution = spec.ratios1KOnly?.includes(aspect) ? '1K' : asked;
+  if (resolution !== asked) {
+    console.warn(`[kie-image] ${spec.id} serve ${aspect} solo a 1K: ${asked} abbassato a 1K`);
   }
 
   return {
-    prompt: opts.prompt.slice(0, 10_000), // limite dichiarato dalla API
-    aspect_ratio: aspect,
-    // 1K è la parità con quello che Gemini rende oggi: cambiare la dimensione dell'immagine è una
-    // decisione di prodotto, non un effetto collaterale di una migrazione di costo. Su
-    // nano-banana-pro 2K costa uguale (18 crediti), su nano-banana-2 costa il 50% in più (8→12):
-    // KIE_IMAGE_RESOLUTION la alza senza deploy quando qualcuno vorrà davvero il 2K.
-    resolution:
-      opts.resolution ?? (isKieResolution(env.KIE_IMAGE_RESOLUTION) ? env.KIE_IMAGE_RESOLUTION : '1K'),
-    output_format: 'png',
-    ...(refUrls.length ? { image_input: refUrls.slice(0, KIE_IMAGE_INPUT_MAX) } : {})
+    prompt: opts.prompt.slice(0, 10_000),
+    [spec.aspectField]: aspect,
+    ...(spec.sizeField === 'resolution' ? { resolution } : {}),
+    // Seedream non ha 4K: basic = 1K, high = tutto il resto di quello che il prodotto chiede.
+    ...(spec.sizeField === 'quality' ? { quality: resolution === '1K' ? 'basic' : 'high' } : {}),
+    ...(spec.outputFormat ? { output_format: spec.outputFormat } : {}),
+    ...(refUrls.length ? { [spec.refField]: refUrls.slice(0, spec.maxRefs) } : {})
   };
 }
 
@@ -386,13 +369,13 @@ export async function generateImageOnKie(
   opts: { label?: string; context?: string; signal?: AbortSignal } = {}
 ): Promise<string | undefined> {
   const label = opts.label ?? 'renderPostImage';
-  const model = kieImageModel(req.model);
   const parts = req.contents?.[0]?.parts ?? [];
   const prompt = parts
     .map((p) => p.text)
     .filter(Boolean)
     .join('\n');
   const refs = parts.flatMap((p) => (p.inlineData ? [p.inlineData] : []));
+  const model = kieImageModel(req.model, refs.length);
   const t0 = Date.now();
 
   const fail = (error: string) => {


### PR DESCRIPTION
## What?

Seedream 5 Pro, GPT Image 2 and Qwen3 Pro join the Nano Banana family in the brand's image-model choice (Settings → Images & video), so a brand now picks from six models instead of three. Nothing changes for a brand on **Platform default** — the renderer still decides per image.

Follow-up to #139, which shipped the picker itself with the Nano Banana family only.

## Why?

Nano Banana is one vendor's family. The point of a model choice is that a brand can pick the look it wants — a Seedream frame does not look like a GPT Image frame — and kie already serves all of them behind the same endpoint we already call.

## How?

### One row per model, because every model is a different dialect

On kie each model speaks its own payload on the same `POST /jobs/createTask`. A wrong field name is not an error: it is a render that succeeds while silently ignoring the brand's product photo.

| model | references | ratio field | size field | separate t2i/i2i ids |
|---|---|---|---|---|
| `nano-banana-pro` / `-2` | `image_input` (8) | `aspect_ratio` | `resolution` | no |
| `nano-banana-2-lite` | `image_urls` (10) | `aspect_ratio` | — | no |
| `seedream/5-pro` | `image_urls` (10) | `aspect_ratio` | `quality` basic/high | **yes** |
| `gpt-image-2` | `input_urls` (16) | `aspect_ratio` | `resolution` | **yes** |
| `qwen3/pro` | `image_urls` (**3**) | **`image_size`** | `resolution` | **yes** |

The table lives in `src/lib/image-models.ts` and `buildKieImageInput` composes the payload from it instead of a chain of `if`s — the old hand-written "Lite dialect" branch is gone, it is now just another row. Adding a family is a row.

`kieImageModel(model, refCount)` gained the reference count because half these families swap model id once a reference is attached: `seedream/5-pro-text-to-image` refuses `image_urls`, and its twin requires them.

### Two facts the docs do not give you, and a render does

<details><summary><b>GPT Image 2 rejects 4:5 at 2K</b> — and production runs at 2K</summary>

```
POST /jobs/createTask {"model":"gpt-image-2-text-to-image","input":{"aspect_ratio":"4:5","resolution":"2K",…}}
→ {"code":500,"msg":"aspect_ratio is not within the range of allowed options"}

same 4:5 at 1K   → 200, success, 6 credits
9:16 at 2K       → 200, success, 10 credits
```

`KIE_IMAGE_RESOLUTION=2K` in production, so without the `ratios1KOnly` row **every Instagram post** on that model would have failed. The frame is a product decision and the resolution is a knob: lower the knob, keep the frame.
</details>

<details><summary><b>4:5 does not exist on Seedream or Qwen at all</b></summary>

Falling back to the `1:1` default would have silently reframed every portrait post of the brand. `kieAspectRatio` picks the nearest served ratio by proportion instead — 4:5 → 3:4, never a square. Seen in the app log during the manual test:

```
[kie-image] seedream-5-pro non serve aspect_ratio "4:5" — uso 3:4
```
</details>

### The two gaps this PR also closes

- **`renderPreviewImages` — the weekly production — took no image model from any of its seven callers.** #139's preference reached single posts, carousels, chat and the media generator, but not the batch that produces the week. It now reads the brand's choice itself, in one place, the way `generateStandaloneImage` does. An explicit `imageModel` (the guest preview) still wins, and the UGC cover still overrides everything.
- **A kie-only model reaching Google is a 400 on every image**, exactly when kie is down and the fallback matters. `googleImageModel()` sends the house model instead and says so; only Nano Banana has a real Gemini id, which is why the spec carries `google: null` for the rest.

## Testing?

- **Unit** (written first, watched fail): the new blocks in `src/lib/image-models.test.ts` and `src/lib/server/kie-jobs.test.ts` are the executable copy of the kie docs — field names per family, the 1K-only ratios, 4:5 → 3:4, the per-model reference caps, the t2i/i2i id swap, and the Google guard. `image-models` + `kie-jobs` + `content-preview` + `changelog` → **142 passed** on this branch, rebased on current `dev`.
- One existing assertion changed on purpose: `buildKieImageInput` used to send `1:1` for an unknown ratio. It now sends the nearest ratio the model actually serves, and the test asserts the stronger invariant (the result is always in that model's own enum).
- **Live against kie**, `createTask` + `recordInfo`, both text-to-image and image-to-image for all three new families:

```
nano-banana-pro                 success   18 credits
seedream/5-pro-text-to-image    success   14 credits
seedream/5-pro-image-to-image   success   14 credits
qwen3/pro-text-to-image         success   12 credits
qwen3/pro-image-to-image        accepted  12.5 credits
gpt-image-2-text-to-image       success    6 credits (1K) / 10 (2K)
gpt-image-2-image-to-image      success    6 credits
```

- **Manual, on the local stack** (self-hosted Supabase in Docker + worktree dev server, logged in as `test@anomalia.so` on brand `demo`): picked Seedream 5 Pro in Settings, saved, generated a real Instagram post. The evidence is `ai_calls`, and the ratio warning above is from the same run:

```
08:12:35 | renderPostImage | kie | seedream/5-pro-text-to-image | ok
06:32:39 | renderPostImage | kie | nano-banana-pro              | ok | $0.090
06:36:08 | renderPostImage | kie | nano-banana-2                | ok          ← Platform default
```

- **Not tested**: the Google fallback end to end (it needs the kie key removed from a running instance) — it is covered by a unit test on `googleImageModel`; and the new families with a full reference stack (logo + product + person at once), where Qwen's cap of 3 will drop some.

## Evidence (screenshots/videos)

The Settings row and its seven options, on the local stack, is unchanged from #139 apart from the longer list and the panel title (**Video** → **Images & video**, since it now holds an image setting).

## Anything Else?

- **Qwen3 Pro forwards only 3 references.** A render with logo + product + person + user attachments will lose some, with a warning. That is the model's real ceiling, not a bug, but it makes Qwen a poor pick for brands that lean on product fidelity.
- `IMAGE_CREDITS` in `content-cost.ts` is still the median measured on the default model. A brand pinned to Pro (18 credits) or Seedream (14) costs more than the planner believes. Worth re-measuring once a brand actually uses one.
- No plan gate on the choice. If the model is meant to be an upsell, that is a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KNGMMYSbWxEJCssaxzFMAv