### PR TITLE
Load Sentry after the first paint, not before it

### DIFF
--- a/changelog/2026-09-02-sentry-differito.md
+++ b/changelog/2026-09-02-sentry-differito.md
@@ -1,0 +1,69 @@
+# Sentry non è più la cosa più pesante che l'app scarica prima di disegnare
+
+Misurato, non sospettato: due build identici a meno del client Sentry, stesso metodo su entrambi
+(grafo di import statico del bundle client, nodi `[0, 5, 6, 150]` della rotta chat, raw e gzip).
+
+| | percorso critico chat | `entry/app.js` | file JS |
+| --- | --- | --- | --- |
+| prima | 1.972 KB raw / **611,4 KB gz** | 303,8 / **93,7 gz** | 143 |
+| dopo | 1.755 KB raw / **537,8 KB gz** | 83,1 / **20,1 gz** | 141 |
+| Sentry tolto del tutto (tetto) | 1.642 KB raw / 488,0 KB gz | 82,0 / 19,3 gz | 140 |
+
+**−217 KB raw, −73,6 KB gzip: il 12,0% del critico.** Il file d'ingresso — quello che OGNI pagina
+dell'app scarica prima di disegnare qualsiasi cosa — cala del 78%.
+
+## Cos'era
+
+`hooks.client.ts` importava `@sentry/sveltekit` staticamente. Sono **329 moduli** `@sentry/*` nel
+bundle client (222 solo `@sentry/core`), quindi finivano dentro `entry/app.js` e stavano sulla
+strada del primo fotogramma sempre — anche sulle pagine dove non succede niente da segnalare, che
+sono tutte tranne quelle rotte. L'init era già condizionato (dev, DSN mancante, pagine marketing),
+ma condizionare l'INIT non toglie i byte: quelli li porta l'`import`.
+
+## Cosa cambia
+
+L'import diventa dinamico e parte quando il browser è libero (`requestIdleCallback`, tetto 3 s)
+sulle pagine dell'app; sulle marketing resta legato alla prima interazione, come già faceva il
+replay. Il modulo si carica una volta sola (`sentryModule ??= import(...)`), e `init` conserva
+esattamente le opzioni e le tre guardie di prima.
+
+`error-report.ts` dell'onboarding aveva lo stesso import statico e riceve lo stesso trattamento:
+la funzione gira solo quando è già andata male, quindi i byte li paga allora.
+
+## Il buco che apre, e la rete che lo copre
+
+Fra il caricamento della pagina e l'idle c'è una finestra senza nessuno che raccolga gli errori —
+ed è proprio la finestra in cui l'app si idrata, cioè dove succedono quelli interessanti. Prima
+quella finestra era quasi zero sulle pagine dell'app, perché l'init girava al caricamento del
+modulo.
+
+`$lib/sentry-buffer` la copre: due listener globali (`error`, `unhandledrejection`) armati subito,
+che costano nulla e non importano niente, tengono da parte fino a venti errori e li rigiocano con
+`captureException` appena il client è pronto. Dopo il primo svuotamento la coda si spegne per
+sempre — da lì in poi ci sono gli handler globali di Sentry, e continuare a ricordare vorrebbe
+dire spedire tutto due volte. È la proprietà che i test pinnano.
+
+L'errore che passa dall'hook `handleError` di SvelteKit paga il caricamento del modulo se non è
+ancora arrivato: succede una volta, e solo quando qualcosa è già rotto.
+
+## Perché non gli altri candidati
+
+Nella stessa analisi (plugin Rollup temporaneo che risale gli importatori) sono stati misurati e
+scartati:
+
+- **zod, 18 KB gz (2,9%)** — ingresso unico, `chat-model-policy.ts` che importa a runtime lo schema
+  `AgentModelPolicy` da `@anomalia/agent-contracts/contracts`. Toglierlo vuol dire spezzare un
+  package condiviso e riscrivere a mano la validazione. Non paga.
+- **supabase-js, 56 KB gz (9,2%)** — importatore applicativo unico (`src/lib/supabase/client.ts`),
+  ma la chat lo usa SEMPRE per il canale Realtime: un import dinamico non lo toglie dal critico, lo
+  sposta di un istante. L'unica rimozione vera è `@supabase/realtime-js` nudo con token e refresh
+  scritti in casa: non si tocca l'auth per il 6,5%.
+- **CSS morto** — non esiste. I 192 `Unused CSS selector` che il build stampa sono selettori che
+  Svelte ha già rimosso, e infatti fra i due build il CSS è identico al byte (322 KB / 59,6 gz).
+
+## Quello che resta
+
+Fra il risultato (537,8) e il tetto della rimozione totale (488,0) ci sono 49,8 KB gz: non un
+blocco di Sentry rimasto in piedi, ma l'strumentazione che il plugin `sentrySvelteKit()` intreccia
+in altri chunk, più le differenze di partizionamento fra i due build. Toglierla vorrebbe dire
+rinunciare al plugin, cioè alle tracce: non è lo stesso scambio.

--- a/src/hooks.client.test.ts
+++ b/src/hooks.client.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+/**
+ * Misurato il 2/9 su due build identici a meno di Sentry: il client Sentry vale **123,4 KB gzip
+ * del percorso critico** della pagina chat (611,4 → 488,0), e 74,4 di quei KB stanno dentro
+ * `entry/app.js`, cioè il file che ogni pagina dell'app carica prima di disegnare qualsiasi cosa.
+ * Sono 329 moduli `@sentry/*`, tirati dentro da un `import` statico.
+ *
+ * L'unica cosa che li tiene fuori dal critico è che l'import resti DINAMICO. Un `import` statico
+ * rimesso qui dentro — anche solo per un tipo, se non è `import type` — li riporta tutti nel
+ * chunk d'ingresso senza che nessuno se ne accorga.
+ */
+describe('hooks.client: Sentry non entra nel chunk di ingresso', () => {
+	const src = readFileSync(new URL('./hooks.client.ts', import.meta.url), 'utf8');
+
+	it("non ha import statici da @sentry: solo l'import dinamico", () => {
+		const statics = src.match(/^import\s+(?!type\b)[^;]*from\s+['"]@sentry\/[^'"]+['"]/gm) ?? [];
+		expect(statics).toEqual([]);
+		expect(src).toMatch(/\bimport\(['"]@sentry\/sveltekit['"]\)/);
+	});
+
+	it("gli errori della finestra prima del caricamento non si perdono", () => {
+		expect(src).toContain('rememberError');
+		expect(src).toContain('drainErrors');
+	});
+});

--- a/src/hooks.client.ts
+++ b/src/hooks.client.ts
@@ -1,26 +1,48 @@
-import { handleErrorWithSentry, replayIntegration } from "@sentry/sveltekit";
-import * as Sentry from '@sentry/sveltekit';
+import type { HandleClientError } from '@sveltejs/kit';
 import { dev } from '$app/environment';
 import { env } from '$env/dynamic/public';
 import { dropIfInternal, isInternalViewer } from '$lib/analytics';
+import { drainErrors, rememberError } from '$lib/sentry-buffer';
 
+type SentryModule = typeof import('@sentry/sveltekit');
+
+/**
+ * IL CLIENT SENTRY ARRIVA DOPO, E NON PER GUSTO DELL'OTTIMIZZAZIONE.
+ *
+ * Misurato il 2/9 su due build identici a meno di Sentry: 329 moduli `@sentry/*` valgono
+ * **123,4 KB gzip del percorso critico** della pagina chat (611,4 → 488,0), e 74,4 di quei KB
+ * stanno dentro `entry/app.js` — il file che OGNI pagina dell'app scarica prima di disegnare
+ * qualsiasi cosa. Con un `import` statico quei byte sono sulla strada del primo fotogramma
+ * sempre, anche quando non c'è niente da segnalare.
+ *
+ * Quindi l'import è dinamico e parte a idle (o alla prima interazione, come già faceva il
+ * replay). Quel che si perde è la finestra fra il caricamento e l'idle: la copre
+ * `$lib/sentry-buffer`, che tiene gli errori da parte e li rigioca appena il client c'è.
+ */
+let sentryModule: Promise<SentryModule> | null = null;
 let sentryReady = false;
 
-function bootSentry() {
+function sentryEnabled(): boolean {
+  return !dev && !!env.PUBLIC_SENTRY_DSN;
+}
+
+async function bootSentry(): Promise<SentryModule | null> {
   // Guard 1 — l'ambiente. In locale Sentry non parte proprio: niente client, quindi niente
   // tracce, niente log, niente replay, niente sessioni. Prima il campionamento in dev era 1.0,
   // cioè `npm run dev` spediva OGNI transazione all'ingest: quota bruciata, e le 429 di risposta
   // che tornavano indietro sembravano errori dell'applicazione (ci hanno già fatto perdere una
-  // diagnosi). Un errore in dev resta comunque visibile: `handleErrorWithSentry()` senza handler
-  // custom fa console.error, e `captureException` senza client è un no-op silenzioso.
+  // diagnosi).
   // Guard 3 — self-hosted senza PUBLIC_SENTRY_DSN: nessun default nostro, altrimenti ogni fork
-  // manderebbe i suoi errori al NOSTRO progetto Sentry. Non configurato → stesso no-op del dev.
-  const dsn = env.PUBLIC_SENTRY_DSN;
-  if (sentryReady || dev || !dsn) return;
+  // manderebbe i suoi errori al NOSTRO progetto Sentry. Non configurato → non si carica nemmeno.
+  if (!sentryEnabled()) return null;
+
+  sentryModule ??= import('@sentry/sveltekit');
+  const Sentry = await sentryModule;
+  if (sentryReady) return Sentry;
   sentryReady = true;
 
   Sentry.init({
-    dsn,
+    dsn: env.PUBLIC_SENTRY_DSN,
 
     // 10% — 100% traccerebbe ogni richiesta e cresce in fretta.
     tracesSampleRate: 0.1,
@@ -36,39 +58,53 @@ function bootSentry() {
     // https://docs.sentry.io/platforms/javascript/guides/sveltekit/configuration/options/#sendDefaultPii
     sendDefaultPii: true,
 
-    // Guard 2 — chi sta guardando. Il client si inizializza lo stesso (a questo punto l'identità
-    // non è nota: `bootSentry` gira al caricamento del modulo, il layout dice chi è solo
-    // all'idratazione), ma ogni evento viene scartato se il visitatore è dei nostri. Valutato a
-    // ogni invio, non una volta qui, così un login lato client conta subito.
+    // Guard 2 — chi sta guardando. Il client si inizializza lo stesso, ma ogni evento viene
+    // scartato se il visitatore è dei nostri. Valutato a ogni invio, non una volta qui, così un
+    // login lato client conta subito.
     beforeSend: dropIfInternal,
     beforeSendTransaction: dropIfInternal,
     beforeSendLog: dropIfInternal
   });
-  // ponytail: resta fuori un solo envelope `session` (release health) per caricamento a freddo
-  // dello shell app: `browserSessionIntegration` lo manda dentro init, prima che il layout dica
-  // chi sta guardando. Niente errori, niente transazioni, niente replay, nessun payload. Sulle
-  // pagine marketing non succede nemmeno quello, perché lì l'init è differito al wake. Se anche
-  // quel residuo dà fastidio: togliere `BrowserSession` dalle integrazioni di default e
-  // riaggiungerla da `setInternalViewer(false)`.
+
+  // Quello che è successo mentre il modulo era per strada.
+  for (const error of drainErrors()) Sentry.captureException(error);
+
+  return Sentry;
 }
 
-function attachReplay() {
+async function attachReplay(): Promise<void> {
   // La registrazione della sessione non si aggiunge nemmeno, per noi: scartare gli eventi dopo
   // basterebbe, ma il replay inizia a bufferizzare il DOM appena è agganciato ed è la cosa che
   // vogliamo evitare per prima. Arriviamo qui alla prima interazione o dopo 8–10s, quindi
   // l'identità è già nota da un pezzo (il layout la imposta all'idratazione).
   if (dev || isInternalViewer()) return;
-  bootSentry();
+  const Sentry = await bootSentry();
+  if (!Sentry) return;
   try {
-    Sentry.addIntegration(replayIntegration());
+    Sentry.addIntegration(Sentry.replayIntegration());
   } catch {
     // ignore — Sentry may already have it, or client not ready
   }
 }
 
+/** Quando il browser non ha di meglio da fare, e comunque non oltre `timeout`. */
+function whenIdle(fn: () => void, timeout: number): void {
+  const ric = (
+    window as Window & { requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => void }
+  ).requestIdleCallback;
+  if (ric) ric(fn, { timeout });
+  else setTimeout(fn, timeout);
+}
+
 if (!dev && typeof window !== 'undefined') {
-  // App shell: init Sentry soon (errors matter). Marketing: wait for interaction / idle so
-  // the ingest envelope stays off the LCP critical path (PSI network tree).
+  // La rete di sicurezza si arma SUBITO, e non costa niente: è la finestra in cui Sentry non c'è
+  // ancora. Si spegne da sola al primo `drainErrors`, quando i suoi handler globali prendono il
+  // posto — o gli stessi errori partirebbero due volte.
+  window.addEventListener('error', (event) => rememberError(event.error ?? event.message));
+  window.addEventListener('unhandledrejection', (event) => rememberError(event.reason));
+
+  // App shell: init appena il browser è libero (gli errori contano). Marketing: si aspetta
+  // l'interazione, così l'envelope verso l'ingest resta fuori dall'albero di rete dell'LCP.
   const path = window.location.pathname;
   const isApp =
     path === '/app' ||
@@ -78,13 +114,10 @@ if (!dev && typeof window !== 'undefined') {
     path === '/start' ||
     path.startsWith('/start/');
 
-  if (isApp) {
-    bootSentry();
-  }
+  if (isApp) whenIdle(() => void bootSentry(), 3000);
 
   const wake = () => {
-    bootSentry();
-    attachReplay();
+    void attachReplay();
   };
   for (const e of ['scroll', 'pointerdown', 'keydown', 'touchstart'] as const) {
     window.addEventListener(e, wake, { once: true, passive: true, capture: true });
@@ -98,5 +131,20 @@ if (!dev && typeof window !== 'undefined') {
   );
 }
 
-// If you have a custom error handler, pass it to `handleErrorWithSentry`
-export const handleError = handleErrorWithSentry();
+/**
+ * L'errore che passa da SvelteKit paga il caricamento del modulo, se non è già arrivato: succede
+ * una volta sola, e solo quando qualcosa è già andato storto — il momento in cui quei byte
+ * valgono davvero. Senza DSN resta il `console.error` di prima.
+ */
+export const handleError: HandleClientError = async (input) => {
+  const Sentry = await bootSentry();
+  if (!Sentry) {
+    console.error(input.error);
+    return;
+  }
+  // `@sentry/sveltekit` tipa `handleErrorWithSentry` sull'evento del SERVER anche quando lo si
+  // usa come hook del client: a runtime legge solo `error` e la rotta, ed è la stessa funzione
+  // che stava qui prima: il cast tiene il comportamento identico invece di riscriverne uno.
+  const report = Sentry.handleErrorWithSentry() as unknown as HandleClientError;
+  return report(input);
+};

--- a/src/lib/content/changelog/2026-09-02-faster-first-paint.ts
+++ b/src/lib/content/changelog/2026-09-02-faster-first-paint.ts
@@ -1,0 +1,9 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-02',
+  title: 'Every page starts faster',
+  items: [
+    'The app now downloads 12% less code before it can draw anything, and the very first file it needs is 78% smaller — error reporting loads quietly afterwards instead of standing in the way.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/sentry-buffer.test.ts
+++ b/src/lib/sentry-buffer.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { __resetErrorBufferForTests, drainErrors, rememberError } from './sentry-buffer';
+
+/**
+ * Sentry non parte più al caricamento del modulo: arriva a idle, o alla prima interazione. In
+ * mezzo c'è una finestra in cui un errore non ha ancora nessuno che lo raccolga — ed è proprio
+ * la finestra in cui l'app si idrata, cioè dove gli errori interessanti succedono. Questa coda
+ * li tiene da parte e li rigioca quando il client è pronto.
+ *
+ * Le due proprietà che contano: niente si perde prima, niente si duplica dopo (una volta che
+ * Sentry è agganciato, i suoi handler globali vedono già tutto da soli).
+ */
+describe('la coda degli errori prima che Sentry arrivi', () => {
+	beforeEach(() => __resetErrorBufferForTests());
+
+	it('tiene quello che è successo prima e lo restituisce in ordine', () => {
+		rememberError('primo');
+		rememberError('secondo');
+		expect(drainErrors()).toEqual(['primo', 'secondo']);
+	});
+
+	it('dopo lo svuotamento non accumula più: da lì in poi guarda Sentry', () => {
+		rememberError('prima');
+		drainErrors();
+		rememberError('dopo');
+		expect(drainErrors()).toEqual([]);
+	});
+
+	it('non cresce senza limite se la pagina va in loop di errori', () => {
+		for (let i = 0; i < 500; i++) rememberError(i);
+		expect(drainErrors().length).toBeLessThanOrEqual(20);
+	});
+});

--- a/src/lib/sentry-buffer.ts
+++ b/src/lib/sentry-buffer.ts
@@ -1,0 +1,33 @@
+/**
+ * Gli errori accaduti PRIMA che il client Sentry sia arrivato.
+ *
+ * Sentry non si carica più al primo istante — vale 123 KB gzip del percorso critico, misurati —
+ * quindi fra il primo byte e l'idle c'è una finestra senza nessuno che raccolga gli errori. È
+ * proprio la finestra in cui l'app si idrata: buttarla via significherebbe smettere di vedere
+ * la classe di errori più interessante che abbiamo.
+ *
+ * Dopo lo svuotamento la coda si spegne per sempre: da lì in poi ci sono gli handler globali di
+ * Sentry, e continuare a ricordare vorrebbe dire spedire ogni errore due volte.
+ */
+const MAX_PENDING = 20;
+
+let pending: unknown[] = [];
+let drained = false;
+
+export function rememberError(error: unknown): void {
+  if (drained || pending.length >= MAX_PENDING) return;
+  pending.push(error);
+}
+
+export function drainErrors(): unknown[] {
+  drained = true;
+  const out = pending;
+  pending = [];
+  return out;
+}
+
+/** Solo per i test: riporta la coda allo stato di una pagina appena aperta. */
+export function __resetErrorBufferForTests(): void {
+  pending = [];
+  drained = false;
+}

--- a/src/routes/app/onboarding/components/error-report.ts
+++ b/src/routes/app/onboarding/components/error-report.ts
@@ -1,4 +1,3 @@
-import * as Sentry from '@sentry/sveltekit';
 import { track } from '$lib/analytics';
 
 export type ErrorPageCtx = {
@@ -18,10 +17,14 @@ export function reportOnboardingError(
   const msg = String(message ?? 'unknown').slice(0, 500);
   track('onboarding_error', { step, message: msg });
   try {
-    Sentry.captureException(new Error(`[onboarding:${step}] ${msg}`), {
-      tags: { onboarding_step: step },
-      extra: context
-    });
+    // Dinamico come in `hooks.client.ts`: un import statico qui rimetterebbe i 329 moduli di
+    // Sentry dentro il chunk della rotta, e questa funzione gira solo quando è già andata male.
+    void import('@sentry/sveltekit').then((Sentry) =>
+      Sentry.captureException(new Error(`[onboarding:${step}] ${msg}`), {
+        tags: { onboarding_step: step },
+        extra: context
+      })
+    );
   } catch {
     // Sentry può non essere ancora avviato in un passaggio a freddo marketing→app
   }


### PR DESCRIPTION
## What?

`hooks.client.ts` no longer imports `@sentry/sveltekit` statically. The client is loaded dynamically when the browser goes idle on app pages, and on first interaction elsewhere — the treatment the replay integration already had. A small buffer keeps the errors that happen in the meantime and replays them once the client is up.

Nothing about what gets reported changes: same `init` options, same three guards (dev, missing DSN, internal viewer), same `handleError` behaviour.

## Why?

Two builds identical but for the Sentry client, measured the same way on both (static import graph of the client bundle, nodes `[0, 5, 6, 150]` of the chat route, raw and gzip):

| | critical path | `entry/app.js` | JS files |
| --- | --- | --- | --- |
| before | 1,972 KB raw / **611.4 KB gz** | 303.8 / **93.7 gz** | 143 |
| after | 1,755 KB raw / **537.8 KB gz** | 83.1 / **20.1 gz** | 141 |
| Sentry removed entirely (ceiling) | 1,642 KB raw / 488.0 KB gz | 82.0 / 19.3 gz | 140 |

**−217 KB raw, −73.6 KB gzip — 12.0% of the critical path.** The entry file, the one every page of the app must download before drawing anything, drops 78%.

There are **329** `@sentry/*` modules in the client bundle (222 in `@sentry/core` alone). Init was already conditional, but conditioning init does not move bytes — the `import` does.

## How?

`bootSentry()` becomes async and does `sentryModule ??= import('@sentry/sveltekit')`, so the module loads once and only when asked. App pages schedule it through `requestIdleCallback` with a 3 s ceiling; marketing pages keep waiting for a real interaction. `attachReplay()` awaits the same loader instead of holding its own reference.

`src/routes/app/onboarding/components/error-report.ts` had the same static import and gets the same treatment — that function only runs when something has already gone wrong, so it can pay for the module then.

**The window this opens, and the net under it.** Between page load and idle nobody collects errors, and that is exactly the window where hydration breaks. `$lib/sentry-buffer` covers it: two global listeners armed immediately (they cost nothing and import nothing) keep up to twenty errors and replay them through `captureException` as soon as the client is ready. After the first drain the queue shuts off for good — from then on Sentry's own global handlers see everything, and remembering would send each error twice. That is the property the tests pin.

An error arriving through SvelteKit's `handleError` hook pays for the module if it has not landed yet: once, and only when something is already broken.

**Rejected, with the numbers that killed them** — from the same analysis (a temporary Rollup plugin walking importers):

- **zod, 18 KB gz (2.9%)** — single entry point: `chat-model-policy.ts` imports the `AgentModelPolicy` schema at runtime from `@anomalia/agent-contracts/contracts`, and any *value* import from that module drags zod in. Removing it means splitting a shared package and hand-rolling the validation. Not worth 2.9%.
- **supabase-js, 56 KB gz (9.2%)** — one app importer (`src/lib/supabase/client.ts`), but the chat page needs it *always* for the Realtime channel, so a dynamic import does not take it off the critical path, it just delays it by a moment. The only real removal is bare `@supabase/realtime-js` with the token and its refresh written by hand. We do not hand-roll auth for 6.5%.
- **Dead CSS** — does not exist. The 192 `Unused CSS selector` warnings the build prints are selectors Svelte has already stripped, and the CSS is identical to the byte across both builds (322 KB / 59.6 gz).

## Testing?

**Unit** — 8 green. Three behaviour tests on the buffer, written red first: it keeps what happened before in order, it stops accumulating after the drain (no duplicates), and it does not grow without bound if the page loops on errors. Two source pins on `hooks.client.ts`: no static `@sentry` import survives, and the buffer stays wired — a static import put back here silently returns all 329 modules to the entry chunk.

**Type check** — `svelte-check` reports 378 errors on this branch, all pre-existing on `dev` (blog route prop drift, a duplicate `hookTimeout` key in `vite.config.ts`). The one error this change introduced — `handleErrorWithSentry` typed on the *server* event even when used as the client hook — is fixed in the diff with a cast and a comment; the previous code had the same mismatch, implicitly, by not annotating the export.

**Browser, against the production build** (`vite preview` on the built output, fake DSN pointing at an unreachable host so nothing lands in the real project), `/app/demo`:

| | files | transferred | decoded |
| --- | --- | --- | --- |
| JS fetched **before** `loadEventEnd` (1,495 ms) | 77 | 299 KB | 787 KB |
| JS fetched **after** | 71 | 508 KB | 1,436 KB |

The Sentry chunk is in the second group: 411 KB decoded, fetched at **1,534 ms**, and fingerprinted to be sure (`sentry-trace` ×15, `baggage` ×16, `captureException` ×7, `browserTracing`, `replayIntegration`). It is no longer on the pre-paint path.

It still boots on its own: `window.__SENTRY__` is present afterwards and one request to the DSN host shows in resource timing — in a **background tab, with no interaction**, so the idle scheduling is not merely deferring it forever. The shell renders, console clean.

**Not verified:** the replay of errors buffered before boot. Two reasons, both about the harness rather than the code — the browser automation injects its script about twelve seconds after navigation, long after the client is already up, so the pre-boot window cannot be entered from outside; and this test user is an internal viewer, so `dropIfInternal` discards events by design. That path is covered by the three unit tests on the buffer and by reading the wiring, not by a browser run.

**Risk:** if the dynamic import fails (blocked CDN, offline), errors stay in the buffer and are never reported — before, Sentry would have been there. The cap is twenty, so nothing grows unbounded. This is the trade the measurement buys.

## Evidence (screenshots/videos)

The change has no visual surface; the evidence is the table above — two builds on the same machine measured with the same script, plus the module count from the import-graph analysis.

## Anything Else?

- Between this result (537.8) and the total-removal ceiling (488.0) sit 49.8 KB gz. That is not a block of Sentry left standing but the instrumentation the `sentrySvelteKit()` plugin weaves into other chunks, plus chunk-splitting differences between the two builds. Removing it would mean giving up tracing — a different trade, not a free one.
- The next largest single item on the critical path is now `chunks/*.js` at 55.9 KB gz — supabase-js. It stays for the reason above.
