### PR TITLE
Charge a turn what the gateway actually billed

### DIFF
--- a/changelog/2026-09-02-gateway-real-cost.md
+++ b/changelog/2026-09-02-gateway-real-cost.md
@@ -1,0 +1,58 @@
+# Il turno lo prezza chi ce lo fattura
+
+`computeCostUsd` prezzava per token con `RATES`: una tabella scritta a mano, un modello per riga.
+Un modello che non c'è non vale «prudentemente null», vale **zero crediti**. Contato sul database:
+
+| modello loggato | righe | con costo |
+|---|---|---|
+| `z-ai/glm-5.3-flash` | 181 | 175 |
+| `llm/z-ai/glm-5.3-flash` | 54 | **0** |
+| `google/gemini-3.7-flash` | 30 | **0** |
+| `deepseek/deepseek-v4-flash-vision-exp` (il default di oggi) | 7 | **0** |
+
+Cioè: il modello su cui gira la chat non ha mai toccato i crediti, e la stessa riga cambiava
+prezzo a seconda di quale strada l'avesse scritta.
+
+## Tre cose, in ordine di quanto sono profonde
+
+**Il prefisso.** `llm/z-ai/glm-5.3-flash` e `z-ai/glm-5.3-flash` sono lo stesso modello: il
+prefisso lo mette il bridge dell'harness (`adapters.ts`), la normalizzazione ne toglieva uno solo
+(`openrouter/`). Una riga di regex, 54 righe di log che tornano a costare.
+
+**La fattura vera, dove possiamo leggerla.** OpenRouter allega `usage.cost` alla risposta se glielo
+si chiede (`usage: {include: true}`), streaming compreso, nell'ultimo chunk. `llmClient` lo chiede
+e legge il costo da una **copia** della risposta (`res.clone()`), così l'originale continua a
+scorrere verso l'utente alla sua velocità. Il costo si somma in una cassetta di scope — la stessa
+idea dei crediti kie — e `logAiCall` la ritira: un turno di chat è N chiamate e la riga aggregata
+le comprende tutte.
+
+Scartato: `GET /generation?id=` con l'`x-generation-id` dell'header. Funziona, ed è stato scritto,
+ma **misurato**: il record compare 9 secondi dopo la risposta. Tenere viva una funzione serverless
+ad aspettarlo significa perdere anche la riga di log.
+
+**Il listino, dove NON possiamo leggerla.** Il turno di chat passa dall'harness pi, che ha un suo
+client HTTP: `usage.cost` non lo vediamo. Lì il prezzo arriva da `/models` di OpenRouter —
+prompt e completion per token, più il tier di cache — caricato una volta per processo e tenuto sei
+ore. È lo stesso modulo che servirà al selettore di modello: un modello nuovo non va aggiunto in
+due posti, perché non va aggiunto in nessuno.
+
+## Ordine di precedenza, e perché
+
+`flatCostUsd` (fattura del gateway) → `RATES` (scritte a mano) → listino live → null. Le RATES
+restano davanti al listino di proposito: contengono correzioni volute che un listino non ha —
+alias storici che riprezzano righe vecchie alla tariffa su cui girarono davvero, e la nota che
+DeepSeek raddoppia in fascia oraria.
+
+`usage: {include: true}` si aggiunge **solo** verso `openrouter.ai`: su un altro gateway
+OpenAI-compatibile un campo sconosciuto nel corpo è un 400 su ogni chiamata.
+
+## Verificato sullo stack locale, non dedotto
+
+Stessa chiamata, prima e dopo, su `deepseek/deepseek-v4-flash-vision-exp`:
+
+```
+08:37:56 | createSingleContent | (nessun costo)     ← prima
+08:42:06 | createSingleContent | $0.003759          ← dopo, via usage.cost
+08:43:48 | chat (harness)      | (nessun costo)     ← prima
+08:46:16 | chat (harness)      | $0.008869          ← dopo, via listino live
+```

--- a/src/lib/content/changelog/2026-09-02-gateway-real-cost.ts
+++ b/src/lib/content/changelog/2026-09-02-gateway-real-cost.ts
@@ -1,0 +1,10 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-02',
+  title: 'Credits now follow the real bill',
+  items: [
+    'Chat and agent turns are charged at what the model provider actually billed for them, instead of a price list that had to be updated by hand for every model.',
+    'Turns on models that were missing from that list used to cost no credits at all. They now count, so what you see spent is what was really spent.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/ai-log.test.ts
+++ b/src/lib/server/ai-log.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { computeCostUsd, extractGeminiUsage, extractSdkUsage, extractXiaomiUsage, withBrandContext } from './ai-log';
+import { computeCostUsd, extractGeminiUsage, extractSdkUsage, extractXiaomiUsage, noteLlmCost, takeLlmCost, withBrandContext } from './ai-log';
 import { GEMINI_FLASH, NANO_BANANA_PRO } from './gemini';
 
 const GO = 'go';
@@ -20,6 +20,17 @@ describe('computeCostUsd', () => {
     // $0.075/M input + $0.25/M output
     expect(bare).toBeCloseTo(0.325, 4);
     expect(prefixed).toBeCloseTo(0.325, 4);
+  });
+
+  /**
+   * MISURATO sul database, non dedotto: 54 righe `llm/z-ai/glm-5.3-flash` con zero costo accanto a
+   * 181 righe dello STESSO modello, prezzate, sotto l'id nudo. Il prefisso lo mette il bridge
+   * (`adapters.ts`), la normalizzazione ne toglieva uno solo, e il tier che scrive le composizioni
+   * motion smetteva di toccare i crediti passando dall'harness.
+   */
+  it('prezza lo stesso modello anche sotto il prefisso `llm/` del bridge', () => {
+    const usage = { label: 'chat', ms: 0, ok: true, inputTokens: 1_000_000, outputTokens: 1_000_000 };
+    expect(computeCostUsd({ ...usage, provider: 'llm', model: 'llm/z-ai/glm-5.3-flash' })).toBeCloseTo(0.325, 4);
   });
 
   it('un modello openrouter senza tariffa resta null: meglio non misurato che misurato a caso', () => {
@@ -388,5 +399,42 @@ describe('extractSdkUsage', () => {
       cachedTokens: undefined,
       thinkingTokens: undefined
     });
+  });
+});
+
+
+/**
+ * Un turno di chat non è UNA chiamata: ogni passo con i tool ne è una, e ognuna ha la sua
+ * generazione fatturata. La riga aggregata che si scrive alla fine deve poterle sommare tutte,
+ * quindi gli id si accumulano nello scope come già fanno i crediti kie.
+ */
+describe('fatture del gateway nello scope', () => {
+  it('somma i passi del turno e li consegna una volta sola', async () => {
+    await withBrandContext('brand-1', async () => {
+      noteLlmCost(0.001);
+      noteLlmCost(0.002);
+      expect(takeLlmCost()).toBeCloseTo(0.003, 10);
+      expect(takeLlmCost()).toBeUndefined();
+    });
+  });
+
+  it('due turni paralleli non si mescolano i costi', async () => {
+    await Promise.all([
+      withBrandContext('brand-1', async () => {
+        noteLlmCost(1);
+        await new Promise((r) => setTimeout(r, 5));
+        expect(takeLlmCost()).toBe(1);
+      }),
+      withBrandContext('brand-2', async () => {
+        noteLlmCost(2);
+        await new Promise((r) => setTimeout(r, 5));
+        expect(takeLlmCost()).toBe(2);
+      })
+    ]);
+  });
+
+  it('fuori da uno scope non esplode e non ricorda nulla', () => {
+    noteLlmCost(5);
+    expect(takeLlmCost()).toBeUndefined();
   });
 });

--- a/src/lib/server/ai-log.ts
+++ b/src/lib/server/ai-log.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto';
 import { AsyncLocalStorage } from 'node:async_hooks';
+import { gatewayRate } from '$lib/server/openrouter-models';
 import { createAdminClient } from '$lib/server/supabase-admin';
 import { GEMINI_FLASH, geminiFlash, isGeminiFlashId, isKieFlashId, kieFlashId, NANO_BANANA_PRO, isNanoBananaProId, geminiVisualCreditShare } from '$lib/server/gemini';
 
@@ -15,6 +16,8 @@ type BrandLogContext = {
   plan?: string | null;
   /** Crediti kie letti dalle risposte HTTP di questo scope, in attesa della riga che li scrive. */
   kieCredits?: number;
+  /** Costo fatturato dal gateway in questo scope, sommato: la fattura vera del turno. */
+  llmCostUsd?: number;
 };
 
 const brandStorage = new AsyncLocalStorage<BrandLogContext>();
@@ -81,6 +84,26 @@ function takeKieCredits(): number | undefined {
   if (!ctx || !credits) return undefined;
   ctx.kieCredits = 0;
   return credits;
+}
+
+/**
+ * Il costo che il gateway ci ha fatturato in questo scope. Un turno di chat è N chiamate (una per
+ * passo con i tool) e ognuna ha la sua fattura: si sommano qui e la riga aggregata le scrive,
+ * esattamente come i crediti kie qui sopra. `llmClient` le deposita leggendo `usage.cost` da una
+ * copia della risposta, senza rallentare quella che sta leggendo l'utente.
+ */
+export function noteLlmCost(usd: number): void {
+  const ctx = brandStorage.getStore();
+  if (!ctx || !Number.isFinite(usd) || usd < 0) return;
+  ctx.llmCostUsd = (ctx.llmCostUsd ?? 0) + usd;
+}
+
+export function takeLlmCost(): number | undefined {
+  const ctx = brandStorage.getStore();
+  const cost = ctx?.llmCostUsd;
+  if (!ctx || cost == null) return undefined;
+  ctx.llmCostUsd = undefined;
+  return cost;
 }
 
 /** $5 = 1000 crediti kie. */
@@ -251,12 +274,17 @@ export function computeCostUsd(entry: AiCallLog, plan?: string | null): number |
   if (isKieFlashId(entry.model) && !RATES[entry.model ?? '']) return null;
   // Modello ASSENTE su una chiamata gemini = Flash; modello PRESENTE ma ignoto deve restare null,
   // non essere prezzato come Flash.
-  // `openrouter/z-ai/glm-5.3-flash` e `z-ai/glm-5.3-flash` sono lo stesso modello allo stesso
-  // prezzo: il prefisso dice il trasporto, non la tariffa. Normalizzare qui costa una riga e
-  // vale per OGNI modello del provider, invece di una seconda chiave per ciascuno.
-  const modelKey = (entry.model ?? '').replace(/^openrouter\//, '');
+  // `openrouter/z-ai/glm-5.3-flash`, `llm/z-ai/glm-5.3-flash` e `z-ai/glm-5.3-flash` sono lo
+  // stesso modello allo stesso prezzo: il prefisso dice il trasporto, non la tariffa. Il bridge
+  // dell'harness scrive `llm/`, e finché la normalizzazione ne toglieva uno solo quelle righe
+  // restavano senza costo — 54 su 235 dello stesso modello.
+  const modelKey = (entry.model ?? '').replace(/^(?:openrouter|llm)\//, '');
   const rate =
     RATES[modelKey] ??
+    // Il listino del gateway, chiesto al gateway: è ciò che rende fatturabile un modello che
+    // l'utente ha scelto e che nessuno ha scritto qui sopra. Vuoto finché `ensureGatewayModels`
+    // non ha caricato — e allora decidono le RATES, come prima.
+    gatewayRate(entry.model) ??
     (isGeminiFlashId(entry.model) ? RATES[GEMINI_FLASH] : null) ??
     (!entry.model && entry.provider === 'gemini' ? RATES[GEMINI_FLASH] : null);
   if (!rate) return null;
@@ -306,12 +334,26 @@ export function logAiCall(entry: AiCallLog): void {
       const credits = takeKieCredits();
       if (credits != null) entry = { ...entry, providerCredits: credits };
     }
+    // La fattura vera del gateway, se questo turno ne ha lasciata una. Si ritira QUI, sincrono:
+    // dopo il primo await un'altra riga dello stesso scope se la porterebbe via.
+    if (entry.provider === 'llm' && entry.flatCostUsd == null) {
+      const billed = takeLlmCost();
+      // Il prezzo del gateway batte le RATES scritte a mano: copre il modello che ha risposto
+      // davvero, il provider a monte e il markup, e vale per un modello che nessuno ha listato.
+      if (billed != null) entry = { ...entry, flatCostUsd: billed };
+    }
     const admin = createAdminClient();
     const brandId = entry.brandId ?? getBrandContext();
     const planFromAls = getBrandPlanContext();
     void (async () => {
       const plan =
         planFromAls !== undefined ? planFromAls : brandId ? await resolveBrandPlan(brandId) : null;
+      // Il listino serve PRIMA di prezzare, e solo per le righe che possono averne bisogno: la
+      // prima chiamata del processo lo carica, le altre lo trovano in memoria.
+      if (entry.provider === 'llm' && entry.flatCostUsd == null) {
+        const { ensureGatewayModels } = await import('$lib/server/openrouter-models');
+        await ensureGatewayModels();
+      }
       const { error } = await admin.from('ai_calls').insert({
         label: entry.label,
         provider: entry.provider,

--- a/src/lib/server/llm-usage-cost.test.ts
+++ b/src/lib/server/llm-usage-cost.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { costFromJson, costFromStreamText, withUsageAccounting } from './llm-usage-cost';
+
+describe('costo reale dal gateway', () => {
+  it('legge il costo dalla risposta non-streaming', () => {
+    expect(costFromJson({ usage: { prompt_tokens: 14, completion_tokens: 5, cost: 2.3e-6 } })).toBe(2.3e-6);
+  });
+
+  // Il turno di chat è streaming: il costo arriva nell'ULTIMO chunk, dopo che l'utente ha già
+  // letto la risposta. Senza leggerlo lì, ogni turno di chat resta senza prezzo.
+  it('legge il costo dall\'ultimo chunk di uno stream', () => {
+    const sse = [
+      'data: {"choices":[{"delta":{"content":"O"}}]}',
+      'data: {"choices":[{"delta":{"content":"K"}}]}',
+      'data: {"choices":[{"finish_reason":"stop"}],"usage":{"prompt_tokens":14,"completion_tokens":5,"cost":0.0000023}}',
+      'data: [DONE]'
+    ].join('\n\n');
+    expect(costFromStreamText(sse)).toBeCloseTo(0.0000023, 10);
+  });
+
+  it('senza campo cost non inventa uno zero', () => {
+    expect(costFromJson({ usage: { prompt_tokens: 1 } })).toBeNull();
+    expect(costFromStreamText('data: {"choices":[]}\n\ndata: [DONE]')).toBeNull();
+    expect(costFromStreamText('roba che non è SSE')).toBeNull();
+  });
+
+  /**
+   * `usage: {include: true}` è un'estensione di OpenRouter. Su un gateway OpenAI-compatibile
+   * qualunque un campo sconosciuto nel corpo è un 400 su OGNI chiamata: si aggiunge solo quando
+   * si sta parlando davvero con loro.
+   */
+  it('chiede il conto solo a OpenRouter', () => {
+    const body = JSON.stringify({ model: 'x', messages: [] });
+    expect(JSON.parse(withUsageAccounting(body, 'https://openrouter.ai/api/v1')!).usage).toEqual({ include: true });
+    expect(withUsageAccounting(body, 'https://api.openai.com/v1')).toBeNull();
+  });
+
+  it('un corpo che non è JSON resta intatto', () => {
+    expect(withUsageAccounting('non-json', 'https://openrouter.ai/api/v1')).toBeNull();
+  });
+});

--- a/src/lib/server/llm-usage-cost.ts
+++ b/src/lib/server/llm-usage-cost.ts
@@ -1,0 +1,63 @@
+/**
+ * Quanto ci è costato DAVVERO questo turno, detto da chi ce lo fattura.
+ *
+ * `RATES` in ai-log.ts prezza per token i modelli che qualcuno ha scritto lì a mano, e un modello
+ * assente non vale "prudentemente null": vale zero crediti. Misurato sul database — 54 righe
+ * `llm/z-ai/glm-5.3-flash`, 30 `google/gemini-3.7-flash` e ogni riga del modello di default,
+ * tutte senza costo. Un listino a mano non regge un catalogo che sceglie l'utente.
+ *
+ * OpenRouter allega `usage.cost` alla risposta quando glielo si chiede (`usage: {include: true}`),
+ * anche in streaming, dentro l'ULTIMO chunk. È la fattura: copre il modello che ha risposto
+ * davvero, il provider a monte e il markup.
+ *
+ * L'alternativa era `GET /generation?id=` con l'`x-generation-id` dell'header. Scartata dopo
+ * averla misurata: il record compare **9 secondi** dopo la risposta, e tenere in vita una
+ * funzione serverless per aspettarlo significa perdere anche la riga di log.
+ */
+
+const OPENROUTER_HOST = 'openrouter.ai';
+
+function costOf(usage: unknown): number | null {
+  const raw = (usage as { cost?: unknown } | null | undefined)?.cost;
+  // `Number(null)` è 0, e uno zero finto è peggio di un costo mancante: sarebbe un turno
+  // dichiarato gratuito invece che non misurato.
+  const cost = typeof raw === 'number' ? raw : typeof raw === 'string' ? Number(raw) : NaN;
+  return Number.isFinite(cost) ? cost : null;
+}
+
+export function costFromJson(body: unknown): number | null {
+  return costOf((body as { usage?: unknown } | null | undefined)?.usage);
+}
+
+/** L'ultimo chunk che porta un costo vince: i precedenti sono parziali o assenti. */
+export function costFromStreamText(text: string): number | null {
+  let last: number | null = null;
+  for (const line of text.split('\n')) {
+    const payload = line.startsWith('data:') ? line.slice(5).trim() : '';
+    if (!payload || payload === '[DONE]') continue;
+    try {
+      const cost = costFromJson(JSON.parse(payload));
+      if (cost != null) last = cost;
+    } catch {
+      // Un chunk troncato non è un guasto: il costo sta nell'ultimo, che arriva intero.
+    }
+  }
+  return last;
+}
+
+/**
+ * Il corpo della richiesta con la contabilità chiesta, o null se non c'è niente da cambiare.
+ * Solo verso OpenRouter: su un altro gateway OpenAI-compatibile un campo sconosciuto nel corpo
+ * è un 400 su ogni chiamata.
+ */
+export function withUsageAccounting(body: string, baseUrl: string): string | null {
+  if (!new URL(baseUrl).hostname.endsWith(OPENROUTER_HOST)) return null;
+  try {
+    const parsed = JSON.parse(body) as Record<string, unknown>;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+    if (parsed.usage) return null;
+    return JSON.stringify({ ...parsed, usage: { include: true } });
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/server/llm.ts
+++ b/src/lib/server/llm.ts
@@ -7,7 +7,8 @@
 import { createOpenAI } from '@ai-sdk/openai';
 import { embedMany, generateObject, generateText, jsonSchema } from 'ai';
 import { env } from '$env/dynamic/private';
-import { extractSdkUsage, logAiCall } from '$lib/server/ai-log';
+import { extractSdkUsage, logAiCall, noteLlmCost } from '$lib/server/ai-log';
+import { costFromJson, costFromStreamText, withUsageAccounting } from '$lib/server/llm-usage-cost';
 
 export const LLM_UNCONFIGURED = 'llm_unconfigured';
 export const LLM_VIDEO_UNCONFIGURED = 'llm_video_unconfigured';
@@ -80,6 +81,31 @@ export function llmModelForPicker(choice: string | null | undefined): string {
 let cached: ReturnType<typeof createOpenAI> | null = null;
 let cachedSig = '';
 
+/**
+ * Chiede il conto al gateway e lo mette nella cassetta dello scope, senza rallentare la risposta.
+ *
+ * `res.clone()` e non `res.text()`: l'originale continua a scorrere verso l'utente alla sua
+ * velocità mentre la copia viene letta a parte. Su un turno in streaming il costo arriva
+ * nell'ultimo chunk, quindi si conosce quando l'utente ha già finito di leggere — che è esattamente
+ * quando `logAiCall` scrive la riga.
+ */
+const billedFetch: typeof fetch = async (input, init) => {
+	const patched = typeof init?.body === 'string' ? withUsageAccounting(init.body, llmBaseUrl()) : null;
+	const res = await fetch(input, patched ? { ...init, body: patched } : init);
+	if (!patched) return res;
+	const copy = res.clone();
+	void (async () => {
+		try {
+			const text = await copy.text();
+			const cost = text.trimStart().startsWith('{') ? costFromJson(JSON.parse(text)) : costFromStreamText(text);
+			if (cost != null) noteLlmCost(cost);
+		} catch {
+			// Nessun costo lasciato dal gateway: decidono le RATES, come prima di questa cassetta.
+		}
+	})();
+	return res;
+};
+
 export function llmClient(): ReturnType<typeof createOpenAI> {
 	const key = llmApiKey();
 	if (!key) throw new Error('LLM_API_KEY is not configured');
@@ -88,7 +114,8 @@ export function llmClient(): ReturnType<typeof createOpenAI> {
 	cached = createOpenAI({
 		baseURL: llmBaseUrl(),
 		apiKey: key,
-		name: 'llm'
+		name: 'llm',
+		fetch: billedFetch
 	});
 	cachedSig = sig;
 	return cached;

--- a/src/lib/server/openrouter-models.test.ts
+++ b/src/lib/server/openrouter-models.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { __resetGatewayModels, ensureGatewayModels, gatewayModel, gatewayRate } from './openrouter-models';
+
+const MODELS = {
+  data: [
+    {
+      id: 'anthropic/claude-opus-5',
+      name: 'Claude Opus 5',
+      context_length: 1_000_000,
+      supported_parameters: ['tools', 'reasoning'],
+      architecture: { input_modalities: ['text', 'image'] },
+      pricing: { prompt: '0.000005', completion: '0.000025', input_cache_read: '0.0000005' }
+    },
+    {
+      id: 'someone/text-only-no-tools',
+      name: 'Text only',
+      context_length: 8000,
+      supported_parameters: [],
+      architecture: { input_modalities: ['text'] },
+      pricing: { prompt: '0.000001', completion: '0.000002' }
+    }
+  ]
+};
+
+function fetchImpl(body: unknown = MODELS, status = 200) {
+  return (async () => ({ ok: status < 300, status, json: async () => body })) as unknown as typeof fetch;
+}
+
+beforeEach(() => __resetGatewayModels());
+
+describe('catalogo dei modelli del gateway', () => {
+  it('trasforma il prezzo per token in dollari per milione', async () => {
+    await ensureGatewayModels({ fetchImpl: fetchImpl(), baseUrl: 'https://openrouter.ai/api/v1' });
+    expect(gatewayRate('anthropic/claude-opus-5')).toEqual({ input: 5, cachedInput: 0.5, output: 25 });
+  });
+
+  /**
+   * Il bridge dell'harness scrive `llm/<id>` e il vecchio ponte scriveva `openrouter/<id>`: è lo
+   * stesso modello allo stesso prezzo, e senza questo la riga più cara del prodotto resta a zero.
+   */
+  it('riconosce l\'id anche sotto i prefissi di trasporto', async () => {
+    await ensureGatewayModels({ fetchImpl: fetchImpl(), baseUrl: 'https://openrouter.ai/api/v1' });
+    expect(gatewayRate('llm/anthropic/claude-opus-5')?.input).toBe(5);
+    expect(gatewayRate('openrouter/anthropic/claude-opus-5')?.input).toBe(5);
+  });
+
+  it('senza cache prezzata resta null, non zero', async () => {
+    expect(gatewayRate('anthropic/claude-opus-5')).toBeNull();
+    await ensureGatewayModels({ fetchImpl: fetchImpl(), baseUrl: 'https://openrouter.ai/api/v1' });
+    expect(gatewayRate('mai/visto')).toBeNull();
+  });
+
+  it('un gateway irraggiungibile non fa esplodere il log', async () => {
+    await expect(
+      ensureGatewayModels({ fetchImpl: fetchImpl({}, 500), baseUrl: 'https://openrouter.ai/api/v1' })
+    ).resolves.toBeUndefined();
+    expect(gatewayRate('anthropic/claude-opus-5')).toBeNull();
+  });
+
+  // Gli agenti chiamano tool e leggono immagini: un modello senza quelle due cose non è una scelta,
+  // è un turno che muore a metà.
+  it('il picker vede solo i modelli che sanno usare i tool e leggere immagini', async () => {
+    await ensureGatewayModels({ fetchImpl: fetchImpl(), baseUrl: 'https://openrouter.ai/api/v1' });
+    expect(gatewayModel('anthropic/claude-opus-5')?.usable).toBe(true);
+    expect(gatewayModel('someone/text-only-no-tools')?.usable).toBe(false);
+    expect(gatewayModel('anthropic/claude-opus-5')?.contextLength).toBe(1_000_000);
+  });
+});

--- a/src/lib/server/openrouter-models.ts
+++ b/src/lib/server/openrouter-models.ts
@@ -1,0 +1,116 @@
+/**
+ * Il listino del gateway, chiesto al gateway.
+ *
+ * `RATES` in ai-log.ts è scritto a mano, modello per modello: regge finché i modelli li scegliamo
+ * noi, e smette di reggere il giorno in cui li sceglie l'utente. Un modello assente non costa
+ * "prudentemente null": costa **zero crediti**, e il conto lo paghiamo comunque.
+ *
+ * OpenRouter pubblica prezzo, finestra di contesto e capacità di ogni modello su `/models`. Da qui
+ * arrivano due cose che prima non c'erano:
+ *   · il prezzo per i turni che NON passano dall'AI SDK — l'harness della chat ha il suo client
+ *     HTTP e `usage.cost` non lo vediamo (v. llm-usage-cost.ts, che copre tutto il resto);
+ *   · l'elenco che il picker mostra, senza un secondo posto dove un modello nuovo va aggiunto.
+ *
+ * La cache è in memoria e per processo: un listino vecchio di qualche ora non ha mai fatto danni,
+ * una chiamata di rete dentro `computeCostUsd` sì.
+ */
+import { env } from '$env/dynamic/private';
+
+const CACHE_TTL_MS = 6 * 60 * 60 * 1000;
+const TRANSPORT_PREFIX = /^(?:openrouter|llm)\//;
+
+export type GatewayRate = { input: number; cachedInput: number; output: number };
+
+export type GatewayModel = {
+  id: string;
+  label: string;
+  contextLength: number;
+  rate: GatewayRate;
+  /** Gli agenti chiamano tool e leggono immagini: senza, il turno muore a metà. */
+  usable: boolean;
+  reasoning: boolean;
+};
+
+let models = new Map<string, GatewayModel>();
+let loadedAt = 0;
+let inFlight: Promise<void> | null = null;
+
+/** Solo per i test: il modulo tiene stato di processo apposta. */
+export function __resetGatewayModels(): void {
+  models = new Map();
+  loadedAt = 0;
+  inFlight = null;
+}
+
+const perMillion = (v: unknown): number => {
+  const n = typeof v === 'string' ? Number(v) : typeof v === 'number' ? v : NaN;
+  return Number.isFinite(n) ? n * 1e6 : 0;
+};
+
+type RawModel = {
+  id?: string;
+  name?: string;
+  context_length?: number;
+  supported_parameters?: string[];
+  architecture?: { input_modalities?: string[] };
+  pricing?: Record<string, unknown>;
+};
+
+export async function ensureGatewayModels(opts: { fetchImpl?: typeof fetch; baseUrl?: string } = {}): Promise<void> {
+  if (models.size && Date.now() - loadedAt < CACHE_TTL_MS) return;
+  if (inFlight) return inFlight;
+  const doFetch = opts.fetchImpl ?? fetch;
+  const baseUrl = (opts.baseUrl ?? env.LLM_BASE_URL?.trim() ?? '').replace(/\/$/, '');
+  if (!baseUrl) return;
+
+  inFlight = (async () => {
+    try {
+      const res = await doFetch(`${baseUrl}/models`);
+      if (!res.ok) return;
+      const body = (await res.json()) as { data?: RawModel[] };
+      const next = new Map<string, GatewayModel>();
+      for (const m of body?.data ?? []) {
+        if (!m?.id) continue;
+        const params = m.supported_parameters ?? [];
+        next.set(m.id, {
+          id: m.id,
+          label: m.name?.trim() || m.id,
+          contextLength: Number(m.context_length) || 0,
+          rate: {
+            input: perMillion(m.pricing?.prompt),
+            cachedInput: perMillion(m.pricing?.input_cache_read ?? m.pricing?.prompt),
+            output: perMillion(m.pricing?.completion)
+          },
+          usable: params.includes('tools') && (m.architecture?.input_modalities ?? []).includes('image'),
+          reasoning: params.includes('reasoning')
+        });
+      }
+      if (next.size) {
+        models = next;
+        loadedAt = Date.now();
+      }
+    } catch {
+      // Un listino irraggiungibile lascia il prezzo alle RATES, come prima di questo modulo.
+    } finally {
+      inFlight = null;
+    }
+  })();
+  return inFlight;
+}
+
+export function gatewayModel(modelId: string | undefined): GatewayModel | null {
+  const id = (modelId ?? '').trim().replace(TRANSPORT_PREFIX, '');
+  return (id && models.get(id)) || null;
+}
+
+/** Null quando il listino non conosce il modello: meglio non misurato che misurato a caso. */
+export function gatewayRate(modelId: string | undefined): GatewayRate | null {
+  const hit = gatewayModel(modelId);
+  if (!hit) return null;
+  return hit.rate.input || hit.rate.output ? hit.rate : null;
+}
+
+/** Tutti i modelli che il picker può offrire, ordinati per nome. */
+export function usableGatewayModels(): GatewayModel[] {
+  return [...models.values()].filter((m) => m.usable).sort((a, b) => a.label.localeCompare(b.label));
+}


### PR DESCRIPTION
## What?

Chat and agent turns are now charged the amount the model provider actually billed, instead of a hand-written per-model price list. Turns whose model was missing from that list used to cost **zero credits**; they now count.

This is the groundwork for letting a brand pick its own chat model (the follow-up PR): a catalogue the user chooses from cannot be billed by a table someone has to remember to update.

## Why?

`computeCostUsd` prices by token from `RATES` in `ai-log.ts`, one row per model. A model that is not there returns `null`, and `credits = Σ ai_calls.cost_usd × 100` — so the turn is free. Counted on the database:

| model as logged | rows | with a cost |
|---|---|---|
| `z-ai/glm-5.3-flash` | 181 | 175 |
| `llm/z-ai/glm-5.3-flash` | 54 | **0** |
| `google/gemini-3.7-flash` | 30 | **0** |
| `deepseek/deepseek-v4-flash-vision-exp` (today's default) | 7 | **0** |

The model the product actually runs on has never touched the ledger, and the same model was priced or not depending on which code path wrote the row.

## How?

Three changes, shallowest first.

**1. The transport prefix.** `llm/z-ai/glm-5.3-flash` is the same model as `z-ai/glm-5.3-flash` — the prefix is added by the harness bridge (`adapters.ts:152`) while the normalisation stripped only `openrouter/`. One regex; 54 rows of that model start costing again.

**2. The real invoice, where we can read it.** OpenRouter attaches `usage.cost` to the response when asked (`usage: {include: true}`), streaming included, in the final chunk. `llmClient`'s fetch adds the flag and reads the cost from `res.clone()`, so the original response keeps streaming to the user at full speed. Costs accumulate in an AsyncLocalStorage box — the same shape as the existing kie-credits box — and `logAiCall` drains it: a chat turn is N calls and the one aggregated row covers them all.

The flag is only added when the base URL is `openrouter.ai`: on any other OpenAI-compatible gateway an unknown body field is a 400 on every call.

<details><summary>Rejected: <code>GET /generation?id=</code> — written, then measured</summary>

Every response carries `x-generation-id`, and that endpoint returns the exact `total_cost`. It works. But the record appears **9 seconds** after the response (measured, twice), and holding a serverless function open to wait loses the log row itself. The code was deleted rather than kept as a slower second path.
</details>

**3. The live price list, where we cannot.** The chat turn runs through the pi harness, which has its own HTTP client — `usage.cost` never reaches us there. For those rows the price comes from OpenRouter's own `/models` (prompt, completion and cache-read per token), fetched once per process and kept six hours. The same module exposes `usableGatewayModels()`, which is what the model picker will read: a new model will not need adding in two places, because it will not need adding anywhere.

**Order of precedence**: `flatCostUsd` (the invoice) → `RATES` → live list → null. `RATES` deliberately stays ahead of the live list: it holds corrections a price list does not have — historical aliases that re-price old rows at the rate they actually ran on, and the note that DeepSeek doubles during peak hours.

## Testing?

- **Unit** (written first, watched fail): `llm-usage-cost.test.ts` (cost from a JSON body, cost from the last SSE chunk, no invented zero when the field is absent, the flag added only for OpenRouter), `openrouter-models.test.ts` (per-token → per-million, the transport prefixes, an unreachable list does not throw, the tools+vision filter), and the new blocks in `ai-log.test.ts` (the `llm/` prefix, the scope box summing a turn and not leaking between two concurrent brands).
- Full affected suites — `ai-log`, `llm`, `chat`, `agent`, `model-routing` and the two new files: **1409 passed**.
- **Manual, on the local stack** (self-hosted Supabase + worktree dev server, brand `demo`). Same call before and after, same model, from `ai_calls`:

```
08:37:56 | createSingleContent | (no cost)   ← before
08:42:06 | createSingleContent | $0.003759   ← after, via usage.cost
08:43:48 | chat (harness)      | (no cost)   ← before
08:46:16 | chat (harness)      | $0.008869   ← after, via the live list
```

  The chat number cross-checks against the list: 21,587 input tokens at $0.44/M ≈ $0.0095 before the cache discount.
- **Not tested**: a non-OpenRouter `LLM_BASE_URL` (covered by a unit test on the guard, not exercised against a real gateway), and the behaviour when `/models` is unreachable for a long stretch — the code falls back to `RATES`, which is today's behaviour.

## Anything Else?

- Credit consumption for existing brands will go **up**, because turns that were free start counting. That is the point, but it is a visible change for anyone watching their usage graph.
- Historical rows are not backfilled. The cost of a past turn is knowable (OpenRouter keeps the generations), but rewriting the ledger backwards is a separate decision, not a side effect of this PR.
- The `usableGatewayModels()` filter — tools + image input — is where the picker's list will come from. 227 of OpenRouter's 421 models pass it today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KNGMMYSbWxEJCssaxzFMAv