### PR TITLE
Fix every queued chat turn failing on the Render worker

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -279,6 +279,17 @@ conta i chiamanti del chokepoint e verifica ciascuno.
 
 ## Build e bundle
 
+### Nel bundle esbuild un modulo che lancia in cima lancia UNA volta sola
+`billingProvider()` dichiara assente il provider anomalia nel modo ESM naturale: il modulo lancia
+in valutazione, il `try/catch` assorbe e si ricade su quello aperto. In ESM standard regge per
+sempre — un modulo in errore rilancia lo stesso errore a ogni import. Nel bundle esbuild del
+worker no: `__esm` azzera il proprio flag PRIMA di eseguire il corpo, quindi dal secondo giro
+l'init non lancia piu`, torna il namespace vuoto, e la destrutturazione da` `undefined`. In
+produzione: primo job dopo ogni restart ok, tutti gli altri morti con `Cannot read properties of
+undefined (reading 'gate')`. Segnale: un errore che sul worker c'e` e su Vercel no, e che risparmia
+la prima invocazione dopo ogni deploy. Mossa: l'assenza di un modulo non si legge dal `throw` — si
+legge dall'export (`x ?? fallback`), col `try/catch` a coprire solo il primo giro.
+
 ### Un chunk sovradimensionato non è il colpevole del build che muore per memoria
 `index3.js` (5,4 MB, dieci volte il secondo chunk) era `simple-icons` intero, bundlato via `ssr.noExternal` per un motivo Vercel-only (nft duplica il pacchetto per funzione) che non vale per `DEPLOY_TARGET=node`. Rimuoverlo lo porta a 295 KB (-94,5%) — ma bisecando `--max-old-space-size` (4096/4608/5120) il build muore e riesce agli stessi tetti prima e dopo: zero spostamento. Strumentando `adapter-node`'s `adapt()` (scritture sincrone `appendFileSync`, non `console.error` — l'OOM abort salta il flush dei buffer stdio e perde l'ultimo log) l'heap è già a ~3,4 GB PRIMA che `adapt()` faccia alcunché di suo, durante la sola copia/compressione asset. Segnale: bisecare il tetto di memoria prima e dopo un fix e vedere la stessa soglia di crash — il chunk grande era un difetto reale (fix corretto, va tenuto) ma non la causa del crash. Mossa: non fidarsi della dimensione di un chunk come proxy del picco di memoria; misurare il picco stesso, e quando serve isolare DOVE cresce, strumentare con scritture sincrone perché un OOM non flush-a l'output normale.
 

--- a/changelog/2026-09-02-worker-billing-provider-fallback.md
+++ b/changelog/2026-09-02-worker-billing-provider-fallback.md
@@ -1,0 +1,33 @@
+# Il provider di billing che spariva dopo il primo giro
+
+In produzione, sul worker di Render, ogni turno di chat accodato falliva con
+`TypeError: Cannot read properties of undefined (reading 'gate')` dentro `gateCredits`. Solo lì:
+su Vercel lo stesso codice funziona.
+
+`billingProvider()` dichiara "provider anomalia assente" nel modo più naturale in ESM — il modulo
+`anomalia-provider.ts` lancia in cima al corpo, il `try/catch` lo assorbe e si ricade su
+`openBillingProvider`. In ESM standard un modulo che lancia in valutazione resta marcato in errore
+e **rilancia lo stesso errore a ogni import successivo**, quindi il catch continua a funzionare
+per sempre. Nel bundle esbuild del worker no: `__esm` esegue il corpo una volta sola e azzera il
+suo flag *prima* di eseguirlo, quindi al secondo giro l'init non lancia più, torna il namespace
+vuoto, e `anomaliaBillingProvider` è `undefined`. `provider.gate(...)` su `undefined` esplode.
+
+Primo job dopo ogni restart: ok. Tutti gli altri: falliti. Repro fuori dal repo, tre giri:
+
+```
+0 provider = { kind: 'open', gate: [AsyncFunction: gate] }
+1 provider = undefined
+2 provider = undefined
+```
+
+Il fallback ora copre entrambe le forme dell'assenza — il modulo che lancia e il modulo che non
+esporta niente — con `?? openBillingProvider`. Il test blocca la seconda, che è quella che il
+`try/catch` non poteva vedere.
+
+**Scartato:** memoizzare il provider risolto in una variabile di modulo. Nasconde lo stesso
+sintomo (una sola risoluzione per processo) senza dire che l'assenza ha due forme, e lascia il
+`return` sbagliato in piedi per il prossimo che tocca il file.
+
+**Scartato:** togliere il `throw` da `anomalia-provider.ts` e lasciare il file esportare
+`undefined`. È il file che una fork privata sostituisce: deve continuare a dichiararsi assente in
+modo rumoroso quando qualcuno lo importa direttamente.

--- a/src/lib/content/changelog/2026-09-02-background-chat-turns-fixed.ts
+++ b/src/lib/content/changelog/2026-09-02-background-chat-turns-fixed.ts
@@ -1,0 +1,9 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-02',
+  title: 'Background replies stop failing',
+  items: [
+    'Chat turns picked up in the background no longer fail with an internal error before the agent starts working.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/billing/index.test.ts
+++ b/src/lib/server/billing/index.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('$env/dynamic/private', () => ({ env: {} }));
+
+// Il modulo `anomalia-provider` non esiste nel build aperto: si dichiara assente lanciando. Nel
+// bundle esbuild del worker il corpo di un modulo gira UNA volta sola — dopo il primo throw (che
+// il catch qui sotto assorbe) ogni import successivo restituisce un namespace vuoto invece di
+// rilanciare, quindi `anomaliaBillingProvider` arriva `undefined`.
+vi.mock('./anomalia-provider', () => ({ anomaliaBillingProvider: undefined }));
+
+describe('billingProvider()', () => {
+	it('ricade su open quando il modulo del provider non esporta niente', async () => {
+		const { billingProvider } = await import('./index');
+		const provider = await billingProvider();
+
+		expect(provider.kind).toBe('open');
+		await expect(provider.gate('credits', { brandId: 'brand-1' })).resolves.toBeUndefined();
+	});
+});

--- a/src/lib/server/billing/index.ts
+++ b/src/lib/server/billing/index.ts
@@ -4,13 +4,14 @@ import { openBillingProvider } from '$lib/billing/open-provider';
 
 // The one place that decides which billing provider answers gate()/quota()/upgradeUrl().
 // Default: anomalia (today's product, unchanged). BILLING_PROVIDER=open forces the permissive
-// default — and so does anomalia-provider.ts simply not existing, which is what a self-hosted
-// fork looks like once it's extracted into its own (absent, private) npm package.
+// default — and so does anomalia-provider.ts not being there, which is what a self-hosted fork
+// looks like once it's extracted into its own (absent, private) npm package. "Not there" has two
+// shapes, and both fall back: the module throws on load, or it hands back no provider at all.
 export async function billingProvider(): Promise<BillingProvider> {
   if (env.BILLING_PROVIDER === 'open') return openBillingProvider;
   try {
     const { anomaliaBillingProvider } = await import('./anomalia-provider');
-    return anomaliaBillingProvider;
+    return anomaliaBillingProvider ?? openBillingProvider;
   } catch {
     return openBillingProvider;
   }


### PR DESCRIPTION
## What?

`billingProvider()` now falls back to the open provider when `anomalia-provider` hands back no
provider — not only when it throws. Without it the worker returned `undefined` from the billing
chokepoint and **every queued chat turn after the first one since the last restart** died with
`TypeError: Cannot read properties of undefined (reading 'gate')` inside `gateCredits`.

## Why?

Production, Render worker, all day:

```
[Chat Queue] Failed job=220f3231-… Cannot read properties of undefined (reading 'gate')
    at gateCredits (build-worker/index.js:46203:18)
    at async chatCreditsBlocked (…:77269:5)
    at async processNextQueuedChatJob (…:87877:9)
```

Three jobs per lap, every lap, all failed before the agent did a single thing.

## How?

`anomalia-provider.ts` declares itself absent the natural ESM way: it throws at the top of the
module body, the `try/catch` absorbs it and we fall back. Under standard ESM that holds forever —
a module that throws during evaluation stays marked errored and **re-throws on every later
import**. That is why Vercel never saw this.

The worker is bundled by esbuild, and esbuild's `__esm` runs a module body **once**, clearing its
own flag *before* running it. Second lap: init no longer throws, the empty namespace comes back,
`anomaliaBillingProvider` is `undefined`, and `provider.gate(...)` explodes. Minimal repro,
outside this repo:

```
0 provider = { kind: 'open', gate: [AsyncFunction: gate] }
1 provider = undefined
2 provider = undefined
```

So absence is read off the **export** (`?? openBillingProvider`), with the `catch` covering only
the first lap. Rejected: memoizing the resolved provider in a module variable — hides the same
symptom per process while leaving the wrong `return` in place for the next reader. Rejected:
dropping the `throw` from `anomalia-provider.ts` — that file is what a private fork replaces, and
it should keep announcing itself loudly to anyone importing it directly.

## Testing?

- New unit test `src/lib/server/billing/index.test.ts` — mocks the provider module to the shape
  the bundler actually produces (`anomaliaBillingProvider: undefined`). Written first, watched
  fail with the production error verbatim (`Cannot read properties of undefined (reading 'kind')`),
  then made green by the fix.
- `credits-billing-gate.test.ts`, `billing/contract`, `billing/open-provider` and the changelog
  loader test still pass.
- End-to-end against the real bundler: the same `billingProvider()` module graph bundled with
  esbuild (the worker's bundler, same aliases) and called three times — evidence below.

Not tested: the browser gate. This is a worker-only bundling defect with no UI surface; the
verification that counts is the bundled-module one.

## Evidence

<details><summary>Same module, same bundler — before and after</summary>

Before (dev):

```
0 kind = open gate = function
1 kind = undefined gate = undefined
2 kind = undefined gate = undefined
```

After (this branch):

```
0 kind = open gate = function
1 kind = open gate = function
2 kind = open gate = function
```

</details>

## Anything Else?

**This is not the only reason turns are dying in production.** The `chat_turn_died (heartbeat
lost)` alerts have a second, independent cause: the Render worker is being killed by V8, not by
anything in this diff.

```
562030 ms: Mark-Compact 254.3 (258.0) -> 253.5 (258.5) MB … allocation failure
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
```

The old-space ceiling is ~258 MB — Node's default for a 512 MB container — while the instance has
512 MB and peaks around 380 MB RSS. On 31/8 the worker OOM'd **every ~20 minutes for 29 hours
straight**; it did it again at 08:52 today. Each crash kills the turn in flight, its heartbeat
stops, and the reaper reports it. That one is a Render-side knob (heap flag and/or instance plan)
plus a look at what the analyst run was retaining, and is deliberately left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fn9Xw3t9BtRqoYogogYsX
