### PR TITLE
Let the brand pick its chat model from the real catalogue

### DIFF
--- a/changelog/2026-09-02-chat-model-catalog.md
+++ b/changelog/2026-09-02-chat-model-catalog.md
@@ -1,0 +1,58 @@
+# Il modello della chat lo sceglie il brand, dal catalogo vero
+
+Il picker offriva tre preset e tre "modelli custom" scritti a mano — e mentiva. In
+`llmModelForPicker`, con `LLM_MODELS = deepseek/…-flash, openai/gpt-5.6-sol`:
+
+| voce nel menu | modello che girava |
+|---|---|
+| Auto / Fast | `deepseek/…-flash` |
+| **Pro**, **DeepSeek Pro**, **GPT Sol** | `openai/gpt-5.6-sol` — tre etichette, un modello |
+| **GPT Terra** | `deepseek/…-flash` — l'etichetta dice OpenAI, girava DeepSeek |
+
+Ora il menu mostra il catalogo del gateway: 16 modelli di punta più tutto ciò che l'operatore ha
+messo in `LLM_MODELS`, con nome, finestra di contesto e prezzo **letti vivi** da `/models` di
+OpenRouter (v. `openrouter-models.ts`, arrivato con la fatturazione reale). Nessun elenco scritto
+a mano: un modello ritirato sparisce da solo invece di fallire al primo turno, e un prezzo che
+cambia non resta qui dentro a mentire.
+
+Il filtro non è editoriale: **tools + visione**. I nostri agenti chiamano strumenti e leggono
+immagini; un modello che non sa farlo non è una scelta, è un turno che muore a metà. Dei 421
+modelli di OpenRouter ne passano 227.
+
+## Cinque punti da attraversare, e ognuno era rotto
+
+La scelta è un id (`anthropic/claude-opus-5`), non più una delle sei parole nostre. Ognuno di
+questi cinque punti la buttava via, e ognuno è stato trovato **facendo girare un turno vero**:
+
+1. `isChatTier` conosceva sei valori: un id non era un tier. Ora la FORMA la riconosce il client,
+   l'ESISTENZA la verifica il server contro il listino.
+2. `REASONING_LEVELS[tier]` e `DEFAULT_REASONING[tier]` erano mappe con sei chiavi: su un id nuovo
+   tornavano `undefined`, e il menu si schiantava su `.length`. Ora passano da `familyForTier`, che
+   per un id del gateway dà la scala comune a tre gradini.
+3. `AgentModelPolicy` sul thread era `{family, thinking}`: non sa dire "claude-opus-5". Ha un campo
+   `model` in più; le righe salvate prima non ce l'hanno e continuano a valere.
+4. `resolveHarnessModelRef` ignorava il tier quando non era `pro`/`fast` e cadeva sul primo id di
+   `LLM_MODELS`. **Il default del brand era qwen e il turno girava su deepseek.**
+5. `ensureKieAgentDir` dichiarava all'harness solo i due id di `LLM_MODELS`. Un id fuori da quella
+   lista l'harness non lo conosce: ripiegava sul gateway Vercel e tornava `403 Free tier users do
+   not have access` su `zai/glm-5.1` — un modello che nessuno aveva scelto.
+
+E il default di brand non arrivava mai al composer della home: l'effetto di idratazione usciva
+subito quando non c'era ancora un thread (`id === hydratedThread`, entrambi `null`), quindi ogni
+chat nuova partiva su Auto. Difetto che c'era già con "Pro", solo che nessuno lo vedeva.
+
+## Il vincolo sul database
+
+`brands_chat_default_tier_check` ammetteva solo le sei parole: salvare un id era un errore SQL
+mostrato in faccia all'utente. La migration lo allarga alla FORMA di un id — che esista lo dice il
+listino vivo, non un CHECK che nessuno aggiornerà mai.
+
+## Quello che NON funziona ancora, misurato
+
+Il turno su `qwen/qwen3.8-flash` è arrivato in fondo, ma l'harness non ha riportato l'uso di token
+(`? in / ? out`) e quella riga di `ai_calls` è rimasta senza costo. Sul modello di default i token
+c'erano. Non so ancora se dipenda dal modello o dall'harness, e non l'ho indovinato: è una misura.
+
+La strada strutturale è togliere all'harness il suo client HTTP — puntarlo a un endpoint nostro
+che inoltra a OpenRouter, aggiunge `usage: {include: true}` e registra il conto, come fa già
+`llmClient` per tutto il resto. Non è in questa PR.

--- a/packages/agent-contracts/src/contracts.ts
+++ b/packages/agent-contracts/src/contracts.ts
@@ -19,7 +19,13 @@ export type ModelFamilyId = (typeof MODEL_FAMILY_IDS)[number];
  */
 export const AgentModelPolicy = z.object({
 	family: z.enum(MODEL_FAMILY_IDS),
-	thinking: z.enum(['off', 'low', 'medium', 'high', 'max']).default('medium')
+	thinking: z.enum(['off', 'low', 'medium', 'high', 'max']).default('medium'),
+	/**
+	 * L'id del modello sul gateway (`anthropic/claude-opus-5`), quando l'utente ne ha scelto uno dal
+	 * catalogo invece di un preset. `family` resta a dire quali gradini di ragionamento offrire: le
+	 * righe salvate prima di questo campo non ce l'hanno e continuano a valere.
+	 */
+	model: z.string().min(1).max(120).optional()
 });
 export type AgentModelPolicy = z.infer<typeof AgentModelPolicy>;
 

--- a/src/lib/agent/bridge/adapters.test.ts
+++ b/src/lib/agent/bridge/adapters.test.ts
@@ -115,6 +115,31 @@ describe('resolveHarnessModelRef — la catena preferenza → tier → lista, tu
 		expect(ref).toEqual({ provider: 'llm', id: 'llm/x-ai/grok-4-6', label: 'grok-4-6' });
 	});
 
+	/**
+	 * Il picker offre il catalogo del gateway e il tier PUÒ essere un id di modello. Qui veniva
+	 * ignorato e si finiva sul primo di LLM_MODELS: il menu diceva un nome e rispondeva un altro
+	 * modello — visto nel browser, non nei test, con il default di brand su qwen e il turno su
+	 * deepseek.
+	 */
+	it('un id del catalogo scelto dall\'utente arriva al gateway', () => {
+		env.LLM_API_KEY = 'k';
+		env.LLM_DEFAULT_MODEL = 'z-ai/glm-5.3-flash';
+		env.LLM_MODELS = 'z-ai/glm-5.3-flash,openai/gpt-5.6-sol';
+		expect(resolveHarnessModelRef({ tier: 'openai/gpt-5.6-sol' })?.id).toBe('llm/openai/gpt-5.6-sol');
+		// La preferenza salvata sul thread porta l'id nel campo `model`: vince sulla famiglia, che
+		// lì dentro dice solo la scala di ragionamento.
+		expect(resolveHarnessModelRef({ family: 'luna', model: 'openai/gpt-5.6-sol', tier: 'fast' })?.id).toBe(
+			'llm/openai/gpt-5.6-sol'
+		);
+	});
+
+	it('un id che il gateway non serve non diventa una chiamata persa', () => {
+		env.LLM_API_KEY = 'k';
+		env.LLM_DEFAULT_MODEL = 'z-ai/glm-5.3-flash';
+		env.LLM_MODELS = 'z-ai/glm-5.3-flash';
+		expect(resolveHarnessModelRef({ tier: 'vendor/mai-visto' })?.id).toBe('llm/z-ai/glm-5.3-flash');
+	});
+
 	it('una famiglia che il centralino non serve degrada sul tier, mai sul wireId nudo', () => {
 		env.LLM_API_KEY = 'k';
 		env.LLM_DEFAULT_MODEL = 'z-ai/glm-5.3-flash';

--- a/src/lib/agent/bridge/adapters.ts
+++ b/src/lib/agent/bridge/adapters.ts
@@ -37,6 +37,8 @@ import { resolveChatModel, geminiFast } from '$lib/server/chat/model';
 import { MODEL_FAMILIES } from '$lib/models/catalog';
 import { MODEL_FAMILY_IDS } from '@anomalia/agent-contracts/contracts';
 import { llmApiKey, llmBaseUrl, llmLanguageModel, llmModelForPicker, llmModels } from '$lib/server/llm';
+import { gatewayModel, usableGatewayModels } from '$lib/server/openrouter-models';
+import { isGatewayModelTier } from '$lib/chat-tiers';
 import { ServerBrandFs } from '@anomalia/agent-adapters/brand-fs';
 import { PostgresMemoryStore } from '@anomalia/agent-adapters/memory-postgres';
 import { VercelSandboxProvider } from '@anomalia/agent-adapters/vercel-sandbox';
@@ -123,6 +125,8 @@ export interface HarnessModelRef {
 
 export interface HarnessModelPreference {
 	family?: unknown;
+	/** L'id del gateway scelto dall'utente dal catalogo (`anthropic/claude-opus-5`). */
+	model?: unknown;
 	tier?: unknown;
 }
 
@@ -139,12 +143,26 @@ function servableWireId(family: unknown): string | null {
 	return llmModels().find((id) => id === wire || id.endsWith(`/${wire}`)) ?? null;
 }
 
+/**
+ * Un id scelto dal catalogo passa intatto — se il gateway lo serve davvero. È la differenza fra
+ * "il menu dice Qwen e risponde Qwen" e il difetto visto nel browser: il default del brand su
+ * `qwen/qwen3.8-flash` e il turno che girava sul primo id di LLM_MODELS.
+ */
+function servableModelId(value: unknown): string | null {
+	if (typeof value !== 'string' || !isGatewayModelTier(value)) return null;
+	const id = value.trim();
+	return llmModels().includes(id) || gatewayModel(id)?.usable ? id : null;
+}
+
 export function resolveHarnessModelRef(pref?: HarnessModelPreference | string | null): HarnessModelRef | null {
 	if (!llmApiKey()) return null;
 	const family = typeof pref === 'object' && pref ? pref.family : undefined;
+	const chosen = typeof pref === 'object' && pref ? pref.model : undefined;
 	const tier = typeof pref === 'string' ? pref : pref?.tier;
 
 	const wire =
+		servableModelId(chosen) ??
+		servableModelId(tier) ??
 		servableWireId(family) ??
 		(tier === 'pro' || tier === 'fast' ? llmModelForPicker(tier) : undefined) ??
 		(llmModels()[0] ?? null);
@@ -234,16 +252,33 @@ export interface HarnessTurnStream {
 }
 
 let kieAgentDirCache: string | null = null;
+let kieAgentDirModels = '';
 
 export function harnessSessionSettings(sessionKey?: string): { extensionFactories: unknown[] } | undefined {
 	if (!sessionKey) return undefined;
 	return { extensionFactories: [stickySessionExtension(`thread:${sessionKey}`)] };
 }
 
+/**
+ * I modelli che l'harness DICHIARA di poter chiamare. Non e` un dettaglio di configurazione: un id
+ * che non sta qui dentro l'harness non lo conosce, il turno ripiega su un altro gateway e finisce
+ * in un 403 su un modello che nessuno ha scelto. Quindi qui va anche il catalogo, non solo i due
+ * id di `LLM_MODELS`.
+ */
+function harnessDeclaredModels(): string[] {
+	const ids = new Set(llmModels());
+	for (const m of usableGatewayModels()) ids.add(m.id);
+	return [...ids];
+}
+
 export function ensureKieAgentDir(): string | undefined {
 	const key = llmApiKey();
 	if (!key) return undefined;
-	if (kieAgentDirCache) return kieAgentDirCache;
+	const declared = harnessDeclaredModels();
+	const signature = declared.join(',');
+	// Il listino arriva dopo il primo turno del processo: quando cambia, il file va riscritto o
+	// l'harness resta con l'elenco corto di prima.
+	if (kieAgentDirCache && kieAgentDirModels === signature) return kieAgentDirCache;
 	const dir = join(tmpdir(), 'anomalia-pi-agent');
 	mkdirSync(dir, { recursive: true });
 	writeFileSync(
@@ -254,11 +289,12 @@ export function ensureKieAgentDir(): string | undefined {
 					baseUrl: llmBaseUrl(),
 					api: 'openai-completions',
 					apiKey: key,
-					models: llmModels().map((id) => ({ id, input: ['text', 'image'] }))
+					models: declared.map((id) => ({ id, input: ['text', 'image'] }))
 				}
 			}
 		})
 	);
+	kieAgentDirModels = signature;
 	kieAgentDirCache = dir;
 	return dir;
 }

--- a/src/lib/agent/bridge/live.ts
+++ b/src/lib/agent/bridge/live.ts
@@ -186,6 +186,8 @@ export interface RunKitTurnInput {
 	/** Il tier scelto dall'utente nel composer (auto|fast|pro…). Senza, il bridge cablava 'auto'. */
 	tier?: unknown;
 	modelFamily?: unknown;
+	/** L'id del gateway scelto dal catalogo, quando l'utente ne ha pinnato uno. */
+	modelId?: unknown;
 	/** Lo sforzo di ragionamento scelto dall'utente. */
 	reasoning?: unknown;
 	/**
@@ -487,7 +489,11 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
 	let brandSandbox: Awaited<ReturnType<typeof openBrandHarnessSession>> | null = null;
 
 	try {
-		const modelRef = resolveHarnessModelRef({ family: input.modelFamily, tier: input.tier });
+		const modelRef = resolveHarnessModelRef({
+			family: input.modelFamily,
+			model: input.modelId,
+			tier: input.tier
+		});
 		if (!modelRef) throw new Error('harness_model_missing: nessun modello configurato per il provider attivo');
 		console.log(
 			`[AGENT_KIT] run ${run.id} start — agente=${spec.id}, modello=${modelRef.label} (${modelRef.provider}), thread=${threadId}`

--- a/src/lib/chat-model-policy.test.ts
+++ b/src/lib/chat-model-policy.test.ts
@@ -84,3 +84,27 @@ describe('migration 0225_agent_model_preference', () => {
 		expect(sql).not.toMatch(/create policy/i);
 	});
 });
+
+
+/**
+ * Il picker offre il catalogo del gateway, quindi la scelta salvata sul thread non è più solo una
+ * famiglia: `{family, thinking}` non sa dire "claude-opus-5". Il campo `model` porta l'id, e la
+ * famiglia resta a dire quali gradini di ragionamento mostrare.
+ */
+describe('un modello del gateway sul thread', () => {
+  it('salva l\'id e lo ritrova', () => {
+    const row = policyForChoice('anthropic/claude-opus-5', 'high');
+    expect(row?.model).toBe('anthropic/claude-opus-5');
+    expect(choiceForPolicy(row)?.tier).toBe('anthropic/claude-opus-5');
+  });
+
+  it('le righe salvate prima, senza `model`, continuano a tornare al loro tier', () => {
+    const row = policyForChoice('pro', 'high');
+    expect(row?.model).toBeUndefined();
+    expect(choiceForPolicy(row)?.tier).toBe('pro');
+  });
+
+  it('Auto resta null: il thread torna alla risoluzione di default', () => {
+    expect(policyForChoice('auto', 'high')).toBeNull();
+  });
+});

--- a/src/lib/chat-model-policy.ts
+++ b/src/lib/chat-model-policy.ts
@@ -1,8 +1,8 @@
 import { AgentModelPolicy, type AgentModelPolicy as ModelPreference } from '@anomalia/agent-contracts/contracts';
-import type { ChatTier } from '$lib/chat-tiers';
+import { isGatewayModelTier, type ChatTier } from '$lib/chat-tiers';
 import {
-	TIER_DEFAULT_FAMILY,
 	coerceThinking,
+	familyForTier,
 	modelFamily,
 	type ModelFamilyId,
 	type ThinkingLevel
@@ -23,8 +23,9 @@ export function turnModelFamily(
  */
 export function policyForChoice(tier: ChatTier, thinking: unknown): ModelPreference | null {
 	if (tier === 'auto') return null;
-	const family = modelFamily(TIER_DEFAULT_FAMILY[tier]);
-	return { family: family.id, thinking: coerceThinking(thinking, family) };
+	const family = familyForTier(tier);
+	const policy: ModelPreference = { family: family.id, thinking: coerceThinking(thinking, family) };
+	return isGatewayModelTier(tier) ? { ...policy, model: tier } : policy;
 }
 
 /** Il tier che nel picker rappresenta ogni famiglia; gemini-flash non ha un tier e non si ripristina. */
@@ -43,7 +44,9 @@ function parseModelPolicy(raw: unknown): ModelPreference | null {
 
 export function choiceForPolicy(raw: unknown): { tier: ChatTier; reasoning: ThinkingLevel } | null {
 	const policy = parseModelPolicy(raw);
-	const tier = policy ? TIER_BY_FAMILY[policy.family] : undefined;
-	if (!policy || !tier) return null;
+	if (!policy) return null;
+	// Un id del catalogo vince sulla famiglia: la famiglia lì dentro dice solo la scala.
+	const tier = policy.model ?? TIER_BY_FAMILY[policy.family];
+	if (!tier) return null;
 	return { tier, reasoning: coerceThinking(policy.thinking, modelFamily(policy.family)) };
 }

--- a/src/lib/chat-reasoning.test.ts
+++ b/src/lib/chat-reasoning.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { coerceChatTier, DEFAULT_CHAT_TIER, CHAT_TIERS, type ChatTier } from './chat-tiers';
+import { defaultReasoningFor, reasoningLevelsFor } from './chat-reasoning';
 import {
   coerceReasoning,
   DEFAULT_REASONING,
@@ -193,5 +194,23 @@ describe('coerceChatTier', () => {
     expect(coerceChatTier('gpt-sol')).toBe('gpt-sol');
     expect(coerceChatTier(null)).toBe(DEFAULT_CHAT_TIER);
     expect(coerceChatTier('gpt-9')).toBe('auto');
+  });
+});
+
+
+/**
+ * Con il catalogo del gateway il tier può essere un id qualunque: `REASONING_LEVELS[tier]` e
+ * `DEFAULT_REASONING[tier]` erano mappe con sei chiavi, e su un id nuovo restituivano undefined —
+ * cioè il picker si schiantava su `.length` alla prima apertura del menu.
+ */
+describe('un tier che è un id di modello', () => {
+  it('ha comunque una scala di ragionamento', () => {
+    expect(reasoningLevelsFor('anthropic/claude-opus-5').length).toBeGreaterThan(0);
+    expect(defaultReasoningFor('anthropic/claude-opus-5')).toBeTruthy();
+  });
+
+  it('i preset restano quelli di prima', () => {
+    expect(defaultReasoningFor('pro')).toBe(DEFAULT_REASONING.pro);
+    expect(reasoningLevelsFor('fast')).toEqual(REASONING_LEVELS.fast);
   });
 });

--- a/src/lib/chat-reasoning.ts
+++ b/src/lib/chat-reasoning.ts
@@ -42,6 +42,11 @@ export const REASONING_LEVELS: Record<ChatTier, readonly ThinkingLevel[]> = {
   'gpt-sol': familyForTier('gpt-sol').thinking
 };
 
+/** Il default di un tier qualunque, id del gateway compresi: la mappa qui sopra ha sei chiavi. */
+export function defaultReasoningFor(tier: ChatTier, agentFamily?: ModelFamilyId | null): ThinkingLevel {
+  return familyForTier(tier, agentFamily).defaultThinking;
+}
+
 export function penultimateLevel(levels: readonly ThinkingLevel[]): ThinkingLevel {
   return levels[Math.max(0, levels.length - 2)];
 }

--- a/src/lib/chat-tiers.test.ts
+++ b/src/lib/chat-tiers.test.ts
@@ -5,6 +5,7 @@ import {
   CHAT_PRESET_TIERS,
   CHAT_TIERS,
   isChatTier,
+  isGatewayModelTier,
   isCustomChatModel,
   isGptCustomModel
 } from './chat-tiers';
@@ -46,6 +47,33 @@ describe('chat tiers', () => {
     const tier = en.chat.tier;
     for (const [k, v] of Object.entries(tier)) {
       expect(`${k}:${v}`).not.toContain('{mult}');
+    }
+  });
+});
+
+
+/**
+ * Il picker non offre più tre modelli scritti a mano: offre il catalogo del gateway, e un id come
+ * `anthropic/claude-opus-5` è una scelta valida quanto "pro". Chi può dire se ESISTE è il server,
+ * che ha il listino; qui si riconosce solo la forma, perché il client non deve indovinare.
+ */
+describe('un id di modello è un tier', () => {
+  it('riconosce la forma vendor/modello', () => {
+    expect(isChatTier('anthropic/claude-opus-5')).toBe(true);
+    expect(isChatTier('openai/gpt-5.6-sol')).toBe(true);
+    expect(isGatewayModelTier('anthropic/claude-opus-5')).toBe(true);
+    expect(isGatewayModelTier('pro')).toBe(false);
+  });
+
+  it('non scambia per modello una stringa qualunque', () => {
+    for (const junk of ['', '/', 'solo-testo', 'a/', '/b', 'a//b', 'spazi nel mezzo/x']) {
+      expect(isGatewayModelTier(junk)).toBe(false);
+    }
+  });
+
+  it('i preset e i tre custom storici restano validi: ci sono thread che li hanno salvati', () => {
+    for (const t of ['auto', 'fast', 'pro', 'deepseek-pro', 'gpt-terra', 'gpt-sol']) {
+      expect(isChatTier(t)).toBe(true);
     }
   });
 });

--- a/src/lib/chat-tiers.ts
+++ b/src/lib/chat-tiers.ts
@@ -13,7 +13,20 @@ import type { ModelFamilyId } from '@anomalia/agent-contracts/contracts';
 export type ChatPresetTier = 'auto' | 'fast' | 'pro';
 const CHAT_CUSTOM_MODEL_IDS = ['deepseek-pro', 'gpt-terra', 'gpt-sol'] as const satisfies readonly ModelFamilyId[];
 export type ChatCustomModel = (typeof CHAT_CUSTOM_MODEL_IDS)[number];
-export type ChatTier = ChatPresetTier | ChatCustomModel;
+/**
+ * Un id del gateway (`anthropic/claude-opus-5`) è una scelta valida quanto un preset: il picker
+ * offre il catalogo, non tre nomi scritti a mano. Qui se ne riconosce solo la FORMA — se quel
+ * modello esista davvero lo sa il server, che ha il listino, e un id sconosciuto ricade sul
+ * default invece di rompere il turno.
+ */
+export type ChatGatewayModelTier = string;
+export type ChatTier = ChatPresetTier | ChatCustomModel | ChatGatewayModelTier;
+
+const GATEWAY_MODEL_ID = /^[a-z0-9][a-z0-9._-]*\/[a-z0-9][a-z0-9._:-]*$/i;
+
+export function isGatewayModelTier(v: unknown): boolean {
+  return typeof v === 'string' && GATEWAY_MODEL_ID.test(v.trim());
+}
 
 export const CHAT_PRESET_TIERS: ChatPresetTier[] = ['auto', 'fast', 'pro'];
 export const CHAT_CUSTOM_MODELS: ChatCustomModel[] = [...CHAT_CUSTOM_MODEL_IDS];
@@ -40,7 +53,7 @@ export const DEFAULT_CHAT_TIER: ChatTier = 'auto';
  */
 
 export function isChatTier(v: unknown): v is ChatTier {
-  return typeof v === 'string' && (CHAT_TIERS as readonly string[]).includes(v);
+  return (typeof v === 'string' && (CHAT_TIERS as readonly string[]).includes(v)) || isGatewayModelTier(v);
 }
 
 export function isCustomChatModel(v: unknown): v is ChatCustomModel {

--- a/src/lib/components/ChatColumn.svelte
+++ b/src/lib/components/ChatColumn.svelte
@@ -277,6 +277,9 @@
   // Il modello scelto nel composer vale per QUESTA conversazione; la prossima riparte dal
   // default del brand (Settings → Chat).
   const brandDefaultTier = $derived(coerceChatTier(($page.data as { brand?: { chat_default_tier?: unknown } }).brand?.chat_default_tier));
+  const catalogModels = $derived(
+    ($page.data as { chatModels?: Array<{ id: string; label: string; contextLength: number; inputUsdPerM: number; outputUsdPerM: number }> }).chatModels ?? []
+  );
   let chatTier = $state<ChatTier>('auto');
   let chatReasoning = $state<ChatReasoning>(DEFAULT_REASONING.auto);
   const saveModelChoice = createModelChoiceSave({
@@ -287,7 +290,10 @@
   // Aprire una conversazione mostra il modello CHE HA, non il default del brand: la riga arriva
   // dalla lista dei thread, quindi si idrata quando c'è — una volta sola per thread, o la lista
   // che si aggiorna a ogni messaggio riscriverebbe la scelta appena fatta.
-  let hydratedThread: string | null = null;
+  // `undefined` e non `null`: senza thread (composer della home) il primo giro deve ENTRARE, o il
+  // default di modello del brand non viene mai applicato e ogni chat nuova parte su Auto — con il
+  // menu che mostra il modello scelto e il turno che gira su un altro.
+  let hydratedThread: string | null | undefined = undefined;
   $effect(() => {
     const id = threadId ?? null;
     const row = id ? $chatThreads.find((t) => t.id === id) : null;
@@ -1709,6 +1715,7 @@
       bind:mode={chatMode}
       bind:tier={chatTier}
         bind:reasoning={chatReasoning}
+      chatModels={catalogModels}
       brandSlug={brandSlug}
       draftKey={`anomalia:chat-draft:${brandSlug}:${threadId ?? 'new'}`}
       onsubmit={(text, meta) => send(text, meta)}

--- a/src/lib/components/ChatPrompt.svelte
+++ b/src/lib/components/ChatPrompt.svelte
@@ -19,7 +19,7 @@
     isCustomChatModel,
     type ChatTier
   } from '$lib/chat-tiers';
-  import { DEFAULT_REASONING, REASONING_LEVELS, isValidForTier, type ChatReasoning } from '$lib/chat-reasoning';
+  import { DEFAULT_REASONING, defaultReasoningFor, reasoningLevelsFor, isValidForTier, type ChatReasoning } from '$lib/chat-reasoning';
   import type { AgentMeta } from '$lib/agent-icons';
   import {
     buildAttachmentsPayload,
@@ -101,6 +101,8 @@
     agentLocked = false,
     agent = null,
     onagentchange = (_id: string) => {},
+    /** I modelli che il gateway serve adesso: il menu li mostra al posto di una lista fissa. */
+    chatModels = [] as Array<{ id: string; label: string; contextLength: number; inputUsdPerM: number; outputUsdPerM: number }>,
     /** La scelta di modello è cambiata dal picker: chi possiede il thread la salva cross-device. */
     onmodelchange = (_choice: { tier: ChatTier; reasoning: ChatReasoning }) => {},
     // The user's own agents, from Custom agents. Picking one hands the thread its brief.
@@ -138,6 +140,7 @@
     agentLocked?: boolean;
     agent?: string | null;
     onagentchange?: (id: string) => void;
+    chatModels?: Array<{ id: string; label: string; contextLength: number; inputUsdPerM: number; outputUsdPerM: number }>;
     onmodelchange?: (choice: { tier: ChatTier; reasoning: ChatReasoning }) => void;
     customAgents?: Array<{ id: string; name: string; face: string; color: string }>;
     customAgent?: string | null;
@@ -174,6 +177,23 @@
   let docs = $state<Array<ChatDocument & { converting?: boolean; error?: string }>>([]);
   let picks = $state<ChatAttachmentPick[]>([]);
   let pendingCommand = $state<string | undefined>(undefined);
+  // Un preset ha una chiave i18n; un modello del catalogo porta il suo nome dal gateway, e
+  // inventargli una chiave significherebbe mostrarne il nome tecnico appena ne arriva uno nuovo.
+  function tierLabel(t: ChatTier): string {
+    const model = chatModels.find((m) => m.id === t);
+    if (model) return model.label;
+    return (CHAT_PRESET_TIERS as readonly string[]).includes(t) || (CHAT_CUSTOM_MODELS as readonly string[]).includes(t)
+      ? $_('chat.tier.' + t)
+      : t;
+  }
+
+  const K_TOKENS = 1000;
+  function modelSub(m: { contextLength: number; inputUsdPerM: number; outputUsdPerM: number }): string {
+    const ctx = m.contextLength ? `${Math.round(m.contextLength / K_TOKENS)}k` : '';
+    const price = m.inputUsdPerM || m.outputUsdPerM ? `$${m.inputUsdPerM}/$${m.outputUsdPerM} per 1M` : '';
+    return [ctx, price].filter(Boolean).join(' · ');
+  }
+
   let menu = $state<'none' | 'plus' | 'commands' | 'mode' | 'agents' | 'tier' | 'reasoning' | 'picker'>('none');
 
   /**
@@ -365,11 +385,11 @@
       /* ignore */
     }
     // Default thinking is the penultimate level of the current model's own list.
-    reasoning = DEFAULT_REASONING[tier];
+    reasoning = defaultReasoningFor(tier);
   });
 
   $effect(() => {
-    if (!isValidForTier(reasoning, tier)) reasoning = DEFAULT_REASONING[tier];
+    if (!isValidForTier(reasoning, tier)) reasoning = defaultReasoningFor(tier);
   });
 
   // Draft che sopravvive a un refresh (per thread, in sessionStorage). Ripristino UNA volta per
@@ -420,7 +440,7 @@
   // Picking a model applies to the conversation in front of you; the default for a NEW chat is the
   // brand setting (Settings → Chat), not whatever this device happened to pick last.
   function setTier(t: ChatTier) {
-    const nextReasoning = DEFAULT_REASONING[t];
+    const nextReasoning = defaultReasoningFor(t);
     tier = t;
     reasoning = nextReasoning;
     menu = 'none';
@@ -953,10 +973,10 @@
               title={$_('chat.tier.' + tier + 'Hint')}
             >
               <Cpu class="size-4" />
-              <span>{$_('chat.tier.label')}: {$_('chat.tier.' + tier)}</span>
+              <span>{$_('chat.tier.label')}: {tierLabel(tier)}</span>
               <ChevronRight class="size-3.5 ch-dd-chevron" />
             </button>
-            {#if REASONING_LEVELS[tier].length > 1}
+            {#if reasoningLevelsFor(tier).length > 1}
               <!-- Il ragionamento è una preferenza rara: sta col modello dentro il `+` invece di
                    occupare la barra. -->
               <button
@@ -1162,19 +1182,19 @@
                 <span class="ch-dd-sub">{$_('chat.tier.' + t + 'Hint')}</span>
               </button>
             {/each}
-            {#if CHAT_CUSTOM_MODELS.length}
+            {#if chatModels.length}
               <div class="ch-dd-group">{$_('chat.tier.custom')}</div>
-              {#each CHAT_CUSTOM_MODELS as t (t)}
+              {#each chatModels as m (m.id)}
                 <button
                   type="button"
                   class="ch-dd-item ch-dd-item-stack"
-                  class:active={tier === t}
+                  class:active={tier === m.id}
                   role="option"
-                  aria-selected={tier === t}
-                  onclick={() => setTier(t)}
+                  aria-selected={tier === m.id}
+                  onclick={() => setTier(m.id)}
                 >
-                  <span class="ch-dd-title">{$_('chat.tier.' + t)}</span>
-                  <span class="ch-dd-sub">{$_('chat.tier.' + t + 'Hint')}</span>
+                  <span class="ch-dd-title">{m.label}</span>
+                  <span class="ch-dd-sub">{modelSub(m)}</span>
                 </button>
               {/each}
             {/if}
@@ -1290,14 +1310,14 @@
         </div>
       {/if}
 
-      {#if REASONING_LEVELS[tier].length > 1}
+      {#if reasoningLevelsFor(tier).length > 1}
         <div class="ch-tier-wrap" data-menu-root>
           {#if menu === 'reasoning'}
             <div class="ch-dropdown ch-tier-dd" role="listbox">
               <button type="button" class="ch-dd-back" onclick={() => (menu = 'plus')}>
                 ← {$_('chat.reasoning.label')}
               </button>
-              {#each REASONING_LEVELS[tier] as level (level)}
+              {#each reasoningLevelsFor(tier) as level (level)}
                 <button
                   type="button"
                   class="ch-dd-item ch-dd-item-stack"

--- a/src/lib/content/changelog/2026-09-02-chat-model-catalog.ts
+++ b/src/lib/content/changelog/2026-09-02-chat-model-catalog.ts
@@ -1,0 +1,11 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-02',
+  title: 'Choose the model your chat runs on',
+  items: [
+    'The model menu in chat now lists the real catalogue — Claude, GPT, Gemini, Grok, DeepSeek, Qwen, Kimi, Llama, Mistral and more — with each model\'s context window and price shown next to it.',
+    'Settings → Chat sets which model new conversations start on; inside a chat you can still switch per conversation, and the choice follows you across devices.',
+    'Picking "Pro", "DeepSeek Pro" or "GPT Sol" used to run the same single model, and "GPT Terra" ran a different one entirely. The menu now runs what it says.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/models/catalog.ts
+++ b/src/lib/models/catalog.ts
@@ -206,13 +206,13 @@ export function modelFamily(id: ModelFamilyId): ModelFamily {
 
 // ── Tier utente → famiglia di default (senza agente) ──────────────────────────
 
-import type { ChatTier } from '$lib/chat-tiers';
+import { isGatewayModelTier, type ChatTier } from '$lib/chat-tiers';
 
 /**
  * Cosa risolve un tier del picker quando nessun agente impone altro.
  * Auto = Luna (default prodotto). Pro = Grok. Fast = Luna.
  */
-export const TIER_DEFAULT_FAMILY: Record<ChatTier, ModelFamilyId> = {
+export const TIER_DEFAULT_FAMILY: Record<string, ModelFamilyId> = {
   auto: 'luna',
   fast: 'luna',
   pro: 'grok',
@@ -221,12 +221,20 @@ export const TIER_DEFAULT_FAMILY: Record<ChatTier, ModelFamilyId> = {
   'gpt-sol': 'gpt-sol'
 };
 
-/** Famiglia sotto un tier, opzionalmente sovrascritta dalla policy dell'agente. */
+/**
+ * Famiglia sotto un tier, opzionalmente sovrascritta dalla policy dell'agente.
+ *
+ * Un tier che è un id del gateway non ha una famiglia qui dentro — e non deve averla: la famiglia
+ * serve SOLO a dire quali gradini di ragionamento mostrare, e su un modello scelto dall'utente si
+ * usa la scala comune a tre gradini invece di inventargli un vocabolario nativo che non conosciamo.
+ */
 export function familyForTier(
   tier: ChatTier,
   agentFamily?: ModelFamilyId | null
 ): ModelFamily {
   // Solo Auto è "scelta dell'agente". Fast/Pro/custom restano la scelta esplicita dell'utente.
   if (tier === 'auto' && agentFamily) return modelFamily(agentFamily);
-  return modelFamily(TIER_DEFAULT_FAMILY[tier]);
+  const known = TIER_DEFAULT_FAMILY[tier as keyof typeof TIER_DEFAULT_FAMILY];
+  if (known) return modelFamily(known);
+  return isGatewayModelTier(tier) ? LUNA : modelFamily(TIER_DEFAULT_FAMILY.auto);
 }

--- a/src/lib/server/chat-models.test.ts
+++ b/src/lib/server/chat-models.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { __resetGatewayModels, ensureGatewayModels } from './openrouter-models';
+import { chatModelChoices } from './chat-models';
+
+const raw = (id: string, name: string, opts: { tools?: boolean; image?: boolean } = {}) => ({
+  id,
+  name,
+  context_length: 200_000,
+  supported_parameters: opts.tools === false ? [] : ['tools', 'reasoning'],
+  architecture: { input_modalities: opts.image === false ? ['text'] : ['text', 'image'] },
+  pricing: { prompt: '0.000001', completion: '0.000002' }
+});
+
+const LIVE = {
+  data: [
+    raw('anthropic/claude-opus-5', 'Claude Opus 5'),
+    raw('openai/gpt-5.6-sol', 'GPT-5.6 Sol'),
+    raw('deepseek/deepseek-v4-flash-vision-exp', 'DeepSeek V4 Flash'),
+    raw('someone/deprecated-text-model', 'Solo testo', { tools: false, image: false }),
+    raw('vendor/not-featured', 'Non in vetrina')
+  ]
+};
+
+const fetchImpl = (async () => ({ ok: true, status: 200, json: async () => LIVE })) as unknown as typeof fetch;
+
+beforeEach(async () => {
+  __resetGatewayModels();
+  await ensureGatewayModels({ fetchImpl, baseUrl: 'https://openrouter.ai/api/v1' });
+});
+
+describe('catalogo della chat', () => {
+  it('offre solo modelli che il gateway serve davvero, adesso', async () => {
+    const ids = (await chatModelChoices({ configured: [] })).map((c) => c.id);
+    expect(ids).toContain('anthropic/claude-opus-5');
+    expect(ids).toContain('openai/gpt-5.6-sol');
+    // In vetrina ci sono anche modelli che questo gateway non ha: non si mostrano invece di
+    // fallire al primo turno.
+    expect(ids).not.toContain('x-ai/grok-4.6');
+    // Non in vetrina e non configurato: fuori.
+    expect(ids).not.toContain('vendor/not-featured');
+  });
+
+  /** Un modello messo in LLM_MODELS dall'operatore è una scelta esplicita: sta nel menu. */
+  it('include quello che l\'operatore ha configurato, anche se non è in vetrina', async () => {
+    const ids = (await chatModelChoices({ configured: ['vendor/not-featured'] })).map((c) => c.id);
+    expect(ids).toContain('vendor/not-featured');
+  });
+
+  it('non offre un modello che non sa usare i tool o leggere immagini', async () => {
+    const ids = (await chatModelChoices({ configured: ['someone/deprecated-text-model'] })).map((c) => c.id);
+    expect(ids).not.toContain('someone/deprecated-text-model');
+  });
+
+  it('porta prezzo e contesto, così il menu non deve indovinarli', async () => {
+    const opus = (await chatModelChoices({ configured: [] })).find((c) => c.id === 'anthropic/claude-opus-5');
+    expect(opus).toMatchObject({ label: 'Claude Opus 5', contextLength: 200_000, inputUsdPerM: 1, outputUsdPerM: 2 });
+  });
+
+  it('senza listino raggiungibile il menu resta vuoto invece di mentire', async () => {
+    __resetGatewayModels();
+    const bad = (async () => ({ ok: false, status: 500, json: async () => ({}) })) as unknown as typeof fetch;
+    await ensureGatewayModels({ fetchImpl: bad, baseUrl: 'https://openrouter.ai/api/v1' });
+    expect(await chatModelChoices({ configured: [], fetchImpl: bad, baseUrl: 'https://openrouter.ai/api/v1' })).toEqual([]);
+  });
+});

--- a/src/lib/server/chat-models.ts
+++ b/src/lib/server/chat-models.ts
@@ -1,0 +1,78 @@
+/**
+ * I modelli che il picker della chat offre: la vetrina, non il magazzino.
+ *
+ * OpenRouter ne serve 421, di cui 227 sanno usare i tool e leggere immagini — il minimo perché un
+ * turno con gli agenti arrivi in fondo. Duecento voci non sono una scelta, sono un menu che
+ * nessuno legge, quindi la vetrina è un elenco corto di modelli di punta più tutto ciò che
+ * l'operatore ha messo in `LLM_MODELS`.
+ *
+ * La vetrina dichiara solo gli ID. Nome, prezzo, finestra di contesto e capacità arrivano vivi da
+ * `openrouter-models.ts`: un modello ritirato sparisce dal menu da solo invece di fallire al primo
+ * turno, e un prezzo che cambia non resta scritto qui dentro a mentire.
+ *
+ * Verificati presenti su OpenRouter il 2026-09-02, con tools + visione.
+ */
+import { llmModels } from '$lib/server/llm';
+import { ensureGatewayModels, gatewayModel } from '$lib/server/openrouter-models';
+
+export const FEATURED_CHAT_MODEL_IDS = [
+  'anthropic/claude-opus-5',
+  'anthropic/claude-sonnet-5',
+  'anthropic/claude-haiku-4.5',
+  'openai/gpt-5.6-sol',
+  'openai/gpt-5.6-terra',
+  'openai/gpt-5.6-luna',
+  'google/gemini-3.7-flash',
+  'google/gemini-3.1-pro-preview',
+  'x-ai/grok-4.6',
+  'deepseek/deepseek-v4-flash-vision-exp',
+  'z-ai/glm-5.3-flash',
+  'qwen/qwen3.8-max',
+  'qwen/qwen3.8-flash',
+  'moonshotai/kimi-k3',
+  'meta-llama/llama-4-maverick',
+  'mistralai/mistral-large-2512'
+] as const;
+
+export type ChatModelChoice = {
+  id: string;
+  label: string;
+  contextLength: number;
+  inputUsdPerM: number;
+  outputUsdPerM: number;
+  reasoning: boolean;
+};
+
+/**
+ * L'ordine è quello della vetrina, non alfabetico: è una gerarchia editoriale, e i modelli
+ * configurati dall'operatore vanno in fondo perché sono un'aggiunta, non una raccomandazione.
+ */
+export async function chatModelChoices(
+  opts: { configured?: string[]; fetchImpl?: typeof fetch; baseUrl?: string } = {}
+): Promise<ChatModelChoice[]> {
+  await ensureGatewayModels({ fetchImpl: opts.fetchImpl, baseUrl: opts.baseUrl });
+  const configured = opts.configured ?? llmModels();
+  const ids = [...FEATURED_CHAT_MODEL_IDS, ...configured.filter((id) => !FEATURED_CHAT_MODEL_IDS.includes(id as never))];
+
+  const out: ChatModelChoice[] = [];
+  for (const id of ids) {
+    const model = gatewayModel(id);
+    if (!model?.usable) continue;
+    out.push({
+      id: model.id,
+      label: model.label,
+      contextLength: model.contextLength,
+      inputUsdPerM: model.rate.input,
+      outputUsdPerM: model.rate.output,
+      reasoning: model.reasoning
+    });
+  }
+  return out;
+}
+
+/** Vero quando quell'id è una scelta che il picker può davvero offrire adesso. */
+export async function isOfferedChatModel(id: unknown): Promise<boolean> {
+  const v = String(id ?? '').trim();
+  if (!v) return false;
+  return (await chatModelChoices()).some((c) => c.id === v);
+}

--- a/src/lib/server/chat/queue.ts
+++ b/src/lib/server/chat/queue.ts
@@ -789,6 +789,7 @@ await maybeCompactThread(admin, {
 						mode: params.mode,
 						tier: typeof params.tier === 'string' ? params.tier : undefined,
 						modelFamily: turnModelFamily(threadRow?.model, persona?.model)?.family,
+						modelId: turnModelFamily(threadRow?.model, persona?.model)?.model,
 						reasoning: typeof params.reasoning === 'string' ? params.reasoning : undefined,
 						// La ripresa di un run lasciato dal reaper: lo stesso turno continua, con il
 						// fence successivo, invece di aprirne uno nuovo accanto al lavoro a metà.

--- a/src/lib/server/llm.test.ts
+++ b/src/lib/server/llm.test.ts
@@ -65,6 +65,45 @@ describe('llm — catalogo e fallback', () => {
 		expect(llmModelForPicker('anthropic/claude-sonnet-4')).toBe('anthropic/claude-sonnet-4');
 	});
 
+	/**
+	 * Il picker offre il catalogo del gateway, non solo i due id di LLM_MODELS: un modello scelto
+	 * dall'utente deve arrivare INTATTO al gateway. Prima cadeva sul default in silenzio — cioè
+	 * "GPT Terra" nel menu e DeepSeek nella risposta.
+	 */
+	it('un id del catalogo passa intatto, anche fuori da LLM_MODELS', async () => {
+		setEnv({
+			LLM_API_KEY: 'k',
+			LLM_DEFAULT_MODEL: 'google/gemini-2.5-flash',
+			LLM_MODELS: 'google/gemini-2.5-flash'
+		});
+		const { llmModelForPicker } = await import('./llm');
+		const { __resetGatewayModels, ensureGatewayModels } = await import('./openrouter-models');
+		__resetGatewayModels();
+		await ensureGatewayModels({
+			baseUrl: 'https://openrouter.ai/api/v1',
+			fetchImpl: (async () => ({
+				ok: true,
+				status: 200,
+				json: async () => ({
+					data: [
+						{
+							id: 'anthropic/claude-opus-5',
+							name: 'Claude Opus 5',
+							context_length: 1000,
+							supported_parameters: ['tools'],
+							architecture: { input_modalities: ['text', 'image'] },
+							pricing: { prompt: '0.000001', completion: '0.000002' }
+						}
+					]
+				})
+			})) as unknown as typeof fetch
+		});
+		expect(llmModelForPicker('anthropic/claude-opus-5')).toBe('anthropic/claude-opus-5');
+		// Un id che il gateway non serve non diventa una chiamata persa: si torna al default.
+		expect(llmModelForPicker('vendor/mai-visto')).toBe('google/gemini-2.5-flash');
+		__resetGatewayModels();
+	});
+
 	it('GEO Gemini search vuole un id google/gemini-*', async () => {
 		setEnv({ LLM_API_KEY: 'k', LLM_DEFAULT_MODEL: 'anthropic/claude-sonnet-4' });
 		const { llmGeminiSearchModel } = await import('./llm');

--- a/src/lib/server/llm.ts
+++ b/src/lib/server/llm.ts
@@ -9,6 +9,7 @@ import { embedMany, generateObject, generateText, jsonSchema } from 'ai';
 import { env } from '$env/dynamic/private';
 import { extractSdkUsage, logAiCall, noteLlmCost } from '$lib/server/ai-log';
 import { costFromJson, costFromStreamText, withUsageAccounting } from '$lib/server/llm-usage-cost';
+import { gatewayModel } from '$lib/server/openrouter-models';
 
 export const LLM_UNCONFIGURED = 'llm_unconfigured';
 export const LLM_VIDEO_UNCONFIGURED = 'llm_video_unconfigured';
@@ -69,11 +70,19 @@ export function llmModels(): string[] {
 	return def ? [def] : [];
 }
 
-/** Fast/auto = primo della lista (o default). Pro = secondo se c’è. Un id OpenRouter passa così. */
+/**
+ * L'id che va sul filo per questa scelta del picker.
+ *
+ * Un id che il gateway serve davvero passa intatto: è il modello che l'utente ha scelto dal
+ * catalogo, e cadere sul default sarebbe scrivere un nome nel menu e chiamarne un altro. Gli id
+ * ignoti al listino tornano al default invece di diventare una chiamata persa.
+ *
+ * Fast/auto = primo della lista (o default). Pro = secondo se c'è.
+ */
 export function llmModelForPicker(choice: string | null | undefined): string {
 	const models = llmModels();
 	const id = typeof choice === 'string' ? choice.trim() : '';
-	if (id && models.includes(id)) return id;
+	if (id && (models.includes(id) || gatewayModel(id)?.usable)) return id;
 	if ((id === 'pro' || id === 'deepseek-pro' || id === 'gpt-sol') && models[1]) return models[1];
 	return llmDefaultModel();
 }

--- a/src/lib/server/settings-actions.ts
+++ b/src/lib/server/settings-actions.ts
@@ -9,7 +9,7 @@ import { sendEmail, brandInviteEmailSubject, brandInviteEmailHtml, brandInviteEm
 import { emailLocale } from '$lib/server/email-i18n';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { RequestEvent } from '@sveltejs/kit';
-import { isChatTier } from '$lib/chat-tiers';
+import { isChatTier, isGatewayModelTier } from '$lib/chat-tiers';
 import { invalidateBrandNav } from '$lib/server/nav-cache';
 import { readUploadImage } from '$lib/server/raster-image';
 import { createAdminClient } from '$lib/server/supabase-admin';
@@ -195,6 +195,12 @@ export async function setChatDefaultTier({ request, params, locals: { supabase }
   const data = await request.formData();
   const tier = String(data.get('tier') ?? '').trim();
   if (!isChatTier(tier)) return { error: 'Pick a model' };
+  // Un id che ha la forma giusta ma che il gateway non serve sarebbe un default rotto per ogni
+  // chat nuova del brand: qui si controlla che sia una scelta davvero offerta.
+  if (isGatewayModelTier(tier)) {
+    const { isOfferedChatModel } = await import('$lib/server/chat-models');
+    if (!(await isOfferedChatModel(tier))) return { error: 'That model is not available' };
+  }
   const { error } = await supabase
     .from('brands')
     .update({ chat_default_tier: tier })

--- a/src/routes/app/[brand]/+layout.server.ts
+++ b/src/routes/app/[brand]/+layout.server.ts
@@ -20,6 +20,7 @@ import {
 } from '$lib/server/nav-cache';
 import { resolveTenant } from '$lib/server/tenant';
 import type { LayoutServerLoad } from './$types';
+import { chatModelChoices } from '$lib/server/chat-models';
 
 // Flag globali da env (Vercel, nessun rebuild con $env/dynamic).
 // `ads` è ORTOGONALE a hasAds(plan): il piano dice CHI può usarlo, il flag se esiste. Default OFF.
@@ -330,6 +331,9 @@ export const load: LayoutServerLoad = async ({ params, cookies, locals: { supaba
   return {
     brand,
     brandId: brand.id,
+    // Il menu dei modelli della chat: elenco vivo del gateway, non una lista scritta a mano che
+    // invecchia. È in cache di processo, quindi non è una chiamata di rete per navigazione.
+    chatModels: await chatModelChoices().catch(() => []),
     logoUrl,
     switcherBrands,
     onboarding,

--- a/src/routes/app/[brand]/chat/+server.ts
+++ b/src/routes/app/[brand]/chat/+server.ts
@@ -304,6 +304,7 @@ export const POST: RequestHandler = async ({ request, params, locals: { supabase
       mode,
       tier: body.tier,
       modelFamily: modelPref?.family,
+      modelId: modelPref?.model,
       reasoning: body.reasoning,
       escalationText,
       persona: kitPersona,

--- a/src/routes/app/[brand]/chat/[thread]/+page.server.ts
+++ b/src/routes/app/[brand]/chat/[thread]/+page.server.ts
@@ -1,4 +1,5 @@
 import { error, fail } from '@sveltejs/kit';
+import { chatModelChoices } from '$lib/server/chat-models';
 import { getThread, loadThreadUiHistory } from '$lib/server/chat/persistence';
 import { loadLiveRun } from '$lib/server/chat/live-run';
 import { agentDesktopEnabled } from '$lib/server/agent-desktop';
@@ -244,6 +245,10 @@ export const load: PageServerLoad = async ({ params, locals: { supabase, safeGet
 
   return {
     thread,
+    // Il menu dei modelli lo serve anche il layout, ma la pagina lo DICHIARA: il guardiano di
+    // shell.test.ts controlla che ogni `data.<campo>` letto qui dentro esista nel payload, e un
+    // campo che arriva solo dal layout è un campo che sparisce senza che nessun test se ne accorga.
+    chatModels: await chatModelChoices().catch(() => []),
     agentPanel,
     agentDesktopEnabled: agentDesktopEnabled(),
     messages: threadHistory.messages,

--- a/src/routes/app/[brand]/chat/[thread]/+page.svelte
+++ b/src/routes/app/[brand]/chat/[thread]/+page.svelte
@@ -1048,6 +1048,7 @@
     bind:mode={chatMode}
     bind:tier={chatTier}
     bind:reasoning={chatReasoning}
+    chatModels={data.chatModels ?? []}
     agentOptions={agentOptions}
     agentLocked={messages.length > 0}
     agent={agentSel}

--- a/src/routes/app/[brand]/chat/components/ComposerDock.svelte
+++ b/src/routes/app/[brand]/chat/components/ComposerDock.svelte
@@ -21,6 +21,7 @@
   type SubmitMeta = {
     mode: ChatMode;
     tier?: ChatTier;
+    chatModels?: Array<{ id: string; label: string; contextLength: number; inputUsdPerM: number; outputUsdPerM: number }>;
     reasoning?: ChatReasoning;
     command?: string;
     attachments?: ChatAttachmentsPayload;
@@ -41,6 +42,7 @@
     mode = $bindable('agent' as ChatMode),
     tier = $bindable('auto' as ChatTier),
     reasoning = $bindable(),
+    chatModels = [],
     agentOptions,
     agentLocked,
     agent,
@@ -139,6 +141,7 @@
     bind:mode={mode}
     bind:tier={tier}
     bind:reasoning={reasoning}
+    chatModels={chatModels}
     {brandSlug}
     draftKey={`anomalia:chat-draft:${threadId}`}
     {loading}

--- a/src/routes/app/[brand]/settings/chat/+page.server.ts
+++ b/src/routes/app/[brand]/settings/chat/+page.server.ts
@@ -1,4 +1,9 @@
-import type { Actions } from './$types';
+import type { Actions, PageServerLoad } from './$types';
 import { setChatDefaultTier } from '$lib/server/settings-actions';
+import { chatModelChoices } from '$lib/server/chat-models';
+
+export const load: PageServerLoad = async () => ({
+  chatModels: await chatModelChoices().catch(() => [])
+});
 
 export const actions: Actions = { setChatDefaultTier };

--- a/src/routes/app/[brand]/settings/chat/+page.svelte
+++ b/src/routes/app/[brand]/settings/chat/+page.svelte
@@ -1,15 +1,14 @@
 <script lang="ts">
   import { enhance } from '$app/forms';
   import { _ } from 'svelte-i18n';
-  import {
-    CHAT_PRESET_TIERS,
-    CHAT_CUSTOM_MODELS,
-    coerceChatTier
-  } from '$lib/chat-tiers';
+  import { CHAT_PRESET_TIERS, coerceChatTier } from '$lib/chat-tiers';
 
   let { data, form } = $props();
   // NULL in the DB means "never chosen" — show what the chat actually starts on.
   const current = $derived(coerceChatTier(data.brand?.chat_default_tier));
+  const models = $derived(data.chatModels ?? []);
+  const currentModel = $derived(models.find((m) => m.id === current));
+  const K_TOKENS = 1000;
 </script>
 
 <section class="panel">
@@ -24,10 +23,10 @@
         {#each CHAT_PRESET_TIERS as t (t)}
           <option value={t} selected={t === current}>{$_('chat.tier.' + t)}</option>
         {/each}
-        {#if CHAT_CUSTOM_MODELS.length}
+        {#if models.length}
           <optgroup label={$_('chat.tier.custom')}>
-            {#each CHAT_CUSTOM_MODELS as t (t)}
-              <option value={t} selected={t === current}>{$_('chat.tier.' + t)}</option>
+            {#each models as m (m.id)}
+              <option value={m.id} selected={m.id === current}>{m.label}</option>
             {/each}
           </optgroup>
         {/if}
@@ -38,7 +37,11 @@
   <div class="field">
     <div class="ftxt">
       <div class="fs">
-        {$_('chat.tier.' + current + 'Hint')}
+        {#if currentModel}
+          {Math.round(currentModel.contextLength / K_TOKENS)}k · ${currentModel.inputUsdPerM}/${currentModel.outputUsdPerM} per 1M token
+        {:else}
+          {$_('chat.tier.' + current + 'Hint')}
+        {/if}
       </div>
     </div>
   </div>

--- a/supabase/migrations/20260902160000_chat_default_tier_gateway_models.sql
+++ b/supabase/migrations/20260902160000_chat_default_tier_gateway_models.sql
@@ -1,0 +1,14 @@
+-- Il default di modello di un brand poteva essere solo uno dei sei nomi inventati da noi
+-- ('auto','fast','pro','deepseek-pro','gpt-terra','gpt-sol'). Ora il picker offre il catalogo del
+-- gateway, quindi il valore può essere anche un id di modello — `anthropic/claude-opus-5`.
+--
+-- Il vincolo resta, e resta stretto: o uno dei preset, o qualcosa che ABBIA LA FORMA di un id
+-- (`vendor/modello`). Che quel modello esista davvero lo verifica il server contro il listino
+-- vivo, perché è una cosa che cambia ogni settimana e un CHECK non può inseguirla.
+alter table public.brands drop constraint if exists brands_chat_default_tier_check;
+
+alter table public.brands add constraint brands_chat_default_tier_check check (
+  chat_default_tier is null
+  or chat_default_tier in ('auto', 'fast', 'pro', 'deepseek-pro', 'gpt-terra', 'gpt-sol')
+  or chat_default_tier ~ '^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._:-]*$'
+);


### PR DESCRIPTION
## What?

The chat model picker now lists what the gateway actually serves: sixteen featured models — Claude Opus 5 / Sonnet 5 / Haiku 4.5, GPT-5.6 Sol / Terra / Luna, Gemini 3.7 Flash and 3.1 Pro, Grok 4.6, DeepSeek V4, GLM 5.3 Flash, Qwen3.8 Max / Flash, Kimi K3, Llama 4 Maverick, Mistral Large — plus whatever the operator put in `LLM_MODELS`. Name, context window and price come live from OpenRouter's `/models`.

The choice lives in two places, as before: **Settings → Chat** sets what new conversations start on, and the `+` menu inside a chat switches the open conversation (saved on the thread, cross-device).

Builds on #144, which made a turn cost what the gateway billed — a catalogue the user picks from cannot be billed by a hand-written table.

## Why?

The old menu had three presets plus three hand-written "custom models", and it did not run what it said. With `LLM_MODELS = deepseek/…-flash, openai/gpt-5.6-sol`, from `llmModelForPicker`:

| menu entry | model that actually ran |
|---|---|
| Auto / Fast | `deepseek/…-flash` |
| **Pro**, **DeepSeek Pro**, **GPT Sol** | `openai/gpt-5.6-sol` — three labels, one model |
| **GPT Terra** | `deepseek/…-flash` — the label says OpenAI, DeepSeek answered |

## How?

**The catalogue is not a list in the code.** `chat-models.ts` declares sixteen ids; everything else — label, context, price, capabilities — is read from the live `/models` and cached per process (the module #144 added). A model OpenRouter retires disappears from the menu instead of failing on the first turn.

**The filter is capability, not taste**: tools + image input, because our agents call tools and read images and a model without both is a turn that dies halfway. 227 of OpenRouter's 421 pass it.

### Five places threw the choice away, and each was found by running a real turn

1. `isChatTier` knew six words. Now the client recognises the *shape* of an id and the server checks it *exists* against the live list.
2. `REASONING_LEVELS[tier]` / `DEFAULT_REASONING[tier]` were six-key maps: an unknown id returned `undefined` and the menu crashed on `.length`. They now go through `familyForTier`, which gives a gateway id the common three-step scale.
3. `AgentModelPolicy` on the thread was `{family, thinking}` — it cannot say "claude-opus-5". It gained an optional `model`; rows saved before it keep working.
4. `resolveHarnessModelRef` ignored the tier unless it was `pro`/`fast` and fell to the first id of `LLM_MODELS`. **The brand default was qwen and the turn ran on deepseek.**
5. `ensureKieAgentDir` declared only the two `LLM_MODELS` ids to the pi harness. An id outside that list is unknown to it, so the turn fell through to the Vercel gateway and came back `403 Free tier users do not have access` on `zai/glm-5.1` — a model nobody chose.

And the brand default never reached the home composer: the hydration effect returned early while there was no thread (`id === hydratedThread`, both `null`), so every new chat started on Auto whatever Settings said. That bug predates this PR — it applied to "Pro" too.

### Database

`brands_chat_default_tier_check` allowed only the six words, so saving an id was a SQL error shown to the user. The migration widens it to the *shape* of an id; whether the model exists is the live list's job, not a CHECK nobody will update. **This repo does not run migrations on deploy — it has to be applied by hand.**

## Testing?

- **Unit** (written first, watched fail): id-shaped tiers (`chat-tiers`), the reasoning scale for an unknown id (`chat-reasoning`), the model carried on the saved policy (`chat-model-policy`), the catalogue's filters and its fallback to an empty menu when the list is unreachable (`chat-models`), the picker passing a catalogue id through (`llm`), and the harness honouring a chosen id (`adapters`). Suites run: chat, routes, agent, models, packages — **1181 + 735 passed**.
- **Manual, local stack** (self-hosted Supabase + worktree dev server, brand `demo`):
  - Settings → Chat lists all 16 with their real names read from the gateway.
  - Saving `qwen/qwen3.8-flash` failed first with the CHECK violation — that is how the constraint was found — then saved after the migration.
  - A new chat from the home then ran on it: `[AGENT_KIT] run 678b3c9b… start — modello=qwen3.8-flash (llm)` … `done — 18s`, and `ai_calls.model = llm/qwen/qwen3.8-flash`.
  - Before the harness fix, the same turn produced the 403 above.

## Anything Else?

- **Known gap, and now measured well enough to name the culprit.** On that qwen turn the harness reported no token usage (`? in / ? out`), so the row carries no cost. It is not OpenRouter: called in streaming with *no* flag at all, the last chunk carries usage — including `cost` — for both models:

  ```
  qwen/qwen3.8-flash       → "usage":{"prompt_tokens":62,"completion_tokens":3,"cost":0.00001071,…}
  deepseek/…-flash-vision  → "usage":{"prompt_tokens":84,"completion_tokens":3,"cost":0.00002046,…}
  ```

  The number is already in the response and the harness is not reading it. That makes the structural fix smaller than it looked: point the harness's `baseUrl` at an endpoint of ours that forwards to OpenRouter and records `usage.cost`, the way `llmClient` already does for everything else. **Not in this PR**, and worth doing before the picker is offered widely.
- The three legacy tier ids (`deepseek-pro`, `gpt-terra`, `gpt-sol`) still resolve, because threads have them saved. They are no longer offered in the menu.
- No plan gate: a brand on any plan can pin Claude Opus 5 at $5/$25 per 1M. If model choice is meant to be an upsell, that is a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KNGMMYSbWxEJCssaxzFMAv
