### PR TITLE
Stop chasing transport prefixes one at a time

### DIFF
--- a/changelog/2026-09-02-transport-prefix-billing.md
+++ b/changelog/2026-09-02-transport-prefix-billing.md
@@ -1,0 +1,36 @@
+# L'ultimo prefisso che mangiava i crediti
+
+Contato su produzione, 30 giorni. Delle righe di `ai_calls` senza costo, la stragrande maggioranza
+è **giusta**: sono chiamate FALLITE, che non ci vengono fatturate (1456 deepseek, 467 kie, 169
+xiaomi, 140 gemini — tutte `ok = false`, zero token).
+
+I buchi veri sono le righe **riuscite, con i token contati e nessun addebito**:
+
+| provider | modello | righe | in | out |
+|---|---|---|---|---|
+| openrouter | `openrouter/stealth/ox-alpha` | 20 | 2.079.159 | 31.120 |
+| llm | `llm/z-ai/glm-5.3-flash` | 6 | 1.113.621 | 25.838 |
+| llm | `llm/deepseek/…-vision-exp` | 2 | 682.070 | 41.970 |
+| llm | `google/gemini-3.7-flash` | 42 | 126.912 | 100.141 |
+| openrouter | `minimax/minimax-m3:free` | 3 | 148.290 | 7.130 |
+| kie | `kie/gpt-5-6-luna` | 4 | 49.474 | 56 |
+| llm | `google/gemini-embedding-001` | 10 | 479 | 0 |
+
+Ai prezzi di listino fanno **circa un dollaro in trenta giorni** — su $450 fatturati nello stesso
+periodo. Non è un'emorragia: è piccolo perché il traffico sul gateway è ancora piccolo, ed è
+esattamente la ragione per cui va chiuso adesso, non quando il picker lo avrà moltiplicato.
+
+Due voci non erano nemmeno un buco: `minimax-m3:free` costa zero davvero, e `stealth/ox-alpha` era
+un modello a tempo (oggi non è più nel listino) servito gratis durante la prova.
+
+## La rincorsa ai prefissi, chiusa
+
+`llm/`, `kie/`, `google/`: ogni trasporto che passa aggiunge il suo davanti all'id, e la
+normalizzazione ne toglieva due su elenco. Elencarli è una rincorsa che si perde al prossimo
+trasporto. Ora si prova l'id intero e poi il suo **ultimo segmento**, e solo se le RATES lo
+conoscono davvero — un id sconosciuto resta senza prezzo invece di prendere quello di qualcosa che
+gli somiglia (`vendor/deepseek-v4-flash-vision-exp` non diventa `deepseek-v4-flash`).
+
+Il resto di quelle righe lo chiudono le due cose già in `dev`: il listino live di OpenRouter per i
+modelli che nessuno ha scritto nelle RATES, e `usage.cost` letto dalla risposta. **Nessuna delle
+due è ancora in produzione**: `main` è indietro di quindici commit.

--- a/src/lib/server/ai-log.test.ts
+++ b/src/lib/server/ai-log.test.ts
@@ -33,6 +33,28 @@ describe('computeCostUsd', () => {
     expect(computeCostUsd({ ...usage, provider: 'llm', model: 'llm/z-ai/glm-5.3-flash' })).toBeCloseTo(0.325, 4);
   });
 
+  /**
+   * MISURATO su produzione, 30 giorni: 4 righe `kie/gpt-5-6-luna` e 10 `google/gemini-embedding-001`
+   * riuscite, con i token contati, e senza costo — perché le RATES tengono quegli id NUDI e la
+   * normalizzazione toglieva solo `openrouter/` e `llm/`. Ogni trasporto nuovo aggiungeva un
+   * prefisso e un buco: la regola ora è una sola, l'ULTIMO segmento, e vale anche per il prossimo.
+   */
+  it('prezza un modello sotto il prefisso di QUALUNQUE trasporto', () => {
+    const usage = { label: 'chat', ms: 0, ok: true, inputTokens: 1_000_000, outputTokens: 0 };
+    expect(computeCostUsd({ ...usage, provider: 'kie', model: 'kie/gpt-5-6-luna' })).toBeCloseTo(0.056, 4);
+    expect(computeCostUsd({ ...usage, provider: 'llm', model: 'google/gemini-embedding-001' })).toBeCloseTo(0.15, 4);
+  });
+
+  /** Un id che somiglia a uno noto non è quello noto: `-vision-exp` è un altro modello. */
+  it('non spaccia per noto un modello diverso che finisce in modo simile', () => {
+    expect(
+      computeCostUsd({
+        label: 'chat', provider: 'llm', model: 'vendor/deepseek-v4-flash-vision-exp',
+        ms: 0, ok: true, inputTokens: 10, outputTokens: 10
+      })
+    ).toBeNull();
+  });
+
   it('un modello openrouter senza tariffa resta null: meglio non misurato che misurato a caso', () => {
     expect(
       computeCostUsd({ label: 'chat', provider: 'openrouter', model: 'openrouter/qualcosa/mai-visto', ms: 0, ok: true, inputTokens: 10, outputTokens: 10 })

--- a/src/lib/server/ai-log.ts
+++ b/src/lib/server/ai-log.ts
@@ -275,12 +275,18 @@ export function computeCostUsd(entry: AiCallLog, plan?: string | null): number |
   // Modello ASSENTE su una chiamata gemini = Flash; modello PRESENTE ma ignoto deve restare null,
   // non essere prezzato come Flash.
   // `openrouter/z-ai/glm-5.3-flash`, `llm/z-ai/glm-5.3-flash` e `z-ai/glm-5.3-flash` sono lo
-  // stesso modello allo stesso prezzo: il prefisso dice il trasporto, non la tariffa. Il bridge
-  // dell'harness scrive `llm/`, e finché la normalizzazione ne toglieva uno solo quelle righe
-  // restavano senza costo — 54 su 235 dello stesso modello.
-  const modelKey = (entry.model ?? '').replace(/^(?:openrouter|llm)\//, '');
+  // stesso modello allo stesso prezzo: il prefisso dice il trasporto, non la tariffa. Ogni
+  // trasporto nuovo ne ha aggiunto uno — e con esso un buco: `llm/` dal bridge dell'harness
+  // (54 righe), `kie/` (4), il vendor `google/` davanti a un id che le RATES tengono nudo (10).
+  // Elencarli è una rincorsa persa: si prova l'id intero, poi il suo ultimo segmento.
+  const rawModel = (entry.model ?? '').trim();
+  const modelKey = rawModel.replace(/^(?:openrouter|llm)\//, '');
+  const bareModel = modelKey.includes('/') ? modelKey.slice(modelKey.lastIndexOf('/') + 1) : '';
   const rate =
     RATES[modelKey] ??
+    // L'ultimo segmento vale solo se le RATES lo conoscono: un id sconosciuto resta senza prezzo,
+    // non diventa il prezzo di qualcosa che gli somiglia.
+    (bareModel ? RATES[bareModel] : undefined) ??
     // Il listino del gateway, chiesto al gateway: è ciò che rende fatturabile un modello che
     // l'utente ha scelto e che nessuno ha scritto qui sopra. Vuoto finché `ensureGatewayModels`
     // non ha caricato — e allora decidono le RATES, come prima.


### PR DESCRIPTION
## What?

Closes the last known way a successful AI call reaches the credit ledger costing nothing: the transport prefix in front of the model id. `kie/gpt-5-6-luna` and `google/gemini-embedding-001` were priced as unknown models because the normalisation stripped a hard-coded list of two prefixes (`openrouter/`, `llm/`).

Also writes down what the billing hole is actually worth, measured on production rather than guessed.

## Why?

Counted over 30 days of production `ai_calls`:

**Most uncosted rows are correct.** They are failed calls — we are not billed for them, so they cost nothing: 1456 deepseek, 467 kie, 169 xiaomi, 140 gemini, all `ok = false` with zero tokens.

**The real holes are the successful, token-counted, uncharged rows:**

| provider | model | rows | in | out |
|---|---|---|---|---|
| openrouter | `openrouter/stealth/ox-alpha` | 20 | 2,079,159 | 31,120 |
| llm | `llm/z-ai/glm-5.3-flash` | 6 | 1,113,621 | 25,838 |
| llm | `llm/deepseek/…-vision-exp` | 2 | 682,070 | 41,970 |
| llm | `google/gemini-3.7-flash` | 42 | 126,912 | 100,141 |
| openrouter | `minimax/minimax-m3:free` | 3 | 148,290 | 7,130 |
| kie | `kie/gpt-5-6-luna` | 4 | 49,474 | 56 |
| llm | `google/gemini-embedding-001` | 10 | 479 | 0 |

At list prices that is **about one dollar in thirty days**, against $450 billed in the same period. Two of those lines were never a hole at all: `minimax-m3:free` really is free, and `stealth/ox-alpha` was a time-limited model served free during its trial (it is no longer in OpenRouter's list).

So: not an emergency. It is small because gateway traffic is still small — 220 rows out of 46,000 — which is exactly why it is worth closing before the model picker multiplies that path.

**None of the fixes are in production yet**: `main` is fifteen commits behind `dev`.

## How?

`llm/`, `kie/`, `google/` — every transport that carries a call puts its own word in front of the id, and the lookup stripped two of them by name. Listing them loses to the next transport.

The lookup now tries the whole id, then its **last segment**, and only accepts the second when the rates actually hold that key. An id nobody knows stays unpriced rather than borrowing the price of something that resembles it — `vendor/deepseek-v4-flash-vision-exp` does not become `deepseek-v4-flash`.

The rest of those rows are already closed in `dev` by the two pieces that shipped earlier today: OpenRouter's live price list for models nobody wrote into `RATES`, and `usage.cost` read from the response.

## Testing?

- **Unit** (written first, watched fail): a model priced under *any* transport prefix (`kie/gpt-5-6-luna` → $0.056/M, `google/gemini-embedding-001` → $0.15/M), and the guard that a similar-looking unknown id stays `null`.
- `ai-log`, `llm`, `openrouter-models`, `llm-usage-cost`, `chat-models` → **68 passed**.
- **Not tested**: the production backfill. Historical rows keep their `null`; recomputing the ledger backwards is a separate decision.

## Anything Else?

- The remaining known gap is the one named in #146: the pi harness has its own HTTP client and did not report token usage on one turn, so that row carries no cost even though OpenRouter had put `usage.cost` in the response. Pointing the harness at an endpoint of ours is the fix, and it is still not written.
- Worth deploying `dev` to production sooner rather than later — all three billing fixes are sitting there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KNGMMYSbWxEJCssaxzFMAv