### PR TITLE
Round a model price before showing it

### DIFF
--- a/changelog/2026-09-02-model-price-label.md
+++ b/changelog/2026-09-02-model-price-label.md
@@ -1,0 +1,16 @@
+# Diciassette cifre di errore di arrotondamento, spacciate per un prezzo
+
+Nel menu dei modelli si leggeva:
+
+```
+OpenAI: GPT-5.6 Luna   1050k · $0.19999999999999998/$1.2 per 1M
+```
+
+Il gateway pubblica il prezzo in dollari per TOKEN (`0.0000002`) e noi lo portiamo per milione con
+una moltiplicazione. In binario quel prodotto non fa `0.2`, e il menu mostrava la coda intera.
+
+`usdPerMillion` arrotonda dove il prezzo cambia davvero: tre decimali sotto il dollaro — un modello
+economico costa `$0.075` e la terza cifra È il prezzo — due sopra, dove il millesimo è rumore. Zero
+diventa `free`, non `$0.000`.
+
+Trovato aprendo il menu nel browser, che è l'unico posto dove un prezzo si legge.

--- a/changelog/2026-09-02-transport-prefix-billing.md
+++ b/changelog/2026-09-02-transport-prefix-billing.md
@@ -1,0 +1,36 @@
+# L'ultimo prefisso che mangiava i crediti
+
+Contato su produzione, 30 giorni. Delle righe di `ai_calls` senza costo, la stragrande maggioranza
+è **giusta**: sono chiamate FALLITE, che non ci vengono fatturate (1456 deepseek, 467 kie, 169
+xiaomi, 140 gemini — tutte `ok = false`, zero token).
+
+I buchi veri sono le righe **riuscite, con i token contati e nessun addebito**:
+
+| provider | modello | righe | in | out |
+|---|---|---|---|---|
+| openrouter | `openrouter/stealth/ox-alpha` | 20 | 2.079.159 | 31.120 |
+| llm | `llm/z-ai/glm-5.3-flash` | 6 | 1.113.621 | 25.838 |
+| llm | `llm/deepseek/…-vision-exp` | 2 | 682.070 | 41.970 |
+| llm | `google/gemini-3.7-flash` | 42 | 126.912 | 100.141 |
+| openrouter | `minimax/minimax-m3:free` | 3 | 148.290 | 7.130 |
+| kie | `kie/gpt-5-6-luna` | 4 | 49.474 | 56 |
+| llm | `google/gemini-embedding-001` | 10 | 479 | 0 |
+
+Ai prezzi di listino fanno **circa un dollaro in trenta giorni** — su $450 fatturati nello stesso
+periodo. Non è un'emorragia: è piccolo perché il traffico sul gateway è ancora piccolo, ed è
+esattamente la ragione per cui va chiuso adesso, non quando il picker lo avrà moltiplicato.
+
+Due voci non erano nemmeno un buco: `minimax-m3:free` costa zero davvero, e `stealth/ox-alpha` era
+un modello a tempo (oggi non è più nel listino) servito gratis durante la prova.
+
+## La rincorsa ai prefissi, chiusa
+
+`llm/`, `kie/`, `google/`: ogni trasporto che passa aggiunge il suo davanti all'id, e la
+normalizzazione ne toglieva due su elenco. Elencarli è una rincorsa che si perde al prossimo
+trasporto. Ora si prova l'id intero e poi il suo **ultimo segmento**, e solo se le RATES lo
+conoscono davvero — un id sconosciuto resta senza prezzo invece di prendere quello di qualcosa che
+gli somiglia (`vendor/deepseek-v4-flash-vision-exp` non diventa `deepseek-v4-flash`).
+
+Il resto di quelle righe lo chiudono le due cose già in `dev`: il listino live di OpenRouter per i
+modelli che nessuno ha scritto nelle RATES, e `usage.cost` letto dalla risposta. **Nessuna delle
+due è ancora in produzione**: `main` è indietro di quindici commit.

--- a/src/lib/components/ChatPrompt.svelte
+++ b/src/lib/components/ChatPrompt.svelte
@@ -19,6 +19,7 @@
     isCustomChatModel,
     type ChatTier
   } from '$lib/chat-tiers';
+  import { usdPerMillion } from '$lib/model-price';
   import { DEFAULT_REASONING, defaultReasoningFor, reasoningLevelsFor, isValidForTier, type ChatReasoning } from '$lib/chat-reasoning';
   import type { AgentMeta } from '$lib/agent-icons';
   import {
@@ -190,7 +191,10 @@
   const K_TOKENS = 1000;
   function modelSub(m: { contextLength: number; inputUsdPerM: number; outputUsdPerM: number }): string {
     const ctx = m.contextLength ? `${Math.round(m.contextLength / K_TOKENS)}k` : '';
-    const price = m.inputUsdPerM || m.outputUsdPerM ? `$${m.inputUsdPerM}/$${m.outputUsdPerM} per 1M` : '';
+    const price =
+      m.inputUsdPerM || m.outputUsdPerM
+        ? `${usdPerMillion(m.inputUsdPerM)}/${usdPerMillion(m.outputUsdPerM)} per 1M`
+        : '';
     return [ctx, price].filter(Boolean).join(' · ');
   }
 

--- a/src/lib/model-price.test.ts
+++ b/src/lib/model-price.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { usdPerMillion } from './model-price';
+
+describe('prezzo per milione di token', () => {
+  /**
+   * VISTO nel menu: «GPT-5.6 Luna 1050k · $0.19999999999999998/$1.2 per 1M». Il prezzo arriva dal
+   * gateway come dollari per TOKEN e diventa per milione con una moltiplicazione: il binario non
+   * ha 0.2, e il menu mostrava diciassette cifre di errore di arrotondamento.
+   */
+  it('non mostra la coda binaria di una moltiplicazione', () => {
+    expect(usdPerMillion(0.19999999999999998)).toBe('$0.2');
+    expect(usdPerMillion(0.696)).toBe('$0.696');
+  });
+
+  it('tiene le cifre che contano sui modelli economici', () => {
+    expect(usdPerMillion(0.075)).toBe('$0.075');
+    expect(usdPerMillion(0.0006)).toBe('$0.001');
+  });
+
+  it('sui modelli cari basta il centesimo', () => {
+    expect(usdPerMillion(5)).toBe('$5');
+    expect(usdPerMillion(25)).toBe('$25');
+    expect(usdPerMillion(3.7500001)).toBe('$3.75');
+  });
+
+  it('gratis è gratis, non "$0.000"', () => {
+    expect(usdPerMillion(0)).toBe('free');
+  });
+});

--- a/src/lib/model-price.ts
+++ b/src/lib/model-price.ts
@@ -1,0 +1,20 @@
+/**
+ * Il prezzo di un modello come lo legge una persona.
+ *
+ * Il gateway lo pubblica in dollari per TOKEN (`0.0000002`) e diventa per milione con una
+ * moltiplicazione — che in binario non fa 0.2 ma 0.19999999999999998. Nel menu si leggeva
+ * «$0.19999999999999998/$1.2 per 1M»: diciassette cifre di errore di arrotondamento presentate
+ * come un prezzo.
+ *
+ * Tre decimali sotto il dollaro (un modello economico costa $0.075 e la terza cifra è il prezzo),
+ * due sopra: più in là è rumore.
+ */
+const CHEAP = 1;
+const CHEAP_DECIMALS = 3;
+const DEAR_DECIMALS = 2;
+
+export function usdPerMillion(usd: number): string {
+  if (!Number.isFinite(usd) || usd <= 0) return 'free';
+  const rounded = Number(usd.toFixed(usd < CHEAP ? CHEAP_DECIMALS : DEAR_DECIMALS));
+  return `$${rounded}`;
+}

--- a/src/lib/server/ai-log.test.ts
+++ b/src/lib/server/ai-log.test.ts
@@ -33,6 +33,28 @@ describe('computeCostUsd', () => {
     expect(computeCostUsd({ ...usage, provider: 'llm', model: 'llm/z-ai/glm-5.3-flash' })).toBeCloseTo(0.325, 4);
   });
 
+  /**
+   * MISURATO su produzione, 30 giorni: 4 righe `kie/gpt-5-6-luna` e 10 `google/gemini-embedding-001`
+   * riuscite, con i token contati, e senza costo — perché le RATES tengono quegli id NUDI e la
+   * normalizzazione toglieva solo `openrouter/` e `llm/`. Ogni trasporto nuovo aggiungeva un
+   * prefisso e un buco: la regola ora è una sola, l'ULTIMO segmento, e vale anche per il prossimo.
+   */
+  it('prezza un modello sotto il prefisso di QUALUNQUE trasporto', () => {
+    const usage = { label: 'chat', ms: 0, ok: true, inputTokens: 1_000_000, outputTokens: 0 };
+    expect(computeCostUsd({ ...usage, provider: 'kie', model: 'kie/gpt-5-6-luna' })).toBeCloseTo(0.056, 4);
+    expect(computeCostUsd({ ...usage, provider: 'llm', model: 'google/gemini-embedding-001' })).toBeCloseTo(0.15, 4);
+  });
+
+  /** Un id che somiglia a uno noto non è quello noto: `-vision-exp` è un altro modello. */
+  it('non spaccia per noto un modello diverso che finisce in modo simile', () => {
+    expect(
+      computeCostUsd({
+        label: 'chat', provider: 'llm', model: 'vendor/deepseek-v4-flash-vision-exp',
+        ms: 0, ok: true, inputTokens: 10, outputTokens: 10
+      })
+    ).toBeNull();
+  });
+
   it('un modello openrouter senza tariffa resta null: meglio non misurato che misurato a caso', () => {
     expect(
       computeCostUsd({ label: 'chat', provider: 'openrouter', model: 'openrouter/qualcosa/mai-visto', ms: 0, ok: true, inputTokens: 10, outputTokens: 10 })

--- a/src/lib/server/ai-log.ts
+++ b/src/lib/server/ai-log.ts
@@ -275,12 +275,18 @@ export function computeCostUsd(entry: AiCallLog, plan?: string | null): number |
   // Modello ASSENTE su una chiamata gemini = Flash; modello PRESENTE ma ignoto deve restare null,
   // non essere prezzato come Flash.
   // `openrouter/z-ai/glm-5.3-flash`, `llm/z-ai/glm-5.3-flash` e `z-ai/glm-5.3-flash` sono lo
-  // stesso modello allo stesso prezzo: il prefisso dice il trasporto, non la tariffa. Il bridge
-  // dell'harness scrive `llm/`, e finché la normalizzazione ne toglieva uno solo quelle righe
-  // restavano senza costo — 54 su 235 dello stesso modello.
-  const modelKey = (entry.model ?? '').replace(/^(?:openrouter|llm)\//, '');
+  // stesso modello allo stesso prezzo: il prefisso dice il trasporto, non la tariffa. Ogni
+  // trasporto nuovo ne ha aggiunto uno — e con esso un buco: `llm/` dal bridge dell'harness
+  // (54 righe), `kie/` (4), il vendor `google/` davanti a un id che le RATES tengono nudo (10).
+  // Elencarli è una rincorsa persa: si prova l'id intero, poi il suo ultimo segmento.
+  const rawModel = (entry.model ?? '').trim();
+  const modelKey = rawModel.replace(/^(?:openrouter|llm)\//, '');
+  const bareModel = modelKey.includes('/') ? modelKey.slice(modelKey.lastIndexOf('/') + 1) : '';
   const rate =
     RATES[modelKey] ??
+    // L'ultimo segmento vale solo se le RATES lo conoscono: un id sconosciuto resta senza prezzo,
+    // non diventa il prezzo di qualcosa che gli somiglia.
+    (bareModel ? RATES[bareModel] : undefined) ??
     // Il listino del gateway, chiesto al gateway: è ciò che rende fatturabile un modello che
     // l'utente ha scelto e che nessuno ha scritto qui sopra. Vuoto finché `ensureGatewayModels`
     // non ha caricato — e allora decidono le RATES, come prima.

--- a/src/routes/app/[brand]/settings/chat/+page.svelte
+++ b/src/routes/app/[brand]/settings/chat/+page.svelte
@@ -2,6 +2,7 @@
   import { enhance } from '$app/forms';
   import { _ } from 'svelte-i18n';
   import { CHAT_PRESET_TIERS, coerceChatTier } from '$lib/chat-tiers';
+  import { usdPerMillion } from '$lib/model-price';
 
   let { data, form } = $props();
   // NULL in the DB means "never chosen" — show what the chat actually starts on.
@@ -38,7 +39,7 @@
     <div class="ftxt">
       <div class="fs">
         {#if currentModel}
-          {Math.round(currentModel.contextLength / K_TOKENS)}k · ${currentModel.inputUsdPerM}/${currentModel.outputUsdPerM} per 1M token
+          {Math.round(currentModel.contextLength / K_TOKENS)}k · {usdPerMillion(currentModel.inputUsdPerM)}/{usdPerMillion(currentModel.outputUsdPerM)} per 1M token
         {:else}
           {$_('chat.tier.' + current + 'Hint')}
         {/if}


### PR DESCRIPTION
## What?

The model menu showed `OpenAI: GPT-5.6 Luna 1050k · $0.19999999999999998/$1.2 per 1M`. Prices are now rounded where they stop meaning anything.

## Why?

OpenRouter publishes the price in dollars per **token** (`0.0000002`); we multiply by a million to show it per 1M. In binary that product is not `0.2`, and the whole floating-point tail went on screen next to a model name — in the chat composer and in Settings → Chat.

## How?

`usdPerMillion` in `src/lib/model-price.ts`: three decimals below a dollar, because a cheap model costs `$0.075` and the third digit still *is* the price; two above it, where the thousandth is noise. Zero prints as `free` instead of `$0.000`.

## Testing?

- **Unit** (written first, watched fail): the exact string from the menu (`0.19999999999999998` → `$0.2`), the cheap-model digits (`$0.075`), the dear-model rounding (`3.7500001` → `$3.75`), and `free`.
- **Manual, local stack**: opened the `+` → Model menu before and after.

```
before   OpenAI: GPT-5.6 Luna 1050k · $0.19999999999999998/$1.2 per 1M
after    OpenAI: GPT-5.6 Luna 1050k · $0.2/$1.2 per 1M
```

  The rest of the menu, unchanged and correct: `Claude Opus 5 1000k · $5/$25`, `Z.ai: GLM 5.3 Flash 1311k · $0.075/$0.25`, `Google: Gemini 3.7 Flash 1049k · $0.75/$3.75`.

## Anything Else?

Found by opening the menu in a browser, which is the only place a price is ever read. The catalogue PR verified the Settings select and a real turn, and never opened the composer menu itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KNGMMYSbWxEJCssaxzFMAv