### PR TITLE
Keep the thread list tied to the brand it belongs to

### DIFF
--- a/changelog/2026-09-02-chat-threads-brand-leak.md
+++ b/changelog/2026-09-02-chat-threads-brand-leak.md
@@ -1,0 +1,23 @@
+# Le chat del brand di prima, nella sidebar del brand nuovo
+
+Riportato: si crea un brand da uno che ha già delle chat, e nella sidebar del brand appena nato
+compaiono le conversazioni di quello di prima. Spariscono «dopo un po'» — cioè quando arriva la
+lista vera.
+
+`chatThreads` è UNO store per tutta la shell, e niente lo legava al brand di cui contiene la lista.
+Chi la ripuliva erano due posti, e nessuno dei due copre questo passaggio:
+
+- `beforeNavigate` in `app/[brand]/+layout.svelte` confronta lo slug di partenza con quello di
+  arrivo — creando un brand si passa da `/app/onboarding`, che uno slug non ce l'ha, quindi il
+  confronto non scatta né all'andata né al ritorno;
+- l'effect di `DashboardSidebar` confronta con il brand del render precedente, ma su quel percorso
+  la sidebar si SMONTA (rotta fuori dalla shell del brand) e si rimonta senza un brand di prima —
+  mentre lo store, che vive nel modulo, la sopravvive intatto.
+
+Il confronto ora sta dove passano tutti: `refreshThreads(slug)` ricorda di che brand è la lista che
+ha in memoria e, se gliene chiedono un'altra, butta quella vecchia PRIMA di partire con la fetch.
+Un solo posto, e vale per qualunque strada porti a un brand diverso — non solo per la creazione.
+
+Alla sidebar resta il compito che è suo e solo suo: mollare il thread aperto quando il brand cambia
+davvero (mai al primo mount, o un deep link a una chat verrebbe cancellato prima che ChatColumn si
+allinei all'URL).

--- a/src/lib/components/DashboardSidebar.svelte
+++ b/src/lib/components/DashboardSidebar.svelte
@@ -284,15 +284,13 @@
   // sopra la pagina viva (PageModal), quindi un clic sbagliato costa un Esc. Niente nemmeno il
   // pannello dei figli sull'hover: era il terzo modo di arrivare alle stesse sottopagine.
 
-  // Thread caricati subito, e azzerati solo quando il brand cambia davvero: azzerarli al primo
-  // mount cancellerebbe un thread deep-linked prima che ChatColumn si allinei all'URL.
+  // Il thread aperto si molla solo quando il brand cambia davvero: mollarlo al primo mount
+  // cancellerebbe un thread deep-linked prima che ChatColumn si allinei all'URL. La lista la
+  // azzera `refreshThreads`, che sa a quale brand appartiene quella che ha in memoria.
   let threadsBrandSlug = $state<string | null>(null);
   $effect(() => {
     const slug = brandSlug || null;
-    if (threadsBrandSlug !== null && threadsBrandSlug !== slug) {
-      chatThreads.set([]);
-      chatThreadId.set(null);
-    }
+    if (threadsBrandSlug !== null && threadsBrandSlug !== slug) chatThreadId.set(null);
     threadsBrandSlug = slug;
     if (slug) refreshThreads(slug);
   });

--- a/src/lib/content/changelog/2026-09-02-brand-chat-list.ts
+++ b/src/lib/content/changelog/2026-09-02-brand-chat-list.ts
@@ -1,0 +1,9 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-02',
+  title: 'A new brand starts with an empty chat list',
+  items: [
+    'Creating a brand while working in another one no longer shows the previous brand’s conversations in the new brand’s sidebar.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/stores/chat.test.ts
+++ b/src/lib/stores/chat.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { get } from 'svelte/store';
 import {
   chatThreadId,
+  chatThreads,
   clearUnread,
   markThreadRead,
   markThreadUnread,
@@ -113,5 +114,46 @@ describe('refreshThreads non chiede la stessa lista più volte insieme', () => {
     await refreshThreads('acme');
     await refreshThreads('acme');
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+/**
+ * Riportato il 2/9: da un brand con delle chat se ne crea uno nuovo, e la sidebar del brand nuovo
+ * mostra ancora le chat di quello di prima — spariscono «dopo un po'», cioè quando la lista nuova
+ * arriva. La lista in memoria è di UN brand solo: appena se ne chiede un altro, quella di prima
+ * non vale più. Il reset stava nella sidebar, che al passaggio per una rotta senza brand (la
+ * creazione) si rimonta e non ha un brand precedente da confrontare.
+ */
+describe('la lista dei thread appartiene a un brand solo', () => {
+  beforeEach(() => {
+    chatThreads.set([]);
+    unreadThreadIds.set(new Map());
+    chatThreadId.set(null);
+  });
+
+  it('cambiando brand la lista di prima sparisce subito, non quando arriva la nuova', async () => {
+    let resolve!: (v: Response) => void;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => new Promise<Response>((r) => (resolve = r)))
+    );
+
+    const first = refreshThreads('acme');
+    resolve(
+      new Response(JSON.stringify({ threads: [{ id: 't1', unread: true, unread_count: 2 }] }), {
+        status: 200
+      })
+    );
+    await first;
+    expect(get(chatThreads)).toHaveLength(1);
+    expect(get(unreadThreadIds).size).toBe(1);
+
+    const second = refreshThreads('brand-nuovo');
+    expect(get(chatThreads)).toEqual([]);
+    expect(get(unreadThreadIds).size).toBe(0);
+
+    resolve(new Response(JSON.stringify({ threads: [] }), { status: 200 }));
+    await second;
+    vi.unstubAllGlobals();
   });
 });

--- a/src/lib/stores/chat.ts
+++ b/src/lib/stores/chat.ts
@@ -124,7 +124,21 @@ export function markThreadRead(brandSlug: string, threadId: string): void {
  */
 const threadsInFlight = new Map<string, Promise<void>>();
 
+/**
+ * Di CHI è la lista che sta in memoria. Lo store è uno solo per tutta la shell, e finché non
+ * arrivava la lista nuova continuava a mostrare quella del brand precedente: creando un brand si
+ * passa da una rotta senza slug, quindi né la sidebar (che si rimonta) né `beforeNavigate` (che
+ * confronta due slug) avevano un brand di prima da riconoscere. Qui il confronto c'è sempre.
+ */
+let listedBrand: string | null = null;
+
 export function refreshThreads(brandSlug: string): Promise<void> {
+  if (listedBrand !== brandSlug) {
+    listedBrand = brandSlug;
+    chatThreads.set([]);
+    unreadThreadIds.set(new Map());
+  }
+
   const running = threadsInFlight.get(brandSlug);
   if (running) return running;
 


### PR DESCRIPTION
## What?

La sidebar di un brand appena creato mostrava le conversazioni del brand da cui si veniva, e le
teneva a schermo finché la lista vera non arrivava. `chatThreads` è uno store solo per tutta la
shell, e niente lo legava al brand di cui contiene le righe: ora `refreshThreads(slug)` ricorda di
chi è la lista che ha in memoria e la butta **prima** di partire con la fetch di un altro brand.
Alla sidebar resta il compito che è suo — mollare il thread aperto quando il brand cambia davvero.

Chiude la task Notion **#135** ("Quando stai in un brand con le chat, e ne crei uno nuovo di brand,
quello nuovo mostra ancora le chat dell'altro brand nella sidebar").

## Why?

È il primo schermo di un brand appena nato: mostrarci dentro le conversazioni di un altro cliente
non è un dettaglio estetico, è una fuga di contesto apparente — chi crea il secondo brand non ha
modo di sapere che quelle righe non sono sue finché non spariscono da sole. E spariscono tardi:
la lista dei thread è sei query lato server, quindi la finestra dura quanto la risposta.

## How?

I due posti che ripulivano la lista non coprono questo passaggio, e nessuno dei due poteva:

- `beforeNavigate` in `app/[brand]/+layout.svelte` confronta lo slug di partenza con quello di
  arrivo, e `/app/onboarding` — da cui passa la creazione — uno slug non ce l'ha (è in
  `NON_BRAND_APP_SEGMENTS`): il confronto non scatta né all'andata né al ritorno;
- l'effect di `DashboardSidebar` confronta col brand del render precedente, ma su quella rotta la
  sidebar si **smonta** e torna senza un brand di prima, mentre lo store, che vive nel modulo, la
  sopravvive intatto.

Scartato: aggiungere un terzo confronto in un terzo posto (la rotta del wizard). Il confronto ora
sta nell'imbuto da cui passano tutti e sette i chiamanti — `refreshThreads` — quindi vale per
qualunque strada porti a un brand diverso, non solo per la creazione. La sidebar non azzera più
la lista: quella riga era il duplicato che divergeva.

## Testing?

**Unit** — un test nuovo in `src/lib/stores/chat.test.ts`, scritto rosso prima del fix: cambiando
brand la lista di prima sparisce **subito**, non quando arriva la nuova (sincrono, prima che la
fetch risolva). Suite intera: **6229 passed, 4 skipped, 0 failed**.

**Manuale, browser reale, stack locale** — login `test@anomalia.so` sul brand `demo` (108 chat in
sidebar), navigazione client-side verso `/app/onboarding` (la rotta senza brand da cui il wizard
porta al brand nuovo) e da lì dentro `audit-ecommerce`, che di thread non ne ha nessuno. Rete
rallentata via CDP (latenza 400 ms): in locale la lista torna in decine di millisecondi e la
finestra del difetto è invisibile — in produzione dura quanto la load.

| | chat del brand precedente viste sul brand nuovo |
|---|---|
| prima | **108** (campionate ogni 100 ms per 6 s) |
| dopo | **0** |

Stress, tutto dopo il fix: brand con chat proprie (la lista giusta arriva, 4 righe, e quella di
prima non compare mai); 5 giri avanti e indietro fra due brand → 0 righe del brand sbagliato;
back/forward del browser, 4+4 → 0.

**Non testato**: la creazione di un brand *vera* end-to-end (il wizard richiede l'analisi del sito
e una spesa AI). Riprodotta la forma esatta della navigazione — brand → rotta senza brand →
brand — che è la condizione del difetto. Rischio: nessuno noto; il cambiamento è sottrattivo
(una lista in meno a schermo, mai una in più).

## Evidence

Screenshot catturati sull'app del worktree contro lo stack locale (`localhost:8000`), non su
hosted. Sono in `/tmp/anomalia-verify/` sulla macchina di sviluppo:

- `before-3-leak.png` — arrivo su `/app/audit-ecommerce`: in basso a sinistra il brand è **Retro
  Vogue**, che ha 0 thread, e la sidebar è quella di **Demo Brand**, 108 righe.
- `after-4-settled.png` — stesso percorso, stesso istante, con il fix: sidebar vuota, come deve
  essere per un brand senza conversazioni.

Architettura della verifica:
- Local DB: [x] compose self-hosted, `PUBLIC_SUPABASE_URL=http://localhost:8000`
- Worktree app running: [x] porta 5176, env overlay (mai l'.env del repo)
- Login: [x] `test@anomalia.so` / `123456`

## Anything Else?

`DashboardSidebar` tiene ancora il proprio `threadsBrandSlug`, ma solo per mollare il **thread
aperto** al cambio brand: azzerarlo al primo mount cancellerebbe un thread deep-linked prima che
ChatColumn si allinei all'URL.

Tocca `src/routes/app/[brand]/+layout.svelte`? No — ma la PR di `fix/thread-switch-stale-transcript`
e quella di `fix/dm-thread-identity` sì, entrambe: chi merga per secondo rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GpsbC3tQzxsBSg4Cns3x1C
