### PR TITLE
Give a private agent thread the two agents in it

### DIFF
--- a/changelog/2026-09-02-dm-thread-identity.md
+++ b/changelog/2026-09-02-dm-thread-identity.md
@@ -1,0 +1,26 @@
+# Il thread privato fra due agenti si chiamava Anomalia
+
+Dal chip «1 messaggio con Content Creator» si entra nel thread privato fra i due agenti, e in
+testa c'era **Anomalia** — nome e faccia del generalista, che in quel thread non c'è. Le battute
+avevano già l'etichetta di chi le ha scritte, ma l'avatar accanto era lo stesso neutro per tutti e
+due.
+
+La causa è che un DM non assomiglia a niente di quello che `threadIdentity` sapeva leggere: `agent`
+e `custom_agent_id` sono null (li lascia così `getOrCreateDmThread`), `room_agents` porta un
+OGGETTO invece dell'array delle stanze — apposta, così per il codice delle room «non è una
+stanza» — e il thread è escluso dalla lista in sidebar, quindi non arriva nemmeno la riga con gli
+avatar risolti dal server. Restava l'ultimo ripiego: Anomalia.
+
+I due membri stanno nel marcatore, con i loro nomi: si leggono da lì. `threadIdentity` ha il suo
+ramo DM (nome = i due, faccia = il primo), la testata mostra la pila di entrambi, e ogni battuta
+prende il volto del membro che l'ha scritta. L'avatar di un membro DM ora si deriva in UN posto —
+`dmMemberAvatar` — che è lo stesso che disegna la chip: la faccia che vedi nel chip e quella che
+trovi entrando sono la stessa per costruzione, non per coincidenza. La chip aveva la sua copia
+della derivazione, ed è stata tolta.
+
+## L'intestazione che il modello si scriveva da solo
+
+Nello stesso DM le risposte aprivano con «Allegato: risposta operativa ad Analyst.»: il modello si
+etichettava la battuta perché niente altro diceva chi scriveva a chi. Ora lo dicono la firma di
+ogni riga e la testata, e il brief del DM — l'unico posto che governa quel turno — chiude la porta
+alla riga di intestazione invece di lasciarla all'iniziativa del modello.

--- a/src/lib/chat-dm.test.ts
+++ b/src/lib/chat-dm.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 import {
+  dmBrief,
   dmReplyBackMessage,
   dmSendsFromCall,
   dmSendsFromOutput,
@@ -86,5 +87,24 @@ describe('la chip sta su ogni surface, come lo sticker', () => {
     ]) {
       expect(reads(f)).toContain('<ChatDmChip');
     }
+  });
+});
+
+/**
+ * Misurato su un DM vero (2/9): la risposta del Content Creator all'Analyst apriva con
+ * «Allegato: risposta operativa ad Analyst.» — una riga di trasporto, non di merito. Il modello
+ * si etichettava la battuta perché niente altro diceva chi scriveva a chi; adesso lo dicono la
+ * firma di ogni battuta e la testata del thread, e il brief chiude la porta all'intestazione.
+ */
+describe('dmBrief', () => {
+  it('vieta la riga di intestazione, in entrambe le lingue', () => {
+    expect(dmBrief('Content Creator', 'Analyst', 'it')).toContain('niente riga di intestazione');
+    expect(dmBrief('Content Creator', 'Analyst', 'en')).toContain('no header line');
+  });
+
+  it('nomina i due agenti: chi risponde e a chi', () => {
+    const brief = dmBrief('Content Creator', 'Analyst', 'it');
+    expect(brief).toContain('Content Creator');
+    expect(brief).toContain('Analyst');
   });
 });

--- a/src/lib/chat-dm.ts
+++ b/src/lib/chat-dm.ts
@@ -13,6 +13,13 @@
  * battute senza una query sui custom agent a ogni render.
  */
 
+import {
+  BUILTIN_AGENT_AVATARS,
+  fallbackAvatarColor,
+  fallbackAvatarFace,
+  type AgentAvatarFace
+} from '$lib/agent-avatars';
+
 export type DmMarker = { dm: [string, string]; names?: Record<string, string> };
 
 /**
@@ -43,6 +50,35 @@ export function dmNames(raw: unknown): Record<string, string> {
   return out;
 }
 
+/**
+ * Volto e colore di un membro di un DM. I builtin hanno un'identità fissa; un custom
+ * (`custom:<uuid>`) il suo avatar nel marcatore non ce l'ha, quindi vale la derivazione
+ * deterministica del resto del prodotto — una faccia stabile basta a riconoscerlo.
+ *
+ * ponytail: per un custom agent questa faccia non è quella SALVATA su `custom_agents` — è
+ * derivata, quindi in un DM ha un volto e in sidebar un altro. Si chiude scrivendo l'avatar nel
+ * marcatore alla creazione del DM (accanto a `names`), il giorno in cui la differenza dà fastidio.
+ */
+export function dmMemberAvatar(key: string): { face: AgentAvatarFace; color: string } {
+  return (
+    BUILTIN_AGENT_AVATARS[key] ?? { face: fallbackAvatarFace(key), color: fallbackAvatarColor(key) }
+  );
+}
+
+/**
+ * I due membri come avatar, nell'ordine del marcatore: la pila che sidebar e testata disegnano.
+ * null se il thread non è un DM. È l'UNICA derivazione dell'avatar di un membro DM — la chip
+ * «N messaggi con X» e la testata del thread devono mostrare la stessa faccia.
+ */
+export function dmAvatars(
+  raw: unknown
+): Array<{ id: string; name: string; face: AgentAvatarFace; color: string }> | null {
+  const pair = dmAgents(raw);
+  if (!pair) return null;
+  const names = dmNames(raw);
+  return pair.map((key) => ({ id: key, name: names[key] || key, ...dmMemberAvatar(key) }));
+}
+
 /** Il marcatore da scrivere alla creazione. La coppia è ordinata: (A,B) e (B,A) sono LO stesso DM. */
 export function dmMarker(a: { key: string; name: string }, b: { key: string; name: string }): DmMarker {
   const pair = [a.key, b.key].sort() as [string, string];
@@ -57,8 +93,8 @@ export function dmMarker(a: { key: string; name: string }, b: { key: string; nam
  */
 export function dmBrief(meName: string, otherName: string, locale: string): string {
   return locale === 'en'
-    ? `## PRIVATE AGENT CHAT — READ FIRST\nThis thread is NOT a conversation with the end user. It is a private thread between two AI agents of this brand: you (**${meName}**) and **${otherName}**. Every "user" message here was written by ${otherName} — an AI agent, never a human. Reply TO ${otherName}: concise and operational — facts, decisions, blockers, next steps. NEVER greet or address the user or the brand, never introduce yourself, no customer-facing prose. The user can read this thread but cannot write in it.\nIf the request needs the PERSON — a decision, an approval, a question only they can answer, a result to hand over — OPEN YOUR OWN USER SESSION: call open_session_with_user with your visible opening line to them. It opens your own user thread (the one with your face in the sidebar), writes your line, and puts you to work there. Then tell ${otherName} in ONE line that you did, so they can point the user to it. Do not do the user-facing work here and do not write your answer as if the user could reply.\nIf the request needs an action of your craft, do it with your tools and report the outcome. Your reply text IS your message to ${otherName} — do not use message_agent here.`
-    : `## CHAT PRIVATA TRA AGENTI — LEGGI PRIMA\nQuesto thread NON è una conversazione con l'utente finale. È un thread privato fra due agenti AI di questo brand: tu (**${meName}**) e **${otherName}**. Ogni messaggio "user" qui l'ha scritto ${otherName} — un agente AI, mai una persona. Rispondi A ${otherName}: conciso e operativo — fatti, decisioni, blocchi, prossimi passi. MAI salutare o rivolgerti all'utente o al brand, mai presentarti, niente prosa da cliente. L'utente può leggere questo thread ma non scriverci.\nSe la richiesta ha bisogno della PERSONA — una scelta, un'approvazione, una domanda che solo lei può rispondere, un risultato da consegnare — APRI LA TUA SESSIONE UTENTE: chiama open_session_with_user con la tua riga di apertura rivolta a lei. Apre il tuo thread utente (quello con la tua faccia in sidebar), scrive la tua riga e ti mette al lavoro lì. Poi di' a ${otherName} in UNA riga che l'hai fatto, così può indirizzare l'utente lì. Non fare il lavoro per l'utente qui e non scrivere la tua risposta come se l'utente potesse rispondere.\nSe serve un'azione del tuo mestiere, falla con i tuoi tool e riferisci l'esito. Il testo della tua risposta È il messaggio per ${otherName} — non usare message_agent qui.`;
+    ? `## PRIVATE AGENT CHAT — READ FIRST\nThis thread is NOT a conversation with the end user. It is a private thread between two AI agents of this brand: you (**${meName}**) and **${otherName}**. Every "user" message here was written by ${otherName} — an AI agent, never a human. Reply TO ${otherName}: concise and operational — facts, decisions, blockers, next steps. NEVER greet or address the user or the brand, never introduce yourself, no customer-facing prose. The user can read this thread but cannot write in it.\nIf the request needs the PERSON — a decision, an approval, a question only they can answer, a result to hand over — OPEN YOUR OWN USER SESSION: call open_session_with_user with your visible opening line to them. It opens your own user thread (the one with your face in the sidebar), writes your line, and puts you to work there. Then tell ${otherName} in ONE line that you did, so they can point the user to it. Do not do the user-facing work here and do not write your answer as if the user could reply.\nIf the request needs an action of your craft, do it with your tools and report the outcome. Your reply text IS your message to ${otherName} — do not use message_agent here. Start with the substance: no header line, no \"Attachment:\", no recipient name on top — every line here is already signed with who wrote it.`
+    : `## CHAT PRIVATA TRA AGENTI — LEGGI PRIMA\nQuesto thread NON è una conversazione con l'utente finale. È un thread privato fra due agenti AI di questo brand: tu (**${meName}**) e **${otherName}**. Ogni messaggio "user" qui l'ha scritto ${otherName} — un agente AI, mai una persona. Rispondi A ${otherName}: conciso e operativo — fatti, decisioni, blocchi, prossimi passi. MAI salutare o rivolgerti all'utente o al brand, mai presentarti, niente prosa da cliente. L'utente può leggere questo thread ma non scriverci.\nSe la richiesta ha bisogno della PERSONA — una scelta, un'approvazione, una domanda che solo lei può rispondere, un risultato da consegnare — APRI LA TUA SESSIONE UTENTE: chiama open_session_with_user con la tua riga di apertura rivolta a lei. Apre il tuo thread utente (quello con la tua faccia in sidebar), scrive la tua riga e ti mette al lavoro lì. Poi di' a ${otherName} in UNA riga che l'hai fatto, così può indirizzare l'utente lì. Non fare il lavoro per l'utente qui e non scrivere la tua risposta come se l'utente potesse rispondere.\nSe serve un'azione del tuo mestiere, falla con i tuoi tool e riferisci l'esito. Il testo della tua risposta È il messaggio per ${otherName} — non usare message_agent qui. Attacca dal merito: niente riga di intestazione, niente «Allegato:», niente nome del destinatario in cima — ogni battuta qui porta già la firma di chi l'ha scritta.`;
 }
 
 /**

--- a/src/lib/components/ChatDmChip.svelte
+++ b/src/lib/components/ChatDmChip.svelte
@@ -1,12 +1,7 @@
 <script lang="ts">
   import { _ } from 'svelte-i18n';
   import AgentAvatar from '$lib/components/AgentAvatar.svelte';
-  import {
-    BUILTIN_AGENT_AVATARS,
-    fallbackAvatarColor,
-    fallbackAvatarFace
-  } from '$lib/agent-avatars';
-  import { dmSendsFromCall } from '$lib/chat-dm';
+  import { dmMemberAvatar, dmSendsFromCall } from '$lib/chat-dm';
 
   /**
    * La riga "N messaggi con X" sotto un turno che ha usato `message_agent`: un link compatto al
@@ -42,24 +37,12 @@
     return [...byThread.entries()];
   });
 
-  /** Il volto del destinatario: identità fissa per i builtin (`web`, `content`, …); per i
-   *  custom (`custom:<uuid>`) la stessa derivazione deterministica del resto del prodotto —
-   *  l'avatar salvato non viaggia nel tool output, e una faccia stabile basta a riconoscerlo. */
-  function avatarFor(g: { to: string; name: string }) {
-    const seed = g.to || g.name;
-    return (
-      BUILTIN_AGENT_AVATARS[g.to] ?? {
-        face: fallbackAvatarFace(seed),
-        color: fallbackAvatarColor(seed)
-      }
-    );
-  }
 </script>
 
 {#if groups.length}
   <div class="dm-chips">
     {#each groups as [threadId, g] (threadId)}
-      {@const av = avatarFor(g)}
+      {@const av = dmMemberAvatar(g.to || g.name)}
       <a class="dm-chip" href={`/app/${brandSlug}/chat/${threadId}`}>
         <AgentAvatar face={av.face} color={av.color} size={16} title={g.name} />
         <span>{$_('chat.dmChip', { values: { n: g.n, name: g.name } })}</span>

--- a/src/lib/content/changelog/2026-09-02-agent-dm-identity.ts
+++ b/src/lib/content/changelog/2026-09-02-agent-dm-identity.ts
@@ -1,0 +1,11 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-02',
+  title: 'A private agent chat now shows the two agents in it',
+  items: [
+    'Opening the private thread between two of your agents now shows both of them — names and faces — instead of the generic Anomalia identity.',
+    'Each line in that thread carries the face of the agent who wrote it, the same face you see on the “N messages with…” link that took you there.',
+    'Agents no longer open their replies to each other with a header line naming the recipient.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/thread-identity.test.ts
+++ b/src/lib/thread-identity.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { composerIdentity, roomMemberAvatar, threadIdentity } from './thread-identity';
+import { dmAvatars } from './chat-dm';
 import {
   BUILTIN_AGENT_AVATARS,
   DEFAULT_CHAT_AGENT_AVATAR,
@@ -141,9 +142,63 @@ describe('threadIdentity: chat di gruppo', () => {
     expect(who.name).toBe('Content Creator, motion');
   });
 
-  it('un DM (oggetto, non array) non è una stanza: resta la risoluzione di prima', () => {
+  it('un DM (oggetto, non array) non è una stanza: non entra nel ramo delle stanze', () => {
     const who = threadIdentity({ agent: 'content', room_agents: { dm: ['content', 'analyst'] } }, t);
-    expect(who.name).toBe('Content Creator');
+    expect(who.name).not.toContain(',');
+  });
+});
+
+/**
+ * Riportato il 2/9: dal chip «1 messaggio con Content Creator» si entra nel thread privato fra i
+ * due agenti e in testa c'è «Anomalia», nome e faccia — il generalista, che in quel thread non c'è.
+ * Un DM ha `agent` e `custom_agent_id` a null (lo crea `getOrCreateDmThread`) e `room_agents` come
+ * OGGETTO, quindi cadeva nell'ultimo ripiego. I due membri stanno nel marcatore: si leggono da lì.
+ */
+describe('threadIdentity: DM fra agenti', () => {
+  const dm = {
+    title: 'Analyst ⇄ Content Creator',
+    agent: null,
+    custom_agent_id: null,
+    room_agents: {
+      dm: ['analyst', 'content'],
+      names: { analyst: 'Analyst', content: 'Content Creator' }
+    }
+  };
+
+  it('si presenta con i DUE agenti, mai con Anomalia', () => {
+    const who = threadIdentity(dm, t);
+    expect(who.name).toBe('Analyst ⇄ Content Creator');
+    expect(who.face).toBe(BUILTIN_AGENT_AVATARS.analyst.face);
+    expect(who.color).toBe(BUILTIN_AGENT_AVATARS.analyst.color);
+    expect(who.fixed).toBe(true);
+  });
+
+  it('senza i nomi nel marcatore ripiega sulle etichette i18n, mai sulla chiave nuda tradotta', () => {
+    const who = threadIdentity({ agent: null, room_agents: { dm: ['content', 'web'] } }, t);
+    expect(who.name).toBe('Content Creator ⇄ web');
+  });
+
+  it('la coppia esce come pila di avatar: in testata si vedono entrambi', () => {
+    const stack = dmAvatars(dm.room_agents);
+    expect(stack?.map((a) => a.id)).toEqual(['analyst', 'content']);
+    expect(stack?.map((a) => a.name)).toEqual(['Analyst', 'Content Creator']);
+    expect(stack?.[1].face).toBe(BUILTIN_AGENT_AVATARS.content.face);
+  });
+
+  it('un agente custom non porta il suo avatar nel marcatore: faccia derivata, mai vuota', () => {
+    const key = 'custom:11111111-2222-3333-4444-555555555555';
+    const stack = dmAvatars({ dm: ['analyst', key], names: { [key]: 'Il Copy' } });
+    expect(stack?.[1]).toMatchObject({
+      id: key,
+      name: 'Il Copy',
+      face: fallbackAvatarFace(key),
+      color: fallbackAvatarColor(key)
+    });
+  });
+
+  it('un thread che non è un DM non ha pila', () => {
+    expect(dmAvatars(['content', 'web'])).toBeNull();
+    expect(dmAvatars(null)).toBeNull();
   });
 });
 

--- a/src/lib/thread-identity.ts
+++ b/src/lib/thread-identity.ts
@@ -11,6 +11,7 @@ import {
   type AgentAvatarFace
 } from '$lib/agent-avatars';
 import { JOB_OWNERS } from '$lib/agent-owners';
+import { dmAgents, dmMemberAvatar, dmNames } from '$lib/chat-dm';
 
 /** Il minimo di un thread che serve per dargli un volto e un nome. */
 export type ThreadIdentitySource = {
@@ -81,6 +82,8 @@ export function roomMemberAvatar(
 /**
  * Risolve nome + avatar di un thread. Il nome è SEMPRE l'agente, mai il titolo/riassunto: come in
  * una lista di messaggi l'identità è il contatto.
+ * - DM fra agenti (`room_agents` OGGETTO) → i due membri, con la faccia del primo. Non ha un
+ *   agente né una riga in lista: tutto quello che serve sta nel marcatore.
  * - `agent = 'job:<key>'` (LEGACY) → nome della routine con la faccia dell'agente PROPRIETARIO.
  * - thread con custom agent → il suo nome e il suo avatar salvati; finché non è risolto resta
  *   "Anomalia", mai l'etichetta dello specialista che gli sta sotto.
@@ -110,6 +113,20 @@ export function threadIdentity(
       name: translated === i18nKey ? title || 'Anomalia' : translated,
       face: ownerAvatar?.face ?? fallbackAvatarFace(key),
       color: ownerAvatar?.color ?? fallbackAvatarColor(key),
+      fixed: true
+    };
+  }
+
+  // DM fra agenti: l'identità sono i DUE, e stanno nel marcatore. Un DM non ha `agent` né
+  // `custom_agent_id` e non compare nella lista dei thread, quindi senza questo ramo cadeva
+  // nell'ultimo ripiego e si presentava come Anomalia — il generalista, che lì dentro non c'è.
+  const pair = dmAgents(thread.room_agents);
+  if (pair) {
+    const names = dmNames(thread.room_agents);
+    const memberName = (key: string) => names[key] || roomMemberName(key, thread.agents, t);
+    return {
+      name: pair.map(memberName).join(' ⇄ '),
+      ...dmMemberAvatar(pair[0]),
       fixed: true
     };
   }

--- a/src/routes/app/[brand]/+layout.svelte
+++ b/src/routes/app/[brand]/+layout.svelte
@@ -48,6 +48,7 @@
   import { brandChannel } from '$lib/realtime/brand-channel.svelte';
   import { get } from 'svelte/store';
   import { chatThreadId, chatThreads, markThreadUnread, refreshThreads, unreadThreadIds } from '$lib/stores/chat';
+  import { dmAvatars } from '$lib/chat-dm';
   import { roomMemberKeys, threadIdentity, type ThreadIdentitySource } from '$lib/thread-identity';
   import { hasAds, hasWebHub } from '$lib/plans';
   let { data, children } = $props();
@@ -145,8 +146,12 @@
       if (t) {
         const who = threadIdentity(t, (k) => $_(k));
         // Una stanza (≥2 membri) non ha UN agente: nel topbar vanno tutti. Gli avatar sono già
-        // risolti dal server (`roomAvatars`), qui non si ricalcola niente.
-        const room = roomMemberKeys(t.room_agents).length >= 2 ? (t.agents ?? null) : null;
+        // risolti dal server (`roomAvatars`), qui non si ricalcola niente. Un DM ha due membri
+        // allo stesso modo, ma non passa dalla lista dei thread: la pila esce dal marcatore.
+        const room =
+          roomMemberKeys(t.room_agents).length >= 2
+            ? (t.agents ?? null)
+            : dmAvatars(t.room_agents);
         setPageMeta({
           title: who.name,
           subtitle: null,

--- a/src/routes/app/[brand]/chat/components/TranscriptList.svelte
+++ b/src/routes/app/[brand]/chat/components/TranscriptList.svelte
@@ -7,7 +7,7 @@
   import { dayDividers, firstUnreadIndex } from '$lib/chat-day-groups';
   import { renderMd, escapeChatText } from '$lib/chat-markdown';
   import { stripAttachedDocsForDisplay } from '$lib/chat-documents';
-  import { dmAgents, dmNames, isDmReplyBackMessage } from '$lib/chat-dm';
+  import { dmAgents, dmMemberAvatar, dmNames, isDmReplyBackMessage } from '$lib/chat-dm';
   import { roomMemberAvatar, roomMemberKeys, roomMemberName, threadIdentity } from '$lib/thread-identity';
   import { chatThreads } from '$lib/stores/chat';
   import type { ChatStreamState, StreamToolCallState } from '$lib/chat-stream-events';
@@ -143,8 +143,11 @@
   );
   const speakerLabel = (name: string | null | undefined) =>
     dmPair ? dmSpeakerLabel(name) : roomMemberName(name ?? '', roomAgentList, (k) => $_(k));
-  const speakerAvatar = (name: string | null | undefined) =>
-    roomKeys.length >= 2 && name ? roomMemberAvatar(name, roomAgentList) : threadWho;
+  const speakerAvatar = (name: string | null | undefined) => {
+    if (!name) return threadWho;
+    if (dmPair) return dmMemberAvatar(name);
+    return roomKeys.length >= 2 ? roomMemberAvatar(name, roomAgentList) : threadWho;
+  };
 
   /** Chi sta parlando ora: in una stanza la voce cambia a ogni battuta. La firma arriva dal
    * server (header `X-Chat-Speaker`, o `speaker` del job accodato). */


### PR DESCRIPTION
## What?

Entrando nel thread privato fra due agenti — quello dietro la chip "N messaggi con X" — in testa
c'era **Anomalia**, nome e faccia del generalista, che in quel thread non c'è; e le battute, già
etichettate col nome di chi le aveva scritte, avevano tutte lo stesso avatar neutro accanto. Ora
il thread si presenta con i **due agenti** che ci stanno dentro, e ogni riga porta il volto del
membro che l'ha scritta. Nello stesso giro il brief del DM chiude la riga di intestazione che il
modello si scriveva da solo ("Allegato: risposta operativa ad Analyst.").

Chiude la task Notion **#136**.

## Why?

La chip dice "1 messaggio con Content Creator" e promette una destinazione. Se aprendola trovi un
agente che non è quello, non sai più se stai leggendo la conversazione giusta — e il thread è in
sola lettura, quindi non hai nemmeno il modo di chiederlo. È l'unico posto del prodotto dove si
vede il lavoro che gli agenti si passano fra loro: deve dire chi sono.

## How?

Un DM non assomiglia a niente di quello che `threadIdentity` sapeva leggere, e ognuna delle tre
ragioni è deliberata:

- `agent` e `custom_agent_id` sono null — `getOrCreateDmThread` non li scrive, perché il thread non
  è di nessuno dei due;
- `room_agents` porta un **oggetto** invece dell'array delle stanze, apposta: così `parseRoomAgents`
  lo scarta e per tutto il codice delle room un DM "non è una stanza" senza un solo `if` in più;
- il thread è **escluso** dalla lista in sidebar (in sidebar stanno solo le conversazioni con
  l'utente), quindi non arriva nemmeno la riga con gli avatar risolti dal server.

Sommate, lasciavano solo l'ultimo ripiego: Anomalia. Ma i due membri, con i loro nomi, stanno nel
marcatore da sempre — è per questo che ci sono. `threadIdentity` ha il suo ramo DM (nome = i due
separati da ⇄, faccia = il primo), la testata mostra la pila di entrambi, `TranscriptList` d&agrave; a
ogni battuta il volto del suo membro.

**Una derivazione sola.** L'avatar di un membro DM ora esce da `dmMemberAvatar` in `$lib/chat-dm`,
che è la stessa funzione che disegna la chip: la faccia sul link e quella dentro al thread sono
uguali per costruzione, non per coincidenza. `ChatDmChip` aveva la sua copia privata della
derivazione ed è stata tolta.

**Scartato**: mostrare *un* solo agente, il destinatario. Il marcatore ordina la coppia
alfabeticamente e non registra chi ha scritto per primo — la direzione non è una proprietà del
thread (lo stesso thread è riusato per sempre, in entrambi i versi). Inventarla avrebbe voluto dire
scrivere un dato nuovo per mostrarne uno arbitrario; i due nomi sono l'informazione vera.

**Sulla riga di intestazione**: la causa non è il modello che si allarga, è che niente diceva chi
scriveva a chi, e lui compensava etichettandosi la battuta. Adesso lo dicono la firma di ogni riga
e la testata; il brief del DM — l'unico posto che governa quel turno, non un `if` sparso — chiude
la porta esplicitamente invece di lasciarla all'iniziativa.

## Testing?

**Unit** — 5 test nuovi in `src/lib/thread-identity.test.ts`, scritti rossi prima del fix: un DM si
presenta con i due agenti e mai con Anomalia; senza i nomi nel marcatore ripiega sulle etichette
i18n; la coppia esce come pila di avatar; un agente custom ha una faccia derivata e mai vuota; un
thread che non è un DM non ha pila. Più 2 su `dmBrief` in `src/lib/chat-dm.test.ts`. Suite intera:
**6235 passed, 4 skipped, 0 failed**.

**Manuale, browser reale, stack locale** — login `test@anomalia.so`, brand `demo`, due DM veri già
presenti nel database locale (nati da run precedenti, non seminati a mano):

| thread | prima | dopo |
|---|---|---|
| `4a96bdad…` Analyst ⇄ Content Creator | testata **"Anomalia"**, avatar neutro | **"Analyst ⇄ Content Creator"**, i due volti |
| `95c02204…` Content Creator ⇄ Scriba Fischietto (agente **custom**) | testata **"Anomalia"** | **"Content Creator ⇄ Scriba Fischietto"**, faccia derivata |

In entrambi: le firme delle battute restano quelle giuste (`CONTENT CREATOR`, `ANALYST`,
`SCRIBA FISCHIETTO`) e il piede "Questa chat è tra agenti ed è in sola lettura" non cambia.

**Non testato**: la chip "N messaggi con X" ridisegnata da un turno vivo — richiede un turno con
`message_agent`, quindi una spesa AI reale. La derivazione dell'avatar che la chip usa è la stessa
funzione coperta dai test unitari, e il rendering della chip non è stato toccato oltre alla
sostituzione della copia privata. Non verificata nemmeno la sparizione della riga "Allegato:", che
è un comportamento del modello: si vedrà al prossimo DM vero.

## Evidence

Screenshot in `/tmp/anomalia-verify/` sulla macchina di sviluppo, catturati sull'app del worktree
contro lo stack locale:

- `before-dm-builtin.png` — `/app/demo/chat/4a96bdad`: in testa "Anomalia" col volto neutro, e lo
  stesso volto neutro accanto alla battuta.
- `after-dm-builtin.png` — stesso thread: "Analyst ⇄ Content Creator", i due volti nella pila, e la
  battuta col volto dell'Analyst che l'ha scritta.
- `after-dm-custom.png` — caso limite, il DM con l'agente custom: nome dal marcatore, faccia
  derivata in modo deterministico.

Architettura della verifica:
- Local DB: [x] `localhost:8000`
- Worktree app running: [x] porta 5177
- Login: [x] `test@anomalia.so` / `123456`, brand `demo`

## Anything Else?

Debito segnato in codice (`ponytail:` su `dmMemberAvatar`): per un agente **custom** la faccia in un
DM è derivata, non quella salvata su `custom_agents` — quindi lo stesso agente ha un volto nel DM e
un altro in sidebar. Si chiude scrivendo l'avatar nel marcatore alla creazione del DM, accanto ai
nomi; non l'ho fatto qui perché vale solo per i DM nuovi e la differenza oggi non è quella che
qualcuno ha riportato.

Tocca `src/routes/app/[brand]/+layout.svelte`, come `fix/thread-switch-stale-transcript`: chi merga
per secondo rebase (righe diverse, blocco import in comune).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GpsbC3tQzxsBSg4Cns3x1C
