### PR TITLE
Wire the real billing provider back to gateCreditsCore

### DIFF
--- a/changelog/2026-09-02-anomalia-provider-was-a-stub.md
+++ b/changelog/2026-09-02-anomalia-provider-was-a-stub.md
@@ -1,0 +1,33 @@
+# anomalia-provider.ts non chiamava più gateCreditsCore
+
+`src/lib/server/billing/anomalia-provider.ts` era `throw new Error('not available in the
+open build')` fin dal primo commit di questo repo (`5ae5049`, l'import della build
+self-hostable). `billingProvider()` (`src/lib/server/billing/index.ts`) intercetta quel throw
+in un `try/catch` muto e ricade su `openBillingProvider` — `gate()` che non lancia mai,
+`quota()` sempre `Infinity`. `gateCredits()`, l'unico chokepoint chiamato dai 29 call site
+(17 diretti + 12 via `gateAiAction`), delega interamente a `billingProvider().gate(...)`: senza
+un provider `anomalia` reale, nessuno chiamava mai `gateCreditsCore` — la vera applicazione dei
+limiti, rimasta intatta e inutilizzata in `credits.ts:269-294`.
+
+Confermato non essere un meccanismo di sostituzione a build/deploy time: nessuna dipendenza
+privata in `package.json`, nessun `.npmrc`, nessun alias Vite/SvelteKit, nessuno script che scrive
+il file, un solo commit su tutta la storia git (`git log --all`). `anomaliaso/anomalia` è il repo
+pubblico da cui Vercel deploya in produzione (confermato via `vercel env ls` + Vercel API); nessuna
+fork privata che sostituisca questo file esiste oggi, in nessun posto verificabile.
+
+`anomalia-provider.ts` ora esporta un `anomaliaBillingProvider` reale: `gate('credits', ...)`
+chiama `gateCreditsCore`, `quota()` legge `creditQuota`/`postQuota` da `credits.ts`/`plans.ts`,
+`plansAbove`/`isTopPlan` delegano a `plans.ts`, `upgradeUrl` punta a
+`/app/<slug>/settings/billing`. Nessuna di queste funzioni è stata riscritta: erano già lì,
+pubbliche, semplicemente non collegate a niente.
+
+**Scartato:** aspettare l'estrazione fisica in un pacchetto npm privato ("split 2b", già
+menzionato nel changelog di agosto sul billing-come-plugin) prima di ripristinare il gating. I
+numeri reali (quote per piano, formula crediti) sono già pubblici in `credits.ts`/`plans.ts`: non
+c'è una seconda fuga di dati a tenerli anche nel file di collante. Il buco nel gating è urgente,
+l'estrazione in pacchetto privato no.
+
+Test aggiunti prima del fix, osservati falliti (rosso) sullo stub esistente, poi verdi:
+`src/lib/server/billing/anomalia-provider.test.ts` (nuovo), più un caso in
+`src/lib/server/billing/index.test.ts` che prova che `billingProvider()` sceglie il provider
+`anomalia` quando il modulo non lancia più.

--- a/src/lib/content/changelog/2026-09-02-credit-and-plan-limits.ts
+++ b/src/lib/content/changelog/2026-09-02-credit-and-plan-limits.ts
@@ -1,0 +1,9 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-02',
+  title: 'AI credit and plan limits are enforced again',
+  items: [
+    'Monthly AI credit and post limits for your plan are now applied correctly, closing a gap where they were not being checked.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/billing/anomalia-provider.test.ts
+++ b/src/lib/server/billing/anomalia-provider.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const gateCreditsCoreMock = vi.fn(async () => {});
+vi.mock('$lib/server/credits', () => ({
+	gateCreditsCore: gateCreditsCoreMock,
+	creditQuota: (plan: string | null | undefined) => (plan === 'pro' ? 4000 : 400)
+}));
+vi.mock('$lib/server/plans', () => ({
+	postQuota: (plan: string | null | undefined) => (plan === 'pro' ? 90 : 15),
+	plansAbove: (plan: string | null | undefined) => (plan === 'pro' ? [] : [{ key: 'pro' }]),
+	isTopPlan: (plan: string | null | undefined) => plan === 'pro'
+}));
+
+describe('anomaliaBillingProvider', () => {
+	it('is kind anomalia', async () => {
+		const { anomaliaBillingProvider } = await import('./anomalia-provider');
+		expect(anomaliaBillingProvider.kind).toBe('anomalia');
+	});
+
+	it('gate("credits", ...) calls the real enforcement, not a no-op', async () => {
+		const { anomaliaBillingProvider } = await import('./anomalia-provider');
+		await anomaliaBillingProvider.gate('credits', { brandId: 'brand-1' });
+		expect(gateCreditsCoreMock).toHaveBeenCalledWith('brand-1');
+	});
+
+	it('gate("credits", ...) propagates a denial from gateCreditsCore', async () => {
+		gateCreditsCoreMock.mockRejectedValueOnce(new Error('exhausted'));
+		const { anomaliaBillingProvider } = await import('./anomalia-provider');
+		await expect(anomaliaBillingProvider.gate('credits', { brandId: 'brand-1' })).rejects.toThrow(
+			'exhausted'
+		);
+	});
+
+	it('quota("credits", ...) reads the real per-plan quota', async () => {
+		const { anomaliaBillingProvider } = await import('./anomalia-provider');
+		await expect(anomaliaBillingProvider.quota('credits', { brandId: 'b', plan: 'pro' })).resolves.toBe(
+			4000
+		);
+		await expect(anomaliaBillingProvider.quota('credits', { brandId: 'b', plan: null })).resolves.toBe(
+			400
+		);
+	});
+
+	it('quota("posts", ...) reads the real per-plan quota', async () => {
+		const { anomaliaBillingProvider } = await import('./anomalia-provider');
+		await expect(anomaliaBillingProvider.quota('posts', { brandId: 'b', plan: 'pro' })).resolves.toBe(
+			90
+		);
+	});
+
+	it('plansAbove/isTopPlan delegate to the real plan ladder', async () => {
+		const { anomaliaBillingProvider } = await import('./anomalia-provider');
+		expect(anomaliaBillingProvider.plansAbove('pro')).toEqual([]);
+		expect(anomaliaBillingProvider.isTopPlan('pro')).toBe(true);
+		expect(anomaliaBillingProvider.isTopPlan(null)).toBe(false);
+	});
+
+	it('upgradeUrl points at the brand billing settings when a slug is known', async () => {
+		const { anomaliaBillingProvider } = await import('./anomalia-provider');
+		expect(anomaliaBillingProvider.upgradeUrl({ brandId: 'b', brandSlug: 'demo' })).toBe(
+			'/app/demo/settings/billing'
+		);
+		expect(anomaliaBillingProvider.upgradeUrl({ brandId: 'b' })).toBeUndefined();
+	});
+});

--- a/src/lib/server/billing/anomalia-provider.ts
+++ b/src/lib/server/billing/anomalia-provider.ts
@@ -1,3 +1,29 @@
-throw new Error('not available in the open build')
+import type { BillingProvider } from '$lib/billing/contract';
+import { creditQuota, gateCreditsCore } from '$lib/server/credits';
+import { isTopPlan, plansAbove, postQuota } from '$lib/server/plans';
 
-export {}
+export const anomaliaBillingProvider: BillingProvider = {
+  kind: 'anomalia',
+
+  async gate(kind, ctx) {
+    if (kind === 'credits') {
+      await gateCreditsCore(ctx.brandId);
+    }
+  },
+
+  async quota(kind, ctx) {
+    return kind === 'credits' ? creditQuota(ctx.plan) : postQuota(ctx.plan);
+  },
+
+  upgradeUrl(ctx) {
+    return ctx.brandSlug ? `/app/${ctx.brandSlug}/settings/billing` : undefined;
+  },
+
+  plansAbove(plan) {
+    return plansAbove(plan);
+  },
+
+  isTopPlan(plan) {
+    return isTopPlan(plan);
+  }
+};

--- a/src/lib/server/billing/index.test.ts
+++ b/src/lib/server/billing/index.test.ts
@@ -17,3 +17,24 @@ describe('billingProvider()', () => {
 		await expect(provider.gate('credits', { brandId: 'brand-1' })).resolves.toBeUndefined();
 	});
 });
+
+describe('billingProvider() with the real anomalia-provider present', () => {
+	it('picks the anomalia provider instead of falling back to open', async () => {
+		vi.resetModules();
+		vi.doUnmock('./anomalia-provider');
+		vi.doMock('$lib/server/credits', () => ({
+			gateCreditsCore: async () => {},
+			creditQuota: () => 400
+		}));
+		vi.doMock('$lib/server/plans', () => ({
+			postQuota: () => 15,
+			plansAbove: () => [],
+			isTopPlan: () => false
+		}));
+
+		const { billingProvider } = await import('./index');
+		const provider = await billingProvider();
+
+		expect(provider.kind).toBe('anomalia');
+	});
+});


### PR DESCRIPTION
## What?
`anomalia-provider.ts` has thrown `not available in the open build`
since this repo's very first commit. `billingProvider()` catches that
silently and falls back to `openBillingProvider` (`gate()` never
throws, `quota()` is `Infinity`), so `gateCredits()` — the chokepoint
all 29 credit-gate call sites use (17 direct + 12 via `gateAiAction`)
— never reached `gateCreditsCore`, the real enforcement. This restores
it: `anomalia-provider.ts` now wires the existing
`gateCreditsCore`/`creditQuota`/`postQuota`/`plansAbove`/`isTopPlan`
into the `BillingProvider` interface. None of that logic is rewritten,
only connected.

## Why?
`anomaliaso/anomalia` (this repo, `dev`/`main`) is confirmed to be
what Vercel deploys to production — not a stripped public mirror of a
separate private source. No private fork, private npm package, build
alias, or postinstall step was found anywhere that could substitute
this file. Since `BILLING_PROVIDER` is also unset in every Vercel
environment, there is no explicit "open" opt-in either — the fallback
happens purely because the module throws. Net effect: AI credit and
plan-based post limits have not been enforced in production since the
commit that introduced the stub, silently (the `catch` never logs).

## How?
- Read `credits.ts`/`plans.ts` to confirm the real enforcement
  (`gateCreditsCore`) and quota/plan-ladder helpers
  (`creditQuota`, `postQuota`, `plansAbove`, `isTopPlan`) were already
  there, intact, just never called from a live `anomalia` provider.
- Wrote `anomalia-provider.test.ts` **first**, ran it against the
  unmodified stub, watched all 7 cases fail with the stub's own throw
  — the red before the fix.
- Implemented `anomaliaBillingProvider` to satisfy the `BillingProvider`
  contract by delegating to those existing functions; `upgradeUrl`
  points at `/app/<slug>/settings/billing`, the one surface that
  already exists for it.
- Added one case to `index.test.ts` proving `billingProvider()` picks
  the `anomalia` provider once the module doesn't throw, instead of
  only testing the fallback path (which the existing test already
  covered).
- **Considered and rejected**: waiting for the physical extraction into
  a private npm package ("split 2b", mentioned in the original
  billing-as-plugin changelog) before restoring gating. The real
  numbers (per-plan quotas, credit formula) are already public in this
  same repo's `credits.ts`/`plans.ts` — wiring the glue file doesn't
  leak anything new, and the gap is urgent while the private-package
  extraction isn't.

## Testing?
`npx vitest run` on the touched files plus the surrounding suite —
`anomalia-provider.test.ts` (new, 7 cases), `index.test.ts` (existing
fallback case unchanged + 1 new case), `credits-billing-gate.test.ts`,
`credits.test.ts`, `plans.test.ts`, `contract.test.ts`,
`open-provider.test.ts`, `changelog/index.test.ts`: 62/62 passing.
`node scripts/typecheck-runtime.mjs`: no new fatal errors (357
pre-existing non-fatal, unchanged baseline).

Not tested: an actual browser/production run against real Supabase
data (this is a server-only gating path with no UI surface of its
own; the existing per-brand credits UI already reads from
`getCreditsUsage`, untouched here). Risk if wrong: a brand could be
gated incorrectly (false positive) or continue ungated (silent
false negative, same as today) — both bounded by `gateCreditsCore`'s
existing fail-open `catch` on any Supabase error.

## Evidence (screenshots/videos)
No UI surface — server-only gating logic.

<details>
<summary>Test run before the fix (red)</summary>

```
❯ src/lib/server/billing/anomalia-provider.test.ts (7 tests | 7 failed)
   × anomaliaBillingProvider > is kind anomalia
     → not available in the open build
   (6 more, same error)
❯ src/lib/server/billing/index.test.ts (2 tests | 1 failed)
   × billingProvider() with the real anomalia-provider present > picks the anomalia provider instead of falling back to open
     → expected 'open' to be 'anomalia'
```
</details>

<details>
<summary>Test run after the fix (green)</summary>

```
 Test Files  8 passed (8)
      Tests  62 passed (62)
```
</details>

<details>
<summary>Production evidence gathered while diagnosing (Vercel MCP)</summary>

- `vercel env ls` (all environments): no `BILLING_PROVIDER` variable
  exists anywhere.
- Latest READY production deployment's build log: no mention of
  `anomalia-provider`, `BILLING_PROVIDER`, or any private-registry
  install — plain `npm ci`.
- 7-day production runtime error clusters (44 total): zero contain
  `CreditsExhaustedError`, `QuotaExceededError`, or `PlanRequiredError`
  — the exceptions real enforcement would eventually throw.
</details>

## Anything Else?
This restores enforcement in the public repo as an immediate fix. The
originally intended architecture (billing logic physically extracted
into a private npm package, "split 2b" from the earlier
billing-as-plugin changelog) is still open future work — this PR does
not build that, it only stops the silent gap in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RgPP6gw4d7xW7Y92vJJrPZ