### PR TITLE
Let a thread be born with the model chosen before it existed

### DIFF
--- a/src/lib/chat-recipients.test.ts
+++ b/src/lib/chat-recipients.test.ts
@@ -52,6 +52,8 @@ describe('recipientsAgent — chi risponde lo dice il campo "A"', () => {
 
 describe('il composer usa QUESTA regola, non una copia', () => {
   const src = readFileSync(join(__dirname, 'components/ChatColumn.svelte'), 'utf8');
+  /** La chiamata su una riga sola: cosi` un a capo in piu` non spegne la guardia. */
+  const call = src.slice(src.indexOf('await createThread('), src.indexOf('await createThread(') + 400).replace(/\s+/g, ' ');
 
   it('il ramo senza thread chiede al campo "A" invece di riscrivere il default', () => {
     expect(src).toContain("from '$lib/chat-recipients'");
@@ -61,10 +63,15 @@ describe('il composer usa QUESTA regola, non una copia', () => {
   });
 
   it('il thread nasce con l’agente selezionato, non con una costante', () => {
-    expect(src).toMatch(/createThread\(brandSlug, undefined, agentSel, roomSel, /);
+    expect(call).toMatch(/^await createThread\( brandSlug, undefined, agentSel, roomSel, /);
   });
 
   it('l’agente custom scelto viaggia con la CREAZIONE del thread, non con una PATCH dopo', () => {
-    expect(src).toMatch(/createThread\(brandSlug, undefined, agentSel, roomSel, roomSel\.length \? null : customAgentSel\)/);
+    expect(call).toMatch(/roomSel\.length \? null : customAgentSel/);
+  });
+
+  /** Come l'agente, anche il modello: sceglierlo dalla home e ritrovare il default era un bug. */
+  it('e con lui la scelta di modello, per la stessa ragione', () => {
+    expect(call).toMatch(/policyForChoice\(chatTier, chatReasoning\)/);
   });
 });

--- a/src/lib/components/ChatColumn.svelte
+++ b/src/lib/components/ChatColumn.svelte
@@ -87,6 +87,7 @@
   import type { ChatMode } from '$lib/chat-modes';
   import { coerceChatTier, type ChatTier } from '$lib/chat-tiers';
   import { defaultReasoningFor, type ChatReasoning } from '$lib/chat-reasoning';
+  import { policyForChoice } from '$lib/chat-model-policy';
   import type { ChatAttachmentsPayload } from '$lib/chat-attachments';
   import {
     attachedDocNamesFromContent,
@@ -280,7 +281,8 @@
   const catalogModels = $derived(
     ($page.data as { chatModels?: Array<{ id: string; label: string; contextLength: number; inputUsdPerM: number; outputUsdPerM: number }> }).chatModels ?? []
   );
-  let chatTier = $state<ChatTier>('auto');
+  // null = nessuna scelta: la chat parte dal default del catalogo, e lo segue quando cambia.
+  let chatTier = $state<ChatTier | null>(null);
   let chatReasoning = $state<ChatReasoning>(defaultReasoningFor(null));
   const saveModelChoice = createModelChoiceSave({
     brandSlug: () => brandSlug,
@@ -855,7 +857,14 @@
     if (liveSendThreadId) return liveSendThreadId;
     // Chat di gruppo: la stanza scelta nel picker nasce insieme al thread, al primo messaggio.
     // Se il server la rifiuta (feature spenta, meno di due membri) resta un thread normale.
-    const id = await createThread(brandSlug, undefined, agentSel, roomSel, roomSel.length ? null : customAgentSel);
+    const id = await createThread(
+      brandSlug,
+      undefined,
+      agentSel,
+      roomSel,
+      roomSel.length ? null : customAgentSel,
+      policyForChoice(chatTier, chatReasoning)
+    );
     if (id) {
       liveSendThreadId = id;
       // Da qui in poi la stanza è il thread: la memoria del campo "A" copre solo l'attesa fra
@@ -1028,7 +1037,7 @@
     text?: string,
     meta?: {
       mode: ChatMode;
-      tier?: ChatTier;
+      tier?: ChatTier | null;
       reasoning?: ChatReasoning;
       command?: string;
       attachments?: ChatAttachmentsPayload;

--- a/src/lib/components/ChatPrompt.svelte
+++ b/src/lib/components/ChatPrompt.svelte
@@ -89,7 +89,7 @@
     /** Chiave sessionStorage per far sopravvivere il testo non inviato a un refresh. Vuota = off. */
     draftKey = '',
     mode = $bindable<ChatMode>('agent'),
-    tier = $bindable<ChatTier>('fast'),
+    tier = $bindable<ChatTier | null>(null),
     reasoning = $bindable<ChatReasoning>(defaultReasoningFor(null)),
     onsubmit = (_text: string, _meta?: ChatSubmitMeta) => {},
     onstop = () => {},

--- a/src/lib/server/chat-models.test.ts
+++ b/src/lib/server/chat-models.test.ts
@@ -1,4 +1,16 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+/**
+ * La vetrina viene dalla TABELLA quando c'e`, e da `LLM_MODELS` quando non c'e`. Qui si prova il
+ * secondo caso, quindi la tabella deve essere davvero assente — non "assente sul database che
+ * questa macchina riesce a raggiungere". Senza questo mock la suite passava solo finche' la
+ * migration non era applicata, e ha iniziato a fallire il giorno in cui lo e` stata.
+ */
+vi.mock('$lib/server/supabase-admin', () => ({
+  createAdminClient: () => {
+    throw new Error('nessun catalogo in questo test');
+  }
+}));
 import { __resetGatewayModels, ensureGatewayModels } from './openrouter-models';
 import { chatModelChoices } from './chat-models';
 

--- a/src/lib/server/chat/persistence.ts
+++ b/src/lib/server/chat/persistence.ts
@@ -71,7 +71,11 @@ export async function createThread(
   // I thread di squadra nascono con surface='team' + surface_key=<agentId>, per essere ritrovabili
   // senza ambiguità fra le normali chat dell'utente con lo stesso specialista.
   surface: string | null = null,
-  surfaceKey: string | null = null
+  surfaceKey: string | null = null,
+  // La scelta di modello fatta nel composer PRIMA che il thread esistesse: senza, il thread nasce
+  // senza preferenza e il picker torna al default appena l'app ci naviga sopra — da fuori sembra
+  // che la selezione non abbia avuto effetto.
+  model: unknown = null
 ): Promise<ChatThreadRow | null> {
   const { data } = await supabase
     .from('chat_threads')
@@ -81,7 +85,8 @@ export async function createThread(
       title,
       post_id: postId,
       agent,
-      ...(surface ? { surface, surface_key: surfaceKey } : {})
+      ...(surface ? { surface, surface_key: surfaceKey } : {}),
+      ...(model ? { model } : {})
     })
     .select('*')
     .single();

--- a/src/lib/stores/chat-session.ts
+++ b/src/lib/stores/chat-session.ts
@@ -505,8 +505,8 @@ export async function startChatSession(opts: {
     tabs: Array<{ href: string; label: string }>;
   };
   mode?: 'agent' | 'plan' | 'ask';
-  /** Auto = the app picks, Fast = Gemini 3.7 Flash, Pro = Grok via kie, plus named custom models (DeepSeek Pro, GPT 5.6 Terra/Sol). */
-  tier?: ChatTier;
+  /** Un id del catalogo, o un custom model. `null` = nessuna scelta: decide il default. */
+  tier?: ChatTier | null;
   /** Reasoning effort for this turn; mapped per provider server-side. */
   reasoning?: ChatReasoning;
   /** Specialized agent id (publish/brand/grow/web) — scopes prompt + tools for this turn. */
@@ -1075,7 +1075,7 @@ export async function enqueueChatMessage(opts: {
   threadId: string;
   userText: string;
   mode?: 'agent' | 'plan' | 'ask';
-  tier?: ChatTier;
+  tier?: ChatTier | null;
   reasoning?: ChatReasoning;
   agent?: string | null;
   documents?: Array<{ name: string; markdown?: string; title?: string | null; path?: string }>;

--- a/src/lib/stores/chat.ts
+++ b/src/lib/stores/chat.ts
@@ -181,7 +181,10 @@ export async function createThread(
   title?: string,
   agent?: string,
   agents?: string[],
-  customAgentId?: string | null
+  customAgentId?: string | null,
+  // La scelta di modello fatta nel composer prima che il thread esistesse: senza, il thread nasce
+  // senza preferenza e il picker torna al default appena l'app ci naviga sopra.
+  model?: unknown
 ): Promise<string | null> {
   try {
     console.log('[createThread] Creating thread for:', brandSlug);
@@ -192,6 +195,7 @@ export async function createThread(
         title: title ?? undefined,
         agent: agent ?? undefined,
         custom_agent_id: customAgentId ?? undefined,
+        ...(model ? { model } : {}),
         ...(agents && agents.length >= 2 ? { agents } : {})
       })
     });

--- a/src/routes/app/[brand]/chat/+server.ts
+++ b/src/routes/app/[brand]/chat/+server.ts
@@ -31,7 +31,8 @@ import { hasWebHub } from '$lib/server/plans';
 import { reportChatError, CHAT_USER_ERROR } from '$lib/server/chat/report-error';
 import { withStepDeadline } from '$lib/server/chat/step-deadline';
 import { getChatRateUsage, chatRateLimitResponse, chatCreditsBlocked } from '$lib/server/chat/rate-limits';
-import { isChatTier } from '$lib/chat-tiers';
+import { coerceChatTier, isChatTier } from '$lib/chat-tiers';
+import { policyForChoice } from '$lib/chat-model-policy';
 import { threadModelPreference } from '$lib/server/chat/model-preference';
 import { withBrandContext } from '$lib/server/ai-log';
 import { shouldUseKit, runKitTurn } from '$lib/agent/bridge/live';
@@ -99,18 +100,25 @@ export const POST: RequestHandler = async ({ request, params, locals: { supabase
     threadRoomAgents = thread.room_agents ?? null;
     threadModel = (thread as { model?: unknown }).model ?? null;
   } else {
+    // Il thread nasce con la scelta fatta nel composer: da `/app/<brand>` il thread non esiste
+    // ancora, quindi `createModelChoiceSave` non ha nessuno a cui scriverla e viaggia solo qui.
+    const bornWith = policyForChoice(coerceChatTier(body.tier), body.reasoning);
     const thread = await createThread(
       supabase,
       brand.id,
       user.id,
       'Nuova chat',
       null,
-      resolveAgentForPlan(body.agent, webHubEnabled)
+      resolveAgentForPlan(body.agent, webHubEnabled),
+      null,
+      null,
+      bornWith
     );
     if (!thread) return new Response('Failed to create thread', { status: 500 });
     threadId = thread.id;
     threadAgent = thread.agent;
     threadCustomAgentId = thread.custom_agent_id ?? null;
+    threadModel = bornWith;
   }
 
   type ApprovalRecord = { id: string; run_id: string; status: string; tool_call_id: string; harness_approval_id: string };

--- a/src/routes/app/[brand]/chat/[thread]/+page.svelte
+++ b/src/routes/app/[brand]/chat/[thread]/+page.svelte
@@ -145,7 +145,8 @@
   let input = $state('');
   let chatMode = $state<ChatMode>('agent');
   const brandDefaultTier = $derived(coerceChatTier($page.data.brand?.chat_default_tier));
-  let chatTier = $state<ChatTier>('auto');
+  // null = nessuna scelta: la chat parte dal default del catalogo, e lo segue quando cambia.
+  let chatTier = $state<ChatTier | null>(null);
   let chatReasoning = $state<ChatReasoning>(defaultReasoningFor(null));
   const saveModelChoice = createModelChoiceSave({
     brandSlug: () => data.brandSlug,
@@ -710,7 +711,7 @@
     text?: string,
     meta?: {
       mode: ChatMode;
-      tier?: ChatTier;
+      tier?: ChatTier | null;
       reasoning?: ChatReasoning;
       command?: string;
       attachments?: ChatAttachmentsPayload;

--- a/src/routes/app/[brand]/chat/components/ComposerDock.svelte
+++ b/src/routes/app/[brand]/chat/components/ComposerDock.svelte
@@ -20,7 +20,7 @@
 
   type SubmitMeta = {
     mode: ChatMode;
-    tier?: ChatTier;
+    tier?: ChatTier | null;
     chatModels?: Array<{ id: string; label: string; contextLength: number; inputUsdPerM: number; outputUsdPerM: number }>;
     reasoning?: ChatReasoning;
     command?: string;
@@ -40,7 +40,7 @@
     queueBusy,
     value = $bindable(''),
     mode = $bindable('agent' as ChatMode),
-    tier = $bindable('auto' as ChatTier),
+    tier = $bindable<ChatTier | null>(null),
     reasoning = $bindable(),
     chatModels = [],
     agentOptions,
@@ -68,7 +68,7 @@
     queueBusy: boolean;
     value?: string;
     mode?: ChatMode;
-    tier?: ChatTier;
+    tier?: ChatTier | null;
     reasoning?: ChatReasoning;
     agentOptions: AgentMeta[] | null;
     agentLocked: boolean;
@@ -77,7 +77,7 @@
     onsubmit: (text?: string, meta?: SubmitMeta, opts?: { resend?: boolean; redoMessageId?: string; truncateFromMessageId?: string }) => void | Promise<void>;
     onstop: () => void;
     onagentchange: (id: string) => void | Promise<void>;
-    onmodelchange?: (choice: { tier: ChatTier; reasoning: ChatReasoning }) => void;
+    onmodelchange?: (choice: { tier: ChatTier | null; reasoning: ChatReasoning }) => void;
     onqueueedit: (jobId: string, text: string) => void | Promise<void>;
     onqueuedelete: (jobId: string) => void | Promise<void>;
     onqueuesendnow: (jobId: string) => void | Promise<void>;

--- a/src/routes/app/[brand]/chat/new-thread-model.test.ts
+++ b/src/routes/app/[brand]/chat/new-thread-model.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+/**
+ * LA SCELTA FATTA PRIMA CHE IL THREAD ESISTA.
+ *
+ * Dal composer di `/app/<brand>` non c'e` ancora un thread, quindi `createModelChoiceSave` non
+ * salva niente: la scelta viaggia solo nel payload del turno. Il turno gira sul modello giusto —
+ * e poi l'app naviga sul thread appena nato, che nasce SENZA preferenza, e il picker torna a
+ * mostrare il default. Da fuori sembra che la selezione non abbia avuto effetto.
+ *
+ * Il thread deve nascere con la scelta che l'ha creato.
+ */
+const read = (rel: string) => readFileSync(fileURLToPath(new URL(rel, import.meta.url)), 'utf8');
+
+vi.mock('$env/dynamic/private', () => ({ env: {} }));
+
+function fakeSupabase() {
+  const inserts: Array<Record<string, unknown>> = [];
+  const client = {
+    from: () => ({
+      insert: (row: Record<string, unknown>) => {
+        inserts.push(row);
+        return {
+          select: () => ({ single: async () => ({ data: { id: 'thread-1', created_at: 'now' } }) })
+        };
+      },
+      upsert: async () => ({ error: null })
+    })
+  } as unknown as SupabaseClient;
+  return { client, inserts };
+}
+
+describe('un thread nasce con la scelta di modello del turno che lo ha creato', () => {
+  it('createThread scrive la preferenza sulla riga', async () => {
+    const { createThread } = await import('$lib/server/chat/persistence');
+    const { client, inserts } = fakeSupabase();
+
+    await createThread(client, 'brand-1', 'user-1', 'Nuova chat', null, null, null, null, {
+      family: 'luna',
+      thinking: 'high',
+      model: 'anthropic/claude-opus-5'
+    });
+
+    expect(inserts[0]?.model).toEqual({
+      family: 'luna',
+      thinking: 'high',
+      model: 'anthropic/claude-opus-5'
+    });
+  });
+
+  it('senza scelta la riga non porta un model finto', async () => {
+    const { createThread } = await import('$lib/server/chat/persistence');
+    const { client, inserts } = fakeSupabase();
+
+    await createThread(client, 'brand-1', 'user-1');
+
+    expect(inserts[0]).not.toHaveProperty('model');
+  });
+
+  /**
+   * Il difetto non stava in `createThread`, stava in chi lo chiama: il POST della chat creava il
+   * thread e buttava via `tier` e `reasoning` del corpo. Un test sul solo `createThread` non
+   * sarebbe mai fallito.
+   */
+  /**
+   * IL PERCORSO VERO, e quello che il primo fix aveva mancato. Dalla home il thread NON nasce dal
+   * POST della chat: il composer chiama prima `POST /chat/threads` e poi manda il turno su un
+   * thread che esiste gia`. La suite era verde e il bug era ancora li` — l'ha trovato il browser.
+   */
+  it('la creazione del thread dalla home porta con se\' la scelta', () => {
+    const store = read('../../../../lib/stores/chat.ts');
+    const create = store.slice(store.indexOf('export async function createThread('), store.indexOf('[createThread] Response status'));
+    expect(create).toMatch(/model/);
+
+    const endpoint = read('./threads/+server.ts');
+    const post = endpoint.slice(endpoint.indexOf('// POST: create a new thread'), endpoint.indexOf('const customAgentId ='));
+    expect(post).toMatch(/turnModelFamily/);
+
+    const column = read('../../../../lib/components/ChatColumn.svelte');
+    expect(column).toMatch(/createThread\([\s\S]{0,220}policyForChoice/);
+  });
+
+  it('il POST della chat passa la scelta del turno al thread che crea', () => {
+    const server = read('./+server.ts');
+    const call = server.indexOf('await createThread(');
+    const start = server.lastIndexOf('} else {', call);
+    const branch = server.slice(start, server.indexOf('\n  }', call));
+
+    // La scelta del corpo diventa la riga del thread...
+    expect(branch).toMatch(/policyForChoice/);
+    // ...e vale anche per QUESTO turno, non solo per i successivi.
+    expect(branch).toMatch(/threadModel = /);
+  });
+});

--- a/src/routes/app/[brand]/chat/threads/+server.ts
+++ b/src/routes/app/[brand]/chat/threads/+server.ts
@@ -109,7 +109,10 @@ export const POST: RequestHandler = async ({ request, params, locals: { supabase
   // Optional: bind the specialized agent right at creation (multi-agent chat).
   const agent = resolveAgentForPlan(body.agent, hasWebHub(brand.plan));
 
-  const thread = await createThread(supabase, brand.id, user.id, title, null, agent);
+  // Il thread nasce con la scelta gia` fatta nel composer: da `/app/<brand>` il picker non ha
+  // ancora un thread a cui scriverla, e senza questa riga si perde al primo passo.
+  const bornWith = body.model === undefined || body.model === null ? null : turnModelFamily(body.model);
+  const thread = await createThread(supabase, brand.id, user.id, title, null, agent, null, null, bornWith);
 
   const customAgentId =
     typeof body.custom_agent_id === 'string' && body.custom_agent_id ? body.custom_agent_id : null;


### PR DESCRIPTION
## What?

Scegliendo un modello (o un livello di ragionamento) dal composer di `/app/<brand>` — cioè **prima**
che il thread esista — la selezione spariva: il turno girava sul modello giusto, ma appena l'app
navigava sul thread appena nato il picker tornava a mostrare il default, come se non avesse avuto
effetto.

Ora il thread nasce con la scelta che l'ha creato, esattamente come già faceva con l'agente
selezionato.

## Why?

Dalla home il picker non ha un thread a cui scrivere, quindi `createModelChoiceSave` non salva
niente (lo dice il suo stesso commento) e la scelta viaggia solo nel payload del turno. Il thread
veniva creato senza preferenza, e `hydrate(thread.model)` sul thread page leggeva `null` → default.

## How?

**Il primo fix era nel posto sbagliato, ed è la parte che vale la pena raccontare.** Il POST della
chat crea davvero un thread quando non ne riceve uno, e adesso porta la scelta — ma **non è il
percorso che la home usa**: il composer chiama prima `POST /chat/threads` e solo dopo manda il
turno su un thread che esiste già. La suite era verde e il bug era ancora lì. L'ha trovato il
browser, non i test.

Quindi la scelta viaggia con la creazione su **entrambi** i percorsi:

- `stores/chat.ts createThread()` accetta e invia `model`;
- `POST /chat/threads` lo valida con `turnModelFamily` (la stessa funzione che già usa la PATCH) e
  lo passa a `createThread`;
- `ChatColumn` lo costruisce con `policyForChoice(chatTier, chatReasoning)`;
- `createThread` (server) scrive la riga solo se c'è, così un thread senza scelta non porta un
  `model` finto.

Sistemati anche i quattro inizializzatori di stato del tier rimasti su `'auto'` / `'fast'`: dopo la
rimozione dei preset avrebbero stampato nel menu il nome grezzo di un preset che non risolve più
niente.

## Testing?

Suite intera verde (6312).

Nuovo `new-thread-model.test.ts`, scritto **rosso prima del fix**: che `createThread` scriva la
preferenza, che senza scelta non inventi un `model`, e — nello stile di `stop-affordance.test.ts`
già presente qui — che **i chiamanti la passino davvero**, su entrambi i percorsi. È la parte che
il primo tentativo aveva mancato: un test sul solo `createThread` sarebbe rimasto verde col bug
vivo.

Aggiornati i due test di `chat-recipients` che pinnavano la chiamata su una riga sola: ora guardano
la sostanza e non la formattazione, e ne è stato aggiunto uno sul modello per la stessa ragione per
cui esistevano quelli sull'agente.

Pinnato infine `chat-models.test.ts` a un catalogo davvero assente: leggeva la tabella viva, quindi
passava solo finché la migration non era applicata e ha iniziato a fallire il giorno in cui lo è
stata.

## Evidence

<details><summary>Prima e dopo, stessa sequenza dal browser</summary>

```
# prima
select model from chat_threads where id='cbfe6bd3…';
 (vuoto)          ← il picker mostrava "Default"

# dopo
select model from chat_threads where id='2570b54b…';
 {"model": "z-ai/glm-5.3-flash", "family": "luna", "thinking": "medium"}
```

Nel browser, dopo la navigazione **e** dopo un reload: `["Model: Z.ai: GLM 5.3 Flash", "Reasoning: Medium"]`.
</details>

## Anything Else?

Nessuna migration. Un thread creato prima di questo fix resta senza preferenza e continua a seguire
il default — è il comportamento giusto, non ci sono righe da correggere.
