### PR TITLE
Stop draining a dead turn before answering the next one

### DIFF
--- a/src/lib/agent/bridge/adapters.ts
+++ b/src/lib/agent/bridge/adapters.ts
@@ -38,6 +38,7 @@ import { MODEL_FAMILIES } from '$lib/models/catalog';
 import { MODEL_FAMILY_IDS } from '@anomalia/agent-contracts/contracts';
 import { llmApiKey, llmBaseUrl, llmLanguageModel, llmModelForPicker, llmModels } from '$lib/server/llm';
 import { defaultChatModelId } from '$lib/server/chat-model-catalog';
+import { reuseDecision } from './harness-reuse';
 import { gatewayModel, usableGatewayModels } from '$lib/server/openrouter-models';
 import { isGatewayModelTier } from '$lib/chat-tiers';
 import { ServerBrandFs } from '@anomalia/agent-adapters/brand-fs';
@@ -381,25 +382,20 @@ export async function startHarnessTurn(opts: {
 		/**
 		 * RIUSARE UNA SESSIONE E` UN'OTTIMIZZAZIONE, NON UN OBBLIGO — e da quando Stop aborta il
 		 * turno davvero, la sessione viva resta con un turno NON finito. Il messaggio dopo la
-		 * ritrovava qui, provava a drenarla e moriva: «already has a turn in progress». Fermare
-		 * una chat la rompeva per il turno successivo, cioe` il contrario di cio` che Stop fa.
+		 * ritrovava qui e provava a drenarla; la regola di `harness-reuse.ts` dice invece di
+		 * sfrattarla, perche' quel drain costava 60 secondi al primo token e non salvava niente.
 		 *
-		 * `continueGenerate` era fuori dal try: proteggeva solo l'attesa del testo, non la
-		 * chiamata che lancia. Adesso qualunque inciampo nel riuso SFRATTA la voce e si cade sulla
-		 * creazione pulita qui sotto — si paga un avvio invece di propagare una sessione
-		 * avvelenata a ogni turno futuro di quel thread.
+		 * Qualunque inciampo nel riuso SFRATTA la voce e si cade sulla creazione pulita qui sotto
+		 * — si paga un avvio invece di propagare una sessione avvelenata a ogni turno futuro di
+		 * quel thread.
 		 */
 		try {
-			const rawSession = cached.session as {
-				hasUnfinishedTurn?: () => boolean;
-			};
-			if (rawSession.hasUnfinishedTurn?.() && !hasApprovalResponse(opts.messages)) {
-				const drained = await (cached.agent as {
-					continueGenerate: (o: { session: unknown }) => Promise<{ text?: Promise<string> }>;
-				}).continueGenerate({ session: cached.session });
-				try {
-					await drained.text;
-				} catch {}
+			const rawSession = cached.session as { hasUnfinishedTurn?: () => boolean };
+			// Un turno non finito NON si drena qui: `continueGenerate` non tornava, il guardiano a
+			// 60 secondi era l'unica cosa che sbloccava la chat, e si ripartiva comunque da zero.
+			// Si sfratta e si paga l'avvio subito — che è ciò che si pagava comunque, un minuto prima.
+			if (reuseDecision(rawSession, { isApprovalResponse: hasApprovalResponse(opts.messages) }) === 'evict') {
+				throw new Error('stale_harness_session');
 			}
 			return {
 				result: await (cached.agent as typeof agent).stream({

--- a/src/lib/agent/bridge/harness-reuse.test.ts
+++ b/src/lib/agent/bridge/harness-reuse.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { reuseDecision } from './harness-reuse';
+
+/**
+ * IL COSTO PAGATO, 2026-09-03. Su un thread gia` avviato il primo token arrivava dopo 78 secondi.
+ *
+ * Il ramo che riusa la sessione viva trovava un turno precedente NON finito e provava a drenarlo
+ * (`continueGenerate` + `await drained.text`). Il drain non tornava mai; il guardiano
+ * `HARNESS_START_TIMEOUT_MS` scattava a 60 secondi esatti; e solo allora si ripartiva con una
+ * sessione fresca, pagando comunque gli ~8s che si sarebbero pagati subito.
+ *
+ * Il riuso e` un'OTTIMIZZAZIONE: quando non e` gratis, non si fa. L'unico caso in cui un turno non
+ * finito va riusato e` la risposta a un'approvazione — quel turno e` fermo esattamente li`, ad
+ * aspettarla, e ripartire da capo perderebbe il lavoro gia` fatto.
+ */
+describe('cosa fare di una sessione viva trovata in cache', () => {
+  it('un turno non finito si sfratta: drenarlo costava 60 secondi al prossimo messaggio', () => {
+    expect(reuseDecision({ hasUnfinishedTurn: () => true }, { isApprovalResponse: false })).toBe('evict');
+  });
+
+  it("ma la risposta a un'approvazione riusa quel turno: e` lui che la sta aspettando", () => {
+    expect(reuseDecision({ hasUnfinishedTurn: () => true }, { isApprovalResponse: true })).toBe('reuse');
+  });
+
+  it('una sessione pulita si riusa: e` il caso per cui la cache esiste', () => {
+    expect(reuseDecision({ hasUnfinishedTurn: () => false }, { isApprovalResponse: false })).toBe('reuse');
+  });
+
+  /** Una sessione che non sa dire come sta non e` una ragione per buttarla. */
+  it('senza `hasUnfinishedTurn` si riusa', () => {
+    expect(reuseDecision({}, { isApprovalResponse: false })).toBe('reuse');
+  });
+});

--- a/src/lib/agent/bridge/harness-reuse.ts
+++ b/src/lib/agent/bridge/harness-reuse.ts
@@ -1,0 +1,22 @@
+/**
+ * Cosa fare di una sessione dell'harness trovata viva in cache.
+ *
+ * Riusarla è un'ottimizzazione: risparmia l'avvio, che è secondi. Quando smette di essere gratis,
+ * non si fa — ed è esattamente il caso che costava 78 secondi al primo token su un thread già
+ * avviato: la sessione aveva un turno non finito, si provava a drenarlo, il drain non tornava, e
+ * il guardiano a 60 secondi era l'unica cosa che sbloccava la chat. Poi si ripartiva comunque da
+ * zero. Sessanta secondi per non risparmiare niente.
+ *
+ * L'eccezione è una sola, e non è un'ottimizzazione: la risposta a un'approvazione. Quel turno non
+ * è finito perché sta fermo ad aspettare proprio quella, e buttarlo perderebbe il lavoro già
+ * fatto — insieme all'approvazione che l'utente ha appena dato.
+ */
+export type SessionReuse = 'reuse' | 'evict';
+
+export function reuseDecision(
+  session: { hasUnfinishedTurn?: () => boolean },
+  turn: { isApprovalResponse: boolean }
+): SessionReuse {
+  if (!session.hasUnfinishedTurn?.()) return 'reuse';
+  return turn.isApprovalResponse ? 'reuse' : 'evict';
+}

--- a/src/lib/server/chat-models.test.ts
+++ b/src/lib/server/chat-models.test.ts
@@ -1,4 +1,16 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+/**
+ * La vetrina viene dalla TABELLA quando c'e`, e da `LLM_MODELS` quando non c'e`. Qui si prova il
+ * secondo caso, quindi la tabella deve essere davvero assente — non "assente sul database che
+ * questa macchina riesce a raggiungere". Senza questo mock la suite passava solo finche' la
+ * migration non era applicata, e ha iniziato a fallire il giorno in cui lo e` stata.
+ */
+vi.mock('$lib/server/supabase-admin', () => ({
+  createAdminClient: () => {
+    throw new Error('nessun catalogo in questo test');
+  }
+}));
 import { __resetGatewayModels, ensureGatewayModels } from './openrouter-models';
 import { chatModelChoices } from './chat-models';
 


### PR DESCRIPTION
## What?

Su un thread già avviato il primo token arrivava dopo **78 secondi**. Sessanta di quei secondi
erano una singola attesa, e non servivano a niente.

Trovando una sessione viva in cache, il ramo del riuso vedeva un turno precedente mai finito e
provava a **drenarlo** (`continueGenerate`, poi `await drained.text`). Il drain non tornava. L'unica
cosa che sbloccava la chat era `HARNESS_START_TIMEOUT_MS`, a 60 secondi esatti — dopo i quali si
ripartiva comunque con una sessione fresca, pagando gli ~8s che si sarebbero pagati subito.

Il riuso è un'ottimizzazione: quando smette di essere gratis, non si fa.

## Why?

Misurato, non dedotto. Instrumentando i confini del turno kit:

```
thread già avviato, PRIMA
  skill caricate            +1ms
  prima di createSession    +60052ms   ← il drain, fino al guardiano
  createSession fatto       +8829ms    (secondo avvio, da capo)
  RESPONSE restituita       +78571ms

thread già avviato, DOPO
  skill caricate            +4ms
  prima di createSession    +5ms       ← sfrattata subito
  createSession fatto       +8047ms
  RESPONSE restituita       +9791ms
```

Dal client: `tHeaders` **78s → 10.5s** sullo stesso thread, stesso messaggio.

## How?

Un turno non finito **sfratta** la sessione e cade sull'avvio pulito, che era comunque l'esito.

L'eccezione è una sola e non è un'ottimizzazione: **la risposta a un'approvazione**. Quel turno non
è finito proprio perché sta aspettando quella, e buttarlo perderebbe il lavoro fatto insieme
all'approvazione appena data.

La regola sta in `harness-reuse.ts` con il suo test, invece che dentro l'`if` in cui era sepolta —
era una decisione di prodotto travestita da guardia difensiva.

## Testing?

Suite intera verde (6311). Nuovo `harness-reuse.test.ts`: sfratto sul turno non finito, riuso sulla
risposta a un'approvazione, riuso su sessione pulita, riuso quando la sessione non sa dire come sta.

Verificato sullo stack locale con browser reale, utente `test@anohmalia.so`, brand `demo`: turno
inviato dalla UI su un thread già avviato, risposta `UI-OK` in chat.

## Anything Else?

**Quello che resta NON è questo bug, ed è misurato:** `agent.createSession` ~8s e l'apertura della
sandbox ~1.6s, identici su un thread nuovo. La risposta HTTP resta chiusa finché entrambi non
finiscono — ed è per questo che sullo schermo non compare nulla nel frattempo.

Renderlo visibile vuol dire **aprire l'SSE prima che l'harness sia pronto** ed emettere lo stato
mentre parte: è un cambio alla forma di `runKitTurn`, non una riga, e merita una decisione sua.
Ridurre gli 8s va invece cercato dentro il boot dell'harness.

Due ipotesi sono state **falsificate** dalla misura, e vale la pena scriverlo: il system prompt
costa 379ms (non è lui), le skill 1ms (già parallele di fatto), e il modello non è nemmeno
coinvolto — il tempo è tutto prima che esista uno stream.

Questa PR porta anche la correzione di `chat-models.test.ts` già presente in #164: senza, la suite
di `dev` è rossa, perché quel test leggeva la tabella viva e la migration ora è applicata. Se #164
entra prima, le due modifiche sono identiche.
