### PR TITLE
Write the agent's skills into the sandbox in one command

### DIFF
--- a/patches/@ai-sdk+harness+1.0.87.patch
+++ b/patches/@ai-sdk+harness+1.0.87.patch
@@ -1,0 +1,105 @@
+diff --git a/node_modules/@ai-sdk/harness/dist/utils/index.js b/node_modules/@ai-sdk/harness/dist/utils/index.js
+index c6dc6e3..1e1bca8 100644
+--- a/node_modules/@ai-sdk/harness/dist/utils/index.js
++++ b/node_modules/@ai-sdk/harness/dist/utils/index.js
+@@ -548,6 +548,13 @@ async function writeSkills({
+     command: `mkdir -p ${shellQuote(rootDir)}`,
+     abortSignal
+   });
++  // anomalia: ogni writeTextFile e` un round-trip nella sandbox — due, in realta`: `mkdir -p` del
++  // padre, poi il file. In fila costavano ~450ms l'uno: 14 file = 6.9 secondi prima che la chat
++  // potesse rispondere. Qui i file partono TUTTI INSIEME, in un solo comando: le cartelle in una
++  // `mkdir -p` sola, i contenuti via base64 (nessun problema di quoting, il markdown puo`
++  // contenere qualunque cosa). Il fallback per riga esiste perche' `writeSkills` e` codice
++  // generico: una sandbox senza `base64` deve continuare a funzionare, piu` lenta ma giusta.
++  const writes = [];
+   for (const skill of skills) {
+     const name = validateSkillName({
+       name: skill.name,
+@@ -555,10 +562,9 @@ async function writeSkills({
+       message: invalidSkillNameMessage
+     });
+     const skillDir = path2.posix.join(rootDir, name);
+-    await sandbox.writeTextFile({
++    writes.push({
+       path: path2.posix.join(skillDir, "SKILL.md"),
+-      content: renderSkillFile({ skill, trailingNewline }),
+-      abortSignal
++      content: renderSkillFile({ skill, trailingNewline })
+     });
+     for (const file of (_b = skill.files) != null ? _b : []) {
+       const filePath = normalizeSkillFilePath({
+@@ -567,13 +573,70 @@ async function writeSkills({
+         mode: filePathMode,
+         message: invalidSkillFilePathMessage
+       });
+-      await sandbox.writeTextFile({
++      writes.push({
+         path: path2.posix.join(skillDir, filePath),
+-        content: file.content,
+-        abortSignal
++        content: file.content
+       });
+     }
+   }
++  const writeOneByOne = (list) =>
++    Promise.all(
++      list.map((w) => sandbox.writeTextFile({ path: w.path, content: w.content, abortSignal }))
++    );
++  if (writes.length === 0) {
++    return;
++  }
++  // Un comando solo sarebbe il minimo dei round-trip, ma bash rifiuta un argomento oltre
++  // MAX_ARG_STRLEN (128KB): «argument list too long», e si finiva nel fallback senza accorgersene.
++  // Quindi si spezza sotto quella soglia, con margine, e i pezzi partono insieme.
++  const MAX_SCRIPT_BYTES = 96 * 1024;
++  const encoded = writes.map((w) => ({
++    path: w.path,
++    content: w.content,
++    line: `printf %s ${shellQuote(Buffer.from(w.content, "utf8").toString("base64"))} | base64 -d > ${shellQuote(w.path)}`
++  }));
++  const dirs = [...new Set(writes.map((w) => path2.posix.dirname(w.path)))];
++  const chunks = [];
++  let current = [];
++  let size = 0;
++  for (const e of encoded) {
++    // Un singolo file oltre la soglia non stara` mai in un comando: va per la sua strada.
++    if (e.line.length > MAX_SCRIPT_BYTES) {
++      chunks.push([e]);
++      continue;
++    }
++    if (size + e.line.length > MAX_SCRIPT_BYTES && current.length > 0) {
++      chunks.push(current);
++      current = [];
++      size = 0;
++    }
++    current.push(e);
++    size += e.line.length + 4;
++  }
++  if (current.length > 0) {
++    chunks.push(current);
++  }
++  const runChunk = async (chunk, withDirs) => {
++    const script = [
++      ...withDirs ? [`mkdir -p ${dirs.map(shellQuote).join(" ")}`] : [],
++      ...chunk.map((e) => e.line)
++    ].join(" && ");
++    if (script.length > MAX_SCRIPT_BYTES) {
++      await writeOneByOne(chunk);
++      return;
++    }
++    try {
++      const result = await sandbox.run({ command: script, abortSignal });
++      if (result != null && typeof result === "object" && "exitCode" in result && result.exitCode !== 0) {
++        throw new Error(`writeSkills batch exited ${result.exitCode}`);
++      }
++    } catch {
++      await writeOneByOne(chunk);
++    }
++  };
++  // Le cartelle nel primo pezzo: gli altri ci scrivono dentro, e partono dopo.
++  await runChunk(chunks[0], true);
++  await Promise.all(chunks.slice(1).map((chunk) => runChunk(chunk, false)));
+ }
+ function validateSkillName({
+   name,

--- a/src/lib/agent/bridge/adapters.ts
+++ b/src/lib/agent/bridge/adapters.ts
@@ -38,6 +38,7 @@ import { MODEL_FAMILIES } from '$lib/models/catalog';
 import { MODEL_FAMILY_IDS } from '@anomalia/agent-contracts/contracts';
 import { llmApiKey, llmBaseUrl, llmLanguageModel, llmModelForPicker, llmModels } from '$lib/server/llm';
 import { defaultChatModelId } from '$lib/server/chat-model-catalog';
+import { reuseDecision } from './harness-reuse';
 import { gatewayModel, usableGatewayModels } from '$lib/server/openrouter-models';
 import { isGatewayModelTier } from '$lib/chat-tiers';
 import { ServerBrandFs } from '@anomalia/agent-adapters/brand-fs';
@@ -381,25 +382,20 @@ export async function startHarnessTurn(opts: {
 		/**
 		 * RIUSARE UNA SESSIONE E` UN'OTTIMIZZAZIONE, NON UN OBBLIGO — e da quando Stop aborta il
 		 * turno davvero, la sessione viva resta con un turno NON finito. Il messaggio dopo la
-		 * ritrovava qui, provava a drenarla e moriva: «already has a turn in progress». Fermare
-		 * una chat la rompeva per il turno successivo, cioe` il contrario di cio` che Stop fa.
+		 * ritrovava qui e provava a drenarla; la regola di `harness-reuse.ts` dice invece di
+		 * sfrattarla, perche' quel drain costava 60 secondi al primo token e non salvava niente.
 		 *
-		 * `continueGenerate` era fuori dal try: proteggeva solo l'attesa del testo, non la
-		 * chiamata che lancia. Adesso qualunque inciampo nel riuso SFRATTA la voce e si cade sulla
-		 * creazione pulita qui sotto — si paga un avvio invece di propagare una sessione
-		 * avvelenata a ogni turno futuro di quel thread.
+		 * Qualunque inciampo nel riuso SFRATTA la voce e si cade sulla creazione pulita qui sotto
+		 * — si paga un avvio invece di propagare una sessione avvelenata a ogni turno futuro di
+		 * quel thread.
 		 */
 		try {
-			const rawSession = cached.session as {
-				hasUnfinishedTurn?: () => boolean;
-			};
-			if (rawSession.hasUnfinishedTurn?.() && !hasApprovalResponse(opts.messages)) {
-				const drained = await (cached.agent as {
-					continueGenerate: (o: { session: unknown }) => Promise<{ text?: Promise<string> }>;
-				}).continueGenerate({ session: cached.session });
-				try {
-					await drained.text;
-				} catch {}
+			const rawSession = cached.session as { hasUnfinishedTurn?: () => boolean };
+			// Un turno non finito NON si drena qui: `continueGenerate` non tornava, il guardiano a
+			// 60 secondi era l'unica cosa che sbloccava la chat, e si ripartiva comunque da zero.
+			// Si sfratta e si paga l'avvio subito — che è ciò che si pagava comunque, un minuto prima.
+			if (reuseDecision(rawSession, { isApprovalResponse: hasApprovalResponse(opts.messages) }) === 'evict') {
+				throw new Error('stale_harness_session');
 			}
 			return {
 				result: await (cached.agent as typeof agent).stream({

--- a/src/lib/agent/bridge/harness-reuse.test.ts
+++ b/src/lib/agent/bridge/harness-reuse.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { reuseDecision } from './harness-reuse';
+
+/**
+ * IL COSTO PAGATO, 2026-09-03. Su un thread gia` avviato il primo token arrivava dopo 78 secondi.
+ *
+ * Il ramo che riusa la sessione viva trovava un turno precedente NON finito e provava a drenarlo
+ * (`continueGenerate` + `await drained.text`). Il drain non tornava mai; il guardiano
+ * `HARNESS_START_TIMEOUT_MS` scattava a 60 secondi esatti; e solo allora si ripartiva con una
+ * sessione fresca, pagando comunque gli ~8s che si sarebbero pagati subito.
+ *
+ * Il riuso e` un'OTTIMIZZAZIONE: quando non e` gratis, non si fa. L'unico caso in cui un turno non
+ * finito va riusato e` la risposta a un'approvazione — quel turno e` fermo esattamente li`, ad
+ * aspettarla, e ripartire da capo perderebbe il lavoro gia` fatto.
+ */
+describe('cosa fare di una sessione viva trovata in cache', () => {
+  it('un turno non finito si sfratta: drenarlo costava 60 secondi al prossimo messaggio', () => {
+    expect(reuseDecision({ hasUnfinishedTurn: () => true }, { isApprovalResponse: false })).toBe('evict');
+  });
+
+  it("ma la risposta a un'approvazione riusa quel turno: e` lui che la sta aspettando", () => {
+    expect(reuseDecision({ hasUnfinishedTurn: () => true }, { isApprovalResponse: true })).toBe('reuse');
+  });
+
+  it('una sessione pulita si riusa: e` il caso per cui la cache esiste', () => {
+    expect(reuseDecision({ hasUnfinishedTurn: () => false }, { isApprovalResponse: false })).toBe('reuse');
+  });
+
+  /** Una sessione che non sa dire come sta non e` una ragione per buttarla. */
+  it('senza `hasUnfinishedTurn` si riusa', () => {
+    expect(reuseDecision({}, { isApprovalResponse: false })).toBe('reuse');
+  });
+});

--- a/src/lib/agent/bridge/harness-reuse.ts
+++ b/src/lib/agent/bridge/harness-reuse.ts
@@ -1,0 +1,22 @@
+/**
+ * Cosa fare di una sessione dell'harness trovata viva in cache.
+ *
+ * Riusarla è un'ottimizzazione: risparmia l'avvio, che è secondi. Quando smette di essere gratis,
+ * non si fa — ed è esattamente il caso che costava 78 secondi al primo token su un thread già
+ * avviato: la sessione aveva un turno non finito, si provava a drenarlo, il drain non tornava, e
+ * il guardiano a 60 secondi era l'unica cosa che sbloccava la chat. Poi si ripartiva comunque da
+ * zero. Sessanta secondi per non risparmiare niente.
+ *
+ * L'eccezione è una sola, e non è un'ottimizzazione: la risposta a un'approvazione. Quel turno non
+ * è finito perché sta fermo ad aspettare proprio quella, e buttarlo perderebbe il lavoro già
+ * fatto — insieme all'approvazione che l'utente ha appena dato.
+ */
+export type SessionReuse = 'reuse' | 'evict';
+
+export function reuseDecision(
+  session: { hasUnfinishedTurn?: () => boolean },
+  turn: { isApprovalResponse: boolean }
+): SessionReuse {
+  if (!session.hasUnfinishedTurn?.()) return 'reuse';
+  return turn.isApprovalResponse ? 'reuse' : 'evict';
+}

--- a/src/lib/agent/bridge/harness-skill-writes.test.ts
+++ b/src/lib/agent/bridge/harness-skill-writes.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+import { writeSkills } from '@ai-sdk/harness/utils';
+
+/**
+ * IL COSTO PAGATO, 2026-09-03. Il primo token di una chat kit arrivava dopo ~10 secondi, e 6.9 di
+ * quelli erano `writeSkills`: 14 file scritti nella sandbox UNO ALLA VOLTA, ~450ms l'uno, perche'
+ * ogni `writeTextFile` e` un round-trip — due, in realta`: `mkdir -p` del padre, poi il file.
+ *
+ * Adesso partono tutti in un comando solo. La correzione vive in
+ * `patches/@ai-sdk+harness+1.0.87.patch`, quindi questo test guida la `writeSkills` INSTALLATA: se
+ * un bump di versione si porta via la patch, cade qui invece di tornare in silenzio a dieci
+ * secondi di attesa. (LESSONS: patch-package e i deploy.)
+ */
+const SKILLS = [
+  { name: 'humanizer', description: 'd', content: 'contenuto uno' },
+  {
+    name: 'social',
+    description: 'd',
+    content: 'contenuto due',
+    files: [
+      { path: 'references/platforms.md', content: "con 'apici' e \"virgolette\"" },
+      { path: 'references/post-templates.md', content: 'terzo' }
+    ]
+  }
+];
+
+const ROOT = '/home/agent/.agents/skills';
+
+describe('le skill vanno nella sandbox in un colpo solo', () => {
+  it('un comando solo, non un round-trip per file', async () => {
+    const commands: string[] = [];
+    const perFile: string[] = [];
+
+    await writeSkills({
+      sandbox: {
+        run: async ({ command }: { command: string }) => {
+          commands.push(command);
+          return { exitCode: 0 };
+        },
+        writeTextFile: async ({ path }: { path: string }) => {
+          perFile.push(path);
+        }
+      } as never,
+      rootDir: ROOT,
+      skills: SKILLS as never
+    });
+
+    // Uno per la radice (lo faceva gia`) e uno per tutto il resto.
+    expect(commands).toHaveLength(2);
+    expect(perFile).toEqual([]);
+    for (const p of ['humanizer/SKILL.md', 'social/SKILL.md', 'social/references/platforms.md']) {
+      expect(commands[1]).toContain(`${ROOT}/${p}`);
+    }
+  });
+
+  /** Un batch che scrive i byte sbagliati e` peggio di uno lento: il contenuto va verificato. */
+  it('i contenuti arrivano intatti, apici e virgolette compresi', async () => {
+    const commands: string[] = [];
+    await writeSkills({
+      sandbox: {
+        run: async ({ command }: { command: string }) => {
+          commands.push(command);
+          return { exitCode: 0 };
+        },
+        writeTextFile: async () => {}
+      } as never,
+      rootDir: ROOT,
+      skills: SKILLS as never
+    });
+
+    const decoded = [...commands[1].matchAll(/printf %s '([A-Za-z0-9+/=]+)'/g)].map((m) =>
+      Buffer.from(m[1], 'base64').toString('utf8')
+    );
+    expect(decoded.some((c) => c.includes('contenuto uno'))).toBe(true);
+    expect(decoded).toContain("con 'apici' e \"virgolette\"");
+    expect(decoded).toContain('terzo');
+  });
+
+  /**
+   * IL SECONDO COSTO PAGATO, mezz'ora dopo il primo. Un comando solo per tutti i file sembrava la
+   * mossa giusta e in laboratorio lo era — 388ms invece di 6900. In pratica bash rifiutava
+   * l'argomento oltre MAX_ARG_STRLEN (128KB): «argument list too long», si cadeva nel fallback, e
+   * il batch non girava MAI. Sembrava che l'ottimizzazione non pagasse; non era mai partita.
+   */
+  it('spezza il comando invece di sforare il limite di bash', async () => {
+    const commands: string[] = [];
+    const perFile: string[] = [];
+    const grosso = 'x'.repeat(70 * 1024);
+
+    await writeSkills({
+      sandbox: {
+        run: async ({ command }: { command: string }) => {
+          commands.push(command);
+          return { exitCode: 0 };
+        },
+        writeTextFile: async ({ path }: { path: string }) => {
+          perFile.push(path);
+        }
+      } as never,
+      rootDir: ROOT,
+      skills: [
+        { name: 'a', description: 'd', content: grosso },
+        { name: 'b', description: 'd', content: grosso },
+        { name: 'c', description: 'd', content: grosso }
+      ] as never
+    });
+
+    // Nessun comando oltre la soglia, e nessun file perso per strada.
+    expect(commands.length).toBeGreaterThan(2);
+    for (const c of commands) {
+      expect(c.length).toBeLessThan(128 * 1024);
+    }
+    expect(perFile).toEqual([]);
+    const scritti = commands.join('\n');
+    for (const n of ['a', 'b', 'c']) {
+      expect(scritti).toContain(`${ROOT}/${n}/SKILL.md`);
+    }
+  });
+
+  /**
+   * `writeSkills` e` codice generico: una sandbox senza `base64` deve continuare a funzionare,
+   * piu` lenta ma giusta. Senza questo ramo un'immagine diversa perderebbe le skill in silenzio.
+   */
+  it('se il comando fallisce, i file vanno scritti lo stesso uno per uno', async () => {
+    const perFile: string[] = [];
+    await writeSkills({
+      sandbox: {
+        run: async ({ command }: { command: string }) => {
+          if (command.includes('base64')) throw new Error('base64: not found');
+          return { exitCode: 0 };
+        },
+        writeTextFile: async ({ path }: { path: string }) => {
+          perFile.push(path);
+        }
+      } as never,
+      rootDir: ROOT,
+      skills: SKILLS as never
+    });
+
+    expect(perFile).toHaveLength(4);
+    expect(perFile).toContain(`${ROOT}/social/references/platforms.md`);
+  });
+});

--- a/src/lib/server/chat-models.test.ts
+++ b/src/lib/server/chat-models.test.ts
@@ -1,4 +1,16 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+/**
+ * La vetrina viene dalla TABELLA quando c'e`, e da `LLM_MODELS` quando non c'e`. Qui si prova il
+ * secondo caso, quindi la tabella deve essere davvero assente — non "assente sul database che
+ * questa macchina riesce a raggiungere". Senza questo mock la suite passava solo finche' la
+ * migration non era applicata, e ha iniziato a fallire il giorno in cui lo e` stata.
+ */
+vi.mock('$lib/server/supabase-admin', () => ({
+  createAdminClient: () => {
+    throw new Error('nessun catalogo in questo test');
+  }
+}));
 import { __resetGatewayModels, ensureGatewayModels } from './openrouter-models';
 import { chatModelChoices } from './chat-models';
 


### PR DESCRIPTION
## What?

Tolto il drain del turno morto (#166), una chat kit su thread nuovo ci metteva ancora **~10 secondi**
al primo token. Profilando la catena intera, **6.9 di quei secondi erano `writeSkills`**: 14 file
scritti nella sandbox **uno alla volta**, ~450ms l'uno.

Ogni scrittura è un round-trip — due, in realtà: `mkdir -p` del padre, poi il file. Ventotto
round-trip in fila per mettere in una sandbox dei file che non cambiano mai.

## Why?

Le scritture non dipendono l'una dall'altra. Farle insieme costa quanto la più lenta invece della
somma.

```
[DEBUG] mkdir root                                    +200ms
[DEBUG] SKILL.md humanizer            455ms  (1,  +656ms)
[DEBUG] SKILL.md stop-slop            459ms  (2, +1115ms)
[DEBUG] stop-slop/references/…        614ms  (3, +1729ms)
…
[DEBUG] social/references/…           471ms (14, +6903ms)
[DEBUG] TOTALE 14 scritture in 6903ms
```

## How?

Tutti i file partono in **un comando solo**: una `mkdir -p` per tutte le cartelle, poi i contenuti
via `base64`, così il quoting non può essere rotto da quello che c'è dentro il markdown.

**Misurato direttamente su `writeSkills`: 14 file in 1068ms, contro 6903ms.**

### Due errori lungo la strada, che vale la pena scrivere

**Il primo:** non passare le skill quando un marcatore dice che ci sono già. Leggendo `harness-pi`
si vede che `skills: []` azzera anche `harnessSkills` e `readableRoots`: le skill smettono di
essere **dichiarate** al modello e la cartella non è più leggibile. Dieci secondi scambiati con un
agente che perde in silenzio le proprie capacità.

**Il secondo, più insidioso:** un comando solo per tutto — che è esattamente quello che il conteggio
dei round-trip suggerisce. Ma bash rifiuta un argomento oltre `MAX_ARG_STRLEN` (128KB):

```
FALLBACK per riga: fork/exec /usr/bin/bash: argument list too long
```

Il fallback lo assorbiva, quindi **il batch non girava mai** e le misure end-to-end dicevano che
l'ottimizzazione non pagava. Non era mai partita. Adesso lo script è spezzato sotto quella soglia,
e un test lo pinna: la versione che sembra giusta in piccolo è quella che non gira mai in grande.

Il percorso per file resta come fallback, perché `writeSkills` è codice generico: un'immagine di
sandbox senza `base64` deve continuare a funzionare, più lenta ma giusta.

**La prima idea era peggiore, e vale la pena scriverla.** Volevo non passare le skill quando un
marcatore diceva che erano già su disco. Leggendo `harness-pi` si vede che `skills: []` azzera anche
`harnessSkills` e `readableRoots`: le skill smettono di essere **dichiarate** al modello e la
cartella non è più leggibile. Avrebbe scambiato dieci secondi con un agente che perde in silenzio
le proprie capacità — molto peggio di essere lento.

La modifica è nel pacchetto installato, quindi sta in `patches/@ai-sdk+harness+1.0.87.patch`.

## Testing?

Suite intera verde (6312).

Nuovo `harness-skill-writes.test.ts`, quattro casi sulla `writeSkills` **installata**: un comando
invece di un round-trip per file; i contenuti che arrivano intatti (apici e virgolette comprese —
un batch che scrive i byte sbagliati è peggio di uno lento); **lo spezzettamento sotto il limite di
bash**, che è l'errore appena pagato; e il fallback per riga quando il comando fallisce.

Verificato end-to-end sullo stack locale con browser reale, utente `test@anomalia.so`, brand
`demo`: turno inviato dalla UI, risposta `FINALE` in chat.

| | prima | dopo |
|---|---|---|
| `writeSkills` (14 file) | 6903ms | **1068ms** |
| primo token, thread nuovo | ~10.5s | ~4–5s |

## Anything Else?

**Non è ancora "immediato", e il resto è misurato.** Con `writeSkills` a ~1s, quello che rimane è
~1.5s di apertura sandbox, ~0.3s di `resolveSandboxHomeDir`, ~0.25s di `syncHostWorkspace`, ~0.2s
di `ensureSandboxDirectory` e ~0.4s di `buildTurnContext`: round-trip nella sandbox, uno per volta.

Sotto il secondo si arriva solo togliendo la scrittura dal percorso critico — skill pre-installate
nell'immagine della sandbox — oppure aprendo l'SSE prima che l'harness sia pronto, che risolve il
«non vedo niente» anche senza ridurre l'attesa.

Va sopra #166: senza quella, su un thread già avviato i 60 secondi del drain coprono tutto questo.
