### PR TITLE
Render N graphics on one sandbox

### DIFF
--- a/changelog/2026-09-03-graphic-batch-sandbox.md
+++ b/changelog/2026-09-03-graphic-batch-sandbox.md
@@ -1,0 +1,61 @@
+# Una sandbox per N grafiche
+
+## Il rapporto che non regge
+
+Misurato nella VM, per UNA grafica:
+
+```
+apertura sandbox + progetto   ~6.0s
+`remotion still`               ~3.4s
+lettura del PNG                ~0.2s
+coda: release + addebito       ~8.0s
+                              ─────
+totale                        ~17.5s
+```
+
+**~14s di macchina per 3.5s di lavoro.** Per una grafica chiesta in chat è accettabile. Ripetuto
+è il costo dominante, e si ripete: due chiamate consecutive pagano entrambe l'apertura per intero —
+misurato 6075ms e 6022ms. Il nome della VM è stabile per brand e gli holder esistono, ma
+`openBrandSandbox` non si attacca a una macchina viva: rifà il giro ogni volta.
+
+## Il taglio
+
+`renderGraphicStills` rende N grafiche su UNA apertura. Misurato, quattro grafiche:
+
+```
+22.9s in totale   ← contro ~67s facendole una per volta (−66%)
+  6.1s apertura + progetto
+  3.4s la prima
+  1.9s / 1.8s / 1.8s le successive
+  7.9s coda
+```
+
+Il marginale crolla da 17.5s a **~1.85s**. Un carosello da dieci slide passa da tre minuti a mezzo
+minuto.
+
+`renderGraphicStill` resta come forma comoda sopra il plurale, così i chiamanti di oggi non cambiano.
+
+## L'isolamento, che è il motivo per cui non è un `Promise.all`
+
+L'ordine dell'array è l'ordine dei risultati, e un fallimento su una grafica torna il suo errore
+**al suo posto** invece di far cadere le altre. Perdere nove slide perché la decima non compila
+significherebbe pagare un render intero per niente — e il lease si controlla prima di ogni grafica,
+così una macchina che sta per spegnersi restituisce quelle fatte invece di perderle tutte.
+
+## Onestà su cosa questo NON accende
+
+**Oggi nessuno lo chiama col plurale.** Le slide di un carosello si compongono e si modificano una
+alla volta (`design_graphic` con `slide_index`, `editCarouselSlide`), e `produce_week` genera foto
+AI, non grafiche tipografiche. Quindi il −66% è una capacità pronta, non un risparmio già in corso:
+si realizza quando un percorso carosello chiederà N slide in un colpo.
+
+L'ho scritto lo stesso perché il numero che lo giustifica è misurato e perché il costo che evita —
+dieci aperture di VM per un carosello — è quello che terrebbe il renderer Chromium spento anche
+dopo che tutto il resto funziona.
+
+## Il prossimo taglio, più grande e non speculativo
+
+Gli **~8s di coda** valgono anche per una grafica sola: quando quel tempo scorre il PNG **esiste
+già**. Aspettare `release()` prima di rispondere è far pagare all'utente una pulizia che non lo
+riguarda. Spostarla fuori dal percorso della risposta vale ~8s su OGNI render, oggi, senza bisogno
+di un chiamante nuovo.

--- a/src/lib/server/graphic-sandbox.live.test.ts
+++ b/src/lib/server/graphic-sandbox.live.test.ts
@@ -17,7 +17,7 @@ import { expect, it } from 'vitest';
 import { writeFileSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { renderGraphicWithChromium } from './design-render-chromium';
-import { renderGraphicStill } from './motion-video/render-tools';
+import { renderGraphicStill, renderGraphicStills } from './motion-video/render-tools';
 
 const BRAND = process.env.LIVE_BRAND_ID ?? '6859115e-df6a-40f3-846e-6c577faf0e9c';
 
@@ -62,6 +62,29 @@ it.skipIf(process.env.GRAPHIC_RENDER_LIVE !== '1')(
     const b = await renderGraphicStill({ brandId: BRAND, source: g('#0000ff'), width: 1080, height: 1920 });
     expect('png' in a && 'png' in b, JSON.stringify([a, b]).slice(0, 300)).toBe(true);
     if ('png' in a && 'png' in b) expect(h(a.png)).not.toBe(h(b.png));
+  },
+  900_000
+);
+
+it.skipIf(process.env.GRAPHIC_RENDER_LIVE !== '1')(
+  'quattro grafiche su UNA sandbox, tutte distinte',
+  async () => {
+    // Il numero che giustifica il plurale: misurato, quattro grafiche in 22.9s su una apertura
+    // sola, contro ~67s facendole una per volta (17s l'una, di cui ~14 di apertura e chiusura).
+    // E l'isolamento: un fallimento su una slide non porta via le altre.
+    const g = (bg: string) => ({
+      source: `const Graphic = () => <div style={{width:'100%',height:'100%',background:'${bg}',display:'flex'}}>x</div>;`,
+      width: 1080,
+      height: 1080
+    });
+    const out = await renderGraphicStills({
+      brandId: BRAND,
+      graphics: [g('#ff0000'), g('#00ff00'), g('#0000ff'), g('#ffff00')]
+    });
+    expect(out).toHaveLength(4);
+    expect(out.every((o) => 'png' in o), JSON.stringify(out).slice(0, 300)).toBe(true);
+    const hashes = out.map((o) => ('png' in o ? createHash('sha1').update(o.png).digest('hex') : ''));
+    expect(new Set(hashes).size, 'quattro sorgenti diversi, quattro PNG diversi').toBe(4);
   },
   900_000
 );

--- a/src/lib/server/motion-video/render-tools.ts
+++ b/src/lib/server/motion-video/render-tools.ts
@@ -559,23 +559,40 @@ async function buildBundle(sb: SandboxHandle, onLog?: (l: string) => void): Prom
  * progetto — una grafica È un motion video da un fotogramma. Quello che NON condivide è il modo di
  * arrivare al sorgente: qui via `--props`, così il bundle resta riusabile.
  */
-export async function renderGraphicStill(opts: {
+/**
+ * Una o PIÙ grafiche, su UNA sola apertura di sandbox.
+ *
+ * Il plurale non è comodità: misurato, aprire la macchina e chiuderla costa ~12.5s contro i 3.4s
+ * del render. Una grafica sola paga quel rapporto una volta e va bene; un carosello da dieci slide
+ * lo pagherebbe DIECI volte — tre minuti di macchina per trentaquattro secondi di lavoro. Con una
+ * apertura sola diventa 12.5s + 10×3.4s.
+ *
+ * L'ordine dell'array è l'ordine dei risultati, e un fallimento su una slide non porta via le
+ * altre: torna il suo errore al suo posto. Perdere nove slide perché la decima non compila
+ * sarebbe pagare un render intero per niente.
+ */
+export async function renderGraphicStills(opts: {
 	brandId: string;
 	userId?: string;
-	source: string;
-	width: number;
-	height: number;
+	graphics: Array<{ source: string; width: number; height: number }>;
 	remainingMs?: () => number;
 	abortSignal?: AbortSignal;
 	onLog?: (line: string) => void;
-}): Promise<{ png: Buffer } | { error: string }> {
+}): Promise<Array<{ png: Buffer } | { error: string }>> {
+	if (!opts.graphics.length) return [];
 	const left = opts.remainingMs?.();
 	let sb: SandboxHandle | null = null;
 	return await withSandboxBilling(
-		{ brandId: opts.brandId, userId: opts.userId, use: 'graphic_still', detail: `${opts.width}x${opts.height}` },
+		{
+			brandId: opts.brandId,
+			userId: opts.userId,
+			use: 'graphic_still',
+			detail: opts.graphics.length > 1 ? `x${opts.graphics.length}` : `${opts.graphics[0].width}x${opts.graphics[0].height}`
+		},
 		async () => {
 			const startedAt = Date.now();
 			const lease = Math.min(typeof left === 'number' ? left : 600_000, 600_000);
+			const out: Array<{ png: Buffer } | { error: string }> = [];
 			try {
 				sb = await openBrandSandbox({
 					brandId: opts.brandId,
@@ -592,24 +609,36 @@ export async function renderGraphicStill(opts: {
 					opts.onLog,
 					budgetWithin(lease, Date.now() - startedAt, RENDER_TIMEOUT_MS + 15_000, INSTALL_TIMEOUT_MS)
 				);
-				opts.onLog?.(`[t] progetto pronto +${Date.now() - startedAt}ms`);
 				await sb.run('mkdir', ['-p', `${PROJECT_DIR}/out`]);
-				const out = `out/graphic-${Date.now()}.png`;
-				// Le misure viaggiano DENTRO il sorgente perché `calculateMetadata` legge da lì: un
-				// marcatore, non un parametro in più da tenere allineato in due posti.
-				const source = `${opts.source}\n// __w=${opts.width} __h=${opts.height}`;
+				opts.onLog?.(`[t] progetto pronto +${Date.now() - startedAt}ms`);
+
 				const hasBundle = await sb.run('test', ['-d', `${PROJECT_DIR}/bundle`]);
 				const entry = hasBundle.exitCode === 0 ? 'bundle' : 'src/index.ts';
-				const res = await sb.run(
-					'npx',
-					['remotion', 'still', entry, 'Graphic', out, `--props=${JSON.stringify({ source })}`, '--log=error'],
-					{ cwd: PROJECT_DIR, timeoutMs: RENDER_TIMEOUT_MS }
-				);
-				opts.onLog?.(`[t] still finito +${Date.now() - startedAt}ms`);
-				if (res.exitCode !== 0) return { error: `[${sb.name}] ${res.stderr || res.stdout}`.slice(-800) };
-				const png = await sb.readBuffer(`${PROJECT_DIR}/${out}`);
-				opts.onLog?.(`[t] png letto +${Date.now() - startedAt}ms`);
-				return { png };
+
+				for (const [i, g] of opts.graphics.entries()) {
+					const budget = budgetWithin(lease, Date.now() - startedAt, 10_000, RENDER_TIMEOUT_MS);
+					if (budget < 15_000) {
+						// Meglio tornare con quelle rese che farsi spegnere la macchina a metà.
+						out.push({ error: 'sandbox lease exhausted before this graphic' });
+						continue;
+					}
+					const file = `out/graphic-${Date.now()}-${i}.png`;
+					// Le misure viaggiano DENTRO il sorgente perché `calculateMetadata` legge da lì: un
+					// marcatore, non un parametro in più da tenere allineato in due posti.
+					const source = `${g.source}\n// __w=${g.width} __h=${g.height}`;
+					const res = await sb.run(
+						'npx',
+						['remotion', 'still', entry, 'Graphic', file, `--props=${JSON.stringify({ source })}`, '--log=error'],
+						{ cwd: PROJECT_DIR, timeoutMs: budget }
+					);
+					if (res.exitCode !== 0) {
+						out.push({ error: `[${sb.name}] ${res.stderr || res.stdout}`.slice(-800) });
+						continue;
+					}
+					out.push({ png: await sb.readBuffer(`${PROJECT_DIR}/${file}`) });
+					opts.onLog?.(`[t] grafica ${i + 1}/${opts.graphics.length} +${Date.now() - startedAt}ms`);
+				}
+				return out;
 			} catch (e) {
 				throw describeSandboxDeath(e);
 			} finally {
@@ -617,6 +646,28 @@ export async function renderGraphicStill(opts: {
 			}
 		}
 	);
+}
+
+/** Una sola grafica: la forma comoda sopra {@link renderGraphicStills}. */
+export async function renderGraphicStill(opts: {
+	brandId: string;
+	userId?: string;
+	source: string;
+	width: number;
+	height: number;
+	remainingMs?: () => number;
+	abortSignal?: AbortSignal;
+	onLog?: (line: string) => void;
+}): Promise<{ png: Buffer } | { error: string }> {
+	const [only] = await renderGraphicStills({
+		brandId: opts.brandId,
+		userId: opts.userId,
+		graphics: [{ source: opts.source, width: opts.width, height: opts.height }],
+		remainingMs: opts.remainingMs,
+		abortSignal: opts.abortSignal,
+		onLog: opts.onLog
+	});
+	return only ?? { error: 'no graphic rendered' };
 }
 
 export async function renderMotionStills(opts: {


### PR DESCRIPTION
## What?

`renderGraphicStills` renders **N graphics on one sandbox open**. `renderGraphicStill` stays as the
convenience form over it, so today's callers do not change.

Stacked on #169.

## Why?

Measured in the VM, for **one** graphic:

```
open sandbox + project   ~6.0s
`remotion still`         ~3.4s
read the PNG             ~0.2s
tail: release + billing  ~8.0s
                        ─────
total                   ~17.5s
```

**~14s of machine for 3.5s of work.** Acceptable once, in chat. It is the dominant cost when
repeated — and it does repeat: two consecutive calls each pay the open in full, **6075ms and
6022ms**. The VM name is stable per brand and holders exist, but `openBrandSandbox` does not attach
to a live machine; it redoes the round trip.

## How?

Measured with four graphics:

```
22.9s total       ← against ~67s one at a time (−66%)
  6.1s open + project
  3.4s the first
  1.9s / 1.8s / 1.8s the rest
  7.9s tail
```

Marginal cost falls from 17.5s to **~1.85s**. A ten-slide carousel goes from three minutes to half a
minute.

**Not a `Promise.all`.** The array order is the result order and a failure comes back **in its own
slot** rather than taking the others down — losing nine slides to a tenth that does not compile
would pay for a whole render and keep nothing. The lease is checked before each graphic, so a
machine about to expire returns what it already made instead of losing all of it.

## Testing?

Full suite: 6329 passed.

The live test (opt-in, `GRAPHIC_RENDER_LIVE=1`) renders four graphics on one sandbox and asserts
**four distinct hashes** — four different sources must not come back as four copies of the same PNG,
which is precisely how the stale-bundle defect in #169 presented.

## Evidence (screenshots/videos)

<details>
<summary>Four graphics, one sandbox — real run</summary>

```
[+5937ms] render project cached
[+6138ms] progetto pronto
[+9541ms] grafica 1/4
[+11398ms] grafica 2/4
[+13242ms] grafica 3/4
[+15029ms] grafica 4/4
TOTALE 22893ms per 4 grafiche
hash: a2e8422cd2 e7fd496b0e 6620ece6f8 d83f227294
```
</details>

## Anything Else?

**Nothing calls the plural yet, and I want that stated plainly.** Carousel slides are composed and
edited one at a time (`design_graphic` with `slide_index`, `editCarouselSlide`), and `produce_week`
renders AI photos, not typographic graphics. So the −66% is a **capability with a measured number
behind it, not a saving already running**. It is here because ten VM opens for one carousel is
exactly the cost that would keep the Chromium renderer switched off after everything else works.

**The next cut is bigger and not speculative.** Those ~8s of tail apply to a single graphic too, and
when that time is passing **the PNG already exists**. Awaiting `release()` before answering charges
the user for a cleanup that does not concern them. Moving it off the response path is worth ~8s on
**every** render, today, with no new caller needed.

**And `openBrandSandbox` not attaching to a live VM** is worth looking at on its own: two calls
seconds apart both paid 6s. If a chat turn already holds that brand's machine, a graphic should be
joining it, not provisioning another.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01123CrHo6dd8neJU5ZryKFh
