### PR TITLE
Treat a NULL run row as a lost claim

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -87,6 +87,9 @@ Dopo un merge da dev, un test della PR entra in timeout di 30s invece di fallire
 ### Le factory `vi.mock` invecchiano col merge, non col typecheck
 Il mock scritto nell'era della PR non dichiara gli export nuovi di dev (`createSubagentTools`, `MAX_CRITERION_CHARS`, `loadMemoryEntries`): l'errore `No "X" export is defined on the "Y" mock` esplode a runtime a metà test, mai in compilazione. Stesso segno per il fake supabase che manca di un metodo nuovo (`query.or is not a function`). Mossa: a ogni errore di quel tipo aggiungi l'export — o meglio `...actual` via `importOriginal` e override selettivi.
 
+### Il fake di una RPC che torna `null` dove il plpgsql torna una riga di NULL
+Una funzione `returns public.<tabella>` che non prende righe NON torna `null`: la riga composita esce tutta NULL e PostgREST la consegna come oggetto con ogni colonna a `null`. Un fake che risponde `{ data: null }` rende verde un client che controlla `if (!data)` e lascia passare in produzione un record fantasma — `agent_kit_claim_run` faceva girare turni interi con `run.id === null`: ogni scrittura filtrata per `id` toccava zero righe e la chiusura non depositava il messaggio, quindi il turno spariva dalla chat dopo aver speso il modello. Segnale: `run null` nei log, o «sfrattato prima della chiusura» su un run che nessuno ha sfrattato. Mossa: nel fake torna la riga di NULL, e nel client controlla la CHIAVE (`if (!row?.id)`), mai la sola presenza dell'oggetto.
+
 ### Il test della PR può aspettare il vecchio contratto
 `toHaveBeenCalledWith` con 6 argomenti contro un executor passato a 7 (dev ha aggiunto la riga `job`): fallisce nel merge senza che nessuno abbia toccato il file. Mossa: nel riesame di un merge, fai girare PRIMA i test dei file in conflitto — sono gli unici che fanno da spec su entrambi i lati.
 

--- a/changelog/2026-09-03-claim-null-composite.md
+++ b/changelog/2026-09-03-claim-null-composite.md
@@ -1,0 +1,32 @@
+# La presa persa di un run non fa più girare un turno fantasma
+
+`agent_kit_claim_run` (migration 0229) è dichiarata `returns public.agent_kit_runs`. Quando
+l'UPDATE non prende righe — la riga è già di un altro worker, il lease è ancora valido — la
+funzione non torna `null`: la riga composita esce tutta NULL, e PostgREST la consegna come
+oggetto con ogni colonna a `null`.
+
+`claimRun` controllava solo `if (!data) return null`. L'oggetto passava, e il turno partiva con
+`run.id === null`: ogni scrittura filtrata per `id` toccava zero righe, il battito non batteva su
+nessuna riga, e `agent_kit_close_run(null)` tornava `closed:false`. Nei log restava solo
+`[AGENT_KIT] run null sfrattato prima della chiusura: nessun messaggio salvato` — cioè un turno
+pagato per intero al modello che non lasciava niente in chat, e un utente davanti a una domanda
+senza risposta.
+
+È esattamente il caso che il commento in `live.ts` («DOPPIO RESUME: due dispositivi rispondono
+insieme») dava per chiuso da un 409 ritentabile: il 409 non arrivava mai, perché il perdente
+credeva di aver vinto.
+
+Il controllo ora è sulla chiave, non sulla presenza dell'oggetto: `if (!run?.id) return null`.
+Chi perde la presa riceve `busy`, il client riaccoda, e nessun run fantasma tocca il database.
+
+## Perché i test non l'avevano visto
+
+Perché i due fake mentivano nello stesso modo: sia `run-store.test.ts` sia `live.test.ts`
+rispondevano `{ data: null }` alla presa persa, una risposta che il plpgsql non dà. Rendere
+onesti i fake ha fatto cadere da solo un test che esisteva già («un lease ancora valido non si
+porta via»). Il test nuovo di `live.test.ts` fa perdere la presa nell'istante fra
+`currentWaitingRun` e il claim — senza il fix risponde `200` e deposita un turno, con il fix
+risponde `409` e non tocca la riga.
+
+La lezione sta in `LESSONS.md`: un fake che risponde `null` dove il database risponde con una
+riga di NULL non è un'approssimazione, è il bug che nasconde.

--- a/packages/agent-core/src/run-store.test.ts
+++ b/packages/agent-core/src/run-store.test.ts
@@ -21,6 +21,33 @@ import {
 
 type Row = Record<string, unknown>;
 
+/**
+ * `agent_kit_claim_run` è `returns public.agent_kit_runs`: quando l'UPDATE non prende righe la
+ * riga composita esce TUTTA NULL, e PostgREST la consegna come oggetto con ogni colonna a null.
+ * Non come `null` — ed è la differenza fra una presa persa e un run fantasma.
+ */
+function nullComposite(): Row {
+	return Object.fromEntries(
+		[
+			'id',
+			'brand_id',
+			'thread_id',
+			'agent_id',
+			'user_id',
+			'state',
+			'reason',
+			'question',
+			'lease_until',
+			'lease_owner',
+			'lease_fence',
+			'attempt',
+			'heartbeat_at',
+			'created_at',
+			'updated_at'
+		].map((column) => [column, null])
+	);
+}
+
 function fakeDb(seed: Row[] = []) {
 	const rows: Row[] = seed.map((r) => ({ ...r }));
 	const calls: Array<{ method: string; args: unknown[] }> = [];
@@ -114,12 +141,12 @@ function fakeDb(seed: Row[] = []) {
 		const run = rows.find((r) => r.id === params.p_run_id);
 
 		if (fn === 'agent_kit_claim_run') {
-			if (!run) return Promise.resolve({ data: null, error: null });
+			if (!run) return Promise.resolve({ data: nullComposite(), error: null });
 			const openState = ['queued', 'waiting_input', 'waiting_takeover'].includes(run.state as string);
 			const expired =
 				['running'].includes(run.state as string) &&
 				(run.lease_until == null || (run.lease_until as string) <= (params.p_now as string));
-			if (!openState && !expired) return Promise.resolve({ data: null, error: null });
+			if (!openState && !expired) return Promise.resolve({ data: nullComposite(), error: null });
 			run.state = 'running';
 			run.lease_owner = params.p_owner;
 			run.lease_fence = ((run.lease_fence as number) ?? 0) + 1;
@@ -325,6 +352,33 @@ describe('il lease del run: proprietario e fence', () => {
 		expect(claimed).toBeNull();
 		expect(rows[0].lease_owner).toBe('worker-vecchio');
 		expect(rows[0].lease_fence).toBe(3);
+	});
+
+	it('la riga di NULL che torna dal plpgsql è una presa PERSA, non un run senza id', async () => {
+		const rpc = async () => ({
+			data: {
+				id: null,
+				brand_id: null,
+				thread_id: null,
+				agent_id: null,
+				user_id: null,
+				state: null,
+				lease_owner: null,
+				lease_fence: null,
+				attempt: null,
+				heartbeat_at: null,
+				created_at: null,
+				updated_at: null
+			},
+			error: null
+		});
+
+		const claimed = await claimRun({ rpc } as unknown as SupabaseClient, 'run-1', 'worker-nuovo', {
+			ttlMs: 300_000,
+			now: new Date('2026-08-30T10:05:00.000Z')
+		});
+
+		expect(claimed).toBeNull();
 	});
 
 	it('LO ZOMBIE NON CHIUDE: dopo la presa, il worker sfrattato non salva niente', async () => {

--- a/packages/agent-core/src/run-store.ts
+++ b/packages/agent-core/src/run-store.ts
@@ -120,9 +120,10 @@ export async function claimRun(
 		p_lease_until: new Date(now.getTime() + ttlMs).toISOString()
 	});
 	if (error) throw new Error(`run: presa fallita — ${error.message}`);
-	if (!data) return null;
-	const run = (Array.isArray(data) ? data[0] : data) as RunRow | undefined;
-	if (!run) return null;
+	const run = (Array.isArray(data) ? data[0] : data) as RunRow | null | undefined;
+	// La RPC è `returns public.agent_kit_runs`: l'UPDATE che non prende righe torna una riga
+	// composita di soli NULL, non `null`. È l'`id` a dire se la presa è riuscita.
+	if (!run?.id) return null;
 	return { run, fence: run.lease_fence ?? 0 };
 }
 

--- a/src/lib/agent/bridge/live.test.ts
+++ b/src/lib/agent/bridge/live.test.ts
@@ -362,6 +362,15 @@ const { specById } = await import('../specs');
 
 type Row = Record<string, unknown>;
 
+/** Quello che `agent_kit_claim_run` consegna a chi perde la presa: ogni colonna a null. */
+function nullClaimRow(): Row {
+	return Object.fromEntries(
+		['id', 'brand_id', 'thread_id', 'agent_id', 'user_id', 'state', 'lease_owner', 'lease_fence', 'attempt'].map(
+			(column) => [column, null]
+		)
+	);
+}
+
 /**
  * Lo stesso finto client di `run-store.test.ts`, esteso con `order`/`maybeSingle` — il bridge li
  * usa per trovare un run `waiting_input` sul thread prima di aprirne uno nuovo.
@@ -557,12 +566,14 @@ type Row = Record<string, unknown>;
 		}
 		if (fn === 'agent_kit_claim_run') {
 			const claimable = rows.find((r) => r.id === params.p_run_id);
-			if (!claimable) return Promise.resolve({ data: null, error: null });
+			// La presa persa NON torna `null`: la RPC è `returns public.agent_kit_runs`, e l'UPDATE
+			// a vuoto consegna una riga composita di soli NULL.
+			if (!claimable) return Promise.resolve({ data: nullClaimRow(), error: null });
 			const openState = ['queued', 'waiting_input', 'waiting_takeover'].includes(claimable.state as string);
 			const expired =
 				claimable.state === 'running' &&
 				(claimable.lease_until == null || (claimable.lease_until as string) <= (params.p_now as string));
-			if (!openState && !expired) return Promise.resolve({ data: null, error: null });
+			if (!openState && !expired) return Promise.resolve({ data: nullClaimRow(), error: null });
 			claimable.state = 'running';
 			claimable.lease_owner = params.p_owner;
 			claimable.lease_fence = ((claimable.lease_fence as number) ?? 0) + 1;
@@ -1245,6 +1256,58 @@ describe('runKitTurn — doppio resume su una waiting_input (due dispositivi ris
 		expect(rows[0].state).toBe('running');
 		expect(rows[0].lease_owner).toBe('altro-dispositivo');
 		expect(rows[0].lease_fence).toBe(1);
+	});
+
+	it('la presa persa FRA la lettura e il claim non fa girare un run fantasma: 409, nessun messaggio', async () => {
+		toolCallModel('reply', { message: 'non dovrebbe arrivarci', delivered: [] });
+		const { db, rows, chatMessages } = fakeDb([
+			{
+				id: 'run-1',
+				brand_id: 'b1',
+				thread_id: 't1',
+				agent_id: 'content',
+				user_id: 'u1',
+				state: 'waiting_input',
+				lease_owner: null,
+				lease_fence: 0,
+				lease_until: null,
+				heartbeat_at: new Date().toISOString(),
+				reason: null,
+				question: { question: 'quale palette?' },
+				created_at: '2026-08-21T00:00:00.000Z',
+				updated_at: '2026-08-21T00:00:00.000Z'
+			}
+		]);
+		// L'ALTRO DISPOSITIVO VINCE NELL'ISTANTE FRA `currentWaitingRun` E LA PRESA: la riga che
+		// questo turno ha letto `waiting_input` è già `running` di un altro quando arriva il claim,
+		// e la RPC gli consegna la riga di soli NULL.
+		const perdente = {
+			from: (table: string) => (db as unknown as { from: (t: string) => unknown }).from(table),
+			rpc: (fn: string, params: Record<string, unknown>) =>
+				fn === 'agent_kit_claim_run'
+					? Promise.resolve({ data: nullClaimRow(), error: null })
+					: (db as unknown as { rpc: (f: string, p: Record<string, unknown>) => unknown }).rpc(fn, params)
+		} as unknown as SupabaseClient;
+
+		const res = await runKitTurn({
+			supabase: fakeSupabase,
+			admin: perdente,
+			brand: { id: 'b1' },
+			user: { id: 'u1' },
+			threadId: 't1',
+			spec,
+			messages: [
+				{ role: 'assistant', content: 'quale palette?' },
+				{ role: 'user', content: 'quella scura, dal secondo telefono' }
+			],
+			locale: 'it'
+		});
+
+		expect(res.status).toBe(409);
+		expect((await res.json()).error).toBe('busy');
+		// Il turno NON è partito: nessun messaggio depositato e la riga intatta.
+		expect(chatMessages).toHaveLength(0);
+		expect(rows[0].state).toBe('waiting_input');
 	});
 });
 

--- a/src/lib/content/changelog/2026-09-03-turn-never-lost.ts
+++ b/src/lib/content/changelog/2026-09-03-turn-never-lost.ts
@@ -1,0 +1,9 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-03',
+  title: 'No more answers that vanish',
+  items: [
+    'When two devices reply to the same question at once, the second one now retries instead of running a turn whose answer was thrown away.'
+  ]
+} satisfies ChangelogEntry;


### PR DESCRIPTION
## What?

`claimRun` accepted a row of NULLs as a successful claim, so a worker that lost the lease race
ran a whole chat turn against `run.id === null`. This makes the check read the run's key instead
of the presence of a payload, so the loser gets the retriable `409 busy` the resume path always
assumed it would get. Both test fakes that hid the defect now return what the database really
returns.

## Why?

`agent_kit_claim_run` (migration 0229) is declared `returns public.agent_kit_runs`. When its
UPDATE matches no row — the run is already held by another worker on a valid lease —
plpgsql does not return `null`: the composite comes back all NULL, and PostgREST hands it over as
an object with every column set to `null`. `claimRun` only checked `if (!data) return null`, so
that object walked straight through as a claimed run.

What follows is silent and expensive. Every write is filtered by `id`, so it touches zero rows:
the heartbeat beats on nothing, the mirror writes `partial` nowhere, and
`agent_kit_close_run(null)` returns `closed:false`. The only trace is one log line:

```
[AGENT_KIT] run null start — agente=analyst, modello=gemini-3.8-flash (llm), thread=8387cd13
[AGENT_KIT] run null sfrattato prima della chiusura: nessun messaggio salvato
[AGENT_KIT] run null done — 99s, modello=gemini-3.8-flash, 0 in / 0 out
```

99 seconds of model time billed, and the user is left looking at a question that never got an
answer. This is exactly the case the comment in `live.ts` ("DOPPIO RESUME: due dispositivi
rispondono insieme… il secondo la trova già presa e perde") considered handled: the 409 never
arrived, because the loser believed it had won.

## How?

One guard, at the seam every caller routes through:

```ts
const run = (Array.isArray(data) ? data[0] : data) as RunRow | null | undefined;
if (!run?.id) return null;
```

The alternative — teaching the plpgsql to `return null` explicitly — was rejected: this repo's
deploys do not run migrations (see `CLAUDE.md`), so a schema-side fix would leave production
broken for an unknown window while the code shipped ahead of it. The client-side guard is correct
against both the current function and a future one, and it costs one line.

`agent_kit_close_run` in the same migration already checks `if v_run.id is null`, so the NULL
composite was a known shape on the SQL side. Only the TypeScript caller had missed it.

I checked the other composite-returning RPC (`decide_agent_kit_approval`, 0227) — it raises when
the row is missing and its UPDATE is fenced by a `select … for update`, so it cannot produce this
shape.

## Testing?

Unit, red before green:

- `packages/agent-core/src/run-store.test.ts` — the fake now returns the row of NULLs instead of
  `{ data: null }`. That change alone turned an existing test red ("un lease ancora valido non si
  porta via"), which is the whole point: the fake was the reason a green suite never saw this.
  A new test pins the shape at the seam, independently of the fake.
- `src/lib/agent/bridge/live.test.ts` — the same fake told the same lie. A new test loses the
  claim in the instant between `currentWaitingRun` and the claim itself. **Without the fix it
  answers `200` and runs a turn; with it, `409` and the row is untouched.**

```
✓ packages/agent-core/src/run-store.test.ts (21 tests)
✓ src/lib/agent/bridge/live.test.ts (84 tests)
```

Not tested, and worth saying plainly: **no browser verification**. The defect needs two workers
racing for one lease inside the same millisecond — a real double resume, or a reaper handing a run
over. It is not reachable by hand in a browser, and staging it against the local stack would prove
less than the test that loses the claim deterministically. The risk this leaves is a behaviour
change on the losing path only: a caller that used to get `200` (and silently lose its work) now
gets `409` with `user_message_saved: true`, which the client already handles by re-queueing — the
same response the path returns when a run is already live.

## Evidence (screenshots/videos)

Backend change, no UI. The failing state, from production logs:

<details>
<summary>The phantom turn, before the fix</summary>

```
[AGENT_KIT] run null start — agente=analyst, modello=gemini-3.8-flash (llm), thread=8387cd13-abd5-43a3-a8c8-7c0d11ad8c7e
[AGENT_KIT] run null sfrattato prima della chiusura: nessun messaggio salvato
[AGENT_KIT] run null done — 99s, modello=gemini-3.8-flash, 0 in / 0 out
```

</details>

<details>
<summary>The new test, with the fix reverted</summary>

```
FAIL src/lib/agent/bridge/live.test.ts > la presa persa FRA la lettura e il claim
     non fa girare un run fantasma: 409, nessun messaggio
AssertionError: expected 200 to be 409
```

</details>

## Anything Else?

The `0 in / 0 out` in those log lines is a second, unrelated problem: `result.totalUsage` comes
back empty from the harness, so every kit turn writes a zero-token row into `ai_calls` and the
spend of the new engine is not measured. Not touched here.

`LESSONS.md` gains the general lesson, because the shape will come back: a fake that answers
`null` where the database answers with a row of NULLs is not an approximation, it is the bug it
hides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GpsbC3tQzxsBSg4Cns3x1C
