### PR TITLE
Key a progress event by its mirror, not just its run

### DIFF
--- a/changelog/2026-09-03-progress-lane-per-mirror.md
+++ b/changelog/2026-09-03-progress-lane-per-mirror.md
@@ -1,0 +1,37 @@
+# La corsia `progress` è dello specchio, non del run
+
+Ogni specchio (`mirrorSseToRun`, `live.ts`) scriveva i suoi snapshot durevoli sotto la chiave
+`<runId>:progress:<tick>`, dove `tick` è un contatore che nasce e muore con l'istanza dello
+specchio. Finché di uno stesso run gira un solo specchio la chiave è unica; e uno stesso run può
+avere due specchi in almeno due modi che capitano davvero:
+
+- la sessione harness riusata non parte, il turno la butta e riprova con una fresca — stesso
+  `run.id`, stessa invocazione, secondo stream (`live.ts`, «la sessione riusata non partiva»);
+- un worker sfratta il lease di un altro che sta ancora scaricando il suo stream: le scritture su
+  `agent_kit_runs` dello sfrattato le ferma il fence, gli append di `thread_events` no.
+
+I due ripartono entrambi da `tick = 1`, con testo diverso: la seconda scrittura è un conflitto di
+chiave, `append_thread_event` alza, `publishProgress` chiude la corsia (`progressLane = 'closed'`)
+e per tutto il resto del turno nessun evento durevole viene più scritto. In log:
+
+```
+[AGENT_KIT] run <id> progress event Error: thread event append failed: thread event source key conflict
+```
+
+Chi ricaricava la scheda a metà turno perdeva il log durevole e restava sul solo `partial` —
+poll da 4 secondi, testo a scatti. Degradazione silenziosa: nessuno se ne accorge finché non
+legge i log.
+
+La chiave ora porta l'identità dello specchio: `<runId>:progress:<mirrorId>:<tick>`. L'idempotenza
+resta dov'era davvero utile — una RPC ritentata dallo stesso specchio con lo stesso tick e lo
+stesso payload torna la riga di prima — e due specchi non si pestano più i piedi. Il riduttore
+(`reduceThreadEvents`) indicizza il progress per `runId`, quindi due corsie dello stesso run
+restano una sola voce di proiezione, l'ultima per `seq`; e `pruneRunProgress` pota per `runId`,
+quindi le pota entrambe.
+
+## Perché i test non l'avevano visto
+
+Il fake di `append_thread_event` in `live.test.ts` accodava e basta: nessuna chiave unica, nessun
+conflitto. Ora ha la semantica della migration 0226 — stessa chiave e stesso payload tornano la
+riga esistente, stessa chiave e payload diverso sono un errore. Con quel fake, il test che fa
+riprendere lo stesso run da due worker cade sulla chiave contesa `run-dead:progress:1`.

--- a/src/lib/agent/bridge/live.test.ts
+++ b/src/lib/agent/bridge/live.test.ts
@@ -375,6 +375,9 @@ type Row = Record<string, unknown>;
 	const chatMessages: Row[] = [];
 	// Gli eventi durevoli (`append_thread_event`/`thread_events`): progress dello specchio e messaggi.
 	const threadEvents: Row[] = [];
+	// Ogni append TENTATO, potatura compresa: `threadEvents` dice cosa è sopravvissuto, questo
+	// dice cosa è stato chiesto — ed è lì che si vede una chiave scritta due volte.
+	const appendCalls: Array<{ source_key: string; kind: string; payload: unknown }> = [];
 	let eventSeq = 0;
 
 	function from(_table: string) {
@@ -509,6 +512,20 @@ type Row = Record<string, unknown>;
 	// `chatMessages` vive in testa a `fakeDb`: `from('chat_messages')` ci opera sopra.
 	function rpc(fn: string, params: Record<string, unknown>) {
 		if (fn === 'append_thread_event') {
+			appendCalls.push({ source_key: params.p_source_key as string, kind: params.p_kind as string, payload: params.p_payload });
+			// LA STESSA SEMANTICA DEL PLPGSQL (0226): la chiave è unica per thread, e una seconda
+			// scrittura sotto la stessa chiave o è identica — e allora torna la riga di prima — o
+			// è un conflitto che ALZA. Un fake che accodava e basta rendeva verde un chiamante che
+			// in produzione si vedeva chiudere la corsia in faccia.
+			const existing = threadEvents.find(
+				(e) => e.thread_id === params.p_thread_id && e.source_key === params.p_source_key
+			);
+			if (existing) {
+				if (existing.kind !== params.p_kind || JSON.stringify(existing.payload) !== JSON.stringify(params.p_payload)) {
+					return Promise.resolve({ data: null, error: { message: 'thread event source key conflict' } });
+				}
+				return Promise.resolve({ data: [{ ...existing }], error: null });
+			}
 			const row: Row = {
 				thread_id: params.p_thread_id,
 				seq: ++eventSeq,
@@ -601,7 +618,7 @@ type Row = Record<string, unknown>;
 		return Promise.resolve({ data: { closed: true, message_id: msgId }, error: null });
 	}
 
-	return { db: { from, rpc } as unknown as SupabaseClient, rows, chatMessages, approvals, threadEvents };
+	return { db: { from, rpc } as unknown as SupabaseClient, rows, chatMessages, approvals, threadEvents, appendCalls };
 }
 
 /** Un turno che chiama UN tool (e unico) e basta. */
@@ -1930,6 +1947,70 @@ describe('runKitTurn — resumeRunId (il reaper lascia la riga viva, un worker n
 		expect(rows[0].lease_owner).not.toBe('dead-owner');
 		expect(rows[0].state).toBe('done');
 		expect(staleClose?.closed).toBe(false);
+	});
+
+	it('due specchi dello stesso run non si contendono la stessa chiave: la corsia progress regge il secondo giro', async () => {
+		const morto = {
+			id: 'run-dead',
+			brand_id: 'b1',
+			thread_id: 't-reap',
+			agent_id: 'content',
+			user_id: 'u1',
+			state: 'running',
+			reason: null,
+			question: null,
+			lease_owner: 'dead-owner',
+			lease_fence: 3,
+			lease_until: '2020-01-01T00:00:00.000Z',
+			created_at: '2026-08-21T00:00:00.000Z',
+			updated_at: '2026-08-21T00:00:00.000Z'
+		};
+		const { db, rows, appendCalls } = fakeDb([morto]);
+
+		textThenReplyModel(['primo giro'], 'fatto');
+		await (
+			await runKitTurn({
+				supabase: fakeSupabase,
+				admin: db,
+				brand: { id: 'b1' },
+				user: { id: 'u1' },
+				threadId: 't-reap',
+				spec,
+				messages: [{ role: 'user', content: 'ciao' }],
+				locale: 'it',
+				resumeRunId: 'run-dead'
+			})
+		).text();
+
+		// IL REAPER LASCIA LA RIGA VIVA UN'ALTRA VOLTA: stesso run, secondo worker, secondo
+		// specchio. `MAX_RUN_ATTEMPTS` ne ammette tre — e ogni specchio riparte dal suo tick 1.
+		rows[0].state = 'running';
+		rows[0].lease_until = '2020-01-01T00:00:00.000Z';
+
+		textThenReplyModel(['secondo giro, testo diverso'], 'rifatto');
+		await (
+			await runKitTurn({
+				supabase: fakeSupabase,
+				admin: db,
+				brand: { id: 'b1' },
+				user: { id: 'u1' },
+				threadId: 't-reap',
+				spec,
+				messages: [{ role: 'user', content: 'e allora?' }],
+				locale: 'it',
+				resumeRunId: 'run-dead'
+			})
+		).text();
+
+		const perChiave = new Map<string, Set<string>>();
+		for (const call of appendCalls.filter((c) => c.kind === 'progress')) {
+			const payloads = perChiave.get(call.source_key) ?? new Set<string>();
+			payloads.add(JSON.stringify(call.payload));
+			perChiave.set(call.source_key, payloads);
+		}
+		const contese = [...perChiave].filter(([, payloads]) => payloads.size > 1).map(([key]) => key);
+
+		expect(contese).toEqual([]);
 	});
 
 	it('la riga già ripresa da un altro non parte una seconda volta', async () => {

--- a/src/lib/agent/bridge/live.ts
+++ b/src/lib/agent/bridge/live.ts
@@ -1517,6 +1517,12 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
 				let inFlight: Promise<void> | null = null;
 				let progressTick = 0;
 				let lastProgressAt = 0;
+				// L'IDENTITÀ DI QUESTO SPECCHIO, non del run: la chiave di un evento `progress` deve
+				// restare unica anche quando dello stesso run ne girano due — la sessione riusata che
+				// non parte e riprova fresca, o un worker sfrattato che sta ancora scaricando lo
+				// stream. Senza, i due ripartono dal tick 1, la seconda scrittura è un conflitto di
+				// chiave e la corsia durevole si chiude per tutto il turno.
+				const mirrorId = crypto.randomUUID().slice(0, 8);
 				// Il log durevole vive dietro una migration che i deploy di questo repo non applicano.
 				// Dove non c'e`, il primo append fallisce e la corsia si chiude: il turno continua sul
 				// mirror, e non si paga un errore ogni 250ms per tutto il turno.
@@ -1527,7 +1533,7 @@ export async function runKitTurn(input: RunKitTurnInput): Promise<Response> {
 					if (when === 'throttled' && now - lastProgressAt < PROGRESS_EVENT_MS) return;
 					lastProgressAt = now;
 					try {
-						const seq = await appendRunProgress(admin, threadId, ++progressTick, {
+						const seq = await appendRunProgress(admin, threadId, { id: mirrorId, tick: ++progressTick }, {
 							runId: run.id,
 							status: 'running',
 							text: state.text,

--- a/src/lib/content/changelog/2026-09-03-live-text-survives-a-retry.ts
+++ b/src/lib/content/changelog/2026-09-03-live-text-survives-a-retry.ts
@@ -1,0 +1,9 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-03',
+  title: 'Live text survives a retry',
+  items: [
+    'When a turn has to restart itself mid-answer, reopening the chat keeps showing the answer as it is written instead of falling back to a slower refresh.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/chat/thread-events.test.ts
+++ b/src/lib/server/chat/thread-events.test.ts
@@ -102,13 +102,13 @@ describe('thread event writer', () => {
 });
 
 describe('run progress lane', () => {
-	it('appends an absolute snapshot under a per-tick source key', async () => {
+	it('appends an absolute snapshot under a per-mirror, per-tick source key', async () => {
 		const rpc = vi.fn(async () => ({
-			data: [{ thread_id: 'thread-1', seq: 9, source_key: 'run-1:progress:3', kind: 'progress', payload: {} }],
+			data: [{ thread_id: 'thread-1', seq: 9, source_key: 'run-1:progress:mirror-a:3', kind: 'progress', payload: {} }],
 			error: null
 		}));
 
-		const seq = await appendRunProgress({ rpc } as unknown as SupabaseClient, 'thread-1', 3, {
+		const seq = await appendRunProgress({ rpc } as unknown as SupabaseClient, 'thread-1', { id: 'mirror-a', tick: 3 }, {
 			runId: 'run-1',
 			status: 'running',
 			text: 'half a sentence'
@@ -117,22 +117,36 @@ describe('run progress lane', () => {
 		expect(seq).toBe(9);
 		expect(rpc).toHaveBeenCalledWith('append_thread_event', {
 			p_thread_id: 'thread-1',
-			p_source_key: 'run-1:progress:3',
+			p_source_key: 'run-1:progress:mirror-a:3',
 			p_kind: 'progress',
 			p_payload: { runId: 'run-1', status: 'running', text: 'half a sentence' }
 		});
 	});
 
+	it('two mirrors of one run never share a key, even on the same tick', async () => {
+		const keys: string[] = [];
+		const rpc = vi.fn(async (_fn: string, params: Record<string, unknown>) => {
+			keys.push(params.p_source_key as string);
+			return { data: [{ thread_id: 'thread-1', seq: keys.length, source_key: params.p_source_key, kind: 'progress', payload: {} }], error: null };
+		});
+		const db = { rpc } as unknown as SupabaseClient;
+
+		await appendRunProgress(db, 'thread-1', { id: 'mirror-a', tick: 1 }, { runId: 'run-1', status: 'running', text: 'primo' });
+		await appendRunProgress(db, 'thread-1', { id: 'mirror-b', tick: 1 }, { runId: 'run-1', status: 'running', text: 'secondo' });
+
+		expect(new Set(keys).size).toBe(2);
+	});
+
 	it('replays one tick to the same sequence instead of appending twice', async () => {
 		const rpc = vi.fn(async () => ({
-			data: [{ thread_id: 'thread-1', seq: 9, source_key: 'run-1:progress:3', kind: 'progress', payload: {} }],
+			data: [{ thread_id: 'thread-1', seq: 9, source_key: 'run-1:progress:mirror-a:3', kind: 'progress', payload: {} }],
 			error: null
 		}));
 		const db = { rpc } as unknown as SupabaseClient;
 		const snapshot = { runId: 'run-1', status: 'running', text: 'half a sentence' };
 
-		expect(await appendRunProgress(db, 'thread-1', 3, snapshot)).toBe(9);
-		expect(await appendRunProgress(db, 'thread-1', 3, snapshot)).toBe(9);
+		expect(await appendRunProgress(db, 'thread-1', { id: 'mirror-a', tick: 3 }, snapshot)).toBe(9);
+		expect(await appendRunProgress(db, 'thread-1', { id: 'mirror-a', tick: 3 }, snapshot)).toBe(9);
 	});
 
 	it('prunes only the progress of the finished run', async () => {

--- a/src/lib/server/chat/thread-events.ts
+++ b/src/lib/server/chat/thread-events.ts
@@ -91,13 +91,20 @@ export async function appendThreadEvent(
 	return row as StoredThreadEvent;
 }
 
+/**
+ * Chi scrive questo snapshot: uno specchio, non un run. Il tick è un contatore che vive quanto
+ * l'istanza dello specchio, quindi da solo non basta a fare una chiave — due specchi dello stesso
+ * run (un worker sfrattato che non lo sa ancora, o una sessione ripresa) ripartono entrambi da 1.
+ */
+export type RunProgressMirror = { id: string; tick: number };
+
 export async function appendRunProgress(
 	db: SupabaseClient,
 	threadId: string,
-	tick: number,
+	mirror: RunProgressMirror,
 	progress: ThreadProgress
 ): Promise<number> {
-	const event = progressEvent(threadId, `${progress.runId}:progress:${tick}`, progress);
+	const event = progressEvent(threadId, `${progress.runId}:progress:${mirror.id}:${mirror.tick}`, progress);
 	const stored = await appendThreadEvent(db, event);
 	return stored.seq;
 }


### PR DESCRIPTION
## What?

The durable `progress` events a turn writes were keyed `<runId>:progress:<tick>`, where the tick
is a counter that lives and dies with one mirror instance. When one run has two mirrors, both
start at tick 1 with different text, the second append is a source key conflict, and the durable
lane closes for the rest of the turn. The key now carries the mirror's own id.

## Why?

From the logs:

```
[AGENT_KIT] run d1e0c0cb progress event Error: thread event append failed:
    thread event source key conflict
    at appendThreadEvent (src/lib/server/chat/thread-events.ts:42:20)
    at async publishProgress (src/lib/agent/bridge/live.ts:284:25)
```

`append_thread_event` (migration 0226) treats a repeated source key as an idempotent replay only
when the payload is identical; a different payload under the same key is a conflict and raises.
`publishProgress` catches that, sets `progressLane = 'closed'` and stops writing durable events —
deliberately, so a broken lane does not cost an error every 250ms for the whole turn.

One run gets two mirrors in at least two ways that happen for real:

- the reused harness session fails to start, the turn drops it and retries with a fresh one —
  same `run.id`, same invocation, second stream (`live.ts`, "la sessione riusata non partiva");
- a worker takes over a lease while the evicted one is still draining its stream. The fence stops
  the evicted worker's writes to `agent_kit_runs`; it does not stop its `thread_events` appends.

The cost is a silent degradation. The durable log is what lets a tab reopened mid-turn see what a
live tab is accumulating; without it the reader falls back to polling `partial` every 4 seconds —
text in jumps instead of flowing. Declared as a fallback, but here it was triggered by a defect,
not by a lost Realtime channel.

## How?

The source key becomes `<runId>:progress:<mirrorId>:<tick>`, with `mirrorId` minted inside
`mirrorSseToRun` — the scope the tick counter actually belongs to. The signature says it too:

```ts
appendRunProgress(admin, threadId, { id: mirrorId, tick: ++progressTick }, snapshot)
```

Idempotency survives exactly where it was real: the same mirror replaying the same tick with the
same payload still lands on the row it already wrote. What is given up is cross-mirror
deduplication, which never worked — two mirrors have different text, so they were never
deduplicating, only colliding.

Rejected: fencing the progress lane the way `agent_kit_runs` writes are fenced (the evicted worker
stops writing). It is a bigger change, and it is the wrong shape for the retry case, where both
mirrors belong to the same live turn and both have something true to say. Also rejected: relaxing
the conflict rule in the plpgsql — that rule is what protects the message log, and deploys here do
not run migrations anyway.

Nothing reads the key back: `reduceThreadEvents` indexes progress by `runId`, so two lanes of one
run stay one projection entry (the newest by `seq`), and `pruneRunProgress` deletes by `runId`, so
it prunes both.

## Testing?

Unit, red before green:

- `src/lib/agent/bridge/live.test.ts` — the fake for `append_thread_event` used to append blindly:
  no unique key, no conflict, so no test could ever see this. It now has the semantics of
  migration 0226 (same key + same payload → the existing row; same key + different payload →
  error). With that fake, a new test resumes one run with two workers and **fails on the contested
  key `run-dead:progress:1`**; with the fix, the key spaces are disjoint.
- `src/lib/server/chat/thread-events.test.ts` — a seam test: two mirrors, one run, the same tick,
  two different keys.

```
✓ src/lib/agent/bridge/live.test.ts (84 tests)
✓ src/lib/server/chat/ (72 files, 932 tests)
✓ packages/agent-kit/src/thread-events.test.ts
```

Not tested: **no browser verification**. Reproducing it by hand means making a harness session
fail to start, or evicting a lease mid-stream, while a second tab watches the durable lane — the
test reproduces the same race deterministically and the browser would only re-stage it. The user
visible effect of the fix is the absence of a degradation, which is why the guard is a test and
not a screenshot.

## Evidence (screenshots/videos)

Backend change, no UI.

<details>
<summary>The red test, before the fix</summary>

```
FAIL src/lib/agent/bridge/live.test.ts > due specchi dello stesso run non si contendono
     la stessa chiave: la corsia progress regge il secondo giro
AssertionError: expected [ 'run-dead:progress:1' ] to deeply equal []
```

</details>

## Anything Else?

`pruneRunProgress` deletes every `progress` row whose payload carries the run id — including the
`run:<id>:state:<state>` event that `agent_kit_close_run` appends inside the same transaction that
closes the run. Whether that event is meant to survive the prune is a separate question, and it
predates this change; left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GpsbC3tQzxsBSg4Cns3x1C
