### PR TITLE
Take the sandbox cleanup off the response path

### DIFF
--- a/changelog/2026-09-03-release-off-response-path.md
+++ b/changelog/2026-09-03-release-off-response-path.md
@@ -1,0 +1,52 @@
+# La pulizia della sandbox esce dal percorso della risposta
+
+## Il numero
+
+Un render di grafica costava **~17.5s**, così divisi:
+
+```
+apertura sandbox + progetto   ~6.0s
+`remotion still`               ~3.4s
+lettura del PNG                ~0.2s
+release + addebito             ~8.0s   ← qui il PNG esiste GIÀ
+```
+
+**Quasi metà del tempo scorre dopo che il lavoro è finito.** `release()` fa `rm -rf` della directory
+di run e rilascia l'holder, un giro di rete verso la VM ciascuno, e mentre lo fa il chiamante
+aspetta una pulizia che non lo riguarda.
+
+Misurato dopo:
+
+```
+prima grafica   8925ms
+seconda         4876ms
+```
+
+Da 17.5s a **8.9s**, e la seconda a **4.9s** — perché la macchina non viene più smontata sotto la
+chiamata successiva, che quindi si attacca a una VM ancora calda.
+
+## Perché non basta non attendere la Promise
+
+In una funzione serverless l'istanza si congela appena la risposta parte: una Promise pendente può
+non finire mai. Qui significherebbe una directory di run che resta e — peggio — **un holder mai
+rilasciato**, cioè una VM che nessuno spegne e che continua a costare.
+
+`waitUntil` di `@vercel/functions` è il modo di dire alla piattaforma «ho ancora questo da fare».
+Dove non c'è — server lungo con `DEPLOY_TARGET=node`, i test — una Promise pendente è già corretta,
+perché lì il processo non si congela. `runInBackground` copre entrambi i casi e non fallisce mai: un
+errore nel fondo verrebbe altrimenti fuori come rifiuto non gestito e ucciderebbe il processo che
+stava rispondendo, cioè l'esatto contrario di quello che questo modulo serve a fare.
+
+## Cosa NON è stato toccato
+
+Il render del motion e le altre chiamate alla sandbox: continuano ad attendere la release. Qui il
+guadagno è certo perché il PNG è già in mano al chiamante quando la pulizia parte; altrove va
+verificato caso per caso, e un cambio a tappeto sulla gestione delle VM non è una cosa da fare di
+sponda.
+
+## Cosa resta
+
+**~4.5s di apertura**, che è `Sandbox.getOrCreate` più quattro o cinque giri di rete verso la VM —
+lo script di `sandbox_browse` (che a un render di grafica non serve), un `mkdir`, il marcatore del
+browser. Unirli in un comando solo vale forse 1–2s. I 4.5s di `getOrCreate` sono il pavimento di
+quell'API.

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "@tiptap/pm": "^3.27.1",
         "@tiptap/starter-kit": "^3.27.1",
         "@vercel/analytics": "^2.0.1",
+        "@vercel/functions": "^3.9.5",
         "@vercel/sandbox": "^3.0.1",
         "ai": "^7.0.77",
         "bits-ui": "^2.18.1",
@@ -7392,6 +7393,84 @@
         }
       }
     },
+    "node_modules/@vercel/cli-config": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@vercel/cli-config/-/cli-config-0.2.4.tgz",
+      "integrity": "sha512-kZ5SojbrV06GHoU6QIWGwDXLov+s9rWZ7QqdqKfJfBGCNUieGfgaCjeeenNy8Y+QC0bwC0dZ2B4l5Hvdmrgpdw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "xdg-app-paths": "5",
+        "zod": "4.1.11"
+      }
+    },
+    "node_modules/@vercel/cli-config/node_modules/zod": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
+      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@vercel/cli-exec": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/cli-exec/-/cli-exec-1.0.1.tgz",
+      "integrity": "sha512-g9XerViJ/paZujufXYcu5XYI2vU2rtB4sgdpjUHde5RnOkdmpu0ngH46LCFGHoPXO/C+qDPSczIHIRN+8Q2YKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "execa": "5.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@vercel/functions": {
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/@vercel/functions/-/functions-3.9.5.tgz",
+      "integrity": "sha512-EUfqlb7AzoEh7URlMNAO4jbJiLWz9grDBHvfjKTDvEP9c8y3DqX3SWPvfaQkUjtkm3b83flhaUUMuewdHa+qmw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/oidc": "3.8.5"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-web-identity": "*",
+        "ws": ">=8"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-web-identity": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vercel/functions/node_modules/@vercel/oidc": {
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.8.5.tgz",
+      "integrity": "sha512-RwXYtnt6za+5UO4IaLywN/6B95AlLqynPRUWRJxeJ/qufwkcLUbZNUxYtzT0uMpuraWhlNcGqPNGkTnZr4BGBw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/cli-config": "0.2.4",
+        "@vercel/cli-exec": "1.0.1",
+        "jose": "^5.9.6"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@vercel/functions/node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/@vercel/nft": {
       "version": "0.30.4",
       "resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-0.30.4.tgz",
@@ -9415,6 +9494,35 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -9984,6 +10092,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/github-from-package": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
@@ -10246,6 +10366,15 @@
         "node": ">= 14"
       }
     },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
     "node_modules/iceberg-js": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
@@ -10454,6 +10583,18 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.6"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-unsafe": {
@@ -11492,6 +11633,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "license": "MIT"
+    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -11538,6 +11685,15 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/mimic-response": {
@@ -11861,6 +12017,18 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/nth-check": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -11929,6 +12097,21 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/open": {
@@ -13954,6 +14137,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/strip-json-comments": {

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "@tiptap/pm": "^3.27.1",
     "@tiptap/starter-kit": "^3.27.1",
     "@vercel/analytics": "^2.0.1",
+    "@vercel/functions": "^3.9.5",
     "@vercel/sandbox": "^3.0.1",
     "ai": "^7.0.77",
     "bits-ui": "^2.18.1",

--- a/src/lib/server/background-work.test.ts
+++ b/src/lib/server/background-work.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest';
+import { runInBackground } from './background-work';
+
+describe('il lavoro di fondo avviene, e non fa aspettare', () => {
+	it('non blocca chi chiama', async () => {
+		let done = false;
+		const t = Date.now();
+		runInBackground(async () => {
+			await new Promise((r) => setTimeout(r, 120));
+			done = true;
+		}, 'test');
+		// Il punto dell'esercizio: la chiamata torna PRIMA che il lavoro finisca.
+		expect(Date.now() - t).toBeLessThan(60);
+		expect(done).toBe(false);
+		await new Promise((r) => setTimeout(r, 200));
+		expect(done, 'il lavoro deve comunque avvenire').toBe(true);
+	});
+
+	it('un fallimento nel fondo non diventa un rifiuto non gestito', async () => {
+		const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		runInBackground(async () => {
+			throw new Error('boom');
+		}, 'test');
+		await new Promise((r) => setTimeout(r, 50));
+		// Se questo diventasse un unhandled rejection, in produzione ucciderebbe il processo che
+		// stava rispondendo — cioè il contrario di quello che questo modulo esiste per fare.
+		expect(spy).toHaveBeenCalled();
+		spy.mockRestore();
+	});
+});

--- a/src/lib/server/background-work.ts
+++ b/src/lib/server/background-work.ts
@@ -1,0 +1,32 @@
+/**
+ * Lavoro che deve AVVENIRE ma non deve far aspettare chi risponde.
+ *
+ * Il caso che l'ha reso necessario: `sandbox.release()` costa ~8 secondi — `rm -rf` della directory
+ * di run e rilascio dell'holder, ciascuno un giro di rete verso la VM — e quando quel tempo scorre
+ * il PNG è GIÀ in mano nostra. Aspettarlo prima di rispondere fa pagare all'utente una pulizia che
+ * non lo riguarda: su un render da 17.5s totali, otto sono questi.
+ *
+ * Non basta lasciare la Promise pendente. In una funzione serverless l'istanza si congela appena la
+ * risposta parte, e il lavoro non atteso può non finire mai: la directory resterebbe, e l'holder
+ * pure — cioè una VM che nessuno spegne. `waitUntil` è il modo di dire alla piattaforma «ho ancora
+ * questo da fare»; dove non c'è (server lungo, test), una Promise pendente basta davvero, perché
+ * lì il processo non si congela.
+ */
+
+/** Non fallisce mai: se il lavoro di fondo esplode, non deve portarsi via la risposta. */
+export function runInBackground(work: () => Promise<unknown>, label: string): void {
+	const promise = Promise.resolve()
+		.then(work)
+		.catch((e) => {
+			console.error(`[background:${label}]`, e instanceof Error ? e.message : e);
+		});
+
+	void (async () => {
+		try {
+			const { waitUntil } = await import('@vercel/functions');
+			waitUntil(promise);
+		} catch {
+			// Fuori da Vercel la Promise pendente è già la cosa giusta: nessuno congela il processo.
+		}
+	})();
+}

--- a/src/lib/server/motion-video/render-tools.ts
+++ b/src/lib/server/motion-video/render-tools.ts
@@ -55,6 +55,7 @@ import {
 } from '$lib/motion-video/modules';
 import { compileMotionSource } from '$lib/motion-video/compile';
 import { withSandboxBilling } from '$lib/server/sandbox-credits';
+import { runInBackground } from '$lib/server/background-work';
 import type { SupabaseClient } from '@supabase/supabase-js';
 
 /** Di chi è la macchina su cui Remotion gira: la stessa chiave con cui il pannello nomina l'agente. */
@@ -642,7 +643,16 @@ export async function renderGraphicStills(opts: {
 			} catch (e) {
 				throw describeSandboxDeath(e);
 			} finally {
-				await sb?.release().catch((error) => { swallow('release failed', error); return undefined; });
+				// La pulizia NON si aspetta: quando parte, i PNG sono gia' in mano al chiamante, e
+				// `release()` costa ~8s dei ~17.5s di un render — rm -rf della directory di run e
+				// rilascio dell'holder, un giro di rete l'uno. Deve comunque AVVENIRE, o restano una
+				// directory e un holder che nessuno spegne: per questo passa da `runInBackground`,
+				// che su Vercel lo dichiara con `waitUntil` invece di lasciarlo a una Promise che
+				// l'istanza congelata non finirebbe mai.
+				const toRelease = sb;
+				if (toRelease) {
+					runInBackground(() => toRelease.release(), `sandbox-release:${toRelease.name}`);
+				}
 			}
 		}
 	);


### PR DESCRIPTION
## What?

`sandbox.release()` moves off the response path on the graphic render. **17.5s → 8.9s**, and a
second render → **4.9s**.

Stacked on #169 and #171, both merged.

## Why?

Nearly half a graphic render ran **after the work was finished**:

```
open sandbox + project   ~6.0s
`remotion still`         ~3.4s
read the PNG             ~0.2s
release + billing        ~8.0s   ← the PNG already exists here
                        ─────
                        ~17.5s
```

`release()` does an `rm -rf` of the run directory and drops the holder — a network round trip each —
while the caller waits for a cleanup that does not concern it.

Measured after:

```
first graphic   8925ms
second          4876ms
```

The second is faster because the machine is no longer torn down under the next call, so it attaches
to a warm VM instead of paying the open again.

## How?

`runInBackground(work, label)`.

**Leaving the promise floating is not enough.** A serverless instance freezes as soon as the response
leaves, so unawaited work may never finish — here that leaves the run directory and, worse, **a
holder nobody released: a VM nothing shuts down**, still costing. `waitUntil` from
`@vercel/functions` declares it to the platform. Outside Vercel (long-lived `DEPLOY_TARGET=node`
server, tests) a floating promise is already correct, because nothing freezes there, and the import
failure is caught.

And it **never throws**: an unhandled rejection would kill the process that was answering — the
exact opposite of the point. Both properties have a test.

## Testing?

Full suite: 6330 passed. The one red file (`hooks.server.test.ts`) needs a local `.env` and fails the
same on `dev`.

The two tests assert what would silently regress: that the call returns **before** the work
finishes, and that the work **still happens**; and that a failure in the background becomes a log
rather than an unhandled rejection.

## Evidence (screenshots/videos)

<details>
<summary>Before and after, same path, real sandbox</summary>

```
before:  17354ms, 18639ms
after:    8925ms,  4876ms
```
</details>

## Anything Else?

**Only the graphic path changed.** Motion renders still await their release. The win is certain here
because the result is already in the caller's hands when the cleanup starts; elsewhere it needs
checking case by case, and retuning VM lifecycle across the codebase is not something to do in
passing.

**What is left: ~4.5s of open.** That is `Sandbox.getOrCreate` plus four or five round trips to the
VM — the `sandbox_browse` script (which a graphic render does not need), a `mkdir`, the browser
marker. Merging them into one command is worth maybe 1–2s. The `getOrCreate` itself is the floor of
that API.

**And a finding from the previous PR that has not been acted on:** graphic carousels do not exist —
`create_post` with `graphic_brief` sets `contentTypeOut = 'generated_graphic'`, always a single
image, and slides are edited one at a time. So #171's batch renderer still has no caller. Giving it
one is a feature (composing N typographic slides from one brief), not a rendering change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01123CrHo6dd8neJU5ZryKFh
