### PR TITLE
Keep the machine alive between consecutive graphics

### DIFF
--- a/changelog/2026-09-03-sandbox-grace.md
+++ b/changelog/2026-09-03-sandbox-grace.md
@@ -1,0 +1,51 @@
+# La macchina resta viva fra una grafica e la successiva
+
+## Il difetto che la pulizia in fondo aveva introdotto
+
+Togliere `release()` dal percorso della risposta ha portato un render da 17.5s a 8.9s. Ma tre render
+di fila davano questo:
+
+```
+13.5s   25.6s   4.4s
+```
+
+Il picco centrale non è rumore. `releaseHolder` chiama `stopWhenIdle`, che **spegne la VM** appena
+non resta nessun holder valido: la pulizia della prima grafica spegneva la macchina mentre la
+seconda la stava chiedendo, e quella pagava il risveglio da capo. Spostare la pulizia in background
+l'aveva resa *invisibile*, non innocua — corre accanto al lavoro successivo invece che prima.
+
+## La grazia
+
+Il rilascio aspetta 25 secondi. Abbastanza da coprire due richieste dello stesso turno di chat,
+abbastanza poco da non tenere una VM accesa per niente — e comunque non è un tetto di vita: il lease
+della sandbox la spegne lo stesso.
+
+```
+prima:   13.5s   25.6s    4.4s
+dopo:     9.6s    4.4s    4.5s
+poi:      5.2s    4.8s    4.9s   (macchina già calda)
+```
+
+## Dove sono finiti i 17.5s iniziali
+
+```
+apertura      1.2s a caldo   (4.7s a freddo: 3.5s sono la VM che si sveglia alla prima scrittura)
+render        ~2.5s
+lettura       ~0.2s
+pulizia       fuori dal percorso
+             ─────
+             ~4.8s per grafica, di fila
+```
+
+Da 17.5s a **~4.8s**: −73%. E l'apertura, che avevo dato per 4.5s incomprimibili, a caldo è **1.2s**
+— i 3.5s che la gonfiavano erano la prima scrittura sulla VM addormentata, non il numero di giri.
+
+## Cosa resta, e dove guarderei
+
+Il pezzo grosso ora è il **render** (~2.5s): `npx remotion still` fa partire node, carica il bundle e
+lancia Chromium a ogni invocazione. Riusare un browser vivo fra un render e l'altro chiede un
+processo che resti in piedi dentro la VM — un piccolo server di render invece di un comando — e non
+è un aggiustamento, è un pezzo nuovo.
+
+L'apertura a freddo (~4.7s) non si comprime: 3.5s sono la VM che si sveglia, e quello lo paga la
+prima richiesta di chiunque.

--- a/src/lib/server/motion-video/render-tools.ts
+++ b/src/lib/server/motion-video/render-tools.ts
@@ -64,6 +64,14 @@ const MOTION_AGENT = 'motion';
 /** Il progetto di render, nella home della VM: sopravvive alla run, non ai riavvii della macchina. */
 const PROJECT_DIR = '.anomalia/motion-render';
 
+/**
+ * Quanto la macchina resta in piedi dopo una grafica, in attesa della prossima.
+ *
+ * Abbastanza da coprire due richieste dello stesso turno di chat, abbastanza poco da non tenere
+ * una VM accesa per niente. Non e' un tetto di vita: il lease della sandbox la spegne comunque.
+ */
+const GRAPHIC_RELEASE_GRACE_MS = 25_000;
+
 /** Fotogrammi per chiamata. Oltre, il contesto si riempie di PNG e il modello smette di guardarli. */
 export const MAX_STILLS_PER_RENDER = 4;
 /** Render per turno: ognuno è una VM, un render e dei megabyte di immagini nel contesto. */
@@ -651,7 +659,15 @@ export async function renderGraphicStills(opts: {
 				// l'istanza congelata non finirebbe mai.
 				const toRelease = sb;
 				if (toRelease) {
-					runInBackground(() => toRelease.release(), `sandbox-release:${toRelease.name}`);
+					runInBackground(async () => {
+						// GRAZIA prima di rilasciare. `releaseHolder` chiama `stopWhenIdle`, che spegne
+						// la VM quando nessun holder resta: senza attesa, la pulizia della prima
+						// grafica spegne la macchina mentre la seconda la sta chiedendo, e quella
+						// paga il risveglio. Misurato: tre render di fila hanno dato 13.5s, 25.6s e
+						// 4.4s — il picco centrale e' esattamente questa collisione.
+						await new Promise((r) => setTimeout(r, GRAPHIC_RELEASE_GRACE_MS));
+						await toRelease.release();
+					}, `sandbox-release:${toRelease.name}`);
 				}
 			}
 		}


### PR DESCRIPTION
## What?

The sandbox release waits **25 seconds** before running, so two graphics in the same chat turn share
the machine.

Three renders in a row: **9.6s, 4.4s, 4.5s** — and **5.2s, 4.8s, 4.9s** on an already warm machine.
From the 17.5s this thread started at, that is **−73%**.

## Why?

#174 took `release()` off the response path — 17.5s → 8.9s. But three renders in a row measured:

```
13.5s   25.6s   4.4s
```

**The middle peak is not noise.** `releaseHolder` calls `stopWhenIdle`, which stops the VM as soon
as no valid holder remains. So the first graphic's cleanup was **shutting the machine down while the
second was asking for it**, and that one paid the wake-up from scratch.

Backgrounding the cleanup had made it *invisible*, not harmless: it now runs alongside the next job
instead of before it. That is a defect my own previous PR introduced, and it only showed up because
I measured three in a row instead of two.

## How?

A 25s grace before the release. Long enough to cover two requests in one chat turn, short enough not
to hold a VM for nothing — and not a lifetime cap either way, since the sandbox lease stops it
regardless.

## Testing?

Full suite: 6335 passed. Three failures, none mine:

- `hooks.server.test.ts` — the known `.env`-dependent one;
- `harness-skill-writes.test.ts` (×3) — **pre-existing on `dev`**, verified by running that file on a
  clean `dev` checkout.

## Evidence (screenshots/videos)

<details>
<summary>Where the original 17.5s went</summary>

```
open        1.2s warm   (4.7s cold — 3.5s of it is the VM waking on the first write)
render      ~2.5s
read        ~0.2s
cleanup     off the path
           ─────
           ~4.8s per graphic, back to back
```

The open I had called an incompressible 4.5s is **1.2s warm**. The 3.5s inflating it was the first
write to a sleeping VM, not the number of round trips — so the fix was never "fewer commands".
</details>

## Anything Else?

**You were right that 4.5s was not the floor.** It was not even the number: it was one cold write
being counted as steady-state cost.

**What dominates now is the render itself (~2.5s).** `npx remotion still` starts node, loads the
bundle and launches Chromium on every invocation. Reusing a live browser between renders needs a
process that stays up inside the VM — a small render server rather than a command — and that is a
new piece, not an adjustment.

**The cold open (~4.7s) does not compress:** 3.5s is the VM waking, and somebody's first request
always pays it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01123CrHo6dd8neJU5ZryKFh
