### PR TITLE
Stop rewriting skills the sandbox already has

### DIFF
--- a/patches/@ai-sdk+harness+1.0.87.patch
+++ b/patches/@ai-sdk+harness+1.0.87.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@ai-sdk/harness/dist/utils/index.js b/node_modules/@ai-sdk/harness/dist/utils/index.js
-index c6dc6e3..1e1bca8 100644
+index c6dc6e3..8618175 100644
 --- a/node_modules/@ai-sdk/harness/dist/utils/index.js
 +++ b/node_modules/@ai-sdk/harness/dist/utils/index.js
 @@ -548,6 +548,13 @@ async function writeSkills({
@@ -29,7 +29,7 @@ index c6dc6e3..1e1bca8 100644
      });
      for (const file of (_b = skill.files) != null ? _b : []) {
        const filePath = normalizeSkillFilePath({
-@@ -567,13 +573,70 @@ async function writeSkills({
+@@ -567,13 +573,108 @@ async function writeSkills({
          mode: filePathMode,
          message: invalidSkillFilePathMessage
        });
@@ -97,9 +97,47 @@ index c6dc6e3..1e1bca8 100644
 +      await writeOneByOne(chunk);
 +    }
 +  };
-+  // Le cartelle nel primo pezzo: gli altri ci scrivono dentro, e partono dopo.
-+  await runChunk(chunks[0], true);
-+  await Promise.all(chunks.slice(1).map((chunk) => runChunk(chunk, false)));
++  // Le skill NON cambiano fra un turno e l'altro, e la sandbox del brand vive fra i turni:
++  // riscriverle ogni volta e` lavoro gia` fatto. Il marcatore porta l'impronta del contenuto e sta
++  // DENTRO la cartella delle skill, quindi una sandbox nuova non ce l'ha e una modifica lo
++  // invalida. Sta qui, e non nel chiamante, perche' non passare le skill all'agent le toglierebbe
++  // anche dal catalogo del modello: qui si salta la SCRITTURA, non la dichiarazione.
++  const identity = fingerprintSkillWrites(writes);
++  const markerPath = path2.posix.join(rootDir, ".harness-skills-id");
++  try {
++    const seen = await sandbox.run({
++      command: `cat ${shellQuote(markerPath)} 2>/dev/null || true`,
++      abortSignal
++    });
++    const stdout = seen != null && typeof seen === "object" && "stdout" in seen ? String(seen.stdout) : "";
++    if (stdout.trim() === identity) {
++      return;
++    }
++  } catch {
++    // Non sapere se ci sono non e` una ragione per non scriverle.
++  }
++  // Le cartelle prima, poi tutti i pezzi insieme.
++  await sandbox.run({ command: `mkdir -p ${dirs.map(shellQuote).join(" ")}`, abortSignal });
++  await Promise.all(chunks.map((chunk) => runChunk(chunk, false)));
++  // Il marcatore per ULTIMO: se una scrittura fallisce non deve restare scritto che ci sono.
++  await sandbox
++    .run({ command: `printf %s ${shellQuote(identity)} > ${shellQuote(markerPath)}`, abortSignal })
++    .catch(() => {});
++}
++function fingerprintSkillWrites(writes) {
++  const payload = writes
++    .map((w) => `${w.path}\0${w.content}`)
++    .sort()
++    .join("\0\0");
++  // FNV-1a: serve a dire "e` cambiato", non a resistere a un avversario.
++  let h1 = 2166136261;
++  let h2 = 2166136261 ^ payload.length;
++  for (let i = 0; i < payload.length; i++) {
++    const c = payload.charCodeAt(i);
++    h1 = Math.imul(h1 ^ c, 16777619);
++    h2 = Math.imul(h2 ^ (c + i), 16777619);
++  }
++  return `${(h1 >>> 0).toString(16)}${(h2 >>> 0).toString(16)}`;
  }
  function validateSkillName({
    name,

--- a/src/lib/agent/bridge/harness-skill-writes.test.ts
+++ b/src/lib/agent/bridge/harness-skill-writes.test.ts
@@ -6,9 +6,9 @@ import { writeSkills } from '@ai-sdk/harness/utils';
  * quelli erano `writeSkills`: 14 file scritti nella sandbox UNO ALLA VOLTA, ~450ms l'uno, perche'
  * ogni `writeTextFile` e` un round-trip — due, in realta`: `mkdir -p` del padre, poi il file.
  *
- * Adesso partono tutti in un comando solo. La correzione vive in
- * `patches/@ai-sdk+harness+1.0.87.patch`, quindi questo test guida la `writeSkills` INSTALLATA: se
- * un bump di versione si porta via la patch, cade qui invece di tornare in silenzio a dieci
+ * Adesso partono insieme, e se ci sono gia` non partono affatto. La correzione vive in
+ * `patches/@ai-sdk+harness+1.0.87.patch`, quindi questi test guidano la `writeSkills` INSTALLATA:
+ * un bump di versione che si porta via la patch cade qui, invece di tornare in silenzio a sette
  * secondi di attesa. (LESSONS: patch-package e i deploy.)
  */
 const SKILLS = [
@@ -26,49 +26,54 @@ const SKILLS = [
 
 const ROOT = '/home/agent/.agents/skills';
 
-describe('le skill vanno nella sandbox in un colpo solo', () => {
-  it('un comando solo, non un round-trip per file', async () => {
-    const commands: string[] = [];
-    const perFile: string[] = [];
-
-    await writeSkills({
-      sandbox: {
-        run: async ({ command }: { command: string }) => {
-          commands.push(command);
-          return { exitCode: 0 };
-        },
-        writeTextFile: async ({ path }: { path: string }) => {
-          perFile.push(path);
+/** Una sandbox finta che ricorda i comandi e finge un filesystem per il marcatore. */
+function fakeSandbox(opts: { marker?: string; failBatch?: boolean; failPerFile?: boolean } = {}) {
+  const commands: string[] = [];
+  const perFile: string[] = [];
+  let marker = opts.marker ?? '';
+  return {
+    commands,
+    perFile,
+    marker: () => marker,
+    sandbox: {
+      run: async ({ command }: { command: string }) => {
+        commands.push(command);
+        if (command.startsWith('cat ')) return { exitCode: 0, stdout: marker };
+        if (command.includes('.harness-skills-id') && command.startsWith('printf')) {
+          marker = command.split("'")[1];
+          return { exitCode: 0, stdout: '' };
         }
-      } as never,
-      rootDir: ROOT,
-      skills: SKILLS as never
-    });
+        if (opts.failBatch && command.includes('base64 -d')) throw new Error('base64: not found');
+        return { exitCode: 0, stdout: '' };
+      },
+      writeTextFile: async ({ path }: { path: string }) => {
+        if (opts.failPerFile) throw new Error('sandbox morta');
+        perFile.push(path);
+      }
+    } as never
+  };
+}
 
-    // Uno per la radice (lo faceva gia`) e uno per tutto il resto.
-    expect(commands).toHaveLength(2);
-    expect(perFile).toEqual([]);
+const batchCommands = (commands: string[]) => commands.filter((c) => c.includes('base64 -d'));
+
+describe('le skill vanno nella sandbox in un colpo solo', () => {
+  it('un comando solo per tutti i file, non un round-trip per file', async () => {
+    const s = fakeSandbox();
+    await writeSkills({ sandbox: s.sandbox, rootDir: ROOT, skills: SKILLS as never });
+
+    expect(batchCommands(s.commands)).toHaveLength(1);
+    expect(s.perFile).toEqual([]);
     for (const p of ['humanizer/SKILL.md', 'social/SKILL.md', 'social/references/platforms.md']) {
-      expect(commands[1]).toContain(`${ROOT}/${p}`);
+      expect(batchCommands(s.commands)[0]).toContain(`${ROOT}/${p}`);
     }
   });
 
   /** Un batch che scrive i byte sbagliati e` peggio di uno lento: il contenuto va verificato. */
   it('i contenuti arrivano intatti, apici e virgolette compresi', async () => {
-    const commands: string[] = [];
-    await writeSkills({
-      sandbox: {
-        run: async ({ command }: { command: string }) => {
-          commands.push(command);
-          return { exitCode: 0 };
-        },
-        writeTextFile: async () => {}
-      } as never,
-      rootDir: ROOT,
-      skills: SKILLS as never
-    });
+    const s = fakeSandbox();
+    await writeSkills({ sandbox: s.sandbox, rootDir: ROOT, skills: SKILLS as never });
 
-    const decoded = [...commands[1].matchAll(/printf %s '([A-Za-z0-9+/=]+)'/g)].map((m) =>
+    const decoded = [...batchCommands(s.commands)[0].matchAll(/printf %s '([A-Za-z0-9+/=]+)'/g)].map((m) =>
       Buffer.from(m[1], 'base64').toString('utf8')
     );
     expect(decoded.some((c) => c.includes('contenuto uno'))).toBe(true);
@@ -77,26 +82,58 @@ describe('le skill vanno nella sandbox in un colpo solo', () => {
   });
 
   /**
-   * IL SECONDO COSTO PAGATO, mezz'ora dopo il primo. Un comando solo per tutti i file sembrava la
-   * mossa giusta e in laboratorio lo era — 388ms invece di 6900. In pratica bash rifiutava
-   * l'argomento oltre MAX_ARG_STRLEN (128KB): «argument list too long», si cadeva nel fallback, e
-   * il batch non girava MAI. Sembrava che l'ottimizzazione non pagasse; non era mai partita.
+   * La sandbox del brand vive fra i turni e le skill non cambiano: riscriverle ogni volta e`
+   * lavoro gia` fatto, ~1 secondo prima che la chat possa rispondere.
+   */
+  it('la seconda volta non scrive niente', async () => {
+    const s = fakeSandbox();
+    await writeSkills({ sandbox: s.sandbox, rootDir: ROOT, skills: SKILLS as never });
+    const dopoLaPrima = s.commands.length;
+
+    await writeSkills({ sandbox: s.sandbox, rootDir: ROOT, skills: SKILLS as never });
+
+    // Nessuna scrittura nuova: solo il `mkdir -p` della radice e la lettura del marcatore.
+    expect(batchCommands(s.commands)).toHaveLength(1);
+    expect(s.commands.slice(dopoLaPrima).every((c) => c.startsWith('mkdir') || c.startsWith('cat'))).toBe(true);
+    expect(s.perFile).toEqual([]);
+  });
+
+  it('ma se il contenuto cambia le riscrive', async () => {
+    const s = fakeSandbox();
+    await writeSkills({ sandbox: s.sandbox, rootDir: ROOT, skills: SKILLS as never });
+
+    const cambiate = [{ ...SKILLS[0], content: 'contenuto DIVERSO' }, SKILLS[1]];
+    await writeSkills({ sandbox: s.sandbox, rootDir: ROOT, skills: cambiate as never });
+
+    expect(batchCommands(s.commands)).toHaveLength(2);
+  });
+
+  /**
+   * Il marcatore mentirebbe se restasse scritto senza i file: il turno dopo salterebbe la
+   * scrittura e l'agente si troverebbe una cartella vuota. Va scritto per ULTIMO, e mai se
+   * nemmeno il fallback ce l'ha fatta.
+   */
+  it('non lascia il marcatore quando i file non sono arrivati', async () => {
+    const s = fakeSandbox({ failBatch: true, failPerFile: true });
+
+    await expect(
+      writeSkills({ sandbox: s.sandbox, rootDir: ROOT, skills: SKILLS as never })
+    ).rejects.toThrow();
+
+    expect(s.marker()).toBe('');
+  });
+
+  /**
+   * IL SECONDO COSTO PAGATO. Un comando solo per tutti i file sembrava la mossa giusta, e in
+   * laboratorio lo era. In pratica bash rifiutava l'argomento oltre MAX_ARG_STRLEN (128KB):
+   * «argument list too long», si cadeva nel fallback, e il batch non girava MAI. Sembrava che
+   * l'ottimizzazione non pagasse; non era mai partita.
    */
   it('spezza il comando invece di sforare il limite di bash', async () => {
-    const commands: string[] = [];
-    const perFile: string[] = [];
+    const s = fakeSandbox();
     const grosso = 'x'.repeat(70 * 1024);
-
     await writeSkills({
-      sandbox: {
-        run: async ({ command }: { command: string }) => {
-          commands.push(command);
-          return { exitCode: 0 };
-        },
-        writeTextFile: async ({ path }: { path: string }) => {
-          perFile.push(path);
-        }
-      } as never,
+      sandbox: s.sandbox,
       rootDir: ROOT,
       skills: [
         { name: 'a', description: 'd', content: grosso },
@@ -105,13 +142,12 @@ describe('le skill vanno nella sandbox in un colpo solo', () => {
       ] as never
     });
 
-    // Nessun comando oltre la soglia, e nessun file perso per strada.
-    expect(commands.length).toBeGreaterThan(2);
-    for (const c of commands) {
+    expect(batchCommands(s.commands).length).toBeGreaterThan(1);
+    for (const c of s.commands) {
       expect(c.length).toBeLessThan(128 * 1024);
     }
-    expect(perFile).toEqual([]);
-    const scritti = commands.join('\n');
+    expect(s.perFile).toEqual([]);
+    const scritti = s.commands.join('\n');
     for (const n of ['a', 'b', 'c']) {
       expect(scritti).toContain(`${ROOT}/${n}/SKILL.md`);
     }
@@ -122,22 +158,10 @@ describe('le skill vanno nella sandbox in un colpo solo', () => {
    * piu` lenta ma giusta. Senza questo ramo un'immagine diversa perderebbe le skill in silenzio.
    */
   it('se il comando fallisce, i file vanno scritti lo stesso uno per uno', async () => {
-    const perFile: string[] = [];
-    await writeSkills({
-      sandbox: {
-        run: async ({ command }: { command: string }) => {
-          if (command.includes('base64')) throw new Error('base64: not found');
-          return { exitCode: 0 };
-        },
-        writeTextFile: async ({ path }: { path: string }) => {
-          perFile.push(path);
-        }
-      } as never,
-      rootDir: ROOT,
-      skills: SKILLS as never
-    });
+    const s = fakeSandbox({ failBatch: true });
+    await writeSkills({ sandbox: s.sandbox, rootDir: ROOT, skills: SKILLS as never });
 
-    expect(perFile).toHaveLength(4);
-    expect(perFile).toContain(`${ROOT}/social/references/platforms.md`);
+    expect(s.perFile).toHaveLength(4);
+    expect(s.perFile).toContain(`${ROOT}/social/references/platforms.md`);
   });
 });


### PR DESCRIPTION
## What?

Il batch (#170) ha portato `writeSkills` da **6903ms a 1068ms**. Questo porta il caso comune a
**318ms**, non scrivendo affatto.

Le skill non cambiano fra un turno e l'altro, e la sandbox del brand vive più a lungo di loro:
riscriverle ogni volta è lavoro già fatto.

## Why?

Un marcatore con l'impronta del contenuto sta **dentro** la cartella delle skill. Una sandbox nuova
non ce l'ha; una skill modificata lo invalida. Quando non è cambiato niente, l'intera chiamata è una
lettura sola.

**Misurato nella stessa esecuzione:** `SCRITTE 14 file in 2 comandi, 1728ms` → turno successivo
`SALTATE, 318ms`.

## How?

**Il marcatore sta dentro `writeSkills`, e non nel chiamante — è la parte che conta.** Il primo
tentativo lo metteva fuori, non passando le skill quando erano già su disco. Leggendo `harness-pi`
si vede che `skills: []` azzera anche `harnessSkills` e `readableRoots`: le skill smettono di essere
**dichiarate** al modello e la cartella non è più leggibile. Sarebbe stato un secondo scambiato con
un agente che perde in silenzio le proprie capacità. Qui si salta la **scrittura**, mai la
dichiarazione.

Il marcatore si scrive **per ultimo**, e mai se i file non sono arrivati — altrimenti il turno dopo
salterebbe la scrittura su una cartella vuota. Un test lo tiene: falliscono entrambe le strade di
scrittura, `writeSkills` rifiuta, e il marcatore resta vuoto.

L'impronta è una FNV-1a sul contenuto: serve a dire «è cambiato», non a resistere a un avversario.

## Testing?

Suite intera verde (6350). Sette casi sulla `writeSkills` **installata**, quindi un bump di versione
che si porta via `patches/@ai-sdk+harness+1.0.87.patch` fa cadere la suite invece di tornare in
silenzio a sette secondi:

- un comando solo per tutti i file, non un round-trip per file;
- i contenuti intatti, apici e virgolette comprese (un batch che scrive i byte sbagliati è peggio di
  uno lento);
- **la seconda volta non scrive niente**, e **se il contenuto cambia riscrive**;
- **il marcatore non resta quando i file non sono arrivati**;
- lo spezzettamento sotto il limite di `bash`;
- il fallback per riga quando il comando fallisce.

## Anything Else?

**Sulle misure end-to-end, in trasparenza.** Il primo-token oscilla molto su questa macchina
(4–5s in una sessione, 13–33s in un'altra, con la stessa identica build): ci sono più dev server,
Docker e la suite che girano insieme. Le cifre affidabili sono quelle **interne alla stessa
esecuzione**, ed è quelle che ho riportato — 6903 → 1068 → 318ms su `writeSkills`.

**Cosa resta, misurato:** ~1.5s di apertura sandbox, ~0.3s `resolveSandboxHomeDir`, ~0.25s
`syncHostWorkspace`, ~0.2s `ensureSandboxDirectory`, ~0.4s `buildTurnContext`. Sono round-trip nella
sandbox, uno per volta, e adesso sono loro il costo dominante — non più le skill.

Sotto il secondo si va solo in due modi, ed entrambi sono cambi di forma, non micro-ottimizzazioni:
skill pre-installate nell'immagine della sandbox, oppure **aprire l'SSE prima che l'harness sia
pronto** — che non riduce l'attesa ma toglie lo schermo vuoto, cioè l'altra metà del problema
segnalato all'inizio.
