### PR TITLE
Stop forcing a tool when the user said not to

### DIFF
--- a/src/lib/server/chat/model.test.ts
+++ b/src/lib/server/chat/model.test.ts
@@ -165,6 +165,37 @@ describe('le richieste di produzione pesanti riconosciute senza chiamate modello
     expect(isHeavyProductionAsk('render the motion trailer')).toBe(true);
   });
 
+  /**
+   * IL DIFETTO PAGATO, 2026-09-03. «Non fare alcun post» e l'agente generava un'immagine lo
+   * stesso. Non e` che ignorasse l'istruzione: gliela facevamo ignorare noi. Questo classificatore
+   * ha un solo consumatore, `forcedFirstStepTools`, che su un "si" OBBLIGA il modello a chiamare
+   * un tool al primo step — e le stesse parole ci sono in «crea un post» e in «non creare un
+   * post», perche' la negazione non veniva guardata.
+   *
+   * Il costo dei due errori non e` simmetrico, ed e` questo che decide la regola: non forzare
+   * quando avremmo potuto lascia il modello libero di chiamare il tool lo stesso; forzare quando
+   * l'utente ha detto di no scavalca un'istruzione esplicita. Nel dubbio non si forza.
+   */
+  it('una negazione toglie la forzatura, comunque sia scritta', () => {
+    expect(isHeavyProductionAsk('non fare alcun post')).toBe(false);
+    expect(isHeavyProductionAsk('non creare nessun post')).toBe(false);
+    expect(isHeavyProductionAsk('senza generare immagini')).toBe(false);
+    expect(isHeavyProductionAsk('non generare immagini, dimmi solo cosa faresti')).toBe(false);
+    expect(isHeavyProductionAsk("non voglio che tu crei un post, voglio solo un'analisi")).toBe(false);
+    expect(isHeavyProductionAsk('evita di creare post')).toBe(false);
+    expect(isHeavyProductionAsk('do not create any post')).toBe(false);
+    expect(isHeavyProductionAsk("don't generate images")).toBe(false);
+    expect(isHeavyProductionAsk('without creating a carousel')).toBe(false);
+    expect(isHeavyProductionAsk('avoid generating the video')).toBe(false);
+  });
+
+  /** Anche i termini che da soli valgono "produzione" si spengono davanti a un no. */
+  it('la negazione vale anche sui termini forti da soli', () => {
+    expect(isHeavyProductionAsk('serve un UGC per TikTok')).toBe(true);
+    expect(isHeavyProductionAsk('non fare nessun UGC')).toBe(false);
+    expect(isHeavyProductionAsk('niente carosello, solo il piano')).toBe(false);
+  });
+
   it('NON scala su domande e conversazione normale', () => {
     expect(isHeavyProductionAsk("com'è andata la settimana?")).toBe(false);
     expect(isHeavyProductionAsk('what does my plan include?')).toBe(false);

--- a/src/lib/server/chat/model.ts
+++ b/src/lib/server/chat/model.ts
@@ -82,9 +82,19 @@ export function modelSeesImages(m: ChatModelResolved): boolean {
 /**
  * True quando il messaggio è una richiesta di produzione (post/immagini/video/motion/UGC e simili).
  *
- * Non sceglie piu` il modello: l'escalation Auto→Pro e` morta coi preset, e non c'e` piu` un "Pro"
- * su cui scalare. Resta perche' l'harness la usa per decidere cosa mettere a disposizione del
- * turno — un incarico di produzione e una domanda non chiedono gli stessi strumenti.
+ * Ha UN solo consumatore, `forcedFirstStepTools`, e su un "sì" quel consumatore OBBLIGA il modello
+ * a chiamare un tool al primo step. Quindi la domanda vera non è «parla di produzione?» ma
+ * «possiamo costringerlo a produrre?».
+ *
+ * Ed è per questo che la negazione conta. «Non fare alcun post» ha le stesse parole di «fai un
+ * post», e senza guardarla l'agente generava un'immagine mentre l'utente gli diceva di non farne
+ * nessuna — non ignorando l'istruzione, ma perché gliela facevamo ignorare noi.
+ *
+ * I due errori non costano uguale, ed è questo che decide la regola: non forzare quando avremmo
+ * potuto lascia il modello libero di chiamare il tool lo stesso; forzare quando l'utente ha detto
+ * di no scavalca un'istruzione esplicita. Nel dubbio non si forza — quindi basta una negazione in
+ * qualunque punto del messaggio, senza provare a capire su cosa cade.
+ *
  * Classificatore DETERMINISTICO (regex it/en, zero chiamate modello).
  */
 const HEAVY_VERB_RE =
@@ -94,9 +104,13 @@ const HEAVY_NOUN_RE =
 /** Termini che da soli dicono già "produzione pesante" — non servono verbi attorno. */
 const HEAVY_ALONE_RE = /\b(motion|ugc|trailer|render|storyboard|carousel(s)?|carosell[oi])\b/i;
 
+const NEGATION_RE =
+  /\b(non|senza|evita(re|ndo)?|niente|nessun[aeio]?|mai|no(n)?\s+voglio|don'?t|do\s+not|without|avoid(ing)?|never|no\s+need)\b/i;
+
 export function isHeavyProductionAsk(text: string | null | undefined): boolean {
   if (!text) return false;
   const t = text.slice(0, 4000);
+  if (NEGATION_RE.test(t)) return false;
   if (HEAVY_ALONE_RE.test(t)) return true;
   return HEAVY_VERB_RE.test(t) && HEAVY_NOUN_RE.test(t);
 }

--- a/src/lib/server/harness/run.ts
+++ b/src/lib/server/harness/run.ts
@@ -32,11 +32,15 @@ type AnyOpts = Record<string, any>;
  * al primo step `toolChoice: 'required'`. Ed è vincolato due volte, perché forzare uno strumento
  * dove non serve è peggio del difetto che ripara:
  *   · solo la chat (`surface: 'chat'`) — gli agenti di batch hanno i loro gate;
- *   · solo se il messaggio è una richiesta di PRODUZIONE, secondo `isHeavyProductionAsk` — lo
- *     stesso classificatore deterministico (regex it/en, zero chiamate modello) che decide la
- *     scalata Auto→Pro. Una domanda («cos'è un gatto», «come va il brand?») resta libera di essere
- *     risposta e basta: è il TRIAGE di WORK_ETHIC_BLOCK, e forzarle una chiamata produrrebbe un
- *     turno assurdo.
+ *   · solo se il messaggio è una richiesta di PRODUZIONE, secondo `isHeavyProductionAsk`
+ *     (regex it/en, zero chiamate modello). Una domanda («cos'è un gatto», «come va il brand?»)
+ *     resta libera di essere risposta e basta: è il TRIAGE di WORK_ETHIC_BLOCK, e forzarle una
+ *     chiamata produrrebbe un turno assurdo;
+ *   · e mai quando l'utente ha detto di NO. «Non fare alcun post» ha le stesse parole di «fai un
+ *     post»: finché la negazione non veniva guardata, `required` obbligava l'agente a generare
+ *     un'immagine mentre gli si diceva di non farne nessuna. Il filtro qui sotto toglie solo
+ *     `ask_user_questions`, quindi `generate_image` è fra i candidati e il modello sceglieva
+ *     proprio quello.
  *
  * `ask_user_questions` è tolto dallo step forzato: è in `stopWhen`, quindi chiuderebbe il turno —
  * sarebbe l'unico modo di obbedire al `required` senza fare niente, cioè il difetto con un'altra


### PR DESCRIPTION
## What?

`isHeavyProductionAsk` ha **un solo consumatore**, `forcedFirstStepTools`, e su un "sì" quel
consumatore mette `toolChoice: 'required'` — il modello **deve** chiamare un tool al primo step.
Quindi la domanda a cui risponde non è «parla di produzione?» ma «possiamo obbligarlo a produrre?».

Non guardava la negazione, e «non creare nessun post» ha le stesse parole di «crea un post».

## Why?

Misurato sulla funzione vera, prima del fix:

```
PRODUZIONE  non creare nessun post
PRODUZIONE  senza generare immagini
PRODUZIONE  non generare immagini, dimmi solo cosa faresti
PRODUZIONE  evita di creare post
```

`FORCED_STEP_EXCLUDE` toglie solo `ask_user_questions`, quindi `generate_image` è fra i candidati e
il modello sceglieva quello. **L'agente non stava ignorando l'istruzione: gliela facevamo ignorare
noi.**

## How?

Una negazione in qualunque punto del messaggio spegne la forzatura.

Sembra grossolano, ed è deliberato: **i due errori non costano uguale.** Non forzare quando avremmo
potuto lascia il modello libero di chiamare il tool lo stesso — non si perde niente. Forzare quando
l'utente ha detto di no scavalca un'istruzione esplicita, ed è il difetto segnalato. Nel dubbio non
si forza, quindi non si prova a capire su cosa cade la negazione.

Aggiornato anche il commento di `forcedFirstStepTools`, che diceva ancora «lo stesso classificatore
che decide la scalata Auto→Pro» — la scalata non esiste più.

## Testing?

Suite intera verde (6349). Due casi nuovi in `model.test.ts`, **visti fallire prima del fix**: dieci
formulazioni negate in italiano e inglese (`non`, `senza`, `evita`, `niente`, `nessun`, `don't`,
`do not`, `without`, `avoid`), e la negazione che vale anche sui termini che da soli significano
produzione (`UGC`, `carosello`).

I test esistenti restano verdi: «crea un carosello per il lancio» continua a forzare.

## Anything Else?

**Questo NON è il difetto che l'utente aveva segnalato**, e vale la pena dirlo. La segnalazione era
«chiedo una grafica ma niente post, e usa `content generate image`». Indagando: `design_graphic` ha
`post_id` **obbligatorio** (`z.string()`, non `.optional()`), quindi una grafica senza post non è
esprimibile, e `generate_image` standalone è l'unico tool che produce un'immagine senza toccare un
post. L'agente sceglieva l'unica mossa disponibile — e ti dava una foto AI invece di una grafica.

Quello si risolve rendendo `design_graphic` utilizzabile senza post, ed è un lavoro a parte.

Questo difetto è emerso lungo la strada, è reale e riproducibile per conto suo.
