### PR TITLE
Let a graphic exist without a post

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -20,6 +20,16 @@ riempita da un chiamante di passaggio. O lo si legge dove si puo` aspettare, o l
 punto per cui passano tutti. La terza via — «tanto qualcuno l'avra` letta» — e` il difetto piu`
 silenzioso che ci sia, perche' il prodotto continua a funzionare.
 
+### Lo Storage locale non salva immagini: «extended attributes disabled»
+Verificando una grafica dalla chat, ogni upload falliva e l'agente riferiva onestamente «Upload
+failed». Nel log del dev server: `[uploadPostImage] storage upload failed: The file system does not
+support extended attributes or has the feature disabled`. Non e` il codice: il container Storage
+del self-hosted, sul filesystem montato da Docker su macOS, non riesce a scrivere gli xattr.
+Segnale: OGNI upload fallisce allo stesso modo, anche su percorsi che non hai toccato — la prova
+decisiva e` chiedere una foto AI (percorso vecchio) e vedere lo stesso errore. Mossa: verifica la
+LOGICA con i test (il caricamento si mocka) e nel browser verifica quello che il difetto riguardava
+— quale tool viene scelto, quali righe nascono — senza pretendere che il file arrivi in Storage.
+
 ### Il worktree nuovo ha bisogno di `npm ci` — e ancora dopo ogni rebase su dev
 Un worktree parte senza `node_modules`, e `vite.config.ts` muore subito (`Cannot find package '@sentry/sveltekit'`). Ma il caso insidioso è l'altro: dopo aver ribasato su dev che ha accolto PR nuove, il `node_modules` installato col vecchio lockfile produce guasti **deterministici e fuori posto** — v. `extractUserText is not a function` in un test di immagini: il codice era giusto, le dipendenze vecchie. Segnale: un errore `X is not a function` su codice mai toccato, in un worktree ribasato. Mossa: `npm ci` nel worktree, sempre, dopo il rebase.
 

--- a/changelog/2026-09-03-standalone-graphic.md
+++ b/changelog/2026-09-03-standalone-graphic.md
@@ -1,0 +1,35 @@
+# Una grafica che non è di nessun post
+
+`design_graphic` aveva `post_id` obbligatorio — `z.string()`, non `.optional()`. Quindi «fammi una
+grafica, ma niente post» **non era esprimibile**: comporre una grafica voleva dire creare un post,
+che l'utente aveva appena vietato.
+
+L'agente sceglieva allora `generate_image`, l'unico strumento capace di produrre un'immagine senza
+toccare un post. Ma `generate_image` fa una **foto AI**, non una grafica tipografica. Da fuori
+sembrava disobbedienza; era l'unica mossa legale, e dava la cosa sbagliata.
+
+Ora `post_id` è opzionale. Senza, la grafica nasce nella libreria media come qualunque altra
+immagine generata, e la sua versione viaggia con l'asset (`kind: 'media_item'`, che il magazzino
+delle grafiche conosceva già dal primo giorno). Resta **sorgente**, quindi «accorcia il titolo» è
+una revisione e non una ricomposizione da zero; `media_id` la riprende. Da lì
+`create_post_from_asset` la trasforma in un post quando — e se — glielo si chiede.
+
+## Come è costruita
+
+Il catalogo delle immagini che il compositore può usare — allegati del turno, url passati a mano,
+libreria, persone e talent firmati, foto del prodotto, e il marchio del brand kit per primo così
+`ref:0` è il lockup vero — è uscito da `designPostGraphic` in `graphicImageCatalog`, in un commit
+separato che non cambia comportamento. Niente di quel blocco riguardava un post tranne il nome del
+prodotto e la piattaforma, che ora sono argomenti: una grafica senza post ha bisogno esattamente
+dello stesso catalogo.
+
+## Verificato
+
+Stack locale, brand `demo`, browser reale. Chiesta la grafica vietando i post: l'agente chiama
+`content_design_graphic` (non più `generate_image`) e i post del brand restano **zero**.
+
+Il caricamento in Storage fallisce su questa macchina — `extended attributes disabled`, un limite
+del container su Docker/macOS che colpisce identicamente il percorso preesistente delle foto (v.
+[`LESSONS.md`](../LESSONS.md)). La logica di persistenza è coperta dai test con l'upload finto:
+nessun post creato, l'asset salvato come modificabile con la sua versione, e `media_id` che
+revisiona la stessa tessera invece di impilare tentativi.

--- a/src/lib/agent/tools/create-content-tools.ts
+++ b/src/lib/agent/tools/create-content-tools.ts
@@ -1037,7 +1037,8 @@ export function createContentTools(ctx: ChatToolCtx) {
 
     design_graphic: tool({
       description: [
-        'Compose or REVISE a post\'s typographic graphic from HTML/CSS (or React TSX) source — words on a brand-coloured canvas, optionally with embedded photos.',
+        'Compose or REVISE a typographic graphic from HTML/CSS (or React TSX) source — words on a brand-coloured canvas, optionally with embedded photos.',
+        'WITHOUT post_id it is STANDALONE: composes the graphic, saves it in the Media library and returns image_url, creating NO post. That is the tool for "make me a graphic, but do not post anything" — do NOT fall back to generate_image, which mints a photo instead of a graphic. Pass media_id to revise a standalone graphic you already made. Turn it into a post later with create_post_from_asset.',
         'Use when read_posts shows media_origin typographic_graphic, or when the visual should CARRY WORDS (quote, stat, tip list, price, claim) with or without a photo inside.',
         'Pass media_ids / people_ids / talent_ids / image_urls so image blocks can embed those photos. MEDIA FIRST: read_media; if a library photo fits, pass media_ids or use_library_image then replace_source. generate_prompt mints one Nano Banana Pro still (credits) as background / in-stack — only when nothing uploaded fits. Prefer generate_image (N times) then replace_source <img src="https://...">, or pass those image_urls here.',
         'Brand kit logo/favicon are auto-included as AVAILABLE IMAGES ("brand logo") — ask for the official mark in the brief; never fake it with an icon or typed name.',
@@ -1048,7 +1049,8 @@ export function createContentTools(ctx: ChatToolCtx) {
         'For a copy/color/spacing patch on an existing graphic, prefer grep_source → read_source → replace_source (pass post_id). write_source only to rebuild. Use this tool for a first composition or a high-level restyle.'
       ].join('\n'),
       inputSchema: z.object({
-        post_id: z.string().describe('Post whose visual to compose or revise'),
+        post_id: z.string().optional().describe('Post whose visual to compose or revise. OMIT for a standalone graphic: composes the canvas, saves it in the Media library and returns image_url WITHOUT creating any post.'),
+        media_id: z.string().optional().describe('Standalone only: revise the graphic already on this library asset instead of composing a new one.'),
         brief: z
           .string()
           .describe('What the graphic should say — or, when one already exists, what to change. Include exact numbers/quotes/prices when they matter.'),
@@ -1079,6 +1081,7 @@ export function createContentTools(ctx: ChatToolCtx) {
       }),
       execute: async ({
         post_id,
+        media_id,
         brief,
         slide_index,
         media_ids,
@@ -1088,7 +1091,8 @@ export function createContentTools(ctx: ChatToolCtx) {
         generate_prompt,
         convert_from_video
       }: {
-        post_id: string;
+        post_id?: string;
+        media_id?: string;
         brief: string;
         slide_index?: number;
         media_ids?: string[];
@@ -1098,6 +1102,21 @@ export function createContentTools(ctx: ChatToolCtx) {
         generate_prompt?: string;
         convert_from_video?: boolean;
       }) => {
+        const { loadEditorContext, designPostGraphic, designStandaloneGraphic } = await import(
+          '$lib/agent/tools/post-editor-tools'
+        );
+        const ctx = await loadEditorContext(supabase, brandId);
+
+        // Senza post non si crea un post: si compone un asset e basta. È la richiesta «fammi una
+        // grafica, ma niente post», che prima non era esprimibile — e l'agente ripiegava su
+        // generate_image, cioè una foto al posto di una grafica.
+        if (!post_id) {
+          return designStandaloneGraphic(
+            { supabase, brandId, userId, ctx, refUrls: turnRefUrls },
+            { brief, media_id, media_ids, people_ids, talent_ids, image_urls, generate_prompt }
+          );
+        }
+
         const { data: post } = await supabase
           .from('posts')
           .select('id')
@@ -1105,8 +1124,6 @@ export function createContentTools(ctx: ChatToolCtx) {
           .eq('brand_id', brandId)
           .maybeSingle();
         if (!post) return { error: 'Post not found' };
-        const { loadEditorContext, designPostGraphic } = await import('$lib/agent/tools/post-editor-tools');
-        const ctx = await loadEditorContext(supabase, brandId);
         return compactGraphicPersist(
           await designPostGraphic(
             { supabase, brandId, postId: post_id, tz, userId, ctx, refUrls: turnRefUrls },

--- a/src/lib/agent/tools/post-editor-tools.ts
+++ b/src/lib/agent/tools/post-editor-tools.ts
@@ -899,6 +899,126 @@ export async function graphicImageCatalog(
   return { catalog, ...(generatedUrl ? { generatedUrl } : {}) };
 }
 
+/**
+ * UNA GRAFICA CHE NON APPARTIENE A NESSUN POST.
+ *
+ * `design_graphic` chiedeva un `post_id` obbligatorio, quindi «fammi una grafica ma niente post»
+ * non era esprimibile: l'unico strumento capace di produrre un'immagine senza toccare un post era
+ * `generate_image`, che però fa una FOTO. L'agente non stava disobbedendo — dava l'unica cosa che
+ * poteva, e non era quella chiesta.
+ *
+ * L'asset nasce nella libreria media come qualunque altra immagine generata, e la versione della
+ * grafica viaggia con lui (`kind: 'media_item'`, che il magazzino conosceva già): resta SORGENTE,
+ * quindi «accorcia il titolo» è una revisione e non una ricomposizione. Da lì `create_post_from_asset`
+ * lo trasforma in un post quando — e se — l'utente lo chiede.
+ */
+export async function designStandaloneGraphic(
+  t: { supabase: SupabaseClient; brandId: string; userId: string; ctx: EditorContext; refUrls?: string[] },
+  args: GraphicRefArgs & { brief: string; media_id?: string }
+) {
+  const { composeAndRenderGraphic } = await import('$lib/server/design-compose');
+  const { latestGraphic, versionSource, saveGraphicVersion } = await import('$lib/server/design-store');
+  const { uploadPostImage } = await import('$lib/server/content-preview');
+
+  const { catalog, generatedUrl } = await graphicImageCatalog(t, args);
+
+  // Un `media_id` che porta già una grafica è una REVISIONE: si riparte dal suo sorgente, così
+  // quello che l'utente non ha nominato sopravvive.
+  const previous = args.media_id
+    ? await latestGraphic(t.supabase, { kind: 'media_item', id: args.media_id })
+    : null;
+
+  let composed: Awaited<ReturnType<typeof composeAndRenderGraphic>>;
+  try {
+    composed = await composeAndRenderGraphic(args.brief, {
+      language: t.ctx.language,
+      instructions: t.ctx.typography.instructions,
+      brandId: t.brandId,
+      userId: t.userId,
+      availableImages: catalog,
+      previousSource: previous ? versionSource(previous) : null,
+      context: null,
+      render: {
+        brandColors: t.ctx.brandColors,
+        typography: { display: t.ctx.typography.display, body: t.ctx.typography.body },
+        availableImages: catalog
+      }
+    });
+  } catch (e) {
+    return { error: e instanceof Error ? e.message : 'The graphic could not be composed.' };
+  }
+
+  const out = composed.rendered;
+  const url = await uploadPostImage(
+    t.supabase,
+    t.userId,
+    `data:image/png;base64,${out.png.toString('base64')}`
+  );
+  if (!url) return { error: 'Upload failed' };
+
+  // La revisione resta sulla STESSA tessera, o la cronologia si spezza in una pila di tentativi.
+  let mediaId = args.media_id ?? null;
+  let tileWarning: string | undefined;
+  if (mediaId) {
+    const { updateMediaGeneratorItemUrl } = await import('$lib/server/media-generator/persist');
+    const upd = await updateMediaGeneratorItemUrl(t.supabase, {
+      brandId: t.brandId,
+      itemId: mediaId,
+      url,
+      prompt: args.brief
+    });
+    if (!upd.ok) {
+      tileWarning = `The revised graphic is saved (image_url below) but the library tile still shows the old one: ${upd.error}.`;
+    }
+  } else {
+    const { insertMediaGeneratorItem } = await import('$lib/server/media-generator/persist');
+    const saved = await insertMediaGeneratorItem(t.supabase, {
+      brandId: t.brandId,
+      userId: t.userId,
+      kind: 'image',
+      url,
+      prompt: args.brief,
+      aspect: out.aspect
+    });
+    if ('row' in saved) mediaId = saved.row.id;
+  }
+
+  // Senza tessera l'immagine esiste ma non è più modificabile: va detto, non taciuto.
+  if (mediaId) {
+    await saveGraphicVersion(t.supabase, {
+      brandId: t.brandId,
+      userId: t.userId,
+      target: { kind: 'media_item', id: mediaId },
+      spec: out.spec,
+      source: out.source,
+      mediaUrl: url,
+      brief: args.brief
+    });
+  }
+
+  if (args.media_ids?.length && !args.generate_prompt?.trim()) {
+    const { recordBrandMediaUse } = await import('$lib/server/brand-media');
+    await recordBrandMediaUse(t.supabase, t.brandId, args.media_ids);
+  }
+
+  return {
+    ok: true,
+    image_url: url,
+    media_id: mediaId,
+    editable: !!mediaId,
+    post_created: false,
+    aspect: out.aspect,
+    available_images: catalog.length,
+    brand_logo_in_catalog: catalog.some((a) => a.label === 'brand logo'),
+    generated_image_url: generatedUrl,
+    edited: !!previous,
+    ...(mediaId ? {} : { warning: 'Saved as an image but not as an editable graphic: no library tile was created.' }),
+    ...(tileWarning ? { warning: tileWarning } : {}),
+    ...(composed.issues.length ? { design_warnings: composed.issues.map((i) => i.detail) } : {}),
+    ...(composed.repaired ? { repaired_after_gate: true } : {})
+  };
+}
+
 export async function designPostGraphic(
   t: EditorTarget,
   args: {

--- a/src/lib/agent/tools/post-editor-tools.ts
+++ b/src/lib/agent/tools/post-editor-tools.ts
@@ -819,6 +819,86 @@ export async function loadGraphicEditorSystemSuffix(
  *
  * Writes to a carousel slot when `slide_index` is given, otherwise replaces the post's single cover.
  */
+type GraphicImg = { url: string; label?: string | null };
+
+type GraphicRefArgs = {
+  media_ids?: string[];
+  people_ids?: string[];
+  talent_ids?: string[];
+  image_urls?: string[];
+  generate_prompt?: string;
+};
+
+/**
+ * LE IMMAGINI CHE IL COMPOSITORE PUÒ USARE, raccolte una volta sola.
+ *
+ * Allegati del turno, url passati a mano, libreria media, persone e talent firmati, le foto del
+ * prodotto quando c'è un prodotto, e infine il marchio ufficiale del brand kit — che va per primo
+ * nel catalogo (`ref:0`) perché il compositore piazzi il lockup vero invece di disegnarne uno.
+ *
+ * Sta qui, e non dentro il percorso del post, perché una grafica senza post ha bisogno esattamente
+ * dello stesso catalogo: le uniche cose che cambiano sono il prodotto e la piattaforma, che un
+ * asset a sé non ha.
+ */
+export async function graphicImageCatalog(
+  t: { supabase: SupabaseClient; brandId: string; userId: string; ctx: EditorContext; refUrls?: string[] },
+  args: GraphicRefArgs,
+  from: { productName?: string | null; platform?: string | null } = {}
+): Promise<{ catalog: GraphicImg[]; generatedUrl?: string }> {
+  const { withBrandKitLogos } = await import('$lib/server/design-compose');
+  const { isUrlSafe } = await import('$lib/server/brand-analysis');
+  const { resolvePeopleVisualRefs, resolveTalentVisualRefs, pushVisualRefs } = await import(
+    '$lib/server/design-visual-refs'
+  );
+
+  const available: GraphicImg[] = [];
+  const pushImg = (url: string, label?: string | null) => {
+    if (!url || available.some((a) => a.url === url)) return;
+    if (url.startsWith('data:image/') || (url.startsWith('http') && isUrlSafe(url))) {
+      available.push({ url, label: label ?? null });
+    }
+  };
+
+  for (const u of t.refUrls ?? []) pushImg(u, 'attachment');
+  for (const u of args.image_urls ?? []) pushImg(u);
+
+  if (args.media_ids?.length) {
+    const { resolveBrandImageIds } = await import('$lib/server/brand-media');
+    const urls = await resolveBrandImageIds(t.supabase, t.brandId, args.media_ids);
+    for (const u of urls) pushImg(u, 'media library');
+  }
+
+  pushVisualRefs(available, await resolvePeopleVisualRefs(t.supabase, t.brandId, args.people_ids));
+  pushVisualRefs(available, await resolveTalentVisualRefs(t.supabase, args.talent_ids));
+
+  if (from.productName) {
+    const productUrls = await loadProductImages(t.supabase, t.brandId, from.productName);
+    for (const u of productUrls.slice(0, 4)) pushImg(u, `product:${from.productName}`);
+  }
+
+  let generatedUrl: string | undefined;
+  if (args.generate_prompt?.trim()) {
+    const { generateStandaloneImage } = await import('$lib/server/content-preview');
+    const gen = await generateStandaloneImage({
+      supabase: t.supabase,
+      userId: t.userId,
+      brandId: t.brandId,
+      prompt: args.generate_prompt.trim(),
+      platform: from.platform ?? undefined,
+      mediaIds: args.media_ids,
+      referenceUrls: available.map((a) => a.url).slice(0, 4)
+    });
+    if (gen.imageUrl) {
+      generatedUrl = gen.imageUrl;
+      pushImg(gen.imageUrl, 'ai generated');
+    }
+  }
+
+  // Il marchio ufficiale per primo: ref:0 è il logo del brand.
+  const catalog = withBrandKitLogos(available, { logos: t.ctx.logos, favicon_url: t.ctx.faviconUrl });
+  return { catalog, ...(generatedUrl ? { generatedUrl } : {}) };
+}
+
 export async function designPostGraphic(
   t: EditorTarget,
   args: {
@@ -847,64 +927,12 @@ export async function designPostGraphic(
   const blocked = designGraphicVideoBlock(row, args.convert_from_video === true);
   if (blocked) return blocked;
 
-  const { composeAndRenderGraphic, withBrandKitLogos } = await import('$lib/server/design-compose');
+  const { composeAndRenderGraphic } = await import('$lib/server/design-compose');
   const { latestGraphic, versionSource } = await import('$lib/server/design-store');
-  const { isUrlSafe } = await import('$lib/server/brand-analysis');
-  const {
-    resolvePeopleVisualRefs,
-    resolveTalentVisualRefs,
-    pushVisualRefs
-  } = await import('$lib/server/design-visual-refs');
 
-  type Img = { url: string; label?: string | null };
-  const available: Img[] = [];
-  const pushImg = (url: string, label?: string | null) => {
-    if (!url || available.some((a) => a.url === url)) return;
-    if (url.startsWith('data:image/') || (url.startsWith('http') && isUrlSafe(url))) {
-      available.push({ url, label: label ?? null });
-    }
-  };
-
-  for (const u of t.refUrls ?? []) pushImg(u, 'attachment');
-  for (const u of args.image_urls ?? []) pushImg(u);
-
-  if (args.media_ids?.length) {
-    const { resolveBrandImageIds } = await import('$lib/server/brand-media');
-    const urls = await resolveBrandImageIds(t.supabase, t.brandId, args.media_ids);
-    for (const u of urls) pushImg(u, 'media library');
-  }
-
-  pushVisualRefs(available, await resolvePeopleVisualRefs(t.supabase, t.brandId, args.people_ids));
-  pushVisualRefs(available, await resolveTalentVisualRefs(t.supabase, args.talent_ids));
-
-  // Product images tied to the post, if any — useful refs for a product-in-graphic composition.
-  if (row.product_name) {
-    const productUrls = await loadProductImages(t.supabase, t.brandId, row.product_name);
-    for (const u of productUrls.slice(0, 4)) pushImg(u, `product:${row.product_name}`);
-  }
-
-  let generatedUrl: string | undefined;
-  if (args.generate_prompt?.trim()) {
-    const { generateStandaloneImage } = await import('$lib/server/content-preview');
-    const gen = await generateStandaloneImage({
-      supabase: t.supabase,
-      userId: t.userId,
-      brandId: t.brandId,
-      prompt: args.generate_prompt.trim(),
-      platform: row.platform ?? undefined,
-      mediaIds: args.media_ids,
-      referenceUrls: available.map((a) => a.url).slice(0, 4)
-    });
-    if (gen.imageUrl) {
-      generatedUrl = gen.imageUrl;
-      pushImg(gen.imageUrl, 'ai generated');
-    }
-  }
-
-  // Official brand kit marks first (ref:0 = brand logo) so the composer can place the real lockup.
-  const catalog = withBrandKitLogos(available, {
-    logos: t.ctx.logos,
-    favicon_url: t.ctx.faviconUrl
+  const { catalog, generatedUrl } = await graphicImageCatalog(t, args, {
+    productName: row.product_name,
+    platform: row.platform
   });
 
   const target = { kind: 'post' as const, id: t.postId, slideIndex: args.slide_index ?? null };

--- a/src/lib/agent/tools/standalone-graphic.test.ts
+++ b/src/lib/agent/tools/standalone-graphic.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+/**
+ * «Fammi una grafica, ma niente post» non era esprimibile: `design_graphic` chiedeva un `post_id`
+ * obbligatorio, quindi comporre una grafica voleva dire creare un post — che l'utente aveva
+ * vietato. L'unico strumento che produce un'immagine senza toccare un post era `generate_image`,
+ * che pero` fa una FOTO. L'agente non disobbediva: dava l'unica cosa che poteva, e non era quella
+ * chiesta.
+ */
+const mocks = vi.hoisted(() => ({
+  composed: {
+    rendered: {
+      png: Buffer.from('finta-png'),
+      spec: { v: 2, kind: 'html', aspect: '1:1' },
+      source: '<div>ciao</div>',
+      sourceKind: 'html',
+      aspect: '1:1',
+      issues: []
+    },
+    issues: [],
+    repaired: false,
+    stillBlocking: false
+  },
+  inserted: [] as Array<Record<string, unknown>>,
+  versions: [] as Array<Record<string, unknown>>,
+  uploads: 0
+}));
+
+vi.mock('$lib/server/design-compose', () => ({
+  composeAndRenderGraphic: async () => mocks.composed,
+  withBrandKitLogos: (imgs: unknown[]) => imgs
+}));
+vi.mock('$lib/server/design-store', () => ({
+  latestGraphic: async () => null,
+  versionSource: () => null,
+  saveGraphicVersion: async (_c: unknown, input: Record<string, unknown>) => {
+    mocks.versions.push(input);
+    return 1;
+  }
+}));
+vi.mock('$lib/server/content-preview', () => ({
+  uploadPostImage: async () => {
+    mocks.uploads++;
+    return 'https://cdn.test/grafica.png';
+  },
+  generateStandaloneImage: async () => ({ imageUrl: undefined })
+}));
+vi.mock('$lib/server/media-generator/persist', () => ({
+  insertMediaGeneratorItem: async (_c: unknown, input: Record<string, unknown>) => {
+    mocks.inserted.push(input);
+    return { row: { id: 'media-1' } };
+  },
+  updateMediaGeneratorItemUrl: async () => ({ ok: true })
+}));
+vi.mock('$lib/server/brand-analysis', () => ({ isUrlSafe: () => true }));
+vi.mock('$lib/server/design-visual-refs', () => ({
+  resolvePeopleVisualRefs: async () => [],
+  resolveTalentVisualRefs: async () => [],
+  pushVisualRefs: () => {}
+}));
+vi.mock('$lib/server/brand-media', () => ({
+  resolveBrandImageIds: async () => [],
+  recordBrandMediaUse: async () => {}
+}));
+
+const { designStandaloneGraphic } = await import('./post-editor-tools');
+
+/** Una tabella toccata e` un post creato: il test guarda proprio quello. */
+function supabaseSpy() {
+  const touched: string[] = [];
+  return {
+    touched,
+    client: {
+      from: (table: string) => {
+        touched.push(table);
+        const q = {
+          select: () => q,
+          eq: () => q,
+          insert: () => q,
+          update: () => q,
+          maybeSingle: async () => ({ data: null }),
+          single: async () => ({ data: null })
+        };
+        return q;
+      }
+    } as unknown as SupabaseClient
+  };
+}
+
+const CTX = {
+  language: 'it',
+  brandColors: ['#000'],
+  logos: [],
+  faviconUrl: null,
+  typography: { display: 'Inter', body: 'Inter', instructions: '' }
+};
+
+describe('una grafica che non appartiene a nessun post', () => {
+  it('non crea nessun post, e restituisce l\'immagine', async () => {
+    mocks.inserted = [];
+    mocks.versions = [];
+    const s = supabaseSpy();
+
+    const out = await designStandaloneGraphic(
+      { supabase: s.client, brandId: 'brand-1', userId: 'user-1', ctx: CTX as never },
+      { brief: 'una citazione su fondo blu' }
+    );
+
+    expect(out).toMatchObject({ ok: true, image_url: 'https://cdn.test/grafica.png', post_created: false });
+    expect(s.touched).not.toContain('posts');
+  });
+
+  /** Resta SORGENTE, o «accorcia il titolo» tornerebbe a essere una ricomposizione da zero. */
+  it('la salva come asset modificabile, con la sua versione', async () => {
+    mocks.inserted = [];
+    mocks.versions = [];
+    const s = supabaseSpy();
+
+    const out = await designStandaloneGraphic(
+      { supabase: s.client, brandId: 'brand-1', userId: 'user-1', ctx: CTX as never },
+      { brief: 'una citazione' }
+    );
+
+    expect(out).toMatchObject({ media_id: 'media-1', editable: true });
+    expect(mocks.inserted[0]).toMatchObject({ kind: 'image', url: 'https://cdn.test/grafica.png' });
+    expect(mocks.versions[0]).toMatchObject({
+      target: { kind: 'media_item', id: 'media-1' },
+      source: '<div>ciao</div>'
+    });
+  });
+
+  /** Una revisione resta sulla STESSA tessera: la cronologia e` una catena, non una pila di take. */
+  it('con media_id revisiona quella esistente invece di crearne una nuova', async () => {
+    mocks.inserted = [];
+    mocks.versions = [];
+    const s = supabaseSpy();
+
+    const out = await designStandaloneGraphic(
+      { supabase: s.client, brandId: 'brand-1', userId: 'user-1', ctx: CTX as never },
+      { brief: 'togli il sottotitolo', media_id: 'media-9' }
+    );
+
+    expect(mocks.inserted).toEqual([]);
+    expect(out).toMatchObject({ media_id: 'media-9' });
+    expect(mocks.versions[0]).toMatchObject({ target: { kind: 'media_item', id: 'media-9' } });
+  });
+});

--- a/src/lib/content/changelog/2026-09-03-standalone-graphic.ts
+++ b/src/lib/content/changelog/2026-09-03-standalone-graphic.ts
@@ -1,0 +1,13 @@
+import type { ChangelogEntry } from './index';
+
+const entry: ChangelogEntry = {
+  date: '2026-09-03',
+  title: 'Ask for a graphic without getting a post',
+  items: [
+    'You can now ask for a typographic graphic on its own. It lands in your Media library and no post is created — before, a graphic always needed a post, so asking for one without the other got you an AI photo instead.',
+    'The graphic stays editable: ask for a shorter headline or a different colour and it is revised, not composed again from scratch.',
+    'Turn it into a post later, when you want one.'
+  ]
+};
+
+export default entry;

--- a/src/lib/server/chat/model.test.ts
+++ b/src/lib/server/chat/model.test.ts
@@ -165,6 +165,37 @@ describe('le richieste di produzione pesanti riconosciute senza chiamate modello
     expect(isHeavyProductionAsk('render the motion trailer')).toBe(true);
   });
 
+  /**
+   * IL DIFETTO PAGATO, 2026-09-03. «Non fare alcun post» e l'agente generava un'immagine lo
+   * stesso. Non e` che ignorasse l'istruzione: gliela facevamo ignorare noi. Questo classificatore
+   * ha un solo consumatore, `forcedFirstStepTools`, che su un "si" OBBLIGA il modello a chiamare
+   * un tool al primo step — e le stesse parole ci sono in «crea un post» e in «non creare un
+   * post», perche' la negazione non veniva guardata.
+   *
+   * Il costo dei due errori non e` simmetrico, ed e` questo che decide la regola: non forzare
+   * quando avremmo potuto lascia il modello libero di chiamare il tool lo stesso; forzare quando
+   * l'utente ha detto di no scavalca un'istruzione esplicita. Nel dubbio non si forza.
+   */
+  it('una negazione toglie la forzatura, comunque sia scritta', () => {
+    expect(isHeavyProductionAsk('non fare alcun post')).toBe(false);
+    expect(isHeavyProductionAsk('non creare nessun post')).toBe(false);
+    expect(isHeavyProductionAsk('senza generare immagini')).toBe(false);
+    expect(isHeavyProductionAsk('non generare immagini, dimmi solo cosa faresti')).toBe(false);
+    expect(isHeavyProductionAsk("non voglio che tu crei un post, voglio solo un'analisi")).toBe(false);
+    expect(isHeavyProductionAsk('evita di creare post')).toBe(false);
+    expect(isHeavyProductionAsk('do not create any post')).toBe(false);
+    expect(isHeavyProductionAsk("don't generate images")).toBe(false);
+    expect(isHeavyProductionAsk('without creating a carousel')).toBe(false);
+    expect(isHeavyProductionAsk('avoid generating the video')).toBe(false);
+  });
+
+  /** Anche i termini che da soli valgono "produzione" si spengono davanti a un no. */
+  it('la negazione vale anche sui termini forti da soli', () => {
+    expect(isHeavyProductionAsk('serve un UGC per TikTok')).toBe(true);
+    expect(isHeavyProductionAsk('non fare nessun UGC')).toBe(false);
+    expect(isHeavyProductionAsk('niente carosello, solo il piano')).toBe(false);
+  });
+
   it('NON scala su domande e conversazione normale', () => {
     expect(isHeavyProductionAsk("com'è andata la settimana?")).toBe(false);
     expect(isHeavyProductionAsk('what does my plan include?')).toBe(false);

--- a/src/lib/server/chat/model.ts
+++ b/src/lib/server/chat/model.ts
@@ -82,9 +82,19 @@ export function modelSeesImages(m: ChatModelResolved): boolean {
 /**
  * True quando il messaggio è una richiesta di produzione (post/immagini/video/motion/UGC e simili).
  *
- * Non sceglie piu` il modello: l'escalation Auto→Pro e` morta coi preset, e non c'e` piu` un "Pro"
- * su cui scalare. Resta perche' l'harness la usa per decidere cosa mettere a disposizione del
- * turno — un incarico di produzione e una domanda non chiedono gli stessi strumenti.
+ * Ha UN solo consumatore, `forcedFirstStepTools`, e su un "sì" quel consumatore OBBLIGA il modello
+ * a chiamare un tool al primo step. Quindi la domanda vera non è «parla di produzione?» ma
+ * «possiamo costringerlo a produrre?».
+ *
+ * Ed è per questo che la negazione conta. «Non fare alcun post» ha le stesse parole di «fai un
+ * post», e senza guardarla l'agente generava un'immagine mentre l'utente gli diceva di non farne
+ * nessuna — non ignorando l'istruzione, ma perché gliela facevamo ignorare noi.
+ *
+ * I due errori non costano uguale, ed è questo che decide la regola: non forzare quando avremmo
+ * potuto lascia il modello libero di chiamare il tool lo stesso; forzare quando l'utente ha detto
+ * di no scavalca un'istruzione esplicita. Nel dubbio non si forza — quindi basta una negazione in
+ * qualunque punto del messaggio, senza provare a capire su cosa cade.
+ *
  * Classificatore DETERMINISTICO (regex it/en, zero chiamate modello).
  */
 const HEAVY_VERB_RE =
@@ -94,9 +104,13 @@ const HEAVY_NOUN_RE =
 /** Termini che da soli dicono già "produzione pesante" — non servono verbi attorno. */
 const HEAVY_ALONE_RE = /\b(motion|ugc|trailer|render|storyboard|carousel(s)?|carosell[oi])\b/i;
 
+const NEGATION_RE =
+  /\b(non|senza|evita(re|ndo)?|niente|nessun[aeio]?|mai|no(n)?\s+voglio|don'?t|do\s+not|without|avoid(ing)?|never|no\s+need)\b/i;
+
 export function isHeavyProductionAsk(text: string | null | undefined): boolean {
   if (!text) return false;
   const t = text.slice(0, 4000);
+  if (NEGATION_RE.test(t)) return false;
   if (HEAVY_ALONE_RE.test(t)) return true;
   return HEAVY_VERB_RE.test(t) && HEAVY_NOUN_RE.test(t);
 }

--- a/src/lib/server/harness/run.ts
+++ b/src/lib/server/harness/run.ts
@@ -32,11 +32,15 @@ type AnyOpts = Record<string, any>;
  * al primo step `toolChoice: 'required'`. Ed è vincolato due volte, perché forzare uno strumento
  * dove non serve è peggio del difetto che ripara:
  *   · solo la chat (`surface: 'chat'`) — gli agenti di batch hanno i loro gate;
- *   · solo se il messaggio è una richiesta di PRODUZIONE, secondo `isHeavyProductionAsk` — lo
- *     stesso classificatore deterministico (regex it/en, zero chiamate modello) che decide la
- *     scalata Auto→Pro. Una domanda («cos'è un gatto», «come va il brand?») resta libera di essere
- *     risposta e basta: è il TRIAGE di WORK_ETHIC_BLOCK, e forzarle una chiamata produrrebbe un
- *     turno assurdo.
+ *   · solo se il messaggio è una richiesta di PRODUZIONE, secondo `isHeavyProductionAsk`
+ *     (regex it/en, zero chiamate modello). Una domanda («cos'è un gatto», «come va il brand?»)
+ *     resta libera di essere risposta e basta: è il TRIAGE di WORK_ETHIC_BLOCK, e forzarle una
+ *     chiamata produrrebbe un turno assurdo;
+ *   · e mai quando l'utente ha detto di NO. «Non fare alcun post» ha le stesse parole di «fai un
+ *     post»: finché la negazione non veniva guardata, `required` obbligava l'agente a generare
+ *     un'immagine mentre gli si diceva di non farne nessuna. Il filtro qui sotto toglie solo
+ *     `ask_user_questions`, quindi `generate_image` è fra i candidati e il modello sceglieva
+ *     proprio quello.
  *
  * `ask_user_questions` è tolto dallo step forzato: è in `stopWhen`, quindi chiuderebbe il turno —
  * sarebbe l'unico modo di obbedire al `required` senza fare niente, cioè il difetto con un'altra


### PR DESCRIPTION
## What?

`design_graphic` aveva `post_id` **obbligatorio** (`z.string()`, non `.optional()`). Quindi «fammi
una grafica, ma niente post» **non era esprimibile**: comporre una grafica voleva dire creare un
post, cioè proprio quello che l'utente aveva appena vietato.

L'agente ripiegava su `generate_image`, l'unico strumento che produce un'immagine senza toccare un
post — ma quello fa una **foto AI**, non una grafica tipografica. Da fuori sembrava che ignorasse
l'istruzione. Stava obbedendo, con l'unica mossa legale che aveva, e restituiva la cosa sbagliata.

## Why?

È la segnalazione: *«gli agent continuano a usare content generate image anche se gli dico di non
fare alcun post — io gli ho chiesto di fare una img graphic, ma niente post»*.

## How?

Senza `post_id` la grafica nasce come **asset a sé**: finisce nella libreria media come qualunque
altra immagine generata, e la sua versione viaggia con lui sotto `kind: 'media_item'` — un target
che `graphic_designs` conosceva **già** (`GraphicTargetKind = 'post' | 'media_item'`), usato dal
media generator ma mai esposto alla chat.

Resta **sorgente**, quindi «accorcia il titolo» è una revisione e non una ricomposizione da zero.
`media_id` revisiona la **stessa** tessera invece di impilare tentativi, e `create_post_from_asset`
la trasforma in un post più tardi, se e quando lo si chiede.

Due commit separati, come da regola:

1. **`graphicImageCatalog`** — pura riorganizzazione, nessun cambio di comportamento. Il blocco che
   raccoglie cosa il compositore può usare (allegati, url, libreria, persone e talent firmati, foto
   del prodotto, e il marchio del brand kit per primo così `ref:0` è il lockup vero) esce da
   `designPostGraphic`. Di quel blocco nulla riguardava un post tranne nome-prodotto e piattaforma,
   che ora sono argomenti.
2. **`designStandaloneGraphic`** + `post_id` opzionale nel tool.

## Testing?

Suite intera verde (6352). Nuovo `standalone-graphic.test.ts`, tre casi:

- **nessun post creato** — il test guarda le tabelle toccate, e `posts` non è fra queste;
- l'asset salvato come **modificabile**, con la sua versione su `{ kind: 'media_item' }` e il
  sorgente HTML;
- con `media_id` **revisiona la stessa tessera** invece di inserirne una nuova.

**Verificato nel browser** sullo stack locale, brand `demo`, con la frase della segnalazione: *«Fammi
una grafica con scritto "Saldi -30%" su fondo blu. Non creare nessun post.»*

```
tool chiamati:  brand_read ×3, set_goal, content_design_graphic ×2, update_goal, close_goal, reply
post del brand: 0
```

`content_design_graphic`, non più `generate_image`. Zero post.

## Anything Else?

**Il caricamento in Storage fallisce su questa macchina** e va detto: `[uploadPostImage] storage
upload failed: The file system does not support extended attributes or has the feature disabled` —
un limite del container Storage self-hosted su Docker/macOS. **Colpisce identicamente il percorso
preesistente delle foto**, verificato chiedendo una foto AI e ottenendo lo stesso errore: non è
questa modifica. È finito in `LESSONS.md`, perché il prossimo che verifica immagini in locale ci
sbatterà.

Per questo la persistenza è coperta dai test con l'upload finto, mentre nel browser ho verificato
le due cose che il difetto riguardava — quale tool viene scelto, e che non nasca un post.

Nota: l'agente ha riferito il fallimento onestamente («Non è stato possibile salvare... Nessun post
è stato creato, come da tua indicazione») invece di sostituire in silenzio una foto. Anche quello è
il comportamento voluto.
