### PR TITLE
Open a graphic's code even when it has no post

### DIFF
--- a/changelog/2026-09-03-graphic-source-anywhere.md
+++ b/changelog/2026-09-03-graphic-source-anywhere.md
@@ -1,0 +1,42 @@
+# Il codice di una grafica si apre anche quando la grafica non è di un post
+
+Ieri una grafica standalone è diventata possibile. Nasceva con il suo sorgente HTML/TSX e la sua
+cronologia di versioni — e nessuno sapeva aprirlo: `grep_source`, `read_source`, `replace_source` e
+`write_source` conoscevano solo `{ kind: 'post' }`.
+
+Si poteva rifare a parole con `design_graphic`, e non correggere di una parola. **Una feature a
+metà**, spedita come se fosse intera.
+
+## Cosa c'era e cosa mancava
+
+Il magazzino non era il problema: `graphic_designs` indirizza `{ kind, id }` — post o asset di
+libreria — dal primo giorno. Mancavano due cose sopra di lui:
+
+- **il bersaglio**, che negli strumenti del sorgente era `EditorTarget`, cioè un post e basta.
+  Adesso è `GraphicEditTarget`, o post o asset; `loadWorkingGraphicSource` e la scrittura
+  scelgono la destinazione da lì;
+- **il resolver della chat**, che rifiutava senza `post_id`. Adesso accetta anche `media_id` e,
+  se non ne arriva nessuno dei due, lo dice invece di indovinare.
+
+`applyStandaloneGraphicSource` è il gemello di `applyPostGraphicSource`: renderizza il sorgente,
+salva l'immagine sull'asset e versiona. Sta accanto a lui apposta — sono le due destinazioni
+possibili di un render, e tenerle lontane è ciò che fa dimenticare un pezzo all'una o all'altra.
+
+Corretta anche una risposta rotta: `grep_source` restituiva `post_id: undefined` su un asset. Ora
+il risultato nomina il bersaglio vero.
+
+## Cosa NON è stato verificato, e va detto
+
+Nel browser l'agente ha **risposto giusto senza usare questi strumenti**: prima con `query`, poi —
+richiesto esplicitamente — con `bash` e `grep` dentro la sandbox. Ha letto il sorgente e riportato
+riga e colore corretti, ma per un'altra strada. Il percorso nuovo end-to-end non l'ho quindi visto
+girare in chat, e non lo dichiaro verificato.
+
+Quello che è verificato: le funzioni sul bersaglio asset (ricerca, lettura, la guardia «leggi prima
+di scrivere», la scrittura che finisce sull'asset e non su un post), e la tool chiamata **come la
+chiama il modello** — schema, risoluzione del bersaglio, esecuzione. Più una guardia sul cablaggio
+del resolver, perché il difetto stava lì e non nelle funzioni.
+
+L'upload in Storage resta rotto in locale (`extended attributes disabled`, v.
+[`LESSONS.md`](../LESSONS.md)), quindi un `replace_source` completo su questa macchina non arriva
+in fondo comunque.

--- a/src/lib/agent/tools/graphic-source-wiring.test.ts
+++ b/src/lib/agent/tools/graphic-source-wiring.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Il resolver della CHAT decide su cosa lavorano grep/read/replace/write_source. Finché nominava
+ * solo `post_id`, una grafica senza post aveva un sorgente che nessuno sapeva aprire: modificabile
+ * a parole con `design_graphic`, non correggibile di una parola. Questa guardia sta qui perché il
+ * difetto era nel CABLAGGIO, non nelle funzioni — che erano gia` a posto e testate.
+ */
+const read = (rel: string) => readFileSync(fileURLToPath(new URL(rel, import.meta.url)), 'utf8');
+
+describe('la chat sa raggiungere una grafica senza post', () => {
+  it('il resolver accetta media_id e risolve sull\'asset di libreria', () => {
+    const src = read('./index.ts');
+    const start = src.indexOf('createGraphicSourceEditTools(');
+    const block = src.slice(start, src.indexOf('requirePostId: true', start));
+
+    expect(block).toMatch(/media_id/);
+    expect(block).toMatch(/media_generator_items/);
+    expect(block).toMatch(/mediaId: media_id/);
+    // Un bersaglio va nominato: senza nessuno dei due l'errore lo dice, invece di indovinare.
+    expect(block).toMatch(/post_id.*media_id|media_id.*post_id/s);
+  });
+});

--- a/src/lib/agent/tools/index.ts
+++ b/src/lib/agent/tools/index.ts
@@ -163,19 +163,36 @@ export function createChatTools(
     // 300 — la guardia sul tempo rimasto veniva semplicemente saltata su questa superficie.
     ...createMotionOutputTools({ supabase, brandId, userId, fps: () => MOTION_FPS, remainingMs, locale }),
 
+    // Una grafica vive su un post o su un asset di libreria, e questi strumenti devono
+    // raggiungerle entrambe: nominare solo il post lasciava la grafica standalone con un sorgente
+    // che nessuno sapeva aprire — modificabile a parole, non a mano.
     ...createGraphicSourceEditTools(
-      async ({ post_id }) => {
-        if (!post_id) return { error: 'post_id required' };
+      async ({ post_id, media_id }) => {
+        if (!post_id && !media_id) return { error: 'Name the graphic: post_id (from read_posts) or media_id (from read_media).' };
+        if (post_id && media_id) return { error: 'Give post_id OR media_id, not both.' };
+        const { loadEditorContext } = await import('$lib/agent/tools/post-editor-tools');
+
+        if (media_id) {
+          const { data: item } = await supabase
+            .from('media_generator_items')
+            .select('id')
+            .eq('id', media_id)
+            .eq('brand_id', brandId)
+            .maybeSingle();
+          if (!item) return { error: 'Library asset not found' };
+          const ctx = await loadEditorContext(supabase, brandId);
+          return { supabase, brandId, userId, ctx, mediaId: media_id };
+        }
+
         const { data: post } = await supabase
           .from('posts')
           .select('id')
-          .eq('id', post_id)
+          .eq('id', post_id!)
           .eq('brand_id', brandId)
           .maybeSingle();
         if (!post) return { error: 'Post not found' };
-        const { loadEditorContext } = await import('$lib/agent/tools/post-editor-tools');
         const ctx = await loadEditorContext(supabase, brandId);
-        return { supabase, brandId, postId: post_id, tz, userId, ctx, refUrls: turnRefUrls };
+        return { supabase, brandId, postId: post_id!, tz, userId, ctx, refUrls: turnRefUrls };
       },
       { requirePostId: true }
     ),

--- a/src/lib/agent/tools/post-editor-tools.ts
+++ b/src/lib/agent/tools/post-editor-tools.ts
@@ -912,6 +912,120 @@ export async function graphicImageCatalog(
  * quindi «accorcia il titolo» è una revisione e non una ricomposizione. Da lì `create_post_from_asset`
  * lo trasforma in un post quando — e se — l'utente lo chiede.
  */
+/**
+ * DOVE FINISCE UNA GRAFICA CHE NON HA UN POST: nella libreria, come asset, con la sua versione.
+ *
+ * Il gemello di `persistRenderedGraphic`, che invece scrive sulla riga del post. Sta qui accanto a
+ * lui apposta: sono le DUE destinazioni possibili di un render, e tenerle vicine è ciò che impedisce
+ * a una delle due di dimenticare un pezzo — la versione, per esempio, senza la quale l'immagine
+ * esiste ma non è più modificabile.
+ */
+async function persistStandaloneGraphic(
+  t: { supabase: SupabaseClient; brandId: string; userId: string },
+  out: RenderedGraphic,
+  opts: { mediaId?: string | null; brief: string }
+): Promise<{ url: string; mediaId: string | null; tileWarning?: string } | { error: string }> {
+  const { uploadPostImage } = await import('$lib/server/content-preview');
+  const { saveGraphicVersion } = await import('$lib/server/design-store');
+
+  const url = await uploadPostImage(
+    t.supabase,
+    t.userId,
+    `data:image/png;base64,${out.png.toString('base64')}`
+  );
+  if (!url) return { error: 'Upload failed' };
+
+  // La revisione resta sulla STESSA tessera, o la cronologia si spezza in una pila di tentativi.
+  let mediaId = opts.mediaId ?? null;
+  let tileWarning: string | undefined;
+  if (mediaId) {
+    const { updateMediaGeneratorItemUrl } = await import('$lib/server/media-generator/persist');
+    const upd = await updateMediaGeneratorItemUrl(t.supabase, {
+      brandId: t.brandId,
+      itemId: mediaId,
+      url,
+      prompt: opts.brief
+    });
+    if (!upd.ok) {
+      tileWarning = `The revised graphic is saved (image_url below) but the library tile still shows the old one: ${upd.error}.`;
+    }
+  } else {
+    const { insertMediaGeneratorItem } = await import('$lib/server/media-generator/persist');
+    const saved = await insertMediaGeneratorItem(t.supabase, {
+      brandId: t.brandId,
+      userId: t.userId,
+      kind: 'image',
+      url,
+      prompt: opts.brief,
+      aspect: out.aspect
+    });
+    if ('row' in saved) mediaId = saved.row.id;
+  }
+
+  // Senza tessera l'immagine esiste ma non è più modificabile: va detto, non taciuto.
+  if (mediaId) {
+    await saveGraphicVersion(t.supabase, {
+      brandId: t.brandId,
+      userId: t.userId,
+      target: { kind: 'media_item', id: mediaId },
+      spec: out.spec,
+      source: out.source,
+      mediaUrl: url,
+      brief: opts.brief
+    });
+  }
+  return { url, mediaId, ...(tileWarning ? { tileWarning } : {}) };
+}
+
+/**
+ * Scrivi un SORGENTE su una grafica standalone: renderizza, salva, versiona.
+ *
+ * È il gemello di `applyPostGraphicSource`, e senza di lui `replace_source` / `write_source` non
+ * potevano toccare una grafica che non appartiene a un post — la si poteva rifare a parole e non
+ * correggere una parola. Una feature a metà.
+ */
+export async function applyStandaloneGraphicSource(
+  t: { supabase: SupabaseClient; brandId: string; userId: string; ctx: EditorContext; mediaId: string },
+  args: { source: string; brief?: string | null }
+) {
+  const source = unwrapGraphicSource(args.source);
+  if (!source) return { error: 'Empty source' };
+  if (source.length > GRAPHIC_SOURCE_MAX_CHARS) {
+    return { error: `Source exceeds ${GRAPHIC_SOURCE_MAX_CHARS} characters` };
+  }
+
+  const { renderGraphicSource } = await import('$lib/server/design-render');
+  let out: RenderedGraphic;
+  try {
+    out = await renderGraphicSource(source, {
+      brandId: t.brandId,
+      userId: t.userId,
+      brandColors: t.ctx.brandColors,
+      typography: { display: t.ctx.typography.display, body: t.ctx.typography.body }
+    });
+  } catch (e) {
+    return { error: e instanceof Error ? e.message : 'Render failed' };
+  }
+
+  const stored = await persistStandaloneGraphic(t, out, {
+    mediaId: t.mediaId,
+    brief: args.brief ?? 'source editor'
+  });
+  if ('error' in stored) return stored;
+
+  const { latestGraphic } = await import('$lib/server/design-store');
+  const current = await latestGraphic(t.supabase, { kind: 'media_item', id: t.mediaId });
+  return {
+    success: true as const,
+    media_origin: 'typographic_graphic' as const,
+    media_url: stored.url,
+    media_id: stored.mediaId,
+    version: current?.version,
+    graphic_source: out.source,
+    ...(stored.tileWarning ? { warning: stored.tileWarning } : {})
+  };
+}
+
 export async function designStandaloneGraphic(
   t: { supabase: SupabaseClient; brandId: string; userId: string; ctx: EditorContext; refUrls?: string[] },
   args: GraphicRefArgs & { brief: string; media_id?: string }
@@ -948,53 +1062,13 @@ export async function designStandaloneGraphic(
     return { error: e instanceof Error ? e.message : 'The graphic could not be composed.' };
   }
 
+  const stored = await persistStandaloneGraphic(t, composed.rendered, {
+    mediaId: args.media_id ?? null,
+    brief: args.brief
+  });
+  if ('error' in stored) return stored;
+  const { url, mediaId, tileWarning } = stored;
   const out = composed.rendered;
-  const url = await uploadPostImage(
-    t.supabase,
-    t.userId,
-    `data:image/png;base64,${out.png.toString('base64')}`
-  );
-  if (!url) return { error: 'Upload failed' };
-
-  // La revisione resta sulla STESSA tessera, o la cronologia si spezza in una pila di tentativi.
-  let mediaId = args.media_id ?? null;
-  let tileWarning: string | undefined;
-  if (mediaId) {
-    const { updateMediaGeneratorItemUrl } = await import('$lib/server/media-generator/persist');
-    const upd = await updateMediaGeneratorItemUrl(t.supabase, {
-      brandId: t.brandId,
-      itemId: mediaId,
-      url,
-      prompt: args.brief
-    });
-    if (!upd.ok) {
-      tileWarning = `The revised graphic is saved (image_url below) but the library tile still shows the old one: ${upd.error}.`;
-    }
-  } else {
-    const { insertMediaGeneratorItem } = await import('$lib/server/media-generator/persist');
-    const saved = await insertMediaGeneratorItem(t.supabase, {
-      brandId: t.brandId,
-      userId: t.userId,
-      kind: 'image',
-      url,
-      prompt: args.brief,
-      aspect: out.aspect
-    });
-    if ('row' in saved) mediaId = saved.row.id;
-  }
-
-  // Senza tessera l'immagine esiste ma non è più modificabile: va detto, non taciuto.
-  if (mediaId) {
-    await saveGraphicVersion(t.supabase, {
-      brandId: t.brandId,
-      userId: t.userId,
-      target: { kind: 'media_item', id: mediaId },
-      spec: out.spec,
-      source: out.source,
-      mediaUrl: url,
-      brief: args.brief
-    });
-  }
 
   if (args.media_ids?.length && !args.generate_prompt?.trim()) {
     const { recordBrandMediaUse } = await import('$lib/server/brand-media');

--- a/src/lib/content/changelog/2026-09-03-graphic-source-anywhere.ts
+++ b/src/lib/content/changelog/2026-09-03-graphic-source-anywhere.ts
@@ -1,0 +1,12 @@
+import type { ChangelogEntry } from './index';
+
+const entry: ChangelogEntry = {
+  date: '2026-09-03',
+  title: 'Edit the code of any graphic, post or not',
+  items: [
+    'A graphic that belongs to no post can now be edited the way a post graphic always could: ask for one word, one colour or one spacing to change, and only that changes.',
+    'Before, a standalone graphic could only be redone from a fresh brief — the code was there, and nothing could open it.'
+  ]
+};
+
+export default entry;

--- a/src/lib/server/chat/graphic-source-edit.ts
+++ b/src/lib/server/chat/graphic-source-edit.ts
@@ -8,28 +8,63 @@ import {
 	grepSource,
 	sliceSource
 } from '$lib/motion-video/source-ops';
-import type { EditorTarget } from '$lib/agent/tools/post-editor-tools';
+import type { EditorTarget, EditorContext } from '$lib/agent/tools/post-editor-tools';
+import type { SupabaseClient } from '@supabase/supabase-js';
 import { noteRead, requireFreshRead } from './read-guards';
+
+/**
+ * DUE POSTI DOVE PUÒ VIVERE UNA GRAFICA, e un solo modo di modificarla.
+ *
+ * Il sorgente sta in `graphic_designs`, che indirizza `{ kind, id }` — un post o un asset di
+ * libreria — da sempre. Questi strumenti però conoscevano solo il post, quindi una grafica
+ * standalone si poteva rifare a parole e non correggere di una parola: aveva il codice e nessuno
+ * sapeva aprirlo.
+ */
+export type StandaloneTarget = {
+	supabase: SupabaseClient;
+	brandId: string;
+	userId: string;
+	ctx: EditorContext;
+	mediaId: string;
+};
+
+export type GraphicEditTarget = EditorTarget | StandaloneTarget;
+
+const isStandalone = (t: GraphicEditTarget): t is StandaloneTarget => 'mediaId' in t;
+
+/** Il risultato nomina il bersaglio VERO: `post_id: undefined` su un asset era una risposta rotta. */
+const targetEcho = (t: GraphicEditTarget) =>
+	isStandalone(t) ? { media_id: t.mediaId } : { post_id: t.postId };
+
+const graphicTarget = (t: GraphicEditTarget, slideIndex?: number | null) =>
+	isStandalone(t)
+		? ({ kind: 'media_item' as const, id: t.mediaId })
+		: ({ kind: 'post' as const, id: t.postId, slideIndex: slideIndex ?? null });
 
 export { MOTION_READ_DEFAULT_CHARS as GRAPHIC_READ_DEFAULT_CHARS, MOTION_READ_MAX_CHARS as GRAPHIC_READ_MAX_CHARS };
 
 type SlideArgs = { slide_index?: number };
 
 /** La chiave del receipt: stessa derivazione da args in lettura e in scrittura. */
-const receiptId = (t: EditorTarget, slideIndex?: number | null) => `${t.postId}|${slideIndex ?? ''}`;
+const receiptId = (t: GraphicEditTarget, slideIndex?: number | null) =>
+	isStandalone(t) ? `media:${t.mediaId}` : `${t.postId}|${slideIndex ?? ''}`;
 
 const SOURCE_READ_TOOL = 'read_source({ slide_index })';
 
-async function loadWorkingGraphicSource(t: EditorTarget, slideIndex?: number | null) {
+async function loadWorkingGraphicSource(t: GraphicEditTarget, slideIndex?: number | null) {
 	const { latestGraphic, versionSource } = await import('$lib/server/design-store');
-	const load = (idx: number | null) =>
-		latestGraphic(t.supabase, { kind: 'post', id: t.postId, slideIndex: idx });
-	let graphic = await load(slideIndex ?? null);
-	if (!graphic && (slideIndex == null || slideIndex === 0)) {
-		graphic = await load(slideIndex == null ? 0 : null);
+	let graphic = await latestGraphic(t.supabase, graphicTarget(t, slideIndex));
+	// Le carousel indirizzano uno slot; una cover puo` essere salvata con `null` o con `0`, e le
+	// due scritture convivono da prima che lo slot esistesse. Non vale per un asset standalone.
+	if (!graphic && !isStandalone(t) && (slideIndex == null || slideIndex === 0)) {
+		graphic = await latestGraphic(t.supabase, graphicTarget(t, slideIndex == null ? 0 : null));
 	}
 	if (!graphic) {
-		return { error: 'No graphic source on this post. Compose one with design_graphic first.' };
+		return {
+			error: isStandalone(t)
+				? 'No graphic source on this library asset. Compose one with design_graphic first.'
+				: 'No graphic source on this post. Compose one with design_graphic first.'
+		};
 	}
 	return {
 		source: versionSource(graphic),
@@ -49,7 +84,7 @@ async function loadWorkingGraphicSource(t: EditorTarget, slideIndex?: number | n
  * Solo `text_below_feed_floor` blocca: il px è letterale nel sorgente e si corregge alzandolo.
  * Il resto torna come `design_warnings` nel risultato — vedi l'intestazione di graphic-check.ts.
  */
-async function inspectSource(t: EditorTarget, source: string) {
+async function inspectSource(t: GraphicEditTarget, source: string) {
 	try {
 		const [{ sourceToSatoriTree }, { inspectGraphicTree }] = await Promise.all([
 			import('$lib/server/design-render'),
@@ -61,6 +96,21 @@ async function inspectSource(t: EditorTarget, source: string) {
 		// Sorgente illeggibile: il render lo dirà con l'errore vero. Il gate non inventa il suo.
 		return [];
 	}
+}
+
+/** L'unica differenza fra i due posti: dove il PNG viene scritto. */
+async function applyGraphicSource(
+	t: GraphicEditTarget,
+	source: string,
+	slideIndex: number | undefined,
+	brief: string
+) {
+	if (isStandalone(t)) {
+		const { applyStandaloneGraphicSource } = await import('$lib/agent/tools/post-editor-tools');
+		return applyStandaloneGraphicSource(t, { source, brief });
+	}
+	const { applyPostGraphicSource } = await import('$lib/agent/tools/post-editor-tools');
+	return applyPostGraphicSource(t, { source, slide_index: slideIndex, brief });
 }
 
 function refusal(issues: Array<{ blocking: boolean; detail: string }>) {
@@ -94,7 +144,7 @@ export function compactGraphicPersist(result: object, extra: Record<string, unkn
 }
 
 export async function grepPostGraphicSource(
-	t: EditorTarget,
+	t: GraphicEditTarget,
 	args: SlideArgs & { query: string; regex?: boolean; ignore_case?: boolean }
 ) {
 	const working = await loadWorkingGraphicSource(t, args.slide_index);
@@ -105,7 +155,7 @@ export async function grepPostGraphicSource(
 			ignoreCase: args.ignore_case === true
 		});
 		return {
-			post_id: t.postId,
+			...targetEcho(t),
 			slide_index: args.slide_index ?? null,
 			kind: working.kind,
 			query: args.query,
@@ -117,7 +167,7 @@ export async function grepPostGraphicSource(
 }
 
 export async function readPostGraphicSource(
-	t: EditorTarget,
+	t: GraphicEditTarget,
 	args: SlideArgs & { start_from?: number; max_chars?: number }
 ) {
 	const working = await loadWorkingGraphicSource(t, args.slide_index);
@@ -129,7 +179,7 @@ export async function readPostGraphicSource(
 	);
 	noteRead('graphic', receiptId(t, args.slide_index), working.version);
 	return {
-		post_id: t.postId,
+		...targetEcho(t),
 		slide_index: args.slide_index ?? null,
 		kind: working.kind,
 		...page
@@ -137,7 +187,7 @@ export async function readPostGraphicSource(
 }
 
 export async function replacePostGraphicSource(
-	t: EditorTarget,
+	t: GraphicEditTarget,
 	args: SlideArgs & { old_str: string; new_str: string; replace_all?: boolean; count?: number }
 ) {
 	const working = await loadWorkingGraphicSource(t, args.slide_index);
@@ -163,12 +213,7 @@ export async function replacePostGraphicSource(
 	const issues = await inspectSource(t, next);
 	const refused = refusal(issues);
 	if (refused) return refused;
-	const { applyPostGraphicSource } = await import('$lib/agent/tools/post-editor-tools');
-	const saved = await applyPostGraphicSource(t, {
-		source: next,
-		slide_index: args.slide_index,
-		brief: 'replace_source'
-	});
+	const saved = await applyGraphicSource(t, next, args.slide_index, 'replace_source');
 	const out = compactGraphicPersist(saved, { replaced, ...warnings(issues) });
 	if ('success' in saved && typeof saved.version !== 'undefined') {
 		noteRead('graphic', receiptId(t, args.slide_index), saved.version);
@@ -176,7 +221,7 @@ export async function replacePostGraphicSource(
 	return out;
 }
 
-export async function writePostGraphicSource(t: EditorTarget, args: SlideArgs & { source: string }) {
+export async function writePostGraphicSource(t: GraphicEditTarget, args: SlideArgs & { source: string }) {
 	const staleGate = await loadWorkingGraphicSource(t, args.slide_index);
 	if (!('error' in staleGate)) {
 		const stale = requireFreshRead(
@@ -192,12 +237,7 @@ export async function writePostGraphicSource(t: EditorTarget, args: SlideArgs & 
 	const issues = await inspectSource(t, source);
 	const refused = refusal(issues);
 	if (refused) return refused;
-	const { applyPostGraphicSource } = await import('$lib/agent/tools/post-editor-tools');
-	const saved = await applyPostGraphicSource(t, {
-		source,
-		slide_index: args.slide_index,
-		brief: 'write_source'
-	});
+	const saved = await applyGraphicSource(t, source, args.slide_index, 'write_source');
 	const out = compactGraphicPersist(saved, warnings(issues));
 	if ('success' in saved && typeof saved.version !== 'undefined') {
 		noteRead('graphic', receiptId(t, args.slide_index), saved.version);
@@ -207,20 +247,32 @@ export async function writePostGraphicSource(t: EditorTarget, args: SlideArgs & 
 
 type ResolveTarget = (args: {
 	post_id?: string;
+	media_id?: string;
 	slide_index?: number;
-}) => Promise<EditorTarget | { error: string }>;
+}) => Promise<GraphicEditTarget | { error: string }>;
 
 /**
  * grep_source / read_source / replace_source / write_source — same contract as motion-video.
  * Post editor: resolve ignores post_id. Brand chat: requirePostId.
  */
 export function createGraphicSourceEditTools(resolve: ResolveTarget, opts: { requirePostId?: boolean } = {}) {
+	// Nella chat il bersaglio va nominato, e ci sono due modi di nominarlo: il post che porta la
+	// grafica, o l'asset di libreria quando la grafica non appartiene a nessun post. Nell'editor
+	// il bersaglio è la pagina stessa, quindi restano entrambi opzionali e ignorati.
 	const postId = opts.requirePostId
 		? {
-				post_id: z.string().describe('Post id from read_posts')
+				post_id: z
+					.string()
+					.optional()
+					.describe('Post id from read_posts. Give this OR media_id.'),
+				media_id: z
+					.string()
+					.optional()
+					.describe('Library asset id from read_media, for a graphic that belongs to no post. Give this OR post_id.')
 			}
 		: {
-				post_id: z.string().optional()
+				post_id: z.string().optional(),
+				media_id: z.string().optional()
 			};
 	const slide = {
 		slide_index: z
@@ -237,7 +289,7 @@ export function createGraphicSourceEditTools(resolve: ResolveTarget, opts: { req
 	return {
 		grep_source: tool({
 			description:
-				'Find a word or snippet in this post\'s graphic HTML/TSX. Returns char indexes for read_source start_from. Literal match by default. Max 40 hits.',
+				"Find a word or snippet in a graphic's HTML/TSX — the post's (post_id) or a standalone library asset's (media_id). Returns char indexes for read_source start_from. Literal match by default. Max 40 hits.",
 			inputSchema: z.object({
 				query: z.string().min(1).max(500),
 				regex: z.boolean().optional(),
@@ -252,7 +304,7 @@ export function createGraphicSourceEditTools(resolve: ResolveTarget, opts: { req
 			}
 		}),
 		read_source: tool({
-			description: `Read a slice of this post's graphic HTML/TSX. Default ${MOTION_READ_DEFAULT_CHARS} chars from start_from (0-based). If next_start is set, call again with start_from=next_start. Cap ${MOTION_READ_MAX_CHARS}.`,
+			description: `Read a slice of a graphic's HTML/TSX — the post's (post_id) or a standalone library asset's (media_id). Default ${MOTION_READ_DEFAULT_CHARS} chars from start_from (0-based). If next_start is set, call again with start_from=next_start. Cap ${MOTION_READ_MAX_CHARS}.`,
 			inputSchema: z.object({
 				start_from: z.number().int().min(0).optional(),
 				max_chars: z.number().int().min(1).max(MOTION_READ_MAX_CHARS).optional(),

--- a/src/lib/server/chat/graphic-source-standalone.test.ts
+++ b/src/lib/server/chat/graphic-source-standalone.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+/**
+ * UNA FEATURE A META`, e la seconda meta`.
+ *
+ * Una grafica standalone nasceva con il suo sorgente HTML/TSX e la sua cronologia di versioni, ma
+ * `grep_source` / `read_source` / `replace_source` conoscevano solo `{ kind: 'post' }`. Il codice
+ * c'era e nessuno sapeva aprirlo: la grafica si poteva rifare a parole (`design_graphic`) e non
+ * correggere di una parola. Questi test tengono aperta la porta.
+ */
+const store = vi.hoisted(() => ({
+  targets: [] as Array<Record<string, unknown>>,
+  source: '<div class="t">Saldi -30%</div>',
+  version: 3,
+  applied: [] as Array<Record<string, unknown>>
+}));
+
+vi.mock('$lib/server/design-store', () => ({
+  latestGraphic: async (_c: unknown, target: Record<string, unknown>) => {
+    store.targets.push(target);
+    if (target.kind !== 'media_item') return null;
+    return {
+      id: 'g1',
+      version: store.version,
+      spec: { v: 2, kind: 'html', aspect: '1:1' },
+      source: store.source,
+      sourceKind: 'html',
+      aspect: '1:1',
+      mediaUrl: 'https://cdn.test/a.png',
+      brief: null,
+      createdAt: 'now'
+    };
+  },
+  versionSource: (g: { source: string }) => g.source,
+  saveGraphicVersion: async () => 1
+}));
+
+vi.mock('$lib/agent/tools/post-editor-tools', () => ({
+  applyStandaloneGraphicSource: async (t: Record<string, unknown>, args: Record<string, unknown>) => {
+    store.applied.push({ mediaId: t.mediaId, ...args });
+    return { success: true, media_url: 'https://cdn.test/b.png', version: store.version + 1, graphic_source: args.source };
+  },
+  applyPostGraphicSource: async () => ({ error: 'il post non c\'entra in questo test' })
+}));
+
+vi.mock('$lib/server/design-render', () => ({ sourceToSatoriTree: async () => ({ tree: {}, width: 1080, height: 1080 }) }));
+vi.mock('$lib/design/graphic-check', () => ({ inspectGraphicTree: () => [] }));
+
+const { grepPostGraphicSource, readPostGraphicSource, replacePostGraphicSource } = await import(
+  './graphic-source-edit'
+);
+
+const TARGET = {
+  supabase: {} as SupabaseClient,
+  brandId: 'brand-1',
+  userId: 'user-1',
+  ctx: { brandColors: ['#000'], typography: { display: 'Inter', body: 'Inter' } } as never,
+  mediaId: 'media-7'
+};
+
+beforeEach(() => {
+  store.targets = [];
+  store.applied = [];
+  store.source = '<div class="t">Saldi -30%</div>';
+});
+
+describe('il codice di una grafica che non ha un post', () => {
+  it('lo cerca sull\'asset di libreria, non su un post', async () => {
+    const out = await grepPostGraphicSource(TARGET, { query: 'Saldi' });
+
+    expect(store.targets[0]).toMatchObject({ kind: 'media_item', id: 'media-7' });
+    // Il risultato nomina l'asset, non un post_id vuoto.
+    expect(out).toMatchObject({ media_id: 'media-7' });
+    expect(out).not.toHaveProperty('post_id');
+  });
+
+  it('lo legge a pagine, come per un post', async () => {
+    const out = (await readPostGraphicSource(TARGET, {})) as Record<string, unknown>;
+    expect(String(out.source ?? out.slice ?? '')).toContain('Saldi -30%');
+  });
+
+  /**
+   * La guardia «leggi prima di scrivere» vale anche qui: senza, un replace partirebbe da un
+   * sorgente che il modello non ha mai visto.
+   */
+  it('rifiuta la modifica finche\' non e\' stato letto', async () => {
+    // Un asset MAI letto in questo processo: le receipt sono di modulo e le altre prove ne
+    // lasciano una su `media-7`.
+    const out = (await replacePostGraphicSource({ ...TARGET, mediaId: 'media-mai-letto' }, {
+      old_str: 'Saldi -30%',
+      new_str: 'Saldi -40%'
+    })) as Record<string, unknown>;
+
+    expect(String(out.error ?? '')).toMatch(/read_source/i);
+    expect(store.applied).toEqual([]);
+  });
+
+  it('dopo la lettura scrive sull\'asset, non su un post', async () => {
+    await readPostGraphicSource(TARGET, {});
+
+    const out = (await replacePostGraphicSource(TARGET, {
+      old_str: 'Saldi -30%',
+      new_str: 'Saldi -40%'
+    })) as Record<string, unknown>;
+
+    expect(out.ok).toBe(true);
+    expect(store.applied).toHaveLength(1);
+    expect(store.applied[0]).toMatchObject({ mediaId: 'media-7', brief: 'replace_source' });
+    expect(String(store.applied[0].source)).toContain('Saldi -40%');
+  });
+});
+
+/**
+ * IL CABLAGGIO, non solo le funzioni.
+ *
+ * Le prove qui sopra chiamano le funzioni con un bersaglio gia` costruito. Questa chiama la TOOL
+ * come la chiama il modello: schema, risoluzione del bersaglio, esecuzione. E` il pezzo che il
+ * browser non ha esercitato — l'agente ha preferito `query` e poi `bash`+`grep`, quindi la strada
+ * nuova non era mai stata percorsa davvero.
+ */
+describe('la tool che il modello chiama davvero', () => {
+  it('accetta media_id e arriva alla grafica dell\'asset', async () => {
+    const { createGraphicSourceEditTools } = await import('./graphic-source-edit');
+    const seen: Array<Record<string, unknown>> = [];
+
+    const tools = createGraphicSourceEditTools(
+      async ({ post_id, media_id }) => {
+        seen.push({ post_id, media_id });
+        if (!media_id) return { error: 'atteso media_id' };
+        return { ...TARGET, mediaId: media_id };
+      },
+      { requirePostId: true }
+    );
+
+    const out = (await tools.grep_source.execute!(
+      { query: 'Saldi', media_id: 'media-42' },
+      {} as never
+    )) as Record<string, unknown>;
+
+    expect(seen[0]).toMatchObject({ media_id: 'media-42' });
+    expect(store.targets.at(-1)).toMatchObject({ kind: 'media_item', id: 'media-42' });
+    expect(out).toMatchObject({ media_id: 'media-42' });
+  });
+
+  /** Lo schema deve DICHIARARE media_id, o il modello non sa che esiste. */
+  it('dichiara media_id nello schema, non solo lo accetta', async () => {
+    const { createGraphicSourceEditTools } = await import('./graphic-source-edit');
+    const tools = createGraphicSourceEditTools(async () => TARGET, { requirePostId: true });
+
+    for (const name of ['grep_source', 'read_source', 'replace_source', 'write_source'] as const) {
+      const shape = (tools[name].inputSchema as { shape?: Record<string, unknown> }).shape ?? {};
+      expect(Object.keys(shape)).toContain('media_id');
+    }
+  });
+});


### PR DESCRIPTION
## What?

Ieri ho reso possibile una grafica **senza post** (#180). Nasceva con il suo sorgente HTML/TSX e la
sua cronologia di versioni — e **nessuno sapeva aprirlo**: `grep_source`, `read_source`,
`replace_source` e `write_source` conoscevano solo `{ kind: 'post' }`.

Si poteva rifare a parole con `design_graphic`, e non correggere di una parola. Una feature a metà,
spedita come se fosse intera. Questa è l'altra metà, **in chat** — non solo nell'editor del post.

## Why?

Il magazzino non è mai stato il problema: `graphic_designs` indirizza `{ kind, id }` — post o asset
di libreria — dal primo giorno. Erano due cose sopra di lui a essere modellate sul post:

- **il bersaglio**: negli strumenti del sorgente era `EditorTarget`, cioè un post. Adesso è
  `GraphicEditTarget`, o post o asset; `loadWorkingGraphicSource` e la scrittura scelgono da lì;
- **il resolver della chat** (`agent/tools/index.ts`): rifiutava senza `post_id`. Adesso accetta
  anche `media_id`, e se non arriva nessuno dei due lo dice invece di indovinare.

## How?

`applyStandaloneGraphicSource` è il gemello di `applyPostGraphicSource`: renderizza il sorgente,
salva l'immagine sull'asset, versiona. Sta accanto a lui apposta — sono le due destinazioni
possibili di un render, e tenerle lontane è ciò che fa dimenticare un pezzo all'una o all'altra.
La logica di persistenza standalone è stata estratta da `designStandaloneGraphic` in
`persistStandaloneGraphic`, così composizione e scrittura-sorgente non ne tengono due copie.

Corretta anche una risposta rotta che avevo introdotto: `grep_source` restituiva
`post_id: undefined` su un asset. Ora il risultato nomina il bersaglio vero (`media_id`).

## Testing?

Suite intera verde (6362).

`graphic-source-standalone.test.ts` — sei casi: la ricerca che va sull'asset e non su un post; la
lettura a pagine; **la guardia «leggi prima di scrivere»**, che vale anche qui; la scrittura che
finisce sull'asset; e — il pezzo che conta — la **tool chiamata come la chiama il modello**
(schema, risoluzione del bersaglio, esecuzione), più il fatto che `media_id` sia **dichiarato**
nello schema di tutte e quattro, o il modello non saprebbe che esiste.

`graphic-source-wiring.test.ts` — una guardia sul resolver della chat, perché il difetto stava nel
**cablaggio** e non nelle funzioni: quelle erano già a posto.

### Cosa NON è verificato, e va detto

Nel browser, con una grafica standalone seminata nel database locale, l'agente ha **risposto giusto
senza usare questi strumenti**: prima con `query`, poi — richiesto esplicitamente di usare
`grep_source` — con `bash` e `grep` dentro la sandbox. Ha letto il sorgente e riportato riga e
colore corretti, ma per un'altra strada.

Quindi il percorso nuovo **end-to-end in chat non l'ho visto girare**, e non lo dichiaro verificato.
È lo stesso errore che ho quasi commesso col batch delle skill: un risultato giusto ottenuto da un
codice che non era il mio.

L'upload in Storage resta rotto in locale (`extended attributes disabled`, in `LESSONS.md`), quindi
un `replace_source` completo su questa macchina non arriva in fondo comunque.

## Anything Else?

**Che il modello preferisca `bash`+`grep` al tool dedicato è un fatto da guardare a parte.** Se
legge i sorgenti dalla sandbox invece che dagli strumenti, salta la guardia «leggi prima di
scrivere» e il gate di render — che sono lì per ragioni pagate. Non l'ho toccato qui: è un problema
di prompt e di priorità fra strumenti, non di questo cablaggio.
