### PR TITLE
Let an external agent reuse the brand's media

### DIFF
--- a/changelog/2026-09-03-external-agent-media.md
+++ b/changelog/2026-09-03-external-agent-media.md
@@ -1,0 +1,55 @@
+# Un agente esterno può riusare i media del brand
+
+Seconda slice verticale della Fase 1 del piano [external agent](../docs/external-agent-plan.md),
+dopo la creazione text-only. `create_post` accetta `media_ids`, e `list_media` dice quali id
+esistono.
+
+## Cosa sbloccava
+
+Senza media, `create_post` rifiutava `instagram` e `tiktok` in blocco — le due piattaforme dove
+un post di solo testo non esiste — e `youtube` sempre. Un agente esterno poteva scrivere solo
+per LinkedIn e X.
+
+## Il downgrade silenzioso
+
+`resolveMediaUrls` saltava in silenzio ogni media che non riusciva a risolvere:
+
+```ts
+if ('publicUrl' in copied && copied.publicUrl) urls.push(copied.publicUrl);
+```
+
+Un id di un altro brand, o una copia fallita, non erano un errore: erano un post **senza
+immagine**. Su LinkedIn nasceva una bozza text-only che nessuno aveva chiesto; su Instagram
+usciva `need_media`, che sembrava colpa di chi aveva chiamato mentre il media c'era ed era stato
+scartato da noi. È esattamente il «silent downgrade to text-only» che il piano vieta.
+
+Ora la regola è una sola e sta in un posto solo: **un media che il chiamante ha indicato e che non
+si risolve ferma la creazione**. Vale per gli id di libreria e per i percorsi di upload, perché
+sono lo stesso caso — un identificativo che il chiamante ha dato e noi non onoriamo.
+
+Questo cambia anche la UI di manual posting: un percorso fuori dagli upload dell'utente ora è un
+errore invece di un post muto. Non dovrebbe capitare in uso normale (i percorsi li produce
+l'upload stesso), e quando capita è meglio dirlo.
+
+## La proprietà, chiesta all'adapter
+
+`findBrandMediaByIds` risponde quali id sono davvero di quel brand. Il servizio confronta con
+quelli chiesti: chi manca è di un altro brand o non esiste, e **la differenza fra i due non viene
+detta** — distinguerle sarebbe un modo per sondare gli id altrui.
+
+Il `kind` della riga decide anche come si pubblica: un video di libreria adesso soddisfa
+`youtube`, che prima nessun percorso esterno poteva raggiungere.
+
+## Il registry alla prova
+
+`list_media` è il primo endpoint aggiunto *dopo* il registry, ed è servito a misurarlo: una riga
+in `BRAND_ENDPOINTS` più la route, e il metodo del client e il tool MCP sono comparsi da soli.
+Nessun blocco `registerTool` scritto a mano, nessun tipo ricopiato in `cli/lib/api.ts`.
+
+Il tetto di 8 media resta un taglio silenzioso: la UI non limita i file selezionati, quindi
+trasformarlo in errore romperebbe a distanza chi ne carica nove. Resta com'era.
+
+## Fuori da questo giro
+
+`import_media_url` — la slice 4 — ha una superficie di sicurezza sua (reti private, redirect,
+MIME, dimensione) e merita una PR che la si possa leggere da sola.

--- a/cli/lib/contracts/index.ts
+++ b/cli/lib/contracts/index.ts
@@ -1,5 +1,5 @@
 import type { z } from 'zod';
-import { CREATE_POST, GET_CALENDAR, LIST_POSTS } from './posts';
+import { CREATE_POST, GET_CALENDAR, LIST_MEDIA, LIST_POSTS } from './posts';
 
 export type EndpointFailure = { readonly error: string; readonly status: number };
 
@@ -15,7 +15,7 @@ export type BrandEndpoint = {
   readonly destructive: boolean;
 };
 
-export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [CREATE_POST, LIST_POSTS, GET_CALENDAR];
+export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [CREATE_POST, LIST_POSTS, GET_CALENDAR, LIST_MEDIA];
 
 export function pathFor(endpoint: BrandEndpoint, slug: string): string {
   return `/api/v1/brands/${encodeURIComponent(slug)}${endpoint.pathUnderBrand}`;
@@ -25,5 +25,5 @@ export function statusForFailure(endpoint: BrandEndpoint, error: string): number
   return endpoint.failures.find((f) => f.error === error)?.status ?? 500;
 }
 
-export { CREATE_POST, GET_CALENDAR, LIST_POSTS };
+export { CREATE_POST, GET_CALENDAR, LIST_MEDIA, LIST_POSTS };
 export type { CreatePostInput, CreatePostResult } from './posts';

--- a/cli/lib/contracts/posts.ts
+++ b/cli/lib/contracts/posts.ts
@@ -38,6 +38,14 @@ const CreatePostInputSchema = z.object({
       'Proposed publication instant, ISO. Without an offset it is read on the brand clock. ' +
         'It is a calendar proposal only: nothing is scheduled or published until the post is approved'
     ),
+  media_ids: z
+    .array(z.string().min(1))
+    .max(8)
+    .optional()
+    .describe(
+      'Ids from this brand media library (see list_media). An id that is not this brand is ' +
+        'rejected: the post is never quietly created without it'
+    ),
   title: z.string().optional().describe('Required for Reddit'),
   subreddit: z.string().optional(),
   link_url: z.string().optional()
@@ -76,7 +84,8 @@ export const CREATE_POST = {
     { error: 'over_limit', status: 400 },
     { error: 'reddit_title', status: 400 },
     { error: 'too_soon', status: 400 },
-    { error: 'invalid_scheduled_for', status: 400 }
+    { error: 'invalid_scheduled_for', status: 400 },
+    { error: 'media_not_found', status: 400 }
   ],
   destructive: false
 } satisfies BrandEndpoint;
@@ -119,6 +128,38 @@ export const GET_CALENDAR = {
     nextYM: z.string(),
     timezone: z.string()
   }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+const MediaRow = z.object({
+  id: z.string(),
+  kind: z.string(),
+  mime: z.string().nullable(),
+  width: z.number().nullable(),
+  height: z.number().nullable(),
+  title: z.string().nullable(),
+  description: z.string().nullable(),
+  tags: z.array(z.string()).nullable(),
+  signed_url: z.string().nullable(),
+  created_at: z.string()
+});
+
+export const LIST_MEDIA = {
+  tool: 'list_media',
+  title: 'List brand media',
+  description:
+    'Assets already in the brand library, newest first, with a preview URL. Use an id from here ' +
+    'as media_ids on create_post to reuse an asset instead of paying for a new render.',
+  method: 'GET',
+  pathUnderBrand: '/media',
+  input: z
+    .object({
+      query: z.string().optional().describe('Free-text filter over title, description and tags'),
+      limit: z.coerce.number().int().min(1).max(200).optional()
+    })
+    .strict(),
+  output: z.object({ media: z.array(MediaRow) }),
   failures: [],
   destructive: false
 } satisfies BrandEndpoint;

--- a/cli/mcp/create-post.test.ts
+++ b/cli/mcp/create-post.test.ts
@@ -40,7 +40,7 @@ describe('i tool di brand derivati dal registry', () => {
     const createPost = find(await tools(), 'create_post');
 
     expect(Object.keys(createPost.inputSchema?.properties ?? {}).sort()).toEqual(
-      ['caption', 'link_url', 'platform_captions', 'platforms', 'scheduled_for', 'slug', 'subreddit', 'title'].sort(),
+      ['caption', 'link_url', 'media_ids', 'platform_captions', 'platforms', 'scheduled_for', 'slug', 'subreddit', 'title'].sort(),
     );
     expect((createPost.inputSchema?.required ?? []).sort()).toEqual(['caption', 'platforms', 'slug']);
   });
@@ -63,6 +63,24 @@ describe('i tool di brand derivati dal registry', () => {
       'month',
       'slug',
     ]);
+  });
+
+  test('list_media compare senza una riga di codice scritta a mano', async () => {
+    const listMedia = find(await tools(), 'list_media');
+
+    expect(listMedia.annotations?.readOnlyHint).toBe(true);
+    expect(Object.keys(listMedia.inputSchema?.properties ?? {}).sort()).toEqual([
+      'limit',
+      'query',
+      'slug',
+    ]);
+    expect((listMedia.inputSchema?.required ?? [])).toEqual(['slug']);
+  });
+
+  test('create_post accetta i media della libreria', async () => {
+    const createPost = find(await tools(), 'create_post');
+
+    expect(Object.keys(createPost.inputSchema?.properties ?? {})).toContain('media_ids');
   });
 
   test('nessun tool è registrato due volte dopo la migrazione', async () => {

--- a/cli/plugins/anomalia/skills/anomalia/SKILL.md
+++ b/cli/plugins/anomalia/skills/anomalia/SKILL.md
@@ -55,6 +55,9 @@ Setup details: [references/mcp.md](references/mcp.md).
 calendar time, and `approve_post` is what authorizes distribution. Hand the operator the
 `review_url` that comes back.
 
+**Reuse an asset instead of paying for a render** → `list_media` → pass its id to `create_post`
+as `media_ids`. That is also how you post to Instagram or TikTok, which never accept text alone.
+
 **Approve pending posts** → `list_posts` (status pending) → optional `get_post` → `approve_posts`.
 
 **Fix one carousel slide** → `get_post` → `regenerate_slide` (`index`, instruction; 0 = cover).

--- a/cli/plugins/anomalia/skills/anomalia/references/tools.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/tools.md
@@ -24,6 +24,7 @@ All tools take a brand `slug` when brand-scoped. Ids accept short unambiguous pr
 | `list_products` | (studio / products views) |
 | `list_posts` | `anomalia content <slug> [--status …]` |
 | `create_post` | (MCP only) |
+| `list_media` | (MCP only) |
 | `approve_posts` | `anomalia approve <slug> --all` |
 | `get_post` | `anomalia post <slug> <id>` |
 | `edit_post` | `anomalia post <slug> <id> edit …` |
@@ -35,11 +36,15 @@ All tools take a brand `slug` when brand-scoped. Ids accept short unambiguous pr
 | `reorder_slides` | `anomalia post <slug> <id> reorder --order "0,2,1"` |
 | `make_video` | `anomalia post <slug> <id> video …` |
 
+`list_media` lists what is already in the brand library; an id from there goes into `create_post`
+as `media_ids` and costs no render. A media id that is not this brand's stops the creation —
+the post is never made without it.
+
 `create_post` stores copy **you** wrote: Anomalia calls no model and spends no credits. It does
 not publish and does not schedule — `scheduled_for` is the proposed calendar time and stays a
 proposal until `approve_post`, which is what authorizes distribution. Text-capable platforms
-only (`facebook`, `linkedin`, `x`, `threads`, `bluesky`, `reddit`); `instagram` and `tiktok` need
-an image, `youtube` a video. Required: `slug`, `platforms`, `caption`. Optional:
+only (`facebook`, `linkedin`, `x`, `threads`, `bluesky`, `reddit`) unless you pass `media_ids`;
+`instagram` and `tiktok` need an image, `youtube` a video. Required: `slug`, `platforms`, `caption`. Optional:
 `platform_captions`, `scheduled_for` (ISO — no offset means the brand's timezone), `title`
 (required for Reddit), `subreddit`, `link_url`. The result carries the post id, its
 `pending_user` status, the stored instant and a `review_url` the operator can open.

--- a/cli/skills/anomalia/SKILL.md
+++ b/cli/skills/anomalia/SKILL.md
@@ -55,6 +55,9 @@ Setup details: [references/mcp.md](references/mcp.md).
 calendar time, and `approve_post` is what authorizes distribution. Hand the operator the
 `review_url` that comes back.
 
+**Reuse an asset instead of paying for a render** → `list_media` → pass its id to `create_post`
+as `media_ids`. That is also how you post to Instagram or TikTok, which never accept text alone.
+
 **Approve pending posts** → `list_posts` (status pending) → optional `get_post` → `approve_posts`.
 
 **Fix one carousel slide** → `get_post` → `regenerate_slide` (`index`, instruction; 0 = cover).

--- a/cli/skills/anomalia/references/tools.md
+++ b/cli/skills/anomalia/references/tools.md
@@ -24,6 +24,7 @@ All tools take a brand `slug` when brand-scoped. Ids accept short unambiguous pr
 | `list_products` | (studio / products views) |
 | `list_posts` | `anomalia content <slug> [--status …]` |
 | `create_post` | (MCP only) |
+| `list_media` | (MCP only) |
 | `approve_posts` | `anomalia approve <slug> --all` |
 | `get_post` | `anomalia post <slug> <id>` |
 | `edit_post` | `anomalia post <slug> <id> edit …` |
@@ -35,11 +36,15 @@ All tools take a brand `slug` when brand-scoped. Ids accept short unambiguous pr
 | `reorder_slides` | `anomalia post <slug> <id> reorder --order "0,2,1"` |
 | `make_video` | `anomalia post <slug> <id> video …` |
 
+`list_media` lists what is already in the brand library; an id from there goes into `create_post`
+as `media_ids` and costs no render. A media id that is not this brand's stops the creation —
+the post is never made without it.
+
 `create_post` stores copy **you** wrote: Anomalia calls no model and spends no credits. It does
 not publish and does not schedule — `scheduled_for` is the proposed calendar time and stays a
 proposal until `approve_post`, which is what authorizes distribution. Text-capable platforms
-only (`facebook`, `linkedin`, `x`, `threads`, `bluesky`, `reddit`); `instagram` and `tiktok` need
-an image, `youtube` a video. Required: `slug`, `platforms`, `caption`. Optional:
+only (`facebook`, `linkedin`, `x`, `threads`, `bluesky`, `reddit`) unless you pass `media_ids`;
+`instagram` and `tiktok` need an image, `youtube` a video. Required: `slug`, `platforms`, `caption`. Optional:
 `platform_captions`, `scheduled_for` (ISO — no offset means the brand's timezone), `title`
 (required for Reddit), `subreddit`, `link_url`. The result carries the post id, its
 `pending_user` status, the stored instant and a `review_url` the operator can open.

--- a/docs/api/02-brands-core.md
+++ b/docs/api/02-brands-core.md
@@ -359,3 +359,45 @@ Note: `skipped > 0` indica brand non "due" per cadenza o run già in corso; `err
 ```bash
 curl -s -X POST "https://anomalia.so/api/v1/brands/mio-brand/tick" -H "Authorization: Bearer $TOKEN"
 ```
+
+---
+
+## `GET /api/v1/brands/:slug/media`
+
+Elenca la libreria media del brand, dalla più recente, con una URL firmata per l'anteprima.
+Gli id restituiti sono quelli che `POST /posts` accetta in `media_ids`.
+
+**Query params**
+
+| Param | Tipo | Obbligatorio | Descrizione |
+|---|---|---|---|
+| `query` | string | No | Filtro libero su titolo, descrizione e tag |
+| `limit` | number | No | 1–200, default 100 |
+
+**Response** `200`:
+
+```json
+{
+  "media": [
+    {
+      "id": "a1b2c3d4-…",
+      "kind": "image",
+      "mime": "image/png",
+      "width": 1080,
+      "height": 1350,
+      "title": "Foto prodotto",
+      "description": "…",
+      "tags": ["prodotto"],
+      "signed_url": "https://…",
+      "created_at": "2026-08-13T10:00:00.000Z"
+    }
+  ]
+}
+```
+
+**Esempio**:
+
+```bash
+curl -s "https://anomalia.so/api/v1/brands/mio-brand/media?query=logo&limit=20" \
+  -H "Authorization: Bearer $TOKEN"
+```

--- a/docs/api/03-posts.md
+++ b/docs/api/03-posts.md
@@ -56,9 +56,9 @@ Non chiama nessun modello e **non consuma crediti**: niente `gateAiAction`. Non 
 programma niente — `scheduled_for` è la data **proposta**, e resta un metadato del calendario
 finché il post non viene approvato. È `POST /posts/:id/approve` ad autorizzare la distribuzione.
 
-Solo piattaforme che reggono il testo da solo: `facebook`, `linkedin`, `x`, `threads`, `bluesky`,
-`reddit`. `instagram` e `tiktok` vogliono un'immagine, `youtube` un video: senza media vengono
-rifiutate. Questo endpoint non accetta ancora media.
+Senza media valgono solo le piattaforme che reggono il testo da solo: `facebook`, `linkedin`, `x`,
+`threads`, `bluesky`, `reddit`. Con `media_ids` si sbloccano anche `instagram` e `tiktok`, e
+`youtube` se il media è un video.
 
 **Body**
 
@@ -68,6 +68,7 @@ rifiutate. Questo endpoint non accetta ancora media.
 | `caption` | string | Sì | La copy, salvata così com'è |
 | `platform_captions` | object | No | Override per piattaforma, `{"x": "…"}` |
 | `scheduled_for` | string | No | Istante proposto, ISO. Senza offset è letto sul fuso del brand; con `Z` o `±hh:mm` è preso come scritto. Almeno 2 minuti nel futuro |
+| `media_ids` | string[] | No | Fino a 8 id dalla libreria del brand (`GET /media`). Un id che non è di questo brand fa fallire la creazione: il post non nasce mai senza |
 | `title` | string | No | Obbligatorio per Reddit (max 300 char) |
 | `subreddit` | string | No | Senza `r/` |
 | `link_url` | string | No | |
@@ -102,6 +103,7 @@ post resta una bozza senza data, fuori dal calendario ma elencata da `GET /posts
 | `400` | `{"error":"reddit_title"}` |
 | `400` | `{"error":"invalid_scheduled_for","details":"…"}` — data illeggibile |
 | `400` | `{"error":"too_soon"}` — data passata o troppo vicina |
+| `400` | `{"error":"media_not_found"}` — un id media non è di questo brand, o non si è potuto copiare |
 | `403` | `{"error":"API key is read-only"}` |
 
 **Esempio**:

--- a/packages/api-contracts/src/index.test.ts
+++ b/packages/api-contracts/src/index.test.ts
@@ -67,15 +67,30 @@ describe('il registry degli endpoint di brand', () => {
 
   it('un campo che nessun endpoint dichiara viene rifiutato, non scartato in silenzio', () => {
     for (const e of BRAND_ENDPOINTS) {
-      expect(e.input.safeParse({ media_ids: ['abc'] }).success, e.tool).toBe(false);
+      expect(e.input.safeParse({ campo_che_non_esiste: 'x' }).success, e.tool).toBe(false);
     }
     expect(
       byTool('create_post').input.safeParse({
         platforms: ['linkedin'],
         caption: 'ciao',
-        media_ids: ['abc']
+        campo_che_non_esiste: 'x'
       }).success
     ).toBe(false);
+  });
+
+  it('create_post accetta i media della libreria, che prima non avevano dove passare', () => {
+    const { input } = byTool('create_post');
+    expect(
+      input.safeParse({ platforms: ['instagram'], caption: 'ciao', media_ids: ['asset-1'] }).success
+    ).toBe(true);
+  });
+
+  it('list_media è una lettura e non dichiara fallimenti propri', () => {
+    const listMedia = byTool('list_media');
+    expect(listMedia.method).toBe('GET');
+    expect(listMedia.destructive).toBe(false);
+    expect(listMedia.input.safeParse({ query: 'logo', limit: 10 }).success).toBe(true);
+    expect(listMedia.input.safeParse({ limit: 500 }).success).toBe(false);
   });
 
   it('create_post promette un post pending_user con la data proposta', () => {

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -1,5 +1,5 @@
 import type { z } from 'zod';
-import { CREATE_POST, GET_CALENDAR, LIST_POSTS } from './posts';
+import { CREATE_POST, GET_CALENDAR, LIST_MEDIA, LIST_POSTS } from './posts';
 
 export type EndpointFailure = { readonly error: string; readonly status: number };
 
@@ -15,7 +15,7 @@ export type BrandEndpoint = {
   readonly destructive: boolean;
 };
 
-export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [CREATE_POST, LIST_POSTS, GET_CALENDAR];
+export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [CREATE_POST, LIST_POSTS, GET_CALENDAR, LIST_MEDIA];
 
 export function pathFor(endpoint: BrandEndpoint, slug: string): string {
   return `/api/v1/brands/${encodeURIComponent(slug)}${endpoint.pathUnderBrand}`;
@@ -25,5 +25,5 @@ export function statusForFailure(endpoint: BrandEndpoint, error: string): number
   return endpoint.failures.find((f) => f.error === error)?.status ?? 500;
 }
 
-export { CREATE_POST, GET_CALENDAR, LIST_POSTS };
+export { CREATE_POST, GET_CALENDAR, LIST_MEDIA, LIST_POSTS };
 export type { CreatePostInput, CreatePostResult } from './posts';

--- a/packages/api-contracts/src/posts.ts
+++ b/packages/api-contracts/src/posts.ts
@@ -38,6 +38,14 @@ const CreatePostInputSchema = z.object({
       'Proposed publication instant, ISO. Without an offset it is read on the brand clock. ' +
         'It is a calendar proposal only: nothing is scheduled or published until the post is approved'
     ),
+  media_ids: z
+    .array(z.string().min(1))
+    .max(8)
+    .optional()
+    .describe(
+      'Ids from this brand media library (see list_media). An id that is not this brand is ' +
+        'rejected: the post is never quietly created without it'
+    ),
   title: z.string().optional().describe('Required for Reddit'),
   subreddit: z.string().optional(),
   link_url: z.string().optional()
@@ -76,7 +84,8 @@ export const CREATE_POST = {
     { error: 'over_limit', status: 400 },
     { error: 'reddit_title', status: 400 },
     { error: 'too_soon', status: 400 },
-    { error: 'invalid_scheduled_for', status: 400 }
+    { error: 'invalid_scheduled_for', status: 400 },
+    { error: 'media_not_found', status: 400 }
   ],
   destructive: false
 } satisfies BrandEndpoint;
@@ -119,6 +128,38 @@ export const GET_CALENDAR = {
     nextYM: z.string(),
     timezone: z.string()
   }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+const MediaRow = z.object({
+  id: z.string(),
+  kind: z.string(),
+  mime: z.string().nullable(),
+  width: z.number().nullable(),
+  height: z.number().nullable(),
+  title: z.string().nullable(),
+  description: z.string().nullable(),
+  tags: z.array(z.string()).nullable(),
+  signed_url: z.string().nullable(),
+  created_at: z.string()
+});
+
+export const LIST_MEDIA = {
+  tool: 'list_media',
+  title: 'List brand media',
+  description:
+    'Assets already in the brand library, newest first, with a preview URL. Use an id from here ' +
+    'as media_ids on create_post to reuse an asset instead of paying for a new render.',
+  method: 'GET',
+  pathUnderBrand: '/media',
+  input: z
+    .object({
+      query: z.string().optional().describe('Free-text filter over title, description and tags'),
+      limit: z.coerce.number().int().min(1).max(200).optional()
+    })
+    .strict(),
+  output: z.object({ media: z.array(MediaRow) }),
   failures: [],
   destructive: false
 } satisfies BrandEndpoint;

--- a/src/lib/content/changelog/2026-09-03-external-agent-media.ts
+++ b/src/lib/content/changelog/2026-09-03-external-agent-media.ts
@@ -1,0 +1,13 @@
+import type { ChangelogEntry } from './index';
+
+const entry: ChangelogEntry = {
+  date: '2026-09-03',
+  title: 'Your AI can reuse photos you already have',
+  items: [
+    'Your own AI can now browse the brand library and attach a photo or video you already own to a post it writes — no new render, nothing to pay for.',
+    'That also opens Instagram and TikTok to it, which never accept a post made of text alone.',
+    'If an asset cannot be attached, the post is not created at all. It used to be saved quietly without the image, which was easy to miss until the day it went out.'
+  ]
+};
+
+export default entry;

--- a/src/lib/server/brand-media.ts
+++ b/src/lib/server/brand-media.ts
@@ -119,6 +119,25 @@ export async function probeImageDimensions(
   }
 }
 
+/**
+ * Le righe di libreria che appartengono DAVVERO a questo brand, fra quelle chieste. Chi chiama
+ * confronta con la lista che ha mandato: un id che manca è di un altro brand o non esiste, e la
+ * differenza fra i due non va detta a chi chiede — sarebbe un modo per sondare gli id altrui.
+ */
+export async function findBrandMediaByIds(
+  supabase: SupabaseClient,
+  brandId: string,
+  ids: string[]
+): Promise<BrandMediaRow[]> {
+  if (!ids.length) return [];
+  const { data } = await supabase
+    .from('brand_media')
+    .select('*')
+    .eq('brand_id', brandId)
+    .in('id', ids);
+  return (data ?? []) as BrandMediaRow[];
+}
+
 export async function listBrandMedia(
   supabase: SupabaseClient,
   brandId: string,

--- a/src/lib/server/manual-posting.test.ts
+++ b/src/lib/server/manual-posting.test.ts
@@ -12,8 +12,13 @@ vi.mock('$lib/server/research', () => ({
 vi.mock('$lib/server/ai-log', () => ({
   withBrandContext: (_brandId: string, fn: () => unknown) => fn()
 }));
+const findBrandMediaByIds = vi.fn();
+const publishLibraryMediaAsPostMedia = vi.fn();
+
 vi.mock('$lib/server/brand-media', () => ({
-  publishLibraryImageAsPostMedia: vi.fn()
+  publishLibraryImageAsPostMedia: vi.fn(),
+  findBrandMediaByIds: (...args: unknown[]) => findBrandMediaByIds(...args),
+  publishLibraryMediaAsPostMedia: (...args: unknown[]) => publishLibraryMediaAsPostMedia(...args)
 }));
 
 import { createManualPost } from './manual-posting';
@@ -129,5 +134,85 @@ describe('createManualPost', () => {
     await create({ platforms: ['linkedin'], caption: 'copy scritto a mano', mode: 'draft' });
 
     expect(structured).not.toHaveBeenCalled();
+  });
+});
+
+describe('createManualPost con media della libreria', () => {
+  const IMAGE = { id: 'media-img', kind: 'image' as const };
+  const VIDEO = { id: 'media-vid', kind: 'video' as const };
+
+  beforeEach(() => {
+    findBrandMediaByIds.mockResolvedValue([IMAGE, VIDEO]);
+    publishLibraryMediaAsPostMedia.mockImplementation(async (_c: unknown, o: { mediaId: string }) => ({
+      publicUrl: `https://cdn.test/${o.mediaId}.bin`,
+      media: { id: o.mediaId }
+    }));
+  });
+
+  it('attacca l immagine della libreria e la pubblica con la sua natura', async () => {
+    const { result, rows } = await create({
+      platforms: ['instagram'],
+      caption: 'copy con immagine',
+      libraryIds: [IMAGE.id],
+      mode: 'propose'
+    });
+
+    expect(result).toMatchObject({ ok: true, status: 'pending_user' });
+    expect(rows[0].media_url).toBe('https://cdn.test/media-img.bin');
+    expect(publishLibraryMediaAsPostMedia.mock.calls[0][1]).toMatchObject({ kind: 'image' });
+  });
+
+  it('un video della libreria soddisfa una piattaforma che vuole il video', async () => {
+    const { result, rows } = await create({
+      platforms: ['youtube'],
+      caption: 'copy con video',
+      title: 'Titolo',
+      libraryIds: [VIDEO.id],
+      mode: 'propose'
+    });
+
+    expect(result).toMatchObject({ ok: true });
+    expect(rows[0].content_type).toBe('uploaded_video');
+  });
+
+  it('un id che non è di questo brand viene rifiutato, non scartato', async () => {
+    findBrandMediaByIds.mockResolvedValue([]);
+
+    const { result, rows } = await create({
+      platforms: ['linkedin'],
+      caption: 'copy',
+      libraryIds: ['media-di-un-altro-brand'],
+      mode: 'propose'
+    });
+
+    expect(result).toEqual({ ok: false, error: 'media_not_found' });
+    expect(rows).toEqual([]);
+    expect(publishLibraryMediaAsPostMedia).not.toHaveBeenCalled();
+  });
+
+  it('un media che esiste ma non si riesce a copiare non diventa un post senza immagine', async () => {
+    publishLibraryMediaAsPostMedia.mockResolvedValue({ error: 'Upload of library media failed' });
+
+    const { result, rows } = await create({
+      platforms: ['linkedin'],
+      caption: 'copy',
+      libraryIds: [IMAGE.id],
+      mode: 'propose'
+    });
+
+    expect(result).toEqual({ ok: false, error: 'media_not_found' });
+    expect(rows).toEqual([]);
+  });
+
+  it('un percorso fuori dagli upload di chi chiama viene rifiutato', async () => {
+    const { result, rows } = await create({
+      platforms: ['linkedin'],
+      caption: 'copy',
+      mediaPaths: ['un-altro-utente/uploads/foto.png'],
+      mode: 'propose'
+    });
+
+    expect(result).toEqual({ ok: false, error: 'media_not_found' });
+    expect(rows).toEqual([]);
   });
 });

--- a/src/lib/server/manual-posting.ts
+++ b/src/lib/server/manual-posting.ts
@@ -5,7 +5,7 @@ import { aiActCopyGuardrail } from '$lib/ai-act';
 import { platformPlaybook, houseVoiceFor, type ContentPrefs } from '$lib/server/content-preview';
 import { publishApprovedPost, type ApprovablePost } from '$lib/server/publish';
 import { wallClockToUtc, zonedClock } from '$lib/server/schedule';
-import { publishLibraryImageAsPostMedia } from '$lib/server/brand-media';
+import { findBrandMediaByIds, publishLibraryMediaAsPostMedia } from '$lib/server/brand-media';
 import { EDITOR_POST_COLS } from '$lib/server/post-editing';
 import {
   PLATFORM_CHAR_LIMITS,
@@ -186,31 +186,55 @@ function earliestMs(): number {
   return Math.floor(Date.now() / 60000) * 60000 + MIN_LEAD_MS;
 }
 
+type ResolvedMedia =
+  | { ok: true; urls: string[]; video: boolean }
+  | { ok: false; error: 'media_not_found' };
+
+/**
+ * Un media che il chiamante ha indicato e che non si risolve ferma la creazione. Veniva saltato
+ * in silenzio: l'id di un altro brand diventava una bozza senza immagine che nessuno aveva
+ * chiesto, e su Instagram un `need_media` che sembrava colpa di chi chiedeva.
+ */
 async function resolveMediaUrls(
   supabase: SupabaseClient,
   userId: string,
   brandId: string,
   paths: string[],
   libraryIds: string[]
-): Promise<{ urls: string[]; video: boolean }> {
+): Promise<ResolvedMedia> {
   const urls: string[] = [];
   let video = false;
+
   for (const raw of paths.slice(0, MAX_MEDIA)) {
     const path = String(raw ?? '');
-    if (!path.startsWith(`${userId}/uploads/`)) continue;
+    if (!path.startsWith(`${userId}/uploads/`)) return { ok: false, error: 'media_not_found' };
     const publicUrl = supabase.storage.from('media').getPublicUrl(path).data.publicUrl;
-    if (publicUrl) urls.push(publicUrl);
+    if (!publicUrl) return { ok: false, error: 'media_not_found' };
+    urls.push(publicUrl);
     if (/\.(mp4|webm|mov)(\?|$)/i.test(path)) video = true;
   }
-  for (const id of libraryIds.slice(0, MAX_MEDIA - urls.length)) {
-    const copied = await publishLibraryImageAsPostMedia(supabase, {
+
+  const wanted = libraryIds.slice(0, MAX_MEDIA - urls.length).map(String);
+  if (!wanted.length) return { ok: true, urls: urls.slice(0, MAX_MEDIA), video };
+
+  const owned = new Map(
+    (await findBrandMediaByIds(supabase, brandId, wanted)).map((row) => [row.id, row])
+  );
+  for (const id of wanted) {
+    const media = owned.get(id);
+    if (!media) return { ok: false, error: 'media_not_found' };
+    const copied = await publishLibraryMediaAsPostMedia(supabase, {
       brandId,
       userId,
-      mediaId: String(id)
+      mediaId: id,
+      kind: media.kind
     });
-    if ('publicUrl' in copied && copied.publicUrl) urls.push(copied.publicUrl);
+    if (!('publicUrl' in copied) || !copied.publicUrl) return { ok: false, error: 'media_not_found' };
+    urls.push(copied.publicUrl);
+    if (media.kind === 'video') video = true;
   }
-  return { urls: urls.slice(0, MAX_MEDIA), video };
+
+  return { ok: true, urls: urls.slice(0, MAX_MEDIA), video };
 }
 
 export async function createManualPost(opts: {
@@ -226,13 +250,15 @@ export async function createManualPost(opts: {
   const caption = String(opts.input.caption ?? '').trim();
   if (!caption) return { ok: false, error: 'need_caption' };
 
-  const { urls, video: pathVideo } = await resolveMediaUrls(
+  const media = await resolveMediaUrls(
     opts.supabase,
     opts.userId,
     opts.brandId,
     opts.input.mediaPaths ?? [],
     opts.input.libraryIds ?? []
   );
+  if (!media.ok) return { ok: false, error: media.error };
+  const { urls, video: pathVideo } = media;
   const isVideo = opts.input.isVideo === true || pathVideo;
   const hasMedia = urls.length > 0;
   const needsVisual = platforms.some((p) => VISUAL_REQUIRED_PLATFORMS.has(p));

--- a/src/routes/api/v1/brands/[slug]/media/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/media/+server.ts
@@ -1,0 +1,34 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { authenticate, loadBrandForUser } from '$lib/server/cli-auth';
+import { listBrandMedia } from '$lib/server/brand-media';
+import { LIST_MEDIA } from '@anomalia/api-contracts';
+
+export const GET: RequestHandler = async ({ request, params, url }) => {
+  const { supabase, error, apiKey } = await authenticate(request);
+  if (error) return error;
+
+  const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
+  if (brandError) return brandError;
+
+  const parsed = LIST_MEDIA.input.safeParse(Object.fromEntries(url.searchParams));
+  if (!parsed.success) {
+    return json({ error: 'invalid_input', details: parsed.error.issues }, { status: 400 });
+  }
+
+  const media = await listBrandMedia(supabase, brand.id, parsed.data);
+  return json({
+    media: media.map((m) => ({
+      id: m.id,
+      kind: m.kind,
+      mime: m.mime,
+      width: m.width,
+      height: m.height,
+      title: m.title,
+      description: m.description,
+      tags: m.tags,
+      signed_url: m.signed_url,
+      created_at: m.created_at
+    }))
+  });
+};

--- a/src/routes/api/v1/brands/[slug]/posts/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/posts/+server.ts
@@ -54,6 +54,7 @@ export const POST: RequestHandler = async ({ request, params, url }) => {
       platforms: input.platforms,
       caption: input.caption,
       platformCaptions: input.platform_captions,
+      libraryIds: input.media_ids,
       title: input.title,
       subreddit: input.subreddit,
       linkUrl: input.link_url,

--- a/src/routes/api/v1/brands/[slug]/posts/server.create.test.ts
+++ b/src/routes/api/v1/brands/[slug]/posts/server.create.test.ts
@@ -3,6 +3,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const publishApprovedPost = vi.fn();
 const structured = vi.fn();
 const gateCredits = vi.fn();
+const findBrandMediaByIds = vi.fn();
+const publishLibraryMediaAsPostMedia = vi.fn();
 
 vi.mock('$lib/server/cli-auth', () => ({
   authenticate: vi.fn(),
@@ -21,7 +23,11 @@ vi.mock('$lib/server/publish', () => ({
 }));
 vi.mock('$lib/server/research', () => ({ structured: (...args: unknown[]) => structured(...args) }));
 vi.mock('$lib/server/ai-log', () => ({ withBrandContext: (_b: string, fn: () => unknown) => fn() }));
-vi.mock('$lib/server/brand-media', () => ({ publishLibraryImageAsPostMedia: vi.fn() }));
+vi.mock('$lib/server/brand-media', () => ({
+  publishLibraryImageAsPostMedia: vi.fn(),
+  findBrandMediaByIds: (...args: unknown[]) => findBrandMediaByIds(...args),
+  publishLibraryMediaAsPostMedia: (...args: unknown[]) => publishLibraryMediaAsPostMedia(...args)
+}));
 vi.mock('$lib/server/credits', () => ({
   gateCredits: (...args: unknown[]) => gateCredits(...args),
   CreditsExhaustedError: class extends Error {}
@@ -84,6 +90,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(checkApiKeyWriteAccess).mockReturnValue(undefined);
   publishApprovedPost.mockResolvedValue({ scheduled: 1, failed: 0 });
+  findBrandMediaByIds.mockResolvedValue([]);
 });
 
 describe('POST /api/v1/brands/:slug/posts', () => {
@@ -204,16 +211,49 @@ describe('POST /api/v1/brands/:slug/posts', () => {
     expect(rows).toEqual([]);
   });
 
-  it('rifiuta i media invece di scartarli: un post text-only silenzioso è peggio di un errore', async () => {
+  it('rifiuta un campo che il contratto non dichiara, invece di scartarlo in silenzio', async () => {
     const { res, body, rows } = await call({
       platforms: ['linkedin'],
       caption: 'copy',
-      media_ids: ['asset-1']
+      campo_che_non_esiste: 'x'
     });
 
     expect(res.status).toBe(400);
     expect(body.error).toBe('invalid_input');
     expect(rows).toEqual([]);
+  });
+
+  it('un media di un altro brand ferma la creazione invece di produrre un post senza immagine', async () => {
+    findBrandMediaByIds.mockResolvedValue([]);
+
+    const { res, body, rows } = await call({
+      platforms: ['instagram'],
+      caption: 'copy',
+      media_ids: ['asset-di-un-altro-brand']
+    });
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('media_not_found');
+    expect(rows).toEqual([]);
+  });
+
+  it('un media della libreria sblocca instagram, che da sola la copy non regge', async () => {
+    findBrandMediaByIds.mockResolvedValue([{ id: 'asset-1', kind: 'image' }]);
+    publishLibraryMediaAsPostMedia.mockResolvedValue({
+      publicUrl: 'https://cdn.test/asset-1.png',
+      media: { id: 'asset-1' }
+    });
+
+    const { res, body, rows } = await call({
+      platforms: ['instagram'],
+      caption: 'copy con immagine riusata',
+      media_ids: ['asset-1']
+    });
+
+    expect(res.status).toBe(200);
+    expect(body.status).toBe('pending_user');
+    expect(rows[0].media_url).toBe('https://cdn.test/asset-1.png');
+    expect(rows[0].content_type).toBe('uploaded_image');
   });
 
   it('rifiuta una piattaforma sconosciuta al dominio', async () => {


### PR DESCRIPTION
## What?

`create_post` accepts `media_ids`, and a new `list_media` says which ids exist. An external agent
can now attach a photo or video already in the brand library — no render, no credits — and that
opens `instagram` and `tiktok`, which never accept a post made of text alone, plus `youtube` when
the asset is a video.

Second vertical slice of the plan's Phase 1, after the text-only tracer. **Stacked on #194** —
base is `feat/external-agent-posts`, not `dev`.

## Why?

Without media, `create_post` refused `instagram` and `tiktok` outright and `youtube` always. An
external agent could write for LinkedIn and X and nothing else, which is not a social product.

## How?

### The silent downgrade, which is the real fix here

`resolveMediaUrls` skipped, in silence, every asset it could not resolve:

```ts
if ('publicUrl' in copied && copied.publicUrl) urls.push(copied.publicUrl);
```

An id from another brand, or a failed copy, was not an error — it was a post **without its
image**. On LinkedIn that saved a text-only draft nobody asked for. On Instagram it came back as
`need_media`, which reads like the caller forgot the picture when in fact we had discarded it.
That is precisely the *"silent downgrade to text-only"* the plan forbids.

One rule now, in one place: **an identifier the caller supplied that we cannot honour stops the
creation.** Library ids and upload paths alike, because they are the same case.

### Ownership is asked, not re-derived

`findBrandMediaByIds` answers which ids really belong to the brand; the service compares against
what was requested. A missing id and a non-existent id come back identically **on purpose** —
telling them apart would be a way to probe another brand's ids.

The row's `kind` also decides how the asset is published, so a library video now satisfies
`youtube`.

### The registry, measured

`list_media` is the first endpoint added *after* the contract registry landed, so it doubles as
its measurement: **one row in `BRAND_ENDPOINTS` plus the route**, and the client method and the
MCP tool appeared on their own. No hand-written `registerTool` block, no type re-copied into
`cli/lib/api.ts`. That is the thing you asked for, working.

## Testing?

Red observed before each change.

```
npx vitest run src/lib/server/manual-posting.test.ts            10 passed
npx vitest run ".../posts/"                                     24 passed
npx vitest run packages/api-contracts                           13 passed
cd cli && bun test                                              30 passed
npm run test:unit                             6391 passed, 11 skipped, 0 failed
npm run check          no error in any of the 18 files this branch touches
cd cli && bun run typecheck                                          clean
```

New coverage: a library image attaches and is published with its own kind; a library video
satisfies a video-only platform; **an id from another brand is refused, not skipped**; an asset
that exists but cannot be copied does not become an image-less post; an upload path outside the
caller's own storage is refused; and at the REST seam, a foreign id returns `400 media_not_found`
while a valid one unblocks Instagram.

## Evidence (screenshots/videos)

Not yet run against the browser or a real client — this is the code-level slice. Worth doing
before merge, the same way #194 was: seed a library asset locally, then ask Claude over MCP to
reuse it. Saying so rather than implying it was done.

## Anything Else?

**Behaviour change to flag:** the manual-posting UI now errors on an upload path outside the
caller's own storage instead of silently saving a text-only post. It should not happen in normal
use — the upload produces those paths — and when it does, saying so is better than not.

**Left as it was:** the eight-media cap is still a silent truncation. The UI does not limit how
many files a user picks, so turning it into an error would break, at a distance, whoever selects
nine.

**Deliberately not here:** `import_media_url`, the plan's fourth slice. Private networks,
redirects, MIME and size give it a security surface that deserves a diff someone can read on its
own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY