### PR TITLE
Replace the eval:ux gate in the plan with one that can be run

### DIFF
--- a/docs/external-agent-plan.md
+++ b/docs/external-agent-plan.md
@@ -1019,9 +1019,15 @@ Completion criteria:
 - The Anomalia skill and MCP tool catalogue include the new workflow.
 - An external agent can edit a post created by social autopilot without
   regenerating its text or media.
-- `npm run eval:ux` runs before merge because the tool surface changed. If the
-  environment prevents it, the PR reports the scenario as unrun rather than
-  green.
+- The tool is exercised from a real external client against a local stack
+  before merge, and the PR records which tools the model chose and with what
+  arguments. A contract test proves the tool is registered; only a real client
+  proves the description is usable.
+
+`npm run eval:ux` was the gate here and no longer exists. It graded the in-app
+onboarding chat, not the MCP surface, and it built a whole stack and spent real
+model money on every run — a gate nobody could afford to run is a line a report
+can cite without anyone having executed it.
 
 ### Creative support
 


### PR DESCRIPTION
## What?

The external-agent plan's Phase-1 MCP completion criteria required `npm run eval:ux` before
merging a tool-surface change. That command was removed in #194, so the criterion became
unsatisfiable as written and the plan now contradicted the code. This replaces it with the check
that actually does the job.

One line of prose in `docs/external-agent-plan.md`. No code.

## Why?

Two reasons, and the second matters more.

It was **stale**: PR #194 deleted `eval:ux`, so a reader following the plan would look for a
command that isn't there.

It was also the **wrong gate**. `eval:ux` graded the in-app onboarding chat — `chat_threads`,
`agent_kit_runs`, editorial plans, team contacts — and never touched the MCP surface it was
guarding. It built a full compose stack and spent real model money on every run, so in practice
nobody ran it. A gate nobody can afford to run is not a gate: it is a line a report can cite
without anyone having executed it.

## How?

The criterion now asks for what caught real problems on #194: drive the new tool from a real
external client against a local stack, and record in the PR which tools the model chose and with
what arguments.

That distinction is the point. A contract test proves a tool is *registered*. Only a real client
proves its *description* is usable — that a model reading it reaches for `create_post` instead of
falling back to `chat`. On #194 that check is what showed the tool description carried the
contract: unprompted, the model told the operator distribution starts only on approval.

The paragraph explaining why `eval:ux` is gone stays in the plan rather than being deleted
silently, so the next reader does not go looking for it.

## Testing?

Prose only — nothing to execute. `git diff --check` clean. The claim that `eval:ux` no longer
exists is verifiable: `git show origin/dev:package.json | grep eval` on the branch that removes it
(#194), and `scripts/eval/ux*` is deleted there.

## Evidence (screenshots/videos)

None — documentation change.

## Anything Else?

This depends on #194 being merged for the statement to be true of `dev`. If #194 is rejected,
close this too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY