### PR TITLE
Let an external agent check copy before creating it

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -618,3 +618,21 @@ curl -s http://127.0.0.1:5200/login | grep -oE 'Anomalia|anomalia/leads' | head 
 
 Vite può comunque slittare di porta se trova occupato ("Port 5199 is in use, trying another
 one"): l'unica porta di cui fidarsi è quella stampata nel log, verificata con la riga sopra.
+
+## Un test che mocka il cancello di cui parla non dimostra niente
+
+**Segnale.** Un test di route asserisce un comportamento di autorizzazione — «una chiave di sola
+lettura passa», «un utente scaduto viene fermato» — e passa al primo colpo, senza essere mai stato
+rosso per la ragione giusta. In cima al file c'è `vi.mock('$lib/server/cli-auth', …)`.
+
+**Cosa succede.** Il verdetto che il test crede di misurare lo produce il mock, non il sistema.
+È capitato con `check_content`: la route non chiama `checkApiKeyWriteAccess` perché sarebbe
+ridondante, e il test concludeva che quindi una chiave di sola lettura arriva a calcolare. Falso:
+`resolveCaller` nega **ogni** non-GET a una chiave `read` prima che la route parta. Il test
+asseriva uno stato che la produzione non può produrre, quindi non poteva fallire mai — e intanto
+diceva al prossimo lettore l'opposto della verità, che è peggio di non dire niente.
+
+**La mossa.** Prima di asserire su un permesso, leggi dove il permesso viene deciso davvero, e
+chiediti se il mock lo sta scavalcando. Se lo scavalca, resta una sola asserzione onesta: dato il
+verdetto che l'upstream produce sul serio, la route lo rispetta e non lavora. Il resto — che
+l'upstream produca quel verdetto — è un test dell'upstream, e va scritto lì o non va scritto.

--- a/changelog/2026-09-03-external-agent-check-content.md
+++ b/changelog/2026-09-03-external-agent-check-content.md
@@ -1,0 +1,108 @@
+# Un agente esterno può controllare la copy prima di crearla
+
+Terza slice verticale della Fase 1 del piano [external agent](../docs/external-agent-plan.md),
+dopo la creazione e i media. `check_content` prende una content spec e restituisce errori
+bloccanti, avvisi, punteggi e il campo esatto da riparare, **senza chiamare nessun modello**.
+
+## Il vincolo che ha deciso tutto
+
+Il piano è esplicito: «Reuse the existing brand context, platform guidance, post templates,
+approved rubrics, performance history, deterministic content score, and feasibility checks. **Do
+not copy their rules into the MCP adapter.**»
+
+Quindi il lavoro non è stato scrivere delle regole, è stato trovarle. Ce n'erano già,
+deterministiche, pure e con dei test:
+
+| Cosa controlla | Dove vive già |
+|---|---|
+| Limiti di caratteri per piattaforma | `captionViolations` in `platform-limits.ts` |
+| Piattaforme che non reggono il solo testo, e YouTube che vuole un video | `VISUAL_REQUIRED_PLATFORMS` / `VIDEO_ONLY_PLATFORMS` |
+| Caption vuota o segnaposto | `isPlaceholderCaption` in `prepublish-check.ts` |
+| Marcatori `[NEED: …]` | `needMarkers` in `proof-discipline.ts` |
+| Indice di qualità 0–100, dodici check pesati | `scoreContentQuality` in `content-quality.ts` |
+| Proprietà di un media | `findBrandMediaByIds` in `brand-media.ts` |
+| Doppia prenotazione dello stesso minuto | `listCalendarConflicts` in `schedule.ts` |
+| Hashtag da reach | `reachChasingHashtags` in `platform-hygiene.ts` |
+
+`content-check.ts` non contiene una sola soglia sua. Contiene **la composizione** — quali di
+quei verdetti bloccano e quali avvisano — e la versione di quella composizione.
+
+## Due regole che stavano dentro il percorso che scrive
+
+`need_media`, `need_video`, `over_limit` e `reddit_title` erano una catena di `if` dentro
+`createManualPost`: raggiungibili solo creando un post. Un chiamante che voleva sapere se una copy
+sarebbe passata, senza creare niente, avrebbe dovuto riscriverle — e due copie di una regola
+divergono al primo cambiamento, in silenzio.
+
+Sono diventate `publishBlockers`, una tabella ordinata in `platform-limits.ts`, accanto agli
+insiemi di piattaforme e ai limiti che già leggevano. `createManualPost` restituisce il primo
+blocker che la tabella trova, nello stesso ordine di prima: l'errore che dà per un dato input non
+cambia. Il commit che sposta è separato da quello che aggiunge.
+
+Stessa storia per il preavviso minimo di programmazione (`MIN_SCHEDULE_LEAD_MS`), che è finito in
+`schedule.ts` dove stanno le altre regole di calendario.
+
+## Perché una POST che non scrive
+
+`check_content` è una lettura che ha bisogno di un body. Il registry degli endpoint regge GET con
+query e POST con body: una POST che calcola e restituisce senza scrivere ci sta, e si dichiara
+`destructive: false`.
+
+La route **non chiama `checkApiKeyWriteAccess`**, ma non per lasciar passare le chiavi di sola
+lettura: perché sarebbe ridondante. `resolveCaller` in `cli-auth.ts` quel controllo lo fa già, una
+volta sola, per **ogni** richiesta che non sia `GET` o `HEAD`:
+
+```ts
+// Write scope, enforced once here instead of per-route: a read-only key may only ever read.
+// Every mutating CLI route is a non-GET, so the method is the whole check.
+```
+
+**Quindi oggi una chiave di sola lettura `check_content` non lo raggiunge**: prende `403` prima
+che la route parta. Va detto perché è controintuitivo — un endpoint che non scrive niente,
+rifiutato a chi può solo leggere — e perché la causa non sta qui.
+
+`check_content` è il primo POST del repo che **calcola senza scrivere**. Quel commento dice «ogni
+route che muta è una non-GET», e resta vero; quello che non è più vero è l'implicito opposto, che
+ogni non-GET muti. Cambiare la regola — far dichiarare a un endpoint se scrive, invece di dedurlo
+dal metodo — tocca ogni route del repo, e non si fa di straforo dentro la PR che ha trovato il
+controesempio. Sta scritto qui perché chi la cambierà sappia che questo endpoint la aspetta.
+
+Una prima versione di questa PR aveva un test che affermava il contrario — chiave di sola lettura,
+`200` — e passava soltanto perché `authenticate` era mockato. Un test che asserisce uno stato che
+la produzione non può produrre non fallisce mai, e intanto racconta al prossimo lettore l'opposto
+della verità. È stato sostituito con quello che fissa il comportamento vero: quando `authenticate`
+ha già negato, la route restituisce quel `403` e non calcola niente.
+
+Un verdetto negativo è un `200` con `ok: false`. È un referto, non un cancello: chi chiama vuole
+sapere *tutto* quello che non va, non il primo errore con uno status.
+
+## Cosa non c'è, e perché non l'ho inventato
+
+- **Cadenza delle rubriche.** Esiste (`checkRubricsAndBatchFeasibility`), ma è una regola di
+  *batch*: pretende i seed di tutta la settimana e i conti attesi per rubrica. Su una singola
+  content spec non ha niente da confrontare. Inventare un sostituto per post singolo avrebbe
+  prodotto un controllo che finge di essere la regola di Anomalia mentre è una mia — che è peggio
+  di un controllo che manca.
+- **Qualsiasi giudizio percettivo.** Il piano lo vuole come azione separata e pagata. Qui non si
+  guarda un pixel, e il test verifica che né `structured` né `llmStructured` vengano chiamati.
+- **`assertRedditCraft`.** Il suo «missing title» duplica `reddit_title`, e deduplicare
+  confrontando stringhe di messaggio sarebbe esattamente la condizione sparsa che vietiamo. Il suo
+  pezzo unico — il sospetto di self-promo con link — resta per dopo.
+- **`link_url` e `subreddit`.** `create_post` li accetta; qui non c'è nessuna regola dietro, e un
+  campo dichiarato che non controlla niente è peso morto. Lo schema `.strict()` li rifiuta invece
+  di ignorarli, così chi li manda lo scopre subito.
+
+## Le versioni, che sono il punto
+
+Ogni risposta porta `versions: { rules, scorer }`. `CONTENT_SCORER_VERSION` esisteva già e il suo
+modulo spiega perché: i campioni si conservano per versione e l'aggregazione si rifiuta di
+mescolarle, o una modifica alle regole si legge come una regressione del prodotto. `check_content`
+eredita quel vincolo e ne aggiunge uno suo, `CONTENT_CHECK_RULES_VERSION`, che si alza quando una
+regola entra, esce, o si sposta fra bloccante e avviso.
+
+## Il registry, di nuovo
+
+Una riga in `BRAND_ENDPOINTS` più la route. Il metodo del client CLI e il tool MCP sono comparsi
+da soli — c'è un test in `cli/mcp/create-post.test.ts` che lo dimostra elencando i tool esposti.
+Il contratto sta in `packages/api-contracts/src/content.ts`, un file nuovo, perché due PR in
+parallelo che aggiungono un endpoint non devono litigare su `posts.ts`.

--- a/cli/lib/contracts/content.ts
+++ b/cli/lib/contracts/content.ts
@@ -1,0 +1,73 @@
+import { z } from 'zod';
+import type { BrandEndpoint } from './index';
+
+const CheckContentInputSchema = z
+  .object({
+    platforms: z
+      .array(z.string().min(1))
+      .min(1)
+      .describe('Where this would be published, e.g. ["instagram","x"]'),
+    caption: z.string().describe('The copy you wrote. It is read, scored and returned untouched'),
+    platform_captions: z
+      .record(z.string(), z.string())
+      .optional()
+      .describe('Per-platform overrides: each platform is checked against the copy IT would publish'),
+    media_ids: z
+      .array(z.string().min(1))
+      .max(8)
+      .optional()
+      .describe('Ids from this brand media library (see list_media). An id that is not this brand is reported'),
+    title: z.string().optional().describe('Required for Reddit'),
+    scheduled_for: z
+      .string()
+      .optional()
+      .describe('Proposed publication instant, ISO. Without an offset it is read on the brand clock')
+  })
+  .strict();
+
+const IssueSchema = z.object({
+  code: z.string(),
+  field: z.string(),
+  detail: z.string()
+});
+
+const CheckContentResultSchema = z.object({
+  ok: z.boolean(),
+  errors: z.array(IssueSchema),
+  warnings: z.array(IssueSchema),
+  scores: z.array(
+    z.object({
+      platform: z.string(),
+      index: z.number(),
+      checks: z.array(
+        z.object({
+          id: z.string(),
+          value: z.number(),
+          weight: z.number(),
+          note: z.string()
+        })
+      )
+    })
+  ),
+  versions: z.object({ rules: z.number(), scorer: z.number() })
+});
+
+export type CheckContentInput = z.infer<typeof CheckContentInputSchema>;
+export type CheckContentResult = z.infer<typeof CheckContentResultSchema>;
+
+export const CHECK_CONTENT = {
+  tool: 'check_content',
+  title: 'Check content',
+  description:
+    'Run the checks Anomalia runs on its own copy against a spec you wrote, before you create ' +
+    'anything. Returns blocking errors, warnings and a 0-100 quality score per platform, each ' +
+    'naming the field to repair. Deterministic: it calls no model, spends no credits, writes ' +
+    'nothing, and the same spec always returns the same verdict. Perceptual review of an image ' +
+    'or a video is a separate, explicitly paid action — this never looks at pixels.',
+  method: 'POST',
+  pathUnderBrand: '/content/check',
+  input: CheckContentInputSchema,
+  output: CheckContentResultSchema,
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/cli/lib/contracts/index.ts
+++ b/cli/lib/contracts/index.ts
@@ -1,4 +1,5 @@
 import type { z } from 'zod';
+import { CHECK_CONTENT } from './content';
 import { CREATE_POST, GET_CALENDAR, LIST_MEDIA, LIST_POSTS } from './posts';
 
 export type EndpointFailure = { readonly error: string; readonly status: number };
@@ -15,7 +16,7 @@ export type BrandEndpoint = {
   readonly destructive: boolean;
 };
 
-export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [CREATE_POST, LIST_POSTS, GET_CALENDAR, LIST_MEDIA];
+export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [CREATE_POST, LIST_POSTS, GET_CALENDAR, LIST_MEDIA, CHECK_CONTENT];
 
 export function pathFor(endpoint: BrandEndpoint, slug: string): string {
   return `/api/v1/brands/${encodeURIComponent(slug)}${endpoint.pathUnderBrand}`;
@@ -25,5 +26,6 @@ export function statusForFailure(endpoint: BrandEndpoint, error: string): number
   return endpoint.failures.find((f) => f.error === error)?.status ?? 500;
 }
 
-export { CREATE_POST, GET_CALENDAR, LIST_MEDIA, LIST_POSTS };
+export { CHECK_CONTENT, CREATE_POST, GET_CALENDAR, LIST_MEDIA, LIST_POSTS };
+export type { CheckContentInput, CheckContentResult } from './content';
 export type { CreatePostInput, CreatePostResult } from './posts';

--- a/cli/mcp/create-post.test.ts
+++ b/cli/mcp/create-post.test.ts
@@ -83,6 +83,17 @@ describe('i tool di brand derivati dal registry', () => {
     expect(Object.keys(createPost.inputSchema?.properties ?? {})).toContain('media_ids');
   });
 
+  test('check_content compare da solo e si dichiara gratuito e senza modello', async () => {
+    const check = find(await tools(), 'check_content');
+
+    expect(Object.keys(check.inputSchema?.properties ?? {}).sort()).toEqual(
+      ['caption', 'media_ids', 'platform_captions', 'platforms', 'scheduled_for', 'slug', 'title'].sort(),
+    );
+    expect((check.inputSchema?.required ?? []).sort()).toEqual(['caption', 'platforms', 'slug']);
+    expect(check.annotations?.destructiveHint).toBe(false);
+    expect(check.description ?? '').toContain('spends no credits');
+  });
+
   test('nessun tool è registrato due volte dopo la migrazione', async () => {
     const names = (await tools()).map((t) => t.name);
 

--- a/cli/plugins/anomalia/skills/anomalia/SKILL.md
+++ b/cli/plugins/anomalia/skills/anomalia/SKILL.md
@@ -58,6 +58,11 @@ calendar time, and `approve_post` is what authorizes distribution. Hand the oper
 **Reuse an asset instead of paying for a render** → `list_media` → pass its id to `create_post`
 as `media_ids`. That is also how you post to Instagram or TikTok, which never accept text alone.
 
+**Check your copy before you create it** → `check_content` with the same spec you would send to
+`create_post`. It returns blocking errors, warnings and a 0–100 score per platform, each naming
+the field to repair. It costs nothing and calls no model, so run it on every draft and fix what
+it names before creating.
+
 **Approve pending posts** → `list_posts` (status pending) → optional `get_post` → `approve_posts`.
 
 **Fix one carousel slide** → `get_post` → `regenerate_slide` (`index`, instruction; 0 = cover).

--- a/cli/plugins/anomalia/skills/anomalia/references/tools.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/tools.md
@@ -25,6 +25,7 @@ All tools take a brand `slug` when brand-scoped. Ids accept short unambiguous pr
 | `list_posts` | `anomalia content <slug> [--status …]` |
 | `create_post` | (MCP only) |
 | `list_media` | (MCP only) |
+| `check_content` | (MCP only) |
 | `approve_posts` | `anomalia approve <slug> --all` |
 | `get_post` | `anomalia post <slug> <id>` |
 | `edit_post` | `anomalia post <slug> <id> edit …` |
@@ -48,6 +49,26 @@ only (`facebook`, `linkedin`, `x`, `threads`, `bluesky`, `reddit`) unless you pa
 `platform_captions`, `scheduled_for` (ISO — no offset means the brand's timezone), `title`
 (required for Reddit), `subreddit`, `link_url`. The result carries the post id, its
 `pending_user` status, the stored instant and a `review_url` the operator can open.
+
+`check_content` runs the checks Anomalia runs on its own copy against a spec you wrote, before
+you create anything. It calls no model, spends no credits and writes nothing, so the same spec
+always returns the same verdict. Required: `slug`, `platforms`, `caption`. Optional:
+`platform_captions`, `media_ids`, `title`, `scheduled_for` — the fields that carry a rule.
+
+It answers with `ok`, `errors`, `warnings`, `scores` and `versions`:
+
+- **errors** block: `no_platforms`, `caption_empty`, `caption_placeholder`, `caption_needs_proof`
+  (a `[NEED: …]` marker — supply the fact, never delete the marker), `need_media`, `need_video`,
+  `over_limit`, `reddit_title`, `media_not_found`, `invalid_scheduled_for`, `too_soon`. Each one
+  names the `field` to repair.
+- **warnings** do not block: `calendar_conflict` (that minute is already taken),
+  `reach_chasing_hashtags`.
+- **scores** carry, per platform, the 0–100 quality index and the twelve weighted checks with a
+  note each — hook, AI tells, self-repetition against the brand's recent posts, specificity, CTA,
+  length, readability, hashtags, emoji. Fix the low value with the highest weight first.
+- **versions** pins the ruleset and the scorer: two verdicts compare only when they match.
+
+It never looks at pixels — judging an image or a video is a separate, explicitly paid action.
 
 ## Plans
 

--- a/cli/skills/anomalia/SKILL.md
+++ b/cli/skills/anomalia/SKILL.md
@@ -58,6 +58,11 @@ calendar time, and `approve_post` is what authorizes distribution. Hand the oper
 **Reuse an asset instead of paying for a render** → `list_media` → pass its id to `create_post`
 as `media_ids`. That is also how you post to Instagram or TikTok, which never accept text alone.
 
+**Check your copy before you create it** → `check_content` with the same spec you would send to
+`create_post`. It returns blocking errors, warnings and a 0–100 score per platform, each naming
+the field to repair. It costs nothing and calls no model, so run it on every draft and fix what
+it names before creating.
+
 **Approve pending posts** → `list_posts` (status pending) → optional `get_post` → `approve_posts`.
 
 **Fix one carousel slide** → `get_post` → `regenerate_slide` (`index`, instruction; 0 = cover).

--- a/cli/skills/anomalia/references/tools.md
+++ b/cli/skills/anomalia/references/tools.md
@@ -25,6 +25,7 @@ All tools take a brand `slug` when brand-scoped. Ids accept short unambiguous pr
 | `list_posts` | `anomalia content <slug> [--status …]` |
 | `create_post` | (MCP only) |
 | `list_media` | (MCP only) |
+| `check_content` | (MCP only) |
 | `approve_posts` | `anomalia approve <slug> --all` |
 | `get_post` | `anomalia post <slug> <id>` |
 | `edit_post` | `anomalia post <slug> <id> edit …` |
@@ -48,6 +49,26 @@ only (`facebook`, `linkedin`, `x`, `threads`, `bluesky`, `reddit`) unless you pa
 `platform_captions`, `scheduled_for` (ISO — no offset means the brand's timezone), `title`
 (required for Reddit), `subreddit`, `link_url`. The result carries the post id, its
 `pending_user` status, the stored instant and a `review_url` the operator can open.
+
+`check_content` runs the checks Anomalia runs on its own copy against a spec you wrote, before
+you create anything. It calls no model, spends no credits and writes nothing, so the same spec
+always returns the same verdict. Required: `slug`, `platforms`, `caption`. Optional:
+`platform_captions`, `media_ids`, `title`, `scheduled_for` — the fields that carry a rule.
+
+It answers with `ok`, `errors`, `warnings`, `scores` and `versions`:
+
+- **errors** block: `no_platforms`, `caption_empty`, `caption_placeholder`, `caption_needs_proof`
+  (a `[NEED: …]` marker — supply the fact, never delete the marker), `need_media`, `need_video`,
+  `over_limit`, `reddit_title`, `media_not_found`, `invalid_scheduled_for`, `too_soon`. Each one
+  names the `field` to repair.
+- **warnings** do not block: `calendar_conflict` (that minute is already taken),
+  `reach_chasing_hashtags`.
+- **scores** carry, per platform, the 0–100 quality index and the twelve weighted checks with a
+  note each — hook, AI tells, self-repetition against the brand's recent posts, specificity, CTA,
+  length, readability, hashtags, emoji. Fix the low value with the highest weight first.
+- **versions** pins the ruleset and the scorer: two verdicts compare only when they match.
+
+It never looks at pixels — judging an image or a video is a separate, explicitly paid action.
 
 ## Plans
 

--- a/docs/api/03-posts.md
+++ b/docs/api/03-posts.md
@@ -121,6 +121,105 @@ curl -s -X POST "https://anomalia.so/api/v1/brands/mio-brand/posts" \
 
 ---
 
+## `POST /api/v1/brands/:slug/content/check`
+
+Fa girare su una copy che hai scritto tu **gli stessi controlli deterministici** che Anomalia fa
+sulla propria: requisiti di piattaforma, tenuta della caption, punteggio di qualità, calendario.
+
+Non chiama nessun modello, non consuma crediti e **non scrive niente**: è una POST solo perché
+porta un body. La stessa richiesta restituisce sempre lo stesso verdetto. Non guarda i pixel:
+giudicare un'immagine o un video è un'azione separata e a pagamento.
+
+**Una API key di sola lettura oggi non può chiamarlo** e riceve `403`. Non è una proprietà di
+questo endpoint: `resolveCaller` nega a una chiave `read` **ogni** richiesta che non sia `GET` o
+`HEAD`, perché finora ogni route che muta era una non-GET. `check_content` è il primo POST che
+calcola senza scrivere, quindi il primo controesempio a quella regola; cambiarla è una decisione
+a parte, con un raggio d'azione molto più ampio di questo endpoint.
+
+Un verdetto negativo è comunque un `200` con `ok: false` — è un referto, non un cancello.
+
+**Body**
+
+| Campo | Tipo | Obbligatorio | Descrizione |
+|---|---|---|---|
+| `platforms` | string[] | Sì | Dove uscirebbe. Le sconosciute → `no_platforms` |
+| `caption` | string | Sì | La copy. Letta, punteggiata e restituita intatta |
+| `platform_captions` | object | No | Override per piattaforma: ognuna è controllata sulla copy che pubblicherebbe davvero |
+| `media_ids` | string[] | No | Fino a 8 id della libreria del brand. Un id che non è di questo brand è riportato |
+| `title` | string | No | Obbligatorio per Reddit |
+| `scheduled_for` | string | No | Istante proposto, ISO. Senza offset è letto sul fuso del brand |
+
+Sono i campi che portano una regola: `subreddit` e `link_url`, che `create_post` accetta, qui non
+hanno nessun controllo dietro e vengono rifiutati dallo schema invece di essere ignorati.
+
+**Response** `200`:
+
+```json
+{
+  "ok": false,
+  "errors": [
+    { "code": "over_limit", "field": "caption", "detail": "X: 812 characters, limit 280" }
+  ],
+  "warnings": [
+    { "code": "calendar_conflict", "field": "scheduled_for", "detail": "2030-05-16T07:00 is already taken by a1b2c3d4-…" }
+  ],
+  "scores": [
+    {
+      "platform": "linkedin",
+      "index": 62.4,
+      "checks": [
+        { "id": "hook_strength", "value": 0.4, "weight": 18, "note": "apre parlando del brand" }
+      ]
+    }
+  ],
+  "versions": { "rules": 1, "scorer": 3 }
+}
+```
+
+**Errori bloccanti** (dentro `errors`, ognuno col campo da riparare)
+
+| `code` | `field` | Quando |
+|---|---|---|
+| `no_platforms` | `platforms` | Nessuna piattaforma riconosciuta |
+| `caption_empty` | `caption` | Caption senza testo |
+| `caption_placeholder` | `caption` | Lorem ipsum, `TODO`, solo hashtag |
+| `caption_needs_proof` | `caption` | Resta un marcatore `[NEED: …]`. Si riempie con il fatto, non si cancella |
+| `need_media` | `media_ids` | `instagram` / `tiktok` / `youtube` senza asset |
+| `need_video` | `media_ids` | `youtube` con un asset che non è un video |
+| `over_limit` | `caption` | Copy oltre il limite di una piattaforma (dice quale e di quanto) |
+| `reddit_title` | `title` | Reddit senza titolo |
+| `media_not_found` | `media_ids` | Un id non è nella libreria di questo brand |
+| `invalid_scheduled_for` | `scheduled_for` | Data illeggibile |
+| `too_soon` | `scheduled_for` | Data passata o troppo vicina |
+
+**Avvisi** (dentro `warnings`, non bloccano): `calendar_conflict` — quel minuto è già occupato da
+un altro post vivo; `reach_chasing_hashtags` — `#fyp`, `#viral` e simili.
+
+**Punteggi**: uno per piattaforma richiesta, con l'indice 0–100 e i dodici check pesati dello
+scorer interno (hook, tell da AI, ripetizione rispetto ai post recenti del brand, concretezza,
+CTA, lunghezza, leggibilità, hashtag, emoji). `versions` fissa il ruleset e lo scorer: due
+verdetti sono confrontabili solo se coincidono.
+
+**Errori specifici**
+
+| Status | Body |
+|---|---|
+| `400` | `{"error":"invalid_input","details":[…]}` — body fuori schema |
+
+**Esempio**:
+
+```bash
+curl -s -X POST "https://anomalia.so/api/v1/brands/mio-brand/content/check" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  --data-raw '{
+    "platforms": ["linkedin","x"],
+    "caption": "Tre cose che abbiamo imparato spedendo di venerdì."
+  }'
+```
+
+---
+
 ## `DELETE /api/v1/brands/:slug/posts`
 
 Elimina in blocco i post di uno status (default `pending_user`). Rifiuta `published`.

--- a/packages/api-contracts/src/content.ts
+++ b/packages/api-contracts/src/content.ts
@@ -1,0 +1,73 @@
+import { z } from 'zod';
+import type { BrandEndpoint } from './index';
+
+const CheckContentInputSchema = z
+  .object({
+    platforms: z
+      .array(z.string().min(1))
+      .min(1)
+      .describe('Where this would be published, e.g. ["instagram","x"]'),
+    caption: z.string().describe('The copy you wrote. It is read, scored and returned untouched'),
+    platform_captions: z
+      .record(z.string(), z.string())
+      .optional()
+      .describe('Per-platform overrides: each platform is checked against the copy IT would publish'),
+    media_ids: z
+      .array(z.string().min(1))
+      .max(8)
+      .optional()
+      .describe('Ids from this brand media library (see list_media). An id that is not this brand is reported'),
+    title: z.string().optional().describe('Required for Reddit'),
+    scheduled_for: z
+      .string()
+      .optional()
+      .describe('Proposed publication instant, ISO. Without an offset it is read on the brand clock')
+  })
+  .strict();
+
+const IssueSchema = z.object({
+  code: z.string(),
+  field: z.string(),
+  detail: z.string()
+});
+
+const CheckContentResultSchema = z.object({
+  ok: z.boolean(),
+  errors: z.array(IssueSchema),
+  warnings: z.array(IssueSchema),
+  scores: z.array(
+    z.object({
+      platform: z.string(),
+      index: z.number(),
+      checks: z.array(
+        z.object({
+          id: z.string(),
+          value: z.number(),
+          weight: z.number(),
+          note: z.string()
+        })
+      )
+    })
+  ),
+  versions: z.object({ rules: z.number(), scorer: z.number() })
+});
+
+export type CheckContentInput = z.infer<typeof CheckContentInputSchema>;
+export type CheckContentResult = z.infer<typeof CheckContentResultSchema>;
+
+export const CHECK_CONTENT = {
+  tool: 'check_content',
+  title: 'Check content',
+  description:
+    'Run the checks Anomalia runs on its own copy against a spec you wrote, before you create ' +
+    'anything. Returns blocking errors, warnings and a 0-100 quality score per platform, each ' +
+    'naming the field to repair. Deterministic: it calls no model, spends no credits, writes ' +
+    'nothing, and the same spec always returns the same verdict. Perceptual review of an image ' +
+    'or a video is a separate, explicitly paid action — this never looks at pixels.',
+  method: 'POST',
+  pathUnderBrand: '/content/check',
+  input: CheckContentInputSchema,
+  output: CheckContentResultSchema,
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/packages/api-contracts/src/index.test.ts
+++ b/packages/api-contracts/src/index.test.ts
@@ -108,6 +108,32 @@ describe('il registry degli endpoint di brand', () => {
     expect(output.safeParse({ ok: true, id: 'post-1', status: 'approved' }).success).toBe(false);
   });
 
+  it('check_content è una POST per forma e una lettura per effetto', () => {
+    const check = byTool('check_content');
+    expect(check.method).toBe('POST');
+    expect(check.destructive).toBe(false);
+    expect(pathFor(check, 'demo')).toBe('/api/v1/brands/demo/content/check');
+  });
+
+  it('check_content promette errori, avvisi, punteggi e le versioni delle regole', () => {
+    const { output } = byTool('check_content');
+    const ok = output.safeParse({
+      ok: false,
+      errors: [{ code: 'over_limit', field: 'caption', detail: 'LinkedIn: 3001 characters, limit 3000' }],
+      warnings: [],
+      scores: [
+        {
+          platform: 'linkedin',
+          index: 42.5,
+          checks: [{ id: 'hook_strength', value: 0.4, weight: 18, note: 'hook generico' }]
+        }
+      ],
+      versions: { rules: 1, scorer: 3 }
+    });
+    expect(ok.success).toBe(true);
+    expect(output.safeParse({ ok: true, errors: [], warnings: [], scores: [] }).success).toBe(false);
+  });
+
   it('una response con outputSchema è un oggetto: MCP non sa trasportare un array', () => {
     for (const e of BRAND_ENDPOINTS) {
       if (!(e.output instanceof z.ZodObject)) continue;

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -1,4 +1,5 @@
 import type { z } from 'zod';
+import { CHECK_CONTENT } from './content';
 import { CREATE_POST, GET_CALENDAR, LIST_MEDIA, LIST_POSTS } from './posts';
 
 export type EndpointFailure = { readonly error: string; readonly status: number };
@@ -15,7 +16,7 @@ export type BrandEndpoint = {
   readonly destructive: boolean;
 };
 
-export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [CREATE_POST, LIST_POSTS, GET_CALENDAR, LIST_MEDIA];
+export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [CREATE_POST, LIST_POSTS, GET_CALENDAR, LIST_MEDIA, CHECK_CONTENT];
 
 export function pathFor(endpoint: BrandEndpoint, slug: string): string {
   return `/api/v1/brands/${encodeURIComponent(slug)}${endpoint.pathUnderBrand}`;
@@ -25,5 +26,6 @@ export function statusForFailure(endpoint: BrandEndpoint, error: string): number
   return endpoint.failures.find((f) => f.error === error)?.status ?? 500;
 }
 
-export { CREATE_POST, GET_CALENDAR, LIST_MEDIA, LIST_POSTS };
+export { CHECK_CONTENT, CREATE_POST, GET_CALENDAR, LIST_MEDIA, LIST_POSTS };
+export type { CheckContentInput, CheckContentResult } from './content';
 export type { CreatePostInput, CreatePostResult } from './posts';

--- a/src/lib/content/changelog/2026-09-03-external-agent-check-content.ts
+++ b/src/lib/content/changelog/2026-09-03-external-agent-check-content.ts
@@ -1,0 +1,13 @@
+import type { ChangelogEntry } from './index';
+
+const entry: ChangelogEntry = {
+  date: '2026-09-03',
+  title: 'Your AI can check its copy before it writes anything',
+  items: [
+    'Your own AI can now run the same checks Anomalia runs on its own posts — before it creates one. It gets back what blocks publication, what is only worth knowing, and a 0-100 quality score for each platform.',
+    'Every problem names the field to fix: the caption that is over the limit and by how much, the platform that will not take text alone, the asset that is not in your library, the minute already taken on your calendar.',
+    'It costs nothing and calls no model, so it can run on every draft.'
+  ]
+};
+
+export default entry;

--- a/src/lib/platform-limits.ts
+++ b/src/lib/platform-limits.ts
@@ -203,9 +203,8 @@ export type PublishBlockerCode = 'need_media' | 'need_video' | 'over_limit' | 'r
 
 export type PublishBlocker = { code: PublishBlockerCode; field: string; detail: string };
 
-// Ogni requisito di piattaforma che impedisce la pubblicazione sta qui, in una riga sola: il
-// percorso che crea un post e quello che lo controlla senza crearlo leggono la stessa tabella,
-// nello stesso ordine, e una piattaforma nuova si aggiunge in un posto solo.
+// Il percorso che crea un post e quello che lo controlla senza crearlo leggono questa tabella,
+// nello stesso ordine: una piattaforma nuova si aggiunge in un posto solo.
 const PUBLISH_REQUIREMENTS: {
   code: PublishBlockerCode;
   field: string;

--- a/src/lib/platform-limits.ts
+++ b/src/lib/platform-limits.ts
@@ -190,6 +190,77 @@ export function ensureShortNetworkCuts(
   return cuts;
 }
 
+export type PublishTarget = {
+  platforms: string[];
+  caption: string;
+  platformCaptions?: PlatformCaptions;
+  hasMedia: boolean;
+  hasVideo: boolean;
+  title?: string | null;
+};
+
+export type PublishBlockerCode = 'need_media' | 'need_video' | 'over_limit' | 'reddit_title';
+
+export type PublishBlocker = { code: PublishBlockerCode; field: string; detail: string };
+
+// Ogni requisito di piattaforma che impedisce la pubblicazione sta qui, in una riga sola: il
+// percorso che crea un post e quello che lo controlla senza crearlo leggono la stessa tabella,
+// nello stesso ordine, e una piattaforma nuova si aggiunge in un posto solo.
+const PUBLISH_REQUIREMENTS: {
+  code: PublishBlockerCode;
+  field: string;
+  blocking: (target: PublishTarget) => string | null;
+}[] = [
+  {
+    code: 'need_media',
+    field: 'media_ids',
+    blocking: ({ platforms, hasMedia }) => {
+      const need = platforms.filter((p) => VISUAL_REQUIRED_PLATFORMS.has(p));
+      return need.length && !hasMedia
+        ? `${need.map(platformLabel).join(', ')} cannot publish text alone: attach at least one asset`
+        : null;
+    }
+  },
+  {
+    code: 'need_video',
+    field: 'media_ids',
+    blocking: ({ platforms, hasVideo }) => {
+      const need = platforms.filter((p) => VIDEO_ONLY_PLATFORMS.has(p));
+      return need.length && !hasVideo
+        ? `${need.map(platformLabel).join(', ')} accepts video only: the attached asset is not a video`
+        : null;
+    }
+  },
+  {
+    code: 'over_limit',
+    field: 'caption',
+    blocking: ({ caption, platforms, platformCaptions }) => {
+      const over = captionViolations(caption, platforms, platformCaptions);
+      return over.length
+        ? over.map((v) => `${v.label}: ${v.length} characters, limit ${v.limit}`).join('; ')
+        : null;
+    }
+  },
+  {
+    code: 'reddit_title',
+    field: 'title',
+    blocking: ({ platforms, title }) =>
+      platforms.includes('reddit') && !String(title ?? '').trim()
+        ? 'Reddit needs a title of its own, max 300 characters'
+        : null
+  }
+];
+
+/** Which platform requirements this content fails (empty = publishable). No I/O, no model. */
+export function publishBlockers(target: PublishTarget): PublishBlocker[] {
+  const out: PublishBlocker[] = [];
+  for (const rule of PUBLISH_REQUIREMENTS) {
+    const detail = rule.blocking(target);
+    if (detail) out.push({ code: rule.code, field: rule.field, detail });
+  }
+  return out;
+}
+
 export type CaptionViolation = { platform: string; label: string; limit: number; length: number };
 
 // Which target platforms' char limit the post exceeds (empty = all good). Each platform is checked

--- a/src/lib/server/content-check.test.ts
+++ b/src/lib/server/content-check.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const findBrandMediaByIds = vi.fn();
+const getPosts = vi.fn();
+const structured = vi.fn();
+const llmStructured = vi.fn();
+
+vi.mock('$lib/server/brand-media', () => ({
+  findBrandMediaByIds: (...args: unknown[]) => findBrandMediaByIds(...args)
+}));
+vi.mock('$lib/server/cli-queries', () => ({ getPosts: (...args: unknown[]) => getPosts(...args) }));
+vi.mock('$lib/server/research', () => ({ structured: (...args: unknown[]) => structured(...args) }));
+vi.mock('$lib/server/llm', () => ({
+  llmStructured: (...args: unknown[]) => llmStructured(...args),
+  llmConfigured: () => false,
+  llmImagesFromInline: () => []
+}));
+
+import { checkContent, CONTENT_CHECK_RULES_VERSION } from './content-check';
+import { CONTENT_SCORER_VERSION, scoreContentQuality } from './content-quality';
+import { deterministicPrepublishIssues } from './prepublish-check';
+
+const TZ = 'Europe/Rome';
+
+const GOOD_CAPTION = [
+  'Spedivamo il venerdì e il 22% dei resi arrivava il lunedì.',
+  '',
+  'Abbiamo spostato il cut-off al giovedì alle 14 e i resi sono scesi a 9% in tre settimane.',
+  'Il magazzino non ha cambiato niente: è cambiata solo l ora di chiusura degli ordini.',
+  '',
+  'Raccontaci come gestisci il tuo cut-off.'
+].join('\n');
+
+function check(spec: Record<string, unknown>) {
+  return checkContent({
+    supabase: {} as never,
+    brandId: 'brand-1',
+    timezone: TZ,
+    spec: { platforms: ['linkedin'], caption: GOOD_CAPTION, ...spec } as never
+  });
+}
+
+const codes = (issues: { code: string }[]) => issues.map((i) => i.code);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  findBrandMediaByIds.mockResolvedValue([]);
+  getPosts.mockResolvedValue([]);
+});
+
+describe('checkContent', () => {
+  it('promuove una copy sana e non inventa un errore per riempire il report', async () => {
+    const report = await check({});
+
+    expect(report.ok).toBe(true);
+    expect(report.errors).toEqual([]);
+  });
+
+  it('non chiama nessun modello: il verdetto è calcolato, non giudicato', async () => {
+    await check({ platforms: ['instagram', 'x'], caption: 'a'.repeat(500) });
+
+    expect(structured).not.toHaveBeenCalled();
+    expect(llmStructured).not.toHaveBeenCalled();
+  });
+
+  it('dà lo stesso verdetto due volte: nessun orologio, nessun caso', async () => {
+    const first = await check({});
+    const second = await check({});
+
+    expect(second.scores).toEqual(first.scores);
+    expect(second.errors).toEqual(first.errors);
+  });
+
+  it('dichiara le versioni delle regole che ha applicato', async () => {
+    const report = await check({});
+
+    expect(report.versions).toEqual({
+      rules: CONTENT_CHECK_RULES_VERSION,
+      scorer: CONTENT_SCORER_VERSION
+    });
+  });
+
+  it.each([
+    ['vuota', ''],
+    ['segnaposto', 'lorem ipsum dolor sit amet'],
+    ['solo hashtag', '#uno #due #tre']
+  ])(
+    'ferma una caption %s, come già la ferma il gate di pubblicazione',
+    async (_label, caption) => {
+      const report = await check({ caption });
+
+      expect(deterministicPrepublishIssues({ id: '', brand_id: '', platform: 'linkedin', caption, media_url: null })).not.toEqual([]);
+      expect(report.ok).toBe(false);
+      expect(report.errors.map((e) => e.field)).toContain('caption');
+    }
+  );
+
+  it('ferma un segnaposto [NEED:] invece di lasciarlo uscire come numero vero', async () => {
+    const caption = 'Abbiamo tagliato i resi del [NEED: percentuale reale] in un mese.';
+    const report = await check({ caption });
+
+    expect(report.ok).toBe(false);
+    expect(codes(report.errors)).toContain('caption_needs_proof');
+  });
+
+  it('una copy oltre il limite dice quale piattaforma e quale campo riparare', async () => {
+    const report = await check({ platforms: ['linkedin', 'x'], caption: 'a'.repeat(3001) });
+
+    const overLimit = report.errors.find((e) => e.code === 'over_limit');
+    expect(overLimit?.field).toBe('caption');
+    expect(overLimit?.detail).toContain('LinkedIn');
+    expect(overLimit?.detail).toContain('3000');
+  });
+
+  it('legge ogni piattaforma sulla copy che pubblicherebbe davvero, non su quella principale', async () => {
+    const report = await check({
+      platforms: ['linkedin', 'x'],
+      caption: 'a'.repeat(2000),
+      platformCaptions: { x: 'un pensiero corto' }
+    });
+
+    expect(codes(report.errors)).not.toContain('over_limit');
+  });
+
+  it.each(['instagram', 'tiktok'])('dice che %s non regge il solo testo, e quale campo lo risolve', async (platform) => {
+    const report = await check({ platforms: [platform] });
+
+    const needMedia = report.errors.find((e) => e.code === 'need_media');
+    expect(needMedia?.field).toBe('media_ids');
+  });
+
+  it('youtube senza video chiede un video, non una foto', async () => {
+    findBrandMediaByIds.mockResolvedValue([{ id: 'asset-1', kind: 'image' }]);
+    const report = await check({ platforms: ['youtube'], mediaIds: ['asset-1'] });
+
+    expect(codes(report.errors)).toContain('need_video');
+  });
+
+  it('un video della libreria soddisfa youtube', async () => {
+    findBrandMediaByIds.mockResolvedValue([{ id: 'asset-1', kind: 'video' }]);
+    const report = await check({ platforms: ['youtube'], mediaIds: ['asset-1'] });
+
+    expect(codes(report.errors)).not.toContain('need_video');
+    expect(codes(report.errors)).not.toContain('need_media');
+  });
+
+  it('reddit senza titolo nomina il campo title', async () => {
+    const report = await check({ platforms: ['reddit'] });
+
+    expect(report.errors.find((e) => e.code === 'reddit_title')?.field).toBe('title');
+  });
+
+  it('un media che non è di questo brand è un errore, non un post muto', async () => {
+    findBrandMediaByIds.mockResolvedValue([]);
+    const report = await check({ platforms: ['instagram'], mediaIds: ['asset-di-un-altro'] });
+
+    const missing = report.errors.find((e) => e.code === 'media_not_found');
+    expect(missing?.field).toBe('media_ids');
+    expect(missing?.detail).toContain('asset-di-un-altro');
+  });
+
+  it('una piattaforma che il dominio non conosce non passa in silenzio', async () => {
+    const report = await check({ platforms: ['myspace'] });
+
+    expect(report.errors.find((e) => e.code === 'no_platforms')?.field).toBe('platforms');
+  });
+
+  it('una data illeggibile nomina scheduled_for', async () => {
+    const report = await check({ scheduledFor: 'domani alle 18' });
+
+    expect(report.errors.find((e) => e.code === 'invalid_scheduled_for')?.field).toBe('scheduled_for');
+  });
+
+  it('una data già passata è ferma qui, non alla creazione', async () => {
+    const report = await check({ scheduledFor: '2020-01-01T09:00' });
+
+    expect(codes(report.errors)).toContain('too_soon');
+  });
+
+  it('uno slot già occupato è un avviso, non un blocco: il calendario lo permette', async () => {
+    getPosts.mockResolvedValue([
+      { id: 'post-esistente', status: 'scheduled', scheduled_for: '2030-05-16T07:00:00.000Z', slot: null, platform: 'x', caption: 'già in calendario' }
+    ]);
+    const report = await check({ scheduledFor: '2030-05-16T09:00' });
+
+    expect(report.ok).toBe(true);
+    const clash = report.warnings.find((w) => w.code === 'calendar_conflict');
+    expect(clash?.field).toBe('scheduled_for');
+    expect(clash?.detail).toContain('post-esistente');
+  });
+
+  it('gli hashtag da reach sono un avviso sulla caption', async () => {
+    const report = await check({ caption: `${GOOD_CAPTION}\n#fyp #viral` });
+
+    expect(report.ok).toBe(true);
+    expect(report.warnings.find((w) => w.code === 'reach_chasing_hashtags')?.field).toBe('caption');
+  });
+
+  it('dà lo stesso indice dello scorer interno, non un punteggio suo', async () => {
+    const report = await check({ platforms: ['linkedin'] });
+
+    expect(report.scores[0]).toMatchObject({
+      platform: 'linkedin',
+      index: scoreContentQuality({ caption: GOOD_CAPTION, platform: 'linkedin' }).index
+    });
+  });
+
+  it('confronta con i post recenti del brand: la ripetizione esiste solo tra vicini', async () => {
+    getPosts.mockResolvedValue([
+      { id: 'p1', status: 'published', scheduled_for: null, slot: null, platform: 'linkedin', caption: GOOD_CAPTION }
+    ]);
+    const report = await check({ platforms: ['linkedin'] });
+
+    const repetition = report.scores[0].checks.find((c) => c.id === 'self_repetition');
+    expect(repetition?.value).toBeLessThan(1);
+  });
+
+  it('punteggia ogni piattaforma richiesta, perché la stessa copy non vale uguale ovunque', async () => {
+    findBrandMediaByIds.mockResolvedValue([{ id: 'asset-1', kind: 'image' }]);
+    const report = await check({ platforms: ['linkedin', 'instagram'], mediaIds: ['asset-1'] });
+
+    expect(report.scores.map((s) => s.platform)).toEqual(['linkedin', 'instagram']);
+  });
+});

--- a/src/lib/server/content-check.ts
+++ b/src/lib/server/content-check.ts
@@ -1,0 +1,228 @@
+/**
+ * Runs the checks Anomalia already runs on its own copy against a spec somebody else wrote.
+ *
+ * Every rule here belongs to another module and is called, never restated: the platform
+ * requirements to `platform-limits.ts`, the caption soundness to `prepublish-check.ts` and
+ * `proof-discipline.ts`, the score to `content-quality.ts`, the double-booking to `schedule.ts`,
+ * the hashtag hygiene to `platform-hygiene.ts`. What this file owns is the composition — which of
+ * those verdicts blocks and which only warns — and the version of that composition.
+ *
+ * No model, ever. A verdict that costs a model call cannot be run before every draft, and one that
+ * moves when a model is swapped is not a verdict.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { assemblePlatformCaptions, captionFor, publishBlockers } from '$lib/platform-limits';
+import { normalizePlatforms } from '$lib/manual-posting-captions';
+import { findBrandMediaByIds } from '$lib/server/brand-media';
+import { getPosts } from '$lib/server/cli-queries';
+import { CONTENT_SCORER_VERSION, scoreContentQuality } from '$lib/server/content-quality';
+import { isPlaceholderCaption } from '$lib/server/prepublish-check';
+import { needMarkers } from '$lib/server/proof-discipline';
+import { reachChasingHashtags } from '$lib/server/platform-hygiene';
+import { datetimeInputToUtc, earliestScheduleMs, listCalendarConflicts } from '$lib/server/schedule';
+
+/** Bump when a rule is added, removed, or moves between blocking and warning. */
+export const CONTENT_CHECK_RULES_VERSION = 1;
+
+const RECENT_CAPTIONS = 20;
+const CANDIDATE_ID = 'the-content-being-checked';
+
+export type ContentIssue = { code: string; field: string; detail: string };
+
+export type PlatformScore = {
+  platform: string;
+  index: number;
+  checks: { id: string; value: number; weight: number; note: string }[];
+};
+
+export type ContentSpec = {
+  platforms: string[];
+  caption: string;
+  platformCaptions?: Record<string, string>;
+  mediaIds?: string[];
+  title?: string;
+  scheduledFor?: string;
+};
+
+export type ContentCheckReport = {
+  ok: boolean;
+  errors: ContentIssue[];
+  warnings: ContentIssue[];
+  scores: PlatformScore[];
+  versions: { rules: number; scorer: number };
+};
+
+// Il predicato di ognuna vive nel modulo che la governa: qui c'è solo quali bloccano.
+const CAPTION_RULES: { code: string; blocking: (caption: string) => string | null }[] = [
+  {
+    code: 'caption_empty',
+    blocking: (caption) => (caption ? null : 'The caption has no text')
+  },
+  {
+    code: 'caption_placeholder',
+    blocking: (caption) =>
+      caption && isPlaceholderCaption(caption)
+        ? 'The caption is a placeholder or carries no words of its own'
+        : null
+  },
+  {
+    code: 'caption_needs_proof',
+    blocking: (caption) => {
+      const needs = needMarkers(caption);
+      return needs.length
+        ? `Supply the facts these markers are waiting for, never delete them: ${needs.slice(0, 3).join('; ')}`
+        : null;
+    }
+  }
+];
+
+function captionErrors(caption: string): ContentIssue[] {
+  const out: ContentIssue[] = [];
+  for (const rule of CAPTION_RULES) {
+    const detail = rule.blocking(caption);
+    if (detail) out.push({ code: rule.code, field: 'caption', detail });
+  }
+  return out;
+}
+
+type ResolvedMedia = { hasMedia: boolean; hasVideo: boolean; missing: string[] };
+
+async function resolveMedia(
+  supabase: SupabaseClient,
+  brandId: string,
+  ids: string[]
+): Promise<ResolvedMedia> {
+  if (!ids.length) return { hasMedia: false, hasVideo: false, missing: [] };
+  const owned = await findBrandMediaByIds(supabase, brandId, ids);
+  const byId = new Map(owned.map((row) => [row.id, row]));
+  return {
+    hasMedia: owned.length > 0,
+    hasVideo: owned.some((row) => row.kind === 'video'),
+    missing: ids.filter((id) => !byId.has(id))
+  };
+}
+
+function scheduleIssues(
+  scheduledFor: string | undefined,
+  timezone: string,
+  calendar: Parameters<typeof listCalendarConflicts>[0]
+): { errors: ContentIssue[]; warnings: ContentIssue[] } {
+  if (!scheduledFor) return { errors: [], warnings: [] };
+
+  const instant = datetimeInputToUtc(scheduledFor, timezone);
+  if (!instant) {
+    return {
+      errors: [{ code: 'invalid_scheduled_for', field: 'scheduled_for', detail: `Not a datetime: ${scheduledFor}` }],
+      warnings: []
+    };
+  }
+  if (new Date(instant).getTime() < earliestScheduleMs()) {
+    return {
+      errors: [
+        {
+          code: 'too_soon',
+          field: 'scheduled_for',
+          detail: `${instant} is in the past or too close to now to be honoured`
+        }
+      ],
+      warnings: []
+    };
+  }
+
+  const candidate = { id: CANDIDATE_ID, scheduled_for: instant, status: 'pending_user', slot: null };
+  const clash = listCalendarConflicts([...calendar, candidate], timezone).find((group) =>
+    group.posts.some((p) => p.id === CANDIDATE_ID)
+  );
+  if (!clash) return { errors: [], warnings: [] };
+
+  const neighbours = clash.posts.filter((p) => p.id !== CANDIDATE_ID).map((p) => p.id ?? p.platform ?? 'a post');
+  return {
+    errors: [],
+    warnings: [
+      {
+        code: 'calendar_conflict',
+        field: 'scheduled_for',
+        detail: `${clash.at} is already taken by ${neighbours.join(', ')}`
+      }
+    ]
+  };
+}
+
+export async function checkContent(opts: {
+  supabase: SupabaseClient;
+  brandId: string;
+  timezone: string;
+  spec: ContentSpec;
+}): Promise<ContentCheckReport> {
+  const { spec } = opts;
+  const platforms = normalizePlatforms(spec.platforms);
+  const caption = String(spec.caption ?? '').trim();
+  const assembled = assemblePlatformCaptions(caption, spec.platformCaptions ?? {}, platforms);
+
+  const media = await resolveMedia(opts.supabase, opts.brandId, spec.mediaIds ?? []);
+  const recent = await getPosts(opts.supabase, opts.brandId);
+
+  const errors: ContentIssue[] = [];
+  const warnings: ContentIssue[] = [];
+
+  if (!platforms.length) {
+    errors.push({
+      code: 'no_platforms',
+      field: 'platforms',
+      detail: `None of ${spec.platforms.join(', ') || '(none given)'} is a platform Anomalia publishes to`
+    });
+  }
+  if (media.missing.length) {
+    errors.push({
+      code: 'media_not_found',
+      field: 'media_ids',
+      detail: `Not in this brand library: ${media.missing.join(', ')}`
+    });
+  }
+  errors.push(...captionErrors(caption));
+  errors.push(
+    ...publishBlockers({
+      platforms,
+      caption: assembled.caption,
+      platformCaptions: assembled.platform_captions,
+      hasMedia: media.hasMedia,
+      hasVideo: media.hasVideo,
+      title: spec.title
+    }).map(({ code, field, detail }) => ({ code, field, detail }))
+  );
+
+  const schedule = scheduleIssues(spec.scheduledFor, opts.timezone, recent);
+  errors.push(...schedule.errors);
+  warnings.push(...schedule.warnings);
+
+  const chasing = reachChasingHashtags(assembled.caption);
+  if (chasing.length) {
+    warnings.push({
+      code: 'reach_chasing_hashtags',
+      field: 'caption',
+      detail: `Tags that buy impressions and no readers: ${chasing.join(' ')}`
+    });
+  }
+
+  const recentCaptions = recent.map((post) => post.caption).slice(0, RECENT_CAPTIONS);
+  const scores = platforms.map((platform) => {
+    const quality = scoreContentQuality({
+      caption: captionFor(assembled.caption, assembled.platform_captions, platform),
+      platform,
+      recentCaptions
+    });
+    return {
+      platform,
+      index: quality.index,
+      checks: quality.checks.map(({ id, value, weight, note }) => ({ id, value, weight, note }))
+    };
+  });
+
+  return {
+    ok: errors.length === 0,
+    errors,
+    warnings,
+    scores,
+    versions: { rules: CONTENT_CHECK_RULES_VERSION, scorer: CONTENT_SCORER_VERSION }
+  };
+}

--- a/src/lib/server/manual-posting.ts
+++ b/src/lib/server/manual-posting.ts
@@ -4,15 +4,13 @@ import { withBrandContext } from '$lib/server/ai-log';
 import { aiActCopyGuardrail } from '$lib/ai-act';
 import { platformPlaybook, houseVoiceFor, type ContentPrefs } from '$lib/server/content-preview';
 import { publishApprovedPost, type ApprovablePost } from '$lib/server/publish';
-import { wallClockToUtc, zonedClock } from '$lib/server/schedule';
+import { earliestScheduleMs, wallClockToUtc, zonedClock } from '$lib/server/schedule';
 import { findBrandMediaByIds, publishLibraryMediaAsPostMedia } from '$lib/server/brand-media';
 import { EDITOR_POST_COLS } from '$lib/server/post-editing';
 import {
   PLATFORM_CHAR_LIMITS,
   assemblePlatformCaptions,
-  captionViolations,
-  VISUAL_REQUIRED_PLATFORMS,
-  VIDEO_ONLY_PLATFORMS,
+  publishBlockers,
   youtubeTitleFrom
 } from '$lib/platform-limits';
 import {
@@ -24,7 +22,6 @@ import {
 export { clampGeneratedCaptions, normalizePlatforms };
 export type { GeneratedCaptions };
 
-const MIN_LEAD_MS = 2 * 60 * 1000;
 const MAX_MEDIA = 8;
 const DOW_EN = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
@@ -182,10 +179,6 @@ function slotAt(iso: string, tz: string): string {
   return `${dow} ${time}`;
 }
 
-function earliestMs(): number {
-  return Math.floor(Date.now() / 60000) * 60000 + MIN_LEAD_MS;
-}
-
 type ResolvedMedia =
   | { ok: true; urls: string[]; video: boolean }
   | { ok: false; error: 'media_not_found' };
@@ -261,17 +254,8 @@ export async function createManualPost(opts: {
   const { urls, video: pathVideo } = media;
   const isVideo = opts.input.isVideo === true || pathVideo;
   const hasMedia = urls.length > 0;
-  const needsVisual = platforms.some((p) => VISUAL_REQUIRED_PLATFORMS.has(p));
-  if (needsVisual && !hasMedia) return { ok: false, error: 'need_media' };
-  const needsVideo = platforms.some((p) => VIDEO_ONLY_PLATFORMS.has(p));
-  if (needsVideo && !isVideo) return { ok: false, error: 'need_video' };
 
   const assembled = assemblePlatformCaptions(caption, opts.input.platformCaptions ?? {}, platforms);
-  const violations = captionViolations(assembled.caption, platforms, assembled.platform_captions);
-  if (violations.length) {
-    return { ok: false, error: 'over_limit' };
-  }
-
   const reddit = platforms.includes('reddit');
   const youtube = platforms.includes('youtube');
   const title = reddit
@@ -279,7 +263,17 @@ export async function createManualPost(opts: {
     : youtube
       ? youtubeTitleFrom(assembled.caption, opts.input.title)
       : '';
-  if (reddit && !title) return { ok: false, error: 'reddit_title' };
+
+  const blockers = publishBlockers({
+    platforms,
+    caption: assembled.caption,
+    platformCaptions: assembled.platform_captions,
+    hasMedia,
+    hasVideo: isVideo,
+    title
+  });
+  if (blockers.length) return { ok: false, error: blockers[0].code };
+
   const subreddit = reddit
     ? String(opts.input.subreddit ?? '')
         .trim()
@@ -295,7 +289,7 @@ export async function createManualPost(opts: {
   const behaviour = MODE_BEHAVIOUR[opts.input.mode];
   const when = behaviour.dateFrom(opts.input, opts.timezone);
   if (!when && behaviour.dateRequired) return { ok: false, error: 'too_soon' };
-  if (when && new Date(when).getTime() < earliestMs()) return { ok: false, error: 'too_soon' };
+  if (when && new Date(when).getTime() < earliestScheduleMs()) return { ok: false, error: 'too_soon' };
   const scheduledFor = when;
   const slot = when ? slotAt(when, opts.timezone) : null;
 

--- a/src/lib/server/prepublish-check.ts
+++ b/src/lib/server/prepublish-check.ts
@@ -131,7 +131,8 @@ function targetsOf(post: PrepublishPost): string[] {
   return (list ?? []).map((p) => String(p ?? '').toLowerCase()).filter(Boolean);
 }
 
-function isPlaceholderCaption(caption: string): boolean {
+/** Lorem ipsum, "TODO", a caption made of hashtags only: text that exists and says nothing. */
+export function isPlaceholderCaption(caption: string): boolean {
   const t = caption.replace(/\s+/g, ' ').trim();
   if (t.length < 2) return true;
   if (PLACEHOLDER_RE.test(t)) return true;

--- a/src/lib/server/schedule.ts
+++ b/src/lib/server/schedule.ts
@@ -4,6 +4,14 @@
 const NAMES = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'];
 const SHORT: Record<string, number> = { Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6 };
 
+/** Minimum notice a proposed slot needs: closer than this and the pipeline cannot honour it. */
+export const MIN_SCHEDULE_LEAD_MS = 2 * 60 * 1000;
+
+/** The earliest instant a post may still be scheduled for, rounded down to the current minute. */
+export function earliestScheduleMs(nowMs = Date.now()): number {
+  return Math.floor(nowMs / 60000) * 60000 + MIN_SCHEDULE_LEAD_MS;
+}
+
 // Convert a wall-clock time in `tz` to the matching UTC Date (derives the offset via Intl).
 function zonedToUtc(y: number, m: number, d: number, h: number, min: number, tz: string): Date {
   const asUtc = Date.UTC(y, m - 1, d, h, min, 0);

--- a/src/routes/api/v1/brands/[slug]/content/check/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/content/check/+server.ts
@@ -1,0 +1,35 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { authenticate, loadBrandForUser } from '$lib/server/cli-auth';
+import { checkContent } from '$lib/server/content-check';
+import { CHECK_CONTENT } from '@anomalia/api-contracts';
+
+export const POST: RequestHandler = async ({ request, params }) => {
+  const { supabase, error, apiKey } = await authenticate(request);
+  if (error) return error;
+
+  const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
+  if (brandError) return brandError;
+
+  const parsed = CHECK_CONTENT.input.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return json({ error: 'invalid_input', details: parsed.error.issues }, { status: 400 });
+  }
+  const input = parsed.data;
+
+  return json(
+    await checkContent({
+      supabase,
+      brandId: brand.id,
+      timezone: (brand.timezone as string) ?? 'Europe/Rome',
+      spec: {
+        platforms: input.platforms,
+        caption: input.caption,
+        platformCaptions: input.platform_captions,
+        mediaIds: input.media_ids,
+        title: input.title,
+        scheduledFor: input.scheduled_for
+      }
+    })
+  );
+};

--- a/src/routes/api/v1/brands/[slug]/content/check/server.test.ts
+++ b/src/routes/api/v1/brands/[slug]/content/check/server.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const structured = vi.fn();
+const llmStructured = vi.fn();
+const gateCredits = vi.fn();
+const findBrandMediaByIds = vi.fn();
+const getPosts = vi.fn();
+
+vi.mock('$lib/server/cli-auth', () => ({
+  authenticate: vi.fn(),
+  loadBrandForUser: vi.fn(),
+  gateAiAction: vi.fn()
+}));
+vi.mock('$lib/server/cli-queries', () => ({ getPosts: (...args: unknown[]) => getPosts(...args) }));
+vi.mock('$lib/server/brand-media', () => ({
+  findBrandMediaByIds: (...args: unknown[]) => findBrandMediaByIds(...args)
+}));
+vi.mock('$lib/server/research', () => ({ structured: (...args: unknown[]) => structured(...args) }));
+vi.mock('$lib/server/llm', () => ({
+  llmStructured: (...args: unknown[]) => llmStructured(...args),
+  llmConfigured: () => false,
+  llmImagesFromInline: () => []
+}));
+vi.mock('$lib/server/credits', () => ({
+  gateCredits: (...args: unknown[]) => gateCredits(...args),
+  CreditsExhaustedError: class extends Error {}
+}));
+
+import { POST } from './+server';
+import { authenticate, loadBrandForUser, gateAiAction } from '$lib/server/cli-auth';
+
+const CAPTION = 'Spedivamo il venerdì e il 22% dei resi arrivava il lunedì. Guarda cosa abbiamo cambiato.';
+
+function call(body: unknown, slug = 'demo') {
+  vi.mocked(authenticate).mockResolvedValue({
+    supabase: {},
+    user: { id: 'user-1' },
+    apiKey: undefined,
+    error: null
+  } as never);
+  vi.mocked(loadBrandForUser).mockResolvedValue({
+    brand: { id: 'brand-1', slug, timezone: 'Europe/Rome' },
+    error: null
+  } as never);
+  const url = new URL(`https://anomalia.test/api/v1/brands/${slug}/content/check`);
+  return (POST as (event: unknown) => Promise<Response>)({
+    request: new Request(url, { method: 'POST', body: JSON.stringify(body) }),
+    params: { slug },
+    url
+  }).then(async (res) => ({ res, body: await res.json() }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  findBrandMediaByIds.mockResolvedValue([]);
+  getPosts.mockResolvedValue([]);
+});
+
+describe('POST /api/v1/brands/:slug/content/check', () => {
+  it('risponde 200 con il verdetto, anche quando il verdetto è negativo', async () => {
+    const { res, body } = await call({ platforms: ['linkedin'], caption: 'a'.repeat(3001) });
+
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(false);
+    expect(body.errors.map((e: { code: string }) => e.code)).toContain('over_limit');
+  });
+
+  it('non chiama il modello e non tocca i crediti: il controllo non si paga', async () => {
+    await call({ platforms: ['linkedin'], caption: CAPTION });
+
+    expect(structured).not.toHaveBeenCalled();
+    expect(llmStructured).not.toHaveBeenCalled();
+    expect(gateAiAction).not.toHaveBeenCalled();
+    expect(gateCredits).not.toHaveBeenCalled();
+  });
+
+  // `resolveCaller` nega ogni non-GET a una API key di sola lettura, prima che la route parta:
+  // «Every mutating CLI route is a non-GET, so the method is the whole check». check_content è il
+  // primo POST che calcola senza scrivere, quindi è il primo controesempio a quella frase — ma la
+  // regola resta quella, e finché resta una chiave di sola lettura qui non arriva.
+  it('non arriva a calcolare quando authenticate ha già negato la chiamata', async () => {
+    vi.mocked(authenticate).mockResolvedValue({
+      error: new Response(JSON.stringify({ error: 'API key is read-only' }), { status: 403 })
+    } as never);
+    const url = new URL('https://anomalia.test/api/v1/brands/demo/content/check');
+    const res = await (POST as (event: unknown) => Promise<Response>)({
+      request: new Request(url, { method: 'POST', body: JSON.stringify({ platforms: ['linkedin'], caption: CAPTION }) }),
+      params: { slug: 'demo' },
+      url
+    });
+
+    expect(res.status).toBe(403);
+    expect(loadBrandForUser).not.toHaveBeenCalled();
+    expect(getPosts).not.toHaveBeenCalled();
+  });
+
+  it('rifiuta una richiesta senza autenticazione', async () => {
+    vi.mocked(authenticate).mockResolvedValue({
+      error: new Response('Unauthorized', { status: 401 })
+    } as never);
+    const url = new URL('https://anomalia.test/api/v1/brands/demo/content/check');
+    const res = await (POST as (event: unknown) => Promise<Response>)({
+      request: new Request(url, { method: 'POST', body: '{}' }),
+      params: { slug: 'demo' },
+      url
+    });
+
+    expect(res.status).toBe(401);
+  });
+
+  it('rifiuta un brand a cui il chiamante non accede', async () => {
+    vi.mocked(authenticate).mockResolvedValue({
+      supabase: {},
+      user: { id: 'user-1' },
+      apiKey: undefined,
+      error: null
+    } as never);
+    vi.mocked(loadBrandForUser).mockResolvedValue({
+      error: new Response(JSON.stringify({ error: 'Brand not found' }), { status: 404 })
+    } as never);
+    const url = new URL('https://anomalia.test/api/v1/brands/altrui/content/check');
+    const res = await (POST as (event: unknown) => Promise<Response>)({
+      request: new Request(url, { method: 'POST', body: '{}' }),
+      params: { slug: 'altrui' },
+      url
+    });
+
+    expect(res.status).toBe(404);
+  });
+
+  it.each([
+    ['senza piattaforme', { platforms: [], caption: 'copy' }],
+    ['senza campi', {}],
+    ['con un campo che il contratto non dichiara', { platforms: ['linkedin'], caption: 'copy', campo_inventato: 'x' }]
+  ])('rifiuta una richiesta %s', async (_label, body) => {
+    const { res, body: out } = await call(body);
+
+    expect(res.status).toBe(400);
+    expect(out.error).toBe('invalid_input');
+  });
+
+  it('porta le versioni delle regole nella risposta', async () => {
+    const { body } = await call({ platforms: ['linkedin'], caption: CAPTION });
+
+    expect(typeof body.versions.rules).toBe('number');
+    expect(typeof body.versions.scorer).toBe('number');
+  });
+});


### PR DESCRIPTION
## What?

Adds `check_content`: an external agent submits a content spec — platforms, caption, per-platform
overrides, media ids, title, proposed date — and gets back every blocking error, every warning, a
0–100 quality score per platform and the exact field to repair, in one answer.

It calls **no model**, spends **no credits** and **writes nothing**. A negative verdict is a `200`
with `ok: false`: it is a report, not a gate.

- `POST /api/v1/brands/:slug/content/check`
- MCP tool `check_content` — it appeared on its own from the contract registry; no `registerTool`
  block and no method in `cli/lib/api.ts` were written by hand.

This is the deterministic half of step 2 of the [external-agent plan](docs/external-agent-plan.md)
(“Creative support”). The other half, `get_creation_kit`, is not in this PR.

### A note on the base

This PR was built on `feat/external-agent-media` (PR #195). That PR merged and its branch was
deleted while this work was in flight, so the two commits were replayed onto `dev` and the PR
targets `dev`. `git log --oneline origin/dev..HEAD` lists only the two commits below, and the tree
`npm run check` ran against is byte-identical to `dev`.

## Why?

An external model could already write a post and create it, but had no way to ask whether the copy
would survive. It learned about a caption over X's limit, a placeholder that slipped through, or an
Instagram post with no asset only when `create_post` refused — one error at a time, after the fact.

The plan's constraint decided the whole design:

> Reuse the existing brand context, platform guidance, post templates, approved rubrics,
> performance history, deterministic content score, and feasibility checks. **Do not copy their
> rules into the MCP adapter.**

So the work was not writing rules. It was finding them.

## How?

### Which existing modules are bridged

`src/lib/server/content-check.ts` contains **no threshold of its own**. Every verdict comes from a
module that already owned it:

| What it checks | Where the rule already lived |
|---|---|
| Per-platform character limits | `captionViolations` — `src/lib/platform-limits.ts` |
| Platforms that cannot publish text alone, YouTube needing a video | `VISUAL_REQUIRED_PLATFORMS` / `VIDEO_ONLY_PLATFORMS` — same file |
| Empty or placeholder caption | `isPlaceholderCaption` — `src/lib/server/prepublish-check.ts` |
| `[NEED: …]` markers | `needMarkers` — `src/lib/server/proof-discipline.ts` |
| 0–100 index, twelve weighted checks | `scoreContentQuality` + `CONTENT_SCORER_VERSION` — `src/lib/server/content-quality.ts` |
| Media ownership | `findBrandMediaByIds` — `src/lib/server/brand-media.ts` |
| Same minute double-booked | `listCalendarConflicts` — `src/lib/server/schedule.ts` |
| Reach-chasing hashtags | `reachChasingHashtags` — `src/lib/server/platform-hygiene.ts` |

What the new file owns is the **composition** — which of those verdicts blocks and which only warns
— and the version of that composition.

### Two rules were trapped inside the write path

`need_media`, `need_video`, `over_limit` and `reddit_title` were a chain of `if`s inside
`createManualPost`, reachable only by creating a post. A caller that wanted to know whether copy
would pass, without creating anything, would have had to restate them — and two copies of a rule
diverge at the first change, silently.

They became `publishBlockers`, one ordered table in `platform-limits.ts`, next to the platform sets
and character limits they already read. `createManualPost` now returns the first blocker the table
finds, **in the same order it checked before**, so the error it returns for any given input is
unchanged. Same story for the minimum scheduling lead (`MIN_SCHEDULE_LEAD_MS` → `schedule.ts`).

That move is a **separate commit** with no behaviour change; the feature commit sits on top.

### Decisions worth arguing with

- **No `checkApiKeyWriteAccess` in the route** — not to let read-only keys through, but because it
  would be redundant. `resolveCaller` in `cli-auth.ts` already enforces write scope once, for every
  request that is not `GET`/`HEAD`. **So a read-only key cannot reach `check_content` today**: it
  gets `403` before the route runs, even though the endpoint writes nothing. That is a consequence
  of the method-based rule, not a property of this endpoint, and it is now stated in `docs/api` and
  the internal changelog. See *Anything Else?* — this is the first counter-example to that rule.
- **`failures: []` in the contract.** Content problems are the payload, not HTTP failures. The only
  non-200 the route produces itself is `400 invalid_input` for a body outside the schema.
- **`subreddit` and `link_url` are not accepted**, although `create_post` takes them: no
  deterministic rule reads either one, and a declared field that checks nothing is dead weight. The
  `.strict()` schema rejects them loudly instead of ignoring them, so a caller finds out at once.
- **New file `packages/api-contracts/src/content.ts`** rather than adding to `posts.ts`, so a
  parallel PR adding an endpoint conflicts on one line of `index.ts` and nothing else.
- **`over_limit` rarely fires for X/Threads**, because `assemblePlatformCaptions` synthesises the
  short-network cut — exactly as `createManualPost` does. That is parity, not a miss: `create_post`
  would accept the same spec.

### What is NOT implemented, and was not faked

- **Rubric cadence.** The rule exists (`checkRubricsAndBatchFeasibility`) but it is a *batch* rule:
  it wants a whole week of seeds and the expected per-rubric counts. Against a single content spec
  it has nothing to compare. Inventing a single-post substitute would have shipped a check that
  pretends to be Anomalia's while being mine — worse than a missing check.
- **Any perceptual review.** No pixel is looked at. The plan wants that as a separate paid action.
- **`assertRedditCraft`.** Its “missing title” duplicates `reddit_title`, and de-duplicating by
  comparing message strings is precisely the scattered condition the repo rules forbid. Its unique
  part — the self-promo-link smell — is left for a follow-up.
- **Brand hashtag preferences** (`assertHashtagPrefs`) need `ContentPrefs` loaded; one more query
  and one more module for one more warning. Skipped deliberately.

## Testing?

TDD: the tests were written first and watched fail.

<details><summary>Red, before any implementation existed</summary>

```
 ❯ src/routes/api/v1/brands/[slug]/content/check/server.test.ts (0 test)
 ❯ src/lib/server/content-check.test.ts (0 test)

⎯⎯⎯⎯⎯⎯ Failed Suites 2 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  src/lib/server/content-check.test.ts [ src/lib/server/content-check.test.ts ]
Error: Failed to load url ./content-check (resolved id: ./content-check) in
.../src/lib/server/content-check.test.ts. Does the file exist?

 FAIL  src/routes/api/v1/brands/[slug]/content/check/server.test.ts [ ... ]
Error: Failed to load url ./+server (resolved id: ./+server) in
.../src/routes/api/v1/brands/[slug]/content/check/server.test.ts. Does the file exist?

 Test Files  2 failed (2)
      Tests  no tests
```
</details>

**33 new tests** (24 service, 9 route) plus 2 contract-registry tests and 1 MCP tool test. They
cover: a caption the existing publish gate already rejects is rejected here too and by the same
rule; a healthy caption passes; the over-limit error naming the platform, the limit and the field;
per-platform captions read on the copy each platform would actually publish; `need_media` /
`need_video` / `reddit_title` / `media_not_found` / `no_platforms` each naming its field; an
unreadable and a past date; a taken slot as a *warning*, not a block; determinism (same spec twice,
identical scores); versions in every response; **no model call and no credit debit**; and
unauthenticated / inaccessible brand / already-denied caller through the existing auth contract.

The no-model assertion spies both entry points — `structured` from `$lib/server/research` **and**
`llmStructured` from `$lib/server/llm` (the one actually in this route's import graph, via
`prepublish-check`) — plus `gateAiAction` and `gateCredits`.

```
$ npx vitest run src/lib/server/content-check.test.ts \
    "src/routes/api/v1/brands/[slug]/content/check/server.test.ts" \
    packages/api-contracts/src/index.test.ts src/lib/server/manual-posting.test.ts \
    "src/routes/api/v1/brands/[slug]/posts/server.create.test.ts" \
    src/lib/server/prepublish-check.test.ts

 ✓ src/lib/server/prepublish-check.test.ts (18 tests)
 ✓ src/lib/server/content-check.test.ts (24 tests)
 ✓ src/routes/api/v1/brands/[slug]/content/check/server.test.ts (9 tests)
 ✓ src/routes/api/v1/brands/[slug]/posts/server.create.test.ts (22 tests)
 ✓ src/lib/server/manual-posting.test.ts (10 tests)
 Test Files  6 passed (6)
      Tests  98 passed (98)

$ npm run test:unit
 Test Files  581 passed | 3 skipped (584)
      Tests  6430 passed | 11 skipped (6441)

$ cd cli && bun test
 31 pass / 0 fail / 77 expect() calls

$ cd cli && bun run typecheck
$ tsc --noEmit          # clean

$ git diff --check      # clean
```

`npm run check` reports **378 errors repo-wide, all pre-existing**. Proof that none are mine — the
55 files carrying those errors intersected with the 21 files this PR touches:

```
$ comm -12 <errors-by-file> <git diff dev --name-only>
(empty)
```

**What was NOT run, and why**

- **No browser verification, no local-stack login.** This PR adds no UI: the surface is one REST
  endpoint and one MCP tool. The `.env` in this worktree points at hosted Supabase, and repointing
  it at the local stack plus seeding a user only to re-derive what the route tests already assert
  was not worth it. I did start the dev server and hit the real route over HTTP — see Evidence — but
  that proves routing and the auth contract, not an authenticated end-to-end call.
- **`npm run eval:ux` was not run.** The tool surface changed, so the plan asks for it before merge.
  Reporting it as **unrun**, not green.

## Evidence (screenshots/videos)

<details><summary>The route is live and answers through the real auth contract (dev server, port 5199)</summary>

```
$ curl -s -X POST "http://localhost:5199/api/v1/brands/demo/content/check" \
    -H "Content-Type: application/json" \
    --data-raw '{"platforms":["linkedin"],"caption":"ciao"}'
{"error":"Missing or invalid Authorization header"}
HTTP 401
```
</details>

<details><summary>Real reports from the service — bad spec, good spec, and an honest gap</summary>

Errors, warnings, versions and the three weakest weighted checks, verbatim from
`checkContent` (full twelve-check payload elided for length).

**A spec that fails: placeholder copy, Instagram with no asset, a taken slot**

```json
{
  "ok": false,
  "errors": [
    { "code": "caption_placeholder", "field": "caption",
      "detail": "The caption is a placeholder or carries no words of its own" },
    { "code": "need_media", "field": "media_ids",
      "detail": "Instagram cannot publish text alone: attach at least one asset" }
  ],
  "warnings": [
    { "code": "calendar_conflict", "field": "scheduled_for",
      "detail": "2030-05-16T07:00 is already taken by a1b2c3d4-0000-0000-0000-000000000001" }
  ],
  "scores": [
    { "platform": "instagram", "index": 60.7, "weakest": [
      { "id": "hook_strength", "value": 0.4, "weight": 18, "note": "hook generico, nessun segnale" },
      { "id": "specificity",   "value": 0,   "weight": 10, "note": "poco concreto (0 numeri, 0 nomi propri)" },
      { "id": "cta",           "value": 0,   "weight": 9,  "note": "nessuna CTA riconoscibile" } ] },
    { "platform": "x", "index": 64.2, "weakest": [ "… same three …" ] }
  ],
  "versions": { "rules": 1, "scorer": 3 }
}
```

**A spec that passes** — note the scorer still earns its keep: it flags a percentage asserted as
measured with no source, without blocking.

```json
{
  "ok": true,
  "errors": [],
  "warnings": [],
  "scores": [
    { "platform": "linkedin", "index": 87.5, "weakest": [
      { "id": "hook_strength",    "value": 0.55, "weight": 18, "note": "numero" },
      { "id": "proof_discipline", "value": 0.55, "weight": 6,
        "note": "\"22%\" è presentato come dato misurato ma la frase non dice da dove viene. O si cita la fonte, o si scrive [NEED: fonte del dato]." } ] }
  ],
  "versions": { "rules": 1, "scorer": 3 }
}
```

**A `[NEED: …]` marker** — the generator being honest about a number it was never given. Blocking,
and the message says to supply the fact rather than delete the marker, because deleting it turns an
honest gap back into an unsupported claim.

```json
{
  "ok": false,
  "errors": [
    { "code": "caption_needs_proof", "field": "caption",
      "detail": "Supply the facts these markers are waiting for, never delete them: percentuale reale" }
  ],
  "versions": { "rules": 1, "scorer": 3 }
}
```
</details>

<details><summary>The MCP tool appears from the registry, no hand-written block</summary>

`cli/mcp/create-post.test.ts`, asserting against the live `tools/list` response:

```
test('check_content compare da solo e si dichiara gratuito e senza modello')
  properties → caption, media_ids, platform_captions, platforms, scheduled_for, slug, title
  required   → caption, platforms, slug
  destructiveHint → false
  description contains 'spends no credits'

 31 pass  0 fail
```
</details>

## Anything Else?

- **`CONTENT_CHECK_RULES_VERSION` starts at 1** and must be bumped when a rule is added, removed, or
  moves between blocking and warning. It sits next to `CONTENT_SCORER_VERSION`, which already
  carries that discipline for the score; two verdicts compare only when both match.
- **`check_content` is the repo's first POST that computes without writing**, and it breaks an
  assumption the auth layer encodes. `resolveCaller` carries this comment:

  ```ts
  // Write scope, enforced once here instead of per-route: a read-only key may only ever read.
  // Every mutating CLI route is a non-GET, so the method is the whole check.
  ```

  "Every mutating route is a non-GET" is still true. What is no longer true is the converse the
  rule leans on — that every non-GET mutates. The consequence is a read-only key being refused an
  endpoint that writes nothing. Fixing it properly means letting an endpoint declare whether it
  writes instead of inferring it from the method, which touches every route in the repo; that is a
  separate decision with a much wider blast radius and is deliberately **not** made here. It is
  written down so whoever makes it knows this endpoint is waiting on it.
- **A test in the first revision of this PR asserted the opposite** — read-only key, `200` — and
  passed only because `authenticate` was mocked. It asserted a state production cannot produce, so
  it could never fail, and meanwhile told the next reader the opposite of the truth. Replaced with
  one that pins the real behaviour: given the verdict the upstream actually produces, the route
  returns that `403` and computes nothing. The general lesson is recorded in `LESSONS.md`.
- **Composition drift is a real risk.** `check_content` decides on its own that empty / placeholder
  / `[NEED:]` block. If `prepublish-check` later adds a caption rule, this endpoint will not inherit
  it. The alternative — synthesising a fake post row to feed `deterministicPrepublishIssues` — would
  have duplicated `reddit_title` and `need_video` and fabricated media URLs to satisfy a gate built
  for stored rows. Shared **predicates**, local composition, was the smaller wrong.
- **`self_repetition` costs one query.** The check is meaningless without neighbours, so the brand's
  recent posts are loaded (the existing `getPosts`) and the same rows also feed the calendar-clash
  check. One query, two uses.
- **Follow-ups**: `get_creation_kit` (the other half of step 2), `assertRedditCraft`'s self-promo
  warning, brand hashtag preferences, and a rubric check if a single-post rubric rule is ever
  defined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
