### PR TITLE
Tell a broken media pipeline from a wrong id

### DIFF
--- a/changelog/2026-09-03-external-agent-media.md
+++ b/changelog/2026-09-03-external-agent-media.md
@@ -49,6 +49,12 @@ Nessun blocco `registerTool` scritto a mano, nessun tipo ricopiato in `cli/lib/a
 Il tetto di 8 media resta un taglio silenzioso: la UI non limita i file selezionati, quindi
 trasformarlo in errore romperebbe a distanza chi ne carica nove. Resta com'era.
 
+> **Correzione — vedi `2026-09-03-media-failure-is-ours.md`.** La frase sopra vale solo per il
+> manual posting dalla UI, dove `resolveMediaUrls` taglia a 8 in silenzio. Sul contratto esterno
+> non c'è nessun taglio: `media_ids` porta `.max(8)` in zod, quindi il nono id fa fallire tutta
+> la richiesta con `invalid_input` prima ancora di arrivare al servizio. Due percorsi, due
+> comportamenti: uno tronca, l'altro rifiuta.
+
 ## Fuori da questo giro
 
 `import_media_url` — la slice 4 — ha una superficie di sicurezza sua (reti private, redirect,

--- a/changelog/2026-09-03-media-failure-is-ours.md
+++ b/changelog/2026-09-03-media-failure-is-ours.md
@@ -1,0 +1,68 @@
+# Un guasto nostro non si chiama `media_not_found`
+
+`create_post` aveva un solo modo di dire «il media non c'è», e lo usava per tre situazioni
+diverse: l'id è di un altro brand, l'id non esiste, oppure il media **è di questo brand** e siamo
+noi a non essere riusciti a firmarlo, scaricarlo e ricaricarlo.
+
+Le prime due sono deliberatamente indistinguibili e restano tali: dire quale delle due è
+sarebbe un modo per sondare gli id altrui, e `findBrandMediaByIds` lo dichiara. La terza no: è un
+guasto nostro travestito da errore del chiamante.
+
+## Cosa ha mostrato la sessione vera
+
+Con lo Storage locale rotto, un modello esterno ha chiesto un post con un media suo e si è preso
+`400 media_not_found`. Un 400 dice «quello che mi hai dato è sbagliato», quindi il modello ha
+fatto l'unica cosa sensata data quella risposta: ha corretto. Ha provato altri id della libreria,
+poi un prefisso più corto, poi un'altra piattaforma — sei tentativi, nessuno dei quali poteva
+funzionare, perché lo Storage non avrebbe servito nessun byte a nessuna richiesta.
+
+Per un agente la confusione fra le due classi non è un fastidio estetico, è un moltiplicatore di
+costo. Un umano davanti a un 400 opaco si ferma e apre un ticket; un agente **riprova**, e ogni
+riprova è un turno pagato. Uno status dice quanto vale insistere: 4xx significa cambia qualcosa,
+5xx significa non sei tu, torna dopo.
+
+## La distinzione, in un posto solo
+
+`resolveMediaUrls` tornava già un risultato taggato. Il tag adesso porta due esiti invece di uno:
+
+- `media_not_found` (400) — l'id non è di questo brand. Percorso di upload fuori dalla cartella
+  di chi chiama, id di un altro brand, id inesistente: tutti indistinguibili fra loro, per
+  costruzione.
+- `media_unavailable` (502) — il media è di questo brand e `publishLibraryMediaAsPostMedia` non
+  ce l'ha fatta. La pipeline media è una dipendenza a valle: 502 è la classe onesta.
+
+Niente condizione nuova alla chiamata né nella route. La tabella che decide gli status è sempre
+`CREATE_POST.failures`, e la route continua a passare da `statusForFailure`: aggiungere l'esito è
+stata una riga in quella tabella. Le due costanti `NOT_THIS_CALLERS_MEDIA` e
+`MEDIA_PIPELINE_BROKEN` esistono perché il nome dica di chi è la colpa nel punto in cui si
+decide, senza un commento che lo spieghi.
+
+La descrizione del tool dice adesso cosa significano i due esiti, perché è l'unica cosa che il
+modello dall'altra parte legge davvero.
+
+## L'asimmetria dei prefissi, dichiarata invece che risolta
+
+Un id di post si può passare come prefisso non ambiguo (`resolvePostId`); un id media no. Il
+modello della sessione vera ha provato anche quello, e si è preso lo stesso rifiuto opaco.
+
+Aggiungere la risoluzione per prefisso ai media sarebbe una feature, con una sua superficie
+(collisioni, quale errore quando il prefisso è ambiguo) e merita di essere letta da sola. Qui la
+scelta è stata rendere onesto il contratto: `media_ids` dichiara che vuole id interi da
+`list_media`, e i docs lo ripetono. Costa una frase invece di una feature, e toglie al modello
+esattamente il tentativo che ha sprecato.
+
+## Correzione a `2026-09-03-external-agent-media.md`
+
+Quella entry dice che il tetto di 8 media «resta un taglio silenzioso». Vale solo per il manual
+posting dalla UI, dove `resolveMediaUrls` tronca a 8. Sul contratto esterno il nono id fa fallire
+tutta la richiesta con `invalid_input`, perché `media_ids` porta `.max(8)` in zod e la route
+valida prima di chiamare il servizio. Un percorso tronca, l'altro rifiuta; la nota è stata
+aggiunta in fondo a quella entry invece di riscrivere la storia.
+
+## Cosa non è stato provato
+
+Il guasto vero — Storage giù, byte non scaricabili, upload rifiutato — non è riproducibile su
+questa macchina: lo Storage locale di Supabase è rotto di suo (xattr non supportato sul bind
+mount). I test forzano il fallimento dal seam già mockato (`publishLibraryMediaAsPostMedia`), che
+è il confine dove la distinzione viene decisa. Non è una riproduzione end-to-end e non viene
+spacciata per tale.

--- a/cli/lib/contracts/content.ts
+++ b/cli/lib/contracts/content.ts
@@ -16,7 +16,10 @@ const CheckContentInputSchema = z
       .array(z.string().min(1))
       .max(8)
       .optional()
-      .describe('Ids from this brand media library (see list_media). An id that is not this brand is reported'),
+      .describe(
+        'Full ids from this brand media library (see list_media) — unlike a post id, a media id ' +
+          'is never resolved from a prefix. An id that is not this brand is reported'
+      ),
     title: z.string().optional().describe('Required for Reddit'),
     scheduled_for: z
       .string()

--- a/cli/lib/contracts/posts.ts
+++ b/cli/lib/contracts/posts.ts
@@ -43,8 +43,9 @@ const CreatePostInputSchema = z.object({
     .max(8)
     .optional()
     .describe(
-      'Ids from this brand media library (see list_media). An id that is not this brand is ' +
-        'rejected: the post is never quietly created without it'
+      'Full ids from this brand media library (see list_media) — unlike a post id, a media id ' +
+        'is never resolved from a prefix. An id that is not this brand is rejected: the post is ' +
+        'never quietly created without it. At most 8: a ninth is refused, not dropped'
     ),
   title: z.string().optional().describe('Required for Reddit'),
   subreddit: z.string().optional(),
@@ -71,7 +72,11 @@ export const CREATE_POST = {
     'Store copy you already wrote as one pending post for review. Anomalia calls no model and ' +
     'spends no credits. It does not publish and does not schedule: `scheduled_for` is the ' +
     'proposed calendar time, and approve_post remains the action that authorizes distribution. ' +
-    'Text-capable platforms only — instagram and tiktok need an image, youtube needs a video.',
+    'Text-capable platforms only — instagram and tiktok need an image, youtube needs a video. ' +
+    'Two different media failures: `media_not_found` (400) means the id is not this brand — ' +
+    'check it with list_media, and pass the full id, never a prefix; `media_unavailable` (502) ' +
+    'means the id is yours and Anomalia could not attach it, so retrying other ids is wasted ' +
+    'work — retry later or leave the media out.',
   method: 'POST',
   pathUnderBrand: '/posts',
   input: CreatePostInputSchema,
@@ -85,7 +90,8 @@ export const CREATE_POST = {
     { error: 'reddit_title', status: 400 },
     { error: 'too_soon', status: 400 },
     { error: 'invalid_scheduled_for', status: 400 },
-    { error: 'media_not_found', status: 400 }
+    { error: 'media_not_found', status: 400 },
+    { error: 'media_unavailable', status: 502 }
   ],
   destructive: false
 } satisfies BrandEndpoint;

--- a/cli/plugins/anomalia/skills/anomalia/references/tools.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/tools.md
@@ -38,8 +38,14 @@ All tools take a brand `slug` when brand-scoped. Ids accept short unambiguous pr
 | `make_video` | `anomalia post <slug> <id> video …` |
 
 `list_media` lists what is already in the brand library; an id from there goes into `create_post`
-as `media_ids` and costs no render. A media id that is not this brand's stops the creation —
-the post is never made without it.
+as `media_ids` and costs no render. Pass the **full** id: unlike a post id, a media id is never
+resolved from a prefix. A media id that is not this brand's stops the creation — the post is
+never made without it.
+
+The two media failures of `create_post` mean opposite things. `media_not_found` (400) is yours:
+the id is not this brand's, so check it against `list_media`. `media_unavailable` (502) is ours:
+the media is this brand's and we could not attach it. Trying other ids, a shorter id or another
+platform changes nothing — retry later, or create the post without the media.
 
 `create_post` stores copy **you** wrote: Anomalia calls no model and spends no credits. It does
 not publish and does not schedule — `scheduled_for` is the proposed calendar time and stays a

--- a/cli/skills/anomalia/references/tools.md
+++ b/cli/skills/anomalia/references/tools.md
@@ -38,8 +38,14 @@ All tools take a brand `slug` when brand-scoped. Ids accept short unambiguous pr
 | `make_video` | `anomalia post <slug> <id> video …` |
 
 `list_media` lists what is already in the brand library; an id from there goes into `create_post`
-as `media_ids` and costs no render. A media id that is not this brand's stops the creation —
-the post is never made without it.
+as `media_ids` and costs no render. Pass the **full** id: unlike a post id, a media id is never
+resolved from a prefix. A media id that is not this brand's stops the creation — the post is
+never made without it.
+
+The two media failures of `create_post` mean opposite things. `media_not_found` (400) is yours:
+the id is not this brand's, so check it against `list_media`. `media_unavailable` (502) is ours:
+the media is this brand's and we could not attach it. Trying other ids, a shorter id or another
+platform changes nothing — retry later, or create the post without the media.
 
 `create_post` stores copy **you** wrote: Anomalia calls no model and spends no credits. It does
 not publish and does not schedule — `scheduled_for` is the proposed calendar time and stays a

--- a/docs/api/03-posts.md
+++ b/docs/api/03-posts.md
@@ -68,7 +68,7 @@ Senza media valgono solo le piattaforme che reggono il testo da solo: `facebook`
 | `caption` | string | Sì | La copy, salvata così com'è |
 | `platform_captions` | object | No | Override per piattaforma, `{"x": "…"}` |
 | `scheduled_for` | string | No | Istante proposto, ISO. Senza offset è letto sul fuso del brand; con `Z` o `±hh:mm` è preso come scritto. Almeno 2 minuti nel futuro |
-| `media_ids` | string[] | No | Fino a 8 id dalla libreria del brand (`GET /media`). Un id che non è di questo brand fa fallire la creazione: il post non nasce mai senza |
+| `media_ids` | string[] | No | Fino a 8 id **interi** dalla libreria del brand (`GET /media`): a differenza di un id di post, un id media non si risolve da un prefisso. Un id che non è di questo brand fa fallire la creazione: il post non nasce mai senza. Il nono id è rifiutato (`invalid_input`), non scartato |
 | `title` | string | No | Obbligatorio per Reddit (max 300 char) |
 | `subreddit` | string | No | Senza `r/` |
 | `link_url` | string | No | |
@@ -103,8 +103,9 @@ post resta una bozza senza data, fuori dal calendario ma elencata da `GET /posts
 | `400` | `{"error":"reddit_title"}` |
 | `400` | `{"error":"invalid_scheduled_for","details":"…"}` — data illeggibile |
 | `400` | `{"error":"too_soon"}` — data passata o troppo vicina |
-| `400` | `{"error":"media_not_found"}` — un id media non è di questo brand, o non si è potuto copiare |
+| `400` | `{"error":"media_not_found"}` — un id media non è di questo brand (o non esiste: le due cose non si distinguono). Colpa di chi chiama: l'id va corretto |
 | `403` | `{"error":"API key is read-only"}` |
+| `502` | `{"error":"media_unavailable"}` — il media è di questo brand ma non siamo riusciti ad allegarlo. Guasto nostro: riprovare con altri id non serve |
 
 **Esempio**:
 

--- a/packages/api-contracts/src/content.ts
+++ b/packages/api-contracts/src/content.ts
@@ -16,7 +16,10 @@ const CheckContentInputSchema = z
       .array(z.string().min(1))
       .max(8)
       .optional()
-      .describe('Ids from this brand media library (see list_media). An id that is not this brand is reported'),
+      .describe(
+        'Full ids from this brand media library (see list_media) — unlike a post id, a media id ' +
+          'is never resolved from a prefix. An id that is not this brand is reported'
+      ),
     title: z.string().optional().describe('Required for Reddit'),
     scheduled_for: z
       .string()

--- a/packages/api-contracts/src/index.test.ts
+++ b/packages/api-contracts/src/index.test.ts
@@ -58,6 +58,12 @@ describe('il registry degli endpoint di brand', () => {
     expect(statusForFailure(createPost, 'insert_failed')).toBe(500);
   });
 
+  it('un guasto della pipeline media non è colpa di chi chiama: 5xx, non 400', () => {
+    const createPost = byTool('create_post');
+    expect(statusForFailure(createPost, 'media_not_found')).toBe(400);
+    expect(statusForFailure(createPost, 'media_unavailable')).toBe(502);
+  });
+
   it('create_post accetta la copy e rifiuta una richiesta senza piattaforme', () => {
     const { input } = byTool('create_post');
     expect(input.safeParse({ platforms: ['linkedin'], caption: 'ciao' }).success).toBe(true);

--- a/packages/api-contracts/src/posts.ts
+++ b/packages/api-contracts/src/posts.ts
@@ -43,8 +43,9 @@ const CreatePostInputSchema = z.object({
     .max(8)
     .optional()
     .describe(
-      'Ids from this brand media library (see list_media). An id that is not this brand is ' +
-        'rejected: the post is never quietly created without it'
+      'Full ids from this brand media library (see list_media) — unlike a post id, a media id ' +
+        'is never resolved from a prefix. An id that is not this brand is rejected: the post is ' +
+        'never quietly created without it. At most 8: a ninth is refused, not dropped'
     ),
   title: z.string().optional().describe('Required for Reddit'),
   subreddit: z.string().optional(),
@@ -71,7 +72,11 @@ export const CREATE_POST = {
     'Store copy you already wrote as one pending post for review. Anomalia calls no model and ' +
     'spends no credits. It does not publish and does not schedule: `scheduled_for` is the ' +
     'proposed calendar time, and approve_post remains the action that authorizes distribution. ' +
-    'Text-capable platforms only — instagram and tiktok need an image, youtube needs a video.',
+    'Text-capable platforms only — instagram and tiktok need an image, youtube needs a video. ' +
+    'Two different media failures: `media_not_found` (400) means the id is not this brand — ' +
+    'check it with list_media, and pass the full id, never a prefix; `media_unavailable` (502) ' +
+    'means the id is yours and Anomalia could not attach it, so retrying other ids is wasted ' +
+    'work — retry later or leave the media out.',
   method: 'POST',
   pathUnderBrand: '/posts',
   input: CreatePostInputSchema,
@@ -85,7 +90,8 @@ export const CREATE_POST = {
     { error: 'reddit_title', status: 400 },
     { error: 'too_soon', status: 400 },
     { error: 'invalid_scheduled_for', status: 400 },
-    { error: 'media_not_found', status: 400 }
+    { error: 'media_not_found', status: 400 },
+    { error: 'media_unavailable', status: 502 }
   ],
   destructive: false
 } satisfies BrandEndpoint;

--- a/src/lib/content/changelog/2026-09-03-media-failure-is-ours.ts
+++ b/src/lib/content/changelog/2026-09-03-media-failure-is-ours.ts
@@ -1,0 +1,12 @@
+import type { ChangelogEntry } from './index';
+
+const entry: ChangelogEntry = {
+  date: '2026-09-03',
+  title: 'When an asset cannot be attached, we say so',
+  items: [
+    'If Anomalia cannot attach a photo or video your AI picked, it now says the fault is ours instead of implying the asset was wrong. Your AI stops and tells you, rather than burning turns trying other assets that could never have worked.',
+    'An asset that really is not yours still comes back as a plain rejection, and the post is never created without it.'
+  ]
+};
+
+export default entry;

--- a/src/lib/server/manual-posting.test.ts
+++ b/src/lib/server/manual-posting.test.ts
@@ -190,7 +190,26 @@ describe('createManualPost con media della libreria', () => {
     expect(publishLibraryMediaAsPostMedia).not.toHaveBeenCalled();
   });
 
-  it('un media che esiste ma non si riesce a copiare non diventa un post senza immagine', async () => {
+  it('un id malformato non si distingue da un id di un altro brand', async () => {
+    findBrandMediaByIds.mockResolvedValue([]);
+
+    const { result: altroBrand } = await create({
+      platforms: ['linkedin'],
+      caption: 'copy',
+      libraryIds: ['media-di-un-altro-brand'],
+      mode: 'propose'
+    });
+    const { result: malformato } = await create({
+      platforms: ['linkedin'],
+      caption: 'copy',
+      libraryIds: ['%%%'],
+      mode: 'propose'
+    });
+
+    expect(malformato).toEqual(altroBrand);
+  });
+
+  it('un media che esiste ma che non riusciamo a materializzare è un guasto nostro, non un id sbagliato', async () => {
     publishLibraryMediaAsPostMedia.mockResolvedValue({ error: 'Upload of library media failed' });
 
     const { result, rows } = await create({
@@ -200,7 +219,7 @@ describe('createManualPost con media della libreria', () => {
       mode: 'propose'
     });
 
-    expect(result).toEqual({ ok: false, error: 'media_not_found' });
+    expect(result).toEqual({ ok: false, error: 'media_unavailable' });
     expect(rows).toEqual([]);
   });
 

--- a/src/lib/server/manual-posting.ts
+++ b/src/lib/server/manual-posting.ts
@@ -179,15 +179,15 @@ function slotAt(iso: string, tz: string): string {
   return `${dow} ${time}`;
 }
 
+export type MediaFailure = 'media_not_found' | 'media_unavailable';
+
 type ResolvedMedia =
   | { ok: true; urls: string[]; video: boolean }
-  | { ok: false; error: 'media_not_found' };
+  | { ok: false; error: MediaFailure };
 
-/**
- * Un media che il chiamante ha indicato e che non si risolve ferma la creazione. Veniva saltato
- * in silenzio: l'id di un altro brand diventava una bozza senza immagine che nessuno aveva
- * chiesto, e su Instagram un `need_media` che sembrava colpa di chi chiedeva.
- */
+const NOT_THIS_CALLERS_MEDIA: ResolvedMedia = { ok: false, error: 'media_not_found' };
+const MEDIA_PIPELINE_BROKEN: ResolvedMedia = { ok: false, error: 'media_unavailable' };
+
 async function resolveMediaUrls(
   supabase: SupabaseClient,
   userId: string,
@@ -200,9 +200,9 @@ async function resolveMediaUrls(
 
   for (const raw of paths.slice(0, MAX_MEDIA)) {
     const path = String(raw ?? '');
-    if (!path.startsWith(`${userId}/uploads/`)) return { ok: false, error: 'media_not_found' };
+    if (!path.startsWith(`${userId}/uploads/`)) return NOT_THIS_CALLERS_MEDIA;
     const publicUrl = supabase.storage.from('media').getPublicUrl(path).data.publicUrl;
-    if (!publicUrl) return { ok: false, error: 'media_not_found' };
+    if (!publicUrl) return NOT_THIS_CALLERS_MEDIA;
     urls.push(publicUrl);
     if (/\.(mp4|webm|mov)(\?|$)/i.test(path)) video = true;
   }
@@ -215,14 +215,14 @@ async function resolveMediaUrls(
   );
   for (const id of wanted) {
     const media = owned.get(id);
-    if (!media) return { ok: false, error: 'media_not_found' };
+    if (!media) return NOT_THIS_CALLERS_MEDIA;
     const copied = await publishLibraryMediaAsPostMedia(supabase, {
       brandId,
       userId,
       mediaId: id,
       kind: media.kind
     });
-    if (!('publicUrl' in copied) || !copied.publicUrl) return { ok: false, error: 'media_not_found' };
+    if (!('publicUrl' in copied) || !copied.publicUrl) return MEDIA_PIPELINE_BROKEN;
     urls.push(copied.publicUrl);
     if (media.kind === 'video') video = true;
   }

--- a/src/routes/api/v1/brands/[slug]/posts/server.create.test.ts
+++ b/src/routes/api/v1/brands/[slug]/posts/server.create.test.ts
@@ -237,6 +237,35 @@ describe('POST /api/v1/brands/:slug/posts', () => {
     expect(rows).toEqual([]);
   });
 
+  it('un id malformato torna lo stesso 400 di un id altrui, senza rivelare la differenza', async () => {
+    findBrandMediaByIds.mockResolvedValue([]);
+
+    const { res, body, rows } = await call({
+      platforms: ['instagram'],
+      caption: 'copy',
+      media_ids: ['%%%']
+    });
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('media_not_found');
+    expect(rows).toEqual([]);
+  });
+
+  it('un media suo che non riusciamo a materializzare torna 502, non un 400 che accusa chi chiama', async () => {
+    findBrandMediaByIds.mockResolvedValue([{ id: 'asset-1', kind: 'image' }]);
+    publishLibraryMediaAsPostMedia.mockResolvedValue({ error: 'Upload of library media failed' });
+
+    const { res, body, rows } = await call({
+      platforms: ['instagram'],
+      caption: 'copy',
+      media_ids: ['asset-1']
+    });
+
+    expect(res.status).toBe(502);
+    expect(body.error).toBe('media_unavailable');
+    expect(rows).toEqual([]);
+  });
+
   it('un media della libreria sblocca instagram, che da sola la copy non regge', async () => {
     findBrandMediaByIds.mockResolvedValue([{ id: 'asset-1', kind: 'image' }]);
     publishLibraryMediaAsPostMedia.mockResolvedValue({


### PR DESCRIPTION
## What?

`create_post` had one way of saying "the media is not there", and used it for three different
situations: the id belongs to another brand, the id matches nothing, and the media **is this
brand's** but we failed to sign, download and re-upload the bytes.

The third one now has its own outcome, distinct in name and in class:

| Outcome | Status | Meaning |
|---|---|---|
| `media_not_found` | `400` | The id is not this brand's (or does not exist — the two stay indistinguishable). The caller's input is wrong. |
| `media_unavailable` | `502` | The media *is* this brand's and Anomalia could not attach it. Our downstream failure. |

Two smaller corrections ride along: the contract now states that `media_ids` needs **full** ids
from `list_media` (a media id is never resolved from a prefix, unlike a post id), and the
internal changelog entry that shipped the eight-media cap is corrected — it truncates on one
path and rejects on the other.

## Why?

Cases 1 and 2 are indistinguishable on purpose, and must stay that way: telling them apart would
let a caller probe another brand's ids. `findBrandMediaByIds` says so where the property lives,
and a test holds it.

Case 3 is the defect. A `400` says *what you gave me is wrong*, so a caller that gets one
corrects its input. In a real run against a broken local Storage, an external model asked for a
post with an asset that was genuinely its own, got `400 media_not_found`, and did the only
sensible thing that answer allowed — it corrected. **It tried other library ids, then a shorter
prefix, then a different platform. Six recovery attempts, against a Storage that could not have
served a single byte to any of them.**

For an agent, conflating our failure with the caller's is not cosmetic, it is a cost multiplier.
A human facing an opaque 400 stops and files a ticket; an agent **retries**, and every retry is a
paid turn. The status class is what says whether insisting is worth anything: 4xx means change
something, 5xx means it is not you, come back later.

The prefix asymmetry fed the same loop. Post ids accept an unambiguous prefix (`resolvePostId`);
media ids do not, and nothing in the contract said so — so the model spent one of its six
attempts there. Adding prefix resolution for media is a feature with its own surface (collisions,
what error an ambiguous prefix returns) and deserves a PR that can be read on its own. **I do not
think it belongs here.** What belongs here is a contract that stops implying it exists.

## How?

`resolveMediaUrls` already returned a small tagged result, so the distinction was extended there
rather than added at the call site or in the route:

```ts
export type MediaFailure = 'media_not_found' | 'media_unavailable';

type ResolvedMedia =
  | { ok: true; urls: string[]; video: boolean }
  | { ok: false; error: MediaFailure };

const NOT_THIS_CALLERS_MEDIA: ResolvedMedia = { ok: false, error: 'media_not_found' };
const MEDIA_PIPELINE_BROKEN: ResolvedMedia = { ok: false, error: 'media_unavailable' };
```

The two constants exist so the name says *whose fault it is* at the point where it is decided,
without a comment explaining it. Neither `createManualPost` nor `+server.ts` grew a branch: the
route still maps through `statusForFailure`, and `CREATE_POST.failures` stays the single table
that assigns a status to an outcome — the new outcome is one row in it.

`502` over `500`: the media pipeline (Storage sign → fetch → re-upload) is a downstream
dependency, which is exactly what 502 is for, and it distinguishes the failure from an internal
error the caller could not classify.

The `CREATE_POST` description now spells out what each outcome means, because that description is
the only thing the model on the other side reads. Same for the `media_ids` field description
(full ids, and a ninth id is refused rather than dropped).

Rejected: a boolean `retryable` flag next to the existing error. It would have left the status at
400, and the status is precisely the part an agent reads before deciding to retry.

The doc comment above `resolveMediaUrls` was removed. The rule in `AGENTS.md` is that this
knowledge lives in names and test names, and it does: `NOT_THIS_CALLERS_MEDIA`,
`MEDIA_PIPELINE_BROKEN`, and `un media che esiste ma che non riusciamo a materializzare è un
guasto nostro, non un id sbagliato`.

## Testing?

Test first, watched fail, then the fix. The red:

<details>
<summary><code>npx vitest run …</code> — 3 failed, before the fix</summary>

```
 FAIL  src/lib/server/manual-posting.test.ts > createManualPost con media della libreria > un media che esiste ma che non riusciamo a materializzare è un guasto nostro, non un id sbagliato
AssertionError: expected { ok: false, error: 'media_not_found' } to deeply equal { ok: false, …(1) }

- Expected
+ Received

  Object {
-   "error": "media_unavailable",
+   "error": "media_not_found",
    "ok": false,
  }

 ❯ src/lib/server/manual-posting.test.ts:222:20
    222|     expect(result).toEqual({ ok: false, error: 'media_unavailable' });
       |                    ^

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/3]⎯

 FAIL  src/routes/api/v1/brands/[slug]/posts/server.create.test.ts > POST /api/v1/brands/:slug/posts > un media suo che non riusciamo a materializzare torna 502, non un 400 che accusa chi chiama
AssertionError: expected 400 to be 502 // Object.is equality

- Expected
+ Received

- 502
+ 400

 ❯ src/routes/api/v1/brands/[slug]/posts/server.create.test.ts:264:24
    264|     expect(res.status).toBe(502);
       |                        ^

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/3]⎯

 FAIL  packages/api-contracts/src/index.test.ts > il registry degli endpoint di brand > un guasto della pipeline media non è colpa di chi chiama: 5xx, non 400
AssertionError: expected 500 to be 502 // Object.is equality

- Expected
+ Received

- 502
+ 500

 ❯ packages/api-contracts/src/index.test.ts:64:63
     64|     expect(statusForFailure(createPost, 'media_unavailable')).toBe(502…
       |                                                               ^

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/3]⎯

 Test Files  3 failed | 1 passed (4)
      Tests  3 failed | 48 passed (51)
```

</details>

What the tests cover, at both seams:

- **service** — another brand's id → `media_not_found`, no row inserted, and
  `publishLibraryMediaAsPostMedia` never called;
- **service** — a malformed id produces a result *deeply equal* to the other-brand one, so the
  indistinguishability is asserted rather than assumed;
- **service** — a media that exists and belongs to the brand whose materialization fails →
  `media_unavailable`, no row inserted;
- **service** — the happy paths (library image on Instagram, library video on YouTube, the
  `kind` passed through) unchanged;
- **REST** — the three map to `400 media_not_found`, `400 media_not_found`, `502
  media_unavailable`, each with an empty `rows` array;
- **contract** — `statusForFailure(create_post, 'media_unavailable') === 502` while
  `media_not_found` stays 400, plus the pre-existing guard that an undeclared failure is 500.

<details>
<summary>Green, after the fix</summary>

```
 ✓ packages/api-contracts/src/index.test.ts (14 tests) 5ms
 ✓ src/routes/api/v1/brands/[slug]/posts/server.create.test.ts (24 tests) 23ms
 ✓ src/lib/server/manual-posting.test.ts (11 tests) 16ms
 ✓ src/routes/api/v1/brands/[slug]/posts/server.delete.test.ts (2 tests) 5ms

 Test Files  4 passed (4)
      Tests  51 passed (51)
```

</details>

<details>
<summary><code>npm run test:unit</code> — full suite, and the three failures that are not mine</summary>

On the branch as first written (base `452a994`) the suite was clean:

```
 Test Files  580 passed | 3 skipped (583)
      Tests  6400 passed | 11 skipped (6411)
```

After rebasing onto current `dev` (through #198 and #200) three files fail:

```
 Test Files  3 failed | 579 passed | 3 skipped (585)
      Tests  2 failed | 6397 passed | 48 skipped (6447)

 FAIL  src/lib/server/chat/brand-studio-tools.test.ts
 FAIL  src/lib/agent/bridge/live.test.ts > runKitTurn — resumeRunId … prende in carico la riga running con lease scaduta
 FAIL  src/lib/server/chat/motion-output-mount.test.ts > … inoltra remainingMs del turno al render
```

None is in a file this PR touches, and `LESSONS.md` §"La suite completa fallisce da sola" gives
the protocol, which was followed:

1. **Rerun the subset isolated.** `brand-studio-tools` and `live.test.ts` both pass — the two
   are the documented timing/race flakes under parallel-worker load (`live.test.ts` took 407s in
   the full run). The failing set also differed run to run, which a real defect does not do.
2. **Run it on pure dev, same setup.** `motion-output-mount.test.ts` fails in isolation too, so
   it went to `origin/dev` detached (`4d62a50`, no change of mine present):

```
 FAIL  src/lib/server/chat/motion-output-mount.test.ts > … inoltra remainingMs del turno al render
Error: Test timed out in 30000ms.

 Test Files  1 failed (1)
      Tests  1 failed (1)
```

Identical failure on clean `dev`. Pre-existing, and not this PR's to fix.

The subset that actually covers this change — including the sibling `check_content` suites from
\#198 — is green:

```
 ✓ packages/api-contracts/src/index.test.ts (16 tests)
 ✓ src/routes/api/v1/brands/[slug]/content/check/server.test.ts (9 tests)
 ✓ src/lib/server/content-check.test.ts (24 tests)
 ✓ src/routes/api/v1/brands/[slug]/posts/server.create.test.ts (24 tests)
 ✓ src/routes/api/v1/brands/[slug]/posts/server.delete.test.ts (2 tests)
 ✓ src/lib/server/manual-posting.test.ts (11 tests)

 Test Files  6 passed (6)
      Tests  86 passed (86)
```

</details>

<details>
<summary><code>npm run check</code> — 378 pre-existing errors, none in touched files</summary>

```
COMPLETED 10259 FILES 378 ERRORS 248 WARNINGS 174 FILES_WITH_PROBLEMS
```

Filtering the report for every file this PR touches returns no `ERROR` line. The only hits are
two pre-existing `WARNING`s in `src/routes/app/[brand]/manual-posting/+page.svelte` — the UI
page, which this PR does not touch (the changed file is `src/lib/server/manual-posting.ts`) —
and `src/lib/content/changelog/legacy.ts`, likewise untouched.

</details>

<details>
<summary><code>cd cli && bun test && bun run typecheck</code></summary>

```
 30 pass
 0 fail
 72 expect() calls
Ran 30 tests across 8 files. [553.00ms]

$ tsc --noEmit
```

`./cli/scripts/sync-contracts.sh` and `./cli/scripts/sync-plugin-skill.sh` both run; the guard
tests pass. `git diff --check` is clean.

</details>

**Not run, and not claimed.** The real failure — Storage down, bytes unfetchable, upload
rejected — is **not reproducible on this machine**: local Supabase Storage is itself broken here
(xattr unsupported on the bind mount). The tests force case 3 through the already-mocked
`publishLibraryMediaAsPostMedia` seam, which is the exact boundary where the distinction is
decided, and that is legitimate. It is not an end-to-end reproduction and is not presented as
one. No browser verification either: the change has no UI surface — the manual-posting page reads
the same `{ ok: false, error }` shape it always did, and an error string it does not enumerate
already falls through to its generic message. `npm run eval` was not run: this touches no prompt,
tool, model or chat path.

## Evidence (screenshots/videos)

No UI change, so no screenshots. The observable surface is the HTTP response, and the REST-seam
evidence is the route test output above: the same request shape returns `400 media_not_found`
when the id is not the brand's and `502 media_unavailable` when the pipeline fails, with no post
row written in either case.

## Anything Else?

- **Prefix resolution for `media_ids` is deliberately not built.** It is a feature, with
  collision semantics and an ambiguity error of its own. The contract and the docs now say the
  full id is required, which removes the wasted attempt without shipping the surface.
- **The upload-path branch is untouched.** `getPublicUrl` only builds a string; when it returns
  nothing the path itself is empty, which is the caller's input. It stays `media_not_found`.
- **`check_content` was checked for the same defect and does not have it.** It is the only other
  caller that resolves `media_ids`, but it stops at `findBrandMediaByIds` and never materializes
  bytes, so its `media_not_found` genuinely only covers the caller-fault case. Its `media_ids`
  description did carry the same prefix ambiguity, so it got the same one-line correction —
  leaving one of two identical fields honest is how a rule starts diverging.
- **The eight-media correction is a note appended to
  `changelog/2026-09-03-external-agent-media.md`**, not a rewrite of history: the original claim
  stays visible with the correction under it.
- The `media_unavailable` response carries no detail about *why* the pipeline failed. Deliberate:
  the caller cannot act on it, and the underlying error is already logged on our side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
