### PR TITLE
Lift the billing columns from brands to organizations

### DIFF
--- a/changelog/2026-09-03-org-billing-schema.md
+++ b/changelog/2026-09-03-org-billing-schema.md
@@ -1,0 +1,49 @@
+# Lo schema del billing sale di un livello, senza che nulla lo legga ancora
+
+Primo passo della migrazione a "un abbonamento per organization, brand illimitati, pool crediti
+condiviso" (mappa #183). Solo schema: nessun comportamento cambia finché il codice applicativo
+non lo usa, e quello arriva nei passi successivi.
+
+`organizations` guadagna `stripe_subscription_id`, `plan` e `activated_at` — stessi nomi e tipi
+che hanno su `brands`, così ogni lettore a valle mantiene la stessa forma. `stripe_customer_id`
+c'era già dalla 0001 e non l'aveva mai usato nessuno: ora è quello vero.
+
+**Il trigger diventa org-first, brand-fallback.** `sync_brand_from_stripe_subscription()` cerca
+prima un'organization con quel `stripe_customer_id`; se la trova scrive lì i campi di
+fatturazione e propaga lo `status` a tutti i brand dell'org (un abbonamento, tutti i brand lo
+seguono). Se non la trova, esegue l'update per-brand di prima, invariato. Non c'è un flag di
+stato della migrazione: "org migrata" significa `organizations.stripe_customer_id` valorizzato.
+I campi `stripe_*` e `plan` sui brand di un'org migrata restano **congelati** apposta — sono la
+rete di sicurezza del rollout org-per-org, e cadranno in una migration finale unica.
+
+Il `return NEW` dentro il ramo org non è cosmetico: senza, ogni webhook riscriverebbe anche le
+colonne congelate del brand, cioè proprio la rete di rollback. È l'invariante che
+`org-billing-schema.test.ts` pinna (verificata mutando la migration e guardando il test cadere).
+
+`credit_grants` accetta ora un `org_id` con `brand_id` nullable e un CHECK che ne imponga
+**esattamente uno**: un regalo va a un brand specifico (tracciabilità) o all'org intera. La
+policy RLS filtrava sul solo `brand_id`, quindi un grant org-level sarebbe stato invisibile a chi
+lo possiede — ora copre entrambi i casi.
+
+Due RPC gemelle di quelle per-brand: `org_billing_period` (0089) e `sum_org_ai_cost_usd` (0164),
+che somma la spesa di **tutti** i brand dell'org. Più `auth_org_ids()`, la metà org del choke
+point RLS che `auth_brand_ids()` copre per i brand.
+
+**Scartato: rinominare `brand_usage` in `org_usage`.** Il ticket la descriveva come la tabella
+del timestamp anti-spam, ma `brand_usage` è in realtà il contatore delle quote **post e video**
+per brand (`posts_count`, `videos_count`), letto da `usage.ts` e `cli-queries.ts` — e le quote
+post restano un concetto per-brand. Spostarla avrebbe cambiato una semantica che nessuno ha
+deciso di cambiare. Sale di livello solo il flag anti-spam dell'email all'80%, quindi ha una
+tabella sua, piccola: `org_usage (org_id, month, credits_warned_at)`. I `credits_warned_at`
+già presenti in `brand_usage` **non vengono migrati**: sono timestamp di email già spedite, e
+ripartire puliti costa al massimo un avviso duplicato nel periodo corrente.
+
+**Scartato: scrivere `organizations.activated_at` dall'onboarding.** Il ticket indicava
+`onboarding/+page.server.ts:328` come il punto che scrive `brands.activated_at`: quella riga
+scrive `editorial_plans.activated_at`. `brands.activated_at` non lo scrive nessun codice
+applicativo — solo il trigger Stripe. Quindi anche la versione org la scrive il trigger, con la
+stessa identica condizione (prima attivazione, mai più). Per un'org free resta `null` e
+`credits.ts` ricade sull'inizio del mese solare, esattamente come fa oggi per un brand free.
+
+**Scartato: il backfill di `activated_at` dai brand esistenti.** Popolare le colonne delle org
+già esistenti è il passo D (migrazione dati), non questo.

--- a/src/lib/server/org-billing-schema.test.ts
+++ b/src/lib/server/org-billing-schema.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+/**
+ * Step A of the org-level billing migration is pure SQL, so the invariants the follow-up steps
+ * (credits/gating, settings-actions, UI) will lean on live only in the migration file. These pin
+ * the three that break silently rather than loudly if someone edits it.
+ */
+const MIGRATION = readFileSync(
+	new URL('../../../supabase/migrations/20260903190000_org_billing_schema.sql', import.meta.url),
+	'utf8'
+);
+
+describe('org billing schema migration', () => {
+	it('syncs the org before falling back to the brand', () => {
+		const orgUpdate = MIGRATION.indexOf('update public.organizations o set');
+		const brandFallback = MIGRATION.indexOf('update public.brands b set');
+		expect(orgUpdate).toBeGreaterThan(-1);
+		expect(brandFallback).toBeGreaterThan(orgUpdate);
+		// The fallback runs ONLY when no org claimed the customer; without this guard a migrated
+		// org would have its frozen brand columns rewritten on every webhook.
+		expect(MIGRATION).toMatch(/if _org_id is not null then[\s\S]*?return NEW;\s*end if;/);
+	});
+
+	it('lets a credit grant target exactly one of brand or org', () => {
+		expect(MIGRATION).toContain('alter column brand_id drop not null');
+		expect(MIGRATION).toMatch(
+			/check \(\(brand_id is null\) <> \(org_id is null\)\)/
+		);
+		// An org-targeted grant has a null brand_id, so a brand-only policy would hide it.
+		expect(MIGRATION).toMatch(/or org_id in \(select public\.auth_org_ids\(\)\)/);
+	});
+
+	it('keeps the new org-scoped tables and functions behind RLS', () => {
+		expect(MIGRATION).toContain('alter table public.org_usage enable row level security');
+		expect(MIGRATION).toMatch(
+			/revoke execute on function public\.sum_org_ai_cost_usd\(uuid, timestamptz, timestamptz\) from public, anon/
+		);
+		expect(MIGRATION).toMatch(/revoke execute on function public\.auth_org_ids\(\) from public, anon/);
+	});
+});

--- a/supabase/migrations/20260903190000_org_billing_schema.sql
+++ b/supabase/migrations/20260903190000_org_billing_schema.sql
@@ -1,0 +1,190 @@
+-- Org-level billing, step A: schema only. Nothing reads these columns yet — the application
+-- code that does arrives in the follow-up steps (credits/gating, settings-actions, UI).
+--
+-- Today one Stripe subscription belongs to one BRAND. The destination is one subscription per
+-- ORGANIZATION covering every brand under it, with a shared credit pool. The rollout is
+-- org-by-org, so both shapes must work at once: an org is "migrated" exactly when
+-- organizations.stripe_customer_id is set, and until then its brands keep answering as before.
+
+-- ── 1. The billing columns, mirrored from brands onto organizations ──────────────
+-- Same names and types as brands', so every downstream reader keeps the same shape.
+-- stripe_customer_id already exists (0001) and was never used; it becomes the real one.
+alter table public.organizations
+  add column if not exists stripe_subscription_id text,
+  add column if not exists plan text,
+  add column if not exists activated_at timestamptz;
+
+create index if not exists organizations_stripe_customer_idx
+  on public.organizations (stripe_customer_id);
+
+-- ── 2. The org half of the RLS choke point ───────────────────────────────────────
+-- auth_brand_ids() (0001, widened in 0077) answers "which brands are mine". The new org-scoped
+-- objects need the same answer one level up. Ownership only: org_members exists but billing has
+-- always been owner-only, and this function guards billing rows.
+create or replace function public.auth_org_ids() returns setof uuid
+  language sql security definer set search_path = public stable as $$
+  select id from public.organizations where owner_id = auth.uid();
+$$;
+revoke execute on function public.auth_org_ids() from public, anon;
+grant execute on function public.auth_org_ids() to authenticated;
+
+-- ── 3. The sync trigger becomes org-first, brand-fallback ────────────────────────
+-- Same plan/status derivation as 0104, only the target moves. When the customer belongs to a
+-- migrated org the billing fields land on the org and the status fans out to all of its brands
+-- (one subscription, every brand follows it). When it doesn't, the old per-brand update runs
+-- untouched — that is what a not-yet-migrated org looks like.
+--
+-- A migrated org's brands keep their old stripe_* and plan values FROZEN on purpose: they are
+-- the rollback net for the org-by-org rollout, dropped in one final migration at the end.
+create or replace function public.sync_brand_from_stripe_subscription() returns trigger
+  language plpgsql security definer set search_path = public as $$
+declare
+  _price_id text;
+  _plan text;
+  _status brand_status;
+  _org_id uuid;
+begin
+  _price_id := NEW.items->'data'->0->'price'->>'id';
+  _plan := public.plan_from_price_id(_price_id);
+
+  _status := case
+    when NEW.status in ('active','trialing') then 'active'::brand_status
+    when NEW.status in ('past_due','unpaid','incomplete') then 'paused'::brand_status
+    else 'canceled'::brand_status
+  end;
+
+  update public.organizations o set
+    stripe_subscription_id = NEW.id,
+    plan = case
+      when _status in ('active','paused') then coalesce(_plan, NEW.metadata->>'plan', o.plan)
+      else null
+    end,
+    activated_at = case
+      when NEW.status in ('active','trialing') and o.activated_at is null then now()
+      else o.activated_at
+    end
+  where o.stripe_customer_id = NEW.customer
+  returning o.id into _org_id;
+
+  if _org_id is not null then
+    -- The subscription covers every brand in the org, so its status covers them too.
+    update public.brands set status = _status where org_id = _org_id;
+    return NEW;
+  end if;
+
+  update public.brands b set
+    stripe_subscription_id = NEW.id,
+    plan = case
+      when _status in ('active','paused') then coalesce(_plan, NEW.metadata->>'plan', b.plan)
+      else null
+    end,
+    status = _status,
+    activated_at = case
+      when NEW.status in ('active','trialing') and b.activated_at is null then now()
+      else b.activated_at
+    end
+  where b.stripe_customer_id = NEW.customer;
+  return NEW;
+end; $$;
+
+-- ── 4. Credit grants can target an org, not just one of its brands ───────────────
+-- A grant is either for one brand (traceability: "we gave this brand 500") or for the org as a
+-- whole. Exactly one, never both, never neither.
+alter table public.credit_grants
+  add column if not exists org_id uuid references public.organizations(id) on delete cascade;
+
+alter table public.credit_grants
+  alter column brand_id drop not null;
+
+alter table public.credit_grants
+  drop constraint if exists credit_grants_one_target;
+alter table public.credit_grants
+  add constraint credit_grants_one_target
+  check ((brand_id is null) <> (org_id is null));
+
+create index if not exists credit_grants_org_idx
+  on public.credit_grants (org_id);
+
+-- The old policy filtered on brand_id alone, so an org-targeted grant (brand_id null) would be
+-- invisible to the very people it belongs to.
+drop policy if exists "credit_grants readable by brand members" on public.credit_grants;
+create policy "credit_grants readable by brand members" on public.credit_grants
+  for select using (
+    brand_id in (select public.auth_brand_ids())
+    or org_id in (select public.auth_org_ids())
+  );
+
+-- ── 5. Billing period, one level up ──────────────────────────────────────────────
+-- Twin of brand_billing_period (0089) reading the org's own subscription. Same coalesce chain:
+-- Stripe moved current_period_* onto the items, the top-level columns are null on new API
+-- versions, and annual plans report a year-long window that credits.ts normalises to the
+-- monthly anniversary.
+create or replace function public.org_billing_period(_org_id uuid)
+returns table(period_start timestamptz, period_end timestamptz)
+language sql stable security definer set search_path = public, stripe as $$
+  select
+    to_timestamp(coalesce((s.items->'data'->0->>'current_period_start')::bigint, s.current_period_start, s.billing_cycle_anchor)),
+    to_timestamp(coalesce((s.items->'data'->0->>'current_period_end')::bigint, s.current_period_end))
+  from public.organizations o
+  join stripe.subscriptions s on s.id = o.stripe_subscription_id
+  where o.id = _org_id
+    and s.status in ('active', 'trialing')
+  limit 1;
+$$;
+grant execute on function public.org_billing_period(uuid) to authenticated;
+
+-- ── 6. Spend, summed across every brand in the org ───────────────────────────────
+-- Twin of sum_brand_ai_cost_usd (0164): the shared pool is the sum of what all the org's brands
+-- spent. Same guard — service role, or the caller owns the org.
+create or replace function public.sum_org_ai_cost_usd(
+  p_org_id uuid,
+  p_start timestamptz,
+  p_end timestamptz
+)
+returns numeric
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select coalesce(sum(c.cost_usd), 0)::numeric
+  from public.ai_calls c
+  join public.brands b on b.id = c.brand_id
+  where b.org_id = p_org_id
+    and c.created_at >= p_start
+    and c.created_at < p_end
+    and c.cost_usd is not null
+    and (
+      auth.role() = 'service_role'
+      or p_org_id in (select public.auth_org_ids())
+    );
+$$;
+
+revoke execute on function public.sum_org_ai_cost_usd(uuid, timestamptz, timestamptz) from public, anon;
+grant execute on function public.sum_org_ai_cost_usd(uuid, timestamptz, timestamptz) to authenticated, service_role;
+
+-- The org sum walks every brand of the org, so it needs org_id on the join side.
+create index if not exists brands_org_id_idx on public.brands (org_id);
+
+-- ── 7. One 80%-warning email per org, not per brand ──────────────────────────────
+-- brand_usage stays exactly as it is: it is the per-brand POST/VIDEO quota counter
+-- (posts_count, videos_count) that usage.ts and cli-queries.ts read, and post quotas remain a
+-- per-brand concept. Only the credit-warning anti-spam flag moves up, so it gets its own small
+-- table instead of dragging the counters along.
+create table if not exists public.org_usage (
+  id uuid primary key default gen_random_uuid(),
+  org_id uuid not null references public.organizations(id) on delete cascade,
+  month date not null,
+  credits_warned_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (org_id, month)
+);
+
+create index if not exists org_usage_org_month_idx on public.org_usage (org_id, month);
+
+alter table public.org_usage enable row level security;
+drop policy if exists "org_usage via org" on public.org_usage;
+create policy "org_usage via org" on public.org_usage for all
+  using (org_id in (select public.auth_org_ids()))
+  with check (org_id in (select public.auth_org_ids()));


### PR DESCRIPTION
## What?

Step A — schema only — of the org-level billing migration ([map #183](https://github.com/anomaliaso/anomalia/issues/183)).
`organizations` gains `stripe_subscription_id`, `plan` and `activated_at` (mirroring `brands`;
`stripe_customer_id` was already there, unused, since 0001). The Stripe sync trigger becomes
org-first with a brand fallback. `credit_grants` can target an org. Two RPCs mirror their
per-brand twins one level up, and the 80% credit-warning flag gets its own `org_usage` table.

**Nothing reads any of this yet.** No behaviour changes until the follow-up steps
(credits/gating, `settings-actions` repointing, UI) land.

## Why?

Today one Stripe subscription belongs to one *brand*. The destination is one subscription per
*organization*, covering unlimited brands, with a shared credit pool — decided in
[#185](https://github.com/anomaliaso/anomalia/issues/185) and
[#186](https://github.com/anomaliaso/anomalia/issues/186). The rollout is org-by-org rather than
big-bang, so both shapes have to work at the same time, and the schema has to exist before any
code can read it.

## How?

- **Trigger: org-first, brand-fallback.** `sync_brand_from_stripe_subscription()` looks for an
  `organizations` row with the webhook's `stripe_customer_id`. Found → billing fields land on the
  org and `status` fans out to every brand under it (one subscription, all brands follow it), then
  it returns. Not found → the existing per-brand update runs untouched. No migration-status flag:
  *migrated* means `organizations.stripe_customer_id is not null`. A migrated org's brand columns
  stay **frozen** on purpose — they are the rollback net, dropped in one final migration at the end.
- **`credit_grants`**: nullable `brand_id` + new `org_id` + a `check ((brand_id is null) <> (org_id is null))`.
  The RLS policy filtered on `brand_id` alone, so an org grant would have been invisible to its own
  owner; it now covers both.
- **`auth_org_ids()`**: the org half of the RLS choke point `auth_brand_ids()` covers for brands.
  Ownership only, matching billing's existing owner-only posture.
- **`org_billing_period` / `sum_org_ai_cost_usd`**: twins of 0089's and 0164's per-brand versions,
  the latter summing across every brand of the org.

**Rejected — renaming `brand_usage` to `org_usage`.** The ticket described `brand_usage` as the
anti-spam-timestamp table; it is actually the per-brand **post and video quota counter**
(`posts_count`, `videos_count`) read by `usage.ts` and `cli-queries.ts`, and post quotas stay a
per-brand concept. Moving it would have silently changed quota semantics nobody decided to change.
Only the 80% warning flag goes up a level, so it gets a small table of its own. Existing
`brand_usage.credits_warned_at` values are **not** migrated: they are timestamps of already-sent
emails, and starting clean costs at most one duplicate warning in the current period.

**Rejected — writing `organizations.activated_at` from onboarding.** The ticket pointed at
`onboarding/+page.server.ts:328` as the line that writes `brands.activated_at`; that line writes
`editorial_plans.activated_at`. No application code writes `brands.activated_at` at all — only the
Stripe trigger does. So the org column is written by the trigger too, under the identical
first-activation-only condition. A free org keeps it `null` and `credits.ts` falls back to the
calendar month, exactly as it does today for a free brand.

**Rejected — backfilling `activated_at` from existing brands.** Populating existing org rows is
step D (the data migration), not this one.

## Testing?

`src/lib/server/org-billing-schema.test.ts` pins the three invariants the follow-up steps depend
on, following the existing `sandbox-leases.test.ts` pattern of asserting a migration's shape as
text (this change is pure SQL — there is no application code to unit test).

Honest note on TDD ordering: the migration was written before the test, because a
text-shape assertion can only be written against a file that exists. To prove the test is not
tautological I mutated the migration — removing the `return NEW;` inside the org branch, the exact
edit that would let a migrated org's frozen brand columns be rewritten on every webhook — and
watched the test fail, then restored it and watched it pass.

`node scripts/typecheck-runtime.mjs`: **not completed** — three runs were still buffering
after ~10 minutes each while other work contended for the machine, so I am not claiming a result
I did not see. The only TypeScript this PR adds is the test file, which vitest compiled and ran
green; the migration is SQL and the changelog is Markdown, so neither reaches tsc. Worth a CI
confirmation on the PR rather than my word.

**Not tested:** the SQL itself has not been executed anywhere. It is not applied to production
(see below), and this repo has no local plpgsql harness for trigger logic.

## Evidence

<details><summary>Test bites — mutation, then restore</summary>

```
# with `return NEW;` removed from the org branch:
 × org billing schema migration > syncs the org before falling back to the brand
      Tests  1 failed | 2 passed (3)

# restored:
 ✓ src/lib/server/org-billing-schema.test.ts (3 tests)
      Tests  3 passed (3)
```
</details>

<details><summary>schema-drift-check.mjs — before and after</summary>

Before (baseline on `dev`):
```
VERDE — ogni nome che il codice pronuncia esiste nel database.
```

After (expected: the migration is not applied yet):
```
assenti nel database: organizations.stripe_subscription_id, organizations.plan,
organizations.activated_at, credit_grants.org_id, org_usage
ROSSO — 5 divergenze. Le migration si applicano a mano: i deploy di questo repo non lo fanno.
```
Exactly the five names this migration adds, nothing else.
</details>

## Anything Else?

**Migration to apply by hand before merging** — this repo's deploys do not run migrations:

- `supabase/migrations/20260903190000_org_billing_schema.sql`

After applying it, `schema-drift-check.mjs` should go back to green.

Two things worth flagging:

- This step alone changes **no behaviour**. The trigger's org branch can only fire once some org
  has a `stripe_customer_id`, and nothing sets one until step D. Until then every webhook takes the
  brand fallback, exactly as today.
- Adjacent work, not in this diff: PR #197 on `fix/org-owner-race` originally added a unique
  constraint on `organizations.owner_id` and has since moved to an "always answer with the oldest
  org" approach, on the grounds that production already has owners with several orgs. Nothing here
  depends on `owner_id` being unique, so the two do not collide — but step D will need to know
  which org of a multi-org owner receives the subscription.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RgPP6gw4d7xW7Y92vJJrPZ

