### PR TITLE
Let Stripe's portal own the plan change, and fix two defects #200 shipped

### DIFF
--- a/changelog/2026-09-03-stripe-provider-was-a-stub.md
+++ b/changelog/2026-09-03-stripe-provider-was-a-stub.md
@@ -10,32 +10,52 @@ the only import in `src/lib/server/settings-actions.ts`, inside `billingPortal()
 for the file, no private dependency, no build alias, no script that ever wrote real content into
 it.
 
-`settings-actions.ts` already fully specifies the five functions' contracts (parameter names,
-return shapes) — none of that changed. Implemented against the real `stripe` npm package
-(newly added dependency, `^22.6.1` — none existed before):
+`settings-actions.ts` already fully specifies the functions' contracts (parameter names, return
+shapes) — none of that changed. Implemented against the real `stripe` npm package (newly added
+dependency, `^22.6.1` — none existed before):
 
-- `createBillingPortalSession` / `createUpgradePortalSession` call
-  `stripe.billingPortal.sessions.create`, using Stripe's hosted Customer Portal `flow_data`
-  (`payment_method_update`, `subscription_update`, `subscription_update_confirm`) — no proration,
+- `createBillingPortalSession` calls `stripe.billingPortal.sessions.create`, using Stripe's hosted
+  Customer Portal `flow_data` (`payment_method_update`, `subscription_update`) — no proration,
   dunning, or retry logic written here, because none of that lives in this codebase: it's
   Dashboard configuration on the Customer Portal itself, unchanged.
 - `applyRetentionCoupon` / `cancelSubscriptionAtPeriodEnd` call `stripe.subscriptions.update`
-  directly (coupon, `cancel_at_period_end` + `cancellation_details`).
-- `ensureSubscriptionCanceled` reads the subscription's `status` and throws `'active_plan'`
-  (mapped by `deleteBrand` to `deleteError: 'activePlan'`) unless it's already `canceled` — it
-  never cancels a subscription as a side effect of a brand delete.
+  directly (`discounts`, `cancel_at_period_end` + `cancellation_details`).
+- `ensureSubscriptionCanceled` throws `'active_plan'` (mapped by `deleteBrand` to
+  `deleteError: 'activePlan'`) only while the subscription can still charge someone — it never
+  cancels a subscription as a side effect of a brand delete.
 
-**New env vars needed to fully activate `upgrade()`:** `STRIPE_PRICE_GO`, `STRIPE_PRICE_STARTER`,
-`STRIPE_PRICE_PRO` — the Stripe Price ids for each plan, mapped by
-`priceIdForPlan()`. Nothing in this repo held that mapping before (no code, no env var), and this
-fix can't discover it from Stripe's API for the right account from here — until they're set,
-`createUpgradePortalSession` throws a clear "No Stripe price configured for plan …" instead of
-crashing on an undefined lookup, and `billingPortal()`/`applyRetention()`/`cancelPlan()`/
-`deleteBrand()` are unaffected (they only need `STRIPE_SECRET_KEY`, already set on Vercel).
+Two defects in the first pass, both invisible to tests that mock the SDK, both found by review:
+
+**`coupon` no longer exists on a subscription update.** `stripe@22.6.1` pins API
+`2026-08-26.dahlia`, where the parameter became `discounts: [{ coupon }]`; the old spelling
+compiles to `TS2353: 'coupon' does not exist in type 'SubscriptionUpdateParams'` and would have
+been a 400 "unknown parameter" at runtime — so the retention offer never worked. The test now
+asserts the parameter's real shape rather than that *some* update was called, which is the only
+version of it that could have failed.
+
+**`status === 'canceled'` was the wrong question.** The right one is "can this still charge
+someone". An owner who had just used "cancel plan" carries `cancel_at_period_end` with the status
+still `active`: the UI told them they had cancelled, and the delete refused for up to a month.
+A subscription id Stripe no longer knows was worse — `retrieve` throws `resource_missing`,
+`deleteBrand` mapped that to a generic failure, and the brand became undeletable forever. Both now
+pass, along with the settled `unpaid`/`incomplete_expired` states. `past_due` and `incomplete`
+deliberately still refuse: they recover on a retry, and cancelling is one click away. Every other
+Stripe failure still refuses too — failing open on a network or auth error would delete a brand
+whose subscription is very much alive.
+
+**Every plan change happens in Stripe's portal, on the prices configured there.** A first pass
+mapped each plan to a Stripe Price id through `STRIPE_PRICE_GO`/`STARTER`/`PRO` env vars and
+opened the portal's `subscription_update_confirm` flow already pointed at that price. Andrea's
+rule is narrower and simpler: the upgrade *is* the portal. So the app names no price at all — it
+opens the plain `subscription_update` flow and the customer picks there, from the catalogue the
+Stripe dashboard already defines. Three env vars that never existed stay non-existent, and the
+plan ladder can be re-priced in Stripe without a deploy.
+
+That collapsed `createUpgradePortalSession` into exactly what `createBillingPortalSession` with
+`flow: 'upgrade'` already did, so it is gone rather than kept as a second name for one behaviour;
+`upgrade()` calls the surviving function. The `plan` value it reads from the form still gates the
+action (`plansAbove`) and still rides the `/activate` redirect for a brand with no subscription
+yet — it just no longer reaches Stripe.
 
 **Scope**: brand-level, exactly as `settings-actions.ts` already reads/writes `brands.*` today.
 Repointing this at the org-level billing migration (wayfinder map #183) is separate, later work.
-
-**Discarded**: querying Stripe live for the plan → Price id mapping instead of an env var. The
-Stripe MCP connection available in this session is a different account (`leads.anomalia`, not the
-production Anomalia SaaS account) — querying it would have returned the wrong catalogue entirely.

--- a/src/lib/content/changelog/2026-09-03-billing-portal-restored.ts
+++ b/src/lib/content/changelog/2026-09-03-billing-portal-restored.ts
@@ -2,8 +2,9 @@ import type { ChangelogEntry } from './index';
 
 export default {
   date: '2026-09-03',
-  title: 'Billing portal and plan upgrades work again',
+  title: 'Billing portal and plan changes work again',
   items: [
-    'Managing billing, upgrading your plan, applying a retention offer, and canceling a plan all work again, closing a gap where they failed with an error.'
+    'Managing billing, changing your plan, and canceling all work again, closing a gap where they failed with an error.',
+    'Deleting a brand no longer refuses after you have already canceled its plan.'
   ]
 } satisfies ChangelogEntry;

--- a/src/lib/server/settings-actions.ts
+++ b/src/lib/server/settings-actions.ts
@@ -87,11 +87,11 @@ export async function upgrade({ request, params, url, locals: { supabase } }: Ev
 
   let upgradeUrl: string;
   try {
-    const { createUpgradePortalSession } = await stripeApi();
-    upgradeUrl = await createUpgradePortalSession({
+    const { createBillingPortalSession } = await stripeApi();
+    upgradeUrl = await createBillingPortalSession({
       customerId: brand.stripe_customer_id,
       subscriptionId: brand.stripe_subscription_id,
-      plan,
+      flow: 'upgrade',
       returnUrl: `${url.origin}/app/${brand.slug}/settings/billing`
     });
   } catch (e) {

--- a/src/lib/server/stripe.test.ts
+++ b/src/lib/server/stripe.test.ts
@@ -6,12 +6,7 @@ const subscriptionsUpdate = vi.fn();
 const subscriptionsCancel = vi.fn();
 
 vi.mock('$env/dynamic/private', () => ({
-	env: {
-		STRIPE_SECRET_KEY: 'sk_test_123',
-		STRIPE_PRICE_GO: 'price_go',
-		STRIPE_PRICE_STARTER: 'price_starter',
-		STRIPE_PRICE_PRO: 'price_pro'
-	}
+	env: { STRIPE_SECRET_KEY: 'sk_test_123' }
 }));
 
 vi.mock('stripe', () => ({
@@ -74,7 +69,7 @@ describe('createBillingPortalSession', () => {
 		});
 	});
 
-	it('requests the generic subscription_update flow', async () => {
+	it('sends an upgrade to the portal to pick the plan, naming no price', async () => {
 		billingPortalSessionsCreate.mockResolvedValue({ url: 'https://portal/upgrade' });
 		const { createBillingPortalSession } = await import('./stripe');
 
@@ -90,50 +85,7 @@ describe('createBillingPortalSession', () => {
 			return_url: 'https://app/return',
 			flow_data: { type: 'subscription_update', subscription_update: { subscription: 'sub_1' } }
 		});
-	});
-});
-
-describe('createUpgradePortalSession', () => {
-	it('looks up the subscription item and confirms the new price', async () => {
-		subscriptionsRetrieve.mockResolvedValue({
-			items: { data: [{ id: 'si_1', quantity: 1 }] }
-		});
-		billingPortalSessionsCreate.mockResolvedValue({ url: 'https://portal/confirm' });
-		const { createUpgradePortalSession } = await import('./stripe');
-
-		const url = await createUpgradePortalSession({
-			customerId: 'cus_1',
-			subscriptionId: 'sub_1',
-			plan: 'pro',
-			returnUrl: 'https://app/return'
-		});
-
-		expect(url).toBe('https://portal/confirm');
-		expect(subscriptionsRetrieve).toHaveBeenCalledWith('sub_1');
-		expect(billingPortalSessionsCreate).toHaveBeenCalledWith({
-			customer: 'cus_1',
-			return_url: 'https://app/return',
-			flow_data: {
-				type: 'subscription_update_confirm',
-				subscription_update_confirm: {
-					subscription: 'sub_1',
-					items: [{ id: 'si_1', price: 'price_pro', quantity: 1 }]
-				}
-			}
-		});
-	});
-
-	it('rejects a plan with no configured Stripe price', async () => {
-		const { createUpgradePortalSession } = await import('./stripe');
-
-		await expect(
-			createUpgradePortalSession({
-				customerId: 'cus_1',
-				subscriptionId: 'sub_1',
-				plan: 'nonexistent',
-				returnUrl: 'https://app/return'
-			})
-		).rejects.toThrow('No Stripe price configured for plan "nonexistent"');
+		expect(subscriptionsRetrieve).not.toHaveBeenCalled();
 	});
 });
 
@@ -141,7 +93,11 @@ describe('applyRetentionCoupon', () => {
 	it('applies the coupon to the subscription', async () => {
 		const { applyRetentionCoupon } = await import('./stripe');
 		await applyRetentionCoupon('sub_1', 'SAVE20');
-		expect(subscriptionsUpdate).toHaveBeenCalledWith('sub_1', { coupon: 'SAVE20' });
+		// `coupon` was removed from subscription updates in the API version this SDK pins
+		// (2026-08-26.dahlia); sending it back would be a 400 "unknown parameter".
+		expect(subscriptionsUpdate).toHaveBeenCalledWith('sub_1', {
+			discounts: [{ coupon: 'SAVE20' }]
+		});
 	});
 });
 
@@ -182,5 +138,41 @@ describe('ensureSubscriptionCanceled', () => {
 		subscriptionsRetrieve.mockResolvedValue({ status: 'active' });
 		const { ensureSubscriptionCanceled } = await import('./stripe');
 		await expect(ensureSubscriptionCanceled('sub_1')).rejects.toThrow('active_plan');
+	});
+
+	// The owner used "cancel plan", was told it was cancelled, and Stripe keeps the status
+	// `active` until the period runs out. Refusing here left them unable to delete their own
+	// brand for up to a month.
+	it('lets the delete through once cancellation is scheduled', async () => {
+		subscriptionsRetrieve.mockResolvedValue({ status: 'active', cancel_at_period_end: true });
+		const { ensureSubscriptionCanceled } = await import('./stripe');
+		await expect(ensureSubscriptionCanceled('sub_1')).resolves.toBeUndefined();
+	});
+
+	it.each(['incomplete_expired', 'unpaid'])(
+		'lets the delete through on the settled status %s',
+		async (status) => {
+			subscriptionsRetrieve.mockResolvedValue({ status });
+			const { ensureSubscriptionCanceled } = await import('./stripe');
+			await expect(ensureSubscriptionCanceled('sub_1')).resolves.toBeUndefined();
+		}
+	);
+
+	// A stale id bills nobody. Refusing on it made the brand undeletable forever.
+	it('lets the delete through when Stripe no longer knows the subscription', async () => {
+		subscriptionsRetrieve.mockRejectedValue(
+			Object.assign(new Error('No such subscription'), { code: 'resource_missing' })
+		);
+		const { ensureSubscriptionCanceled } = await import('./stripe');
+		await expect(ensureSubscriptionCanceled('sub_1')).resolves.toBeUndefined();
+	});
+
+	// Failing open on an outage would delete a brand whose subscription is still charging.
+	it('refuses when Stripe fails for any other reason', async () => {
+		subscriptionsRetrieve.mockRejectedValue(
+			Object.assign(new Error('connection error'), { code: 'api_connection_error' })
+		);
+		const { ensureSubscriptionCanceled } = await import('./stripe');
+		await expect(ensureSubscriptionCanceled('sub_1')).rejects.toThrow('connection error');
 	});
 });

--- a/src/lib/server/stripe.ts
+++ b/src/lib/server/stripe.ts
@@ -11,18 +11,10 @@ function stripe(): Stripe {
   return client;
 }
 
-const PLAN_PRICE_ENV: Record<string, string | undefined> = {
-  go: env.STRIPE_PRICE_GO,
-  starter: env.STRIPE_PRICE_STARTER,
-  pro: env.STRIPE_PRICE_PRO
-};
-
-function priceIdForPlan(plan: string): string {
-  const id = PLAN_PRICE_ENV[plan];
-  if (!id) throw new Error(`No Stripe price configured for plan "${plan}"`);
-  return id;
-}
-
+/**
+ * Every plan change happens inside Stripe's hosted portal, on the prices configured there — the
+ * app never names a price id, so there is nothing here to drift from the Stripe dashboard.
+ */
 export async function createBillingPortalSession(opts: {
   customerId: string;
   returnUrl: string;
@@ -47,33 +39,8 @@ export async function createBillingPortalSession(opts: {
   return session.url;
 }
 
-export async function createUpgradePortalSession(opts: {
-  customerId: string;
-  subscriptionId: string;
-  plan: string;
-  returnUrl: string;
-}): Promise<string> {
-  const price = priceIdForPlan(opts.plan);
-  const subscription = await stripe().subscriptions.retrieve(opts.subscriptionId);
-  const item = subscription.items.data[0];
-  if (!item) throw new Error('Subscription has no items to upgrade');
-
-  const session = await stripe().billingPortal.sessions.create({
-    customer: opts.customerId,
-    return_url: opts.returnUrl,
-    flow_data: {
-      type: 'subscription_update_confirm',
-      subscription_update_confirm: {
-        subscription: opts.subscriptionId,
-        items: [{ id: item.id, price, quantity: item.quantity ?? 1 }]
-      }
-    }
-  });
-  return session.url;
-}
-
 export async function applyRetentionCoupon(subscriptionId: string, coupon: string): Promise<void> {
-  await stripe().subscriptions.update(subscriptionId, { coupon });
+  await stripe().subscriptions.update(subscriptionId, { discounts: [{ coupon }] });
 }
 
 export async function cancelSubscriptionAtPeriodEnd(
@@ -91,11 +58,37 @@ export async function cancelSubscriptionAtPeriodEnd(
 }
 
 /**
- * Blocks brand deletion while a paid subscription is still on (deleteBrand maps 'active_plan' to
- * an explicit "cancel your plan first" error) instead of silently canceling it as a side effect.
+ * States that will never bill again on their own: Stripe has either ended the subscription or
+ * given up collecting. `past_due` and `incomplete` stay out — those still recover on a retry, and
+ * the owner can end them from the portal in one click.
+ */
+const SETTLED_STATUSES: ReadonlySet<Stripe.Subscription.Status> = new Set([
+  'canceled',
+  'incomplete_expired',
+  'unpaid'
+]);
+
+/**
+ * Blocks brand deletion while a subscription can still charge someone (deleteBrand maps
+ * 'active_plan' to an explicit "cancel your plan first" error) instead of silently canceling it
+ * as a side effect.
+ *
+ * Anything that cannot charge again lets the delete through, including the case the strict
+ * `status === 'canceled'` check used to trap: an owner who just used "cancel plan" carries
+ * `cancel_at_period_end` with the status still `active`, was told they had cancelled, and could
+ * not delete their own brand until the period ran out. A subscription id Stripe no longer knows
+ * is treated the same way — it bills nobody, and refusing on it made the brand undeletable
+ * forever. Every other Stripe failure (network, auth) still refuses: failing open there would
+ * delete a brand whose subscription is very much alive.
  */
 export async function ensureSubscriptionCanceled(subscriptionId: string): Promise<void> {
-  const sub = await stripe().subscriptions.retrieve(subscriptionId);
-  if (sub.status === 'canceled') return;
+  let sub: Stripe.Subscription;
+  try {
+    sub = await stripe().subscriptions.retrieve(subscriptionId);
+  } catch (e) {
+    if ((e as Stripe.errors.StripeError)?.code === 'resource_missing') return;
+    throw e;
+  }
+  if (SETTLED_STATUSES.has(sub.status) || sub.cancel_at_period_end) return;
   throw new Error('active_plan');
 }


### PR DESCRIPTION
## What?
Three corrections on top of #200, which merged before this review landed. `dev` today
still has the first pass: a plan→Price mapping through env vars that never existed, a
retention coupon sent in a parameter the pinned Stripe API removed, and a brand-delete
guard strict enough to trap owners who had already cancelled.

## Why?
Two of the three are real defects that reach users, and #200's tests could not see either
because they mock the Stripe SDK and asserted only that *some* call happened:

- **The retention offer never worked.** `stripe@22.6.1` pins API `2026-08-26.dahlia`, where
  `coupon` is no longer a subscription-update parameter — it became `discounts: [{ coupon }]`.
  The old spelling is a compile error against the SDK's own types and a 400
  "unknown parameter" at runtime.
- **A cancelled plan made a brand undeletable.** `ensureSubscriptionCanceled` demanded
  `status === 'canceled'`, but an owner who has just used "cancel plan" carries
  `cancel_at_period_end: true` with the status still `active`. The UI told them they had
  cancelled; the delete refused anyway, for up to a month. Worse, a subscription id Stripe
  no longer knows throws `resource_missing`, which `deleteBrand` maps to a generic failure —
  that brand could never be deleted at all.

The third is Andrea's rule for the upgrade path: *"l'upgrade deve avvenire sempre e solo
tramite stripe portal"*.

## How?
- **`applyRetentionCoupon`** sends `discounts: [{ coupon }]`. Verified against the real
  `.d.ts` rather than asserted: the old form is `TS2353: 'coupon' does not exist in type
  'SubscriptionUpdateParams'`, the new one compiles clean.
- **`ensureSubscriptionCanceled`** now asks the question the guard is actually for — can this
  still charge someone. It lets the delete through on `cancel_at_period_end`, on the settled
  `canceled`/`unpaid`/`incomplete_expired` statuses, and on `resource_missing`. `past_due` and
  `incomplete` still refuse deliberately: they recover on a retry and cancelling is one click
  away. Every other Stripe error still refuses too — failing open on a network or auth blip
  would delete a brand whose subscription is very much alive.
- **The upgrade names no price.** It opens the plain `subscription_update` portal flow and the
  customer picks from the catalogue the Stripe dashboard already defines, so
  `STRIPE_PRICE_GO`/`STARTER`/`PRO` are not needed and the ladder can be re-priced without a
  deploy. With no price to resolve, `createUpgradePortalSession` was byte-for-byte
  `createBillingPortalSession` with `flow: 'upgrade'` — deleted rather than kept as a second
  name for one behaviour, with `upgrade()` calling the survivor. The `plan` read from the form
  still gates the action (`plansAbove`) and still rides the `/activate` redirect; it just no
  longer reaches Stripe.

## Testing?
`src/lib/server/stripe.test.ts` is now 13 cases, all green. The new ones fail without their
fix: the retention test asserts the parameter's real shape instead of that an update happened,
and the guard has a case per state it must let through (`cancel_at_period_end`, `unpaid`,
`incomplete_expired`, `resource_missing`) plus one proving an unrelated Stripe error still
refuses.

**Not tested**: a call against the production Stripe account (the MCP connection here is
`leads.anomalia`, a different account) or the billing UI in a browser. Everything is mocked at
the SDK boundary.

## Evidence (screenshots/videos)
No UI change — server-only.

<details>
<summary>The removed parameter, checked against the installed SDK's types</summary>

```
$ npx tsc --noEmit src/tscheck-tmp.ts   # s.subscriptions.update('sub', { coupon: 'X' })
src/tscheck-tmp.ts(3,33): error TS2353: Object literal may only specify known properties,
and 'coupon' does not exist in type 'SubscriptionUpdateParams'.

$ npx tsc --noEmit src/tscheck-tmp.ts   # { discounts: [{ coupon: 'X' }] }
(clean)

$ cat node_modules/stripe/cjs/apiVersion.js
exports.ApiVersion = '2026-08-26.dahlia';
```
</details>

<details>
<summary>Test run</summary>

```
 ✓ src/lib/server/stripe.test.ts (13 tests)
 Test Files  1 passed (1)
      Tests  13 passed (13)
```
</details>

## Anything Else?
**No new env vars**, and one dashboard dependency worth knowing: the `subscription_update`
flow only shows a plan picker for products enabled under Dashboard → Customer portal →
Subscriptions. If that is off, the portal opens without an upgrade option — a Stripe setting,
not a code change, and one this PR deliberately does not touch.

Still brand-level, exactly as `settings-actions.ts` reads `brands.*` today. Repointing it at
the org-level migration (wayfinder map #183) is separate, later work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RgPP6gw4d7xW7Y92vJJrPZ
