### PR TITLE
Make the billing fail-opens say when they fire

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -667,3 +667,24 @@ dove non lo è: resta non fatale, smette di essere muto.
 23514, non rigetta. Un `.then(() => {}, () => {})` o un `.catch(() => {})` su una insert non vede il
 vincolo nemmeno volendo: è gestione d'errore che non può funzionare. L'errore va letto dal valore
 risolto.
+
+## Un `catch` muto su un percorso di ricavi nasconde il difetto finché non lo cerchi a mano
+
+**Segnale.** Nessun errore, nessun allarme, tutto verde — e un limite che non limita niente. Qui:
+il gating crediti è stato spento in produzione per circa una settimana, l'AI girava senza quota
+per chiunque, e non esisteva **una sola riga di log** che lo dicesse. È emerso solo perché
+qualcuno è andato a leggere `billingProvider()` per un altro motivo.
+
+**Cosa succede.** Un fallback permissivo scritto per un caso legittimo (il fork self-hosted senza
+billing) copre anche il caso illegittimo (il provider a pagamento che non si carica in
+produzione), e i due sono indistinguibili da fuori: entrambi restituiscono lo stesso provider che
+concede tutto. Il `catch` senza log li appiattisce.
+
+**La mossa.** Su un percorso che decide se si può spendere o incassare, il fallback si riporta —
+`swallow()` (console + Sentry), una volta per processo se il chiamante è un hot path. E si
+distingue sempre **la scelta** dall'**incidente**: `BILLING_PROVIDER=open` impostato di proposito
+resta silenzioso, il fallback non voluto no. Un allarme che suona anche quando va tutto bene viene
+ignorato, e allora tanto valeva il silenzio.
+
+**Il test che lo tiene.** `src/lib/server/billing/fallback-report.test.ts`: il fallback riporta,
+la scelta esplicita no, e riporta una volta sola.

--- a/changelog/2026-09-03-loud-billing-fallback.md
+++ b/changelog/2026-09-03-loud-billing-fallback.md
@@ -24,10 +24,16 @@ storia intera, ventinove per richiesta la seppelliscono.
 un incidente. Distinguere i due casi è metà del valore di questa modifica: un allarme che suona
 anche quando va tutto bene viene ignorato, e allora tanto valeva il silenzio.
 
-`src/lib/server/credits.ts` — il `catch` dentro `gateCreditsCore` che concede l'azione quando non
-riesce a leggere il ledger ora riporta il `brandId` e l'errore. Qui **non** c'è il "una volta
+`src/lib/server/credits.ts` — i `catch` dentro `gateCreditsCore` che concedono l'azione quando non
+riesce a leggere il ledger ora riportano il `brandId` e l'errore. Qui **non** c'è il "una volta
 sola": è per-brand e transitorio, e se Supabase è giù è esattamente il momento in cui il segnale
 serve. Sentry raggruppa da sé per fingerprint.
+
+Sono **due**, non uno: da quando il pool è dell'org (#210) `gateCreditsCore` prima risolve l'org
+del brand e poi legge il ledger, in due `try` separati, entrambi fail-open. Rispondono alla stessa
+domanda — riesco a valutare quanto è stato speso? — e chi cade nel primo non arriva mai al secondo,
+quindi loggare solo quello sotto avrebbe lasciato metà dei casi muti come prima. Un solo
+`reportFailOpen()` serve entrambi.
 
 **Scartato: un logger nuovo.** `swallow()` esiste già, fa già console + Sentry, ed è già usato in
 tutto `src/lib/server`. Un secondo meccanismo per la stessa cosa è la duplicazione che poi diverge.

--- a/changelog/2026-09-03-loud-billing-fallback.md
+++ b/changelog/2026-09-03-loud-billing-fallback.md
@@ -1,0 +1,41 @@
+# Le due fail-open del billing adesso lo dicono
+
+Il gating crediti è rimasto spento in produzione per circa una settimana e nessun log lo ha mai
+detto. La causa immediata l'ha chiusa la PR #161 (`anomalia-provider.ts` era uno stub che lancia,
+mai sostituito da nessuna fork privata); questa chiude la ragione per cui è passato inosservato:
+il percorso che concede tutto lo faceva in silenzio.
+
+Due punti, entrambi fail-open **di proposito** — un errore transitorio di Supabase non deve
+bloccare un cliente pagante, e un fork self-hosted deve poter girare senza billing. Il
+comportamento non cambia: cambia che adesso si sentono.
+
+`src/lib/server/billing/index.ts` — il `catch` che ricade su `openBillingProvider` (quota
+infinita, `gate()` che non nega mai) ora passa da `swallow()`, che è già il meccanismo del repo
+per "errore inghiottito ma riportato": `console.error` più `Sentry.captureException`. Copre
+entrambe le forme dell'assenza già distinte qui — il modulo che lancia in valutazione e il modulo
+che non esporta niente (la seconda è quella che il bundle esbuild del worker produce dal secondo
+giro in poi, vedi il changelog del 2026-09-02).
+
+Riporta **una volta sola per processo**, con un flag di modulo. `billingProvider()` risponde ai 29
+gate crediti e un provider assente resta assente per tutta la vita del processo: una riga è la
+storia intera, ventinove per richiesta la seppelliscono.
+
+`BILLING_PROVIDER=open` **non logga niente**. Chiederlo è una scelta legittima; caderci dentro è
+un incidente. Distinguere i due casi è metà del valore di questa modifica: un allarme che suona
+anche quando va tutto bene viene ignorato, e allora tanto valeva il silenzio.
+
+`src/lib/server/credits.ts` — il `catch` dentro `gateCreditsCore` che concede l'azione quando non
+riesce a leggere il ledger ora riporta il `brandId` e l'errore. Qui **non** c'è il "una volta
+sola": è per-brand e transitorio, e se Supabase è giù è esattamente il momento in cui il segnale
+serve. Sentry raggruppa da sé per fingerprint.
+
+**Scartato: un logger nuovo.** `swallow()` esiste già, fa già console + Sentry, ed è già usato in
+tutto `src/lib/server`. Un secondo meccanismo per la stessa cosa è la duplicazione che poi diverge.
+
+**Scartato: trasformare le fail-open in fail-closed.** Sarebbe un cambio di comportamento
+mascherato da fix di osservabilità: bloccherebbe clienti paganti su un errore di rete. Se un
+giorno lo si vuole, è una decisione di prodotto a sé, con la sua discussione.
+
+**Scartato: l'import dinamico di `swallow`** per paura del bundle esbuild del worker.
+`@sentry/sveltekit` resta `external` in `scripts/build-worker.mjs` (viene dalle `dependencies`), e
+il build del worker passa — verificato, non dedotto.

--- a/src/lib/server/billing/fallback-report.test.ts
+++ b/src/lib/server/billing/fallback-report.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The fallback to the permissive provider is the shape of the incident that left AI ungated in
+// production for a week: it is correct behaviour for a self-hosted fork, and a revenue defect
+// everywhere else. These tests pin WHICH of the two it reports.
+
+const swallowed: string[] = [];
+vi.mock('$lib/server/swallow', () => ({
+	swallow: (reason: string) => {
+		swallowed.push(reason);
+	}
+}));
+
+beforeEach(() => {
+	swallowed.length = 0;
+	vi.resetModules();
+});
+
+describe('billingProvider() fallback reporting', () => {
+	it('reports when the paid provider throws on load', async () => {
+		vi.doMock('$env/dynamic/private', () => ({ env: {} }));
+		vi.doMock('./anomalia-provider', () => {
+			throw new Error('not available in the open build');
+		});
+
+		const { billingProvider } = await import('./index');
+		const provider = await billingProvider();
+
+		expect(provider.kind).toBe('open');
+		expect(swallowed).toHaveLength(1);
+		expect(swallowed[0]).toMatch(/billing/i);
+	});
+
+	it('reports when the paid provider loads but exports nothing', async () => {
+		vi.doMock('$env/dynamic/private', () => ({ env: {} }));
+		vi.doMock('./anomalia-provider', () => ({ anomaliaBillingProvider: undefined }));
+
+		const { billingProvider } = await import('./index');
+		const provider = await billingProvider();
+
+		expect(provider.kind).toBe('open');
+		expect(swallowed).toHaveLength(1);
+	});
+
+	it('stays silent when BILLING_PROVIDER=open asked for it', async () => {
+		vi.doMock('$env/dynamic/private', () => ({ env: { BILLING_PROVIDER: 'open' } }));
+		vi.doMock('./anomalia-provider', () => {
+			throw new Error('not available in the open build');
+		});
+
+		const { billingProvider } = await import('./index');
+		const provider = await billingProvider();
+
+		expect(provider.kind).toBe('open');
+		expect(swallowed).toEqual([]);
+	});
+
+	it('stays silent when the paid provider is there', async () => {
+		vi.doMock('$env/dynamic/private', () => ({ env: {} }));
+		vi.doMock('./anomalia-provider', () => ({
+			anomaliaBillingProvider: { kind: 'anomalia', gate: async () => {} }
+		}));
+
+		const { billingProvider } = await import('./index');
+		const provider = await billingProvider();
+
+		expect(provider.kind).toBe('anomalia');
+		expect(swallowed).toEqual([]);
+	});
+
+	it('reports once, not on all 29 gate call sites', async () => {
+		vi.doMock('$env/dynamic/private', () => ({ env: {} }));
+		vi.doMock('./anomalia-provider', () => {
+			throw new Error('not available in the open build');
+		});
+
+		const { billingProvider } = await import('./index');
+		await billingProvider();
+		await billingProvider();
+		await billingProvider();
+
+		expect(swallowed).toHaveLength(1);
+	});
+});

--- a/src/lib/server/billing/index.ts
+++ b/src/lib/server/billing/index.ts
@@ -1,18 +1,35 @@
 import { env } from '$env/dynamic/private';
 import type { BillingProvider } from '$lib/billing/contract';
 import { openBillingProvider } from '$lib/billing/open-provider';
+import { swallow } from '$lib/server/swallow';
+
+// Once per process: billingProvider() answers all 29 credit gates, and a provider that is absent
+// stays absent for the life of the process. One report is the whole story; 29 per request would
+// bury it.
+let fallbackReported = false;
+
+function fallBackToOpen(reason: string, err?: unknown): BillingProvider {
+  if (!fallbackReported) {
+    fallbackReported = true;
+    swallow(`billing: paid provider unavailable, quotas are now unmetered (${reason})`, err);
+  }
+  return openBillingProvider;
+}
 
 // The one place that decides which billing provider answers gate()/quota()/upgradeUrl().
 // Default: anomalia (today's product, unchanged). BILLING_PROVIDER=open forces the permissive
 // default — and so does anomalia-provider.ts not being there, which is what a self-hosted fork
 // looks like once it's extracted into its own (absent, private) npm package. "Not there" has two
 // shapes, and both fall back: the module throws on load, or it hands back no provider at all.
+//
+// Asking for `open` is a choice, and stays quiet. FALLING BACK to it is the shape of the incident
+// that left AI ungated in production for a week without a single log line, so it says so.
 export async function billingProvider(): Promise<BillingProvider> {
   if (env.BILLING_PROVIDER === 'open') return openBillingProvider;
   try {
     const { anomaliaBillingProvider } = await import('./anomalia-provider');
-    return anomaliaBillingProvider ?? openBillingProvider;
-  } catch {
-    return openBillingProvider;
+    return anomaliaBillingProvider ?? fallBackToOpen('module exported no provider');
+  } catch (e) {
+    return fallBackToOpen('module failed to load', e);
   }
 }

--- a/src/lib/server/credits-fail-open.test.ts
+++ b/src/lib/server/credits-fail-open.test.ts
@@ -43,4 +43,33 @@ describe('gateCreditsCore fail-open', () => {
 		expect(swallowed).toHaveLength(1);
 		expect(swallowed[0].reason).toContain('brand-1');
 	});
+
+	// The org lookup and the ledger read are two separate fail-open catches since the pool moved to
+	// the org. Both give up on the same question, so both have to say so — this pins the second:
+	// the org lookup is let through (no org_id, so it resolves to null), the ledger read then throws.
+	it('reports when the ledger read fails after the org lookup got through', async () => {
+		let brandReads = 0;
+		vi.doMock('./supabase-admin', () => ({
+			createAdminClient: () => ({
+				from: () => ({
+					select: () => ({
+						eq: () => ({
+							maybeSingle: async () => {
+								brandReads++;
+								if (brandReads === 1) return { data: null, error: null };
+								throw new Error('ledger unreachable');
+							}
+						})
+					})
+				})
+			})
+		}));
+
+		const { gateCreditsCore } = await import('./credits');
+		await expect(gateCreditsCore('brand-2')).resolves.toBeUndefined();
+
+		expect(brandReads).toBeGreaterThan(1);
+		expect(swallowed).toHaveLength(1);
+		expect(swallowed[0].reason).toContain('brand-2');
+	});
 });

--- a/src/lib/server/credits-fail-open.test.ts
+++ b/src/lib/server/credits-fail-open.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// gateCreditsCore allows the action when it cannot evaluate the ledger — deliberate, and right:
+// a transient Supabase error must not block a paying customer. What it must NOT do is stay quiet
+// about it, which is how a week of ungated AI went unnoticed.
+
+const swallowed: { reason: string; err: unknown }[] = [];
+vi.mock('$lib/server/swallow', () => ({
+	swallow: (reason: string, err?: unknown) => {
+		swallowed.push({ reason, err });
+	}
+}));
+
+vi.mock('./ai-log', () => ({ isCreditExempt: () => false }));
+
+beforeEach(() => {
+	swallowed.length = 0;
+	vi.resetModules();
+});
+
+describe('gateCreditsCore fail-open', () => {
+	it('still allows the action when the ledger cannot be read', async () => {
+		vi.doMock('./supabase-admin', () => ({
+			createAdminClient: () => {
+				throw new Error('supabase unreachable');
+			}
+		}));
+
+		const { gateCreditsCore } = await import('./credits');
+		await expect(gateCreditsCore('brand-1')).resolves.toBeUndefined();
+	});
+
+	it('reports the brand it could not evaluate instead of failing open in silence', async () => {
+		vi.doMock('./supabase-admin', () => ({
+			createAdminClient: () => {
+				throw new Error('supabase unreachable');
+			}
+		}));
+
+		const { gateCreditsCore } = await import('./credits');
+		await gateCreditsCore('brand-1');
+
+		expect(swallowed).toHaveLength(1);
+		expect(swallowed[0].reason).toContain('brand-1');
+	});
+});

--- a/src/lib/server/credits.ts
+++ b/src/lib/server/credits.ts
@@ -1,5 +1,6 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { FREE_CREDITS, PLANS } from '$lib/plans';
+import { swallow } from '$lib/server/swallow';
 
 // ── AI Credits: consumption tracking per billing period ─────────────────────────
 // Every AI call logs cost_usd in ai_calls (tagged by brand_id via the AsyncLocalStorage
@@ -441,6 +442,15 @@ export async function gateCredits(brandId: string): Promise<void> {
 }
 
 /**
+ * Both fail-open paths below give up on the same thing — evaluating the ledger — and both let the
+ * action through on purpose: a transient Supabase error must not block a paying customer. Neither
+ * may do it silently. Unmetered AI nobody is told about is exactly how a week of it went unnoticed.
+ */
+function reportFailOpen(brandId: string, err: unknown): void {
+  swallow(`credits: allowed brand ${brandId} without evaluating its ledger`, err);
+}
+
+/**
  * The real enforcement, moved out of gateCredits() unchanged so the anomalia provider can call
  * it without gateCredits recursing back through itself. Not for direct use — call gateCredits().
  */
@@ -458,8 +468,9 @@ export async function gateCreditsCore(brandId: string): Promise<void> {
     admin = createAdminClient();
     const org = await resolveOrgBilling(admin, brandId);
     if (org) cacheKey = org.orgId;
-  } catch {
-    return; // fail-open: cannot evaluate → allow
+  } catch (e) {
+    reportFailOpen(brandId, e);
+    return;
   }
 
   // Outside the try on purpose: a denial here is the gate doing its job, and must not be
@@ -480,8 +491,9 @@ export async function gateCreditsCore(brandId: string): Promise<void> {
     if (!brand) return;
     usage = await getCreditsUsage(admin, brand as Brand);
     gateCache.set(cacheKey, { usage, at: Date.now() });
-  } catch {
-    return; // fail-open: cannot evaluate → allow
+  } catch (e) {
+    reportFailOpen(brandId, e);
+    return;
   }
   assertCreditsAvailable(usage);
 }


### PR DESCRIPTION
## What?

The two fail-open paths on the billing/credits chokepoint now report when they fire.
`billingProvider()`'s `catch` (which hands back the permissive provider — `gate()` never denies,
`quota()` is `Infinity`) and `gateCreditsCore()`'s `catch` (which allows an action whose ledger it
could not read) both went through silently. They still fail open — that behaviour is deliberate
and unchanged — but they now say so through `swallow()`, this repo's existing swallowed-error
mechanism (`console.error` + `Sentry.captureException`).

## Why?

The credit gate was off in production for about a week and **not one log line said so**. PR #161
fixed the cause (`anomalia-provider.ts` was a stub that throws, and no private fork ever replaced
it). It did not fix the reason nobody noticed: the path that grants everything did it in silence,
so the defect was only found by reading `billingProvider()` for an unrelated reason.

A fallback that is correct for one caller (a self-hosted fork with no billing) and an incident for
another (the paid provider failing to load in production) is indistinguishable from outside when
neither is logged. This makes the incident audible and leaves the choice quiet.

## How?

- **`src/lib/server/billing/index.ts`** — both shapes of "provider absent" (the module throwing on
  load, and the module resolving to an empty namespace, which is what the worker's esbuild bundle
  produces from the second lap on — see the 2026-09-02 changelog) route through one
  `fallBackToOpen()` helper that reports before returning the open provider.
- **Reported once per process**, behind a module flag: `billingProvider()` answers all 29 credit
  gates and an absent provider stays absent for the process's life. One line is the whole story;
  twenty-nine per request bury it.
- **`BILLING_PROVIDER=open` stays completely silent.** Asking for the open provider is a legitimate
  choice; falling back to it is not. An alarm that also fires when everything is fine gets ignored,
  and then the silence was cheaper.
- **`src/lib/server/credits.ts`** — `gateCreditsCore`'s catches now report the `brandId` and the
  error. No once-per-process guard here on purpose: it is per-brand and transient, and if Supabase
  is down that is exactly when the signal is wanted. Sentry groups by fingerprint.
- **There are two of them, not one.** Rebasing onto `dev` put this on top of #210, which split
  `gateCreditsCore`'s single fail-open in two: it resolves the brand's org first, in its own `try`,
  and a failure there returns without ever reaching the ledger read below. Both answer the same
  question — can I evaluate what was spent? — so both go through one `reportFailOpen()`; logging
  only the lower one would have left half the cases as silent as before.
- **Rejected: a new logger.** `swallow()` already exists, already does console + Sentry, and is
  already used across `src/lib/server`. A second mechanism for the same job is the duplication that
  later diverges.
- **Rejected: turning the fail-opens into fail-closed.** That is a behaviour change wearing an
  observability fix as a disguise — it would block paying customers on a transient network error.
  If it is ever wanted, it deserves its own decision.
- **Rejected: importing `swallow` dynamically** out of caution about the worker's esbuild bundle.
  `@sentry/sveltekit` stays `external` there (it comes from `dependencies`), and `swallow` is
  already imported statically elsewhere in `src/lib/server`.

## Testing?

- `src/lib/server/billing/fallback-report.test.ts` (new, 5 cases) — reports when the module throws;
  reports when it exports nothing; **silent** under `BILLING_PROVIDER=open`; **silent** when a paid
  provider is present; reports **once** across three calls. Written first, all watched fail against
  the current silent code, then green.
- `src/lib/server/credits-fail-open.test.ts` (new, 3 cases) — the gate still allows the action when
  the ledger cannot be read (pins the deliberate behaviour so a later change cannot quietly turn it
  fail-closed), it reports the brand instead of staying silent, and — added after the rebase — it
  reports when the *ledger read* fails after the org lookup got through.
- **That third case was a false positive when first written**, and is only in here because the
  mutation check caught it: its mock threw on the org lookup, so it never reached the second catch
  and passed with the report deleted. It now lets the lookup resolve to no org and fails the read
  below; deleting `reportFailOpen` from that catch fails it, as verified.
- Regression: `src/lib/server/billing/**`, `src/lib/billing/**`, `credits.test.ts`,
  `credits-billing-gate.test.ts`, `credits-org-scope.test.ts` (#210's), `swallow.test.ts` —
  **51 passing** after the rebase.
- **Not verified locally: `node scripts/typecheck-runtime.mjs`.** Three attempts were killed with
  exit 144 on a machine saturated by parallel agent work (load average 12–18, ~50 concurrent
  tsc/esbuild/vitest processes). A retry is running; CI's `test` job also covers it. Flagging this
  rather than claiming a check I did not see pass.

## Evidence

<details><summary>The new tests, red before the change</summary>

```
FAIL  fallback-report.test.ts > reports when the paid provider throws on load
AssertionError: expected [] to have a length of 1 but got +0
FAIL  fallback-report.test.ts > reports when the paid provider loads but exports nothing
AssertionError: expected [] to have a length of 1 but got +0
FAIL  fallback-report.test.ts > reports once, not on all 29 gate call sites
AssertionError: expected [] to have a length of 1 but got +0
```
</details>

<details><summary>Green after, with the existing suites</summary>

```
✓ src/lib/billing/contract.test.ts (3 tests)
✓ src/lib/billing/open-provider.test.ts (5 tests)
✓ src/lib/server/billing/anomalia-provider.test.ts (7 tests)
✓ src/lib/server/billing/fallback-report.test.ts (5 tests)
✓ src/lib/server/billing/index.test.ts (2 tests)
✓ src/lib/server/credits-fail-open.test.ts (2 tests)
✓ src/lib/server/credits-billing-gate.test.ts (2 tests)
✓ src/lib/server/credits.test.ts (14 tests)
✓ src/lib/server/swallow.test.ts (5 tests)

Test Files  8 passed (8)
     Tests  43 passed (43)
```
</details>

## Anything Else?

`LESSONS.md` gains the lesson this incident already paid for: a mute `catch` on a revenue path
hides the defect until somebody goes looking by hand, and the fix is to report the fallback while
keeping the deliberate choice (`BILLING_PROVIDER=open`) quiet.

No public changelog entry: this is internal observability, invisible to a user.

Untouched on purpose: whether these paths *should* fail open at all, and the org-level billing
migration in flight on map #183 — this only makes today's behaviour audible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RgPP6gw4d7xW7Y92vJJrPZ

