### PR TITLE
Write brand_media.source values the database accepts

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -636,3 +636,34 @@ diceva al prossimo lettore l'opposto della verità, che è peggio di non dire ni
 chiediti se il mock lo sta scavalcando. Se lo scavalca, resta una sola asserzione onesta: dato il
 verdetto che l'upstream produce sul serio, la route lo rispetta e non lavora. Il resto — che
 l'upstream produca quel verdetto — è un test dell'upstream, e va scritto lì o non va scritto.
+
+## Un valore che il CHECK rifiuta è invisibile a una suite che mocka il database
+
+**Segnale.** Una funzione che deposita qualcosa in una tabella «riesce» in ogni test e in
+produzione la riga non c'è. Il codice scrive una stringa in una colonna con un `CHECK ... in (…)`,
+e quella stringa non è nella lista. Nei log non c'è niente, perché il fallimento è gestito
+best-effort: `{ error }` restituito al chiamante e mai stampato.
+
+**Cosa succede.** Il vincolo vive nel database, il valore vive nel codice, e la suite mocka
+Supabase: un insert finto accetta qualunque stringa, quindi il test è verde per costruzione. È
+capitato a `brand_media.source`: `saveRenderedVideoToLibrary` scriveva `'ai'` e il `save_to_library`
+della sandbox scriveva `'sandbox'`, nessuno dei due nel vincolo. Ogni video renderizzato veniva
+pagato, caricato su storage e poi rifiutato dalla libreria con 23514 — l'esatto vicolo cieco che
+quella funzione era stata scritta per chiudere. Il best-effort è la scelta giusta (non si fa fallire
+un render pagato per un INSERT) ma trasforma il difetto in lavoro pagato e buttato in silenzio.
+
+**La mossa.** L'insieme ammesso diventa **una costante esportata accanto al modello che governa la
+colonna**, il campo è tipato su quella costante, e tre asserzioni la tengono onesta: la costante
+confrontata con l'array dell'ultima migration che definisce il vincolo; una scansione del sorgente
+che pretende ogni literal scritto in quella colonna dentro la costante; un `@ts-expect-error` sul
+valore vecchio, che fa fallire `npm run check` il giorno in cui il tipo smette di mordere. Il test
+che vale non è «il mock ha accettato l'insert» — quello non può fallire — ma «il valore è
+nell'insieme che il database ammette», e va munito di un guardiano contro il passaggio a vuoto
+(`written.length > N`): una scansione che non trova più niente deve fallire, non passare. E il
+fallimento best-effort si fa sentire — `swallow()` dove `$lib` è già in casa, `console.error('[X] …')`
+dove non lo è: resta non fatale, smette di essere muto.
+
+**Il corollario che è costato due minuti in più.** `supabase-js` **risolve** con `{ error }` su un
+23514, non rigetta. Un `.then(() => {}, () => {})` o un `.catch(() => {})` su una insert non vede il
+vincolo nemmeno volendo: è gestione d'errore che non può funzionare. L'errore va letto dal valore
+risolto.

--- a/changelog/2026-09-03-brand-media-source-values.md
+++ b/changelog/2026-09-03-brand-media-source-values.md
@@ -1,0 +1,94 @@
+# `brand_media.source`: due valori che il database rifiutava da sempre
+
+`brand_media_source_check` ammette otto valori:
+
+```
+'upload','chat_drop','shoot','generate','remotion_export','post_render','website_capture','agent'
+```
+
+Due punti del codice ne scrivevano altri due:
+
+- `saveRenderedVideoToLibrary` scriveva `'ai'`;
+- il `save_to_library` della sandbox scriveva `'sandbox'`.
+
+Nessuno dei due è mai entrato in `brand_media`. Ogni insert prendeva 23514.
+
+## Cosa costava
+
+`saveRenderedVideoToLibrary` esiste per un motivo solo, e lo dice la sua stessa docstring: senza
+quel passo «un video generato e' un file pagato che nessun tool sa raggiungere». Il render veniva
+pagato, l'mp4 caricato su storage, e poi la riga in libreria veniva rifiutata — rimettendo la clip
+esattamente nel vicolo cieco che la funzione era stata scritta per chiudere. La funzione è
+deliberatamente best-effort (giusto: non si fa fallire un render già pagato per un INSERT), quindi
+l'errore tornava al chiamante come `library_error` e finiva nel risultato del tool, letto
+dall'agente e da nessun altro. Nei log del server: niente.
+
+Stessa storia per la sandbox: un'immagine prodotta nella VM dell'agente e mai depositata.
+
+## Perché nessun test l'ha preso
+
+La suite (6394 test) mocka Supabase. Un insert finto accetta qualunque stringa: `source: 'ai'`
+passava verde in ogni test che toccasse quel percorso. Il vincolo vive nel database, il valore vive
+nel codice, e fra i due non c'era niente che li confrontasse. Anche
+`scripts/schema-drift-check.mjs` ha già un confronto «literal contro CHECK» (sezione C), ma sa
+leggere solo le catene `.from('x').insert({...})` scritte in chiaro: `insertBrandMedia(supabase,
+{ source: 'ai' })` è una chiamata a un helper, e gli passava sotto.
+
+## La scelta: mappare, non allargare
+
+Due strade. Allargare il vincolo con una migration sarebbe stata la quattordicesima cosa che
+qualcuno deve ricordarsi di applicare a mano — i deploy di questo repo non eseguono le migration —
+e fino ad allora il codice sarebbe rimasto rotto in produzione. Non serviva: entrambi i valori
+hanno già un sinonimo esatto nel vincolo.
+
+- `'ai'` → **`'generate'`**. È il valore che il vincolo ha da sempre per «l'abbiamo generato noi».
+  Prima di questo fix non lo scriveva nessuno: la provenienza esisteva nello schema e non nel
+  codice.
+- `'sandbox'` → **`'agent'`**. È il valore che la 0220 ha aggiunto descrivendo *esattamente* questo
+  caso: «l'agente che carica un file dalla propria VM nella galleria del brand». Lo scrive già
+  `bridge/attach.ts`, che fa la stessa cosa dallo stesso posto.
+
+Zero migration. Funziona in produzione appena il codice ci arriva.
+
+## Il fix durevole
+
+`BRAND_MEDIA_SOURCES` è ora una costante esportata accanto al modello che governa quella colonna, e
+`InsertBrandMediaInput.source` è tipato su di essa: un valore inventato non compila più.
+`brand-media.source.test.ts` chiude il cerchio con tre asserzioni:
+
+1. la costante è **identica** all'array dell'ultima migration che ridefinisce
+   `brand_media_source_check` — costante e vincolo non possono più divergere;
+2. ogni `source: '...'` scritto nell'oggetto di un `insertBrandMedia(...)` o di un
+   `.from('brand_media').insert(...)` in tutto `src/` è nella costante;
+3. un `@ts-expect-error` su `const rejected: BrandMediaSource = 'ai'` — se il tipo smettesse di
+   mordere, `npm run check` fallirebbe per l'errore che non c'è più.
+
+Il secondo è il test che avrebbe preso il difetto: non asserisce che un insert *finto* è riuscito,
+asserisce che il valore è nell'insieme che il database ammette. Ha un guardiano contro il passaggio
+a vuoto (`written.length > 3`): una scansione che non trova più niente fallisce invece di passare.
+Oggi trova quattro punti — `attach.ts` `'agent'`, `sandbox-tools.ts` `'agent'`, `brand-media.ts`
+`'generate'`, `website-capture.ts` `'website_capture'` — più il default `'upload'`, che ora passa da
+una variabile tipata invece che da un literal dentro l'oggetto.
+
+Verifica finale sul Postgres locale, in transazione e rollback: `upload`, `generate`, `agent`,
+`website_capture` accettati; `ai` e `sandbox` rifiutati con 23514. `catalog_status` era già a posto
+(`pending`/`ready`/`failed`, tutti scritti, tutti ammessi).
+
+## E il silenzio
+
+`saveRenderedVideoToLibrary` resta best-effort — il ragionamento della docstring è giusto, un render
+pagato non si fa morire per un INSERT — ma ora il fallimento passa da `swallow()`, quindi
+console.error più Sentry. I due chiamanti (`job-executor` `generate_video` e `create-content-tools`)
+già restituivano `library_error` all'agente; quello che mancava era che lo sapesse anche chi gestisce
+il prodotto.
+
+`bridge/attach.ts` era il punto più buio di tutti: la sua insert in `brand_media` finiva in
+`.then(() => {}, () => {})`. Peggio del previsto — supabase-js **risolve** con `{ error }` su un
+23514, non rigetta, quindi quel gestore di rigetto non avrebbe visto il vincolo nemmeno volendo: era
+gestione d'errore che non poteva funzionare. Ora l'errore risolto viene letto e stampato.
+
+Lì il log NON passa da `swallow()`, e non per distrazione: `src/lib/agent/bridge/` non ha **un solo**
+import di `$lib`, statico o dinamico, in nessuno dei suoi file — tutto arriva dai `deps`. Il primo
+`import { swallow } from '$lib/server/swallow'` sarebbe stato un buco nel confine (e avrebbe tirato
+`@sentry/sveltekit` dentro il grafo di `live.test.ts`, 372 s di test, per una riga di log). La
+convenzione che il bridge usa già è `console.error('[AGENT_KIT] …')`, ed è quella che si segue.

--- a/src/lib/agent/bridge/attach.ts
+++ b/src/lib/agent/bridge/attach.ts
@@ -120,7 +120,7 @@ export async function attachForChat(
 		const url = deps.supabase.storage.from('media').getPublicUrl(storagePath).data.publicUrl;
 
 		// In galleria (e quindi in artifacts/): un allegato dell'agente è un asset del brand.
-		await deps.supabase
+		const { error: galleryErr } = await deps.supabase
 			.from('brand_media')
 			.insert({
 				brand_id: deps.brandId,
@@ -131,8 +131,9 @@ export async function attachForChat(
 				source: 'agent',
 				mime,
 				bytes: bytes.byteLength
-			})
-			.then(() => {}, () => {}); // la galleria è un di-più: se la insert fallisce, l'allegato resta valido
+			});
+		// la galleria è un di-più: se la insert fallisce l'allegato resta valido, ma si sente dire.
+		if (galleryErr) console.error('[AGENT_KIT] attach: allegato fuori dalla galleria', galleryErr.message);
 
 		deps.collect.push(url);
 		return ok(`allegato in chat (visibile nella tua bolla): ${url}`);

--- a/src/lib/agent/tools/sandbox-tools.ts
+++ b/src/lib/agent/tools/sandbox-tools.ts
@@ -633,7 +633,7 @@ export function createSandboxTools(opts: SandboxToolsOptions): SandboxSession {
             bytes: buf.length,
             fileName: p.split('/').pop() ?? `sandbox.${ext}`,
             title: input.title,
-            source: 'sandbox'
+            source: 'agent'
           });
           if (insErr || !row) return { error: insErr ?? 'Could not register the asset' };
           void catalogBrandMedia(supabase, row.id, brandId).catch(() => {});

--- a/src/lib/content/changelog/2026-09-03-generated-videos-in-library.ts
+++ b/src/lib/content/changelog/2026-09-03-generated-videos-in-library.ts
@@ -1,0 +1,10 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-03',
+  title: 'Generated videos land in the Media library',
+  items: [
+    'A video Anomalia renders for you now reliably appears in the Media library, so you can reuse it in a post instead of only having a link.',
+    'An image an agent saves out of its own workspace now reaches the Media library too.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/brand-media.source.test.ts
+++ b/src/lib/server/brand-media.source.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { BRAND_MEDIA_SOURCES, type BrandMediaSource } from './brand-media';
+
+const ROOT = fileURLToPath(new URL('../../../', import.meta.url));
+const MIGRATIONS = join(ROOT, 'supabase/migrations');
+const SRC = join(ROOT, 'src');
+
+const CONSTRAINT = 'add constraint brand_media_source_check';
+
+function sourcesTheDatabaseAllows(): string[] {
+  let allowed: string[] = [];
+  for (const file of readdirSync(MIGRATIONS).filter((f) => f.endsWith('.sql')).sort()) {
+    const sql = readFileSync(join(MIGRATIONS, file), 'utf8');
+    const at = sql.lastIndexOf(CONSTRAINT);
+    if (at < 0) continue;
+    const statement = sql.slice(at, sql.indexOf(';', at));
+    allowed = [...statement.matchAll(/'([a-z_]+)'/g)].map((m) => m[1]);
+  }
+  return allowed;
+}
+
+function tsFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'node_modules') continue;
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...tsFiles(full));
+      continue;
+    }
+    if (/\.(ts|svelte)$/.test(entry.name) && !entry.name.includes('.test.')) out.push(full);
+  }
+  return out;
+}
+
+function objectLiteralAfter(text: string, from: number): string | null {
+  const open = text.indexOf('{', from);
+  if (open < 0) return null;
+  let depth = 0;
+  for (let i = open; i < text.length; i++) {
+    if (text[i] === '{') depth++;
+    else if (text[i] === '}' && --depth === 0) return text.slice(open, i + 1);
+  }
+  return null;
+}
+
+const WRITE_SITES = [
+  /insertBrandMedia\s*\(/g,
+  /from\(\s*['"]brand_media['"]\s*\)[\s\S]{0,160}?\.insert\s*\(/g
+];
+
+function sourcesTheCodeWrites(): Array<{ where: string; value: string }> {
+  const written: Array<{ where: string; value: string }> = [];
+  for (const file of tsFiles(SRC)) {
+    const text = readFileSync(file, 'utf8');
+    for (const pattern of WRITE_SITES) {
+      for (const call of text.matchAll(pattern)) {
+        const block = objectLiteralAfter(text, call.index + call[0].length);
+        if (!block) continue;
+        for (const field of block.matchAll(/\bsource:\s*'([^']*)'/g)) {
+          const line = text.slice(0, call.index).split('\n').length;
+          written.push({ where: `${relative(ROOT, file)}:${line}`, value: field[1] });
+        }
+      }
+    }
+  }
+  return written;
+}
+
+describe('brand_media.source', () => {
+  it('lists exactly the values the CHECK constraint admits', () => {
+    expect([...BRAND_MEDIA_SOURCES]).toEqual(sourcesTheDatabaseAllows());
+  });
+
+  it('is written by the code only with values the database accepts', () => {
+    const written = sourcesTheCodeWrites();
+
+    expect(written.length).toBeGreaterThan(3);
+    expect(written.filter((w) => !BRAND_MEDIA_SOURCES.includes(w.value as never))).toEqual([]);
+  });
+
+  it('does not typecheck a value the constraint would reject', () => {
+    // @ts-expect-error 'ai' is what saveRenderedVideoToLibrary wrote, and 23514 is what it got.
+    const rejected: BrandMediaSource = 'ai';
+
+    expect(BRAND_MEDIA_SOURCES).not.toContain(rejected);
+  });
+});

--- a/src/lib/server/brand-media.ts
+++ b/src/lib/server/brand-media.ts
@@ -13,6 +13,19 @@ const BUCKET = 'brand-knowledge';
 
 export type BrandMediaKind = 'image' | 'video';
 
+export const BRAND_MEDIA_SOURCES = [
+  'upload',
+  'chat_drop',
+  'shoot',
+  'generate',
+  'remotion_export',
+  'post_render',
+  'website_capture',
+  'agent'
+] as const;
+
+export type BrandMediaSource = (typeof BRAND_MEDIA_SOURCES)[number];
+
 export type BrandMediaRow = {
   id: string;
   brand_id: string;
@@ -341,7 +354,7 @@ export type InsertBrandMediaInput = {
   width?: number | null;
   height?: number | null;
   durationSeconds?: number | null;
-  source?: string;
+  source?: BrandMediaSource;
   title?: string | null;
 };
 
@@ -350,6 +363,7 @@ export async function insertBrandMedia(
   input: InsertBrandMediaInput
 ): Promise<{ row: BrandMediaRow | null; error?: string }> {
   const kind = inferKind(input.mime);
+  const source: BrandMediaSource = input.source ?? 'upload';
   const { data, error } = await supabase
     .from('brand_media')
     .insert({
@@ -359,7 +373,7 @@ export async function insertBrandMedia(
       storage_path: input.storagePath,
       // Private bucket: store path as url; UI signs via storage_path.
       url: input.storagePath,
-      source: input.source ?? 'upload',
+      source,
       mime: input.mime,
       bytes: input.bytes ?? null,
       width: input.width ?? null,
@@ -782,9 +796,12 @@ export async function saveRenderedVideoToLibrary(
     durationSeconds: opts.durationSeconds,
     fileName: storagePath.split('/').pop() ?? 'generated.mp4',
     title: opts.title,
-    source: 'ai'
+    source: 'generate'
   });
-  if (error || !row) return { error: error ?? 'could not register the clip in the library' };
+  if (error || !row) {
+    swallow('rendered clip not registered in the library', error ?? 'insert returned no row');
+    return { error: error ?? 'could not register the clip in the library' };
+  }
   return { mediaId: row.id };
 }
 


### PR DESCRIPTION
## What?

`brand_media.source` is guarded by a CHECK constraint that admits eight values. Two call sites
wrote values that are not among them, so their `INSERT` took a `23514` every single time and the
row never landed:

| call site | wrote | in the constraint? |
|---|---|---|
| `src/lib/server/brand-media.ts` — `saveRenderedVideoToLibrary` | `'ai'` | **no** |
| `src/lib/agent/tools/sandbox-tools.ts` — `save_to_library` | `'sandbox'` | **no** |

This PR maps both onto values the constraint already admits (`'generate'` and `'agent'`), pins the
allowed set into one exported constant beside the model that governs the column, types the field on
it, and adds the test that would have caught the defect. It also stops two best-effort failures from
being completely silent.

**Every `source` value written to `brand_media` anywhere in the codebase, after this PR:**

| where | value | allowed | note |
|---|---|---|---|
| `src/lib/server/brand-media.ts:366` — `insertBrandMedia` default | `'upload'` | yes | was already fine; now flows through a `BrandMediaSource` variable so TS checks it |
| `src/routes/app/[brand]/media/+page.server.ts:65` | *(omitted → default)* | yes | was already fine |
| `src/lib/server/website-capture.ts:432` | `'website_capture'` | yes | was already fine |
| `src/lib/agent/bridge/attach.ts:124` | `'agent'` | yes | was already fine |
| `src/lib/agent/tools/sandbox-tools.ts:628` | ~~`'sandbox'`~~ → `'agent'` | **fixed** | |
| `src/lib/server/brand-media.ts:790` — `saveRenderedVideoToLibrary` | ~~`'ai'`~~ → `'generate'` | **fixed** | |

Three notes on the sweep:

- `sandbox-tools.ts:582` also writes `source: 'sandbox'`, but into **`chat_artifacts`**, not
  `brand_media`. That table has **no** CHECK constraint at all (verified against the live DB), so
  that value is correct and is left alone.
- `'chat_drop'`, `'shoot'`, `'remotion_export'`, `'post_render'` are admitted by the constraint and
  written by nobody. `'generate'` was in the same group until this PR — the provenance existed in
  the schema and not in the code, which is exactly how `'ai'` got invented.
- The other CHECK-constrained column touched here, `brand_media.catalog_status`
  (`'pending'|'ready'|'failed'`), was already correct: the code writes only those three, and
  `BrandMediaRow` already types it. Verified by insert probe, see Evidence.

## Why?

`saveRenderedVideoToLibrary` exists for one reason, and its own docstring says it: without that
step *«un video generato e' un file pagato che nessun tool sa raggiungere: e' il vicolo cieco in cui
`refine_video` e' nato»*. It is also deliberately best-effort — *«Perdere l'id e' un fastidio; far
fallire un render gia' pagato per un INSERT no»* — which is the right call and the reason nobody
noticed.

So every video the product generated was **paid for, rendered, uploaded to storage, and then
rejected by the library**, putting the clip straight back into the dead end the function was written
to close. The caller got a `library_error` in the tool result; the server logs got nothing.

## How?

**Map onto existing values, do not widen the constraint.** Deploys in this repo do not run
migrations, and `scripts/schema-drift-check.mjs` already lists 13 CHECK-widening migrations that
cannot be verified from outside, including `0220_widen_source_checks.sql`. A new migration would be
a fourteenth thing someone has to remember to apply by hand — and until they did, the code would
still be broken in production. Neither value needed one:

- **`'ai'` → `'generate'`.** `'generate'` has been in the constraint since the beginning and means
  precisely "we made it". An AI-rendered clip is the textbook case.
- **`'sandbox'` → `'agent'`.** `'agent'` is the value `0220` added while describing *this exact
  situation*: *«l'agente che carica un file dalla propria VM nella galleria del brand»*.
  `bridge/attach.ts` already writes it for the same act from the same place.

Both accepted by the running database **today** — see Evidence.

**The durable half.** `BRAND_MEDIA_SOURCES` is now an exported constant in `brand-media.ts`, beside
the model that governs the column, and `InsertBrandMediaInput.source` is typed on it. The value
changes are the symptom fix; the constant is what stops the code and the constraint drifting apart
again.

**Rejected alternative — routing `attach.ts` through `swallow()`.** `src/lib/agent/bridge/` has not
a single `$lib` import, static or dynamic, in any of its files: everything arrives through `deps`.
Adding `import { swallow } from '$lib/server/swallow'` would have been the first hole in that
boundary, and would have pulled `@sentry/sveltekit` into the module graph of `live.test.ts` (372 s
of tests) for one log line. The bridge's own convention is `console.error('[AGENT_KIT] …')`, so that
is what it uses.

## Testing?

**The failing test came first**, and it fails for the right reason — it names both defects by file
and line, and it is not the kind that a mocked insert can satisfy. The seam matters here: the suite
mocks Supabase, so a fake insert accepts any string. `brand-media.source.test.ts` never asserts
"the insert succeeded"; it asserts "the value is in the set the database admits":

1. `BRAND_MEDIA_SOURCES` is **identical** to the array in the last migration that redefines
   `brand_media_source_check` — constant and constraint cannot diverge.
2. Every `source: '…'` literal in the object argument of an `insertBrandMedia(…)` call or a
   `.from('brand_media').insert(…)` chain, across all of `src/`, is in the constant. Guarded against
   passing vacuously: a scan that stops finding write sites fails (`written.length > 3`).
3. `@ts-expect-error` on `const rejected: BrandMediaSource = 'ai'` — the day the type stops biting,
   `npm run check` fails because the expected error is gone.

<details>
<summary><b>The red, before the fix</b> — <code>npx vitest run src/lib/server/brand-media.source.test.ts</code></summary>

```
 ❯ src/lib/server/brand-media.source.test.ts (2 tests | 1 failed) 433ms
   × brand_media.source > is written by the code only with values the database accepts 386ms
     → expected [ { …(2) }, { …(2) } ] to deeply equal []

 FAIL  src/lib/server/brand-media.source.test.ts > brand_media.source > is written by the code only with values the database accepts
AssertionError: expected [ { …(2) }, { …(2) } ] to deeply equal []

- Expected
+ Received

- Array []
+ Array [
+   Object {
+     "value": "sandbox",
+     "where": "src/lib/agent/tools/sandbox-tools.ts:628",
+   },
+   Object {
+     "value": "ai",
+     "where": "src/lib/server/brand-media.ts:789",
+   },
+ ]
```
</details>

<details>
<summary><b>The green, after</b></summary>

```
 ✓ src/lib/server/brand-media.source.test.ts (3 tests) 3616ms
 Test Files  1 passed (1)
      Tests  3 passed (3)
```
</details>

<details>
<summary><b>Against the real Postgres</b> — the only check that cannot lie (transaction, rolled back)</summary>

The live constraint, read from the running local database:

```
$ docker exec anomalia-db psql -U postgres -c "select conname, pg_get_constraintdef(oid) from pg_constraint where conrelid='public.brand_media'::regclass and contype='c';"

 brand_media_catalog_status_check | CHECK ((catalog_status = ANY (ARRAY['pending'::text, 'ready'::text, 'failed'::text])))
 brand_media_source_check         | CHECK ((source = ANY (ARRAY['upload'::text, 'chat_drop'::text, 'shoot'::text, 'generate'::text, 'remotion_export'::text, 'post_render'::text, 'website_capture'::text, 'agent'::text])))
```

One real `INSERT` per value, inside `begin … rollback`:

```
BEGIN
NOTICE:  source=upload -> ACCEPTED
NOTICE:  source=generate -> ACCEPTED
NOTICE:  source=agent -> ACCEPTED
NOTICE:  source=website_capture -> ACCEPTED
NOTICE:  source=ai -> REJECTED (23514 new row for relation "brand_media" violates check constraint "brand_media_source_check")
NOTICE:  source=sandbox -> REJECTED (23514 new row for relation "brand_media" violates check constraint "brand_media_source_check")
NOTICE:  catalog_status=pending -> ACCEPTED
NOTICE:  catalog_status=ready -> ACCEPTED
NOTICE:  catalog_status=failed -> ACCEPTED
NOTICE:  catalog_status=queued -> REJECTED (23514)
ROLLBACK
```

Every value this PR writes is accepted; both values it removes are rejected. `catalog_status` needed
no change.
</details>

<details>
<summary><b>Full unit suite</b> — <code>npm run test:unit</code>, on the committed code</summary>

```
 Test Files  583 passed | 3 skipped (586)
      Tests  6435 passed | 11 skipped (6446)
   Duration  267.53s
```

Fully green, zero failures.

An earlier run, on an intermediate state, showed two failures — both 120 s / 30 s **timeouts**
under full-suite load, in files this PR does not touch (`src/lib/agent/bridge/live.test.ts`,
`src/lib/server/chat/motion-output-mount.test.ts`). Both passed when re-run in isolation
(`motion-output-mount` alone burns 21 s of its own 30 s budget), and both pass in the run above.
That is the full-suite flakiness LESSONS.md already describes, not a defect introduced here.
</details>

<details>
<summary><b>CLI</b> — <code>bun test</code> + <code>bun run typecheck</code></summary>

```
 31 pass
 0 fail
 77 expect() calls
Ran 31 tests across 8 files. [5.53s]

$ tsc --noEmit
(clean)
```
</details>

<details>
<summary><b>svelte-check</b> — <code>npm run check</code></summary>

```
COMPLETED 10267 FILES 378 ERRORS 248 WARNINGS 174 FILES_WITH_PROBLEMS
```

378 errors, the known pre-existing baseline, across 111 distinct files. **None of them is in a file
this PR touches** — filtering the run's own error list by the five files in the diff returns nothing:

```
src/lib/server/brand-media.ts                                    → 0
src/lib/server/brand-media.source.test.ts                        → 0
src/lib/agent/tools/sandbox-tools.ts                             → 0
src/lib/agent/bridge/attach.ts                                   → 0
src/lib/content/changelog/2026-09-03-generated-videos-in-library.ts → 0
```

That zero on the test file is itself the third assertion doing its job: an unused
`@ts-expect-error` is an error, so a silent file means the type really does reject `'ai'`. (Test
files are in scope — the same run reports errors inside `src/lib/agent/bridge/harness-pi-images.test.ts`.)
</details>

`git diff --check`: clean.

**Not tested, and why.** No browser run: this change has no UI surface — it is a string in an
`INSERT` and a log line. The claim that matters ("the database accepts what we write") is not
something a browser can prove and a `psql` transaction can, so that is where it was proved. The
production database was **not** touched: the probe ran against the local stack, in a transaction,
rolled back.

**Risk.** `'agent'` reaches the constraint through `0220_widen_source_checks.sql`, one of the
migrations `schema-drift-check.mjs` cannot verify from outside. If `0220` is not applied to
production, `sandbox save_to_library` still fails there — but it fails *today* with `'sandbox'` too,
and so does `attach.ts`, which has been writing `'agent'` since August. This PR does not make that
worse, and after it the failure is no longer silent. `'generate'` predates every widening migration,
so the paid-render path — the expensive one — is safe regardless.

## Evidence (screenshots/videos)

No UI change. All evidence is CLI/SQL output, in the `<details>` blocks above: the live constraint
definition, the per-value insert probe against the real Postgres, the captured red, the green, the
suite, and the CLI.

## Anything Else?

- **`schema-drift-check.mjs` has a blind spot worth closing later.** Its section C already compares
  literals against CHECK constraints, but it only reads `.from('x').insert({…})` chains written out
  in full. `insertBrandMedia(supabase, { source: 'ai' })` is a helper call, and it walked straight
  past. Widening that walker to known insert helpers would have flagged this months ago. Not done
  here — it is a change to a diagnostic tool, not to the defect.
- **The remaining silence, deliberately left.** `sandbox-tools.ts` still returns its insert failure
  to the agent without a server-side log. That one is read by the agent and surfaced in the tool
  result, so it is not silent in the way the paid-render path was; adding a second logging
  convention for it was not worth the diff.
- `changelog/2026-09-03-brand-media-source-values.md` (internal),
  `src/lib/content/changelog/2026-09-03-generated-videos-in-library.ts` (public), and a new
  `LESSONS.md` entry ship in the same commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
