### PR TITLE
Drop the owner unique constraint, prefer the paying org

### DIFF
--- a/changelog/2026-09-03-org-owner-race.md
+++ b/changelog/2026-09-03-org-owner-race.md
@@ -1,21 +1,48 @@
-# ensureOrgForUser() poteva creare due org per lo stesso owner
+# Quale org risponde a `ensureOrgForUser`, quando l'utente ne possiede più di una
 
-`ensureOrgForUser()` (`src/lib/server/org.ts`) era check-then-insert senza nessun vincolo
-DB su `organizations.owner_id`: due richieste concorrenti di creazione del primo brand per
-lo stesso utente nuovo (doppio submit, due tab) potevano entrambe superare il check e
-inserire una riga ciascuna. `organizations.owner_id` aveva solo un indice non-unique
-(`organizations_owner_id_idx`, migration 0164, per performance RLS), niente che impedisse
-il duplicato.
+`ensureOrgForUser()` (`src/lib/server/org.ts`) sceglieva l'org dell'utente con
+`.eq('owner_id', …).limit(1).maybeSingle()`, **senza `order by`**. Con più righe per lo stesso
+owner, quale riga risponde non è definito: Postgres restituisce quello che gli conviene, e può
+cambiare tra una richiesta e l'altra. Un brand nuovo finiva quindi in un'org a caso tra quelle
+dell'utente — e con la fatturazione che si sposta a livello org (mappa #183), "a caso" diventa
+la differenza tra un'org che paga e una che non paga.
 
-Aggiunto il vincolo unico `organizations_owner_id_key` (droppando l'indice non-unique
-ridondante, la stessa colonna). `ensureOrgForUser` ora tenta l'insert e, se perde la race
-(violazione del vincolo), ri-seleziona la riga del vincitore invece di tornare `null` — lo
-stesso pattern già in uso in `insertBrandWithSlug` (`brand-create.ts`) per la stessa classe
-di problema su `brands.slug`.
+Non è un caso teorico: in produzione ci sono **94 org su 89 owner distinti**, e **due owner
+possiedono più org** — uno ne ha cinque, quattro delle quali con un brand dentro.
 
-**Scartato:** un lock applicativo (advisory lock o `SELECT ... FOR UPDATE`). Il vincolo
-unico più il retry-by-reselect è più corto, non tiene una connessione bloccata in attesa,
-e ricalca un pattern già presente e testato nel repo invece di introdurne uno nuovo.
+`ensureOrgForUser` ora risponde con **l'org che paga**, se ce n'è una: quella che possiede un
+brand con una subscription Stripe e un piano pagante. Solo quando nessuna paga si ricade sulla
+**più vecchia** (`created_at`, con `id` come spareggio su timestamp identici), e sulla via della
+creazione rilegge con lo stesso criterio: due chiamate concorrenti che inseriscono ciascuna la
+propria riga convergono comunque sullo stesso id, invece di andarsene con due org diverse.
 
-Test: `src/lib/server/org.test.ts`, osservato rosso (la chiamata che perde la race tornava
-`null` invece dell'org condivisa) prima del fix.
+La precedenza all'org pagante non è un dettaglio: senza, l'unico owner con cinque org
+continuerebbe a creare brand nell'org più vecchia mentre paga su un'altra — e a fatturazione
+org-level quel brand nuovo non riceverebbe alcun pool di crediti.
+
+**Come si riconosce l'org pagante: dai brand, non dall'org.** Le colonne `stripe_subscription_id`
+e `plan` su `organizations` arrivano con la migrazione del billing org-level (PR #202) e oggi non
+esistono ancora; leggerle qui legherebbe questa patch all'ordine di merge di quella. I campi sui
+brand invece ci sono già, e per decisione di #185 restano popolati per tutto il rollout come rete
+di sicurezza: la lettura resta corretta prima, durante e dopo. Servono entrambe le condizioni —
+una subscription cancellata conserva il suo id ma si vede azzerare il piano (migration 0104).
+
+**Scartato: il vincolo unico su `organizations.owner_id`.** Era la prima versione di questa
+patch, ed era sbagliata due volte. Sarebbe fallita in applicazione (i duplicati in produzione
+esistono già), ma soprattutto avrebbe deciso una regola di prodotto — «un utente possiede al
+massimo un'organizzazione» — nascondendola dentro un fix di concorrenza. Il multi-org resta
+supportato, per scelta esplicita.
+
+**Scartato: la prevenzione della race con advisory lock in una funzione Postgres.** Impedirebbe
+la riga duplicata, ma la riga duplicata non fa danno: è un'org vuota che, con la scelta
+deterministica, nessuno userà mai. Costerebbe una migration, una funzione SQL e un nuovo modo
+di fallire (contesa sul lock) per un sintomo già neutralizzato.
+
+I due owner con org duplicate in produzione restano come sono: nessun dedupe, che significherebbe
+ri-puntare `brands.org_id` di brand veri. Ora però il comportamento è stabile.
+
+Test: `src/lib/server/org.test.ts`, osservati rossi prima del fix (la selezione rispondeva con
+l'org sbagliata, e due chiamate concorrenti tornavano due id diversi). I due casi di guardia —
+una subscription cancellata non conta come pagante, il brand pagante di un altro owner non conta
+— sono stati verificati mutando la query: tolta la condizione sul piano fallisce il primo, tolto
+il filtro sull'owner fallisce il secondo.

--- a/src/lib/server/org.test.ts
+++ b/src/lib/server/org.test.ts
@@ -1,13 +1,27 @@
 import { describe, expect, it } from 'vitest';
-import { ensureOrgForUser, OWNER_CONSTRAINT } from './org';
+import { ensureOrgForUser } from './org';
 
 type Row = Record<string, any>;
 
-/** organizations with the unique index production enforces on owner_id. */
-function makeDb() {
-	const orgs: Row[] = [];
+/**
+ * organizations as production has it: several rows may share one owner_id, no unique constraint.
+ * brands rows carry the billing columns the paying-org lookup joins through.
+ */
+function makeDb(seed: Row[] = [], brands: Row[] = []) {
+	const orgs: Row[] = seed.map((r) => ({ ...r }));
+	const brandRows: Row[] = brands.map((r) => ({ ...r }));
 	const members: Row[] = [];
-	let orgInsertCalls = 0;
+	let clock = orgs.length;
+
+	function sorted(rows: Row[], sorts: { col: string; asc: boolean }[]) {
+		return [...rows].sort((a, b) => {
+			for (const { col, asc } of sorts) {
+				if (a[col] === b[col]) continue;
+				return (a[col] < b[col] ? -1 : 1) * (asc ? 1 : -1);
+			}
+			return 0;
+		});
+	}
 
 	const client = {
 		from: (table: string) => {
@@ -15,21 +29,23 @@ function makeDb() {
 				return {
 					select: () => {
 						const filters: Record<string, unknown> = {};
+						const sorts: { col: string; asc: boolean }[] = [];
 						const chain = {
 							eq: (k: string, v: unknown) => {
 								filters[k] = v;
 								return chain;
 							},
+							order: (col: string, opts?: { ascending?: boolean }) => {
+								sorts.push({ col, asc: opts?.ascending !== false });
+								return chain;
+							},
 							limit: () => chain,
 							maybeSingle: async () => {
-								const row = orgs.find((r) => Object.entries(filters).every(([k, v]) => r[k] === v));
-								return { data: row ? { id: row.id } : null, error: null };
-							},
-							single: async () => {
-								const row = orgs.find((r) => Object.entries(filters).every(([k, v]) => r[k] === v));
-								return row
-									? { data: { id: row.id }, error: null }
-									: { data: null, error: { message: 'no rows returned' } };
+								const rows = sorted(
+									orgs.filter((r) => Object.entries(filters).every(([k, v]) => r[k] === v)),
+									sorts
+								);
+								return { data: rows[0] ? { id: rows[0].id } : null, error: null };
 							}
 						};
 						return chain;
@@ -37,21 +53,53 @@ function makeDb() {
 					insert: (row: Row) => ({
 						select: () => ({
 							single: async () => {
-								orgInsertCalls++;
-								if (orgs.some((r) => r.owner_id === row.owner_id)) {
-									return {
-										data: null,
-										error: {
-											message: `duplicate key value violates unique constraint "${OWNER_CONSTRAINT}"`
-										}
-									};
-								}
-								const id = `org-${orgs.length + 1}`;
-								orgs.push({ id, ...row });
-								return { data: { id }, error: null };
+								const n = ++clock;
+								const created = { id: `org-${n}`, created_at: `2026-09-0${n}`, ...row };
+								orgs.push(created);
+								return { data: { id: created.id }, error: null };
 							}
 						})
 					})
+				};
+			}
+			if (table === 'brands') {
+				return {
+					select: () => {
+						let rows = [...brandRows];
+						const sorts: { col: string; asc: boolean }[] = [];
+						const chain = {
+							// Only shape used: the embedded organizations.owner_id filter.
+							eq: (k: string, v: unknown) => {
+								if (k === 'organizations.owner_id') {
+									const owned = new Set(
+										orgs.filter((o) => o.owner_id === v).map((o) => o.id)
+									);
+									rows = rows.filter((b) => owned.has(b.org_id));
+								} else {
+									rows = rows.filter((b) => b[k] === v);
+								}
+								return chain;
+							},
+							not: (k: string, _op: string, _v: unknown) => {
+								rows = rows.filter((b) => b[k] !== null && b[k] !== undefined);
+								return chain;
+							},
+							in: (k: string, vals: unknown[]) => {
+								rows = rows.filter((b) => vals.includes(b[k]));
+								return chain;
+							},
+							order: (col: string, opts?: { ascending?: boolean }) => {
+								sorts.push({ col, asc: opts?.ascending !== false });
+								return chain;
+							},
+							limit: () => chain,
+							maybeSingle: async () => {
+								const hit = sorted(rows, sorts)[0];
+								return { data: hit ? { org_id: hit.org_id } : null, error: null };
+							}
+						};
+						return chain;
+					}
 				};
 			}
 			if (table === 'org_members') {
@@ -66,32 +114,78 @@ function makeDb() {
 		}
 	};
 
-	return { client, orgs, members, get orgInsertCalls() { return orgInsertCalls; } };
+	return { client, orgs, brandRows, members };
 }
 
+const USER = { id: 'u1', email: 'ana@example.com' } as never;
+
+const THREE_ORGS = [
+	{ id: 'org-new', owner_id: 'u1', created_at: '2026-09-01' },
+	{ id: 'org-mid', owner_id: 'u1', created_at: '2026-05-01' },
+	{ id: 'org-old', owner_id: 'u1', created_at: '2026-01-01' }
+];
+
 describe('ensureOrgForUser', () => {
-	it('gives two concurrent calls for the same user the same org, not two', async () => {
+	it('answers with the paying org, not the oldest one', async () => {
+		const db = makeDb(THREE_ORGS, [
+			{ org_id: 'org-mid', plan: 'pro', stripe_subscription_id: 'sub_1' },
+			{ org_id: 'org-old', plan: null, stripe_subscription_id: null }
+		]);
+
+		expect(await ensureOrgForUser(db.client as never, USER)).toBe('org-mid');
+	});
+
+	it('ignores a brand whose subscription was cancelled (plan cleared)', async () => {
+		const db = makeDb(THREE_ORGS, [
+			{ org_id: 'org-mid', plan: null, stripe_subscription_id: 'sub_dead' }
+		]);
+
+		expect(await ensureOrgForUser(db.client as never, USER)).toBe('org-old');
+	});
+
+	it('ignores another owner’s paying brand', async () => {
+		const db = makeDb(
+			[...THREE_ORGS, { id: 'org-theirs', owner_id: 'u2', created_at: '2026-02-01' }],
+			[{ org_id: 'org-theirs', plan: 'pro', stripe_subscription_id: 'sub_2' }]
+		);
+
+		expect(await ensureOrgForUser(db.client as never, USER)).toBe('org-old');
+	});
+
+	it('always answers with the same org when the owner has several and none pays', async () => {
+		// Stored newest-first on purpose: picking "whatever row comes back" answers wrong.
+		const db = makeDb(THREE_ORGS);
+
+		const answers = [
+			await ensureOrgForUser(db.client as never, USER),
+			await ensureOrgForUser(db.client as never, USER),
+			await ensureOrgForUser(db.client as never, USER)
+		];
+
+		expect(answers).toEqual(['org-old', 'org-old', 'org-old']);
+		expect(db.orgs).toHaveLength(3);
+	});
+
+	it('gives two concurrent first calls the same org id', async () => {
 		const db = makeDb();
-		const user = { id: 'u1', email: 'ana@example.com' } as never;
 
 		const [a, b] = await Promise.all([
-			ensureOrgForUser(db.client as never, user),
-			ensureOrgForUser(db.client as never, user)
+			ensureOrgForUser(db.client as never, USER),
+			ensureOrgForUser(db.client as never, USER)
 		]);
 
 		expect(a).not.toBeNull();
 		expect(a).toBe(b);
-		expect(db.orgs).toHaveLength(1);
 	});
 
-	it('still returns the existing org id on a normal, non-concurrent second call', async () => {
+	it('creates the org on a first call and reuses it on the next', async () => {
 		const db = makeDb();
-		const user = { id: 'u1', email: 'ana@example.com' } as never;
 
-		const first = await ensureOrgForUser(db.client as never, user);
-		const second = await ensureOrgForUser(db.client as never, user);
+		const first = await ensureOrgForUser(db.client as never, USER);
+		const second = await ensureOrgForUser(db.client as never, USER);
 
 		expect(first).toBe(second);
 		expect(db.orgs).toHaveLength(1);
+		expect(db.members).toEqual([{ org_id: first, user_id: 'u1', role: 'owner' }]);
 	});
 });

--- a/src/lib/server/org.ts
+++ b/src/lib/server/org.ts
@@ -1,23 +1,49 @@
 import type { SupabaseClient, User } from '@supabase/supabase-js';
+import { PAID_PLAN_IDS } from '$lib/plans';
 
-export const OWNER_CONSTRAINT = 'organizations_owner_id_key';
-
-function violatesOwnerConstraint(error: { message?: string; details?: string } | null): boolean {
-  if (!error) return false;
-  return `${error.message ?? ''} ${error.details ?? ''}`.includes(OWNER_CONSTRAINT);
+/**
+ * The owner's org that is actually paying, if any. Read through `brands` rather than through
+ * the org's own billing columns: those arrive with the org-level billing migration and do not
+ * exist yet, while the brand ones stay populated throughout that rollout. Both conditions are
+ * required — a cancelled subscription keeps its id but has its plan cleared.
+ */
+async function payingOrgId(supabase: SupabaseClient, ownerId: string): Promise<string | null> {
+  const { data } = await supabase
+    .from('brands')
+    .select('org_id, organizations!inner(owner_id)')
+    .eq('organizations.owner_id', ownerId)
+    .not('stripe_subscription_id', 'is', null)
+    .in('plan', [...PAID_PLAN_IDS])
+    .order('org_id', { ascending: true })
+    .limit(1)
+    .maybeSingle();
+  return (data?.org_id as string | undefined) ?? null;
 }
 
-// Every user gets one organization (their workspace) lazily on first need.
+/**
+ * The owner's oldest organization: where brands land when nothing is paying yet. A user may own
+ * several (production does), so "their org" has to mean one specific row, always the same one —
+ * otherwise a new brand lands in whichever org the database happened to return. `id` breaks a tie
+ * on identical timestamps.
+ */
+async function oldestOrgId(supabase: SupabaseClient, ownerId: string): Promise<string | null> {
+  const { data } = await supabase
+    .from('organizations')
+    .select('id')
+    .eq('owner_id', ownerId)
+    .order('created_at', { ascending: true })
+    .order('id', { ascending: true })
+    .limit(1)
+    .maybeSingle();
+  return data?.id ?? null;
+}
+
+// Every user gets an organization (their workspace) lazily on first need.
 // Brands hang off an org, so this must run before a brand can be created.
 // RLS-safe: the user owns the org they insert (owner_id = auth.uid()).
 export async function ensureOrgForUser(supabase: SupabaseClient, user: User): Promise<string | null> {
-  const { data: existing } = await supabase
-    .from('organizations')
-    .select('id')
-    .eq('owner_id', user.id)
-    .limit(1)
-    .maybeSingle();
-  if (existing) return existing.id;
+  const existing = (await payingOrgId(supabase, user.id)) ?? (await oldestOrgId(supabase, user.id));
+  if (existing) return existing;
 
   const handle = user.email?.split('@')[0] ?? 'My';
   const { data: org, error } = await supabase
@@ -25,19 +51,11 @@ export async function ensureOrgForUser(supabase: SupabaseClient, user: User): Pr
     .insert({ name: `${handle}'s workspace`, owner_id: user.id })
     .select('id')
     .single();
+  if (error || !org) return null;
 
-  if (!error) {
-    await supabase.from('org_members').insert({ org_id: org.id, user_id: user.id, role: 'owner' });
-    return org.id;
-  }
+  await supabase.from('org_members').insert({ org_id: org.id, user_id: user.id, role: 'owner' });
 
-  // Lost a race with another concurrent call for this same user: organizations.owner_id is
-  // unique, so the winner's row is this user's org too — fetch it instead of returning null.
-  if (!violatesOwnerConstraint(error)) return null;
-  const { data: winner } = await supabase
-    .from('organizations')
-    .select('id')
-    .eq('owner_id', user.id)
-    .single();
-  return winner?.id ?? null;
+  // A concurrent first call may have inserted its own row a moment earlier: both answers
+  // converge on the oldest, so two tabs cannot walk away with two different orgs.
+  return (await oldestOrgId(supabase, user.id)) ?? org.id;
 }

--- a/supabase/migrations/20260903182027_organizations_owner_unique.sql
+++ b/supabase/migrations/20260903182027_organizations_owner_unique.sql
@@ -1,8 +1,0 @@
--- ensureOrgForUser() (src/lib/server/org.ts) is check-then-insert with no DB-level
--- uniqueness on owner_id: two concurrent first-brand-creation requests for the same
--- new user can each pass the check and insert their own org. This constraint makes
--- the second insert fail instead, so the code can fall back to the winner's row.
-drop index if exists public.organizations_owner_id_idx;
-
-alter table public.organizations
-  add constraint organizations_owner_id_key unique (owner_id);


### PR DESCRIPTION
## What?

PR #197 was merged at its **first** commit, so `dev` now carries the version that work had
already replaced: a unique constraint on `organizations.owner_id` (code helpers plus the
migration `20260903182027_organizations_owner_unique.sql`) and an org selection with no
`order by`.

This PR lands the corrected state:

- **Deletes** the migration and the constraint helpers.
- `ensureOrgForUser()` answers with **the org that pays**, if the owner has one — the org owning
  a brand that has a Stripe subscription *and* a paid plan.
- Otherwise with the owner's **oldest** org (`created_at`, `id` breaking ties), re-read after the
  insert so two concurrent first calls converge on one id instead of walking away with two.

## Why?

**The migration in `dev` cannot be applied.** Production holds **94 organizations across 89
distinct owners**, and **two owners own several** — one owns five, four of them holding a brand.
`alter table … add constraint … unique (owner_id)` fails on the first duplicate.

It is also the wrong rule. It would have decided, silently, that a user owns at most one
organization — a product decision hidden inside a concurrency fix. Multi-org stays supported by
explicit decision (#203).

The paying-org step is not a nicety either: without it, that owner with five organizations keeps
creating brands in the oldest one while the subscription lives in another. Once billing is
org-level (map #183), such a brand draws on no credit pool at all.

## How?

- `payingOrgId()` reads through `brands`, not through the org's own billing columns.
  `organizations.stripe_subscription_id` / `.plan` arrive with the org-level billing migration
  (#202) and do not exist yet; reading them here would tie this PR to that one's merge order. The
  brand columns exist today and, by #185's decision, stay populated for the whole rollout as a
  rollback net — so the lookup is correct before, during and after it.
- Both conditions are required: a cancelled subscription keeps its id but has its plan cleared
  (migration 0104), so an id alone does not mean "paying".
- **Rejected: preventing the race with an advisory lock in a Postgres function.** It would stop
  the duplicate row, but the duplicate row does no harm once selection is deterministic — it is an
  empty org nobody is ever handed. A migration, a SQL function and a new failure mode (lock
  contention) to neutralise a symptom already neutralised.

## Testing?

`src/lib/server/org.test.ts` — 6 cases, written before the code and watched fail: the wrong org
answering (seeded newest-first on purpose), two concurrent calls returning two different ids, and
the oldest org answering while a paying one exists.

The two guard cases were verified by mutating the query rather than trusting them: dropping the
paid-plan condition makes "ignores a cancelled subscription" fail; dropping the owner filter makes
"ignores another owner's paying brand" fail. 15/15 green together with `brand-create.test.ts`, the
sibling pattern this mirrors.

**`node scripts/typecheck-runtime.mjs` was not run** — this machine could not complete it (several
concurrent worktree jobs; runs killed at exit 144). Verified by other means: no residual references
to the removed constraint helpers anywhere in `src/`, `supabase/` or `changelog/`; all four callers
of `ensureOrgForUser` use the unchanged `Promise<string | null>` signature; `$lib/plans` is imported
directly by seven other server modules including `credits.ts`, so the import shape is the
established one. CI's `test` job covers it independently.

## Evidence (screenshots/videos)

No UI surface — server-side selection logic.

<details><summary>What <code>dev</code> holds right now</summary>

```
$ git show origin/dev:src/lib/server/org.ts | head -6
export const OWNER_CONSTRAINT = 'organizations_owner_id_key';
…
    .eq('owner_id', user.id)
    .limit(1)          ← no order by
$ git ls-tree origin/dev supabase/migrations/ | grep owner_unique
supabase/migrations/20260903182027_organizations_owner_unique.sql
```
</details>

<details><summary>The paying-org case failing before the fix</summary>

```
× ensureOrgForUser > answers with the paying org, not the oldest one
  → expected 'org-old' to be 'org-mid'
```
</details>

<details><summary>Both guard tests biting under mutation</summary>

```
# paid-plan condition removed:
× ensureOrgForUser > ignores a brand whose subscription was cancelled (plan cleared)

# owner filter removed:
× ensureOrgForUser > ignores another owner's paying brand
```
</details>

## Anything Else?

**Nothing needs undoing in production**: the bad migration was never applied by hand, and this PR
deletes the file before it can be. Worth confirming it was not applied before merging.

The two owners with duplicate orgs stay as they are — no dedupe, which would mean re-pointing
`brands.org_id` on real brands. The behaviour around them is now stable, which is the part that
mattered.

Noted in passing, out of scope: `src/lib/server/referrals.ts:138` picks an org with the same
`.limit(1)`-without-`order` shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RgPP6gw4d7xW7Y92vJJrPZ
