### PR TITLE
Let an external agent save a plan and week seeds

### DIFF
--- a/changelog/2026-09-03-external-plan-and-seeds.md
+++ b/changelog/2026-09-03-external-plan-and-seeds.md
@@ -1,0 +1,68 @@
+# Un piano e una settimana scritti fuori, salvati come i nostri
+
+Fase 2 del piano agenti esterni. `propose_plan` e `plan_week` sanno solo **generare**: chiedono il
+piano al nostro modello e lo fatturano. Un agente esterno che il piano l'ha già scritto — con
+l'account modello del suo utente — non aveva dove metterlo. Stessa lacuna sui seed della settimana.
+
+Ora ci sono due scritture deterministiche accanto a quelle gestite, non al loro posto:
+
+- `POST /editorial-plan/save` (`save_plan`) — il piano supplito diventa la **proposta pendente**;
+- `POST /weekly-plan/seeds` (`save_week_seeds`) — le righe supplite diventano la **bozza** della
+  settimana.
+
+Nessuna chiamata al modello, nessun credito: i test lo verificano spiando `structured`,
+`gateAiAction` e `gateCredits` e pretendendo che nessuno sia chiamato.
+
+## Perché sono indistinguibili da quelli generati
+
+Il requisito era «managed and external-authoring paths produce the same domain states», e una
+promessa del genere si mantiene solo condividendo il codice, non copiandolo.
+
+- **Il piano.** Il writer che `proposeFirstPlan` aveva inline è uscito in `saveProposedPlan`
+  (`editorial-plan.ts`, accanto al modello che governa la tabella), in un commit che non cambia
+  comportamento. Ora entrambe le strade passano da lì: stessa riga, stesso `status: 'proposed'`,
+  stesso `source: 'manual'`. Il body supplito passa da `normalizePlan`, la stessa funzione che
+  normalizza l'output del modello — quindi anche il padding a 4 settimane, le piattaforme in
+  minuscolo e il `clampCadence` sono gli stessi.
+- **I seed.** Passano da `normalizeWeeklyStrategy`, che il repo dichiara «single rehydration
+  point»: id di riga assegnato, formati legacy mappati sull'enum, capacità media clampate. La
+  bozza scritta è una riga `content_plans` identica a quella di `plan`.
+
+## Cosa è stato deciso, e cosa scartato
+
+**Il piano salvato non si attiva da solo.** Finisce `proposed`; `approve_plan` resta il passo che
+attiva. Un `activate: true` sarebbe stato comodo e avrebbe tolto la revisione umana da una scrittura
+che nessun operatore ha visto: scartato. Il piano **attivo** non viene mai toccato — solo una
+proposta pendente precedente passa a `rejected`, esattamente come fa `propose`.
+
+**`source` resta `'manual'`, non `'external'`.** `editorial_plans.source` ha un CHECK
+(`onboarding | revision | rollover | manual | analytics_review | autopilot`) e questo repo **non
+esegue le migrazioni al deploy**: un valore nuovo passerebbe in locale e romperebbe in produzione
+con un 23514. `posts.source` non ha vincolo, ed è per questo che `create_post` poteva scrivere
+`'external'`; qui no. Un test blocca i valori scritti contro gli array reali del CHECK. La
+provenienza «agente esterno» distinta dalla web resta un follow-up che richiede una migrazione
+applicata a mano.
+
+**Una bozza sola.** La pagina piano legge la bozza `draft` più recente: una seconda riga
+nasconderebbe la prima. Quindi `save_week_seeds` sostituisce quella in revisione (come fa l'azione
+web), invece di inserirne un'altra come fa la rotta CLI `plan`. La risposta dice `replaced`.
+
+**Attaccati al piano attivo se c'è, altrimenti in piedi da soli** (`editorial_plan_id: null`) —
+lo stesso fallback della rotta gestita.
+
+**Rifiuta invece di scartare.** `normalizeWeeklyStrategy` butta silenziosamente un seed senza
+piattaforma. Lo schema del contratto lo rifiuta prima, nominando la riga (`seeds.0.platform`):
+un'agente che riceve `ok: true` per tre seed e ne trova due salvati non ha modo di accorgersene.
+
+## Cosa NON c'è
+
+- **Nessun controllo `media_id` sui seed.** `PostSeed` porta `media_id`/`media_mode`, ma
+  accettarli richiederebbe la verifica di proprietà del brand che fa `create_post`
+  (`media_not_found`). Non l'ho aggiunta, quindi i due campi non sono nel contratto.
+- **Nessun `beats`.** La storia per slide di un carosello è una struttura annidata con un
+  contratto suo; fuori da questa PR.
+- **Nessuna guardia «settimana già prodotta».** L'azione web rifiuta di ripianificare una
+  settimana che ha già post (`week_has_posts`, la trappola del 3+3); vive inline nella page
+  server e non è estratta. La rotta CLI `plan` ha lo stesso buco: salvare seed su una settimana
+  già prodotta e poi chiamare `produce` duplica i post. Parità con l'esistente, non un
+  peggioramento — ma è un buco.

--- a/cli/lib/contracts/index.ts
+++ b/cli/lib/contracts/index.ts
@@ -1,5 +1,6 @@
 import type { z } from 'zod';
 import { CHECK_CONTENT } from './content';
+import { PLAN_CADENCES, PLAN_CYCLE_WEEKS, SAVE_PLAN, SAVE_WEEK_SEEDS } from './plans';
 import { CREATE_POST, GET_CALENDAR, LIST_MEDIA, LIST_POSTS } from './posts';
 
 export type EndpointFailure = { readonly error: string; readonly status: number };
@@ -16,7 +17,7 @@ export type BrandEndpoint = {
   readonly destructive: boolean;
 };
 
-export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [CREATE_POST, LIST_POSTS, GET_CALENDAR, LIST_MEDIA, CHECK_CONTENT];
+export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [CREATE_POST, LIST_POSTS, GET_CALENDAR, LIST_MEDIA, CHECK_CONTENT, SAVE_PLAN, SAVE_WEEK_SEEDS];
 
 export function pathFor(endpoint: BrandEndpoint, slug: string): string {
   return `/api/v1/brands/${encodeURIComponent(slug)}${endpoint.pathUnderBrand}`;
@@ -29,3 +30,5 @@ export function statusForFailure(endpoint: BrandEndpoint, error: string): number
 export { CHECK_CONTENT, CREATE_POST, GET_CALENDAR, LIST_MEDIA, LIST_POSTS };
 export type { CheckContentInput, CheckContentResult } from './content';
 export type { CreatePostInput, CreatePostResult } from './posts';
+export { PLAN_CADENCES, PLAN_CYCLE_WEEKS, SAVE_PLAN, SAVE_WEEK_SEEDS };
+export type { SavePlanInput, SavePlanResult, SaveWeekSeedsInput, SaveWeekSeedsResult } from './plans';

--- a/cli/lib/contracts/plans.ts
+++ b/cli/lib/contracts/plans.ts
@@ -1,0 +1,172 @@
+import { z } from 'zod';
+import type { BrandEndpoint } from './index';
+
+// The deterministic half of planning: an agent that already wrote the plan or the week's rows
+// deposits them here. Anomalia stores them and calls no model. The generating endpoints
+// (propose_plan, plan_week) stay: this sits beside them, it does not replace them.
+//
+// These two constants mirror the app's PLAN_WEEKS and CADENCES, which live behind $lib and
+// cannot be imported from a package. The route tests import both and fail if they diverge.
+
+export const PLAN_CYCLE_WEEKS = 4;
+export const PLAN_CADENCES = ['3/week', '5/week', 'daily'] as const;
+const MAX_WEEK_SEEDS = 30;
+
+const line = z.string().min(1);
+
+const PlanWeekInput = z
+  .object({
+    theme: line.describe('The editorial theme tying the week together'),
+    focus: line.describe('What the week concretely pushes'),
+    content_mix: z
+      .array(z.object({ type: line, count: z.number().int().min(1) }).strict())
+      .min(1)
+      .describe('Post types and how many of each. The counts are the volume the week produces'),
+    rationale: z.string().optional(),
+    brief: z.string().optional().describe('Operator direction for this week, kept verbatim'),
+    products: z.array(line).optional().describe('Exact product titles this week must feature')
+  })
+  .strict();
+
+const PlanGtmInput = z
+  .object({
+    stage: z.enum(['zero_to_one', 'growth']),
+    summary: z.string(),
+    platform_recs: z
+      .array(
+        z
+          .object({
+            platform: line,
+            priority: z.enum(['primary', 'secondary', 'experiment']),
+            why: z.string(),
+            organic_potential: z.string()
+          })
+          .strict()
+      )
+      .optional(),
+    plays: z.array(z.string()).optional()
+  })
+  .strict();
+
+const SavePlanInputSchema = z
+  .object({
+    strategy: line.describe('The strategy document you wrote, in prose'),
+    voice: z.object({ mood: line, tone: line, goal: line, personality: line }).strict(),
+    cadence: z.enum(PLAN_CADENCES).describe('How a week is spread across days'),
+    platform_mix: z
+      .array(z.object({ platform: line, share: line, role: line }).strict())
+      .min(1),
+    gtm: PlanGtmInput.optional(),
+    weeks: z
+      .array(PlanWeekInput)
+      .min(1)
+      .max(PLAN_CYCLE_WEEKS)
+      .describe(`Up to ${PLAN_CYCLE_WEEKS} weeks; a short cycle is padded with empty weeks`)
+  })
+  .strict();
+
+const SavePlanResultSchema = z.object({
+  ok: z.literal(true),
+  plan_id: z.string(),
+  status: z.literal('proposed'),
+  weeks: z.number(),
+  review_url: z.string()
+});
+
+export type SavePlanInput = z.infer<typeof SavePlanInputSchema>;
+export type SavePlanResult = z.infer<typeof SavePlanResultSchema>;
+
+export const SAVE_PLAN = {
+  tool: 'save_plan',
+  title: 'Save an editorial plan',
+  description:
+    'Store an editorial plan you wrote yourself. Anomalia calls no model and spends no credits. ' +
+    'It lands as the pending proposal, exactly where propose_plan leaves a generated one: the ' +
+    'brand active plan is left untouched and approve_plan remains the step that activates it. ' +
+    'Saving replaces an earlier pending proposal.',
+  method: 'POST',
+  pathUnderBrand: '/editorial-plan/save',
+  input: SavePlanInputSchema,
+  output: SavePlanResultSchema,
+  failures: [{ error: 'invalid_input', status: 400 }, { error: 'insert_failed', status: 500 }],
+  destructive: false
+} satisfies BrandEndpoint;
+
+const WeekSeedInput = z
+  .object({
+    platform: line.describe('Primary publish target, e.g. "instagram"'),
+    platforms: z.array(line).optional().describe('Full cross-post set; defaults to [platform]'),
+    pillar: z.string().optional().describe('The content pillar this post serves'),
+    format: z.string().optional().describe('single_image, carousel, video, text…'),
+    media: z.enum(['image', 'text', 'link', 'video']).optional(),
+    slide_count: z.number().int().min(2).max(20).optional().describe('Carousels only'),
+    art_direction: z.string().optional().describe('The medium: comic, illustration, reportage…'),
+    sourced_from: z.string().optional().describe('Where the situation comes from, URL included'),
+    day: z.string().optional().describe('Day of week, e.g. "Tue"'),
+    time: z.string().optional().describe('Time of day, e.g. "09:00"'),
+    angle: line.describe('The intent the copywriter must serve'),
+    subject: z.string().optional().describe('Main subject in frame'),
+    setting: z.string().optional().describe('Location or environment'),
+    props: z.string().optional().describe('Supporting objects and styling'),
+    product: z.string().optional().describe('Exact product title, or omitted'),
+    person: z.string().optional().describe('Exact name from the brand people list, or omitted'),
+    title: z.string().optional().describe('Reddit title'),
+    subreddit: z.string().optional(),
+    link_url: z.string().optional(),
+    hook: z.string().optional().describe('Video only: the spoken opening'),
+    hook_visual: z.string().optional().describe('Video only: what happens on screen in second one'),
+    hook_text: z.string().optional().describe('Video only: on-screen text over the first seconds'),
+    body: z.string().optional().describe('Video only: problem, demo, proof'),
+    cta: z.string().optional().describe('Video only: the closing ask'),
+    ugc: z.boolean().optional().describe('Video only: handheld UGC instead of the cinematic default')
+  })
+  .strict();
+
+const SaveWeekSeedsInputSchema = z
+  .object({
+    week_index: z
+      .number()
+      .int()
+      .min(0)
+      .max(PLAN_CYCLE_WEEKS - 1)
+      .describe('Which week of the active editorial cycle these rows belong to'),
+    theme: line.describe('The single editorial angle tying the week together'),
+    rationale: z.string().optional().describe('Why this theme now'),
+    do_dont: z.string().optional().describe('Guardrails for whoever writes the copy'),
+    seeds: z.array(WeekSeedInput).min(1).max(MAX_WEEK_SEEDS)
+  })
+  .strict();
+
+const SaveWeekSeedsResultSchema = z.object({
+  ok: z.literal(true),
+  draft_id: z.string(),
+  week_index: z.number(),
+  seeds_saved: z.number(),
+  editorial_plan_id: z.string().nullable(),
+  replaced: z.boolean(),
+  review_url: z.string()
+});
+
+export type SaveWeekSeedsInput = z.infer<typeof SaveWeekSeedsInputSchema>;
+export type SaveWeekSeedsResult = z.infer<typeof SaveWeekSeedsResultSchema>;
+
+export const SAVE_WEEK_SEEDS = {
+  tool: 'save_week_seeds',
+  title: 'Save weekly content seeds',
+  description:
+    'Store the week rows you planned yourself — one per post, no copy and no image yet. ' +
+    'Anomalia calls no model and spends no credits. The rows land as the week draft, exactly ' +
+    'where plan_week leaves generated ones: the plan page shows them, they are editable, and ' +
+    'produce_week is the separate (paid) step that turns them into posts. A brand keeps one ' +
+    'draft, so saving replaces the one in review.',
+  method: 'POST',
+  pathUnderBrand: '/weekly-plan/seeds',
+  input: SaveWeekSeedsInputSchema,
+  output: SaveWeekSeedsResultSchema,
+  failures: [
+    { error: 'invalid_input', status: 400 },
+    { error: 'no_seeds', status: 400 },
+    { error: 'save_failed', status: 500 }
+  ],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/cli/plugins/anomalia/skills/anomalia/SKILL.md
+++ b/cli/plugins/anomalia/skills/anomalia/SKILL.md
@@ -63,6 +63,15 @@ as `media_ids`. That is also how you post to Instagram or TikTok, which never ac
 the field to repair. It costs nothing and calls no model, so run it on every draft and fix what
 it names before creating.
 
+**Write the plan yourself** → `save_plan`. You write the strategy, voice, cadence, platform mix
+and the four weeks; Anomalia stores them and calls no model. It lands as the pending proposal —
+the active plan is untouched, and `approve_plan` is what activates it. `propose_plan` remains
+there for when you want Anomalia to write one and bill it.
+
+**Plan a week yourself** → `save_week_seeds` (`week_index`, `theme`, one seed per planned post).
+No model call, no credits. The rows become the week draft the plan page shows; `produce_week` is
+the separate paid step that turns them into posts.
+
 **Approve pending posts** → `list_posts` (status pending) → optional `get_post` → `approve_posts`.
 
 **Fix one carousel slide** → `get_post` → `regenerate_slide` (`index`, instruction; 0 = cover).

--- a/cli/plugins/anomalia/skills/anomalia/references/tools.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/tools.md
@@ -79,6 +79,29 @@ It never looks at pixels — judging an image or a video is a separate, explicit
 | `save_brief` / `replan_week` | `anomalia plan <slug> save-brief\|replan --week N …` |
 | `get_weekly_plan` | `anomalia weekly-plan <slug>` |
 | `plan_week` / `produce_week` | `anomalia weekly-plan <slug> plan\|produce --week N` |
+| `save_plan` | (MCP only) |
+| `save_week_seeds` | (MCP only) |
+
+`propose_plan` and `plan_week` ask Anomalia's model to write the strategy and the week's rows,
+and they bill it. `save_plan` and `save_week_seeds` are the other half: you wrote them, Anomalia
+only stores them — no model call, no credits. Both paths land in the same place, so a saved plan
+is reviewed, approved and produced exactly like a generated one.
+
+`save_plan` deposits the plan as the brand's **pending proposal**. The active plan is left alone:
+`approve_plan` stays the step that activates one, and saving replaces an earlier pending proposal,
+never an active plan. Required: `strategy`, `voice` (`mood`, `tone`, `goal`, `personality`),
+`cadence` (`3/week`, `5/week`, `daily`), `platform_mix` (`platform`, `share`, `role`), and
+`weeks` — up to 4, each with `theme`, `focus` and a `content_mix` whose counts are the week's
+volume. Optional per week: `rationale`, `brief`, `products`. Optional `gtm`. A short cycle is
+padded to 4 weeks, like a generated one.
+
+`save_week_seeds` deposits the week's rows — one per planned post, no copy and no image yet.
+Required: `week_index` (0–3), `theme`, `seeds` (each needs `platform` and `angle`). Optional per
+seed: `platforms`, `pillar`, `format`, `media`, `slide_count`, `day`, `time`, `subject`,
+`setting`, `props`, `product`, `person`, `title`, `subreddit`, `link_url`, `art_direction`,
+`sourced_from`, and the video script (`hook`, `hook_visual`, `hook_text`, `body`, `cta`, `ugc`).
+A brand keeps one draft in review, so saving replaces the one that is there (`replaced` says so).
+`produce_week` is the separate, paid step that turns the rows into posts.
 
 ## Studio
 

--- a/cli/skills/anomalia/SKILL.md
+++ b/cli/skills/anomalia/SKILL.md
@@ -63,6 +63,15 @@ as `media_ids`. That is also how you post to Instagram or TikTok, which never ac
 the field to repair. It costs nothing and calls no model, so run it on every draft and fix what
 it names before creating.
 
+**Write the plan yourself** → `save_plan`. You write the strategy, voice, cadence, platform mix
+and the four weeks; Anomalia stores them and calls no model. It lands as the pending proposal —
+the active plan is untouched, and `approve_plan` is what activates it. `propose_plan` remains
+there for when you want Anomalia to write one and bill it.
+
+**Plan a week yourself** → `save_week_seeds` (`week_index`, `theme`, one seed per planned post).
+No model call, no credits. The rows become the week draft the plan page shows; `produce_week` is
+the separate paid step that turns them into posts.
+
 **Approve pending posts** → `list_posts` (status pending) → optional `get_post` → `approve_posts`.
 
 **Fix one carousel slide** → `get_post` → `regenerate_slide` (`index`, instruction; 0 = cover).

--- a/cli/skills/anomalia/references/tools.md
+++ b/cli/skills/anomalia/references/tools.md
@@ -79,6 +79,29 @@ It never looks at pixels — judging an image or a video is a separate, explicit
 | `save_brief` / `replan_week` | `anomalia plan <slug> save-brief\|replan --week N …` |
 | `get_weekly_plan` | `anomalia weekly-plan <slug>` |
 | `plan_week` / `produce_week` | `anomalia weekly-plan <slug> plan\|produce --week N` |
+| `save_plan` | (MCP only) |
+| `save_week_seeds` | (MCP only) |
+
+`propose_plan` and `plan_week` ask Anomalia's model to write the strategy and the week's rows,
+and they bill it. `save_plan` and `save_week_seeds` are the other half: you wrote them, Anomalia
+only stores them — no model call, no credits. Both paths land in the same place, so a saved plan
+is reviewed, approved and produced exactly like a generated one.
+
+`save_plan` deposits the plan as the brand's **pending proposal**. The active plan is left alone:
+`approve_plan` stays the step that activates one, and saving replaces an earlier pending proposal,
+never an active plan. Required: `strategy`, `voice` (`mood`, `tone`, `goal`, `personality`),
+`cadence` (`3/week`, `5/week`, `daily`), `platform_mix` (`platform`, `share`, `role`), and
+`weeks` — up to 4, each with `theme`, `focus` and a `content_mix` whose counts are the week's
+volume. Optional per week: `rationale`, `brief`, `products`. Optional `gtm`. A short cycle is
+padded to 4 weeks, like a generated one.
+
+`save_week_seeds` deposits the week's rows — one per planned post, no copy and no image yet.
+Required: `week_index` (0–3), `theme`, `seeds` (each needs `platform` and `angle`). Optional per
+seed: `platforms`, `pillar`, `format`, `media`, `slide_count`, `day`, `time`, `subject`,
+`setting`, `props`, `product`, `person`, `title`, `subreddit`, `link_url`, `art_direction`,
+`sourced_from`, and the video script (`hook`, `hook_visual`, `hook_text`, `body`, `cta`, `ugc`).
+A brand keeps one draft in review, so saving replaces the one that is there (`replaced` says so).
+`produce_week` is the separate, paid step that turns the rows into posts.
 
 ## Studio
 

--- a/docs/api/05-editorial-plan.md
+++ b/docs/api/05-editorial-plan.md
@@ -91,6 +91,77 @@ curl -s -X POST "https://anomalia.so/api/v1/brands/mio-brand/editorial-plan/prop
 
 ---
 
+## `POST /api/v1/brands/:slug/editorial-plan/save`
+
+Salva un piano **scritto fuori da Anomalia**: nessuna chiamata al modello, nessun credito. La riga
+prodotta è la stessa di `propose` — `status: "proposed"`, `source: "manual"` — quindi il piano si
+legge, si revisiona e si approva dalle stesse superfici. Le proposte precedenti passano a
+`rejected`; **il piano attivo non viene toccato**: resta `approve` il passo che attiva.
+
+Il body è validato in modo stretto (`invalid_input` nomina il campo). Un ciclo più corto di 4
+settimane viene completato con settimane vuote, come per un piano generato.
+
+**Body**:
+
+```json
+{
+  "strategy": "Portare fuori il lavoro vero di chi monta le tastiere.",
+  "voice": { "mood": "diretto", "tone": "asciutto", "goal": "far provare", "personality": "un artigiano che spiega" },
+  "cadence": "3/week",
+  "platform_mix": [{ "platform": "instagram", "share": "70%", "role": "vetrina" }],
+  "gtm": {
+    "stage": "zero_to_one",
+    "summary": "…",
+    "platform_recs": [{ "platform": "instagram", "priority": "primary", "why": "…", "organic_potential": "…" }],
+    "plays": ["…"]
+  },
+  "weeks": [
+    {
+      "theme": "Il banco di lavoro",
+      "focus": "Mostrare il montaggio a mano",
+      "content_mix": [{ "type": "behind the scenes", "count": 3 }],
+      "rationale": "…",
+      "brief": null,
+      "products": ["Tastiera 65%"]
+    }
+  ]
+}
+```
+
+Obbligatori: `strategy`, `voice` (tutti e quattro i campi), `cadence` (`3/week` | `5/week` |
+`daily`), `platform_mix` (almeno una voce), `weeks` (1–4, ciascuna con `theme`, `focus` e un
+`content_mix` non vuoto). Opzionali: `gtm`, e per settimana `rationale`, `brief`, `products`.
+
+**Response** `200`:
+
+```json
+{
+  "ok": true,
+  "plan_id": "b2c3d4e5-f6a7-8901-bcde-f1234567890",
+  "status": "proposed",
+  "weeks": 4,
+  "review_url": "https://anomalia.so/app/mio-brand/editorial"
+}
+```
+
+**Errori specifici**
+
+| Status | Body |
+|---|---|
+| `400` | `{"error":"invalid_input","details":[…]}` — `details[0].path` nomina il campo |
+| `403` | `{"error":"API key is read-only"}` |
+| `500` | `{"error":"insert_failed","details":"…"}` |
+
+**Esempio**:
+
+```bash
+curl -s -X POST "https://anomalia.so/api/v1/brands/mio-brand/editorial-plan/save" \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"strategy":"…","voice":{"mood":"…","tone":"…","goal":"…","personality":"…"},"cadence":"3/week","platform_mix":[{"platform":"instagram","share":"70%","role":"vetrina"}],"weeks":[{"theme":"…","focus":"…","content_mix":[{"type":"educational","count":3}]}]}'
+```
+
+---
+
 ## `POST /api/v1/brands/:slug/editorial-plan/approve`
 
 Attiva la proposta più recente: diventa il piano `active` (con `week_start` calcolati dal lunedì corrente nel timezone del brand), il piano attivo precedente passa a `superseded`, voice+cadence sincronizzati nelle preferenze del brand.

--- a/docs/api/06-weekly-plan.md
+++ b/docs/api/06-weekly-plan.md
@@ -137,6 +137,90 @@ curl -s -X POST "https://anomalia.so/api/v1/brands/mio-brand/weekly-plan/plan" \
 
 ---
 
+## `POST /api/v1/brands/:slug/weekly-plan/seeds`
+
+Salva i seed di una settimana **scritti fuori da Anomalia**: nessuna chiamata al modello, nessun
+credito. Le righe finiscono dove le lascia `plan` — una bozza `content_plans` con
+`status: "draft"`, `source: "manual"`, `editorial_week = week_index` — quindi la pagina piano le
+mostra, sono modificabili e `produce` (a pagamento) resta il passo che le trasforma in post.
+
+Un brand tiene **una** bozza in revisione: se ce n'è già una, viene sostituita (`replaced: true`)
+invece di nasconderla dietro una seconda. I seed sono attaccati al piano editoriale attivo se
+c'è; senza piano attivo stanno in piedi da soli (`editorial_plan_id: null`).
+
+I seed passano dalla stessa normalizzazione dei seed generati: piattaforme in minuscolo, formati
+legacy mappati sull'enum, id di riga assegnato. Un seed senza `platform` viene **rifiutato**
+nominando la riga, non scartato in silenzio.
+
+**Body**:
+
+```json
+{
+  "week_index": 0,
+  "theme": "Il banco di lavoro",
+  "rationale": "La gente compra da chi vede lavorare",
+  "do_dont": "Niente superlativi",
+  "seeds": [
+    {
+      "platform": "instagram",
+      "platforms": ["instagram"],
+      "pillar": "dietro le quinte",
+      "format": "carousel",
+      "slide_count": 4,
+      "media": "image",
+      "day": "Tue",
+      "time": "09:00",
+      "angle": "Il primo switch che monti storto",
+      "subject": "…",
+      "setting": "…",
+      "props": "…",
+      "product": "Tastiera 65%",
+      "person": ""
+    }
+  ]
+}
+```
+
+Obbligatori: `week_index` (0–3), `theme`, `seeds` (1–30, ciascuno con `platform` e `angle`).
+Opzionali per seed: `platforms`, `pillar`, `format`, `media`, `slide_count`, `art_direction`,
+`sourced_from`, `day`, `time`, `subject`, `setting`, `props`, `product`, `person`, `title`,
+`subreddit`, `link_url`, e il copione video (`hook`, `hook_visual`, `hook_text`, `body`, `cta`,
+`ugc`).
+
+**Response** `200`:
+
+```json
+{
+  "ok": true,
+  "draft_id": "c3d4e5f6-a7b8-9012-cdef-1234567890ab",
+  "week_index": 0,
+  "seeds_saved": 3,
+  "editorial_plan_id": "b2c3d4e5-f6a7-8901-bcde-f1234567890",
+  "replaced": false,
+  "review_url": "https://anomalia.so/app/mio-brand/plan"
+}
+```
+
+**Errori specifici**
+
+| Status | Body |
+|---|---|
+| `400` | `{"error":"invalid_input","details":[…]}` — `details[0].path` nomina il campo o la riga |
+| `400` | `{"error":"no_seeds"}` |
+| `403` | `{"error":"API key is read-only"}` |
+| `500` | `{"error":"save_failed"}` |
+
+**Esempio**:
+
+```bash
+curl -s -X POST "https://anomalia.so/api/v1/brands/mio-brand/weekly-plan/seeds" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"week_index":0,"theme":"Il banco di lavoro","seeds":[{"platform":"instagram","angle":"Il primo switch che monti storto"}]}'
+```
+
+---
+
 ## `POST /api/v1/brands/:slug/weekly-plan/produce`
 
 Trasforma i seed di una bozza in post reali (caption + prompt immagine via AI), li inserisce in `posts` con status `pending_user` e marca la bozza come `produced`. **Consuma crediti.**

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -1,5 +1,6 @@
 import type { z } from 'zod';
 import { CHECK_CONTENT } from './content';
+import { PLAN_CADENCES, PLAN_CYCLE_WEEKS, SAVE_PLAN, SAVE_WEEK_SEEDS } from './plans';
 import { CREATE_POST, GET_CALENDAR, LIST_MEDIA, LIST_POSTS } from './posts';
 
 export type EndpointFailure = { readonly error: string; readonly status: number };
@@ -16,7 +17,7 @@ export type BrandEndpoint = {
   readonly destructive: boolean;
 };
 
-export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [CREATE_POST, LIST_POSTS, GET_CALENDAR, LIST_MEDIA, CHECK_CONTENT];
+export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [CREATE_POST, LIST_POSTS, GET_CALENDAR, LIST_MEDIA, CHECK_CONTENT, SAVE_PLAN, SAVE_WEEK_SEEDS];
 
 export function pathFor(endpoint: BrandEndpoint, slug: string): string {
   return `/api/v1/brands/${encodeURIComponent(slug)}${endpoint.pathUnderBrand}`;
@@ -29,3 +30,5 @@ export function statusForFailure(endpoint: BrandEndpoint, error: string): number
 export { CHECK_CONTENT, CREATE_POST, GET_CALENDAR, LIST_MEDIA, LIST_POSTS };
 export type { CheckContentInput, CheckContentResult } from './content';
 export type { CreatePostInput, CreatePostResult } from './posts';
+export { PLAN_CADENCES, PLAN_CYCLE_WEEKS, SAVE_PLAN, SAVE_WEEK_SEEDS };
+export type { SavePlanInput, SavePlanResult, SaveWeekSeedsInput, SaveWeekSeedsResult } from './plans';

--- a/packages/api-contracts/src/plans.test.ts
+++ b/packages/api-contracts/src/plans.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+import { PLAN_CYCLE_WEEKS, SAVE_PLAN, SAVE_WEEK_SEEDS } from './plans';
+
+const validPlan = () => ({
+  strategy: 'Portare fuori il lavoro vero di chi monta le tastiere.',
+  voice: { mood: 'diretto', tone: 'asciutto', goal: 'far provare', personality: 'un artigiano che spiega' },
+  cadence: '3/week',
+  platform_mix: [{ platform: 'instagram', share: '70%', role: 'vetrina' }],
+  weeks: [
+    {
+      theme: 'Il banco di lavoro',
+      focus: 'Mostrare il montaggio a mano',
+      content_mix: [{ type: 'behind the scenes', count: 3 }]
+    }
+  ]
+});
+
+const validSeeds = () => ({
+  week_index: 0,
+  theme: 'Il banco di lavoro',
+  seeds: [{ platform: 'instagram', angle: 'Il primo switch che monti storto' }]
+});
+
+describe('il contratto di un piano scritto fuori da Anomalia', () => {
+  it('accetta un piano completo', () => {
+    expect(SAVE_PLAN.input.safeParse(validPlan()).success).toBe(true);
+  });
+
+  it('non spende niente: non è distruttivo ed è una scrittura', () => {
+    expect(SAVE_PLAN.method).toBe('POST');
+    expect(SAVE_PLAN.destructive).toBe(false);
+  });
+
+  it.each([
+    ['strategy', { strategy: '' }],
+    ['cadence', { cadence: '2/week' }],
+    ['platform_mix', { platform_mix: [] }],
+    ['weeks', { weeks: [] }]
+  ])('rifiuta un piano senza %s, nominando il campo', (field, patch) => {
+    const parsed = SAVE_PLAN.input.safeParse({ ...validPlan(), ...patch });
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.error?.issues[0]?.path[0]).toBe(field);
+  });
+
+  it('nomina la settimana e il campo che le manca, non solo "weeks"', () => {
+    const plan = validPlan();
+    plan.weeks[0].theme = '';
+    const parsed = SAVE_PLAN.input.safeParse(plan);
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.error?.issues[0]?.path).toEqual(['weeks', 0, 'theme']);
+  });
+
+  it('rifiuta più settimane di quante ne ha un ciclo', () => {
+    const plan = validPlan();
+    plan.weeks = Array.from({ length: PLAN_CYCLE_WEEKS + 1 }, () => validPlan().weeks[0]);
+
+    expect(SAVE_PLAN.input.safeParse(plan).success).toBe(false);
+  });
+
+  it('rifiuta un campo che il contratto non dichiara invece di scartarlo', () => {
+    expect(SAVE_PLAN.input.safeParse({ ...validPlan(), campo_inventato: 'x' }).success).toBe(false);
+  });
+});
+
+describe('il contratto dei seed scritti fuori da Anomalia', () => {
+  it('accetta una settimana di seed', () => {
+    expect(SAVE_WEEK_SEEDS.input.safeParse(validSeeds()).success).toBe(true);
+  });
+
+  it.each([
+    ['week_index', { week_index: PLAN_CYCLE_WEEKS }],
+    ['theme', { theme: '' }],
+    ['seeds', { seeds: [] }]
+  ])('rifiuta i seed con %s fuori contratto', (field, patch) => {
+    const parsed = SAVE_WEEK_SEEDS.input.safeParse({ ...validSeeds(), ...patch });
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.error?.issues[0]?.path[0]).toBe(field);
+  });
+
+  it('nomina il seed a cui manca la piattaforma: senza, la normalizzazione lo butterebbe muta', () => {
+    const parsed = SAVE_WEEK_SEEDS.input.safeParse({
+      ...validSeeds(),
+      seeds: [{ platform: '', angle: 'un angolo' }]
+    });
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.error?.issues[0]?.path).toEqual(['seeds', 0, 'platform']);
+  });
+
+  it('porta il copione parlato di un video, o una clip esce muta', () => {
+    const parsed = SAVE_WEEK_SEEDS.input.safeParse({
+      ...validSeeds(),
+      seeds: [
+        {
+          platform: 'instagram',
+          angle: 'la prova sul banco',
+          format: 'video',
+          media: 'video',
+          hook: 'Questa tastiera fa un rumore che nessuno ti racconta',
+          body: 'La monto e te la faccio sentire',
+          cta: 'Provala in negozio'
+        }
+      ]
+    });
+
+    expect(parsed.success).toBe(true);
+  });
+});

--- a/packages/api-contracts/src/plans.ts
+++ b/packages/api-contracts/src/plans.ts
@@ -1,0 +1,172 @@
+import { z } from 'zod';
+import type { BrandEndpoint } from './index';
+
+// The deterministic half of planning: an agent that already wrote the plan or the week's rows
+// deposits them here. Anomalia stores them and calls no model. The generating endpoints
+// (propose_plan, plan_week) stay: this sits beside them, it does not replace them.
+//
+// These two constants mirror the app's PLAN_WEEKS and CADENCES, which live behind $lib and
+// cannot be imported from a package. The route tests import both and fail if they diverge.
+
+export const PLAN_CYCLE_WEEKS = 4;
+export const PLAN_CADENCES = ['3/week', '5/week', 'daily'] as const;
+const MAX_WEEK_SEEDS = 30;
+
+const line = z.string().min(1);
+
+const PlanWeekInput = z
+  .object({
+    theme: line.describe('The editorial theme tying the week together'),
+    focus: line.describe('What the week concretely pushes'),
+    content_mix: z
+      .array(z.object({ type: line, count: z.number().int().min(1) }).strict())
+      .min(1)
+      .describe('Post types and how many of each. The counts are the volume the week produces'),
+    rationale: z.string().optional(),
+    brief: z.string().optional().describe('Operator direction for this week, kept verbatim'),
+    products: z.array(line).optional().describe('Exact product titles this week must feature')
+  })
+  .strict();
+
+const PlanGtmInput = z
+  .object({
+    stage: z.enum(['zero_to_one', 'growth']),
+    summary: z.string(),
+    platform_recs: z
+      .array(
+        z
+          .object({
+            platform: line,
+            priority: z.enum(['primary', 'secondary', 'experiment']),
+            why: z.string(),
+            organic_potential: z.string()
+          })
+          .strict()
+      )
+      .optional(),
+    plays: z.array(z.string()).optional()
+  })
+  .strict();
+
+const SavePlanInputSchema = z
+  .object({
+    strategy: line.describe('The strategy document you wrote, in prose'),
+    voice: z.object({ mood: line, tone: line, goal: line, personality: line }).strict(),
+    cadence: z.enum(PLAN_CADENCES).describe('How a week is spread across days'),
+    platform_mix: z
+      .array(z.object({ platform: line, share: line, role: line }).strict())
+      .min(1),
+    gtm: PlanGtmInput.optional(),
+    weeks: z
+      .array(PlanWeekInput)
+      .min(1)
+      .max(PLAN_CYCLE_WEEKS)
+      .describe(`Up to ${PLAN_CYCLE_WEEKS} weeks; a short cycle is padded with empty weeks`)
+  })
+  .strict();
+
+const SavePlanResultSchema = z.object({
+  ok: z.literal(true),
+  plan_id: z.string(),
+  status: z.literal('proposed'),
+  weeks: z.number(),
+  review_url: z.string()
+});
+
+export type SavePlanInput = z.infer<typeof SavePlanInputSchema>;
+export type SavePlanResult = z.infer<typeof SavePlanResultSchema>;
+
+export const SAVE_PLAN = {
+  tool: 'save_plan',
+  title: 'Save an editorial plan',
+  description:
+    'Store an editorial plan you wrote yourself. Anomalia calls no model and spends no credits. ' +
+    'It lands as the pending proposal, exactly where propose_plan leaves a generated one: the ' +
+    'brand active plan is left untouched and approve_plan remains the step that activates it. ' +
+    'Saving replaces an earlier pending proposal.',
+  method: 'POST',
+  pathUnderBrand: '/editorial-plan/save',
+  input: SavePlanInputSchema,
+  output: SavePlanResultSchema,
+  failures: [{ error: 'invalid_input', status: 400 }, { error: 'insert_failed', status: 500 }],
+  destructive: false
+} satisfies BrandEndpoint;
+
+const WeekSeedInput = z
+  .object({
+    platform: line.describe('Primary publish target, e.g. "instagram"'),
+    platforms: z.array(line).optional().describe('Full cross-post set; defaults to [platform]'),
+    pillar: z.string().optional().describe('The content pillar this post serves'),
+    format: z.string().optional().describe('single_image, carousel, video, text…'),
+    media: z.enum(['image', 'text', 'link', 'video']).optional(),
+    slide_count: z.number().int().min(2).max(20).optional().describe('Carousels only'),
+    art_direction: z.string().optional().describe('The medium: comic, illustration, reportage…'),
+    sourced_from: z.string().optional().describe('Where the situation comes from, URL included'),
+    day: z.string().optional().describe('Day of week, e.g. "Tue"'),
+    time: z.string().optional().describe('Time of day, e.g. "09:00"'),
+    angle: line.describe('The intent the copywriter must serve'),
+    subject: z.string().optional().describe('Main subject in frame'),
+    setting: z.string().optional().describe('Location or environment'),
+    props: z.string().optional().describe('Supporting objects and styling'),
+    product: z.string().optional().describe('Exact product title, or omitted'),
+    person: z.string().optional().describe('Exact name from the brand people list, or omitted'),
+    title: z.string().optional().describe('Reddit title'),
+    subreddit: z.string().optional(),
+    link_url: z.string().optional(),
+    hook: z.string().optional().describe('Video only: the spoken opening'),
+    hook_visual: z.string().optional().describe('Video only: what happens on screen in second one'),
+    hook_text: z.string().optional().describe('Video only: on-screen text over the first seconds'),
+    body: z.string().optional().describe('Video only: problem, demo, proof'),
+    cta: z.string().optional().describe('Video only: the closing ask'),
+    ugc: z.boolean().optional().describe('Video only: handheld UGC instead of the cinematic default')
+  })
+  .strict();
+
+const SaveWeekSeedsInputSchema = z
+  .object({
+    week_index: z
+      .number()
+      .int()
+      .min(0)
+      .max(PLAN_CYCLE_WEEKS - 1)
+      .describe('Which week of the active editorial cycle these rows belong to'),
+    theme: line.describe('The single editorial angle tying the week together'),
+    rationale: z.string().optional().describe('Why this theme now'),
+    do_dont: z.string().optional().describe('Guardrails for whoever writes the copy'),
+    seeds: z.array(WeekSeedInput).min(1).max(MAX_WEEK_SEEDS)
+  })
+  .strict();
+
+const SaveWeekSeedsResultSchema = z.object({
+  ok: z.literal(true),
+  draft_id: z.string(),
+  week_index: z.number(),
+  seeds_saved: z.number(),
+  editorial_plan_id: z.string().nullable(),
+  replaced: z.boolean(),
+  review_url: z.string()
+});
+
+export type SaveWeekSeedsInput = z.infer<typeof SaveWeekSeedsInputSchema>;
+export type SaveWeekSeedsResult = z.infer<typeof SaveWeekSeedsResultSchema>;
+
+export const SAVE_WEEK_SEEDS = {
+  tool: 'save_week_seeds',
+  title: 'Save weekly content seeds',
+  description:
+    'Store the week rows you planned yourself — one per post, no copy and no image yet. ' +
+    'Anomalia calls no model and spends no credits. The rows land as the week draft, exactly ' +
+    'where plan_week leaves generated ones: the plan page shows them, they are editable, and ' +
+    'produce_week is the separate (paid) step that turns them into posts. A brand keeps one ' +
+    'draft, so saving replaces the one in review.',
+  method: 'POST',
+  pathUnderBrand: '/weekly-plan/seeds',
+  input: SaveWeekSeedsInputSchema,
+  output: SaveWeekSeedsResultSchema,
+  failures: [
+    { error: 'invalid_input', status: 400 },
+    { error: 'no_seeds', status: 400 },
+    { error: 'save_failed', status: 500 }
+  ],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/src/lib/content/changelog/2026-09-03-external-plan-and-seeds.ts
+++ b/src/lib/content/changelog/2026-09-03-external-plan-and-seeds.ts
@@ -1,0 +1,11 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-03',
+  title: 'Bring your own plan',
+  items: [
+    'Your AI assistant can now save an editorial plan it wrote itself — Anomalia stores it as the pending proposal, with no AI cost, and you review and approve it exactly as usual.',
+    'The same goes for a week of content: your assistant can save the planned rows, and producing them stays a separate step you choose.',
+    'Asking Anomalia to write the plan or the week for you still works, unchanged.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/editorial-plan.ts
+++ b/src/lib/server/editorial-plan.ts
@@ -907,6 +907,38 @@ export async function syncPrefsFromPlan(supabase: SupabaseClient, brandId: strin
   await supabase.from('brands').update({ content_prefs: prefsFromPlan(plan, existing) }).eq('id', brandId);
 }
 
+export type ProposalSaved = { ok: true; id: string } | { ok: false; error: 'insert_failed'; message: string };
+
+// Deposit a plan as the brand's pending proposal — the ONE writer both the generated and the
+// externally authored path use, so the two produce the same row. The active plan is not touched:
+// only an earlier pending proposal is superseded, and activatePlan stays the step that flips it.
+export async function saveProposedPlan(
+  supabase: SupabaseClient,
+  brandId: string,
+  plan: EditorialPlan
+): Promise<ProposalSaved> {
+  await supabase.from('editorial_plans').update({ status: 'rejected' }).eq('brand_id', brandId).eq('status', 'proposed');
+
+  const { data, error } = await supabase
+    .from('editorial_plans')
+    .insert({
+      brand_id: brandId,
+      status: 'proposed',
+      strategy: plan.strategy || null,
+      voice: plan.voice,
+      cadence: plan.cadence,
+      platform_mix: plan.platform_mix,
+      gtm: plan.gtm,
+      weeks: plan.weeks,
+      source: 'manual'
+    })
+    .select('id')
+    .single();
+
+  if (error || !data) return { ok: false, error: 'insert_failed', message: error?.message ?? 'editorial_plans insert failed' };
+  return { ok: true, id: data.id as string };
+}
+
 // Activate a proposed plan: supersede the current active one, stamp week_starts from this week's
 // Monday (brand tz), flip status, and sync content_prefs. Every approval path goes through here.
 export async function activatePlan(

--- a/src/lib/server/planner-inputs.ts
+++ b/src/lib/server/planner-inputs.ts
@@ -4,7 +4,7 @@ import { genaiClient, strategyBriefFromReport, type Benchmark, type StrategyRepo
 import { rankRecentWinners } from '$lib/server/scheduler';
 import { ensureBrandHistory } from '$lib/server/scrapecreators';
 import { attachBrandPages } from '$lib/server/content-library';
-import { proposePlan, cadenceAllowed } from '$lib/server/editorial-plan';
+import { proposePlan, cadenceAllowed, saveProposedPlan } from '$lib/server/editorial-plan';
 import { activeGtmBrief } from '$lib/server/gtm';
 import { loadApprovedRubrics } from '$lib/server/rubrics';
 import { localeLanguageName } from '$lib/i18n/locale';
@@ -169,22 +169,7 @@ export async function proposeFirstPlan(
     planTier: brand.plan,
     timezone: brand.timezone
   });
-  await supabase.from('editorial_plans').update({ status: 'rejected' }).eq('brand_id', brand.id).eq('status', 'proposed');
-  const { data: row, error: err } = await supabase
-    .from('editorial_plans')
-    .insert({
-      brand_id: brand.id,
-      status: 'proposed',
-      strategy: proposal.strategy || null,
-      voice: proposal.voice,
-      cadence: proposal.cadence,
-      platform_mix: proposal.platform_mix,
-      gtm: proposal.gtm,
-      weeks: proposal.weeks,
-      source: 'manual'
-    })
-    .select('id')
-    .single();
-  if (err || !row) throw new Error(err?.message ?? 'editorial_plans insert failed');
-  return { id: row.id as string };
+  const saved = await saveProposedPlan(supabase, brand.id, proposal);
+  if (!saved.ok) throw new Error(saved.message);
+  return { id: saved.id };
 }

--- a/src/routes/api/v1/brands/[slug]/editorial-plan/save/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/editorial-plan/save/+server.ts
@@ -1,0 +1,38 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { authenticate, loadBrandForUser, checkApiKeyWriteAccess } from '$lib/server/cli-auth';
+import { cadenceAllowed, normalizePlan, saveProposedPlan } from '$lib/server/editorial-plan';
+import { appOrigin } from '$lib/server/app-url';
+import { SAVE_PLAN, statusForFailure } from '@anomalia/api-contracts';
+
+export const POST: RequestHandler = async ({ request, params, url }) => {
+  const { supabase, error, apiKey } = await authenticate(request);
+  if (error) return error;
+
+  const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
+  if (brandError) return brandError;
+  const writeDenied = checkApiKeyWriteAccess(apiKey);
+  if (writeDenied) return writeDenied;
+
+  const parsed = SAVE_PLAN.input.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return json(
+      { error: 'invalid_input', details: parsed.error.issues },
+      { status: statusForFailure(SAVE_PLAN, 'invalid_input') }
+    );
+  }
+
+  const plan = normalizePlan(parsed.data, cadenceAllowed(brand.plan));
+  const saved = await saveProposedPlan(supabase, brand.id, plan);
+  if (!saved.ok) {
+    return json({ error: saved.error, details: saved.message }, { status: statusForFailure(SAVE_PLAN, saved.error) });
+  }
+
+  return json({
+    ok: true,
+    plan_id: saved.id,
+    status: 'proposed',
+    weeks: plan.weeks.length,
+    review_url: `${appOrigin(url)}/app/${brand.slug}/editorial`
+  });
+};

--- a/src/routes/api/v1/brands/[slug]/editorial-plan/save/server.test.ts
+++ b/src/routes/api/v1/brands/[slug]/editorial-plan/save/server.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const structured = vi.fn();
+const gateCredits = vi.fn();
+
+vi.mock('$lib/server/cli-auth', () => ({
+  authenticate: vi.fn(),
+  loadBrandForUser: vi.fn(),
+  checkApiKeyWriteAccess: vi.fn(() => null),
+  gateAiAction: vi.fn()
+}));
+vi.mock('$lib/server/research', () => ({
+  structured: (...args: unknown[]) => structured(...args),
+  benchmarkDigest: vi.fn()
+}));
+vi.mock('$lib/server/credits', () => ({
+  gateCredits: (...args: unknown[]) => gateCredits(...args),
+  CreditsExhaustedError: class extends Error {}
+}));
+vi.mock('$lib/server/app-url', () => ({ appOrigin: () => 'https://anomalia.test' }));
+
+import { POST } from './+server';
+import { authenticate, loadBrandForUser, checkApiKeyWriteAccess, gateAiAction } from '$lib/server/cli-auth';
+import { PLAN_CADENCES, PLAN_CYCLE_WEEKS } from '@anomalia/api-contracts';
+import { CADENCES } from '$lib/server/editorial-plan';
+import { PLAN_WEEKS } from '$lib/plans';
+
+type Row = Record<string, unknown>;
+type Op = { table: string; kind: 'insert' | 'update'; payload: Row; filters: Record<string, unknown> };
+
+const EDITORIAL_PLAN_SOURCES = ['onboarding', 'revision', 'rollover', 'manual', 'analytics_review', 'autopilot'];
+const EDITORIAL_PLAN_STATUSES = ['proposed', 'active', 'superseded', 'rejected'];
+
+function fakeSupabase(insertFails = false): { client: unknown; ops: Op[] } {
+  const ops: Op[] = [];
+  const client = {
+    from(table: string) {
+      const op: Op = { table, kind: 'insert', payload: {}, filters: {} };
+      const q = {
+        insert(payload: Row) {
+          op.kind = 'insert';
+          op.payload = payload;
+          ops.push(op);
+          return q;
+        },
+        update(payload: Row) {
+          op.kind = 'update';
+          op.payload = payload;
+          ops.push(op);
+          return q;
+        },
+        select: () => q,
+        eq(column: string, value: unknown) {
+          op.filters[column] = value;
+          return q;
+        },
+        single: async () =>
+          insertFails ? { data: null, error: { message: 'boom' } } : { data: { id: 'plan-1' }, error: null },
+        then: (resolve: (v: unknown) => unknown) => Promise.resolve({ data: null, error: null }).then(resolve)
+      };
+      return q;
+    }
+  };
+  return { client, ops };
+}
+
+const validPlan = () => ({
+  strategy: 'Portare fuori il lavoro vero di chi monta le tastiere.',
+  voice: { mood: 'diretto', tone: 'asciutto', goal: 'far provare', personality: 'un artigiano che spiega' },
+  cadence: '3/week',
+  platform_mix: [{ platform: 'Instagram', share: '70%', role: 'vetrina' }],
+  weeks: [
+    {
+      theme: 'Il banco di lavoro',
+      focus: 'Mostrare il montaggio a mano',
+      content_mix: [{ type: 'behind the scenes', count: 3 }],
+      rationale: 'La gente compra da chi vede lavorare'
+    }
+  ]
+});
+
+function call(body: unknown, slug = 'demo', insertFails = false) {
+  const { client, ops } = fakeSupabase(insertFails);
+  vi.mocked(authenticate).mockResolvedValue({
+    supabase: client,
+    user: { id: 'user-1' },
+    apiKey: undefined,
+    error: null
+  } as never);
+  vi.mocked(loadBrandForUser).mockResolvedValue({
+    brand: { id: 'brand-1', slug, timezone: 'Europe/Rome', plan: 'pro' },
+    error: null
+  } as never);
+  const url = new URL(`https://anomalia.test/api/v1/brands/${slug}/editorial-plan/save`);
+  return (POST as (event: unknown) => Promise<Response>)({
+    request: new Request(url, { method: 'POST', body: JSON.stringify(body) }),
+    params: { slug },
+    url
+  }).then(async (res) => ({ res, body: await res.json(), ops }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(checkApiKeyWriteAccess).mockReturnValue(undefined);
+});
+
+describe('POST /api/v1/brands/:slug/editorial-plan/save', () => {
+  it('deposita il piano come proposta e dice dove rivederlo', async () => {
+    const { res, body, ops } = await call(validPlan());
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({
+      ok: true,
+      plan_id: 'plan-1',
+      status: 'proposed',
+      weeks: PLAN_WEEKS,
+      review_url: 'https://anomalia.test/app/demo/editorial'
+    });
+    const inserted = ops.find((o) => o.kind === 'insert')!;
+    expect(inserted.table).toBe('editorial_plans');
+    expect(inserted.payload).toMatchObject({
+      brand_id: 'brand-1',
+      status: 'proposed',
+      source: 'manual',
+      cadence: '3/week',
+      strategy: 'Portare fuori il lavoro vero di chi monta le tastiere.'
+    });
+  });
+
+  it('scrive solo valori che il CHECK del database accetta', async () => {
+    const { ops } = await call(validPlan());
+
+    for (const op of ops.filter((o) => o.table === 'editorial_plans')) {
+      if (op.payload.source !== undefined) {
+        expect(EDITORIAL_PLAN_SOURCES).toContain(op.payload.source);
+      }
+      if (op.payload.status !== undefined) {
+        expect(EDITORIAL_PLAN_STATUSES).toContain(op.payload.status);
+      }
+    }
+  });
+
+  it('un piano salvato è indistinguibile da uno generato: stessa riga, stesse chiavi', async () => {
+    const { ops } = await call(validPlan());
+    const inserted = ops.find((o) => o.kind === 'insert')!;
+
+    expect(Object.keys(inserted.payload).sort()).toEqual(
+      ['brand_id', 'cadence', 'gtm', 'platform_mix', 'source', 'status', 'strategy', 'voice', 'weeks'].sort()
+    );
+    const weeks = inserted.payload.weeks as Record<string, unknown>[];
+    expect(weeks).toHaveLength(PLAN_WEEKS);
+    expect(weeks[0]).toEqual({
+      index: 0,
+      week_start: null,
+      theme: 'Il banco di lavoro',
+      focus: 'Mostrare il montaggio a mano',
+      content_mix: [{ type: 'behind the scenes', count: 3 }],
+      rationale: 'La gente compra da chi vede lavorare',
+      brief: null,
+      products: null,
+      status: 'upcoming'
+    });
+  });
+
+  it('non tocca il piano attivo: supera solo la proposta pendente', async () => {
+    const { ops } = await call(validPlan());
+    const updates = ops.filter((o) => o.kind === 'update');
+
+    expect(updates).toHaveLength(1);
+    expect(updates[0].filters).toEqual({ brand_id: 'brand-1', status: 'proposed' });
+    expect(updates[0].payload).toEqual({ status: 'rejected' });
+  });
+
+  it('non chiama il modello e non tocca i crediti', async () => {
+    await call(validPlan());
+
+    expect(structured).not.toHaveBeenCalled();
+    expect(gateAiAction).not.toHaveBeenCalled();
+    expect(gateCredits).not.toHaveBeenCalled();
+  });
+
+  it('un insert fallito è un errore, non un falso successo', async () => {
+    const { res, body } = await call(validPlan(), 'demo', true);
+
+    expect(res.status).toBe(500);
+    expect(body.error).toBe('insert_failed');
+  });
+
+  it.each([
+    ['senza strategia', { strategy: '' }, 'strategy'],
+    ['con una cadenza che non esiste', { cadence: '2/week' }, 'cadence'],
+    ['senza piattaforme', { platform_mix: [] }, 'platform_mix'],
+    ['senza settimane', { weeks: [] }, 'weeks']
+  ])('rifiuta un piano %s nominando il campo, prima di scrivere', async (_label, patch, field) => {
+    const { res, body, ops } = await call({ ...validPlan(), ...patch });
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('invalid_input');
+    expect(body.details[0].path[0]).toBe(field);
+    expect(ops).toEqual([]);
+  });
+
+  it('rifiuta un campo che il contratto non dichiara', async () => {
+    const { res, body, ops } = await call({ ...validPlan(), campo_inventato: 'x' });
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('invalid_input');
+    expect(ops).toEqual([]);
+  });
+
+  it('rifiuta una richiesta senza autenticazione', async () => {
+    vi.mocked(authenticate).mockResolvedValue({ error: new Response('Unauthorized', { status: 401 }) } as never);
+    const url = new URL('https://anomalia.test/api/v1/brands/demo/editorial-plan/save');
+    const res = await (POST as (event: unknown) => Promise<Response>)({
+      request: new Request(url, { method: 'POST', body: '{}' }),
+      params: { slug: 'demo' },
+      url
+    });
+
+    expect(res.status).toBe(401);
+  });
+
+  it('rifiuta un brand a cui il chiamante non accede', async () => {
+    vi.mocked(authenticate).mockResolvedValue({
+      supabase: fakeSupabase().client,
+      user: { id: 'user-1' },
+      apiKey: undefined,
+      error: null
+    } as never);
+    vi.mocked(loadBrandForUser).mockResolvedValue({
+      error: new Response(JSON.stringify({ error: 'Brand not found' }), { status: 404 })
+    } as never);
+    const url = new URL('https://anomalia.test/api/v1/brands/altrui/editorial-plan/save');
+    const res = await (POST as (event: unknown) => Promise<Response>)({
+      request: new Request(url, { method: 'POST', body: '{}' }),
+      params: { slug: 'altrui' },
+      url
+    });
+
+    expect(res.status).toBe(404);
+  });
+
+  it('rifiuta una API key di sola lettura', async () => {
+    vi.mocked(checkApiKeyWriteAccess).mockReturnValue(
+      new Response(JSON.stringify({ error: 'API key is read-only' }), { status: 403 }) as never
+    );
+    const { res, ops } = await call(validPlan());
+
+    expect(res.status).toBe(403);
+    expect(ops).toEqual([]);
+  });
+});
+
+describe('le costanti del contratto e quelle del dominio', () => {
+  it('dicono lo stesso numero di settimane e le stesse cadenze', () => {
+    expect(PLAN_CYCLE_WEEKS).toBe(PLAN_WEEKS);
+    expect([...PLAN_CADENCES]).toEqual([...CADENCES]);
+  });
+});

--- a/src/routes/api/v1/brands/[slug]/weekly-plan/seeds/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/weekly-plan/seeds/+server.ts
@@ -1,0 +1,102 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { authenticate, loadBrandForUser, checkApiKeyWriteAccess } from '$lib/server/cli-auth';
+import { normalizeWeeklyStrategy, type WeeklyStrategy } from '$lib/server/content-preview';
+import { appOrigin } from '$lib/server/app-url';
+import { SAVE_WEEK_SEEDS, statusForFailure } from '@anomalia/api-contracts';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+type DraftWritten = { ok: true; id: string; replaced: boolean } | { ok: false };
+
+// A brand keeps ONE week draft in review — the plan page reads the newest and a second row would
+// hide the first. So the rows land on the draft that is there, or open a new one.
+async function writeWeekDraft(
+  supabase: SupabaseClient,
+  brandId: string,
+  weekIndex: number,
+  editorialPlanId: string | null,
+  strategy: WeeklyStrategy
+): Promise<DraftWritten> {
+  const columns = { seeds: strategy, editorial_plan_id: editorialPlanId, editorial_week: weekIndex };
+
+  const { data: existing } = await supabase
+    .from('content_plans')
+    .select('id')
+    .eq('brand_id', brandId)
+    .eq('status', 'draft')
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (existing?.id) {
+    const { error } = await supabase
+      .from('content_plans')
+      .update(columns)
+      .eq('id', existing.id as string)
+      .eq('brand_id', brandId);
+    if (error) return { ok: false };
+    return { ok: true, id: existing.id as string, replaced: true };
+  }
+
+  const { data, error } = await supabase
+    .from('content_plans')
+    .insert({
+      brand_id: brandId,
+      title: `External · ${new Date().toISOString().slice(0, 10)}`,
+      source: 'manual',
+      status: 'draft',
+      ...columns
+    })
+    .select('id')
+    .single();
+
+  if (error || !data) return { ok: false };
+  return { ok: true, id: data.id as string, replaced: false };
+};
+
+export const POST: RequestHandler = async ({ request, params, url }) => {
+  const { supabase, error, apiKey } = await authenticate(request);
+  if (error) return error;
+
+  const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
+  if (brandError) return brandError;
+  const writeDenied = checkApiKeyWriteAccess(apiKey);
+  if (writeDenied) return writeDenied;
+
+  const parsed = SAVE_WEEK_SEEDS.input.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return json(
+      { error: 'invalid_input', details: parsed.error.issues },
+      { status: statusForFailure(SAVE_WEEK_SEEDS, 'invalid_input') }
+    );
+  }
+
+  const { week_index, ...supplied } = parsed.data;
+  const strategy = normalizeWeeklyStrategy(supplied);
+  if (!strategy.seeds.length) {
+    return json({ error: 'no_seeds' }, { status: statusForFailure(SAVE_WEEK_SEEDS, 'no_seeds') });
+  }
+
+  const { data: activePlan } = await supabase
+    .from('editorial_plans')
+    .select('id')
+    .eq('brand_id', brand.id)
+    .eq('status', 'active')
+    .maybeSingle();
+  const editorialPlanId = (activePlan?.id as string) ?? null;
+
+  const written = await writeWeekDraft(supabase, brand.id, week_index, editorialPlanId, strategy);
+  if (!written.ok) {
+    return json({ error: 'save_failed' }, { status: statusForFailure(SAVE_WEEK_SEEDS, 'save_failed') });
+  }
+
+  return json({
+    ok: true,
+    draft_id: written.id,
+    week_index,
+    seeds_saved: strategy.seeds.length,
+    editorial_plan_id: editorialPlanId,
+    replaced: written.replaced,
+    review_url: `${appOrigin(url)}/app/${brand.slug}/plan`
+  });
+};

--- a/src/routes/api/v1/brands/[slug]/weekly-plan/seeds/server.test.ts
+++ b/src/routes/api/v1/brands/[slug]/weekly-plan/seeds/server.test.ts
@@ -1,0 +1,276 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const structured = vi.fn();
+const gateCredits = vi.fn();
+
+vi.mock('$lib/server/cli-auth', () => ({
+  authenticate: vi.fn(),
+  loadBrandForUser: vi.fn(),
+  checkApiKeyWriteAccess: vi.fn(() => null),
+  gateAiAction: vi.fn()
+}));
+vi.mock('$lib/server/research', () => ({
+  structured: (...args: unknown[]) => structured(...args),
+  benchmarkDigest: vi.fn()
+}));
+vi.mock('$lib/server/credits', () => ({
+  gateCredits: (...args: unknown[]) => gateCredits(...args),
+  CreditsExhaustedError: class extends Error {}
+}));
+vi.mock('$lib/server/app-url', () => ({ appOrigin: () => 'https://anomalia.test' }));
+
+import { POST } from './+server';
+import { authenticate, loadBrandForUser, checkApiKeyWriteAccess, gateAiAction } from '$lib/server/cli-auth';
+
+type Row = Record<string, unknown>;
+type Op = { table: string; kind: 'insert' | 'update'; payload: Row; filters: Record<string, unknown> };
+type World = { activePlanId: string | null; draftId: string | null; writeFails: boolean };
+
+function fakeSupabase(world: World): { client: unknown; ops: Op[] } {
+  const ops: Op[] = [];
+  const client = {
+    from(table: string) {
+      const op: Op = { table, kind: 'insert', payload: {}, filters: {} };
+      const rows = () => {
+        if (table === 'editorial_plans') {
+          return world.activePlanId ? [{ id: world.activePlanId }] : [];
+        }
+        return world.draftId ? [{ id: world.draftId }] : [];
+      };
+      const q = {
+        insert(payload: Row) {
+          op.kind = 'insert';
+          op.payload = payload;
+          ops.push(op);
+          return q;
+        },
+        update(payload: Row) {
+          op.kind = 'update';
+          op.payload = payload;
+          ops.push(op);
+          return q;
+        },
+        select: () => q,
+        eq(column: string, value: unknown) {
+          op.filters[column] = value;
+          return q;
+        },
+        order: () => q,
+        limit: () => q,
+        maybeSingle: async () => ({ data: rows()[0] ?? null, error: null }),
+        single: async () =>
+          world.writeFails ? { data: null, error: { message: 'boom' } } : { data: { id: 'draft-new' }, error: null },
+        then: (resolve: (v: unknown) => unknown) =>
+          Promise.resolve(
+            op.kind === 'update' && world.writeFails
+              ? { data: null, error: { message: 'boom' } }
+              : { data: rows(), error: null }
+          ).then(resolve)
+      };
+      return q;
+    }
+  };
+  return { client, ops };
+}
+
+const validSeeds = () => ({
+  week_index: 1,
+  theme: 'Il banco di lavoro',
+  rationale: 'La gente compra da chi vede lavorare',
+  do_dont: 'Niente superlativi',
+  seeds: [
+    {
+      platform: 'Instagram',
+      angle: 'Il primo switch che monti storto',
+      format: 'carousel',
+      slide_count: 4,
+      day: 'Tue',
+      time: '09:00',
+      pillar: 'dietro le quinte'
+    }
+  ]
+});
+
+function call(body: unknown, world: Partial<World> = {}, slug = 'demo') {
+  const full: World = { activePlanId: 'plan-1', draftId: null, writeFails: false, ...world };
+  const { client, ops } = fakeSupabase(full);
+  vi.mocked(authenticate).mockResolvedValue({
+    supabase: client,
+    user: { id: 'user-1' },
+    apiKey: undefined,
+    error: null
+  } as never);
+  vi.mocked(loadBrandForUser).mockResolvedValue({
+    brand: { id: 'brand-1', slug, timezone: 'Europe/Rome', plan: 'pro' },
+    error: null
+  } as never);
+  const url = new URL(`https://anomalia.test/api/v1/brands/${slug}/weekly-plan/seeds`);
+  return (POST as (event: unknown) => Promise<Response>)({
+    request: new Request(url, { method: 'POST', body: JSON.stringify(body) }),
+    params: { slug },
+    url
+  }).then(async (res) => ({ res, body: await res.json(), ops }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(checkApiKeyWriteAccess).mockReturnValue(undefined);
+});
+
+describe('POST /api/v1/brands/:slug/weekly-plan/seeds', () => {
+  it('deposita le righe come bozza della settimana, attaccate al piano attivo', async () => {
+    const { res, body, ops } = await call(validSeeds());
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({
+      ok: true,
+      draft_id: 'draft-new',
+      week_index: 1,
+      seeds_saved: 1,
+      editorial_plan_id: 'plan-1',
+      replaced: false,
+      review_url: 'https://anomalia.test/app/demo/plan'
+    });
+    const inserted = ops.find((o) => o.kind === 'insert')!;
+    expect(inserted.table).toBe('content_plans');
+    expect(inserted.payload).toMatchObject({
+      brand_id: 'brand-1',
+      status: 'draft',
+      source: 'manual',
+      editorial_plan_id: 'plan-1',
+      editorial_week: 1
+    });
+  });
+
+  it('salva la forma che la lettura settimanale sa già leggere', async () => {
+    const { ops } = await call(validSeeds());
+    const stored = ops.find((o) => o.kind === 'insert')!.payload.seeds as Record<string, unknown>;
+
+    expect(stored.theme).toBe('Il banco di lavoro');
+    expect(stored.rationale).toBe('La gente compra da chi vede lavorare');
+    expect(stored.doDont).toBe('Niente superlativi');
+    const seeds = stored.seeds as Record<string, unknown>[];
+    expect(seeds).toHaveLength(1);
+    expect(seeds[0]).toMatchObject({
+      platform: 'instagram',
+      platforms: ['instagram'],
+      format: 'carousel',
+      slide_count: 4,
+      angle: 'Il primo switch che monti storto',
+      day: 'Tue',
+      time: '09:00'
+    });
+    expect(typeof seeds[0].id).toBe('string');
+  });
+
+  it('senza piano attivo le righe stanno in piedi da sole', async () => {
+    const { body, ops } = await call(validSeeds(), { activePlanId: null });
+
+    expect(body.editorial_plan_id).toBeNull();
+    expect(ops.find((o) => o.kind === 'insert')!.payload).toMatchObject({
+      editorial_plan_id: null,
+      editorial_week: 1
+    });
+  });
+
+  it('sostituisce la bozza in revisione invece di nasconderla dietro una seconda', async () => {
+    const { body, ops } = await call(validSeeds(), { draftId: 'draft-esistente' });
+
+    expect(body.replaced).toBe(true);
+    expect(body.draft_id).toBe('draft-esistente');
+    expect(ops.some((o) => o.kind === 'insert')).toBe(false);
+    const updated = ops.find((o) => o.kind === 'update')!;
+    expect(updated.table).toBe('content_plans');
+    expect(updated.filters).toMatchObject({ id: 'draft-esistente', brand_id: 'brand-1' });
+    expect(updated.payload).toMatchObject({ editorial_week: 1, editorial_plan_id: 'plan-1' });
+  });
+
+  it('non chiama il modello e non tocca i crediti', async () => {
+    await call(validSeeds());
+
+    expect(structured).not.toHaveBeenCalled();
+    expect(gateAiAction).not.toHaveBeenCalled();
+    expect(gateCredits).not.toHaveBeenCalled();
+  });
+
+  it('una scrittura fallita è un errore, non un falso successo', async () => {
+    const { res, body } = await call(validSeeds(), { writeFails: true });
+
+    expect(res.status).toBe(500);
+    expect(body.error).toBe('save_failed');
+  });
+
+  it.each([
+    ['una settimana fuori dal ciclo', { week_index: 4 }, 'week_index'],
+    ['senza tema', { theme: '' }, 'theme'],
+    ['senza righe', { seeds: [] }, 'seeds']
+  ])('rifiuta %s nominando il campo, prima di scrivere', async (_label, patch, field) => {
+    const { res, body, ops } = await call({ ...validSeeds(), ...patch });
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('invalid_input');
+    expect(body.details[0].path[0]).toBe(field);
+    expect(ops).toEqual([]);
+  });
+
+  it('nomina la riga senza piattaforma invece di scartarla in silenzio', async () => {
+    const { res, body, ops } = await call({
+      ...validSeeds(),
+      seeds: [{ platform: '', angle: 'un angolo' }]
+    });
+
+    expect(res.status).toBe(400);
+    expect(body.details[0].path).toEqual(['seeds', 0, 'platform']);
+    expect(ops).toEqual([]);
+  });
+
+  it('rifiuta un campo che il contratto non dichiara', async () => {
+    const { res, body, ops } = await call({ ...validSeeds(), campo_inventato: 'x' });
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('invalid_input');
+    expect(ops).toEqual([]);
+  });
+
+  it('rifiuta una richiesta senza autenticazione', async () => {
+    vi.mocked(authenticate).mockResolvedValue({ error: new Response('Unauthorized', { status: 401 }) } as never);
+    const url = new URL('https://anomalia.test/api/v1/brands/demo/weekly-plan/seeds');
+    const res = await (POST as (event: unknown) => Promise<Response>)({
+      request: new Request(url, { method: 'POST', body: '{}' }),
+      params: { slug: 'demo' },
+      url
+    });
+
+    expect(res.status).toBe(401);
+  });
+
+  it('rifiuta un brand a cui il chiamante non accede', async () => {
+    vi.mocked(authenticate).mockResolvedValue({
+      supabase: fakeSupabase({ activePlanId: null, draftId: null, writeFails: false }).client,
+      user: { id: 'user-1' },
+      apiKey: undefined,
+      error: null
+    } as never);
+    vi.mocked(loadBrandForUser).mockResolvedValue({
+      error: new Response(JSON.stringify({ error: 'Brand not found' }), { status: 404 })
+    } as never);
+    const url = new URL('https://anomalia.test/api/v1/brands/altrui/weekly-plan/seeds');
+    const res = await (POST as (event: unknown) => Promise<Response>)({
+      request: new Request(url, { method: 'POST', body: '{}' }),
+      params: { slug: 'altrui' },
+      url
+    });
+
+    expect(res.status).toBe(404);
+  });
+
+  it('rifiuta una API key di sola lettura', async () => {
+    vi.mocked(checkApiKeyWriteAccess).mockReturnValue(
+      new Response(JSON.stringify({ error: 'API key is read-only' }), { status: 403 }) as never
+    );
+    const { res, ops } = await call(validSeeds());
+
+    expect(res.status).toBe(403);
+    expect(ops).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What?

Two deterministic endpoints let an external agent persist planning work it wrote itself, with no
Anomalia model call and no credit debit:

- `POST /api/v1/brands/:slug/editorial-plan/save` (`save_plan`) — a supplied editorial plan is
  stored as the brand's **pending proposal**;
- `POST /api/v1/brands/:slug/weekly-plan/seeds` (`save_week_seeds`) — supplied weekly rows are
  stored as the **week draft**.

They sit **beside** `propose_plan` and `plan_week`, which are untouched. The CLI/MCP surface comes
from the registry: one `satisfies BrandEndpoint` entry each in the new
`packages/api-contracts/src/plans.ts`, mirrored into `cli/lib/contracts/`, and the MCP tools appear
on their own — no hand-written `registerTool`, no hand-written method in `cli/lib/api.ts`.

This is Phase 2 of `docs/external-agent-plan.md`: the rows "Save an externally authored plan"
(Build) and "Save externally authored seeds" (Bridge).

## Why?

`propose_plan` and `plan_week` can only **generate**. An external client that already wrote the
plan — with its own user's model account, which is the whole point of the external-agent plan —
had nowhere to put it, and the same gap existed for a week's rows. Without these, "an external
client can build a month of content without a text-model call from Anomalia" is not reachable.

The hard requirement was `managed and external-authoring paths produce the same domain states`.
Anything downstream — review, approval, the plan page, `produce_week` — must not be able to tell
the two apart.

## How?

**Modules composed, not duplicated.** The identity is structural:

| Concern | Reused |
|---|---|
| Plan normalisation (week padding to `PLAN_WEEKS`, lowercased platforms, `clampCadence`) | `normalizePlan` / `cadenceAllowed` — `$lib/server/editorial-plan` |
| The proposal write itself | `saveProposedPlan` — **extracted** from `proposeFirstPlan` in a separate, behaviour-preserving commit, so both paths now go through one writer |
| Seed rehydration (row ids, legacy formats → enum, media-capability clamp) | `normalizeWeeklyStrategy` — `$lib/server/content-preview`, the repo's declared "single rehydration point" |
| Auth | `authenticate` → `loadBrandForUser` → `checkApiKeyWriteAccess` |
| Error → status | the contract's `failures` + `statusForFailure`, never a chain of `||` |

`gateAiAction` is deliberately **not** called: this path spends nothing.

**Design decisions.**

1. **What a supplied plan must contain.** `strategy`, all four `voice` fields, a `cadence` from the
   real enum, at least one `platform_mix` entry, and 1–4 `weeks` each with `theme`, `focus` and a
   non-empty `content_mix`. Optional: `gtm`, and per week `rationale`, `brief`, `products`. A short
   cycle is padded to 4 weeks — exactly what a generated plan gets. Input is `.strict()`, so an
   undeclared field is rejected rather than silently dropped, and the rejection names the path
   (`weeks.0.theme`).
2. **Saving never destroys an active plan.** The plan lands `proposed`; only an earlier *pending*
   proposal is marked `rejected` — the same two statements `propose` already ran. `approve_plan`
   remains the only step that activates. An `activate: true` shortcut was considered and rejected:
   it removes human review from a write no operator has seen.
3. **`source` stays `'manual'`.** `editorial_plans.source` carries a CHECK
   (`onboarding | revision | rollover | manual | analytics_review | autopilot`) and this repo does
   **not** run migrations on deploy — a new value would pass locally and fail with `23514` in
   production. `posts.source` has no such constraint, which is why `create_post` could write
   `'external'`; this table is not that situation. A test pins every value written against the real
   CHECK arrays. Distinguishing "external agent" from "web UI" provenance is a follow-up that needs
   a hand-applied migration — **not** done here.
4. **Seeds attach to the active plan when there is one**, stand alone otherwise
   (`editorial_plan_id: null`) — the same fallback the managed `plan` route uses.
5. **One draft, replaced.** The plan page reads the newest `draft` row, so a second one would hide
   the first. The endpoint updates the draft in review (the web action's behaviour) instead of
   inserting a second (the CLI `plan` route's behaviour), and the response says `replaced`.
6. **Reject instead of drop.** `normalizeWeeklyStrategy` silently discards a seed with no platform.
   The contract rejects it first and names the row — an agent told `ok: true` for three seeds and
   given two has no way to notice.

**Contract constants.** `PLAN_CYCLE_WEEKS` and `PLAN_CADENCES` duplicate `PLAN_WEEKS` and
`CADENCES`, which live behind `$lib` and cannot be imported from a package
(`packages/no-app-imports.test.ts`). A route test imports both sides and fails if they diverge.

## Testing?

**Written first, watched fail.** Contract test against a missing module:

```
 ❯ packages/api-contracts/src/plans.test.ts (0 test)
⎯⎯⎯⎯⎯⎯ Failed Suites 1 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  packages/api-contracts/src/plans.test.ts
Error: Failed to load url ./plans (resolved id: ./plans) … Does the file exist?
 Test Files  1 failed (1)
      Tests  no tests
```

Route tests against missing handlers:

```
 ❯ src/routes/api/v1/brands/[slug]/editorial-plan/save/server.test.ts (0 test)
 ❯ src/routes/api/v1/brands/[slug]/weekly-plan/seeds/server.test.ts (0 test)
⎯⎯⎯⎯⎯⎯ Failed Suites 2 ⎯⎯⎯⎯⎯⎯⎯
Error: Failed to load url ./+server … Does the file exist?
 Test Files  2 failed (2)
      Tests  no tests
```

**Green after the implementation** (59 tests across the four files):

```
 ✓ packages/api-contracts/src/plans.test.ts (15 tests)
 ✓ packages/api-contracts/src/index.test.ts (15 tests)
 ✓ src/routes/api/v1/brands/[slug]/editorial-plan/save/server.test.ts (15 tests)
 ✓ src/routes/api/v1/brands/[slug]/weekly-plan/seeds/server.test.ts (14 tests)
 Test Files  4 passed (4)
      Tests  59 passed (59)
```

What they cover: a valid plan stored with the exact column set a generated one gets and 4 weeks;
an invalid plan rejected with the field named, before any write; **only one update, filtered
`status = 'proposed'`, so the active plan is never touched**; `structured` (the model entry point),
`gateAiAction` and `gateCredits` all `not.toHaveBeenCalled()`; every value written checked against
the real `editorial_plans` CHECK arrays; unauthenticated → 401, inaccessible brand → 404,
read-only key → 403 with nothing written; seeds attached to the right week, stored in the shape
the weekly read already parses, existing draft replaced rather than shadowed.

**CLI:** `bun test` → `31 pass, 0 fail`. `bun run typecheck` → clean.

**Full suite:** `6448 passed | 48 skipped | 3 failed`. The three failures are
`src/lib/agent/bridge/live.test.ts` (plus a collect failure in
`src/lib/server/chat/brand-studio-tools.test.ts`) — **not files this PR touches**, and they differ
run to run (1 failure on the first pass, 3 on the second). Run in isolation they are green:

```
npx vitest run src/lib/agent/bridge/live.test.ts src/lib/server/chat/brand-studio-tools.test.ts
 Test Files  2 passed (2)
      Tests  122 passed (122)
```

That is the full-suite flakiness `LESSONS.md` already describes, not a defect from this branch.

**Types.** `npm run check` never finished here — three attempts were each killed with SIGTERM
after ~20 minutes, at 19 lines of output. So I ran the compiler directly instead:

```
npx tsc --noEmit -p tsconfig.json | grep -E "editorial-plan/save|weekly-plan/seeds|api-contracts/src/plans|editorial-plan\.ts|planner-inputs"
src/lib/server/editorial-plan.ts(1016,7): error TS2345: Argument of type 'PromiseLike<void>' is not assignable to parameter of type 'Promise<void>'.
src/lib/server/editorial-plan.ts(1029,7): error TS2345: Argument of type 'PromiseLike<void>' is not assignable to parameter of type 'Promise<void>'.
```

Zero errors in the four new files, in `planner-inputs.ts`, or in the contract. The two that do
appear are **pre-existing**, in `loadEditorialPlans` — a function this PR does not touch:

```
$ diff <(git show origin/dev:src/lib/server/editorial-plan.ts | sed -n '/^export async function loadEditorialPlans/,/^}/p') \
       <(sed -n '/^export async function loadEditorialPlans/,/^}/p' src/lib/server/editorial-plan.ts)
loadEditorialPlans IDENTICAL to origin/dev

$ git diff origin/dev -- src/lib/server/editorial-plan.ts | grep -c "^-[^-]"
0
```

The diff to that file deletes nothing — it is a 32-line addition above the error site, which is
why the line numbers moved. The errors are Supabase's thenable not being a real `Promise`, in
`tasks.push(...)`, unrelated to anything added here. I did try to confirm this with a baseline
`tsc` run on `origin/dev` in a sibling worktree; it was killed before finishing, so the proof
above is textual rather than a second compiler run.

**`git diff --check`:** clean.

## Evidence (screenshots/videos)

Local Docker stack (`anomalia-db`, `anomalia-kong`) and this worktree's dev server on `:5199`,
brand `demo` (pro, active) owned by `test@anomalia.so`. Real HTTP, real database — never hosted.

<details><summary>1. A plan supplied by an external agent is stored as the pending proposal, and the active plan survives</summary>

Before — the brand has one active plan and no proposal:

```
 15ed80a7-… | active | manual | Raccontare la burocrazia vissuta e spieg
```

The call (2 weeks supplied, no gtm):

```
$ curl -X POST .../api/v1/brands/demo/editorial-plan/save -d '{"strategy":"Il montaggio a mano è la prova…", …}'
{"ok":true,"plan_id":"7c097ced-…","status":"proposed","weeks":4,
 "review_url":"http://localhost:5199/app/demo/editorial"}
```

After — the proposal is there, **the active plan is untouched**, and the 2 supplied weeks were
padded to 4 exactly as a generated plan is:

```
  status  | source | weeks | cadence |                   strategy
----------+--------+-------+---------+-----------------------------------------------
 proposed | manual |     4 | 3/week  | Il montaggio a mano è la prova: chi lo vede,
 active   | manual |     4 | 3/week  | Raccontare la burocrazia vissuta e spiegarla.
```
</details>

<details><summary>2. The saved plan comes back from the read path the web UI and the CLI share</summary>

`GET /api/v1/brands/demo/editorial-plan` (`getEditorialPlan` — the same query
`src/routes/app/[brand]/editorial/+page.server.ts` runs):

```json
{
  "active_status": "active",
  "active_strategy": "Raccontare la burocrazia vissuta e spiegarla.",
  "proposed_status": "proposed",
  "proposed_source": "manual",
  "proposed_strategy": "Il montaggio a mano è la prova: chi lo vede, ",
  "proposed_weeks": 4,
  "proposed_week0": {
    "index": 0, "week_start": null, "theme": "Il banco di lavoro",
    "focus": "Mostrare il montaggio a mano", "brief": null, "products": null,
    "rationale": "La gente compra da chi vede lavorare", "status": "upcoming",
    "content_mix": [{ "type": "behind the scenes", "count": 3 }]
  }
}
```

Every key of a generated week is present, with the same defaults (`week_start: null`,
`status: "upcoming"`, `brief`/`products` null).
</details>

<details><summary>3. The strongest proof: the untouched approval path activates it</summary>

`POST /api/v1/brands/demo/editorial-plan/approve` — the existing endpoint, not modified by this PR:

```
{"ok":true}

   status   | source | week0_start |                   strategy
------------+--------+-------------+-----------------------------------------------
 active     | manual | 2026-08-31  | Il montaggio a mano è la prova: chi lo vede,
 superseded | manual | 2026-08-31  | Raccontare la burocrazia vissuta e spiegarla.
```

The externally authored plan went `proposed → active` through `activatePlan`, got its
`week_start` stamped from the brand-timezone Monday, and superseded the previous active plan.
Same lifecycle, same transitions, same writer.
</details>

<details><summary>4. Seeds: saved, normalised like generated ones, attached to the right week</summary>

Three rows supplied, deliberately dirty: `LinkedIn` capitalised, `reel` as a legacy format.

```
$ curl -X POST .../api/v1/brands/demo/weekly-plan/seeds -d '{"week_index":0,"theme":"Il banco di lavoro", …}'
{"ok":true,"draft_id":"0f235fce-…","week_index":0,"seeds_saved":3,
 "editorial_plan_id":"15ed80a7-…","replaced":true,
 "review_url":"http://localhost:5199/app/demo/plan"}
```

`replaced: true` — the draft already in review was updated, not shadowed by a second one.
The stored jsonb, straight from the database:

```json
{ "n": 3, "theme": "Il banco di lavoro", "doDont": "Niente superlativi. Mostra le mani.",
  "first": { "id": "a5deebf8-…", "platform": "instagram", "platforms": ["instagram"],
             "format": "carousel", "slide_count": 4, "media": "image",
             "day": "Tue", "time": "09:00", "pillar": "dietro le quinte",
             "angle": "Il primo switch che monti storto", "subject": "le mani sul banco",
             "setting": "laboratorio", "props": "pinzette, switch sfusi",
             "product": "", "person": "", "title": "", "subreddit": "", "link_url": "" },
  "third_format": "video", "third_media": "video", "third_hook": "Ascolta questa" }
```

Row id minted, `doDont` in the camel key the pipeline reads, `reel` mapped onto the `video` enum,
media capabilities clamped — the same treatment a generated batch gets.
</details>

<details><summary>5. The weekly read returns them</summary>

`GET /api/v1/brands/demo/weekly-plan` (`getWeeklyPlan`, and `loadDraft` on the plan page runs the
same query):

```json
{
  "seeds_draft_id": "0f235fce-…",
  "editorial_week": 0,
  "theme": "Il banco di lavoro",
  "rows": [
    { "platform": "instagram", "format": "carousel",     "day": "Tue", "angle": "Il primo switch che monti storto" },
    { "platform": "linkedin",  "format": "single_image", "day": "Thu", "angle": "Perche montiamo a mano e non a m" },
    { "platform": "instagram", "format": "video",        "day": "Sat", "angle": "Il suono, senza parlare" }
  ]
}
```

`LinkedIn` → `linkedin`: the normalisation the generated path applies, applied here.
</details>

**What I could NOT show, and will not pretend otherwise.** I logged into the local app in a real
browser as `test@anomalia.so` and the app shell rendered, but I could not get
`/app/demo/editorial` or `/app/demo/plan` to render: in this local build both redirect back to
`/app/demo`, and the renderer then froze on that brand's chat surface. So there is **no screenshot
of the saved plan and seeds inside the web pages**. What is proven above is the layer below them:
the exact server-side reads those pages perform (`getEditorialPlan`, `getWeeklyPlan`,
`loadDraft`'s query) return the saved rows, and the untouched `approve` endpoint moves the saved
plan through the real lifecycle. A reviewer who wants the visual confirmation should open both
pages on a brand where they render.

## Anything Else?

**Deliberately left out.**

- **`media_id` / `media_mode` on a seed.** `PostSeed` carries them, but accepting them needs the
  brand-ownership check `create_post` does (`media_not_found`). Without that check an agent could
  point a seed at another brand's asset, so the two fields are not in the contract.
- **`beats`** — the per-slide story of a narrative carousel. A nested structure with a contract of
  its own; out of scope here.
- **No "week already produced" guard.** The web plan action refuses to replan a week that already
  has posts (`week_has_posts`, the 3+3 trap). That rule lives inline in the page server and is not
  extracted, and the CLI `plan` route has the same hole. So saving seeds onto an already-produced
  week and then calling `produce_week` duplicates posts. This is parity with what exists today, not
  a regression — but it is a hole, and extracting that guard into one place is the honest follow-up.

**Follow-ups.** Distinguishing external-agent provenance from web-UI provenance on
`editorial_plans` needs a widened CHECK, which needs a hand-applied migration on an instance where
`0220_widen_source_checks.sql` is already uncertain — worth doing deliberately, not as a side
effect of this PR.

**No migration.** Existing storage expresses the whole contract: `editorial_plans` for the plan,
`content_plans.seeds` for the rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
