### PR TITLE
Route remote media fetches through the SSRF guard

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -618,3 +618,68 @@ curl -s http://127.0.0.1:5200/login | grep -oE 'Anomalia|anomalia/leads' | head 
 
 Vite può comunque slittare di porta se trova occupato ("Port 5199 is in use, trying another
 one"): l'unica porta di cui fidarsi è quella stampata nel log, verificata con la riga sopra.
+
+## Una guardia che legge il nome dell'host, e segue i redirect, non è una guardia
+
+**Segnale.** Una funzione scarica un URL e la difesa è una lista di pattern di hostname
+(`isUrlSafe`, `!u.includes('localhost')`, una regex su `.local`), oppure il tetto di byte sta
+DOPO un `await res.arrayBuffer()`, oppure `fetch` è chiamata senza `redirect: 'manual'`. Tre
+sintomi diversi dello stesso difetto: ciò che viene controllato non è ciò che viene raggiunto.
+
+**Perché non regge.** Il nome è scelto da chi attacca e il DNS pure: `cdn-innocuo.example` può
+risolvere su `127.0.0.1` o su `169.254.169.254` e la stringa resta impeccabile. Il redirect è
+peggio, perché la destinazione non l'hai nemmeno vista: un URL pubblico risponde `302 Location:`
+e la guardia aveva già approvato l'unico URL che ha guardato. E un tetto applicato dopo aver
+bufferizzato è un tetto che si applica a memoria già consumata — 100MB entrati per rifiutarne 5.
+
+**Mossa.** Tre proprietà, e servono tutte e tre insieme:
+
+- **risolvi, poi controlla** l'indirizzo che torna dal resolver, non l'hostname;
+- **ricontrolla ogni hop** (`redirect: 'manual'` + ciclo tuo), schema compreso: un `302` da https
+  a http consegna il file a chiunque stia sul percorso;
+- **applica il tetto mentre il corpo arriva**, e per un file **rifiuta** invece di troncare — un
+  JPEG tagliato è un asset corrotto salvato come se fosse intero.
+
+In questo repo tutto ciò esiste già in `safeFetchBytes` (`tool-guard.ts`): **riusala, non
+riscriverla.** Due copie di una guardia SSRF sono due guardie che divergono, e la seconda diverge
+in silenzio. Se un chiamante ha bisogno di regole diverse (solo https, un tetto più alto, un altro
+User-Agent) quelle sono *parametri* della guardia — mai un `if` prima della chiamata, che il ciclo
+dei redirect non vedrebbe.
+
+**Dove guardare per prima.** Le funzioni il cui URL lo sceglie un MODELLO: lì l'input è già
+collegato a contenuto ostile, e il difetto smette di essere teorico.
+
+**E il test che lo prova non è quello dell'esito.** Bufferizzare-e-poi-misurare restituisce lo
+stesso rifiuto di fermarsi a metà: il test passa e non prova niente. Conta i pezzi che il lettore
+TIRA — prima ne chiedeva 400 su un tetto di venti.
+
+## Un fake che risponde alla domanda sbagliata nasconde il difetto che cercavi
+
+**Segnale.** Uno stub di `fetch` fatto a mano: `headers: { get: () => 'image/png' }`, più un
+`arrayBuffer()` e nessun corpo. Risponde `'image/png'` a `location` e a `content-length`, cioè
+racconta una risposta che nessun server manderebbe mai — e il giorno che il codice sotto comincia
+a leggere quegli header, o a leggere il corpo a stream, il test si rompe per il motivo sbagliato.
+
+**Mossa.** Negli stub di rete usa una `Response` vera: `new Response(bytes, { status, headers })`.
+Costa una riga in meno e non può mentire su un header che non hai previsto.
+
+**Corollario sulle fixture.** Un URL di prova come `https://cdn.example` smette di funzionare nel
+momento in cui la guardia RISOLVE l'host invece di leggerlo: il rifiuto arriva da `ENOTFOUND` e
+non dalla proprietà sotto esame. Usa un indirizzo scritto per esteso (`https://93.184.216.34`):
+`dns.lookup` lo restituisce senza interrogare nessuno, e resta pubblico.
+
+## Un timeout nella suite completa non è un difetto finché non lo riproduci da solo
+
+**Segnale.** `npm run test:unit` riporta `Hook timed out in 60000ms` o `Test timed out in
+30000ms` su file che non hai toccato, e la stessa suite era verde un'ora prima.
+
+**Cosa succede.** Il costo è il *transform* di Vite, non il test: con la cache fredda — o con
+altri lavori pesanti sulla stessa macchina — il grafo di `$lib/agent/tools/index` supera da solo
+il budget del `beforeAll`. Nella stessa sessione lo stesso file è passato in 53s e fallito a 60s
+solo perché in parallelo girava un'altra suite.
+
+**La mossa.** Prima di diagnosticare, isola: esegui il file DA SOLO, a macchina scarica. Se serve
+la prova che il difetto non è tuo, salva le modifiche in una patch
+(`git diff > /tmp/x.patch`, mai `git stash`), ripristina i sorgenti, riesegui: se fallisce anche
+senza le tue modifiche, è ambiente. Il timeout del `beforeAll` scritto nel file vince sul flag
+`--hookTimeout` della CLI, quindi per una diagnosi va alzato nel file e rimesso subito dopo.

--- a/changelog/2026-09-03-url-fetch-ssrf.md
+++ b/changelog/2026-09-03-url-fetch-ssrf.md
@@ -1,0 +1,80 @@
+# Le tre funzioni che scaricano un URL remoto passano dalla stessa guardia
+
+`storeBrandLogoFromUrl`, `archiveImageToBucket` e `archiveMarketMedia` scaricavano un URL e lo
+depositavano ciascuna a modo suo. Tutte e tre con lo stesso identico difetto in tre punti, e la
+prima raggiungibile davvero: **l'URL del logo lo sceglie un modello** (`set_brand_logo`), quindi
+un contenuto ostile che il modello legge — una pagina, un documento, un post — può dettarlo. Non
+è un difetto teorico in attesa di un attaccante: la superficie è già collegata all'ingresso.
+
+## I tre buchi, che erano lo stesso buco
+
+1. **Il nome invece dell'indirizzo.** `isUrlSafe` confronta *pattern di hostname*. Un nome
+   pubblico il cui record DNS punta su `127.0.0.1` o su `169.254.169.254` lo supera senza storie,
+   perché la stringa è innocua: è la risposta del resolver a non esserlo.
+2. **Il redirect non ricontrollato.** `fetch` seguiva i redirect da solo. Un URL pubblico che
+   risponde `302 Location:` arriva dove vuole — una rete privata, il metadata service — e la
+   guardia aveva già detto sì all'unico URL che ha guardato. Il metadata service non si raggiunge
+   digitandolo: si raggiunge facendosi rispondere da qualcosa che sembra innocuo.
+3. **Il corpo bufferizzato prima di essere misurato.** `await res.arrayBuffer()` porta in memoria
+   *tutto*, poi si controlla la dimensione. Il tetto c'era e non serviva a niente: la memoria è
+   già finita quando lo si applica. Il test che lo dimostra conta i pezzi che il lettore tira —
+   prima ne chiedeva 400 (100MB) su un tetto di 5MB.
+
+Nessuna guardia nuova è stata scritta. `tool-guard.ts` aveva già `safeFetchBytes`, con
+resolve-then-check su **ogni** hop e il tetto applicato *mentre* il corpo arriva, con rifiuto e
+non troncamento. Il lavoro è stato portarci sopra i tre chiamanti, non riscriverlo: due copie di
+una guardia SSRF sono due guardie che divergono, e la seconda diverge in silenzio.
+
+## Lo schema è un parametro, non un `if` nel chiamante
+
+`media-import` pretendeva https su ogni hop e se lo implementava in casa (`assertImportableHop`),
+passato alla guardia come `gate`. Un gate iniettabile è un buco travestito da estensibilità: il
+prossimo chiamante ne scrive un altro leggermente diverso. Ora la latitudine dello schema è un
+argomento — `scheme: 'https-only' | 'http-or-https'` — che la guardia applica **dentro** il ciclo
+dei redirect, dove serve: un chiamante che pretende https e controlla solo l'URL che gli hanno
+dato consegna comunque il file in chiaro al primo `302` che scende a http.
+
+## Cosa è stato deciso di NON stringere, e perché
+
+I tre chiamanti migrati **continuano ad accettare http**. È una scelta, non una dimenticanza:
+
+- il logo di onboarding arriva dal sito del brand, e `packages/site-analysis` accetta
+  esplicitamente `http://` — rifiutarlo qui romperebbe l'onboarding dei brand ancora in chiaro;
+- le CDN delle piattaforme servono ancora link in chiaro, e un archivio che smette di funzionare
+  non fallisce: restituisce `null` e tiene l'URL che marcisce, cioè non lo scopre nessuno.
+
+Il buco si chiude comunque, perché a chiuderlo è la risoluzione dell'indirizzo, non lo schema.
+`media-import` resta `https-only`: lì l'ingresso è un agente esterno e non c'è niente di
+preesistente da rompere.
+
+## Comportamento che cambia davvero
+
+- **`archiveMarketMedia`** ha una ragione di fallimento in più, `blocked_host`, distinta da
+  `bad_url`: "l'URL era malformato" e "l'URL puntava dove non andiamo" chiedono correzioni
+  diverse, e la ragione finisce nel log del run.
+- **Tutti e tre** ora rifiutano un host che non risolve, un redirect oltre i 4 hop, e un corpo
+  oltre il tetto *durante* la lettura invece che dopo.
+- Lo **User-Agent** degli archiviatori (`Mozilla/5.0 (compatible; AnomaliaArchive/1.0)`) è
+  passato alla guardia come parametro invece di essere sostituito con quello dei tool. Una CDN
+  che non riconosce chi chiede risponde 403, e un 403 qui è indistinguibile dal link scaduto che
+  questo archivio esiste per battere.
+
+## `isUrlSafe` resta, e non è una svista
+
+Ha una trentina di chiamanti (`design-render`, `create-content-tools`, `youtube-thumbnail`,
+`prepublish-check`, `demo-account`, `website-capture`, …) e vive in `packages/site-analysis`.
+Cancellarlo qui sarebbe stato un secondo PR travestito da pulizia. Molti di quei punti passano
+l'URL a un renderer di terze parti invece di scaricarlo loro, che è un rischio diverso; alcuni
+però scaricano davvero, e restano da portare sulla guardia — in particolare
+`catalog-tools.ts:516`, che passa ad `archiveImageToBucket` un URL scelto da un modello e ora è
+coperto solo perché la funzione a valle è stata migrata.
+
+## Due fixture che raccontavano una risposta impossibile
+
+`brand-studio-tools.test.ts` sostituiva `fetch` con un oggetto a mano il cui `headers.get()`
+rispondeva `'image/png'` a **qualsiasi** header — `location` e `content-length` compresi — e che
+non aveva corpo a stream. Con la guardia vera quel finto diventa una risposta che nessun server
+manderebbe mai. Sostituito con una `Response` vera. Il suo URL di prova, `https://cdn.example`,
+non esiste: con la risoluzione dell'indirizzo il rifiuto sarebbe arrivato dal DNS invece che dalla
+proprietà sotto esame, quindi ora è un indirizzo scritto per esteso — `dns.lookup` lo restituisce
+senza interrogare nessuno.

--- a/src/lib/content/changelog/2026-09-03-url-fetch-ssrf.ts
+++ b/src/lib/content/changelog/2026-09-03-url-fetch-ssrf.ts
@@ -1,0 +1,13 @@
+import type { ChangelogEntry } from './index';
+
+const entry: ChangelogEntry = {
+  date: '2026-09-03',
+  title: 'Pictures brought in from a link are checked more carefully',
+  items: [
+    'Importing a picture from a link — a logo, a style reference, a post we archive for you — now refuses any address that is not on the public internet, and keeps checking as the link forwards you along.',
+    'An oversized file is now turned away while it downloads instead of after, so a bad link can no longer slow the rest of your work down.',
+    'Links that still start with http keep working, so logos taken from an older brand site import as they always did.'
+  ]
+};
+
+export default entry;

--- a/src/lib/server/chat/brand-studio-tools.test.ts
+++ b/src/lib/server/chat/brand-studio-tools.test.ts
@@ -115,6 +115,14 @@ vi.mock('$lib/server/brand-analysis', () => ({
   extractColorsFromImage: async () => ['#112233', 'not-a-color']
 }));
 
+/**
+ * La guardia del logo RISOLVE l'host invece di leggerne il nome, e `cdn.example` non esiste: il
+ * rifiuto arriverebbe dal DNS invece che dalla proprietà sotto esame. Un indirizzo scritto per
+ * esteso lo evita — `dns.lookup` lo restituisce senza interrogare nessuno — e resta pubblico,
+ * quindi il cammino felice resta provato e non è un errore di rete travestito.
+ */
+const PUBLIC_CDN = 'https://93.184.216.34';
+
 const fontAvailable = vi.fn(async (family: string) => family !== 'Fake Sans');
 vi.mock('$lib/server/design-typography', () => ({
   fontIsAvailable: (f: string) => fontAvailable(f)
@@ -203,12 +211,12 @@ beforeEach(() => {
   pub.requireZernioCancellation.mockClear();
   pub.regeneratePost.mockClear();
   pub.createSingleContent.mockClear();
-  vi.stubGlobal('fetch', async () => ({
-    ok: true,
-    status: 200,
-    headers: { get: () => 'image/png' },
-    arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer
-  }));
+  // Una Response vera, non un oggetto a mano: la guardia legge `location`, `content-length` e il
+  // corpo a stream, e il finto headers.get() — che rispondeva 'image/png' a QUALSIASI header —
+  // raccontava una risposta che nessun server manderebbe mai.
+  vi.stubGlobal('fetch', async () =>
+    new Response(new Uint8Array([1, 2, 3]), { status: 200, headers: { 'content-type': 'image/png' } })
+  );
 });
 
 describe('update_brand_colors', () => {
@@ -235,7 +243,7 @@ describe('update_logo', () => {
   it('SOSTITUISCE lo slot invece di accodare, e salva nel bucket del brand', async () => {
     singles.brand_kit = { logos: [{ url: 'https://old.test/logo.png', type: 'uploaded' }], favicon_url: null };
     const t = tools();
-    const res = await run(t.update_logo, { image_url: 'https://cdn.example/new.png' });
+    const res = await run(t.update_logo, { image_url: `${PUBLIC_CDN}/new.png` });
 
     expect(res.success).toBe(true);
     // Un solo logo, e non è l'URL remoto passato: è la copia nel bucket `media`.

--- a/src/lib/server/market-media.ts
+++ b/src/lib/server/market-media.ts
@@ -14,6 +14,7 @@
  * URL. The harvest must never fail because a CDN was slow — and it must never hide that it did.
  */
 import type { SupabaseClient } from '@supabase/supabase-js';
+import { ARCHIVE_USER_AGENT, safeFetchBytes, SafeFetchError, type SafeFetchReason } from '$lib/server/tool-guard';
 
 const BUCKET = 'brand-knowledge';
 /** Harvested market media lives under its own prefix, apart from per-brand knowledge files. */
@@ -42,12 +43,19 @@ export type ArchivedMedia = {
  */
 export type ArchiveFailure =
   | 'bad_url'
+  | 'blocked_host'
   | 'fetch_failed'
   | 'http_error'
   | 'unsupported_type'
   | 'too_large'
   | 'empty'
   | 'upload_failed';
+
+const FAILURE_BY_FETCH_REASON: Record<SafeFetchReason, ArchiveFailure> = {
+  not_public: 'blocked_host',
+  too_large: 'too_large',
+  fetch_failed: 'fetch_failed'
+};
 
 export type ArchiveResult =
   | { ok: true; media: ArchivedMedia }
@@ -88,13 +96,19 @@ export async function archiveMarketMedia(
   const url = String(opts.url ?? '').trim();
   if (!url || !/^https?:\/\//i.test(url)) return { ok: false, reason: 'bad_url' };
 
-  let res: Response;
+  // The transfer ceiling is the largest thing we would ever keep; the per-kind cap below is the
+  // one that decides, and it can only be applied once the content-type has arrived.
+  let res;
   try {
-    res = await fetch(url, {
-      signal: AbortSignal.timeout(TIMEOUT_MS),
-      headers: { 'User-Agent': 'Mozilla/5.0 (compatible; AnomaliaArchive/1.0)' }
+    res = await safeFetchBytes(url, {
+      maxBytes: MAX_VIDEO_BYTES,
+      timeoutMs: TIMEOUT_MS,
+      userAgent: ARCHIVE_USER_AGENT
     });
   } catch (e) {
+    if (e instanceof SafeFetchError) {
+      return { ok: false, reason: FAILURE_BY_FETCH_REASON[e.reason], detail: e.message.slice(0, 200) };
+    }
     return {
       ok: false,
       reason: 'fetch_failed',
@@ -103,44 +117,25 @@ export async function archiveMarketMedia(
   }
   if (!res.ok) return { ok: false, reason: 'http_error', detail: String(res.status) };
 
-  const mime = (res.headers.get('content-type') ?? '').split(';')[0].trim().toLowerCase();
-  const kind: 'image' | 'video' | null = mime.startsWith('image/')
+  const kind: 'image' | 'video' | null = res.mime.startsWith('image/')
     ? 'image'
-    : mime.startsWith('video/')
+    : res.mime.startsWith('video/')
       ? 'video'
       : null;
-  if (!kind) return { ok: false, reason: 'unsupported_type', detail: mime || 'no content-type' };
+  if (!kind) return { ok: false, reason: 'unsupported_type', detail: res.mime || 'no content-type' };
 
   const cap = kind === 'video' ? MAX_VIDEO_BYTES : MAX_IMAGE_BYTES;
+  if (!res.bytes.length) return { ok: false, reason: 'empty' };
+  if (res.bytes.length > cap) return { ok: false, reason: 'too_large', detail: `${res.bytes.length} > ${cap}` };
 
-  // Reject on the declared length before buffering, when the server tells us — downloading 200MB
-  // only to discard it is the expensive way to learn the same fact.
-  const declared = Number(res.headers.get('content-length') ?? '');
-  if (Number.isFinite(declared) && declared > cap) {
-    return { ok: false, reason: 'too_large', detail: `${declared} > ${cap}` };
-  }
-
-  let buf: Buffer;
-  try {
-    buf = Buffer.from(await res.arrayBuffer());
-  } catch (e) {
-    return {
-      ok: false,
-      reason: 'fetch_failed',
-      detail: (e instanceof Error ? e.message : String(e)).slice(0, 200)
-    };
-  }
-  if (!buf.length) return { ok: false, reason: 'empty' };
-  if (buf.length > cap) return { ok: false, reason: 'too_large', detail: `${buf.length} > ${cap}` };
-
-  const ext = EXT_BY_MIME[mime] ?? (kind === 'video' ? 'mp4' : 'jpg');
+  const ext = EXT_BY_MIME[res.mime] ?? (kind === 'video' ? 'mp4' : 'jpg');
   const path = mediaPathFor(opts.platform, opts.externalId, ext);
   const { error } = await supabase.storage
     .from(BUCKET)
-    .upload(path, buf, { contentType: mime, upsert: true });
+    .upload(path, res.bytes, { contentType: res.mime, upsert: true });
   if (error) return { ok: false, reason: 'upload_failed', detail: error.message.slice(0, 200) };
 
-  return { ok: true, media: { path, bytes: buf.length, kind } };
+  return { ok: true, media: { path, bytes: res.bytes.length, kind } };
 }
 
 /** Signed read URLs for archived market media. Same bucket helper the rest of the app uses. */

--- a/src/lib/server/media-archive.ts
+++ b/src/lib/server/media-archive.ts
@@ -1,4 +1,5 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
+import { ARCHIVE_USER_AGENT, safeFetchBytes } from '$lib/server/tool-guard';
 
 // Tiny, dependency-free media archival helpers (deliberately imports nothing from the AI modules,
 // so scrapecreators/content-preview/brand-context can all use it without import cycles).
@@ -12,24 +13,28 @@ const MAX_BYTES = 5 * 1024 * 1024;
 const TIMEOUT_MS = 10_000;
 
 // Download an external image and store it at `path` in the brand-knowledge bucket. Returns the
-// path on success, null on any failure (dead URL, non-image, oversized) — callers keep the URL
-// fallback. Upsert so re-archiving the same key is idempotent.
+// path on success, null on any failure (dead URL, non-image, oversized, a target we refuse to
+// reach) — callers keep the URL fallback. Upsert so re-archiving the same key is idempotent.
+//
+// The fetch goes through safeFetchBytes rather than bare fetch: at least one caller (the chat's
+// style-reference tool) hands it a URL a model chose, and a plain fetch of a model-chosen URL is
+// a request forger with our network position.
 export async function archiveImageToBucket(
   supabase: SupabaseClient,
   path: string,
   url: string
 ): Promise<string | null> {
   try {
-    const res = await fetch(url, {
-      signal: AbortSignal.timeout(TIMEOUT_MS),
-      headers: { 'User-Agent': 'Mozilla/5.0 (compatible; AnomaliaArchive/1.0)' }
+    const res = await safeFetchBytes(url, {
+      maxBytes: MAX_BYTES,
+      timeoutMs: TIMEOUT_MS,
+      userAgent: ARCHIVE_USER_AGENT
     });
-    if (!res.ok) return null;
-    const mime = (res.headers.get('content-type') ?? '').split(';')[0].trim().toLowerCase();
-    if (!mime.startsWith('image/')) return null;
-    const buf = Buffer.from(await res.arrayBuffer());
-    if (!buf.length || buf.length > MAX_BYTES) return null;
-    const { error } = await supabase.storage.from(BUCKET).upload(path, buf, { contentType: mime, upsert: true });
+    if (!res.ok || !res.mime.startsWith('image/') || !res.bytes.length) return null;
+
+    const { error } = await supabase.storage
+      .from(BUCKET)
+      .upload(path, res.bytes, { contentType: res.mime, upsert: true });
     return error ? null : path;
   } catch {
     return null;

--- a/src/lib/server/media-fetch-guard.test.ts
+++ b/src/lib/server/media-fetch-guard.test.ts
@@ -1,0 +1,383 @@
+/**
+ * Le tre funzioni che scaricano un URL remoto e lo depositano: il logo del brand, l'archivio
+ * immagini e l'archivio dei media di mercato. Il test è uno solo perché la guardia è una sola —
+ * `safeFetchBytes` — e ciò che va dimostrato per ognuna è identico: un nome pubblico che risolve
+ * su un indirizzo privato, un redirect che ci cammina dentro, un corpo oltre il tetto con e senza
+ * content-length. Tre copie di questi helper sarebbero tre copie che divergono.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('$env/static/public', () => ({ PUBLIC_SUPABASE_URL: 'https://example.supabase.co' }));
+vi.mock('$env/dynamic/private', () => ({ env: {} }));
+vi.mock('node:dns/promises', () => ({ lookup: vi.fn() }));
+
+import { lookup } from 'node:dns/promises';
+import { archiveImageToBucket } from './media-archive';
+import { archiveMarketMedia } from './market-media';
+import { storeBrandLogoFromUrl } from './studio-actions';
+
+const PNG = Buffer.from('89504e470d0a1a0a0000000d49484452', 'hex');
+
+const OVER_LOGO_CEILING = Buffer.alloc(4_500_000, 1);
+const OVER_ARCHIVE_CEILING = Buffer.alloc(5_500_000, 1);
+const OVER_MARKET_IMAGE_CEILING = Buffer.alloc(8_500_000, 1);
+
+const PUBLIC_ADDRESS = '93.184.216.34';
+const LITERAL_IPV4 = /^\d{1,3}(\.\d{1,3}){3}$/;
+
+type Hop = { status: number; location?: string; type?: string; length?: string; body?: Buffer };
+
+function resolvesTo(byHost: Record<string, string>) {
+  vi.mocked(lookup).mockImplementation((async (host: string) => {
+    // Come il resolver vero: un indirizzo scritto per esteso torna se stesso, così il rifiuto
+    // arriva da isPrivateAddress e non dal fatto che il nome non esiste.
+    const address = LITERAL_IPV4.test(host) ? host : byHost[host];
+    if (!address) throw Object.assign(new Error('ENOTFOUND'), { code: 'ENOTFOUND' });
+    return [{ address, family: 4 }];
+  }) as never);
+}
+
+function serves(hops: Record<string, Hop>): { requested: string[]; headers: Array<Record<string, string>> } {
+  const requested: string[] = [];
+  const headers: Array<Record<string, string>> = [];
+
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: URL | string, init?: RequestInit) => {
+      const url = String(input);
+      requested.push(url);
+      headers.push(Object.fromEntries(new Headers(init?.headers ?? {}).entries()));
+
+      const hop = hops[url];
+      if (!hop) throw new Error(`ECONNREFUSED ${url}`);
+
+      const out = new Headers();
+      if (hop.location) out.set('location', hop.location);
+      if (hop.type) out.set('content-type', hop.type);
+      if (hop.length) out.set('content-length', hop.length);
+      return new Response(hop.body ? new Uint8Array(hop.body) : null, { status: hop.status, headers: out });
+    })
+  );
+
+  return { requested, headers };
+}
+
+/**
+ * Un corpo che arriva a pezzi, contando quanti ne vengono TIRATI.
+ *
+ * Il tetto di byte non si dimostra dall'esito: bufferizzare tutto e poi misurare restituisce lo
+ * stesso rifiuto di fermarsi a metà. La differenza — l'unica che conta, perché è quella che
+ * riempie la memoria della funzione — è quanti pezzi il lettore chiede prima di mollare.
+ */
+function servesChunked(url: string, opts: { type: string; chunkBytes: number; chunks: number }) {
+  const pulled = { count: 0 };
+
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: URL | string) => {
+      if (String(input) !== url) throw new Error(`ECONNREFUSED ${String(input)}`);
+
+      let sent = 0;
+      const body = new ReadableStream<Uint8Array>({
+        pull(controller) {
+          if (sent >= opts.chunks) {
+            controller.close();
+            return;
+          }
+          sent++;
+          pulled.count++;
+          controller.enqueue(new Uint8Array(opts.chunkBytes));
+        }
+      });
+
+      return new Response(body, { status: 200, headers: { 'content-type': opts.type } });
+    })
+  );
+
+  return pulled;
+}
+
+function fakeSupabase(fails: { upload?: string } = {}) {
+  const uploads: Array<{ path: string; contentType: string; bytes: number }> = [];
+
+  const client = {
+    storage: {
+      from: () => ({
+        upload: async (path: string, body: Buffer, opts: { contentType: string }) => {
+          if (fails.upload) return { error: { message: fails.upload } };
+          uploads.push({ path, contentType: opts.contentType, bytes: body.byteLength });
+          return { error: null };
+        },
+        getPublicUrl: (path: string) => ({ data: { publicUrl: `https://public.test/${path}` } })
+      })
+    }
+  };
+
+  return { client, uploads };
+}
+
+function archiveImage(url: string) {
+  const supa = fakeSupabase();
+  return archiveImageToBucket(supa.client as never, 'brand-1/thumb.jpg', url).then((path) => ({
+    path,
+    ...supa
+  }));
+}
+
+function archiveMarket(url: string) {
+  const supa = fakeSupabase();
+  return archiveMarketMedia(supa.client as never, {
+    platform: 'threads',
+    externalId: 'threads:abc',
+    url
+  }).then((result) => ({ result, ...supa }));
+}
+
+function storeLogo(url: string) {
+  const supa = fakeSupabase();
+  return storeBrandLogoFromUrl(supa.client as never, { userId: 'user-1', imageUrl: url }).then(
+    (result) => ({ result, ...supa })
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resolvesTo({ 'cdn.example.com': PUBLIC_ADDRESS });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('storeBrandLogoFromUrl', () => {
+  it('deposita il logo e ne restituisce l URL pubblico', async () => {
+    serves({ 'https://cdn.example.com/logo.png': { status: 200, type: 'image/png', body: PNG } });
+
+    const { result, uploads } = await storeLogo('https://cdn.example.com/logo.png');
+
+    expect(result).toEqual({ url: expect.stringContaining('https://public.test/user-1/studio/logo-') });
+    expect(uploads).toHaveLength(1);
+    expect(uploads[0].contentType).toBe('image/png');
+  });
+
+  it('accetta ancora http: un logo di onboarding arriva anche da un sito in chiaro', async () => {
+    resolvesTo({ 'old-brand.example.com': PUBLIC_ADDRESS });
+    serves({ 'http://old-brand.example.com/logo.png': { status: 200, type: 'image/png', body: PNG } });
+
+    const { result, uploads } = await storeLogo('http://old-brand.example.com/logo.png');
+
+    expect(result).toEqual({ url: expect.any(String) });
+    expect(uploads).toHaveLength(1);
+  });
+
+  it('rifiuta un nome pubblico che il DNS risolve su un indirizzo privato', async () => {
+    resolvesTo({ 'cdn.example.com': '169.254.169.254' });
+    const { requested } = serves({});
+
+    const { result, uploads } = await storeLogo('https://cdn.example.com/logo.png');
+
+    expect(result).toEqual({ error: expect.stringMatching(/not fetchable/i) });
+    expect(requested).toEqual([]);
+    expect(uploads).toEqual([]);
+  });
+
+  it('rifiuta un redirect che entra in una rete privata, senza seguirlo', async () => {
+    resolvesTo({ 'cdn.example.com': PUBLIC_ADDRESS, 'internal.example.com': '127.0.0.1' });
+    const { requested } = serves({
+      'https://cdn.example.com/logo.png': { status: 302, location: 'https://internal.example.com/secret' },
+      'https://internal.example.com/secret': { status: 200, type: 'image/png', body: PNG }
+    });
+
+    const { result, uploads } = await storeLogo('https://cdn.example.com/logo.png');
+
+    expect(result).toEqual({ error: expect.stringMatching(/not fetchable/i) });
+    expect(requested).toEqual(['https://cdn.example.com/logo.png']);
+    expect(uploads).toEqual([]);
+  });
+
+  it('rifiuta un corpo oltre il tetto quando il content-length mente', async () => {
+    serves({
+      'https://cdn.example.com/big.png': {
+        status: 200,
+        type: 'image/png',
+        length: '120',
+        body: OVER_LOGO_CEILING
+      }
+    });
+
+    const { result, uploads } = await storeLogo('https://cdn.example.com/big.png');
+
+    expect(result).toEqual({ error: expect.stringMatching(/too large/i) });
+    expect(uploads).toEqual([]);
+  });
+
+  it('rifiuta un corpo oltre il tetto anche quando il content-length manca', async () => {
+    serves({
+      'https://cdn.example.com/nolength.png': { status: 200, type: 'image/png', body: OVER_LOGO_CEILING }
+    });
+
+    const { result, uploads } = await storeLogo('https://cdn.example.com/nolength.png');
+
+    expect(result).toEqual({ error: expect.stringMatching(/too large/i) });
+    expect(uploads).toEqual([]);
+  });
+});
+
+describe('archiveImageToBucket', () => {
+  it('archivia la miniatura e conserva lo User-Agent con cui le CDN ci conoscono', async () => {
+    const { headers } = serves({
+      'https://cdn.example.com/thumb.jpg': { status: 200, type: 'image/jpeg', body: PNG }
+    });
+
+    const { path, uploads } = await archiveImage('https://cdn.example.com/thumb.jpg');
+
+    expect(path).toBe('brand-1/thumb.jpg');
+    expect(uploads).toHaveLength(1);
+    expect(headers[0]['user-agent']).toContain('AnomaliaArchive');
+  });
+
+  it('rifiuta un nome pubblico che il DNS risolve su un indirizzo privato', async () => {
+    resolvesTo({ 'cdn.example.com': '10.0.0.5' });
+    const { requested } = serves({});
+
+    const { path, uploads } = await archiveImage('https://cdn.example.com/thumb.jpg');
+
+    expect(path).toBeNull();
+    expect(requested).toEqual([]);
+    expect(uploads).toEqual([]);
+  });
+
+  it('rifiuta un redirect che entra in una rete privata, senza seguirlo', async () => {
+    resolvesTo({ 'cdn.example.com': PUBLIC_ADDRESS, 'internal.example.com': '169.254.169.254' });
+    const { requested } = serves({
+      'https://cdn.example.com/thumb.jpg': { status: 302, location: 'https://internal.example.com/latest/meta-data' },
+      'https://internal.example.com/latest/meta-data': { status: 200, type: 'image/jpeg', body: PNG }
+    });
+
+    const { path, uploads } = await archiveImage('https://cdn.example.com/thumb.jpg');
+
+    expect(path).toBeNull();
+    expect(requested).toEqual(['https://cdn.example.com/thumb.jpg']);
+    expect(uploads).toEqual([]);
+  });
+
+  it('rifiuta un corpo oltre il tetto quando il content-length mente', async () => {
+    serves({
+      'https://cdn.example.com/big.jpg': {
+        status: 200,
+        type: 'image/jpeg',
+        length: '120',
+        body: OVER_ARCHIVE_CEILING
+      }
+    });
+
+    const { path, uploads } = await archiveImage('https://cdn.example.com/big.jpg');
+
+    expect(path).toBeNull();
+    expect(uploads).toEqual([]);
+  });
+
+  it('rifiuta un corpo oltre il tetto anche quando il content-length manca', async () => {
+    serves({
+      'https://cdn.example.com/nolength.jpg': { status: 200, type: 'image/jpeg', body: OVER_ARCHIVE_CEILING }
+    });
+
+    const { path, uploads } = await archiveImage('https://cdn.example.com/nolength.jpg');
+
+    expect(path).toBeNull();
+    expect(uploads).toEqual([]);
+  });
+
+  it('smette di leggere appena supera il tetto, invece di tenere in memoria tutto il corpo', async () => {
+    const CHUNK_BYTES = 256 * 1024;
+    const SERVED_CHUNKS = 400; // 100MB, se qualcuno li chiedesse tutti.
+    const pulled = servesChunked('https://cdn.example.com/flood.jpg', {
+      type: 'image/jpeg',
+      chunkBytes: CHUNK_BYTES,
+      chunks: SERVED_CHUNKS
+    });
+
+    const { path, uploads } = await archiveImage('https://cdn.example.com/flood.jpg');
+
+    expect(path).toBeNull();
+    expect(uploads).toEqual([]);
+    // Il tetto è 5MB: venti pezzi bastano a superarlo, e il ventunesimo è quello che lo dimostra.
+    expect(pulled.count).toBeLessThan(SERVED_CHUNKS / 2);
+  });
+});
+
+describe('archiveMarketMedia', () => {
+  it('archivia il video e ne riporta peso e tipo', async () => {
+    serves({ 'https://cdn.example.com/clip.mp4': { status: 200, type: 'video/mp4', body: PNG } });
+
+    const { result, uploads } = await archiveMarket('https://cdn.example.com/clip.mp4');
+
+    expect(result).toEqual({
+      ok: true,
+      media: { path: 'market/threads/threads_abc.mp4', bytes: PNG.byteLength, kind: 'video' }
+    });
+    expect(uploads).toHaveLength(1);
+  });
+
+  it('rifiuta un nome pubblico che il DNS risolve su un indirizzo privato', async () => {
+    resolvesTo({ 'cdn.example.com': '127.0.0.1' });
+    const { requested } = serves({});
+
+    const { result, uploads } = await archiveMarket('https://cdn.example.com/clip.mp4');
+
+    expect(result).toMatchObject({ ok: false, reason: 'blocked_host' });
+    expect(requested).toEqual([]);
+    expect(uploads).toEqual([]);
+  });
+
+  it('rifiuta un redirect che entra in una rete privata, senza seguirlo', async () => {
+    resolvesTo({ 'cdn.example.com': PUBLIC_ADDRESS, 'internal.example.com': '192.168.1.9' });
+    const { requested } = serves({
+      'https://cdn.example.com/clip.mp4': { status: 302, location: 'https://internal.example.com/secret' },
+      'https://internal.example.com/secret': { status: 200, type: 'video/mp4', body: PNG }
+    });
+
+    const { result, uploads } = await archiveMarket('https://cdn.example.com/clip.mp4');
+
+    expect(result).toMatchObject({ ok: false, reason: 'blocked_host' });
+    expect(requested).toEqual(['https://cdn.example.com/clip.mp4']);
+    expect(uploads).toEqual([]);
+  });
+
+  it('rifiuta un immagine oltre il suo tetto quando il content-length mente', async () => {
+    serves({
+      'https://cdn.example.com/big.jpg': {
+        status: 200,
+        type: 'image/jpeg',
+        length: '120',
+        body: OVER_MARKET_IMAGE_CEILING
+      }
+    });
+
+    const { result, uploads } = await archiveMarket('https://cdn.example.com/big.jpg');
+
+    expect(result).toMatchObject({ ok: false, reason: 'too_large' });
+    expect(uploads).toEqual([]);
+  });
+
+  it('rifiuta un immagine oltre il suo tetto anche quando il content-length manca', async () => {
+    serves({
+      'https://cdn.example.com/nolength.jpg': { status: 200, type: 'image/jpeg', body: OVER_MARKET_IMAGE_CEILING }
+    });
+
+    const { result, uploads } = await archiveMarket('https://cdn.example.com/nolength.jpg');
+
+    expect(result).toMatchObject({ ok: false, reason: 'too_large' });
+    expect(uploads).toEqual([]);
+  });
+
+  it('accetta ancora http: le CDN delle piattaforme servono ancora link in chiaro', async () => {
+    resolvesTo({ 'cdn.example.com': PUBLIC_ADDRESS });
+    serves({ 'http://cdn.example.com/clip.mp4': { status: 200, type: 'video/mp4', body: PNG } });
+
+    const { result, uploads } = await archiveMarket('http://cdn.example.com/clip.mp4');
+
+    expect(result).toMatchObject({ ok: true });
+    expect(uploads).toHaveLength(1);
+  });
+});

--- a/src/lib/server/media-import.ts
+++ b/src/lib/server/media-import.ts
@@ -14,12 +14,7 @@
  * operator can ask for it from the library when they want it.
  */
 import type { SupabaseClient } from '@supabase/supabase-js';
-import {
-  assertPublicUrl,
-  safeFetchBytes,
-  SafeFetchError,
-  type SafeFetchReason
-} from '$lib/server/tool-guard';
+import { safeFetchBytes, SafeFetchError, type SafeFetchReason } from '$lib/server/tool-guard';
 import {
   insertBrandMedia,
   probeImageDimensions,
@@ -79,16 +74,6 @@ export type MediaImportResult =
   | { ok: true; media: ImportedMedia }
   | { ok: false; error: MediaImportFailure };
 
-/**
- * Il gate di ogni hop. `assertPublicUrl` da solo accetterebbe http, e un 302 da https a http
- * consegna il file a chiunque stia sul percorso — quindi lo schema si ricontrolla qui, dove il
- * controllo vale anche per le destinazioni che non abbiamo scelto noi.
- */
-async function assertImportableHop(url: URL): Promise<void> {
-  if (url.protocol !== 'https:') throw new SafeFetchError('not_public', 'Only https URLs can be imported');
-  await assertPublicUrl(url);
-}
-
 function failureFor(e: unknown): MediaImportFailure {
   return e instanceof SafeFetchError ? FAILURE_BY_FETCH_REASON[e.reason] : 'fetch_failed';
 }
@@ -106,7 +91,9 @@ export async function importBrandMediaFromUrl(
       maxBytes: TRANSFER_CEILING,
       timeoutMs: TIMEOUT_MS,
       maxRedirects: MAX_REDIRECTS,
-      gate: assertImportableHop
+      // Un 302 da https a http consegna il file a chiunque stia sul percorso, quindi lo schema
+      // vale anche per le destinazioni che non abbiamo scelto noi.
+      scheme: 'https-only'
     });
   } catch (e) {
     return { ok: false, error: failureFor(e) };

--- a/src/lib/server/studio-actions.ts
+++ b/src/lib/server/studio-actions.ts
@@ -8,6 +8,7 @@ import { localeLanguageName } from '$lib/i18n/locale';
 import { withBrandContext } from '$lib/server/ai-log';
 import { syncBrandPostHistoryFromSocials, type ScrapeSyncResult } from '$lib/server/scrapecreators';
 import { signKnowledgePaths, archiveImageToBucket } from '$lib/server/media-archive';
+import { safeFetchBytes, SafeFetchError, type SafeFetchReason } from '$lib/server/tool-guard';
 import { extractText, isSupportedDoc } from '$lib/server/documents';
 import { personConsentColumns, CONSENT_NOT_ATTESTED } from '$lib/server/people-consent';
 import {
@@ -73,8 +74,22 @@ async function withBrand<T>(supabase: any, slug: string | undefined, fn: (brand:
  * L'unica differenza col form è inevitabile: lì l'ingresso è un File e passa da `readUploadImage`
  * (che converte anche gli HEIC), qui è un URL, quindi c'è un fetch con guardia SSRF. Il tetto di
  * byte, il path e la riga sono gli stessi.
+ *
+ * L'URL lo sceglie un MODELLO (`set_brand_logo`), quindi è testo che un contenuto ostile può
+ * dettare: la guardia deve risolvere l'indirizzo, non leggere l'hostname, e deve ricontrollarlo
+ * su ogni redirect. `safeFetchBytes` fa entrambe le cose ed è l'unica copia di quel controllo.
  */
 const LOGO_MAX_BYTES = 4_000_000;
+const LOGO_TIMEOUT_MS = 15_000;
+
+// http resta ammesso: il logo di onboarding arriva dal sito del brand, e un sito ancora in chiaro
+// è comune abbastanza che rifiutarlo romperebbe l'onboarding per chiudere un buco che si chiude
+// comunque risolvendo l'indirizzo.
+const LOGO_ERROR_BY_REASON: Record<SafeFetchReason, string> = {
+  not_public: 'That image URL is not fetchable (blocked or not http/https).',
+  too_large: 'Too large — the logo must be under 4MB.',
+  fetch_failed: 'Could not download the image.'
+};
 
 export async function storeBrandLogoFromUrl(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -83,22 +98,20 @@ export async function storeBrandLogoFromUrl(
 ): Promise<{ url: string } | { error: string }> {
   const src = String(opts.imageUrl ?? '').trim();
   if (!src) return { error: 'No image URL' };
-  const { isUrlSafe } = await import('$lib/server/brand-analysis');
-  if (!isUrlSafe(src)) return { error: 'That image URL is not fetchable (blocked or not http/https).' };
 
-  let bytes: Buffer;
-  let mime: string;
+  let fetched;
   try {
-    const res = await fetch(src, { signal: AbortSignal.timeout(15_000) });
-    if (!res.ok) return { error: `Could not download the image (HTTP ${res.status}).` };
-    mime = (res.headers.get('content-type') ?? '').split(';')[0].trim().toLowerCase();
-    if (!mime.startsWith('image/')) return { error: 'That URL is not an image.' };
-    bytes = Buffer.from(await res.arrayBuffer());
-  } catch {
+    fetched = await safeFetchBytes(src, { maxBytes: LOGO_MAX_BYTES, timeoutMs: LOGO_TIMEOUT_MS });
+  } catch (e) {
+    if (e instanceof SafeFetchError) return { error: LOGO_ERROR_BY_REASON[e.reason] };
     return { error: 'Could not download the image.' };
   }
-  if (!bytes.length) return { error: 'The image is empty.' };
-  if (bytes.length > LOGO_MAX_BYTES) return { error: 'Too large — the logo must be under 4MB.' };
+
+  if (!fetched.ok) return { error: `Could not download the image (HTTP ${fetched.status}).` };
+  if (!fetched.mime.startsWith('image/')) return { error: 'That URL is not an image.' };
+  if (!fetched.bytes.length) return { error: 'The image is empty.' };
+
+  const { mime, bytes } = fetched;
 
   // Stessa mappa del form: tutto ciò che non è png/gif/webp finisce come jpg.
   const ext = mime === 'image/png' ? 'png' : mime === 'image/gif' ? 'gif' : mime === 'image/webp' ? 'webp' : 'jpg';

--- a/src/lib/server/tool-guard.test.ts
+++ b/src/lib/server/tool-guard.test.ts
@@ -1,9 +1,11 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('$env/static/public', () => ({ PUBLIC_SUPABASE_URL: 'https://example.supabase.co' }));
 vi.mock('$env/dynamic/private', () => ({ env: { SUPABASE_SERVICE_ROLE_KEY: 'test' } }));
+vi.mock('node:dns/promises', () => ({ lookup: vi.fn() }));
 
-import { isPrivateAddress } from './tool-guard';
+import { lookup } from 'node:dns/promises';
+import { isPrivateAddress, safeFetchBytes } from './tool-guard';
 
 describe('isPrivateAddress', () => {
   it('blocks every range an SSRF payload would aim at', () => {
@@ -32,5 +34,49 @@ describe('isPrivateAddress', () => {
     expect(isPrivateAddress('169.253.0.1')).toBe(false);
     expect(isPrivateAddress('100.63.0.1')).toBe(false);
     expect(isPrivateAddress('2606:4700::1111')).toBe(false);
+  });
+});
+
+/**
+ * Lo schema ammesso è un PARAMETRO della guardia, non un `if` nel chiamante: chi importa da un
+ * agente esterno pretende https su ogni hop, chi archivia una CDN di piattaforma accetta ancora
+ * http. Due politiche, una sola guardia — e il redirect le deve rispettare entrambe.
+ */
+describe('lo schema ammesso da safeFetchBytes', () => {
+  const PNG = Buffer.from('89504e470d0a1a0a', 'hex');
+
+  function servesRedirectToHttp() {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: URL | string) => {
+        const url = String(input);
+        if (url === 'https://cdn.example.com/a.png') {
+          return new Response(null, { status: 302, headers: { location: 'http://cdn.example.com/a.png' } });
+        }
+        return new Response(new Uint8Array(PNG), { status: 200, headers: { 'content-type': 'image/png' } });
+      })
+    );
+  }
+
+  beforeEach(() => {
+    vi.mocked(lookup).mockImplementation((async () => [{ address: '93.184.216.34', family: 4 }]) as never);
+    servesRedirectToHttp();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("rifiuta un redirect che scende a http quando il chiamante chiede 'https-only'", async () => {
+    await expect(
+      safeFetchBytes('https://cdn.example.com/a.png', { maxBytes: 1_000_000, scheme: 'https-only' })
+    ).rejects.toThrow(/https/i);
+  });
+
+  it('segue lo stesso redirect quando il chiamante accetta http', async () => {
+    const res = await safeFetchBytes('https://cdn.example.com/a.png', { maxBytes: 1_000_000 });
+
+    expect(res.url).toBe('http://cdn.example.com/a.png');
+    expect(res.mime).toBe('image/png');
   });
 });

--- a/src/lib/server/tool-guard.ts
+++ b/src/lib/server/tool-guard.ts
@@ -183,14 +183,33 @@ export class SafeFetchError extends Error {
 }
 
 /**
- * Reject anything that isn't a public http(s) host. Throws with a user-safe message.
+ * How much latitude the scheme gets, per caller.
+ *
+ * It is an argument and not an `if` at the call site because the redirect chain has to obey it
+ * too: a caller that demands https and only checks the URL it was handed still ships the file in
+ * clear the moment a hop answers `302 Location: http://…`. Declared here, it applies to every hop.
+ */
+export type UrlScheme = 'https-only' | 'http-or-https';
+
+const SCHEMES_ALLOWED: Record<UrlScheme, readonly string[]> = {
+  'https-only': ['https:'],
+  'http-or-https': ['http:', 'https:']
+};
+
+const SCHEME_REFUSAL: Record<UrlScheme, string> = {
+  'https-only': 'Only https URLs are supported',
+  'http-or-https': 'Only http(s) URLs are supported'
+};
+
+/**
+ * Reject anything that isn't a public host on an allowed scheme. Throws with a user-safe message.
  *
  * Exported because /start/preview is the same shape of caller as the tools above — an
  * anonymous stranger's URL — and must not fall back to the hostname-pattern check.
  */
-export async function assertPublicUrl(url: URL): Promise<void> {
-  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
-    throw new SafeFetchError('not_public', 'Only http(s) URLs are supported');
+export async function assertPublicUrl(url: URL, scheme: UrlScheme = 'http-or-https'): Promise<void> {
+  if (!SCHEMES_ALLOWED[scheme].includes(url.protocol)) {
+    throw new SafeFetchError('not_public', SCHEME_REFUSAL[scheme]);
   }
   const host = url.hostname.toLowerCase();
   if (host === 'localhost' || host.endsWith('.localhost') || host.endsWith('.local') || host.endsWith('.internal')) {
@@ -205,14 +224,26 @@ export async function assertPublicUrl(url: URL): Promise<void> {
   }
 }
 
+/**
+ * The name the platform CDNs already know the archivers by. It predates the guard and is kept
+ * verbatim: a CDN that starts refusing an unfamiliar agent answers 403, and a 403 here is
+ * indistinguishable from the expired link this whole archive exists to beat.
+ */
+export const ARCHIVE_USER_AGENT = 'Mozilla/5.0 (compatible; AnomaliaArchive/1.0)';
+
 export type SafeFetchResult = { url: string; status: number; ok: boolean; headers: Headers; body: string };
 
 type HopOptions = {
   timeoutMs?: number;
   maxRedirects?: number;
   method?: 'GET' | 'HEAD';
-  /** Runs before every hop. Defaults to assertPublicUrl; a caller with a stricter rule passes its own. */
-  gate?: (url: URL) => Promise<void>;
+  /** Checked on every hop, not just the first. Defaults to accepting http and https. */
+  scheme?: UrlScheme;
+  /**
+   * Platform CDNs answer differently depending on who is asking, and an archiver that suddenly
+   * changed its name would start collecting 403s that look exactly like expired links.
+   */
+  userAgent?: string;
 };
 
 /**
@@ -229,19 +260,20 @@ async function fetchFollowingGatedRedirects(
 ): Promise<{ url: URL; res: Response }> {
   const timeoutMs = opts.timeoutMs ?? 15_000;
   const maxRedirects = opts.maxRedirects ?? 4;
-  const gate = opts.gate ?? assertPublicUrl;
+  const scheme = opts.scheme ?? 'http-or-https';
+  const userAgent = opts.userAgent ?? `Anomalia-Tools/1.0 (+${env.CRAWLER_CONTACT_URL || 'https://anomalia.so'})`;
 
   let current = new URL(/^https?:\/\//i.test(input.trim()) ? input.trim() : `https://${input.trim()}`);
   const deadline = Date.now() + timeoutMs;
 
   for (let hop = 0; hop <= maxRedirects; hop++) {
-    await gate(current);
+    await assertPublicUrl(current, scheme);
     const remaining = deadline - Date.now();
     if (remaining <= 0) throw new SafeFetchError('fetch_failed', 'Request timed out');
 
     const res = await fetch(current, {
       method: opts.method ?? 'GET',
-      headers: { 'User-Agent': `Anomalia-Tools/1.0 (+${env.CRAWLER_CONTACT_URL || 'https://anomalia.so'})`, Accept: '*/*' },
+      headers: { 'User-Agent': userAgent, Accept: '*/*' },
       redirect: 'manual',
       signal: AbortSignal.timeout(remaining)
     });
@@ -288,7 +320,7 @@ export type SafeFetchBytesResult = { url: string; status: number; ok: boolean; m
  */
 export async function safeFetchBytes(
   input: string,
-  opts: { maxBytes: number; timeoutMs?: number; maxRedirects?: number; gate?: (url: URL) => Promise<void> }
+  opts: { maxBytes: number; timeoutMs?: number; maxRedirects?: number; scheme?: UrlScheme; userAgent?: string }
 ): Promise<SafeFetchBytesResult> {
   const { url, res } = await fetchFollowingGatedRedirects(input, opts);
 


### PR DESCRIPTION
> **Base branch is `feat/external-agent-media-import` (#199), not `dev`.** #199 is still open and
> it is where `safeFetchBytes` lives. Copying the guard to build on `dev` instead would put a
> second copy of an SSRF check in the tree, and the second copy is the one that drifts silently —
> which is the whole reason it was extracted. **Merge #199 first; this retargets to `dev` on its
> own.**

## What?

Three functions download a remote URL and store what comes back —
`storeBrandLogoFromUrl` (the brand logo), `archiveImageToBucket` (thumbnails and style
references) and `archiveMarketMedia` (harvested market media). Each did it its own way, and each
was weak in the same three places. They now go through the one guard that already handles all
three correctly, `safeFetchBytes`.

No new guard was written. The work was moving the callers onto the existing one and making the
one rule that genuinely differs between them — how much latitude the URL scheme gets — an
argument of the guard rather than a check in front of it.

## Why?

The three weaknesses were the same defect wearing different clothes: **what gets checked is not
what gets reached.**

1. **The name instead of the address.** `isUrlSafe` compares hostname *patterns*. A perfectly
   public-looking name whose DNS record points inside a private network passes it without a
   murmur — the string is innocent; the resolver's answer is not.
2. **Redirects followed with nothing re-checked.** `fetch` followed them itself, so the guard had
   approved only the one URL it ever looked at, and the destination was never examined at all.
3. **The body buffered before it was measured.** `await res.arrayBuffer()` pulls *everything* into
   memory and the size check happens after. The ceiling existed and protected nothing.

What makes this reachable rather than theoretical is who picks the URL: **the logo URL is chosen
by a model** (`set_brand_logo`), so hostile content the model reads can name it. The chat's
style-reference tool feeds `archiveImageToBucket` the same way. The market archivers are fed
platform-CDN URLs today, so they were less exposed — but they are the same defect waiting for a
caller that passes model or user input, and the fix costs the same either way.

## How?

**Reuse, not a second guard.** `safeFetchBytes` (from #199) already resolves-then-checks on every
hop, enforces HTTPS through the hop loop when asked, treats `Content-Length` as an early refusal
only, and applies the real ceiling while the body streams — *rejecting* rather than truncating,
because a truncated JPEG is a corrupt asset stored as if it were whole.

**The scheme became a parameter** (first commit, no behaviour change). `safeFetchBytes` used to
accept an injected per-hop `gate`, and `media-import` used it to demand https. An injectable gate
is a hole dressed as extensibility — the next caller writes a slightly different one. It is now
`scheme: 'https-only' | 'http-or-https'`, applied *inside* the redirect loop, which is the only
place it works: a caller that demands https and checks only the URL it was handed still hands the
file over the moment a hop answers `302 Location: http://…`.

**The ceiling is passed, not forked.** A logo is 4MB, an archived image 5MB, market media up to
64MB. One guard, three arguments.

**The archivers' User-Agent is passed too.** It is unchanged (`AnomaliaArchive/1.0`) on purpose:
a CDN that stops recognising the caller answers 403, and a 403 here is indistinguishable from the
expired link this archive exists to beat. Silently swapping it would have been a quiet outage.

### The deliberate decision on `http`

**All three migrated call sites keep accepting `http`.** Stated plainly because it is a choice,
not an oversight:

- onboarding logos come from the brand's own website, and `packages/site-analysis` explicitly
  accepts `http://` — refusing it here would break logo import for every brand still serving
  assets in plaintext;
- platform CDNs still hand out plaintext links, and an archiver that starts refusing them does
  not fail loudly: it returns `null`, keeps the rotting URL, and nobody finds out.

The hole closes regardless, because what closes it is resolving the address, not the scheme.
`media-import` stays `https-only` — its input is an external agent and there is nothing
pre-existing to break.

### Behaviour that is now stricter

| Call site | Now refuses |
|---|---|
| `storeBrandLogoFromUrl` | a host that resolves private, a redirect into one, a host that does not resolve, >4 hops, an oversized body *during* the read |
| `archiveImageToBucket` | same, returning `null` as before so callers keep their URL fallback |
| `archiveMarketMedia` | same, with a new `blocked_host` reason distinct from `bad_url` |

`archiveMarketMedia` gains one `ArchiveFailure` member. "The URL was malformed" and "the URL
pointed somewhere we refuse" call for different fixes, and the reason rides out to the run log.

### What I did NOT do

**`isUrlSafe` stays.** The brief said to delete it if nothing else used it — about thirty call
sites do (`design-render`, `create-content-tools`, `youtube-thumbnail`, `prepublish-check`,
`demo-account`, `website-capture`, …), and it lives in `packages/site-analysis`. Removing it here
would have been a second PR disguised as cleanup. Many of those sites hand the URL to a
third-party renderer rather than fetching it themselves, which is a different risk; some do fetch
and still need migrating. Listed under *Anything Else?*.

## Testing?

**TDD, and the red was watched.** New tests first, run against the unfixed code:

```
 × safeFetchBytes > rifiuta un redirect che scende a http quando il chiamante chiede 'https-only'
 × storeBrandLogoFromUrl > rifiuta un nome pubblico che il DNS risolve su un indirizzo privato
 × storeBrandLogoFromUrl > rifiuta un redirect che entra in una rete privata, senza seguirlo
 × archiveImageToBucket > rifiuta un nome pubblico che il DNS risolve su un indirizzo privato
 × archiveImageToBucket > smette di leggere appena supera il tetto, invece di tenere in memoria tutto il corpo
   → expected 400 to be less than 200
 × archiveMarketMedia > rifiuta un nome pubblico che il DNS risolve su un indirizzo privato
 × archiveMarketMedia > rifiuta un redirect che entra in una rete privata, senza seguirlo

 Test Files  2 failed (2)
      Tests  7 failed | 15 passed (22)
```

`expected 400 to be less than 200` is the memory hole, and it is the one worth pausing on. **The
size defect is invisible from the outcome**: buffering everything and then measuring returns the
same refusal as stopping halfway, so an outcome-only test passes before the fix and proves
nothing. The test counts the chunks the reader *pulls* — 400 chunks of 256KB, 100MB, against a
5MB ceiling. After the fix it stops at 21.

Coverage in `src/lib/server/media-fetch-guard.test.ts` (one `describe` per migrated call site):
a hostname resolving to a private address; a public URL redirecting into one (asserting the
second hop was never requested); an oversized body with a lying `Content-Length` and with none;
the streaming ceiling; the happy path storing the file; and `http` still accepted. The
`https-only` downgrade refusal sits in `tool-guard.test.ts` next to the parameter it exercises.

Helpers live in one file rather than three because the guard is one — three copies of a
resolver stub are three copies that drift.

**Two pre-existing fixtures had to be corrected**, and both were lying:

- `brand-studio-tools.test.ts` stubbed `fetch` with a hand-rolled object whose
  `headers.get()` returned `'image/png'` for **every** header — `location` and `content-length`
  included — and which had no body stream. That is a response no server would ever send. Replaced
  with a real `Response`.
- Its fixture URL, `https://cdn.example`, does not resolve. Once the guard resolves the address,
  the refusal would have come from `ENOTFOUND` rather than the property under test, so it is now
  a literal address (`dns.lookup` returns it without asking anyone, and it stays public).

**Results**

- `npx vitest run src/lib/server/media-fetch-guard.test.ts src/lib/server/tool-guard.test.ts src/lib/server/media-import.test.ts` → **46 passed**
- `npm run test:unit` → **6420 passed, 0 assertion failures**
- `cd cli && bun test` → **31 passed**; `bun run typecheck` → clean
- `git diff --check` → clean

<details>
<summary>Three files time out in the full suite under load, and it is not this change</summary>

`brand-studio-tools.test.ts`, `live.test.ts` and `motion-output-mount.test.ts` intermittently hit
`Hook timed out in 60000ms` / `Test timed out in 30000ms` during `npm run test:unit`. A
*different* test fails each run, which is the signature of load, not a defect. Confirmed two ways:

1. All three pass standalone on a quiet machine — **123 passed (123)**, `brand-studio-tools`
   37/37.
2. I saved my changes as a patch (`git diff > …`, never `git stash` — the hook blocks it and it
   corrupts sibling worktrees), restored the base sources, and re-ran: **it times out identically
   with none of my changes applied.** The cost is Vite's transform of the `$lib/agent/tools/index`
   graph exceeding the `beforeAll` budget, not anything in the diff.

The in-file `beforeAll` timeout beats the CLI `--hookTimeout` flag, so diagnosing it means
raising it in the file and putting it back. Written up in `LESSONS.md`.
</details>

**Not tested:** no browser verification. This change has no UI — the three functions are called
from chat tools and cron-driven harvesting, and the behaviour under test is refusal of hostile
URLs, which is exactly what unit tests with a stubbed resolver can assert and a browser cannot.

**Risk:** the guard now refuses things that previously succeeded — a host that does not resolve, a
chain over four redirects, a body past the ceiling. For the archivers that surfaces as the
existing `null` / failure-reason path, which callers already handle by keeping the source URL. The
`http` decision above is the one that would have caused real breakage, and it was left permissive
for that reason.

## Evidence (screenshots/videos)

No UI surface. Evidence is the red-then-green above: the failing run before the fix, and 46/46
focused plus 6420 suite-wide after it.

## Anything Else?

**Still unguarded, and each is its own change:**

- `catalog-tools.ts:516` gates a **model-chosen** `sourceUrl` with `isUrlSafe` before handing it
  to `archiveImageToBucket`. It is covered *today* only because the function underneath was
  migrated — the check at the call site is still the weak one.
- `create-content-tools.ts`, `design-render.ts`, `design-visual-refs.ts`,
  `media-generator/agent.ts`, `post-editor-tools.ts` filter URLs with `isUrlSafe` before passing
  them to renderers and model calls. Mostly a different risk shape (the URL is handed onward, not
  fetched by us), but worth a pass.
- `youtube-thumbnail.ts`, `demo-account.ts`, `website-capture.ts`, `prepublish-check.ts` —
  same check, mixed shapes.
- `routes/app/onboarding/people/import/+server.ts` has its own local `assertPublicUrl` that
  parses the URL without resolving it. Same defect, different copy.

**Deliberate ceiling:** `archiveMarketMedia` passes the 64MB video ceiling to the guard and
applies the 8MB image cap after the content-type arrives, so an oversized *image* streams up to
64MB before refusal instead of being rejected on its declared length. That is the pattern
`media-import` already uses, memory stays bounded where it previously was not, and making the
guard take a per-MIME ceiling would complicate it for one caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
