### PR TITLE
Spend credits from the org's pool, not the brand's

### DIFF
--- a/changelog/2026-09-04-org-scoped-credits.md
+++ b/changelog/2026-09-04-org-scoped-credits.md
@@ -1,0 +1,37 @@
+# I crediti diventano il pool dell'organizzazione, non del singolo brand
+
+Il passo B della migrazione billing (mappa #183). Lo schema esiste già in #202: qui il codice
+comincia a leggerlo. `getCreditsUsage` e `gateCreditsCore` risolvono da soli l'org partendo dal
+brandId, così **nessuno dei 29 punti di gate cambia firma** — continuano a passare un brand, e la
+risposta arriva dal pool che quel brand condivide con gli altri della sua org.
+
+Cosa cambia dentro: la spesa passa da `sum_brand_ai_cost_usd` a `sum_org_ai_cost_usd` (somma i
+brand dell'org), i grant sommano sia quelli intestati all'org sia quelli dei suoi brand, la quota
+viene da `organizations.plan`, il periodo da `org_billing_period`, e la cache a 60s del gate è
+chiavata sull'org: cinque brand della stessa org fanno una lettura sola invece di cinque copie
+degli stessi numeri.
+
+**Il punto che decide se questa PR è mergiabile o no: funziona in entrambi gli stati del
+rollout.** Il rollout è org-per-org (#185) e finché non finisce la maggioranza delle org ha le
+colonne vuote, mentre i loro brand hanno ancora tutto. Quindi ogni lettura è org-first con
+fallback sul brand che porta la subscription — non sul brand che il chiamante ha in mano, che può
+essere un altro. È la differenza che conta: leggendo un brand free di un'org che paga tramite un
+suo fratello, la risposta giusta è la quota pagata, non `FREE_CREDITS`. Il test che pinna questo
+caso è quello che fallisce per primo se qualcuno "semplifica" il fallback.
+
+`sumActiveCreditGrants` cambia firma (prende l'`OrgBilling` invece del brandId): è esportata ma
+la chiamava solo `credits.ts`.
+
+**Scartato: risolvere l'org nei 29 chiamanti.** Sarebbe stato esplicito, ma 29 firme cambiate
+sono 29 occasioni di dimenticarne una, e chi dimentica ottiene silenziosamente il pool sbagliato.
+Risolvendo al centro, l'unico modo di sbagliare è non chiamare affatto il gate.
+
+**Scartato: una seconda cache per la risoluzione org.** C'è già `stripePeriodByBrand` con lo
+stesso TTL di 5 minuti per la stessa ragione; le nuove mappe la seguono invece di inventare un
+meccanismo diverso.
+
+**Nota sul fail-open.** `gateCreditsCore` risolve l'org dentro un try/catch che ricade in
+fail-open, ma il controllo di cache e l'`assertCreditsAvailable` finale stanno **fuori** da quel
+catch: un diniego per crediti esauriti è il gate che fa il suo lavoro, e se finisse dentro il
+catch verrebbe scambiato per un errore di lettura e lascerebbe passare. È lo stesso silenzio che
+in produzione ha tenuto il gating spento per una settimana.

--- a/src/lib/server/billing/anomalia-provider.test.ts
+++ b/src/lib/server/billing/anomalia-provider.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it, vi } from 'vitest';
 
 const gateCreditsCoreMock = vi.fn(async () => {});
+const orgPlanForBrandMock = vi.fn(async (): Promise<string | null> => null);
 vi.mock('$lib/server/credits', () => ({
 	gateCreditsCore: gateCreditsCoreMock,
+	orgPlanForBrand: orgPlanForBrandMock,
 	creditQuota: (plan: string | null | undefined) => (plan === 'pro' ? 4000 : 400)
 }));
+vi.mock('$lib/server/supabase-admin', () => ({ createAdminClient: () => ({}) }));
 vi.mock('$lib/server/plans', () => ({
 	postQuota: (plan: string | null | undefined) => (plan === 'pro' ? 90 : 15),
 	plansAbove: (plan: string | null | undefined) => (plan === 'pro' ? [] : [{ key: 'pro' }]),
@@ -42,6 +45,24 @@ describe('anomaliaBillingProvider', () => {
 	});
 
 	it('quota("posts", ...) reads the real per-plan quota', async () => {
+		const { anomaliaBillingProvider } = await import('./anomalia-provider');
+		await expect(anomaliaBillingProvider.quota('posts', { brandId: 'b', plan: 'pro' })).resolves.toBe(
+			90
+		);
+	});
+
+	it("quota answers on the org's plan, not the brand plan the caller passed", async () => {
+		// After an org migrates, a caller's ctx.plan is the brand's frozen rollback copy. The org
+		// is the one paying, so it decides the quota.
+		orgPlanForBrandMock.mockResolvedValueOnce('pro');
+		const { anomaliaBillingProvider } = await import('./anomalia-provider');
+		await expect(anomaliaBillingProvider.quota('posts', { brandId: 'b', plan: null })).resolves.toBe(
+			90
+		);
+	});
+
+	it('keeps the caller-supplied plan when the org cannot be resolved', async () => {
+		orgPlanForBrandMock.mockRejectedValueOnce(new Error('supabase down'));
 		const { anomaliaBillingProvider } = await import('./anomalia-provider');
 		await expect(anomaliaBillingProvider.quota('posts', { brandId: 'b', plan: 'pro' })).resolves.toBe(
 			90

--- a/src/lib/server/billing/anomalia-provider.ts
+++ b/src/lib/server/billing/anomalia-provider.ts
@@ -1,6 +1,21 @@
 import type { BillingProvider } from '$lib/billing/contract';
-import { creditQuota, gateCreditsCore } from '$lib/server/credits';
+import { creditQuota, gateCreditsCore, orgPlanForBrand } from '$lib/server/credits';
 import { isTopPlan, plansAbove, postQuota } from '$lib/server/plans';
+import { createAdminClient } from '$lib/server/supabase-admin';
+
+/**
+ * The plan a quota answers to belongs to the ORG, not to the brand the caller happens to hold:
+ * one subscription covers every brand under it. `ctx.plan` is the brand's, which after that org
+ * migrates is the frozen rollback copy — right often enough to hide the times it is stale. It
+ * stays as the fallback so a failed lookup never shrinks a paying brand's quota.
+ */
+async function planForQuota(ctx: { brandId: string; plan?: string | null }): Promise<string | null> {
+  try {
+    return (await orgPlanForBrand(createAdminClient(), ctx.brandId)) ?? ctx.plan ?? null;
+  } catch {
+    return ctx.plan ?? null;
+  }
+}
 
 export const anomaliaBillingProvider: BillingProvider = {
   kind: 'anomalia',
@@ -12,7 +27,8 @@ export const anomaliaBillingProvider: BillingProvider = {
   },
 
   async quota(kind, ctx) {
-    return kind === 'credits' ? creditQuota(ctx.plan) : postQuota(ctx.plan);
+    const plan = await planForQuota(ctx);
+    return kind === 'credits' ? creditQuota(plan) : postQuota(plan);
   },
 
   upgradeUrl(ctx) {

--- a/src/lib/server/credits-org-scope.test.ts
+++ b/src/lib/server/credits-org-scope.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { creditQuota } from './credits';
+
+// credits.ts caches the resolved org and its period for 5 minutes at module scope. Without a
+// reset each test would answer from the previous one's seed — and quietly pass for it.
+beforeEach(() => {
+  vi.resetModules();
+});
+
+// The pool is the ORG's, not the brand's: spend, grants and quota all answer for every brand
+// under the org. During the org-by-org rollout an org may not carry its billing columns yet
+// (#185 keeps the brand ones populated as the rollback net), so every read is org-first with a
+// fall back to whichever brand of that org still holds the subscription.
+
+type Row = Record<string, any>;
+
+type Seed = {
+  organizations?: Row[];
+  brands?: Row[];
+  credit_grants?: Row[];
+  org_usage?: Row[];
+  /** sum_org_ai_cost_usd answers, in USD, per org id. */
+  spendByOrg?: Record<string, number>;
+  /** org_billing_period answers, per org id. */
+  periodByOrg?: Record<string, string>;
+  /** brand_billing_period answers, per brand id. */
+  periodByBrand?: Record<string, string>;
+};
+
+function makeDb(seed: Seed = {}) {
+  const db = {
+    organizations: seed.organizations ?? [],
+    brands: seed.brands ?? [],
+    credit_grants: seed.credit_grants ?? [],
+    org_usage: seed.org_usage ?? []
+  };
+  const calls: string[] = [];
+
+  function rows(table: string): Row[] {
+    return (db as Record<string, Row[]>)[table] ?? [];
+  }
+
+  function query(table: string) {
+    const eq: Record<string, unknown> = {};
+    const inList: Record<string, unknown[]> = {};
+    const chain: any = {
+      eq: (k: string, v: unknown) => {
+        eq[k] = v;
+        return chain;
+      },
+      in: (k: string, v: unknown[]) => {
+        inList[k] = v;
+        return chain;
+      },
+      select: () => chain,
+      limit: () => chain,
+      order: () => chain,
+      matched: () =>
+        rows(table).filter(
+          (r) =>
+            Object.entries(eq).every(([k, v]) => r[k] === v) &&
+            Object.entries(inList).every(([k, v]) => v.includes(r[k]))
+        ),
+      maybeSingle: async () => {
+        calls.push(`${table}.select`);
+        const row = chain.matched()[0];
+        return { data: row ? withChildren(table, row) : null, error: null };
+      },
+      then: (resolve: (v: any) => unknown) => {
+        calls.push(`${table}.select`);
+        return Promise.resolve({ data: chain.matched(), error: null }).then(resolve);
+      }
+    };
+    return chain;
+  }
+
+  // organizations rows carry their brands, the way a PostgREST embed does.
+  function withChildren(table: string, row: Row): Row {
+    if (table !== 'organizations') return row;
+    return { ...row, brands: db.brands.filter((b) => b.org_id === row.id) };
+  }
+
+  const client = {
+    from: (table: string) => ({
+      select: () => query(table),
+      insert: async (row: Row) => {
+        calls.push(`${table}.insert`);
+        const dup = rows(table).some(
+          (r) => r.org_id === row.org_id && r.month === row.month && table === 'org_usage'
+        );
+        if (dup) return { data: null, error: { message: 'duplicate key' } };
+        rows(table).push({ id: `${table}-${rows(table).length + 1}`, ...row });
+        return { data: null, error: null };
+      },
+      update: (patch: Row) => {
+        const eq: Record<string, unknown> = {};
+        const chain: any = {
+          eq: (k: string, v: unknown) => {
+            eq[k] = v;
+            return chain;
+          },
+          or: () => chain,
+          select: async () => {
+            calls.push(`${table}.update`);
+            const hit = rows(table).filter((r) =>
+              Object.entries(eq).every(([k, v]) => r[k] === v)
+            );
+            hit.forEach((r) => Object.assign(r, patch));
+            return { data: hit, error: null };
+          }
+        };
+        return chain;
+      }
+    }),
+    rpc: (name: string, args: Row) => {
+      calls.push(name);
+      if (name === 'sum_org_ai_cost_usd') {
+        return Promise.resolve({ data: seed.spendByOrg?.[args.p_org_id as string] ?? 0, error: null });
+      }
+      const period =
+        name === 'org_billing_period'
+          ? seed.periodByOrg?.[args._org_id as string]
+          : seed.periodByBrand?.[args._brand_id as string];
+      const result = {
+        data: period ? { period_start: period, period_end: null } : null,
+        error: null
+      };
+      return { maybeSingle: async () => result, then: (r: any) => Promise.resolve(result).then(r) };
+    }
+  };
+
+  return { client, db, calls };
+}
+
+const ORG = 'org-1';
+
+/** An org whose billing columns are already filled in — a migrated one. */
+function migratedOrg(plan: string) {
+  return {
+    organizations: [
+      { id: ORG, plan, activated_at: null, stripe_customer_id: 'cus_1', stripe_subscription_id: 'sub_1' }
+    ],
+    brands: [
+      { id: 'brand-a', org_id: ORG, plan: null, activated_at: null, stripe_subscription_id: null },
+      { id: 'brand-b', org_id: ORG, plan: null, activated_at: null, stripe_subscription_id: null }
+    ]
+  };
+}
+
+/** An org still waiting its turn in the rollout: the paying brand still holds everything. */
+function notMigratedOrg(plan: string) {
+  return {
+    organizations: [
+      { id: ORG, plan: null, activated_at: null, stripe_customer_id: null, stripe_subscription_id: null }
+    ],
+    brands: [
+      { id: 'brand-a', org_id: ORG, plan, activated_at: null, stripe_subscription_id: 'sub_1' },
+      { id: 'brand-b', org_id: ORG, plan: null, activated_at: null, stripe_subscription_id: null }
+    ]
+  };
+}
+
+const FREE_BRAND = { id: 'brand-b', plan: null, activated_at: null, status: 'active' };
+
+describe('getCreditsUsage, org-scoped', () => {
+  it('reads the quota from the org when the org is migrated', async () => {
+    const { client } = makeDb({ ...migratedOrg('pro'), spendByOrg: { [ORG]: 0 } });
+    const { getCreditsUsage } = await import('./credits');
+
+    const usage = await getCreditsUsage(client as never, FREE_BRAND);
+
+    expect(usage.quota).toBe(creditQuota('pro'));
+  });
+
+  it("falls back to the org's paying brand while the org is not migrated yet", async () => {
+    // brand-b is free and carries nothing; the org pays through brand-a. Reading brand-b must
+    // still answer with the pool the org actually has.
+    const { client } = makeDb({ ...notMigratedOrg('pro'), spendByOrg: { [ORG]: 0 } });
+    const { getCreditsUsage } = await import('./credits');
+
+    const usage = await getCreditsUsage(client as never, FREE_BRAND);
+
+    expect(usage.quota).toBe(creditQuota('pro'));
+  });
+
+  it('spends from one shared pool: every brand of the org counts', async () => {
+    const { client, calls } = makeDb({ ...migratedOrg('pro'), spendByOrg: { [ORG]: 3 } });
+    const { getCreditsUsage } = await import('./credits');
+
+    const usage = await getCreditsUsage(client as never, FREE_BRAND);
+
+    expect(calls).toContain('sum_org_ai_cost_usd');
+    expect(calls).not.toContain('sum_brand_ai_cost_usd');
+    expect(usage.used).toBe(300); // 3 USD × 100 credits
+  });
+
+  it('adds org-targeted grants and the grants of every brand in the org', async () => {
+    const { client } = makeDb({
+      ...migratedOrg('pro'),
+      spendByOrg: { [ORG]: 0 },
+      credit_grants: [
+        { amount: 500, expires_at: null, org_id: ORG, brand_id: null },
+        { amount: 250, expires_at: null, org_id: null, brand_id: 'brand-a' },
+        { amount: 999, expires_at: null, org_id: null, brand_id: 'brand-elsewhere' }
+      ]
+    });
+    const { getCreditsUsage } = await import('./credits');
+
+    const usage = await getCreditsUsage(client as never, FREE_BRAND);
+
+    expect(usage.bonus).toBe(750); // 500 org + 250 sibling brand, never the outsider's 999
+  });
+
+  it("takes the billing period from the org's own subscription", async () => {
+    const { client, calls } = makeDb({
+      ...migratedOrg('pro'),
+      spendByOrg: { [ORG]: 0 },
+      periodByOrg: { [ORG]: '2026-07-15T00:00:00Z' }
+    });
+    const { getCreditsUsage } = await import('./credits');
+
+    const usage = await getCreditsUsage(client as never, FREE_BRAND);
+
+    expect(calls).toContain('org_billing_period');
+    expect(usage.periodStart.getUTCDate()).toBe(15);
+  });
+
+  it("falls back to the paying brand's period while the org is not migrated", async () => {
+    const { client, calls } = makeDb({
+      ...notMigratedOrg('pro'),
+      spendByOrg: { [ORG]: 0 },
+      periodByBrand: { 'brand-a': '2026-07-15T00:00:00Z' }
+    });
+    const { getCreditsUsage } = await import('./credits');
+
+    const usage = await getCreditsUsage(client as never, FREE_BRAND);
+
+    expect(calls).toContain('brand_billing_period');
+    expect(usage.periodStart.getUTCDate()).toBe(15);
+  });
+});
+
+describe('gateCreditsCore, org-scoped cache', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('two brands of the same org share one pool reading', async () => {
+    // The cache keys on the org: the second brand must not pay for the same sum all over again.
+    const { client, calls } = makeDb({ ...migratedOrg('pro'), spendByOrg: { [ORG]: 0 } });
+    vi.doMock('./supabase-admin', () => ({ createAdminClient: () => client }));
+    vi.doMock('./ai-log', () => ({ isCreditExempt: () => false }));
+
+    const { gateCreditsCore } = await import('./credits');
+    await gateCreditsCore('brand-a');
+    await gateCreditsCore('brand-b');
+
+    expect(calls.filter((c) => c === 'sum_org_ai_cost_usd')).toHaveLength(1);
+  });
+});
+
+describe('maybeSendCreditWarning', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('claims the warning once per org, not once per brand', async () => {
+    const { client, db } = makeDb({ ...migratedOrg('pro'), spendByOrg: { [ORG]: 0 } });
+    vi.doMock('./scheduler', () => ({
+      brandContacts: async () => [{ email: 'ana@example.com', locale: 'en' }]
+    }));
+    vi.doMock('$lib/server/brand-notify', () => ({ notifyBrandContacts: async () => {} }));
+
+    const { maybeSendCreditWarning } = await import('./credits');
+    const usage = {
+      used: 900,
+      quota: 1000,
+      bonus: 0,
+      remaining: 100,
+      periodStart: new Date('2026-09-01T00:00:00Z'),
+      periodEnd: new Date('2026-10-01T00:00:00Z'),
+      percent: 90
+    };
+
+    await maybeSendCreditWarning(client as never, { id: 'brand-a', name: 'A', org_id: ORG }, usage);
+    await maybeSendCreditWarning(client as never, { id: 'brand-b', name: 'B', org_id: ORG }, usage);
+
+    expect(db.org_usage).toHaveLength(1);
+    expect(db.org_usage[0].org_id).toBe(ORG);
+  });
+});

--- a/src/lib/server/credits.ts
+++ b/src/lib/server/credits.ts
@@ -115,6 +115,120 @@ export async function fetchStripePeriodStart(
   return value;
 }
 
+// ── Org scope ────────────────────────────────────────────────────────────────────
+// One subscription belongs to an ORGANIZATION and covers every brand under it, so the pool a
+// brand spends from is the org's. The rollout is org-by-org: an org that has not had its turn
+// yet carries nothing, and its paying brand still holds the plan, the subscription and the
+// period — so every read is org-first and falls back to that brand. Both shapes answer the
+// same numbers, which is what lets the migration run one org at a time.
+
+export type OrgBilling = {
+  orgId: string;
+  /** organizations.plan, or the plan of whichever brand of the org still carries the subscription. */
+  plan: string | null;
+  activatedAt: string | null;
+  /** The org's brand holding a subscription — the period source until the org has its own. */
+  billingBrandId: string | null;
+  brandIds: string[];
+};
+
+type OrgBrandRow = {
+  id: string;
+  plan: string | null;
+  activated_at: string | null;
+  stripe_subscription_id: string | null;
+};
+
+type OrgRow = {
+  id: string;
+  plan: string | null;
+  activated_at: string | null;
+  stripe_subscription_id: string | null;
+  brands?: OrgBrandRow[];
+};
+
+const orgBillingByBrand = new Map<string, { value: OrgBilling | null; at: number }>();
+
+/** The org a brand bills through, with plan and period source resolved for both rollout states. */
+export async function resolveOrgBilling(
+  supabase: SupabaseClient,
+  brandId: string
+): Promise<OrgBilling | null> {
+  const hit = orgBillingByBrand.get(brandId);
+  if (hit && Date.now() - hit.at < STRIPE_PERIOD_TTL_MS) return hit.value;
+
+  const value = await readOrgBilling(supabase, brandId);
+  orgBillingByBrand.set(brandId, { value, at: Date.now() });
+  return value;
+}
+
+async function readOrgBilling(
+  supabase: SupabaseClient,
+  brandId: string
+): Promise<OrgBilling | null> {
+  const { data: brand } = await supabase
+    .from('brands')
+    .select('org_id')
+    .eq('id', brandId)
+    .maybeSingle();
+  const orgId = (brand as { org_id?: string } | null)?.org_id;
+  if (!orgId) return null;
+
+  const { data } = await supabase
+    .from('organizations')
+    .select(
+      'id, plan, activated_at, stripe_subscription_id, brands(id, plan, activated_at, stripe_subscription_id)'
+    )
+    .eq('id', orgId)
+    .maybeSingle();
+  const org = data as OrgRow | null;
+  if (!org) return null;
+
+  const brands = org.brands ?? [];
+  // At most one brand of an org pays (no customer holds two subscriptions), but pick by quota
+  // rather than by arrival order so a stray second one can never shrink the pool.
+  const paying = brands
+    .filter((b) => b.stripe_subscription_id && b.plan)
+    .sort((a, b) => creditQuota(b.plan) - creditQuota(a.plan))[0];
+
+  return {
+    orgId: org.id,
+    plan: org.plan ?? paying?.plan ?? null,
+    activatedAt: org.activated_at ?? paying?.activated_at ?? null,
+    billingBrandId: org.stripe_subscription_id ? null : (paying?.id ?? null),
+    brandIds: brands.map((b) => b.id)
+  };
+}
+
+/** The plan the org bills on, for a caller holding only a brand id. */
+export async function orgPlanForBrand(
+  supabase: SupabaseClient,
+  brandId: string
+): Promise<string | null> {
+  return (await resolveOrgBilling(supabase, brandId))?.plan ?? null;
+}
+
+const orgPeriodByOrg = new Map<string, { value: Date | null; at: number }>();
+
+/** Period anchor for the org: its own subscription first, its paying brand's while it waits. */
+async function fetchOrgPeriodStart(
+  supabase: SupabaseClient,
+  org: OrgBilling
+): Promise<Date | null> {
+  const hit = orgPeriodByOrg.get(org.orgId);
+  if (hit && Date.now() - hit.at < STRIPE_PERIOD_TTL_MS) return hit.value;
+
+  const { data, error } = await supabase
+    .rpc('org_billing_period', { _org_id: org.orgId })
+    .maybeSingle<{ period_start: string | null }>();
+  let value = !error && data?.period_start ? new Date(data.period_start) : null;
+  if (!value && org.billingBrandId) {
+    value = await fetchStripePeriodStart(supabase, org.billingBrandId);
+  }
+  orgPeriodByOrg.set(org.orgId, { value, at: Date.now() });
+  return value;
+}
+
 // ── Usage query ──────────────────────────────────────────────────────────────────
 
 const CREDITS_PER_USD = 100;
@@ -129,14 +243,58 @@ export async function getCreditsUsage(
   supabase: SupabaseClient,
   brand: Brand
 ): Promise<CreditsUsage> {
+  const org = await resolveOrgBilling(supabase, brand.id);
+  // No org in reach (a brand row that isn't there, or a read that failed): answer for the brand
+  // alone, exactly as before org-level billing. Never leave a caller without a budget.
+  if (!org) return brandCreditsUsage(supabase, brand);
+
+  const periodStart = await fetchOrgPeriodStart(supabase, org);
+  const { start, end } = currentBillingPeriod(
+    { activated_at: org.activatedAt ?? brand.activated_at },
+    periodStart
+  );
+  const planQuota = creditQuota(org.plan);
+
+  // Grants + spend don't depend on each other. Spend is summed in SQL (PostgREST
+  // aggregates are disabled — see 0158 / sum_org_ai_cost_usd).
+  const [bonus, { data: spentUsd, error }] = await Promise.all([
+    sumActiveCreditGrants(supabase, org),
+    supabase.rpc('sum_org_ai_cost_usd', {
+      p_org_id: org.orgId,
+      p_start: start.toISOString(),
+      p_end: end.toISOString()
+    })
+  ]);
+  const quota = planQuota + bonus;
+
+  if (error) {
+    console.warn('[credits] query failed:', error.message);
+    return { used: 0, quota, bonus, remaining: quota, periodStart: start, periodEnd: end, percent: 0 };
+  }
+
+  const used = Math.round(Number(spentUsd ?? 0) * CREDITS_PER_USD);
+  return {
+    used,
+    quota,
+    bonus,
+    remaining: Math.max(0, quota - used),
+    periodStart: start,
+    periodEnd: end,
+    percent: quota > 0 ? Math.min(100, Math.round((used / quota) * 100)) : 0
+  };
+}
+
+/** The brand-only reading, kept whole for the case where no org can be resolved. */
+async function brandCreditsUsage(
+  supabase: SupabaseClient,
+  brand: Brand
+): Promise<CreditsUsage> {
   const periodStart = await fetchStripePeriodStart(supabase, brand.id);
   const { start, end } = currentBillingPeriod(brand, periodStart);
   const planQuota = creditQuota(brand.plan);
 
-  // Grants + spend don't depend on each other. Spend is summed in SQL (PostgREST
-  // aggregates are disabled — see 0158 / sum_brand_ai_cost_usd).
   const [bonus, { data: spentUsd, error }] = await Promise.all([
-    sumActiveCreditGrants(supabase, brand.id),
+    sumGrantRows(supabase, (q) => q.eq('brand_id', brand.id)),
     supabase.rpc('sum_brand_ai_cost_usd', {
       p_brand_id: brand.id,
       p_start: start.toISOString(),
@@ -162,24 +320,42 @@ export async function getCreditsUsage(
   };
 }
 
-/** Active grants: never-expiring, or expires_at still in the future. */
+/**
+ * Active grants for the whole org: the ones handed to the org itself, plus the ones handed to
+ * any of its brands. A grant names one or the other (migration 20260903190000's check
+ * constraint), and both land in the same shared pool.
+ */
 export async function sumActiveCreditGrants(
   supabase: SupabaseClient,
-  brandId: string
+  org: OrgBilling
+): Promise<number> {
+  const [orgGrants, brandGrants] = await Promise.all([
+    sumGrantRows(supabase, (q) => q.eq('org_id', org.orgId)),
+    org.brandIds.length
+      ? sumGrantRows(supabase, (q) => q.in('brand_id', org.brandIds))
+      : Promise.resolve(0)
+  ]);
+  return orgGrants + brandGrants;
+}
+
+/** Active: never-expiring, or expires_at still in the future. */
+async function sumGrantRows(
+  supabase: SupabaseClient,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  filter: (q: any) => any
 ): Promise<number> {
   const now = new Date().toISOString();
-  const { data, error } = await supabase
-    .from('credit_grants')
-    .select('amount, expires_at')
-    .eq('brand_id', brandId);
+  const { data, error } = await filter(
+    supabase.from('credit_grants').select('amount, expires_at')
+  );
 
   if (error) {
     console.warn('[credits] grants query failed:', error.message);
     return 0;
   }
 
-  return (data ?? []).reduce((sum, row) => {
-    const exp = row.expires_at as string | null;
+  return ((data ?? []) as { amount: unknown; expires_at: string | null }[]).reduce((sum, row) => {
+    const exp = row.expires_at;
     if (exp && exp <= now) return sum;
     const n = Number(row.amount);
     return sum + (Number.isFinite(n) && n > 0 ? n : 0);
@@ -245,8 +421,10 @@ export async function grantCredits(
     expires_at: opts.expiresAt ?? null
   });
   if (error) throw new Error(`grantCredits failed: ${error.message}`);
-  // Invalidate the hard-gate cache so the gift is visible immediately.
-  gateCache.delete(opts.brandId);
+  // Invalidate the hard-gate cache so the gift is visible immediately. The gate keys on the org
+  // now, so the entry to drop is the org's — the gift lands in the pool all its brands share.
+  const org = await resolveOrgBilling(supabase, opts.brandId);
+  gateCache.delete(org?.orgId ?? opts.brandId);
 }
 
 /**
@@ -271,14 +449,29 @@ export async function gateCreditsCore(brandId: string): Promise<void> {
   // its own runaway watchdog. Dynamic import dodges any credits↔ai-log init-order cycle.
   const { isCreditExempt } = await import('./ai-log');
   if (isCreditExempt()) return;
-  const hit = gateCache.get(brandId);
+
+  // The pool is the org's, so the cache entry is too: every brand under an org reads and refreshes
+  // the same one, instead of each paying for its own copy of the same numbers.
+  let admin: SupabaseClient | null = null;
+  let cacheKey = brandId;
+  try {
+    admin = createAdminClient();
+    const org = await resolveOrgBilling(admin, brandId);
+    if (org) cacheKey = org.orgId;
+  } catch {
+    return; // fail-open: cannot evaluate → allow
+  }
+
+  // Outside the try on purpose: a denial here is the gate doing its job, and must not be
+  // swallowed by the fail-open catch below.
+  const hit = gateCache.get(cacheKey);
   if (hit && Date.now() - hit.at < GATE_TTL_MS) {
     assertCreditsAvailable(hit.usage);
     return;
   }
+
   let usage: CreditsUsage | null = null;
   try {
-    const admin = createAdminClient();
     const { data: brand } = await admin
       .from('brands')
       .select('id, plan, activated_at, status')
@@ -286,7 +479,7 @@ export async function gateCreditsCore(brandId: string): Promise<void> {
       .maybeSingle();
     if (!brand) return;
     usage = await getCreditsUsage(admin, brand as Brand);
-    gateCache.set(brandId, { usage, at: Date.now() });
+    gateCache.set(cacheKey, { usage, at: Date.now() });
   } catch {
     return; // fail-open: cannot evaluate → allow
   }
@@ -308,19 +501,19 @@ import { creditWarningEmailSubject, creditWarningEmailHtml, creditWarningEmailTe
  */
 async function claimCreditWarning(
   supabase: SupabaseClient,
-  brandId: string,
+  orgId: string,
   monthKey: string,
   start: Date
 ): Promise<boolean> {
   const now = new Date().toISOString();
   const { error: insErr } = await supabase
-    .from('brand_usage')
-    .insert({ brand_id: brandId, month: monthKey, credits_warned_at: now });
+    .from('org_usage')
+    .insert({ org_id: orgId, month: monthKey, credits_warned_at: now });
   if (!insErr) return true; // la riga del mese non c'era: l'abbiamo creata noi
   const { data } = await supabase
-    .from('brand_usage')
+    .from('org_usage')
     .update({ credits_warned_at: now })
-    .eq('brand_id', brandId)
+    .eq('org_id', orgId)
     .eq('month', monthKey)
     .or(`credits_warned_at.is.null,credits_warned_at.lt.${start.toISOString()}`)
     .select('id');
@@ -340,22 +533,27 @@ export async function maybeSendCreditWarning(
   try {
     if (usage.percent < WARNING_THRESHOLD) return;
 
+    // One pool, one warning: the anti-spam flag lives on the org, so an org with five brands
+    // gets one email when the shared pool crosses the threshold, not five identical ones.
+    const orgId = brand.org_id ?? (await resolveOrgBilling(supabase, brand.id))?.orgId;
+    if (!orgId) return;
+
     // The billing window is already resolved inside `usage` — reuse it, don't recompute.
     const start = usage.periodStart;
-    const monthKey = start.toISOString().slice(0, 10); // YYYY-MM-DD, aligned to brand_usage.month
+    const monthKey = start.toISOString().slice(0, 10); // YYYY-MM-DD, aligned to org_usage.month
 
     // Anti-spam: already warned this period?
     const { data: u } = await supabase
-      .from('brand_usage')
+      .from('org_usage')
       .select('credits_warned_at')
-      .eq('brand_id', brand.id)
+      .eq('org_id', orgId)
       .eq('month', monthKey)
       .maybeSingle();
 
     if (u?.credits_warned_at && new Date(u.credits_warned_at as string) >= start) return; // already sent
 
     // Resolve recipients
-    const contacts = await brandContacts(supabase, brand.org_id ?? '', brand.id);
+    const contacts = await brandContacts(supabase, orgId, brand.id);
     if (!contacts.length) return;
 
     // Si prenota PRIMA di spedire, e solo chi vince la corsa spedisce. La lettura qui sopra da sola
@@ -363,7 +561,7 @@ export async function maybeSendCreditWarning(
     // che il layout interroga ogni 45s da ogni scheda aperta — due poll simultanei passavano
     // entrambi il controllo e mandavano due mail. Se poi l'invio fallisce si perde un avviso: è
     // esattamente il compromesso che questa funzione dichiara ("non critico"), al contrario dello spam.
-    if (!(await claimCreditWarning(supabase, brand.id, monthKey, start))) return;
+    if (!(await claimCreditWarning(supabase, orgId, monthKey, start))) return;
 
     const appBase = (publicEnv.PUBLIC_APP_URL || '').replace(/\/$/, '');
     const dashboardUrl = brand.slug ? `${appBase}/app/${brand.slug}` : appBase;


### PR DESCRIPTION
## What?

Step B of the org-level billing migration (map #183): the credit pool a brand spends from
becomes its **organization's**. `getCreditsUsage` and `gateCreditsCore` resolve the org from the
brand id internally, so **none of the 29 gate call sites change signature** — they keep passing a
brand id and get back the pool that brand shares with its siblings.

Inside: spend moves from `sum_brand_ai_cost_usd` to `sum_org_ai_cost_usd`, grants sum both the
org's own and every one of its brands', the quota reads `organizations.plan`, the period comes
from `org_billing_period`, and the gate's 60s cache keys on the org — five brands of one org make
one reading instead of five copies of the same numbers. `quota('posts', …)` in the provider stops
trusting the caller's `ctx.plan` and resolves the org's plan too (#187, point 2).

## Why?

The destination is one subscription per org covering unlimited brands with a shared pool (#186,
#187). The schema for it landed in #202; this is the code that starts reading it. Until an org is
actually migrated nothing changes for anyone — see Anything Else.

## How?

**The decision that shapes the whole diff: both rollout states have to answer correctly.** The
rollout is org-by-org (#185), so for most of it the majority of orgs have empty billing columns
while their brands still hold everything. Every read is therefore org-first with a fallback to
**whichever brand of that org carries the subscription** — deliberately *not* the brand the
caller handed in, which may be a free sibling. Reading a free brand of a paying org must answer
with the paid quota, not `FREE_CREDITS`; that case has its own test, and it is the first one to
fail if the fallback is ever "simplified".

- `resolveOrgBilling(supabase, brandId)` → `{orgId, plan, activatedAt, billingBrandId, brandIds}`,
  cached 5 min per brand alongside the existing `stripePeriodByBrand` cache (same TTL, same
  reason — a second mechanism for the same job is the duplication that later diverges).
- The paying brand is picked by highest `creditQuota`, not by arrival order: at most one brand
  per org pays today, but a stray second one must never shrink the pool.
- `gateCreditsCore` resolves the org inside a fail-open `try`, but the **cache check and the final
  `assertCreditsAvailable` sit outside it** — a credits denial is the gate working, and swallowing
  it in the fail-open catch is exactly the silence that kept gating off in production for a week.
- `sumActiveCreditGrants` now takes the resolved `OrgBilling` instead of a brand id. It is
  exported, but `credits.ts` was its only caller.

**Rejected: resolving the org at the 29 call sites.** More explicit, but 29 signatures are 29
chances to miss one, and a missed one silently reads the wrong pool. Resolved centrally, the only
way to get it wrong is not to call the gate at all.

## Testing?

`src/lib/server/credits-org-scope.test.ts`, 8 cases, written first and **watched fail 8/8** before
the code existed. They cover: quota from a migrated org; quota falling back to the paying sibling
while the org waits its turn; spend read via the org RPC and never the brand one; org grants plus
sibling-brand grants summed while an outsider's grant is ignored; period from the org's own
subscription; period falling back to the paying brand's; the gate cache shared across sibling
brands; and one warning email per org rather than per brand.

Two of those started as **false passes** and were fixed: `credits.ts`'s module-scope caches leaked
between tests, so a later test was answering from an earlier test's seed. `vi.resetModules()` in a
top-level `beforeEach` is what makes them honest.

Rather than trust green, each rule was **mutation-checked** — every mutation was caught by exactly
the test that should catch it:

| Mutation | Test that failed |
|---|---|
| drop the sibling-brand plan fallback | "falls back to the org's paying brand…" |
| drop org-targeted grants from the sum | "adds org-targeted grants and…" |
| key the gate cache on the brand again | "two brands of the same org share one pool reading" |
| `quota()` uses `ctx.plan` again | "quota answers on the org's plan…" |

Regression: 67/67 green across `credits*`, `billing/**`, `lib/billing/**`, `usage`, `scheduler`,
`image-agent` — plus 9/9 on `anomalia-provider.test.ts` with two new cases.

**Not verified: `node scripts/typecheck-runtime.mjs`.** It has been killed (exit 144) on every
attempt by every fork on this machine today under memory contention, so I did not run it rather
than report a result I never saw. The PR's CI `test` job covers it. What the diff could break was
checked another way: no caller of the changed exports outside `credits.ts`, and `getCreditsUsage`
keeps its exact signature for all 12 of its call sites.

## Evidence

<details><summary>The 8 new tests, red before the code</summary>

```
 ❯ src/lib/server/credits-org-scope.test.ts (8 tests | 8 failed)
 Test Files  1 failed (1)
      Tests  8 failed (8)
```
</details>

<details><summary>Green after, with the surrounding suite</summary>

```
 ✓ src/lib/server/credits-org-scope.test.ts (8 tests)
 ✓ src/lib/server/billing/anomalia-provider.test.ts (9 tests)
 ✓ src/lib/server/credits.test.ts (14 tests)
 ✓ src/lib/server/credits-billing-gate.test.ts (2 tests)
 ✓ src/lib/server/scheduler.test.ts (12 tests)
 Test Files  9 passed (9)
      Tests  67 passed (67)
```
</details>

## Anything Else?

**This depends on #202 (`feat/org-billing-schema`) and must not merge before it.** It reads
`organizations.plan`/`activated_at`/`stripe_subscription_id`, `credit_grants.org_id`,
`org_billing_period()`, `sum_org_ai_cost_usd()` and `org_usage`, none of which exist until #202's
migration is applied by hand.

**No public changelog entry**, deliberately. Merging this changes nothing observable: until an org
is actually migrated (#191) every org still reads through the brand fallback and gets exactly
today's numbers. The user-facing line ("your brands share one pool") belongs to the rollout that
makes it true, not to the code that prepares for it.

Steps C (repointing `settings-actions.ts` and the read-only consumers) and D (the account-level
billing page) are not in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RgPP6gw4d7xW7Y92vJJrPZ
