### PR TITLE
Read billing from the org, not from the brand

### DIFF
--- a/changelog/2026-09-04-org-billing-repoint.md
+++ b/changelog/2026-09-04-org-billing-repoint.md
@@ -1,0 +1,34 @@
+# Le letture di billing guardano l'org, non più il brand
+
+L'abbonamento appartiene all'organizzazione e copre tutti i suoi brand (mappa #183). Restavano
+tredici punti che leggevano `stripe_customer_id`/`stripe_subscription_id`/`plan` da `brands`: le
+cinque azioni di `settings-actions.ts` che chiamano Stripe, e otto letture di sola
+visualizzazione (il contesto degli agenti, `hasBilling` nei settings, il tool
+`get_subscription`).
+
+`src/lib/server/org-billing.ts` risponde a una domanda sola — **con quale customer e quale
+subscription paga questo brand** — org-first, con fallback sul brand. Il fallback è sul brand
+**che porta la subscription**, non su quello che il chiamante ha in mano: durante il rollout
+org-per-org (#185) le colonne del brand restano popolate, ma il brand in mano può essere un
+fratello free di un'org che paga, e chiedere a lui significa rispondere "qui non c'è
+fatturazione" a un'organizzazione che sta pagando. È il caso che il fallback ingenuo sbaglia, ed
+è coperto da un test.
+
+**Il difetto che il repointing meccanico avrebbe introdotto**: `deleteBrand` cancellava la
+subscription ogni volta che il brand ne aveva una. Con l'abbonamento sull'org, cancellare un
+brand di tre avrebbe spento la fatturazione anche per gli altri due. Ora la subscription se ne va
+solo con l'ultimo brand dell'org (`brandCount <= 1`).
+
+Per il contesto degli agenti la strada è diversa: `system-prompt.ts` riceve un brand già letto e
+non ha un client Supabase in mano. Invece di far risalire una risoluzione fino a lì, le quattro
+select che lo alimentano incorporano `organizations(plan, stripe_customer_id,
+stripe_subscription_id)` e il prompt legge org-first. Per un ospite (`brand_members` senza
+appartenenza all'org) la RLS non restituisce l'org: il `??` cade sul brand e risponde come prima.
+
+**Scartato:** riusare `resolveOrgBilling()` di `credits.ts` (PR #210). Fa le stesse due letture ma
+vive su un branch non ancora in `dev`, e restituisce quota/periodo, non gli id di Stripe. Basare
+questa PR su quel branch avrebbe legato due merge già dipendenti da #202. Quando entrambe sono su
+`dev` le due funzioni vanno unite: stessa lettura, campi diversi.
+
+**Scartato:** una migrazione dei dati per popolare in anticipo le colonne dell'org. È il lavoro
+di #191, org per org, con la sua verifica — non un effetto collaterale di una PR di codice.

--- a/src/lib/agent/tools/read-tools.ts
+++ b/src/lib/agent/tools/read-tools.ts
@@ -64,13 +64,16 @@ export function readTools(ctx: ChatToolCtx) {
         const { canConnectSocials, hasSocialPublishing, hasWebHub, isPaidPlan } = await import('$lib/plans');
         const { PLAN_LABELS } = await import('$lib/server/plans');
         const { isPlanGoEnabled } = await import('$lib/server/feature-flags');
+        const { orgBillingForBrand } = await import('$lib/server/org-billing');
         const { data: b } = await supabase
           .from('brands')
-          .select('plan, status, activated_at, stripe_customer_id, stripe_subscription_id, timezone')
+          .select('plan, status, activated_at, timezone')
           .eq('id', brandId)
           .maybeSingle();
         if (!b) return { error: 'Brand not found' };
-        const plan = (b.plan as string | null) ?? null;
+        // The subscription lives on the org: a brand of a paying org is paid, whatever its own row says.
+        const billing = await orgBillingForBrand(supabase, { id: brandId });
+        const plan = billing?.plan ?? ((b.plan as string | null) ?? null);
         const status = (b.status as string) || 'trial';
         const paid = isPaidPlan(plan);
         const webHub = hasWebHub(plan);
@@ -93,8 +96,8 @@ export function readTools(ctx: ChatToolCtx) {
           plan,
           plan_label: plan ? (PLAN_LABELS[plan] ?? plan) : null,
           activated_at: b.activated_at ?? null,
-          stripe_customer_linked: !!b.stripe_customer_id,
-          stripe_subscription_linked: !!b.stripe_subscription_id,
+          stripe_customer_linked: !!billing?.customerId,
+          stripe_subscription_linked: !!billing?.subscriptionId,
           can_connect_socials: canConnectSocials(plan, status),
           has_social_publishing: hasSocialPublishing(plan),
           web_hub_unlocked: webHub,

--- a/src/lib/server/chat/queue.ts
+++ b/src/lib/server/chat/queue.ts
@@ -563,7 +563,7 @@ export async function processNextQueuedChatJob(
 		const { data: brand } = await admin
 			.from('brands')
 			.select(
-				'id, org_id, name, slug, website, timezone, onboarding_state, setup_completed_at, plan, status, activated_at, stripe_customer_id, stripe_subscription_id, brand_kit(*)'
+				'id, org_id, name, slug, website, timezone, onboarding_state, setup_completed_at, plan, status, activated_at, stripe_customer_id, stripe_subscription_id, organizations(plan, stripe_customer_id, stripe_subscription_id), brand_kit(*)'
 			)
 			.eq('id', job.brand_id)
 			.maybeSingle();

--- a/src/lib/server/chat/subagents.ts
+++ b/src/lib/server/chat/subagents.ts
@@ -489,7 +489,7 @@ export async function runSubagentRun(
     const { data } = await supabase
       .from('brands')
       .select(
-        'id, org_id, name, slug, website, timezone, onboarding_state, setup_completed_at, plan, status, activated_at, stripe_customer_id, stripe_subscription_id'
+        'id, org_id, name, slug, website, timezone, onboarding_state, setup_completed_at, plan, status, activated_at, stripe_customer_id, stripe_subscription_id, organizations(plan, stripe_customer_id, stripe_subscription_id)'
       )
       .eq('id', brandId)
       .maybeSingle();

--- a/src/lib/server/chat/system-prompt.ts
+++ b/src/lib/server/chat/system-prompt.ts
@@ -578,12 +578,19 @@ VIDEO ENGINE NOTE: the default engine is Grok Imagine (grok-imagine-video-1-5-pr
 
   // Subscription identity — changes only when the brand's plan actually changes.
   {
-    const planKey = (brand.plan as string | null) ?? null;
+    // Billing belongs to the org and covers all its brands, so read it there first and fall back
+    // to the brand's own columns while the org waits its turn in the rollout. `organizations` is
+    // absent for a guest who cannot read it — the fallback answers for them as it always did.
+    const org = brand.organizations as
+      | { plan?: string | null; stripe_customer_id?: string | null; stripe_subscription_id?: string | null }
+      | null
+      | undefined;
+    const planKey = org?.plan ?? (brand.plan as string | null) ?? null;
     const planLabel = planKey ? (PLAN_LABELS[planKey] ?? planKey) : 'none (free / unpaid)';
     const subStatus = (brand.status as string) || 'trial';
     const activatedAt = (brand.activated_at as string | null) ?? null;
-    const hasStripeCustomer = !!(brand.stripe_customer_id as string | null);
-    const hasStripeSub = !!(brand.stripe_subscription_id as string | null);
+    const hasStripeCustomer = !!(org?.stripe_customer_id ?? (brand.stripe_customer_id as string | null));
+    const hasStripeSub = !!(org?.stripe_subscription_id ?? (brand.stripe_subscription_id as string | null));
     const paid = isPaidPlan(planKey);
     const socialPublishing = hasSocialPublishing(planKey);
     const socialOk = canConnectSocials(planKey, subStatus);

--- a/src/lib/server/org-billing.test.ts
+++ b/src/lib/server/org-billing.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+import { orgBillingForBrand } from './org-billing';
+
+type Row = Record<string, any>;
+
+/**
+ * organizations + brands in both rollout shapes: an org that has had its turn carries the
+ * billing columns, one that has not still leaves them on its paying brand.
+ */
+function makeDb(org: Row | null, brands: Row[]) {
+	return {
+		from: (table: string) => {
+			if (table === 'brands') {
+				const filters: Record<string, unknown> = {};
+				const chain = {
+					select: () => chain,
+					eq: (k: string, v: unknown) => {
+						filters[k] = v;
+						return chain;
+					},
+					maybeSingle: async () => {
+						const row = brands.find((b) => Object.entries(filters).every(([k, v]) => b[k] === v));
+						return { data: row ? { org_id: row.org_id } : null, error: null };
+					}
+				};
+				return chain;
+			}
+			if (table === 'organizations') {
+				const chain = {
+					select: () => chain,
+					eq: () => chain,
+					maybeSingle: async () => ({
+						data: org ? { ...org, brands } : null,
+						error: null
+					})
+				};
+				return chain;
+			}
+			throw new Error(`unexpected table ${table}`);
+		}
+	};
+}
+
+const MIGRATED = {
+	id: 'org-1',
+	plan: 'pro',
+	stripe_customer_id: 'cus_org',
+	stripe_subscription_id: 'sub_org'
+};
+
+const NOT_MIGRATED = {
+	id: 'org-1',
+	plan: null,
+	stripe_customer_id: null,
+	stripe_subscription_id: null
+};
+
+const PAYING_BRAND = {
+	id: 'b1',
+	slug: 'paying',
+	org_id: 'org-1',
+	plan: 'pro',
+	stripe_customer_id: 'cus_brand',
+	stripe_subscription_id: 'sub_brand'
+};
+
+const FREE_SIBLING = {
+	id: 'b2',
+	slug: 'free',
+	org_id: 'org-1',
+	plan: null,
+	stripe_customer_id: null,
+	stripe_subscription_id: null
+};
+
+describe('orgBillingForBrand', () => {
+	it('uses the org ids once the org has been migrated', async () => {
+		const db = makeDb(MIGRATED, [PAYING_BRAND]);
+		const billing = await orgBillingForBrand(db as never, { slug: 'paying' });
+
+		expect(billing).toMatchObject({
+			orgId: 'org-1',
+			customerId: 'cus_org',
+			subscriptionId: 'sub_org',
+			plan: 'pro'
+		});
+	});
+
+	it('falls back to the paying brand while the org waits its turn', async () => {
+		const db = makeDb(NOT_MIGRATED, [PAYING_BRAND]);
+		const billing = await orgBillingForBrand(db as never, { slug: 'paying' });
+
+		expect(billing).toMatchObject({
+			customerId: 'cus_brand',
+			subscriptionId: 'sub_brand',
+			plan: 'pro'
+		});
+	});
+
+	it("answers for a free brand with its paying sibling's subscription", async () => {
+		const db = makeDb(NOT_MIGRATED, [FREE_SIBLING, PAYING_BRAND]);
+		const billing = await orgBillingForBrand(db as never, { slug: 'free' });
+
+		// The naive fallback — the caller's own brand — answers "no billing here" and hides the
+		// billing UI from an org that pays.
+		expect(billing).toMatchObject({
+			customerId: 'cus_brand',
+			subscriptionId: 'sub_brand',
+			plan: 'pro'
+		});
+	});
+
+	it('reports no billing when nothing in the org pays', async () => {
+		const db = makeDb(NOT_MIGRATED, [FREE_SIBLING]);
+		const billing = await orgBillingForBrand(db as never, { slug: 'free' });
+
+		expect(billing).toMatchObject({ customerId: null, subscriptionId: null, plan: null });
+	});
+
+	it('counts the org brands, so deleting one of several can spare the subscription', async () => {
+		const db = makeDb(MIGRATED, [PAYING_BRAND, FREE_SIBLING]);
+		const billing = await orgBillingForBrand(db as never, { slug: 'paying' });
+
+		expect(billing?.brandCount).toBe(2);
+	});
+
+	it('is null for a brand that is not there', async () => {
+		const db = makeDb(MIGRATED, [PAYING_BRAND]);
+		expect(await orgBillingForBrand(db as never, { slug: 'ghost' })).toBeNull();
+	});
+});

--- a/src/lib/server/org-billing.ts
+++ b/src/lib/server/org-billing.ts
@@ -1,0 +1,75 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+// Which Stripe customer and subscription a brand bills through.
+//
+// One subscription belongs to an ORGANIZATION and covers every brand under it. The rollout runs
+// one org at a time, so both shapes are live at once: an org that has had its turn carries the
+// ids itself, one that has not still leaves them on whichever of its brands pays. Every read is
+// org-first and falls back to that brand — never to the caller's own brand, which may be a free
+// sibling of a paying org and would answer "nothing here" for an org that pays.
+//
+// Twin of resolveOrgBilling() in credits.ts (PR #210, quota and period side): same two reads,
+// different fields. Once both are on dev they should become one call.
+
+export type OrgBilling = {
+	orgId: string;
+	customerId: string | null;
+	subscriptionId: string | null;
+	plan: string | null;
+	/** Brands under the org — deleting one of several must not cancel what covers the others. */
+	brandCount: number;
+};
+
+type BrandRow = {
+	id: string;
+	slug: string;
+	plan: string | null;
+	stripe_customer_id: string | null;
+	stripe_subscription_id: string | null;
+};
+
+type OrgRow = {
+	id: string;
+	plan: string | null;
+	stripe_customer_id: string | null;
+	stripe_subscription_id: string | null;
+	brands?: BrandRow[];
+};
+
+export async function orgBillingForBrand(
+	supabase: SupabaseClient,
+	brand: { slug?: string; id?: string }
+): Promise<OrgBilling | null> {
+	const key = brand.slug ? 'slug' : 'id';
+	const value = brand.slug ?? brand.id;
+	if (!value) return null;
+
+	const { data: row } = await supabase
+		.from('brands')
+		.select('org_id')
+		.eq(key, value)
+		.maybeSingle();
+	const orgId = (row as { org_id?: string } | null)?.org_id;
+	if (!orgId) return null;
+
+	const { data } = await supabase
+		.from('organizations')
+		.select(
+			'id, plan, stripe_customer_id, stripe_subscription_id, brands(id, slug, plan, stripe_customer_id, stripe_subscription_id)'
+		)
+		.eq('id', orgId)
+		.maybeSingle();
+	const org = data as OrgRow | null;
+	if (!org) return null;
+
+	const brands = org.brands ?? [];
+	const paying = brands.find((b) => b.stripe_customer_id);
+
+	return {
+		orgId: org.id,
+		customerId: org.stripe_customer_id ?? paying?.stripe_customer_id ?? null,
+		subscriptionId: org.stripe_subscription_id ?? paying?.stripe_subscription_id ?? null,
+		plan: org.plan ?? paying?.plan ?? null,
+		brandCount: brands.length
+	};
+}

--- a/src/lib/server/settings-actions.ts
+++ b/src/lib/server/settings-actions.ts
@@ -14,6 +14,7 @@ import { invalidateBrandNav } from '$lib/server/nav-cache';
 import { readUploadImage } from '$lib/server/raster-image';
 import { createAdminClient } from '$lib/server/supabase-admin';
 import { setJobEnabled } from '$lib/server/job-roster';
+import { orgBillingForBrand } from '$lib/server/org-billing';
 
 const stripeApi = () => import('$lib/server/stripe');
 
@@ -43,22 +44,18 @@ export async function billingPortal({ request, params, url, locals: { supabase }
   const flowRaw = String(data.get('flow') ?? 'invoices');
   const flow = flowRaw === 'payment_method' || flowRaw === 'upgrade' ? flowRaw : undefined;
 
-  const { data: brand } = await supabase
-    .from('brands')
-    .select('slug, stripe_customer_id, stripe_subscription_id')
-    .eq('slug', params.brand!)
-    .maybeSingle();
-  if (!brand) return fail(404, { billingError: 'Brand not found' });
-  if (!brand.stripe_customer_id) throw redirect(303, `/app/${brand.slug}/activate`);
+  const billing = await orgBillingForBrand(supabase, { slug: params.brand! });
+  if (!billing) return fail(404, { billingError: 'Brand not found' });
+  if (!billing.customerId) throw redirect(303, `/app/${params.brand}/activate`);
 
   let portalUrl: string;
   try {
     const { createBillingPortalSession } = await stripeApi();
     portalUrl = await createBillingPortalSession({
-      customerId: brand.stripe_customer_id,
-      returnUrl: `${url.origin}/app/${brand.slug}/settings/billing`,
+      customerId: billing.customerId,
+      returnUrl: `${url.origin}/app/${params.brand}/settings/billing`,
       flow,
-      subscriptionId: brand.stripe_subscription_id
+      subscriptionId: billing.subscriptionId
     });
   } catch (e) {
     return fail(500, { billingError: e instanceof Error ? e.message : 'Could not open billing' });
@@ -71,28 +68,24 @@ export async function upgrade({ request, params, url, locals: { supabase } }: Ev
   const data = await request.formData();
   const plan = String(data.get('plan') ?? '');
 
-  const { data: brand } = await supabase
-    .from('brands')
-    .select('slug, plan, stripe_customer_id, stripe_subscription_id')
-    .eq('slug', params.brand!)
-    .maybeSingle();
-  if (!brand) return fail(404, { billingError: 'Brand not found' });
+  const billing = await orgBillingForBrand(supabase, { slug: params.brand! });
+  if (!billing) return fail(404, { billingError: 'Brand not found' });
   // Same ladder as the settings modal / chat widget — Go included only while FEATURE_PLAN_GO is on.
-  if (!plansAbove(brand.plan).some((p) => p.key === plan)) {
+  if (!plansAbove(billing.plan).some((p) => p.key === plan)) {
     return fail(400, { billingError: 'Unknown plan' });
   }
-  if (!brand.stripe_customer_id || !brand.stripe_subscription_id) {
-    throw redirect(303, `/app/${brand.slug}/activate?plan=${encodeURIComponent(plan)}`);
+  if (!billing.customerId || !billing.subscriptionId) {
+    throw redirect(303, `/app/${params.brand}/activate?plan=${encodeURIComponent(plan)}`);
   }
 
   let upgradeUrl: string;
   try {
     const { createBillingPortalSession } = await stripeApi();
     upgradeUrl = await createBillingPortalSession({
-      customerId: brand.stripe_customer_id,
-      subscriptionId: brand.stripe_subscription_id,
+      customerId: billing.customerId,
+      subscriptionId: billing.subscriptionId,
       flow: 'upgrade',
-      returnUrl: `${url.origin}/app/${brand.slug}/settings/billing`
+      returnUrl: `${url.origin}/app/${params.brand}/settings/billing`
     });
   } catch (e) {
     return fail(500, { billingError: e instanceof Error ? e.message : 'Could not start the upgrade' });
@@ -105,16 +98,12 @@ export async function applyRetention({ params, locals: { supabase } }: Ev) {
   const coupon = env.STRIPE_RETENTION_COUPON;
   if (!coupon) return fail(400, { billingError: 'Retention offer is not configured.' });
 
-  const { data: brand } = await supabase
-    .from('brands')
-    .select('stripe_subscription_id')
-    .eq('slug', params.brand!)
-    .maybeSingle();
-  if (!brand?.stripe_subscription_id) return fail(400, { billingError: 'No active subscription.' });
+  const billing = await orgBillingForBrand(supabase, { slug: params.brand! });
+  if (!billing?.subscriptionId) return fail(400, { billingError: 'No active subscription.' });
 
   try {
     const { applyRetentionCoupon } = await stripeApi();
-    await applyRetentionCoupon(brand.stripe_subscription_id, coupon);
+    await applyRetentionCoupon(billing.subscriptionId, coupon);
   } catch (e) {
     return fail(500, { billingError: e instanceof Error ? e.message : 'Could not apply the offer' });
   }
@@ -127,18 +116,14 @@ export async function cancelPlan({ request, params, locals: { supabase } }: Ev) 
   const reason = String(data.get('reason') ?? '');
   const comment = String(data.get('explanation') ?? '').trim();
 
-  const { data: brand } = await supabase
-    .from('brands')
-    .select('plan, stripe_subscription_id')
-    .eq('slug', params.brand!)
-    .maybeSingle();
-  if (!isPaidPlan(brand?.plan)) return fail(400, { billingError: 'No paid plan to cancel.' });
-  if (!brand?.stripe_subscription_id) return fail(400, { billingError: 'No active subscription.' });
+  const billing = await orgBillingForBrand(supabase, { slug: params.brand! });
+  if (!isPaidPlan(billing?.plan)) return fail(400, { billingError: 'No paid plan to cancel.' });
+  if (!billing?.subscriptionId) return fail(400, { billingError: 'No active subscription.' });
 
   let endsAt: string | null = null;
   try {
     const { cancelSubscriptionAtPeriodEnd } = await stripeApi();
-    ({ endsAt } = await cancelSubscriptionAtPeriodEnd(brand.stripe_subscription_id, {
+    ({ endsAt } = await cancelSubscriptionAtPeriodEnd(billing.subscriptionId, {
       feedback: FEEDBACK[reason],
       comment
     }));
@@ -155,16 +140,19 @@ export async function deleteBrand({ request, params, locals: { supabase } }: Ev)
 
   const { data: brand } = await supabase
     .from('brands')
-    .select('id, name, slug, stripe_subscription_id')
+    .select('id, name, slug')
     .eq('slug', params.brand!)
     .maybeSingle();
   if (!brand) return fail(404, { deleteError: 'failed' });
   if (confirm !== brand.name) return fail(400, { deleteError: 'nameMismatch' });
 
-  if (brand.stripe_subscription_id) {
+  // The subscription belongs to the org and covers every brand under it, so deleting one of
+  // several leaves the others paid for: only the last brand out takes the subscription with it.
+  const billing = await orgBillingForBrand(supabase, { slug: params.brand! });
+  if (billing?.subscriptionId && billing.brandCount <= 1) {
     try {
       const { ensureSubscriptionCanceled } = await stripeApi();
-      await ensureSubscriptionCanceled(brand.stripe_subscription_id);
+      await ensureSubscriptionCanceled(billing.subscriptionId);
     } catch (e) {
       return fail(400, {
         deleteError: e instanceof Error && e.message === 'active_plan' ? 'activePlan' : 'failed'

--- a/src/routes/api/v1/chat/respond/run/+server.ts
+++ b/src/routes/api/v1/chat/respond/run/+server.ts
@@ -64,7 +64,7 @@ export const POST: RequestHandler = async ({ request, locals: { supabase, safeGe
     // Load brand
     const { data: brand } = await supabase
       .from('brands')
-      .select('id, org_id, name, slug, website, timezone, onboarding_state, setup_completed_at, plan, status, activated_at, stripe_customer_id, stripe_subscription_id, brand_kit(*)')
+      .select('id, org_id, name, slug, website, timezone, onboarding_state, setup_completed_at, plan, status, activated_at, stripe_customer_id, stripe_subscription_id, organizations(plan, stripe_customer_id, stripe_subscription_id), brand_kit(*)')
       .eq('id', job.brand_id)
       .maybeSingle();
 

--- a/src/routes/app/[brand]/chat/+server.ts
+++ b/src/routes/app/[brand]/chat/+server.ts
@@ -69,7 +69,7 @@ export const POST: RequestHandler = async ({ request, params, locals: { supabase
 
   const { data: brand } = await supabase
     .from('brands')
-    .select('id, org_id, name, slug, website, timezone, onboarding_state, setup_completed_at, plan, status, activated_at, stripe_customer_id, stripe_subscription_id, content_prefs, brand_kit(*)')
+    .select('id, org_id, name, slug, website, timezone, onboarding_state, setup_completed_at, plan, status, activated_at, stripe_customer_id, stripe_subscription_id, organizations(plan, stripe_customer_id, stripe_subscription_id), content_prefs, brand_kit(*)')
     .eq('slug', params.brand)
     .maybeSingle();
   if (!brand) return new Response('Brand not found', { status: 404 });

--- a/src/routes/app/[brand]/settings/+layout.server.ts
+++ b/src/routes/app/[brand]/settings/+layout.server.ts
@@ -3,10 +3,11 @@ import { accountLimit, plansAbove, isTopPlan } from '$lib/server/plans';
 import { isBrandOwner } from '$lib/server/settings-actions';
 import { loadStudioDeferred } from '$lib/server/studio-deferred';
 import { forgetBrandJobOptOuts, jobEnabledForBrand } from '$lib/server/job-roster';
+import { orgBillingForBrand } from '$lib/server/org-billing';
 
 export const load: LayoutServerLoad = async ({ parent, params, locals: { supabase } }) => {
   const { brand } = await parent();
-  const [{ data: accounts }, { data: cfg }, { data: apiKeysRaw }, isOwner, { data: invites }] =
+  const [{ data: accounts }, { data: cfg }, { data: apiKeysRaw }, isOwner, { data: invites }, billing] =
     await Promise.all([
       supabase
         .from('social_accounts')
@@ -15,7 +16,7 @@ export const load: LayoutServerLoad = async ({ parent, params, locals: { supabas
         .order('connected_at', { ascending: true }),
       supabase
         .from('brands')
-        .select('last_autopilot_run_at, autopilot_failure_count, stripe_customer_id')
+        .select('last_autopilot_run_at, autopilot_failure_count')
         .eq('id', brand.id)
         .maybeSingle(),
       supabase
@@ -27,7 +28,8 @@ export const load: LayoutServerLoad = async ({ parent, params, locals: { supabas
         .from('brand_invites')
         .select('id, email, accepted_at, created_at')
         .eq('brand_id', brand.id)
-        .order('created_at', { ascending: true })
+        .order('created_at', { ascending: true }),
+      orgBillingForBrand(supabase, { id: brand.id })
     ]);
 
   const list = accounts ?? [];
@@ -49,9 +51,10 @@ export const load: LayoutServerLoad = async ({ parent, params, locals: { supabas
     })(),
     lastAutopilotRunAt: cfg?.last_autopilot_run_at ?? null,
     autopilotFailureCount: cfg?.autopilot_failure_count ?? 0,
-    hasBilling: !!cfg?.stripe_customer_id,
-    upgrades: plansAbove(brand.plan),
-    atTopPlan: isTopPlan(brand.plan),
+    // The org pays, so a free brand sitting next to a paying sibling still has billing to show.
+    hasBilling: !!billing?.customerId,
+    upgrades: plansAbove(billing?.plan ?? brand.plan),
+    atTopPlan: isTopPlan(billing?.plan ?? brand.plan),
     apiKeys,
     isOwner,
     invites: invites ?? [],


### PR DESCRIPTION
## What?

Thirteen places asked the **brand** which Stripe customer, subscription and plan it billed
through. The subscription belongs to the **organization** and covers every brand under it, so all
thirteen now read org-first and fall back to the brand while the org waits its turn in the
org-by-org rollout.

New `src/lib/server/org-billing.ts` answers exactly one question — *which customer and which
subscription does this brand bill through* — and every caller uses it:

- `settings-actions.ts`: `billingPortal`, `upgrade`, `applyRetention`, `cancelPlan`, `deleteBrand`
- display-only: `settings/+layout.server.ts` (`hasBilling`, upgrade ladder),
  `agent/tools/read-tools.ts` (`get_subscription`), and `chat/system-prompt.ts` via an
  `organizations(...)` embed on the four selects that build the agent's brand context.

## Why?

Step C of the org-level billing map (#183), implementing the decision closed in #189. Without it,
a brand of a paying org reads its own empty columns and concludes the org doesn't pay: the
billing UI hides, the agent tells the user they're unpaid, and the portal button 404s — while the
credit pool (#210) correctly hands that same brand the paid quota.

## How?

**The fallback is on the brand that carries the subscription, not the caller's brand.** This is
the whole design point. During the rollout the brand columns stay populated (#185), so a naive
"org first, else *this* brand" works for the paying brand and fails for its free siblings. A test
pins that case.

**`deleteBrand` changed behavior deliberately, and it is the one thing worth reviewing closely.**
It used to cancel the subscription whenever the brand had one. With billing on the org, deleting
one brand of three would have stopped payment for the other two. The subscription now leaves only
with the org's last brand (`brandCount <= 1`).

**`system-prompt.ts` took a different route** than the other consumers: it receives an
already-fetched brand and has no Supabase client in scope. Rather than thread a resolver up into
it, the four selects that feed it embed `organizations(plan, stripe_customer_id,
stripe_subscription_id)` and the prompt reads org-first. For a `brand_members` guest, RLS returns
no org and the `??` falls back to the brand exactly as before.

**Rejected:** reusing `resolveOrgBilling()` from `credits.ts` (#210). Same two reads, but it
returns quota/period rather than Stripe ids, and it lives on a branch not yet in `dev` — basing
this PR there would have chained two merges that already depend on #202. When both land, the two
functions should become one; noted in the changelog.

## Testing?

`src/lib/server/org-billing.test.ts`, 6 cases, written first and **watched fail** (module absent).
The two that carry the design were verified by mutation rather than trusted:

- removing the paying-sibling fallback → "falls back to the paying brand" and "answers for a free
  brand with its paying sibling's subscription" both fail
- flipping org-first to brand-first → "uses the org ids once the org has been migrated" fails

**Regression: 1077 passed, 37 skipped across 91 suites** covering `settings-actions`, `chat/**`,
`agent/tools/**`, `credits*`.

One suite, `chat/brand-studio-tools.test.ts`, fails on a 60s hook timeout — **pre-existing, not
from this change**: it fails identically on the untouched main checkout of `dev` (verified, same
60s hook timeout, 37 skipped).

`typecheck-runtime.mjs` **was not run** — it is being killed on this machine under load from
parallel worktrees. Verified instead that no reference to the removed brand fields survives
outside the intended fallbacks, and that every touched call site keeps its signature.

## Evidence

<details><summary>Mutation: drop the paying-sibling fallback</summary>

```
× orgBillingForBrand > falls back to the paying brand while the org waits its turn
× orgBillingForBrand > answers for a free brand with its paying sibling's subscription
  Tests  2 failed | 4 passed (6)
```
</details>

<details><summary>Mutation: brand-first instead of org-first</summary>

```
× orgBillingForBrand > uses the org ids once the org has been migrated
  Tests  1 failed | 5 passed (6)
```
</details>

<details><summary>The pre-existing failure, on untouched dev</summary>

```
$ npx vitest run src/lib/server/chat/brand-studio-tools.test.ts   # main checkout, no changes
Error: Hook timed out in 60000ms.
 Test Files  1 failed (1)
      Tests  37 skipped (37)
```
</details>

## Anything Else?

**Depends on #202** (`feat/org-billing-schema`): this reads `organizations.plan`,
`.stripe_customer_id` and `.stripe_subscription_id`, which exist only after that migration is
applied by hand. Do not merge before it.

**No public changelog**, on purpose: until an org is actually migrated (#191) every read falls
back to the brand and the user sees exactly today's numbers. The user-facing line belongs to the
rollout that makes it true.

**Overlap with #204/#207**: none found. Both were already merged into `dev` when this branched —
`settings-actions.ts` here builds on #204's single `createBillingPortalSession` (no
`createUpgradePortalSession`), and `org.ts`'s `payingOrgId` from #207 is untouched.

**Left for later:** `resolveOrgBilling` (#210) and `orgBillingForBrand` (this PR) perform the same
org+brands read for different fields. Unify once both are on `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RgPP6gw4d7xW7Y92vJJrPZ
