### PR TITLE
Clean every bucket an eval user wrote to

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -272,6 +272,24 @@ l'utente. E il caso che perde davvero è la creazione fallita a METÀ — utente
 fixture restituito, `destroyFixture(null)` che esce subito: la creazione ripulisce da sola prima
 di rilanciare.
 
+### Una `list()` piatta su un bucket non pulisce uno Storage che annida per brand
+Stessa pulizia, un piano più sotto. `deleteEvalUser` faceva `storage.from('media').list(userId)` e
+cancellava `${userId}/${nome}`: ma sotto `<userId>/` ci sono CARTELLE, quindi chiedeva di
+cancellare `<userId>/library` — che non è un oggetto — e Supabase rispondeva `200` con una lista
+vuota. Intanto `brand-knowledge/<userId>/<brandId>/media/` non veniva nemmeno aperto. Segnale: la
+pulizia "riesce" sempre e `storage.objects` continua a crescere; in produzione l'asset importato
+di un giro di eval era ancora lì. Mossa: attraversare RICORSIVO (in `list` una cartella torna con
+`id` nullo) su OGNI bucket — `listBuckets()`, non una lista di nomi scritta a mano che ricomincia
+a perdere al primo tipo di asset nuovo — sempre sotto `<userId>/`, che è il prefisso imposto dalle
+policy di Storage e non una convenzione. E il test che vede il difetto asserisce QUALI percorsi
+sono stati cancellati: «la pulizia è stata chiamata» passa anche quando non cancella niente.
+
+### Una pulizia best effort che fallisce in silenzio si accumula per mesi
+Il `.catch()` muto sulla pulizia dello Storage è la ragione per cui nessuno ha visto i file
+restare: best effort è giusto — un eval non deve fallire perché la pulizia è fallita — ma muto no.
+Segnale: nessun errore da nessuna parte e lo spazio che cresce. Mossa: `swallow('…')` invece di
+`catch(() => {})`, così l'errore finisce su stderr e su Sentry e la pulizia resta non bloccante.
+
 ### PostgREST tiene in CACHE lo schema: la migration applicata in locale non basta
 Applicate 0226/0227/0229 allo stack locale, la chat continuava a ricadere sul percorso vecchio e la
 lettura per cursore rispondeva 503. La RLS era sana (provata a mano: l'utente leggeva i suoi eventi),

--- a/changelog/2026-09-03-eval-teardown-storage.md
+++ b/changelog/2026-09-03-eval-teardown-storage.md
@@ -1,0 +1,91 @@
+# La pulizia di un utente di eval guarda in ogni bucket, e a ogni profondità
+
+`deleteEvalUser` cancellava lo Storage con una `list()` **piatta** su **un solo** bucket:
+
+```ts
+const { data: files } = await admin.storage.from('media').list(userId, { limit: 1000 });
+const paths = files.map((f) => `${userId}/${f.name}`);
+await admin.storage.from('media').remove(paths);
+```
+
+Sotto `media/<userId>/` non ci sono file: ci sono **cartelle**. Quella `list` restituisce
+`library`, `chat`, `uploads` — e la `remove` che segue chiede a Supabase di cancellare
+`<userId>/library`, che non è un oggetto e quindi non cancella niente. Non fallisce: risponde
+`200` con una lista vuota. Ogni giro di eval che toccava un media lasciava i file in
+**produzione**, e nessuno lo vedeva perché la pulizia non si lamentava mai.
+
+Una verifica su produzione l'ha confermato dall'altro lato: un asset importato è rimasto a
+`brand-knowledge/<userId>/<brandId>/media/import-<uuid>.png`, in un bucket che quella riga non
+apriva nemmeno.
+
+## Perché il test che c'era non poteva vederlo
+
+Non c'era test. Ma il test facile da scrivere — «la pulizia è stata chiamata» — sarebbe passato
+comunque: `remove()` viene invocata, con due percorsi, e risponde senza errori. L'unica
+asserzione che vede il difetto è **quali percorsi** sono stati cancellati. Il rosso di questa PR
+dice esattamente questo:
+
+```
++   "media/<user>/chat"
++   "media/<user>/library"
+-   "brand-knowledge/<user>/<brand>/artifacts/1-plan.md"
+-   "brand-knowledge/<user>/<brand>/media/import-abc.png"
+-   "media/<user>/chat/attachment.jpg"
+-   "media/<user>/library/copy.png"
+```
+
+Due nomi di cartella al posto di quattro oggetti, e un bucket intero mai aperto.
+
+## I bucket e le forme di percorso che un giro di eval può creare
+
+I bucket del progetto sono sette. Solo due hanno il prefisso per utente, e non per convenzione:
+è la policy di Storage a imporlo, `(storage.foldername(name))[1] = auth.uid()::text`
+(`0004_content_plans_posts.sql` per `media`, `0021_brand_documents.sql` per `brand-knowledge`).
+
+**`media/<userId>/…`** — `uploads/`, `library/`, `onboarding/`, `chat/`, `chat-refs/`,
+`generated/`, `blog/`, `profile/`, `studio/`, `media-generator/`, `requests/`, `youtube-thumbs/`.
+
+**`brand-knowledge/<userId>/<brandId>/…`** — `media/`, `mood/`, `people/`, `artifacts/`,
+`onboarding/`, `chat-convert/`, `competitors/`, `competitors/ads/`, `market/`, `history/`, e
+i documenti caricati dal browser direttamente sotto `<brandId>/`.
+
+Gli altri cinque non sono per utente: `talent` (catalogo globale), `wall` (galleria pubblica,
+chiave per piattaforma e post), `agent-docs` (`defaults/`, `overrides/`, `INDEX/` — globali),
+`agent-homes` (`<brandId>/<timestamp>/`), `email-assets` (`trends/`).
+
+## Quello che resta fuori, e si dice
+
+Tre scritture su Storage sono indicizzate sul **brand**, non sull'utente, quindi nessuna pulizia
+per prefisso utente può portarle via: `media/<brandId>/motion/*.mp4` (`motion-video/render-tools`),
+`media/<brandId>/voiceover/*.wav` (`gemini-audio`) e `agent-homes/<brandId>/<ts>/`
+(`checkpoint-storage`). Un eval che rendesse un video di motion o svegliasse un computer d'agente
+le lascerebbe a terra. Sta a `destroyFixture`, che il brand ce l'ha — non a questa funzione, che
+di proposito non sa cosa sia un brand.
+
+## Perché non una lista di bucket scritta a mano
+
+L'alternativa era `['media', 'brand-knowledge']`. È la stessa trappola un piano più in su: la
+lista è giusta oggi e sbagliata al primo tipo di asset nuovo, in silenzio e senza che nessun test
+possa accorgersene. `listBuckets()` toglie la lista: si guarda dentro **tutti** i bucket, sempre
+sotto `<userId>/`, e un bucket che quel prefisso non ce l'ha costa una `list` vuota.
+
+## La guardia, che è del codice e non della disciplina
+
+Questa funzione cancella in produzione, quindi «cancella solo sotto il prefisso dell'utente» non
+può restare una cosa da ricordare. `ownedBy(userId)` è l'unico punto da cui passa un percorso
+prima della `remove`, e rifiuta tutto ciò che non ha `userId` come primo segmento o contiene un
+`..`. Prima ancora, pretende che l'id sia un uuid: il caso che fa davvero danno è un id **vuoto**,
+perché il prefisso diventa `/` e ogni oggetto del bucket lo soddisfa. Un test lo pinna — con id
+vuoto non parte nemmeno una `list`.
+
+## Rumorosa, non muta
+
+La pulizia resta best effort: un eval non deve fallire perché è fallita la pulizia. Ma il
+`.catch()` ora è `swallow(...)`, che scrive su stderr e manda a Sentry. Il silenzio è il motivo
+per cui questi file si sono accumulati per mesi.
+
+## Verifica
+
+Statica e unit, di proposito: nessun eval è stato girato contro produzione: costa denaro vero e
+crea righe vere. `scripts/eval/user.test.ts` è l'unica cosa che serve, perché quello che era
+rotto è l'attraversamento, non la rete.

--- a/scripts/eval/user.test.ts
+++ b/scripts/eval/user.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const admin = vi.hoisted(() => ({ client: null as unknown }));
+vi.mock('$lib/server/supabase-admin', () => ({ createAdminClient: () => admin.client }));
+
+const { deleteEvalUser } = await import('./user');
+
+const USER = '11111111-1111-1111-1111-111111111111';
+const OTHER = '22222222-2222-2222-2222-222222222222';
+const BRAND = '33333333-3333-3333-3333-333333333333';
+
+type Buckets = Record<string, string[]>;
+
+/**
+ * Storage finto che risponde come quello vero: `list` di una cartella restituisce i figli
+ * DIRETTI, e una sottocartella arriva con `id: null`. È la forma che il difetto non guardava.
+ */
+function fakeAdmin(buckets: Buckets, escapes: string[] = []) {
+  const removed: string[] = [];
+  const deleted: string[] = [];
+  const listed: string[] = [];
+
+  const client = {
+    storage: {
+      listBuckets: async () => ({ data: Object.keys(buckets).map((name) => ({ name })), error: null }),
+      from(bucket: string) {
+        const objects = buckets[bucket] ?? [];
+        return {
+          async list(prefix: string, options?: { limit?: number; offset?: number }) {
+            listed.push(`${bucket}/${prefix}`);
+            const limit = options?.limit ?? 100;
+            const offset = options?.offset ?? 0;
+            const children = new Map<string, string | null>();
+            for (const path of objects) {
+              if (!path.startsWith(`${prefix}/`)) continue;
+              const rest = path.slice(prefix.length + 1);
+              const cut = rest.indexOf('/');
+              if (cut === -1) children.set(rest, 'file-id');
+              else children.set(rest.slice(0, cut), null);
+            }
+            for (const name of prefix === USER ? escapes : []) children.set(name, 'file-id');
+            const page = [...children].map(([name, id]) => ({ name, id }));
+            return { data: page.slice(offset, offset + limit), error: null };
+          },
+          async remove(paths: string[]) {
+            removed.push(...paths.map((p) => `${bucket}/${p}`));
+            return { data: null, error: null };
+          }
+        };
+      }
+    },
+    auth: {
+      admin: {
+        deleteUser: async (id: string) => {
+          deleted.push(id);
+          return { data: null, error: null };
+        }
+      }
+    }
+  };
+
+  admin.client = client;
+  return { removed, deleted, listed };
+}
+
+describe('la pulizia dello Storage di un utente usa e getta', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('porta via gli oggetti annidati che un giro di eval produce davvero', async () => {
+    const seen = fakeAdmin({
+      media: [`${USER}/library/copy.png`, `${USER}/chat/attachment.jpg`],
+      'brand-knowledge': [`${USER}/${BRAND}/media/import-abc.png`, `${USER}/${BRAND}/artifacts/1-plan.md`]
+    });
+
+    await deleteEvalUser(USER);
+
+    expect(seen.removed.sort()).toEqual([
+      `brand-knowledge/${USER}/${BRAND}/artifacts/1-plan.md`,
+      `brand-knowledge/${USER}/${BRAND}/media/import-abc.png`,
+      `media/${USER}/chat/attachment.jpg`,
+      `media/${USER}/library/copy.png`
+    ]);
+    expect(seen.deleted).toEqual([USER]);
+  });
+
+  test('non tocca un oggetto che non è sotto il prefisso dell’utente', async () => {
+    const seen = fakeAdmin({
+      media: [`${USER}/library/mine.png`, `${OTHER}/library/not-mine.png`]
+    });
+
+    await deleteEvalUser(USER);
+
+    expect(seen.removed).toEqual([`media/${USER}/library/mine.png`]);
+  });
+
+  test('un id che non è un utente non fa cancellare niente, e si sente', async () => {
+    const seen = fakeAdmin({ media: [`${USER}/library/mine.png`] });
+    const shouted = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await deleteEvalUser('');
+
+    expect(seen.listed).toEqual([]);
+    expect(seen.removed).toEqual([]);
+    expect(shouted).toHaveBeenCalled();
+    expect(seen.deleted).toEqual(['']);
+  });
+
+  test('un nome che risale fuori dal prefisso viene rifiutato prima della remove', async () => {
+    const seen = fakeAdmin({ media: [`${USER}/library/mine.png`] }, [`../${OTHER}/stolen.png`]);
+    const shouted = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await deleteEvalUser(USER);
+
+    expect(seen.removed).toEqual([]);
+    expect(shouted).toHaveBeenCalled();
+    expect(seen.deleted).toEqual([USER]);
+  });
+
+  test('una pulizia fallita resta rumorosa e non impedisce di cancellare l’utente', async () => {
+    fakeAdmin({});
+    (admin.client as { storage: { listBuckets: () => Promise<unknown> } }).storage.listBuckets = async () => {
+      throw new Error('storage giù');
+    };
+    const shouted = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(deleteEvalUser(USER)).resolves.toBeUndefined();
+
+    expect(shouted).toHaveBeenCalled();
+  });
+});

--- a/scripts/eval/user.ts
+++ b/scripts/eval/user.ts
@@ -1,4 +1,5 @@
 import { createAdminClient } from '$lib/server/supabase-admin';
+import { swallow } from '$lib/server/swallow';
 
 export type EvalUser = {
   id: string;
@@ -7,6 +8,23 @@ export type EvalUser = {
 };
 
 const EMAIL_DOMAIN = 'anomalia.so';
+const PAGE_SIZE = 1000;
+const USER_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+type StorageEntry = { name: string; id: string | null };
+
+type BucketApi = {
+  list(
+    prefix: string,
+    options: { limit: number; offset: number }
+  ): Promise<{ data: StorageEntry[] | null }>;
+  remove(paths: string[]): Promise<unknown>;
+};
+
+type StorageApi = {
+  listBuckets(): Promise<{ data: { name: string }[] | null }>;
+  from(bucket: string): BucketApi;
+};
 
 export function evalEmail(now: number = Date.now()): string {
   return `eval-ux-${now}@${EMAIL_DOMAIN}`;
@@ -25,13 +43,72 @@ export async function createEvalUser(email: string, password: string): Promise<E
   return { id: data.user.id, email, password };
 }
 
+/**
+ * L'UNICO PUNTO DA CUI PASSA UNA CANCELLAZIONE, e gira in produzione.
+ *
+ * Il prefisso non è una convenzione da ricordare: le policy di Storage impongono
+ * `(storage.foldername(name))[1] = auth.uid()::text` (migration 0004 e 0021), quindi ogni oggetto
+ * di un utente sta sotto `<userId>/` e niente fuori da lì è suo. L'id deve essere un uuid perché
+ * il caso che fa davvero danno è un id vuoto: `''` rende il prefisso `/`, e qualsiasi oggetto del
+ * bucket passerebbe il controllo.
+ */
+function ownedBy(userId: string): (path: string) => string {
+  if (!USER_ID.test(userId)) throw new Error(`eval teardown: '${userId}' is not a user id`);
+
+  return (path) => {
+    const segments = path.split('/');
+    if (segments[0] !== userId || segments.length < 2 || segments.includes('..')) {
+      throw new Error(`eval teardown refused '${path}': outside ${userId}/`);
+    }
+    return path;
+  };
+}
+
+/** Ricorsivo: le cartelle tornano da `list` con `id` nullo, gli oggetti stanno in fondo. */
+async function objectsUnder(bucket: BucketApi, prefix: string): Promise<string[]> {
+  const objects: string[] = [];
+  const folders = [prefix];
+
+  while (folders.length) {
+    const folder = folders.pop()!;
+
+    for (let offset = 0; ; offset += PAGE_SIZE) {
+      const { data } = await bucket.list(folder, { limit: PAGE_SIZE, offset });
+      if (!data?.length) break;
+
+      for (const entry of data) {
+        (entry.id === null ? folders : objects).push(`${folder}/${entry.name}`);
+      }
+      if (data.length < PAGE_SIZE) break;
+    }
+  }
+
+  return objects;
+}
+
+/**
+ * Ogni bucket, non quelli che oggi ci vengono in mente: quali ne tocca un giro di eval cambia con
+ * il prodotto, e una lista scritta a mano ricomincia a perdere al primo tipo di asset nuovo.
+ * Guardare in un bucket che quel prefisso non ce l'ha costa una `list` vuota.
+ */
+async function purgeUserStorage(storage: StorageApi, userId: string): Promise<void> {
+  const owned = ownedBy(userId);
+  const { data: buckets } = await storage.listBuckets();
+
+  for (const { name } of buckets ?? []) {
+    const bucket = storage.from(name);
+    const objects = await objectsUnder(bucket, userId);
+    if (objects.length) await bucket.remove(objects.map(owned));
+  }
+}
+
 export async function deleteEvalUser(userId: string): Promise<void> {
   const admin = createAdminClient();
-  const { data: files } = await admin.storage.from('media').list(userId, { limit: 1000 });
-  if (files?.length) {
-    const paths = files.map((f) => `${userId}/${f.name}`);
-    await admin.storage.from('media').remove(paths);
-  }
+
+  // Best effort di proposito — un eval non deve fallire perché è fallita la pulizia — ma non
+  // muto: i file che si sono accumulati per mesi si sono accumulati in silenzio.
+  await purgeUserStorage(admin.storage, userId).catch(swallow(`eval storage teardown ${userId}`));
+
   const { error } = await admin.auth.admin.deleteUser(userId);
   if (error) {
     throw new Error(`eval user teardown failed: ${error.message}`);


### PR DESCRIPTION
## What?

`deleteEvalUser` — the teardown that every disposable eval brand runs against **production** —
cleaned Storage with a single flat listing of a single bucket:

```ts
const { data: files } = await admin.storage.from('media').list(userId, { limit: 1000 });
const paths = files.map((f) => `${userId}/${f.name}`);
await admin.storage.from('media').remove(paths);
```

Under `media/<userId>/` there are no files — there are **folders**. That `list` returns
`library`, `chat`, `uploads`, and the `remove` that follows asks Supabase to delete
`<userId>/library`, which is not an object. Supabase answers `200` with an empty list. Meanwhile
`brand-knowledge/<userId>/<brandId>/…` was never opened at all.

This PR makes the teardown walk **recursively**, across **every** bucket, always under the
disposable user's own prefix, and makes a failed cleanup loud instead of silent.

## Why?

`AGENTS.md` already carries the rule this broke: *"The trial brand is always destroyed, even on
errors (finally). And Storage is cleaned separately."* The intent was right; the implementation
reached one shape of path.

A production verification found the leak from the other side: an imported asset from a real run
was still sitting at

```
brand-knowledge/<userId>/<brandId>/media/import-<uuid>.png
```

and the verifying agent had to walk both buckets by hand to clean up. `LESSONS.md` already
records four stray `eval-mt*` brands left in production by eval runs — this is the same class of
leak one layer down, except this one leaves **files** that cost storage and can contain brand
imagery.

## How?

**Recursive traversal, not a flat list.** In Supabase Storage a `list()` entry with a null `id`
is a folder; objects are the leaves. `objectsUnder()` walks the tree from `<userId>` and pages
each folder with `limit`/`offset`, so a partial clean cannot pass for a complete one.

**Every bucket, from `listBuckets()`, not a hand-written list.** The rejected alternative was
`['media', 'brand-knowledge']`. That is the same trap one floor up: correct today, wrong at the
first new asset kind, silently, with no test able to notice. `email-assets` is already proof —
it exists in code with no migration creating it, so any list derived from `supabase/migrations`
would have missed it. Looking inside a bucket that has no `<userId>/` folder costs one empty
`list`.

**A guard, not a convention.** This function deletes in production, so "only under the user's
prefix" cannot be something to remember. `ownedBy(userId)` is the single point every path
crosses before `remove`, and it rejects anything whose first segment is not `userId` or that
contains a `..` segment. Before that it requires the id to be a **uuid**, because the case that
does real damage is an empty id: `''` makes the prefix `/`, and every object in the bucket
satisfies `startsWith('/')`. A test pins it — with an empty id not even a `list` is issued.

**Loud, still best-effort.** The cleanup stays non-blocking (an eval must not fail because
cleanup failed), but `.catch()` is now `swallow(...)`, the repo's existing convention: stderr
plus Sentry. Silence is precisely how these files accumulated unnoticed. Verified under the eval
runtime itself, not only under vitest — `swallow` had never been imported on the vite-node path
before:

```
$ npx vite-node --config scripts/vite-node.config.ts scripts/_swallow-probe.ts
[swallowed] probe: boom
SWALLOW OK UNDER VITE-NODE
```

### Every bucket and path shape an eval run can produce

Seven buckets exist. Only two are user-prefixed, and not by convention — the Storage policy
enforces it: `(storage.foldername(name))[1] = auth.uid()::text` (`0004_content_plans_posts.sql`
for `media`, `0021_brand_documents.sql` for `brand-knowledge`).

| Bucket | Prefix | Shapes |
| --- | --- | --- |
| `media` | `<userId>/` | `uploads/`, `library/`, `onboarding/`, `chat/`, `chat-refs/`, `generated/`, `blog/`, `profile/`, `studio/`, `media-generator/`, `requests/`, `youtube-thumbs/` |
| `brand-knowledge` | `<userId>/<brandId>/` | `media/`, `mood/`, `people/`, `artifacts/`, `onboarding/`, `chat-convert/`, `competitors/`, `competitors/ads/`, `market/`, `history/`, plus browser uploads flat under `<brandId>/` |
| `talent` | — | global catalogue, seeded by script |
| `wall` | — | public gallery, keyed by platform + post |
| `agent-docs` | — | global `defaults/`, `overrides/`, `INDEX/` |
| `agent-homes` | `<brandId>/<ts>/` | workspace checkpoints |
| `email-assets` | — | `trends/` |

The two shapes the production run hit — `media/<userId>/library/` and
`brand-knowledge/<userId>/<brandId>/media/` — are two rows of the first two lines. Both are now
covered, along with everything else under those prefixes, at any depth.

## Testing?

`scripts/eval/user.test.ts`, five cases, all through the real entry point `deleteEvalUser` with
`createAdminClient` mocked by a fake Storage that answers the way the real one does (direct
children only, folders with a null `id`).

The seam that let this through is that "cleanup was called" passes while the traversal misses
everything — `remove()` *is* invoked, with two paths, and returns no error. So the tests assert
**which paths were deleted**. Watched red before the fix:

```
 ❯ scripts/eval/user.test.ts (5 tests | 5 failed)
   × porta via gli oggetti annidati che un giro di eval produce davvero
     → expected [ …(2) ] to deeply equal [ …(4) ]

  Array [
-   "brand-knowledge/<user>/<brand>/artifacts/1-plan.md",
-   "brand-knowledge/<user>/<brand>/media/import-abc.png",
-   "media/<user>/chat/attachment.jpg",
-   "media/<user>/library/copy.png",
+   "media/<user>/chat",
+   "media/<user>/library",
  ]
```

Two folder names instead of four objects, and a whole bucket never opened. That is the defect,
exactly as production showed it.

Green after:

```
 ✓ scripts/eval/user.test.ts (5 tests) 8ms
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

**Not tested live, deliberately.** No eval was run against production: it costs real money and
creates real rows. Static verification plus unit tests is the right level here — what was broken
is the traversal and the scoping, not the network. The risk this leaves is the usual one for a
fake: if Supabase's `list()` ever stopped marking folders with a null `id`, these tests would
still pass. That contract is stable and is the same one the previous code implicitly relied on.

**One runtime check that a fake cannot give.** `swallow` had never been imported on the
`vite-node` path the evals actually run on, and it pulls `@sentry/sveltekit` — so it was exercised
there directly rather than assumed:

```
$ npx vite-node --config scripts/vite-node.config.ts scripts/_swallow-probe.ts
[swallowed] probe: boom
SWALLOW OK UNDER VITE-NODE
```

(throwaway probe file, not committed).

### On `npm run check`

**It does not cover this change, and saying otherwise would be false.** `npm run check` is
`svelte-check --tsconfig ./tsconfig.json`, which extends `.svelte-kit/tsconfig.json`, whose
`include` is `../src/**`, `../test/**`, `../tests/**` and the vite config — **`scripts/` is not in
it**. So `scripts/eval/user.ts` is never typechecked by it, and a clean run would prove nothing
about this PR.

What does prove it is a `tsc` pointed at the file, with `$lib` and the eval shims wired the way
`scripts/vite-node.config.ts` wires them. One error, and it is not in a file this PR touches:

```
$ npx tsc -p tsconfig.evalcheck.json --pretty false
src/lib/server/supabase-admin.ts(10,23): error TS2345: Argument of type 'string | undefined'
  is not assignable to parameter of type 'string'.
```

That one is an artifact of the eval shim itself (`scripts/_shims/env-public.ts` types the env as
`Record<string, string | undefined>`), pre-existing and untouched here. **Zero errors in
`scripts/eval/user.ts`** — which is also the proof that the real `StorageClient` is structurally
assignable to the `StorageApi` port, i.e. that the fake and production agree on the shape.

For completeness, and because a silent omission here is exactly the habit this PR is about:
`npm run check` was attempted four times on this tree and **never completed**. Three runs were
killed by the OS (`exit=143`, SIGTERM) with the machine at ~80 MB free; the fourth was still
running past 25 minutes when this was written. The cause is contention, not this branch — around
nineteen `svelte-check` processes from sibling worktrees were resident at the same time. So no
error count is quoted, because none was measured. Given the `include` above, a completed run could
not have covered `scripts/eval/user.ts` in any case; the targeted `tsc` is the verification that
actually applies.

## Evidence (screenshots/videos)

No UI change — this is an internal script.

<details>
<summary>Full suite, typecheck, CLI — all on the rebased tree that is proposed here</summary>

```
$ npm run test:unit
 ✓ scripts/eval/user.test.ts (5 tests) 6ms
 ...
 Test Files  589 passed | 3 skipped (592)
      Tests  6510 passed | 11 skipped (6521)
   Duration  352.04s
exit=0
```

```
$ cd cli && bun test
 31 pass
 0 fail
 77 expect() calls
Ran 31 tests across 8 files. [1100.00ms]

$ bun run typecheck
$ tsc --noEmit
```

```
$ git diff --check
(clean)
```
</details>

## Anything Else?

**Still leaking, and named on purpose.** Three Storage writes are indexed on the **brand**, not
the user, so no user-prefix cleanup can reach them:

- `media/<brandId>/motion/*.mp4` — `motion-video/render-tools.ts`
- `media/<brandId>/voiceover/*.wav` — `gemini-audio.ts`
- `agent-homes/<brandId>/<ts>/` — `checkpoint-storage.ts`

An eval that rendered a motion video or woke an agent computer would leave those behind. They
belong to `destroyFixture`, which has the brand id — not to this function, which deliberately
does not know what a brand is. Not fixed here because it is a different owner and a different
test; worth its own PR if the durability scenarios grow to touch those paths.

**Public changelog skipped.** This is internal tooling with no customer-visible surface: nobody
outside the team can observe an eval teardown. The repo's rule allows skipping only when a change
is genuinely invisible from outside, and this qualifies. `changelog/2026-09-03-eval-teardown-storage.md`
and two `LESSONS.md` entries carry it instead.

**`evalEmail()` is dead** — it produces `eval-ux-…@anomalia.so` for an `eval:ux` command that does
not exist in `package.json`. Left alone: out of scope for a defect fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY

