### PR TITLE
Give an external agent full control of an article

### DIFF
--- a/changelog/2026-09-03-article-control.md
+++ b/changelog/2026-09-03-article-control.md
@@ -1,0 +1,65 @@
+# Controllo deterministico di un articolo dall'MCP pubblico
+
+Fase 2 del piano agenti esterni. L'MCP pubblico sapeva elencare i sommari degli articoli,
+generarli, ottimizzarli, pubblicarli, depubblicarli ed eliminarli. Non sapeva **leggerne uno
+intero** né **modificarlo**: ogni strada per cambiare una parola passava da un modello. Un agente
+esterno che aveva già scritto la prosa non aveva dove metterla, e un articolo auto-generato non
+si correggeva — si rigenerava.
+
+Due endpoint, entrambi deterministici, sullo stesso indirizzo `/web/article`:
+
+- `GET` → l'articolo completo in **qualsiasi** stato (draft, planned, approved, published):
+  corpo, SEO, cover, categoria, tag, autore, lingua, schedule, stato, `translation_of`.
+- `POST` → scrive titolo, corpo markdown, meta title, meta description, categoria, tag, autore,
+  lingua e schedule. Nessuna chiamata a un modello, nessun addebito.
+
+## Cosa è stato composto, non riscritto
+
+`authenticate` / `loadBrandForUser` / `checkApiKeyWriteAccess` (`cli-auth`), `createAdminClient`
+(`brand_articles` è SELECT-only sotto RLS, come già fa `POST /web`), `resolveScheduleInput`
+(`clock`) e `formatInZone` (`schedule`) per l'orologio del brand, `BLOG_LOCALE_LANGUAGE` +
+`isBlogLocale` (`blog-locales`), il registry `BRAND_ENDPOINTS` per il tool MCP e il metodo CLI.
+`renderArticleHtml` non è stato toccato: il corpo resta markdown e l'HTML grezzo continua a
+essere escapato dal blog pubblico (`blog-site.xss.test.ts`).
+
+## La regola di stato, in un posto solo
+
+`schedule_article` decideva in-line cosa uno stato permette: published rifiutato, planned tiene
+il suo slot, tutto il resto va ad approved. Le stesse tre regole servivano all'API, e una regola
+scritta due volte diverge al primo cambiamento. Ora stanno in `ARTICLE_EDIT_RULES`
+(`src/lib/server/article-editing.ts`): quattro righe, tre colonne, ogni cella o un esito
+permesso o il nome del rifiuto. Il tool di chat la legge e tiene le sue frasi. L'estrazione è un
+commit separato dal cambiamento di comportamento — l'ordine dei rifiuti, la patch scritta e le
+stringhe d'errore sono quelle che restituiva già.
+
+## L'articolo pubblicato
+
+Il piano dice: *"Changes to a published article create a revision; making that revision live is a
+separate consequential action"*. Il flusso di revisione non esiste ancora (`brand_article_versions`
+oggi è il ledger delle versioni della chat sul blog, non un meccanismo di pubblicazione), quindi
+un `POST` su un articolo `published` **rifiuta** con `409 article_published` e indica la strada che
+il codice già ha: `unpublish` → modifica → `publish`. È la stessa scelta che `schedule_article`
+faceva già. Non si tocca in silenzio quello che è live, e non si è inventato mezzo flusso di
+revisione per arrivarci.
+
+## Scartato
+
+- **Una migration.** Nessuna: `brand_articles` non ha CHECK constraint (verificato su
+  `pg_constraint`), gli stati scritti sono quelli che il dominio già usa, e i deploy di questo
+  repo non applicano migration.
+- **`status` come campo scrivibile.** Lo stato è una conseguenza dello schedule, non un input:
+  esporlo avrebbe dato un secondo modo — divergente — di pubblicare.
+- **`slug`, cover, immagini in-body, video, traduzioni, revisione di un pubblicato.** Fette
+  separate con rischi propri.
+- **`content_html` nella risposta.** L'agente scrive markdown; l'escaping è già coperto da un test
+  suo, non serve rirenderizzare a ogni lettura.
+- **Rifattorizzare `update_article` della chat sul modulo nuovo.** Guadagnerebbe il rifiuto sul
+  pubblicato, che è un cambiamento di comportamento di una superficie interna: non in questa PR.
+
+## Nota sulla lingua
+
+`language` si scrive con un codice ISO 639-1 e si salva come nome inglese (`it` → `Italian`),
+che è la forma che `localeToScope` legge. Per un articolo **originale** il blog ignora comunque
+la colonna (il locale di default è il dato, non la stringa); conta per le traduzioni, e proprio
+per questo una riga con `translation_of` valorizzato rifiuta il cambio con `translation_locked`:
+il locale di una traduzione è la sua identità, e le traduzioni sono fuori da questa fetta.

--- a/cli/lib/contracts/articles.ts
+++ b/cli/lib/contracts/articles.ts
@@ -1,0 +1,140 @@
+import { z } from 'zod';
+import type { BrandEndpoint } from './index';
+
+const MAX_TITLE = 200;
+const MAX_META_TITLE = 70;
+const MAX_META_DESCRIPTION = 200;
+const MAX_TAGS = 20;
+
+const TaxonomyRef = z.object({ id: z.string(), name: z.string(), slug: z.string() });
+
+const ArticleSchema = z.object({
+  id: z.string(),
+  slug: z.string(),
+  title: z.string(),
+  meta_title: z.string().nullable(),
+  meta_description: z.string().nullable(),
+  body_md: z.string(),
+  status: z.string(),
+  language: z.string().nullable(),
+  cover_image: z.string().nullable(),
+  category: TaxonomyRef.nullable(),
+  author: TaxonomyRef.nullable(),
+  tags: z.array(TaxonomyRef),
+  scheduled_for: z.string().nullable(),
+  scheduled_for_local: z.string().nullable(),
+  published_at: z.string().nullable(),
+  translation_of: z.string().nullable(),
+  source: z.string().nullable(),
+  version_seq: z.number().nullable(),
+  created_at: z.string(),
+  updated_at: z.string().nullable()
+});
+
+const GetArticleInputSchema = z
+  .object({
+    id: z.string().min(1).describe('Article id, from list_articles or the Site page URL')
+  })
+  .strict();
+
+const UpdateArticleInputSchema = z
+  .object({
+    id: z.string().min(1).describe('Article id, from list_articles or the Site page URL'),
+    title: z.string().min(1).max(MAX_TITLE).optional(),
+    body_md: z
+      .string()
+      .optional()
+      .describe(
+        'The COMPLETE new markdown body: a replacement, not a diff. Stored exactly as sent — ' +
+          'the public blog escapes any raw HTML in it, so markdown is the only markup that renders'
+      ),
+    meta_title: z.string().max(MAX_META_TITLE).nullable().optional().describe('null clears it'),
+    meta_description: z.string().max(MAX_META_DESCRIPTION).nullable().optional().describe('null clears it'),
+    category_id: z
+      .string()
+      .nullable()
+      .optional()
+      .describe('A category of THIS brand. null clears it; a category of another brand is rejected'),
+    author_id: z
+      .string()
+      .nullable()
+      .optional()
+      .describe('An author of THIS brand. null clears the byline; an author of another brand is rejected'),
+    tag_ids: z
+      .array(z.string().min(1))
+      .max(MAX_TAGS)
+      .optional()
+      .describe('The COMPLETE tag set of this brand — it replaces the current one. [] clears every tag'),
+    language: z
+      .string()
+      .min(2)
+      .max(5)
+      .optional()
+      .describe('ISO 639-1 code, e.g. "it". Refused on a translation row: its locale is its identity'),
+    scheduled_for: z
+      .string()
+      .nullable()
+      .optional()
+      .describe(
+        'Publication instant, ISO. Without an offset it is read on the brand clock. Dating a ' +
+          'draft approves it, and an approved article auto-publishes at that time — this is the ' +
+          'consequential half of the tool. null clears the schedule back to a plain draft'
+      )
+  })
+  .strict();
+
+const GetArticleResultSchema = z.object({ article: ArticleSchema });
+
+const UpdateArticleResultSchema = z.object({
+  ok: z.literal(true),
+  updated_fields: z.array(z.string()),
+  article: ArticleSchema
+});
+
+export type Article = z.infer<typeof ArticleSchema>;
+export type GetArticleInput = z.infer<typeof GetArticleInputSchema>;
+export type UpdateArticleInput = z.infer<typeof UpdateArticleInputSchema>;
+export type UpdateArticleResult = z.infer<typeof UpdateArticleResultSchema>;
+
+export const GET_ARTICLE = {
+  tool: 'get_article',
+  title: 'Read article',
+  description:
+    'One blog article in full, in any state — draft, planned, approved or published: body, SEO ' +
+    'fields, cover, category, tags, author, language, schedule and status. Read it before ' +
+    'editing, and read it after to see what changed. Calls no model and spends no credits.',
+  method: 'GET',
+  pathUnderBrand: '/web/article',
+  input: GetArticleInputSchema,
+  output: GetArticleResultSchema,
+  failures: [{ error: 'article_not_found', status: 404 }],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const UPDATE_ARTICLE = {
+  tool: 'update_article',
+  title: 'Update article',
+  description:
+    'Write text and metadata you already have onto an article: title, markdown body, meta title, ' +
+    'meta description, category, tags, author, language, schedule. Anomalia calls no model and ' +
+    'spends no credits — nothing is rewritten, regenerated or reformatted. A field you do not ' +
+    'send is left exactly as it was, so changing the title never touches the body, the cover or ' +
+    'the description. A published article is refused: what is live is not edited in place.',
+  method: 'POST',
+  pathUnderBrand: '/web/article',
+  input: UpdateArticleInputSchema,
+  output: UpdateArticleResultSchema,
+  failures: [
+    { error: 'article_not_found', status: 404 },
+    { error: 'no_changes', status: 400 },
+    { error: 'invalid_language', status: 400 },
+    { error: 'invalid_scheduled_for', status: 400 },
+    { error: 'category_not_found', status: 400 },
+    { error: 'author_not_found', status: 400 },
+    { error: 'tags_not_found', status: 400 },
+    { error: 'article_published', status: 409 },
+    { error: 'planned_needs_slot', status: 409 },
+    { error: 'translation_locked', status: 409 }
+  ],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/cli/lib/contracts/index.ts
+++ b/cli/lib/contracts/index.ts
@@ -1,4 +1,5 @@
 import type { z } from 'zod';
+import { GET_ARTICLE, UPDATE_ARTICLE } from './articles';
 import { CHECK_CONTENT } from './content';
 import {
   GET_AUDIT_FINDINGS,
@@ -59,6 +60,7 @@ export type BrandEndpoint = ResourcelessEndpoint | ResourceEndpoint;
 export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   CHECK_CONTENT,
   CREATE_POST,
+  GET_ARTICLE,
   GET_AUDIT_FINDINGS,
   GET_CALENDAR,
   GET_POST,
@@ -71,6 +73,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   RESCHEDULE_POST,
   SAVE_PLAN,
   SAVE_WEEK_SEEDS,
+  UPDATE_ARTICLE,
 ];
 
 export function pathFor(endpoint: ResourcelessEndpoint, slug: string): string;
@@ -89,6 +92,7 @@ export function statusForFailure(endpoint: BrandEndpoint, error: string): number
 export {
   CHECK_CONTENT,
   CREATE_POST,
+  GET_ARTICLE,
   GET_AUDIT_FINDINGS,
   GET_CALENDAR,
   GET_POST,
@@ -99,7 +103,9 @@ export {
   LIST_WEB_FIXES,
   RENDER_POST,
   RESCHEDULE_POST,
+  UPDATE_ARTICLE,
 };
+export type { Article, GetArticleInput, UpdateArticleInput, UpdateArticleResult } from './articles';
 export {
   AUDIT_CITATIONS_DEFAULT,
   AUDIT_CITATIONS_MAX,

--- a/cli/plugins/anomalia/skills/anomalia/SKILL.md
+++ b/cli/plugins/anomalia/skills/anomalia/SKILL.md
@@ -84,6 +84,11 @@ the share of voice (engine, question asked, verdict, domains cited) → `list_we
 body, verbatim. All four are free reads: never run a new audit just to see what a past one already
 measured.
 
+**Write or fix an article yourself** → `get_article` to read it whole, `update_article` to write
+your own title, markdown body, SEO fields, category, tags, author or schedule. No model, no
+credits, and a field you do not send is untouched. A published article is refused: `unpublish_article`
+first, then edit, then `publish_article`.
+
 ## References (load on demand)
 
 - [references/mcp.md](references/mcp.md) — connect MCP (stdio / HTTP), Cursor config, auth

--- a/cli/plugins/anomalia/skills/anomalia/references/tools.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/tools.md
@@ -132,6 +132,7 @@ A brand keeps one draft in review, so saving replaces the one that is there (`re
 | `list_web_fixes` | (MCP only) |
 | `get_keywords` / `refresh_keywords` | `anomalia keywords <slug> [refresh]` |
 | `list_articles` / `generate_article` / `optimize_article` | `anomalia web <slug> …` |
+| `get_article` / `update_article` | (MCP only) |
 | `publish_article` / `unpublish_article` / `delete_article` | `anomalia web <slug> publish\|…` |
 | `get_ads` / `ads_action` | `anomalia ads <slug> [--propose\|--create\|--approve\|--pause\|--resume\|--duplicate\|--delete\|--reject] [--ad <adId>]` |
 | `chat` | `anomalia ai <slug> --message "…" --pipe` |
@@ -157,3 +158,27 @@ happens to hold more data; an audit outside the brand answers `audit: null`.
 only name. `surface` is `seo` for growth assets tied to a plan initiative, `geo` for citability
 fixes. Filter with `fix_id` or `status` (`draft` / `accepted` / `dismissed`); bodies are long, so
 `limit` defaults to 3 and stops at 10.
+
+`get_article` returns one article **in full and in any state** — draft, planned, approved or
+published: `body_md`, `meta_title`, `meta_description`, `cover_image`, `category`, `tags`,
+`author`, `language`, `status`, `scheduled_for` (plus the brand-local reading) and
+`translation_of`. `list_articles` only summarises; read this one before editing and again after.
+
+`update_article` writes text and metadata you already have: `title`, `body_md` (the COMPLETE
+markdown, a replacement not a diff), `meta_title`, `meta_description`, `category_id`,
+`author_id`, `tag_ids` (the complete set — it replaces the current one), `language` (ISO 639-1),
+`scheduled_for`. Anomalia calls no model and spends no credits; nothing is rewritten or
+reformatted, and a field you do not send is left exactly as it was — changing the title never
+touches the body, the cover or the description. Raw HTML inside `body_md` is stored as you sent
+it and escaped by the public blog, so markdown is the only markup that renders.
+
+Two halves with different weight: the text fields are safe, `scheduled_for` is consequential —
+dating a draft moves it to `approved`, and `approved` is the status that auto-publishes. Pass
+`null` to clear the schedule back to a draft.
+
+Refusals name the field: `article_not_found` (an article of another brand included),
+`no_changes`, `category_not_found`, `author_not_found`, `tags_not_found`, `invalid_language`,
+`invalid_scheduled_for`, `planned_needs_slot` (a `planned` placeholder cannot lose its slot),
+`translation_locked` (a translation's locale is its identity) and `article_published` — what is
+live is never edited in place. To correct a published article: `unpublish_article`,
+`update_article`, `publish_article`.

--- a/cli/skills/anomalia/SKILL.md
+++ b/cli/skills/anomalia/SKILL.md
@@ -84,6 +84,11 @@ the share of voice (engine, question asked, verdict, domains cited) → `list_we
 body, verbatim. All four are free reads: never run a new audit just to see what a past one already
 measured.
 
+**Write or fix an article yourself** → `get_article` to read it whole, `update_article` to write
+your own title, markdown body, SEO fields, category, tags, author or schedule. No model, no
+credits, and a field you do not send is untouched. A published article is refused: `unpublish_article`
+first, then edit, then `publish_article`.
+
 ## References (load on demand)
 
 - [references/mcp.md](references/mcp.md) — connect MCP (stdio / HTTP), Cursor config, auth

--- a/cli/skills/anomalia/references/tools.md
+++ b/cli/skills/anomalia/references/tools.md
@@ -132,6 +132,7 @@ A brand keeps one draft in review, so saving replaces the one that is there (`re
 | `list_web_fixes` | (MCP only) |
 | `get_keywords` / `refresh_keywords` | `anomalia keywords <slug> [refresh]` |
 | `list_articles` / `generate_article` / `optimize_article` | `anomalia web <slug> …` |
+| `get_article` / `update_article` | (MCP only) |
 | `publish_article` / `unpublish_article` / `delete_article` | `anomalia web <slug> publish\|…` |
 | `get_ads` / `ads_action` | `anomalia ads <slug> [--propose\|--create\|--approve\|--pause\|--resume\|--duplicate\|--delete\|--reject] [--ad <adId>]` |
 | `chat` | `anomalia ai <slug> --message "…" --pipe` |
@@ -157,3 +158,27 @@ happens to hold more data; an audit outside the brand answers `audit: null`.
 only name. `surface` is `seo` for growth assets tied to a plan initiative, `geo` for citability
 fixes. Filter with `fix_id` or `status` (`draft` / `accepted` / `dismissed`); bodies are long, so
 `limit` defaults to 3 and stops at 10.
+
+`get_article` returns one article **in full and in any state** — draft, planned, approved or
+published: `body_md`, `meta_title`, `meta_description`, `cover_image`, `category`, `tags`,
+`author`, `language`, `status`, `scheduled_for` (plus the brand-local reading) and
+`translation_of`. `list_articles` only summarises; read this one before editing and again after.
+
+`update_article` writes text and metadata you already have: `title`, `body_md` (the COMPLETE
+markdown, a replacement not a diff), `meta_title`, `meta_description`, `category_id`,
+`author_id`, `tag_ids` (the complete set — it replaces the current one), `language` (ISO 639-1),
+`scheduled_for`. Anomalia calls no model and spends no credits; nothing is rewritten or
+reformatted, and a field you do not send is left exactly as it was — changing the title never
+touches the body, the cover or the description. Raw HTML inside `body_md` is stored as you sent
+it and escaped by the public blog, so markdown is the only markup that renders.
+
+Two halves with different weight: the text fields are safe, `scheduled_for` is consequential —
+dating a draft moves it to `approved`, and `approved` is the status that auto-publishes. Pass
+`null` to clear the schedule back to a draft.
+
+Refusals name the field: `article_not_found` (an article of another brand included),
+`no_changes`, `category_not_found`, `author_not_found`, `tags_not_found`, `invalid_language`,
+`invalid_scheduled_for`, `planned_needs_slot` (a `planned` placeholder cannot lose its slot),
+`translation_locked` (a translation's locale is its identity) and `article_published` — what is
+live is never edited in place. To correct a published article: `unpublish_article`,
+`update_article`, `publish_article`.

--- a/docs/api/07-growth-seo-geo.md
+++ b/docs/api/07-growth-seo-geo.md
@@ -620,6 +620,117 @@ curl -s -X POST "https://anomalia.so/api/v1/brands/mio-brand/web" \
 
 ---
 
+## `GET /api/v1/brands/:slug/web/article`
+
+Un articolo **completo, in qualsiasi stato** (draft, planned, approved, published): corpo markdown,
+campi SEO, cover, categoria, tag, autore, lingua, schedule e stato. È la lettura che serve prima di
+modificare, e quella che serve dopo per vedere cos'è cambiato. Non chiama nessun modello e non
+consuma crediti; una API key di sola lettura la raggiunge.
+
+Tool MCP: `get_article`.
+
+**Query params**
+
+| Campo | Tipo | Obbligatorio | Descrizione |
+|---|---|---|---|
+| `id` | string | Sì | UUID articolo |
+
+**Response** `200`
+
+```json
+{
+  "article": {
+    "id": "99999999-9999-9999-9999-999999999999",
+    "slug": "guida-al-campeggio",
+    "title": "Guida al campeggio",
+    "meta_title": "Guida al campeggio | Demo",
+    "meta_description": "Come si monta una tenda senza litigare.",
+    "body_md": "# Guida\n\n…",
+    "status": "draft",
+    "language": "Italian",
+    "cover_image": "https://…/cover.png",
+    "category": { "id": "…", "name": "Outdoor", "slug": "outdoor" },
+    "author": { "id": "…", "name": "Giulia", "slug": "giulia" },
+    "tags": [{ "id": "…", "name": "Tende", "slug": "tende" }],
+    "scheduled_for": null,
+    "scheduled_for_local": null,
+    "published_at": null,
+    "translation_of": null,
+    "source": "ai",
+    "version_seq": 3,
+    "created_at": "2026-08-01T10:00:00.000Z",
+    "updated_at": "2026-08-02T10:00:00.000Z"
+  }
+}
+```
+
+**Errori specifici**
+
+| Status | Body |
+|---|---|
+| `400` | `{"error":"invalid_input","details":[…]}` |
+| `404` | `{"error":"article_not_found"}` — inclusi gli articoli di un altro brand |
+
+---
+
+## `POST /api/v1/brands/:slug/web/article`
+
+Scrive testo e metadati che hai già scritto tu. **Nessun modello, nessun credito**: niente viene
+riscritto, rigenerato o riformattato. Un campo che non mandi resta esattamente com'era, quindi
+cambiare il titolo non tocca il corpo, la cover o la meta description.
+
+Tool MCP: `update_article`.
+
+**Body**
+
+| Campo | Tipo | Descrizione |
+|---|---|---|
+| `id` | string | UUID articolo (obbligatorio) |
+| `title` | string | 1–200 caratteri |
+| `body_md` | string | Il markdown COMPLETO, sostituisce il precedente. Salvato tale e quale: il blog pubblico **escapa** l'HTML grezzo, quindi l'unico markup che renderizza è il markdown |
+| `meta_title` | string \| null | max 70; `null` lo azzera |
+| `meta_description` | string \| null | max 200; `null` la azzera |
+| `category_id` | string \| null | Una categoria **di questo brand**; `null` la toglie |
+| `author_id` | string \| null | Un autore **di questo brand**; `null` toglie la firma |
+| `tag_ids` | string[] | Il set COMPLETO (max 20), sostituisce quello attuale; `[]` toglie tutti i tag |
+| `language` | string | Codice ISO 639-1, es. `"it"`. Salvato come nome inglese della lingua (`Italian`), la forma che il blog legge |
+| `scheduled_for` | string \| null | Istante ISO; senza offset è letto sull'orologio del brand. **Datare un draft lo porta ad `approved`, che è lo stato che auto-pubblica.** `null` riporta a draft |
+
+**Response** `200`
+
+```json
+{ "ok": true, "updated_fields": ["title"], "article": { "…": "come sopra" } }
+```
+
+`updated_fields` elenca i campi passati; se lo schedule ha cambiato lo stato, contiene anche
+`status`.
+
+**Errori specifici**
+
+| Status | Body | Quando |
+|---|---|---|
+| `400` | `{"error":"invalid_input","details":[…]}` | Campo non dichiarato, o fuori limite |
+| `400` | `{"error":"no_changes"}` | Solo `id`, niente da scrivere |
+| `400` | `{"error":"invalid_language"}` | Codice locale che il blog non pubblica |
+| `400` | `{"error":"invalid_scheduled_for","details":{…}}` | Data non interpretabile o già passata |
+| `400` | `{"error":"category_not_found"}` | Categoria assente o di un altro brand |
+| `400` | `{"error":"author_not_found"}` | Autore assente o di un altro brand |
+| `400` | `{"error":"tags_not_found"}` | Almeno un tag assente o di un altro brand — non ne scrive nessuno |
+| `404` | `{"error":"article_not_found"}` | Inclusi gli articoli di un altro brand |
+| `409` | `{"error":"article_published"}` | Quello che è live non si modifica in place: `unpublish`, modifica, ripubblica |
+| `409` | `{"error":"planned_needs_slot"}` | Un segnaposto `planned` senza data non verrebbe mai scritto |
+| `409` | `{"error":"translation_locked"}` | La lingua di una traduzione è la sua identità |
+
+**Esempio**:
+
+```bash
+curl -s -X POST "https://anomalia.so/api/v1/brands/mio-brand/web/article" \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"id":"99999999-9999-9999-9999-999999999999","title":"Titolo mio","body_md":"# Titolo mio\n\nTesto scritto da me."}'
+```
+
+---
+
 ## `GET /api/v1/brands/:slug/articles`
 
 API headless read-only: elenca SOLO gli articoli **pubblicati** (riepilogo, senza corpo). Paginata.

--- a/packages/api-contracts/src/articles.ts
+++ b/packages/api-contracts/src/articles.ts
@@ -1,0 +1,140 @@
+import { z } from 'zod';
+import type { BrandEndpoint } from './index';
+
+const MAX_TITLE = 200;
+const MAX_META_TITLE = 70;
+const MAX_META_DESCRIPTION = 200;
+const MAX_TAGS = 20;
+
+const TaxonomyRef = z.object({ id: z.string(), name: z.string(), slug: z.string() });
+
+const ArticleSchema = z.object({
+  id: z.string(),
+  slug: z.string(),
+  title: z.string(),
+  meta_title: z.string().nullable(),
+  meta_description: z.string().nullable(),
+  body_md: z.string(),
+  status: z.string(),
+  language: z.string().nullable(),
+  cover_image: z.string().nullable(),
+  category: TaxonomyRef.nullable(),
+  author: TaxonomyRef.nullable(),
+  tags: z.array(TaxonomyRef),
+  scheduled_for: z.string().nullable(),
+  scheduled_for_local: z.string().nullable(),
+  published_at: z.string().nullable(),
+  translation_of: z.string().nullable(),
+  source: z.string().nullable(),
+  version_seq: z.number().nullable(),
+  created_at: z.string(),
+  updated_at: z.string().nullable()
+});
+
+const GetArticleInputSchema = z
+  .object({
+    id: z.string().min(1).describe('Article id, from list_articles or the Site page URL')
+  })
+  .strict();
+
+const UpdateArticleInputSchema = z
+  .object({
+    id: z.string().min(1).describe('Article id, from list_articles or the Site page URL'),
+    title: z.string().min(1).max(MAX_TITLE).optional(),
+    body_md: z
+      .string()
+      .optional()
+      .describe(
+        'The COMPLETE new markdown body: a replacement, not a diff. Stored exactly as sent — ' +
+          'the public blog escapes any raw HTML in it, so markdown is the only markup that renders'
+      ),
+    meta_title: z.string().max(MAX_META_TITLE).nullable().optional().describe('null clears it'),
+    meta_description: z.string().max(MAX_META_DESCRIPTION).nullable().optional().describe('null clears it'),
+    category_id: z
+      .string()
+      .nullable()
+      .optional()
+      .describe('A category of THIS brand. null clears it; a category of another brand is rejected'),
+    author_id: z
+      .string()
+      .nullable()
+      .optional()
+      .describe('An author of THIS brand. null clears the byline; an author of another brand is rejected'),
+    tag_ids: z
+      .array(z.string().min(1))
+      .max(MAX_TAGS)
+      .optional()
+      .describe('The COMPLETE tag set of this brand — it replaces the current one. [] clears every tag'),
+    language: z
+      .string()
+      .min(2)
+      .max(5)
+      .optional()
+      .describe('ISO 639-1 code, e.g. "it". Refused on a translation row: its locale is its identity'),
+    scheduled_for: z
+      .string()
+      .nullable()
+      .optional()
+      .describe(
+        'Publication instant, ISO. Without an offset it is read on the brand clock. Dating a ' +
+          'draft approves it, and an approved article auto-publishes at that time — this is the ' +
+          'consequential half of the tool. null clears the schedule back to a plain draft'
+      )
+  })
+  .strict();
+
+const GetArticleResultSchema = z.object({ article: ArticleSchema });
+
+const UpdateArticleResultSchema = z.object({
+  ok: z.literal(true),
+  updated_fields: z.array(z.string()),
+  article: ArticleSchema
+});
+
+export type Article = z.infer<typeof ArticleSchema>;
+export type GetArticleInput = z.infer<typeof GetArticleInputSchema>;
+export type UpdateArticleInput = z.infer<typeof UpdateArticleInputSchema>;
+export type UpdateArticleResult = z.infer<typeof UpdateArticleResultSchema>;
+
+export const GET_ARTICLE = {
+  tool: 'get_article',
+  title: 'Read article',
+  description:
+    'One blog article in full, in any state — draft, planned, approved or published: body, SEO ' +
+    'fields, cover, category, tags, author, language, schedule and status. Read it before ' +
+    'editing, and read it after to see what changed. Calls no model and spends no credits.',
+  method: 'GET',
+  pathUnderBrand: '/web/article',
+  input: GetArticleInputSchema,
+  output: GetArticleResultSchema,
+  failures: [{ error: 'article_not_found', status: 404 }],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const UPDATE_ARTICLE = {
+  tool: 'update_article',
+  title: 'Update article',
+  description:
+    'Write text and metadata you already have onto an article: title, markdown body, meta title, ' +
+    'meta description, category, tags, author, language, schedule. Anomalia calls no model and ' +
+    'spends no credits — nothing is rewritten, regenerated or reformatted. A field you do not ' +
+    'send is left exactly as it was, so changing the title never touches the body, the cover or ' +
+    'the description. A published article is refused: what is live is not edited in place.',
+  method: 'POST',
+  pathUnderBrand: '/web/article',
+  input: UpdateArticleInputSchema,
+  output: UpdateArticleResultSchema,
+  failures: [
+    { error: 'article_not_found', status: 404 },
+    { error: 'no_changes', status: 400 },
+    { error: 'invalid_language', status: 400 },
+    { error: 'invalid_scheduled_for', status: 400 },
+    { error: 'category_not_found', status: 400 },
+    { error: 'author_not_found', status: 400 },
+    { error: 'tags_not_found', status: 400 },
+    { error: 'article_published', status: 409 },
+    { error: 'planned_needs_slot', status: 409 },
+    { error: 'translation_locked', status: 409 }
+  ],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/packages/api-contracts/src/index.test.ts
+++ b/packages/api-contracts/src/index.test.ts
@@ -182,6 +182,51 @@ describe('il registry degli endpoint di brand', () => {
     expect(output.safeParse({ ok: true, errors: [], warnings: [], scores: [] }).success).toBe(false);
   });
 
+  it('get_article è una lettura, quindi una API key di sola lettura la raggiunge', () => {
+    const get = byTool('get_article');
+    expect(get.method).toBe('GET');
+    expect(get.destructive).toBe(false);
+    expect(pathFor(get, 'demo')).toBe('/api/v1/brands/demo/web/article');
+    expect(get.input.safeParse({ id: 'art-1' }).success).toBe(true);
+    expect(get.input.safeParse({}).success).toBe(false);
+  });
+
+  it('update_article dichiara ogni campo che si può scrivere senza un modello', () => {
+    const { input } = byTool('update_article');
+    expect(
+      input.safeParse({
+        id: 'art-1',
+        title: 'Guida',
+        body_md: '# Guida',
+        meta_title: null,
+        meta_description: null,
+        category_id: 'cat-1',
+        author_id: null,
+        tag_ids: ['tag-1'],
+        language: 'it',
+        scheduled_for: null
+      }).success
+    ).toBe(true);
+    expect(input.safeParse({ id: 'art-1', title: '' }).success).toBe(false);
+    expect(input.safeParse({ id: 'art-1', title: 'a'.repeat(201) }).success).toBe(false);
+    expect(input.safeParse({ id: 'art-1', meta_title: 'a'.repeat(71) }).success).toBe(false);
+    expect(input.safeParse({ id: 'art-1', cover_image: 'https://cdn/x.png' }).success).toBe(false);
+  });
+
+  it('un articolo pubblicato non si aggiorna: il rifiuto è un 409, non un 500 muto', () => {
+    const update = byTool('update_article');
+    expect(statusForFailure(update, 'article_published')).toBe(409);
+    expect(statusForFailure(update, 'planned_needs_slot')).toBe(409);
+    expect(statusForFailure(update, 'translation_locked')).toBe(409);
+    expect(statusForFailure(update, 'category_not_found')).toBe(400);
+    expect(statusForFailure(update, 'article_not_found')).toBe(404);
+  });
+
+  it('leggere e scrivere un articolo passano dallo stesso indirizzo', () => {
+    expect(byTool('update_article').pathUnderBrand).toBe(byTool('get_article').pathUnderBrand);
+    expect(byTool('update_article').method).toBe('POST');
+  });
+
   it('una response con outputSchema è un oggetto: MCP non sa trasportare un array', () => {
     for (const e of BRAND_ENDPOINTS) {
       if (!(e.output instanceof z.ZodObject)) continue;

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -1,4 +1,5 @@
 import type { z } from 'zod';
+import { GET_ARTICLE, UPDATE_ARTICLE } from './articles';
 import { CHECK_CONTENT } from './content';
 import {
   GET_AUDIT_FINDINGS,
@@ -59,6 +60,7 @@ export type BrandEndpoint = ResourcelessEndpoint | ResourceEndpoint;
 export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   CHECK_CONTENT,
   CREATE_POST,
+  GET_ARTICLE,
   GET_AUDIT_FINDINGS,
   GET_CALENDAR,
   GET_POST,
@@ -71,6 +73,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   RESCHEDULE_POST,
   SAVE_PLAN,
   SAVE_WEEK_SEEDS,
+  UPDATE_ARTICLE,
 ];
 
 export function pathFor(endpoint: ResourcelessEndpoint, slug: string): string;
@@ -89,6 +92,7 @@ export function statusForFailure(endpoint: BrandEndpoint, error: string): number
 export {
   CHECK_CONTENT,
   CREATE_POST,
+  GET_ARTICLE,
   GET_AUDIT_FINDINGS,
   GET_CALENDAR,
   GET_POST,
@@ -99,7 +103,9 @@ export {
   LIST_WEB_FIXES,
   RENDER_POST,
   RESCHEDULE_POST,
+  UPDATE_ARTICLE,
 };
+export type { Article, GetArticleInput, UpdateArticleInput, UpdateArticleResult } from './articles';
 export {
   AUDIT_CITATIONS_DEFAULT,
   AUDIT_CITATIONS_MAX,

--- a/src/lib/agent/tools/catalog-tools.ts
+++ b/src/lib/agent/tools/catalog-tools.ts
@@ -7,6 +7,12 @@ import { resolveScheduleInput } from '$lib/server/clock';
 import type { ChatToolCtx } from './shared';
 import { startLongToolJob, type AnyRec } from './shared';
 import { noteRead, requireFreshRead } from '$lib/server/chat/read-guards';
+import { articleEditRefusal, articleScheduleChange, type ScheduleRefusal } from '$lib/server/article-editing';
+
+const SCHEDULE_REFUSAL_MESSAGE: Record<ScheduleRefusal, string> = {
+  article_published: 'Article is already published',
+  planned_needs_slot: 'Planned placeholders need a slot — reschedule it instead, or delete it from the Site page.'
+};
 
 export function catalogTools(ctx: ChatToolCtx) {
   const { supabase, brandId, tz, userId, origin } = ctx;
@@ -119,21 +125,17 @@ export function catalogTools(ctx: ChatToolCtx) {
         const { admin } = await blogAdmin();
         const { data: art } = await admin.from('brand_articles').select('id, title, status').eq('id', article_id).eq('brand_id', brandId).maybeSingle();
         if (!art) return { error: 'Article not found' };
-        if (art.status === 'published') return { error: 'Article is already published' };
-        let patch: AnyRec;
+        const denied = articleEditRefusal(art.status);
+        if (denied) return { error: SCHEDULE_REFUSAL_MESSAGE[denied] };
         let when: string | null = null;
-        if (!scheduled_for) {
-          // A month-plan placeholder without a date would never get written — refuse to clear it.
-          if (art.status === 'planned') return { error: 'Planned placeholders need a slot — reschedule it instead, or delete it from the Site page.' };
-          patch = { scheduled_for: null, status: 'draft' };
-        } else {
+        if (scheduled_for) {
           const parsed = resolveScheduleInput(scheduled_for, tz);
           if ('error' in parsed) return parsed;
           when = parsed.utc;
-          // Placeholders only move their slot — 'approved' (auto-publish) is reserved for real drafts.
-          patch = art.status === 'planned' ? { scheduled_for: when } : { scheduled_for: when, status: 'approved' };
         }
-        const { error } = await admin.from('brand_articles').update({ ...patch, updated_at: new Date().toISOString() }).eq('id', article_id).eq('brand_id', brandId);
+        const change = articleScheduleChange(art.status, when);
+        if (!change.ok) return { error: SCHEDULE_REFUSAL_MESSAGE[change.reason] };
+        const { error } = await admin.from('brand_articles').update({ ...change.patch, updated_at: new Date().toISOString() }).eq('id', article_id).eq('brand_id', brandId);
         if (error) return { error: error.message };
         return {
           success: true,

--- a/src/lib/content/changelog/2026-09-03-article-control.ts
+++ b/src/lib/content/changelog/2026-09-03-article-control.ts
@@ -1,0 +1,15 @@
+import type { ChangelogEntry } from './index';
+
+const entry: ChangelogEntry = {
+  date: '2026-09-03',
+  title: 'Your AI can read and rewrite an article itself',
+  items: [
+    'Your own AI can now open any article in full — draft, planned, scheduled or published — and see the body, the SEO fields, the cover, the category, the tags, the author, the language and the schedule.',
+    'It can write its own title, body, meta title, meta description, category, tags, author and publication date straight onto the article. Anomalia rewrites nothing and charges nothing for it.',
+    'A field it does not send is left untouched, so fixing a title never quietly changes the body or the description.',
+    'An article that is already live is refused instead of edited underneath your readers: unpublish it, correct it, publish it again.',
+    'An auto-generated article can now be corrected instead of regenerated from scratch.'
+  ]
+};
+
+export default entry;

--- a/src/lib/server/article-editing.test.ts
+++ b/src/lib/server/article-editing.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { articleEditRefusal, articleScheduleChange } from './article-editing';
+
+describe('la tabella che dice cosa uno stato permette', () => {
+  it.each(['draft', 'planned', 'approved'])('%s si modifica', (status) => {
+    expect(articleEditRefusal(status)).toBeNull();
+  });
+
+  it('published non si modifica: quello che è live non cambia di nascosto', () => {
+    expect(articleEditRefusal('published')).toBe('article_published');
+  });
+
+  it('uno stato che la tabella non conosce è trattato come un draft, non come un published', () => {
+    expect(articleEditRefusal('qualcosa_di_nuovo')).toBeNull();
+  });
+
+  it('datare un draft lo porta ad approved, che è l unico stato che auto-pubblica', () => {
+    expect(articleScheduleChange('draft', '2030-05-16T07:00:00.000Z')).toEqual({
+      ok: true,
+      patch: { scheduled_for: '2030-05-16T07:00:00.000Z', status: 'approved' }
+    });
+  });
+
+  it('spostare un planned muove solo lo slot: il segnaposto non diventa auto-pubblicabile', () => {
+    expect(articleScheduleChange('planned', '2030-05-16T07:00:00.000Z')).toEqual({
+      ok: true,
+      patch: { scheduled_for: '2030-05-16T07:00:00.000Z' }
+    });
+  });
+
+  it('togliere la data a un approved lo riporta a draft', () => {
+    expect(articleScheduleChange('approved', null)).toEqual({
+      ok: true,
+      patch: { scheduled_for: null, status: 'draft' }
+    });
+  });
+
+  it('un planned senza slot non verrebbe mai scritto: rifiutato', () => {
+    expect(articleScheduleChange('planned', null)).toEqual({ ok: false, reason: 'planned_needs_slot' });
+  });
+
+  it.each([
+    ['datandolo', '2030-05-16T07:00:00.000Z'],
+    ['togliendogli la data', null]
+  ])('un published non si tocca nemmeno %s', (_label, when) => {
+    expect(articleScheduleChange('published', when)).toEqual({ ok: false, reason: 'article_published' });
+  });
+});

--- a/src/lib/server/article-editing.ts
+++ b/src/lib/server/article-editing.ts
@@ -1,0 +1,48 @@
+/**
+ * Deterministic article editing. No model runs here and no credit is spent: every field the
+ * caller sends is stored as it arrived, and every field it did not send is left untouched.
+ *
+ * ARTICLE_EDIT_RULES is the only place that says what a status allows. Adding a status is a row,
+ * not another `if` scattered over the chat tool, the web editor and the API.
+ */
+export const ARTICLE_STATUSES = ['draft', 'planned', 'approved', 'published'] as const;
+export type ArticleStatus = (typeof ARTICLE_STATUSES)[number];
+
+const SCHEDULE_REFUSALS = ['article_published', 'planned_needs_slot'] as const;
+export type ScheduleRefusal = (typeof SCHEDULE_REFUSALS)[number];
+
+type ScheduleOutcome = ArticleStatus | 'keep' | ScheduleRefusal;
+
+const ARTICLE_EDIT_RULES: Record<
+  ArticleStatus,
+  { edit: 'allow' | ScheduleRefusal; schedule: ScheduleOutcome; unschedule: ScheduleOutcome }
+> = {
+  draft: { edit: 'allow', schedule: 'approved', unschedule: 'draft' },
+  planned: { edit: 'allow', schedule: 'keep', unschedule: 'planned_needs_slot' },
+  approved: { edit: 'allow', schedule: 'approved', unschedule: 'draft' },
+  published: { edit: 'article_published', schedule: 'article_published', unschedule: 'article_published' }
+};
+
+const isScheduleRefusal = (value: string): value is ScheduleRefusal =>
+  (SCHEDULE_REFUSALS as readonly string[]).includes(value);
+
+const rulesFor = (status: string) => ARTICLE_EDIT_RULES[status as ArticleStatus] ?? ARTICLE_EDIT_RULES.draft;
+
+export function articleEditRefusal(status: string): ScheduleRefusal | null {
+  const outcome = rulesFor(status).edit;
+  return outcome === 'allow' ? null : outcome;
+}
+
+export type SchedulePatch = { scheduled_for: string | null; status?: ArticleStatus };
+
+export function articleScheduleChange(
+  status: string,
+  when: string | null
+): { ok: true; patch: SchedulePatch } | { ok: false; reason: ScheduleRefusal } {
+  const outcome = when ? rulesFor(status).schedule : rulesFor(status).unschedule;
+  if (isScheduleRefusal(outcome)) return { ok: false, reason: outcome };
+  return {
+    ok: true,
+    patch: outcome === 'keep' ? { scheduled_for: when } : { scheduled_for: when, status: outcome }
+  };
+}

--- a/src/lib/server/article-editing.ts
+++ b/src/lib/server/article-editing.ts
@@ -122,6 +122,7 @@ export type ArticleEditFailure =
   | 'article_not_found'
   | 'no_changes'
   | 'invalid_language'
+  | 'translation_locked'
   | 'invalid_scheduled_for'
   | 'category_not_found'
   | 'author_not_found'

--- a/src/lib/server/article-editing.ts
+++ b/src/lib/server/article-editing.ts
@@ -1,10 +1,3 @@
-/**
- * Deterministic article editing. No model runs here and no credit is spent: every field the
- * caller sends is stored as it arrived, and every field it did not send is left untouched.
- *
- * ARTICLE_EDIT_RULES is the only place that says what a status allows. Adding a status is a row,
- * not another `if` scattered over the chat tool, the web editor and the API.
- */
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { Article } from '@anomalia/api-contracts';
 import { BLOG_LOCALE_LANGUAGE, isBlogLocale } from '$lib/blog-locales';

--- a/src/lib/server/article-editing.ts
+++ b/src/lib/server/article-editing.ts
@@ -5,6 +5,12 @@
  * ARTICLE_EDIT_RULES is the only place that says what a status allows. Adding a status is a row,
  * not another `if` scattered over the chat tool, the web editor and the API.
  */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Article } from '@anomalia/api-contracts';
+import { BLOG_LOCALE_LANGUAGE, isBlogLocale } from '$lib/blog-locales';
+import { resolveScheduleInput } from '$lib/server/clock';
+import { formatInZone } from '$lib/server/schedule';
+
 export const ARTICLE_STATUSES = ['draft', 'planned', 'approved', 'published'] as const;
 export type ArticleStatus = (typeof ARTICLE_STATUSES)[number];
 
@@ -45,4 +51,174 @@ export function articleScheduleChange(
     ok: true,
     patch: outcome === 'keep' ? { scheduled_for: when } : { scheduled_for: when, status: outcome }
   };
+}
+
+const ARTICLE_COLUMNS = `
+  id, slug, title, meta_title, meta_description, body_md, status, language, cover_image,
+  scheduled_for, published_at, translation_of, source, version_seq, created_at, updated_at,
+  category:blog_categories(id, name, slug),
+  author:blog_authors(id, name, slug),
+  tags:brand_article_tags(blog_tags(id, name, slug))
+`;
+
+type ArticleRow = Record<string, unknown>;
+
+function toArticle(row: ArticleRow, timezone: string): Article {
+  const scheduledFor = (row.scheduled_for as string | null) ?? null;
+  const tags = (row.tags as { blog_tags: Article['tags'][number] }[] | null) ?? [];
+  return {
+    ...(row as unknown as Article),
+    category: (row.category as Article['category']) ?? null,
+    author: (row.author as Article['author']) ?? null,
+    tags: tags.map((t) => t.blog_tags).filter(Boolean),
+    scheduled_for: scheduledFor,
+    scheduled_for_local: scheduledFor ? `${formatInZone(scheduledFor, timezone)} (${timezone})` : null
+  };
+}
+
+export async function readArticle(
+  client: SupabaseClient,
+  brandId: string,
+  articleId: string,
+  timezone: string
+): Promise<Article | null> {
+  const { data } = await client
+    .from('brand_articles')
+    .select(ARTICLE_COLUMNS)
+    .eq('id', articleId)
+    .eq('brand_id', brandId)
+    .maybeSingle();
+  return data ? toArticle(data as ArticleRow, timezone) : null;
+}
+
+export type ArticlePatch = {
+  title?: string;
+  body_md?: string;
+  meta_title?: string | null;
+  meta_description?: string | null;
+  category_id?: string | null;
+  author_id?: string | null;
+  tag_ids?: string[];
+  language?: string;
+  scheduled_for?: string | null;
+};
+
+const DIRECT_COLUMNS = [
+  'title',
+  'body_md',
+  'meta_title',
+  'meta_description',
+  'category_id',
+  'author_id'
+] as const;
+
+const BRAND_REFERENCES = {
+  category_id: { table: 'blog_categories', failure: 'category_not_found' },
+  author_id: { table: 'blog_authors', failure: 'author_not_found' }
+} as const;
+
+export type ArticleEditFailure =
+  | ScheduleRefusal
+  | 'article_not_found'
+  | 'no_changes'
+  | 'invalid_language'
+  | 'invalid_scheduled_for'
+  | 'category_not_found'
+  | 'author_not_found'
+  | 'tags_not_found';
+
+export type ArticleUpdate =
+  | { ok: true; updatedFields: string[]; article: Article }
+  | { ok: false; error: ArticleEditFailure; details?: unknown };
+
+async function idsOwnedByBrand(
+  client: SupabaseClient,
+  table: string,
+  brandId: string,
+  ids: string[]
+): Promise<Set<string>> {
+  const { data } = await client.from(table).select('id').eq('brand_id', brandId).in('id', ids);
+  return new Set(((data ?? []) as { id: string }[]).map((row) => row.id));
+}
+
+export async function updateArticle(args: {
+  client: SupabaseClient;
+  brandId: string;
+  articleId: string;
+  timezone: string;
+  patch: ArticlePatch;
+}): Promise<ArticleUpdate> {
+  const { client, brandId, articleId, timezone, patch } = args;
+
+  const requested = Object.keys(patch).filter((key) => patch[key as keyof ArticlePatch] !== undefined);
+  if (!requested.length) return { ok: false, error: 'no_changes' };
+
+  const { data: current } = await client
+    .from('brand_articles')
+    .select('id, status, translation_of')
+    .eq('id', articleId)
+    .eq('brand_id', brandId)
+    .maybeSingle();
+  if (!current) return { ok: false, error: 'article_not_found' };
+
+  const denied = articleEditRefusal(current.status);
+  if (denied) return { ok: false, error: denied };
+
+  const columns: Record<string, unknown> = {};
+  for (const column of DIRECT_COLUMNS) {
+    if (patch[column] !== undefined) columns[column] = patch[column];
+  }
+
+  if (patch.language !== undefined) {
+    if (current.translation_of) return { ok: false, error: 'translation_locked' };
+    if (!isBlogLocale(patch.language)) return { ok: false, error: 'invalid_language' };
+    columns.language = BLOG_LOCALE_LANGUAGE[patch.language];
+  }
+
+  if (patch.scheduled_for !== undefined) {
+    let when: string | null = null;
+    if (patch.scheduled_for !== null) {
+      const parsed = resolveScheduleInput(patch.scheduled_for, timezone);
+      if ('error' in parsed) return { ok: false, error: 'invalid_scheduled_for', details: parsed };
+      when = parsed.utc;
+    }
+    const change = articleScheduleChange(current.status, when);
+    if (!change.ok) return { ok: false, error: change.reason };
+    Object.assign(columns, change.patch);
+  }
+
+  for (const [field, reference] of Object.entries(BRAND_REFERENCES)) {
+    const id = patch[field as keyof typeof BRAND_REFERENCES];
+    if (typeof id !== 'string') continue;
+    const owned = await idsOwnedByBrand(client, reference.table, brandId, [id]);
+    if (!owned.has(id)) return { ok: false, error: reference.failure };
+  }
+
+  if (patch.tag_ids?.length) {
+    const wanted = new Set(patch.tag_ids);
+    const owned = await idsOwnedByBrand(client, 'blog_tags', brandId, [...wanted]);
+    if (owned.size !== wanted.size) return { ok: false, error: 'tags_not_found' };
+  }
+
+  const { error } = await client
+    .from('brand_articles')
+    .update({ ...columns, updated_at: new Date().toISOString() })
+    .eq('id', articleId)
+    .eq('brand_id', brandId);
+  if (error) throw new Error(error.message);
+
+  if (patch.tag_ids !== undefined) {
+    await client.from('brand_article_tags').delete().eq('article_id', articleId);
+    if (patch.tag_ids.length) {
+      await client
+        .from('brand_article_tags')
+        .insert(patch.tag_ids.map((tag_id) => ({ article_id: articleId, tag_id })));
+    }
+  }
+
+  const article = await readArticle(client, brandId, articleId, timezone);
+  if (!article) return { ok: false, error: 'article_not_found' };
+
+  const updatedFields = columns.status === undefined ? requested : [...requested, 'status'];
+  return { ok: true, updatedFields, article };
 }

--- a/src/routes/api/v1/brands/[slug]/web/article/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/web/article/+server.ts
@@ -1,0 +1,62 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { authenticate, loadBrandForUser, checkApiKeyWriteAccess } from '$lib/server/cli-auth';
+import { createAdminClient } from '$lib/server/supabase-admin';
+import { readArticle, updateArticle } from '$lib/server/article-editing';
+import { GET_ARTICLE, UPDATE_ARTICLE, statusForFailure } from '@anomalia/api-contracts';
+
+const DEFAULT_TIMEZONE = 'Europe/Rome';
+
+export const GET: RequestHandler = async ({ request, params, url }) => {
+  const { supabase, error, apiKey } = await authenticate(request);
+  if (error) return error;
+
+  const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
+  if (brandError) return brandError;
+
+  const parsed = GET_ARTICLE.input.safeParse(Object.fromEntries(url.searchParams));
+  if (!parsed.success) {
+    return json({ error: 'invalid_input', details: parsed.error.issues }, { status: 400 });
+  }
+
+  const timezone = (brand.timezone as string) ?? DEFAULT_TIMEZONE;
+  const article = await readArticle(supabase, brand.id, parsed.data.id, timezone);
+  if (!article) {
+    return json({ error: 'article_not_found' }, { status: statusForFailure(GET_ARTICLE, 'article_not_found') });
+  }
+
+  return json({ article });
+};
+
+export const POST: RequestHandler = async ({ request, params }) => {
+  const { supabase, error, apiKey } = await authenticate(request);
+  if (error) return error;
+
+  const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
+  if (brandError) return brandError;
+  const writeDenied = checkApiKeyWriteAccess(apiKey);
+  if (writeDenied) return writeDenied;
+
+  const parsed = UPDATE_ARTICLE.input.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return json({ error: 'invalid_input', details: parsed.error.issues }, { status: 400 });
+  }
+  const { id, ...patch } = parsed.data;
+
+  const result = await updateArticle({
+    client: createAdminClient(),
+    brandId: brand.id,
+    articleId: id,
+    timezone: (brand.timezone as string) ?? DEFAULT_TIMEZONE,
+    patch
+  });
+
+  if (!result.ok) {
+    return json(
+      { error: result.error, details: result.details },
+      { status: statusForFailure(UPDATE_ARTICLE, result.error) }
+    );
+  }
+
+  return json({ ok: true, updated_fields: result.updatedFields, article: result.article });
+};

--- a/src/routes/api/v1/brands/[slug]/web/article/server.test.ts
+++ b/src/routes/api/v1/brands/[slug]/web/article/server.test.ts
@@ -1,0 +1,454 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { GET_ARTICLE } from '@anomalia/api-contracts';
+
+const structured = vi.fn();
+const gateCredits = vi.fn();
+
+vi.mock('$lib/server/cli-auth', () => ({
+  authenticate: vi.fn(),
+  loadBrandForUser: vi.fn(),
+  checkApiKeyWriteAccess: vi.fn(() => null),
+  gateAiAction: vi.fn()
+}));
+vi.mock('$lib/server/research', () => ({ structured: (...args: unknown[]) => structured(...args) }));
+vi.mock('$lib/server/credits', () => ({
+  gateCredits: (...args: unknown[]) => gateCredits(...args),
+  CreditsExhaustedError: class extends Error {}
+}));
+vi.mock('$lib/server/supabase-admin', () => ({ createAdminClient: () => adminDouble }));
+
+import { GET, POST } from './+server';
+import { authenticate, loadBrandForUser, checkApiKeyWriteAccess, gateAiAction } from '$lib/server/cli-auth';
+
+type Row = Record<string, unknown>;
+
+const BRAND = { id: 'brand-1', slug: 'demo', timezone: 'Europe/Rome' };
+
+const DRAFT: Row = {
+  id: 'art-1',
+  brand_id: BRAND.id,
+  slug: 'guida-al-campeggio',
+  title: 'Guida al campeggio',
+  meta_title: 'Guida al campeggio | Demo',
+  meta_description: 'Come si monta una tenda senza litigare.',
+  body_md: '# Guida\n\nUn corpo che nessuno deve riscrivere.',
+  status: 'draft',
+  language: 'Italian',
+  cover_image: 'https://cdn.test/cover.png',
+  scheduled_for: null,
+  published_at: null,
+  translation_of: null,
+  source: 'ai',
+  version_seq: 3,
+  created_at: '2026-08-01T10:00:00.000Z',
+  updated_at: '2026-08-02T10:00:00.000Z',
+  category: { id: 'cat-1', name: 'Outdoor', slug: 'outdoor' },
+  author: { id: 'aut-1', name: 'Giulia', slug: 'giulia' },
+  tags: [{ blog_tags: { id: 'tag-1', name: 'Tende', slug: 'tende' } }]
+};
+
+type World = {
+  article: Row | null;
+  categories: string[];
+  authors: string[];
+  tags: string[];
+};
+
+let world: World;
+let updates: Row[] = [];
+let tagInserts: string[][] = [];
+let tagDeletes = 0;
+let adminDouble: unknown;
+
+function fakeSupabase() {
+  const owned: Record<string, string[]> = {
+    blog_categories: world.categories,
+    blog_authors: world.authors,
+    blog_tags: world.tags
+  };
+
+  const applied = () => Object.assign({}, ...updates) as Row;
+
+  return {
+    from(table: string) {
+      const filters: [string, unknown][] = [];
+      let asked: string[] = [];
+      const self: Record<string, unknown> = {};
+
+      const listOwned = async () => ({
+        data: asked.filter((id) => (owned[table] ?? []).includes(id)).map((id) => ({ id })),
+        error: null
+      });
+
+      self.select = () => self;
+      self.eq = (column: string, value: unknown) => {
+        filters.push([column, value]);
+        return self;
+      };
+      self.in = (_column: string, values: string[]) => {
+        asked = values;
+        return self;
+      };
+      self.maybeSingle = async () => {
+        const row = world.article ? { ...world.article, ...applied() } : null;
+        const matches =
+          row && filters.every(([column, value]) => (column in row ? row[column] === value : true));
+        return { data: matches ? row : null, error: null };
+      };
+      self.then = (ok: (v: unknown) => unknown, ko?: (e: unknown) => unknown) => listOwned().then(ok, ko);
+      self.update = (patch: Row) => {
+        updates.push(patch);
+        return self;
+      };
+      self.delete = () => {
+        tagDeletes += 1;
+        return self;
+      };
+      self.insert = async (rows: Row[]) => {
+        tagInserts.push(rows.map((r) => String(r.tag_id)));
+        return { error: null };
+      };
+      return self;
+    }
+  };
+}
+
+function authorize(slug = BRAND.slug) {
+  const client = fakeSupabase();
+  adminDouble = client;
+  vi.mocked(authenticate).mockResolvedValue({
+    supabase: client,
+    user: { id: 'user-1' },
+    apiKey: undefined,
+    error: null
+  } as never);
+  vi.mocked(loadBrandForUser).mockResolvedValue({ brand: { ...BRAND, slug }, error: null } as never);
+}
+
+function read(id: string, slug = BRAND.slug) {
+  authorize(slug);
+  const url = new URL(`https://anomalia.test/api/v1/brands/${slug}/web/article?id=${id}`);
+  return (GET as (event: unknown) => Promise<Response>)({
+    request: new Request(url),
+    params: { slug },
+    url
+  }).then(async (res) => ({ res, body: await res.json() }));
+}
+
+function write(body: unknown, slug = BRAND.slug) {
+  authorize(slug);
+  const url = new URL(`https://anomalia.test/api/v1/brands/${slug}/web/article`);
+  return (POST as (event: unknown) => Promise<Response>)({
+    request: new Request(url, { method: 'POST', body: JSON.stringify(body) }),
+    params: { slug },
+    url
+  }).then(async (res) => ({ res, body: await res.json() }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(checkApiKeyWriteAccess).mockReturnValue(undefined);
+  world = { article: { ...DRAFT }, categories: ['cat-1', 'cat-2'], authors: ['aut-1'], tags: ['tag-1', 'tag-2'] };
+  updates = [];
+  tagInserts = [];
+  tagDeletes = 0;
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-08-08T15:00:00Z'));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('GET /api/v1/brands/:slug/web/article', () => {
+  it.each(['draft', 'planned', 'approved', 'published'])(
+    'restituisce il record completo di un articolo %s, non solo il sommario',
+    async (status) => {
+      world.article = { ...DRAFT, status };
+
+      const { res, body } = await read('art-1');
+
+      expect(res.status).toBe(200);
+      expect(GET_ARTICLE.output.safeParse(body).success).toBe(true);
+      expect(body.article).toMatchObject({
+        id: 'art-1',
+        status,
+        title: DRAFT.title,
+        body_md: DRAFT.body_md,
+        meta_title: DRAFT.meta_title,
+        meta_description: DRAFT.meta_description,
+        cover_image: DRAFT.cover_image,
+        language: 'Italian',
+        category: { id: 'cat-1', name: 'Outdoor', slug: 'outdoor' },
+        author: { id: 'aut-1', name: 'Giulia', slug: 'giulia' },
+        tags: [{ id: 'tag-1', name: 'Tende', slug: 'tende' }]
+      });
+    }
+  );
+
+  it('un articolo di un altro brand non si legge', async () => {
+    world.article = { ...DRAFT, brand_id: 'brand-di-un-altro' };
+
+    const { res, body } = await read('art-1');
+
+    expect(res.status).toBe(404);
+    expect(body.error).toBe('article_not_found');
+  });
+
+  it('porta la data sull orologio del brand, non su quello del server', async () => {
+    world.article = { ...DRAFT, status: 'approved', scheduled_for: '2026-08-09T16:00:00.000Z' };
+
+    const { body } = await read('art-1');
+
+    expect(body.article.scheduled_for).toBe('2026-08-09T16:00:00.000Z');
+    expect(body.article.scheduled_for_local).toBe('2026-08-09 18:00 (Europe/Rome)');
+  });
+
+  it('rifiuta una richiesta senza autenticazione', async () => {
+    vi.mocked(authenticate).mockResolvedValue({
+      error: new Response('Unauthorized', { status: 401 })
+    } as never);
+    const url = new URL('https://anomalia.test/api/v1/brands/demo/web/article?id=art-1');
+    const res = await (GET as (event: unknown) => Promise<Response>)({
+      request: new Request(url),
+      params: { slug: 'demo' },
+      url
+    });
+
+    expect(res.status).toBe(401);
+  });
+
+  it('rifiuta un brand a cui il chiamante non accede', async () => {
+    authorize();
+    vi.mocked(loadBrandForUser).mockResolvedValue({
+      error: new Response(JSON.stringify({ error: 'Brand not found' }), { status: 404 })
+    } as never);
+    const url = new URL('https://anomalia.test/api/v1/brands/altrui/web/article?id=art-1');
+    const res = await (GET as (event: unknown) => Promise<Response>)({
+      request: new Request(url),
+      params: { slug: 'altrui' },
+      url
+    });
+
+    expect(res.status).toBe(404);
+  });
+
+  it('rifiuta una richiesta senza id invece di restituire un articolo a caso', async () => {
+    authorize();
+    const url = new URL('https://anomalia.test/api/v1/brands/demo/web/article');
+    const res = await (GET as (event: unknown) => Promise<Response>)({
+      request: new Request(url),
+      params: { slug: 'demo' },
+      url
+    });
+
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('POST /api/v1/brands/:slug/web/article', () => {
+  it('cambiare il titolo non tocca nessun altro campo', async () => {
+    const { res, body } = await write({ id: 'art-1', title: 'Guida al campeggio, rivista' });
+
+    expect(res.status).toBe(200);
+    expect(updates).toHaveLength(1);
+    expect(Object.keys(updates[0]).sort()).toEqual(['title', 'updated_at']);
+    expect(body.updated_fields).toEqual(['title']);
+    expect(body.article).toMatchObject({
+      title: 'Guida al campeggio, rivista',
+      body_md: DRAFT.body_md,
+      meta_title: DRAFT.meta_title,
+      meta_description: DRAFT.meta_description,
+      cover_image: DRAFT.cover_image,
+      status: 'draft'
+    });
+  });
+
+  it('il corpo arriva così come è stato scritto: nessuno lo riformatta', async () => {
+    const body_md = '# Titolo\n\n<script>alert(1)</script>\n\nTesto **grassetto**.';
+
+    const { body } = await write({ id: 'art-1', body_md });
+
+    expect(updates[0].body_md).toBe(body_md);
+    expect(body.article.body_md).toBe(body_md);
+  });
+
+  it('non chiama nessun modello e non tocca i crediti', async () => {
+    await write({ id: 'art-1', title: 'x', body_md: 'y', meta_description: 'z' });
+
+    expect(structured).not.toHaveBeenCalled();
+    expect(gateAiAction).not.toHaveBeenCalled();
+    expect(gateCredits).not.toHaveBeenCalled();
+  });
+
+  it('un articolo già pubblicato non si modifica di nascosto', async () => {
+    world.article = { ...DRAFT, status: 'published', published_at: '2026-08-01T10:00:00.000Z' };
+
+    const { res, body } = await write({ id: 'art-1', title: 'Titolo nuovo' });
+
+    expect(res.status).toBe(409);
+    expect(body.error).toBe('article_published');
+    expect(updates).toEqual([]);
+  });
+
+  it('un articolo di un altro brand non si scrive', async () => {
+    world.article = { ...DRAFT, brand_id: 'brand-di-un-altro' };
+
+    const { res, body } = await write({ id: 'art-1', title: 'Titolo nuovo' });
+
+    expect(res.status).toBe(404);
+    expect(body.error).toBe('article_not_found');
+    expect(updates).toEqual([]);
+  });
+
+  it('una categoria di un altro brand è rifiutata nominando il campo', async () => {
+    const { res, body } = await write({ id: 'art-1', category_id: 'cat-di-un-altro-brand' });
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('category_not_found');
+    expect(updates).toEqual([]);
+  });
+
+  it('un autore di un altro brand è rifiutato nominando il campo', async () => {
+    const { res, body } = await write({ id: 'art-1', author_id: 'aut-di-un-altro-brand' });
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('author_not_found');
+    expect(updates).toEqual([]);
+  });
+
+  it('un tag di un altro brand ferma tutta la scrittura', async () => {
+    const { res, body } = await write({ id: 'art-1', tag_ids: ['tag-1', 'tag-di-un-altro-brand'] });
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('tags_not_found');
+    expect(updates).toEqual([]);
+    expect(tagDeletes).toBe(0);
+  });
+
+  it('i tag passati sostituiscono quelli attuali, non si sommano', async () => {
+    const { res } = await write({ id: 'art-1', tag_ids: ['tag-2'] });
+
+    expect(res.status).toBe(200);
+    expect(tagDeletes).toBe(1);
+    expect(tagInserts).toEqual([['tag-2']]);
+  });
+
+  it('una lista vuota toglie ogni tag senza reinserirne', async () => {
+    const { res } = await write({ id: 'art-1', tag_ids: [] });
+
+    expect(res.status).toBe(200);
+    expect(tagDeletes).toBe(1);
+    expect(tagInserts).toEqual([]);
+  });
+
+  it('datare un draft lo porta ad approved, e lo dice', async () => {
+    const { res, body } = await write({ id: 'art-1', scheduled_for: '2026-08-09T18:00' });
+
+    expect(res.status).toBe(200);
+    expect(updates[0]).toMatchObject({
+      scheduled_for: '2026-08-09T16:00:00.000Z',
+      status: 'approved'
+    });
+    expect(body.updated_fields).toContain('status');
+  });
+
+  it('rifiuta una data che non è una data, senza scrivere niente', async () => {
+    const { res, body } = await write({ id: 'art-1', scheduled_for: 'domani alle 18' });
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('invalid_scheduled_for');
+    expect(updates).toEqual([]);
+  });
+
+  it('un segnaposto planned non resta senza slot', async () => {
+    world.article = { ...DRAFT, status: 'planned', scheduled_for: '2026-09-01T08:00:00.000Z' };
+
+    const { res, body } = await write({ id: 'art-1', scheduled_for: null });
+
+    expect(res.status).toBe(409);
+    expect(body.error).toBe('planned_needs_slot');
+    expect(updates).toEqual([]);
+  });
+
+  it('la lingua di una traduzione non si sposta da qui', async () => {
+    world.article = { ...DRAFT, translation_of: 'art-originale' };
+
+    const { res, body } = await write({ id: 'art-1', language: 'es' });
+
+    expect(res.status).toBe(409);
+    expect(body.error).toBe('translation_locked');
+    expect(updates).toEqual([]);
+  });
+
+  it('la lingua è scritta col nome che il blog legge', async () => {
+    const { res } = await write({ id: 'art-1', language: 'es' });
+
+    expect(res.status).toBe(200);
+    expect(updates[0]).toMatchObject({ language: 'Spanish' });
+  });
+
+  it('rifiuta una lingua che il blog non pubblica', async () => {
+    const { res, body } = await write({ id: 'art-1', language: 'xx' });
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('invalid_language');
+    expect(updates).toEqual([]);
+  });
+
+  it('una richiesta senza nessun campo da cambiare non passa per il database', async () => {
+    const { res, body } = await write({ id: 'art-1' });
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('no_changes');
+    expect(updates).toEqual([]);
+  });
+
+  it('rifiuta un campo che il contratto non dichiara, invece di scartarlo in silenzio', async () => {
+    const { res, body } = await write({ id: 'art-1', campo_che_non_esiste: 'x' });
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('invalid_input');
+    expect(updates).toEqual([]);
+  });
+
+  it('rifiuta una API key di sola lettura', async () => {
+    vi.mocked(checkApiKeyWriteAccess).mockReturnValue(
+      new Response(JSON.stringify({ error: 'API key is read-only' }), { status: 403 }) as never
+    );
+
+    const { res } = await write({ id: 'art-1', title: 'Titolo nuovo' });
+
+    expect(res.status).toBe(403);
+    expect(updates).toEqual([]);
+  });
+
+  it('rifiuta una richiesta senza autenticazione', async () => {
+    vi.mocked(authenticate).mockResolvedValue({
+      error: new Response('Unauthorized', { status: 401 })
+    } as never);
+    const url = new URL('https://anomalia.test/api/v1/brands/demo/web/article');
+    const res = await (POST as (event: unknown) => Promise<Response>)({
+      request: new Request(url, { method: 'POST', body: '{}' }),
+      params: { slug: 'demo' },
+      url
+    });
+
+    expect(res.status).toBe(401);
+  });
+
+  it('rifiuta un brand a cui il chiamante non accede', async () => {
+    authorize();
+    vi.mocked(loadBrandForUser).mockResolvedValue({
+      error: new Response(JSON.stringify({ error: 'Brand not found' }), { status: 404 })
+    } as never);
+    const url = new URL('https://anomalia.test/api/v1/brands/altrui/web/article');
+    const res = await (POST as (event: unknown) => Promise<Response>)({
+      request: new Request(url, { method: 'POST', body: '{}' }),
+      params: { slug: 'altrui' },
+      url
+    });
+
+    expect(res.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## What?

Public MCP could list article summaries, generate, optimize, publish, unpublish and delete. It
could not **read a complete article** or **change a word of one**: every editing path went through
an Anomalia model. An external agent that had already written the prose had nowhere to put it, and
an auto-generated article could only be regenerated, never corrected.

This adds two deterministic endpoints, both on `/api/v1/brands/:slug/web/article`:

| | |
|---|---|
| `GET` → `get_article` | One article **in any status** — draft, planned, approved, published: markdown body, meta title, meta description, cover, category, tags, author, language, schedule, status, `translation_of`, `version_seq`. |
| `POST` → `update_article` | Writes `title`, `body_md`, `meta_title`, `meta_description`, `category_id`, `author_id`, `tag_ids`, `language`, `scheduled_for`. No model call, no credit debit, nothing reformatted. |

A field the caller does not send is left untouched, so changing the title never moves the body, the
cover or the description. A **published** article is refused with `409 article_published` rather
than edited underneath its readers.

## Why?

Phase 2 of [`docs/external-agent-plan.md`](docs/external-agent-plan.md) — "External plans and full
article control". Its completion criteria this PR serves:

- *"An auto-generated article remains fully editable through MCP without regenerating it."*
- *"Direct article edits cause no Anomalia model call or text-AI debit."*
- *"Editing one field never regenerates another."*
- *"Updating a published article does not silently change the live version."*
- *"Raw HTML remains escaped."*
- *"Every resulting artifact is visible and editable in the existing web UI."*

## How?

**Composed, not rewritten.** The modules this endpoint stands on, all pre-existing:

| Module | What it does here |
|---|---|
| `$lib/server/cli-auth` | `authenticate`, `loadBrandForUser`, `checkApiKeyWriteAccess`. **`gateAiAction` is deliberately not called.** |
| `$lib/server/supabase-admin` | `createAdminClient` — `brand_articles` is SELECT-only under RLS, exactly as `POST /web` already does |
| `$lib/server/clock` | `resolveScheduleInput` — the brand wall clock, and the "already past" refusal |
| `$lib/server/schedule` | `formatInZone` for `scheduled_for_local` |
| `$lib/blog-locales` | `isBlogLocale` + `BLOG_LOCALE_LANGUAGE` |
| `@anomalia/api-contracts` | `BRAND_ENDPOINTS` — the CLI method and the MCP tool follow on their own; no hand-written `registerTool` |
| `$lib/server/blog-site` | untouched: `renderArticleHtml` still escapes raw HTML, so the body stays markdown-only |

**The status rule now lives in one place** (`src/lib/server/article-editing.ts`). `schedule_article`
decided in-line what a status allows — published refused, `planned` keeps its slot, everything else
goes to `approved`. The API needed the same three rules, and a rule written twice diverges at the
first change. `ARTICLE_EDIT_RULES` is four rows and three columns, every cell either a permitted
outcome or the name of the refusal:

```
             edit                 schedule             unschedule
draft        allow                approved             draft
planned      allow                keep                 planned_needs_slot
approved     allow                approved             draft
published    article_published    article_published    article_published
```

That extraction is **its own commit** (`Extract the article status rule into one table`), separate
from the behaviour change, per Kent Beck. The refusal order, the written patch and the chat tool's
error strings are the ones it already returned.

**The published article.** The plan says *"Changes to a published article create a revision; making
that revision live is a separate consequential action."* That revision flow does not exist yet
(`brand_article_versions` is today the blog-chat undo ledger, not a publication mechanism), so
rather than invent half of it, the endpoint **refuses** and points at the path the code already
has: `unpublish` → edit → `publish`. It is the same choice `schedule_article` already made. Nothing
live changes silently, and there is no half-built revision flow to unpick later.

**Alternatives rejected**

- *A migration.* None written. `brand_articles` has **no CHECK constraints** (read from
  `pg_constraint`, output below), the statuses written are the ones the domain already uses, and
  this repo's deploys do not run migrations.
- *`status` as a writable field.* Status is a consequence of the schedule, not an input — exposing
  it would have given a second, divergent way to publish.
- *Routing the chat's `update_article` through the new module.* It would gain the published-article
  refusal, which is a behaviour change to an internal surface. Out of scope here.
- *`content_html` in the response.* The agent writes markdown; escaping already has its own test.

## Testing?

**Red first.** The route test was written before the route. Its first run, with no `+server.ts`:

```
 ❯ src/routes/api/v1/brands/[slug]/web/article/server.test.ts (0 test)
 FAIL  src/routes/api/v1/brands/[slug]/web/article/server.test.ts
Error: Failed to load url ./+server (resolved id: ./+server) in
  .../web/article/server.test.ts. Does the file exist?
 Test Files  1 failed (1)
      Tests  no tests
```

A missing module is a shallow red, so the assertions were re-run against a **stub route** that
returns `{ok:true, article:null}` — all 29 bite, none pass vacuously:

```
   × restituisce il record completo di un articolo draft, non solo il sommario
   × restituisce il record completo di un articolo planned/approved/published
   × un articolo di un altro brand non si legge
   × porta la data sull orologio del brand, non su quello del server
   × cambiare il titolo non tocca nessun altro campo
   × il corpo arriva così come è stato scritto: nessuno lo riformatta
   × un articolo già pubblicato non si modifica di nascosto
   × una categoria / un autore / un tag di un altro brand è rifiutato nominando il campo
   × i tag passati sostituiscono quelli attuali, non si sommano
   × datare un draft lo porta ad approved, e lo dice
   × un segnaposto planned non resta senza slot
   × la lingua di una traduzione non si sposta da qui
   × rifiuta una API key di sola lettura / senza autenticazione / brand non accessibile
   ... 29 failed
```

**Green.**

Re-measured on the final rebased tree — `origin/dev` at **483f51c**:

```
$ npx vitest run src/routes/api/v1/brands/[slug]/web/article/server.test.ts \
                 src/lib/server/article-editing.test.ts \
                 packages/api-contracts/src/index.test.ts
 ✓ src/lib/server/article-editing.test.ts (11 tests)
 ✓ packages/api-contracts/src/index.test.ts (23 tests)
 ✓ src/routes/api/v1/brands/[slug]/web/article/server.test.ts (30 tests)
 Test Files  3 passed (3)
      Tests  64 passed (64)

$ npm run test:unit
 Test Files  1 failed | 597 passed | 3 skipped (601)
      Tests  1 failed | 6634 passed | 11 skipped (6646)
# The one red is src/lib/agent/bridge/live.test.ts, "il run NON sfrattato salva una volta sola" —
# `Test timed out in 120000ms` on a machine in swap. Run alone the same file is 84 passed / 1
# timeout, same test, same way. It is a timeout, not an assertion, and this PR touches nothing in
# the agent bridge or the run-lease path.

$ cd cli && bun test
 39 pass / 0 fail / 104 expect() calls across 8 files
$ cd cli && bun run typecheck
tsc --noEmit          # clean

$ git diff --check origin/dev..HEAD
                      # clean
```

**`npm run check` did NOT complete, and I am reporting no number for it.** It was killed by the
OS twice (`EXIT=143`, SIGTERM) with the machine in swap. `npx tsc --noEmit` **did** complete on
this branch on an earlier base, and it is what caught the one real defect below.

**The defect `tsc` caught that vitest could not.** `updateArticle` returned
`{ ok: false, error: 'translation_locked' }` while `ArticleEditFailure` did not list that member —
`TS2322`. The contract, the route test, the docs and the changelog all named it, and the test
asserting it passed, because vitest does not typecheck. It is declared now, in its own commit
(`Declare translation_locked as a failure`), and `tsc` is clean on the file afterwards.

**Verification scope, stated plainly.** This is unit tests plus typecheck. The browser gate in
`CLAUDE.md` does not apply: the diff touches no `.svelte` file and nothing under
`src/lib/components/`, so a browser exercises nothing the unit tests do not already cover. No
Docker stack, no dev server and no Playwright run was started for this PR; the live-stack evidence
further down was captured by the original author on an earlier revision and is left as it was
recorded.

**No model, no credits** — spies assert it, not prose:

```js
expect(structured).not.toHaveBeenCalled();      // $lib/server/research
expect(gateAiAction).not.toHaveBeenCalled();    // $lib/server/cli-auth
expect(gateCredits).not.toHaveBeenCalled();     // $lib/server/credits
```

### Verified against the real local stack, not only mocks

A hand-rolled fake Supabase cannot prove a nested PostgREST select is shaped correctly, so the
whole thing was exercised against the running local Docker stack (`anomalia-db`) with the worktree
app on `:5199` and a real login as `test@anomalia.so`.

<details><summary>The CHECK constraints, read before writing any status</summary>

```
$ docker exec anomalia-db psql -U postgres -c "select conname, pg_get_constraintdef(oid)
    from pg_constraint where conrelid in ('public.brand_articles'::regclass,
    'public.brand_article_tags'::regclass,'public.blog_categories'::regclass,
    'public.blog_authors'::regclass,'public.blog_tags'::regclass) and contype='c';"

 conname | pg_get_constraintdef
---------+----------------------
(0 rows)
```

No CHECK constraint on any table this PR writes. The statuses used (`draft`, `planned`,
`approved`, `published`) are the ones `blog-generate`, `schedule_article` and the Site page
already write. No migration.
</details>

<details><summary>The nested select, straight at local PostgREST — the shape the mapper assumes</summary>

```json
{
  "id": "66666666-…", "title": "Guida al campeggio", "status": "draft",
  "language": "Italian", "cover_image": "https://cdn.test/cover.png",
  "category": { "id": "…", "name": "Outdoor", "slug": "outdoor" },
  "author":   { "id": "…", "name": "Giulia",  "slug": "giulia"  },
  "tags": [ { "blog_tags": { "id": "…", "name": "Tende", "slug": "tende" } } ]
}
```

`category`/`author` come back as objects, `tags` as `[{blog_tags:{…}}]` — exactly what `toArticle`
unwraps. This is the one thing the mocked suite could not have caught.
</details>

<details><summary>The endpoint against the real database, every refusal firing</summary>

```
--- titolo soltanto
{"ok": true, "updated_fields": ["title"], "article": {"title": "Guida al campeggio, rivista",
 "body_md": "# Guida\n\nUn corpo che nessuno deve riscrivere.", "meta_title": "Guida | Demo",
 "meta_description": "Come si monta una tenda.", "cover_image": "https://cdn.test/cover.png",
 "status": "draft", …}}                                                          HTTP 200

--- articolo published      {"error": "article_published"}                        HTTP 409
--- categoria altro brand   {"error": "category_not_found"}                       HTTP 400
--- tag altro brand         {"error": "tags_not_found"}                           HTTP 400
--- niente da cambiare      {"error": "no_changes"}                               HTTP 400
--- campo non dichiarato    {"error": "invalid_input", "details": [{"code":
                             "unrecognized_keys", "keys": ["cover_image"], …}]}   HTTP 400
--- data non interpretabile {"error": "invalid_scheduled_for", "details":
                             {"error": "Invalid datetime: \"domani alle 18\"", …}} HTTP 400
--- lingua sconosciuta      {"error": "invalid_language"}                         HTTP 400

--- schedula il draft
{"ok":true,"updated_fields":["scheduled_for","status"], … "status":"approved",
 "scheduled_for":"2030-05-16T07:00:00+00:00"}                                     HTTP 200

$ psql -c "select status, scheduled_for from brand_articles where id='66666666-…'"
  status  |     scheduled_for
----------+------------------------
 approved | 2030-05-16 07:00:00+00        # 09:00 Rome, stored as UTC

$ psql -c "select language, status, tag_id from brand_articles a
             left join brand_article_tags t on t.article_id=a.id where a.id='66666666-…'"
 language |  status  |                tag_id
----------+----------+--------------------------------------
 Spanish  | approved | 57575757-…                    # 'es' stored as the name the blog reads,
                                                     # tags replaced not merged
```

Fixtures were created and deleted again; the local `demo` brand is back to 0 articles.
</details>

## Evidence (screenshots/videos)

The change has no UI of its own, but the plan requires the result to be *visible and editable in
the existing web UI*. Verified in a real browser, logged in as `test@anomalia.so`, on
`/app/demo/site/edit/66666666-…` after the API writes above — read out of the live DOM:

```js
{
  "fields": [
    { "n": "title",            "v": "Guida al campeggio, rivista" },   // written via the API
    { "n": "meta_title",       "v": "Guida | Demo" },                  // untouched, byte-identical
    { "n": "meta_description", "v": "Come si monta una tenda." },      // untouched, byte-identical
    { "n": "cover",            "v": "" }
  ],
  "hasBody": true    // the markdown body is rendered in the editor
}
```

**I could not capture a screenshot image**: the Chrome window this session drives reports a 0×0
viewport (`resize_window` did not take), so `screenshot` fails with `Cannot take screenshot with
0 width`. The DOM read above and `get_page_text` are the evidence I do have — I am not presenting
them as a picture.

## Anything Else?

**Out of scope, deliberately** — each is a separate slice with its own risk:

- article **video blocks** (a new capability, not a current column);
- **cover and in-body images** (already have their own generate/upload paths);
- **translations** (the locale of a translation row is its identity — `language` is refused on one
  with `translation_locked`);
- the **revision flow for a published article** (refused here instead, see above);
- `slug` (changing an indexed slug is consequential and belongs with the publish lifecycle).

**Notes and things that worry me**

1. **`language` is close to a no-op for originals.** `blog-site.ts` resolves the locale from the
   data model, not the stored string ("originals ARE the default locale, whatever their `language`
   column happens to say"). So writing it matters for translations — which are out of scope — and
   is inert for originals. I kept it because the plan lists it and the read has to expose it
   anyway, but a reviewer may reasonably want it dropped.

2. **Pre-existing defect found, not fixed here.** The Site editor's category/tag/author pickers are
   always empty: `src/routes/app/[brand]/site/edit/[id]/+page.server.ts` loads the brand with
   `.select('website')` and then filters `blog_categories`/`blog_tags`/`blog_authors` on
   `brand_id = brand?.id ?? ''` — `id` is never selected, so the filter is always `''`. Confirmed
   live: the article had a category and an author set, and the page showed "Nessuna"/"Nessuno".
   One-word fix, but it is an unrelated defect in a Svelte page and deserves its own PR and test.

3. **Duplication I did not remove.** The chat tool's `update_article` and the Site editor's `save`
   action still write article fields in-line. Only the *status/schedule rule* was unified. Folding
   the field write into the shared module would give the chat tool the published-article refusal —
   correct per the plan, but a behaviour change to an internal surface that belongs in its own PR.

4. **`npm run check` still did not complete**, on the rebase either: SIGTERM'd (`EXIT=143`) with
   nine agents running `svelte-check` in parallel worktrees and the machine in swap. `npx tsc
   --noEmit` on the app is what stood in for it — and it earned its keep, catching the
   `translation_locked` type error described in *Testing?*. `cli`'s `tsc --noEmit` is clean. I am
   not claiming a clean `check` I did not see.

5. **Not run:** `npm run eval:ux` and `npm run eval:durability`. This PR touches no prompt, no
   model, no tool the agent reasons with, and no chat path — the one file it changes under
   `src/lib/agent/` is a pure extraction with the existing tests as its net.

6. The changelog files are dated `2026-09-03` as briefed; the work finished just after midnight on
   the 4th.

7. **Four commits, not two.** The two originals are unchanged in intent; the rebase added
   `Declare translation_locked as a failure` (the `tsc` defect above) and `Drop the header comment
   on article editing` — six lines restating what `ARTICLE_EDIT_RULES` and three tests already
   say, removed per the repo's no-comments rule.

8. **`brand_articles` has no CHECK constraints — re-read from production, not assumed.**
   `select conname, pg_get_constraintdef(oid) from pg_constraint where
   conrelid='public.brand_articles'::regclass and contype='c';` returns zero rows, and every
   column this endpoint writes (`title`, `body_md`, `meta_title`, `meta_description`,
   `category_id`, `author_id`, `language`, `scheduled_for`, `status`) exists there. Still no
   migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY

