### PR TITLE
Let an external agent read the brief before it writes

### DIFF
--- a/changelog/2026-09-03-external-agent-creation-kit.md
+++ b/changelog/2026-09-03-external-agent-creation-kit.md
@@ -1,0 +1,120 @@
+# Un agente esterno può leggere il brief prima di scrivere
+
+Ultima slice della Fase 1 del piano [external agent](../docs/external-agent-plan.md).
+`get_creation_kit` prende un obiettivo, delle piattaforme e un formato, e restituisce il brief
+minimo per quel lavoro — più un identificatore stabile per ogni template, rubrica, esempio e
+versione di regola che ha selezionato.
+
+## La funzione è la selezione, non il recupero
+
+Il piano è netto due volte:
+
+> «Dynamic tools select the smallest relevant subset; they never dump the full library into every
+> model turn.»
+
+> Rischio: «Guidance overwhelms or anchors the external model» → Controllo: «Select one focused
+> creation kit instead of dumping the library.»
+
+Quindi un kit che restituisce tutto è un fallimento anche se ogni test passa. Il budget è in
+codice (`CREATION_KIT_MAX_BYTES = 8192`), è misurato in ogni risposta (`size_bytes`), e un test
+lo tiene: se il kit cresce oltre il tetto, il test fallisce.
+
+Perché 8192 byte: sono circa duemila token, una pagina di indicazioni — la dimensione di una buona
+sezione di system prompt. Grande abbastanza da portare un template, una voce e qualche esempio;
+piccola abbastanza che leggerla prima di ogni post non costi niente. Misurato: un brand appena
+creato produce **3.826 byte**, un brand reale con rubriche, storico e campagna ne produce **5.378**.
+Nessuno dei due taglia niente.
+
+## Il tetto tiene per costruzione, non per amputazione
+
+Ogni campo ha un massimo in caratteri (`CAPS`, una tabella sola). È quello che fa stare il kit nel
+budget: tagliare intere sezioni è la rete, non il meccanismo. La rete c'è comunque, ed è ordinata
+sulla **precedenza dichiarata nel piano** — vincoli di piattaforma, fatti del brand, voce, rubrica,
+template, calendario, settimana, edit dell'operatore, evidenza. Si cede dal fondo: i vincitori
+passati sono *evidence, not instructions*, e cadono per primi; `constraints` non cade mai. Quello
+che cade è elencato in `trimmed`, così chi legge sa cosa non ha ricevuto.
+
+Il primo test scritto su questo — un brand che satura *ogni* campo insieme — ha trovato un difetto
+vero: il nome di una persona era l'unico campo senza tetto, e il kit arrivava a scartare i fatti
+del brand pur di stare nel budget, tenendo un template statico. Il tetto mancante è la correzione;
+il test è la guardia.
+
+## Cosa ho composto, e cosa non ho scritto
+
+Il kit non contiene **una sola regola sua**. Ogni sezione è una selezione sopra un modulo che la
+regola ce l'ha già:
+
+| Sezione | Da dove | Selezione |
+|---|---|---|
+| `constraints` | `platform-limits.ts` | solo le piattaforme richieste |
+| `brand` | `brand_kit`, `products`, `people` | prodotti ordinati per sovrapposizione col goal (max 5); solo persone con `consent = true` |
+| `voice` | `houseVoiceFor` (`caption-quality.ts`) | personalità approvata quando c'è |
+| `rubric` | `loadApprovedRubrics` (`rubrics.ts`) | solo quelle del formato richiesto |
+| `template` | `agent-docs/skills/social/references/post-templates.md` | un gruppo da formato+piattaforma, un blocco dal goal |
+| `template.playbook` | `platformPlaybook` (`seed-model.ts`) | solo le piattaforme richieste |
+| `calendar` | `posts` + `SLOT_OCCUPYING_STATUSES` | solo i minuti occupati da adesso in avanti |
+| `week` | `editorial_plans` attivo + `currentWeekIndex` | solo la settimana corrente |
+| `operator_edits` | `ownerCaptionEditPairs` (`caption-quality.ts`) | le ultime 3 riscritture vere |
+| `history` | `loadOwnPostHistory` + `analyzePostHistory` | solo `source='zernio'`, vincitori sulle piattaforme richieste |
+
+`post-templates.md` è la stessa reference che le skill di brand consegnano agli agenti interni
+(`brand-skills.ts`). Il kit legge quel file e ne passa **un solo blocco**: due consigli diversi
+sullo stesso argomento non possono nascere, perché la sorgente è una.
+
+## Due regole che stavano dentro l'unica funzione che le usava
+
+`listCalendarConflicts` teneva l'insieme degli stati che occupano un minuto in un `new Set([...])`
+locale; `analyzePostHistory` teneva la formula del peso d'ingaggio in una `function weight` privata.
+Un secondo lettore avrebbe dovuto copiarle, e due copie di «quale post ha vinto» classificano post
+diversi. Sono diventate `SLOT_OCCUPYING_STATUSES` e `engagementWeight`, esportate dai moduli che le
+possedevano già. Il commit che sposta è separato da quello che aggiunge, e i 29 test di quei due
+moduli passano identici.
+
+## Cosa ho lasciato fuori, e perché
+
+Il piano elenca più di quello che esiste davvero per brand. Un campo sempre vuoto è peggio di un
+campo assente — insegna a ignorare il kit — quindi:
+
+- **Weak patterns.** Non esistono. `visualInsightsBlock` calcola i bucket perdenti e poi li
+  **scarta** (`delta <= 0`); `post_verdicts.verdict = 'discarded'` è il dato giusto e non ha un
+  solo lettore in tutto il repo. L'unico segnale negativo per brand che esiste è
+  `content_prefs.avoid`, ed è dentro `constraints`. Inventare dei pattern deboli avrebbe prodotto
+  un mio giudizio travestito da regola di Anomalia.
+- **Approved assets.** `list_media` è già un tool, con ricerca e URL firmati. Ripeterli nel kit
+  avrebbe raddoppiato la libreria proprio nello strumento che esiste per non dumparla. Il kit lo
+  dice nella sua descrizione.
+- **Ricerca semantica sulla knowledge base.** `loadCaptionKnowledge` avrebbe usato il goal molto
+  meglio della sovrapposizione lessicale, ma `searchKnowledge` fa un round-trip di embedding quando
+  il recall FTS è magro: una chiamata a modello dentro una lettura che promette di non farne
+  nessuna. Fuori.
+- **Campagne.** Non c'è nessuna tabella: `campaign_id`/`campaign_name`/`campaign_step` sono tre
+  colonne su `posts`, senza stato e senza «corrente». Il contesto di campagna arriva quindi
+  attaccato agli slot occupati — zero query in più, zero euristica — e il contesto strategico vero
+  è la settimana del piano editoriale attivo, che un indice unico parziale garantisce unica.
+- **`post_verdicts` come corpus di edit.** Ha le colonne giuste e nessun lettore. Scriverlo qui
+  sarebbe stato codice nuovo su un dato mai letto, per lo stesso segnale che
+  `content_prefs.captionEditPairs` già dà. Rimane lavoro di dopo.
+
+## Perché una GET
+
+Il kit è una lettura e l'input ci sta in una query string. `resolveCaller` nega le API key di sola
+lettura su qualunque metodo diverso da GET: con la GET, **una chiave read-only può leggere il
+brief prima di scrivere**, che è esattamente il permesso giusto. `platforms` viaggia come stringa
+separata da virgole perché è così che `callEndpoint` serializza una GET; normalizzazione e
+deduplica stanno nella route, e una lista di sole virgole dà `no_platforms` invece di passare per
+vuota.
+
+## Il goal, e cosa fa davvero
+
+Il goal ordina i template dentro il gruppo scelto e i prodotti dentro il catalogo, per
+**sovrapposizione di parole**. Non è ricerca semantica e il codice lo dice nel nome
+(`goalOverlap`): è deterministica, non costa niente e non chiama nessun modello — che è la
+promessa dell'endpoint. Un test lo verifica su due goal diversi che scelgono due template diversi.
+
+## Il valore è dichiarato, non dimostrato
+
+Il piano dice che il kit «ships only if it improves the facts without making completion materially
+slower or more expensive». Quel confronto — stesso modello, stesso task, con e senza kit, su più
+brand reali e abbastanza ripetizioni — **non è stato fatto**. Quello che questa PR porta è la
+dimensione misurata e il costo misurato (zero chiamate a modello, zero crediti, provato da una spia
+nei test). Che aiuti la qualità resta da verificare.

--- a/changelog/2026-09-03-external-agent-creation-kit.md
+++ b/changelog/2026-09-03-external-agent-creation-kit.md
@@ -47,7 +47,7 @@ regola ce l'ha già:
 | Sezione | Da dove | Selezione |
 |---|---|---|
 | `constraints` | `platform-limits.ts` | solo le piattaforme richieste |
-| `brand` | `brand_kit`, `products`, `people` | prodotti ordinati per sovrapposizione col goal (max 5); solo persone con `consent = true` |
+| `brand` | `brand_kit`, `products`, `people` | prodotti ordinati per sovrapposizione col goal (max 5); solo persone che passano `likenessConsented` |
 | `voice` | `houseVoiceFor` (`caption-quality.ts`) | personalità approvata quando c'è |
 | `rubric` | `loadApprovedRubrics` (`rubrics.ts`) | solo quelle del formato richiesto |
 | `template` | `agent-docs/skills/social/references/post-templates.md` | un gruppo da formato+piattaforma, un blocco dal goal |

--- a/changelog/2026-09-03-external-agent-creation-kit.md
+++ b/changelog/2026-09-03-external-agent-creation-kit.md
@@ -118,3 +118,12 @@ slower or more expensive». Quel confronto — stesso modello, stesso task, con 
 brand reali e abbastanza ripetizioni — **non è stato fatto**. Quello che questa PR porta è la
 dimensione misurata e il costo misurato (zero chiamate a modello, zero crediti, provato da una spia
 nei test). Che aiuti la qualità resta da verificare.
+
+## La regola del likeness, non una mia copia
+
+La prima versione del kit selezionava le persone con `.eq('consent', true)` nella query. È
+sbagliata due volte: esclude le persona AI, che non ritraggono nessuno e non vanno mai gated, e
+soprattutto **riscrive una regola che ha già una casa**. `likenessConsented` in
+`design-visual-refs.ts` lo dice nel proprio docblock: «Re-stating the condition anywhere else is
+how the rule diverges». Adesso il kit chiama quella funzione. Il test che lo tiene fallisce con la
+condizione riscritta e passa con la regola vera.

--- a/changelog/2026-09-03-external-agent-creation-kit.md
+++ b/changelog/2026-09-03-external-agent-creation-kit.md
@@ -50,7 +50,7 @@ regola ce l'ha già:
 | `brand` | `brand_kit`, `products`, `people` | prodotti ordinati per sovrapposizione col goal (max 5); solo persone che passano `likenessConsented` |
 | `voice` | `houseVoiceFor` (`caption-quality.ts`) | personalità approvata quando c'è |
 | `rubric` | `loadApprovedRubrics` (`rubrics.ts`) | solo quelle del formato richiesto |
-| `template` | `agent-docs/skills/social/references/post-templates.md` | un gruppo da formato+piattaforma, un blocco dal goal |
+| `template` | `agent-docs/skills/social/references/post-templates.md` | formato+piattaforma scelgono il gruppo e, quando il formato decide da solo, il blocco; il goal sceglie solo dove resta una scelta vera |
 | `template.playbook` | `platformPlaybook` (`seed-model.ts`) | solo le piattaforme richieste |
 | `calendar` | `posts` + `SLOT_OCCUPYING_STATUSES` | solo i minuti occupati da adesso in avanti |
 | `week` | `editorial_plans` attivo + `currentWeekIndex` | solo la settimana corrente |
@@ -127,3 +127,19 @@ soprattutto **riscrive una regola che ha già una casa**. `likenessConsented` in
 `design-visual-refs.ts` lo dice nel proprio docblock: «Re-stating the condition anywhere else is
 how the rule diverges». Adesso il kit chiama quella funzione. Il test che lo tiene fallisce con la
 condizione riscritta e passa con la regola vera.
+
+## Il difetto che solo l'esecuzione vera ha mostrato
+
+Con l'endpoint acceso sullo stack locale e il brand `demo`, un lavoro `format=video` su Instagram
+tornava con **The Carousel Hook**: il gruppo era giusto, ma dentro il gruppo sceglieva il goal, e
+per «show the tasting bench in a short clip» nessun blocco segnava punti, quindi vinceva il primo.
+Il formato è un vincolo duro e sta sopra il goal nella precedenza del piano — una struttura a slide
+consegnata a chi sta girando una clip è una risposta sbagliata.
+
+`TEMPLATE_ROUTES` ha adesso una colonna `pins`: quando il formato decide da solo il blocco è
+fissato (`carousel` → The Carousel Hook, `video` → The Reel Script), altrimenti resta `null` e il
+goal sceglie. Una tabella sola, come prima. Il test è stato scritto prima della correzione e l'ho
+visto fallire con `expected 'The Carousel Hook' to be 'The Reel Script'`.
+
+Nessun test con un doppio di supabase avrebbe trovato questo: il difetto non era nei dati, era
+nella scelta, e si vede solo guardando cosa esce per un lavoro vero.

--- a/cli/lib/contracts/creation-kit.ts
+++ b/cli/lib/contracts/creation-kit.ts
@@ -1,0 +1,118 @@
+import { z } from 'zod';
+import type { BrandEndpoint } from './index';
+
+// Mirrors CONTENT_FORMATS in src/lib/content-formats.ts, which this package may not import.
+// src/lib/server/creation-kit.test.ts fails if the two ever disagree.
+export const KIT_FORMATS = ['single_image', 'carousel', 'text_post', 'link_post', 'video'] as const;
+
+const GetCreationKitInputSchema = z
+  .object({
+    goal: z
+      .string()
+      .min(1)
+      .max(300)
+      .describe('What this post has to achieve, in one line. It selects the template and ranks the products and examples'),
+    platforms: z
+      .string()
+      .min(1)
+      .describe('Where it would be published, comma-separated: "instagram,linkedin"'),
+    format: z.enum(KIT_FORMATS).describe('The format you intend to write')
+  })
+  .strict();
+
+const TemplateSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  group: z.string(),
+  body: z.string(),
+  hooks: z.object({ id: z.string(), name: z.string(), body: z.string() }).optional(),
+  playbook: z.string()
+});
+
+const GetCreationKitResultSchema = z.object({
+  job: z.object({ goal: z.string(), platforms: z.array(z.string()), format: z.enum(KIT_FORMATS) }),
+  versions: z.object({ kit: z.number() }),
+  size_bytes: z.number(),
+  budget_bytes: z.number(),
+  trimmed: z.array(z.string()),
+  constraints: z.object({
+    platforms: z.array(
+      z.object({
+        platform: z.string(),
+        char_limit: z.number().nullable(),
+        needs_media: z.boolean(),
+        video_only: z.boolean()
+      })
+    ),
+    avoid: z.array(z.string())
+  }),
+  brand: z
+    .object({
+      name: z.string(),
+      language: z.string().optional(),
+      about: z.string().optional(),
+      audience: z.string().optional(),
+      products: z.array(z.object({ id: z.string(), title: z.string(), pricing: z.string().optional() })).optional(),
+      people: z.array(z.object({ id: z.string(), name: z.string(), role: z.string().optional() })).optional()
+    })
+    .optional(),
+  voice: z.object({ text: z.string() }).optional(),
+  rubric: z
+    .object({
+      id: z.string().optional(),
+      name: z.string(),
+      format: z.string(),
+      promise: z.string().optional(),
+      cadence: z.string().optional(),
+      art_direction: z.string().optional()
+    })
+    .optional(),
+  template: TemplateSchema.optional(),
+  calendar: z
+    .object({
+      occupied: z.array(
+        z.object({
+          scheduled_for: z.string(),
+          platforms: z.array(z.string()),
+          campaign: z.string().optional(),
+          step: z.string().optional()
+        })
+      )
+    })
+    .optional(),
+  week: z.object({ index: z.number(), theme: z.string() }).optional(),
+  operator_edits: z.array(z.object({ before: z.string(), after: z.string() })).optional(),
+  history: z
+    .object({
+      post_count: z.number(),
+      best_times: z.array(z.string()),
+      top_formats: z.array(z.string()),
+      top_hashtags: z.array(z.string()),
+      cadence: z.string().optional(),
+      untested_hooks: z.array(z.string()),
+      winners: z.array(z.object({ id: z.string(), platform: z.string(), opening: z.string() }))
+    })
+    .optional()
+});
+
+export type GetCreationKitInput = z.infer<typeof GetCreationKitInputSchema>;
+export type GetCreationKitResult = z.infer<typeof GetCreationKitResultSchema>;
+
+export const GET_CREATION_KIT = {
+  tool: 'get_creation_kit',
+  title: 'Creation kit',
+  description:
+    'The smallest brief you need before writing one post: the platform constraints, the brand ' +
+    'facts and approved voice, the matching rubric, ONE Anomalia template chosen for this goal ' +
+    'and format, the operator\'s own rewrites, what has worked on this brand, and which calendar ' +
+    'minutes are taken. It is a SELECTION, not the library: sections with nothing in them are ' +
+    'absent, and the whole kit is capped so it never floods your context. Reads only — no model ' +
+    'call, no credits, nothing written. Assets live in list_media; checking a draft is ' +
+    'check_content.',
+  method: 'GET',
+  pathUnderBrand: '/creation-kit',
+  input: GetCreationKitInputSchema,
+  output: GetCreationKitResultSchema,
+  failures: [{ error: 'no_platforms', status: 400 }],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/cli/lib/contracts/index.ts
+++ b/cli/lib/contracts/index.ts
@@ -1,6 +1,7 @@
 import type { z } from 'zod';
 import { GET_ARTICLE, UPDATE_ARTICLE } from './articles';
 import { CHECK_CONTENT } from './content';
+import { GET_CREATION_KIT } from './creation-kit';
 import {
   GET_AUDIT_FINDINGS,
   LIST_AUDIT_CITATIONS,
@@ -75,6 +76,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   GET_ARTICLE,
   GET_AUDIT_FINDINGS,
   GET_CALENDAR,
+  GET_CREATION_KIT,
   GET_GEO,
   GET_KEYWORDS,
   GET_PLAN,
@@ -115,6 +117,7 @@ export {
   GET_ARTICLE,
   GET_AUDIT_FINDINGS,
   GET_CALENDAR,
+  GET_CREATION_KIT,
   GET_POST,
   IMPORT_MEDIA_URL,
   LIST_AUDIT_CITATIONS,
@@ -154,6 +157,8 @@ export type {
   WebAuditIndexRow,
   WebFixRow
 } from './evidence';
+export { KIT_FORMATS } from './creation-kit';
+export type { GetCreationKitInput, GetCreationKitResult } from './creation-kit';
 export type { CreatePostInput, CreatePostResult } from './posts';
 export { PLAN_CADENCES, PLAN_CYCLE_WEEKS, SAVE_PLAN, SAVE_WEEK_SEEDS };
 export type { SavePlanInput, SavePlanResult, SaveWeekSeedsInput, SaveWeekSeedsResult } from './plans';

--- a/cli/mcp/create-post.test.ts
+++ b/cli/mcp/create-post.test.ts
@@ -150,6 +150,15 @@ describe('i tool di brand derivati dal registry', () => {
     expect(importMedia.description ?? '').toContain('https');
   });
 
+  test('get_creation_kit compare da solo, in sola lettura e senza modello', async () => {
+    const kit = find(await tools(), 'get_creation_kit');
+
+    expect(Object.keys(kit.inputSchema?.properties ?? {}).sort()).toEqual(['format', 'goal', 'platforms', 'slug']);
+    expect((kit.inputSchema?.required ?? []).sort()).toEqual(['format', 'goal', 'platforms', 'slug']);
+    expect(kit.annotations?.readOnlyHint).toBe(true);
+    expect(kit.description ?? '').toContain('no model call, no credits');
+  });
+
   test('nessun tool è registrato due volte dopo la migrazione', async () => {
     const names = (await tools()).map((t) => t.name);
 

--- a/cli/plugins/anomalia/skills/anomalia/SKILL.md
+++ b/cli/plugins/anomalia/skills/anomalia/SKILL.md
@@ -50,6 +50,12 @@ Setup details: [references/mcp.md](references/mcp.md).
 
 ## Quick workflows
 
+**Before you write anything** → `get_creation_kit` with the goal, the platforms and the format.
+It returns the smallest brief for that one job: platform limits, brand facts and approved voice,
+the matching rubric, ONE template with its hook family, the operator's own rewrites, what has
+worked on this brand, and which calendar minutes are taken. It is a selection, not the library —
+sections with nothing in them are absent. Reads only: no model, no credits.
+
 **Write a post yourself** → `create_post`. You write the copy; Anomalia stores it as
 `pending_user` and calls no model. Creating does not publish: `scheduled_for` is the proposed
 calendar time, and `approve_post` is what authorizes distribution. Hand the operator the

--- a/cli/plugins/anomalia/skills/anomalia/references/tools.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/tools.md
@@ -49,7 +49,7 @@ nothing there, so do not go looking for it elsewhere:
 - **constraints** — per requested platform: `char_limit`, `needs_media`, `video_only`; plus the
   brand's `avoid` list. Never dropped.
 - **brand** — name, language, about, audience, the products closest to your goal, and only the
-  people who consented to appear.
+  people the brand may depict — a real person who attested consent, or an AI persona.
 - **voice** — the brand's approved personality when set, otherwise the house voice. Write to it.
 - **rubric** — the approved recurring series matching your format, with its art direction. When
   present, this post is an episode of it.

--- a/cli/plugins/anomalia/skills/anomalia/references/tools.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/tools.md
@@ -23,6 +23,7 @@ All tools take a brand `slug` when brand-scoped. Ids accept short unambiguous pr
 | `get_voice` / `update_voice` | `anomalia voice <slug>` |
 | `list_products` | (studio / products views) |
 | `list_posts` | `anomalia content <slug> [--status …]` |
+| `get_creation_kit` | (MCP only) |
 | `create_post` | (MCP only) |
 | `list_media` | (MCP only) |
 | `check_content` | (MCP only) |
@@ -37,6 +38,36 @@ All tools take a brand `slug` when brand-scoped. Ids accept short unambiguous pr
 | `regenerate_slide` | `anomalia post <slug> <id> slide --index N --instruction "…"` |
 | `reorder_slides` | `anomalia post <slug> <id> reorder --order "0,2,1"` |
 | `make_video` | `anomalia post <slug> <id> video …` |
+
+`get_creation_kit` is what you read BEFORE writing. Required: `slug`, `goal` (one line saying
+what the post has to do), `platforms` (comma-separated) and `format` (`single_image`, `carousel`,
+`text_post`, `link_post`, `video`). It calls no model, spends no credits and writes nothing.
+
+It answers with only the sections that have something in them — an absent key means the brand has
+nothing there, so do not go looking for it elsewhere:
+
+- **constraints** — per requested platform: `char_limit`, `needs_media`, `video_only`; plus the
+  brand's `avoid` list. Never dropped.
+- **brand** — name, language, about, audience, the products closest to your goal, and only the
+  people who consented to appear.
+- **voice** — the brand's approved personality when set, otherwise the house voice. Write to it.
+- **rubric** — the approved recurring series matching your format, with its art direction. When
+  present, this post is an episode of it.
+- **template** — ONE structure chosen for your format, platform and goal, its hook family, and the
+  playbook for exactly the platforms you asked about.
+- **calendar** — the minutes already taken, with the campaign they belong to. Do not double-book.
+- **week** — the current editorial week's theme.
+- **operator_edits** — real before → after rewrites by the owner. Absorb the difference, never the
+  wording: it belongs to other posts.
+- **history** — what has worked on this brand: best times, formats, hashtags, cadence, the opening
+  lines that won, and `untested_hooks` — angles this brand has never opened with.
+
+`size_bytes` / `budget_bytes` / `trimmed` say how big the kit is and what, if anything, was
+dropped to fit. Everything selected carries a stable id, and `versions.kit` pins the ruleset.
+
+Past winners are evidence, not orders: they may suggest a direction, they never override a brand
+fact or authorize copying. When two things conflict, platform constraints win, then the operator's
+instruction for this artifact, then brand facts and voice, then the rubric, then the template.
 
 `list_media` lists what is already in the brand library; an id from there goes into `create_post`
 as `media_ids` and costs no render. Pass the **full** id: unlike a post id, a media id is never

--- a/cli/plugins/anomalia/skills/anomalia/references/tools.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/tools.md
@@ -53,8 +53,10 @@ nothing there, so do not go looking for it elsewhere:
 - **voice** — the brand's approved personality when set, otherwise the house voice. Write to it.
 - **rubric** — the approved recurring series matching your format, with its art direction. When
   present, this post is an episode of it.
-- **template** — ONE structure chosen for your format, platform and goal, its hook family, and the
-  playbook for exactly the platforms you asked about.
+- **template** — ONE structure for your format and platform, its hook family, and the playbook for
+  exactly the platforms you asked about. The format decides first: a `video` job always gets the
+  reel structure, never a carousel's slide plan. The goal only picks where the format leaves a
+  real choice.
 - **calendar** — the minutes already taken, with the campaign they belong to. Do not double-book.
 - **week** — the current editorial week's theme.
 - **operator_edits** — real before → after rewrites by the owner. Absorb the difference, never the

--- a/cli/skills/anomalia/SKILL.md
+++ b/cli/skills/anomalia/SKILL.md
@@ -50,6 +50,12 @@ Setup details: [references/mcp.md](references/mcp.md).
 
 ## Quick workflows
 
+**Before you write anything** → `get_creation_kit` with the goal, the platforms and the format.
+It returns the smallest brief for that one job: platform limits, brand facts and approved voice,
+the matching rubric, ONE template with its hook family, the operator's own rewrites, what has
+worked on this brand, and which calendar minutes are taken. It is a selection, not the library —
+sections with nothing in them are absent. Reads only: no model, no credits.
+
 **Write a post yourself** → `create_post`. You write the copy; Anomalia stores it as
 `pending_user` and calls no model. Creating does not publish: `scheduled_for` is the proposed
 calendar time, and `approve_post` is what authorizes distribution. Hand the operator the

--- a/cli/skills/anomalia/references/tools.md
+++ b/cli/skills/anomalia/references/tools.md
@@ -49,7 +49,7 @@ nothing there, so do not go looking for it elsewhere:
 - **constraints** — per requested platform: `char_limit`, `needs_media`, `video_only`; plus the
   brand's `avoid` list. Never dropped.
 - **brand** — name, language, about, audience, the products closest to your goal, and only the
-  people who consented to appear.
+  people the brand may depict — a real person who attested consent, or an AI persona.
 - **voice** — the brand's approved personality when set, otherwise the house voice. Write to it.
 - **rubric** — the approved recurring series matching your format, with its art direction. When
   present, this post is an episode of it.

--- a/cli/skills/anomalia/references/tools.md
+++ b/cli/skills/anomalia/references/tools.md
@@ -23,6 +23,7 @@ All tools take a brand `slug` when brand-scoped. Ids accept short unambiguous pr
 | `get_voice` / `update_voice` | `anomalia voice <slug>` |
 | `list_products` | (studio / products views) |
 | `list_posts` | `anomalia content <slug> [--status …]` |
+| `get_creation_kit` | (MCP only) |
 | `create_post` | (MCP only) |
 | `list_media` | (MCP only) |
 | `check_content` | (MCP only) |
@@ -37,6 +38,36 @@ All tools take a brand `slug` when brand-scoped. Ids accept short unambiguous pr
 | `regenerate_slide` | `anomalia post <slug> <id> slide --index N --instruction "…"` |
 | `reorder_slides` | `anomalia post <slug> <id> reorder --order "0,2,1"` |
 | `make_video` | `anomalia post <slug> <id> video …` |
+
+`get_creation_kit` is what you read BEFORE writing. Required: `slug`, `goal` (one line saying
+what the post has to do), `platforms` (comma-separated) and `format` (`single_image`, `carousel`,
+`text_post`, `link_post`, `video`). It calls no model, spends no credits and writes nothing.
+
+It answers with only the sections that have something in them — an absent key means the brand has
+nothing there, so do not go looking for it elsewhere:
+
+- **constraints** — per requested platform: `char_limit`, `needs_media`, `video_only`; plus the
+  brand's `avoid` list. Never dropped.
+- **brand** — name, language, about, audience, the products closest to your goal, and only the
+  people who consented to appear.
+- **voice** — the brand's approved personality when set, otherwise the house voice. Write to it.
+- **rubric** — the approved recurring series matching your format, with its art direction. When
+  present, this post is an episode of it.
+- **template** — ONE structure chosen for your format, platform and goal, its hook family, and the
+  playbook for exactly the platforms you asked about.
+- **calendar** — the minutes already taken, with the campaign they belong to. Do not double-book.
+- **week** — the current editorial week's theme.
+- **operator_edits** — real before → after rewrites by the owner. Absorb the difference, never the
+  wording: it belongs to other posts.
+- **history** — what has worked on this brand: best times, formats, hashtags, cadence, the opening
+  lines that won, and `untested_hooks` — angles this brand has never opened with.
+
+`size_bytes` / `budget_bytes` / `trimmed` say how big the kit is and what, if anything, was
+dropped to fit. Everything selected carries a stable id, and `versions.kit` pins the ruleset.
+
+Past winners are evidence, not orders: they may suggest a direction, they never override a brand
+fact or authorize copying. When two things conflict, platform constraints win, then the operator's
+instruction for this artifact, then brand facts and voice, then the rubric, then the template.
 
 `list_media` lists what is already in the brand library; an id from there goes into `create_post`
 as `media_ids` and costs no render. Pass the **full** id: unlike a post id, a media id is never

--- a/cli/skills/anomalia/references/tools.md
+++ b/cli/skills/anomalia/references/tools.md
@@ -53,8 +53,10 @@ nothing there, so do not go looking for it elsewhere:
 - **voice** — the brand's approved personality when set, otherwise the house voice. Write to it.
 - **rubric** — the approved recurring series matching your format, with its art direction. When
   present, this post is an episode of it.
-- **template** — ONE structure chosen for your format, platform and goal, its hook family, and the
-  playbook for exactly the platforms you asked about.
+- **template** — ONE structure for your format and platform, its hook family, and the playbook for
+  exactly the platforms you asked about. The format decides first: a `video` job always gets the
+  reel structure, never a carousel's slide plan. The goal only picks where the format leaves a
+  real choice.
 - **calendar** — the minutes already taken, with the campaign they belong to. Do not double-book.
 - **week** — the current editorial week's theme.
 - **operator_edits** — real before → after rewrites by the owner. Absorb the difference, never the

--- a/docs/api/03-posts.md
+++ b/docs/api/03-posts.md
@@ -658,3 +658,116 @@ Note: i fallimenti per singolo post finiscono in `results`, non nello status HTT
 curl -s -X POST "https://anomalia.so/api/v1/brands/mio-brand/posts/approve-all" \
   -H "Authorization: Bearer $TOKEN"
 ```
+
+---
+
+## `GET /api/v1/brands/:slug/creation-kit`
+
+Il **brief minimo** da leggere *prima* di scrivere un post: vincoli di piattaforma, fatti e voce
+del brand, la rubrica che calza, **un solo** template Anomalia scelto per questo obiettivo e
+formato, le riscritture del proprietario, cosa ha funzionato su questo brand e quali minuti del
+calendario sono già occupati.
+
+Non chiama nessun modello, non consuma crediti e non scrive niente: una API key di sola lettura
+può chiamarla. Gli asset stanno in `GET /media`; controllare una bozza è `POST /content/check`.
+
+**La selezione è la funzione.** Il kit non è la libreria: le sezioni senza contenuto sono
+**assenti** (mai presenti e vuote), e l'intera risposta è tagliata a `budget_bytes`. Un kit tipico
+pesa 3,8–5,4 KB.
+
+**Query**
+
+| Campo | Tipo | Obbligatorio | Descrizione |
+|---|---|---|---|
+| `goal` | string (≤300) | Sì | Cosa deve fare questo post, in una riga. Sceglie il template e ordina prodotti ed esempi |
+| `platforms` | string | Sì | Separate da virgola: `instagram,linkedin`. Normalizzate e deduplicate |
+| `format` | enum | Sì | `single_image` \| `carousel` \| `text_post` \| `link_post` \| `video` |
+
+**Response** `200`:
+
+```json
+{
+  "job": { "goal": "launch the espresso grinder", "platforms": ["linkedin"], "format": "text_post" },
+  "versions": { "kit": 1 },
+  "size_bytes": 5378,
+  "budget_bytes": 8192,
+  "trimmed": [],
+  "constraints": {
+    "platforms": [{ "platform": "linkedin", "char_limit": 3000, "needs_media": false, "video_only": false }],
+    "avoid": ["eccellenza", "sinergia"]
+  },
+  "brand": {
+    "name": "Caffè Nero",
+    "language": "it",
+    "about": "Torrefazione artigianale a Trieste dal 1998…",
+    "audience": "Bar indipendenti e uffici…",
+    "products": [{ "id": "…", "title": "Espresso grinder Mk II", "pricing": "890 €" }],
+    "people": [{ "id": "…", "name": "Marta Rossi", "role": "Head roaster" }]
+  },
+  "voice": { "text": "BRAND PERSONALITY (authoritative — …)" },
+  "rubric": { "id": "…", "name": "Lettere dal lab", "format": "text_post", "art_direction": "foto in bianco e nero" },
+  "template": {
+    "id": "linkedin-post-templates/the-story-post",
+    "name": "The Story Post",
+    "group": "LinkedIn Post Templates",
+    "body": "[Hook: Unexpected outcome or lesson]…",
+    "hooks": { "id": "hook-formulas/story-hooks", "name": "Story Hooks", "body": "- \"Last week, …\"" },
+    "playbook": "PLATFORM PLAYBOOK (…): - linkedin — …"
+  },
+  "calendar": { "occupied": [{ "scheduled_for": "2026-09-05T07:00:00.000Z", "platforms": ["linkedin"], "campaign": "Grinder launch", "step": "announcement" }] },
+  "week": { "index": 0, "theme": "La settimana del grinder" },
+  "operator_edits": [{ "before": "Siamo entusiasti di annunciare…", "after": "Nuovo grinder. Macina 18g in 4 secondi." }],
+  "history": {
+    "post_count": 24,
+    "best_times": ["Sat 09:00"],
+    "top_formats": ["image"],
+    "top_hashtags": ["#caffe", "#tostatura"],
+    "cadence": "~8 posts/week",
+    "untested_hooks": ["contrast", "confession"],
+    "winners": [{ "id": "…", "platform": "linkedin", "opening": "Abbiamo rotto il grinder 23 volte." }]
+  }
+}
+```
+
+**Identificatori stabili.** Ogni pezzo selezionato è citabile: `template.id` e `template.hooks.id`
+(dal file di riferimento `post-templates.md`), `rubric.id`, `brand.products[].id`,
+`brand.people[].id`, `history.winners[].id`. `versions.kit` sale quando cambia la selezione o la
+forma della risposta: due kit si confrontano solo se hanno la stessa versione.
+
+**Come sceglie**
+
+| Sezione | Da dove viene | Come è selezionata |
+|---|---|---|
+| `constraints` | `platform-limits.ts` | Solo le piattaforme richieste |
+| `brand` | `brand_kit`, `products`, `people` | Prodotti ordinati per sovrapposizione lessicale col `goal`, massimo 5. Solo le persone con `consent = true` |
+| `voice` | `houseVoiceFor` | La personalità approvata quando c'è, altrimenti la house voice |
+| `rubric` | `rubrics` (approvate) | Solo quelle del `format` richiesto, poi la più vicina al `goal` |
+| `template` | `post-templates.md` | Un gruppo dal formato+piattaforma, un blocco dal `goal`, più una famiglia di hook |
+| `calendar` | `posts` | Solo i minuti già occupati da qui in avanti, massimo 8 |
+| `week` | `editorial_plans` attivo | Solo la settimana corrente |
+| `operator_edits` | `content_prefs.captionEditPairs` | Le ultime 3 riscritture reali del proprietario |
+| `history` | `social_post_history` (`source='zernio'`) | Solo i post del brand, vincitori filtrati sulle piattaforme richieste |
+
+**Il budget.** Ogni campo ha un tetto in caratteri, quindi il kit sta nel budget *per
+costruzione*. Se dovesse comunque sforare, le sezioni cedono dalla meno autorevole alla più —
+`history`, `operator_edits`, `week`, `calendar`, `template`, `rubric`, `voice`, `brand` — e
+`trimmed` elenca cosa è caduto. `constraints` non cade mai. L'ordine è la precedenza dichiarata nel
+piano: i vincoli di piattaforma vincono su tutto, e i vincitori passati sono *evidenza*, non
+istruzioni.
+
+**Errori**
+
+| `error` | Status | Quando |
+|---|---|---|
+| `invalid_input` | 400 | Campo mancante, formato sconosciuto o campo non previsto (lo schema è `.strict()`) |
+| `no_platforms` | 400 | `platforms` non contiene nessuna piattaforma |
+
+**Esempio**:
+
+```bash
+curl -s -G "https://anomalia.so/api/v1/brands/mio-brand/creation-kit" \
+  --data-urlencode "goal=launch the espresso grinder" \
+  --data-urlencode "platforms=linkedin,instagram" \
+  --data-urlencode "format=text_post" \
+  -H "Authorization: Bearer $TOKEN"
+```

--- a/docs/api/03-posts.md
+++ b/docs/api/03-posts.md
@@ -739,7 +739,7 @@ forma della risposta: due kit si confrontano solo se hanno la stessa versione.
 | Sezione | Da dove viene | Come è selezionata |
 |---|---|---|
 | `constraints` | `platform-limits.ts` | Solo le piattaforme richieste |
-| `brand` | `brand_kit`, `products`, `people` | Prodotti ordinati per sovrapposizione lessicale col `goal`, massimo 5. Solo le persone con `consent = true` |
+| `brand` | `brand_kit`, `products`, `people` | Prodotti ordinati per sovrapposizione lessicale col `goal`, massimo 5. Solo le persone che passano `likenessConsented` (reali con consenso attestato, più le persona AI, che non ritraggono nessuno) |
 | `voice` | `houseVoiceFor` | La personalità approvata quando c'è, altrimenti la house voice |
 | `rubric` | `rubrics` (approvate) | Solo quelle del `format` richiesto, poi la più vicina al `goal` |
 | `template` | `post-templates.md` | Un gruppo dal formato+piattaforma, un blocco dal `goal`, più una famiglia di hook |

--- a/docs/api/03-posts.md
+++ b/docs/api/03-posts.md
@@ -742,7 +742,7 @@ forma della risposta: due kit si confrontano solo se hanno la stessa versione.
 | `brand` | `brand_kit`, `products`, `people` | Prodotti ordinati per sovrapposizione lessicale col `goal`, massimo 5. Solo le persone che passano `likenessConsented` (reali con consenso attestato, più le persona AI, che non ritraggono nessuno) |
 | `voice` | `houseVoiceFor` | La personalità approvata quando c'è, altrimenti la house voice |
 | `rubric` | `rubrics` (approvate) | Solo quelle del `format` richiesto, poi la più vicina al `goal` |
-| `template` | `post-templates.md` | Un gruppo dal formato+piattaforma, un blocco dal `goal`, più una famiglia di hook |
+| `template` | `post-templates.md` | Il formato e la piattaforma scelgono il gruppo; quando il formato decide da solo (`carousel`, `video`) il blocco è fissato, altrimenti lo sceglie il `goal`. Più una famiglia di hook |
 | `calendar` | `posts` | Solo i minuti già occupati da qui in avanti, massimo 8 |
 | `week` | `editorial_plans` attivo | Solo la settimana corrente |
 | `operator_edits` | `content_prefs.captionEditPairs` | Le ultime 3 riscritture reali del proprietario |

--- a/packages/api-contracts/src/creation-kit.ts
+++ b/packages/api-contracts/src/creation-kit.ts
@@ -1,0 +1,118 @@
+import { z } from 'zod';
+import type { BrandEndpoint } from './index';
+
+// Mirrors CONTENT_FORMATS in src/lib/content-formats.ts, which this package may not import.
+// src/lib/server/creation-kit.test.ts fails if the two ever disagree.
+export const KIT_FORMATS = ['single_image', 'carousel', 'text_post', 'link_post', 'video'] as const;
+
+const GetCreationKitInputSchema = z
+  .object({
+    goal: z
+      .string()
+      .min(1)
+      .max(300)
+      .describe('What this post has to achieve, in one line. It selects the template and ranks the products and examples'),
+    platforms: z
+      .string()
+      .min(1)
+      .describe('Where it would be published, comma-separated: "instagram,linkedin"'),
+    format: z.enum(KIT_FORMATS).describe('The format you intend to write')
+  })
+  .strict();
+
+const TemplateSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  group: z.string(),
+  body: z.string(),
+  hooks: z.object({ id: z.string(), name: z.string(), body: z.string() }).optional(),
+  playbook: z.string()
+});
+
+const GetCreationKitResultSchema = z.object({
+  job: z.object({ goal: z.string(), platforms: z.array(z.string()), format: z.enum(KIT_FORMATS) }),
+  versions: z.object({ kit: z.number() }),
+  size_bytes: z.number(),
+  budget_bytes: z.number(),
+  trimmed: z.array(z.string()),
+  constraints: z.object({
+    platforms: z.array(
+      z.object({
+        platform: z.string(),
+        char_limit: z.number().nullable(),
+        needs_media: z.boolean(),
+        video_only: z.boolean()
+      })
+    ),
+    avoid: z.array(z.string())
+  }),
+  brand: z
+    .object({
+      name: z.string(),
+      language: z.string().optional(),
+      about: z.string().optional(),
+      audience: z.string().optional(),
+      products: z.array(z.object({ id: z.string(), title: z.string(), pricing: z.string().optional() })).optional(),
+      people: z.array(z.object({ id: z.string(), name: z.string(), role: z.string().optional() })).optional()
+    })
+    .optional(),
+  voice: z.object({ text: z.string() }).optional(),
+  rubric: z
+    .object({
+      id: z.string().optional(),
+      name: z.string(),
+      format: z.string(),
+      promise: z.string().optional(),
+      cadence: z.string().optional(),
+      art_direction: z.string().optional()
+    })
+    .optional(),
+  template: TemplateSchema.optional(),
+  calendar: z
+    .object({
+      occupied: z.array(
+        z.object({
+          scheduled_for: z.string(),
+          platforms: z.array(z.string()),
+          campaign: z.string().optional(),
+          step: z.string().optional()
+        })
+      )
+    })
+    .optional(),
+  week: z.object({ index: z.number(), theme: z.string() }).optional(),
+  operator_edits: z.array(z.object({ before: z.string(), after: z.string() })).optional(),
+  history: z
+    .object({
+      post_count: z.number(),
+      best_times: z.array(z.string()),
+      top_formats: z.array(z.string()),
+      top_hashtags: z.array(z.string()),
+      cadence: z.string().optional(),
+      untested_hooks: z.array(z.string()),
+      winners: z.array(z.object({ id: z.string(), platform: z.string(), opening: z.string() }))
+    })
+    .optional()
+});
+
+export type GetCreationKitInput = z.infer<typeof GetCreationKitInputSchema>;
+export type GetCreationKitResult = z.infer<typeof GetCreationKitResultSchema>;
+
+export const GET_CREATION_KIT = {
+  tool: 'get_creation_kit',
+  title: 'Creation kit',
+  description:
+    'The smallest brief you need before writing one post: the platform constraints, the brand ' +
+    'facts and approved voice, the matching rubric, ONE Anomalia template chosen for this goal ' +
+    'and format, the operator\'s own rewrites, what has worked on this brand, and which calendar ' +
+    'minutes are taken. It is a SELECTION, not the library: sections with nothing in them are ' +
+    'absent, and the whole kit is capped so it never floods your context. Reads only — no model ' +
+    'call, no credits, nothing written. Assets live in list_media; checking a draft is ' +
+    'check_content.',
+  method: 'GET',
+  pathUnderBrand: '/creation-kit',
+  input: GetCreationKitInputSchema,
+  output: GetCreationKitResultSchema,
+  failures: [{ error: 'no_platforms', status: 400 }],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -1,6 +1,7 @@
 import type { z } from 'zod';
 import { GET_ARTICLE, UPDATE_ARTICLE } from './articles';
 import { CHECK_CONTENT } from './content';
+import { GET_CREATION_KIT } from './creation-kit';
 import {
   GET_AUDIT_FINDINGS,
   LIST_AUDIT_CITATIONS,
@@ -75,6 +76,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   GET_ARTICLE,
   GET_AUDIT_FINDINGS,
   GET_CALENDAR,
+  GET_CREATION_KIT,
   GET_GEO,
   GET_KEYWORDS,
   GET_PLAN,
@@ -115,6 +117,7 @@ export {
   GET_ARTICLE,
   GET_AUDIT_FINDINGS,
   GET_CALENDAR,
+  GET_CREATION_KIT,
   GET_POST,
   IMPORT_MEDIA_URL,
   LIST_AUDIT_CITATIONS,
@@ -154,6 +157,8 @@ export type {
   WebAuditIndexRow,
   WebFixRow
 } from './evidence';
+export { KIT_FORMATS } from './creation-kit';
+export type { GetCreationKitInput, GetCreationKitResult } from './creation-kit';
 export type { CreatePostInput, CreatePostResult } from './posts';
 export { PLAN_CADENCES, PLAN_CYCLE_WEEKS, SAVE_PLAN, SAVE_WEEK_SEEDS };
 export type { SavePlanInput, SavePlanResult, SaveWeekSeedsInput, SaveWeekSeedsResult } from './plans';

--- a/src/lib/content/changelog/2026-09-03-external-agent-creation-kit.ts
+++ b/src/lib/content/changelog/2026-09-03-external-agent-creation-kit.ts
@@ -1,0 +1,11 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-03',
+  title: 'Your own AI can read the brief before it writes',
+  items: [
+    'A new tool, get_creation_kit, hands your AI the brief for one post: platform limits, your brand facts and approved voice, the recurring series it belongs to, one template chosen for that goal and format, your own rewrites of past captions, what has worked on your brand, and which calendar minutes are taken.',
+    'It is a selection, not a data dump: only the sections that actually have something appear, and the whole brief is capped so it never floods your model with the library.',
+    'It reads only — no model call, no credits, nothing written — so a read-only API key can use it before every draft.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/creation-kit.test.ts
+++ b/src/lib/server/creation-kit.test.ts
@@ -75,6 +75,23 @@ describe('il creation kit seleziona invece di svuotare la libreria', () => {
     expect(JSON.stringify(kit)).not.toContain('The Story Post');
   });
 
+  it('il formato batte il goal: un video non riceve la struttura di un carosello', async () => {
+    const clip = 'show the tasting bench in a short clip';
+    const video = await buildCreationKit(
+      fakeSupabase(tables()) as never,
+      BRAND as never,
+      job({ goal: clip, platforms: ['instagram'], format: 'video' })
+    );
+    const carousel = await buildCreationKit(
+      fakeSupabase(tables()) as never,
+      BRAND as never,
+      job({ goal: clip, platforms: ['instagram'], format: 'carousel' })
+    );
+
+    expect(video.template?.name).toBe('The Reel Script');
+    expect(carousel.template?.name).toBe('The Carousel Hook');
+  });
+
   it('il goal sceglie fra i template dello stesso gruppo', async () => {
     const contrarian = await buildCreationKit(
       fakeSupabase(tables()) as never,

--- a/src/lib/server/creation-kit.test.ts
+++ b/src/lib/server/creation-kit.test.ts
@@ -255,6 +255,18 @@ describe('il creation kit è tracciabile e chiuso sul brand', () => {
     expect(kit.history?.winners[0]?.id).toBe('h-win');
   });
 
+  it('nomina solo le persone che la regola del likeness lascia passare', async () => {
+    const people = [
+      { id: 'pe-real-no', brand_id: BRAND.id, name: 'Volto Senza Consenso', kind: 'real', consent: false },
+      { id: 'pe-real-yes', brand_id: BRAND.id, name: 'Marta Rossi', kind: 'real', consent: true },
+      { id: 'pe-ai', brand_id: BRAND.id, name: 'Persona AI', kind: 'ai', consent: false }
+    ];
+    const kit = await buildCreationKit(fakeSupabase(tables({ people })) as never, BRAND as never, job());
+
+    expect(kit.brand?.people?.map((p) => p.id).sort()).toEqual(['pe-ai', 'pe-real-yes']);
+    expect(JSON.stringify(kit)).not.toContain('Volto Senza Consenso');
+  });
+
   it('non fa entrare il materiale di un altro brand', async () => {
     const kit = await buildCreationKit(
       fakeSupabase(

--- a/src/lib/server/creation-kit.test.ts
+++ b/src/lib/server/creation-kit.test.ts
@@ -1,0 +1,303 @@
+import { describe, it, expect } from 'vitest';
+import { CONTENT_FORMATS } from '$lib/content-formats';
+import { KIT_FORMATS } from '@anomalia/api-contracts';
+import { CREATION_KIT_MAX_BYTES, buildCreationKit, type KitJob } from './creation-kit';
+
+type Row = Record<string, unknown>;
+
+// A supabase double that actually APPLIES the .eq() filters, so "another brand's material never
+// appears" is proven by the same mechanism the real client uses, not by a mock that agrees.
+function fakeSupabase(tables: Record<string, Row[]>) {
+  return {
+    from(table: string) {
+      let rows = [...(tables[table] ?? [])];
+      const q = {
+        select: () => q,
+        eq(column: string, value: unknown) {
+          rows = rows.filter((r) => r[column] === value);
+          return q;
+        },
+        in(column: string, values: unknown[]) {
+          rows = rows.filter((r) => values.includes(r[column]));
+          return q;
+        },
+        gte(column: string, value: string) {
+          rows = rows.filter((r) => String(r[column] ?? '') >= value);
+          return q;
+        },
+        order: () => q,
+        limit(n: number) {
+          rows = rows.slice(0, n);
+          return q;
+        },
+        maybeSingle: async () => ({ data: rows[0] ?? null, error: null }),
+        then: (resolve: (v: { data: Row[]; error: null }) => unknown) => resolve({ data: rows, error: null })
+      };
+      return q;
+    }
+  };
+}
+
+const BRAND = {
+  id: 'brand-1',
+  name: 'Caffè Nero',
+  slug: 'caffe-nero',
+  timezone: 'Europe/Rome',
+  target_platforms: ['instagram', 'linkedin'],
+  content_prefs: {}
+};
+
+const OTHER = 'brand-2';
+
+function job(over: Partial<KitJob> = {}): KitJob {
+  return { goal: 'launch the new espresso grinder', platforms: ['linkedin'], format: 'text_post', ...over };
+}
+
+function tables(over: Record<string, Row[]> = {}): Record<string, Row[]> {
+  return {
+    brand_kit: [],
+    products: [],
+    people: [],
+    rubrics: [],
+    social_post_history: [],
+    editorial_plans: [],
+    posts: [],
+    ...over
+  };
+}
+
+describe('il creation kit seleziona invece di svuotare la libreria', () => {
+  it('porta un solo template, scelto per il formato richiesto', async () => {
+    const kit = await buildCreationKit(fakeSupabase(tables()) as never, BRAND as never, job({ format: 'carousel' }));
+
+    expect(kit.template?.group).toBe('Instagram Templates');
+    expect(kit.template?.name).toBe('The Carousel Hook');
+    expect(JSON.stringify(kit)).not.toContain('The Story Post');
+  });
+
+  it('il goal sceglie fra i template dello stesso gruppo', async () => {
+    const contrarian = await buildCreationKit(
+      fakeSupabase(tables()) as never,
+      BRAND as never,
+      job({ goal: 'state an unpopular opinion about agency retainers' })
+    );
+    const story = await buildCreationKit(
+      fakeSupabase(tables()) as never,
+      BRAND as never,
+      job({ goal: 'tell the lesson we learned when the roaster broke down' })
+    );
+
+    expect(contrarian.template?.name).toBe('The Contrarian Take');
+    expect(story.template?.name).not.toBe('The Contrarian Take');
+  });
+
+  it('il playbook copre solo le piattaforme richieste', async () => {
+    const kit = await buildCreationKit(
+      fakeSupabase(tables()) as never,
+      BRAND as never,
+      job({ platforms: ['linkedin'] })
+    );
+
+    expect(kit.template?.playbook.toLowerCase()).toContain('linkedin');
+    expect(kit.template?.playbook.toLowerCase()).not.toContain('tiktok');
+    expect(kit.constraints.platforms.map((p) => p.platform)).toEqual(['linkedin']);
+  });
+
+  it('tiene solo le rubriche del formato richiesto', async () => {
+    const rubrics = [
+      { id: 'r-carousel', brand_id: BRAND.id, status: 'approved', name: 'Dietro le quinte', format: 'carousel', art_direction: 'reportage' },
+      { id: 'r-text', brand_id: BRAND.id, status: 'approved', name: 'Lettere dal lab', format: 'text_post' }
+    ];
+    const kit = await buildCreationKit(
+      fakeSupabase(tables({ rubrics })) as never,
+      BRAND as never,
+      job({ format: 'text_post' })
+    );
+
+    expect(kit.rubric?.id).toBe('r-text');
+    expect(JSON.stringify(kit)).not.toContain('Dietro le quinte');
+  });
+
+  it('classifica i prodotti sul goal invece di elencarli tutti', async () => {
+    const products = Array.from({ length: 30 }, (_, i) => ({
+      id: `p-${i}`,
+      brand_id: BRAND.id,
+      title: `Filtro carta misura ${i}`,
+      pricing: '4 €'
+    }));
+    products.push({ id: 'p-grinder', brand_id: BRAND.id, title: 'Espresso grinder Mk II', pricing: '890 €' });
+
+    const kit = await buildCreationKit(fakeSupabase(tables({ products })) as never, BRAND as never, job());
+
+    expect(kit.brand?.products?.[0]?.id).toBe('p-grinder');
+    expect(kit.brand?.products?.length).toBeLessThanOrEqual(5);
+  });
+});
+
+const HUGE = 'parola '.repeat(4000);
+
+// A brand that maxes out every capped field at once — the only shape that can still overflow the
+// budget once the per-field caps have done their work.
+function maximalTables() {
+  return tables({
+    brand_kit: [{ brand_id: BRAND.id, about: HUGE, target_audience: HUGE }],
+    products: Array.from({ length: 200 }, (_, i) => ({ id: `p-${i}`, brand_id: BRAND.id, title: HUGE, pricing: HUGE })),
+    people: Array.from({ length: 10 }, (_, i) => ({ id: `pe-${i}`, brand_id: BRAND.id, name: HUGE, role: HUGE, consent: true })),
+    rubrics: [
+      { id: 'r-text', brand_id: BRAND.id, status: 'approved', name: 'Lettere', format: 'text_post', promise: HUGE, cadence: HUGE, art_direction: HUGE }
+    ],
+    editorial_plans: [{ brand_id: BRAND.id, status: 'active', weeks: [{ index: 0, week_start: '2020-01-06', theme: HUGE }] }],
+    posts: Array.from({ length: 20 }, (_, i) => ({
+      id: `po-${i}`,
+      brand_id: BRAND.id,
+      status: 'approved',
+      scheduled_for: `2099-01-0${(i % 9) + 1}T09:00:00.000Z`,
+      platform: 'linkedin',
+      campaign_name: HUGE,
+      campaign_step: HUGE
+    })),
+    social_post_history: Array.from({ length: 60 }, (_, i) => ({
+      id: `h-${i}`,
+      brand_id: BRAND.id,
+      source: 'zernio',
+      platform: 'linkedin',
+      content: `${HUGE} #tag${i}`,
+      media_type: 'image',
+      published_at: `2026-08-0${(i % 9) + 1}T0${i % 9}:00:00.000Z`,
+      metrics: { likes: i, comments: i }
+    }))
+  });
+}
+
+const MAXIMAL_PREFS = {
+  language: 'italiano',
+  avoid: Array.from({ length: 30 }, (_, i) => `parolaccia-${i}`),
+  captionEditPairs: [
+    { before: HUGE, after: HUGE },
+    { before: HUGE, after: HUGE },
+    { before: HUGE, after: HUGE }
+  ]
+};
+
+describe('il creation kit resta dentro il budget', () => {
+  it('non supera il tetto e cede per prime le sezioni meno autorevoli', async () => {
+    const kit = await buildCreationKit(
+      fakeSupabase(maximalTables()) as never,
+      { ...BRAND, content_prefs: MAXIMAL_PREFS } as never,
+      job()
+    );
+
+    expect(kit.budget_bytes).toBe(CREATION_KIT_MAX_BYTES);
+    expect(Buffer.byteLength(JSON.stringify(kit), 'utf8')).toBeLessThanOrEqual(CREATION_KIT_MAX_BYTES);
+    expect(kit.size_bytes).toBeLessThanOrEqual(CREATION_KIT_MAX_BYTES);
+    expect(kit.trimmed.length).toBeGreaterThan(0);
+    expect(kit.trimmed[0]).toBe('history');
+  });
+
+  it('i vincoli di piattaforma e i fatti del brand non vengono mai sacrificati', async () => {
+    const kit = await buildCreationKit(
+      fakeSupabase(maximalTables()) as never,
+      { ...BRAND, content_prefs: MAXIMAL_PREFS } as never,
+      job({ platforms: ['x'] })
+    );
+
+    expect(kit.constraints.platforms[0]).toMatchObject({ platform: 'x', char_limit: 280 });
+    expect(kit.brand?.name).toBe('Caffè Nero');
+    expect(kit.trimmed).not.toContain('constraints');
+    expect(kit.trimmed).not.toContain('brand');
+  });
+
+  it('un brand normale non perde niente per il budget', async () => {
+    const kit = await buildCreationKit(
+      fakeSupabase(
+        tables({
+          brand_kit: [{ brand_id: BRAND.id, about: 'Torrefazione a Trieste dal 1998.', target_audience: 'Bar indipendenti.' }],
+          products: [{ id: 'p-1', brand_id: BRAND.id, title: 'Espresso grinder Mk II', pricing: '890 €' }],
+          rubrics: [{ id: 'r-text', brand_id: BRAND.id, status: 'approved', name: 'Lettere dal lab', format: 'text_post' }]
+        })
+      ) as never,
+      BRAND as never,
+      job()
+    );
+
+    expect(kit.trimmed).toEqual([]);
+    expect(kit.size_bytes).toBeLessThan(CREATION_KIT_MAX_BYTES);
+  });
+});
+
+describe('il creation kit è tracciabile e chiuso sul brand', () => {
+  it('ogni pezzo selezionato porta un identificatore stabile e la versione delle regole', async () => {
+    const kit = await buildCreationKit(
+      fakeSupabase(
+        tables({
+          rubrics: [{ id: 'r-text', brand_id: BRAND.id, status: 'approved', name: 'Lettere', format: 'text_post' }],
+          social_post_history: [
+            {
+              id: 'h-win',
+              brand_id: BRAND.id,
+              source: 'zernio',
+              platform: 'linkedin',
+              content: 'Il grinder che abbiamo rotto tre volte.',
+              media_type: 'image',
+              published_at: '2026-08-01T09:00:00.000Z',
+              metrics: { likes: 90, comments: 20 }
+            }
+          ]
+        })
+      ) as never,
+      BRAND as never,
+      job()
+    );
+
+    expect(kit.versions.kit).toBeGreaterThan(0);
+    expect(kit.template?.id).toMatch(/^[a-z0-9-]+\/[a-z0-9-]+$/);
+    expect(kit.rubric?.id).toBe('r-text');
+    expect(kit.history?.winners[0]?.id).toBe('h-win');
+  });
+
+  it('non fa entrare il materiale di un altro brand', async () => {
+    const kit = await buildCreationKit(
+      fakeSupabase(
+        tables({
+          brand_kit: [{ brand_id: OTHER, about: 'SEGRETO-ALTRUI', target_audience: 'SEGRETO-ALTRUI' }],
+          products: [{ id: 'p-x', brand_id: OTHER, title: 'SEGRETO-ALTRUI espresso grinder' }],
+          people: [{ id: 'pe-x', brand_id: OTHER, name: 'SEGRETO-ALTRUI', consent: true }],
+          rubrics: [{ id: 'r-x', brand_id: OTHER, status: 'approved', name: 'SEGRETO-ALTRUI', format: 'text_post' }],
+          social_post_history: [
+            {
+              id: 'h-x',
+              brand_id: OTHER,
+              source: 'zernio',
+              platform: 'linkedin',
+              content: 'SEGRETO-ALTRUI',
+              published_at: '2026-08-01T09:00:00.000Z',
+              metrics: { likes: 900 }
+            }
+          ],
+          editorial_plans: [{ brand_id: OTHER, status: 'active', weeks: [{ index: 0, week_start: '2026-09-01', theme: 'SEGRETO-ALTRUI' }] }],
+          posts: [{ id: 'po-x', brand_id: OTHER, scheduled_for: '2099-01-01T09:00:00.000Z', campaign_name: 'SEGRETO-ALTRUI', status: 'approved' }]
+        })
+      ) as never,
+      BRAND as never,
+      job()
+    );
+
+    expect(JSON.stringify(kit)).not.toContain('SEGRETO-ALTRUI');
+  });
+
+  it('un brand appena creato produce un kit piccolo e coerente, non un muro di null', async () => {
+    const kit = await buildCreationKit(fakeSupabase(tables()) as never, BRAND as never, job());
+
+    expect(kit.constraints.platforms.length).toBe(1);
+    expect(kit.brand?.name).toBe('Caffè Nero');
+    expect(kit).not.toHaveProperty('history');
+    expect(kit).not.toHaveProperty('rubric');
+    expect(kit).not.toHaveProperty('operator_edits');
+    expect(kit).not.toHaveProperty('week');
+    expect(JSON.stringify(kit)).not.toContain('null');
+  });
+
+  it('il contratto e il catalogo dei formati non possono divergere', () => {
+    expect([...KIT_FORMATS]).toEqual([...CONTENT_FORMATS]);
+  });
+});

--- a/src/lib/server/creation-kit.ts
+++ b/src/lib/server/creation-kit.ts
@@ -13,6 +13,7 @@
  * rubrics, the owner's rewrites, the brand's own history, the calendar. What this file owns is
  * KIT_SECTIONS: which sections exist, in what order they yield when the budget runs out.
  */
+import type { GetCreationKitResult } from '@anomalia/api-contracts';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import POST_TEMPLATES from '$lib/agent-docs/skills/social/references/post-templates.md?raw';
 import type { ContentFormat } from '$lib/content-formats';
@@ -129,28 +130,35 @@ const TEMPLATES = parseTemplates(POST_TEMPLATES);
 const HOOK_GROUP = 'Hook Formulas';
 
 /**
- * Which template group a job draws from — the ONE place a format or a platform earns a different
+ * Which templates a job may draw from — the ONE place a format or a platform earns a different
  * answer. First matching row wins; `format: null` matches any format, `platform: null` any
- * platform. Inside the chosen group the goal picks the single block.
+ * platform. `pins` names the block the FORMAT decides on its own, because a requested format is a
+ * hard constraint and outranks the goal: a video job asking for a short clip must never come back
+ * with a carousel's slide plan. Where `pins` is null the format leaves a real choice, and the goal
+ * picks inside the group.
  */
 const TEMPLATE_ROUTES: ReadonlyArray<{
   format: ContentFormat | null;
   platform: string | null;
   group: string;
+  pins: string | null;
 }> = [
-  { format: 'carousel', platform: null, group: 'Instagram Templates' },
-  { format: 'video', platform: null, group: 'Instagram Templates' },
-  { format: null, platform: 'x', group: 'Twitter/X Thread Templates' },
-  { format: null, platform: 'twitter', group: 'Twitter/X Thread Templates' },
-  { format: null, platform: null, group: 'LinkedIn Post Templates' }
+  { format: 'carousel', platform: null, group: 'Instagram Templates', pins: 'The Carousel Hook' },
+  { format: 'video', platform: null, group: 'Instagram Templates', pins: 'The Reel Script' },
+  { format: null, platform: 'x', group: 'Twitter/X Thread Templates', pins: null },
+  { format: null, platform: 'twitter', group: 'Twitter/X Thread Templates', pins: null },
+  { format: null, platform: null, group: 'LinkedIn Post Templates', pins: null }
 ];
 
-function groupForJob(job: KitJob): string {
+const FALLBACK_ROUTE = TEMPLATE_ROUTES[TEMPLATE_ROUTES.length - 1];
+
+function routeForJob(job: KitJob) {
   const wanted = new Set(job.platforms.map((p) => p.toLowerCase()));
-  const route = TEMPLATE_ROUTES.find(
-    (r) => (r.format === null || r.format === job.format) && (r.platform === null || wanted.has(r.platform))
+  return (
+    TEMPLATE_ROUTES.find(
+      (r) => (r.format === null || r.format === job.format) && (r.platform === null || wanted.has(r.platform))
+    ) ?? FALLBACK_ROUTE
   );
-  return route?.group ?? 'LinkedIn Post Templates';
 }
 
 // ── Goal ranking ─────────────────────────────────────────────────────────
@@ -294,12 +302,11 @@ function buildRubric({ job, sources, words }: KitContext) {
 }
 
 function buildTemplate({ job, prefs, words }: KitContext) {
-  const group = groupForJob(job);
-  const picked = bestByGoal(
-    TEMPLATES.filter((t) => t.group === group),
-    words,
-    (t) => `${t.name} ${t.body}`
+  const route = routeForJob(job);
+  const candidates = TEMPLATES.filter(
+    (t) => t.group === route.group && (route.pins === null || t.name === route.pins)
   );
+  const picked = bestByGoal(candidates, words, (t) => `${t.name} ${t.body}`);
   if (!picked) return undefined;
 
   const hooks = bestByGoal(
@@ -415,13 +422,11 @@ function byteLength(value: unknown): number {
   return Buffer.byteLength(JSON.stringify(value), 'utf8');
 }
 
-export type CreationKit = { size_bytes: number; budget_bytes: number; trimmed: string[] } & Record<string, unknown>;
-
 export async function buildCreationKit(
   supabase: SupabaseClient,
   brand: KitBrand,
   job: KitJob
-): Promise<CreationKit> {
+): Promise<GetCreationKitResult> {
   const prefs = (brand.content_prefs ?? {}) as ContentPrefs;
   const sources = await loadSources(supabase, brand);
   const ctx: KitContext = { brand, job, prefs, sources, words: goalWords(job.goal) };
@@ -433,14 +438,19 @@ export async function buildCreationKit(
   }
 
   const trimmed: string[] = [];
-  const assemble = () => ({
-    job: { goal: job.goal, platforms: job.platforms, format: job.format },
-    versions: { kit: CREATION_KIT_VERSION },
-    size_bytes: CREATION_KIT_MAX_BYTES,
-    budget_bytes: CREATION_KIT_MAX_BYTES,
-    trimmed,
-    ...Object.fromEntries(sections)
-  });
+
+  // The section map is keyed by string, so the spread is the one place the shape has to be
+  // asserted. GetCreationKitResult comes straight from the endpoint contract, so a builder that
+  // stops matching what the endpoint declares stops compiling.
+  const assemble = () =>
+    ({
+      job: { goal: job.goal, platforms: job.platforms, format: job.format },
+      versions: { kit: CREATION_KIT_VERSION },
+      size_bytes: CREATION_KIT_MAX_BYTES,
+      budget_bytes: CREATION_KIT_MAX_BYTES,
+      trimmed,
+      ...Object.fromEntries(sections)
+    }) as GetCreationKitResult;
 
   const yieldOrder = KIT_SECTIONS.filter((s) => s.precedence > 1).sort((a, b) => b.precedence - a.precedence);
   while (byteLength(assemble()) > CREATION_KIT_MAX_BYTES && yieldOrder.length) {

--- a/src/lib/server/creation-kit.ts
+++ b/src/lib/server/creation-kit.ts
@@ -23,6 +23,7 @@ import {
 } from '$lib/platform-limits';
 import { houseVoiceFor, ownerCaptionEditPairs } from '$lib/server/content-preview/caption-quality';
 import { platformPlaybook, type ContentPrefs } from '$lib/server/content-preview/seed-model';
+import { likenessConsented } from '$lib/server/design-visual-refs';
 import { currentWeekIndex } from '$lib/server/editorial-plan';
 import { openingLine } from '$lib/server/hook-tactics';
 import { loadOwnPostHistory, type OwnHistoryRow } from '$lib/server/own-post-history';
@@ -63,6 +64,7 @@ const CAPS = {
   untestedHooks: 3,
   occupied: 8,
   historyScan: 60,
+  peopleScan: 50,
   productScan: 200
 } as const;
 
@@ -198,7 +200,7 @@ async function loadSources(supabase: SupabaseClient, brand: KitBrand): Promise<K
   const [kit, products, people, rubrics, history, plan, occupied] = await Promise.all([
     supabase.from('brand_kit').select('about, target_audience').eq('brand_id', brand.id).maybeSingle(),
     supabase.from('products').select('id, title, pricing').eq('brand_id', brand.id).limit(CAPS.productScan),
-    supabase.from('people').select('id, name, role').eq('brand_id', brand.id).eq('consent', true).limit(CAPS.people),
+    supabase.from('people').select('id, name, role, kind, consent').eq('brand_id', brand.id).limit(CAPS.peopleScan),
     loadApprovedRubrics(supabase, brand.id),
     loadOwnPostHistory(supabase, brand.id, { limit: CAPS.historyScan }),
     supabase.from('editorial_plans').select('weeks').eq('brand_id', brand.id).eq('status', 'active').maybeSingle(),
@@ -215,7 +217,7 @@ async function loadSources(supabase: SupabaseClient, brand: KitBrand): Promise<K
   return {
     kit: kit.data ?? null,
     products: (products.data ?? []) as Row[],
-    people: (people.data ?? []) as Row[],
+    people: ((people.data ?? []) as Row[]).filter(likenessConsented),
     rubrics,
     history,
     weeks: (plan.data?.weeks ?? []) as Row[],

--- a/src/lib/server/creation-kit.ts
+++ b/src/lib/server/creation-kit.ts
@@ -1,0 +1,450 @@
+/**
+ * THE CREATION KIT — the brief an external model reads BEFORE it writes one post.
+ *
+ * The feature here is SELECTION, not retrieval. Anomalia already holds a library: nine platform
+ * playbooks, nineteen post templates, every approved rubric, every past post. Handing all of it
+ * over on every turn is the failure mode this tool exists to avoid — it floods the model's context
+ * and anchors it on whatever happened to be longest. So the kit answers ONE job (a goal, some
+ * platforms, one format) with the smallest set that job needs, and it is capped: past
+ * CREATION_KIT_MAX_BYTES the least authoritative sections are dropped and named in `trimmed`.
+ *
+ * Nothing in here defines a rule of its own. Every section is a selection over a module that
+ * already owns its rule — platform limits, the platform playbook, the house voice, the approved
+ * rubrics, the owner's rewrites, the brand's own history, the calendar. What this file owns is
+ * KIT_SECTIONS: which sections exist, in what order they yield when the budget runs out.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import POST_TEMPLATES from '$lib/agent-docs/skills/social/references/post-templates.md?raw';
+import type { ContentFormat } from '$lib/content-formats';
+import {
+  PLATFORM_CHAR_LIMITS,
+  VIDEO_ONLY_PLATFORMS,
+  VISUAL_REQUIRED_PLATFORMS
+} from '$lib/platform-limits';
+import { houseVoiceFor, ownerCaptionEditPairs } from '$lib/server/content-preview/caption-quality';
+import { platformPlaybook, type ContentPrefs } from '$lib/server/content-preview/seed-model';
+import { currentWeekIndex } from '$lib/server/editorial-plan';
+import { openingLine } from '$lib/server/hook-tactics';
+import { loadOwnPostHistory, type OwnHistoryRow } from '$lib/server/own-post-history';
+import { analyzePostHistory, engagementWeight } from '$lib/server/post-history-insights';
+import { loadApprovedRubrics, type Rubric } from '$lib/server/rubrics';
+import { SLOT_OCCUPYING_STATUSES } from '$lib/server/schedule';
+
+export const CREATION_KIT_VERSION = 1;
+
+/**
+ * The kit's whole payload, serialized. Roughly two thousand tokens: one page of guidance, the size
+ * of a good system-prompt section, small enough that reading it before every post is free and
+ * large enough to carry a template, a voice and a handful of examples. It is a hard cap, not a
+ * target — most kits land well under it.
+ */
+export const CREATION_KIT_MAX_BYTES = 8192;
+
+/**
+ * Per-field ceilings, in one table. They are what makes the budget hold by CONSTRUCTION: trimming
+ * whole sections is the backstop, not the mechanism. A brand with a twelve-page "about" and two
+ * hundred products still produces the same shaped kit as an empty one.
+ */
+const CAPS = {
+  about: 400,
+  audience: 300,
+  voice: 2200,
+  templateBody: 900,
+  hookBody: 400,
+  playbook: 1300,
+  rubricText: 240,
+  editPair: 280,
+  winnerOpening: 140,
+  shortText: 80,
+  products: 5,
+  people: 4,
+  avoid: 12,
+  winners: 3,
+  untestedHooks: 3,
+  occupied: 8,
+  historyScan: 60,
+  productScan: 200
+} as const;
+
+export type KitBrand = {
+  id: string;
+  name: string;
+  timezone: string;
+  content_prefs?: ContentPrefs | null;
+};
+
+export type KitJob = { goal: string; platforms: string[]; format: ContentFormat };
+
+type Row = Record<string, unknown>;
+
+// ── Template library ─────────────────────────────────────────────────────
+// post-templates.md is versioned reference material shipped to the in-app agents. The kit reads
+// the same file and hands over exactly one block, so the two never drift into different advice.
+
+type TemplateBlock = { id: string; group: string; name: string; body: string };
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+function parseTemplates(markdown: string): TemplateBlock[] {
+  const blocks: TemplateBlock[] = [];
+  let group = '';
+  let name = '';
+  let body: string[] = [];
+
+  const flush = () => {
+    if (name) {
+      blocks.push({ id: `${slugify(group)}/${slugify(name)}`, group, name, body: body.join('\n').trim() });
+    }
+    name = '';
+    body = [];
+  };
+
+  for (const line of markdown.split('\n')) {
+    if (line.startsWith('## ')) {
+      flush();
+      group = line.slice(3).trim();
+      continue;
+    }
+    if (line.startsWith('### ')) {
+      flush();
+      name = line.slice(4).trim();
+      continue;
+    }
+    if (name) body.push(line);
+  }
+  flush();
+
+  return blocks;
+}
+
+const TEMPLATES = parseTemplates(POST_TEMPLATES);
+
+const HOOK_GROUP = 'Hook Formulas';
+
+/**
+ * Which template group a job draws from — the ONE place a format or a platform earns a different
+ * answer. First matching row wins; `format: null` matches any format, `platform: null` any
+ * platform. Inside the chosen group the goal picks the single block.
+ */
+const TEMPLATE_ROUTES: ReadonlyArray<{
+  format: ContentFormat | null;
+  platform: string | null;
+  group: string;
+}> = [
+  { format: 'carousel', platform: null, group: 'Instagram Templates' },
+  { format: 'video', platform: null, group: 'Instagram Templates' },
+  { format: null, platform: 'x', group: 'Twitter/X Thread Templates' },
+  { format: null, platform: 'twitter', group: 'Twitter/X Thread Templates' },
+  { format: null, platform: null, group: 'LinkedIn Post Templates' }
+];
+
+function groupForJob(job: KitJob): string {
+  const wanted = new Set(job.platforms.map((p) => p.toLowerCase()));
+  const route = TEMPLATE_ROUTES.find(
+    (r) => (r.format === null || r.format === job.format) && (r.platform === null || wanted.has(r.platform))
+  );
+  return route?.group ?? 'LinkedIn Post Templates';
+}
+
+// ── Goal ranking ─────────────────────────────────────────────────────────
+// Word overlap, not meaning. It is deterministic, costs nothing and never calls a model — which is
+// the whole point of this endpoint. Short words are dropped because "the" matches everything.
+
+const MIN_GOAL_WORD = 4;
+const GOAL_WORD = new RegExp(`[\\p{L}0-9]{${MIN_GOAL_WORD},}`, 'gu');
+
+function goalWords(goal: string): string[] {
+  return [...new Set(goal.toLowerCase().match(GOAL_WORD) ?? [])];
+}
+
+function goalOverlap(words: string[], text: string): number {
+  const hay = text.toLowerCase();
+  return words.filter((w) => hay.includes(w)).length;
+}
+
+function bestByGoal<T>(items: T[], words: string[], text: (item: T) => string): T | undefined {
+  let best: T | undefined;
+  let bestScore = -1;
+  for (const item of items) {
+    const score = goalOverlap(words, text(item));
+    if (score > bestScore) {
+      best = item;
+      bestScore = score;
+    }
+  }
+  return best;
+}
+
+// ── Reads ────────────────────────────────────────────────────────────────
+
+type KitSources = {
+  kit: Row | null;
+  products: Row[];
+  people: Row[];
+  rubrics: Rubric[];
+  history: OwnHistoryRow[];
+  weeks: Row[];
+  occupied: Row[];
+};
+
+async function loadSources(supabase: SupabaseClient, brand: KitBrand): Promise<KitSources> {
+  const now = new Date().toISOString();
+
+  const [kit, products, people, rubrics, history, plan, occupied] = await Promise.all([
+    supabase.from('brand_kit').select('about, target_audience').eq('brand_id', brand.id).maybeSingle(),
+    supabase.from('products').select('id, title, pricing').eq('brand_id', brand.id).limit(CAPS.productScan),
+    supabase.from('people').select('id, name, role').eq('brand_id', brand.id).eq('consent', true).limit(CAPS.people),
+    loadApprovedRubrics(supabase, brand.id),
+    loadOwnPostHistory(supabase, brand.id, { limit: CAPS.historyScan }),
+    supabase.from('editorial_plans').select('weeks').eq('brand_id', brand.id).eq('status', 'active').maybeSingle(),
+    supabase
+      .from('posts')
+      .select('scheduled_for, platform, platforms, campaign_name, campaign_step')
+      .eq('brand_id', brand.id)
+      .in('status', [...SLOT_OCCUPYING_STATUSES])
+      .gte('scheduled_for', now)
+      .order('scheduled_for', { ascending: true })
+      .limit(CAPS.occupied)
+  ]);
+
+  return {
+    kit: kit.data ?? null,
+    products: (products.data ?? []) as Row[],
+    people: (people.data ?? []) as Row[],
+    rubrics,
+    history,
+    weeks: (plan.data?.weeks ?? []) as Row[],
+    occupied: (occupied.data ?? []) as Row[]
+  };
+}
+
+// ── Sections ─────────────────────────────────────────────────────────────
+// Each builder returns `undefined` when it has nothing to say, and the key is then absent from the
+// kit. A field that is always empty teaches the reader to stop looking at the kit.
+
+type KitContext = { brand: KitBrand; job: KitJob; prefs: ContentPrefs; sources: KitSources; words: string[] };
+
+function trim(value: unknown, max: number): string | undefined {
+  const text = String(value ?? '').trim();
+  return text ? text.slice(0, max) : undefined;
+}
+
+function buildConstraints({ job, prefs }: KitContext) {
+  return {
+    platforms: job.platforms.map((platform) => ({
+      platform,
+      char_limit: PLATFORM_CHAR_LIMITS[platform] ?? null,
+      needs_media: VISUAL_REQUIRED_PLATFORMS.has(platform),
+      video_only: VIDEO_ONLY_PLATFORMS.has(platform)
+    })),
+    avoid: (prefs.avoid ?? []).slice(0, CAPS.avoid)
+  };
+}
+
+function buildBrand({ brand, prefs, sources, words }: KitContext) {
+  const products = [...sources.products]
+    .sort((a, b) => goalOverlap(words, String(b.title ?? '')) - goalOverlap(words, String(a.title ?? '')))
+    .slice(0, CAPS.products)
+    .map((p) => ({
+      id: String(p.id),
+      title: String(p.title ?? '').slice(0, CAPS.shortText),
+      ...maybe('pricing', trim(p.pricing, CAPS.shortText))
+    }));
+
+  const people = sources.people.slice(0, CAPS.people).map((p) => ({
+    id: String(p.id),
+    name: String(p.name ?? '').slice(0, CAPS.shortText),
+    ...maybe('role', trim(p.role, CAPS.shortText))
+  }));
+
+  return {
+    name: brand.name,
+    ...maybe('language', trim(prefs.language, 32)),
+    ...maybe('about', trim(sources.kit?.about, CAPS.about)),
+    ...maybe('audience', trim(sources.kit?.target_audience, CAPS.audience)),
+    ...maybe('products', products.length ? products : undefined),
+    ...maybe('people', people.length ? people : undefined)
+  };
+}
+
+function buildVoice({ prefs }: KitContext) {
+  return { text: houseVoiceFor(prefs).slice(0, CAPS.voice) };
+}
+
+function buildRubric({ job, sources, words }: KitContext) {
+  const matching = sources.rubrics.filter((r) => r.format === job.format);
+  const picked = bestByGoal(matching, words, (r) => `${r.name} ${r.promise} ${r.strategic_role}`);
+  if (!picked) return undefined;
+
+  return {
+    ...maybe('id', picked.id),
+    name: picked.name,
+    format: picked.format,
+    ...maybe('promise', trim(picked.promise, CAPS.rubricText)),
+    ...maybe('cadence', trim(picked.cadence, CAPS.rubricText)),
+    ...maybe('art_direction', trim(picked.art_direction, CAPS.rubricText))
+  };
+}
+
+function buildTemplate({ job, prefs, words }: KitContext) {
+  const group = groupForJob(job);
+  const picked = bestByGoal(
+    TEMPLATES.filter((t) => t.group === group),
+    words,
+    (t) => `${t.name} ${t.body}`
+  );
+  if (!picked) return undefined;
+
+  const hooks = bestByGoal(
+    TEMPLATES.filter((t) => t.group === HOOK_GROUP),
+    words,
+    (t) => `${t.name} ${t.body}`
+  );
+
+  return {
+    id: picked.id,
+    name: picked.name,
+    group: picked.group,
+    body: picked.body.slice(0, CAPS.templateBody),
+    ...maybe(
+      'hooks',
+      hooks ? { id: hooks.id, name: hooks.name, body: hooks.body.slice(0, CAPS.hookBody) } : undefined
+    ),
+    playbook: platformPlaybook(job.platforms, prefs).trim().slice(0, CAPS.playbook)
+  };
+}
+
+function buildCalendar({ sources }: KitContext) {
+  const occupied = sources.occupied.slice(0, CAPS.occupied).map((p) => ({
+    scheduled_for: String(p.scheduled_for),
+    platforms: (Array.isArray(p.platforms) ? (p.platforms as string[]) : [p.platform]).filter(
+      (x): x is string => typeof x === 'string' && !!x
+    ),
+    ...maybe('campaign', trim(p.campaign_name, CAPS.shortText)),
+    ...maybe('step', trim(p.campaign_step, CAPS.shortText))
+  }));
+  return occupied.length ? { occupied } : undefined;
+}
+
+function buildWeek({ brand, sources }: KitContext) {
+  const index = currentWeekIndex({ weeks: sources.weeks } as never, brand.timezone);
+  if (index === null) return undefined;
+
+  const theme = trim(sources.weeks[index]?.theme, CAPS.rubricText);
+  return theme ? { index, theme } : undefined;
+}
+
+function buildOperatorEdits({ prefs }: KitContext) {
+  const pairs = ownerCaptionEditPairs(prefs).map((p) => ({
+    before: p.before.slice(0, CAPS.editPair),
+    after: p.after.slice(0, CAPS.editPair)
+  }));
+  return pairs.length ? pairs : undefined;
+}
+
+function buildHistory({ job, sources }: KitContext) {
+  if (!sources.history.length) return undefined;
+
+  const insights = analyzePostHistory(
+    sources.history.map((row) => ({
+      content: row.content,
+      mediaType: row.media_type,
+      publishedAt: row.published_at,
+      metrics: row.metrics as never
+    }))
+  );
+
+  const wanted = new Set(job.platforms.map((p) => p.toLowerCase()));
+  const winners = sources.history
+    .filter((row) => wanted.has(String(row.platform ?? '').toLowerCase()))
+    .sort((a, b) => engagementWeight(b.metrics as never) - engagementWeight(a.metrics as never))
+    .slice(0, CAPS.winners)
+    .map((row) => ({
+      id: row.id,
+      platform: String(row.platform ?? ''),
+      opening: openingLine(row.content ?? '').slice(0, CAPS.winnerOpening)
+    }))
+    .filter((w) => !!w.opening);
+
+  return {
+    post_count: insights.postCount,
+    best_times: insights.bestTimes,
+    top_formats: insights.topFormats,
+    top_hashtags: insights.topHashtags,
+    ...maybe('cadence', insights.cadence || undefined),
+    untested_hooks: insights.hooks.untested.slice(0, CAPS.untestedHooks),
+    winners
+  };
+}
+
+/**
+ * The sections, ordered by the plan's guidance precedence: hard platform constraints first, then
+ * verified brand facts and approved voice, then the rubric, then Anomalia's own template. Evidence
+ * comes last because the plan is explicit that past winners are evidence, not instructions — and
+ * `precedence` doubles as the yield order, so what a kit loses to the budget is always the least
+ * authoritative thing it was carrying. Rank 1 is never dropped.
+ */
+const KIT_SECTIONS: ReadonlyArray<{
+  key: string;
+  precedence: number;
+  build: (ctx: KitContext) => unknown;
+}> = [
+  { key: 'constraints', precedence: 1, build: buildConstraints },
+  { key: 'brand', precedence: 2, build: buildBrand },
+  { key: 'voice', precedence: 3, build: buildVoice },
+  { key: 'rubric', precedence: 4, build: buildRubric },
+  { key: 'template', precedence: 5, build: buildTemplate },
+  { key: 'calendar', precedence: 6, build: buildCalendar },
+  { key: 'week', precedence: 7, build: buildWeek },
+  { key: 'operator_edits', precedence: 8, build: buildOperatorEdits },
+  { key: 'history', precedence: 9, build: buildHistory }
+];
+
+function maybe<T>(key: string, value: T | undefined): Record<string, T> {
+  return value === undefined ? {} : ({ [key]: value } as Record<string, T>);
+}
+
+function byteLength(value: unknown): number {
+  return Buffer.byteLength(JSON.stringify(value), 'utf8');
+}
+
+export type CreationKit = { size_bytes: number; budget_bytes: number; trimmed: string[] } & Record<string, unknown>;
+
+export async function buildCreationKit(
+  supabase: SupabaseClient,
+  brand: KitBrand,
+  job: KitJob
+): Promise<CreationKit> {
+  const prefs = (brand.content_prefs ?? {}) as ContentPrefs;
+  const sources = await loadSources(supabase, brand);
+  const ctx: KitContext = { brand, job, prefs, sources, words: goalWords(job.goal) };
+
+  const sections = new Map<string, unknown>();
+  for (const section of KIT_SECTIONS) {
+    const value = section.build(ctx);
+    if (value !== undefined) sections.set(section.key, value);
+  }
+
+  const trimmed: string[] = [];
+  const assemble = () => ({
+    job: { goal: job.goal, platforms: job.platforms, format: job.format },
+    versions: { kit: CREATION_KIT_VERSION },
+    size_bytes: CREATION_KIT_MAX_BYTES,
+    budget_bytes: CREATION_KIT_MAX_BYTES,
+    trimmed,
+    ...Object.fromEntries(sections)
+  });
+
+  const yieldOrder = KIT_SECTIONS.filter((s) => s.precedence > 1).sort((a, b) => b.precedence - a.precedence);
+  while (byteLength(assemble()) > CREATION_KIT_MAX_BYTES && yieldOrder.length) {
+    const victim = yieldOrder.shift()!;
+    if (sections.delete(victim.key)) trimmed.push(victim.key);
+  }
+
+  return { ...assemble(), size_bytes: byteLength(assemble()) };
+}

--- a/src/lib/server/post-history-insights.ts
+++ b/src/lib/server/post-history-insights.ts
@@ -36,8 +36,9 @@ export type HistoryInsights = {
 const WEEKDAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
 // Engagement weight for a post: prefer a real engagement rate, else likes + comments. Comments are
-// a stronger signal than likes, so weight them a touch higher.
-function weight(m?: HistoryPost['metrics']): number {
+// a stronger signal than likes, so weight them a touch higher. Exported because "which post won"
+// is asked in more than one place, and a second copy of this formula would rank a different post.
+export function engagementWeight(m?: HistoryPost['metrics']): number {
   if (!m) return 0;
   if (typeof m.engagementRate === 'number' && m.engagementRate > 0) return m.engagementRate;
   return (m.likes ?? 0) + (m.comments ?? 0) * 2;
@@ -60,7 +61,7 @@ export function analyzePostHistory(posts: HistoryPost[]): HistoryInsights {
   // Hashtags weighted by engagement (baseline 1 so a tag counts even on a zero-metric post).
   const tagW = new Map<string, number>();
   for (const p of list) {
-    const w = weight(p.metrics) || 1;
+    const w = engagementWeight(p.metrics) || 1;
     for (const m of (p.content ?? '').matchAll(/#[\p{L}0-9_]{2,50}/gu)) {
       const t = m[0].toLowerCase();
       tagW.set(t, (tagW.get(t) ?? 0) + w);
@@ -72,13 +73,13 @@ export function analyzePostHistory(posts: HistoryPost[]): HistoryInsights {
   const fmtW = new Map<string, number>();
   for (const p of list) {
     const f = normFormat(p.mediaType);
-    if (f) fmtW.set(f, (fmtW.get(f) ?? 0) + (weight(p.metrics) || 1));
+    if (f) fmtW.set(f, (fmtW.get(f) ?? 0) + (engagementWeight(p.metrics) || 1));
   }
   const topFormats = [...fmtW.entries()].sort((a, b) => b[1] - a[1]).slice(0, 2).map(([f]) => f);
 
   // Best weekday+hour slots (weight + a frequency baseline) and posting cadence — need timestamps.
   const dated = list
-    .map((p) => ({ d: p.publishedAt ? new Date(p.publishedAt) : null, w: weight(p.metrics) }))
+    .map((p) => ({ d: p.publishedAt ? new Date(p.publishedAt) : null, w: engagementWeight(p.metrics) }))
     .filter((x): x is { d: Date; w: number } => !!x.d && !isNaN(x.d.getTime()));
 
   const slotW = new Map<string, number>();
@@ -100,7 +101,7 @@ export function analyzePostHistory(posts: HistoryPost[]): HistoryInsights {
   // "this one won" flag from engagement against the brand's own mean — but only once there are
   // enough posts for "won" to mean anything. Under the floor every post is just a post, and the map
   // still answers the question it exists for: what have we never tried?
-  const weights = list.map((p) => weight(p.metrics));
+  const weights = list.map((p) => engagementWeight(p.metrics));
   const meanWeight = weights.length ? weights.reduce((a, b) => a + b, 0) / weights.length : 0;
   const winnersAreMeaningful = sampleVerdict(list.length) !== 'insufficient' && meanWeight > 0;
   const usages: HookUsage[] = list.map((p, i) => ({

--- a/src/lib/server/schedule.ts
+++ b/src/lib/server/schedule.ts
@@ -176,6 +176,10 @@ export type CalendarConflictGroup = {
   }>;
 };
 
+// The statuses that make a post OCCUPY its minute. Published is behind us and failed never went
+// out, so neither books anything; every reader of "is this slot taken" asks this one list.
+export const SLOT_OCCUPYING_STATUSES = ['pending_user', 'approved', 'scheduled'] as const;
+
 // Groups of 2+ live posts landing on the same minute. A post occupies its scheduled_for, or (for a
 // draft that has none) its slot's next occurrence — matching exactly what the calendar renders.
 export function listCalendarConflicts(
@@ -183,7 +187,7 @@ export function listCalendarConflicts(
   tz: string,
   now = new Date()
 ): CalendarConflictGroup[] {
-  const live = new Set(['pending_user', 'approved', 'scheduled']);
+  const live = new Set<string>(SLOT_OCCUPYING_STATUSES);
   const buckets = new Map<string, { scheduled_for: string; posts: CalendarConflictGroup['posts'] }>();
   for (const p of posts) {
     if (!live.has(p.status)) continue;

--- a/src/routes/api/v1/brands/[slug]/creation-kit/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/creation-kit/+server.ts
@@ -1,0 +1,32 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { authenticate, loadBrandForUser } from '$lib/server/cli-auth';
+import { buildCreationKit } from '$lib/server/creation-kit';
+import { GET_CREATION_KIT, statusForFailure } from '@anomalia/api-contracts';
+
+export const GET: RequestHandler = async ({ request, params, url }) => {
+  const { supabase, error, apiKey } = await authenticate(request);
+  if (error) return error;
+
+  const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
+  if (brandError) return brandError;
+
+  const parsed = GET_CREATION_KIT.input.safeParse(Object.fromEntries(url.searchParams));
+  if (!parsed.success) {
+    return json({ error: 'invalid_input', details: parsed.error.issues }, { status: 400 });
+  }
+
+  const platforms = [
+    ...new Set(
+      parsed.data.platforms
+        .split(',')
+        .map((p) => p.trim().toLowerCase())
+        .filter(Boolean)
+    )
+  ];
+  if (!platforms.length) {
+    return json({ error: 'no_platforms' }, { status: statusForFailure(GET_CREATION_KIT, 'no_platforms') });
+  }
+
+  return json(await buildCreationKit(supabase, brand, { ...parsed.data, platforms }));
+};

--- a/src/routes/api/v1/brands/[slug]/creation-kit/server.get.test.ts
+++ b/src/routes/api/v1/brands/[slug]/creation-kit/server.get.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const structured = vi.fn();
+const gateCredits = vi.fn();
+
+vi.mock('$lib/server/cli-auth', () => ({
+  authenticate: vi.fn(),
+  loadBrandForUser: vi.fn(),
+  checkApiKeyWriteAccess: vi.fn(() => null),
+  gateAiAction: vi.fn()
+}));
+vi.mock('$lib/server/research', () => ({ structured: (...args: unknown[]) => structured(...args) }));
+vi.mock('$lib/server/credits', () => ({
+  gateCredits: (...args: unknown[]) => gateCredits(...args),
+  CreditsExhaustedError: class extends Error {}
+}));
+
+import { GET } from './+server';
+import { authenticate, loadBrandForUser, gateAiAction } from '$lib/server/cli-auth';
+
+type Row = Record<string, unknown>;
+
+function fakeSupabase(tables: Record<string, Row[]> = {}) {
+  return {
+    from(table: string) {
+      let rows = [...(tables[table] ?? [])];
+      const q = {
+        select: () => q,
+        eq(column: string, value: unknown) {
+          rows = rows.filter((r) => r[column] === value);
+          return q;
+        },
+        in: () => q,
+        gte: () => q,
+        order: () => q,
+        limit: () => q,
+        maybeSingle: async () => ({ data: rows[0] ?? null, error: null }),
+        then: (resolve: (v: { data: Row[]; error: null }) => unknown) => resolve({ data: rows, error: null })
+      };
+      return q;
+    }
+  };
+}
+
+function call(query: Record<string, string>, slug = 'demo') {
+  const url = new URL(`https://anomalia.test/api/v1/brands/${slug}/creation-kit`);
+  for (const [k, v] of Object.entries(query)) url.searchParams.set(k, v);
+  return (GET as (event: unknown) => Promise<Response>)({
+    request: new Request(url),
+    params: { slug },
+    url
+  }).then(async (res) => ({ res, body: await res.json() }));
+}
+
+function signedIn(tables: Record<string, Row[]> = {}) {
+  vi.mocked(authenticate).mockResolvedValue({
+    supabase: fakeSupabase(tables),
+    user: { id: 'user-1' },
+    apiKey: undefined,
+    error: null
+  } as never);
+  vi.mocked(loadBrandForUser).mockResolvedValue({
+    brand: { id: 'brand-1', slug: 'demo', name: 'Demo Brand', timezone: 'Europe/Rome', content_prefs: {} },
+    error: null
+  } as never);
+}
+
+const JOB = { goal: 'launch the espresso grinder', platforms: 'linkedin', format: 'text_post' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('GET /creation-kit', () => {
+  it('restituisce un kit selezionato per il lavoro richiesto', async () => {
+    signedIn();
+
+    const { res, body } = await call(JOB);
+
+    expect(res.status).toBe(200);
+    expect(body.job).toEqual({ goal: JOB.goal, platforms: ['linkedin'], format: 'text_post' });
+    expect(body.constraints.platforms[0].platform).toBe('linkedin');
+    expect(body.template.id).toBeTruthy();
+    expect(body.versions.kit).toBeGreaterThan(0);
+    expect(body.size_bytes).toBeLessThanOrEqual(body.budget_bytes);
+  });
+
+  it('non chiama nessun modello e non addebita nessun credito', async () => {
+    signedIn();
+
+    const { res } = await call(JOB);
+
+    expect(res.status).toBe(200);
+    expect(structured).not.toHaveBeenCalled();
+    expect(gateCredits).not.toHaveBeenCalled();
+    expect(gateAiAction).not.toHaveBeenCalled();
+  });
+
+  it('accetta più piattaforme separate da virgola e le normalizza', async () => {
+    signedIn();
+
+    const { body } = await call({ ...JOB, platforms: 'LinkedIn, x , linkedin' });
+
+    expect(body.constraints.platforms.map((p: Row) => p.platform)).toEqual(['linkedin', 'x']);
+  });
+
+  it('rifiuta un input fuori contratto invece di indovinare', async () => {
+    signedIn();
+
+    const missing = await call({ goal: 'x', platforms: 'linkedin' });
+    const unknownField = await call({ ...JOB, tone: 'ironico' });
+    const badFormat = await call({ ...JOB, format: 'poster' });
+
+    expect(missing.res.status).toBe(400);
+    expect(missing.body.error).toBe('invalid_input');
+    expect(unknownField.res.status).toBe(400);
+    expect(badFormat.res.status).toBe(400);
+  });
+
+  it('una lista di piattaforme fatta di sole virgole non passa per vuota', async () => {
+    signedIn();
+
+    const { res, body } = await call({ ...JOB, platforms: ' , , ' });
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('no_platforms');
+  });
+
+  it('senza autenticazione non tocca il brand', async () => {
+    vi.mocked(authenticate).mockResolvedValue({
+      error: new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 })
+    } as never);
+
+    const { res } = await call(JOB);
+
+    expect(res.status).toBe(401);
+    expect(loadBrandForUser).not.toHaveBeenCalled();
+  });
+
+  it('un brand non accessibile passa dall’errore di loadBrandForUser', async () => {
+    vi.mocked(authenticate).mockResolvedValue({
+      supabase: fakeSupabase(),
+      user: { id: 'user-1' },
+      apiKey: undefined,
+      error: null
+    } as never);
+    vi.mocked(loadBrandForUser).mockResolvedValue({
+      error: new Response(JSON.stringify({ error: 'Brand not found' }), { status: 404 })
+    } as never);
+
+    const { res } = await call(JOB, 'altrui');
+
+    expect(res.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## What?

Adds `get_creation_kit`: given a **goal**, some **platforms** and an intended **format**, it returns the smallest useful brief an external model needs before writing one post — plus a stable identifier for every template, rubric, example and rule version it selected.

```
GET /api/v1/brands/:slug/creation-kit?goal=…&platforms=linkedin,instagram&format=text_post
```

The kit carries, and only when the brand actually has them: hard platform constraints, brand facts and approved voice, the matching rubric with its art direction, **one** Anomalia template with its hook family and the playbook for exactly the platforms asked about, the operator's own before/after rewrites, what has worked on this brand, the occupied calendar minutes with their campaign, and the current editorial week.

It is a read: **no model call, no credit debit, nothing written**. A read-only API key can use it.

This is the last piece of step 2 of the [external-agent plan](docs/external-agent-plan.md), and the "before" half of the loop whose "after" half is `check_content` (#198, merged).

## Why?

The plan asks for a creative-intelligence layer that improves the user's model *before* creation, and is emphatic about the failure mode:

> "Dynamic tools select the smallest relevant subset; they never dump the full library into every model turn."

> Risk: "Guidance overwhelms or anchors the external model" → Control: "Select one focused creation kit instead of dumping the library."

So **selection is the feature**. A kit that returns everything is a failure even with every test green. Anomalia already holds the library — nine platform playbooks, nineteen post templates, every approved rubric, every past post — and an external model that receives all of it is worse off than one that receives a page.

## How?

**Nothing here defines a rule of its own.** Every section is a selection over a module that already owns its rule. What `src/lib/server/creation-kit.ts` owns is the `KIT_SECTIONS` table: which sections exist and in what order they yield.

| Section | Composed from | How it is selected |
|---|---|---|
| `constraints` | `$lib/platform-limits` (`PLATFORM_CHAR_LIMITS`, `VISUAL_REQUIRED_PLATFORMS`, `VIDEO_ONLY_PLATFORMS`) | only the requested platforms; plus the brand's `avoid` list |
| `brand` | `brand_kit`, `products`, `people` | products ranked by lexical overlap with the goal, top 5; people gated by `likenessConsented` |
| `voice` | `houseVoiceFor` (`content-preview/caption-quality.ts`) | approved personality when set, else the house voice |
| `rubric` | `loadApprovedRubrics` (`rubrics.ts`) | only rubrics of the requested format, then closest to the goal |
| `template` | `agent-docs/skills/social/references/post-templates.md` — the same reference `brand-skills.ts` ships to the in-app agents | format+platform pick the group and, where the format decides alone, the block; the goal picks where a real choice remains |
| `template.playbook` | `platformPlaybook` (`content-preview/seed-model.ts`) | only the requested platforms |
| `calendar` | `posts` + `SLOT_OCCUPYING_STATUSES` (`schedule.ts`) | only minutes occupied from now on, max 8, carrying their campaign |
| `week` | active `editorial_plans` + `currentWeekIndex` (`editorial-plan.ts`) | only the current week's theme |
| `operator_edits` | `ownerCaptionEditPairs` (`content-preview/caption-quality.ts`) | the last 3 real owner rewrites |
| `history` | `loadOwnPostHistory` + `analyzePostHistory` + `engagementWeight` | `source='zernio'` only; winners filtered to the requested platforms |

**The size budget is enforced, not decorative.** `CREATION_KIT_MAX_BYTES = 8192` — about two thousand tokens, one page of guidance. Every field has a ceiling in one `CAPS` table, so the budget holds *by construction*; trimming whole sections is the backstop. When it does bite, sections yield from the least authoritative upward, following the plan's own **Guidance precedence** — `history`, `operator_edits`, `week`, `calendar`, `template`, `rubric`, `voice`, `brand` — and `trimmed` names what fell. `constraints` never falls. Past winners drop first because the plan says they are *evidence, not instructions*.

**Absent, never empty.** A section with nothing in it is omitted. A field that is always empty teaches the model to stop reading the kit.

**Why GET.** The input fits a query string, and `resolveCaller` denies read-only API keys on any non-GET method — so GET is what lets a read-only key read the brief before writing, which is the correct permission. `platforms` travels comma-separated because that is how `callEndpoint` serialises a GET; the route normalises and dedupes, and a list of only commas returns `no_platforms` rather than passing as empty.

**Two pure refactors first, in their own commit.** `listCalendarConflicts` held the slot-occupancy statuses in a local `new Set([...])` and `analyzePostHistory` held the engagement formula in a private `function weight`. A second reader would have had to copy them, and two copies of "which post won" rank different posts. They are now `SLOT_OCCUPYING_STATUSES` and `engagementWeight`, exported from the modules that already owned them. No behaviour change; their 29 tests pass identically.

**Wiring is the registry, as designed.** One entry `satisfies BrandEndpoint` in the new `packages/api-contracts/src/creation-kit.ts` (a new file, so parallel PRs do not fight over `posts.ts`), added to `BRAND_ENDPOINTS`, mirrored by `sync-contracts.sh`, plus the route. The CLI client method and the MCP tool appeared on their own — `cli/mcp/create-post.test.ts` proves it by listing the exposed tools.

### Rejected

- **Semantic retrieval over the knowledge base.** `loadCaptionKnowledge` would have used the goal far better than lexical overlap, but `searchKnowledge` makes an embedding round-trip when FTS recall is thin — a model call inside a read that promises none. Out.
- **A `post_verdicts` reader.** It has exactly the right columns (`caption_before`/`caption_after`, `verdict='edited'`) and, I checked, *no reader anywhere in the repo*. Writing the first one is new code on never-read data, for the same signal `content_prefs.captionEditPairs` already gives. Left for later.
- **Semantic goal matching.** `goalOverlap` is word overlap and the name says so. Deterministic, free, no model.

### Deliberately not shipped (does not genuinely exist per brand)

The plan lists more than the database actually holds. I left these out rather than emit an invented or permanently empty field:

- **Weak patterns.** They do not exist. `visualInsightsBlock` computes losing buckets and then *discards* them (`delta <= 0`); `post_verdicts.verdict='discarded'` is the right data and nothing reads it. The only real per-brand negative signal is `content_prefs.avoid`, which is in `constraints`.
- **Approved assets.** `list_media` is already a tool, with search and signed URLs. Repeating it here would double the library inside the tool that exists to avoid dumping it. The kit's description points at it.
- **Campaigns.** There is no campaign table — `campaign_id`/`campaign_name`/`campaign_step` are three columns on `posts`, with no state and no "current". So campaign context arrives attached to the occupied slots (zero extra queries, zero heuristic), and the real strategic context is the active editorial plan's week, which a unique partial index guarantees is singular.

## Testing?

**Two real defects were found and fixed test-first; the red was observed both times.**

1. The maximal-brand budget test found the one field with no ceiling (a person's name), which made the kit drop *verified brand facts* to fit while keeping a static template:

```
AssertionError: expected undefined to be 'Caffè Nero'
 ❯ src/lib/server/creation-kit.test.ts:205:29
    expect(kit.brand?.name).toBe('Caffè Nero');
```

2. Running the endpoint live showed a `format=video` job coming back with the carousel structure. Format is a hard constraint and outranks the goal:

```
AssertionError: expected 'The Carousel Hook' to be 'The Reel Script'
 ❯ src/lib/server/creation-kit.test.ts:91:34
    expect(video.template?.name).toBe('The Reel Script');
```

A third red, for the likeness rule — the kit had restated `consent = true` in its own query instead of asking `likenessConsented`, silently dropping AI personas:

```
AssertionError: expected [ 'pe-real-yes' ] to deeply equal [ 'pe-ai', 'pe-real-yes' ]
- "pe-ai",
  "pe-real-yes",
```

**Unit + route: 21 new tests.** `src/lib/server/creation-kit.test.ts` (14) uses a supabase double that actually applies `.eq()` filters, so "another brand's material never appears" is proven by the same mechanism the real client uses. It covers: one template selected for the requested format; format beating goal; goal choosing within a group; playbook limited to the requested platforms; rubrics filtered to the format; products ranked by goal; the budget held with the least authoritative section yielding first; constraints and brand facts never sacrificed; a normal brand losing nothing; stable ids and rule versions; the likeness gate; no other brand's material; a barely-configured brand yielding a small coherent kit rather than a wall of nulls; and a guard that the contract's format enum cannot drift from `CONTENT_FORMATS`.

`src/routes/api/v1/brands/[slug]/creation-kit/server.get.test.ts` (7) covers the auth contract and proves, with spies, that `structured`, `gateCredits` and `gateAiAction` are never called.

**Commands actually run, on the rebased tree (`origin/dev` @ `f038753`):**

```
$ npx vitest run <the 5 files this PR touches or adds>
  Test Files  5 passed (5)
       Tests  53 passed (53)

$ cd cli && bun test
  32 pass, 0 fail
$ cd cli && bun run typecheck
  (clean)
```

`npm run test:unit` on this branch: **6463 passed, 1 failed** — `src/lib/agent/bridge/live.test.ts`, a 120s timeout. It is **not from this PR**: the same test times out on `dev` in the untouched main checkout (`1 failed | 84 passed`). `brand-studio-tools.test.ts` also timed out in one full run and **passes alone (37 tests)**. Nine agents are running on this machine at once; both are contention, not defects.

**Type checking:** see the note at the end of this section for exactly which run produced which number.

**Live, against a real database — the part unit tests cannot do.**

The self-hosted local Supabase stack, a dev server on 5199, a real password login as `test@anomalia.so` / `123456`, and the seeded `demo` brand (2 approved rubrics, an active editorial plan, products, people, own post history, an upcoming campaign post). Not the hosted instance.

Every column the kit reads was verified to exist against the real schema — the thing a supabase double structurally cannot catch:

```
brand_kit: about,target_audience
products: id,brand_id,title,pricing
people: id,brand_id,name,role,kind,consent
editorial_plans: brand_id,status,weeks
posts: brand_id,platform,scheduled_for,status,platforms,campaign_name,campaign_step
rubrics: brand_id,status,format,art_direction
```

## Evidence (screenshots/videos)

No UI: this endpoint has no browser surface. The evidence is the live API against the local stack.

<details>
<summary>A real kit — HTTP 200, 5,323 bytes, real login, real brand</summary>

```
$ curl -G .../api/v1/brands/demo/creation-kit \
    --data-urlencode "goal=launch the new espresso grinder" \
    --data-urlencode "platforms=linkedin" --data-urlencode "format=text_post" \
    -H "Authorization: Bearer $TOKEN"
HTTP 200  bytes=5323
```
```json
{
 "job": { "goal": "launch the new espresso grinder", "platforms": ["linkedin"], "format": "text_post" },
 "versions": { "kit": 1 },
 "size_bytes": 5323, "budget_bytes": 8192, "trimmed": [],
 "constraints": {
  "platforms": [{ "platform": "linkedin", "char_limit": 3000, "needs_media": false, "video_only": false }],
  "avoid": ["eccellenza", "sinergia", "unico nel suo genere"]
 },
 "brand": {
  "name": "Demo Brand",
  "about": "Torrefazione artigianale a Trieste dal 1998: tre miscele, un lab aperto al pubblico…",
  "audience": "Bar indipendenti e uffici che comprano caffe in grani…",
  "products": [
   { "id": "dac7cece-…", "title": "Espresso grinder Mk II", "pricing": "890 EUR" },
   { "id": "e89e4fab-…", "title": "Miscela Nera 1kg", "pricing": "24 EUR" },
   { "id": "a84c6b33-…", "title": "Filtro carta V60", "pricing": "4 EUR" }
  ],
  "people": [
   { "id": "39478712-…", "name": "Marta Rossi", "role": "Head roaster" },
   { "id": "d549a446-…", "name": "Nero Persona", "role": "Volto AI del brand" }
  ]
 },
 "voice": { "text": "BRAND PERSONALITY (authoritative — …): un artigiano che spiega\nHOUSE BAR …" },
 "template": {
  "id": "linkedin-post-templates/the-story-post",
  "name": "The Story Post", "group": "LinkedIn Post Templates",
  "body": "[Hook: Unexpected outcome or lesson]\n\n[Set the scene…",
  "hooks": { "id": "hook-formulas/curiosity-hooks", "name": "Curiosity Hooks", "body": "- \"I was wrong about [common belief].\"…" },
  "playbook": "PLATFORM PLAYBOOK (…):\n- LinkedIn — write LONG-FORM, never one or two lines…"
 },
 "calendar": { "occupied": [{ "scheduled_for": "2026-09-07T04:53:56Z", "platforms": ["linkedin"], "campaign": "Grinder launch", "step": "announcement" }] },
 "week": { "index": 0, "theme": "Il banco di lavoro" },
 "operator_edits": [{
   "before": "Siamo entusiasti di annunciare il nostro nuovo grinder, un vero game-changer!",
   "after": "Nuovo grinder. Macina 18 g in 4 secondi, e le fini si vedono." }],
 "history": {
  "post_count": 3, "best_times": ["Wed 04:00", "Sun 04:00"],
  "top_formats": ["image", "video"], "top_hashtags": ["#caffe", "#tostatura"],
  "cadence": "~3 posts/week", "untested_hooks": ["callout", "question", "contrarian"],
  "winners": [{ "id": "fe931b66-…", "platform": "linkedin", "opening": "Abbiamo rotto il grinder tre volte prima di capire il problema. #caffe #tostatura" }]
 }
}
```

Two things worth reading closely. `Volto Senza Consenso` (real, no consent) is **absent** while `Nero Persona` (AI) is present — the likeness rule live. And `rubric` is **absent** because the demo brand's approved rubrics are `single_image` and `carousel` while the job asked for `text_post` — selection, live.

</details>

<details>
<summary>Selection across seven real jobs on the same brand — after the format fix</summary>

```
goal                                   | platforms | format     -> template               | hooks              | rubric          | size
launch the new espresso grinder        | linkedin  | text_post  -> The Story Post         | Curiosity Hooks    | —               | 5323
state an unpopular opinion about speci | linkedin  | text_post  -> The Contrarian Take    | Contrarian Hooks   | —               | 5227
tell the story of the roaster breakdow | linkedin  | text_post  -> The Story Post         | Story Hooks        | —               | 5295
show the tasting bench in a short clip | instagram | video      -> The Reel Script        | Curiosity Hooks    | —               | 4898
explain the grinder in a carousel      | instagram | carousel   -> The Carousel Hook      | Curiosity Hooks    | Giorni Normali  | 5452
thread breaking down our roasting curv | x         | text_post  -> The Breakdown Thread   | Curiosity Hooks    | —               | 4689
share the new price list link          | linkedin  | link_post  -> The List Post          | Curiosity Hooks    | —               | 5302
```

Before the fix, row 4 returned **The Carousel Hook** — the defect the second red above pins.

</details>

<details>
<summary>No cross-brand leakage, and the error paths — live</summary>

```
another brand in the same local DB: gate

--- cross-brand: demo's owner asking for a brand they do not own ---
HTTP 404 {"error":"Brand not found"}
--- invalid format ---            HTTP 400 invalid_input
--- unknown field (strict) ---    HTTP 400 invalid_input
--- platforms of only commas ---  HTTP 400 {"error":"no_platforms"}
--- unauthenticated ---           HTTP 401 {"error":"Missing or invalid Authorization header"}

--- does another brand's material leak into demo's kit? ---
other brands' product titles in the local DB: 27
leaked into demo's kit: NONE
```

</details>

<details>
<summary>Zero model calls and zero credits, read off the real ledger</summary>

```
ai_calls before: 1367
ai_calls after 5 calls: 1367

latency, 5 sequential calls on a cold Vite dev server:
4.74s  2.29s  1.11s  1.35s  0.85s
```

Not a spy this time — the `ai_calls` table itself, unchanged.

</details>

<details>
<summary>Measured kit sizes</summary>

```
empty/new brand ......... 3,826 bytes   (voice 1,981 + template 1,522 dominate)
realistic seeded brand .. 5,378 bytes   trimmed: []
live demo brand ......... 4,689 – 5,452 bytes across the seven jobs above
budget .................. 8,192 bytes
```

Nothing was trimmed for any realistic brand. The trim path is exercised by the maximal-brand test, which saturates every capped field at once and asserts `history` yields first.

</details>

## Anything Else?

**The value of this kit is unproven and I am not claiming otherwise.** The plan is explicit that it "ships only if it improves the facts without making completion materially slower or more expensive". That comparison — the same external model and task, with and without the kit, across several real brand scenarios, with enough repetitions not to read one stochastic response as a result — **has not been run.** What this PR establishes is the measured size (3.8–5.5 KB) and the measured cost (zero model calls, zero credits, verified against `ai_calls`). Whether it makes the output better is the next question, not an answer this PR contains.

**What I did not run.** `npm run check` was SIGTERM-killed three times at its timeout on this shared machine; the one run that completed (before the final typing change) reported 395 errors across 112 files, of which 21 were in my own test file — caused by my typing `buildCreationKit` as `Record<string, unknown>`. I fixed that by typing it from the contract (`GetCreationKitResult`), which also makes the builder stop compiling if it drifts from what the endpoint declares. The exact final `svelte-check` figure is recorded in the comment below with the run that produced it. `cd cli && bun run typecheck` is clean.

**Known limits, stated plainly.**

- `goalOverlap` is lexical, not semantic. For a goal with no vocabulary in common with any candidate it falls back to the first in file order — deterministic, but arbitrary. The format now pins the block wherever the format decides, so the arbitrary case is confined to choosing among same-format LinkedIn structures.
- `history.winners` can be `[]` when the brand has history only on platforms other than the requested ones. That is a meaningful answer ("nothing won here"), not a permanently empty field.
- Template ids (`linkedin-post-templates/the-story-post`) are stable only as long as the headings in `post-templates.md` are. Renaming a heading changes an id; `versions.kit` should be bumped when that happens.
- `voice` is 1,981 bytes — the single largest item, and it is static product-wide prose. If the budget ever gets tight, that is the first thing to look at, not the brand's own facts.
- The kit reads ~7 tables per call. Warm dev latency was ~0.85–1.35s; that is Vite dev, not production, and it has not been profiled under load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
