### PR TITLE
Unblock dev's red CI: key the credit-warning test on the org

### DIFF
--- a/changelog/2026-09-04-credit-warning-org-dedup.md
+++ b/changelog/2026-09-04-credit-warning-org-dedup.md
@@ -1,0 +1,32 @@
+# Il test dell'avviso 80% seminava ancora la tabella vecchia
+
+`dev` è rimasto rosso dal merge di #210: `credit-warning.test.ts` falliva su
+`expect(notifyBrandContacts).not.toHaveBeenCalled()`, e con lui il CI di ogni PR aperta.
+
+#210 ha spostato la deduplica dell'avviso all'80% da `brand_usage` a `org_usage` — chiave
+`(org_id, month)` invece di `(brand_id, month)`, perché un'org con cinque brand deve ricevere
+una mail sola quando il pool condiviso supera la soglia, non cinque identiche. Il codice è
+coerente: `maybeSendCreditWarning` legge `org_usage` filtrando su `org_id`, e
+`claimCreditWarning` inserisce e aggiorna la stessa tabella con la stessa chiave.
+
+Il test no. Il suo database finto seminava una riga `{ brand_id: 'brand-1', … }` e simulava il
+vincolo unico su `brand_id`: la lettura per `org_id` non trovava nulla, la prenotazione non
+collideva con niente, e la mail ripartiva. Difetto del test, non del codice — verificato
+leggendo entrambi i lati prima di toccare qualcosa, perché "è solo il test da aggiornare" è
+esattamente la conclusione comoda che nasconde un difetto vero quando lo è.
+
+Corretti la riga seminata e la simulazione del vincolo. Aggiornato anche il commento di
+`maybeSendCreditWarning`, che nominava ancora `brand_usage`: un commento scaduto costa più di
+nessun commento, e questo avrebbe mandato il prossimo lettore sulla tabella sbagliata.
+
+**Che il test morda davvero**, verificato per mutazione e non per colore: ri-chiavando la
+deduplica sul brand (`.eq('org_id', brand.id)` e `claimCreditWarning(…, brand.id, …)`, cioè la
+regressione esatta che questo test esiste per prendere) il caso "non rimanda nello stesso
+periodo" fallisce.
+
+**Da guardare in review, e non è farina di questo diff:** il primo caso ("due poll simultanei
+mandano una mail sola") passa anche disabilitando *entrambe* le guardie anti-spam — il return
+in lettura e il valore di ritorno di `claimCreditWarning`. Nessun errore viene loggato, quindi
+non è un'eccezione ingoiata; non sono riuscito a spiegarne la ragione. È così anche prima di
+questo cambiamento, e non c'entra col rosso del CI, ma quel caso oggi non dimostra ciò che il
+suo nome promette.

--- a/src/lib/server/credit-warning.test.ts
+++ b/src/lib/server/credit-warning.test.ts
@@ -19,7 +19,7 @@ vi.mock('./scheduler', () => ({
 
 import { maybeSendCreditWarning, type CreditsUsage } from './credits';
 
-/** brand_usage con il vincolo unico (brand_id, month) che fa perdere il secondo insert. */
+/** org_usage con il vincolo unico (org_id, month) che fa perdere il secondo insert. */
 function makeDb(rows: Row[]) {
 	const table: Row[] = rows.map((r) => ({ ...r }));
 	const build = (mode: 'select' | 'update', patch?: Row) => {
@@ -52,7 +52,7 @@ function makeDb(rows: Row[]) {
 				select: () => build('select'),
 				update: (patch: Row) => build('update', patch),
 				insert: async (row: Row) => {
-					if (table.some((r) => r.brand_id === row.brand_id && r.month === row.month)) {
+					if (table.some((r) => r.org_id === row.org_id && r.month === row.month)) {
 						return { data: null, error: { message: 'duplicate key value violates unique constraint' } };
 					}
 					table.push({ id: `u-${table.length + 1}`, ...row });
@@ -94,7 +94,7 @@ describe('maybeSendCreditWarning', () => {
 
 	it('non rimanda nello stesso periodo, ma riparte nel successivo', async () => {
 		const db = makeDb([
-			{ brand_id: 'brand-1', month: '2026-08-01', credits_warned_at: '2026-08-03T10:00:00.000Z' }
+			{ org_id: 'org-1', month: '2026-08-01', credits_warned_at: '2026-08-03T10:00:00.000Z' }
 		]);
 		await maybeSendCreditWarning(db.client as never, BRAND, usageAt(90));
 		expect(notifyBrandContacts).not.toHaveBeenCalled();

--- a/src/lib/server/credits.ts
+++ b/src/lib/server/credits.ts
@@ -522,7 +522,7 @@ async function claimCreditWarning(
 
 /**
  * Send a one-time email warning when credit usage exceeds 80% of the quota.
- * Uses brand_usage.credits_warned_at for anti-spam: one email per billing period.
+ * Uses org_usage.credits_warned_at for anti-spam: one email per billing period, per org.
  * Fire-and-forget: never throws, never blocks the caller.
  */
 export async function maybeSendCreditWarning(


### PR DESCRIPTION
## What?

`dev` has been red since #210 merged, and every open PR inherits that red — #205, #212, #216 and
the release PR #162 all fail the `test` job on the same single assertion:

```
AssertionError: expected "spy" to not be called at all, but actually been called 1 times
 ❯ src/lib/server/credit-warning.test.ts:100:35
 Test Files  1 failed | 590 passed
      Tests  1 failed | 6522 passed
```

This fixes that test. It is a three-line change plus a stale comment.

## Why?

Nothing merges while `dev` is red, so this takes review priority over the billing queue it is
blocking.

#210 moved the 80%-usage warning's anti-spam key from `brand_usage` to `org_usage` — keyed
`(org_id, month)` instead of `(brand_id, month)` — so an org with five brands gets one email when
the shared pool crosses the threshold instead of five identical ones.

The production code followed that move coherently. The test's fake database did not: it seeded a
row keyed `brand_id` and simulated the unique constraint on `brand_id`, so the code's org-keyed
read matched nothing, the claim collided with nothing, and the email went out a second time.

## How?

**The diagnosis came first, and it mattered.** Two readings were possible — a stale test, or a
genuinely broken dedup shipping duplicate warning emails to real customers. I read both sides
before concluding, because "just update the test" is the comfortable answer that hides a real
defect when it is one:

- `maybeSendCreditWarning` (`src/lib/server/credits.ts:546-551`) reads `org_usage` filtered on
  `org_id`.
- `claimCreditWarning` (`:509-520`) inserts and updates the same table on the same key.
- `org_usage` (migration `20260903190000`) is `(org_id, month)` with `unique (org_id, month)` and
  an `id` column, matching what the claim's `.select('id')` expects.
- `brandContacts(supabase, orgId, brandId)` (`scheduler.ts:1492`) matches the call site.

Coherent end to end — so the test was the stale side. Changed: the seeded row's key, the fake's
unique-constraint check, and the file's doc comment. Also corrected `maybeSendCreditWarning`'s own
comment, which still named `brand_usage` and would have pointed the next reader at the wrong table.

**No public changelog**, deliberately: no user ever received a duplicate email — the defect existed
only in the test's model.

## Testing?

`npx vitest run` over the credits/billing area: **10 files, 55 tests, green** —
`credit-warning`, `credits`, `credits-org-scope`, `credits-billing-gate`, `sandbox-credits`,
`chat/queue-credits`, `billing/**`, `lib/billing/**`.

**That the corrected test still bites was checked by mutation, not by its colour.** Re-keying the
dedup back to the brand — `.eq('org_id', brand.id)` and `claimCreditWarning(…, brand.id, …)`, which
is precisely the regression this test exists to catch — makes "non rimanda nello stesso periodo"
fail.

`typecheck-runtime.mjs` not run: it is killed under load on this machine. The diff adds no new
imports or signatures; this job covers it.

## Evidence

<details><summary>Red before, on dev itself</summary>

```
$ git log origin/dev --oneline -1
f038753 Merge pull request #210 from anomaliaso/feat/org-scoped-credits

$ npx vitest run src/lib/server/credit-warning.test.ts
 × non rimanda nello stesso periodo, ma riparte nel successivo
   → expected "spy" to not be called at all, but actually been called 1 times
 Test Files  1 failed (1)
```
</details>

<details><summary>Green after, and the mutation that proves it bites</summary>

```
$ npx vitest run src/lib/server/credit-warning.test.ts
 ✓ src/lib/server/credit-warning.test.ts (3 tests)

# mutation: dedup re-keyed to the brand
 × non rimanda nello stesso periodo, ma riparte nel successivo
      Tests  1 failed | 2 passed (3)
```
</details>

## Anything Else?

**One finding for review, pre-existing and outside this diff.** The first case — "due poll
simultanei mandano una mail sola" — passes even with *both* anti-spam guards disabled (the
read-side early return and `claimCreditWarning`'s return value). No error is logged, so it is not
a swallowed exception; I could not determine why the second concurrent call does not send. It
behaves this way before this change too and is unrelated to the red CI, but that case does not
today demonstrate what its name promises, and it guards the path that turns "one email per period"
into "one email every 45 seconds".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RgPP6gw4d7xW7Y92vJJrPZ