### PR TITLE
Teach the endpoint registry to address a post by id

### DIFF
--- a/changelog/2026-09-04-registry-resource-id.md
+++ b/changelog/2026-09-04-registry-resource-id.md
@@ -1,0 +1,103 @@
+# Il registry sa parlare di un singolo post
+
+`packages/api-contracts` dichiara un endpoint una volta e ne deriva rotta REST,
+metodo del client e tool MCP. Copriva 11 endpoint su 71 tool esposti, e il motivo
+era uno solo: un test rifiutava qualunque `pathUnderBrand` contenesse `:`.
+
+Il limite era onesto. Un endpoint sotto `/posts/:id` non ha solo un buco nel
+path: chi chiama passa `2b38abc5`, non un uuid intero, e qualcuno deve
+trasformare il prefisso nell'id prima che la rotta lo veda. Il registry non
+sapeva dirlo, quindi quegli endpoint restavano scritti a mano invece di entrare
+qui a metà.
+
+## Come è modellato adesso
+
+Un endpoint può dichiarare una **risorsa**. Il path porta un solo buco `:id`, e
+il tipo non lascia costruire il path senza l'id: `pathFor` è in overload, quindi
+`pathFor(GET_POST, slug)` non compila — non è un controllo a runtime dimenticato
+in un ramo, è il compilatore. L'implementazione lancia comunque, per chi arriva
+da JavaScript.
+
+**Come si risolve l'id è una proprietà della risorsa, non dell'endpoint.**
+`BRAND_RESOURCES` le nomina una volta sola; il client tiene una tabella
+`Record<BrandResource, IdResolver>` in `cli/mcp/util.ts`, accanto a
+`resolvePostId` e `resolveArticleId`, che è dove la risoluzione può stare —
+serve elencare e confrontare, cose che una rotta REST non fa. Una risorsa
+aggiunta al registry senza il suo risolutore non compila. Dodici endpoint che
+ripetono ciascuno "risolvi come un post" sarebbero stati la condizione sparsa
+che questo repo vieta.
+
+La rotta REST non impara niente: continua a ricevere un id già risolto.
+
+Il campo è **opzionale**. Un endpoint che non dichiara una risorsa compila e si
+comporta esattamente come prima — le PR aperte che aggiungono righe a
+`BRAND_ENDPOINTS` continuano a fare merge senza toccare niente.
+
+## Il test che se ne è andato, e quello che lo sostituisce
+
+`non accetta ancora un endpoint con un segmento :id` era il guardiano del
+limite. Al suo posto ce ne sono due più forti: un segmento dinamico esiste **se
+e solo se** la risorsa che lo risolve è dichiarata, e nessun altro `:` entra nel
+path. Un `:slideIndex` mezzo modellato è ancora rifiutato, e ora lo è anche un
+`/posts/:id/...` senza risorsa.
+
+## Cosa è stato migrato
+
+`get_post`, `reschedule_post`, `render_post`: una lettura, una scrittura con
+body, una scrittura senza body. Il registry passa da 11 a 14 endpoint, i tool
+scritti a mano da 60 a 57 — i tool esposti restano 71.
+
+I test di equivalenza sono stati scritti **prima** della migrazione e messi a
+girare sui tool scritti a mano: 13 su 14 passano già lì — nome, schema, campi
+obbligatori, annotazioni, il path REST esatto raggiunto dopo la risoluzione del
+prefisso, il body inviato, la forma del risultato, e un prefisso ambiguo che non
+tocca nessun post. L'unico rosso è quello che pretende la descrizione di `id`
+anche su `reschedule_post`, cioè l'unico miglioramento voluto. Dopo la
+migrazione passano tutti e 14.
+
+`tools/list` è stato catturato attraverso il transport vero su `origin/dev` e
+sul branch, e i due dump confrontati: 71 tool prima e 71 dopo, nessun nome
+aggiunto o tolto, e differenze solo nei tre tool migrati.
+
+Tre differenze reali, tutte volute:
+
+- l'input di ogni endpoint del registry è `.strict()`, quindi i tre schemi ora
+  dichiarano `additionalProperties: false`. Prima un campo inventato veniva
+  scartato in silenzio.
+- `id` su `reschedule_post` e `render_post` non aveva descrizione. Ora la
+  prende dalla risorsa: "Post id or unambiguous prefix", la stessa che
+  `get_post` scriveva a mano.
+- `get_post` dichiarava solo `readOnlyHint: true`; adesso porta accanto
+  `destructiveHint: false`, che il registry deriva da `destructive`. È la stessa
+  coppia che gli altri tool derivati pubblicano già.
+
+Una differenza cosmetica: in `reschedule_post` l'ordine delle proprietà cambia,
+perché il loop estende il contratto con `slug` e `id` invece di anteporli.
+`properties` è un oggetto e `required` un insieme: nessun client legge l'ordine.
+Allinearlo vorrebbe dire cambiarlo per gli undici tool derivati già in produzione.
+
+## Cosa NON è stato migrato, e perché
+
+- **`edit_post`** è una PUT, e il registry conosce solo GET e POST. Aggiungere
+  PUT sono tre righe; il problema è un altro: il tool scritto a mano risponde
+  `{ ok, id, patch }`, dove `patch` è l'eco dell'input, e la rotta restituisce
+  solo `{ ok }`. Derivarlo cambierebbe la forma del risultato, oppure
+  costringerebbe il registry a imparare un concetto — "il risultato rimanda
+  indietro la richiesta" — che serve a un endpoint solo. Resta scritto a mano.
+- **`approve_post`, `publish_post`, `reject_post`** pubblicano davvero, su
+  account social veri. Sono derivabili, ma la prova di equivalenza va fatta
+  eseguendola, non leggendola, e un approve cambiato di sfumatura è la
+  regressione peggiore possibile qui. Restano scritti a mano.
+- **`regenerate_post_media`, `regenerate_slide`, `reorder_slides`,
+  `make_video`** sono quattro tool sullo stesso path `/posts/:id/media`,
+  distinti da un campo `action` costante nel body. Il registry mappa un
+  endpoint su un tool: servirebbe un concetto di "campo fissato dal contratto"
+  che oggi non serve a nient'altro.
+
+## Un difetto trovato per strada, non corretto qui
+
+`reorder_slides` manda `{ action: 'reorder' }` mentre la rotta
+`/posts/[id]/media` conosce solo `restructure`, `regenerate`, `slide` e
+`video`: risponde `Unknown action: reorder`, 400. È rotto da prima di questa PR
+e la sua correzione è una modifica di comportamento, che non sta in una PR
+strutturale.

--- a/cli/lib/api.ts
+++ b/cli/lib/api.ts
@@ -4,7 +4,12 @@
  */
 
 import { appUrl } from './config.ts';
-import { pathFor, type BrandEndpoint } from './contracts/index.ts';
+import {
+  pathFor,
+  type BrandEndpoint,
+  type ResourceEndpoint,
+  type ResourcelessEndpoint,
+} from './contracts/index.ts';
 
 async function request<T>(path: string, token: string, opts?: RequestInit): Promise<T> {
   // Resolved per call, not at import time: loadEnv() sets PUBLIC_APP_URL after the module
@@ -38,12 +43,27 @@ function post<T>(path: string, token: string, body?: unknown): Promise<T> {
 }
 
 export function callEndpoint<T>(
+  endpoint: ResourcelessEndpoint,
+  token: string,
+  slug: string,
+  input?: Record<string, unknown>,
+): Promise<T>;
+export function callEndpoint<T>(
+  endpoint: ResourceEndpoint,
+  token: string,
+  slug: string,
+  input: Record<string, unknown>,
+  id: string,
+): Promise<T>;
+export function callEndpoint<T>(
   endpoint: BrandEndpoint,
   token: string,
   slug: string,
   input: Record<string, unknown> = {},
+  id?: string,
 ): Promise<T> {
-  const path = pathFor(endpoint, slug);
+  const path =
+    endpoint.resource === undefined ? pathFor(endpoint, slug) : pathFor(endpoint, slug, id ?? '');
   if (endpoint.method === 'POST') return post<T>(path, token, input);
 
   const query = new URLSearchParams();

--- a/cli/lib/contracts.test.ts
+++ b/cli/lib/contracts.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from 'bun:test';
 import { existsSync, readdirSync, readFileSync } from 'fs';
 import { join } from 'path';
+import { z } from 'zod';
+import { pathFor, type ResourceEndpoint } from './contracts/index.ts';
 
 const ROOT = join(import.meta.dir, '..');
 const CANONICAL = join(ROOT, '..', 'packages', 'api-contracts', 'src');
@@ -24,5 +26,24 @@ describe('mirror dei contratti', () => {
         readFileSync(join(CANONICAL, name), 'utf8'),
       );
     }
+  });
+
+  test('un endpoint di risorsa non compila senza il suo id', () => {
+    const onAPost = {
+      tool: 'fixture_post_read',
+      title: 'Fixture',
+      description: 'Fixture',
+      method: 'GET',
+      pathUnderBrand: '/posts/:id/media',
+      resource: 'post',
+      input: z.object({}).strict(),
+      output: z.object({ status: z.string() }),
+      failures: [],
+      destructive: false,
+    } satisfies ResourceEndpoint;
+
+    expect(pathFor(onAPost, 'demo', 'abc')).toBe('/api/v1/brands/demo/posts/abc/media');
+    // @ts-expect-error il tipo rifiuta la chiamata senza id; il throw copre chi arriva da JS
+    expect(() => pathFor(onAPost, 'demo')).toThrow(/post/);
   });
 });

--- a/cli/lib/contracts/index.ts
+++ b/cli/lib/contracts/index.ts
@@ -2,7 +2,15 @@ import type { z } from 'zod';
 import { CHECK_CONTENT } from './content';
 import { GET_AUDIT_FINDINGS, LIST_AUDIT_CITATIONS, LIST_WEB_AUDITS, LIST_WEB_FIXES } from './evidence';
 import { PLAN_CADENCES, PLAN_CYCLE_WEEKS, SAVE_PLAN, SAVE_WEEK_SEEDS } from './plans';
-import { CREATE_POST, GET_CALENDAR, LIST_MEDIA, LIST_POSTS } from './posts';
+import {
+  CREATE_POST,
+  GET_CALENDAR,
+  GET_POST,
+  LIST_MEDIA,
+  LIST_POSTS,
+  RENDER_POST,
+  RESCHEDULE_POST
+} from './posts';
 
 export type EndpointFailure = { readonly error: string; readonly status: number };
 
@@ -38,7 +46,22 @@ export type ResourceEndpoint = EndpointShape & {
 
 export type BrandEndpoint = ResourcelessEndpoint | ResourceEndpoint;
 
-export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [CREATE_POST, LIST_POSTS, GET_CALENDAR, LIST_MEDIA, CHECK_CONTENT, SAVE_PLAN, SAVE_WEEK_SEEDS, LIST_WEB_AUDITS, GET_AUDIT_FINDINGS, LIST_AUDIT_CITATIONS, LIST_WEB_FIXES];
+export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
+  CREATE_POST,
+  LIST_POSTS,
+  GET_CALENDAR,
+  LIST_MEDIA,
+  CHECK_CONTENT,
+  SAVE_PLAN,
+  SAVE_WEEK_SEEDS,
+  LIST_WEB_AUDITS,
+  GET_AUDIT_FINDINGS,
+  LIST_AUDIT_CITATIONS,
+  LIST_WEB_FIXES,
+  GET_POST,
+  RESCHEDULE_POST,
+  RENDER_POST
+];
 
 export function pathFor(endpoint: ResourcelessEndpoint, slug: string): string;
 export function pathFor(endpoint: ResourceEndpoint, slug: string, id: string): string;
@@ -53,7 +76,20 @@ export function statusForFailure(endpoint: BrandEndpoint, error: string): number
   return endpoint.failures.find((f) => f.error === error)?.status ?? 500;
 }
 
-export { CHECK_CONTENT, CREATE_POST, GET_AUDIT_FINDINGS, GET_CALENDAR, LIST_AUDIT_CITATIONS, LIST_MEDIA, LIST_POSTS, LIST_WEB_AUDITS, LIST_WEB_FIXES };
+export {
+  CHECK_CONTENT,
+  CREATE_POST,
+  GET_AUDIT_FINDINGS,
+  GET_CALENDAR,
+  GET_POST,
+  LIST_AUDIT_CITATIONS,
+  LIST_MEDIA,
+  LIST_POSTS,
+  LIST_WEB_AUDITS,
+  LIST_WEB_FIXES,
+  RENDER_POST,
+  RESCHEDULE_POST
+};
 export {
   AUDIT_CITATIONS_DEFAULT,
   AUDIT_CITATIONS_MAX,

--- a/cli/lib/contracts/index.ts
+++ b/cli/lib/contracts/index.ts
@@ -6,22 +6,47 @@ import { CREATE_POST, GET_CALENDAR, LIST_MEDIA, LIST_POSTS } from './posts';
 
 export type EndpointFailure = { readonly error: string; readonly status: number };
 
-export type BrandEndpoint = {
+export const BRAND_RESOURCES = {
+  post: 'Post',
+  article: 'Article'
+} as const;
+
+export type BrandResource = keyof typeof BRAND_RESOURCES;
+
+export const RESOURCE_SEGMENT = ':id';
+
+type EndpointShape = {
   readonly tool: string;
   readonly title: string;
   readonly description: string;
   readonly method: 'GET' | 'POST';
-  readonly pathUnderBrand: string;
   readonly input: z.ZodObject<z.ZodRawShape>;
   readonly output: z.ZodType;
   readonly failures: readonly EndpointFailure[];
   readonly destructive: boolean;
 };
 
+export type ResourcelessEndpoint = EndpointShape & {
+  readonly pathUnderBrand: string;
+  readonly resource?: undefined;
+};
+
+export type ResourceEndpoint = EndpointShape & {
+  readonly pathUnderBrand: `${string}/${typeof RESOURCE_SEGMENT}${string}`;
+  readonly resource: BrandResource;
+};
+
+export type BrandEndpoint = ResourcelessEndpoint | ResourceEndpoint;
+
 export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [CREATE_POST, LIST_POSTS, GET_CALENDAR, LIST_MEDIA, CHECK_CONTENT, SAVE_PLAN, SAVE_WEEK_SEEDS, LIST_WEB_AUDITS, GET_AUDIT_FINDINGS, LIST_AUDIT_CITATIONS, LIST_WEB_FIXES];
 
-export function pathFor(endpoint: BrandEndpoint, slug: string): string {
-  return `/api/v1/brands/${encodeURIComponent(slug)}${endpoint.pathUnderBrand}`;
+export function pathFor(endpoint: ResourcelessEndpoint, slug: string): string;
+export function pathFor(endpoint: ResourceEndpoint, slug: string, id: string): string;
+export function pathFor(endpoint: BrandEndpoint, slug: string, id?: string): string {
+  const base = `/api/v1/brands/${encodeURIComponent(slug)}`;
+  if (endpoint.resource === undefined) return `${base}${endpoint.pathUnderBrand}`;
+  if (!id) throw new Error(`${endpoint.tool} needs a ${endpoint.resource} id`);
+  return `${base}${endpoint.pathUnderBrand.replace(RESOURCE_SEGMENT, encodeURIComponent(id))}`;
 }
 
 export function statusForFailure(endpoint: BrandEndpoint, error: string): number {

--- a/cli/lib/contracts/posts.ts
+++ b/cli/lib/contracts/posts.ts
@@ -110,6 +110,71 @@ export const LIST_POSTS = {
   destructive: false
 } satisfies BrandEndpoint;
 
+const PostStateRow = z.looseObject({
+  status: z.string(),
+  content_type: z.string().nullable(),
+  format: z.string().nullable(),
+  platform: z.string().nullable(),
+  platforms: z.array(z.string()).nullable(),
+  caption: z.string().nullable(),
+  media_url: z.string().nullable(),
+  is_carousel: z.boolean(),
+  slide_count: z.number(),
+  slides: z.array(z.record(z.string(), z.unknown())).nullable(),
+  text_only: z.boolean()
+});
+
+const NotFound = z.object({ error: z.string() });
+
+export const GET_POST = {
+  tool: 'get_post',
+  title: 'Get post',
+  description: 'Show a single post including carousel slides / media state. id accepts a short prefix.',
+  method: 'GET',
+  pathUnderBrand: '/posts/:id/media',
+  resource: 'post',
+  input: z.object({}).strict(),
+  output: z.union([PostStateRow, NotFound]),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const RESCHEDULE_POST = {
+  tool: 'reschedule_post',
+  title: 'Reschedule post',
+  description: 'Reschedule a post. scheduled_for is an ISO datetime. id accepts a short prefix.',
+  method: 'POST',
+  pathUnderBrand: '/posts/:id/reschedule',
+  resource: 'post',
+  input: z.object({
+    scheduled_for: z.string().min(1).describe('ISO datetime, e.g. 2026-06-20T10:00')
+  }).strict(),
+  output: z.object({
+    ok: z.literal(true),
+    scheduled_for: z.string(),
+    scheduled_for_local: z.string(),
+    noAccount: z.boolean().optional()
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const RENDER_POST = {
+  tool: 'render_post',
+  title: 'Render post image',
+  description: 'Generate the missing image from the prompt. Bills a render. id accepts a short prefix.',
+  method: 'POST',
+  pathUnderBrand: '/posts/:id/render',
+  resource: 'post',
+  input: z.object({}).strict(),
+  output: z.union([
+    z.object({ ok: z.literal(true), url: z.string().nullable(), error: z.string().nullable() }),
+    z.object({ error: z.string(), url: z.string() })
+  ]),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
 export const GET_CALENDAR = {
   tool: 'get_calendar',
   title: 'Calendar',

--- a/cli/mcp/create-post.test.ts
+++ b/cli/mcp/create-post.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test';
+import { runWithRequestAuth } from './context.ts';
 import { handleMcpFetch } from './http-app.ts';
 
 async function rpc(method: string, params: unknown, id = 1) {
@@ -12,10 +13,55 @@ async function rpc(method: string, params: unknown, id = 1) {
   return (await res.json()) as { result?: Record<string, unknown> };
 }
 
+const FULL_ID = '2b38abc5-7f31-4e0a-9a41-0f2d0c1b8e55';
+
+type ApiCall = { method: string; path: string; body: string | null };
+
+async function callTool(
+  name: string,
+  args: Record<string, unknown>,
+  reply: (path: string) => unknown,
+): Promise<{ calls: ApiCall[]; structured: Record<string, unknown> }> {
+  const calls: ApiCall[] = [];
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = new URL(typeof input === 'string' ? input : input.toString());
+    calls.push({
+      method: init?.method ?? 'GET',
+      path: `${url.pathname}${url.search}`,
+      body: typeof init?.body === 'string' ? init.body : null,
+    });
+    return new Response(JSON.stringify(reply(url.pathname)), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }) as typeof fetch;
+
+  try {
+    const res = await runWithRequestAuth(
+      { access_token: 'tok', user: { id: 'u1', email: 'u@example.com' }, source: 'bearer' },
+      async () => {
+        await rpc('initialize', {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: 'test', version: '0.0.1' },
+        });
+        return rpc('tools/call', { name, arguments: args }, 3);
+      },
+    );
+    return {
+      calls,
+      structured: (res.result?.structuredContent ?? {}) as Record<string, unknown>,
+    };
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+}
+
 type Tool = {
   name: string;
   description?: string;
-  inputSchema?: { properties?: Record<string, unknown>; required?: string[] };
+  inputSchema?: { properties?: Record<string, { description?: string }>; required?: string[] };
   annotations?: Record<string, unknown>;
 };
 
@@ -98,5 +144,89 @@ describe('i tool di brand derivati dal registry', () => {
     const names = (await tools()).map((t) => t.name);
 
     expect(names).toEqual([...new Set(names)]);
+  });
+});
+
+describe('i tool sul singolo post', () => {
+  test('get_post chiede lo slug e un id, e resta una lettura', async () => {
+    const getPost = find(await tools(), 'get_post');
+
+    expect(Object.keys(getPost.inputSchema?.properties ?? {}).sort()).toEqual(['id', 'slug']);
+    expect((getPost.inputSchema?.required ?? []).sort()).toEqual(['id', 'slug']);
+    expect(getPost.annotations?.readOnlyHint).toBe(true);
+    expect(getPost.description ?? '').toContain('id accepts a short prefix');
+  });
+
+  test('reschedule_post chiede anche la data e non si dichiara distruttivo', async () => {
+    const reschedule = find(await tools(), 'reschedule_post');
+
+    expect(Object.keys(reschedule.inputSchema?.properties ?? {}).sort()).toEqual([
+      'id',
+      'scheduled_for',
+      'slug',
+    ]);
+    expect((reschedule.inputSchema?.required ?? []).sort()).toEqual([
+      'id',
+      'scheduled_for',
+      'slug',
+    ]);
+    expect(reschedule.annotations?.readOnlyHint).toBe(false);
+    expect(reschedule.annotations?.destructiveHint).toBe(false);
+    expect(reschedule.description ?? '').toContain('ISO datetime');
+  });
+
+  test('ogni tool sul post dice che l id accetta un prefisso, non solo la sua description', async () => {
+    const all = await tools();
+
+    for (const name of ['get_post', 'reschedule_post', 'render_post']) {
+      const id = find(all, name).inputSchema?.properties?.id as { description?: string };
+      expect(id?.description, name).toBe('Post id or unambiguous prefix');
+    }
+  });
+
+  test('render_post chiede solo il post e avvisa che si paga', async () => {
+    const render = find(await tools(), 'render_post');
+
+    expect(Object.keys(render.inputSchema?.properties ?? {}).sort()).toEqual(['id', 'slug']);
+    expect((render.inputSchema?.required ?? []).sort()).toEqual(['id', 'slug']);
+    expect(render.annotations?.readOnlyHint).toBe(false);
+    expect(render.annotations?.destructiveHint).toBe(false);
+    expect(render.description ?? '').toContain('Bills a render');
+  });
+
+  test('un prefisso diventa l id intero prima che la rotta REST lo veda', async () => {
+    const { calls, structured } = await callTool('get_post', { slug: 'demo', id: '2b38abc5' }, (path) =>
+      path.endsWith('/media') ? { status: 'approved', caption: 'ciao' } : [{ id: FULL_ID }, { id: 'ffff0000-0000-0000-0000-000000000000' }],
+    );
+
+    expect(calls.map((c) => `${c.method} ${c.path}`)).toEqual([
+      'GET /api/v1/brands/demo/posts',
+      `GET /api/v1/brands/demo/posts/${FULL_ID}/media`,
+    ]);
+    expect(structured).toEqual({ id: FULL_ID, status: 'approved', caption: 'ciao' });
+  });
+
+  test('reschedule_post manda la data al post risolto, e niente altro', async () => {
+    const { calls, structured } = await callTool(
+      'reschedule_post',
+      { slug: 'demo', id: '2b38abc5', scheduled_for: '2030-06-20T10:00' },
+      (path) => (path.endsWith('/reschedule') ? { ok: true, scheduled_for: '2030-06-20T08:00:00Z' } : [{ id: FULL_ID }]),
+    );
+
+    expect(calls[1]).toEqual({
+      method: 'POST',
+      path: `/api/v1/brands/demo/posts/${FULL_ID}/reschedule`,
+      body: JSON.stringify({ scheduled_for: '2030-06-20T10:00' }),
+    });
+    expect(structured).toEqual({ id: FULL_ID, ok: true, scheduled_for: '2030-06-20T08:00:00Z' });
+  });
+
+  test('un prefisso ambiguo non tocca nessun post', async () => {
+    const { calls } = await callTool('get_post', { slug: 'demo', id: 'aa' }, () => [
+      { id: 'aa11' },
+      { id: 'aa22' },
+    ]);
+
+    expect(calls).toHaveLength(1);
   });
 });

--- a/cli/mcp/tools/brand-content.ts
+++ b/cli/mcp/tools/brand-content.ts
@@ -167,25 +167,6 @@ export function registerBrandTools(server: McpServer) {
   );
 
   server.registerTool(
-    'get_post',
-    {
-      title: 'Get post',
-      description: 'Show a single post including carousel slides / media state. id accepts a short prefix.',
-      inputSchema: z.object({
-        slug,
-        id: z.string().min(1).describe('Post id or unambiguous prefix'),
-      }),
-      annotations: { readOnlyHint: true },
-    },
-    async ({ slug, id }) =>
-      withAuth(async (token) => {
-        const postId = await resolvePostId(token, slug, id);
-        const media = await api.getPostMedia(token, slug, postId);
-        return { id: postId, ...media };
-      }),
-  );
-
-  server.registerTool(
     'edit_post',
     {
       title: 'Edit post',
@@ -269,43 +250,6 @@ export function registerBrandTools(server: McpServer) {
         const postId = await resolvePostId(token, slug, id);
         await api.deletePost(token, slug, postId);
         return { ok: true, id: postId, deleted: true };
-      }),
-  );
-
-  server.registerTool(
-    'reschedule_post',
-    {
-      title: 'Reschedule post',
-      description: 'Reschedule a post. scheduled_for is an ISO datetime. id accepts a short prefix.',
-      inputSchema: z.object({
-        slug,
-        id: z.string().min(1),
-        scheduled_for: z.string().min(1).describe('ISO datetime, e.g. 2026-06-20T10:00'),
-      }),
-      annotations: { readOnlyHint: false, destructiveHint: false },
-    },
-    async ({ slug, id, scheduled_for }) =>
-      withAuth(async (token) => {
-        const postId = await resolvePostId(token, slug, id);
-        return { id: postId, ...(await api.reschedulePost(token, slug, postId, scheduled_for)) };
-      }),
-  );
-
-  server.registerTool(
-    'render_post',
-    {
-      title: 'Render post image',
-      description: 'Generate the missing image from the prompt. Bills a render. id accepts a short prefix.',
-      inputSchema: z.object({
-        slug,
-        id: z.string().min(1),
-      }),
-      annotations: { readOnlyHint: false, destructiveHint: false },
-    },
-    async ({ slug, id }) =>
-      withAuth(async (token) => {
-        const postId = await resolvePostId(token, slug, id);
-        return { id: postId, ...(await api.renderPost(token, slug, postId)) };
       }),
   );
 

--- a/cli/mcp/tools/brand-content.ts
+++ b/cli/mcp/tools/brand-content.ts
@@ -1,26 +1,48 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { api, callEndpoint } from '../../lib/api.ts';
-import { BRAND_ENDPOINTS } from '../../lib/contracts/index.ts';
-import { resolvePostId, withAuth } from '../util.ts';
+import { BRAND_ENDPOINTS, BRAND_RESOURCES, type BrandResource } from '../../lib/contracts/index.ts';
+import { resolvePostId, resolveResourceId, withAuth } from '../util.ts';
 
 const slug = z.string().min(1).describe('Brand URL slug');
 
+const resourceId = (resource: BrandResource) =>
+  z.string().min(1).describe(`${BRAND_RESOURCES[resource]} id or unambiguous prefix`);
+
 function registerDeclaredEndpoints(server: McpServer) {
   for (const endpoint of BRAND_ENDPOINTS) {
+    const resource = endpoint.resource;
     server.registerTool(
       endpoint.tool,
       {
         title: endpoint.title,
         description: endpoint.description,
-        inputSchema: endpoint.input.extend({ slug }),
+        inputSchema:
+          resource === undefined
+            ? endpoint.input.extend({ slug })
+            : endpoint.input.extend({ slug, id: resourceId(resource) }),
         annotations: {
           readOnlyHint: endpoint.method === 'GET',
           destructiveHint: endpoint.destructive,
         },
       },
       async ({ slug: brandSlug, ...input }) =>
-        withAuth((token) => callEndpoint(endpoint, token, brandSlug as string, input)),
+        withAuth(async (token) => {
+          if (endpoint.resource === undefined) {
+            return callEndpoint(endpoint, token, brandSlug as string, input);
+          }
+
+          const { id, ...payload } = input as { id: string } & Record<string, unknown>;
+          const resolved = await resolveResourceId(endpoint.resource, token, brandSlug as string, id);
+          const body = await callEndpoint<Record<string, unknown>>(
+            endpoint,
+            token,
+            brandSlug as string,
+            payload,
+            resolved,
+          );
+          return { id: resolved, ...body };
+        }),
     );
   }
 }

--- a/cli/mcp/util.ts
+++ b/cli/mcp/util.ts
@@ -1,5 +1,6 @@
 import { api } from '../lib/api.ts';
 import { loadSession, type StoredSession } from '../lib/auth.ts';
+import type { BrandResource } from '../lib/contracts/index.ts';
 import { resolveByPrefix } from '../lib/select.ts';
 import { getRequestAuth } from './context.ts';
 
@@ -99,4 +100,20 @@ export async function resolveArticleId(token: string, slug: string, idOrPrefix: 
     throw new Error(`No article found for id/prefix "${idOrPrefix}". List articles first.`);
   }
   return match.item.id;
+}
+
+type IdResolver = (token: string, slug: string, idOrPrefix: string) => Promise<string>;
+
+const RESOLVE_ID: Record<BrandResource, IdResolver> = {
+  post: resolvePostId,
+  article: resolveArticleId,
+};
+
+export function resolveResourceId(
+  resource: BrandResource,
+  token: string,
+  slug: string,
+  idOrPrefix: string,
+): Promise<string> {
+  return RESOLVE_ID[resource](token, slug, idOrPrefix);
 }

--- a/packages/api-contracts/src/index.test.ts
+++ b/packages/api-contracts/src/index.test.ts
@@ -1,12 +1,36 @@
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
-import { BRAND_ENDPOINTS, pathFor, statusForFailure, type BrandEndpoint } from './index';
+import {
+  BRAND_ENDPOINTS,
+  BRAND_RESOURCES,
+  RESOURCE_SEGMENT,
+  pathFor,
+  statusForFailure,
+  type BrandEndpoint
+} from './index';
 
 const byTool = (tool: string): BrandEndpoint => {
   const found = BRAND_ENDPOINTS.find((e) => e.tool === tool);
   if (!found) throw new Error(`missing endpoint ${tool}`);
   return found;
 };
+
+const ON_A_POST = {
+  tool: 'fixture_post_read',
+  title: 'Fixture',
+  description: 'Fixture',
+  method: 'GET',
+  pathUnderBrand: '/posts/:id/media',
+  resource: 'post',
+  input: z.object({}).strict(),
+  output: z.object({ status: z.string() }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+const modelled = (e: BrandEndpoint): boolean =>
+  e.pathUnderBrand.includes(RESOURCE_SEGMENT) === (e.resource !== undefined) &&
+  !e.pathUnderBrand.replace(RESOURCE_SEGMENT, '').includes(':');
 
 describe('il registry degli endpoint di brand', () => {
   it('descrive almeno una lettura e una scrittura, o non prova niente', () => {
@@ -26,13 +50,31 @@ describe('il registry degli endpoint di brand', () => {
     expect(pathFor(byTool('create_post'), 'demo')).toBe('/api/v1/brands/demo/posts');
   });
 
-  // Il limite dichiarato della versione 1: un endpoint con :id ha anche bisogno della
-  // risoluzione del prefisso (resolvePostId), che il registry non sa fare. Finché non la sa,
-  // quegli endpoint restano scritti a mano invece di entrare qui a metà.
-  it('non accetta ancora un endpoint con un segmento :id', () => {
+  it('un endpoint di risorsa mette l id risolto al posto del segmento', () => {
+    expect(pathFor(ON_A_POST, 'demo', '2b38abc5-7f31-4e0a-9a41-0f2d0c1b8e55')).toBe(
+      '/api/v1/brands/demo/posts/2b38abc5-7f31-4e0a-9a41-0f2d0c1b8e55/media'
+    );
+  });
+
+  it('senza id un endpoint di risorsa non costruisce un path a metà', () => {
+    // @ts-expect-error un endpoint che dichiara una risorsa non è chiamabile senza il suo id
+    expect(() => pathFor(ON_A_POST, 'demo')).toThrow(/post/);
+  });
+
+  it('un segmento dinamico esiste se e solo se la risorsa che lo risolve è dichiarata', () => {
     for (const e of BRAND_ENDPOINTS) {
-      expect(e.pathUnderBrand.includes(':'), e.tool).toBe(false);
+      expect(modelled(e), e.tool).toBe(true);
     }
+    expect(modelled({ ...ON_A_POST, resource: undefined })).toBe(false);
+    expect(modelled({ ...ON_A_POST, pathUnderBrand: '/posts/:id/media/:index' })).toBe(false);
+  });
+
+  it('ogni risorsa nominata da un endpoint ha una riga nella tabella delle risorse', () => {
+    for (const e of BRAND_ENDPOINTS) {
+      if (e.resource === undefined) continue;
+      expect(BRAND_RESOURCES[e.resource], e.tool).toBeDefined();
+    }
+    expect(BRAND_RESOURCES[ON_A_POST.resource]).toBe('Post');
   });
 
   it('una lettura non è mai distruttiva', () => {

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -2,7 +2,15 @@ import type { z } from 'zod';
 import { CHECK_CONTENT } from './content';
 import { GET_AUDIT_FINDINGS, LIST_AUDIT_CITATIONS, LIST_WEB_AUDITS, LIST_WEB_FIXES } from './evidence';
 import { PLAN_CADENCES, PLAN_CYCLE_WEEKS, SAVE_PLAN, SAVE_WEEK_SEEDS } from './plans';
-import { CREATE_POST, GET_CALENDAR, LIST_MEDIA, LIST_POSTS } from './posts';
+import {
+  CREATE_POST,
+  GET_CALENDAR,
+  GET_POST,
+  LIST_MEDIA,
+  LIST_POSTS,
+  RENDER_POST,
+  RESCHEDULE_POST
+} from './posts';
 
 export type EndpointFailure = { readonly error: string; readonly status: number };
 
@@ -38,7 +46,22 @@ export type ResourceEndpoint = EndpointShape & {
 
 export type BrandEndpoint = ResourcelessEndpoint | ResourceEndpoint;
 
-export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [CREATE_POST, LIST_POSTS, GET_CALENDAR, LIST_MEDIA, CHECK_CONTENT, SAVE_PLAN, SAVE_WEEK_SEEDS, LIST_WEB_AUDITS, GET_AUDIT_FINDINGS, LIST_AUDIT_CITATIONS, LIST_WEB_FIXES];
+export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
+  CREATE_POST,
+  LIST_POSTS,
+  GET_CALENDAR,
+  LIST_MEDIA,
+  CHECK_CONTENT,
+  SAVE_PLAN,
+  SAVE_WEEK_SEEDS,
+  LIST_WEB_AUDITS,
+  GET_AUDIT_FINDINGS,
+  LIST_AUDIT_CITATIONS,
+  LIST_WEB_FIXES,
+  GET_POST,
+  RESCHEDULE_POST,
+  RENDER_POST
+];
 
 export function pathFor(endpoint: ResourcelessEndpoint, slug: string): string;
 export function pathFor(endpoint: ResourceEndpoint, slug: string, id: string): string;
@@ -53,7 +76,20 @@ export function statusForFailure(endpoint: BrandEndpoint, error: string): number
   return endpoint.failures.find((f) => f.error === error)?.status ?? 500;
 }
 
-export { CHECK_CONTENT, CREATE_POST, GET_AUDIT_FINDINGS, GET_CALENDAR, LIST_AUDIT_CITATIONS, LIST_MEDIA, LIST_POSTS, LIST_WEB_AUDITS, LIST_WEB_FIXES };
+export {
+  CHECK_CONTENT,
+  CREATE_POST,
+  GET_AUDIT_FINDINGS,
+  GET_CALENDAR,
+  GET_POST,
+  LIST_AUDIT_CITATIONS,
+  LIST_MEDIA,
+  LIST_POSTS,
+  LIST_WEB_AUDITS,
+  LIST_WEB_FIXES,
+  RENDER_POST,
+  RESCHEDULE_POST
+};
 export {
   AUDIT_CITATIONS_DEFAULT,
   AUDIT_CITATIONS_MAX,

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -6,22 +6,47 @@ import { CREATE_POST, GET_CALENDAR, LIST_MEDIA, LIST_POSTS } from './posts';
 
 export type EndpointFailure = { readonly error: string; readonly status: number };
 
-export type BrandEndpoint = {
+export const BRAND_RESOURCES = {
+  post: 'Post',
+  article: 'Article'
+} as const;
+
+export type BrandResource = keyof typeof BRAND_RESOURCES;
+
+export const RESOURCE_SEGMENT = ':id';
+
+type EndpointShape = {
   readonly tool: string;
   readonly title: string;
   readonly description: string;
   readonly method: 'GET' | 'POST';
-  readonly pathUnderBrand: string;
   readonly input: z.ZodObject<z.ZodRawShape>;
   readonly output: z.ZodType;
   readonly failures: readonly EndpointFailure[];
   readonly destructive: boolean;
 };
 
+export type ResourcelessEndpoint = EndpointShape & {
+  readonly pathUnderBrand: string;
+  readonly resource?: undefined;
+};
+
+export type ResourceEndpoint = EndpointShape & {
+  readonly pathUnderBrand: `${string}/${typeof RESOURCE_SEGMENT}${string}`;
+  readonly resource: BrandResource;
+};
+
+export type BrandEndpoint = ResourcelessEndpoint | ResourceEndpoint;
+
 export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [CREATE_POST, LIST_POSTS, GET_CALENDAR, LIST_MEDIA, CHECK_CONTENT, SAVE_PLAN, SAVE_WEEK_SEEDS, LIST_WEB_AUDITS, GET_AUDIT_FINDINGS, LIST_AUDIT_CITATIONS, LIST_WEB_FIXES];
 
-export function pathFor(endpoint: BrandEndpoint, slug: string): string {
-  return `/api/v1/brands/${encodeURIComponent(slug)}${endpoint.pathUnderBrand}`;
+export function pathFor(endpoint: ResourcelessEndpoint, slug: string): string;
+export function pathFor(endpoint: ResourceEndpoint, slug: string, id: string): string;
+export function pathFor(endpoint: BrandEndpoint, slug: string, id?: string): string {
+  const base = `/api/v1/brands/${encodeURIComponent(slug)}`;
+  if (endpoint.resource === undefined) return `${base}${endpoint.pathUnderBrand}`;
+  if (!id) throw new Error(`${endpoint.tool} needs a ${endpoint.resource} id`);
+  return `${base}${endpoint.pathUnderBrand.replace(RESOURCE_SEGMENT, encodeURIComponent(id))}`;
 }
 
 export function statusForFailure(endpoint: BrandEndpoint, error: string): number {

--- a/packages/api-contracts/src/posts.ts
+++ b/packages/api-contracts/src/posts.ts
@@ -110,6 +110,71 @@ export const LIST_POSTS = {
   destructive: false
 } satisfies BrandEndpoint;
 
+const PostStateRow = z.looseObject({
+  status: z.string(),
+  content_type: z.string().nullable(),
+  format: z.string().nullable(),
+  platform: z.string().nullable(),
+  platforms: z.array(z.string()).nullable(),
+  caption: z.string().nullable(),
+  media_url: z.string().nullable(),
+  is_carousel: z.boolean(),
+  slide_count: z.number(),
+  slides: z.array(z.record(z.string(), z.unknown())).nullable(),
+  text_only: z.boolean()
+});
+
+const NotFound = z.object({ error: z.string() });
+
+export const GET_POST = {
+  tool: 'get_post',
+  title: 'Get post',
+  description: 'Show a single post including carousel slides / media state. id accepts a short prefix.',
+  method: 'GET',
+  pathUnderBrand: '/posts/:id/media',
+  resource: 'post',
+  input: z.object({}).strict(),
+  output: z.union([PostStateRow, NotFound]),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const RESCHEDULE_POST = {
+  tool: 'reschedule_post',
+  title: 'Reschedule post',
+  description: 'Reschedule a post. scheduled_for is an ISO datetime. id accepts a short prefix.',
+  method: 'POST',
+  pathUnderBrand: '/posts/:id/reschedule',
+  resource: 'post',
+  input: z.object({
+    scheduled_for: z.string().min(1).describe('ISO datetime, e.g. 2026-06-20T10:00')
+  }).strict(),
+  output: z.object({
+    ok: z.literal(true),
+    scheduled_for: z.string(),
+    scheduled_for_local: z.string(),
+    noAccount: z.boolean().optional()
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const RENDER_POST = {
+  tool: 'render_post',
+  title: 'Render post image',
+  description: 'Generate the missing image from the prompt. Bills a render. id accepts a short prefix.',
+  method: 'POST',
+  pathUnderBrand: '/posts/:id/render',
+  resource: 'post',
+  input: z.object({}).strict(),
+  output: z.union([
+    z.object({ ok: z.literal(true), url: z.string().nullable(), error: z.string().nullable() }),
+    z.object({ error: z.string(), url: z.string() })
+  ]),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
 export const GET_CALENDAR = {
   tool: 'get_calendar',
   title: 'Calendar',

--- a/src/lib/content/changelog/2026-09-04-post-id-prefix.ts
+++ b/src/lib/content/changelog/2026-09-04-post-id-prefix.ts
@@ -1,0 +1,10 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-04',
+  title: 'A short post id is enough, and the tools say so',
+  items: [
+    'The reschedule and render tools now state that a post id can be a short prefix — the same shortcut get_post already documented.',
+    'Those tools reject a field they do not know instead of dropping it in silence.'
+  ]
+} satisfies ChangelogEntry;


### PR DESCRIPTION
## What?

`packages/api-contracts` declares an endpoint once — name, title, description,
method, path, request schema, response schema, failures with their statuses,
annotations — and the REST route, the CLI client method and the MCP tool are
derived from it. It could not describe an endpoint with an `:id` in the path: a
guard test refused any `pathUnderBrand` containing a colon, so the whole
single-post family stayed hand-written.

This PR teaches the registry to model a **resource**, and migrates three post
tools onto it. Two commits, deliberately separate: the first changes the type
and the guard test and migrates nothing, the second migrates and changes no
types.

| | registry-driven | hand-written | exposed by `tools/list` |
|---|---|---|---|
| `origin/dev` (e727e52) | 11 | 60 | 71 |
| this branch | 14 | 57 | 71 |

## Why?

60 of the 71 MCP tools are still hand-written, and a hand-written tool
is a place where the CLI, the MCP surface and the REST route can drift apart
silently. The single largest blocked group is the `:id` family — 15 tools:
every `*_post`, `get_post`, and every `*_article` except `list_articles`.
Nothing could move until the registry could say what an id is and how it is
resolved, so this is the unlock, not the migration.

## How?

**An endpoint may declare a resource.** The path carries exactly one `:id` hole
and the type will not let a path be built without the id:

```ts
export function pathFor(endpoint: ResourcelessEndpoint, slug: string): string;
export function pathFor(endpoint: ResourceEndpoint, slug: string, id: string): string;
```

`pathFor(GET_POST, 'demo')` does not compile — it is the compiler, not a runtime
check forgotten in a branch. The implementation still throws, for a caller
arriving from JavaScript.

**How an id resolves is a property of the resource, not of the endpoint.** A
caller passes `2b38abc5`, not a full uuid, and something has to turn that into
an id before the route sees it. `BRAND_RESOURCES` names the resources once, and
the client keys a table on that type:

```
BRAND_RESOURCES        { post, article }        ← the registry names them once
        │
        ▼
RESOLVE_ID             Record<BrandResource, IdResolver>   ← cli/mcp/util.ts
  post    → resolvePostId      (lists posts,    matches prefix)
  article → resolveArticleId   (lists articles, matches prefix)
```

A resource added to the registry without a resolver does not compile. Twelve
endpoints each restating "resolve like a post" would have been exactly the
scattered condition `AGENTS.md` forbids.

**Resolution lives on the client side**, which can list and match. The REST
route learns nothing: it keeps receiving an id that is already resolved.

**The field is additive and optional.** An endpoint that declares no resource
compiles and behaves exactly as before. This is deliberate: several PRs are open
that add rows to `BRAND_ENDPOINTS`, and a required field would break all of them
on merge.

That is not a hypothesis: while this branch was open, **#211 merged four new
`BRAND_ENDPOINTS` entries** (`LIST_WEB_AUDITS`, `GET_AUDIT_FINDINGS`,
`LIST_AUDIT_CITATIONS`, `LIST_WEB_FIXES`). None of them declares a resource,
none needed a line changed, and rebasing this branch on top of them cost one
merge of the array literal. The registry went 7 → 11 endpoints underneath this
PR without it noticing.

### The guard test was replaced, not weakened

`non accetta ancora un endpoint con un segmento :id` was the guardian of the
limit. Two stronger invariants replace it:

- a dynamic segment exists **if and only if** the resource that resolves it is
  declared, and no other `:` may appear in the path — so a half-modelled
  `/posts/:id/media/:index` is still refused, and now so is a `/posts/:id/…`
  with no resource;
- every resource an endpoint names has a row in `BRAND_RESOURCES`.

### Rejected alternatives

- **Carry the id as a plain input field.** It builds the path but cannot express
  that a post id arrives as a prefix and has to be resolved first. It works only
  for ids that come back verbatim.
- **A resolver per endpoint.** Twelve endpoints, twelve copies of the same rule,
  diverging at the first change.
- **Resolve inside the REST route.** The route would have to list the brand's
  posts to disambiguate a prefix — an extra query on every call, and a concept
  the HTTP API has no reason to know.

### Coordination: this is the canonical implementation

**#220** (`feat/external-agent-studio-writes`) carries a commit
(`cc9d48f` *Teach the endpoint registry to address one row*) that solves the same
problem a second way: the id becomes an ordinary input field that `callEndpoint`
lifts out of the body into the path, plus `PUT`/`DELETE` on
`BrandEndpoint.method`. A reviewer should not be left choosing between two
mechanisms — **`feat/registry-id-endpoints` is the canonical one**, and the
studio PR should build on it:

- the two are not in conflict on substance. That branch's rows (product, person,
  competitor) have ids that come back verbatim from `get_studio` /
  `list_products`, so under this design they are one row each in
  `BRAND_RESOURCES` with an identity resolver in `RESOLVE_ID` — three lines,
  and they gain a compiler-enforced place to declare it if that ever stops being
  true;
- its `PUT`/`DELETE` extension of `method` is orthogonal to this PR and welcome
  on top;
- the alternative, if that branch prefers it, is to carry the id in the request
  body and declare no resource at all — which this PR keeps working, because the
  field is optional.

## Testing?

**Unit and contract tests**

```
npx vitest run packages/api-contracts "src/routes/api/v1/brands/[slug]/posts/"
  Test Files  5 passed (5)
       Tests  71 passed (71)

cd cli && bun test
  39 pass  0 fail   (103 expect() calls, 8 files)

cd cli && bun run typecheck     # tsc --noEmit, clean
cd cli && bun run build && node scripts/build-vercel.mjs
  mcp/api/_bundle.js  3.5mb — the contract mirror still inlines
  (grep confirms 'Post id or unambiguous prefix' and 'posts/:id/reschedule'
   are present in the bundle)

git diff --check      # clean
```

**Full suite** — `npm run test:unit`:

```
Test Files  595 passed | 3 skipped (598)
     Tests  6584 passed | 11 skipped (6595)
```

Zero failures. (An earlier run on the previous base reported
`src/lib/server/chat/brand-studio-tools.test.ts` as a failed *file* —
`Hook timed out in 60000ms`, no assertion failing — while another agent was
running its own full suite on this machine. It is one of the files known to be
flaky under load; it passes in isolation, and it passed in this run.)

`npm run check`, measured on the previous base `5e11adb`:

```
COMPLETED 10519 FILES 379 ERRORS 248 WARNINGS 174 FILES_WITH_PROBLEMS
```

All pre-existing. **Zero of them are in a file this PR touches**: every path in
`git diff --name-only origin/dev...HEAD` was grepped against the report and none
appears, and no error mentions `api-contracts`, `cli/` or the new changelog
entry. (The only error under `src/lib/content/changelog/` is `legacy.ts`, which
this PR does not open.)

<details>
<summary>The red, captured before the migration</summary>

The equivalence tests were written first and run against the **hand-written**
tools, at the commit that only changes the types:

```
$ bun test mcp/create-post.test.ts        # at 'Let the registry model a resource id'

183 |       expect(id?.description, name).toBe('Post id or unambiguous prefix');
                                          ^
error: reschedule_post

Expected: "Post id or unambiguous prefix"
Received: undefined

(fail) i tool sul singolo post > ogni tool sul post dice che l id accetta un
       prefisso, non solo la sua description

 13 pass
 1 fail
```

13 of 14 pass against the hand-written tools — name, schema, required fields,
annotations, the exact REST path reached after the prefix is resolved, the body
sent, the shape of the result, and an ambiguous prefix that touches no post.
The single red is the one case that demands the intentional improvement. After
the migration all 14 pass.

</details>

## Evidence (screenshots/videos)

No UI change: this PR touches `packages/api-contracts`, `cli/lib` and `cli/mcp`.
The surface that *does* change is `tools/list`, so the evidence is that surface
captured through the **real transport** (`handleMcpFetch`), on `origin/dev` and
on this branch, and the two dumps compared field by field.

<details>
<summary>tools/list, origin/dev vs this branch</summary>

```
dev 71 | this branch 71
names equal: true
the 68 untouched tools: byte for byte identical

get_post          name/title/description/property-set/required-set IDENTICAL
reschedule_post   name/title/description/property-set/required-set IDENTICAL
render_post       name/title/description/property-set/required-set IDENTICAL
```

Three deltas, all deliberate:

```diff
  "get_post": {
     "required": [ "slug", "id" ],
+    "additionalProperties": false
   },
   "annotations": {
     "readOnlyHint": true,
+    "destructiveHint": false
   }

  "reschedule_post" / "render_post": {
     "id": {
       "type": "string", "minLength": 1,
+      "description": "Post id or unambiguous prefix"
     },
+    "additionalProperties": false
   }
```

1. **`additionalProperties: false`** — every registry input is `.strict()`, and
   a test in `index.test.ts` already holds that line for the eleven endpoints
   merged before this PR. A misspelled field is now refused instead of dropped
   in silence.
2. **`id` gains its description** on `reschedule_post` and `render_post`, taken
   from the resource. `get_post` already wrote the same string by hand. This is
   an intentional improvement, not part of "no behaviour change".
3. **`get_post` gains `destructiveHint: false`** next to the `readOnlyHint: true`
   it already had — derived from `destructive`, the same pair the other derived
   tools already publish.

One cosmetic difference: in `reschedule_post` the order of `properties` and of
the `required` array changes, because the loop *extends* the contract with `slug`
and `id` rather than prepending them. `properties` is an object and `required` a
set, so no client reads the order; aligning it would change it for the eleven
derived tools already in production.

</details>

<details>
<summary>The prefix is resolved before the route sees it — asserted, not assumed</summary>

`cli/mcp/create-post.test.ts` drives the tool through `handleMcpFetch` with
`fetch` captured, and asserts the exact calls:

```
get_post(slug: 'demo', id: '2b38abc5')
  → GET /api/v1/brands/demo/posts
  → GET /api/v1/brands/demo/posts/2b38abc5-7f31-4e0a-9a41-0f2d0c1b8e55/media

reschedule_post(slug: 'demo', id: '2b38abc5', scheduled_for: '2030-06-20T10:00')
  → POST /api/v1/brands/demo/posts/2b38abc5-…/reschedule
         body {"scheduled_for":"2030-06-20T10:00"}

get_post(slug: 'demo', id: 'aa')     # ambiguous
  → 1 call only: the list. No post is touched.
```

</details>

<details>
<summary>Driven from a real MCP client, against the local stack</summary>

Not a test double: the local Supabase docker stack, the dev server on port 5221
built from this worktree, the seeded brand `demo` owned by `test@anomalia.so`, a
session minted into an isolated `HOME` (the developer's own
`~/.config/anomalia/session.json` was never touched — it still carries its
pre-session timestamp), and `claude -p` with `--mcp-config --strict-mcp-config`,
every destructive tool in `--disallowedTools`. The MCP server is
`cli/mcp/stdio.ts` from this branch.

A post was created through the API first, id `897a0f45-2b4d-…`. The client was
then told to call the tools with the **short prefix** `897a0f45`, never the uuid:

```
1. get_post(slug: 'demo', id: '897a0f45')
2. reschedule_post(slug: 'demo', id: '897a0f45', scheduled_for: '2031-03-05T09:00')
3. get_post(slug: 'demo', id: '897a0f45')
```

What the client reported back:

```
All three calls succeeded, no errors.

Full post id returned by each call — identical in all three:
  897a0f45-2b4d-4321-ad05-ac65f2f4206e

Step 1 (get_post):
  status:  pending_user
  caption: Registry live check — a post to read back.

Step 2 (reschedule_post) returned:
  scheduled_for:       2031-03-05T08:00:00.000Z
  scheduled_for_local: 2031-03-05 09:00 (Europe/Rome)
  ok: true, noAccount: true
```

The prefix was resolved on the client, the route received the full id, and the
brand-clock conversion (09:00 Europe/Rome → 08:00Z) came back intact.

The client also noticed, unprompted, that step 3 shows the status moved from
`pending_user` to `approved`. That is the reschedule route's own behaviour — it
writes `status: 'approved'` alongside the new date — and it is unchanged by this
PR; the hand-written tool did exactly the same. Worth knowing, not a regression.

</details>

## Anything Else?

**What was deliberately NOT migrated, and what blocks it**

- **`approve_post`, `publish_post`, `reject_post`** carry `destructiveHint: true`
  and really do publish to live social accounts. They are derivable on paper,
  but proving equivalence there means *executing* it against real accounts, not
  reading it — and a subtly changed approve tool is the worst regression
  available here. **Left hand-written, on purpose.**
- **`edit_post`** is a `PUT`, and `BrandEndpoint.method` knows only `GET | POST`.
  Adding `PUT` is three lines; the real obstacle is different — the hand-written
  tool answers `{ ok, id, patch }`, where `patch` is the echo of its own input,
  and the route returns only `{ ok }`. Deriving it would either change the result
  shape or force the registry to learn "the result echoes the request", a concept
  one endpoint needs.
- **`regenerate_post_media`, `regenerate_slide`, `reorder_slides`, `make_video`**
  are four tools on the same path `/posts/:id/media`, told apart by a constant
  `action` field in the body. The registry maps one endpoint to one tool.

**The 57 that remain hand-written, by what blocks them**

| Group | Count | Blocker |
|---|---|---|
| The eight brand reads | 8 | nothing — they are the subject of the sibling PR, `feat/registry-read-tools` |
| Ready today, no design work at all | 16 | nothing. `get_analytics`, `get_gtm`, `get_voice`, `update_voice`, `list_products`, `approve_posts`, `propose_plan`, `revise_plan`, `approve_plan`, `discard_plan`, `add_competitor`, `research_competitors`, `sync_history`, `seo_action`, `geo_action`, `refresh_keywords` |
| Reshape an input before sending it | 9 | `week` → `week_index`, `text` → `content_text` plus a constant `kind`, a constant `action`, `extra` spread into the body; and `get_dashboard` sits on `/api/v1/brands/:slug` with nothing under it |
| Still on an `:id` path | 12 | approve/publish/reject, `edit_post`, the four `/media` action tools, and the four `*_article` writes |
| `PUT` / `DELETE` | 5 | `method` is `'GET' \| 'POST'` — `update_brand_kit`, `set_colors`, `delete_document`, `delete_person`, `delete_competitor` |
| Not one call | 3 | `get_status` makes two and reshapes, `produce_week` reads then produces, `chat` does not go through `/api/v1` |
| Not brand-scoped | 4 | `login`, `logout`, `whoami`, `list_brands` — the registry only speaks `/api/v1/brands/:slug/…` |

Every one of the 71 tools is in exactly one row: 14 derived + 8 + 16 + 9 + 12 + 5
+ 3 + 4 = 71. The classification is computed from the captured `tools/list`, not
estimated.

**A defect found on the way, and deliberately not fixed here**

`reorder_slides` sends `{ action: 'reorder' }` while
`/api/v1/brands/[slug]/posts/[id]/media` knows only `restructure`, `regenerate`,
`slide` and `video`. It falls through to `Unknown action: reorder`, HTTP 400 —
the tool has never worked. It is broken from before this PR and its fix is a
behaviour change, which does not belong in a structural PR. Recorded in the
internal changelog.

**Changelogs** — internal changelog added
(`changelog/2026-09-04-registry-resource-id.md`). A public changelog **is**
included (`src/lib/content/changelog/2026-09-04-post-id-prefix.ts`) because two
things are visible to a user of the tools: the `id` description now says a short
prefix is accepted, and an unknown field is refused instead of dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
