### PR TITLE
Let an external agent maintain the brand truth

### DIFF
--- a/changelog/2026-09-04-studio-writes-for-agents.md
+++ b/changelog/2026-09-04-studio-writes-for-agents.md
@@ -62,6 +62,14 @@ proprio input, nessun altro segmento dinamico è ammesso, e un id mancante fa **
 di chiamare la collezione intera (che per `/products` è la risincronizzazione e-commerce: un
 `DELETE` mal costruito lì sarebbe stato un incidente).
 
+Un branch parallelo, `feat/registry-id-endpoints`, ha scritto lo stesso meccanismo in un altro
+modo: un campo `resource` con una tassonomia (`post`, `article`) e una tabella di resolver lato
+client. Non è pushato e non ha una PR. Quella forma serve ai post, che hanno davvero un prefisso
+da risolvere; qui non serve — l'id torna per intero — e i suoi metodi ammessi restano
+`GET | POST`, quindi non può esprimere nessuna delle scritture di questa PR. Le due parti si
+compongono: la tassonomia e il rifiuto a compile-time di un `pathFor` senza id vanno sopra a
+questo, quando i tool dei post entreranno nel registry.
+
 ## Il consenso
 
 `PUT /people/:id` accettava quattro campi in whitelist, quindi non poteva già toccare `consent`.

--- a/changelog/2026-09-04-studio-writes-for-agents.md
+++ b/changelog/2026-09-04-studio-writes-for-agents.md
@@ -1,0 +1,78 @@
+# Le scritture dello studio arrivano all'agente esterno
+
+Il piano `docs/external-agent-plan.md` segna quattro righe della *Brand foundation* come
+**Bridge** — creare/modificare/togliere prodotti, modificare persone, modificare competitor,
+leggere e scrivere la bio pubblica. Bridge nel piano ha una definizione precisa: *"Exists in
+Anomalia REST or web UI and needs MCP exposure"*. Verificata riga per riga contro il codice, la
+mappa è questa:
+
+| Riga del piano | REST prima di questa PR | Tool MCP prima | Buco vero |
+|---|---|---|---|
+| Creare un prodotto | **nessuno** | nessuno | endpoint **e** tool |
+| Modificare un prodotto | `PUT /products/:id` | nessuno | solo il tool |
+| Togliere un prodotto | `DELETE /products/:id` | nessuno | solo il tool |
+| Modificare una persona | `PUT /people/:id` | nessuno | solo il tool |
+| Modificare un competitor | `PUT /studio/competitors/:id` | nessuno | solo il tool |
+| Leggere/scrivere la bio | `GET`/`PUT /bio` | nessuno | solo il tool |
+
+Cinque endpoint su sei esistevano già e sono documentati. **Non ne è stato scritto un secondo per
+nessuno**: un endpoint doppio è un debito che si paga due volte, e la prima volta è la prossima
+persona che non sa quale dei due è quello vero. L'unico endpoint nuovo è
+`POST /studio/products`, perché aggiungere UNA offerta non esisteva da nessuna parte — nemmeno
+nella UI, dove `studioActions` sa solo `updateProduct` e `deleteProduct`. La POST su `/products`
+non è la stessa cosa: risincronizza il catalogo intero da Shopify o WooCommerce e prima cancella
+tutto, quindi una riga scritta a mano non sopravvivrebbe.
+
+Sulla "bio pubblica": l'unica bio che esiste nel prodotto è `social_accounts.bio_url`, il link in
+bio (migration 0151). Il piano la descrive come *"the outward brand description"*, ma la
+descrizione del brand è `brand_kit.about` ed è già raggiungibile da `update_brand_kit`. La riga è
+stata chiusa esponendo l'endpoint che porta quel nome; se l'intenzione era un'altra, la riga va
+riscritta nel piano, non implementata a indovinare.
+
+## Il difetto trovato strada facendo
+
+I tre endpoint di modifica rispondevano `{"ok": true}` anche quando la `update` non toccava
+nessuna riga. Con `.eq('brand_id', …)` questo succede in due casi: l'id non esiste, oppure è di un
+altro brand. Un agente riceveva un successo e credeva di aver corretto un prezzo che nessuno ha
+mai cambiato — il modo più silenzioso di non fare il lavoro.
+
+La regola ora sta in un posto solo, `src/lib/server/brand-rows.ts`: `updateBrandRow` e
+`deleteBrandRow` chiedono `.select('id')` e leggono le righe toccate. Zero righe → `not_found`
+404, **identico** nei due casi, così il 404 non diventa un oracolo che rivela se quell'id esiste
+da qualche altra parte. Nello stesso posto sta anche "un patch vuoto non è una scrittura" →
+`no_fields` 400. Quattro chiamanti, una regola, una riga di test che la tiene.
+
+## Il registry e il segmento `:id`
+
+`BRAND_ENDPOINTS` copriva solo `/<path>` senza segmenti dinamici, e un test lo imponeva. La
+ragione scritta lì era la risoluzione del prefisso (`resolvePostId`): un id di post si scrive
+abbreviato e va risolto prima che il path esista. Quella ragione vale per i post e basta — l'id di
+un prodotto, di una persona o di un competitor torna per intero da `get_studio` o
+`list_products`, e non c'è niente da risolvere.
+
+Due strade erano possibili: portare l'id nel body (semplice, ma avrebbe richiesto un secondo
+endpoint per quattro capacità che ne hanno già uno) o insegnare al registry a sostituire `:id`. È
+stata scelta la seconda, perché è l'unica che non duplica niente. `pathFor` prende un terzo
+argomento opzionale, `callEndpoint` sposta l'id dal body al path, e i metodi ammessi diventano
+anche `PUT` e `DELETE`.
+
+Il test guardiano non è stato indebolito: al posto di *"nessun endpoint può avere `:id`"* ora ci
+sono tre asserzioni più strette — un endpoint che indirizza una riga deve dichiarare `id` nel
+proprio input, nessun altro segmento dinamico è ammesso, e un id mancante fa **eccezione** invece
+di chiamare la collezione intera (che per `/products` è la risincronizzazione e-commerce: un
+`DELETE` mal costruito lì sarebbe stato un incidente).
+
+## Il consenso
+
+`PUT /people/:id` accettava quattro campi in whitelist, quindi non poteva già toccare `consent`.
+Ora il contratto è `.strict()`: una richiesta che *nomina* `consent`, `consent_source`, `kind` o
+`images` viene rifiutata con 400 invece di essere ripulita in silenzio — la differenza conta,
+perché un agente che prova a concedere un consenso deve vedere un errore, non un successo
+parziale. Il test `non lascia che una modifica attesti il consenso o cambi il tipo di persona`
+sta accanto alla rotta, e `people/server.consent.test.ts` continua a coprire la creazione.
+
+## Cosa è stato tolto
+
+`cli/lib/api.ts` aveva già `updateProduct`, `deleteProduct`, `updatePerson` e `updateCompetitor`:
+metodi scritti a mano che **nessun comando chiamava**. Ora quelle chiamate le genera il registry,
+e i metodi morti sono spariti.

--- a/changelog/2026-09-04-studio-writes-for-agents.md
+++ b/changelog/2026-09-04-studio-writes-for-agents.md
@@ -44,31 +44,32 @@ da qualche altra parte. Nello stesso posto sta anche "un patch vuoto non è una 
 
 ## Il registry e il segmento `:id`
 
-`BRAND_ENDPOINTS` copriva solo `/<path>` senza segmenti dinamici, e un test lo imponeva. La
-ragione scritta lì era la risoluzione del prefisso (`resolvePostId`): un id di post si scrive
-abbreviato e va risolto prima che il path esista. Quella ragione vale per i post e basta — l'id di
-un prodotto, di una persona o di un competitor torna per intero da `get_studio` o
-`list_products`, e non c'è niente da risolvere.
+Questa parte è stata scritta due volte in parallelo, e la versione che resta non è la mia. Il
+branch di questa PR aveva insegnato al registry a sostituire `:id` con `addressesRow` e un terzo
+argomento opzionale a `pathFor`; mentre era aperto, la #218 ha portato su `dev` un modello più
+forte per la stessa cosa: un campo `resource` con una tassonomia (`BRAND_RESOURCES`), un
+`pathUnderBrand` tipizzato come template literal e un `pathFor` **overloaded**, così
+`pathFor(GET_POST, slug)` non compila nemmeno — dove la mia versione lanciava a runtime. La mia
+implementazione è stata cancellata dal branch, non fusa: due meccanismi per la stessa cosa sono
+un debito che si paga a ogni endpoint nuovo.
 
-Due strade erano possibili: portare l'id nel body (semplice, ma avrebbe richiesto un secondo
-endpoint per quattro capacità che ne hanno già uno) o insegnare al registry a sostituire `:id`. È
-stata scelta la seconda, perché è l'unica che non duplica niente. `pathFor` prende un terzo
-argomento opzionale, `callEndpoint` sposta l'id dal body al path, e i metodi ammessi diventano
-anche `PUT` e `DELETE`.
+Quello che il modello della #218 non copriva sono esattamente le scritture di questa PR, e sono
+due aggiunte piccole:
 
-Il test guardiano non è stato indebolito: al posto di *"nessun endpoint può avere `:id`"* ora ci
-sono tre asserzioni più strette — un endpoint che indirizza una riga deve dichiarare `id` nel
-proprio input, nessun altro segmento dinamico è ammesso, e un id mancante fa **eccezione** invece
-di chiamare la collezione intera (che per `/products` è la risincronizzazione e-commerce: un
-`DELETE` mal costruito lì sarebbe stato un incidente).
+- `method` ammetteva solo `GET | POST`. Ora anche `PUT` e `DELETE`, e `callEndpoint` li manda
+  (una `DELETE` non porta body).
+- `BRAND_RESOURCES` conosceva `post` e `article`. Ora anche `product`, `person` e `competitor`.
 
-Un branch parallelo, `feat/registry-id-endpoints`, ha scritto lo stesso meccanismo in un altro
-modo: un campo `resource` con una tassonomia (`post`, `article`) e una tabella di resolver lato
-client. Non è pushato e non ha una PR. Quella forma serve ai post, che hanno davvero un prefisso
-da risolvere; qui non serve — l'id torna per intero — e i suoi metodi ammessi restano
-`GET | POST`, quindi non può esprimere nessuna delle scritture di questa PR. Le due parti si
-compongono: la tassonomia e il rifiuto a compile-time di un `pathFor` senza id vanno sopra a
-questo, quando i tool dei post entreranno nel registry.
+I resolver di quei tre non sono identità. `RESOLVE_ID` esisteva già come tabella, ma le due voci
+dentro erano due copie della stessa funzione di dodici righe; una terza, quarta e quinta copia
+sarebbero state il momento in cui la tabella smette di essere una tabella. Ora c'è un solo
+`byPrefix(noun, list)` e cinque righe che lo istanziano — quindi anche un id di prodotto, persona
+o competitor accetta un prefisso, che è ciò che la descrizione del tool generato promette già
+("id or unambiguous prefix"). Un resolver identità avrebbe reso quella descrizione una bugia.
+
+L'alternativa, portare l'id nel body, è stata scartata: avrebbe richiesto un secondo endpoint di
+collezione accanto al `PUT /…/:id` che esiste già, che è esattamente il doppione che questa PR
+evita altrove.
 
 ## Il consenso
 

--- a/cli/lib/api.ts
+++ b/cli/lib/api.ts
@@ -64,7 +64,10 @@ export function callEndpoint<T>(
 ): Promise<T> {
   const path =
     endpoint.resource === undefined ? pathFor(endpoint, slug) : pathFor(endpoint, slug, id ?? '');
-  if (endpoint.method === 'POST') return post<T>(path, token, input);
+  if (endpoint.method === 'DELETE') return request<T>(path, token, { method: 'DELETE' });
+  if (endpoint.method !== 'GET') {
+    return request<T>(path, token, { method: endpoint.method, body: JSON.stringify(input) });
+  }
 
   const query = new URLSearchParams();
   for (const [key, value] of Object.entries(input)) {
@@ -316,9 +319,6 @@ export const api = {
   addCompetitor: (t: string, slug: string, data: { name: string; website?: string; kind?: string; rationale?: string }) =>
     post<{ ok: boolean; competitor: { id: string; name: string; website: string | null; kind: string; source: string } }>(`/api/v1/brands/${slug}/studio/competitors`, t, data),
 
-  updateCompetitor: (t: string, slug: string, compId: string, data: { name?: string; website?: string; kind?: string; rationale?: string }) =>
-    request<{ ok: boolean }>(`/api/v1/brands/${slug}/studio/competitors/${compId}`, t, { method: 'PUT', body: JSON.stringify(data) }),
-
   deleteCompetitor: (t: string, slug: string, compId: string) =>
     request<{ ok: boolean }>(`/api/v1/brands/${slug}/studio/competitors/${compId}`, t, { method: 'DELETE' }),
 
@@ -427,19 +427,6 @@ export const api = {
 
   updateVoice: (t: string, slug: string, data: { mood?: string; tone?: string; register?: number; emotion?: string; character?: string; syntax?: string; platform_instructions?: Record<string, string>; avoid?: string[] }) =>
     post<{ ok: boolean }>(`/api/v1/brands/${slug}/voice/update`, t, data),
-
-  // ── Product editing ───────────────────────────────────────────────────
-
-  updateProduct: (t: string, slug: string, productId: string, data: { title?: string; description?: string; pricing?: string; featured?: boolean }) =>
-    request<{ ok: boolean }>(`/api/v1/brands/${slug}/products/${productId}`, t, { method: 'PUT', body: JSON.stringify(data) }),
-
-  deleteProduct: (t: string, slug: string, productId: string) =>
-    request<{ ok: boolean }>(`/api/v1/brands/${slug}/products/${productId}`, t, { method: 'DELETE' }),
-
-  // ── Person editing ────────────────────────────────────────────────────
-
-  updatePerson: (t: string, slug: string, personId: string, data: { name?: string; role?: string; description?: string; attributes?: unknown }) =>
-    request<{ ok: boolean }>(`/api/v1/brands/${slug}/people/${personId}`, t, { method: 'PUT', body: JSON.stringify(data) }),
 
   // ── SEO ───────────────────────────────────────────────────────────────
 

--- a/cli/lib/contracts/index.ts
+++ b/cli/lib/contracts/index.ts
@@ -33,12 +33,24 @@ import {
   GET_WEEKLY_PLAN,
   LIST_ARTICLES
 } from './reads';
+import {
+  CREATE_PRODUCT,
+  DELETE_PRODUCT,
+  GET_BIO,
+  SET_BIO,
+  UPDATE_COMPETITOR,
+  UPDATE_PERSON,
+  UPDATE_PRODUCT
+} from './studio';
 
 export type EndpointFailure = { readonly error: string; readonly status: number };
 
 export const BRAND_RESOURCES = {
   post: 'Post',
-  article: 'Article'
+  article: 'Article',
+  product: 'Product',
+  person: 'Person',
+  competitor: 'Competitor'
 } as const;
 
 export type BrandResource = keyof typeof BRAND_RESOURCES;
@@ -49,7 +61,7 @@ type EndpointShape = {
   readonly tool: string;
   readonly title: string;
   readonly description: string;
-  readonly method: 'GET' | 'POST';
+  readonly method: 'GET' | 'POST' | 'PUT' | 'DELETE';
   readonly input: z.ZodObject<z.ZodRawShape>;
   readonly output: z.ZodType;
   readonly failures: readonly EndpointFailure[];
@@ -71,9 +83,12 @@ export type BrandEndpoint = ResourcelessEndpoint | ResourceEndpoint;
 export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   CHECK_CONTENT,
   CREATE_POST,
+  CREATE_PRODUCT,
+  DELETE_PRODUCT,
   GET_ADS,
   GET_ARTICLE,
   GET_AUDIT_FINDINGS,
+  GET_BIO,
   GET_CALENDAR,
   GET_GEO,
   GET_KEYWORDS,
@@ -93,7 +108,11 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   RESCHEDULE_POST,
   SAVE_PLAN,
   SAVE_WEEK_SEEDS,
+  SET_BIO,
   UPDATE_ARTICLE,
+  UPDATE_COMPETITOR,
+  UPDATE_PERSON,
+  UPDATE_PRODUCT,
 ];
 
 export function pathFor(endpoint: ResourcelessEndpoint, slug: string): string;
@@ -147,6 +166,15 @@ export {
   GET_WEEKLY_PLAN,
   LIST_ARTICLES
 };
+export {
+  CREATE_PRODUCT,
+  DELETE_PRODUCT,
+  GET_BIO,
+  SET_BIO,
+  UPDATE_COMPETITOR,
+  UPDATE_PERSON,
+  UPDATE_PRODUCT
+} from './studio';
 export type { CheckContentInput, CheckContentResult } from './content';
 export type {
   AuditCitationRow,
@@ -157,3 +185,4 @@ export type {
 export type { CreatePostInput, CreatePostResult } from './posts';
 export { PLAN_CADENCES, PLAN_CYCLE_WEEKS, SAVE_PLAN, SAVE_WEEK_SEEDS };
 export type { SavePlanInput, SavePlanResult, SaveWeekSeedsInput, SaveWeekSeedsResult } from './plans';
+export type { CreateProductInput, CreateProductResult } from './studio';

--- a/cli/lib/contracts/studio.ts
+++ b/cli/lib/contracts/studio.ts
@@ -96,9 +96,6 @@ export const DELETE_PRODUCT = {
   destructive: true
 } satisfies BrandEndpoint;
 
-// Solo i campi descrittivi. `kind`, `images` e le colonne del consenso restano fuori: una modifica
-// non è il posto dove una persona reale diventa un'AI, né dove un volto ottiene il permesso di
-// essere usato — quello lo attesta l'utente, e passa da POST /studio/people.
 const UpdatePersonInputSchema = z
   .object({
     id,

--- a/cli/lib/contracts/studio.ts
+++ b/cli/lib/contracts/studio.ts
@@ -1,0 +1,205 @@
+import { z } from 'zod';
+import type { BrandEndpoint } from './index';
+
+const id = z.string().min(1).describe('Row id, verbatim from get_studio or list_products');
+
+const PRODUCT_FIELDS = {
+  title: z.string().min(1).describe('What the offer is called'),
+  description: z.string().describe('What it is, in the brand’s own words'),
+  pricing: z.string().describe('Free text as the brand writes it, e.g. "18,50 €" or "Free"'),
+  url: z.string().describe('Where the offer lives'),
+  kind: z.string().describe('Catalog bucket, e.g. "product", "service", "feature"'),
+  featured: z.boolean().describe('Whether the planner may lead with it')
+};
+
+const Ok = z.object({ ok: z.literal(true) });
+
+const NOT_FOUND: { error: string; status: number } = { error: 'not_found', status: 404 };
+const NO_FIELDS: { error: string; status: number } = { error: 'no_fields', status: 400 };
+
+const CreateProductInputSchema = z
+  .object({
+    title: PRODUCT_FIELDS.title,
+    description: PRODUCT_FIELDS.description.optional(),
+    pricing: PRODUCT_FIELDS.pricing.optional(),
+    url: PRODUCT_FIELDS.url.optional(),
+    kind: PRODUCT_FIELDS.kind.optional(),
+    featured: PRODUCT_FIELDS.featured.optional()
+  })
+  .strict();
+
+const CreateProductResultSchema = z.object({
+  ok: z.literal(true),
+  product: z.object({
+    id: z.string(),
+    title: z.string(),
+    kind: z.string(),
+    pricing: z.string().nullable(),
+    featured: z.boolean()
+  })
+});
+
+export type CreateProductInput = z.infer<typeof CreateProductInputSchema>;
+export type CreateProductResult = z.infer<typeof CreateProductResultSchema>;
+
+export const CREATE_PRODUCT = {
+  tool: 'create_product',
+  title: 'Create product',
+  description:
+    'Add one offer to the brand catalog. Deterministic: it calls no model and spends no ' +
+    'credits. Use it when the catalog does not come from a connected store — sync_products ' +
+    'replaces the whole catalog from Shopify or WooCommerce and would erase a hand-made row.',
+  method: 'POST',
+  pathUnderBrand: '/studio/products',
+  input: CreateProductInputSchema,
+  output: CreateProductResultSchema,
+  failures: [{ error: 'insert_failed', status: 500 }],
+  destructive: false
+} satisfies BrandEndpoint;
+
+const UpdateProductInputSchema = z
+  .object({
+    id,
+    title: PRODUCT_FIELDS.title.optional(),
+    description: PRODUCT_FIELDS.description.optional(),
+    pricing: PRODUCT_FIELDS.pricing.optional(),
+    url: PRODUCT_FIELDS.url.optional(),
+    featured: PRODUCT_FIELDS.featured.optional()
+  })
+  .strict();
+
+export const UPDATE_PRODUCT = {
+  tool: 'update_product',
+  title: 'Update product',
+  description:
+    'Correct one offer in place. Only the fields you send change; every other column keeps the ' +
+    'value it had. Calls no model and spends no credits.',
+  method: 'PUT',
+  pathUnderBrand: '/products/:id',
+  resource: 'product',
+  input: UpdateProductInputSchema,
+  output: Ok,
+  failures: [NOT_FOUND, NO_FIELDS, { error: 'update_failed', status: 500 }],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const DELETE_PRODUCT = {
+  tool: 'delete_product',
+  title: 'Delete product',
+  description: 'Remove one offer from the brand catalog. It does not come back.',
+  method: 'DELETE',
+  pathUnderBrand: '/products/:id',
+  resource: 'product',
+  input: z.object({ id }).strict(),
+  output: Ok,
+  failures: [NOT_FOUND, { error: 'delete_failed', status: 500 }],
+  destructive: true
+} satisfies BrandEndpoint;
+
+// Solo i campi descrittivi. `kind`, `images` e le colonne del consenso restano fuori: una modifica
+// non è il posto dove una persona reale diventa un'AI, né dove un volto ottiene il permesso di
+// essere usato — quello lo attesta l'utente, e passa da POST /studio/people.
+const UpdatePersonInputSchema = z
+  .object({
+    id,
+    name: z.string().min(1).optional().describe('How the person is called'),
+    role: z.string().optional().describe('What they do for the brand'),
+    description: z
+      .string()
+      .optional()
+      .describe('Who they are, for the generators that may depict them'),
+    attributes: z
+      .record(z.string(), z.string())
+      .optional()
+      .describe('Descriptors of the persona, e.g. { "gender": "female", "ageRange": "30-40" }')
+  })
+  .strict();
+
+export const UPDATE_PERSON = {
+  tool: 'update_person',
+  title: 'Update person',
+  description:
+    'Correct the name, role, description or attributes of a person already in the studio. It ' +
+    'cannot attest consent, change a real person into an AI persona, or touch their photos: ' +
+    'those stay with the operator. Calls no model and spends no credits.',
+  method: 'PUT',
+  pathUnderBrand: '/people/:id',
+  resource: 'person',
+  input: UpdatePersonInputSchema,
+  output: Ok,
+  failures: [NOT_FOUND, NO_FIELDS, { error: 'update_failed', status: 500 }],
+  destructive: false
+} satisfies BrandEndpoint;
+
+const UpdateCompetitorInputSchema = z
+  .object({
+    id,
+    name: z.string().min(1).optional().describe('Competitor name'),
+    website: z.string().optional().describe('Site; a bare host is read as https'),
+    kind: z
+      .enum(['direct', 'indirect'])
+      .optional()
+      .describe('The only two the database accepts'),
+    rationale: z.string().optional().describe('Why they belong in the competitive set')
+  })
+  .strict();
+
+export const UPDATE_COMPETITOR = {
+  tool: 'update_competitor',
+  title: 'Update competitor',
+  description:
+    'Correct a competitor already in the studio: a wrong website, a rationale that no longer ' +
+    'holds, direct versus indirect. Calls no model and spends no credits.',
+  method: 'PUT',
+  pathUnderBrand: '/studio/competitors/:id',
+  resource: 'competitor',
+  input: UpdateCompetitorInputSchema,
+  output: Ok,
+  failures: [NOT_FOUND, NO_FIELDS, { error: 'update_failed', status: 500 }],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const GET_BIO = {
+  tool: 'get_bio',
+  title: 'Read link in bio',
+  description:
+    'Read the link in bio stored for the brand and the short link worth putting there — the one ' +
+    'with the most clicks in the last seven days.',
+  method: 'GET',
+  pathUnderBrand: '/bio',
+  input: z
+    .object({ platform: z.string().optional().describe('Defaults to the first active account') })
+    .strict(),
+  output: z.object({
+    bioUrl: z.string().nullable(),
+    suggested: z
+      .object({ code: z.string(), url: z.string(), clicks: z.number(), targetUrl: z.string() })
+      .nullable()
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const SET_BIO = {
+  tool: 'set_bio',
+  title: 'Set link in bio',
+  description:
+    'Store the link in bio for the brand. It records the value only: no publishing API exposes a ' +
+    'profile bio, so a person still pastes it on the profile by hand. Empty string clears it.',
+  method: 'PUT',
+  pathUnderBrand: '/bio',
+  input: z
+    .object({
+      bio_url: z.string().describe('http(s) URL, max 500 chars; "" clears the bio'),
+      platform: z.string().optional().describe('Defaults to the first active account')
+    })
+    .strict(),
+  output: z.object({ ok: z.literal(true), bioUrl: z.string() }),
+  failures: [
+    { error: 'bio_url is required', status: 400 },
+    { error: 'bio_url is invalid', status: 400 },
+    { error: 'bio_url must be an http(s) URL or empty', status: 400 },
+    { error: 'No active social account', status: 404 }
+  ],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/cli/mcp/studio-writes.test.ts
+++ b/cli/mcp/studio-writes.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from 'bun:test';
+import { handleMcpFetch } from './http-app.ts';
+
+async function rpc(method: string, params: unknown, id = 1) {
+  const res = await handleMcpFetch(
+    new Request('http://localhost/mcp', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json, text/event-stream' },
+      body: JSON.stringify({ jsonrpc: '2.0', id, method, params }),
+    }),
+  );
+  return (await res.json()) as { result?: Record<string, unknown> };
+}
+
+type Tool = {
+  name: string;
+  description?: string;
+  inputSchema?: { properties?: Record<string, unknown>; required?: string[] };
+  annotations?: Record<string, unknown>;
+};
+
+async function tools(): Promise<Tool[]> {
+  await rpc('initialize', {
+    protocolVersion: '2024-11-05',
+    capabilities: {},
+    clientInfo: { name: 'test', version: '0.0.1' },
+  });
+  const listed = await rpc('tools/list', {}, 2);
+  return (listed.result?.tools ?? []) as Tool[];
+}
+
+const find = (all: Tool[], name: string): Tool => {
+  const tool = all.find((t) => t.name === name);
+  if (!tool) throw new Error(`tool ${name} non registrato`);
+  return tool;
+};
+
+describe('le scritture dello studio esposte dal registry', () => {
+  test('un agente esterno vede creare, correggere e togliere, non solo leggere', async () => {
+    const names = (await tools()).map((t) => t.name);
+
+    for (const name of [
+      'create_product',
+      'update_product',
+      'delete_product',
+      'update_person',
+      'update_competitor',
+      'get_bio',
+      'set_bio',
+    ]) {
+      expect(names, name).toContain(name);
+    }
+  });
+
+  test('una modifica chiede lo slug e l’id della riga, senza prefissi da risolvere', async () => {
+    const all = await tools();
+
+    for (const name of ['update_product', 'update_person', 'update_competitor', 'delete_product']) {
+      expect(find(all, name).inputSchema?.required?.sort(), name).toEqual(['id', 'slug']);
+    }
+  });
+
+  test('solo delete_product si annuncia distruttivo', async () => {
+    const all = await tools();
+
+    expect(find(all, 'delete_product').annotations?.destructiveHint).toBe(true);
+    for (const name of ['create_product', 'update_product', 'update_person', 'update_competitor']) {
+      expect(find(all, name).annotations?.destructiveHint, name).toBe(false);
+    }
+  });
+
+  test('get_bio è una lettura, set_bio no', async () => {
+    const all = await tools();
+
+    expect(find(all, 'get_bio').annotations?.readOnlyHint).toBe(true);
+    expect(find(all, 'set_bio').annotations?.readOnlyHint).toBe(false);
+  });
+
+  test('update_person non offre nessun campo con cui attestare un consenso', async () => {
+    const person = find(await tools(), 'update_person');
+
+    expect(Object.keys(person.inputSchema?.properties ?? {}).sort()).toEqual(
+      ['attributes', 'description', 'id', 'name', 'role', 'slug'].sort(),
+    );
+  });
+
+  test('nessun tool è registrato due volte', async () => {
+    const names = (await tools()).map((t) => t.name);
+
+    expect(names).toEqual([...new Set(names)]);
+  });
+});

--- a/cli/mcp/util.ts
+++ b/cli/mcp/util.ts
@@ -74,39 +74,37 @@ export async function withAuth(
   }
 }
 
-export async function resolvePostId(token: string, slug: string, idOrPrefix: string): Promise<string> {
-  const posts = await api.getPosts(token, slug);
-  const match = resolveByPrefix(posts, idOrPrefix);
-  if (!match.ok) {
-    if (match.reason === 'ambiguous') {
-      throw new Error(
-        `Ambiguous post id prefix "${idOrPrefix}" (${match.count} matches). Use a longer prefix.`,
-      );
-    }
-    throw new Error(`No post found for id/prefix "${idOrPrefix}". List posts first.`);
-  }
-  return match.item.id;
-}
-
-export async function resolveArticleId(token: string, slug: string, idOrPrefix: string): Promise<string> {
-  const { articles } = await api.getWeb(token, slug, 'all');
-  const match = resolveByPrefix(articles, idOrPrefix);
-  if (!match.ok) {
-    if (match.reason === 'ambiguous') {
-      throw new Error(
-        `Ambiguous article id prefix "${idOrPrefix}" (${match.count} matches). Use a longer prefix.`,
-      );
-    }
-    throw new Error(`No article found for id/prefix "${idOrPrefix}". List articles first.`);
-  }
-  return match.item.id;
-}
-
 type IdResolver = (token: string, slug: string, idOrPrefix: string) => Promise<string>;
+
+function byPrefix<T extends { id: string }>(
+  noun: string,
+  list: (token: string, slug: string) => Promise<T[]>,
+): IdResolver {
+  return async (token, slug, idOrPrefix) => {
+    const match = resolveByPrefix(await list(token, slug), idOrPrefix);
+    if (match.ok) return match.item.id;
+    if (match.reason === 'ambiguous') {
+      throw new Error(
+        `Ambiguous ${noun} id prefix "${idOrPrefix}" (${match.count} matches). Use a longer prefix.`,
+      );
+    }
+    throw new Error(`No ${noun} found for id/prefix "${idOrPrefix}". List ${noun}s first.`);
+  };
+}
+
+export const resolvePostId: IdResolver = byPrefix('post', (token, slug) => api.getPosts(token, slug));
+
+export const resolveArticleId: IdResolver = byPrefix('article', async (token, slug) => {
+  const { articles } = await api.getWeb(token, slug, 'all');
+  return articles;
+});
 
 const RESOLVE_ID: Record<BrandResource, IdResolver> = {
   post: resolvePostId,
   article: resolveArticleId,
+  product: byPrefix('product', async (token, slug) => (await api.listProducts(token, slug)).products),
+  person: byPrefix('person', async (token, slug) => (await api.getStudio(token, slug)).people),
+  competitor: byPrefix('competitor', async (token, slug) => (await api.getStudio(token, slug)).competitors),
 };
 
 export function resolveResourceId(

--- a/cli/plugins/anomalia/skills/anomalia/SKILL.md
+++ b/cli/plugins/anomalia/skills/anomalia/SKILL.md
@@ -76,6 +76,13 @@ there for when you want Anomalia to write one and bill it.
 No model call, no credits. The rows become the week draft the plan page shows; `produce_week` is
 the separate paid step that turns them into posts.
 
+**Keep the brand truth current from your own source** → `get_studio` returns every row with its
+id. `create_product` / `update_product` / `delete_product` maintain the catalog one offer at a
+time; `update_person` and `update_competitor` fix a role or a wrong website. They change only the
+fields you send, leave every other column as it was, and cost nothing. `update_person` can never
+attest consent: a real person's face stays withheld from every generator until the operator
+states, in their own words, that they have it.
+
 **Approve pending posts** → `list_posts` (status pending) → optional `get_post` → `approve_posts`.
 
 **Fix one carousel slide** → `get_post` → `regenerate_slide` (`index`, instruction; 0 = cover).

--- a/cli/plugins/anomalia/skills/anomalia/references/tools.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/tools.md
@@ -129,8 +129,28 @@ A brand keeps one draft in review, so saving replaces the one that is there (`re
 | `update_brand_kit` / `set_colors` | `anomalia studio <slug> kit-update\|colors …` |
 | `add_note` / `delete_document` | `anomalia studio <slug> add-note\|delete-doc …` |
 | `add_person` / `generate_person` / `delete_person` | `anomalia studio <slug> people-*` |
+| `update_person` | (MCP only) |
 | `add_competitor` / `delete_competitor` / `research_competitors` | `anomalia studio <slug> add-competitor\|…\|research` |
+| `update_competitor` | (MCP only) |
+| `create_product` / `update_product` / `delete_product` | (MCP only) |
+| `get_bio` / `set_bio` | (MCP only) |
 | `sync_history` | `anomalia studio <slug> sync-history` |
+
+`create_product` adds ONE offer. The e-commerce resync behind `sync_products` replaces the whole
+catalog and would erase a hand-made row.
+
+`update_product`, `update_person` and `update_competitor` take the row `id` verbatim from
+`get_studio` or `list_products` — no short prefixes here. They change only the fields you send:
+every other column keeps the value it had. An id from another brand answers `not_found`, exactly
+like one that does not exist anywhere.
+
+`update_person` cannot attest consent, turn a real person into an AI persona, or touch photos. A
+real person's face stays withheld from every generator until the operator states the consent in
+their own words.
+
+`set_bio` records the link in bio; no publishing API writes a profile bio, so a person still
+pastes it on the profile by hand. `get_bio` also returns the short link worth putting there — the
+one with the most clicks in the last seven days.
 
 ## SEO / GEO / blog / ads / AI
 

--- a/cli/skills/anomalia/SKILL.md
+++ b/cli/skills/anomalia/SKILL.md
@@ -76,6 +76,13 @@ there for when you want Anomalia to write one and bill it.
 No model call, no credits. The rows become the week draft the plan page shows; `produce_week` is
 the separate paid step that turns them into posts.
 
+**Keep the brand truth current from your own source** → `get_studio` returns every row with its
+id. `create_product` / `update_product` / `delete_product` maintain the catalog one offer at a
+time; `update_person` and `update_competitor` fix a role or a wrong website. They change only the
+fields you send, leave every other column as it was, and cost nothing. `update_person` can never
+attest consent: a real person's face stays withheld from every generator until the operator
+states, in their own words, that they have it.
+
 **Approve pending posts** → `list_posts` (status pending) → optional `get_post` → `approve_posts`.
 
 **Fix one carousel slide** → `get_post` → `regenerate_slide` (`index`, instruction; 0 = cover).

--- a/cli/skills/anomalia/references/tools.md
+++ b/cli/skills/anomalia/references/tools.md
@@ -129,8 +129,28 @@ A brand keeps one draft in review, so saving replaces the one that is there (`re
 | `update_brand_kit` / `set_colors` | `anomalia studio <slug> kit-update\|colors …` |
 | `add_note` / `delete_document` | `anomalia studio <slug> add-note\|delete-doc …` |
 | `add_person` / `generate_person` / `delete_person` | `anomalia studio <slug> people-*` |
+| `update_person` | (MCP only) |
 | `add_competitor` / `delete_competitor` / `research_competitors` | `anomalia studio <slug> add-competitor\|…\|research` |
+| `update_competitor` | (MCP only) |
+| `create_product` / `update_product` / `delete_product` | (MCP only) |
+| `get_bio` / `set_bio` | (MCP only) |
 | `sync_history` | `anomalia studio <slug> sync-history` |
+
+`create_product` adds ONE offer. The e-commerce resync behind `sync_products` replaces the whole
+catalog and would erase a hand-made row.
+
+`update_product`, `update_person` and `update_competitor` take the row `id` verbatim from
+`get_studio` or `list_products` — no short prefixes here. They change only the fields you send:
+every other column keeps the value it had. An id from another brand answers `not_found`, exactly
+like one that does not exist anywhere.
+
+`update_person` cannot attest consent, turn a real person into an AI persona, or touch photos. A
+real person's face stays withheld from every generator until the operator states the consent in
+their own words.
+
+`set_bio` records the link in bio; no publishing API writes a profile bio, so a person still
+pastes it on the profile by hand. `get_bio` also returns the short link worth putting there — the
+one with the most clicks in the last seven days.
 
 ## SEO / GEO / blog / ads / AI
 

--- a/docs/api/04-studio.md
+++ b/docs/api/04-studio.md
@@ -396,6 +396,47 @@ curl -s -X DELETE "https://anomalia.so/api/v1/brands/mio-brand/studio/people/ID"
 
 ---
 
+## `POST /api/v1/brands/:slug/studio/products`
+
+Aggiunge **una** offerta al catalogo. Deterministico: nessun modello, nessun credito. Non è la stessa cosa di [`POST /products`](08-ads-voice-gtm-misc.md), che risincronizza l'intero catalogo da Shopify o WooCommerce cancellando prima tutto — un prodotto scritto a mano non sopravvivrebbe. Tool MCP: `create_product`.
+
+**Body**
+
+| Campo | Tipo | Obbligatorio | Descrizione |
+|---|---|---|---|
+| `title` | string | sì | Come si chiama l'offerta |
+| `description` | string | no | Cos'è, con le parole del brand |
+| `pricing` | string | no | Testo libero come lo scrive il brand: `"18,50 €"`, `"Free"` |
+| `url` | string | no | Dove sta l'offerta |
+| `kind` | string | no | Categoria di catalogo (default `product`) |
+| `featured` | boolean | no | Se il planner può metterla in primo piano (default `true`) |
+
+I campi non passati non vengono scritti: restano i default del database.
+
+**Response** `200`:
+
+```json
+{ "ok": true, "product": { "id": "ID", "title": "Blend Milano", "kind": "product", "pricing": "18,50 €", "featured": true } }
+```
+
+**Errori specifici**
+
+| Status | Body |
+|---|---|
+| `400` | `{"error":"invalid_input","details":[…]}` — titolo mancante o campo non dichiarato |
+| `500` | `{"error":"insert_failed","details":"<messaggio Supabase>"}` |
+
+**Esempio**:
+
+```bash
+curl -s -X POST "https://anomalia.so/api/v1/brands/mio-brand/studio/products" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"title":"Blend Milano","pricing":"18,50 €","description":"Arabica lavata, tostatura chiara"}'
+```
+
+---
+
 ## `POST /api/v1/brands/:slug/studio/documents`
 
 Aggiunge un documento/conoscenza (`brand_documents`) e ricostruisce il contesto AI (best-effort).
@@ -492,15 +533,15 @@ curl -s -X POST "https://anomalia.so/api/v1/brands/mio-brand/studio/competitors"
 
 ## `PUT /api/v1/brands/:slug/studio/competitors/:id`
 
-Aggiorna un competitor; solo i campi presenti nel body vengono modificati. `website` normalizzato con `https://`.
+Aggiorna un competitor; solo i campi presenti nel body vengono modificati, gli altri restano identici. `website` normalizzato con `https://`. Un campo non dichiarato viene **rifiutato**, non ignorato. Tool MCP: `update_competitor`.
 
-**Body** (tutti opzionali)
+**Body** (tutti opzionali, almeno uno)
 
 | Campo | Tipo | Obbligatorio | Descrizione |
 |---|---|---|---|
 | `name` | string | no | Nuovo nome |
 | `website` | string | no | Nuovo sito |
-| `kind` | string | no | `direct` \| `indirect` |
+| `kind` | string | no | `direct` \| `indirect` — gli unici due che il CHECK del database accetta |
 | `rationale` | string | no | Nuovo rationale |
 
 **Response** `200`:
@@ -508,6 +549,14 @@ Aggiorna un competitor; solo i campi presenti nel body vengono modificati. `webs
 ```json
 { "ok": true }
 ```
+
+**Errori specifici**
+
+| Status | Body |
+|---|---|
+| `400` | `{"error":"invalid_input","details":[…]}` |
+| `400` | `{"error":"no_fields"}` |
+| `404` | `{"error":"not_found"}` — l'id non esiste **o** è di un altro brand: la risposta è la stessa |
 
 **Esempio**:
 
@@ -529,6 +578,8 @@ Elimina un competitor.
 ```json
 { "ok": true }
 ```
+
+**Errori specifici**: `404` `{"error":"not_found"}` — l'id non esiste **o** è di un altro brand.
 
 **Esempio**:
 
@@ -593,7 +644,9 @@ curl -s -X POST "https://anomalia.so/api/v1/brands/mio-brand/studio/history/sync
 
 ## `PUT /api/v1/brands/:slug/people/:id`
 
-Aggiorna una persona (percorso top-level, non sotto `/studio`). Solo i campi presenti vengono modificati.
+Aggiorna una persona (percorso top-level, non sotto `/studio`). Solo i campi presenti vengono modificati, gli altri restano identici. Tool MCP: `update_person`.
+
+`consent`, `consent_source`, `kind` e `images` **non** sono modificabili qui e una richiesta che li nomina viene rifiutata: il consenso lo attesta una persona, non una modifica. Finché non è attestato, `resolvePeopleVisualRefs` nega quel volto a ogni generatore.
 
 **Body** (almeno uno obbligatorio)
 
@@ -602,7 +655,7 @@ Aggiorna una persona (percorso top-level, non sotto `/studio`). Solo i campi pre
 | `name` | string | no | Nuovo nome |
 | `role` | string | no | Nuovo ruolo |
 | `description` | string | no | Nuova descrizione |
-| `attributes` | object | no | Nuovi attributi (es. `{"gender":"female"}`) |
+| `attributes` | object | no | Nuovi attributi, valori stringa (es. `{"gender":"female"}`) |
 
 **Response** `200`:
 
@@ -614,7 +667,9 @@ Aggiorna una persona (percorso top-level, non sotto `/studio`). Solo i campi pre
 
 | Status | Body |
 |---|---|
-| `400` | `{"error":"No fields to update"}` |
+| `400` | `{"error":"invalid_input","details":[…]}` — campo non dichiarato o tipo sbagliato |
+| `400` | `{"error":"no_fields"}` |
+| `404` | `{"error":"not_found"}` — l'id non esiste **o** è di un altro brand: la risposta è la stessa |
 | `500` | `{"error":"<messaggio Supabase>"}` |
 
 **Esempio**:

--- a/docs/api/08-ads-voice-gtm-misc.md
+++ b/docs/api/08-ads-voice-gtm-misc.md
@@ -586,7 +586,7 @@ curl -s "https://anomalia.so/api/v1/brands/mio-brand/products" -H "Authorization
 
 ## `POST /api/v1/brands/:slug/products`
 
-Ri-sincronizza l'intero catalogo dal sito e-commerce del brand (Shopify / WooCommerce): elimina i prodotti esistenti e reinserisce quelli rilevati.
+Ri-sincronizza l'intero catalogo dal sito e-commerce del brand (Shopify / WooCommerce): elimina i prodotti esistenti e reinserisce quelli rilevati. Per aggiungere **una** offerta senza cancellare le altre c'è [`POST /studio/products`](04-studio.md).
 
 **Body**: nessuno
 
@@ -616,7 +616,7 @@ curl -s -X POST "https://anomalia.so/api/v1/brands/mio-brand/products" \
 
 ## `PUT /api/v1/brands/:slug/products/:id`
 
-Aggiorna i campi di un singolo prodotto.
+Aggiorna i campi di un singolo prodotto. Solo i campi presenti nel body cambiano: le altre colonne restano identiche. Un campo non dichiarato viene **rifiutato**, non ignorato. Tool MCP: `update_product`.
 
 **Body**
 
@@ -624,7 +624,8 @@ Aggiorna i campi di un singolo prodotto.
 |---|---|---|---|
 | `title` | string | No | Nuovo titolo |
 | `description` | string | No | Nuova descrizione |
-| `pricing` | string | No | Nuovo prezzo |
+| `pricing` | string | No | Nuovo prezzo (testo libero) |
+| `url` | string | No | Dove sta l'offerta |
 | `featured` | boolean | No | Evidenziato sì/no |
 
 **Response** `200`:
@@ -637,7 +638,9 @@ Aggiorna i campi di un singolo prodotto.
 
 | Status | Body |
 |---|---|
-| `400` | `{"error":"No fields to update"}` |
+| `400` | `{"error":"invalid_input","details":[…]}` — campo sconosciuto o tipo sbagliato |
+| `400` | `{"error":"no_fields"}` — nessun campo da cambiare |
+| `404` | `{"error":"not_found"}` — l'id non esiste **o** è di un altro brand: la risposta è la stessa |
 | `500` | `{"error":"<messaggio Supabase>"}` |
 
 **Esempio**:
@@ -652,7 +655,7 @@ curl -s -X PUT "https://anomalia.so/api/v1/brands/mio-brand/products/PRODUCT_ID"
 
 ## `DELETE /api/v1/brands/:slug/products/:id`
 
-Elimina un prodotto del brand.
+Elimina un prodotto del brand. Tool MCP: `delete_product`.
 
 **Response** `200`:
 
@@ -660,7 +663,12 @@ Elimina un prodotto del brand.
 { "ok": true }
 ```
 
-**Errori specifici**: `500` `{"error":"<messaggio Supabase>"}`
+**Errori specifici**
+
+| Status | Body |
+|---|---|
+| `404` | `{"error":"not_found"}` — l'id non esiste **o** è di un altro brand |
+| `500` | `{"error":"<messaggio Supabase>"}` |
 
 **Esempio**:
 

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -33,12 +33,24 @@ import {
   GET_WEEKLY_PLAN,
   LIST_ARTICLES
 } from './reads';
+import {
+  CREATE_PRODUCT,
+  DELETE_PRODUCT,
+  GET_BIO,
+  SET_BIO,
+  UPDATE_COMPETITOR,
+  UPDATE_PERSON,
+  UPDATE_PRODUCT
+} from './studio';
 
 export type EndpointFailure = { readonly error: string; readonly status: number };
 
 export const BRAND_RESOURCES = {
   post: 'Post',
-  article: 'Article'
+  article: 'Article',
+  product: 'Product',
+  person: 'Person',
+  competitor: 'Competitor'
 } as const;
 
 export type BrandResource = keyof typeof BRAND_RESOURCES;
@@ -49,7 +61,7 @@ type EndpointShape = {
   readonly tool: string;
   readonly title: string;
   readonly description: string;
-  readonly method: 'GET' | 'POST';
+  readonly method: 'GET' | 'POST' | 'PUT' | 'DELETE';
   readonly input: z.ZodObject<z.ZodRawShape>;
   readonly output: z.ZodType;
   readonly failures: readonly EndpointFailure[];
@@ -71,9 +83,12 @@ export type BrandEndpoint = ResourcelessEndpoint | ResourceEndpoint;
 export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   CHECK_CONTENT,
   CREATE_POST,
+  CREATE_PRODUCT,
+  DELETE_PRODUCT,
   GET_ADS,
   GET_ARTICLE,
   GET_AUDIT_FINDINGS,
+  GET_BIO,
   GET_CALENDAR,
   GET_GEO,
   GET_KEYWORDS,
@@ -93,7 +108,11 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   RESCHEDULE_POST,
   SAVE_PLAN,
   SAVE_WEEK_SEEDS,
+  SET_BIO,
   UPDATE_ARTICLE,
+  UPDATE_COMPETITOR,
+  UPDATE_PERSON,
+  UPDATE_PRODUCT,
 ];
 
 export function pathFor(endpoint: ResourcelessEndpoint, slug: string): string;
@@ -147,6 +166,15 @@ export {
   GET_WEEKLY_PLAN,
   LIST_ARTICLES
 };
+export {
+  CREATE_PRODUCT,
+  DELETE_PRODUCT,
+  GET_BIO,
+  SET_BIO,
+  UPDATE_COMPETITOR,
+  UPDATE_PERSON,
+  UPDATE_PRODUCT
+} from './studio';
 export type { CheckContentInput, CheckContentResult } from './content';
 export type {
   AuditCitationRow,
@@ -157,3 +185,4 @@ export type {
 export type { CreatePostInput, CreatePostResult } from './posts';
 export { PLAN_CADENCES, PLAN_CYCLE_WEEKS, SAVE_PLAN, SAVE_WEEK_SEEDS };
 export type { SavePlanInput, SavePlanResult, SaveWeekSeedsInput, SaveWeekSeedsResult } from './plans';
+export type { CreateProductInput, CreateProductResult } from './studio';

--- a/packages/api-contracts/src/studio.test.ts
+++ b/packages/api-contracts/src/studio.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { pathFor, statusForFailure } from './index';
+import {
+  CREATE_PRODUCT,
+  DELETE_PRODUCT,
+  GET_BIO,
+  SET_BIO,
+  UPDATE_COMPETITOR,
+  UPDATE_PERSON,
+  UPDATE_PRODUCT
+} from './studio';
+
+const STUDIO_WRITES = [
+  CREATE_PRODUCT,
+  UPDATE_PRODUCT,
+  DELETE_PRODUCT,
+  UPDATE_PERSON,
+  UPDATE_COMPETITOR,
+  GET_BIO,
+  SET_BIO
+];
+
+describe('i contratti dello studio', () => {
+  it('crea un prodotto solo con un titolo', () => {
+    expect(CREATE_PRODUCT.input.safeParse({ title: 'Blend Milano' }).success).toBe(true);
+    expect(CREATE_PRODUCT.input.safeParse({ pricing: '18,50 €' }).success).toBe(false);
+    expect(CREATE_PRODUCT.input.safeParse({ title: '' }).success).toBe(false);
+  });
+
+  it('non lascia scrivere il brand di appartenenza di una riga', () => {
+    for (const endpoint of STUDIO_WRITES) {
+      expect(endpoint.input.safeParse({ id: 'r1', title: 'x', brand_id: 'brand-2' }).success,
+        endpoint.tool
+      ).toBe(false);
+    }
+  });
+
+  it('modifica un prodotto con un campo solo, senza doverli ripetere tutti', () => {
+    expect(UPDATE_PRODUCT.input.safeParse({ id: 'p1', pricing: '19,90 €' }).success).toBe(true);
+    expect(UPDATE_PRODUCT.input.safeParse({ pricing: '19,90 €' }).success).toBe(false);
+  });
+
+  it('una modifica di persona non tocca consenso, tipo o foto', () => {
+    for (const forbidden of [{ consent: true }, { kind: 'ai' }, { images: [] }, { consent_source: 'owner_attested' }]) {
+      expect(
+        UPDATE_PERSON.input.safeParse({ id: 'per1', ...forbidden }).success,
+        Object.keys(forbidden)[0]
+      ).toBe(false);
+    }
+    expect(UPDATE_PERSON.input.safeParse({ id: 'per1', role: 'Co-fondatrice' }).success).toBe(true);
+  });
+
+  it('un competitor è direct o indirect, come dice il CHECK del database', () => {
+    expect(UPDATE_COMPETITOR.input.safeParse({ id: 'c1', kind: 'indirect' }).success).toBe(true);
+    expect(UPDATE_COMPETITOR.input.safeParse({ id: 'c1', kind: 'laterale' }).success).toBe(false);
+  });
+
+  it('ogni scrittura su una riga dichiara il 404 e nessuna lo lascia diventare un 500', () => {
+    for (const endpoint of [UPDATE_PRODUCT, DELETE_PRODUCT, UPDATE_PERSON, UPDATE_COMPETITOR]) {
+      expect(statusForFailure(endpoint, 'not_found'), endpoint.tool).toBe(404);
+    }
+  });
+
+  it('solo la cancellazione si dichiara distruttiva', () => {
+    expect(DELETE_PRODUCT.destructive).toBe(true);
+    for (const endpoint of STUDIO_WRITES.filter((e) => e.tool !== 'delete_product')) {
+      expect(endpoint.destructive, endpoint.tool).toBe(false);
+    }
+  });
+
+  it('ogni contratto indirizza il percorso REST che esiste già', () => {
+    expect(pathFor(CREATE_PRODUCT, 'demo')).toBe('/api/v1/brands/demo/studio/products');
+    expect(pathFor(UPDATE_PRODUCT, 'demo', 'p1')).toBe('/api/v1/brands/demo/products/p1');
+    expect(pathFor(DELETE_PRODUCT, 'demo', 'p1')).toBe('/api/v1/brands/demo/products/p1');
+    expect(pathFor(UPDATE_PERSON, 'demo', 'per1')).toBe('/api/v1/brands/demo/people/per1');
+    expect(pathFor(UPDATE_COMPETITOR, 'demo', 'c1')).toBe(
+      '/api/v1/brands/demo/studio/competitors/c1'
+    );
+    expect(pathFor(GET_BIO, 'demo')).toBe('/api/v1/brands/demo/bio');
+    expect(pathFor(SET_BIO, 'demo')).toBe('/api/v1/brands/demo/bio');
+  });
+
+  it('il link in bio si legge senza argomenti e si svuota con la stringa vuota', () => {
+    expect(GET_BIO.input.safeParse({}).success).toBe(true);
+    expect(SET_BIO.input.safeParse({ bio_url: '' }).success).toBe(true);
+    expect(SET_BIO.input.safeParse({}).success).toBe(false);
+  });
+});

--- a/packages/api-contracts/src/studio.ts
+++ b/packages/api-contracts/src/studio.ts
@@ -96,9 +96,6 @@ export const DELETE_PRODUCT = {
   destructive: true
 } satisfies BrandEndpoint;
 
-// Solo i campi descrittivi. `kind`, `images` e le colonne del consenso restano fuori: una modifica
-// non è il posto dove una persona reale diventa un'AI, né dove un volto ottiene il permesso di
-// essere usato — quello lo attesta l'utente, e passa da POST /studio/people.
 const UpdatePersonInputSchema = z
   .object({
     id,

--- a/packages/api-contracts/src/studio.ts
+++ b/packages/api-contracts/src/studio.ts
@@ -1,0 +1,205 @@
+import { z } from 'zod';
+import type { BrandEndpoint } from './index';
+
+const id = z.string().min(1).describe('Row id, verbatim from get_studio or list_products');
+
+const PRODUCT_FIELDS = {
+  title: z.string().min(1).describe('What the offer is called'),
+  description: z.string().describe('What it is, in the brand’s own words'),
+  pricing: z.string().describe('Free text as the brand writes it, e.g. "18,50 €" or "Free"'),
+  url: z.string().describe('Where the offer lives'),
+  kind: z.string().describe('Catalog bucket, e.g. "product", "service", "feature"'),
+  featured: z.boolean().describe('Whether the planner may lead with it')
+};
+
+const Ok = z.object({ ok: z.literal(true) });
+
+const NOT_FOUND: { error: string; status: number } = { error: 'not_found', status: 404 };
+const NO_FIELDS: { error: string; status: number } = { error: 'no_fields', status: 400 };
+
+const CreateProductInputSchema = z
+  .object({
+    title: PRODUCT_FIELDS.title,
+    description: PRODUCT_FIELDS.description.optional(),
+    pricing: PRODUCT_FIELDS.pricing.optional(),
+    url: PRODUCT_FIELDS.url.optional(),
+    kind: PRODUCT_FIELDS.kind.optional(),
+    featured: PRODUCT_FIELDS.featured.optional()
+  })
+  .strict();
+
+const CreateProductResultSchema = z.object({
+  ok: z.literal(true),
+  product: z.object({
+    id: z.string(),
+    title: z.string(),
+    kind: z.string(),
+    pricing: z.string().nullable(),
+    featured: z.boolean()
+  })
+});
+
+export type CreateProductInput = z.infer<typeof CreateProductInputSchema>;
+export type CreateProductResult = z.infer<typeof CreateProductResultSchema>;
+
+export const CREATE_PRODUCT = {
+  tool: 'create_product',
+  title: 'Create product',
+  description:
+    'Add one offer to the brand catalog. Deterministic: it calls no model and spends no ' +
+    'credits. Use it when the catalog does not come from a connected store — sync_products ' +
+    'replaces the whole catalog from Shopify or WooCommerce and would erase a hand-made row.',
+  method: 'POST',
+  pathUnderBrand: '/studio/products',
+  input: CreateProductInputSchema,
+  output: CreateProductResultSchema,
+  failures: [{ error: 'insert_failed', status: 500 }],
+  destructive: false
+} satisfies BrandEndpoint;
+
+const UpdateProductInputSchema = z
+  .object({
+    id,
+    title: PRODUCT_FIELDS.title.optional(),
+    description: PRODUCT_FIELDS.description.optional(),
+    pricing: PRODUCT_FIELDS.pricing.optional(),
+    url: PRODUCT_FIELDS.url.optional(),
+    featured: PRODUCT_FIELDS.featured.optional()
+  })
+  .strict();
+
+export const UPDATE_PRODUCT = {
+  tool: 'update_product',
+  title: 'Update product',
+  description:
+    'Correct one offer in place. Only the fields you send change; every other column keeps the ' +
+    'value it had. Calls no model and spends no credits.',
+  method: 'PUT',
+  pathUnderBrand: '/products/:id',
+  resource: 'product',
+  input: UpdateProductInputSchema,
+  output: Ok,
+  failures: [NOT_FOUND, NO_FIELDS, { error: 'update_failed', status: 500 }],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const DELETE_PRODUCT = {
+  tool: 'delete_product',
+  title: 'Delete product',
+  description: 'Remove one offer from the brand catalog. It does not come back.',
+  method: 'DELETE',
+  pathUnderBrand: '/products/:id',
+  resource: 'product',
+  input: z.object({ id }).strict(),
+  output: Ok,
+  failures: [NOT_FOUND, { error: 'delete_failed', status: 500 }],
+  destructive: true
+} satisfies BrandEndpoint;
+
+// Solo i campi descrittivi. `kind`, `images` e le colonne del consenso restano fuori: una modifica
+// non è il posto dove una persona reale diventa un'AI, né dove un volto ottiene il permesso di
+// essere usato — quello lo attesta l'utente, e passa da POST /studio/people.
+const UpdatePersonInputSchema = z
+  .object({
+    id,
+    name: z.string().min(1).optional().describe('How the person is called'),
+    role: z.string().optional().describe('What they do for the brand'),
+    description: z
+      .string()
+      .optional()
+      .describe('Who they are, for the generators that may depict them'),
+    attributes: z
+      .record(z.string(), z.string())
+      .optional()
+      .describe('Descriptors of the persona, e.g. { "gender": "female", "ageRange": "30-40" }')
+  })
+  .strict();
+
+export const UPDATE_PERSON = {
+  tool: 'update_person',
+  title: 'Update person',
+  description:
+    'Correct the name, role, description or attributes of a person already in the studio. It ' +
+    'cannot attest consent, change a real person into an AI persona, or touch their photos: ' +
+    'those stay with the operator. Calls no model and spends no credits.',
+  method: 'PUT',
+  pathUnderBrand: '/people/:id',
+  resource: 'person',
+  input: UpdatePersonInputSchema,
+  output: Ok,
+  failures: [NOT_FOUND, NO_FIELDS, { error: 'update_failed', status: 500 }],
+  destructive: false
+} satisfies BrandEndpoint;
+
+const UpdateCompetitorInputSchema = z
+  .object({
+    id,
+    name: z.string().min(1).optional().describe('Competitor name'),
+    website: z.string().optional().describe('Site; a bare host is read as https'),
+    kind: z
+      .enum(['direct', 'indirect'])
+      .optional()
+      .describe('The only two the database accepts'),
+    rationale: z.string().optional().describe('Why they belong in the competitive set')
+  })
+  .strict();
+
+export const UPDATE_COMPETITOR = {
+  tool: 'update_competitor',
+  title: 'Update competitor',
+  description:
+    'Correct a competitor already in the studio: a wrong website, a rationale that no longer ' +
+    'holds, direct versus indirect. Calls no model and spends no credits.',
+  method: 'PUT',
+  pathUnderBrand: '/studio/competitors/:id',
+  resource: 'competitor',
+  input: UpdateCompetitorInputSchema,
+  output: Ok,
+  failures: [NOT_FOUND, NO_FIELDS, { error: 'update_failed', status: 500 }],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const GET_BIO = {
+  tool: 'get_bio',
+  title: 'Read link in bio',
+  description:
+    'Read the link in bio stored for the brand and the short link worth putting there — the one ' +
+    'with the most clicks in the last seven days.',
+  method: 'GET',
+  pathUnderBrand: '/bio',
+  input: z
+    .object({ platform: z.string().optional().describe('Defaults to the first active account') })
+    .strict(),
+  output: z.object({
+    bioUrl: z.string().nullable(),
+    suggested: z
+      .object({ code: z.string(), url: z.string(), clicks: z.number(), targetUrl: z.string() })
+      .nullable()
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const SET_BIO = {
+  tool: 'set_bio',
+  title: 'Set link in bio',
+  description:
+    'Store the link in bio for the brand. It records the value only: no publishing API exposes a ' +
+    'profile bio, so a person still pastes it on the profile by hand. Empty string clears it.',
+  method: 'PUT',
+  pathUnderBrand: '/bio',
+  input: z
+    .object({
+      bio_url: z.string().describe('http(s) URL, max 500 chars; "" clears the bio'),
+      platform: z.string().optional().describe('Defaults to the first active account')
+    })
+    .strict(),
+  output: z.object({ ok: z.literal(true), bioUrl: z.string() }),
+  failures: [
+    { error: 'bio_url is required', status: 400 },
+    { error: 'bio_url is invalid', status: 400 },
+    { error: 'bio_url must be an http(s) URL or empty', status: 400 },
+    { error: 'No active social account', status: 404 }
+  ],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/src/lib/content/changelog/2026-09-04-studio-writes-for-agents.ts
+++ b/src/lib/content/changelog/2026-09-04-studio-writes-for-agents.ts
@@ -1,0 +1,12 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-04',
+  title: 'Your AI can now correct the brand, not just read it',
+  items: [
+    'Claude, Cursor and any connected AI client can add a product, fix a price, correct a person’s role, repair a competitor’s website and set the link in bio — without opening Anomalia.',
+    'An edit changes only the field you name: every other detail of that product, person or competitor keeps the value it had.',
+    'Editing a person can never grant consent for their likeness. That stays yours to state, and until you do their face is withheld from every generator.',
+    'An edit aimed at a row that is not yours now fails instead of quietly reporting success.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/brand-rows.test.ts
+++ b/src/lib/server/brand-rows.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import { updateBrandRow, deleteBrandRow, ROW_NOT_FOUND, EMPTY_PATCH } from './brand-rows';
+
+type Row = Record<string, unknown>;
+
+function store(rows: Row[]) {
+  const client = {
+    from() {
+      const state: { op: 'update' | 'delete' | ''; patch: Row; filters: Row } = {
+        op: '',
+        patch: {},
+        filters: {}
+      };
+      const q = {
+        update(patch: Row) {
+          state.op = 'update';
+          state.patch = patch;
+          return q;
+        },
+        delete() {
+          state.op = 'delete';
+          return q;
+        },
+        eq(column: string, value: unknown) {
+          state.filters[column] = value;
+          return q;
+        },
+        async select() {
+          const matched = rows.filter((row) =>
+            Object.entries(state.filters).every(([column, value]) => row[column] === value)
+          );
+          if (state.op === 'update') {
+            for (const row of matched) Object.assign(row, state.patch);
+          }
+          if (state.op === 'delete') {
+            for (const row of matched) rows.splice(rows.indexOf(row), 1);
+          }
+          return { data: matched.map((row) => ({ id: row.id })), error: null };
+        }
+      };
+      return q;
+    }
+  };
+  return client as never;
+}
+
+const blend = () => ({
+  id: 'p1',
+  brand_id: 'brand-1',
+  title: 'Blend Milano',
+  description: 'Torrefazione lenta',
+  pricing: '18,50 €',
+  featured: true
+});
+
+describe('updateBrandRow', () => {
+  it('scrive solo i campi passati e lascia gli altri identici', async () => {
+    const rows = [blend()];
+
+    const failure = await updateBrandRow(store(rows), 'products', 'brand-1', 'p1', {
+      pricing: '19,90 €'
+    });
+
+    expect(failure).toBeNull();
+    expect(rows[0]).toEqual({ ...blend(), pricing: '19,90 €' });
+  });
+
+  it('non tocca la riga di un altro brand', async () => {
+    const rows = [{ ...blend(), brand_id: 'brand-2' }];
+
+    const failure = await updateBrandRow(store(rows), 'products', 'brand-1', 'p1', {
+      pricing: '19,90 €'
+    });
+
+    expect(failure).toEqual({ error: ROW_NOT_FOUND, status: 404 });
+    expect(rows[0]).toEqual({ ...blend(), brand_id: 'brand-2' });
+  });
+
+  it('risponde allo stesso modo per un id inesistente e per uno di un altro brand', async () => {
+    const elsewhere = await updateBrandRow(
+      store([{ ...blend(), brand_id: 'brand-2' }]),
+      'products',
+      'brand-1',
+      'p1',
+      { title: 'x' }
+    );
+    const nowhere = await updateBrandRow(store([]), 'products', 'brand-1', 'p1', { title: 'x' });
+
+    expect(nowhere).toEqual(elsewhere);
+  });
+
+  it('non scrive niente quando non c’è niente da cambiare', async () => {
+    const rows = [blend()];
+
+    const failure = await updateBrandRow(store(rows), 'products', 'brand-1', 'p1', {});
+
+    expect(failure).toEqual({ error: EMPTY_PATCH, status: 400 });
+    expect(rows[0]).toEqual(blend());
+  });
+
+  it('riporta l’errore del database come 500, non come riga mancante', async () => {
+    const failing = {
+      from: () => ({
+        update: () => failing.from(),
+        eq: () => failing.from(),
+        select: async () => ({ data: null, error: { message: 'connection reset' } })
+      })
+    };
+
+    const failure = await updateBrandRow(failing as never, 'products', 'brand-1', 'p1', { title: 'x' });
+
+    expect(failure).toEqual({ error: 'connection reset', status: 500 });
+  });
+});
+
+describe('deleteBrandRow', () => {
+  it('cancella la riga del brand', async () => {
+    const rows = [blend()];
+
+    const failure = await deleteBrandRow(store(rows), 'products', 'brand-1', 'p1');
+
+    expect(failure).toBeNull();
+    expect(rows).toEqual([]);
+  });
+
+  it('non cancella la riga di un altro brand e la dichiara introvabile', async () => {
+    const rows = [{ ...blend(), brand_id: 'brand-2' }];
+
+    const failure = await deleteBrandRow(store(rows), 'products', 'brand-1', 'p1');
+
+    expect(failure).toEqual({ error: ROW_NOT_FOUND, status: 404 });
+    expect(rows).toHaveLength(1);
+  });
+});

--- a/src/lib/server/brand-rows.ts
+++ b/src/lib/server/brand-rows.ts
@@ -1,0 +1,54 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+// L'unico posto che decide cosa vuol dire "questa riga non è tua". Una update o una delete
+// filtrata per brand tocca zero righe sia quando l'id non esiste sia quando appartiene a un altro
+// brand: la risposta deve essere la stessa nei due casi, o il 404 diventa un oracolo che dice a
+// chi chiede se quell'id esiste da qualche altra parte.
+
+export const ROW_NOT_FOUND = 'not_found';
+export const EMPTY_PATCH = 'no_fields';
+
+export type RowFailure = { error: string; status: number };
+
+type Affected = { data: { id: string }[] | null; error: { message: string } | null };
+
+export async function updateBrandRow(
+  supabase: SupabaseClient,
+  table: string,
+  brandId: string,
+  id: string,
+  patch: Record<string, unknown>
+): Promise<RowFailure | null> {
+  if (!Object.keys(patch).length) return { error: EMPTY_PATCH, status: 400 };
+
+  return verdict(
+    (await supabase
+      .from(table)
+      .update(patch)
+      .eq('id', id)
+      .eq('brand_id', brandId)
+      .select('id')) as Affected
+  );
+}
+
+export async function deleteBrandRow(
+  supabase: SupabaseClient,
+  table: string,
+  brandId: string,
+  id: string
+): Promise<RowFailure | null> {
+  return verdict(
+    (await supabase
+      .from(table)
+      .delete()
+      .eq('id', id)
+      .eq('brand_id', brandId)
+      .select('id')) as Affected
+  );
+}
+
+function verdict({ data, error }: Affected): RowFailure | null {
+  if (error) return { error: error.message, status: 500 };
+  if (!data?.length) return { error: ROW_NOT_FOUND, status: 404 };
+  return null;
+}

--- a/src/lib/server/brand-rows.ts
+++ b/src/lib/server/brand-rows.ts
@@ -1,10 +1,5 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 
-// L'unico posto che decide cosa vuol dire "questa riga non è tua". Una update o una delete
-// filtrata per brand tocca zero righe sia quando l'id non esiste sia quando appartiene a un altro
-// brand: la risposta deve essere la stessa nei due casi, o il 404 diventa un oracolo che dice a
-// chi chiede se quell'id esiste da qualche altra parte.
-
 export const ROW_NOT_FOUND = 'not_found';
 export const EMPTY_PATCH = 'no_fields';
 

--- a/src/routes/api/v1/brands/[slug]/people/[id]/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/people/[id]/+server.ts
@@ -1,6 +1,8 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { authenticate, loadBrandForUser, checkApiKeyWriteAccess } from '$lib/server/cli-auth';
+import { updateBrandRow } from '$lib/server/brand-rows';
+import { UPDATE_PERSON } from '@anomalia/api-contracts';
 
 export const PUT: RequestHandler = async ({ request, params }) => {
   const { supabase, error, apiKey } = await authenticate(request);
@@ -11,23 +13,15 @@ export const PUT: RequestHandler = async ({ request, params }) => {
   const writeDenied = checkApiKeyWriteAccess(apiKey);
   if (writeDenied) return writeDenied;
 
-  const body = await request.json();
-  const { name, role, description, attributes } = body;
-
-  const updates: Record<string, unknown> = {};
-  if (name !== undefined) updates.name = name;
-  if (role !== undefined) updates.role = role;
-  if (description !== undefined) updates.description = description;
-  if (attributes !== undefined) updates.attributes = attributes;
-
-  if (Object.keys(updates).length === 0) {
-    return json({ error: 'No fields to update' }, { status: 400 });
+  const body = await request.json().catch(() => ({}));
+  const parsed = UPDATE_PERSON.input.safeParse({ ...body, id: params.id });
+  if (!parsed.success) {
+    return json({ error: 'invalid_input', details: parsed.error.issues }, { status: 400 });
   }
 
-  const { error: updateError } = await supabase
-    .from('people').update(updates)
-    .eq('id', params.id).eq('brand_id', brand.id);
+  const { id, ...patch } = parsed.data;
+  const failure = await updateBrandRow(supabase, 'people', brand.id, id, patch);
+  if (failure) return json({ error: failure.error }, { status: failure.status });
 
-  if (updateError) return json({ error: updateError.message }, { status: 500 });
   return json({ ok: true });
 };

--- a/src/routes/api/v1/brands/[slug]/people/[id]/server.edit.test.ts
+++ b/src/routes/api/v1/brands/[slug]/people/[id]/server.edit.test.ts
@@ -49,9 +49,13 @@ describe('PUT /api/v1/brands/:slug/people/:id', () => {
     const res = await put({ role: 'Co-fondatrice' });
 
     expect(res.status).toBe(200);
-    expect(updateBrandRow).toHaveBeenCalledWith(supabase, 'people', 'brand-1', 'per1', {
-      role: 'Co-fondatrice'
-    });
+    expect(updateBrandRow.mock.lastCall).toStrictEqual([
+      supabase,
+      'people',
+      'brand-1',
+      'per1',
+      { role: 'Co-fondatrice' }
+    ]);
   });
 
   // Il consenso lo attesta una persona, non un agente: fino ad allora resolvePeopleVisualRefs

--- a/src/routes/api/v1/brands/[slug]/people/[id]/server.edit.test.ts
+++ b/src/routes/api/v1/brands/[slug]/people/[id]/server.edit.test.ts
@@ -58,8 +58,6 @@ describe('PUT /api/v1/brands/:slug/people/:id', () => {
     ]);
   });
 
-  // Il consenso lo attesta una persona, non un agente: fino ad allora resolvePeopleVisualRefs
-  // nega quel volto a ogni generatore. Una modifica non è la scorciatoia per concederlo.
   it('non lascia che una modifica attesti il consenso o cambi il tipo di persona', async () => {
     for (const forbidden of [
       { consent: true },

--- a/src/routes/api/v1/brands/[slug]/people/[id]/server.edit.test.ts
+++ b/src/routes/api/v1/brands/[slug]/people/[id]/server.edit.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const updateBrandRow = vi.fn();
+const structured = vi.fn();
+const gateCredits = vi.fn();
+
+vi.mock('$lib/server/cli-auth', () => ({
+  authenticate: vi.fn(),
+  loadBrandForUser: vi.fn(),
+  checkApiKeyWriteAccess: vi.fn(() => null),
+  gateAiAction: vi.fn()
+}));
+vi.mock('$lib/server/brand-rows', () => ({
+  ROW_NOT_FOUND: 'not_found',
+  EMPTY_PATCH: 'no_fields',
+  updateBrandRow: (...args: unknown[]) => updateBrandRow(...args),
+  deleteBrandRow: vi.fn()
+}));
+vi.mock('$lib/server/research', () => ({ structured: (...args: unknown[]) => structured(...args) }));
+vi.mock('$lib/server/credits', () => ({
+  gateCredits: (...args: unknown[]) => gateCredits(...args),
+  CreditsExhaustedError: class extends Error {}
+}));
+
+import { PUT } from './+server';
+import { authenticate, loadBrandForUser, checkApiKeyWriteAccess, gateAiAction } from '$lib/server/cli-auth';
+
+const supabase = {};
+
+const put = (body: Record<string, unknown>, id = 'per1') =>
+  (PUT as (e: unknown) => Promise<Response>)({
+    request: new Request('https://example.test/api/v1/brands/demo/people/per1', {
+      method: 'PUT',
+      body: JSON.stringify(body)
+    }),
+    params: { slug: 'demo', id }
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(authenticate).mockResolvedValue({ supabase, apiKey: null, error: null } as never);
+  vi.mocked(loadBrandForUser).mockResolvedValue({ brand: { id: 'brand-1' }, error: null } as never);
+  vi.mocked(checkApiKeyWriteAccess).mockReturnValue(null as never);
+  updateBrandRow.mockResolvedValue(null);
+});
+
+describe('PUT /api/v1/brands/:slug/people/:id', () => {
+  it('corregge il ruolo e non tocca nient’altro della persona', async () => {
+    const res = await put({ role: 'Co-fondatrice' });
+
+    expect(res.status).toBe(200);
+    expect(updateBrandRow).toHaveBeenCalledWith(supabase, 'people', 'brand-1', 'per1', {
+      role: 'Co-fondatrice'
+    });
+  });
+
+  // Il consenso lo attesta una persona, non un agente: fino ad allora resolvePeopleVisualRefs
+  // nega quel volto a ogni generatore. Una modifica non è la scorciatoia per concederlo.
+  it('non lascia che una modifica attesti il consenso o cambi il tipo di persona', async () => {
+    for (const forbidden of [
+      { consent: true },
+      { consent_source: 'owner_attested' },
+      { kind: 'ai' },
+      { images: [] }
+    ]) {
+      const res = await put({ role: 'Co-fondatrice', ...forbidden });
+
+      expect(res.status, Object.keys(forbidden)[0]).toBe(400);
+      expect(updateBrandRow).not.toHaveBeenCalled();
+    }
+  });
+
+  it('rifiuta una persona di un altro brand senza dire se esiste altrove', async () => {
+    updateBrandRow.mockResolvedValue({ error: 'not_found', status: 404 });
+
+    const res = await put({ role: 'Co-fondatrice' }, 'di-un-altro-brand');
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'not_found' });
+  });
+
+  it('non chiama nessun modello e non addebita nessun credito', async () => {
+    await put({ name: 'Marta' });
+
+    expect(structured).not.toHaveBeenCalled();
+    expect(gateAiAction).not.toHaveBeenCalled();
+    expect(gateCredits).not.toHaveBeenCalled();
+  });
+
+  it('si ferma prima di scrivere se la chiave è di sola lettura', async () => {
+    vi.mocked(checkApiKeyWriteAccess).mockReturnValue(
+      new Response('read only', { status: 403 }) as never
+    );
+
+    const res = await put({ name: 'Marta' });
+
+    expect(res.status).toBe(403);
+    expect(updateBrandRow).not.toHaveBeenCalled();
+  });
+
+  it('si ferma prima di scrivere se il brand non è del chiamante', async () => {
+    vi.mocked(loadBrandForUser).mockResolvedValue({
+      brand: null,
+      error: new Response('not found', { status: 404 })
+    } as never);
+
+    const res = await put({ name: 'Marta' });
+
+    expect(res.status).toBe(404);
+    expect(updateBrandRow).not.toHaveBeenCalled();
+  });
+});

--- a/src/routes/api/v1/brands/[slug]/products/[id]/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/products/[id]/+server.ts
@@ -1,6 +1,8 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { authenticate, loadBrandForUser, checkApiKeyWriteAccess } from '$lib/server/cli-auth';
+import { updateBrandRow, deleteBrandRow } from '$lib/server/brand-rows';
+import { UPDATE_PRODUCT } from '@anomalia/api-contracts';
 
 export const PUT: RequestHandler = async ({ request, params }) => {
   const { supabase, error, apiKey } = await authenticate(request);
@@ -11,24 +13,16 @@ export const PUT: RequestHandler = async ({ request, params }) => {
   const writeDenied = checkApiKeyWriteAccess(apiKey);
   if (writeDenied) return writeDenied;
 
-  const body = await request.json();
-  const { title, description, pricing, featured } = body;
-
-  const updates: Record<string, unknown> = {};
-  if (title !== undefined) updates.title = title;
-  if (description !== undefined) updates.description = description;
-  if (pricing !== undefined) updates.pricing = pricing;
-  if (featured !== undefined) updates.featured = featured;
-
-  if (Object.keys(updates).length === 0) {
-    return json({ error: 'No fields to update' }, { status: 400 });
+  const body = await request.json().catch(() => ({}));
+  const parsed = UPDATE_PRODUCT.input.safeParse({ ...body, id: params.id });
+  if (!parsed.success) {
+    return json({ error: 'invalid_input', details: parsed.error.issues }, { status: 400 });
   }
 
-  const { error: updateError } = await supabase
-    .from('products').update(updates)
-    .eq('id', params.id).eq('brand_id', brand.id);
+  const { id, ...patch } = parsed.data;
+  const failure = await updateBrandRow(supabase, 'products', brand.id, id, patch);
+  if (failure) return json({ error: failure.error }, { status: failure.status });
 
-  if (updateError) return json({ error: updateError.message }, { status: 500 });
   return json({ ok: true });
 };
 
@@ -41,9 +35,8 @@ export const DELETE: RequestHandler = async ({ request, params }) => {
   const writeDenied = checkApiKeyWriteAccess(apiKey);
   if (writeDenied) return writeDenied;
 
-  const { error: deleteError } = await supabase
-    .from('products').delete().eq('id', params.id).eq('brand_id', brand.id);
+  const failure = await deleteBrandRow(supabase, 'products', brand.id, params.id);
+  if (failure) return json({ error: failure.error }, { status: failure.status });
 
-  if (deleteError) return json({ error: deleteError.message }, { status: 500 });
   return json({ ok: true });
 };

--- a/src/routes/api/v1/brands/[slug]/products/[id]/server.edit.test.ts
+++ b/src/routes/api/v1/brands/[slug]/products/[id]/server.edit.test.ts
@@ -55,9 +55,13 @@ describe('PUT /api/v1/brands/:slug/products/:id', () => {
     const res = await put({ pricing: '19,90 €' });
 
     expect(res.status).toBe(200);
-    expect(updateBrandRow).toHaveBeenCalledWith(supabase, 'products', 'brand-1', 'p1', {
-      pricing: '19,90 €'
-    });
+    expect(updateBrandRow.mock.lastCall).toStrictEqual([
+      supabase,
+      'products',
+      'brand-1',
+      'p1',
+      { pricing: '19,90 €' }
+    ]);
   });
 
   it('rifiuta un id che non è di questo brand senza dire se esiste altrove', async () => {

--- a/src/routes/api/v1/brands/[slug]/products/[id]/server.edit.test.ts
+++ b/src/routes/api/v1/brands/[slug]/products/[id]/server.edit.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const updateBrandRow = vi.fn();
+const deleteBrandRow = vi.fn();
+const structured = vi.fn();
+const gateCredits = vi.fn();
+
+vi.mock('$lib/server/cli-auth', () => ({
+  authenticate: vi.fn(),
+  loadBrandForUser: vi.fn(),
+  checkApiKeyWriteAccess: vi.fn(() => null),
+  gateAiAction: vi.fn()
+}));
+vi.mock('$lib/server/brand-rows', () => ({
+  ROW_NOT_FOUND: 'not_found',
+  updateBrandRow: (...args: unknown[]) => updateBrandRow(...args),
+  deleteBrandRow: (...args: unknown[]) => deleteBrandRow(...args)
+}));
+vi.mock('$lib/server/research', () => ({ structured: (...args: unknown[]) => structured(...args) }));
+vi.mock('$lib/server/credits', () => ({
+  gateCredits: (...args: unknown[]) => gateCredits(...args),
+  CreditsExhaustedError: class extends Error {}
+}));
+
+import { PUT, DELETE } from './+server';
+import { authenticate, loadBrandForUser, checkApiKeyWriteAccess, gateAiAction } from '$lib/server/cli-auth';
+
+const supabase = {};
+
+function event(body: Record<string, unknown> | null, id = 'p1') {
+  return {
+    request: new Request('https://example.test/api/v1/brands/demo/products/p1', {
+      method: 'PUT',
+      body: body === null ? undefined : JSON.stringify(body)
+    }),
+    params: { slug: 'demo', id }
+  };
+}
+
+const put = (body: Record<string, unknown>, id?: string) =>
+  (PUT as (e: unknown) => Promise<Response>)(event(body, id));
+const del = (id?: string) => (DELETE as (e: unknown) => Promise<Response>)(event(null, id));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(authenticate).mockResolvedValue({ supabase, apiKey: null, error: null } as never);
+  vi.mocked(loadBrandForUser).mockResolvedValue({ brand: { id: 'brand-1' }, error: null } as never);
+  vi.mocked(checkApiKeyWriteAccess).mockReturnValue(null as never);
+  updateBrandRow.mockResolvedValue(null);
+  deleteBrandRow.mockResolvedValue(null);
+});
+
+describe('PUT /api/v1/brands/:slug/products/:id', () => {
+  it('scrive solo il campo passato, non un patch con tutte le colonne', async () => {
+    const res = await put({ pricing: '19,90 €' });
+
+    expect(res.status).toBe(200);
+    expect(updateBrandRow).toHaveBeenCalledWith(supabase, 'products', 'brand-1', 'p1', {
+      pricing: '19,90 €'
+    });
+  });
+
+  it('rifiuta un id che non è di questo brand senza dire se esiste altrove', async () => {
+    updateBrandRow.mockResolvedValue({ error: 'not_found', status: 404 });
+
+    const res = await put({ pricing: '19,90 €' }, 'di-un-altro-brand');
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'not_found' });
+  });
+
+  it('rifiuta un campo che il contratto non dichiara invece di scartarlo in silenzio', async () => {
+    const res = await put({ title: 'Blend Milano', brand_id: 'brand-2' });
+
+    expect(res.status).toBe(400);
+    expect(updateBrandRow).not.toHaveBeenCalled();
+  });
+
+  it('rifiuta una richiesta senza nessun campo da cambiare', async () => {
+    updateBrandRow.mockResolvedValue({ error: 'no_fields', status: 400 });
+
+    const res = await put({});
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'no_fields' });
+  });
+
+  it('non chiama nessun modello e non addebita nessun credito', async () => {
+    await put({ title: 'Blend Milano' });
+
+    expect(structured).not.toHaveBeenCalled();
+    expect(gateAiAction).not.toHaveBeenCalled();
+    expect(gateCredits).not.toHaveBeenCalled();
+  });
+
+  it('si ferma prima di scrivere se la chiave è di sola lettura', async () => {
+    vi.mocked(checkApiKeyWriteAccess).mockReturnValue(
+      new Response('read only', { status: 403 }) as never
+    );
+
+    const res = await put({ title: 'Blend Milano' });
+
+    expect(res.status).toBe(403);
+    expect(updateBrandRow).not.toHaveBeenCalled();
+  });
+
+  it('si ferma prima di scrivere se il brand non è del chiamante', async () => {
+    vi.mocked(loadBrandForUser).mockResolvedValue({
+      brand: null,
+      error: new Response('not found', { status: 404 })
+    } as never);
+
+    const res = await put({ title: 'Blend Milano' });
+
+    expect(res.status).toBe(404);
+    expect(updateBrandRow).not.toHaveBeenCalled();
+  });
+});
+
+describe('DELETE /api/v1/brands/:slug/products/:id', () => {
+  it('cancella la riga del brand', async () => {
+    const res = await del();
+
+    expect(res.status).toBe(200);
+    expect(deleteBrandRow).toHaveBeenCalledWith(supabase, 'products', 'brand-1', 'p1');
+  });
+
+  it('rifiuta la riga di un altro brand invece di rispondere ok su zero righe', async () => {
+    deleteBrandRow.mockResolvedValue({ error: 'not_found', status: 404 });
+
+    const res = await del('di-un-altro-brand');
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'not_found' });
+  });
+});

--- a/src/routes/api/v1/brands/[slug]/studio/competitors/[id]/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/studio/competitors/[id]/+server.ts
@@ -1,6 +1,9 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { authenticate, loadBrandForUser, checkApiKeyWriteAccess } from '$lib/server/cli-auth';
+import { updateBrandRow, deleteBrandRow } from '$lib/server/brand-rows';
+import { normalizeWebsite } from '$lib/brand-fields';
+import { UPDATE_COMPETITOR } from '@anomalia/api-contracts';
 
 export const PUT: RequestHandler = async ({ request, params }) => {
   const { supabase, error, apiKey } = await authenticate(request);
@@ -11,26 +14,21 @@ export const PUT: RequestHandler = async ({ request, params }) => {
   const writeDenied = checkApiKeyWriteAccess(apiKey);
   if (writeDenied) return writeDenied;
 
-  const body = await request.json();
-  const { name, website, kind, rationale } = body;
-
-  let normalizedWebsite = website ?? null;
-  if (normalizedWebsite && !normalizedWebsite.startsWith('http')) {
-    normalizedWebsite = `https://${normalizedWebsite}`;
+  const body = await request.json().catch(() => ({}));
+  const parsed = UPDATE_COMPETITOR.input.safeParse({ ...body, id: params.id });
+  if (!parsed.success) {
+    return json({ error: 'invalid_input', details: parsed.error.issues }, { status: 400 });
   }
 
-  const { error: updateError } = await supabase
-    .from('competitors')
-    .update({
-      ...(name !== undefined && { name }),
-      ...(website !== undefined && { website: normalizedWebsite }),
-      ...(kind !== undefined && { kind }),
-      ...(rationale !== undefined && { rationale }),
-    })
-    .eq('id', params.id)
-    .eq('brand_id', brand.id);
+  const { id, ...fields } = parsed.data;
+  const patch = {
+    ...fields,
+    ...(fields.website !== undefined && { website: normalizeWebsite(fields.website) })
+  };
 
-  if (updateError) return json({ error: updateError.message }, { status: 500 });
+  const failure = await updateBrandRow(supabase, 'competitors', brand.id, id, patch);
+  if (failure) return json({ error: failure.error }, { status: failure.status });
+
   return json({ ok: true });
 };
 
@@ -43,9 +41,8 @@ export const DELETE: RequestHandler = async ({ request, params }) => {
   const writeDenied = checkApiKeyWriteAccess(apiKey);
   if (writeDenied) return writeDenied;
 
-  const { error: deleteError } = await supabase
-    .from('competitors').delete().eq('id', params.id).eq('brand_id', brand.id);
+  const failure = await deleteBrandRow(supabase, 'competitors', brand.id, params.id);
+  if (failure) return json({ error: failure.error }, { status: failure.status });
 
-  if (deleteError) return json({ error: deleteError.message }, { status: 500 });
   return json({ ok: true });
 };

--- a/src/routes/api/v1/brands/[slug]/studio/competitors/[id]/server.edit.test.ts
+++ b/src/routes/api/v1/brands/[slug]/studio/competitors/[id]/server.edit.test.ts
@@ -55,17 +55,25 @@ describe('PUT /api/v1/brands/:slug/studio/competitors/:id', () => {
     const res = await put({ website: 'cafferivale.it' });
 
     expect(res.status).toBe(200);
-    expect(updateBrandRow).toHaveBeenCalledWith(supabase, 'competitors', 'brand-1', 'c1', {
-      website: 'https://cafferivale.it'
-    });
+    expect(updateBrandRow.mock.lastCall).toStrictEqual([
+      supabase,
+      'competitors',
+      'brand-1',
+      'c1',
+      { website: 'https://cafferivale.it' }
+    ]);
   });
 
   it('non azzera il sito quando la modifica riguarda solo la motivazione', async () => {
     await put({ rationale: 'Stesso scaffale, stesso prezzo' });
 
-    expect(updateBrandRow).toHaveBeenCalledWith(supabase, 'competitors', 'brand-1', 'c1', {
-      rationale: 'Stesso scaffale, stesso prezzo'
-    });
+    expect(updateBrandRow.mock.lastCall).toStrictEqual([
+      supabase,
+      'competitors',
+      'brand-1',
+      'c1',
+      { rationale: 'Stesso scaffale, stesso prezzo' }
+    ]);
   });
 
   it('rifiuta un kind che il CHECK del database non accetta', async () => {

--- a/src/routes/api/v1/brands/[slug]/studio/competitors/[id]/server.edit.test.ts
+++ b/src/routes/api/v1/brands/[slug]/studio/competitors/[id]/server.edit.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const updateBrandRow = vi.fn();
+const deleteBrandRow = vi.fn();
+const structured = vi.fn();
+const gateCredits = vi.fn();
+
+vi.mock('$lib/server/cli-auth', () => ({
+  authenticate: vi.fn(),
+  loadBrandForUser: vi.fn(),
+  checkApiKeyWriteAccess: vi.fn(() => null),
+  gateAiAction: vi.fn()
+}));
+vi.mock('$lib/server/brand-rows', () => ({
+  ROW_NOT_FOUND: 'not_found',
+  EMPTY_PATCH: 'no_fields',
+  updateBrandRow: (...args: unknown[]) => updateBrandRow(...args),
+  deleteBrandRow: (...args: unknown[]) => deleteBrandRow(...args)
+}));
+vi.mock('$lib/server/research', () => ({ structured: (...args: unknown[]) => structured(...args) }));
+vi.mock('$lib/server/credits', () => ({
+  gateCredits: (...args: unknown[]) => gateCredits(...args),
+  CreditsExhaustedError: class extends Error {}
+}));
+
+import { PUT, DELETE } from './+server';
+import { authenticate, loadBrandForUser, checkApiKeyWriteAccess, gateAiAction } from '$lib/server/cli-auth';
+
+const supabase = {};
+
+function event(body: Record<string, unknown> | null, id = 'c1') {
+  return {
+    request: new Request('https://example.test/api/v1/brands/demo/studio/competitors/c1', {
+      method: 'PUT',
+      body: body === null ? undefined : JSON.stringify(body)
+    }),
+    params: { slug: 'demo', id }
+  };
+}
+
+const put = (body: Record<string, unknown>, id?: string) =>
+  (PUT as (e: unknown) => Promise<Response>)(event(body, id));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(authenticate).mockResolvedValue({ supabase, apiKey: null, error: null } as never);
+  vi.mocked(loadBrandForUser).mockResolvedValue({ brand: { id: 'brand-1' }, error: null } as never);
+  vi.mocked(checkApiKeyWriteAccess).mockReturnValue(null as never);
+  updateBrandRow.mockResolvedValue(null);
+  deleteBrandRow.mockResolvedValue(null);
+});
+
+describe('PUT /api/v1/brands/:slug/studio/competitors/:id', () => {
+  it('ripara il sito e lascia intatti nome, tipo e motivazione', async () => {
+    const res = await put({ website: 'cafferivale.it' });
+
+    expect(res.status).toBe(200);
+    expect(updateBrandRow).toHaveBeenCalledWith(supabase, 'competitors', 'brand-1', 'c1', {
+      website: 'https://cafferivale.it'
+    });
+  });
+
+  it('non azzera il sito quando la modifica riguarda solo la motivazione', async () => {
+    await put({ rationale: 'Stesso scaffale, stesso prezzo' });
+
+    expect(updateBrandRow).toHaveBeenCalledWith(supabase, 'competitors', 'brand-1', 'c1', {
+      rationale: 'Stesso scaffale, stesso prezzo'
+    });
+  });
+
+  it('rifiuta un kind che il CHECK del database non accetta', async () => {
+    const res = await put({ kind: 'laterale' });
+
+    expect(res.status).toBe(400);
+    expect(updateBrandRow).not.toHaveBeenCalled();
+  });
+
+  it('rifiuta un competitor di un altro brand senza dire se esiste altrove', async () => {
+    updateBrandRow.mockResolvedValue({ error: 'not_found', status: 404 });
+
+    const res = await put({ name: 'Caffè Rivale' }, 'di-un-altro-brand');
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'not_found' });
+  });
+
+  it('non chiama nessun modello e non addebita nessun credito', async () => {
+    await put({ name: 'Caffè Rivale' });
+
+    expect(structured).not.toHaveBeenCalled();
+    expect(gateAiAction).not.toHaveBeenCalled();
+    expect(gateCredits).not.toHaveBeenCalled();
+  });
+
+  it('si ferma prima di scrivere se la chiave è di sola lettura', async () => {
+    vi.mocked(checkApiKeyWriteAccess).mockReturnValue(
+      new Response('read only', { status: 403 }) as never
+    );
+
+    const res = await put({ name: 'Caffè Rivale' });
+
+    expect(res.status).toBe(403);
+    expect(updateBrandRow).not.toHaveBeenCalled();
+  });
+});
+
+describe('DELETE /api/v1/brands/:slug/studio/competitors/:id', () => {
+  it('rifiuta la riga di un altro brand invece di rispondere ok su zero righe', async () => {
+    deleteBrandRow.mockResolvedValue({ error: 'not_found', status: 404 });
+
+    const res = await (DELETE as (e: unknown) => Promise<Response>)(event(null, 'di-un-altro-brand'));
+
+    expect(res.status).toBe(404);
+    expect(deleteBrandRow).toHaveBeenCalledWith(
+      supabase,
+      'competitors',
+      'brand-1',
+      'di-un-altro-brand'
+    );
+  });
+});

--- a/src/routes/api/v1/brands/[slug]/studio/products/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/studio/products/+server.ts
@@ -1,0 +1,37 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { authenticate, loadBrandForUser, checkApiKeyWriteAccess } from '$lib/server/cli-auth';
+import { CREATE_PRODUCT, statusForFailure } from '@anomalia/api-contracts';
+
+// POST /studio/products aggiunge UNA riga al catalogo. La POST su /products è un'altra cosa: quella
+// risincronizza il catalogo intero da Shopify o WooCommerce e prima cancella tutto — un prodotto
+// scritto a mano non sopravviverebbe.
+export const POST: RequestHandler = async ({ request, params }) => {
+  const { supabase, error, apiKey } = await authenticate(request);
+  if (error) return error;
+
+  const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
+  if (brandError) return brandError;
+  const writeDenied = checkApiKeyWriteAccess(apiKey);
+  if (writeDenied) return writeDenied;
+
+  const parsed = CREATE_PRODUCT.input.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return json({ error: 'invalid_input', details: parsed.error.issues }, { status: 400 });
+  }
+
+  const { data, error: insertError } = await supabase
+    .from('products')
+    .insert({ brand_id: brand.id, ...parsed.data })
+    .select('id, title, kind, pricing, featured')
+    .single();
+
+  if (insertError) {
+    return json(
+      { error: 'insert_failed', details: insertError.message },
+      { status: statusForFailure(CREATE_PRODUCT, 'insert_failed') }
+    );
+  }
+
+  return json({ ok: true, product: data });
+};

--- a/src/routes/api/v1/brands/[slug]/studio/products/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/studio/products/+server.ts
@@ -3,9 +3,6 @@ import type { RequestHandler } from './$types';
 import { authenticate, loadBrandForUser, checkApiKeyWriteAccess } from '$lib/server/cli-auth';
 import { CREATE_PRODUCT, statusForFailure } from '@anomalia/api-contracts';
 
-// POST /studio/products aggiunge UNA riga al catalogo. La POST su /products è un'altra cosa: quella
-// risincronizza il catalogo intero da Shopify o WooCommerce e prima cancella tutto — un prodotto
-// scritto a mano non sopravviverebbe.
 export const POST: RequestHandler = async ({ request, params }) => {
   const { supabase, error, apiKey } = await authenticate(request);
   if (error) return error;

--- a/src/routes/api/v1/brands/[slug]/studio/products/server.create.test.ts
+++ b/src/routes/api/v1/brands/[slug]/studio/products/server.create.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const structured = vi.fn();
+const gateCredits = vi.fn();
+
+vi.mock('$lib/server/cli-auth', () => ({
+  authenticate: vi.fn(),
+  loadBrandForUser: vi.fn(),
+  checkApiKeyWriteAccess: vi.fn(() => null),
+  gateAiAction: vi.fn()
+}));
+vi.mock('$lib/server/research', () => ({ structured: (...args: unknown[]) => structured(...args) }));
+vi.mock('$lib/server/credits', () => ({
+  gateCredits: (...args: unknown[]) => gateCredits(...args),
+  CreditsExhaustedError: class extends Error {}
+}));
+
+import { POST } from './+server';
+import { authenticate, loadBrandForUser, checkApiKeyWriteAccess, gateAiAction } from '$lib/server/cli-auth';
+
+type Row = Record<string, unknown>;
+
+function fakeSupabase(insertError: { message: string } | null = null) {
+  const inserted: Row[] = [];
+  const client = {
+    from() {
+      const q = {
+        insert(row: Row) {
+          inserted.push(row);
+          return q;
+        },
+        select: () => q,
+        single: async () => ({
+          data: insertError
+            ? null
+            : { id: 'p1', title: inserted[0].title, kind: 'product', pricing: null, featured: true },
+          error: insertError
+        })
+      };
+      return q;
+    }
+  };
+  return { client, inserted };
+}
+
+let supabase: ReturnType<typeof fakeSupabase>;
+
+const post = (body: Record<string, unknown>) =>
+  (POST as (e: unknown) => Promise<Response>)({
+    request: new Request('https://example.test/api/v1/brands/demo/studio/products', {
+      method: 'POST',
+      body: JSON.stringify(body)
+    }),
+    params: { slug: 'demo' }
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  supabase = fakeSupabase();
+  vi.mocked(authenticate).mockResolvedValue({ supabase: supabase.client, apiKey: null, error: null } as never);
+  vi.mocked(loadBrandForUser).mockResolvedValue({ brand: { id: 'brand-1' }, error: null } as never);
+  vi.mocked(checkApiKeyWriteAccess).mockReturnValue(null as never);
+});
+
+describe('POST /api/v1/brands/:slug/studio/products', () => {
+  it('crea l’offerta sul brand del chiamante e la restituisce', async () => {
+    const res = await post({ title: 'Blend Milano', pricing: '18,50 €' });
+
+    expect(res.status).toBe(200);
+    expect(supabase.inserted[0]).toEqual({
+      brand_id: 'brand-1',
+      title: 'Blend Milano',
+      pricing: '18,50 €'
+    });
+    expect(await res.json()).toEqual({
+      ok: true,
+      product: { id: 'p1', title: 'Blend Milano', kind: 'product', pricing: null, featured: true }
+    });
+  });
+
+  it('non scrive le colonne che il chiamante non ha nominato: restano i default del database', async () => {
+    await post({ title: 'Blend Milano' });
+
+    expect(Object.keys(supabase.inserted[0]).sort()).toEqual(['brand_id', 'title']);
+  });
+
+  it('rifiuta un’offerta senza titolo', async () => {
+    const res = await post({ pricing: '18,50 €' });
+
+    expect(res.status).toBe(400);
+    expect(supabase.inserted).toEqual([]);
+  });
+
+  it('non lascia scegliere il brand a chi chiama', async () => {
+    const res = await post({ title: 'Blend Milano', brand_id: 'brand-2' });
+
+    expect(res.status).toBe(400);
+    expect(supabase.inserted).toEqual([]);
+  });
+
+  it('non chiama nessun modello e non addebita nessun credito', async () => {
+    await post({ title: 'Blend Milano' });
+
+    expect(structured).not.toHaveBeenCalled();
+    expect(gateAiAction).not.toHaveBeenCalled();
+    expect(gateCredits).not.toHaveBeenCalled();
+  });
+
+  it('si ferma prima di scrivere se la chiave è di sola lettura', async () => {
+    vi.mocked(checkApiKeyWriteAccess).mockReturnValue(
+      new Response('read only', { status: 403 }) as never
+    );
+
+    const res = await post({ title: 'Blend Milano' });
+
+    expect(res.status).toBe(403);
+    expect(supabase.inserted).toEqual([]);
+  });
+
+  it('si ferma prima di scrivere se il brand non è del chiamante', async () => {
+    vi.mocked(loadBrandForUser).mockResolvedValue({
+      brand: null,
+      error: new Response('not found', { status: 404 })
+    } as never);
+
+    const res = await post({ title: 'Blend Milano' });
+
+    expect(res.status).toBe(404);
+    expect(supabase.inserted).toEqual([]);
+  });
+
+  it('riporta il fallimento della scrittura come 500 dichiarato', async () => {
+    supabase = fakeSupabase({ message: 'connection reset' });
+    vi.mocked(authenticate).mockResolvedValue({ supabase: supabase.client, apiKey: null, error: null } as never);
+
+    const res = await post({ title: 'Blend Milano' });
+
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('insert_failed');
+  });
+});


### PR DESCRIPTION
## What?

An external agent can now **maintain the brand's own truth**, not only read it: add one product
to the catalog, correct a product, a person or a competitor in place, remove a product, and read
or set the link in bio. Seven MCP tools appear — `create_product`, `update_product`,
`delete_product`, `update_person`, `update_competitor`, `get_bio`, `set_bio` — all deterministic:
no model call, no credit debit.

Only **one** new REST endpoint was written, `POST /api/v1/brands/:slug/studio/products`. The other
six operations already had a route; they were missing only their exposure. Along the way one real
defect was fixed: an edit that matched no row answered `{"ok": true}`.

Rebased onto **#218**, whose `resource` model this PR now uses instead of the `:id` support it had
originally written itself — see *How?*.

## Why?

`docs/external-agent-plan.md` marks four *Brand foundation* rows as **Bridge**, which the plan
defines as *"exists in Anomalia REST or web UI and needs MCP exposure"*. Read against the code row
by row, the map is this:

| Plan row | REST before this PR | MCP tool before | The real gap |
|---|---|---|---|
| Create a product | **none** | none | endpoint **and** tool |
| Edit a product | `PUT /products/:id` | none | tool only |
| Remove a product | `DELETE /products/:id` | none | tool only |
| Edit a person | `PUT /people/:id` | none | tool only |
| Edit a competitor | `PUT /studio/competitors/:id` | none | tool only |
| Read/write the bio | `GET`/`PUT /bio` | none | tool only |

Five of six existed already. **No second endpoint was written for any of them** — a duplicate
endpoint is paid for twice, and the second payment is the next person guessing which one is real.
Adding ONE offer was the genuine hole: not even the web UI has it (`studioActions` knows only
`updateProduct` and `deleteProduct`, and no `updatePerson` at all). `POST /products` is a
different thing — it wipes the catalog and refills it from Shopify or WooCommerce, so a hand-made
row would not survive it.

On the "public bio": the only bio in the product is `social_accounts.bio_url`, the link in bio.
The plan calls it *"the outward brand description"*, but the brand's description is
`brand_kit.about` and `update_brand_kit` already reaches it. The row was closed by exposing the
endpoint that carries the name; if something else was meant, the plan row should be rewritten
rather than implemented by guessing.

## How?

**The existing write path is the one used.** `PUT /products/:id`, `PUT /people/:id`,
`PUT /studio/competitors/:id` and the two `DELETE`s were already there; the routes keep their
address and gain a contract. The competitor route reuses `normalizeWebsite` from
`$lib/brand-fields`, the same helper the web form uses.

**One rule, one place.** All three edits answered `{"ok": true}` when the `update` touched zero
rows. Filtered by `.eq('brand_id', …)`, that happens both when the id does not exist and when it
belongs to someone else — an agent was told it had fixed a price nobody changed.
`src/lib/server/brand-rows.ts` now asks for `.select('id')` and reads the affected rows: zero rows
→ `not_found` 404, **identical in both cases**, so the status never becomes an oracle telling the
caller whether that id exists elsewhere. The empty-patch rule (`no_fields` 400) lives in the same
function. Four callers, one rule.

**A partial edit stays partial.** The route destructures only what the contract parsed, so a
column the caller did not name never reaches the `update`. Proven at two levels: `brand-rows.
test.ts` runs a fake store and asserts the stored row is byte-identical except the edited field;
each route test reads the whole call with `toStrictEqual`, which fails on a widened patch — see
RED 2, which was green until the assertion was tightened.

**Consent is not editable here.** `UpdatePersonInputSchema` is `.strict()` and declares only
`name`, `role`, `description`, `attributes`. A request that even *names* `consent`,
`consent_source`, `kind` or `images` is refused with 400 rather than quietly stripped: an agent
trying to grant a consent must see an error, not a partial success. The existing
`studio/people/server.consent.test.ts` still covers creation and still passes.

**Enum values read from the running database, not from a migration file:**

```
select conrelid::regclass, conname, pg_get_constraintdef(oid) from pg_constraint
where conrelid in ('public.products','public.people','public.competitors') and contype='c';

 competitors | competitors_kind_check   | CHECK ((kind = ANY (ARRAY['direct'::text, 'indirect'::text])))
 competitors | competitors_source_check | CHECK ((source = ANY (ARRAY['ai'::text, 'user'::text])))
 people      | people_kind_check        | CHECK ((kind = ANY (ARRAY['real'::text, 'ai'::text])))
```

So `update_competitor.kind` is `z.enum(['direct','indirect'])` and nothing else. `products.kind`
carries no CHECK (default `'product'`), so it stays a free string on create. **No migration was
written and none is needed.**

Two independent sources agree, which matters because the local stack is in poor shape (see
*Testing?*): the live catalog above, and the migrations that created these tables —
`0028_people.sql` (`kind in ('real','ai')`), `0026_competitor_research.sql`
(`kind in ('direct','indirect')`), `0029_brand_archetype.sql` (`products.kind`, `not null default
'product'`, no CHECK).

### The `:id` question — settled by #218, not by this PR

This branch had originally taught the registry to substitute `:id` itself. While it was open,
**#218 merged the same capability into `dev`** with a stronger design: a `resource` field with a
taxonomy (`BRAND_RESOURCES`), `pathUnderBrand` typed as a template literal, and an **overloaded**
`pathFor` so `pathFor(GET_POST, slug)` does not compile — where mine only threw at runtime.

**My implementation was deleted from the branch, not merged.** The commit that carried it is gone
from this history; the PR rebases onto #218 and rides its model. Two mechanisms for one job is a
debt paid again at every new endpoint. Carrying the id in the request body — the other option —
stays rejected for the reason it always was: it would need a second, collection-level route beside
the `PUT /…/:id` that already exists, which is the duplicate this PR exists to avoid.

What #218's model did not cover is exactly this PR's writes, and it is two small additions:

- `method` allowed only `'GET' | 'POST'`. Now `'PUT'` and `'DELETE'` too, and `callEndpoint` sends
  them (a `DELETE` carries no body).
- `BRAND_RESOURCES` knew `post` and `article`. Now `product`, `person` and `competitor` too.

**#222 landed on top of that**, sorting `BRAND_ENDPOINTS` so two branches adding two endpoints
touch two different lines. This PR follows that convention rather than appending a spread: the
seven studio endpoints are listed individually, in sorted position, and the `STUDIO_ENDPOINTS`
aggregate this branch had introduced is deleted — an aggregate *plus* a list is two places to add
an endpoint and one of them silently wins. `cli/mcp/studio-writes.test.ts` is the guard: it asks
the running MCP server for its tool list and fails if any of the seven is missing.

**The three new resolvers are not identity functions.** `RESOLVE_ID` was already a table, but its
two entries were two copies of the same twelve-line function; a third, fourth and fifth copy is
where a table stops being a table. One `byPrefix(noun, list)` now backs all five — so a product,
person or competitor id accepts a prefix as well, which is what the generated tool description
(`"<Resource> id or unambiguous prefix"`) has been promising all along. An identity resolver would
have made that description a lie.

**Dead code removed.** `cli/lib/api.ts` had hand-written `updateProduct`, `deleteProduct`,
`updatePerson` and `updateCompetitor` that **no command called**. The registry generates those
calls now; the dead methods are gone. No `registerTool` block and no `api.ts` method was written
by hand.

## Testing?

Written first and watched fail. Three reds captured by reintroducing the exact defect each test
names:

<details>
<summary><b>RED 1</b> — zero affected rows answered <code>ok</code> (the behaviour that was on <code>dev</code>): delete the <code>not_found</code> line from <code>brand-rows.ts</code></summary>

```
× updateBrandRow > non tocca la riga di un altro brand
  → expected null to deeply equal { error: 'not_found', status: 404 }
× deleteBrandRow > non cancella la riga di un altro brand e la dichiara introvabile
  → expected null to deeply equal { error: 'not_found', status: 404 }

 Test Files  1 failed (1)
      Tests  2 failed | 5 passed (7)
```
</details>

<details>
<summary><b>RED 2</b> — a partial edit widened into a full-column patch in <code>PUT /products/:id</code></summary>

The first attempt at this red came back **green**, which is why one commit exists only to fix the
assertion: `toHaveBeenCalledWith` compares with `toEqual` semantics, which ignore an `undefined`
key on the received object. Reading the whole call with `toStrictEqual` is the same one line and
does fail:

```
× PUT /api/v1/brands/:slug/products/:id > scrive solo il campo passato, non un patch con tutte le colonne
AssertionError: expected [ {}, 'products', 'brand-1', …(2) ] to strictly equal [ {}, 'products', 'brand-1', …(2) ]

 Test Files  1 failed (1)
      Tests  1 failed | 8 passed (9)
```
</details>

<details>
<summary><b>RED 3</b> — the consent guard: <code>.strict()</code> → <code>.passthrough()</code> on the person contract</summary>

```
× i contratti dello studio > non lascia scrivere il brand di appartenenza di una riga
× i contratti dello studio > una modifica di persona non tocca consenso, tipo o foto
× PUT /api/v1/brands/:slug/people/:id > non lascia che una modifica attesti il consenso o cambi il tipo di persona
AssertionError: consent: expected 200 to be 400 // Object.is equality

 Test Files  2 failed (2)
      Tests  3 failed | 12 passed (15)
```
</details>

Green, all three defects restored, on the current base:

```
$ npx vitest run <the 8 files this PR touches or adds>
 ✓ src/lib/server/brand-rows.test.ts (7 tests)
 ✓ src/routes/api/v1/brands/[slug]/studio/people/server.consent.test.ts (4 tests)
 ✓ src/routes/api/v1/brands/[slug]/studio/products/server.create.test.ts (8 tests)
 ✓ packages/api-contracts/src/studio.test.ts (9 tests)
 ✓ src/routes/api/v1/brands/[slug]/people/[id]/server.edit.test.ts (6 tests)
 ✓ src/routes/api/v1/brands/[slug]/studio/competitors/[id]/server.edit.test.ts (7 tests)
 ✓ src/routes/api/v1/brands/[slug]/products/[id]/server.edit.test.ts (9 tests)
 ✓ packages/api-contracts/src/index.test.ts (25 tests)

 Test Files  8 passed (8)
      Tests  75 passed (75)

$ cd cli && bun test
 50 pass
 0 fail
 180 expect() calls
Ran 50 tests across 10 files. [2.27s]

$ cd cli && bun run typecheck    # tsc --noEmit
(no output, exit 0)

$ git diff --check
(clean)
```

`packages/api-contracts/src/index.test.ts` is **unchanged from `dev`** — the registry assertions
this branch used to add went out with the implementation they guarded.

What the tests cover: each edit changes the intended field and leaves the siblings byte-identical;
a row of another brand is neither editable nor deletable; an unknown id gets the same 404 as a
foreign one, so the status reveals nothing; `update_person` refuses consent, kind and images;
**no model call and no credit debit** (spies on `structured`, `gateAiAction` and `gateCredits`,
all `not.toHaveBeenCalled()`); read-only key and inaccessible brand both stop before the write,
through the existing auth contract.

### What was NOT run locally, and why

- **The full suite is delegated to CI.** `.github/workflows/ci.yml` already runs `npx vitest run`
  in full plus Playwright on every pull request. This machine is running nine agents in parallel
  and is deep in swap; re-running the same 600 test files locally buys nothing CI does not
  produce. Only the files above were run here.
- **`npm run check` was not completed.** It was started twice and the OS killed it both times
  (rc 143, then rc 137 — SIGKILL under memory pressure). A `npx tsc --noEmit` on an earlier
  revision of this branch reported **0 errors in any file this branch touches**; the run against
  the current base was stopped along with the rest of the full-suite work. `cd cli && bun run
  typecheck` (`tsc --noEmit`, clean) does cover the contracts and the whole MCP/CLI side, which is
  where all of this PR's TypeScript lives outside the four routes.
- **No browser evidence, and the browser gate does not apply.** The diff contains **no `.svelte`
  file** and changes nothing an interface renders: it is REST endpoints, contracts and MCP wiring,
  which is exactly what the route tests and the MCP tool-list test exercise. Nothing was started
  to verify it — no Docker stack, no dev server, no browser driver.
- **The routes have never run against real PostgREST on this branch.** What that would catch
  beyond the tests is a wrong column name or a CHECK the tests get wrong. The column list is
  unchanged from the routes that already updated these tables, and the constraints are confirmed
  twice (live catalog + migrations). The genuinely unexercised path is the `POST /studio/products`
  insert, since it is the only new route.

## Evidence (screenshots/videos)

No UI changes, so no screenshots. The backend evidence is the three captured reds, the constraint
query and the command output above.

<details>
<summary>State of the local stack, for whoever tries to reproduce</summary>

The `anomalia-db` container will not start: its bind mounts point into `anomalia-wt/task-59`, a
worktree that was deleted, so Docker refuses the mount. It needs recreating from the main
checkout's compose file. The data volume behind it (`anomalia-selfhost_db-data`) has `products`,
`people` and `competitors` but **no `brands` table**, so it cannot host an end-to-end insert
either — which is why the constraint evidence above is cross-checked against the migrations
instead of resting on one source. The throwaway container used to read those constraints has been
removed.
</details>

## Anything Else?

- **`update_product` cannot change `kind`, `create_product` can.** The edit contract mirrors the
  fields the product form exposes. Adding it is one line if an agent turns out to need it.
- **The extraction is not a separate commit.** `brand-rows.ts` is not a pure lift of the old inline
  code — the old code had no zero-rows verdict — so it lands with the behaviour it introduces
  rather than pretending to be behaviour-preserving.
- **The bio's plan row may be the wrong row**, see *Why?*. If the plan meant the outward brand
  description, that is `brand_kit.about` and is already exposed; the plan needs the edit, not the
  code.
- **This branch has been rebased through #199, #214, #218, #219 and #222.** The conflict is the
  same every time — `packages/api-contracts/src/index.ts` and its `cli/lib/contracts` mirror — and
  the resolution is always the alphabetical union of the `BRAND_ENDPOINTS` lines followed by
  `bash cli/scripts/sync-contracts.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
