### PR TITLE
Send a client a link to one view, not an account

### DIFF
--- a/changelog/2026-09-04-public-shared-views.md
+++ b/changelog/2026-09-04-public-shared-views.md
@@ -1,0 +1,93 @@
+# Viste pubbliche: un link per il cliente, mai un account
+
+Fase 3 del piano agenti esterni. Un'agenzia consegna al cliente il calendario del mese o il
+report di quel mese con un URL, e il cliente lo apre senza registrarsi, senza essere invitato
+nel brand e senza comparire da nessuna parte.
+
+Prima non c'era niente: l'unico modo di far vedere il lavoro a un cliente era invitarlo nel
+brand — cioè dargli un account con accesso a tutto — oppure fare screenshot.
+
+## Perché uno snapshot e non una query dal vivo
+
+La rotta pubblica legge **una riga** e nient'altro. Non torna su `posts`, non torna su `brands`,
+non tocca nessuna tabella viva.
+
+Non è una preferenza di prestazioni, è la sola forma che regge nel tempo. `posts` ha oltre
+cinquanta colonne — `image_prompt`, `qc`, `approval_token`, `attention_reason`, `design` — e ne
+guadagna di nuove ogni mese, scritte da chi sta risolvendo un altro problema. Con una vista dal
+vivo, la prossima colonna esce da ogni link già consegnato: nessuno la aggiunge pensando ai link
+pubblici, e nessun test la ferma. Con lo snapshot, quello che è uscito è quello che l'allowlist
+ha copiato il giorno della creazione, e resta quello per sempre.
+
+Scartato: la vista dal vivo con una `select` ristretta. Una `select` ristretta è una promessa che
+vive in una riga di codice; lo snapshot è un fatto già scritto nel database.
+
+## Perché una allowlist e non una deny-list
+
+Lo snapshot si costruisce campo per campo (`CALENDAR_POST_FIELDS`, `REPORT_POST_FIELDS`), mai
+copiando una riga e cancellando le chiavi scomode. Una deny-list si dimentica del campo
+successivo — e il campo successivo lo aggiunge qualcun altro, in un'altra PR, senza sapere che
+esiste un link pubblico.
+
+Il test che conta non è quello del percorso felice: è quello che asserisce **l'insieme esatto**
+delle chiavi. Il giorno in cui `getCalendar` selezionerà una colonna in più, quel test diventa
+rosso invece che il link diventare loquace. Provato: aggiungendo `image_prompt` alla proiezione,
+tre test cadono prima di qualunque revisione umana — l'insieme esatto delle chiavi, la ricerca
+dei segreti nello snapshot, e quello sulla riga che l'endpoint scrive davvero.
+
+Fuori restano anche gli id — di post, di riga, di brand — e lo slug. Un identificatore privato
+è il punto da cui si parte per indovinare il resto.
+
+Lo `status` non esce grezzo: `pending_user`, `approved`, `failed` sono il nostro workflow, non
+una cosa che un cliente debba leggere. Diventa `planned` o `published`, in una funzione sola.
+
+## Perché il token non viene conservato
+
+Il token è casuale (32 byte, base64url) e la riga tiene solo il suo sha256. Chi lo crea lo vede
+una volta; se non lo salva, non si recupera — si revoca e se ne fa un altro. Un dump del
+database non produce link funzionanti, e nemmeno chi ha accesso alla tabella può aprire una
+vista che non ha creato.
+
+Scartato: un token firmato con HMAC (come `signApproveToken`, che il repo già ha). Non si revoca.
+Un cliente che se ne va, un link finito nel gruppo sbagliato, una collaborazione chiusa: con un
+token firmato l'unica risposta è ruotare `APP_SECRET` e spegnere ogni link esistente, compresi
+quelli degli altri clienti.
+
+## Perché revocato, scaduto e inesistente sono la stessa risposta
+
+Tre motivi per cui un link non vale, **una** funzione che li decide (`liveShare`), un `null` solo
+che risale fino a un `404` identico. Un messaggio tipo «questo link è stato revocato» conferma
+che il link è esistito, quindi che il brand esiste: un oracolo gratis per chi prova URL a caso.
+
+Il controllo sta in JavaScript e non nella `where` della query apposta: in SQL sarebbero tre
+condizioni sparse in una stringa, e la stessa regola andrebbe riscritta in ogni query futura.
+In un posto solo, diverge con nessuno.
+
+Il caso che invece **non** si confonde con un link inesistente è la tabella assente: quello è un
+guasto nostro, risponde `500`, e la superficie autenticata dice per nome quale file applicare.
+
+## La rotta pubblica è fuori dal registry, apposta
+
+`/share/[token]` non sta sotto `/api/v1/brands/:slug` e non entra in `BRAND_ENDPOINTS`. Non è un
+endpoint di brand: non ha uno slug, non ha un chiamante autenticato, e dall'URL non si ricava
+quale brand ci sia dietro. Entrarci significherebbe ereditare `authenticate` +
+`loadBrandForUser`, che è esattamente ciò che non deve succedere.
+
+Legge con la chiave di servizio, come `/approve/[token]` e `/blog/[site]`: l'impronta del token è
+l'unica chiave, e la RLS con `auth.uid()` nullo non avrebbe niente da valutare. Ad `anon` i
+privilegi sulla tabella sono **revocati** — così nemmeno una policy scritta male in futuro può
+aprirla a un visitatore.
+
+## La migration si applica a mano
+
+`supabase/migrations/20260904120000_shared_views.sql`. I deploy di questo repo non eseguono le
+migration: finché non la applica una persona, i tre endpoint rispondono `500 shares_not_migrated`
+col nome del file, invece di far passare un `PGRST205` che diventerebbe una lista vuota.
+
+`node scripts/schema-drift-check.mjs` la vede: contro la produzione dà ROSSO con una divergenza
+sola — `shared_views` assente — e contro lo stack locale, dove è applicata, sparisce.
+
+## Fuori da questa versione
+
+Export PDF, viste `proposal`, calendario dal vivo. La versione uno è fatta di snapshot
+revocabili; il vivo arriva quando privacy e cache saranno provate, come dice il piano.

--- a/cli/lib/contracts/index.ts
+++ b/cli/lib/contracts/index.ts
@@ -35,6 +35,12 @@ import {
   LIST_ARTICLES
 } from './reads';
 import {
+  CREATE_SHARE,
+  LIST_SHARES,
+  REVOKE_SHARE,
+  SHARED_VIEW_TYPES,
+} from './shares';
+import {
   CREATE_PRODUCT,
   DELETE_PRODUCT,
   GET_BIO,
@@ -85,6 +91,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   CHECK_CONTENT,
   CREATE_POST,
   CREATE_PRODUCT,
+  CREATE_SHARE,
   DELETE_PRODUCT,
   GET_ADS,
   GET_ARTICLE,
@@ -104,10 +111,12 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   LIST_AUDIT_CITATIONS,
   LIST_MEDIA,
   LIST_POSTS,
+  LIST_SHARES,
   LIST_WEB_AUDITS,
   LIST_WEB_FIXES,
   RENDER_POST,
   RESCHEDULE_POST,
+  REVOKE_SHARE,
   SAVE_PLAN,
   SAVE_WEEK_SEEDS,
   SET_BIO,
@@ -178,6 +187,12 @@ export {
   UPDATE_PERSON,
   UPDATE_PRODUCT
 } from './studio';
+export {
+  CREATE_SHARE,
+  LIST_SHARES,
+  REVOKE_SHARE,
+  SHARED_VIEW_TYPES,
+};
 export type { CheckContentInput, CheckContentResult } from './content';
 export type {
   AuditCitationRow,
@@ -191,3 +206,4 @@ export type { CreatePostInput, CreatePostResult } from './posts';
 export { PLAN_CADENCES, PLAN_CYCLE_WEEKS, SAVE_PLAN, SAVE_WEEK_SEEDS };
 export type { SavePlanInput, SavePlanResult, SaveWeekSeedsInput, SaveWeekSeedsResult } from './plans';
 export type { CreateProductInput, CreateProductResult } from './studio';
+export type { CreateShareInput, CreateShareResult, SharedViewType } from './shares';

--- a/cli/lib/contracts/shares.ts
+++ b/cli/lib/contracts/shares.ts
@@ -1,0 +1,96 @@
+import { z } from 'zod';
+import type { BrandEndpoint } from './index';
+
+export const SHARED_VIEW_TYPES = ['calendar', 'monthly_report'] as const;
+
+export type SharedViewType = (typeof SHARED_VIEW_TYPES)[number];
+
+const MONTH = z
+  .string()
+  .regex(/^\d{4}-\d{2}$/)
+  .describe('Month YYYY-MM. Defaults to the current month on the brand clock');
+
+const MAX_EXPIRY_DAYS = 365;
+
+const SharedViewRow = z.object({
+  id: z.string(),
+  view: z.enum(SHARED_VIEW_TYPES),
+  month: z.string().nullable(),
+  status: z.enum(['live', 'revoked', 'expired']),
+  created_at: z.string(),
+  expires_at: z.string().nullable(),
+  revoked_at: z.string().nullable()
+});
+
+export const CREATE_SHARE = {
+  tool: 'create_share',
+  title: 'Create a public client link',
+  description:
+    'Freeze one view as a snapshot and return a public link a client can open without an account. ' +
+    'The link grants that snapshot and nothing else: no brand account, no live data, no connectors, ' +
+    'notes, prompts, costs, settings or member data. The token is shown once and never stored in ' +
+    'readable form — save it now or revoke and create another.',
+  method: 'POST',
+  pathUnderBrand: '/shares',
+  input: z
+    .object({
+      view: z.enum(SHARED_VIEW_TYPES).describe('calendar = the month plan; monthly_report = what that month published'),
+      month: MONTH.optional(),
+      expires_in_days: z.coerce
+        .number()
+        .int()
+        .min(1)
+        .max(MAX_EXPIRY_DAYS)
+        .optional()
+        .describe('Days before the link stops working. Omit for a link that lasts until revoked')
+    })
+    .strict(),
+  output: z.object({
+    ok: z.literal(true),
+    id: z.string(),
+    view: z.enum(SHARED_VIEW_TYPES),
+    month: z.string(),
+    url: z.string(),
+    token: z.string(),
+    expires_at: z.string().nullable()
+  }),
+  failures: [
+    { error: 'shares_not_migrated', status: 500 },
+    { error: 'snapshot_failed', status: 500 }
+  ],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const LIST_SHARES = {
+  tool: 'list_shares',
+  title: 'List public client links',
+  description:
+    'Public links created for this brand, newest first, with their state. The tokens are not here: ' +
+    'only their hashes are stored, so a link that was not saved at creation can only be replaced.',
+  method: 'GET',
+  pathUnderBrand: '/shares',
+  input: z.object({}).strict(),
+  output: z.object({ shares: z.array(SharedViewRow) }),
+  failures: [{ error: 'shares_not_migrated', status: 500 }],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const REVOKE_SHARE = {
+  tool: 'revoke_share',
+  title: 'Revoke a public client link',
+  description:
+    'Turn one public link off. From then on it answers exactly like a link that never existed. ' +
+    'Brand membership is untouched: revoking removes nobody from the brand.',
+  method: 'POST',
+  pathUnderBrand: '/shares/revoke',
+  input: z.object({ id: z.string().min(1).describe('Share id from list_shares') }).strict(),
+  output: z.object({ ok: z.literal(true), id: z.string(), revoked_at: z.string() }),
+  failures: [
+    { error: 'share_not_found', status: 404 },
+    { error: 'shares_not_migrated', status: 500 }
+  ],
+  destructive: true
+} satisfies BrandEndpoint;
+
+export type CreateShareInput = z.infer<typeof CREATE_SHARE.input>;
+export type CreateShareResult = z.infer<typeof CREATE_SHARE.output>;

--- a/cli/plugins/anomalia/skills/anomalia/SKILL.md
+++ b/cli/plugins/anomalia/skills/anomalia/SKILL.md
@@ -91,6 +91,12 @@ states, in their own words, that they have it.
 
 **Approve pending posts** → `list_posts` (status pending) → optional `get_post` → `approve_posts`.
 
+**Send a client the calendar or the month's results** → `create_share` (`view`: `calendar` or
+`monthly_report`). It returns a link they open with no account, showing a frozen snapshot of that
+view and nothing else. The token is in the response **once** — hand over the `url` immediately.
+`list_shares` shows what is out there, `revoke_share` turns one off without touching anyone's
+access to the brand.
+
 **Fix one carousel slide** → `get_post` → `regenerate_slide` (`index`, instruction; 0 = cover).
 
 **Blog draft** → `generate_article` → optional `optimize_article` → `publish_article` when asked.

--- a/cli/plugins/anomalia/skills/anomalia/references/tools.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/tools.md
@@ -121,6 +121,35 @@ It answers with `ok`, `errors`, `warnings`, `scores` and `versions`:
 
 It never looks at pixels — judging an image or a video is a separate, explicitly paid action.
 
+## Client links
+
+| MCP | CLI |
+|-----|-----|
+| `create_share` | (MCP only) |
+| `list_shares` | (MCP only) |
+| `revoke_share` | (MCP only) |
+
+`create_share` freezes one view as a snapshot and returns a link a client opens with no account.
+Required: `slug`, `view` (`calendar` or `monthly_report`). Optional: `month` (`YYYY-MM`, default
+the current month on the brand clock) and `expires_in_days` (1–365; without it the link lasts
+until revoked).
+
+The `token` comes back **once**, in the create response, and is never stored in readable form —
+save the `url` right away. A link you did not save cannot be recovered: revoke it and make
+another.
+
+The link grants that snapshot and nothing else. It is not a reduced account: it exposes no
+connectors, notes, prompts, costs, settings, member data or private identifiers, and it never
+re-reads live data — what it shows is what the snapshot held the day it was created. The calendar
+shows `planned` / `published`, never the internal workflow state.
+
+`list_shares` shows what exists (`live`, `revoked`, `expired`) without any token.
+`revoke_share` turns one off by `id`: from then on it answers exactly like a link that never
+existed, and brand membership is untouched.
+
+Both need the `shared_views` table. Until it is migrated the three tools answer
+`shares_not_migrated` and name the file to apply.
+
 ## Plans
 
 | MCP | CLI |

--- a/cli/skills/anomalia/SKILL.md
+++ b/cli/skills/anomalia/SKILL.md
@@ -91,6 +91,12 @@ states, in their own words, that they have it.
 
 **Approve pending posts** → `list_posts` (status pending) → optional `get_post` → `approve_posts`.
 
+**Send a client the calendar or the month's results** → `create_share` (`view`: `calendar` or
+`monthly_report`). It returns a link they open with no account, showing a frozen snapshot of that
+view and nothing else. The token is in the response **once** — hand over the `url` immediately.
+`list_shares` shows what is out there, `revoke_share` turns one off without touching anyone's
+access to the brand.
+
 **Fix one carousel slide** → `get_post` → `regenerate_slide` (`index`, instruction; 0 = cover).
 
 **Blog draft** → `generate_article` → optional `optimize_article` → `publish_article` when asked.

--- a/cli/skills/anomalia/references/tools.md
+++ b/cli/skills/anomalia/references/tools.md
@@ -121,6 +121,35 @@ It answers with `ok`, `errors`, `warnings`, `scores` and `versions`:
 
 It never looks at pixels — judging an image or a video is a separate, explicitly paid action.
 
+## Client links
+
+| MCP | CLI |
+|-----|-----|
+| `create_share` | (MCP only) |
+| `list_shares` | (MCP only) |
+| `revoke_share` | (MCP only) |
+
+`create_share` freezes one view as a snapshot and returns a link a client opens with no account.
+Required: `slug`, `view` (`calendar` or `monthly_report`). Optional: `month` (`YYYY-MM`, default
+the current month on the brand clock) and `expires_in_days` (1–365; without it the link lasts
+until revoked).
+
+The `token` comes back **once**, in the create response, and is never stored in readable form —
+save the `url` right away. A link you did not save cannot be recovered: revoke it and make
+another.
+
+The link grants that snapshot and nothing else. It is not a reduced account: it exposes no
+connectors, notes, prompts, costs, settings, member data or private identifiers, and it never
+re-reads live data — what it shows is what the snapshot held the day it was created. The calendar
+shows `planned` / `published`, never the internal workflow state.
+
+`list_shares` shows what exists (`live`, `revoked`, `expired`) without any token.
+`revoke_share` turns one off by `id`: from then on it answers exactly like a link that never
+existed, and brand membership is untouched.
+
+Both need the `shared_views` table. Until it is migrated the three tools answer
+`shares_not_migrated` and name the file to apply.
+
 ## Plans
 
 | MCP | CLI |

--- a/docs/api/10-shares.md
+++ b/docs/api/10-shares.md
@@ -1,0 +1,144 @@
+# API — 10 · Shares (viste pubbliche per il cliente)
+
+Endpoint per consegnare a un cliente **un link a una vista sola**, senza dargli un account.
+Sono gli endpoint dietro i tool MCP `create_share` / `list_shares` / `revoke_share`.
+
+Il link non è una sessione ridotta: è uno **snapshot congelato**. Alla creazione l'app copia,
+campo per campo, i soli campi dichiarati per quella vista dentro `shared_views.snapshot`. La
+rotta pubblica legge quella riga e nient'altro — non torna mai su `posts`, `brands` o su una
+qualunque tabella viva. Una colonna aggiunta domani non può uscire da un link di ieri.
+
+Il token è casuale (32 byte, base64url) e **viene mostrato una volta sola**: nel database resta
+solo il suo sha256. Un link non salvato non si recupera: si revoca e se ne crea un altro.
+
+> **Prerequisito di schema.** Questi endpoint richiedono la tabella `shared_views`
+> (`supabase/migrations/20260904120000_shared_views.sql`). I deploy di questo repo non applicano
+> le migration: finché non la applica una persona, i tre endpoint rispondono `500` con
+> `{"error":"shares_not_migrated"}` e il nome del file da applicare in `details`.
+
+Nessuno di questi endpoint consuma crediti AI: non c'è nessuna chiamata al modello.
+Errori comuni di auth: vedi [01-overview](01-overview.md).
+
+## `POST /api/v1/brands/:slug/shares`
+
+Crea il link. Richiede una API key con scope `write`.
+
+**Body**:
+
+```json
+{ "view": "calendar", "month": "2026-09", "expires_in_days": 30 }
+```
+
+| Campo | Obbligatorio | Note |
+|---|---|---|
+| `view` | sì | `calendar` o `monthly_report` |
+| `month` | no | `YYYY-MM`. Senza, il mese corrente sull'orologio del brand |
+| `expires_in_days` | no | 1–365. Senza, il link vale finché non viene revocato |
+
+Un campo non dichiarato fa `400 invalid_input`: il body è `.strict()`.
+
+**Response** `200`:
+
+```json
+{
+  "ok": true,
+  "id": "9f0c…",
+  "view": "calendar",
+  "month": "2026-09",
+  "url": "https://anomalia.so/share/x7Qd…",
+  "token": "x7Qd…",
+  "expires_at": "2026-10-04T09:00:00.000Z"
+}
+```
+
+`token` compare **solo qui**. Non è recuperabile da `GET /shares`, né da nessun'altra parte.
+
+**Errori**: `400 invalid_input` · `500 shares_not_migrated`.
+
+## `GET /api/v1/brands/:slug/shares`
+
+I link creati per questo brand, dal più recente, con il loro stato. Nessun token e nessuna
+impronta di token compaiono nella risposta.
+
+**Response** `200`:
+
+```json
+{
+  "shares": [
+    {
+      "id": "9f0c…",
+      "view": "calendar",
+      "month": "2026-09",
+      "status": "live",
+      "created_at": "2026-09-04T09:00:00.000Z",
+      "expires_at": null,
+      "revoked_at": null
+    }
+  ]
+}
+```
+
+`status`: `live` · `revoked` · `expired`.
+
+**Errori**: `500 shares_not_migrated`.
+
+## `POST /api/v1/brands/:slug/shares/revoke`
+
+Spegne un link. Richiede una API key con scope `write`.
+
+L'id sta nel body e non nel path apposta: il registry dei contratti (`packages/api-contracts`)
+non risolve ancora un segmento `:id`, e un endpoint scritto a mano perderebbe il tool MCP che il
+registry genera da solo.
+
+**Body**: `{ "id": "9f0c…" }`
+
+**Response** `200`: `{ "ok": true, "id": "9f0c…", "revoked_at": "2026-09-04T10:00:00.000Z" }`
+
+**Errori**: `400 invalid_input` · `404 share_not_found` (anche quando la share esiste ma è di un
+altro brand) · `500 shares_not_migrated`.
+
+Revocare non tocca l'appartenenza al brand: non toglie nessuno da nessuna parte.
+
+## `GET /share/:token` — la rotta pubblica
+
+Non è sotto `/api/v1/brands/:slug` e non sta nel registry: non è un endpoint di brand. Non
+chiede autenticazione, non legge la sessione e non ha uno slug nel path — dall'URL non si ricava
+né quale brand né quale account ci sia dietro.
+
+Legge con la chiave di servizio, con l'impronta del token come unica chiave; ad `anon` la tabella
+resta revocata, così nemmeno una policy scritta male in futuro può aprirla.
+
+| Caso | Risposta |
+|---|---|
+| Token valido | `200` con la pagina della vista |
+| Token revocato | `404` |
+| Token scaduto | `404` |
+| Token mai esistito | `404` |
+
+Le tre risposte sono **identiche**: nessuna conferma che il brand esista, che il link sia mai
+esistito o che sia stato revocato. Una tabella `shared_views` assente è invece un `500`, perché
+è un guasto del server e non una risposta sul link.
+
+## Cosa esce e cosa no
+
+L'allowlist è nel codice, in `src/lib/server/shared-views.ts`, e un test verifica l'insieme
+esatto delle chiavi: un campo aggiunto a monte fa fallire il test invece di uscire dal link.
+
+**`calendar`** — `brand_name`, `timezone`, `month`, `month_label`, `posts[]`.
+Ogni post: `platform`, `caption`, `media_url`, `scheduled_for`, `slot`, `status`.
+`status` è `planned` o `published`: il workflow interno (`pending_user`, `approved`, `failed`)
+non esce. Le bozze senza data restano fuori.
+
+**`monthly_report`** — `brand_name`, `timezone`, `month`, `month_label`, `published`, `totals`,
+`platforms[]`, `top_posts[]`.
+Ogni top post: `platform`, `caption`, `thumbnail_url`, `url`, `published_at`, `views`, `likes`,
+`comments`, `shares`.
+
+Non escono mai: id di post, brand o riga; prompt e `image_prompt`; `qc`, `needs_attention`,
+`attention_reason`; token di approvazione; connettori, note interne, costi, impostazioni, membri;
+lo slug del brand e la provenienza dei dati.
+
+## Fuori da questa versione
+
+L'export PDF, le viste di tipo `proposal` e il calendario **dal vivo** non ci sono. La versione
+uno è fatta di snapshot revocabili: il vivo arriva dopo, quando privacy e cache saranno provate.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -17,6 +17,7 @@ integrazioni esterne via API key — request, response, query params, body, erro
 | [07 — Growth: SEO/GEO/web](07-growth-seo-geo.md) | `/seo`, `/geo`, `/web/audits`, `/web/fixes`, `/keywords`, `/backlinks`, `/web`, `/articles`, `/gsc`, `/ranks`, `/library/scan` |
 | [08 — Ads, voice, GTM e gestione](08-ads-voice-gtm-misc.md) | `/ads`, `/ads/remix`, `/voice`, `/gtm`, `/rubrics`, `/products`, `/api-keys` |
 | [09 — Connections](09-connections.md) | `/connections`, `/connections/catalog`, `/connections/:id/complete`, `/connections/:id` |
+| [10 — Shares](10-shares.md) | `/shares`, `/shares/revoke`, e la rotta pubblica `/share/:token` |
 
 ## Regole di manutenzione
 

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -35,6 +35,12 @@ import {
   LIST_ARTICLES
 } from './reads';
 import {
+  CREATE_SHARE,
+  LIST_SHARES,
+  REVOKE_SHARE,
+  SHARED_VIEW_TYPES,
+} from './shares';
+import {
   CREATE_PRODUCT,
   DELETE_PRODUCT,
   GET_BIO,
@@ -85,6 +91,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   CHECK_CONTENT,
   CREATE_POST,
   CREATE_PRODUCT,
+  CREATE_SHARE,
   DELETE_PRODUCT,
   GET_ADS,
   GET_ARTICLE,
@@ -104,10 +111,12 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   LIST_AUDIT_CITATIONS,
   LIST_MEDIA,
   LIST_POSTS,
+  LIST_SHARES,
   LIST_WEB_AUDITS,
   LIST_WEB_FIXES,
   RENDER_POST,
   RESCHEDULE_POST,
+  REVOKE_SHARE,
   SAVE_PLAN,
   SAVE_WEEK_SEEDS,
   SET_BIO,
@@ -178,6 +187,12 @@ export {
   UPDATE_PERSON,
   UPDATE_PRODUCT
 } from './studio';
+export {
+  CREATE_SHARE,
+  LIST_SHARES,
+  REVOKE_SHARE,
+  SHARED_VIEW_TYPES,
+};
 export type { CheckContentInput, CheckContentResult } from './content';
 export type {
   AuditCitationRow,
@@ -191,3 +206,4 @@ export type { CreatePostInput, CreatePostResult } from './posts';
 export { PLAN_CADENCES, PLAN_CYCLE_WEEKS, SAVE_PLAN, SAVE_WEEK_SEEDS };
 export type { SavePlanInput, SavePlanResult, SaveWeekSeedsInput, SaveWeekSeedsResult } from './plans';
 export type { CreateProductInput, CreateProductResult } from './studio';
+export type { CreateShareInput, CreateShareResult, SharedViewType } from './shares';

--- a/packages/api-contracts/src/shares.test.ts
+++ b/packages/api-contracts/src/shares.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { CREATE_SHARE, LIST_SHARES, REVOKE_SHARE, SHARED_VIEW_TYPES } from './shares';
+
+describe('il contratto delle viste pubbliche', () => {
+  it('dichiara solo le viste che esistono davvero', () => {
+    expect([...SHARED_VIEW_TYPES]).toEqual(['calendar', 'monthly_report']);
+    expect(CREATE_SHARE.input.safeParse({ view: 'proposal' }).success).toBe(false);
+  });
+
+  it('accetta un mese YYYY-MM e rifiuta qualunque altra forma', () => {
+    expect(CREATE_SHARE.input.safeParse({ view: 'calendar', month: '2026-09' }).success).toBe(true);
+    expect(CREATE_SHARE.input.safeParse({ view: 'calendar', month: '2026-9' }).success).toBe(false);
+    expect(CREATE_SHARE.input.safeParse({ view: 'calendar', month: 'settembre' }).success).toBe(false);
+  });
+
+  it('limita la scadenza a un anno e la vuole intera', () => {
+    expect(CREATE_SHARE.input.safeParse({ view: 'calendar', expires_in_days: 7 }).success).toBe(true);
+    expect(CREATE_SHARE.input.safeParse({ view: 'calendar', expires_in_days: 0 }).success).toBe(false);
+    expect(CREATE_SHARE.input.safeParse({ view: 'calendar', expires_in_days: 400 }).success).toBe(false);
+  });
+
+  it('promette il token solo alla creazione: la lista non ha dove metterlo', () => {
+    expect(
+      CREATE_SHARE.output.safeParse({
+        ok: true,
+        id: 'share-1',
+        view: 'calendar',
+        month: '2026-09',
+        url: 'https://anomalia.so/share/abc',
+        token: 'abc',
+        expires_at: null
+      }).success
+    ).toBe(true);
+
+    const listed = {
+      id: 'share-1',
+      view: 'calendar',
+      month: '2026-09',
+      status: 'live',
+      created_at: '2026-09-01T00:00:00.000Z',
+      expires_at: null,
+      revoked_at: null
+    };
+    expect(LIST_SHARES.output.safeParse({ shares: [listed] }).success).toBe(true);
+    expect(LIST_SHARES.output.safeParse({ shares: [{ ...listed, token: 'abc' }] }).success).toBe(true);
+    expect(Object.keys(LIST_SHARES.output.shape.shares.element.shape)).not.toContain('token');
+  });
+
+  it('la revoca è dichiarata distruttiva e sa già che una share può non esserci', () => {
+    expect(REVOKE_SHARE.destructive).toBe(true);
+    expect(REVOKE_SHARE.failures).toContainEqual({ error: 'share_not_found', status: 404 });
+  });
+
+  it('ogni endpoint sa dire che la tabella non è stata migrata', () => {
+    for (const endpoint of [CREATE_SHARE, LIST_SHARES, REVOKE_SHARE]) {
+      expect(endpoint.failures.map((f) => f.error), endpoint.tool).toContain('shares_not_migrated');
+    }
+  });
+});

--- a/packages/api-contracts/src/shares.ts
+++ b/packages/api-contracts/src/shares.ts
@@ -1,0 +1,96 @@
+import { z } from 'zod';
+import type { BrandEndpoint } from './index';
+
+export const SHARED_VIEW_TYPES = ['calendar', 'monthly_report'] as const;
+
+export type SharedViewType = (typeof SHARED_VIEW_TYPES)[number];
+
+const MONTH = z
+  .string()
+  .regex(/^\d{4}-\d{2}$/)
+  .describe('Month YYYY-MM. Defaults to the current month on the brand clock');
+
+const MAX_EXPIRY_DAYS = 365;
+
+const SharedViewRow = z.object({
+  id: z.string(),
+  view: z.enum(SHARED_VIEW_TYPES),
+  month: z.string().nullable(),
+  status: z.enum(['live', 'revoked', 'expired']),
+  created_at: z.string(),
+  expires_at: z.string().nullable(),
+  revoked_at: z.string().nullable()
+});
+
+export const CREATE_SHARE = {
+  tool: 'create_share',
+  title: 'Create a public client link',
+  description:
+    'Freeze one view as a snapshot and return a public link a client can open without an account. ' +
+    'The link grants that snapshot and nothing else: no brand account, no live data, no connectors, ' +
+    'notes, prompts, costs, settings or member data. The token is shown once and never stored in ' +
+    'readable form — save it now or revoke and create another.',
+  method: 'POST',
+  pathUnderBrand: '/shares',
+  input: z
+    .object({
+      view: z.enum(SHARED_VIEW_TYPES).describe('calendar = the month plan; monthly_report = what that month published'),
+      month: MONTH.optional(),
+      expires_in_days: z.coerce
+        .number()
+        .int()
+        .min(1)
+        .max(MAX_EXPIRY_DAYS)
+        .optional()
+        .describe('Days before the link stops working. Omit for a link that lasts until revoked')
+    })
+    .strict(),
+  output: z.object({
+    ok: z.literal(true),
+    id: z.string(),
+    view: z.enum(SHARED_VIEW_TYPES),
+    month: z.string(),
+    url: z.string(),
+    token: z.string(),
+    expires_at: z.string().nullable()
+  }),
+  failures: [
+    { error: 'shares_not_migrated', status: 500 },
+    { error: 'snapshot_failed', status: 500 }
+  ],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const LIST_SHARES = {
+  tool: 'list_shares',
+  title: 'List public client links',
+  description:
+    'Public links created for this brand, newest first, with their state. The tokens are not here: ' +
+    'only their hashes are stored, so a link that was not saved at creation can only be replaced.',
+  method: 'GET',
+  pathUnderBrand: '/shares',
+  input: z.object({}).strict(),
+  output: z.object({ shares: z.array(SharedViewRow) }),
+  failures: [{ error: 'shares_not_migrated', status: 500 }],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const REVOKE_SHARE = {
+  tool: 'revoke_share',
+  title: 'Revoke a public client link',
+  description:
+    'Turn one public link off. From then on it answers exactly like a link that never existed. ' +
+    'Brand membership is untouched: revoking removes nobody from the brand.',
+  method: 'POST',
+  pathUnderBrand: '/shares/revoke',
+  input: z.object({ id: z.string().min(1).describe('Share id from list_shares') }).strict(),
+  output: z.object({ ok: z.literal(true), id: z.string(), revoked_at: z.string() }),
+  failures: [
+    { error: 'share_not_found', status: 404 },
+    { error: 'shares_not_migrated', status: 500 }
+  ],
+  destructive: true
+} satisfies BrandEndpoint;
+
+export type CreateShareInput = z.infer<typeof CREATE_SHARE.input>;
+export type CreateShareResult = z.infer<typeof CREATE_SHARE.output>;

--- a/src/lib/content/changelog/2026-09-04-public-client-links.ts
+++ b/src/lib/content/changelog/2026-09-04-public-client-links.ts
@@ -1,0 +1,11 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-04',
+  title: 'Send a client a link, not an account',
+  items: [
+    'Share a brand calendar or a month of results as a public link the client opens without signing up.',
+    'A link shows a frozen snapshot of that one view — nothing else about the brand travels with it.',
+    'Revoke a link whenever you want, or set it to expire on its own. Revoking takes nobody off the brand.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/shared-views.test.ts
+++ b/src/lib/server/shared-views.test.ts
@@ -1,0 +1,363 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const getCalendar = vi.fn();
+vi.mock('./cli-queries', () => ({ getCalendar: (...args: unknown[]) => getCalendar(...args) }));
+
+import { SHARED_VIEW_TYPES } from '@anomalia/api-contracts';
+import {
+  CALENDAR_POST_FIELDS,
+  CALENDAR_SNAPSHOT_FIELDS,
+  REPORT_POST_FIELDS,
+  REPORT_SNAPSHOT_FIELDS,
+  SHARE_SNAPSHOT_VERSION,
+  SharedViewsNotMigrated,
+  buildSnapshot,
+  createSharedView,
+  hashShareToken,
+  listSharedViews,
+  mintShareToken,
+  readSharedView,
+  revokeSharedView
+} from './shared-views';
+
+type Row = Record<string, unknown>;
+type Result = { data: unknown; error: unknown };
+
+const BRAND = { id: 'brand-1', name: 'Demo Brand', timezone: 'Europe/Rome', content_prefs: { language: 'it' } };
+const MISSING_TABLE = { code: 'PGRST205', message: "Could not find the table 'public.shared_views' in the schema cache" };
+
+function fakeTable(result: Result | (() => Result)) {
+  const calls: { method: string; args: unknown[] }[] = [];
+  const q: Row = { calls };
+  for (const method of ['select', 'eq', 'neq', 'not', 'gte', 'lte', 'lt', 'gt', 'is', 'or', 'order', 'limit', 'insert', 'update']) {
+    q[method] = (...args: unknown[]) => {
+      calls.push({ method, args });
+      return q;
+    };
+  }
+  const settle = async () => (typeof result === 'function' ? result() : result);
+  q.single = settle;
+  q.maybeSingle = settle;
+  q.then = (onOk: (v: Result) => unknown, onErr?: (e: unknown) => unknown) => settle().then(onOk, onErr);
+  return q as Row & { calls: { method: string; args: unknown[] }[] };
+}
+
+function fakeSupabase(tables: Record<string, ReturnType<typeof fakeTable>>) {
+  return {
+    tables,
+    from: (name: string) => tables[name] ?? fakeTable({ data: null, error: null })
+  } as never;
+}
+
+function argsOf(table: ReturnType<typeof fakeTable>, method: string) {
+  return table.calls.filter((c) => c.method === method).map((c) => c.args);
+}
+
+const A_POST_ROW_WITH_EVERYTHING = {
+  id: 'post-1',
+  brand_id: 'brand-1',
+  platform: 'linkedin',
+  caption: 'Copy che il cliente può leggere',
+  media_url: 'https://cdn.test/a.png',
+  scheduled_for: '2026-09-10T07:00:00.000Z',
+  slot: '2026-09-10',
+  status: 'approved',
+  image_prompt: 'un prompt interno',
+  qc: { verdict: 'borderline' },
+  approval_token: 'token-di-approvazione',
+  attention_reason: 'nota interna',
+  design: { layers: [] },
+  plan_id: 'plan-1'
+};
+
+const A_HISTORY_ROW_WITH_EVERYTHING = {
+  id: 'history-1',
+  brand_id: 'brand-1',
+  source: 'zernio',
+  platform: 'instagram',
+  content: 'Il post pubblicato',
+  platform_post_url: 'https://instagram.com/p/abc',
+  thumbnail_url: 'https://cdn.test/t.jpg',
+  thumbnail_path: 'brand-knowledge/brand-1/t.jpg',
+  published_at: '2026-09-04T10:00:00.000Z',
+  zernio_external_post_id: 'zzz-1',
+  metrics: { views: 1000, likes: 50, comments: 4, shares: 2, saves: 9, impressions: 1200 }
+};
+
+function calendarReturns(posts: Row[]) {
+  getCalendar.mockResolvedValue({
+    posts,
+    year: 2026,
+    month: 9,
+    monthLabel: 'settembre 2026',
+    prevYM: '2026-08',
+    nextYM: '2026-10',
+    timezone: 'Europe/Rome'
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  calendarReturns([A_POST_ROW_WITH_EVERYTHING]);
+});
+
+describe('il token di una vista condivisa', () => {
+  it('è opaco, ad alta entropia e non si ripete', () => {
+    const a = mintShareToken();
+    const b = mintShareToken();
+
+    expect(a.token).toMatch(/^[A-Za-z0-9_-]{43,}$/);
+    expect(a.token).not.toBe(b.token);
+    expect(a.token_hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(a.token_hash).not.toBe(b.token_hash);
+  });
+
+  it('non è ricavabile dall impronta che il database conserva', () => {
+    const { token, token_hash } = mintShareToken();
+
+    expect(token_hash).not.toContain(token);
+    expect(token_hash).toBe(hashShareToken(token));
+    expect(hashShareToken(`${token}x`)).not.toBe(token_hash);
+  });
+});
+
+describe('creare una vista condivisa', () => {
+  it('restituisce il token una volta sola e scrive solo la sua impronta', async () => {
+    const shares = fakeTable({ data: { id: 'share-1' }, error: null });
+    const created = await createSharedView(fakeSupabase({ shared_views: shares }), {
+      brand: BRAND,
+      authorId: 'user-1',
+      view: 'calendar',
+      month: '2026-09'
+    });
+
+    const [[written]] = argsOf(shares, 'insert') as [[Row]];
+    expect(JSON.stringify(written)).not.toContain(created.token);
+    expect(written.token_hash).toBe(hashShareToken(created.token));
+    expect(Object.keys(written)).not.toContain('token');
+    expect(written.brand_id).toBe('brand-1');
+    expect(written.author_id).toBe('user-1');
+    expect(written.snapshot_version).toBe(SHARE_SNAPSHOT_VERSION);
+  });
+
+  it('senza scadenza dichiarata il link non scade, con una la porta scritta', async () => {
+    const shares = fakeTable({ data: { id: 'share-1' }, error: null });
+    const supabase = fakeSupabase({ shared_views: shares });
+
+    await createSharedView(supabase, { brand: BRAND, authorId: 'user-1', view: 'calendar', month: '2026-09' });
+    await createSharedView(supabase, {
+      brand: BRAND,
+      authorId: 'user-1',
+      view: 'calendar',
+      month: '2026-09',
+      expiresInDays: 7
+    });
+
+    const [[first], [second]] = argsOf(shares, 'insert') as [[Row], [Row]];
+    expect(first.expires_at).toBeNull();
+    expect(typeof second.expires_at).toBe('string');
+    expect(Date.parse(second.expires_at as string)).toBeGreaterThan(Date.now());
+  });
+
+  it('dice che la migration manca invece di far passare un errore Postgres', async () => {
+    const shares = fakeTable({ data: null, error: MISSING_TABLE });
+
+    await expect(
+      createSharedView(fakeSupabase({ shared_views: shares }), {
+        brand: BRAND,
+        authorId: 'user-1',
+        view: 'calendar',
+        month: '2026-09'
+      })
+    ).rejects.toBeInstanceOf(SharedViewsNotMigrated);
+  });
+});
+
+describe('lo snapshot del calendario', () => {
+  it('porta solo i campi dichiarati, anche se il post ne ha trenta', async () => {
+    const { snapshot } = await buildSnapshot(fakeSupabase({}), BRAND, 'calendar', '2026-09');
+
+    expect(Object.keys(snapshot).sort()).toEqual([...CALENDAR_SNAPSHOT_FIELDS].sort());
+    expect(Object.keys((snapshot.posts as Row[])[0]).sort()).toEqual([...CALENDAR_POST_FIELDS].sort());
+  });
+
+  it('non fa uscire prompt, qc, note interne o identificatori privati', async () => {
+    const { snapshot } = await buildSnapshot(fakeSupabase({}), BRAND, 'calendar', '2026-09');
+    const serialized = JSON.stringify(snapshot);
+
+    for (const secret of ['un prompt interno', 'borderline', 'token-di-approvazione', 'nota interna', 'post-1', 'brand-1', 'plan-1']) {
+      expect(serialized).not.toContain(secret);
+    }
+  });
+
+  it('mostra al cliente uno stato suo, non il workflow interno', async () => {
+    calendarReturns([
+      { ...A_POST_ROW_WITH_EVERYTHING, status: 'pending_user' },
+      { ...A_POST_ROW_WITH_EVERYTHING, status: 'failed', scheduled_for: '2026-09-11T07:00:00.000Z' },
+      { ...A_POST_ROW_WITH_EVERYTHING, status: 'published', scheduled_for: '2026-09-12T07:00:00.000Z' }
+    ]);
+
+    const { snapshot } = await buildSnapshot(fakeSupabase({}), BRAND, 'calendar', '2026-09');
+
+    expect((snapshot.posts as Row[]).map((p) => p.status)).toEqual(['planned', 'planned', 'published']);
+  });
+
+  it('lascia fuori le bozze senza data: un calendario è fatto di giorni', async () => {
+    calendarReturns([
+      { ...A_POST_ROW_WITH_EVERYTHING, scheduled_for: null, slot: null, isDraft: true },
+      A_POST_ROW_WITH_EVERYTHING
+    ]);
+
+    const { snapshot } = await buildSnapshot(fakeSupabase({}), BRAND, 'calendar', '2026-09');
+
+    expect((snapshot.posts as Row[]).length).toBe(1);
+  });
+});
+
+describe('lo snapshot del report mensile', () => {
+  function reportSupabase(rows: Row[]) {
+    return fakeSupabase({ social_post_history: fakeTable({ data: rows, error: null }) });
+  }
+
+  it('porta solo i campi dichiarati, in cima e su ogni post', async () => {
+    const { snapshot } = await buildSnapshot(reportSupabase([A_HISTORY_ROW_WITH_EVERYTHING]), BRAND, 'monthly_report', '2026-09');
+
+    expect(Object.keys(snapshot).sort()).toEqual([...REPORT_SNAPSHOT_FIELDS].sort());
+    expect(Object.keys((snapshot.top_posts as Row[])[0]).sort()).toEqual([...REPORT_POST_FIELDS].sort());
+  });
+
+  it('non fa uscire identificatori privati né la provenienza dei dati', async () => {
+    const { snapshot } = await buildSnapshot(reportSupabase([A_HISTORY_ROW_WITH_EVERYTHING]), BRAND, 'monthly_report', '2026-09');
+    const serialized = JSON.stringify(snapshot);
+
+    for (const secret of ['history-1', 'brand-1', 'zernio', 'zzz-1', 'brand-knowledge']) {
+      expect(serialized).not.toContain(secret);
+    }
+  });
+
+  it('somma il mese chiesto e lo chiede al database, non tutta la storia', async () => {
+    const history = fakeTable({ data: [A_HISTORY_ROW_WITH_EVERYTHING], error: null });
+    const { snapshot } = await buildSnapshot(fakeSupabase({ social_post_history: history }), BRAND, 'monthly_report', '2026-09');
+
+    expect(snapshot.totals).toEqual({ views: 1000, likes: 50, comments: 4, shares: 2 });
+    expect(snapshot.published).toBe(1);
+    expect(argsOf(history, 'eq')).toContainEqual(['brand_id', 'brand-1']);
+    expect(argsOf(history, 'gte')[0][0]).toBe('published_at');
+    expect(argsOf(history, 'lt')[0][0]).toBe('published_at');
+  });
+});
+
+describe('la tabella dei tipi di vista', () => {
+  it('ogni vista che il contratto dichiara sa costruire il proprio snapshot', async () => {
+    for (const view of SHARED_VIEW_TYPES) {
+      const supabase = fakeSupabase({ social_post_history: fakeTable({ data: [], error: null }) });
+      const { snapshot, version } = await buildSnapshot(supabase, BRAND, view, '2026-09');
+
+      expect(version, view).toBe(SHARE_SNAPSHOT_VERSION);
+      expect(snapshot.month, view).toBe('2026-09');
+      expect(snapshot.brand_name, view).toBe('Demo Brand');
+    }
+  });
+});
+
+describe('leggere una vista condivisa dal token', () => {
+  const LIVE = {
+    view_type: 'calendar',
+    snapshot: { brand_name: 'Demo Brand', posts: [] },
+    snapshot_version: 1,
+    created_at: '2026-09-01T00:00:00.000Z',
+    expires_at: null,
+    revoked_at: null
+  };
+
+  function readWith(row: Row | null) {
+    const shares = fakeTable({ data: row, error: null });
+    return readSharedView(fakeSupabase({ shared_views: shares }), 'un-token-qualunque');
+  }
+
+  it('restituisce lo snapshot per un token valido', async () => {
+    await expect(readWith(LIVE)).resolves.toEqual({
+      view: 'calendar',
+      version: 1,
+      snapshot: LIVE.snapshot,
+      created_at: LIVE.created_at
+    });
+  });
+
+  it('revocato, scaduto e mai esistito sono la stessa risposta', async () => {
+    const results = await Promise.all([
+      readWith({ ...LIVE, revoked_at: '2026-09-02T00:00:00.000Z' }),
+      readWith({ ...LIVE, expires_at: '2026-09-02T00:00:00.000Z' }),
+      readWith(null)
+    ]);
+
+    expect(results).toEqual([null, null, null]);
+    expect(new Set(results.map((r) => JSON.stringify(r))).size).toBe(1);
+  });
+
+  it('cerca per impronta: il token in chiaro non arriva mai al database', async () => {
+    const shares = fakeTable({ data: null, error: null });
+    await readSharedView(fakeSupabase({ shared_views: shares }), 'un-token-qualunque');
+
+    const filters = argsOf(shares, 'eq');
+    expect(filters).toEqual([['token_hash', hashShareToken('un-token-qualunque')]]);
+    expect(JSON.stringify(filters)).not.toContain('un-token-qualunque');
+  });
+
+  it('non legge nessuna tabella viva: lo snapshot è tutto quello che esce', async () => {
+    const tables: string[] = [];
+    const shares = fakeTable({ data: LIVE, error: null });
+    await readSharedView(
+      { from: (name: string) => (tables.push(name), shares) } as never,
+      'un-token-qualunque'
+    );
+
+    expect(tables).toEqual(['shared_views']);
+  });
+});
+
+describe('la lista e la revoca', () => {
+  it('elenca solo il brand chiesto e non mostra mai l impronta del token', async () => {
+    const shares = fakeTable({
+      data: [
+        {
+          id: 'share-1',
+          view_type: 'calendar',
+          snapshot_version: 1,
+          created_at: '2026-09-01T00:00:00.000Z',
+          expires_at: null,
+          revoked_at: null,
+          snapshot: { month: '2026-09' }
+        }
+      ],
+      error: null
+    });
+
+    const list = await listSharedViews(fakeSupabase({ shared_views: shares }), 'brand-1');
+
+    expect(argsOf(shares, 'eq')).toEqual([['brand_id', 'brand-1']]);
+    expect(JSON.stringify(argsOf(shares, 'select'))).not.toContain('token_hash');
+    expect(JSON.stringify(list)).not.toContain('token_hash');
+    expect(Object.keys(list[0]).sort()).toEqual(
+      ['created_at', 'expires_at', 'id', 'month', 'revoked_at', 'status', 'view'].sort()
+    );
+  });
+
+  it('la revoca tocca solo la riga di quel brand', async () => {
+    const shares = fakeTable({ data: { id: 'share-1', revoked_at: '2026-09-04T00:00:00.000Z' }, error: null });
+
+    const revoked = await revokeSharedView(fakeSupabase({ shared_views: shares }), 'brand-1', 'share-1');
+
+    expect(argsOf(shares, 'eq')).toEqual([
+      ['id', 'share-1'],
+      ['brand_id', 'brand-1']
+    ]);
+    expect(revoked).toEqual({ id: 'share-1', revoked_at: '2026-09-04T00:00:00.000Z' });
+  });
+
+  it('una share di un altro brand non si revoca: non risulta', async () => {
+    const shares = fakeTable({ data: null, error: null });
+
+    await expect(revokeSharedView(fakeSupabase({ shared_views: shares }), 'brand-1', 'share-di-un-altro')).resolves.toBeNull();
+  });
+});

--- a/src/lib/server/shared-views.ts
+++ b/src/lib/server/shared-views.ts
@@ -1,0 +1,356 @@
+// Viste pubbliche: un link che consegna UNO snapshot a un visitatore anonimo, mai un brand.
+//
+//   creazione (autenticata)                lettura (anonima)
+//   brand vivo ──allowlist──> snapshot ──> riga ──> pagina /share/<token>
+//
+// Lo snapshot si costruisce QUI, campo per campo, e la lettura pubblica non torna mai indietro
+// sulle tabelle vive: una colonna aggiunta domani a `posts` non può uscire da un link di ieri.
+// Il token è casuale e ne resta solo l'impronta: un dump del database non produce link
+// funzionanti. Revocato, scaduto e mai esistito passano tutti da `liveShare` e valgono `null`,
+// così la risposta è identica e non conferma nemmeno che il brand esista.
+import { createHash, randomBytes } from 'node:crypto';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { SHARED_VIEW_TYPES, type SharedViewType } from '@anomalia/api-contracts';
+import { getCalendar } from './cli-queries';
+import { dedupeSocialHistory, metricNum, type SocialHistoryRow } from './social-history-metrics';
+import { monthKey } from './usage';
+
+export const SHARE_SNAPSHOT_VERSION = 1;
+
+const TOKEN_BYTES = 32;
+const MISSING_TABLE_CODES = new Set(['PGRST205', '42P01']);
+const MIGRATION_FILE = '20260904120000_shared_views.sql';
+const TOP_POSTS = 5;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export const METRIC_FIELDS = ['views', 'likes', 'comments', 'shares'] as const;
+
+export const CALENDAR_POST_FIELDS = ['platform', 'caption', 'media_url', 'scheduled_for', 'slot', 'status'] as const;
+export const CALENDAR_SNAPSHOT_FIELDS = ['brand_name', 'timezone', 'month', 'month_label', 'posts'] as const;
+
+export const REPORT_POST_FIELDS = ['platform', 'caption', 'thumbnail_url', 'url', 'published_at', ...METRIC_FIELDS] as const;
+export const REPORT_SNAPSHOT_FIELDS = ['brand_name', 'timezone', 'month', 'month_label', 'published', 'totals', 'platforms', 'top_posts'] as const;
+
+export class SharedViewsNotMigrated extends Error {
+  constructor() {
+    super(`shared_views is missing — apply supabase/migrations/${MIGRATION_FILE} before using public client links`);
+    this.name = 'SharedViewsNotMigrated';
+  }
+}
+
+/** La tabella dei guasti che una rotta deve saper raccontare. Ogni altro errore resta un 500 muto. */
+export function shareFailure(e: unknown): { error: string; details: string } | null {
+  if (e instanceof SharedViewsNotMigrated) return { error: 'shares_not_migrated', details: e.message };
+  return null;
+}
+
+export type SharedViewBrand = {
+  id: string;
+  name: string;
+  timezone: string;
+  content_prefs?: Record<string, unknown> | null;
+};
+
+export type SharedViewSnapshot = Record<string, unknown>;
+
+export type SharedViewListing = {
+  id: string;
+  view: SharedViewType;
+  month: string | null;
+  status: 'live' | 'revoked' | 'expired';
+  created_at: string;
+  expires_at: string | null;
+  revoked_at: string | null;
+};
+
+type ShareRow = {
+  view_type: SharedViewType;
+  snapshot: SharedViewSnapshot;
+  snapshot_version: number;
+  created_at: string;
+  expires_at: string | null;
+  revoked_at: string | null;
+};
+
+export function hashShareToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+export function mintShareToken(): { token: string; token_hash: string } {
+  const token = randomBytes(TOKEN_BYTES).toString('base64url');
+  return { token, token_hash: hashShareToken(token) };
+}
+
+export function currentShareMonth(timezone: string, now = new Date()): string {
+  return monthKey(timezone, now).slice(0, 7);
+}
+
+function raise(error: unknown): never {
+  const code = (error as { code?: string } | null)?.code;
+  if (code && MISSING_TABLE_CODES.has(code)) throw new SharedViewsNotMigrated();
+  throw error;
+}
+
+/** L'unico posto dove un link smette di valere. Tre motivi, una risposta sola: `null`. */
+function liveShare(row: ShareRow | null, now: Date): ShareRow | null {
+  if (!row) return null;
+  if (row.revoked_at) return null;
+  if (row.expires_at && Date.parse(row.expires_at) <= now.getTime()) return null;
+  return row;
+}
+
+function shareStatus(row: { expires_at: string | null; revoked_at: string | null }, now: Date): SharedViewListing['status'] {
+  if (row.revoked_at) return 'revoked';
+  if (row.expires_at && Date.parse(row.expires_at) <= now.getTime()) return 'expired';
+  return 'live';
+}
+
+function monthBounds(month: string): { start: string; end: string } {
+  const [year, index] = month.split('-').map(Number);
+  return {
+    start: new Date(Date.UTC(year, index - 1, 1)).toISOString(),
+    end: new Date(Date.UTC(year, index, 1)).toISOString()
+  };
+}
+
+/** Lo stato che un cliente può leggere. Il workflow interno (failed, pending_user) resta dentro. */
+function clientStatus(status: unknown): 'planned' | 'published' {
+  return status === 'published' ? 'published' : 'planned';
+}
+
+async function buildCalendar(
+  supabase: SupabaseClient,
+  brand: SharedViewBrand,
+  month: string
+): Promise<SharedViewSnapshot> {
+  const [year, index] = month.split('-').map(Number);
+  const language = (brand.content_prefs?.language as string | undefined) ?? null;
+  const calendar = await getCalendar(supabase, brand.id, brand.timezone, year, index, language);
+
+  const posts = (calendar.posts as Record<string, unknown>[])
+    .filter((post) => post.scheduled_for || post.slot)
+    .map((post) => ({
+      platform: (post.platform as string | null) ?? null,
+      caption: (post.caption as string | null) ?? null,
+      media_url: (post.media_url as string | null) ?? null,
+      scheduled_for: (post.scheduled_for as string | null) ?? null,
+      slot: (post.slot as string | null) ?? null,
+      status: clientStatus(post.status)
+    }))
+    .sort((a, b) => String(a.scheduled_for ?? a.slot).localeCompare(String(b.scheduled_for ?? b.slot)));
+
+  return {
+    brand_name: brand.name,
+    timezone: calendar.timezone,
+    month,
+    month_label: calendar.monthLabel,
+    posts
+  };
+}
+
+type ShareMetrics = Record<(typeof METRIC_FIELDS)[number], number>;
+
+function emptyTotals(): ShareMetrics {
+  return { views: 0, likes: 0, comments: 0, shares: 0 };
+}
+
+function metricsOf(row: SocialHistoryRow): ShareMetrics {
+  const totals = emptyTotals();
+  for (const field of METRIC_FIELDS) totals[field] = metricNum(row.metrics?.[field]);
+  return totals;
+}
+
+function addMetrics(into: ShareMetrics, from: ShareMetrics) {
+  for (const field of METRIC_FIELDS) into[field] += from[field];
+}
+
+const engagementScore = (m: ShareMetrics) => m.likes + m.comments * 2 + m.shares * 3 + m.views * 0.01;
+
+async function buildMonthlyReport(
+  supabase: SupabaseClient,
+  brand: SharedViewBrand,
+  month: string
+): Promise<SharedViewSnapshot> {
+  const { start, end } = monthBounds(month);
+  const { data, error } = await supabase
+    .from('social_post_history')
+    .select('source, platform, content, platform_post_url, thumbnail_url, published_at, metrics')
+    .eq('brand_id', brand.id)
+    .gte('published_at', start)
+    .lt('published_at', end)
+    .order('published_at', { ascending: false })
+    .limit(500);
+
+  if (error) raise(error);
+
+  const rows = dedupeSocialHistory((data ?? []) as SocialHistoryRow[]);
+  const totals = emptyTotals();
+  const byPlatform = new Map<string, { platform: string; published: number } & ShareMetrics>();
+
+  for (const row of rows) {
+    const metrics = metricsOf(row);
+    addMetrics(totals, metrics);
+
+    const platform = (row.platform ?? 'other').toLowerCase();
+    const bucket = byPlatform.get(platform) ?? { platform, published: 0, ...emptyTotals() };
+    bucket.published += 1;
+    addMetrics(bucket, metrics);
+    byPlatform.set(platform, bucket);
+  }
+
+  const top_posts = rows
+    .map((row) => ({
+      platform: (row.platform ?? null) as string | null,
+      caption: (row.content ?? null) as string | null,
+      thumbnail_url: (row.thumbnail_url ?? null) as string | null,
+      url: (row.platform_post_url ?? null) as string | null,
+      published_at: (row.published_at ?? null) as string | null,
+      ...metricsOf(row)
+    }))
+    .sort((a, b) => engagementScore(b) - engagementScore(a))
+    .slice(0, TOP_POSTS);
+
+  const monthLabel = new Date(`${month}-01T00:00:00Z`).toLocaleDateString('en-US', {
+    month: 'long',
+    year: 'numeric',
+    timeZone: 'UTC'
+  });
+
+  return {
+    brand_name: brand.name,
+    timezone: brand.timezone,
+    month,
+    month_label: monthLabel,
+    published: rows.length,
+    totals,
+    platforms: [...byPlatform.values()].sort((a, b) => b.published - a.published),
+    top_posts
+  };
+}
+
+/** L'unica tabella dei tipi di vista: aggiungerne uno è una riga qui più il suo builder. */
+const SNAPSHOT_BUILDERS: Record<
+  SharedViewType,
+  (supabase: SupabaseClient, brand: SharedViewBrand, month: string) => Promise<SharedViewSnapshot>
+> = {
+  calendar: buildCalendar,
+  monthly_report: buildMonthlyReport
+};
+
+export function isSharedViewType(value: unknown): value is SharedViewType {
+  return SHARED_VIEW_TYPES.includes(value as SharedViewType);
+}
+
+export async function buildSnapshot(
+  supabase: SupabaseClient,
+  brand: SharedViewBrand,
+  view: SharedViewType,
+  month: string
+): Promise<{ snapshot: SharedViewSnapshot; version: number }> {
+  const snapshot = await SNAPSHOT_BUILDERS[view](supabase, brand, month);
+  return { snapshot, version: SHARE_SNAPSHOT_VERSION };
+}
+
+export async function createSharedView(
+  supabase: SupabaseClient,
+  input: {
+    brand: SharedViewBrand;
+    authorId: string;
+    view: SharedViewType;
+    month: string;
+    expiresInDays?: number;
+    now?: Date;
+  }
+): Promise<{ id: string; token: string; view: SharedViewType; month: string; expires_at: string | null }> {
+  const now = input.now ?? new Date();
+  const { snapshot, version } = await buildSnapshot(supabase, input.brand, input.view, input.month);
+  const { token, token_hash } = mintShareToken();
+  const expires_at = input.expiresInDays ? new Date(now.getTime() + input.expiresInDays * DAY_MS).toISOString() : null;
+
+  const { data, error } = await supabase
+    .from('shared_views')
+    .insert({
+      brand_id: input.brand.id,
+      author_id: input.authorId,
+      view_type: input.view,
+      snapshot,
+      snapshot_version: version,
+      token_hash,
+      expires_at
+    })
+    .select('id')
+    .single();
+
+  if (error) raise(error);
+
+  return { id: (data as { id: string }).id, token, view: input.view, month: input.month, expires_at };
+}
+
+export async function listSharedViews(
+  supabase: SupabaseClient,
+  brandId: string,
+  now = new Date()
+): Promise<SharedViewListing[]> {
+  const { data, error } = await supabase
+    .from('shared_views')
+    .select('id, view_type, snapshot, created_at, expires_at, revoked_at')
+    .eq('brand_id', brandId)
+    .order('created_at', { ascending: false })
+    .limit(100);
+
+  if (error) raise(error);
+
+  return ((data ?? []) as (ShareRow & { id: string })[]).map((row) => ({
+    id: row.id,
+    view: row.view_type,
+    month: (row.snapshot?.month as string | undefined) ?? null,
+    status: shareStatus(row, now),
+    created_at: row.created_at,
+    expires_at: row.expires_at,
+    revoked_at: row.revoked_at
+  }));
+}
+
+export async function revokeSharedView(
+  supabase: SupabaseClient,
+  brandId: string,
+  id: string,
+  now = new Date()
+): Promise<{ id: string; revoked_at: string } | null> {
+  const { data, error } = await supabase
+    .from('shared_views')
+    .update({ revoked_at: now.toISOString() })
+    .eq('id', id)
+    .eq('brand_id', brandId)
+    .select('id, revoked_at')
+    .maybeSingle();
+
+  if (error) raise(error);
+  if (!data) return null;
+
+  return data as { id: string; revoked_at: string };
+}
+
+export async function readSharedView(
+  admin: SupabaseClient,
+  token: string,
+  now = new Date()
+): Promise<{ view: SharedViewType; version: number; snapshot: SharedViewSnapshot; created_at: string } | null> {
+  const { data, error } = await admin
+    .from('shared_views')
+    .select('view_type, snapshot, snapshot_version, created_at, expires_at, revoked_at')
+    .eq('token_hash', hashShareToken(token))
+    .maybeSingle();
+
+  if (error) raise(error);
+
+  const row = liveShare(data as ShareRow | null, now);
+  if (!row) return null;
+
+  return {
+    view: row.view_type,
+    version: row.snapshot_version,
+    snapshot: row.snapshot,
+    created_at: row.created_at
+  };
+}

--- a/src/routes/api/v1/brands/[slug]/shares/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/shares/+server.ts
@@ -1,0 +1,62 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { authenticate, loadBrandForUser, checkApiKeyWriteAccess } from '$lib/server/cli-auth';
+import { appOrigin } from '$lib/server/app-url';
+import { CREATE_SHARE, LIST_SHARES, statusForFailure } from '@anomalia/api-contracts';
+import { createSharedView, currentShareMonth, listSharedViews, shareFailure } from '$lib/server/shared-views';
+
+export const GET: RequestHandler = async ({ request, params }) => {
+  const { supabase, error, apiKey } = await authenticate(request);
+  if (error) return error;
+
+  const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
+  if (brandError) return brandError;
+
+  try {
+    return json({ shares: await listSharedViews(supabase, brand.id) });
+  } catch (e) {
+    const failure = shareFailure(e);
+    if (!failure) throw e;
+    return json(failure, { status: statusForFailure(LIST_SHARES, failure.error) });
+  }
+};
+
+export const POST: RequestHandler = async ({ request, params, url }) => {
+  const { supabase, user, error, apiKey } = await authenticate(request);
+  if (error) return error;
+
+  const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
+  if (brandError) return brandError;
+  const writeDenied = checkApiKeyWriteAccess(apiKey);
+  if (writeDenied) return writeDenied;
+
+  const parsed = CREATE_SHARE.input.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return json({ error: 'invalid_input', details: parsed.error.issues }, { status: 400 });
+  }
+  const input = parsed.data;
+
+  try {
+    const share = await createSharedView(supabase, {
+      brand,
+      authorId: user.id,
+      view: input.view,
+      month: input.month ?? currentShareMonth(brand.timezone),
+      expiresInDays: input.expires_in_days
+    });
+
+    return json({
+      ok: true,
+      id: share.id,
+      view: share.view,
+      month: share.month,
+      url: `${appOrigin(url)}/share/${share.token}`,
+      token: share.token,
+      expires_at: share.expires_at
+    });
+  } catch (e) {
+    const failure = shareFailure(e);
+    if (!failure) throw e;
+    return json(failure, { status: statusForFailure(CREATE_SHARE, failure.error) });
+  }
+};

--- a/src/routes/api/v1/brands/[slug]/shares/revoke/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/shares/revoke/+server.ts
@@ -1,0 +1,33 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { authenticate, loadBrandForUser, checkApiKeyWriteAccess } from '$lib/server/cli-auth';
+import { REVOKE_SHARE, statusForFailure } from '@anomalia/api-contracts';
+import { revokeSharedView, shareFailure } from '$lib/server/shared-views';
+
+export const POST: RequestHandler = async ({ request, params }) => {
+  const { supabase, error, apiKey } = await authenticate(request);
+  if (error) return error;
+
+  const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
+  if (brandError) return brandError;
+  const writeDenied = checkApiKeyWriteAccess(apiKey);
+  if (writeDenied) return writeDenied;
+
+  const parsed = REVOKE_SHARE.input.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return json({ error: 'invalid_input', details: parsed.error.issues }, { status: 400 });
+  }
+
+  try {
+    const revoked = await revokeSharedView(supabase, brand.id, parsed.data.id);
+    if (!revoked) {
+      return json({ error: 'share_not_found' }, { status: statusForFailure(REVOKE_SHARE, 'share_not_found') });
+    }
+
+    return json({ ok: true, id: revoked.id, revoked_at: revoked.revoked_at });
+  } catch (e) {
+    const failure = shareFailure(e);
+    if (!failure) throw e;
+    return json(failure, { status: statusForFailure(REVOKE_SHARE, failure.error) });
+  }
+};

--- a/src/routes/api/v1/brands/[slug]/shares/server.test.ts
+++ b/src/routes/api/v1/brands/[slug]/shares/server.test.ts
@@ -1,0 +1,292 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const structured = vi.fn();
+const gateCredits = vi.fn();
+
+vi.mock('$lib/server/cli-auth', () => ({
+  authenticate: vi.fn(),
+  loadBrandForUser: vi.fn(),
+  checkApiKeyWriteAccess: vi.fn(() => undefined),
+  gateAiAction: vi.fn()
+}));
+vi.mock('$lib/server/cli-queries', () => ({ getCalendar: vi.fn() }));
+vi.mock('$lib/server/research', () => ({ structured: (...args: unknown[]) => structured(...args) }));
+vi.mock('$lib/server/credits', () => ({
+  gateCredits: (...args: unknown[]) => gateCredits(...args),
+  CreditsExhaustedError: class extends Error {}
+}));
+vi.mock('$lib/server/app-url', () => ({ appOrigin: () => 'https://anomalia.test' }));
+
+import { GET, POST } from './+server';
+import { POST as REVOKE } from './revoke/+server';
+import { authenticate, loadBrandForUser, checkApiKeyWriteAccess, gateAiAction } from '$lib/server/cli-auth';
+import { getCalendar } from '$lib/server/cli-queries';
+import { hashShareToken } from '$lib/server/shared-views';
+
+type Row = Record<string, unknown>;
+type Result = { data: unknown; error: unknown };
+
+const BRAND = { id: 'brand-1', slug: 'demo', name: 'Demo Brand', timezone: 'Europe/Rome', content_prefs: null };
+const MISSING_TABLE = { code: 'PGRST205', message: "Could not find the table 'public.shared_views' in the schema cache" };
+
+type Op = { table: string; method: string; args: unknown[] };
+
+function fakeSupabase(results: Record<string, Result>) {
+  const ops: Op[] = [];
+  const client = {
+    ops,
+    from(table: string) {
+      const q: Row = {};
+      for (const method of ['select', 'eq', 'neq', 'not', 'gte', 'lte', 'lt', 'gt', 'is', 'or', 'order', 'limit', 'insert', 'update', 'delete', 'upsert']) {
+        q[method] = (...args: unknown[]) => {
+          ops.push({ table, method, args });
+          return q;
+        };
+      }
+      const settle = async () => results[table] ?? { data: null, error: null };
+      q.single = settle;
+      q.maybeSingle = settle;
+      q.then = (onOk: (v: Result) => unknown, onErr?: (e: unknown) => unknown) => settle().then(onOk, onErr);
+      return q;
+    }
+  };
+  return client;
+}
+
+const WRITES = new Set(['insert', 'update', 'delete', 'upsert']);
+
+function callWith(
+  handler: (event: unknown) => Promise<Response>,
+  opts: { method: 'GET' | 'POST'; path: string; body?: unknown; slug?: string; results?: Record<string, Result> }
+) {
+  const slug = opts.slug ?? 'demo';
+  const client = fakeSupabase(opts.results ?? {});
+  vi.mocked(authenticate).mockResolvedValue({
+    supabase: client,
+    user: { id: 'user-1' },
+    apiKey: undefined,
+    error: null
+  } as never);
+  vi.mocked(loadBrandForUser).mockResolvedValue({ brand: { ...BRAND, slug }, error: null } as never);
+
+  const url = new URL(`https://anomalia.test/api/v1/brands/${slug}${opts.path}`);
+  const request =
+    opts.method === 'POST'
+      ? new Request(url, { method: 'POST', body: JSON.stringify(opts.body ?? {}) })
+      : new Request(url);
+
+  return handler({ request, params: { slug }, url }).then(async (res) => ({
+    res,
+    body: await res.json(),
+    ops: client.ops
+  }));
+}
+
+const create = (body: unknown, results?: Record<string, Result>) =>
+  callWith(POST as never, { method: 'POST', path: '/shares', body, results });
+
+const list = (results?: Record<string, Result>) => callWith(GET as never, { method: 'GET', path: '/shares', results });
+
+const revoke = (body: unknown, results?: Record<string, Result>) =>
+  callWith(REVOKE as never, { method: 'POST', path: '/shares/revoke', body, results });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(checkApiKeyWriteAccess).mockReturnValue(undefined);
+  vi.mocked(getCalendar).mockResolvedValue({
+    posts: [
+      {
+        id: 'post-1',
+        platform: 'linkedin',
+        caption: 'copy visibile al cliente',
+        media_url: null,
+        scheduled_for: '2026-09-10T07:00:00.000Z',
+        slot: null,
+        status: 'approved',
+        image_prompt: 'prompt interno'
+      }
+    ],
+    year: 2026,
+    month: 9,
+    monthLabel: 'settembre 2026',
+    prevYM: '2026-08',
+    nextYM: '2026-10',
+    timezone: 'Europe/Rome'
+  } as never);
+});
+
+describe('POST /api/v1/brands/:slug/shares', () => {
+  const ok = { shared_views: { data: { id: 'share-1' }, error: null } };
+
+  it('consegna il link una volta e conserva solo l impronta del token', async () => {
+    const { res, body, ops } = await create({ view: 'calendar', month: '2026-09' }, ok);
+
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.url).toBe(`https://anomalia.test/share/${body.token}`);
+
+    const inserted = ops.find((o) => o.method === 'insert')?.args[0] as Row;
+    expect(inserted.token_hash).toBe(hashShareToken(body.token));
+    expect(JSON.stringify(inserted)).not.toContain(body.token);
+  });
+
+  it('congela lo snapshot: dentro la riga ci sono i campi dichiarati, non il post', async () => {
+    const { ops } = await create({ view: 'calendar', month: '2026-09' }, ok);
+    const inserted = ops.find((o) => o.method === 'insert')?.args[0] as Row;
+    const snapshot = JSON.stringify(inserted.snapshot);
+
+    expect(snapshot).not.toContain('prompt interno');
+    expect(snapshot).not.toContain('post-1');
+    expect(snapshot).toContain('copy visibile al cliente');
+  });
+
+  it('non chiama il modello e non tocca i crediti', async () => {
+    await create({ view: 'calendar' }, ok);
+
+    expect(structured).not.toHaveBeenCalled();
+    expect(gateAiAction).not.toHaveBeenCalled();
+    expect(gateCredits).not.toHaveBeenCalled();
+  });
+
+  it('senza mese usa quello corrente invece di rifiutare', async () => {
+    const { res, body } = await create({ view: 'calendar' }, ok);
+
+    expect(res.status).toBe(200);
+    expect(body.month).toMatch(/^\d{4}-\d{2}$/);
+  });
+
+  it.each([
+    ['una vista che non esiste', { view: 'proposal' }],
+    ['un campo non dichiarato', { view: 'calendar', segreto: 'x' }],
+    ['un mese malformato', { view: 'calendar', month: 'settembre' }],
+    ['niente', {}]
+  ])('rifiuta %s prima di scrivere', async (_label, body) => {
+    const { res, body: out, ops } = await create(body, ok);
+
+    expect(res.status).toBe(400);
+    expect(out.error).toBe('invalid_input');
+    expect(ops.filter((o) => WRITES.has(o.method))).toEqual([]);
+  });
+
+  it('dice che la migration manca invece di un errore Postgres', async () => {
+    const { res, body } = await create({ view: 'calendar' }, {
+      shared_views: { data: null, error: MISSING_TABLE }
+    });
+
+    expect(res.status).toBe(500);
+    expect(body.error).toBe('shares_not_migrated');
+    expect(body.details).toContain('20260904120000_shared_views.sql');
+  });
+
+  it('rifiuta una richiesta senza autenticazione', async () => {
+    vi.mocked(authenticate).mockResolvedValue({ error: new Response('Unauthorized', { status: 401 }) } as never);
+    const url = new URL('https://anomalia.test/api/v1/brands/demo/shares');
+    const res = await (POST as (e: unknown) => Promise<Response>)({
+      request: new Request(url, { method: 'POST', body: '{}' }),
+      params: { slug: 'demo' },
+      url
+    });
+
+    expect(res.status).toBe(401);
+  });
+
+  it('rifiuta un brand a cui il chiamante non accede', async () => {
+    vi.mocked(authenticate).mockResolvedValue({
+      supabase: fakeSupabase({}),
+      user: { id: 'user-1' },
+      apiKey: undefined,
+      error: null
+    } as never);
+    vi.mocked(loadBrandForUser).mockResolvedValue({
+      error: new Response(JSON.stringify({ error: 'Brand not found' }), { status: 404 })
+    } as never);
+    const url = new URL('https://anomalia.test/api/v1/brands/altrui/shares');
+    const res = await (POST as (e: unknown) => Promise<Response>)({
+      request: new Request(url, { method: 'POST', body: JSON.stringify({ view: 'calendar' }) }),
+      params: { slug: 'altrui' },
+      url
+    });
+
+    expect(res.status).toBe(404);
+  });
+
+  it('rifiuta una API key di sola lettura senza creare niente', async () => {
+    vi.mocked(checkApiKeyWriteAccess).mockReturnValue(
+      new Response(JSON.stringify({ error: 'API key is read-only' }), { status: 403 }) as never
+    );
+    const { res, ops } = await create({ view: 'calendar' }, ok);
+
+    expect(res.status).toBe(403);
+    expect(ops.filter((o) => WRITES.has(o.method))).toEqual([]);
+  });
+});
+
+describe('GET /api/v1/brands/:slug/shares', () => {
+  it('elenca le share del brand chiesto e non mostra mai un token', async () => {
+    const { res, body, ops } = await list({
+      shared_views: {
+        data: [
+          {
+            id: 'share-1',
+            view_type: 'calendar',
+            snapshot: { month: '2026-09' },
+            created_at: '2026-09-01T00:00:00.000Z',
+            expires_at: null,
+            revoked_at: null
+          }
+        ],
+        error: null
+      }
+    });
+
+    expect(res.status).toBe(200);
+    expect(body.shares[0]).toEqual({
+      id: 'share-1',
+      view: 'calendar',
+      month: '2026-09',
+      status: 'live',
+      created_at: '2026-09-01T00:00:00.000Z',
+      expires_at: null,
+      revoked_at: null
+    });
+    expect(JSON.stringify(body)).not.toContain('token');
+    expect(ops).toContainEqual({ table: 'shared_views', method: 'eq', args: ['brand_id', 'brand-1'] });
+  });
+
+  it('non legge nessuna share di un altro brand: il filtro è sempre lo stesso', async () => {
+    const { ops } = await list({ shared_views: { data: [], error: null } });
+
+    expect(ops.filter((o) => o.method === 'eq')).toEqual([
+      { table: 'shared_views', method: 'eq', args: ['brand_id', 'brand-1'] }
+    ]);
+  });
+});
+
+describe('POST /api/v1/brands/:slug/shares/revoke', () => {
+  it('spegne il link e non tocca l appartenenza al brand', async () => {
+    const { res, body, ops } = await revoke(
+      { id: 'share-1' },
+      { shared_views: { data: { id: 'share-1', revoked_at: '2026-09-04T00:00:00.000Z' }, error: null } }
+    );
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ ok: true, id: 'share-1', revoked_at: '2026-09-04T00:00:00.000Z' });
+    expect(ops.filter((o) => WRITES.has(o.method)).map((o) => o.table)).toEqual(['shared_views']);
+    expect(ops.some((o) => o.table === 'brand_members' || o.table === 'brands')).toBe(false);
+  });
+
+  it('una share che non è di questo brand non risulta', async () => {
+    const { res, body } = await revoke({ id: 'share-di-un-altro' }, { shared_views: { data: null, error: null } });
+
+    expect(res.status).toBe(404);
+    expect(body.error).toBe('share_not_found');
+  });
+
+  it('rifiuta un corpo che il contratto non dichiara', async () => {
+    const { res, body, ops } = await revoke({ id: 'share-1', anche: 'questo' });
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('invalid_input');
+    expect(ops.filter((o) => WRITES.has(o.method))).toEqual([]);
+  });
+});

--- a/src/routes/robots.txt/+server.ts
+++ b/src/routes/robots.txt/+server.ts
@@ -44,6 +44,7 @@ Disallow: /app
 Disallow: /api
 Disallow: /auth
 Disallow: /approve
+Disallow: /share
 Disallow: /waitlist
 Disallow: /it/waitlist
 

--- a/src/routes/share/[token]/+page.server.ts
+++ b/src/routes/share/[token]/+page.server.ts
@@ -1,0 +1,22 @@
+import { error } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+import { createAdminClient } from '$lib/server/supabase-admin';
+import { readSharedView, shareFailure } from '$lib/server/shared-views';
+
+// Rotta pubblica, senza sessione: il token È l'autorizzazione, come /approve/[token] e
+// /blog/[site]. Legge con la chiave di servizio perché la sola riga raggiungibile è quella la cui
+// impronta corrisponde — ad `anon` la tabella resta revocata, così nemmeno una policy sbagliata
+// può aprirla. Un link che non vale è un 404 identico per revoca, scadenza e inesistenza; una
+// tabella mancante è un 500, perché è un guasto nostro e non una risposta sul link.
+export const load: PageServerLoad = async ({ params }) => {
+  const shared = await readSharedView(createAdminClient(), params.token).catch((e) => {
+    const failure = shareFailure(e);
+    if (!failure) throw e;
+    console.error('[share]', failure.details);
+    throw error(500, 'This link cannot be opened right now.');
+  });
+
+  if (!shared) throw error(404, 'Not found');
+
+  return shared;
+};

--- a/src/routes/share/[token]/+page.svelte
+++ b/src/routes/share/[token]/+page.svelte
@@ -1,0 +1,268 @@
+<script lang="ts">
+  let { data } = $props();
+
+  const snapshot = $derived(data.snapshot as Record<string, any>);
+  const isCalendar = $derived(data.view === 'calendar');
+
+  const METRICS = ['views', 'likes', 'comments', 'shares'] as const;
+
+  function day(post: { scheduled_for: string | null; slot: string | null }): string {
+    const raw = post.scheduled_for ?? post.slot ?? '';
+    const parsed = new Date(raw);
+    if (Number.isNaN(parsed.getTime())) return raw;
+    return parsed.toLocaleDateString(undefined, { weekday: 'short', day: 'numeric', month: 'short' });
+  }
+
+  function time(post: { scheduled_for: string | null }): string {
+    if (!post.scheduled_for) return '';
+    const parsed = new Date(post.scheduled_for);
+    if (Number.isNaN(parsed.getTime())) return '';
+    return parsed.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+  }
+
+  const number = (n: unknown) => Number(n ?? 0).toLocaleString();
+</script>
+
+<svelte:head>
+  <title>{snapshot.brand_name} — {snapshot.month_label}</title>
+  <meta name="robots" content="noindex, nofollow" />
+</svelte:head>
+
+<main>
+  <header>
+    <p class="eyebrow">{snapshot.brand_name}</p>
+    <h1>{isCalendar ? 'Content calendar' : 'Monthly report'}</h1>
+    <p class="sub">{snapshot.month_label}</p>
+  </header>
+
+  {#if isCalendar}
+    {#if snapshot.posts.length === 0}
+      <p class="empty">Nothing planned for this month yet.</p>
+    {:else}
+      <ol class="calendar">
+        {#each snapshot.posts as post, i (i)}
+          <li>
+            <div class="when">
+              <span class="date">{day(post)}</span>
+              <span class="hour">{time(post)}</span>
+            </div>
+            <div class="what">
+              <div class="meta">
+                <span class="platform">{post.platform ?? '—'}</span>
+                <span class="status status-{post.status}">{post.status}</span>
+              </div>
+              {#if post.caption}<p class="caption">{post.caption}</p>{/if}
+            </div>
+            {#if post.media_url}
+              <img class="thumb" src={post.media_url} alt="" loading="lazy" />
+            {/if}
+          </li>
+        {/each}
+      </ol>
+    {/if}
+  {:else}
+    <section class="tiles">
+      <div class="tile"><span class="n">{number(snapshot.published)}</span><span class="l">published</span></div>
+      {#each METRICS as metric (metric)}
+        <div class="tile"><span class="n">{number(snapshot.totals[metric])}</span><span class="l">{metric}</span></div>
+      {/each}
+    </section>
+
+    {#if snapshot.platforms.length}
+      <table>
+        <thead>
+          <tr><th>Platform</th><th>Posts</th>{#each METRICS as metric (metric)}<th>{metric}</th>{/each}</tr>
+        </thead>
+        <tbody>
+          {#each snapshot.platforms as row (row.platform)}
+            <tr>
+              <td>{row.platform}</td>
+              <td>{number(row.published)}</td>
+              {#each METRICS as metric (metric)}<td>{number(row[metric])}</td>{/each}
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    {/if}
+
+    {#if snapshot.top_posts.length}
+      <h2>Best performing</h2>
+      <ol class="tops">
+        {#each snapshot.top_posts as post, i (i)}
+          <li>
+            {#if post.thumbnail_url}<img class="thumb" src={post.thumbnail_url} alt="" loading="lazy" />{/if}
+            <div class="what">
+              <span class="platform">{post.platform ?? '—'}</span>
+              {#if post.caption}<p class="caption">{post.caption}</p>{/if}
+              <p class="nums">
+                {#each METRICS as metric (metric)}<span>{number(post[metric])} {metric}</span>{/each}
+              </p>
+            </div>
+          </li>
+        {/each}
+      </ol>
+    {:else}
+      <p class="empty">No published posts recorded for this month.</p>
+    {/if}
+  {/if}
+
+  <footer>Snapshot taken {new Date(data.created_at).toLocaleDateString()}.</footer>
+</main>
+
+<style>
+  main {
+    max-width: 46rem;
+    margin: 0 auto;
+    padding: 3rem 1.25rem 4rem;
+    font-family: ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif;
+    color: #18181b;
+  }
+  .eyebrow {
+    margin: 0;
+    font-size: 0.8rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #71717a;
+  }
+  h1 {
+    margin: 0.35rem 0 0;
+    font-size: 1.75rem;
+    line-height: 1.2;
+  }
+  h2 {
+    margin: 2.5rem 0 0.75rem;
+    font-size: 1.05rem;
+  }
+  .sub {
+    margin: 0.25rem 0 2rem;
+    color: #52525b;
+  }
+  .empty {
+    color: #71717a;
+  }
+  ol {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+  .calendar li,
+  .tops li {
+    display: flex;
+    gap: 1rem;
+    align-items: flex-start;
+    padding: 1rem 0;
+    border-top: 1px solid #e4e4e7;
+  }
+  .when {
+    display: flex;
+    flex-direction: column;
+    min-width: 6rem;
+  }
+  .date {
+    font-weight: 600;
+    font-size: 0.9rem;
+  }
+  .hour {
+    color: #71717a;
+    font-size: 0.8rem;
+  }
+  .what {
+    flex: 1;
+    min-width: 0;
+  }
+  .meta {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    margin-bottom: 0.25rem;
+  }
+  .platform {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #52525b;
+  }
+  .status {
+    font-size: 0.7rem;
+    padding: 0.1rem 0.45rem;
+    border-radius: 999px;
+    background: #f4f4f5;
+    color: #52525b;
+  }
+  .status-published {
+    background: #dcfce7;
+    color: #166534;
+  }
+  .caption {
+    margin: 0;
+    font-size: 0.92rem;
+    line-height: 1.5;
+    white-space: pre-wrap;
+  }
+  .thumb {
+    width: 4.5rem;
+    height: 4.5rem;
+    object-fit: cover;
+    border-radius: 0.5rem;
+    flex: none;
+  }
+  .tiles {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(7rem, 1fr));
+    gap: 0.75rem;
+    margin-bottom: 2rem;
+  }
+  .tile {
+    display: flex;
+    flex-direction: column;
+    padding: 0.9rem 1rem;
+    border: 1px solid #e4e4e7;
+    border-radius: 0.75rem;
+  }
+  .tile .n {
+    font-size: 1.4rem;
+    font-weight: 650;
+  }
+  .tile .l {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #71717a;
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.88rem;
+  }
+  th,
+  td {
+    text-align: right;
+    padding: 0.5rem 0.4rem;
+    border-bottom: 1px solid #e4e4e7;
+  }
+  th:first-child,
+  td:first-child {
+    text-align: left;
+    text-transform: capitalize;
+  }
+  th {
+    color: #71717a;
+    font-weight: 500;
+    text-transform: capitalize;
+  }
+  .nums {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin: 0.4rem 0 0;
+    font-size: 0.78rem;
+    color: #71717a;
+  }
+  footer {
+    margin-top: 3rem;
+    padding-top: 1rem;
+    border-top: 1px solid #e4e4e7;
+    font-size: 0.78rem;
+    color: #a1a1aa;
+  }
+</style>

--- a/src/routes/share/[token]/page.server.test.ts
+++ b/src/routes/share/[token]/page.server.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const adminResult: { data: unknown; error: unknown } = { data: null, error: null };
+const readTables: string[] = [];
+
+vi.mock('$lib/server/supabase-admin', () => ({
+  createAdminClient: () => ({
+    from(table: string) {
+      readTables.push(table);
+      const q: Record<string, unknown> = {};
+      for (const method of ['select', 'eq', 'is', 'or', 'order', 'limit']) q[method] = () => q;
+      q.maybeSingle = async () => adminResult;
+      return q;
+    }
+  })
+}));
+
+import { load } from './+page.server';
+
+const SNAPSHOT = {
+  brand_name: 'Demo Brand',
+  timezone: 'Europe/Rome',
+  month: '2026-09',
+  month_label: 'settembre 2026',
+  posts: [{ platform: 'linkedin', caption: 'copy', media_url: null, scheduled_for: '2026-09-10T07:00:00.000Z', slot: null, status: 'planned' }]
+};
+
+const LIVE_ROW = {
+  view_type: 'calendar',
+  snapshot: SNAPSHOT,
+  snapshot_version: 1,
+  created_at: '2026-09-01T00:00:00.000Z',
+  expires_at: null,
+  revoked_at: null
+};
+
+function anonymousEvent(token: string) {
+  const safeGetSession = vi.fn();
+  return {
+    event: { params: { token }, locals: { safeGetSession, supabase: null } },
+    safeGetSession
+  };
+}
+
+async function loadWith(row: unknown, token = 'un-token-qualunque') {
+  adminResult.data = row;
+  adminResult.error = null;
+  readTables.length = 0;
+  const { event, safeGetSession } = anonymousEvent(token);
+  try {
+    return { ok: true as const, data: await (load as (e: unknown) => Promise<unknown>)(event), safeGetSession };
+  } catch (thrown) {
+    return { ok: false as const, thrown, safeGetSession };
+  }
+}
+
+beforeEach(() => {
+  readTables.length = 0;
+});
+
+describe('GET /share/:token', () => {
+  it('mostra lo snapshot congelato per un token valido', async () => {
+    const result = await loadWith(LIVE_ROW);
+
+    expect(result.ok).toBe(true);
+    expect(result.ok && result.data).toEqual({
+      view: 'calendar',
+      version: 1,
+      snapshot: SNAPSHOT,
+      created_at: '2026-09-01T00:00:00.000Z'
+    });
+  });
+
+  it('non legge nessuna tabella viva: solo la riga della share', async () => {
+    await loadWith(LIVE_ROW);
+
+    expect(readTables).toEqual(['shared_views']);
+  });
+
+  it('non chiede mai chi sta guardando', async () => {
+    const valid = await loadWith(LIVE_ROW);
+    const missing = await loadWith(null);
+
+    expect(valid.safeGetSession).not.toHaveBeenCalled();
+    expect(missing.safeGetSession).not.toHaveBeenCalled();
+  });
+
+  it('revocato, scaduto e mai esistito rispondono nello stesso identico modo', async () => {
+    const revoked = await loadWith({ ...LIVE_ROW, revoked_at: '2026-09-02T00:00:00.000Z' });
+    const expired = await loadWith({ ...LIVE_ROW, expires_at: '2026-09-02T00:00:00.000Z' });
+    const never = await loadWith(null);
+
+    for (const result of [revoked, expired, never]) {
+      expect(result.ok).toBe(false);
+    }
+
+    const shapes = [revoked, expired, never].map((r) =>
+      JSON.stringify({
+        status: (r.thrown as { status: number }).status,
+        body: (r.thrown as { body: unknown }).body
+      })
+    );
+    expect(new Set(shapes).size).toBe(1);
+    expect((revoked.thrown as { status: number }).status).toBe(404);
+  });
+
+  it('non nomina il brand quando il link non vale', async () => {
+    const { thrown } = await loadWith({ ...LIVE_ROW, revoked_at: '2026-09-02T00:00:00.000Z' });
+
+    expect(JSON.stringify(thrown)).not.toContain('Demo Brand');
+    expect(JSON.stringify(thrown)).not.toContain('revoked');
+  });
+
+  it('se la tabella manca lo dice come guasto del server, non come link inesistente', async () => {
+    adminResult.data = null;
+    adminResult.error = { code: 'PGRST205', message: "Could not find the table 'public.shared_views' in the schema cache" };
+    const { event } = anonymousEvent('un-token-qualunque');
+
+    await expect((load as (e: unknown) => Promise<unknown>)(event)).rejects.toMatchObject({ status: 500 });
+  });
+});

--- a/supabase/migrations/20260904120000_shared_views.sql
+++ b/supabase/migrations/20260904120000_shared_views.sql
@@ -1,0 +1,50 @@
+-- Il link che un'agenzia manda al cliente: UNA vista, mai un account.
+--
+-- Perché una TABELLA e non un token firmato: un HMAC non si revoca. Un cliente che se ne va, un
+-- link finito nel gruppo sbagliato, una collaborazione chiusa — con un token firmato l'unica
+-- risposta è ruotare il segreto e spegnere ogni link esistente. Qui la revoca è una riga.
+--
+-- Perché `snapshot` e non una query dal vivo: la lettura pubblica non deve poter tornare sulle
+-- tabelle vive. `posts` ha oltre cinquanta colonne — image_prompt, qc, approval_token,
+-- attention_reason — e ne guadagna di nuove ogni mese. Con una vista dal vivo, la prossima
+-- colonna esce da ogni link già consegnato senza che nessuno decida niente. Con lo snapshot,
+-- quello che è uscito è solo quello che l'allowlist ha copiato il giorno della creazione.
+-- `snapshot_version` dice con quale forma è stato scritto, perché i link vecchi restano validi.
+--
+-- Perché `token_hash` e non il token: un dump di questa tabella non deve produrre link
+-- funzionanti. Il token è casuale (32 byte) e viene mostrato UNA volta a chi lo crea; qui resta
+-- solo il suo sha256. Un link non salvato non si recupera — si revoca e se ne crea un altro.
+--
+-- `author_id` non è ridondante rispetto a `brand_id`: dice CHI ha consegnato quel link, e resta
+-- l'unica traccia quando l'operatore che l'ha creato non lavora più su quel brand.
+create table if not exists public.shared_views (
+  id uuid primary key default gen_random_uuid(),
+  brand_id uuid not null references public.brands (id) on delete cascade,
+  author_id uuid not null references auth.users (id) on delete cascade,
+  view_type text not null check (view_type in ('calendar', 'monthly_report')),
+  snapshot jsonb not null,
+  snapshot_version integer not null default 1,
+  token_hash text not null unique,
+  created_at timestamptz not null default now(),
+  expires_at timestamptz,
+  revoked_at timestamptz
+);
+
+-- La lista di un brand, la più recente in cima: è l'unica query che la superficie autenticata fa.
+-- La ricerca per token passa dall'indice unico su token_hash e non ne serve un altro.
+create index if not exists shared_views_brand_idx on public.shared_views (brand_id, created_at desc);
+
+alter table public.shared_views enable row level security;
+
+-- Chi può già agire sul brand vede e gestisce le sue share. Nessuna policy per `anon`: la rotta
+-- pubblica legge con la chiave di servizio, con l'impronta del token come unica chiave.
+drop policy if exists "shared_views via brand" on public.shared_views;
+create policy "shared_views via brand" on public.shared_views
+  for all
+  using (brand_id in (select public.auth_brand_ids()))
+  with check (brand_id in (select public.auth_brand_ids()));
+
+-- Difesa in profondità, non ridondanza: senza privilegi di tabella, nemmeno una policy scritta
+-- male in futuro può aprire questa tabella a un visitatore anonimo. Il percorso pubblico non
+-- passa da qui — usa la chiave di servizio — quindi la revoca non gli toglie niente.
+revoke all on public.shared_views from anon;


### PR DESCRIPTION
## What?

An agency can hand a client a URL that shows **one view** of a brand — the month's calendar, or that month's results — and nothing else. The client opens it with no account, no invite, and no trace anywhere in the brand. The operator can revoke it at any moment, or give it an expiry when creating it.

Three authenticated endpoints (`POST /shares`, `GET /shares`, `POST /shares/revoke`) go through the contract registry, so the MCP tools `create_share` / `list_shares` / `revoke_share` and the CLI client method are generated rather than hand-written. One public route, `GET /share/:token`, sits outside the registry.

This is Phase 3 of `docs/external-agent-plan.md` ("Phase 3: Public client views"). **PDF export is explicitly out of scope**, as are `proposal` views and a live (non-snapshot) calendar.

> [!IMPORTANT]
> **This PR adds a table and this repo's deploys do not run migrations.**
> `supabase/migrations/20260904120000_shared_views.sql` must be applied by hand before the code ships. Until someone applies it, the three authenticated endpoints answer `500 {"error":"shares_not_migrated"}` with the file name in `details`, rather than letting a raw `PGRST205` through — which would otherwise surface as an empty list and look like "no shares yet".

## Why?

Until now the only way to show a client the work was to invite them into the brand — which is an account with access to everything — or to send screenshots. Neither is a product. This is the first surface in the app that hands data to an **anonymous visitor**, so every property below is structural rather than a promise, and each one has a test that fails if it stops holding.

**Snapshot, not live query.** The row stores serialized presentation data; the public route reads that blob and never reaches back into `posts`, `brands`, or any live table. `posts` has over fifty columns and gains new ones every month, written by people solving unrelated problems. With a live view, next month's column leaves through every link already handed over, and nothing stops it. With a snapshot, what left is what the allowlist copied on the day of creation.

*Rejected: a live view with a narrow `select`.* A narrow `select` is a promise living in one line of code. A snapshot is a fact already written to the database.

**Allowlist, field by field.** The snapshot is built key by key (`CALENDAR_POST_FIELDS`, `REPORT_POST_FIELDS`), never by spreading a row and deleting the awkward keys. A deny-list forgets the next field, and the next field is added by somebody who does not know a public link exists. The load-bearing tests assert the **exact key set**, so an upstream addition turns a test red instead of turning an already-delivered link talkative.

**The token is never stored.** 32 random bytes, base64url, returned **once** in the create response. The row keeps only its sha256. A dump of this table yields no working link; a link that was not saved cannot be recovered, only revoked and replaced.

*Rejected: an HMAC-signed token* (the repo already has `signApproveToken`). A signed token cannot be revoked. A client leaving, a link posted in the wrong group, a collaboration ending — the only answer would be rotating `APP_SECRET`, which kills every other client's link too. Here revocation is one column.

**Revoked, expired and never-existed are indistinguishable.** Three reasons a link stops working, **one** function that decides (`liveShare`), one `null` that becomes an identical `404`. A message like "this link was revoked" confirms the link once existed, hence that the brand exists — a free oracle for anyone trying URLs. The one case that stays distinct is a missing table: that is our fault, answers `500`, and names the file.

**No session leakage into the public route.** `/share/[token]` never touches `locals.safeGetSession`; a test asserts it is not called on either the valid or the invalid path. It reads through the service-role client, following `/approve/[token]` and `/blog/[site]`.

## How?

**Service role for the public read, not RLS — deliberate.** The visitor is anonymous, so `auth.uid()` is null and an RLS policy would have nothing to evaluate against; the token hash *is* the authorization, and it is a value the request carries, not an identity the database knows. So the public path reads with the service key, keyed on the hash and nothing else. To keep that from becoming a single point of failure, the migration also does `revoke all on public.shared_views from anon`: even a badly written policy in the future cannot open this table to a visitor. The authenticated surface keeps normal RLS (`brand_id in (select public.auth_brand_ids())`), like every other brand table.

**One table of view types.** `SNAPSHOT_BUILDERS` is a `Record<SharedViewType, builder>`, so a missing builder is a type error and adding a view is one row plus its function. A test walks `SHARED_VIEW_TYPES` from the contract and asserts every declared view can build its own snapshot — the contract and the implementation cannot drift apart silently.

**The client's status is not our workflow.** `pending_user`, `approved`, `failed` are internal. One function maps them to `planned` / `published`; nothing else in the snapshot carries a status.

**Revoke takes the id in the body, not the path.** The contract registry does not resolve a `:id` path segment yet, and a hand-written endpoint would lose the generated MCP tool. Noted in `docs/api/10-shares.md`.

**The public route is outside the registry, on purpose.** It has no slug, no authenticated caller, and the URL reveals neither which brand nor which account is behind it. Entering `BRAND_ENDPOINTS` would mean inheriting `authenticate` + `loadBrandForUser`, which is exactly what must not happen here.

**Nothing spends.** No `gateAiAction`, no `gateCredits`, no model call — proven by spies, not by reading.

## Testing?

Everything below was run on this branch after rebasing onto `origin/dev` (5e11adb).

**Focused suites — 116 passing**

```
$ npx vitest run src/lib/server/shared-views.test.ts \
    'src/routes/api/v1/brands/[slug]/shares/server.test.ts' \
    'src/routes/share/[token]/page.server.test.ts' \
    packages/no-app-imports.test.ts cli/lib/contracts

 ✓ src/routes/api/v1/brands/[slug]/shares/server.test.ts (17 tests)
 ✓ src/routes/share/[token]/page.server.test.ts (6 tests)
 ✓ src/lib/server/shared-views.test.ts (20 tests)

 Test Files  4 passed (4)
      Tests  116 passed (116)
```

**The allowlist test is load-bearing — captured red.** Adding one field to the calendar projection (`image_prompt: post.image_prompt ?? null`, the shape of any innocent upstream addition):

<details><summary>Three tests fall before any human review</summary>

```
× POST /api/v1/brands/:slug/shares > congela lo snapshot: dentro la riga ci sono i campi dichiarati, non il post
× lo snapshot del calendario > porta solo i campi dichiarati, anche se il post ne ha trenta
× lo snapshot del calendario > non fa uscire prompt, qc, note interne o identificatori privati

AssertionError: expected [ 'caption', 'image_prompt', …(5) ] to deeply equal [ 'caption', 'media_url', …(4) ]
AssertionError: expected '{"brand_name":"Demo Brand","timezone"…' not to contain 'un prompt interno'
AssertionError: expected '{"brand_name":"Demo Brand","timezone"…' not to contain 'prompt interno'

 Test Files  2 failed (2)
      Tests  3 failed | 34 passed (37)
```

The change was reverted; the suite is green above.
</details>

**The indistinguishability test is load-bearing — captured red.** Changing the public route's `throw error(404, 'Not found')` to `throw error(404, 'This link was revoked')`:

<details><summary>The test that guards the oracle fails</summary>

```
× GET /share/:token > non nomina il brand quando il link non vale

AssertionError: expected '{"status":404,"body":{"message":"This…' not to contain 'revoked'
Received: {"status":404,"body":{"message":"This link was revoked"}}

 Test Files  1 failed (1)
      Tests  1 failed | 5 passed (6)
```

Reverted.
</details>

**CLI — 31 passing, typecheck clean**

```
$ cd cli && bun test
 31 pass
 0 fail
 79 expect() calls
Ran 31 tests across 8 files. [1.85s]

$ bun run typecheck
$ tsc --noEmit
(exit 0)
```

**Types.** `npm run check` (svelte-check) reported four real errors in `src/lib/server/shared-views.ts` — a metrics bucket typed `Record<string, number>` while carrying a `platform: string`. Fixed by naming the shape (`ShareMetrics`). `npx tsc --noEmit` now reports **333 errors repo-wide and zero in any file this PR touches**:

```
$ npx tsc --noEmit -p tsconfig.json | grep -c 'error TS'
333
$ ... | grep -E '^(src/lib/server/shared-views\.ts|src/routes/share/|src/routes/api/v1/brands/\[slug\]/shares/|packages/api-contracts/src/shares)'
(no output)
```

**Whitespace.** `git diff --check` — clean.

### Schema drift, before and after

Run against the **local** stack. Nothing was applied to production.

<details><summary>BEFORE — <code>node scripts/schema-drift-check.mjs</code> → exit 1</summary>

```
MIGRATION SCRITTE MA NON APPLICATE (2) — le applica una persona, non questo script
  supabase/migrations/20260901140000_post_verdicts.sql
    assenti nel database: post_verdicts
    → APPLICA LA MIGRATION
  supabase/migrations/20260904120000_shared_views.sql
    assenti nel database: shared_views
    usata da src/lib/server/shared-views.ts:271
    usata da src/lib/server/shared-views.ts:321
    usata da src/lib/server/shared-views.ts:295
    usata da src/lib/server/shared-views.ts:340
    → APPLICA LA MIGRATION

ROSSO — 2 divergenze.
```
</details>

<details><summary>AFTER — <code>docker exec -i anomalia-db psql -U postgres &lt; supabase/migrations/20260904120000_shared_views.sql</code>, then re-run</summary>

```
CREATE TABLE
CREATE INDEX
ALTER TABLE
DROP POLICY
CREATE POLICY
REVOKE

MIGRATION SCRITTE MA NON APPLICATE (1) — le applica una persona, non questo script
  supabase/migrations/20260901140000_post_verdicts.sql
    assenti nel database: post_verdicts
    → APPLICA LA MIGRATION

ROSSO — 1 divergenze.
```

`shared_views` is gone from the list. The one remaining divergence, `post_verdicts`, is **pre-existing on `dev`** and unrelated to this PR.

Applying the file a second time is a no-op, as the conventions require:

```
NOTICE:  relation "shared_views" already exists, skipping
NOTICE:  relation "shared_views_brand_idx" already exists, skipping
```
</details>

**Full unit suite — `npm run test:unit`**

```
 Test Files  3 failed | 594 passed | 3 skipped (600)
      Tests  4 failed | 6581 passed | 11 skipped (6596)
```

Four failures, **none in a file this PR touches**, each checked in isolation:

| Failure | Verdict |
|---|---|
| `src/lib/agent/bridge/live.test.ts` (1) | Load flake. 503451ms in the full run; **85 passed in 22394ms** alone. |
| `src/lib/server/chat/tool-job-background.test.ts` (1) | Load flake. 120069ms (a timeout) in the full run; **8 passed in 40775ms** alone. |
| `src/lib/server/oauth.test.ts` (2) | Local environment, not code. The test asserts `issuer === 'https://www.anomalia.so'`; this worktree's gitignored `.env` sets `PUBLIC_APP_URL=http://localhost:5211`, so the assertion reads back the local value. It passes on a clean `dev` worktree (12/12) and passes here with `PUBLIC_APP_URL=https://www.anomalia.so npx vitest run src/lib/server/oauth.test.ts` (12/12). This PR touches neither `oauth.ts` nor `app-url.ts` — `git diff --name-only origin/dev...HEAD \| grep -E 'oauth\|app-url'` is empty. |

### What was *not* tested, and the risk
- **The `proposal` view type** does not exist; the CHECK constraint rejects it and the contract's enum rejects it earlier.
- **Snapshot migration across versions.** `snapshot_version` is written and returned but there is only version 1, so nothing reads it yet. The risk is deferred, not solved: the day the shape changes, old links keep working only if someone writes that branch.
- **No agent evaluation was run.** This PR touches no prompt, no tool that spends, and no model path.

## Evidence (screenshots/videos)

Real Chromium (`headless: false`), fresh browsing context with **zero cookies**, against the local Docker stack — never a hosted instance. The Claude Chrome extension would not connect in this session and the Playwright MCP server was down, so the browser was driven by a Playwright script instead; it is a real visible browser, not headless, but it is not a hand-driven one.

The operator seeded `test@anomalia.so` / brand `demo` (already present locally), the share was created through the authenticated API with that user's session JWT, and the page was then opened by an anonymous context.

> [!NOTE]
> The three PNGs below were captured on the machine that ran the verification (`shot-calendar-live.png`, `shot-monthly_report-live.png`, `shot-calendar-revoked.png`). They cannot be attached from the CLI — GitHub only accepts image uploads through the web UI — so each is described, and the assertions that actually hold the properties are pasted in full underneath. Drag the files into this description to attach them.

**Calendar, opened logged out** — `shot-calendar-live.png`

The client's own status (`planned` / `published`), the caption, the platform, the date. No ids, no prompts, no internal workflow state.

**Monthly report, opened logged out** — `shot-monthly_report-live.png`

Totals, per-platform breakdown, best performing posts. The stat tiles and table come entirely from the frozen blob.

**The same link after revoking — and a token that never existed** — `shot-calendar-revoked.png`

The app's ordinary 404 ("Questa pagina non esiste"), with no mention of a brand, a link, or a revocation. The assertion that matters is not the picture: the revoked page and the never-existed page were compared and are **byte-identical**.

<details><summary>Full browser run — 28 assertions, all passing</summary>

```
PASS  create calendar → 200
PASS  create monthly_report → 200
PASS  calendar: anonymous visitor gets 200
PASS  calendar: no session cookie exists in this context (0 cookies)
PASS  calendar: the view renders a heading
PASS  calendar: rendered page does not contain "image_prompt"
PASS  calendar: rendered page does not contain "approval_token"
PASS  calendar: rendered page does not contain "attention_reason"
PASS  calendar: rendered page does not contain "pending_user"
PASS  calendar: rendered page does not contain "b6b252a8-1499-4902-940b-b62530108d28"
PASS  calendar: rendered page does not contain "6859115e"
PASS  monthly_report: anonymous visitor gets 200
PASS  monthly_report: no session cookie exists in this context (0 cookies)
PASS  monthly_report: the view renders a heading
PASS  monthly_report: rendered page does not contain "image_prompt"
PASS  monthly_report: rendered page does not contain "approval_token"
PASS  monthly_report: rendered page does not contain "attention_reason"
PASS  monthly_report: rendered page does not contain "pending_user"
PASS  monthly_report: rendered page does not contain "9d9cf216-679d-4542-a79c-10bf15398cdd"
PASS  monthly_report: rendered page does not contain "6859115e"
PASS  revoke → 200
PASS  revoked link → 404
PASS  revoked link does not name the brand
PASS  revoked link does not say it was revoked
PASS  never-existed link → 404
PASS  revoked and never-existed render byte-identical pages
PASS  list reports it revoked to the operator (revoked)
PASS  list carries no token

ALL CHECKS PASSED
```
</details>

<details><summary>Backend evidence — the real row, and what <code>anon</code> can do with it</summary>

The stored row's top-level keys and per-post keys, read straight out of Postgres after a real create — exactly the declared allowlist, nothing more:

```
$ psql -tAc "select distinct jsonb_object_keys(snapshot) from shared_views where view_type='calendar';"
brand_name
month
month_label
posts
timezone

$ psql -tAc "select distinct jsonb_object_keys(p) from shared_views, jsonb_array_elements(snapshot->'posts') p;"
caption
media_url
platform
scheduled_for
slot
status

$ psql -tAc "select count(*) from shared_views where snapshot::text like '%<the token>%'
             or snapshot::text like '%<the brand uuid>%' or snapshot::text ilike '%image_prompt%';"
0
```

Only the hash is stored, and it is the hash of the token that was returned once:

```
$ echo -n cofMim2DUxZ…H8k | shasum -a 256
57db30b6fcc264823790b191c5eb36b5bc04126638e0386aa87dff9a2acbc687
$ psql -tAc "select token_hash from shared_views where view_type='calendar';"
57db30b6fcc264823790b191c5eb36b5bc04126638e0386aa87dff9a2acbc687
```

Defence in depth is not decorative — with the anon key, PostgREST refuses the table outright:

```
$ curl -H "apikey: $ANON" '…/rest/v1/shared_views?select=token_hash,snapshot'
{"code":"42501","message":"permission denied for table shared_views"}
HTTP 401
```
</details>

## Anything Else?

- **The migration must be applied by hand.** Repeating it because it is the one step that cannot be inferred from the diff. Until it is applied the feature answers `500 shares_not_migrated` and names the file — it fails loudly, not silently, but it does fail.
- **`list_shares` reads the whole `snapshot` blob** just to pull `month` out of it. Up to 100 rows of JSON to read one string. It is correct and it is wasteful; `select=month:snapshot->>month` would fix it when list latency is ever measured to matter.
- **No UI surface.** Creating and revoking is API and MCP only. A button in the app is the obvious next PR; it needs no schema change, only the two calls.
- **Deferred on purpose:** PDF export, `proposal` views, and a live (non-snapshot) calendar. The plan puts the live view behind proving privacy and caching first, and version one is deliberately made of revocable frozen snapshots.
- **`snapshot_version` has one value.** It is written and returned so that the day the shape changes there is something to branch on. Nothing branches on it today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
