### PR TITLE
Sort the endpoint registry so branches stop colliding

### DIFF
--- a/cli/lib/contracts/index.ts
+++ b/cli/lib/contracts/index.ts
@@ -1,7 +1,17 @@
 import type { z } from 'zod';
 import { CHECK_CONTENT } from './content';
-import { GET_AUDIT_FINDINGS, LIST_AUDIT_CITATIONS, LIST_WEB_AUDITS, LIST_WEB_FIXES } from './evidence';
-import { PLAN_CADENCES, PLAN_CYCLE_WEEKS, SAVE_PLAN, SAVE_WEEK_SEEDS } from './plans';
+import {
+  GET_AUDIT_FINDINGS,
+  LIST_AUDIT_CITATIONS,
+  LIST_WEB_AUDITS,
+  LIST_WEB_FIXES,
+} from './evidence';
+import {
+  PLAN_CADENCES,
+  PLAN_CYCLE_WEEKS,
+  SAVE_PLAN,
+  SAVE_WEEK_SEEDS,
+} from './plans';
 import {
   CREATE_POST,
   GET_CALENDAR,
@@ -9,7 +19,7 @@ import {
   LIST_MEDIA,
   LIST_POSTS,
   RENDER_POST,
-  RESCHEDULE_POST
+  RESCHEDULE_POST,
 } from './posts';
 
 export type EndpointFailure = { readonly error: string; readonly status: number };
@@ -47,20 +57,20 @@ export type ResourceEndpoint = EndpointShape & {
 export type BrandEndpoint = ResourcelessEndpoint | ResourceEndpoint;
 
 export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
-  CREATE_POST,
-  LIST_POSTS,
-  GET_CALENDAR,
-  LIST_MEDIA,
   CHECK_CONTENT,
+  CREATE_POST,
+  GET_AUDIT_FINDINGS,
+  GET_CALENDAR,
+  GET_POST,
+  LIST_AUDIT_CITATIONS,
+  LIST_MEDIA,
+  LIST_POSTS,
+  LIST_WEB_AUDITS,
+  LIST_WEB_FIXES,
+  RENDER_POST,
+  RESCHEDULE_POST,
   SAVE_PLAN,
   SAVE_WEEK_SEEDS,
-  LIST_WEB_AUDITS,
-  GET_AUDIT_FINDINGS,
-  LIST_AUDIT_CITATIONS,
-  LIST_WEB_FIXES,
-  GET_POST,
-  RESCHEDULE_POST,
-  RENDER_POST
 ];
 
 export function pathFor(endpoint: ResourcelessEndpoint, slug: string): string;
@@ -88,7 +98,7 @@ export {
   LIST_WEB_AUDITS,
   LIST_WEB_FIXES,
   RENDER_POST,
-  RESCHEDULE_POST
+  RESCHEDULE_POST,
 };
 export {
   AUDIT_CITATIONS_DEFAULT,

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -1,7 +1,17 @@
 import type { z } from 'zod';
 import { CHECK_CONTENT } from './content';
-import { GET_AUDIT_FINDINGS, LIST_AUDIT_CITATIONS, LIST_WEB_AUDITS, LIST_WEB_FIXES } from './evidence';
-import { PLAN_CADENCES, PLAN_CYCLE_WEEKS, SAVE_PLAN, SAVE_WEEK_SEEDS } from './plans';
+import {
+  GET_AUDIT_FINDINGS,
+  LIST_AUDIT_CITATIONS,
+  LIST_WEB_AUDITS,
+  LIST_WEB_FIXES,
+} from './evidence';
+import {
+  PLAN_CADENCES,
+  PLAN_CYCLE_WEEKS,
+  SAVE_PLAN,
+  SAVE_WEEK_SEEDS,
+} from './plans';
 import {
   CREATE_POST,
   GET_CALENDAR,
@@ -9,7 +19,7 @@ import {
   LIST_MEDIA,
   LIST_POSTS,
   RENDER_POST,
-  RESCHEDULE_POST
+  RESCHEDULE_POST,
 } from './posts';
 
 export type EndpointFailure = { readonly error: string; readonly status: number };
@@ -47,20 +57,20 @@ export type ResourceEndpoint = EndpointShape & {
 export type BrandEndpoint = ResourcelessEndpoint | ResourceEndpoint;
 
 export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
-  CREATE_POST,
-  LIST_POSTS,
-  GET_CALENDAR,
-  LIST_MEDIA,
   CHECK_CONTENT,
+  CREATE_POST,
+  GET_AUDIT_FINDINGS,
+  GET_CALENDAR,
+  GET_POST,
+  LIST_AUDIT_CITATIONS,
+  LIST_MEDIA,
+  LIST_POSTS,
+  LIST_WEB_AUDITS,
+  LIST_WEB_FIXES,
+  RENDER_POST,
+  RESCHEDULE_POST,
   SAVE_PLAN,
   SAVE_WEEK_SEEDS,
-  LIST_WEB_AUDITS,
-  GET_AUDIT_FINDINGS,
-  LIST_AUDIT_CITATIONS,
-  LIST_WEB_FIXES,
-  GET_POST,
-  RESCHEDULE_POST,
-  RENDER_POST
 ];
 
 export function pathFor(endpoint: ResourcelessEndpoint, slug: string): string;
@@ -88,7 +98,7 @@ export {
   LIST_WEB_AUDITS,
   LIST_WEB_FIXES,
   RENDER_POST,
-  RESCHEDULE_POST
+  RESCHEDULE_POST,
 };
 export {
   AUDIT_CITATIONS_DEFAULT,


### PR DESCRIPTION
## What?

`BRAND_ENDPOINTS` in `packages/api-contracts/src/index.ts` — and its byte-identical mirror `cli/lib/contracts/index.ts` — is **sorted alphabetically**. Two `import` statements that packed four names onto one line are split one name per line, and two trailing commas are added.

No name is added, removed or renamed. No logic changes. This is a formatting change and nothing else.

## Why?

Eight PRs are open against `dev` and nearly all of them add an endpoint. `#218` already put the array one entry per line, which helps — but it left the entries in **insertion order**, so every new endpoint is appended to the same last line. Two branches appending two different endpoints still edit the same line, git still cannot merge them, and the queue still moves one PR at a time with the loser rebasing.

Sorting is the half that actually removes the conflict. `GET_ARTICLE` lands near the top, `LIST_SHARES` lands in the middle, `UPDATE_PRODUCT` lands at the bottom: three branches, three different lines, three clean merges.

## How?

**Sorted, not appended.** Alphabetical order spreads insertions across the file instead of concentrating them on the last line. That is the whole mechanism.

**Order-independence was checked, not assumed.** The array changed from insertion order to alphabetical, so anything reading it positionally would break. Every consumer was inspected:

- `cli/mcp/tools/brand-content.ts` iterates the array and calls `server.registerTool(endpoint.tool, …)` — registration is keyed by name; position is not observable.
- `packages/api-contracts/src/index.test.ts` reads it through `find(e => e.tool === …)`, `.some(…)` and set comparisons. Nothing indexes.
- `packages/api-contracts/src/evidence.test.ts` asserts membership with `toContain`, not position.
- `cli/mcp/create-post.test.ts` and `cli/mcp/http-app.test.ts` read `tools/list` and look tools up by name (`all.find(t => t.name === …)`), assert with `toContain`, and sort key lists before comparing.

**No test pins a `tools/list` order**, so no test needed changing and the sort was kept. Had one pinned an order, the honest fix would have been the test — the MCP protocol does not promise a tool ordering, so a client depending on one is depending on nothing.

**The trailing commas are load-bearing, not cosmetic.** Without one, appending a name means editing the previous last line; with one, an append is a pure insertion. Same reason as the sort.

**The mirror is generated, not hand-edited.** `cli/lib/contracts/index.ts` exists because the CLI ships as a standalone binary rooted at `cli/mcp` and cannot import the workspace. It was regenerated with `./cli/scripts/sync-contracts.sh`; `cli/lib/contracts.test.ts` fails if the two drift.

## Testing?

Run against `dev` at `56f9211`, from a clean install of this worktree (`npm install --ignore-scripts && npx patch-package`, `cd cli && bun install --frozen-lockfile`).

| Check | Result |
|---|---|
| `npx vitest run packages/api-contracts` | 3 files, **45 tests passed**, 0 failed |
| `cd cli && bun test` | 8 files, **39 tests passed**, 0 failed |
| `cd cli && bun run typecheck` | `tsc --noEmit`, exit 0 |
| `git diff --check` | clean, no whitespace errors |
| `diff packages/api-contracts/src/index.ts cli/lib/contracts/index.ts` | identical after `sync-contracts.sh` |

**The set of endpoint names is unchanged**, verified against `dev` rather than eyeballed: both sides parse to the same fourteen names (`CHECK_CONTENT`, `CREATE_POST`, `GET_AUDIT_FINDINGS`, `GET_CALENDAR`, `GET_POST`, `LIST_AUDIT_CITATIONS`, `LIST_MEDIA`, `LIST_POSTS`, `LIST_WEB_AUDITS`, `LIST_WEB_FIXES`, `RENDER_POST`, `RESCHEDULE_POST`, `SAVE_PLAN`, `SAVE_WEEK_SEEDS`).

**Not tested:** nothing was exercised in a browser, because nothing user-visible changes — no route, no payload, no tool name, no schema. The risk this carries is a dropped or duplicated endpoint constant during the reshuffle, which is exactly what the name-set comparison and the contract tests cover.

## Evidence (screenshots/videos)

No UI change, so no screenshots. Backend evidence is the test table above.

<details>
<summary>Why insertion order still collides</summary>

`dev` today, after #218:

```
export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
  CREATE_POST,
  …
  GET_POST,
  RESCHEDULE_POST,
  RENDER_POST          ← every open branch edits this line
];
```

A branch adding `GET_ARTICLE` writes `RENDER_POST,` + `GET_ARTICLE`. A branch adding `LIST_SHARES` writes `RENDER_POST,` + `LIST_SHARES`. Same line, two right-hand sides, no automatic merge.

Sorted, `GET_ARTICLE` inserts after `CREATE_POST` and `LIST_SHARES` after `LIST_POSTS`. Different lines, both merge.
</details>

## Anything Else?

- The `export type { … }` lines are left alone: they are grouped per source module, so a new module adds a new line rather than editing an existing one. That class already merges cleanly.
- This does not stop two branches that add the *same* endpoint name from conflicting, and it should not — that is a real disagreement, not a formatting artifact.
- The open PRs still need one rebase each onto this. After that they stop fighting each other, which is the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
