### PR TITLE
Let an agent hand the user a Stripe link

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -834,3 +834,22 @@ lavorando, il repo non può ripararlo — può solo smettere di regredire. Il te
 serve comunque, perché il giorno in cui il dominio torna a essere servito da qui il difetto
 non rientra; ma la riparazione è ripuntare il progetto, e va detta come tale invece di essere
 spacciata per un fix di codice.
+## Una colonna che la migration non ha mai creato si traveste da «brand non trovato»
+
+**Segnale.** Una lettura che «non può fallire» torna `null` per tutti — non per un tenant, non a
+intermittenza: per tutti — e la superficie sopra risponde con un errore di chi chiama (404, «Brand
+not found»). La suite è verde, perché il client Supabase è mockato e un mock non ha uno schema.
+
+**Cosa succede.** `orgBillingForBrand` seleziona `plan, stripe_customer_id, stripe_subscription_id`
+da `organizations`. In produzione quelle colonne non ci sono: la migration `20260903190000_org_billing_schema.sql`
+non è mai stata applicata, perché i deploy di questo repo non applicano migration. PostgREST
+risponde 400, `supabase-js` **risolve** con `{ data: null, error }`, la funzione ignora `error` e
+restituisce `null`, e il chiamante legge quel `null` come «questo brand non ha un'org». Il bottone
+del portale su `/app/billing` risponde 404 a chiunque, e sembra un problema di permessi.
+
+**La mossa.** Prima di diagnosticare il codice, `node scripts/schema-drift-check.mjs`: è in sola
+lettura, punta alla produzione senza paura, ed esce 1 con l'elenco delle colonne che il codice
+nomina e il database non ha. Va eseguito **dopo ogni migration scritta e prima di ogni PR che
+tocca il database** — non solo quando qualcosa è già rotto. Un `select` di colonne che potrebbero
+non esistere non è mai «non può fallire»: o si legge `error`, o il difetto arriva travestito da
+colpa di chi chiama.

--- a/changelog/2026-09-04-billing-links-for-agents.md
+++ b/changelog/2026-09-04-billing-links-for-agents.md
@@ -1,0 +1,92 @@
+# Due link di pagamento che un agente esterno può mintare
+
+Richiesta del proprietario, alla lettera: «un endpoint per creare un nuovo checkout e uno per
+aprire il portale Stripe dell'utente, così anche gli agenti possono avviarli e ripassarli
+all'utente». Quella frase è anche il confine di sicurezza, e vive nel codice: **l'agente non paga
+e non cambia mai un piano.** Ottiene una URL e la restituisce; l'umano la apre e completa
+l'azione sulla pagina ospitata da Stripe.
+
+`POST /api/v1/brands/:slug/billing/portal` e `POST /api/v1/brands/:slug/billing/checkout`, quindi
+i tool MCP `create_billing_portal_link` e `create_checkout_link`, che nascono da soli dal registry
+dei contratti.
+
+## Cosa è stato riusato, e cosa è stato estratto
+
+`createBillingPortalSession` esisteva già e non è stata toccata. Quello che **non** esisteva è un
+posto da cui chiamarla: la logica stava inline dentro due page action di
+`settings-actions.ts` (`billingPortal` e `upgrade`), ciascuna con la propria risoluzione dell'org,
+la propria chiamata a Stripe e il proprio `throw redirect(303, url)`. Il redirect è il
+comportamento del **form web**, non della funzione — un endpoint API vuole la stessa risposta
+senza il redirect.
+
+Primo commit, separato e a comportamento invariato: `src/lib/server/billing-links.ts` con
+`billingLink()`, che risponde o con una URL o con **una** delle quattro ragioni per cui non può
+mintarla. Le due action mappano quelle ragioni sui redirect e sui messaggi che già producevano.
+Unica differenza, irraggiungibile dalla UI: `billingPortal` con `flow=upgrade` e nessun
+abbonamento ora rifiuta invece di aprire in silenzio la home del portale — nessun form posta quel
+flow, solo `invoices` e `payment_method`.
+
+**Non è stata scritta una seconda integrazione Stripe, e nessun price id è stato introdotto.** Il
+checkout è la stessa pagina ospitata che il bottone di upgrade del prodotto apre oggi
+(`flow_data.subscription_update`): il listino sta su Stripe, e `src/lib/server/stripe.ts` dichiara
+apposta che l'app non nomina mai un prezzo. Il repo non contiene alcuna creazione di Checkout
+Session — non c'è, non è stata inventata. Un'org che non si è mai abbonata riceve `no_customer` /
+`no_subscription` (409) con `app_billing_url`: la pagina in-app da cui la persona parte davvero.
+
+## Org contro brand: dove sono finiti gli endpoint
+
+Il registry dei contratti è scoped sul brand (`/api/v1/brands/:slug/…`), la fatturazione
+appartiene all'organizzazione. Le due strade erano: stare nel registry e risolvere l'org lato
+server, oppure uscirne e mettere gli endpoint altrove.
+
+Sono **dentro** il registry. Ragioni, in ordine: lo slug è l'unica maniglia che un agente ha in
+mano — ogni comando CLI/MCP è brand-scoped; l'org si risolve con `orgBillingForBrand`, la stessa
+funzione che legge `/app/billing`, quindi resta **un solo posto** che decide quale org fattura un
+brand; e il metodo CLI e il tool MCP nascono da soli dal registry, mentre fuori andrebbero
+scritti a mano. Il test di guardia del registry non è stato toccato né indebolito.
+
+## Chi è autorizzato
+
+Raggiungere un brand non è avere autorità sui soldi dell'org. Sul web la guardia è
+`isBrandOwner`, che si appoggia alla RLS; qui la RLS non prova niente, perché il path con API key
+gira come service role e vedrebbe qualunque brand. Quindi `isOrgOwner(supabase, orgId, userId)`,
+scritta accanto al modello che governa (org-billing.ts) e con il confronto esplicito su
+`owner_id`: vale per entrambi i path di autenticazione. Un collaboratore di un brand condiviso
+(0077) prende `not_org_owner` (403), come il browser gli direbbe «Owner only».
+
+## Niente gate sui crediti, mai
+
+Nessuno dei due chiama `gateAiAction` e nessuno guarda i crediti. Sarebbe circolare: chi ha finito
+i crediti è precisamente la persona che deve arrivare al checkout. Due test lo tengono fermo, e
+un terzo verifica che nessuna delle scritture Stripe (`applyRetentionCoupon`,
+`cancelSubscriptionAtPeriodEnd`, `ensureSubscriptionCanceled`) sia raggiungibile da qui.
+
+Una API key **read-only** viene comunque rifiutata: il link porta anche a un bottone di disdetta.
+
+## La URL è una capability al portatore
+
+Una URL del portale dà accesso alla fatturazione di quel cliente a chiunque la possieda, senza
+altra autenticazione. Non viene loggata, non viene salvata, compare una volta sola nel corpo
+della risposta — e la descrizione che un modello esterno legge lo dice, insieme al fatto che da
+quella pagina si può anche **disdire**. `destructiveHint` resta `false` (la chiamata non
+distrugge niente) ma la descrizione non lascia credere che il link sia inerte.
+
+## Status onesti
+
+Un guasto di Stripe è **502**, non un 400 che accusa chi chiama — la stessa linea di #201.
+`no_org_billing` è **500**: dopo che `loadBrandForUser` ha già provato che il brand esiste ed è
+del chiamante, non poter risolvere la sua org è colpa nostra (succede, per esempio, quando due
+righe trial condividono lo slug e la `maybeSingle()` di `orgBillingForBrand` fallisce).
+`no_customer` e `no_subscription` sono **409**: la richiesta è corretta, lo stato dell'account
+non c'è ancora.
+
+## Quello che resta rotto (e non è di questa PR)
+
+`node scripts/schema-drift-check.mjs` è **rosso su dev**: la migration
+`20260903190000_org_billing_schema.sql` non è applicata in produzione — `organizations` ha cinque
+colonne e non ha `plan`, `stripe_subscription_id`, `activated_at`; mancano anche
+`credit_grants.org_id` e la tabella `org_usage`. `orgBillingForBrand` seleziona quelle colonne:
+in produzione quella select fallisce, `data` torna null e la funzione risponde `null`. Significa
+che oggi **anche il bottone del portale su `/app/billing` non funziona**, e che questi due
+endpoint nascerebbero morti allo stesso modo. Non è un difetto introdotto qui e non si ripara con
+del codice: la migration va applicata a mano, perché i deploy di questo repo non lo fanno.

--- a/cli/lib/contracts/billing.ts
+++ b/cli/lib/contracts/billing.ts
@@ -1,0 +1,88 @@
+import { z } from 'zod';
+import type { BrandEndpoint, EndpointFailure } from './index';
+
+const LinkSchema = z
+  .string()
+  .describe('One-time Stripe URL. Give it to the account owner and keep no copy');
+
+const PlanSchema = z.object({ key: z.string(), label: z.string() });
+
+const PortalInputSchema = z.object({}).strict();
+
+const PortalResultSchema = z.object({
+  ok: z.literal(true),
+  url: LinkSchema
+});
+
+const CheckoutInputSchema = z
+  .object({
+    plan: z
+      .string()
+      .min(1)
+      .optional()
+      .describe('Plan key the human wants, e.g. "pro". Refused if the org cannot move up to it')
+  })
+  .strict();
+
+const CheckoutResultSchema = z.object({
+  ok: z.literal(true),
+  url: LinkSchema,
+  plans: z.array(PlanSchema).describe('The plans the hosted page will offer')
+});
+
+/**
+ * Reaching a brand is not authority over its organization's money, and a customer who cannot
+ * pay is not a caller who typed something wrong: `no_customer` and `no_subscription` describe
+ * an account that has not subscribed yet, and `stripe_unavailable` / `no_org_billing` are ours.
+ */
+const BILLING_FAILURES: readonly EndpointFailure[] = [
+  { error: 'not_org_owner', status: 403 },
+  { error: 'no_customer', status: 409 },
+  { error: 'no_org_billing', status: 500 },
+  { error: 'stripe_unavailable', status: 502 }
+];
+
+export type BillingPortalLinkResult = z.infer<typeof PortalResultSchema>;
+export type CheckoutLinkInput = z.infer<typeof CheckoutInputSchema>;
+export type CheckoutLinkResult = z.infer<typeof CheckoutResultSchema>;
+
+export const BILLING_PORTAL_LINK = {
+  tool: 'create_billing_portal_link',
+  title: 'Billing portal link',
+  description:
+    'Mint a one-time link to this organization Stripe billing portal and hand it to the account ' +
+    'owner. On that page THEY can read invoices, change the card, switch plan and CANCEL the ' +
+    'subscription — you never open it and never act inside it, you return the URL and stop. ' +
+    'Treat the URL as a credential: whoever holds it reaches that customer billing, so give it ' +
+    'to the owner once, in the reply, and never store or repeat it. Only the organization owner ' +
+    'can mint one. Calls no model and spends no credits: it works precisely when credits are gone.',
+  method: 'POST',
+  pathUnderBrand: '/billing/portal',
+  input: PortalInputSchema,
+  output: PortalResultSchema,
+  failures: BILLING_FAILURES,
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const CHECKOUT_LINK = {
+  tool: 'create_checkout_link',
+  title: 'Checkout link',
+  description:
+    'Mint a one-time link where the human picks a paid plan and pays, on Stripe own hosted page. ' +
+    'You never pay, never change a plan and never apply a discount: you return the URL, they ' +
+    'complete it. The same page can also CANCEL the subscription, so treat the URL as the owner ' +
+    'credential — whoever holds it reaches that customer billing — and hand it over once, never ' +
+    'stored, never repeated. Only the organization owner can mint one. Calls no model and spends ' +
+    'no credits. An organization that never subscribed has no Stripe customer to check out ' +
+    'against: the refusal carries app_billing_url, which is where the human starts.',
+  method: 'POST',
+  pathUnderBrand: '/billing/checkout',
+  input: CheckoutInputSchema,
+  output: CheckoutResultSchema,
+  failures: [
+    ...BILLING_FAILURES,
+    { error: 'unknown_plan', status: 400 },
+    { error: 'no_subscription', status: 409 }
+  ],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/cli/lib/contracts/index.ts
+++ b/cli/lib/contracts/index.ts
@@ -1,5 +1,6 @@
 import type { z } from 'zod';
 import { ADS_REMIX } from './ads';
+import { BILLING_PORTAL_LINK, CHECKOUT_LINK } from './billing';
 import { GET_ARTICLE, UPDATE_ARTICLE } from './articles';
 import { CHECK_CONTENT } from './content';
 import { GET_CREATION_KIT } from './creation-kit';
@@ -90,6 +91,8 @@ export type BrandEndpoint = ResourcelessEndpoint | ResourceEndpoint;
 
 export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   ADS_REMIX,
+  BILLING_PORTAL_LINK,
+  CHECKOUT_LINK,
   CHECK_CONTENT,
   CREATE_POST,
   CREATE_PRODUCT,
@@ -126,6 +129,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   UPDATE_COMPETITOR,
   UPDATE_PERSON,
   UPDATE_PRODUCT,
+  export const BRAND_ENDPOINTS: readonly BrandEndpoint[,
 ];
 
 export function pathFor(endpoint: ResourcelessEndpoint, slug: string): string;
@@ -196,6 +200,8 @@ export {
   REVOKE_SHARE,
   SHARED_VIEW_TYPES,
 };
+export { BILLING_PORTAL_LINK, CHECKOUT_LINK };
+export type { BillingPortalLinkResult, CheckoutLinkInput, CheckoutLinkResult } from './billing';
 export type { CheckContentInput, CheckContentResult } from './content';
 export type {
   AuditCitationRow,

--- a/cli/lib/contracts/index.ts
+++ b/cli/lib/contracts/index.ts
@@ -129,7 +129,6 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   UPDATE_COMPETITOR,
   UPDATE_PERSON,
   UPDATE_PRODUCT,
-  export const BRAND_ENDPOINTS: readonly BrandEndpoint[,
 ];
 
 export function pathFor(endpoint: ResourcelessEndpoint, slug: string): string;

--- a/cli/plugins/anomalia/skills/anomalia/SKILL.md
+++ b/cli/plugins/anomalia/skills/anomalia/SKILL.md
@@ -88,6 +88,11 @@ time; `update_person` and `update_competitor` fix a role or a wrong website. The
 fields you send, leave every other column as it was, and cost nothing. `update_person` can never
 attest consent: a real person's face stays withheld from every generator until the operator
 states, in their own words, that they have it.
+**Hand over a payment link** → `create_checkout_link` (pick a plan and pay) or
+`create_billing_portal_link` (invoices, card, plan change, **cancel**). You mint the URL and give
+it to the account owner; they complete it on Stripe. Never pay, never switch a plan, never cancel
+on their behalf. The URL is a credential — hand it over once and keep no copy. Owner only, and it
+costs no credits, which is the point: whoever ran out is who needs it.
 
 **Approve pending posts** → `list_posts` (status pending) → optional `get_post` → `approve_posts`.
 

--- a/cli/plugins/anomalia/skills/anomalia/references/tools.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/tools.md
@@ -276,3 +276,30 @@ Refusals name the field: `article_not_found` (an article of another brand includ
 `translation_locked` (a translation's locale is its identity) and `article_published` — what is
 live is never edited in place. To correct a published article: `unpublish_article`,
 `update_article`, `publish_article`.
+## Billing links
+
+| MCP | CLI |
+|-----|-----|
+| `create_billing_portal_link` | (MCP only) |
+| `create_checkout_link` | (MCP only) |
+
+Both mint a **one-time Stripe URL and hand it back**. You never pay, never change a plan, never
+apply a discount and never cancel: you return the URL and stop, and the person completes the
+action on Stripe's own hosted page. The portal is also where a subscription is **cancelled** —
+say so when you hand the link over.
+
+Treat the URL as a credential: whoever holds it reaches that customer's billing without logging
+in. Give it to the account owner once, in the reply, and keep no copy of it anywhere.
+
+`create_billing_portal_link` takes only `slug`: invoices, payment method, plan change, cancel.
+`create_checkout_link` takes an optional `plan` and answers with the `plans` the hosted page will
+offer, so you can name them in one line.
+
+Only the **organization owner** can mint either one — reaching a brand is not authority over the
+organization's money, and a collaborator gets `not_org_owner` (403). Neither call spends credits
+or touches a model: an account out of credits is exactly who needs the link.
+
+Refusals worth reading: `no_customer` / `no_subscription` (409) mean the organization never
+subscribed — the body carries `app_billing_url`, which is where the person starts;
+`stripe_unavailable` (502) and `no_org_billing` (500) are ours, so retrying with different input
+changes nothing.

--- a/cli/skills/anomalia/SKILL.md
+++ b/cli/skills/anomalia/SKILL.md
@@ -88,6 +88,11 @@ time; `update_person` and `update_competitor` fix a role or a wrong website. The
 fields you send, leave every other column as it was, and cost nothing. `update_person` can never
 attest consent: a real person's face stays withheld from every generator until the operator
 states, in their own words, that they have it.
+**Hand over a payment link** → `create_checkout_link` (pick a plan and pay) or
+`create_billing_portal_link` (invoices, card, plan change, **cancel**). You mint the URL and give
+it to the account owner; they complete it on Stripe. Never pay, never switch a plan, never cancel
+on their behalf. The URL is a credential — hand it over once and keep no copy. Owner only, and it
+costs no credits, which is the point: whoever ran out is who needs it.
 
 **Approve pending posts** → `list_posts` (status pending) → optional `get_post` → `approve_posts`.
 

--- a/cli/skills/anomalia/references/tools.md
+++ b/cli/skills/anomalia/references/tools.md
@@ -276,3 +276,30 @@ Refusals name the field: `article_not_found` (an article of another brand includ
 `translation_locked` (a translation's locale is its identity) and `article_published` — what is
 live is never edited in place. To correct a published article: `unpublish_article`,
 `update_article`, `publish_article`.
+## Billing links
+
+| MCP | CLI |
+|-----|-----|
+| `create_billing_portal_link` | (MCP only) |
+| `create_checkout_link` | (MCP only) |
+
+Both mint a **one-time Stripe URL and hand it back**. You never pay, never change a plan, never
+apply a discount and never cancel: you return the URL and stop, and the person completes the
+action on Stripe's own hosted page. The portal is also where a subscription is **cancelled** —
+say so when you hand the link over.
+
+Treat the URL as a credential: whoever holds it reaches that customer's billing without logging
+in. Give it to the account owner once, in the reply, and keep no copy of it anywhere.
+
+`create_billing_portal_link` takes only `slug`: invoices, payment method, plan change, cancel.
+`create_checkout_link` takes an optional `plan` and answers with the `plans` the hosted page will
+offer, so you can name them in one line.
+
+Only the **organization owner** can mint either one — reaching a brand is not authority over the
+organization's money, and a collaborator gets `not_org_owner` (403). Neither call spends credits
+or touches a model: an account out of credits is exactly who needs the link.
+
+Refusals worth reading: `no_customer` / `no_subscription` (409) mean the organization never
+subscribed — the body carries `app_billing_url`, which is where the person starts;
+`stripe_unavailable` (502) and `no_org_billing` (500) are ours, so retrying with different input
+changes nothing.

--- a/docs/api/01-overview.md
+++ b/docs/api/01-overview.md
@@ -69,6 +69,11 @@ Gli endpoint che spendono AI richiedono **piano a pagamento + crediti** e scope 
 | `POST /brands/:slug/rubrics/propose` | Batch rubriche AI |
 | `POST /brands/:slug/web` (generate/optimize) | Articoli blog AI |
 
+**Non gated, di proposito**: `POST /brands/:slug/billing/portal` e
+`POST /brands/:slug/billing/checkout` ([10-billing](10-billing.md)) non chiamano `gateAiAction` e
+non guardano i crediti. Sarebbe circolare — chi ha finito i crediti è chi deve arrivare al
+checkout. Restano scope `write`: il link porta anche a un bottone di disdetta.
+
 ## Convenzioni di risposta
 
 - Successo: `200` (o `201` per creazione key), quasi sempre con `{"ok": true, …}`.

--- a/docs/api/11-billing.md
+++ b/docs/api/11-billing.md
@@ -1,0 +1,123 @@
+# API — 10 · Billing (link di pagamento per gli agenti)
+
+Due endpoint che **mintano una URL Stripe e la restituiscono**. Sono i tool MCP
+`create_billing_portal_link` e `create_checkout_link`, e nascono da una richiesta precisa: un
+agente esterno deve poter *avviare* un pagamento e passare il link all'umano.
+
+Il confine di sicurezza è nel codice, non solo nella descrizione: **l'agente non paga e non
+cambia mai un piano.** Ottiene una URL; chi la apre e completa l'azione sulla pagina ospitata da
+Stripe è la persona. Nessuno dei due endpoint addebita una carta, cambia un abbonamento, applica
+un coupon o disdice qualcosa — `applyRetentionCoupon`, `cancelSubscriptionAtPeriodEnd` e
+`ensureSubscriptionCanceled` non sono raggiungibili da qui, e un test lo verifica.
+
+## La URL è una credenziale
+
+Una URL del portale (o del checkout) Stripe dà accesso alla fatturazione di quel cliente a
+**chiunque la possieda**, senza altra autenticazione. Quindi: non viene mai loggata, non viene
+mai salvata, e compare **una sola volta** nella risposta. Chi la riceve la consegna al
+proprietario dell'account e non ne tiene copia.
+
+## Fatturazione dell'org, registry di brand
+
+Il registry degli endpoint (`packages/api-contracts`) è scoped sul brand
+(`/api/v1/brands/:slug/…`), mentre la fatturazione appartiene all'**organizzazione**. Questi due
+endpoint stanno **dentro** il registry e risolvono l'org lato server con `orgBillingForBrand` —
+la stessa funzione che legge la pagina `/app/billing`. Lo slug è solo la maniglia che l'agente
+ha già in mano: ogni comando CLI/MCP è brand-scoped, e c'è **un solo posto** che decide quale
+org fattura un brand.
+
+## Chi è autorizzato
+
+Accedere a un brand **non** è avere autorità sulla fatturazione dell'org. Sul web la guardia è
+`isBrandOwner` (RLS); qui la RLS non prova niente, perché il path con API key gira come service
+role. Quindi la condizione è scritta a mano: `isOrgOwner(supabase, brand.org_id, user.id)`.
+
+Un collaboratore di un brand condiviso (0077) prende `not_org_owner` (403) — esattamente come il
+browser gli risponderebbe "Owner only".
+
+## Niente gate sui crediti
+
+**Nessuno dei due chiama `gateAiAction` e nessuno guarda i crediti.** Sarebbe circolare: chi ha
+finito i crediti è precisamente la persona che deve arrivare al checkout. Nessuno dei due chiama
+un modello.
+
+Una API key **read-only** viene comunque rifiutata (403): il link porta anche a un bottone di
+disdetta.
+
+---
+
+## `POST /api/v1/brands/:slug/billing/portal`
+
+Portale di fatturazione Stripe dell'org: fatture, metodo di pagamento, cambio piano, disdetta.
+
+**Body**: nessun campo. Un campo non dichiarato viene rifiutato (`invalid_input`, 400).
+
+**Response** `200`:
+
+```json
+{
+  "ok": true,
+  "url": "https://billing.stripe.com/p/session/live_xyz"
+}
+```
+
+```bash
+curl -sS -X POST https://anomalia.so/api/v1/brands/demo/billing/portal \
+  -H "Authorization: Bearer $ANOMALIA_TOKEN" \
+  -H 'content-type: application/json' -d '{}'
+```
+
+## `POST /api/v1/brands/:slug/billing/checkout`
+
+Pagina ospitata da Stripe dove la persona sceglie un piano a pagamento e paga. Il prezzo **non è
+nominato qui**: la scaletta dei prezzi vive su Stripe, e l'app non cita mai un price id.
+
+**Body**:
+
+| Campo | Tipo | Note |
+|---|---|---|
+| `plan` | string, opzionale | Chiave del piano voluto (`starter`, `pro`, …). Rifiutato se l'org non può salirci |
+
+**Response** `200`:
+
+```json
+{
+  "ok": true,
+  "url": "https://billing.stripe.com/p/session/live_upgrade",
+  "plans": [{ "key": "pro", "label": "Pro" }]
+}
+```
+
+`plans` è la stessa scaletta del bottone di upgrade nel prodotto (`plansAbove`), Go incluso solo
+mentre `FEATURE_PLAN_GO` è acceso. Serve all'agente per dire in una riga cosa vedrà la persona.
+
+```bash
+curl -sS -X POST https://anomalia.so/api/v1/brands/demo/billing/checkout \
+  -H "Authorization: Bearer $ANOMALIA_TOKEN" \
+  -H 'content-type: application/json' -d '{"plan":"pro"}'
+```
+
+## Errori
+
+Ogni fallimento è dichiarato nel contratto e lo status arriva da `statusForFailure`, non da una
+catena di `||`. Un guasto di Stripe è **502**: è nostro, non di chi chiama.
+
+| `error` | Status | Endpoint | Significato |
+|---|---|---|---|
+| `invalid_input` | 400 | entrambi | Il body non passa lo schema (campo sconosciuto incluso) |
+| `unknown_plan` | 400 | checkout | Il `plan` chiesto non è fra quelli sopra al piano attuale. La risposta porta `plans` |
+| `not_org_owner` | 403 | entrambi | Il chiamante raggiunge il brand ma non possiede l'org che paga |
+| `API key is read-only` | 403 | entrambi | Chiave senza scope `write` |
+| `Brand not found` | 404 | entrambi | Slug inesistente o non del chiamante (`loadBrandForUser`) |
+| `no_customer` | 409 | entrambi | L'org non ha mai pagato: non esiste un cliente Stripe da aprire |
+| `no_subscription` | 409 | checkout | Non c'è un abbonamento da aggiornare |
+| `no_org_billing` | 500 | entrambi | Non siamo riusciti a risolvere l'org che fattura il brand — nostro |
+| `stripe_unavailable` | 502 | entrambi | Stripe ha risposto male — nostro, non di chi chiama |
+
+`no_customer` e `no_subscription` non sono errori di sintassi: descrivono un account che non si è
+ancora abbonato. La risposta porta `app_billing_url`, la pagina in-app da cui la persona parte —
+oggi l'abbonamento nasce lì, non da questi endpoint, perché il repo non crea Checkout Session e
+non nomina price id (scelta dichiarata in `src/lib/server/stripe.ts`).
+
+Errori di auth comuni (401, 403 accesso non ancora abilitato): vedi
+[01-overview](01-overview.md).

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -18,6 +18,7 @@ integrazioni esterne via API key — request, response, query params, body, erro
 | [08 — Ads, voice, GTM e gestione](08-ads-voice-gtm-misc.md) | `/ads`, `/ads/remix`, `/voice`, `/gtm`, `/rubrics`, `/products`, `/api-keys` |
 | [09 — Connections](09-connections.md) | `/connections`, `/connections/catalog`, `/connections/:id/complete`, `/connections/:id` |
 | [10 — Shares](10-shares.md) | `/shares`, `/shares/revoke`, e la rotta pubblica `/share/:token` |
+| [11 — Billing](11-billing.md) | `/billing/portal`, `/billing/checkout` — link Stripe che l'agente consegna all'umano |
 
 ## Regole di manutenzione
 

--- a/packages/api-contracts/src/billing.ts
+++ b/packages/api-contracts/src/billing.ts
@@ -1,0 +1,88 @@
+import { z } from 'zod';
+import type { BrandEndpoint, EndpointFailure } from './index';
+
+const LinkSchema = z
+  .string()
+  .describe('One-time Stripe URL. Give it to the account owner and keep no copy');
+
+const PlanSchema = z.object({ key: z.string(), label: z.string() });
+
+const PortalInputSchema = z.object({}).strict();
+
+const PortalResultSchema = z.object({
+  ok: z.literal(true),
+  url: LinkSchema
+});
+
+const CheckoutInputSchema = z
+  .object({
+    plan: z
+      .string()
+      .min(1)
+      .optional()
+      .describe('Plan key the human wants, e.g. "pro". Refused if the org cannot move up to it')
+  })
+  .strict();
+
+const CheckoutResultSchema = z.object({
+  ok: z.literal(true),
+  url: LinkSchema,
+  plans: z.array(PlanSchema).describe('The plans the hosted page will offer')
+});
+
+/**
+ * Reaching a brand is not authority over its organization's money, and a customer who cannot
+ * pay is not a caller who typed something wrong: `no_customer` and `no_subscription` describe
+ * an account that has not subscribed yet, and `stripe_unavailable` / `no_org_billing` are ours.
+ */
+const BILLING_FAILURES: readonly EndpointFailure[] = [
+  { error: 'not_org_owner', status: 403 },
+  { error: 'no_customer', status: 409 },
+  { error: 'no_org_billing', status: 500 },
+  { error: 'stripe_unavailable', status: 502 }
+];
+
+export type BillingPortalLinkResult = z.infer<typeof PortalResultSchema>;
+export type CheckoutLinkInput = z.infer<typeof CheckoutInputSchema>;
+export type CheckoutLinkResult = z.infer<typeof CheckoutResultSchema>;
+
+export const BILLING_PORTAL_LINK = {
+  tool: 'create_billing_portal_link',
+  title: 'Billing portal link',
+  description:
+    'Mint a one-time link to this organization Stripe billing portal and hand it to the account ' +
+    'owner. On that page THEY can read invoices, change the card, switch plan and CANCEL the ' +
+    'subscription — you never open it and never act inside it, you return the URL and stop. ' +
+    'Treat the URL as a credential: whoever holds it reaches that customer billing, so give it ' +
+    'to the owner once, in the reply, and never store or repeat it. Only the organization owner ' +
+    'can mint one. Calls no model and spends no credits: it works precisely when credits are gone.',
+  method: 'POST',
+  pathUnderBrand: '/billing/portal',
+  input: PortalInputSchema,
+  output: PortalResultSchema,
+  failures: BILLING_FAILURES,
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const CHECKOUT_LINK = {
+  tool: 'create_checkout_link',
+  title: 'Checkout link',
+  description:
+    'Mint a one-time link where the human picks a paid plan and pays, on Stripe own hosted page. ' +
+    'You never pay, never change a plan and never apply a discount: you return the URL, they ' +
+    'complete it. The same page can also CANCEL the subscription, so treat the URL as the owner ' +
+    'credential — whoever holds it reaches that customer billing — and hand it over once, never ' +
+    'stored, never repeated. Only the organization owner can mint one. Calls no model and spends ' +
+    'no credits. An organization that never subscribed has no Stripe customer to check out ' +
+    'against: the refusal carries app_billing_url, which is where the human starts.',
+  method: 'POST',
+  pathUnderBrand: '/billing/checkout',
+  input: CheckoutInputSchema,
+  output: CheckoutResultSchema,
+  failures: [
+    ...BILLING_FAILURES,
+    { error: 'unknown_plan', status: 400 },
+    { error: 'no_subscription', status: 409 }
+  ],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/packages/api-contracts/src/index.test.ts
+++ b/packages/api-contracts/src/index.test.ts
@@ -246,6 +246,70 @@ describe('il registry degli endpoint di brand', () => {
   it('leggere e scrivere un articolo passano dallo stesso indirizzo', () => {
     expect(byTool('update_article').pathUnderBrand).toBe(byTool('get_article').pathUnderBrand);
     expect(byTool('update_article').method).toBe('POST');
+  it('i due link di fatturazione portano a Stripe e non sono distruttivi', () => {
+    for (const tool of ['create_billing_portal_link', 'create_checkout_link']) {
+      const e = byTool(tool);
+      expect(e.method, tool).toBe('POST');
+      expect(e.destructive, tool).toBe(false);
+    }
+    expect(pathFor(byTool('create_billing_portal_link'), 'demo')).toBe(
+      '/api/v1/brands/demo/billing/portal'
+    );
+    expect(pathFor(byTool('create_checkout_link'), 'demo')).toBe('/api/v1/brands/demo/billing/checkout');
+  });
+
+  it('la descrizione dei link dice che si può anche disdire, e che apre l umano', () => {
+    for (const tool of ['create_billing_portal_link', 'create_checkout_link']) {
+      const { description } = byTool(tool);
+      expect(description.toLowerCase(), tool).toContain('cancel');
+      expect(description.toLowerCase(), tool).toContain('never');
+    }
+  });
+
+  it('un guasto di Stripe è nostro: 502, non un 4xx che accusa chi chiama', () => {
+    for (const tool of ['create_billing_portal_link', 'create_checkout_link']) {
+      expect(statusForFailure(byTool(tool), 'stripe_unavailable'), tool).toBe(502);
+      expect(statusForFailure(byTool(tool), 'no_org_billing'), tool).toBe(500);
+    }
+  });
+
+  it('chi ha il brand ma non la fatturazione dell org prende 403', () => {
+    for (const tool of ['create_billing_portal_link', 'create_checkout_link']) {
+      expect(statusForFailure(byTool(tool), 'not_org_owner'), tool).toBe(403);
+    }
+  });
+
+  it('un org senza cliente Stripe non è un errore di sintassi: 409', () => {
+    expect(statusForFailure(byTool('create_billing_portal_link'), 'no_customer')).toBe(409);
+    expect(statusForFailure(byTool('create_checkout_link'), 'no_customer')).toBe(409);
+    expect(statusForFailure(byTool('create_checkout_link'), 'no_subscription')).toBe(409);
+  });
+
+  it('il checkout accetta un piano opzionale e rifiuta il resto', () => {
+    const { input } = byTool('create_checkout_link');
+    expect(input.safeParse({}).success).toBe(true);
+    expect(input.safeParse({ plan: 'pro' }).success).toBe(true);
+    expect(input.safeParse({ plan: '' }).success).toBe(false);
+    expect(input.safeParse({ coupon: 'FREE' }).success).toBe(false);
+  });
+
+  it('il portale non prende parametri: non c è niente da scegliere per chi chiama', () => {
+    const { input } = byTool('create_billing_portal_link');
+    expect(input.safeParse({}).success).toBe(true);
+    expect(input.safeParse({ flow: 'cancel' }).success).toBe(false);
+  });
+
+  it('entrambi promettono una url e nient altro di sensibile', () => {
+    expect(byTool('create_billing_portal_link').output.safeParse({
+      ok: true,
+      url: 'https://billing.stripe.com/p/session/live_xyz'
+    }).success).toBe(true);
+    expect(byTool('create_checkout_link').output.safeParse({
+      ok: true,
+      url: 'https://billing.stripe.com/p/session/live_xyz',
+      plans: [{ key: 'pro', label: 'Pro' }]
+    }).success).toBe(true);
+    expect(byTool('create_billing_portal_link').output.safeParse({ ok: true }).success).toBe(false);
   });
 
   it('ads_remix è tornato: la rotta esiste, il client la sapeva chiamare, poi solo lui l ha persa', () => {

--- a/packages/api-contracts/src/index.test.ts
+++ b/packages/api-contracts/src/index.test.ts
@@ -246,6 +246,8 @@ describe('il registry degli endpoint di brand', () => {
   it('leggere e scrivere un articolo passano dallo stesso indirizzo', () => {
     expect(byTool('update_article').pathUnderBrand).toBe(byTool('get_article').pathUnderBrand);
     expect(byTool('update_article').method).toBe('POST');
+  });
+
   it('i due link di fatturazione portano a Stripe e non sono distruttivi', () => {
     for (const tool of ['create_billing_portal_link', 'create_checkout_link']) {
       const e = byTool(tool);

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -1,5 +1,6 @@
 import type { z } from 'zod';
 import { ADS_REMIX } from './ads';
+import { BILLING_PORTAL_LINK, CHECKOUT_LINK } from './billing';
 import { GET_ARTICLE, UPDATE_ARTICLE } from './articles';
 import { CHECK_CONTENT } from './content';
 import { GET_CREATION_KIT } from './creation-kit';
@@ -90,6 +91,8 @@ export type BrandEndpoint = ResourcelessEndpoint | ResourceEndpoint;
 
 export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   ADS_REMIX,
+  BILLING_PORTAL_LINK,
+  CHECKOUT_LINK,
   CHECK_CONTENT,
   CREATE_POST,
   CREATE_PRODUCT,
@@ -126,6 +129,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   UPDATE_COMPETITOR,
   UPDATE_PERSON,
   UPDATE_PRODUCT,
+  export const BRAND_ENDPOINTS: readonly BrandEndpoint[,
 ];
 
 export function pathFor(endpoint: ResourcelessEndpoint, slug: string): string;
@@ -196,6 +200,8 @@ export {
   REVOKE_SHARE,
   SHARED_VIEW_TYPES,
 };
+export { BILLING_PORTAL_LINK, CHECKOUT_LINK };
+export type { BillingPortalLinkResult, CheckoutLinkInput, CheckoutLinkResult } from './billing';
 export type { CheckContentInput, CheckContentResult } from './content';
 export type {
   AuditCitationRow,

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -129,7 +129,6 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   UPDATE_COMPETITOR,
   UPDATE_PERSON,
   UPDATE_PRODUCT,
-  export const BRAND_ENDPOINTS: readonly BrandEndpoint[,
 ];
 
 export function pathFor(endpoint: ResourcelessEndpoint, slug: string): string;

--- a/src/lib/content/changelog/2026-09-04-billing-links-for-agents.ts
+++ b/src/lib/content/changelog/2026-09-04-billing-links-for-agents.ts
@@ -1,0 +1,10 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-04',
+  title: 'Your AI assistant can hand you a link to pay',
+  items: [
+    'Ask an assistant connected to Anomalia to upgrade or to open your billing, and it gives you a link — you complete it yourself on Stripe. It never pays, never switches your plan and never cancels anything.',
+    'Only the account owner gets those links, and asking for one costs no credits: running out is exactly when you need it.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/billing-links.test.ts
+++ b/src/lib/server/billing-links.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const orgBillingForBrand = vi.fn();
+const createBillingPortalSession = vi.fn();
+const applyRetentionCoupon = vi.fn();
+const cancelSubscriptionAtPeriodEnd = vi.fn();
+
+vi.mock('$lib/server/org-billing', () => ({
+	orgBillingForBrand: (...args: unknown[]) => orgBillingForBrand(...args)
+}));
+vi.mock('$lib/server/stripe', () => ({
+	createBillingPortalSession: (...args: unknown[]) => createBillingPortalSession(...args),
+	applyRetentionCoupon: (...args: unknown[]) => applyRetentionCoupon(...args),
+	cancelSubscriptionAtPeriodEnd: (...args: unknown[]) => cancelSubscriptionAtPeriodEnd(...args)
+}));
+
+import { billingLink } from './billing-links';
+
+const PAYING_ORG = {
+	orgId: 'org-1',
+	customerId: 'cus_1',
+	subscriptionId: 'sub_1',
+	plan: 'starter',
+	brandCount: 2
+};
+
+const RETURN_URL = 'https://anomalia.test/app/billing';
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	orgBillingForBrand.mockResolvedValue(PAYING_ORG);
+	createBillingPortalSession.mockResolvedValue('https://billing.stripe.com/session/xyz');
+});
+
+describe('billingLink', () => {
+	it('hands back the portal url for the customer the ORG bills through', async () => {
+		const link = await billingLink({} as never, { slug: 'demo', returnUrl: RETURN_URL });
+
+		expect(link).toEqual({ url: 'https://billing.stripe.com/session/xyz' });
+		expect(createBillingPortalSession).toHaveBeenCalledWith({
+			customerId: 'cus_1',
+			returnUrl: RETURN_URL,
+			flow: undefined,
+			subscriptionId: 'sub_1'
+		});
+	});
+
+	it('asks for the subscription_update flow when the caller wants to change plan', async () => {
+		await billingLink({} as never, { slug: 'demo', returnUrl: RETURN_URL, flow: 'upgrade' });
+
+		expect(createBillingPortalSession).toHaveBeenCalledWith({
+			customerId: 'cus_1',
+			returnUrl: RETURN_URL,
+			flow: 'upgrade',
+			subscriptionId: 'sub_1'
+		});
+	});
+
+	it('refuses no_org_billing when the brand bills through no org', async () => {
+		orgBillingForBrand.mockResolvedValue(null);
+
+		const link = await billingLink({} as never, { slug: 'ghost', returnUrl: RETURN_URL });
+
+		expect(link).toEqual({ refusal: 'no_org_billing', message: '' });
+		expect(createBillingPortalSession).not.toHaveBeenCalled();
+	});
+
+	it('refuses no_customer before calling Stripe about a customer that does not exist', async () => {
+		orgBillingForBrand.mockResolvedValue({ ...PAYING_ORG, customerId: null, subscriptionId: null });
+
+		const link = await billingLink({} as never, { slug: 'demo', returnUrl: RETURN_URL });
+
+		expect(link).toEqual({ refusal: 'no_customer', message: '' });
+		expect(createBillingPortalSession).not.toHaveBeenCalled();
+	});
+
+	it('refuses no_subscription when an upgrade has nothing to update', async () => {
+		orgBillingForBrand.mockResolvedValue({ ...PAYING_ORG, subscriptionId: null });
+
+		const link = await billingLink({} as never, {
+			slug: 'demo',
+			returnUrl: RETURN_URL,
+			flow: 'upgrade'
+		});
+
+		expect(link).toEqual({ refusal: 'no_subscription', message: '' });
+		expect(createBillingPortalSession).not.toHaveBeenCalled();
+	});
+
+	it('turns a Stripe failure into stripe_unavailable, keeping what Stripe said', async () => {
+		createBillingPortalSession.mockRejectedValue(new Error('connection error'));
+
+		const link = await billingLink({} as never, { slug: 'demo', returnUrl: RETURN_URL });
+
+		expect(link).toEqual({ refusal: 'stripe_unavailable', message: 'connection error' });
+	});
+
+	it('leaves a Stripe throw that is not an Error without a message to repeat', async () => {
+		createBillingPortalSession.mockRejectedValue('boom');
+
+		const link = await billingLink({} as never, { slug: 'demo', returnUrl: RETURN_URL });
+
+		expect(link).toEqual({ refusal: 'stripe_unavailable', message: '' });
+	});
+
+	it('never cancels, never discounts, never edits the subscription', async () => {
+		await billingLink({} as never, { slug: 'demo', returnUrl: RETURN_URL, flow: 'upgrade' });
+
+		expect(cancelSubscriptionAtPeriodEnd).not.toHaveBeenCalled();
+		expect(applyRetentionCoupon).not.toHaveBeenCalled();
+	});
+});

--- a/src/lib/server/billing-links.ts
+++ b/src/lib/server/billing-links.ts
@@ -1,0 +1,45 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { orgBillingForBrand } from '$lib/server/org-billing';
+
+const stripeApi = () => import('$lib/server/stripe');
+
+/**
+ * The one table of reasons a Stripe link cannot be minted. The web billing actions and the API
+ * endpoints read the same rows, so a reason that means "activate first" in the browser cannot
+ * come to mean something else to an external agent. `stripe_unavailable` is ours, not the
+ * caller's, and every surface has to keep saying so.
+ */
+export type BillingLinkRefusal =
+	| 'no_org_billing'
+	| 'no_customer'
+	| 'no_subscription'
+	| 'stripe_unavailable';
+
+export type BillingLink =
+	| { url: string; refusal?: undefined; message?: undefined }
+	| { url?: undefined; refusal: BillingLinkRefusal; message: string };
+
+const refuse = (refusal: BillingLinkRefusal, message = ''): BillingLink => ({ refusal, message });
+
+export async function billingLink(
+	supabase: SupabaseClient,
+	opts: { slug: string; returnUrl: string; flow?: 'payment_method' | 'upgrade' }
+): Promise<BillingLink> {
+	const billing = await orgBillingForBrand(supabase, { slug: opts.slug });
+	if (!billing) return refuse('no_org_billing');
+	if (!billing.customerId) return refuse('no_customer');
+	if (opts.flow === 'upgrade' && !billing.subscriptionId) return refuse('no_subscription');
+
+	try {
+		const { createBillingPortalSession } = await stripeApi();
+		const url = await createBillingPortalSession({
+			customerId: billing.customerId,
+			returnUrl: opts.returnUrl,
+			flow: opts.flow,
+			subscriptionId: billing.subscriptionId
+		});
+		return { url };
+	} catch (e) {
+		return refuse('stripe_unavailable', e instanceof Error ? e.message : '');
+	}
+}

--- a/src/lib/server/org-billing.ts
+++ b/src/lib/server/org-billing.ts
@@ -73,3 +73,22 @@ export async function orgBillingForBrand(
 		brandCount: brands.length
 	};
 }
+
+/**
+ * Billing authority, not brand access. A collaborator reaches a shared brand (0077) and must not
+ * reach the owner's payment pages through it. The predicate is written out instead of leaned on
+ * RLS because the API-key path runs as service role, where RLS proves nothing.
+ */
+export async function isOrgOwner(
+	supabase: SupabaseClient,
+	orgId: string,
+	userId: string
+): Promise<boolean> {
+	const { data } = await supabase
+		.from('organizations')
+		.select('id')
+		.eq('id', orgId)
+		.eq('owner_id', userId)
+		.maybeSingle();
+	return !!data;
+}

--- a/src/lib/server/settings-actions.ts
+++ b/src/lib/server/settings-actions.ts
@@ -15,6 +15,7 @@ import { readUploadImage } from '$lib/server/raster-image';
 import { createAdminClient } from '$lib/server/supabase-admin';
 import { setJobEnabled } from '$lib/server/job-roster';
 import { orgBillingForBrand } from '$lib/server/org-billing';
+import { billingLink } from '$lib/server/billing-links';
 
 const stripeApi = () => import('$lib/server/stripe');
 
@@ -44,23 +45,18 @@ export async function billingPortal({ request, params, url, locals: { supabase }
   const flowRaw = String(data.get('flow') ?? 'invoices');
   const flow = flowRaw === 'payment_method' || flowRaw === 'upgrade' ? flowRaw : undefined;
 
-  const billing = await orgBillingForBrand(supabase, { slug: params.brand! });
-  if (!billing) return fail(404, { billingError: 'Brand not found' });
-  if (!billing.customerId) throw redirect(303, `/app/${params.brand}/activate`);
-
-  let portalUrl: string;
-  try {
-    const { createBillingPortalSession } = await stripeApi();
-    portalUrl = await createBillingPortalSession({
-      customerId: billing.customerId,
-      returnUrl: `${url.origin}/app/${params.brand}/settings/billing`,
-      flow,
-      subscriptionId: billing.subscriptionId
-    });
-  } catch (e) {
-    return fail(500, { billingError: e instanceof Error ? e.message : 'Could not open billing' });
+  const link = await billingLink(supabase, {
+    slug: params.brand!,
+    returnUrl: `${url.origin}/app/${params.brand}/settings/billing`,
+    flow
+  });
+  if (link.refusal === 'no_org_billing') return fail(404, { billingError: 'Brand not found' });
+  if (link.refusal === 'no_customer' || link.refusal === 'no_subscription') {
+    throw redirect(303, `/app/${params.brand}/activate`);
   }
-  throw redirect(303, portalUrl);
+  if (link.refusal) return fail(500, { billingError: link.message || 'Could not open billing' });
+
+  throw redirect(303, link.url);
 }
 
 export async function upgrade({ request, params, url, locals: { supabase } }: Ev) {
@@ -74,23 +70,18 @@ export async function upgrade({ request, params, url, locals: { supabase } }: Ev
   if (!plansAbove(billing.plan).some((p) => p.key === plan)) {
     return fail(400, { billingError: 'Unknown plan' });
   }
-  if (!billing.customerId || !billing.subscriptionId) {
+
+  const link = await billingLink(supabase, {
+    slug: params.brand!,
+    returnUrl: `${url.origin}/app/${params.brand}/settings/billing`,
+    flow: 'upgrade'
+  });
+  if (link.refusal === 'no_customer' || link.refusal === 'no_subscription') {
     throw redirect(303, `/app/${params.brand}/activate?plan=${encodeURIComponent(plan)}`);
   }
+  if (link.refusal) return fail(500, { billingError: link.message || 'Could not start the upgrade' });
 
-  let upgradeUrl: string;
-  try {
-    const { createBillingPortalSession } = await stripeApi();
-    upgradeUrl = await createBillingPortalSession({
-      customerId: billing.customerId,
-      subscriptionId: billing.subscriptionId,
-      flow: 'upgrade',
-      returnUrl: `${url.origin}/app/${params.brand}/settings/billing`
-    });
-  } catch (e) {
-    return fail(500, { billingError: e instanceof Error ? e.message : 'Could not start the upgrade' });
-  }
-  throw redirect(303, upgradeUrl);
+  throw redirect(303, link.url);
 }
 
 export async function applyRetention({ params, locals: { supabase } }: Ev) {

--- a/src/routes/api/v1/brands/[slug]/billing/checkout/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/billing/checkout/+server.ts
@@ -1,0 +1,63 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { authenticate, checkApiKeyWriteAccess, loadBrandForUser } from '$lib/server/cli-auth';
+import { billingLink } from '$lib/server/billing-links';
+import { isOrgOwner, orgBillingForBrand } from '$lib/server/org-billing';
+import { plansAbove } from '$lib/server/plans';
+import { appOrigin } from '$lib/server/app-url';
+import { CHECKOUT_LINK, statusForFailure } from '@anomalia/api-contracts';
+
+/**
+ * The plan is named nowhere but here: the hosted page carries the prices, so this endpoint only
+ * checks that the plan asked for is one the org can move up to and returns the same ladder the
+ * web upgrade button offers. Like the portal link, the URL is returned once and stored nowhere.
+ */
+export const POST: RequestHandler = async ({ request, params, url }) => {
+  const { supabase, user, apiKey, error } = await authenticate(request);
+  if (error) return error;
+
+  const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
+  if (brandError) return brandError;
+
+  const readOnly = checkApiKeyWriteAccess(apiKey);
+  if (readOnly) return readOnly;
+
+  const parsed = CHECKOUT_LINK.input.safeParse(await request.json().catch(() => ({})));
+  if (!parsed.success) {
+    return json({ error: 'invalid_input', details: parsed.error.issues }, { status: 400 });
+  }
+
+  const appBillingUrl = `${appOrigin(url)}/app/billing`;
+
+  if (!(await isOrgOwner(supabase, brand.org_id, user.id))) {
+    return json(
+      { error: 'not_org_owner' },
+      { status: statusForFailure(CHECKOUT_LINK, 'not_org_owner') }
+    );
+  }
+
+  const billing = await orgBillingForBrand(supabase, { slug: params.slug });
+  const plans = plansAbove(billing?.plan).map((p) => ({ key: p.key, label: p.label }));
+
+  const wanted = parsed.data.plan;
+  if (wanted && !plans.some((p) => p.key === wanted)) {
+    return json(
+      { error: 'unknown_plan', plans },
+      { status: statusForFailure(CHECKOUT_LINK, 'unknown_plan') }
+    );
+  }
+
+  const link = await billingLink(supabase, {
+    slug: params.slug,
+    returnUrl: appBillingUrl,
+    flow: 'upgrade'
+  });
+  if (link.refusal) {
+    return json(
+      { error: link.refusal, message: link.message || undefined, app_billing_url: appBillingUrl },
+      { status: statusForFailure(CHECKOUT_LINK, link.refusal) }
+    );
+  }
+
+  return json({ ok: true, url: link.url, plans });
+};

--- a/src/routes/api/v1/brands/[slug]/billing/checkout/server.test.ts
+++ b/src/routes/api/v1/brands/[slug]/billing/checkout/server.test.ts
@@ -1,0 +1,207 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const orgBillingForBrand = vi.fn();
+const isOrgOwner = vi.fn();
+const createBillingPortalSession = vi.fn();
+const applyRetentionCoupon = vi.fn();
+const cancelSubscriptionAtPeriodEnd = vi.fn();
+const ensureSubscriptionCanceled = vi.fn();
+const gateCredits = vi.fn();
+const structured = vi.fn();
+
+vi.mock('$lib/server/cli-auth', () => ({
+	authenticate: vi.fn(),
+	loadBrandForUser: vi.fn(),
+	checkApiKeyWriteAccess: vi.fn(() => undefined),
+	gateAiAction: vi.fn()
+}));
+vi.mock('$lib/server/org-billing', () => ({
+	orgBillingForBrand: (...args: unknown[]) => orgBillingForBrand(...args),
+	isOrgOwner: (...args: unknown[]) => isOrgOwner(...args)
+}));
+vi.mock('$lib/server/stripe', () => ({
+	createBillingPortalSession: (...args: unknown[]) => createBillingPortalSession(...args),
+	applyRetentionCoupon: (...args: unknown[]) => applyRetentionCoupon(...args),
+	cancelSubscriptionAtPeriodEnd: (...args: unknown[]) => cancelSubscriptionAtPeriodEnd(...args),
+	ensureSubscriptionCanceled: (...args: unknown[]) => ensureSubscriptionCanceled(...args)
+}));
+vi.mock('$lib/server/credits', () => ({
+	gateCredits: (...args: unknown[]) => gateCredits(...args),
+	CreditsExhaustedError: class extends Error {}
+}));
+vi.mock('$lib/server/research', () => ({ structured: (...args: unknown[]) => structured(...args) }));
+vi.mock('$lib/server/app-url', () => ({ appOrigin: () => 'https://anomalia.test' }));
+vi.mock('$lib/server/feature-flags', () => ({ isPlanGoEnabled: () => false }));
+
+import { POST } from './+server';
+import { authenticate, loadBrandForUser, checkApiKeyWriteAccess, gateAiAction } from '$lib/server/cli-auth';
+
+const CHECKOUT_URL = 'https://billing.stripe.com/p/session/live_upgrade';
+
+const ORG_BILLING = {
+	orgId: 'org-1',
+	customerId: 'cus_org',
+	subscriptionId: 'sub_org',
+	plan: 'starter',
+	brandCount: 2
+};
+
+function call(body: unknown = {}, slug = 'demo') {
+	const url = new URL(`https://anomalia.test/api/v1/brands/${slug}/billing/checkout`);
+	return (POST as (event: unknown) => Promise<Response>)({
+		request: new Request(url, { method: 'POST', body: JSON.stringify(body) }),
+		params: { slug },
+		url
+	}).then(async (res) => ({ res, body: await res.json().catch(() => null) }));
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	vi.mocked(authenticate).mockResolvedValue({
+		supabase: {},
+		user: { id: 'user-1' },
+		apiKey: undefined,
+		error: null
+	} as never);
+	vi.mocked(loadBrandForUser).mockResolvedValue({
+		brand: { id: 'brand-1', org_id: 'org-1', slug: 'demo' },
+		error: null
+	} as never);
+	vi.mocked(checkApiKeyWriteAccess).mockReturnValue(undefined);
+	isOrgOwner.mockResolvedValue(true);
+	orgBillingForBrand.mockResolvedValue(ORG_BILLING);
+	createBillingPortalSession.mockResolvedValue(CHECKOUT_URL);
+});
+
+describe('POST /api/v1/brands/:slug/billing/checkout', () => {
+	it('hands back the checkout url and the plans the human will be offered', async () => {
+		const { res, body } = await call();
+
+		expect(res.status).toBe(200);
+		expect(res.headers.get('location')).toBeNull();
+		expect(body).toEqual({ ok: true, url: CHECKOUT_URL, plans: [{ key: 'pro', label: 'Pro' }] });
+	});
+
+	it('sends the ORG subscription to the hosted plan picker, naming no price', async () => {
+		await call({ plan: 'pro' });
+
+		expect(createBillingPortalSession).toHaveBeenCalledWith({
+			customerId: 'cus_org',
+			returnUrl: 'https://anomalia.test/app/billing',
+			flow: 'upgrade',
+			subscriptionId: 'sub_org'
+		});
+	});
+
+	it('checks the owner against the org the brand belongs to', async () => {
+		await call();
+
+		expect(isOrgOwner).toHaveBeenCalledWith(expect.anything(), 'org-1', 'user-1');
+	});
+
+	it('never charges, never changes a plan, never cancels', async () => {
+		await call({ plan: 'pro' });
+
+		expect(cancelSubscriptionAtPeriodEnd).not.toHaveBeenCalled();
+		expect(applyRetentionCoupon).not.toHaveBeenCalled();
+		expect(ensureSubscriptionCanceled).not.toHaveBeenCalled();
+	});
+
+	it('never gates on credits: whoever ran out is exactly who needs this link', async () => {
+		await call();
+
+		expect(gateAiAction).not.toHaveBeenCalled();
+		expect(gateCredits).not.toHaveBeenCalled();
+		expect(structured).not.toHaveBeenCalled();
+	});
+
+	it('refuses a plan the org cannot move up to, before touching Stripe', async () => {
+		const { res, body } = await call({ plan: 'go' });
+
+		expect(res.status).toBe(400);
+		expect(body.error).toBe('unknown_plan');
+		expect(body.plans).toEqual([{ key: 'pro', label: 'Pro' }]);
+		expect(createBillingPortalSession).not.toHaveBeenCalled();
+	});
+
+	it('refuses a caller who reaches the brand but does not own the org billing', async () => {
+		isOrgOwner.mockResolvedValue(false);
+
+		const { res, body } = await call();
+
+		expect(res.status).toBe(403);
+		expect(body.error).toBe('not_org_owner');
+		expect(createBillingPortalSession).not.toHaveBeenCalled();
+	});
+
+	it('says no_subscription, and where the human subscribes, with nothing to upgrade', async () => {
+		orgBillingForBrand.mockResolvedValue({ ...ORG_BILLING, subscriptionId: null });
+
+		const { res, body } = await call();
+
+		expect(res.status).toBe(409);
+		expect(body.error).toBe('no_subscription');
+		expect(body.app_billing_url).toBe('https://anomalia.test/app/billing');
+		expect(createBillingPortalSession).not.toHaveBeenCalled();
+	});
+
+	it('says no_customer when nobody ever paid', async () => {
+		orgBillingForBrand.mockResolvedValue({ ...ORG_BILLING, customerId: null, subscriptionId: null });
+
+		const { res, body } = await call();
+
+		expect(res.status).toBe(409);
+		expect(body.error).toBe('no_customer');
+		expect(body.app_billing_url).toBe('https://anomalia.test/app/billing');
+	});
+
+	it('a Stripe outage is ours: 502, not a 4xx that accuses the caller', async () => {
+		createBillingPortalSession.mockRejectedValue(new Error('connection error'));
+
+		const { res, body } = await call();
+
+		expect(res.status).toBe(502);
+		expect(body.error).toBe('stripe_unavailable');
+	});
+
+	it('rejects a request without authentication', async () => {
+		vi.mocked(authenticate).mockResolvedValue({
+			error: new Response('Unauthorized', { status: 401 })
+		} as never);
+
+		const { res } = await call();
+
+		expect(res.status).toBe(401);
+		expect(createBillingPortalSession).not.toHaveBeenCalled();
+	});
+
+	it('rejects a brand the caller cannot reach', async () => {
+		vi.mocked(loadBrandForUser).mockResolvedValue({
+			error: new Response(JSON.stringify({ error: 'Brand not found' }), { status: 404 })
+		} as never);
+
+		const { res } = await call({}, 'altrui');
+
+		expect(res.status).toBe(404);
+		expect(createBillingPortalSession).not.toHaveBeenCalled();
+	});
+
+	it('rejects a read-only API key', async () => {
+		vi.mocked(checkApiKeyWriteAccess).mockReturnValue(
+			new Response(JSON.stringify({ error: 'API key is read-only' }), { status: 403 }) as never
+		);
+
+		const { res } = await call();
+
+		expect(res.status).toBe(403);
+		expect(createBillingPortalSession).not.toHaveBeenCalled();
+	});
+
+	it('rejects a discount the contract never declared instead of ignoring it', async () => {
+		const { res, body } = await call({ coupon: 'FREE' });
+
+		expect(res.status).toBe(400);
+		expect(body.error).toBe('invalid_input');
+		expect(createBillingPortalSession).not.toHaveBeenCalled();
+	});
+});

--- a/src/routes/api/v1/brands/[slug]/billing/portal/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/billing/portal/+server.ts
@@ -1,0 +1,46 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { authenticate, checkApiKeyWriteAccess, loadBrandForUser } from '$lib/server/cli-auth';
+import { billingLink } from '$lib/server/billing-links';
+import { isOrgOwner } from '$lib/server/org-billing';
+import { appOrigin } from '$lib/server/app-url';
+import { BILLING_PORTAL_LINK, statusForFailure } from '@anomalia/api-contracts';
+
+/**
+ * The URL is a bearer capability over the customer's billing, so it is minted, returned once and
+ * never written anywhere: not a log line, not a row, not the error body.
+ */
+export const POST: RequestHandler = async ({ request, params, url }) => {
+  const { supabase, user, apiKey, error } = await authenticate(request);
+  if (error) return error;
+
+  const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
+  if (brandError) return brandError;
+
+  const readOnly = checkApiKeyWriteAccess(apiKey);
+  if (readOnly) return readOnly;
+
+  const parsed = BILLING_PORTAL_LINK.input.safeParse(await request.json().catch(() => ({})));
+  if (!parsed.success) {
+    return json({ error: 'invalid_input', details: parsed.error.issues }, { status: 400 });
+  }
+
+  const appBillingUrl = `${appOrigin(url)}/app/billing`;
+
+  if (!(await isOrgOwner(supabase, brand.org_id, user.id))) {
+    return json(
+      { error: 'not_org_owner' },
+      { status: statusForFailure(BILLING_PORTAL_LINK, 'not_org_owner') }
+    );
+  }
+
+  const link = await billingLink(supabase, { slug: params.slug, returnUrl: appBillingUrl });
+  if (link.refusal) {
+    return json(
+      { error: link.refusal, message: link.message || undefined, app_billing_url: appBillingUrl },
+      { status: statusForFailure(BILLING_PORTAL_LINK, link.refusal) }
+    );
+  }
+
+  return json({ ok: true, url: link.url });
+};

--- a/src/routes/api/v1/brands/[slug]/billing/portal/server.test.ts
+++ b/src/routes/api/v1/brands/[slug]/billing/portal/server.test.ts
@@ -1,0 +1,197 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const orgBillingForBrand = vi.fn();
+const isOrgOwner = vi.fn();
+const createBillingPortalSession = vi.fn();
+const applyRetentionCoupon = vi.fn();
+const cancelSubscriptionAtPeriodEnd = vi.fn();
+const ensureSubscriptionCanceled = vi.fn();
+const gateCredits = vi.fn();
+const structured = vi.fn();
+
+vi.mock('$lib/server/cli-auth', () => ({
+	authenticate: vi.fn(),
+	loadBrandForUser: vi.fn(),
+	checkApiKeyWriteAccess: vi.fn(() => undefined),
+	gateAiAction: vi.fn()
+}));
+vi.mock('$lib/server/org-billing', () => ({
+	orgBillingForBrand: (...args: unknown[]) => orgBillingForBrand(...args),
+	isOrgOwner: (...args: unknown[]) => isOrgOwner(...args)
+}));
+vi.mock('$lib/server/stripe', () => ({
+	createBillingPortalSession: (...args: unknown[]) => createBillingPortalSession(...args),
+	applyRetentionCoupon: (...args: unknown[]) => applyRetentionCoupon(...args),
+	cancelSubscriptionAtPeriodEnd: (...args: unknown[]) => cancelSubscriptionAtPeriodEnd(...args),
+	ensureSubscriptionCanceled: (...args: unknown[]) => ensureSubscriptionCanceled(...args)
+}));
+vi.mock('$lib/server/credits', () => ({
+	gateCredits: (...args: unknown[]) => gateCredits(...args),
+	CreditsExhaustedError: class extends Error {}
+}));
+vi.mock('$lib/server/research', () => ({ structured: (...args: unknown[]) => structured(...args) }));
+vi.mock('$lib/server/app-url', () => ({ appOrigin: () => 'https://anomalia.test' }));
+
+import { POST } from './+server';
+import { authenticate, loadBrandForUser, checkApiKeyWriteAccess, gateAiAction } from '$lib/server/cli-auth';
+
+const PORTAL_URL = 'https://billing.stripe.com/p/session/live_xyz';
+
+const ORG_BILLING = {
+	orgId: 'org-1',
+	customerId: 'cus_org',
+	subscriptionId: 'sub_org',
+	plan: 'starter',
+	brandCount: 2
+};
+
+function call(body: unknown = {}, slug = 'demo') {
+	const url = new URL(`https://anomalia.test/api/v1/brands/${slug}/billing/portal`);
+	return (POST as (event: unknown) => Promise<Response>)({
+		request: new Request(url, { method: 'POST', body: JSON.stringify(body) }),
+		params: { slug },
+		url
+	}).then(async (res) => ({ res, body: await res.json().catch(() => null) }));
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	vi.mocked(authenticate).mockResolvedValue({
+		supabase: {},
+		user: { id: 'user-1' },
+		apiKey: undefined,
+		error: null
+	} as never);
+	vi.mocked(loadBrandForUser).mockResolvedValue({
+		brand: { id: 'brand-1', org_id: 'org-1', slug: 'demo' },
+		error: null
+	} as never);
+	vi.mocked(checkApiKeyWriteAccess).mockReturnValue(undefined);
+	isOrgOwner.mockResolvedValue(true);
+	orgBillingForBrand.mockResolvedValue(ORG_BILLING);
+	createBillingPortalSession.mockResolvedValue(PORTAL_URL);
+});
+
+describe('POST /api/v1/brands/:slug/billing/portal', () => {
+	it('hands back the portal url instead of redirecting to it', async () => {
+		const { res, body } = await call();
+
+		expect(res.status).toBe(200);
+		expect(res.headers.get('location')).toBeNull();
+		expect(body).toEqual({ ok: true, url: PORTAL_URL });
+	});
+
+	it('opens the portal of the ORG customer, not of the brand in the url', async () => {
+		await call();
+
+		expect(orgBillingForBrand).toHaveBeenCalledWith(expect.anything(), { slug: 'demo' });
+		expect(createBillingPortalSession).toHaveBeenCalledWith({
+			customerId: 'cus_org',
+			returnUrl: 'https://anomalia.test/app/billing',
+			flow: undefined,
+			subscriptionId: 'sub_org'
+		});
+	});
+
+	it('checks the owner against the org the brand belongs to', async () => {
+		await call();
+
+		expect(isOrgOwner).toHaveBeenCalledWith(expect.anything(), 'org-1', 'user-1');
+	});
+
+	it('never charges, never changes a plan, never cancels', async () => {
+		await call();
+
+		expect(cancelSubscriptionAtPeriodEnd).not.toHaveBeenCalled();
+		expect(applyRetentionCoupon).not.toHaveBeenCalled();
+		expect(ensureSubscriptionCanceled).not.toHaveBeenCalled();
+	});
+
+	it('never gates on credits: whoever ran out is exactly who needs this link', async () => {
+		await call();
+
+		expect(gateAiAction).not.toHaveBeenCalled();
+		expect(gateCredits).not.toHaveBeenCalled();
+		expect(structured).not.toHaveBeenCalled();
+	});
+
+	it('refuses a caller who reaches the brand but does not own the org billing', async () => {
+		isOrgOwner.mockResolvedValue(false);
+
+		const { res, body } = await call();
+
+		expect(res.status).toBe(403);
+		expect(body.error).toBe('not_org_owner');
+		expect(createBillingPortalSession).not.toHaveBeenCalled();
+	});
+
+	it('says no_customer, and where the human subscribes, when nobody ever paid', async () => {
+		orgBillingForBrand.mockResolvedValue({ ...ORG_BILLING, customerId: null, subscriptionId: null });
+
+		const { res, body } = await call();
+
+		expect(res.status).toBe(409);
+		expect(body.error).toBe('no_customer');
+		expect(body.app_billing_url).toBe('https://anomalia.test/app/billing');
+		expect(createBillingPortalSession).not.toHaveBeenCalled();
+	});
+
+	it('a Stripe outage is ours: 502, not a 4xx that accuses the caller', async () => {
+		createBillingPortalSession.mockRejectedValue(new Error('connection error'));
+
+		const { res, body } = await call();
+
+		expect(res.status).toBe(502);
+		expect(body.error).toBe('stripe_unavailable');
+	});
+
+	it('an org we cannot resolve is ours too: 500, not a 404 about the brand', async () => {
+		orgBillingForBrand.mockResolvedValue(null);
+
+		const { res, body } = await call();
+
+		expect(res.status).toBe(500);
+		expect(body.error).toBe('no_org_billing');
+	});
+
+	it('rejects a request without authentication', async () => {
+		vi.mocked(authenticate).mockResolvedValue({
+			error: new Response('Unauthorized', { status: 401 })
+		} as never);
+
+		const { res } = await call();
+
+		expect(res.status).toBe(401);
+		expect(createBillingPortalSession).not.toHaveBeenCalled();
+	});
+
+	it('rejects a brand the caller cannot reach', async () => {
+		vi.mocked(loadBrandForUser).mockResolvedValue({
+			error: new Response(JSON.stringify({ error: 'Brand not found' }), { status: 404 })
+		} as never);
+
+		const { res } = await call({}, 'altrui');
+
+		expect(res.status).toBe(404);
+		expect(createBillingPortalSession).not.toHaveBeenCalled();
+	});
+
+	it('rejects a read-only API key: this link leads to a cancel button', async () => {
+		vi.mocked(checkApiKeyWriteAccess).mockReturnValue(
+			new Response(JSON.stringify({ error: 'API key is read-only' }), { status: 403 }) as never
+		);
+
+		const { res } = await call();
+
+		expect(res.status).toBe(403);
+		expect(createBillingPortalSession).not.toHaveBeenCalled();
+	});
+
+	it('rejects a field the contract does not declare instead of ignoring it', async () => {
+		const { res, body } = await call({ flow: 'cancel' });
+
+		expect(res.status).toBe(400);
+		expect(body.error).toBe('invalid_input');
+		expect(createBillingPortalSession).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## What?

Two new endpoints let an external agent **mint a Stripe URL and hand it to the human**, instead
of telling them to go and find the billing page themselves:

| | |
|---|---|
| `POST /api/v1/brands/:slug/billing/portal` | tool `create_billing_portal_link` — invoices, card, plan change, **cancel** |
| `POST /api/v1/brands/:slug/billing/checkout` | tool `create_checkout_link` — pick a paid plan and pay |

Both appear in the CLI/MCP surface on their own, from the contract registry: no `registerTool`
block and no method in `cli/lib/api.ts` was written by hand.

The framing the owner asked for is the safety boundary, and it is in the code, not only in the
prose: **the agent never pays and never changes a plan.** It obtains a URL and returns it; the
human opens it and completes the action on Stripe's own hosted page. No charge, no plan change,
no coupon and no cancellation is reachable from either endpoint — `applyRetentionCoupon`,
`cancelSubscriptionAtPeriodEnd` and `ensureSubscriptionCanceled` are asserted
`not.toHaveBeenCalled()` in both route suites.

## Why?

> «Can the api/cli/mcp interface have an endpoint to create a new checkout, and one to open the
> user's Stripe portal? So that agents can start them too and hand it back to the user.»

An agent that hits a wall on credits, or is asked "how do I upgrade", could only describe the way
there. Now it can produce the link and stop — which is exactly as far as an agent should go with
somebody else's money.

## How?

### What was reused, and what was extracted

`createBillingPortalSession` (`src/lib/server/stripe.ts`) already existed and is **untouched**.
What did not exist was a place to call it from: the logic lived inline inside two page actions in
`settings-actions.ts` (`billingPortal` and `upgrade`), each resolving the org itself, calling
Stripe itself and ending in `throw redirect(303, url)`. The redirect is the **web form's**
behaviour, not the function's.

So the first commit is a **separate, behaviour-preserving extraction**:
`src/lib/server/billing-links.ts` → `billingLink()` answers with a URL **or** one of four named
refusals, and both page actions map those refusals onto the redirects and `fail()` messages they
already produced. One reachable-only-in-theory difference, called out in the commit message:
`billingPortal` with `flow=upgrade` and no subscription now refuses instead of silently opening
the portal home — no form posts that flow (only `invoices` and `payment_method` reach the action).

### No second Stripe integration, and no price id

**There is no Stripe Checkout Session creation anywhere in this repo**, and none was added. I
looked for it: `src/routes/app/[brand]/upgrade/` and `src/routes/api/v1/billing/` do not exist,
`/app/[brand]/activate` is referenced but has no route, and the only Stripe writes in the codebase
are the retention coupon, the cancel and the delete guard. The **only** way a plan is bought today
is the hosted portal with `flow_data.subscription_update` — what the web upgrade button opens — so
that is what `create_checkout_link` mints. `stripe.ts` states explicitly that the app never names
a price id, and introducing one would have contradicted that on purpose.

Consequence, stated plainly rather than papered over: an organization that never subscribed has no
Stripe customer to check out against, and gets `no_customer` / `no_subscription` (409) whose body
carries `app_billing_url` — the in-app page where a person actually starts. The tool description
says so too.

The billing **provider** abstraction (`src/lib/server/billing/`) was read and deliberately not
used: it answers `gate()` / `quota()` / `upgradeUrl()` for credit gating and has nothing to do
with minting a Stripe session.

### Org billing against a brand-scoped registry

The registry is scoped by brand (`/api/v1/brands/:slug/…`); billing belongs to the organization.
I put the endpoints **inside** the registry and resolve the org server-side. Reasons, in order:

1. the slug is the only handle an agent has — every CLI/MCP call is already brand-scoped;
2. the org comes from `orgBillingForBrand`, the same function `/app/billing` reads, so exactly
   **one** place decides which org bills a brand;
3. outside the registry the CLI method and the MCP tool would have to be hand-written, which the
   task rules out.

The registry guard test (`packages/api-contracts/src/index.test.ts`) was **not weakened** — only
added to (+66 lines, zero removals). Both entries are declared `satisfies BrandEndpoint`.

### Who is authorized

Reaching a brand is **not** authority over the organization's money. The web guard is
`isBrandOwner`, which leans on RLS — and RLS proves nothing on the API-key path, which runs as
service role and would see any brand. So the check is written out:
`isOrgOwner(supabase, brand.org_id, user.id)` in `org-billing.ts`, comparing `owner_id`
explicitly, correct under both JWT and API key. A collaborator on a shared brand (0077) gets
`not_org_owner` (403) — what the browser tells them as "Owner only".

### No credit gate — deliberately

Neither endpoint calls `gateAiAction` and neither looks at credits. It would be circular: whoever
ran out of credits is precisely the person who needs to reach checkout. Neither calls a model.
A **read-only** API key is still refused, because the link leads to a cancel button too.

### The URL is a bearer capability

A Stripe portal URL grants access to that customer's billing to **whoever holds it**, with no
further authentication. So it is minted, returned once in the response body, and written nowhere:
not a log line, not a row, not an error body. The tool descriptions say this to the model that
reads them, and say plainly that the portal is also where a subscription is **cancelled**.
`destructiveHint` is `false` — the call itself destroys nothing — but the description does not let
the link read as inert.

### Honest statuses

| `error` | Status | Whose fault |
|---|---|---|
| `invalid_input` | 400 | caller |
| `unknown_plan` | 400 | caller (response carries `plans`) |
| `not_org_owner` | 403 | caller |
| `no_customer` / `no_subscription` | 409 | neither — the account has not subscribed yet |
| `no_org_billing` | 500 | **ours** |
| `stripe_unavailable` | 502 | **ours** |

A Stripe outage is a 502, not a 400 that accuses the caller — the same line as #201.
`no_org_billing` is a 500 because `loadBrandForUser` has already proved the brand exists and
belongs to the caller: failing to resolve its org after that is ours (it happens, for instance,
when duplicate trial rows share a slug and `orgBillingForBrand`'s `maybeSingle()` errors).
Statuses come from the contract's `failures` via `statusForFailure`, never from a chain of `||`.

### Database

**No migration was written, and neither endpoint writes to the database.** I still read the real
constraints before assuming anything about plan values — there is no CHECK on any plan column, so
nothing here can be rejected in production. Plan keys are validated in code against `plansAbove`,
the same ladder the web upgrade button offers.

## Testing?

Failing test first, both times, and the red was watched.

<details>
<summary><b>Red 1</b> — the extraction, before <code>billing-links.ts</code> existed</summary>

```
 RUN  v2.1.9 /Users/.../anomalia-wt/billing-links-for-agents

 ❯ src/lib/server/billing-links.test.ts (0 test)

⎯⎯⎯⎯⎯⎯ Failed Suites 1 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  src/lib/server/billing-links.test.ts [ src/lib/server/billing-links.test.ts ]
Error: Failed to load url ./billing-links (resolved id: ./billing-links) in
  .../src/lib/server/billing-links.test.ts. Does the file exist?

 Test Files  1 failed (1)
      Tests  no tests
```
</details>

<details>
<summary><b>Red 2</b> — the contract and the two routes, before either existed</summary>

```
 RUN  v2.1.9 /Users/.../anomalia-wt/billing-links-for-agents

 ❯ src/routes/api/v1/brands/[slug]/billing/portal/server.test.ts (0 test)
 ❯ src/routes/api/v1/brands/[slug]/billing/checkout/server.test.ts (0 test)
 ❯ packages/api-contracts/src/index.test.ts (24 tests | 8 failed) 20ms
   × i due link di fatturazione portano a Stripe e non sono distruttivi
     → missing endpoint create_billing_portal_link
   × la descrizione dei link dice che si può anche disdire, e che apre l umano
     → missing endpoint create_billing_portal_link
   × un guasto di Stripe è nostro: 502, non un 4xx che accusa chi chiama
     → missing endpoint create_billing_portal_link
   × chi ha il brand ma non la fatturazione dell org prende 403
     → missing endpoint create_billing_portal_link
   × un org senza cliente Stripe non è un errore di sintassi: 409
     → missing endpoint create_billing_portal_link
   × il checkout accetta un piano opzionale e rifiuta il resto
     → missing endpoint create_checkout_link
   × il portale non prende parametri: non c è niente da scegliere per chi chiama
     → missing endpoint create_billing_portal_link
   × entrambi promettono una url e nient altro di sensibile
     → missing endpoint create_billing_portal_link

 FAIL  src/routes/api/v1/brands/[slug]/billing/checkout/server.test.ts
 FAIL  src/routes/api/v1/brands/[slug]/billing/portal/server.test.ts
Error: Failed to load url ./+server (resolved id: ./+server) in
  .../billing/portal/server.test.ts. Does the file exist?

 Test Files  3 failed (3)
      Tests  8 failed | 16 passed (24)
```
</details>

### What the new tests cover

`src/lib/server/billing-links.test.ts` (8) — the URL for the ORG's customer; the
`subscription_update` flow; each of the four refusals; a Stripe throw that is not an `Error`; and
that nothing cancels or discounts.

The two route suites (13 + 14) — a URL is **returned, not redirected to** (`location` header
asserted null); the Stripe stub is called with `cus_org` / `sub_org`, i.e. the org's customer and
not the brand's; `isOrgOwner` is called with the brand's `org_id` and the caller's id; no charge,
plan change or cancellation is ever made; no credit gate (`gateAiAction`, `gateCredits`) and no
model call (`structured`); a caller with brand access but no billing authority is refused 403;
unauthenticated / inaccessible brand / read-only key fail through the existing auth contract; a
Stripe failure surfaces as 502 and an unresolvable org as 500; unknown fields (`flow`, `coupon`)
are rejected, not silently dropped.

**The real Stripe API is never called**: `$lib/server/stripe` is stubbed in every suite.

### Targeted runs (this branch, on the current `origin/dev`)

The full suite is left to CI — `.github/workflows/ci.yml` already runs `npx vitest run` plus
Playwright on every pull request, and this machine is carrying nine agents at once. What I ran
locally is the set that can actually fail because of this diff:

```
npx vitest run src/routes/api/v1/brands/[slug]/billing \
  packages/api-contracts/src/index.test.ts src/lib/server/billing-links.test.ts \
  src/lib/server/org-billing.test.ts src/lib/server/stripe.test.ts \
  src/routes/app/billing/page.server.test.ts

 ✓ src/lib/server/org-billing.test.ts (6 tests)
 ✓ src/lib/server/billing-links.test.ts (8 tests)
 ✓ src/lib/server/stripe.test.ts (13 tests)
 ✓ src/routes/app/billing/page.server.test.ts (5 tests)
 ✓ src/routes/api/v1/brands/[slug]/billing/checkout/server.test.ts (14 tests)
 ✓ src/routes/api/v1/brands/[slug]/billing/portal/server.test.ts (13 tests)
 ✓ packages/api-contracts/src/index.test.ts (33 tests)

 Test Files  7 passed (7)
      Tests  92 passed (92)

cd cli && bun test          → 44 pass, 0 fail (9 files)
cd cli && bun run typecheck → exit 0   (tsc --noEmit; typechecks the mirrored contract,
                                        including both `satisfies BrandEndpoint` entries)

git diff --check            → clean
```

`src/routes/app/billing/page.server.test.ts` is in that list on purpose: it is the suite that
holds the extraction honest.

### What was NOT verified, and why

**No real checkout was performed and no payment was made.** The Stripe SDK is stubbed in every
test; the real Stripe API is never reached from this branch, in tests or by hand.

No browser gate either. The diff touches no `.svelte` file: it is API/CLI/MCP surface, and the
only web-facing change is the behaviour-preserving extraction, covered by the page-action suite
above. No Docker, no Playwright and no dev server were started for this PR.

`npm run check` did not complete locally: two runs were killed after 36 and 44 minutes at ~8% CPU
with the machine deep in swap. Rather than write a number I did not obtain, I am saying so — the
app-side `svelte-check` pass is delegated to CI. The contract package and the CLI mirror, which
is where the type-level work of this PR lives, are covered by `bun run typecheck` above.

`npm run eval:durability` was not run either: it costs real money and measures whether chat work
survives a killed turn. This PR touches no prompt, no chat tool, no model and no chat path.

## Evidence (screenshots/videos)

<details>
<summary>The MCP tools come out of the registry with the right annotations (no hand-written block)</summary>

```
$ bun run /tmp/mcpsmoke.ts   # iterates BRAND_ENDPOINTS exactly as cli/mcp/tools/brand-content.ts does
create_billing_portal_link   /api/v1/brands/demo/billing/portal    slugOnlyOk=true rejectsUnknown=true readOnlyHint=false destructiveHint=false
create_checkout_link         /api/v1/brands/demo/billing/checkout  slugOnlyOk=true rejectsUnknown=true readOnlyHint=false destructiveHint=false
```
</details>

<details>
<summary>The CHECK constraints, read from the real database before writing any enum-ish value</summary>

```
select conrelid::regclass::text as tbl, conname, pg_get_constraintdef(oid)
from pg_constraint
where conrelid in ('public.brands'::regclass,'public.organizations'::regclass) and contype='c';

[{"tbl":"brands","conname":"brands_chat_default_tier_check",
  "pg_get_constraintdef":"CHECK (((chat_default_tier IS NULL) OR (chat_default_tier ~ '^[A-Za-z0-9]…')))"}]
```

One row: no CHECK on any plan column. This PR writes no row anyway.
</details>

## Anything Else?

**A pre-existing production blocker, found while working here and not introduced by this PR.**
`node scripts/schema-drift-check.mjs` is **red on `dev`**: the migration
`20260903190000_org_billing_schema.sql` is not applied. Production's `organizations` table has
five columns and lacks `plan`, `stripe_subscription_id` and `activated_at`; `credit_grants.org_id`
and the `org_usage` table are missing too.

```
supabase/migrations/20260903190000_org_billing_schema.sql
  assenti nel database: organizations.plan, organizations.activated_at,
                        organizations.stripe_subscription_id, credit_grants.org_id, org_usage
  usata da src/lib/server/org-billing.ts:56
  usata da src/routes/app/billing/+page.server.ts:49
  → APPLICA LA MIGRATION

ROSSO — 6 divergenze. Le migration si applicano a mano: i deploy di questo repo non lo fanno.
```

`orgBillingForBrand` selects exactly those columns. In production that select fails, `data` comes
back null and the function answers `null` — which means **the portal button on `/app/billing` is
already broken today**, and these two endpoints would be born dead the same way. Nothing in this
PR can fix it: this repo's deploys do not run migrations, so it has to be applied by hand before
either surface works. Flagging it rather than working around it.

Other notes:

- `isBrandOwner` in `settings-actions.ts` is still the web's guard and still RLS-shaped. I did not
  replace it with `isOrgOwner` — that is a behaviour change on five other actions and belongs in
  its own PR — but the two now sit next to each other and the asymmetry is worth closing.
- `create_checkout_link` accepts a `plan` it only validates: the hosted page carries the prices,
  so the plan does not change the URL. That mirrors the web `upgrade` action exactly, and the
  response returns the `plans` ladder so the agent can name the options in one line.
- The `/app/{slug}/activate` route the web redirects to on `no_customer` does not exist in this
  repo. The API deliberately points at `/app/billing` instead, so an agent never hands a human a
  404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
