### PR TITLE
Take the weekly planner off the agent framework

### DIFF
--- a/changelog/2026-09-04-week-planner-off-the-kit.md
+++ b/changelog/2026-09-04-week-planner-off-the-kit.md
@@ -1,0 +1,165 @@
+# Il week planner esce dal framework, primo dei dodici
+
+`packages/agent-*` (105.226 righe), `src/lib/agent` (23.909) e `src/lib/server/chat`
+(32.031) sono destinati alla cancellazione: 161.166 righe, circa il 31% del repository.
+Le capacità generative restano — produzione di immagini, caroselli, motion e UGC sono il
+differenziatore, non la chat. Quindi ogni orchestratore che oggi passa dal framework va
+riscritto sopra le primitive che già funzionano, uno alla volta, senza che nessuno se ne
+accorga dal lato del cliente.
+
+Questo è il primo. È il week planner, scelto per tre ragioni: un solo punto d'ingresso
+(`runWeekPlannerAgent`), un solo chiamante (`planWeekStrategy`), e un risultato che è un
+valore di ritorno e non un effetto sparso — `{ strategy, notes, costUsd }`. Su 594 righe
+è anche il più piccolo dei due candidati (`produce-agent.ts` ne ha 1.141), e sta sul
+percorso critico dell'autopilot settimanale, cioè dove un errore si vede subito.
+
+## Cosa faceva davvero, prima di toccarlo
+
+Il primo lavoro è stato leggerlo per intero e scrivere cosa fa. Il giro è questo:
+
+1. legge il budget del brand in dollari (`fetchUsdBudget`) e lo converte in crediti — il
+   brief con cui il modello sceglie il mix, e il gate che rifiuta un batch non producibile;
+2. carica in parallelo il piano editoriale attivo e il contesto di fattibilità del batch,
+   poi ci innesta il mix della settimana e le rubriche passate dal chiamante;
+3. carica i subreddit noti **solo** se reddit è fra le piattaforme;
+4. costruisce system e prompt, e apre un giro a strumenti dell'SDK con tetto di 40 step:
+   nove letture gratuite dentro il brand, `research` (max 30, a pagamento), `draft_seeds`
+   (max 4, ognuna una chiamata a `planStrategy`), `check_batch_feasibility`,
+   `repair_seeds` (max 8) e `finish`;
+5. a ogni step aggiorna il costo, calcola un'impronta e si ferma se quattro step di fila
+   sono identici;
+6. `finish` non chiude se i seed violano ancora la fattibilità: restituisce le violazioni;
+7. quando il giro finisce senza `finish`, chiude da solo se i seed passano il gate,
+   altrimenti esce in ripiego togliendo la storia agli episodi la cui fonte non è ancorata
+   a una pagina davvero letta in quel giro;
+8. scrive `agent_runs` (stato, note, step, violazioni, costo) e `ai_calls`.
+
+Niente di tutto questo veniva dal framework. Il framework avvolgeva il punto 4.
+
+## Cosa nascondeva `harnessGenerateText`
+
+`harnessGenerateText` chiama `generateText` dell'SDK e ci appende cinque cose. Su una
+superficie `batch` — questa — solo tre esistono:
+
+- **la traccia di sessione**, che finisce in `agent_sessions` e che la pagina Usage mostra
+  al cliente;
+- **il guardiano di sessione** (`steward`), deterministico, non un secondo modello: toglie
+  dal tavolo uno strumento che ha fallito due volte di fila e ricorda al modello di leggere
+  il brand quando non l'ha ancora fatto;
+- **la toppa al system di ogni step**, che porta le note del guardiano dentro ciò che il
+  modello legge.
+
+Le altre due — il controllore in ombra e lo strumento forzato al primo step — sono
+dichiarate `surface === 'chat'` e su un batch non hanno mai fatto niente. Sono state
+verificate riga per riga prima di lasciarle indietro, non presunte inerti.
+
+Quindi la riscrittura non ha dovuto reinventare un giro: il giro era già dell'SDK. Ha
+tolto l'involucro e ha scritto quelle tre cose al punto di chiamata, in ordine, dove si
+leggono. Il file è più lungo di ventinove righe e non ha più niente di implicito.
+
+## L'arco che spariva
+
+`harness/index` riesporta `harness/run`, e `harness/run` importa `chat/model` e
+`chat/controller` — e `chat/controller` importa `$lib/agent/bridge/verdict`. Ecco come un
+orchestratore di batch, che della chat non sa niente, se la portava dentro insieme a
+`$lib/agent`. Prendere la traccia dai moduli foglia (`harness/session`, `harness/persist`,
+`harness/pipeline`, `harness/steward` — nessuno dei quali importa chat o `$lib/agent`)
+toglie quell'arco.
+
+Misurato con una visita transitiva del grafo dal file: prima, `week-planner-agent.ts`
+raggiungeva `chat/model` e `chat/controller` in tre passi via `harness/index`. Adesso non
+li raggiunge più da sé. Continua a raggiungerli in quattro passi via `strategy-agent.ts`,
+che importa ancora `$lib/server/harness` per il proprio giro: è il prossimo della coda.
+Restano poi due archi che con il framework non c'entrano — `credits → scheduler →
+agent-turns → chat/queue` e `brand-context → design-* → motion-video → chat/artifacts` —
+e sono accoppiamenti di infrastruttura, da sciogliere quando si smonta la chat.
+
+Il framework non è stato toccato: `packages/agent-*` è intatto e continua a servire chat,
+room e gli altri undici orchestratori. Questo PR non cancella niente.
+
+## Perché i test vengono prima, e perché agganciano l'SDK
+
+Non esiste una versione precedente da confrontare: la storia del repository è un solo
+commit squashato. Il comportamento di oggi *è* la specifica, e una riscrittura senza una
+specifica scritta è una riscrittura alla cieca. I 21 test di caratterizzazione sono stati
+scritti e visti passare **sull'implementazione col framework**, prima di toccare una riga.
+
+Il punto di aggancio è `generateText` dell'SDK e non `harnessGenerateText`. È l'unica
+scelta che rende i test una misura invece che una descrizione: `harnessGenerateText`
+sparisce con la riscrittura, `generateText` no, quindi gli stessi 21 test giudicano
+entrambe le implementazioni senza una riga di differenza. Passano su tutte e due.
+
+Fissano: cosa si carica prima di parlare col modello, l'elenco esatto degli strumenti
+offerti, i tetti su bozze e ricerche e che nessuno dei due paga il modello una volta in
+più, lo stallo a quattro step identici, il gate che rifiuta di chiudere, la chiusura
+automatica e quella di ripiego, le righe scritte in `agent_runs` e `agent_sessions`, la
+chiusura forzata quando finiscono tempo o soldi, e il guardiano che il framework applicava
+in silenzio.
+
+## La ricetta per gli altri undici
+
+1. **Misura l'arco prima.** Una visita transitiva del grafo degli import dal file dice
+   quali archi verso `src/lib/agent`, `src/lib/server/chat` e `packages/agent-*` sono
+   *suoi* e quali arrivano da infrastruttura condivisa. Solo i primi sono lavoro di questo
+   PR; gli altri annunciarli e lasciarli.
+2. **Leggi il giro e scrivilo.** Un orchestratore su framework nasconde il controllo
+   dentro l'involucro. Elenca in ordine: chiamate al modello, cosa persiste, cosa ritenta,
+   cosa fa quando fallisce. Se non sai dirlo in dieci righe non sei pronto a spostarlo.
+3. **Aggancia i test all'SDK, mai al framework.** Un finto `generateText` che esegue una
+   sequenza di strumenti scritta a mano, chiama `prepareStep` e `onStepFinish` e valuta le
+   `stopWhen` esercita entrambe le implementazioni. Guardali passare sul vecchio codice
+   prima di scrivere il nuovo: un test che non è mai passato sul vecchio non dimostra
+   niente.
+4. **Conta le chiamate al modello nei test.** `expect(draftWeekSeeds).toHaveBeenCalledTimes(1)`
+   è l'unico modo di dimostrare che la spesa non è cambiata senza pagare due volte per
+   scoprirlo. La spesa che sale è un difetto, non un compromesso.
+5. **Verifica quali aggiunte del framework sono inerti sulla tua superficie**, riga per
+   riga. Su `batch` due delle cinque non fanno niente. Su `room` o `chat` sarà un altro
+   conto: non copiare questa conclusione, rifalla.
+6. **Prendi le foglie, non l'indice.** `harness/session`, `harness/persist`,
+   `harness/pipeline` e `harness/steward` non importano chat né `$lib/agent`; `harness/index`
+   sì, perché riesporta `harness/run`. Sono 1.030 righe di traccia e di politica
+   deterministica che non stanno nelle 161.166 da cancellare: riusarle costa zero e tiene
+   in piedi la pagina Usage.
+7. **Metti il vincolo in un test, non in un commento.** Un import verso i moduli foglia è
+   esattamente ciò che un riordino futuro «semplifica» ricollassando sull'indice, e
+   ricompare l'arco verso la chat senza che nessuno se ne accorga.
+8. **Separa il riordino dal cambio di comportamento**, in commit diversi. Qui il
+   comportamento non cambia affatto: è tutto riordino, e i test lo dimostrano.
+
+Il prossimo naturale è `strategy-agent.ts`: è quello che tiene ancora dentro il week
+planner, e con lui se ne vanno anche `agentModel`, `withAgentFallback` e la matematica del
+budget che quattro orchestratori si passano.
+
+## Cosa dipende ancora dal framework, senza sconti
+
+Il conto va detto per intero, perché una mezza verità qui costa un PR sprecato dopo.
+
+`packages/agent-*` (cinque pacchetti: `agent-adapters`, `agent-client`, `agent-contracts`,
+`agent-core`, `agent-kit`) è intatto, e in `src/lib` è importato direttamente da 37 file
+non di test: quasi tutto `src/lib/agent`, più `chat/action-approval`,
+`chat/model-preference`, `chat/persistence`, `chat/thread-events`,
+`server/agent-kit-effects-store`, `server/sandbox`, `chat-model-policy`, `chat-tiers`,
+`models/catalog` e `thread-cursor`.
+
+Il censimento «file di `src/lib/server` che importano `$lib/agent/`, `@anomalia/agent-*` o
+`server/harness`» conta 27 file non di test **prima e dopo**: `week-planner-agent.ts` ci
+resta dentro perché importa quattro moduli sotto `harness/`. Quello che è cambiato non è
+il conteggio, è l'arco: non importa più `$lib/server/harness` (l'indice) e quindi non
+raggiunge più `chat/model`, `chat/controller` e `$lib/agent/bridge/verdict` per conto suo.
+Il censimento va rifatto sui moduli e non sui prefissi quando i dodici saranno finiti.
+
+Gli undici che restano sul framework: `director.ts`, `produce-agent.ts`,
+`strategy-agent.ts`, `seo-agent.ts`, `image-agent.ts`, `analytics-review-agent.ts`,
+`media-generator/agent.ts`, `media-generator/ugc-agent.ts`,
+`media-generator/ugc-plan-agent.ts`, `motion-video/agent.ts`, `sandbox.ts` — più
+`agent-base.ts`, `agent-kit-effects-store.ts`, `craft-model.ts`, `harness-skills.ts` e
+tutta la chat. Non è stata tolta una riga: la cancellazione arriva quando l'ultimo
+consumatore è uscito.
+
+## Niente changelog pubblico
+
+Il cliente non può osservare nessuna differenza, ed è il criterio di riuscita: stessi seed,
+stesse righe in `agent_runs` e `agent_sessions`, stesso prompt (9.709 caratteri, identico
+prima e dopo su una corsa vera), una sola chiamata al giro. Un changelog pubblico qui
+direbbe che qualcosa è cambiato per chi usa il prodotto, e non è vero.

--- a/src/lib/server/nested-agents.test.ts
+++ b/src/lib/server/nested-agents.test.ts
@@ -21,7 +21,7 @@ const LOOP_DRIVER: Record<string, 'harness' | 'sdk'> = {
 	'image-agent.ts': 'harness',
 	'produce-agent.ts': 'harness',
 	'strategy-agent.ts': 'sdk',
-	'week-planner-agent.ts': 'harness'
+	'week-planner-agent.ts': 'sdk'
 };
 
 const loopFiles = Object.keys(LOOP_DRIVER);

--- a/src/lib/server/week-planner-agent.loop.test.ts
+++ b/src/lib/server/week-planner-agent.loop.test.ts
@@ -1,0 +1,625 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+/**
+ * CARATTERIZZAZIONE DEL GIRO DEL WEEK PLANNER.
+ *
+ * Non c'è una versione precedente da confrontare: la storia del repository è un solo commit. Il
+ * comportamento di oggi È la specifica, e questi test lo fissano PRIMA che l'orchestratore esca
+ * dal framework — la sequenza dei tool, quante volte si paga un modello, cosa finisce in
+ * `agent_runs`, cosa esce quando il giro non chiude.
+ *
+ * Il punto di aggancio è `generateText` dell'SDK, non `harnessGenerateText`: è l'unico confine
+ * che sopravvive alla riscrittura, quindi gli stessi test valgono su entrambe le implementazioni.
+ */
+
+const {
+  generateText,
+  logAiCall,
+  persistAgentRun,
+  draftWeekSeeds,
+  loadActivePlan,
+  weekMixForSpan,
+  loadBatchFeasibilityContext,
+  fetchUsdBudget,
+  groundedText,
+  loadKnownSubreddits,
+  agentSessionWrites
+} = vi.hoisted(() => ({
+  generateText: vi.fn(),
+  logAiCall: vi.fn(),
+  persistAgentRun: vi.fn(),
+  draftWeekSeeds: vi.fn(),
+  loadActivePlan: vi.fn(),
+  weekMixForSpan: vi.fn(),
+  loadBatchFeasibilityContext: vi.fn(),
+  fetchUsdBudget: vi.fn(),
+  groundedText: vi.fn(),
+  loadKnownSubreddits: vi.fn(),
+  agentSessionWrites: [] as Array<Record<string, unknown>>
+}));
+
+vi.mock('$env/dynamic/private', () => ({ env: {} }));
+
+vi.mock('ai', async () => {
+  const actual = await vi.importActual<typeof import('ai')>('ai');
+  return { ...actual, generateText };
+});
+
+vi.mock('$lib/server/llm', async () => {
+  const actual = await vi.importActual<typeof import('$lib/server/llm')>('$lib/server/llm');
+  return {
+    ...actual,
+    llmDefaultModel: () => 'gemini-3.7-flash',
+    llmLanguageModel: () => ({ modelId: 'gemini-3.7-flash' })
+  };
+});
+
+vi.mock('$lib/server/ai-log', async () => {
+  const actual = await vi.importActual<typeof import('$lib/server/ai-log')>('$lib/server/ai-log');
+  return { ...actual, logAiCall };
+});
+
+vi.mock('$lib/server/agent-runs', () => ({ persistAgentRun }));
+
+vi.mock('$lib/server/editorial-plan', () => ({ loadActivePlan, weekMixForSpan }));
+
+vi.mock('$lib/server/content-preview', () => ({ draftWeekSeeds }));
+
+vi.mock('$lib/server/rubrics-feasibility', async () => {
+  const actual =
+    await vi.importActual<typeof import('$lib/server/rubrics-feasibility')>('$lib/server/rubrics-feasibility');
+  return { ...actual, loadBatchFeasibilityContext };
+});
+
+vi.mock('$lib/server/strategy-agent', async () => {
+  const actual = await vi.importActual<typeof import('$lib/server/strategy-agent')>('$lib/server/strategy-agent');
+  return { ...actual, fetchUsdBudget };
+});
+
+vi.mock('$lib/server/strategy-agent-reads', () => ({
+  readBrandStudioForAgent: async () => ({ studio: 'brand kit' }),
+  readEditorialPlanForAgent: async () => ({ plan: 'active' }),
+  readGtmForAgent: async () => ({ gtm: 'phase 1' }),
+  readKnowledgeForAgent: async () => ({ docs: [] }),
+  readLeadsForAgent: async () => ({ leads: [] }),
+  readMediaForAgent: async () => ({ media: [] }),
+  readRubricsForAgent: async () => ({ rubrics: [] }),
+  readStrategyReportForAgent: async () => ({ report: 'none' })
+}));
+
+vi.mock('$lib/server/research', async () => {
+  const actual = await vi.importActual<typeof import('$lib/server/research')>('$lib/server/research');
+  return { ...actual, groundedText };
+});
+
+vi.mock('$lib/server/platform-hygiene', () => ({
+  loadKnownSubreddits,
+  knownSubredditsBlock: (subs: string[]) => `KNOWN SUBREDDITS: ${subs.join(', ')}`
+}));
+
+vi.mock('$lib/server/disruptive-ideas', () => ({
+  createDisruptiveIdeaTools: () => ({})
+}));
+
+vi.mock('$lib/server/supabase-admin', () => ({
+  createAdminClient: () => ({
+    from: (table: string) => ({
+      insert: (row: Record<string, unknown>) => {
+        if (table === 'agent_sessions') agentSessionWrites.push({ op: 'insert', ...row });
+        return Promise.resolve({ error: null });
+      },
+      upsert: (row: Record<string, unknown>) => {
+        if (table === 'agent_sessions') agentSessionWrites.push({ op: 'upsert', ...row });
+        return Promise.resolve({ error: null });
+      },
+      select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: null }) }) })
+    })
+  })
+}));
+
+import { MAX_WEEK_PLANNER_DRAFTS, MAX_WEEK_PLANNER_RESEARCH, MAX_WEEK_PLANNER_STEPS, runWeekPlannerAgent } from './week-planner-agent';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyRec = Record<string, any>;
+
+/** Supabase finto: qualunque catena risolve a `{ data: [] }`. I tool che leggono non sono il soggetto. */
+function stubSupabase(): AnyRec {
+  const chain: AnyRec = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        if (prop === 'then') return undefined;
+        if (prop === 'maybeSingle' || prop === 'single') return async () => ({ data: null, error: null });
+        return () => chain;
+      }
+    }
+  );
+  return { from: () => chain };
+}
+
+type ScriptedCall = { tool: string; input?: unknown };
+type DriveRecord = {
+  prepared: AnyRec[];
+  calls: Array<{ tool: string; output: unknown }>;
+  system: string;
+  prompt: string;
+  toolNames: string[];
+  meta: AnyRec;
+};
+
+/**
+ * Il giro dell'SDK, ridotto a ciò che l'orchestratore osserva: `prepareStep` prima dello step,
+ * il tool eseguito attraverso le opzioni che l'orchestratore ha davvero passato, `onStepFinish`
+ * dopo, e le `stopWhen` valutate alla fine dello step come fa l'SDK.
+ */
+function drive(script: ScriptedCall[], record: DriveRecord) {
+  return async (options: AnyRec) => {
+    record.system = String(options.system ?? '');
+    record.prompt = String(options.prompt ?? '');
+    record.toolNames = Object.keys(options.tools ?? {});
+
+    const steps: AnyRec[] = [];
+    for (const entry of script) {
+      const prepared = (await options.prepareStep?.({ stepNumber: steps.length, steps })) ?? {};
+      record.prepared.push(prepared);
+
+      const impl = options.tools?.[entry.tool];
+      const output = impl ? await impl.execute(entry.input ?? {}, {}) : { error: 'no such tool' };
+      record.calls.push({ tool: entry.tool, output });
+
+      const toolCalls = [{ toolName: entry.tool, input: entry.input ?? {}, type: 'tool-call' }];
+      const toolResults = [{ toolName: entry.tool, output, type: 'tool-result' }];
+      const usage = { inputTokens: 100, outputTokens: 40 };
+      steps.push({ toolCalls, toolResults, text: '', usage });
+      await options.onStepFinish?.({ toolCalls, toolResults, text: '', usage });
+
+      const stops = (options.stopWhen ?? []) as Array<(a: AnyRec) => boolean | Promise<boolean>>;
+      const verdicts = await Promise.all(stops.map((s) => s({ steps, stepNumber: steps.length })));
+      if (verdicts.some(Boolean)) break;
+    }
+    return { text: '', totalUsage: { inputTokens: 100 * steps.length, outputTokens: 40 * steps.length }, steps };
+  };
+}
+
+function seed(over: AnyRec = {}): AnyRec {
+  return {
+    id: 's1',
+    platform: 'instagram',
+    platforms: ['instagram'],
+    format: 'single_image',
+    media: 'image',
+    day: 'Monday',
+    time: '09:00',
+    angle: 'la delega a se stessi',
+    pillar: 'burocrazia',
+    subject: 'scrivania',
+    setting: 'ufficio',
+    props: '',
+    product: '',
+    person: '',
+    ...over
+  };
+}
+
+function feasibilityCtx(over: AnyRec = {}): AnyRec {
+  return {
+    expectedSeedCount: 1,
+    selectedPlatforms: ['instagram'],
+    products: [],
+    people: [],
+    mediaIds: new Set<string>(),
+    rubrics: [],
+    ...over
+  };
+}
+
+function baseOpts(over: AnyRec = {}): AnyRec {
+  return {
+    supabase: stubSupabase(),
+    userId: 'u1',
+    brandId: 'b1',
+    profile: { name: 'Demo Brand' },
+    platforms: ['instagram'],
+    count: 1,
+    weekIndex: 0,
+    deadlineMs: 60_000,
+    ...over
+  };
+}
+
+function newRecord(): DriveRecord {
+  return { prepared: [], calls: [], system: '', prompt: '', toolNames: [], meta: {} };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  agentSessionWrites.length = 0;
+  fetchUsdBudget.mockResolvedValue(2);
+  loadActivePlan.mockResolvedValue({ id: 'plan-1' });
+  weekMixForSpan.mockReturnValue([{ type: 'single_image', count: 1 }]);
+  loadBatchFeasibilityContext.mockResolvedValue(feasibilityCtx());
+  loadKnownSubreddits.mockResolvedValue([]);
+  draftWeekSeeds.mockResolvedValue({ theme: 'Tema', rationale: 'Perché', doDont: 'DO/DON\'T', seeds: [seed()] });
+  groundedText.mockResolvedValue({ text: 'risposta', citations: [{ title: 'Fonte', uri: 'https://esempio.it/a' }] });
+});
+
+describe('il contesto che il planner carica prima di parlare col modello', () => {
+  it('carica piano attivo e contesto di fattibilità con il conteggio e le piattaforme del batch', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(
+      drive([{ tool: 'draft_seeds', input: { brief: 'b' } }, { tool: 'finish', input: { notes: 'fatto' } }], rec)
+    );
+
+    await runWeekPlannerAgent(baseOpts({ count: 3, platforms: ['instagram', 'x'], weeks: 2 }) as never);
+
+    expect(loadActivePlan).toHaveBeenCalledWith(expect.anything(), 'b1');
+    expect(loadBatchFeasibilityContext).toHaveBeenCalledWith(
+      expect.anything(),
+      'b1',
+      expect.objectContaining({ expectedSeedCount: 3, selectedPlatforms: ['instagram', 'x'], weekIndex: 0, weeks: 2 })
+    );
+    expect(weekMixForSpan).toHaveBeenCalledWith({ id: 'plan-1' }, 0, 2);
+  });
+
+  it('non carica i subreddit quando reddit non è fra le piattaforme', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(drive([{ tool: 'finish', input: { notes: 'x' } }], rec));
+    draftWeekSeeds.mockResolvedValue({ theme: '', rationale: '', doDont: '', seeds: [seed()] });
+
+    await expect(runWeekPlannerAgent(baseOpts() as never)).rejects.toThrow();
+    expect(loadKnownSubreddits).not.toHaveBeenCalled();
+  });
+
+  it('carica i subreddit e li mette nel prompt quando reddit è fra le piattaforme', async () => {
+    const rec = newRecord();
+    loadKnownSubreddits.mockResolvedValue(['r/italia']);
+    loadBatchFeasibilityContext.mockResolvedValue(feasibilityCtx({ selectedPlatforms: ['reddit'] }));
+    draftWeekSeeds.mockResolvedValue({
+      theme: '',
+      rationale: '',
+      doDont: '',
+      seeds: [seed({ platform: 'reddit', platforms: ['reddit'], title: 'T', subreddit: 'italia' })]
+    });
+    generateText.mockImplementation(
+      drive([{ tool: 'draft_seeds', input: { brief: 'b' } }, { tool: 'finish', input: { notes: 'ok' } }], rec)
+    );
+
+    await runWeekPlannerAgent(baseOpts({ platforms: ['reddit'] }) as never);
+
+    expect(loadKnownSubreddits).toHaveBeenCalledWith(expect.anything(), 'b1');
+    expect(rec.prompt).toContain('KNOWN SUBREDDITS: r/italia');
+  });
+});
+
+describe('il tavolo dei tool offerto al modello', () => {
+  it('è esattamente questo elenco', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(
+      drive([{ tool: 'draft_seeds', input: { brief: 'b' } }, { tool: 'finish', input: { notes: 'ok' } }], rec)
+    );
+
+    await runWeekPlannerAgent(baseOpts() as never);
+
+    expect(rec.toolNames.sort()).toEqual(
+      [
+        'check_batch_feasibility',
+        'draft_seeds',
+        'finish',
+        'read_brand_studio',
+        'read_competitors',
+        'read_editorial_plan',
+        'read_gtm',
+        'read_knowledge',
+        'read_leads',
+        'read_media',
+        'read_post_history',
+        'read_rubrics',
+        'read_strategy_report',
+        'repair_seeds',
+        'research'
+      ].sort()
+    );
+  });
+});
+
+describe('il percorso che chiude', () => {
+  it('una bozza, un controllo, finish: una sola chiamata al modello di bozza', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(
+      drive(
+        [
+          { tool: 'read_rubrics', input: {} },
+          { tool: 'draft_seeds', input: { brief: 'una settimana' } },
+          { tool: 'check_batch_feasibility', input: { seeds: [{}] } },
+          { tool: 'finish', input: { notes: 'settimana pronta' } }
+        ],
+        rec
+      )
+    );
+
+    const out = await runWeekPlannerAgent(baseOpts() as never);
+
+    expect(draftWeekSeeds).toHaveBeenCalledTimes(1);
+    expect(generateText).toHaveBeenCalledTimes(1);
+    expect(out.strategy.seeds).toHaveLength(1);
+    expect(out.notes).toBe('settimana pronta');
+    expect(out.costUsd).toBeGreaterThan(0);
+    expect(rec.calls.find((c) => c.tool === 'check_batch_feasibility')?.output).toMatchObject({ ok: true });
+    expect(rec.calls.find((c) => c.tool === 'finish')?.output).toMatchObject({ ok: true });
+  });
+
+  it('registra la corsa come `finished` e logga la chiamata riuscita', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(
+      drive([{ tool: 'draft_seeds', input: { brief: 'b' } }, { tool: 'finish', input: { notes: 'ok' } }], rec)
+    );
+
+    await runWeekPlannerAgent(baseOpts() as never);
+
+    expect(persistAgentRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        brandId: 'b1',
+        agent: 'week_planner',
+        mode: 'week_0',
+        status: 'finished',
+        finishedOk: true,
+        notes: 'ok'
+      })
+    );
+    const run = persistAgentRun.mock.calls[0][0];
+    expect(run.steps).toHaveLength(2);
+    expect(run.steps[0].toolCalls[0].name).toBe('draft_seeds');
+    expect(logAiCall).toHaveBeenCalledWith(
+      expect.objectContaining({ label: 'week-planner-agent', ok: true, context: 'week-planner-agent', brandId: 'b1' })
+    );
+  });
+
+  it('lascia una riga di sessione leggibile su agent_sessions', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(
+      drive([{ tool: 'draft_seeds', input: { brief: 'b' } }, { tool: 'finish', input: { notes: 'ok' } }], rec)
+    );
+
+    await runWeekPlannerAgent(baseOpts() as never);
+
+    const finishedRow = agentSessionWrites.find((r) => r.status === 'finished');
+    expect(finishedRow).toMatchObject({ agent: 'week_planner', surface: 'batch', brand_id: 'b1', mode: '0' });
+    expect(Number(finishedRow?.event_count)).toBeGreaterThan(0);
+  });
+});
+
+describe('i tetti che proteggono il budget del batch', () => {
+  it('rifiuta la bozza oltre il tetto e non paga il modello una volta in più', async () => {
+    const rec = newRecord();
+    const script = Array.from({ length: MAX_WEEK_PLANNER_DRAFTS + 1 }, () => ({
+      tool: 'draft_seeds',
+      input: { brief: 'ancora' }
+    }));
+    generateText.mockImplementation(drive(script, rec));
+
+    await expect(runWeekPlannerAgent(baseOpts() as never)).resolves.toBeTruthy();
+
+    expect(draftWeekSeeds).toHaveBeenCalledTimes(MAX_WEEK_PLANNER_DRAFTS);
+    expect(rec.calls[MAX_WEEK_PLANNER_DRAFTS].output).toMatchObject({ error: expect.stringContaining('budget') });
+  });
+
+  it('rifiuta la ricerca oltre il tetto e non interroga il web una volta in più', async () => {
+    const rec = newRecord();
+    fetchUsdBudget.mockResolvedValue(50);
+    const script = [
+      { tool: 'draft_seeds', input: { brief: 'b' } },
+      ...Array.from({ length: MAX_WEEK_PLANNER_RESEARCH + 1 }, (_, i) => ({
+        tool: 'research',
+        input: { question: `domanda numero ${i}` }
+      }))
+    ];
+    generateText.mockImplementation(drive(script, rec));
+
+    await runWeekPlannerAgent(baseOpts() as never);
+
+    expect(groundedText).toHaveBeenCalledTimes(MAX_WEEK_PLANNER_RESEARCH);
+    const last = rec.calls[rec.calls.length - 1].output as AnyRec;
+    expect(last.error).toContain('Research budget spent');
+  });
+
+  it('si ferma dopo quattro step identici di fila, prima del tetto', async () => {
+    const rec = newRecord();
+    fetchUsdBudget.mockResolvedValue(50);
+    const script = [
+      { tool: 'draft_seeds', input: { brief: 'b' } },
+      ...Array.from({ length: 10 }, () => ({ tool: 'research', input: { question: 'sempre la stessa' } }))
+    ];
+    generateText.mockImplementation(drive(script, rec));
+
+    await runWeekPlannerAgent(baseOpts() as never);
+
+    expect(groundedText).toHaveBeenCalledTimes(4);
+  });
+
+  it('si ferma al tetto degli step', async () => {
+    const rec = newRecord();
+    const script = Array.from({ length: MAX_WEEK_PLANNER_STEPS + 5 }, (_, i) => ({
+      tool: 'read_knowledge',
+      input: { limit: (i % 30) + 1 }
+    }));
+    generateText.mockImplementation(drive(script, rec));
+
+    await expect(runWeekPlannerAgent(baseOpts() as never)).rejects.toThrow(
+      'Week planner agent finished without seeds'
+    );
+    expect(rec.calls.length).toBeLessThanOrEqual(MAX_WEEK_PLANNER_STEPS);
+  });
+});
+
+describe('il cancello di fattibilità', () => {
+  it('finish rifiuta i seed che violano ancora, e non chiude la corsa', async () => {
+    const rec = newRecord();
+    loadBatchFeasibilityContext.mockResolvedValue(feasibilityCtx({ expectedSeedCount: 3 }));
+    generateText.mockImplementation(
+      drive([{ tool: 'draft_seeds', input: { brief: 'b' } }, { tool: 'finish', input: { notes: 'chiudo' } }], rec)
+    );
+
+    const out = await runWeekPlannerAgent(baseOpts({ count: 3 }) as never);
+
+    const finish = rec.calls.find((c) => c.tool === 'finish')?.output as AnyRec;
+    expect(finish.error).toBe('Seeds still have feasibility violations');
+    expect(finish.violations.length).toBeGreaterThan(0);
+    expect(out.notes).toBe('Agent ended without finish; using last draft.');
+    expect(persistAgentRun).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'fallback', finishedOk: false, violations: expect.any(Array) })
+    );
+  });
+
+  it('chiude da solo quando il giro finisce con seed che passano', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(drive([{ tool: 'draft_seeds', input: { brief: 'b' } }], rec));
+
+    const out = await runWeekPlannerAgent(baseOpts() as never);
+
+    expect(out.notes).toBe('Auto-closed: seeds passed feasibility.');
+    expect(persistAgentRun).toHaveBeenCalledWith(expect.objectContaining({ status: 'finished', finishedOk: true }));
+  });
+
+  it('senza nessun seed la corsa fallisce e viene registrata come fallita', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(drive([{ tool: 'read_brand_studio', input: {} }], rec));
+
+    await expect(runWeekPlannerAgent(baseOpts() as never)).rejects.toThrow(
+      'Week planner agent finished without seeds'
+    );
+    expect(persistAgentRun).toHaveBeenCalledWith(expect.objectContaining({ status: 'failed', finishedOk: false }));
+  });
+});
+
+describe('una storia senza fonte letta davvero', () => {
+  const storySeed = seed({
+    format: 'carousel',
+    slide_count: 2,
+    beats: [
+      { shows: 'entra', who: 'Marco allo sportello', thinks: 'non ce la faccio' },
+      { shows: 'esce', who: 'Marco fuori', thinks: 'devo tornare' }
+    ]
+  });
+
+  it('sul ripiego toglie la storia e tiene il post', async () => {
+    const rec = newRecord();
+    draftWeekSeeds.mockResolvedValue({
+      theme: '',
+      rationale: '',
+      doDont: '',
+      seeds: [{ ...storySeed, sourced_from: 'Linee guida CNOPD' }]
+    });
+    loadBatchFeasibilityContext.mockResolvedValue(feasibilityCtx({ expectedSeedCount: 2 }));
+    generateText.mockImplementation(drive([{ tool: 'draft_seeds', input: { brief: 'b' } }], rec));
+
+    const out = await runWeekPlannerAgent(baseOpts({ count: 2 }) as never);
+
+    expect(out.notes).toBe('Agent ended without finish; using last draft.');
+    expect(out.strategy.seeds[0].beats).toBeUndefined();
+    expect(out.strategy.seeds[0].sourced_from).toBeUndefined();
+  });
+
+  it('una fonte che punta a una pagina davvero letta passa il cancello', async () => {
+    const rec = newRecord();
+    fetchUsdBudget.mockResolvedValue(50);
+    draftWeekSeeds.mockResolvedValue({
+      theme: '',
+      rationale: '',
+      doDont: '',
+      seeds: [{ ...storySeed, sourced_from: 'racconto su https://esempio.it/a' }]
+    });
+    generateText.mockImplementation(
+      drive(
+        [
+          { tool: 'research', input: { question: 'come lo raccontano?' } },
+          { tool: 'draft_seeds', input: { brief: 'b' } },
+          { tool: 'check_batch_feasibility', input: { seeds: [{}] } },
+          { tool: 'finish', input: { notes: 'storia ancorata' } }
+        ],
+        rec
+      )
+    );
+
+    const out = await runWeekPlannerAgent(baseOpts() as never);
+
+    expect(rec.calls.find((c) => c.tool === 'check_batch_feasibility')?.output).toMatchObject({ ok: true });
+    expect(out.strategy.seeds[0].beats).toHaveLength(2);
+  });
+});
+
+describe('la chiusura forzata quando il tempo o i soldi finiscono', () => {
+  it('con una bozza in mano e il deadline vicino, lo step successivo può solo chiudere', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(
+      drive([{ tool: 'draft_seeds', input: { brief: 'b' } }, { tool: 'finish', input: { notes: 'ok' } }], rec)
+    );
+
+    await runWeekPlannerAgent(baseOpts({ deadlineMs: 1_000 }) as never);
+
+    expect(rec.prepared[1]).toMatchObject({ toolChoice: { type: 'tool', toolName: 'finish' } });
+  });
+
+  it('senza niente in mano non forza la chiusura', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(
+      drive([{ tool: 'read_brand_studio', input: {} }, { tool: 'read_gtm', input: {} }], rec)
+    );
+
+    await expect(runWeekPlannerAgent(baseOpts({ deadlineMs: 1_000 }) as never)).rejects.toThrow();
+    expect(rec.prepared[1]?.toolChoice).toBeUndefined();
+  });
+
+  it('il budget di ogni step è scritto nel system che il modello vede', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(
+      drive([{ tool: 'draft_seeds', input: { brief: 'b' } }, { tool: 'finish', input: { notes: 'ok' } }], rec)
+    );
+
+    await runWeekPlannerAgent(baseOpts() as never);
+
+    expect(String(rec.prepared[0].system)).toContain('drafts_left=');
+    expect(String(rec.prepared[0].system)).toContain('time_left≈');
+  });
+});
+
+describe('il guardiano di sessione, che il framework applicava in silenzio', () => {
+  it('toglie dal tavolo un tool che ha fallito due volte di fila', async () => {
+    const rec = newRecord();
+    fetchUsdBudget.mockResolvedValue(0.001);
+    generateText.mockImplementation(
+      drive(
+        [
+          { tool: 'research', input: { question: 'a' } },
+          { tool: 'research', input: { question: 'b' } },
+          { tool: 'research', input: { question: 'c' } }
+        ],
+        rec
+      )
+    );
+
+    await expect(runWeekPlannerAgent(baseOpts() as never)).rejects.toThrow();
+
+    expect(rec.calls[0].output).toMatchObject({ error: 'USD budget too low for research' });
+    expect(rec.calls[1].output).toMatchObject({ error: 'USD budget too low for research' });
+    expect(rec.calls[2].output).toMatchObject({ blocked_by: 'steward', ran: false });
+  });
+
+  it('ricorda al modello di leggere il brand quando non lo ha ancora fatto', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(
+      drive(
+        [
+          { tool: 'read_gtm', input: {} },
+          { tool: 'read_gtm', input: {} },
+          { tool: 'draft_seeds', input: { brief: 'b' } },
+          { tool: 'finish', input: { notes: 'ok' } }
+        ],
+        rec
+      )
+    );
+
+    await runWeekPlannerAgent(baseOpts() as never);
+
+    expect(String(rec.prepared[2].system)).toContain('read_brand_studio');
+  });
+});

--- a/src/lib/server/week-planner-agent.ts
+++ b/src/lib/server/week-planner-agent.ts
@@ -1,6 +1,9 @@
 import { maxOutputTokensFor } from '$lib/server/ai-output-limits';
-import { tool, stepCountIs, type StopCondition } from 'ai';
-import { harnessGenerateText } from '$lib/server/harness';
+import { generateText, tool, stepCountIs, type StopCondition } from 'ai';
+import { createHarnessSession } from '$lib/server/harness/session';
+import { persistHarnessSession } from '$lib/server/harness/persist';
+import { wrapTools } from '$lib/server/harness/pipeline';
+import { applyStewardPrepareStep, createSessionSteward } from '$lib/server/harness/steward';
 import { z } from 'zod';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { env } from '$env/dynamic/private';
@@ -462,9 +465,10 @@ ${knownSubreddits.length ? `\n${knownSubredditsBlock(knownSubreddits)}` : ''}`;
   let loopModel = agentModel();
 
   try {
-    await withAgentFallback('week-planner-agent', (chosen, markDirty) => {
+    await withAgentFallback('week-planner-agent', async (chosen, markDirty) => {
       loopModel = chosen;
-      return harnessGenerateText({
+
+      const session = createHarnessSession({
         brandId: opts.brandId,
         userId: opts.userId,
         agent: 'week_planner',
@@ -472,55 +476,80 @@ ${knownSubreddits.length ? `\n${knownSubredditsBlock(knownSubreddits)}` : ''}`;
         model: loopModel.modelId,
         provider: loopModel.provider,
         surface: 'batch'
-      }, {
-        // Gemini 3.7 Flash by default, DeepSeek as fallback — see agentModel().
-        model: loopModel.model,
-        maxOutputTokens: maxOutputTokensFor(loopModel.provider),
-        system,
-        prompt: `${userPrompt}\n\nStart with read_rubrics and read_editorial_plan before drafting.`,
-        tools,
-        stopWhen: [
-          () => finished !== null,
-          stepCountIs(MAX_WEEK_PLANNER_STEPS),
-          stallStop,
-          () => deadlineReached(loopT0, deadlineMs)
-        ],
-        temperature: 0.35,
-        prepareStep: () => {
-          const remainingSec = Math.max(0, Math.round((deadlineMs - (Date.now() - loopT0)) / 1000));
-          const stepSystem = appendBudgetToSystem(system, budget, remainingSec);
-          if ((budget.usdRemaining <= 0 || remainingSec <= 30) && working) {
-            return { toolChoice: { type: 'tool' as const, toolName: 'finish' }, system: stepSystem };
-          }
-          return { system: stepSystem };
-        },
-        onStepFinish: ({ usage, toolCalls, toolResults, text }) => {
-          addStrategyStepCost(budget, usage, loopModel);
-          stallFingerprints.push(
-            stepFingerprint(
-              seedFingerprint(working?.seeds ?? null, budget),
-              toolCalls?.map((tc) => ({ toolName: tc.toolName, input: 'input' in tc ? tc.input : undefined }))
-            )
-          );
-          stepNum += 1;
-          stepLog.push({
-            step: stepNum,
-            toolCalls: toolCalls?.map((tc) => ({ name: tc.toolName, input: 'input' in tc ? tc.input : undefined })),
-            toolResults: toolResults?.map((tr) => ({ name: tr.toolName, output: 'output' in tr ? tr.output : undefined })),
-            text: text?.trim() || undefined
-          });
-          if (opts.verbose) {
-            console.log('\n[week-planner-agent] step');
-            for (const tc of toolCalls ?? []) {
-              console.log(`  → ${tc.toolName}`, JSON.stringify('input' in tc ? tc.input : {}, null, 2).slice(0, 1200));
+      });
+      const prompt = `${userPrompt}\n\nStart with read_rubrics and read_editorial_plan before drafting.`;
+      session.captureRequest({ system, prompt });
+
+      const steward = createSessionSteward(session, Object.keys(tools));
+      const watchedTools = wrapTools(session, tools, {
+        before: [...(steward.pipeline().before ?? []), () => { markDirty(); }]
+      });
+
+      try {
+        const result = await generateText({
+          // Gemini 3.7 Flash by default, DeepSeek as fallback — see agentModel().
+          model: loopModel.model,
+          maxOutputTokens: maxOutputTokensFor(loopModel.provider),
+          system,
+          prompt,
+          allowSystemInMessages: true,
+          tools: watchedTools,
+          stopWhen: [
+            () => finished !== null,
+            stepCountIs(MAX_WEEK_PLANNER_STEPS),
+            stallStop,
+            () => deadlineReached(loopT0, deadlineMs)
+          ],
+          temperature: 0.35,
+          prepareStep: () => {
+            const remainingSec = Math.max(0, Math.round((deadlineMs - (Date.now() - loopT0)) / 1000));
+            const stepSystem = appendBudgetToSystem(system, budget, remainingSec);
+            const step =
+              (budget.usdRemaining <= 0 || remainingSec <= 30) && working
+                ? { toolChoice: { type: 'tool' as const, toolName: 'finish' }, system: stepSystem }
+                : { system: stepSystem };
+            const patched = applyStewardPrepareStep(session, steward, step, system) ?? {};
+            session.capturePrepareStep(patched);
+            return patched;
+          },
+          onStepFinish: ({ usage, toolCalls, toolResults, text }) => {
+            session.recordStep({ usage, toolCalls, text });
+            addStrategyStepCost(budget, usage, loopModel);
+            stallFingerprints.push(
+              stepFingerprint(
+                seedFingerprint(working?.seeds ?? null, budget),
+                toolCalls?.map((tc) => ({ toolName: tc.toolName, input: 'input' in tc ? tc.input : undefined }))
+              )
+            );
+            stepNum += 1;
+            stepLog.push({
+              step: stepNum,
+              toolCalls: toolCalls?.map((tc) => ({ name: tc.toolName, input: 'input' in tc ? tc.input : undefined })),
+              toolResults: toolResults?.map((tr) => ({ name: tr.toolName, output: 'output' in tr ? tr.output : undefined })),
+              text: text?.trim() || undefined
+            });
+            if (opts.verbose) {
+              console.log('\n[week-planner-agent] step');
+              for (const tc of toolCalls ?? []) {
+                console.log(`  → ${tc.toolName}`, JSON.stringify('input' in tc ? tc.input : {}, null, 2).slice(0, 1200));
+              }
+              for (const tr of toolResults ?? []) {
+                console.log(`  ← ${tr.toolName}`, JSON.stringify('output' in tr ? tr.output : {}, null, 2).slice(0, 2000));
+              }
+              if (text?.trim()) console.log(`  · ${text.trim().slice(0, 300)}`);
             }
-            for (const tr of toolResults ?? []) {
-              console.log(`  ← ${tr.toolName}`, JSON.stringify('output' in tr ? tr.output : {}, null, 2).slice(0, 2000));
-            }
-            if (text?.trim()) console.log(`  · ${text.trim().slice(0, 300)}`);
           }
-        }
-      }, { before: [() => { markDirty(); }] });
+        });
+        session.recordAssistantText(result.text);
+        session.recordUsage(result.totalUsage ?? result.usage);
+        session.finish('finished');
+        return result;
+      } catch (e) {
+        session.finish('failed', e);
+        throw e;
+      } finally {
+        persistHarnessSession(session);
+      }
     });
 
     if (!finished && working?.seeds?.length) {


### PR DESCRIPTION
## What?

The weekly planner — the orchestrator the autopilot uses to turn an editorial plan into a
week of post seeds — no longer runs its loop through the agent framework. It calls
`generateText` from the AI SDK directly, and the three things `harnessGenerateText` was
silently adding on top are now written at the call site, in the order they happen.

Nothing else changes. Same tools, same caps, same stop conditions, same rows written, same
system prompt. Behaviour is preserved down to the character: on a live run the prompt the
model reads is 9,709 characters before and after.

Ahead of the rewrite, 21 characterization tests were written **against the existing
framework implementation** and watched pass. They hook `generateText`, not
`harnessGenerateText`, so the same 21 tests grade both implementations without a line of
difference. They pass on both. Those tests are as much the deliverable as the new code:
the repository history is a single squashed commit, so there is no earlier version to
diff against and the current behaviour *is* the specification.

This is the first of twelve. `packages/agent-*` is untouched.

## Why?

`packages/agent-*` (105,226 lines), `src/lib/agent` (23,909) and `src/lib/server/chat`
(32,031) are slated for deletion — 161,166 lines, about 31% of the repository. The
generative capabilities stay: image, carousel, thumbnail, motion and UGC production are the
differentiator, not a proprietary chat interface. So every orchestrator that goes through
the framework today has to come off it, one at a time, without a paying customer noticing.

Deletion is blocked by whoever still imports the framework. The weekly planner was one of
them, and not by choice: it wanted a session transcript, and the transcript lives behind
`$lib/server/harness`, whose index re-exports `harness/run`, which imports `chat/model` and
`chat/controller`, which imports `$lib/agent/bridge/verdict`. A batch orchestrator with no
interest in chat was pulling in chat and `$lib/agent` through the front door.

The weekly planner was picked as the first because it is the cleanest cut available: one
entry point (`runWeekPlannerAgent`), one caller (`planWeekStrategy`), a result that is a
return value rather than scattered effects (`{ strategy, notes, costUsd }`), and 594 lines
against `produce-agent.ts`'s 1,141. It also sits on the weekly autopilot's critical path,
which is where a mistake shows up immediately rather than quietly.

## How?

### What the orchestrator actually does

Read end to end first, because a framework orchestrator hides its control flow inside the
wrapper. The loop is:

1. read the brand's dollar budget (`fetchUsdBudget`), convert to credits — this feeds both
   the brief the model uses to choose the format mix and the gate that refuses a batch the
   brand could not produce;
2. load the active editorial plan and the batch feasibility context in parallel, then graft
   on the week's content mix and the caller's rubrics;
3. load known subreddits **only** when reddit is among the platforms;
4. build system + prompt and open an SDK tool loop capped at 40 steps: nine free reads
   inside the brand, `research` (max 30, paid), `draft_seeds` (max 4, each one a
   `planStrategy` model call), `check_batch_feasibility`, `repair_seeds` (max 8), `finish`;
5. per step: charge the budget, compute a fingerprint, stop after four identical steps;
6. `finish` refuses to close while the seeds still violate feasibility — it returns the
   violations instead;
7. if the loop ends without `finish`: auto-close when the seeds pass the gate, otherwise
   fall back, stripping the story from any episode whose source is not anchored to a page
   actually read this run;
8. write `agent_runs` (status, notes, steps, violations, cost) and `ai_calls`.

None of that came from the framework. The framework wrapped step 4.

### What the framework was hiding

`harnessGenerateText` calls `generateText` and appends five things. On a `batch` surface
only three exist:

| addition | live on batch? | what it does |
|---|---|---|
| session transcript → `agent_sessions` | **yes** | the row the Usage page shows the customer |
| session steward | **yes** | deterministic, not a second model: drops a tool that failed twice in a row, reminds the model to read the brand |
| per-step system patch | **yes** | carries the steward's notes into what the model reads |
| shadow controller | no | `controllerEnabled` requires `surface === 'chat'` |
| forced first tool call | no | `forcedFirstStepTools` requires `surface === 'chat'` |

The last two were read line by line before being left behind, not assumed inert.

So the rewrite did not have to reinvent a loop — the loop was always the SDK's. It removed
the wrapper and wrote the three live additions where the loop is. The file is 29 lines
longer and has nothing implicit left in it.

### The alternative that was rejected

Collapsing the agentic loop into a linear pipeline — load context, call `planStrategy`,
check feasibility, repair — would have been a smaller file and a cheaper run. It was
rejected because it is not behaviour-preserving: the `research` tool is what grounds a
narrative carousel, and `stripUngroundedStories` deletes any story whose source is not in
the set of pages the run actually read. A pipeline with no research would ship every
narrative episode with its story stripped. That is a product regression wearing a
refactor's clothes, and it belongs in a product decision, not in this PR.

### Where the transcript comes from now

`harness/session`, `harness/persist`, `harness/pipeline` and `harness/steward` — 1,030
lines — import neither chat nor `$lib/agent`. `harness/index` does, because it re-exports
`harness/run`. Importing the four leaves instead of the index removes the edge and keeps
the Usage page intact at zero cost. These four are not in the 161,166 lines slated for
deletion.

A test holds it (`nested-agents.test.ts`): a future tidy-up collapsing four leaf imports
back to the index is exactly how the chat edge would silently return.

### Commits

Reordering is kept separate from behaviour change, and there is no behaviour change here:

1. `b05e145` — the 21 characterization tests, passing against the framework implementation.
2. `45b8d80` — the rewrite plus the guard tests.
3. `d773b62` — the internal changelog.

## Testing?

### Targeted, locally

Only the files this PR touches. The full suite and Playwright are delegated to CI
(`.github/workflows/ci.yml` runs `npx vitest run` plus Playwright on every pull request);
re-running 583 test files locally would pay for the same work twice. `npm run check` was
not run either — this PR touches no `.svelte` file and no shared type, only server code
whose own tests are below.

```
$ npx vitest run src/lib/server/week-planner-agent.loop.test.ts \
    src/lib/server/week-planner-agent.test.ts \
    src/lib/server/nested-agents.test.ts

 ✓ src/lib/server/nested-agents.test.ts (12 tests) 23ms
 ✓ src/lib/server/week-planner-agent.test.ts (8 tests) 10ms
 ✓ src/lib/server/week-planner-agent.loop.test.ts (21 tests) 586ms

 Test Files  3 passed (3)
      Tests  41 passed (41)
```

The same 21 loop tests were run against the previous implementation first (commit
`b05e145`, before the rewrite existed): `21 passed`. That is the whole point of hooking
the SDK rather than the wrapper.

### What the 21 pin

The context loaded before the model is spoken to; the exact tool table; the draft and
research caps *and that neither pays a model one time more*
(`expect(draftWeekSeeds).toHaveBeenCalledTimes(1)`, `toHaveBeenCalledTimes(MAX_…)`); the
stall detector at four identical steps; the feasibility gate refusing to close; the
auto-close and fallback notes; the rows written to `agent_runs` and `agent_sessions`; the
forced close when time or money runs out; and the session steward's block after two
consecutive tool failures.

### Live, against the local stack

Real model (`google/gemini-3.8-flash`), real local Supabase, brand `demo`, two seeds, one
week. Run twice: once on this branch, once on `HEAD~1` (the framework implementation) with
the identical script, to compare what actually reaches `ai_calls`.

| | this branch | `HEAD~1` (framework) |
|---|---|---|
| `week-planner-agent` loop calls | **1** | **1** |
| loop tokens in / out | 69,554 / 3,699 | 71,467 / 3,711 |
| `agent_runs` | `finished`, `finished_ok=t`, 10 steps | `finished`, `finished_ok=t`, 9 steps |
| `agent_sessions` | `finished`, `batch`, 55 events | `finished`, `batch`, 53 events |
| `system_prompt` length | 9,709 | 9,709 |
| seeds produced | 2 (1 carousel with a sourced story) | 2 |

One loop call each. The rewrite adds no model call. The runs differ in which *primitives*
the model chose to reach for — this branch's run called `draft_seeds` (→ `planStrategy` +
`reviewSeeds`), the baseline's run wrote its seeds inline through `finish` — and that is
model non-determinism between two runs, not a code difference. The deterministic proof that
spend is unchanged is in the tests, which count the calls exactly.

### Schema

`agent_sessions` and `agent_runs` were checked against the live schema for CHECK
constraints before writing anything:

```
$ select conname, pg_get_constraintdef(oid) from pg_constraint
    where conrelid='public.agent_sessions'::regclass and contype='c';
(0 rows)
$ … 'public.agent_runs' …
(0 rows)
```

No CHECK constraints on either table — and the rewrite writes no new value in any case:
`agent: 'week_planner'`, `surface: 'batch'` and the status vocabulary all come through
unchanged code.

### Not tested, and why

- **The full suite ran only in CI**, by policy — see above.
- **No browser evidence.** This is server-side orchestration with no UI surface of its own.
  The one customer-visible artefact — the `agent_sessions` row the Usage page lists — was
  verified directly in the database instead, and is identical in shape before and after.
- **`npm run eval:durability` was not run.** It costs real money and this machine is not a
  reliable bench in its current state. **It should be run before merge**: this PR touches an
  orchestrator that persists work, which is exactly what those scenarios measure.
- **The `withAgentFallback` retry path is untested.** `agentFallbackModel()` returns `null`
  unconditionally today, so the retry is unreachable in both implementations. Unchanged
  here.

<details>
<summary>Import graph, measured (transitive BFS resolving <code>$lib</code>, relative and <code>@anomalia/*</code>, 218 modules visited)</summary>

**Before**, `src/lib/server/week-planner-agent.ts`:

```
REACH src/lib/server/chat/model.ts
   via week-planner-agent.ts -> harness/index.ts -> harness/run.ts -> chat/model.ts
REACH src/lib/server/chat/controller.ts
   via week-planner-agent.ts -> harness/index.ts -> harness/run.ts -> chat/controller.ts
```

**After** — the file's own edge is gone; what remains arrives through `strategy-agent.ts`,
which still imports `$lib/server/harness` for its own loop and is next in the queue:

```
REACH src/lib/server/chat/model.ts
   via week-planner-agent.ts -> strategy-agent.ts -> harness/index.ts -> harness/run.ts -> chat/model.ts
```

Two further reaches are unrelated to the framework and untouched by this PR:
`credits → scheduler → agent-turns → chat/queue`, and
`brand-context → design-* → motion-video → chat/artifacts`. They are infrastructure
coupling, to be untangled when chat itself comes down.
</details>

<details>
<summary>Live run output, this branch</summary>

```
=== RESULT ===
ms        167696
costUsd   0.068
theme     Il banco di lavoro rivelato attraverso gli strumenti essenziali che ne determinano la precisione quotidiana.
seeds     2
  - instagram single_image Tuesday 09:30 :: Lo strumento chiave del banco: le macine piane in acciaio da 64mm…
  - instagram carousel Friday 14:15 :: La pioggia fuori e la prima estrazione che esce a filo…

agent_sessions [{"agent":"week_planner","mode":"0","surface":"batch","status":"finished",
                 "model":"google/gemini-3.8-flash","provider":"llm","event_count":55,"error":null}]
```

```
 agent        | mode   | status   | finished_ok | cost_usd_estimate | steps
 week_planner | week_0 | finished | t           | 0.068             | 10
```
</details>

## Anything Else?

- **What still depends on the framework, without rounding.** `packages/agent-*` (five
  packages) is imported directly by 37 non-test files in `src/lib` — nearly all of
  `src/lib/agent`, plus `chat/action-approval`, `chat/model-preference`, `chat/persistence`,
  `chat/thread-events`, `server/agent-kit-effects-store`, `server/sandbox`,
  `chat-model-policy`, `chat-tiers`, `models/catalog`, `thread-cursor`. The eleven
  orchestrators still on it: `director.ts`, `produce-agent.ts`, `strategy-agent.ts`,
  `seo-agent.ts`, `image-agent.ts`, `analytics-review-agent.ts`, `media-generator/agent.ts`,
  `media-generator/ugc-agent.ts`, `media-generator/ugc-plan-agent.ts`,
  `motion-video/agent.ts`, `sandbox.ts` — plus `agent-base.ts`, `craft-model.ts`,
  `harness-skills.ts`, `agent-kit-effects-store.ts` and all of chat.

- **The census number does not move, and that is worth saying plainly.** "Files in
  `src/lib/server` importing `$lib/agent/`, `@anomalia/agent-*` or `server/harness`" is 27
  non-test files before and after: `week-planner-agent.ts` stays in it because it imports
  four modules under `harness/`. What changed is the *edge*, not the count — it no longer
  imports the index and no longer reaches chat or `$lib/agent` on its own account. That
  census should be redone per module rather than per prefix once the twelve are finished.

- **The recipe for the remaining eleven** is written out in
  `changelog/2026-09-04-week-planner-off-the-kit.md`. In short: measure the import edge
  first and separate what the file owns from what shared infrastructure drags in; read the
  loop and write it down before moving it; hook the tests to the SDK and watch them pass on
  the old code first; count model calls in the tests, because that is the only way to prove
  spend did not move without paying twice to find out; re-derive which framework additions
  are inert on *your* surface rather than copying this conclusion; take the harness leaves,
  not the index; put the constraint in a test, not a comment.

- **`strategy-agent.ts` is the natural next one.** It is what still holds the weekly planner
  in, and with it go `agentModel`, `withAgentFallback` and the budget arithmetic four
  orchestrators share.

- **No public changelog**, deliberately. A customer cannot observe any difference — same
  seeds, same rows, same prompt, one loop call. Claiming otherwise would be false. If a
  later orchestrator in this series *is* observable, that is a signal the rewrite is not
  behaviour-preserving and should be treated as a defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
