### PR TITLE
Read the IPv4 an IPv6 carries inside it

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -781,3 +781,33 @@ la prova che il difetto non è tuo, salva le modifiche in una patch
 (`git diff > /tmp/x.patch`, mai `git stash`), ripristina i sorgenti, riesegui: se fallisce anche
 senza le tue modifiche, è ambiente. Il timeout del `beforeAll` scritto nel file vince sul flag
 `--hookTimeout` della CLI, quindi per una diagnosi va alzato nel file e rimesso subito dopo.
+
+## Un IPv6 può portarsi dentro un IPv4, e il divieto va all'indirizzo dentro
+
+**Segnale.** Un classificatore di indirizzi privati che tratta l'IPv6 per come *comincia* —
+`::1`, `^f[cd]`, `^fe[89ab]` — e l'IPv4 con le sue regole, senza che i due si parlino. Provalo
+con `::ffff:127.0.0.1`: se risponde "pubblico", il buco c'è.
+
+**Cosa succede.** `::ffff:127.0.0.1` (mapped), `2002:7f00:1::` (6to4) e `64:ff9b::7f00:1` (NAT64)
+sono tutti modi di scrivere `127.0.0.1` dentro un IPv6, e l'indirizzo che viene chiamato davvero è
+quello dentro. `dns.lookup(host, { all: true })` restituisce i record **AAAA verbatim**, quindi la
+forma arriva alla guardia esattamente così: basta un AAAA su un nome pubblico. La forma con le
+parentesi è rifiutata solo perché `URL.hostname` le tiene e la risoluzione fallisce — un rifiuto
+per **effetto collaterale**, che sparisce il giorno che qualcuno normalizza l'hostname.
+
+**Mossa.** Estrai l'IPv4 incapsulato e rimandalo alle regole IPv4, invece di allungare la lista
+dei prefissi vietati: una lista si allunga a ogni forma nuova, e la forma nuova la scopri dopo che
+ti è passata davanti. Espandi il `::` e leggi gli hextet per posizione — `::ffff:7f00:1` e
+`0:0:0:0:0:ffff:7f00:1` sono lo stesso indirizzo e una regex sul prefisso ne vede uno solo.
+Un IPv4 pubblico incapsulato deve restare pubblico: la regola è quella dell'IPv4, non un divieto
+sul prefisso.
+
+**E il test giusto non è quello del classificatore.** Quello prova la funzione; la proprietà che
+conta è che `assertPublicUrl` rifiuti un host il cui **AAAA** è una di quelle forme — con
+`lookup` sostituito perché restituisca `family: 6`. È il test che resta vero anche se domani il
+rifiuto smettesse di arrivare dal ramo che lo produce oggi.
+
+**Corollario generale.** Quando un rifiuto arriva "per fortuna" da un ramo diverso da quello che
+dovrebbe produrlo (qui: «could not resolve» invece di «non è pubblico»), non è protezione: è una
+coincidenza con la data di scadenza. Fissala in un test che nomina la proprietà, non il
+meccanismo.

--- a/changelog/2026-09-04-ipv6-mapped-private.md
+++ b/changelog/2026-09-04-ipv6-mapped-private.md
@@ -1,0 +1,74 @@
+# `isPrivateAddress` leggeva il prefisso IPv6 e non l'IPv4 che ci stava dentro
+
+La guardia SSRF di `tool-guard.ts` — `assertPublicUrl`, e quindi `safeFetchUrl` e
+`fetchFollowingGatedRedirects` — risolve l'host e rifiuta gli indirizzi che non stanno
+sull'internet pubblica. Il classificatore che decide *cosa* è privato aveva un buco suo.
+
+## Il difetto
+
+`isPrivateAddress` trattava un IPv6 solo per come comincia: `::1`, `fc00::/7`, `fe80::/10`. Ma un
+IPv6 sa **portarsi dentro** un IPv4, e l'indirizzo che il kernel chiama alla fine è quello dentro,
+non il prefisso davanti:
+
+| Forma | Cosa contiene | Prima |
+|---|---|---|
+| `::ffff:127.0.0.1` | loopback, mappato | `false` |
+| `::ffff:169.254.169.254` | metadata service, mappato | `false` |
+| `::ffff:10.0.0.1` | rete privata, mappata | `false` |
+| `2002:7f00:1::` | loopback via 6to4 | `false` |
+| `64:ff9b::7f00:1` | loopback via NAT64 | `false` |
+
+`assertPublicUrl` chiama `lookup(host, { all: true })`, che restituisce i record **AAAA così come
+sono**. Un nome pubblico con un AAAA di `::ffff:127.0.0.1` passava la guardia e apriva la
+connessione sul loopback. La forma con le parentesi (`https://[::ffff:127.0.0.1]/`) era già
+rifiutata, ma **per caso**: `URL.hostname` tiene le parentesi, la risoluzione fallisce, e a
+rispondere è il ramo «could not resolve». Un domani che qualcuno normalizzasse l'hostname, la
+guardia si sarebbe aperta in silenzio — quindi la proprietà ora sta in un test, indipendente dal
+meccanismo che oggi la produce.
+
+Nessuno ha dimostrato un bypass vivo end-to-end: non è stato trovato un DNS wildcard pubblico che
+serva quei record AAAA. Il buco nel classificatore è verificato; lo sfruttamento resta non provato.
+Non cambia cosa fare: un classificatore che sbaglia è da riparare prima che qualcuno trovi il
+record, non dopo.
+
+## Perché era raggiungibile
+
+Chi passa da questa guardia oggi su `dev` prende l'URL da uno **sconosciuto** o da un **modello**,
+che è la differenza fra un difetto teorico e uno raggiungibile:
+
+- `/start/preview` — l'anteprima pre-login, aperta a chiunque sia su internet;
+- i nove tool gratuiti sotto `/api/tools/*`, via `safeFetchUrl` — stesso ingresso, nessuna sessione;
+- `traceRedirects`, che il redirect-checker cammina hop per hop;
+- i tre archiviatori che scaricano un URL remoto e lo depositano — il logo del brand scelto da un
+  tool della chat, l'archivio immagini, l'archivio dei media di mercato — portati su questa stessa
+  guardia dalla #209, dentro la #199, ora su `dev`;
+- `importBrandMediaFromUrl`, l'import media di un agente esterno.
+
+Il classificatore è l'unico pezzo che nessuna di quelle PR ha toccato: quelle hanno spostato i
+chiamanti sulla guardia giusta, questa ripara la guardia.
+
+## La riparazione
+
+L'IPv4 incapsulato viene estratto e **rimandato alle regole IPv4**, che sono già quelle giuste.
+Non una lista di prefissi vietati in più — una lista si allunga a ogni forma nuova e la forma nuova
+la scopri quando ti è già passata davanti:
+
+- **mappato e compatible** — `::ffff:x.x.x.x`, `::ffff:7f00:1`, `::x.x.x.x`;
+- **6to4** — `2002:<v4>::`, dove l'IPv4 sta nei due hextet dopo il prefisso;
+- **NAT64** — `64:ff9b::<v4>`, nella forma con i punti e in quella esadecimale.
+
+Serviva espandere il `::` per leggere gli hextet per posizione: `::ffff:7f00:1` e
+`0:0:0:0:0:ffff:7f00:1` sono lo stesso indirizzo, e una regex sul prefisso ne vede uno solo.
+
+Un IPv4 **pubblico** incapsulato resta pubblico (`::ffff:8.8.8.8` → `false`): la regola applicata
+è quella dell'IPv4, non un divieto sul prefisso. E le forme degeneri falliscono chiuse —
+`2002::`, `64:ff9b::` e `::ffff:0:0` contengono `0.0.0.0`, che è già privato.
+
+Aggiunto anche lo strip della zone id (`fe80::1%eth0`), che il resolver può restituire.
+
+## Cosa dice il changelog pubblico
+
+Una riga sola: un link che il cliente porta dentro — un'immagine importata, un sito analizzato —
+viene controllato sull'indirizzo su cui il nome risolve, in IPv6 come già in IPv4. Non nomina quali
+forme venivano lette male: è un dettaglio utile solo a chi lo volesse usare. L'entry del 2026-09-03
+aveva già promesso la stessa cosa per i chiamanti; questa la rende vera anche in IPv6.

--- a/src/lib/content/changelog/2026-09-04-ipv6-mapped-private.ts
+++ b/src/lib/content/changelog/2026-09-04-ipv6-mapped-private.ts
@@ -1,0 +1,11 @@
+import type { ChangelogEntry } from './index';
+
+const entry: ChangelogEntry = {
+  date: '2026-09-04',
+  title: 'Links you bring in are checked in IPv6 too',
+  items: [
+    'A link you bring into Anomalia — a picture you import, a site you analyse — is now checked against the address it really resolves to in IPv6 as well, so anything that is not on the public internet is turned away there too.'
+  ]
+};
+
+export default entry;

--- a/src/lib/server/tool-guard.test.ts
+++ b/src/lib/server/tool-guard.test.ts
@@ -5,7 +5,7 @@ vi.mock('$env/dynamic/private', () => ({ env: { SUPABASE_SERVICE_ROLE_KEY: 'test
 vi.mock('node:dns/promises', () => ({ lookup: vi.fn() }));
 
 import { lookup } from 'node:dns/promises';
-import { isPrivateAddress, safeFetchBytes } from './tool-guard';
+import { assertPublicUrl, isPrivateAddress, safeFetchBytes } from './tool-guard';
 
 describe('isPrivateAddress', () => {
   it('blocks every range an SSRF payload would aim at', () => {
@@ -34,6 +34,64 @@ describe('isPrivateAddress', () => {
     expect(isPrivateAddress('169.253.0.1')).toBe(false);
     expect(isPrivateAddress('100.63.0.1')).toBe(false);
     expect(isPrivateAddress('2606:4700::1111')).toBe(false);
+  });
+
+  /**
+   * IPv6 sa portarsi dentro un indirizzo IPv4 — mappato, 6to4, NAT64 — e quello che il kernel
+   * chiama alla fine è l'IPv4 dentro, non il prefisso davanti. Leggere solo il prefisso dichiara
+   * `::ffff:127.0.0.1` pubblico e apre una connessione sul loopback.
+   */
+  it('legge l IPv4 incapsulato in un IPv6, invece del prefisso che lo veste', () => {
+    expect(isPrivateAddress('::ffff:127.0.0.1')).toBe(true);
+    expect(isPrivateAddress('::ffff:10.0.0.1')).toBe(true);
+    expect(isPrivateAddress('::ffff:169.254.169.254')).toBe(true);
+    expect(isPrivateAddress('::ffff:192.168.1.1')).toBe(true);
+    // La stessa cosa scritta in esadecimale, che è come il resolver la restituisce.
+    expect(isPrivateAddress('::ffff:7f00:1')).toBe(true);
+    expect(isPrivateAddress('0:0:0:0:0:ffff:a9fe:a9fe')).toBe(true);
+    // IPv4-compatible, deprecato ma ancora accettato da chi risolve.
+    expect(isPrivateAddress('::127.0.0.1')).toBe(true);
+    expect(isPrivateAddress('2002:7f00:1::')).toBe(true); // 6to4
+    expect(isPrivateAddress('2002:a9fe:a9fe::')).toBe(true); // 6to4 sul metadata service
+    expect(isPrivateAddress('64:ff9b::7f00:1')).toBe(true); // NAT64
+    expect(isPrivateAddress('64:ff9b::127.0.0.1')).toBe(true);
+  });
+
+  it('un IPv4 pubblico incapsulato resta pubblico: la regola è quella dell IPv4, non il divieto del prefisso', () => {
+    expect(isPrivateAddress('::ffff:8.8.8.8')).toBe(false);
+    expect(isPrivateAddress('::ffff:0808:0808')).toBe(false);
+    expect(isPrivateAddress('2002:0808:0808::')).toBe(false);
+    expect(isPrivateAddress('64:ff9b::8.8.8.8')).toBe(false);
+  });
+});
+
+/**
+ * La proprietà che conta davvero: il resolver restituisce i record AAAA così come sono, quindi un
+ * nome pubblico con un AAAA `::ffff:127.0.0.1` arriva alla guardia in quella forma. Se il
+ * classificatore lo chiama pubblico, la guardia apre la connessione al loopback.
+ */
+describe('assertPublicUrl davanti a un AAAA che incapsula un indirizzo privato', () => {
+  const resolvesTo = (address: string, family: number) => {
+    vi.mocked(lookup).mockImplementation((async () => [{ address, family }]) as never);
+  };
+
+  it.each([
+    ['il loopback mappato', '::ffff:127.0.0.1'],
+    ['il metadata service mappato', '::ffff:169.254.169.254'],
+    ['una rete privata in 6to4', '2002:c0a8:101::'],
+    ['il loopback via NAT64', '64:ff9b::7f00:1']
+  ])('rifiuta un host il cui AAAA è %s', async (_label, address) => {
+    resolvesTo(address, 6);
+
+    await expect(assertPublicUrl(new URL('https://cdn.example.com/a.png'))).rejects.toThrow(
+      /not reachable/i
+    );
+  });
+
+  it('lascia passare un AAAA davvero pubblico', async () => {
+    resolvesTo('2606:4700::1111', 6);
+
+    await expect(assertPublicUrl(new URL('https://cdn.example.com/a.png'))).resolves.toBeUndefined();
   });
 });
 

--- a/src/lib/server/tool-guard.ts
+++ b/src/lib/server/tool-guard.ts
@@ -158,11 +158,63 @@ export function isPrivateAddress(ip: string): boolean {
     if (a >= 224) return true; // multicast / reserved
     return false;
   }
-  const v6 = ip.toLowerCase().replace(/^\[|\]$/g, '');
+  const v6 = ip.toLowerCase().replace(/^\[|\]$/g, '').split('%')[0];
   if (v6 === '::1' || v6 === '::') return true;
   if (/^f[cd]/.test(v6)) return true; // unique-local
   if (/^fe[89ab]/.test(v6)) return true; // link-local
-  return false;
+
+  // An IPv6 address can carry an IPv4 one inside it, and the address finally dialled is that
+  // IPv4 one — so it has to face the IPv4 rules above. Reading only the prefix calls
+  // ::ffff:127.0.0.1 public and then opens a connection to loopback. `lookup` returns AAAA
+  // records verbatim, so this is a form a hostname can genuinely deliver.
+  const inner = embeddedIpv4(v6);
+  return inner ? isPrivateAddress(inner) : false;
+}
+
+/** The 8 hextets of an IPv6 address, `::` expanded. Null when it is not one. */
+function hextetsOf(v6: string): string[] | null {
+  const halves = v6.split('::');
+  if (halves.length > 2) return null;
+
+  const left = halves[0] ? halves[0].split(':') : [];
+  if (halves.length === 1) return left.length === 8 ? left : null;
+
+  const right = halves[1] ? halves[1].split(':') : [];
+  const gap = 8 - left.length - right.length;
+  if (gap < 0) return null;
+
+  return [...left, ...Array(gap).fill('0'), ...right];
+}
+
+function quadOf(high: string, low: string): string {
+  const h = parseInt(high, 16);
+  const l = parseInt(low, 16);
+  if (!Number.isFinite(h) || !Number.isFinite(l)) return '';
+  return `${(h >> 8) & 255}.${h & 255}.${(l >> 8) & 255}.${l & 255}`;
+}
+
+/**
+ * The IPv4 address embedded in an IPv6 one, in every shape a resolver can hand back: mapped and
+ * compatible (`::ffff:127.0.0.1`, `::ffff:7f00:1`, `::127.0.0.1`), 6to4 (`2002:7f00:1::`) and
+ * NAT64 (`64:ff9b::7f00:1`).
+ */
+function embeddedIpv4(v6: string): string | null {
+  const dotted = v6.match(/(?:^|:)((?:\d{1,3}\.){3}\d{1,3})$/);
+  if (dotted) return dotted[1];
+
+  const parts = hextetsOf(v6);
+  if (!parts) return null;
+
+  const value = (hextet: string) => parseInt(hextet, 16);
+  const leadingZeros = parts.slice(0, 5).every((p) => value(p) === 0);
+
+  if (leadingZeros && (value(parts[5]) === 0xffff || value(parts[5]) === 0)) {
+    return quadOf(parts[6], parts[7]) || null;
+  }
+  if (value(parts[0]) === 0x64 && value(parts[1]) === 0xff9b) return quadOf(parts[6], parts[7]) || null;
+  if (value(parts[0]) === 0x2002) return quadOf(parts[1], parts[2]) || null;
+
+  return null;
 }
 
 /**


### PR DESCRIPTION
## What?

`isPrivateAddress` in `src/lib/server/tool-guard.ts` judged an IPv6 address by how it *starts* —
`::1`, `fc00::/7`, `fe80::/10` — and an IPv4 by its own rules, with no bridge between the two. So
every form that carries an IPv4 *inside* an IPv6 came back **public**:

| Form | What it contains | Before | After |
|---|---|---|---|
| `::ffff:127.0.0.1` | loopback, mapped | `false` | `true` |
| `::ffff:10.0.0.1` | private network, mapped | `false` | `true` |
| `::ffff:169.254.169.254` | cloud metadata, mapped | `false` | `true` |
| `2002:7f00:1::` | loopback via 6to4 | `false` | `true` |
| `64:ff9b::7f00:1` | loopback via NAT64 | `false` | `true` |
| `::ffff:8.8.8.8` | a **public** IPv4, mapped | `false` | `false` |

This PR sends the embedded IPv4 back through the IPv4 rules, adds the tests that name the property,
an internal changelog, a public changelog line and a `LESSONS.md` entry. Five files, no call site
changed.

**Be precise about the claim.** The classifier hole is verified directly against the module. A live
end-to-end bypass was **not** demonstrated: no public wildcard DNS was found serving those AAAA
records, and faking one by editing `/etc/hosts` was refused. So the wrong classification is proven,
the exploitation is not. That does not change what to do — a classifier that answers wrongly gets
repaired before someone finds the record, not after.

## Why?

`assertPublicUrl` resolves the host with `lookup(host, { all: true })` and refuses when any resolved
address is private. `lookup` returns **AAAA records verbatim**, so `::ffff:127.0.0.1` is a shape a
hostname can genuinely deliver to the guard — and the guard would then have opened the connection to
loopback.

What makes this reachable rather than theoretical is who hands the guard its URL: a **stranger** or a
**model**. Everything below is behind `assertPublicUrl` on `dev` today:

- `/start/preview` — the pre-login guest preview, open to anyone on the internet, no session;
- the nine free tools under `/api/tools/*` (meta-tags, sitemap-analyzer, robots-tester,
  schema-validator, heading-audit, broken-links, redirect-checker and the two llms-txt ones), through
  `safeFetchUrl`;
- `traceRedirects`, which the redirect-checker walks hop by hop;
- the three archivers `#209` moved onto `safeFetchBytes` — `storeBrandLogoFromUrl` (the logo a chat
  tool picks), `archiveImageToBucket`, `archiveMarketMedia`;
- `importBrandMediaFromUrl`, the external-agent media import.

The bracketed literal (`https://[::ffff:127.0.0.1]/`) was already refused, but **by accident**:
`URL.hostname` keeps the brackets, resolution fails, and the branch that answers is «could not
resolve». A refusal arriving from a branch other than the one that should produce it is not
protection, it is a coincidence with an expiry date — the day someone normalises the hostname it
disappears in silence. The property therefore now lives in a test on `assertPublicUrl` itself,
independent of the mechanism that produces it today.

## How?

**The embedded IPv4 is extracted and sent back through the IPv4 rules**, rather than lengthening a
list of banned prefixes. A list grows one form at a time, and you discover the new form after it has
already walked past you; the IPv4 rules are already the right ones and there is one copy of them.

Three shapes a resolver can hand back are recognised:

- **mapped and compatible** — `::ffff:x.x.x.x`, `::ffff:7f00:1`, `::x.x.x.x`;
- **6to4** — `2002:<v4>::`, the IPv4 in the two hextets after the prefix;
- **NAT64** — `64:ff9b::<v4>`, dotted and hexadecimal alike.

`::` is expanded so hextets can be read by position: `::ffff:7f00:1` and `0:0:0:0:0:ffff:7f00:1` are
the same address, and a regex on the prefix sees only one of them. The zone id (`fe80::1%eth0`),
which a resolver can return, is stripped.

**An embedded PUBLIC IPv4 stays public** — the rule applied is the IPv4 one, not a ban on the prefix,
so `::ffff:8.8.8.8` and `2002:0808:0808::` still pass. Degenerate forms fail closed: `2002::`,
`64:ff9b::` and `::ffff:0:0` contain `0.0.0.0`, which the IPv4 rules already call private.

### Which branch this depends on — none

This work was originally branched on top of **#209** (`fix/url-fetch-ssrf`), which was merged into
**#199** (`feat/external-agent-media-import`). Both have since landed on `dev`, and this branch is
now rebased directly onto `dev` with **no dependency on any open PR**.

It would not have needed them anyway: those two moved the *callers* onto the strong guard; this one
repairs the *guard*. `isPrivateAddress` is the single piece neither touched. The two halves compose —
now that the archivers are on `safeFetchBytes`, they inherit this fix for free.

### What got stricter, and what it could break

A hostname whose AAAA record is a mapped / 6to4 / NAT64 form of a private IPv4 is now refused where
it previously passed. Nothing legitimate is expected to sit there. One honest edge, checked rather
than assumed:

- an address like `2001:db8::192.168.1.1` — an ordinary IPv6 whose low 32 bits happen to be written
  in dotted form — is now read as `192.168.1.1` and refused. It fails **closed**, which is the right
  side for a guard, and the shape is vanishingly rare in a real AAAA record. `2001:db8::1` and
  `2606:4700::1111` are unaffected.

**No scheme policy changed here.** `http` remains accepted exactly where it was accepted before —
`storeBrandLogoFromUrl` still takes it, because an onboarding logo comes off the brand's own site and
plaintext sites are common enough that refusing them would break onboarding to close a hole that
resolving the address closes anyway. `importBrandMediaFromUrl` still demands `https-only`. That
policy is a **parameter of the guard** (`UrlScheme`), not an `if` at the call site, so the redirect
chain obeys it too; it shipped in #209 and this PR does not touch it.

## Testing?

Written test-first and **watched fail**. With `src/lib/server/tool-guard.ts` restored to
`origin/dev` and the new tests in place, `tool-guard.test.ts` reports `5 failed | 6 passed` — the
IPv6 classifier case and the four `assertPublicUrl` cases. With the fix, `11 passed`.

The test that carries the weight is not the classifier one. It is on `assertPublicUrl`, with
`node:dns/promises` stubbed to answer `family: 6` with the address under examination — the property
survives even if tomorrow the refusal stopped coming from the branch that produces it today. A
genuinely public AAAA (`2606:4700::1111`) is asserted to still pass, so the test cannot go green by
refusing everything.

**Targeted tests run locally** — the touched file's own tests plus everything that imports the guard:

| Command | Result |
|---|---|
| `npx vitest run tool-guard.test.ts media-fetch-guard.test.ts media-import.test.ts changelog/index.test.ts` | 4 files, **56 passed**, exit 0 |
| the same, with `tool-guard.ts` reverted to `origin/dev` | **5 failed \| 6 passed** (the red step) |
| `npx tsc --noEmit` scoped to the three touched `.ts` files (+ SvelteKit ambient types) | 30 errors, **all 30 in `src/lib/content/changelog/legacy.ts`**, a pre-existing file this PR does not touch. **Zero in the touched files.** |
| `git diff --check` | clean |

`media-fetch-guard.test.ts` and `media-import.test.ts` are the ones that matter beyond the unit: they
already cover, per migrated call site, a public hostname that **resolves** to a private address, a
redirect that walks into a private address, an oversized body with a lying `Content-Length` and with
none, the `https-only` refusal of a redirect down to `http`, and the happy path storing the file.
This PR keeps them green while making the address classifier they lean on correct.

**The full suite is delegated to CI** (`.github/workflows/ci.yml` runs `npx vitest run` plus
Playwright on every PR). It was run green locally on two earlier bases of this same diff
(`6522 passed | 11 skipped`, then `6541 passed | 11 skipped`), but not re-run on this final base:
nine agents share this machine and it is in swap, so re-running 590 test files locally pays for the
same work ten times.

`npm run check` was not re-run on the final base either. One complete run earlier on the identical
diff reported `COMPLETED 10509 FILES 373 ERRORS 248 WARNINGS 173 FILES_WITH_PROBLEMS` — the repo's
existing baseline; later attempts to capture its per-file breakdown were killed by memory pressure,
so the per-file proof above comes from the scoped `tsc --noEmit` instead. **Both were run — this says
which produced which number.**

**Not tested, and why.** No browser verification. The CLAUDE.md browser gate is for changes visible in
the interface; this diff is SSRF/network — a predicate inside a server-side guard, observable only as
a refusal — so a browser proves nothing the unit tests do not already prove, and the unit tests are
the better evidence. Nothing was run against a live host resolving to a mapped private address,
because no such public record was found; that is the same limitation as the claim at the top,
repeated so it is not read as an omission.

## Evidence (screenshots/videos)

No UI changed, so there is nothing to screenshot. The evidence is the red step, the green step, and
the classifier read off the real module.

<details>
<summary>The red step — the new tests failing against <code>origin/dev</code>'s classifier</summary>

```
 FAIL  src/lib/server/tool-guard.test.ts > isPrivateAddress > legge l IPv4 incapsulato in un IPv6, invece del prefisso che lo veste
 FAIL  src/lib/server/tool-guard.test.ts > assertPublicUrl davanti a un AAAA che incapsula un indirizzo privato > rifiuta un host il cui AAAA è il loopback mappato
 FAIL  src/lib/server/tool-guard.test.ts > assertPublicUrl davanti a un AAAA che incapsula un indirizzo privato > rifiuta un host il cui AAAA è il metadata service mappato
 FAIL  src/lib/server/tool-guard.test.ts > assertPublicUrl davanti a un AAAA che incapsula un indirizzo privato > rifiuta un host il cui AAAA è una rete privata in 6to4
 FAIL  src/lib/server/tool-guard.test.ts > assertPublicUrl davanti a un AAAA che incapsula un indirizzo privato > rifiuta un host il cui AAAA è il loopback via NAT64

 Test Files  1 failed (1)
      Tests  5 failed | 6 passed (11)
```

</details>

<details>
<summary>Green — the guard's own tests plus every call site that goes through it</summary>

```
 ✓ src/lib/server/tool-guard.test.ts (11 tests) 25ms
 ✓ src/lib/content/changelog/index.test.ts (3 tests) 52ms
 ✓ src/lib/server/media-import.test.ts (24 tests) 300ms
 ✓ src/lib/server/media-fetch-guard.test.ts (18 tests) 271ms

 Test Files  4 passed (4)
      Tests  56 passed (56)
```

</details>

<details>
<summary>The classifier's edges, read off the real module (throwaway probe, not committed)</summary>

```
2001:db8::192.168.1.1 -> true      # dotted low bits, fails closed
2002::                -> true      # degenerate 6to4 → 0.0.0.0
64:ff9b::             -> true      # degenerate NAT64 → 0.0.0.0
64:ff9b:1::7f00:1     -> true      # local-use NAT64 prefix, also covered
::ffff:0:0            -> true      # mapped 0.0.0.0
::2                   -> true
fe80::1%eth0          -> true      # zone id stripped
::ffff:8.8.8.8        -> false     # public IPv4 stays public
2001:db8::1           -> false
2606:4700::1111       -> false
```

</details>

<details>
<summary>The bracket behaviour this PR leans on, verified against Node</summary>

```
$ node -e "const h=u=>new URL(u).hostname; for (const u of ['http://[fc00::1]/a','http://[::1]/a','http://[::ffff:127.0.0.1]/a']) console.log(u,'->',JSON.stringify(h(u)))"
http://[fc00::1]/a -> "[fc00::1]"
http://[::1]/a -> "[::1]"
http://[::ffff:127.0.0.1]/a -> "[::ffff:7f00:1]"
```

`URL.hostname` keeps the brackets. That is why the bracketed literal was refused only as a side
effect here — and, as noted below, why a different guard in the tree lets every IPv6 literal through.

</details>

## Anything Else?

**Two weaker guards are still in the tree, and both share the shape this PR just repaired.** Neither
is touched here — they are separate call sites with separate blast radii, and folding them in would
make this PR unreviewable — but they should not stay as they are.

1. **`isUrlSafe`** (`packages/site-analysis/src/crawl.ts`, re-exported by
   `src/lib/server/brand-analysis.ts`) matches hostname **patterns** and never resolves, so a public
   hostname pointing at loopback passes. It blocks `^::ffff:` wholesale but knows nothing of 6to4 or
   NAT64. It has roughly twenty call sites and several take a URL **a model chose**:
   `create-content-tools.ts` (`image_urls`, `video_url`, `reference_image_urls`), `catalog-tools.ts`
   (`sourceUrl`), `post-editor-tools.ts`, `media-generator/agent.ts`. It was left in place
   deliberately — it is not dead, and deleting it would have meant migrating twenty callers inside a
   fix.

2. **`src/routes/app/onboarding/people/import/+server.ts`** carries its own private copy of
   `isPrivateHost` / `assertPublicUrl`. It does re-check every redirect hop, which is the right
   instinct, but it runs its regexes against `URL.hostname` — which **keeps the brackets** for an IPv6
   literal (see the evidence block above). `/^f[cd]/` never matches `"[fc00::1]"` and `h === '::1'`
   never matches `"[::1]"`, so **every IPv6 literal walks straight through that guard**, before any of
   the mapped/6to4/NAT64 discussion.

The lasting fix for both is the one #209 applied to the three archivers: route them onto
`tool-guard`'s guard instead of growing a third and fourth copy of the check. Two copies drift; four
drift silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
