### PR TITLE
Gate the CLI render route like its sibling

### DIFF
--- a/changelog/2026-09-04-render-route-gates.md
+++ b/changelog/2026-09-04-render-route-gates.md
@@ -1,0 +1,38 @@
+# Il render da CLI passa dal gate come tutti gli altri
+
+`POST /api/v1/brands/:slug/posts/:id/render` produce la stessa immagine di
+`POST /api/v1/brands/:slug/posts/:id/media` (`action: 'regenerate'`), ma era l'unica delle due a
+non chiamare né `gateAiAction` né `withBrandContext`. Due conseguenze, entrambe silenziose:
+
+- **un brand senza piano e senza crediti renderizzava lo stesso.** `gateCredits` non veniva mai
+  interrogato: la rotta caricava il post e chiamava direttamente `renderPreviewImages`.
+- **il render non compariva in `ai_calls`.** L'attribuzione al brand viaggia su una
+  `AsyncLocalStorage` che `withBrandContext` apre al confine della richiesta; senza quel wrapper
+  le righe scritte da `logAiCall` nascono senza `brand_id`, quindi il costo di quelle immagini
+  non entra nella spesa di nessuno — e la spesa è esattamente ciò che `gateCredits` legge al giro
+  dopo. Il buco si alimentava da solo.
+
+La correzione non inventa niente: sono gli stessi due helper della rotta sorella, con gli stessi
+parametri.
+
+**Dove sta il gate.** Dopo i tre controlli di stato del post (non esiste, non ha `image_prompt`,
+ha già un'immagine), non prima. Quei tre rami non spendono un centesimo: gatearli significherebbe
+rispondere 402 a chi chiede un render che non sarebbe partito comunque.
+
+**Sulla chiave di sola lettura.** Il difetto era stato segnalato anche come «una API key
+read-only può spendere». Non è (più) vero sul percorso HTTP: `resolveCaller` nega ogni non-GET a
+una chiave senza scope `write` prima ancora che la rotta parta, e `/render` è solo POST. Il test
+che copre il caso lo fa comunque, ma sulla difesa della rotta — `gateAiAction` chiama
+`checkApiKeyWriteAccess` come prima cosa — perché è la difesa che la rotta sorella ha e questa
+non aveva, e perché il giorno che qualcuno aggiunge un GET qui il controllo centrale smette di
+coprire.
+
+**Scartato: mockare `gateAiAction` nel test.** Il difetto era «la rotta non lo chiama»: un mock
+del gate non può accorgersene, perché un mock non chiamato e un gate assente si assomigliano
+troppo. Il test importa il modulo vero e sostituisce solo `authenticate` e `loadBrandForUser`,
+così il 403 e il 402 arrivano dal codice che li produce in produzione.
+
+**Scartato: allineare anche `maxDuration`.** La rotta sorella dichiara
+`export const config = { maxDuration: 300 }` e questa no, il che è probabilmente un difetto a sé
+(un carosello lungo può superare il default). È un cambio di comportamento del deploy, non un
+gate: sta in un'altra PR.

--- a/src/lib/content/changelog/2026-09-04-render-route-gates.ts
+++ b/src/lib/content/changelog/2026-09-04-render-route-gates.ts
@@ -1,0 +1,12 @@
+import type { ChangelogEntry } from './index';
+
+const entry: ChangelogEntry = {
+  date: '2026-09-04',
+  title: 'Rendering an image from the CLI is billed like every other render',
+  items: [
+    'Asking your agent or the CLI to render a post image now checks your plan and your remaining credits first, and stops with a clear message when they are gone — before it was the one way to get an image for free.',
+    'Those images now show up in your usage and cost figures, so what you see spent is what was actually spent.'
+  ]
+};
+
+export default entry;

--- a/src/routes/api/v1/brands/[slug]/posts/[id]/render/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/posts/[id]/render/+server.ts
@@ -1,6 +1,7 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { authenticate, loadBrandForUser } from '$lib/server/cli-auth';
+import { authenticate, loadBrandForUser, gateAiAction } from '$lib/server/cli-auth';
+import { withBrandContext } from '$lib/server/ai-log';
 
 export const POST: RequestHandler = async ({ request, params }) => {
   const { supabase, error, apiKey } = await authenticate(request);
@@ -17,6 +18,9 @@ export const POST: RequestHandler = async ({ request, params }) => {
   if (!post) return json({ error: 'Post not found' }, { status: 404 });
   if (!post.image_prompt) return json({ error: 'Post has no image_prompt' }, { status: 400 });
   if (post.media_url) return json({ error: 'Post already has an image', url: post.media_url });
+
+  const gate = await gateAiAction(brand, apiKey);
+  if (gate) return gate;
 
   // Build profile
   const { data: kit } = await supabase
@@ -55,53 +59,55 @@ export const POST: RequestHandler = async ({ request, params }) => {
     }))
   };
 
-  try {
-    const { renderPreviewImages } = await import('$lib/server/content-preview');
-    const { normalizeContentFormat } = await import('$lib/content-formats');
+  return withBrandContext(brand.id, async () => {
+    try {
+      const { renderPreviewImages } = await import('$lib/server/content-preview');
+      const { normalizeContentFormat } = await import('$lib/content-formats');
 
-    const previewPost = {
-      platform: post.platform,
-      platforms: post.platforms,
-      format: normalizeContentFormat(post.format),
-      media: post.content_type === 'text' ? 'text' as const : post.content_type === 'link' ? 'text' as const : 'image' as const,
-      day: '',
-      time: '',
-      caption: post.caption ?? '',
-      image_prompt: post.image_prompt,
-      // Persisted carousel slide prompts → the renderer produces the whole series.
-      image_prompts: Array.isArray(post.image_prompts) && post.image_prompts.length ? post.image_prompts.map(String) : undefined,
-      product: post.product_name ?? '',
-      person: '',
-      pillar: post.pillar ?? '',
-    };
+      const previewPost = {
+        platform: post.platform,
+        platforms: post.platforms,
+        format: normalizeContentFormat(post.format),
+        media: post.content_type === 'text' ? 'text' as const : post.content_type === 'link' ? 'text' as const : 'image' as const,
+        day: '',
+        time: '',
+        caption: post.caption ?? '',
+        image_prompt: post.image_prompt,
+        // Persisted carousel slide prompts → the renderer produces the whole series.
+        image_prompts: Array.isArray(post.image_prompts) && post.image_prompts.length ? post.image_prompts.map(String) : undefined,
+        product: post.product_name ?? '',
+        person: '',
+        pillar: post.pillar ?? '',
+      };
 
-    let renderError: string | null = null;
-    await renderPreviewImages(profile, [previewPost], {
-      supabase,
-      userId: brand.id,
-      onProgress: () => {},
-      onPost: async (p) => {
-        if (p.imageUrl) {
-          const { error: updateErr } = await supabase.from('posts').update({
-            media_url: p.imageUrl,
-            media_urls: p.imageUrls && p.imageUrls.length > 1 ? p.imageUrls : null,
-            // The renderer may have downgraded a failed carousel to a single image.
-            format: p.format ?? null
-          }).eq('id', post.id);
-          if (updateErr) renderError = updateErr.message;
-        } else {
-          renderError = (p as any).__renderError ?? 'no image produced';
+      let renderError: string | null = null;
+      await renderPreviewImages(profile, [previewPost], {
+        supabase,
+        userId: brand.id,
+        onProgress: () => {},
+        onPost: async (p) => {
+          if (p.imageUrl) {
+            const { error: updateErr } = await supabase.from('posts').update({
+              media_url: p.imageUrl,
+              media_urls: p.imageUrls && p.imageUrls.length > 1 ? p.imageUrls : null,
+              // The renderer may have downgraded a failed carousel to a single image.
+              format: p.format ?? null
+            }).eq('id', post.id);
+            if (updateErr) renderError = updateErr.message;
+          } else {
+            renderError = (p as any).__renderError ?? 'no image produced';
+          }
         }
-      }
-    });
+      });
 
-    // Reload to get the image URL
-    const { data: updated } = await supabase
-      .from('posts').select('media_url')
-      .eq('id', post.id).maybeSingle();
+      // Reload to get the image URL
+      const { data: updated } = await supabase
+        .from('posts').select('media_url')
+        .eq('id', post.id).maybeSingle();
 
-    return json({ ok: true, url: updated?.media_url ?? null, error: updated?.media_url ? null : renderError });
-  } catch (e) {
-    return json({ error: `Render failed: ${String(e)}` }, { status: 500 });
-  }
+      return json({ ok: true, url: updated?.media_url ?? null, error: updated?.media_url ? null : renderError });
+    } catch (e) {
+      return json({ error: `Render failed: ${String(e)}` }, { status: 500 });
+    }
+  });
 };

--- a/src/routes/api/v1/brands/[slug]/posts/[id]/render/server.test.ts
+++ b/src/routes/api/v1/brands/[slug]/posts/[id]/render/server.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTestSupabase } from '$lib/testkit/supabase';
+import type { ApiKeyInfo } from '$lib/server/cli-auth';
+
+const gateCredits = vi.fn();
+const renderPreviewImages = vi.fn();
+const brandContexts: string[] = [];
+
+class CreditsExhaustedError extends Error {}
+
+vi.mock('$lib/server/access', () => ({ userCanEnter: async () => true }));
+vi.mock('@supabase/ssr', () => ({ createServerClient: () => ({}) }));
+vi.mock('$lib/server/credits', () => ({
+  gateCredits: (...args: unknown[]) => gateCredits(...args),
+  CreditsExhaustedError
+}));
+vi.mock('$lib/server/content-preview', () => ({
+  renderPreviewImages: (...args: unknown[]) => renderPreviewImages(...args)
+}));
+vi.mock('$lib/server/ai-log', () => ({
+  withBrandContext: <T>(brandId: string, fn: () => T) => {
+    brandContexts.push(brandId);
+    return fn();
+  }
+}));
+
+// gateAiAction e checkApiKeyWriteAccess restano quelli veri: il difetto era che la rotta non li
+// chiamava, e un mock del gate non avrebbe potuto accorgersene.
+vi.mock('$lib/server/cli-auth', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('$lib/server/cli-auth')>()),
+  authenticate: vi.fn(),
+  loadBrandForUser: vi.fn()
+}));
+
+import { POST } from './+server';
+import { authenticate, loadBrandForUser } from '$lib/server/cli-auth';
+
+const BRAND = { id: 'brand-1', org_id: 'org-1', slug: 'demo', name: 'Demo', plan: 'pro' };
+const POST_ROW = {
+  id: 'post-1',
+  brand_id: 'brand-1',
+  platform: 'instagram',
+  platforms: ['instagram'],
+  format: 'single',
+  content_type: 'image',
+  caption: 'copy',
+  image_prompt: 'una tazza sul bancone',
+  image_prompts: null,
+  media_url: null,
+  product_name: null,
+  pillar: null
+};
+
+const READ_ONLY_KEY: ApiKeyInfo = {
+  id: 'key-1',
+  name: 'read only',
+  user_id: 'user-1',
+  permissions: { brand_ids: '*', scopes: ['read'] }
+};
+
+function call(apiKey?: ApiKeyInfo) {
+  const kit = createTestSupabase({ posts: [{ ...POST_ROW }], brand_kit: [], products: [] });
+  vi.mocked(authenticate).mockResolvedValue({
+    supabase: kit.client,
+    user: { id: 'user-1' },
+    apiKey,
+    error: null
+  } as never);
+  vi.mocked(loadBrandForUser).mockResolvedValue({ brand: BRAND, error: null } as never);
+
+  const url = new URL('https://anomalia.test/api/v1/brands/demo/posts/post-1/render');
+  return (POST as (event: unknown) => Promise<Response>)({
+    request: new Request(url, { method: 'POST' }),
+    params: { slug: 'demo', id: 'post-1' },
+    url
+  }).then(async (res) => ({ res, body: await res.json(), kit }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  brandContexts.length = 0;
+  gateCredits.mockResolvedValue(undefined);
+  renderPreviewImages.mockImplementation(
+    async (_profile: unknown, _posts: unknown, opts: { onPost: (p: unknown) => Promise<void> }) => {
+      await opts.onPost({ imageUrl: 'https://cdn.test/a.png', format: 'single' });
+    }
+  );
+});
+
+describe('POST /api/v1/brands/:slug/posts/:id/render', () => {
+  it('nega una API key di sola lettura, e non renderizza niente', async () => {
+    const { res, body } = await call(READ_ONLY_KEY);
+
+    expect(res.status).toBe(403);
+    expect(body.error).toBe('API key is read-only');
+    expect(renderPreviewImages).not.toHaveBeenCalled();
+  });
+
+  it('nega un brand senza crediti, e non renderizza niente', async () => {
+    gateCredits.mockRejectedValue(new CreditsExhaustedError('no credits'));
+
+    const { res, body } = await call();
+
+    expect(res.status).toBe(402);
+    expect(body.error).toBe('credits_exhausted');
+    expect(renderPreviewImages).not.toHaveBeenCalled();
+  });
+
+  it('renderizza quando il gate passa, e attribuisce il render al brand', async () => {
+    const { res, body, kit } = await call();
+
+    expect(res.status).toBe(200);
+    expect(body.url).toBe('https://cdn.test/a.png');
+    expect(gateCredits).toHaveBeenCalledWith('brand-1');
+    expect(brandContexts).toEqual(['brand-1']);
+    expect(kit.tables.get('posts')?.[0].media_url).toBe('https://cdn.test/a.png');
+  });
+});


### PR DESCRIPTION
## What?

`POST /api/v1/brands/:slug/posts/:id/render` now calls `gateAiAction` before it renders anything,
and runs the render inside `withBrandContext`. It is the route the CLI's `anomalia post <slug> <id>
render` and the MCP tool `render_post` hit, and it produces the same image as its sibling
`POST /posts/:id/media` (`action: 'regenerate'`) — which has called both helpers all along.

Net change: three lines of gate and one wrapper in the route, plus a test file that fails without
them, plus the two changelogs.

## Why?

Two things were wrong, and both were silent.

**A brand with no plan and no credits rendered for free.** `gateCredits` was never asked. The
route loaded the post and went straight into `renderPreviewImages`. Every other AI-spending
endpoint in `src/routes/api/v1/` gates; this one was the way around all of them.

**The render never reached `ai_calls`.** Brand attribution rides an `AsyncLocalStorage` that
`withBrandContext` opens at the request boundary; without that wrapper, `logAiCall` writes rows
with no `brand_id`. So the cost of those images landed in nobody's spend — and spend is exactly
what `gateCredits` reads on the next call. The hole fed itself: the more you rendered this way,
the less the gate knew.

The MCP tool `render_post` also advertises "Bills a render". It did not. The description is now
true.

## How?

The same two helpers as the sibling route, with the same arguments — no new gate was invented.

**Where the gate sits.** After the three post-state checks (post not found, no `image_prompt`,
already has an image), not before them. None of those branches spends anything, and gating them
would answer 402 to a render that was never going to start.

**On the read-only API key.** The defect was also reported as "a read-only API key can spend".
Over HTTP that is not true, and the report should say so: `resolveCaller` in `cli-auth.ts` denies
every non-GET to a key without the `write` scope before the handler runs, and `/render` is
POST-only. The test still covers the case, but against the route's own defense — `gateAiAction`
calls `checkApiKeyWriteAccess` first — because that is the defense the sibling has and this route
did not, and because the day someone adds a GET here the central check stops covering it.

**Rejected: mocking `gateAiAction` in the test.** The defect was "the route never calls it", and a
mocked gate cannot see that — an uncalled mock and an absent gate look identical. The test imports
the real `cli-auth` module and stubs only `authenticate` and `loadBrandForUser`, so the 403 and the
402 come out of the code that produces them in production.

**Rejected: aligning `maxDuration` too.** The sibling declares `export const config = { maxDuration:
300 }` and this route does not, which is probably a defect of its own (a long carousel can outrun
the default). That is a deploy-behaviour change, not a gate. Separate PR.

## Testing?

Red first, watched fail, then the fix. Both outputs below.

Targeted, per the coordinator's instruction not to re-run the whole suite locally while nine agents
share a machine in swap:

- `npx vitest run 'src/routes/api/v1/brands/[slug]/posts/[id]/render/server.test.ts'` — 3 passed.
- The full suite is delegated to CI (`.github/workflows/ci.yml` runs `npx vitest run` on every PR).
  For the record, it was run once here before that instruction arrived:
  **6478 passed, 3 failed, 48 skipped (6529)** across 593 files. The failures were
  `live.test.ts`, `brand-studio-tools.test.ts` and `motion-output-mount.test.ts` — the three known
  flaky-under-load files — plus `src/lib/server/credit-warning.test.ts`, which **also fails on an
  untouched `dev` checkout** (verified: same single failure, `maybeSendCreditWarning > non rimanda
  nello stesso periodo`). None of the four is reachable from this diff.

**Not tested, and why:** no browser run. Both surfaces here are HTTP-only (CLI + MCP), the change
is a gate, and the coordinator explicitly told every agent to stop bringing up Docker/dev servers
while the machine is thrashing. No Docker, Playwright or dev server was started for this PR.

**`npm run check`: no result to report.** It ran for ~40 minutes alongside 13 concurrent
`svelte-check` processes from other agents and was killed by the OS (exit 143, SIGTERM) before
printing a single diagnostic — the machine is in swap. Starved, not failed, and I am not passing
off a number from another run. The route change adds two imports and one `withBrandContext(...)`
wrapper; CI's own `check` is the authority here.

**Risk:** a brand at zero credits that previously got a free render now gets `402
credits_exhausted`. That is the point of the change, and it is in the public changelog.

## Evidence

<details>
<summary>RED — the three tests before the fix</summary>

```
 ❯ src/routes/api/v1/brands/[slug]/posts/[id]/render/server.test.ts (3 tests | 3 failed) 67ms
   × POST /api/v1/brands/:slug/posts/:id/render > nega una API key di sola lettura, e non renderizza niente 59ms
     → expected 200 to be 403 // Object.is equality
   × POST /api/v1/brands/:slug/posts/:id/render > nega un brand senza crediti, e non renderizza niente 3ms
     → expected 200 to be 402 // Object.is equality
   × POST /api/v1/brands/:slug/posts/:id/render > renderizza quando il gate passa, e attribuisce il render al brand 4ms
     → expected "spy" to be called with arguments: [ 'brand-1' ]

Received:

Number of calls: 0

 Test Files  1 failed (1)
      Tests  3 failed (3)
```

The three reds are the three holes: no write-scope check, no credits check, no `ai_calls`
attribution. `200` where a `403` and a `402` belong is the route rendering anyway.

</details>

<details>
<summary>GREEN — the same three after the fix</summary>

```
 RUN  v2.1.9 /Users/andreabuttarelli/Documents/GitHub/anomalia-wt/render-route-gates

 ✓ src/routes/api/v1/brands/[slug]/posts/[id]/render/server.test.ts (3 tests) 12ms

 Test Files  1 passed (1)
      Tests  3 passed (3)
   Duration  811ms
```

</details>

<details>
<summary>`credit-warning.test.ts` fails on untouched <code>dev</code> — not from this PR</summary>

```
$ npx vitest run src/lib/server/credit-warning.test.ts    # main checkout, dev @ f038753, clean
 Test Files  1 failed (1)
      Tests  1 failed | 2 passed (3)
```

</details>

No UI changes, so no screenshots: this PR touches one server route and adds a test.

## Anything Else?

- **`maxDuration` is still missing here.** The sibling gets 300s, this route gets the platform
  default. A long carousel render can outrun it. Worth its own PR.
- **`renderPreviewImages` is called with `userId: brand.id`.** That is a brand id in a field named
  after a user, and AI images are stored under `media/<userId>/`. Untouched — out of scope, but
  someone should look at where those files actually land.
- The gate is per-call, not per-image: one render of a five-slide carousel passes one gate. Same as
  the sibling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
