### PR TITLE
Send the action the media route actually implements

### DIFF
--- a/changelog/2026-09-04-reorder-slides.md
+++ b/changelog/2026-09-04-reorder-slides.md
@@ -1,0 +1,33 @@
+# `reorder_slides` mandava un'azione che non è mai esistita
+
+Il tool MCP spediva `action: 'reorder'` a `POST /api/v1/brands/:slug/posts/:id/media`, che conosce
+`restructure | regenerate | slide | video` e risponde `400 Unknown action: reorder`. Non ha mai
+funzionato in nessuna versione: il ramo che avrebbe dovuto servirlo non è mai stato scritto con
+quel nome.
+
+**Il riordino esiste, ed è già implementato.** `restructureCarouselSlides` in
+`post-editor-tools.ts` riordina ed elimina le slide senza renderizzare niente; la chiama la chat
+(`restructure_carousel`), la chiama la rotta (`action: 'restructure'`), e la chiama il comando
+`anomalia post <slug> <id> reorder`, che infatti manda la stringa giusta. L'unico chiamante
+sbagliato era il tool MCP. Quindi la riparazione onesta non è togliere il tool — la capacità c'è,
+e due chiamanti su tre la usano — è mandargli la stessa azione che manda la CLI.
+
+**La correzione è una parola.** Il test che la accompagna, no: il difetto non è "questa stringa è
+sbagliata", è "nessuno controlla queste stringhe". Fra chiamante e rotta il contratto è un
+letterale, e un letterale nessun compilatore lo verifica; sono passati mesi con un tool che
+rispondeva 400 a ogni invocazione senza che una riga rossa lo dicesse. Il test raccoglie le azioni
+che i chiamanti (`cli/mcp/tools/brand-content.ts`, `cli/commands/post.ts`) spediscono e le
+confronta con quelle che la rotta implementa: la prossima azione inventata muore in CI, non in
+produzione.
+
+**Scartato: insegnare `reorder` alla rotta come alias.** Sarebbe stato un secondo nome per la
+stessa cosa, con la CLI a mandarne uno e MCP l'altro — cioè lo stesso disallineamento di prima,
+solo funzionante per caso finché qualcuno non tocca uno dei due rami.
+
+**Scartato: rimuovere il tool.** Era l'esito giusto solo se il riordino non esistesse da nessuna
+parte. Esiste, ed è raggiungibile da chat e da CLI: toglierlo avrebbe tolto a un agente esterno
+l'unica capacità che gli altri due chiamanti hanno già.
+
+**Scartato: un test che invoca il tool via il transport MCP.** Avrebbe richiesto di montare
+`handleMcpFetch` con un token e uno stub di rete per una singola stringa, e avrebbe coperto un
+tool solo. Il test sui letterali costa venti righe e copre tutti e quattro.

--- a/cli/mcp/tools/brand-content.ts
+++ b/cli/mcp/tools/brand-content.ts
@@ -349,7 +349,7 @@ export function registerBrandTools(server: McpServer) {
         const postId = await resolvePostId(token, slug, id);
         return {
           id: postId,
-          ...(await api.postMedia(token, slug, postId, { action: 'reorder', order })),
+          ...(await api.postMedia(token, slug, postId, { action: 'restructure', order })),
         };
       }),
   );

--- a/src/lib/content/changelog/2026-09-04-reorder-slides.ts
+++ b/src/lib/content/changelog/2026-09-04-reorder-slides.ts
@@ -1,0 +1,11 @@
+import type { ChangelogEntry } from './index';
+
+const entry: ChangelogEntry = {
+  date: '2026-09-04',
+  title: 'Reordering carousel slides works from your agent too',
+  items: [
+    'Asking your agent to reorder or drop the slides of a carousel now works. It used to fail every time, while the same thing from the command line always worked.'
+  ]
+};
+
+export default entry;

--- a/src/routes/api/v1/brands/[slug]/posts/[id]/media/server.actions.test.ts
+++ b/src/routes/api/v1/brands/[slug]/posts/[id]/media/server.actions.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+// Il contratto fra i chiamanti e la rotta è una stringa, e una stringa nessun compilatore la
+// controlla: `reorder_slides` mandava `action: 'reorder'` e prendeva 400 da sempre. Qui l'insieme
+// delle azioni spedite deve stare dentro quello delle azioni implementate.
+const ROOT = process.cwd();
+const ROUTE = 'src/routes/api/v1/brands/[slug]/posts/[id]/media/+server.ts';
+const CALLERS = ['cli/mcp/tools/brand-content.ts', 'cli/commands/post.ts'];
+
+const source = (rel: string) => readFileSync(join(ROOT, rel), 'utf8');
+const literals = (text: string, pattern: RegExp) => [...text.matchAll(pattern)].map((m) => m[1]);
+
+describe('le azioni che CLI e MCP mandano a /posts/:id/media', () => {
+  it('sono tutte azioni che la rotta implementa', () => {
+    const handled = literals(source(ROUTE), /body\.action === '([a-z_]+)'/g);
+    const sent = [...new Set(CALLERS.flatMap((file) => literals(source(file), /action: '([a-z_]+)'/g)))].sort();
+
+    expect(sent.length).toBeGreaterThan(0);
+    for (const action of sent) {
+      expect(handled, `'${action}': la rotta risponde 400 a questa azione`).toContain(action);
+    }
+  });
+});


### PR DESCRIPTION
## What?

The MCP tool `reorder_slides` sent `action: 'reorder'` to `POST /api/v1/brands/:slug/posts/:id/media`.
That route knows `restructure | regenerate | slide | video` and answers `400 Unknown action:
reorder`. The tool has never worked, in any version. It now sends `restructure` — the action the
route actually implements and the one the CLI has always sent.

One word of production code, plus a test that makes the whole class of mismatch fail in CI.

## Why?

**The capability exists; only this caller was wrong.** `restructureCarouselSlides` in
`src/lib/agent/tools/post-editor-tools.ts` reorders and drops carousel slides without rendering
anything. Three callers reach it: the in-app chat tool `restructure_carousel`, the route
(`action: 'restructure'`), and `anomalia post <slug> <id> reorder` — which sends the right string.
The MCP tool was the only one sending a name nothing implements.

So removing the tool would have been the wrong repair. It is the honest one only when the
capability is absent, and here it is present and reachable from two of the three surfaces; deleting
it would have taken from an external agent the one thing chat and CLI already do.

**The real defect is that nothing checks these strings.** The contract between caller and route is
a string literal, and no compiler reads a string literal. A tool answered 400 to every single
invocation for months and not one red line said so.

## How?

`cli/mcp/tools/brand-content.ts`: `{ action: 'reorder', order }` → `{ action: 'restructure', order }`.
The tool keeps its name and its description — `reorder_slides` is the verb a user says, the same
way the CLI subcommand is called `reorder` while sending `restructure`.

The test is the part worth reviewing. It collects every `action:` literal the two CLI-side callers
(`cli/mcp/tools/brand-content.ts`, `cli/commands/post.ts`) send to `postMedia`, collects every
action the route branches on, and requires the first set to be inside the second. Twenty lines,
covers all four actions, and the next invented one dies in CI.

**Rejected: teaching the route `reorder` as an alias.** Two names for one thing, with the CLI
sending one and MCP the other — the same drift as before, working by accident until someone touches
one of the branches.

**Rejected: driving the tool through the MCP transport in the test.** It would have meant standing
up `handleMcpFetch` with a token and a network stub to assert one string, and it would have covered
one tool. The literal-comparison test costs less and covers every caller.

**Note on the test's shape:** it reads source files and matches two regexes. That is unusual here,
and it is deliberate — the thing being verified *is* the text of two literals in two packages that
never import each other. A behavioural test cannot see a mismatch between a caller in `cli/` and a
route in `src/` without running both.

## Testing?

Red first, watched fail, then the fix. Both outputs below.

Targeted, per the coordinator's instruction not to re-run the whole suite locally:

- `npx vitest run 'src/routes/api/v1/brands/[slug]/posts/[id]/media/server.actions.test.ts'` — 1 passed.
- `cd cli && bun test` — **31 pass, 0 fail** across 8 files.
- `cd cli && bun run typecheck` (`tsc --noEmit`) — clean.
- Full suite delegated to CI (`.github/workflows/ci.yml` runs `npx vitest run` on every PR). For the
  record, it was run once here before that instruction arrived: **6478 passed, 1 failed, 48 skipped
  (6527)** across 593 files. The one failure is `src/lib/server/credit-warning.test.ts`, which
  **also fails on an untouched `dev` checkout** — verified separately, same single test. Not
  reachable from this diff. `brand-studio-tools.test.ts` also reported a file-level failure under
  load and passes in isolation (it is on the known-flaky list).

**Not tested, and why:** no browser run. This is an MCP tool talking to an HTTP route; there is no
UI. Nine agents share a machine in swap and the coordinator asked everyone to stop starting Docker,
Playwright and dev servers — none was started for this PR.

**`npm run check`: no result to report.** It ran for ~40 minutes alongside 13 concurrent
`svelte-check` processes from other agents and was killed by the OS (exit 143, SIGTERM) before
printing a single diagnostic — the machine is in swap. Starved, not failed, and no number from
another run is being passed off as this one's. `tsc --noEmit` over `cli/` (where the production
change is) is clean, and CI's `check` is the authority for the rest.

**Risk:** a caller that was relying on the 400 — there is none; a 400 is not something to rely on.
The first real invocation of `reorder_slides` now mutates a carousel, which is what it always
claimed to do.

## Evidence

<details>
<summary>RED — before the fix</summary>

```
 ❯ src/routes/api/v1/brands/[slug]/posts/[id]/media/server.actions.test.ts (1 test | 1 failed) 21ms
   × le azioni che CLI e MCP mandano a /posts/:id/media > sono tutte azioni che la rotta implementa 21ms
     → 'reorder': la rotta risponde 400 a questa azione: expected [ 'restructure', 'regenerate', …(2) ] to include 'reorder'

 Test Files  1 failed (1)
      Tests  1 failed (1)
```

The message names the defect exactly: `reorder` is sent, and the route's four actions do not
include it.

</details>

<details>
<summary>GREEN — after the fix</summary>

```
 RUN  v2.1.9 /Users/andreabuttarelli/Documents/GitHub/anomalia-wt/reorder-slides

 ✓ src/routes/api/v1/brands/[slug]/posts/[id]/media/server.actions.test.ts (1 test) 5ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
   Duration  688ms
```

</details>

<details>
<summary>CLI suite and typecheck</summary>

```
$ cd cli && bun test
 31 pass
 0 fail
 78 expect() calls
Ran 31 tests across 8 files. [1036.00ms]

$ cd cli && bun run typecheck
$ tsc --noEmit
(no output)
```

</details>

No UI changes, so no screenshots: one string in an MCP tool and one new test.

## Anything Else?

- The same contract test would catch a drift in the other direction too — an action removed from the
  route while a caller still sends it.
- `restructureCarouselSlides` is deliberately outside the credits gate on that route ("Reordering
  slides renders nothing — don't charge it"). Unchanged: this PR only makes the tool reach it.
- The docs that map `reorder_slides` to `anomalia post <slug> <id> reorder` were already correct and
  are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
