### PR TITLE
Pin the OAuth discovery contract between the two metadata documents

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -811,3 +811,26 @@ rifiuto smettesse di arrivare dal ramo che lo produce oggi.
 dovrebbe produrlo (qui: «could not resolve» invece di «non è pubblico»), non è protezione: è una
 coincidenza con la data di scadenza. Fissala in un test che nomina la proprietà, non il
 meccanismo.
+## Il file che leggi non è sempre il file che è in produzione
+
+`https://mcp.anomalia.so/.well-known/oauth-protected-resource` annunciava
+`authorization_servers: ["https://anomalia.so"]` mentre `authServerUrl()` in `cli/lib/config.ts`
+— letto in questo repo, su `dev` e su `main` — restituisce `https://www.anomalia.so`. Nessuna
+delle due letture era sbagliata: il progetto Vercel che serve quel dominio (`anomalia-cli`) è
+agganciato al repo **pre-monorepo** `andreabuttarelli/anomalia-cli`, il cui `authServerUrl()`
+ritorna ancora l'apex, e la cui ultima deploy di produzione è di tre settimane prima
+dell'import nel monorepo. Il codice giusto non è mai arrivato in produzione perché nessuno
+deploya quel dominio da qui.
+
+Segnale: la produzione contraddice il codice che hai appena letto, e il `git log` del file
+mostra un solo commit — quello di import — senza traccia della modifica che stai cercando.
+Mossa: prima di diagnosticare, chiedi a Vercel **da quale repo e da quale commit** è servito
+quel dominio (`list_projects` → `link.repo`, `list_deployments` → `meta.githubCommitRepo`).
+Una funzione letta in locale non è una prova su cosa gira: il repo di origine è parte della
+domanda.
+
+**La regola dietro**: quando un dominio del prodotto non è servito dal repo in cui stai
+lavorando, il repo non può ripararlo — può solo smettere di regredire. Il test di contratto
+serve comunque, perché il giorno in cui il dominio torna a essere servito da qui il difetto
+non rientra; ma la riparazione è ripuntare il progetto, e va detta come tale invece di essere
+spacciata per un fix di codice.

--- a/changelog/2026-09-04-oauth-discovery-contract.md
+++ b/changelog/2026-09-04-oauth-discovery-contract.md
@@ -99,6 +99,13 @@ e sopra `issuerFor()` — sono stati rimossi: dicevano la stessa cosa in due pun
 `021-app` (un repo che non esiste più) e nessuno dei due poteva fallire quando la coppia si
 fosse sfilata.
 
+Nello stesso giro, le due asserzioni RFC 8414 di `oauth.test.ts` hanno smesso di leggere
+`PUBLIC_APP_URL` dall'ambiente: passano per `appOrigin()`, quindi con il dev server di un altro
+worktree esportato in `PUBLIC_APP_URL` fallivano
+(`expected 'http://localhost:5223' to be 'https://www.anomalia.so'`) su codice che nessuno aveva
+toccato. Ora l'env pubblico è fissato nel file, come già fanno `app-url.test.ts` e
+`team-ignition.test.ts`.
+
 ## Changelog pubblico: assente di proposito
 
 Questa PR non cambia niente che un cliente possa vedere. Il fix visibile — la discovery che si

--- a/changelog/2026-09-04-oauth-discovery-contract.md
+++ b/changelog/2026-09-04-oauth-discovery-contract.md
@@ -1,0 +1,106 @@
+# La discovery OAuth è un contratto fra due documenti, e ora c'è un test che lo cammina
+
+Un client MCP che si collega a `https://mcp.anomalia.so/mcp` non legge un documento: ne legge
+due, e il secondo lo trova solo grazie a una stringa presa dal primo.
+
+1. `GET https://mcp.anomalia.so/.well-known/oauth-protected-resource` (RFC 9728) →
+   `authorization_servers: [<identificatore>]`.
+2. All'identificatore il client attacca `/.well-known/oauth-authorization-server` e lo scarica
+   (RFC 8414 §3.1).
+3. Se quell'URL non risponde 200 — un 308 basta — un client che non segue i redirect in
+   discovery si ferma qui. Smithery riporta
+   `{"code":"oauth/auth_server_discovery_http_error","status":308}`.
+4. Se risponde, RFC 8414 §3.3 pretende che `issuer` sia **identico byte per byte**
+   all'identificatore del passo 1. Diverso → metadata rifiutati.
+
+In produzione oggi il passo 1 dà `https://anomalia.so`, il passo 3 dà 308 e il passo 4 dà
+`https://www.anomalia.so`. Rotto ai passi 3 e 4 insieme.
+
+## Perché è sopravvissuto
+
+Perché ogni URL, provato a mano, risponde 200. `https://mcp.anomalia.so/.well-known/...` → 200.
+`https://www.anomalia.so/.well-known/oauth-authorization-server` → 200 con un `issuer` coerente
+con l'host che l'ha servito. Anche `https://anomalia.so/.well-known/...` "funziona" in un
+browser e in un `curl -L`: segue il redirect e mostra JSON valido. Il difetto non sta in nessun
+documento, sta **nella relazione fra i due** — ed è visibile solo eseguendo l'algoritmo del
+client per intero, incluso il passo che nessun handler può vedere: il 308 apex → www è un
+redirect di *dominio* Vercel, applicato prima del routing del deployment, quindi nessun
+`vercel.json` può escluderne `/.well-known/*` e nessun test che chiami solo gli handler lo
+incontra.
+
+Ed è anche il motivo per cui una asserzione stringa-uguale-stringa non bastava: ce n'erano già
+due, una per lato (`cli/lib/config.test.ts`, `src/lib/server/app-url.test.ts`), verdi entrambe.
+Nessuna delle due sa cosa afferma l'altra.
+
+## Dove si produce l'identificatore
+
+- `cli/mcp/http-router.ts` (rewrite `/.well-known/oauth-protected-resource` → `/api/oauth-protected-resource`,
+  è la via di Vercel) e `cli/mcp/http-app.ts` (la via di Bun locale): entrambi chiamano
+  `authServerUrl()`.
+- `cli/lib/config.ts` — `authServerUrl()`: `PUBLIC_APP_URL` se è locale, altrimenti
+  `PRODUCTION_URL` = `https://www.anomalia.so`.
+- `src/lib/server/oauth.ts` — `issuerFor()` e `endpointsFor()`, entrambi `appOrigin(url)`.
+- `src/lib/server/app-url.ts` — `appOrigin()`: origin della richiesta per localhost e per le
+  preview `*.vercel.app`, origin della richiesta anche quando l'host registrabile combacia con
+  `PUBLIC_APP_URL` (apex e www sono lo stesso host registrabile), altrimenti `PUBLIC_APP_URL`.
+- `src/routes/.well-known/oauth-authorization-server/+server.ts` — il documento RFC 8414.
+
+Su questo repo i due lati **combaciano già**: `authServerUrl()` dà www, e l'app servita su www
+dà `issuer: https://www.anomalia.so`. Il test lo dimostra verde.
+
+## Cosa è rotto allora
+
+Il dominio `mcp.anomalia.so` non è servito da questo repo. Il progetto Vercel `anomalia-cli`
+(`prj_oUOLCxXPSMiEggnTB2QqL0AcuFDd`) è agganciato al repo pre-monorepo
+`andreabuttarelli/anomalia-cli`, la cui `authServerUrl()` ritorna tuttora `'https://anomalia.so'`
+con un commento che documenta la decisione **opposta** ("deliberately the apex"), e la cui
+ultima deploy di produzione è del 2026-08-12 — sedici giorni prima che CLI e MCP entrassero nel
+monorepo. Il codice corretto esiste da prima dell'import e non è mai stato deployato lì.
+
+La riparazione è ripuntare quel progetto su `anomaliaso/anomalia` con Root Directory `cli/mcp`
+(dove vivono già `vercel.json` e `scripts/build-vercel.mjs`) e rideployare: un'azione sulla
+dashboard, non una riga di codice. Finché non accade, la produzione continua a servire il
+comportamento vecchio.
+
+## Perché www e non "fai servire i metadata anche all'apex"
+
+Valutata e scartata. Far rispondere `https://anomalia.so/.well-known/oauth-authorization-server`
+sistemerebbe il passo 3 per i client che non seguono i redirect, ma quel 308 è un redirect di
+dominio configurato sul progetto Vercel: si toglie solo togliendo il redirect apex → www e
+riportandolo dentro l'app, cioè rifacendo la canonicalizzazione di tutto il sito per un
+documento di discovery. www invece è già l'unico host che risponde 200: costa zero e chiude sia
+il passo 3 sia il passo 4. Un solo identificatore, da entrambe le parti.
+
+## Il test
+
+`src/lib/server/oauth-discovery.test.ts` cammina l'algoritmo: prende l'identificatore da
+`authServerUrl()`, applica il redirect di dominio (dichiarato come dato: apex → www, verificato
+con `curl`), costruisce il documento RFC 8414 chiamando il `GET` della route, e pretende che
+l'identificatore sia servito da sé stesso e che `issuer` ed endpoint stiano su quello stesso
+origin. Gira con `PUBLIC_APP_URL` sia apex sia www, così l'accoppiata non dipende da come è
+configurato l'ambiente.
+
+L'anello che manca — che il documento RFC 9728 contenga davvero quel valore — è chiuso dal lato
+CLI, dove i due handler che lo costruiscono girano davvero: `cli/mcp/http-app.test.ts` pretende
+`authorization_servers` uguale a `[authServerUrl()]` sia da `handleMcpFetch` (Bun locale) sia da
+`routeMcpHttp` (la via di Vercel). Prima asseriva solo che l'array non fosse vuoto.
+
+Il test dell'app importa `cli/lib/config.ts` e non gli handler: quel file non ha import, mentre
+`cli/mcp/*` usa specificatori con estensione `.ts` (obbligatori per Bun) che sotto il `tsconfig`
+dell'app diventano 32 errori TS5097. Un test che aggiunge 32 errori al type-check non si merge.
+
+Contro il codice che è in produzione oggi (apex) fallisce 5 test su 7 con
+`expected 'https://www.anomalia.so' to be 'https://anomalia.so'`. Contro questo repo passa.
+Coperti anche il dev locale (l'intera camminata resta sul dev server) e la preview
+(`*.vercel.app` emette il proprio origin, mai quello di produzione).
+
+Con il test dentro, i due commenti a blocco che spiegavano il vincolo — sopra `authServerUrl()`
+e sopra `issuerFor()` — sono stati rimossi: dicevano la stessa cosa in due punti, citavano
+`021-app` (un repo che non esiste più) e nessuno dei due poteva fallire quando la coppia si
+fosse sfilata.
+
+## Changelog pubblico: assente di proposito
+
+Questa PR non cambia niente che un cliente possa vedere. Il fix visibile — la discovery che si
+completa da un client browser-based — arriva quando `mcp.anomalia.so` viene rideployato dal
+repo giusto, e la riga pubblica va scritta in quel momento, non ora.

--- a/cli/lib/config.test.ts
+++ b/cli/lib/config.test.ts
@@ -23,9 +23,6 @@ describe('appUrl', () => {
 });
 
 describe('authServerUrl', () => {
-  // Deve combaciare con issuerFor() in 021-app: RFC 8414 confronta l'issuer byte per byte con
-  // l'identificatore da cui il client ha costruito l'URL di discovery. L'apex 308-redirecta,
-  // quindi l'unico identificatore che regge è quello che risponde 200 — www.
   test('never advertises the apex: it 308-redirects and discovery dies there', () => {
     delete process.env.PUBLIC_APP_URL;
     expect(authServerUrl()).toBe('https://www.anomalia.so');

--- a/cli/lib/config.ts
+++ b/cli/lib/config.ts
@@ -31,21 +31,6 @@ export function appUrl(): string {
 
 const isLocal = (url: string) => /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])/.test(url);
 
-/**
- * Identificativo dell'authorization server annunciato ai client MCP in `authorization_servers`
- * (RFC 9728, `/.well-known/oauth-protected-resource`). È **www**, come PRODUCTION_URL.
- *
- * Qui c'era l'apex, in coppia con `issuerFor()` di 021-app. Il vincolo RFC 8414 è reale — il
- * client prende questa stringa, ci attacca `/.well-known/oauth-authorization-server`, e pretende
- * che l'`issuer` nel JSON sia identico — ma l'apex non serve quel JSON: `https://anomalia.so`
- * 308-redirecta a www a livello di dominio Vercel. Un client che non segue i redirect in
- * discovery (Smithery) muore prima di vedere i metadata:
- *   {"code":"oauth/auth_server_discovery_http_error", "status":308}
- *
- * www è l'unico host che risponde 200, quindi l'identificatore è www da entrambe le parti.
- * Resta decoupled da appUrl() perché un PUBLIC_APP_URL di dev deve comunque vincere: in locale
- * l'OAuth punta al dev server.
- */
 export function authServerUrl(): string {
   const app = appUrl();
   return isLocal(app) ? app : PRODUCTION_URL;

--- a/cli/mcp/http-app.test.ts
+++ b/cli/mcp/http-app.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import { handleMcpFetch } from './http-app.ts';
+import { routeMcpHttp } from './http-router.ts';
+import { authServerUrl } from '../lib/config.ts';
 
 describe('mcp HTTP transport', () => {
   test('health endpoint', async () => {
@@ -17,8 +19,16 @@ describe('mcp HTTP transport', () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.resource).toContain('/mcp');
-    expect(Array.isArray(body.authorization_servers)).toBe(true);
-    expect(body.authorization_servers.length).toBeGreaterThan(0);
+    expect(body.authorization_servers).toEqual([authServerUrl()]);
+  });
+
+  test('the vercel route advertises the same authorization server', async () => {
+    const res = await routeMcpHttp(
+      new Request('https://mcp.anomalia.so/.well-known/oauth-protected-resource'),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.authorization_servers).toEqual([authServerUrl()]);
   });
 
   test('initialize + tools/list over streamable HTTP (JSON)', async () => {

--- a/src/lib/server/oauth-discovery.test.ts
+++ b/src/lib/server/oauth-discovery.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+
+const LOCAL_ORIGIN = 'http://localhost:5173';
+const PREVIEW_ORIGIN = 'https://anomalia-git-branch.vercel.app';
+
+const VERCEL_DOMAIN_REDIRECTS: Record<string, string> = {
+  'https://anomalia.so': 'https://www.anomalia.so'
+};
+
+type AuthorizationServer = {
+  issuer: string;
+  authorization_endpoint: string;
+  token_endpoint: string;
+  registration_endpoint: string;
+};
+
+async function advertisedAuthorizationServer(): Promise<string> {
+  const { authServerUrl } = await import('../../../cli/lib/config');
+  return authServerUrl();
+}
+
+async function authorizationServerMetadata(origin: string): Promise<AuthorizationServer> {
+  const { GET } = await import('../../routes/.well-known/oauth-authorization-server/+server');
+  const url = new URL(`${origin}/.well-known/oauth-authorization-server`);
+  const res = await (GET as (event: { url: URL }) => Response)({ url });
+  return res.json();
+}
+
+async function walkDiscovery() {
+  const identifier = await advertisedAuthorizationServer();
+  const servedBy = VERCEL_DOMAIN_REDIRECTS[identifier] ?? identifier;
+  const server = await authorizationServerMetadata(servedBy);
+  return { identifier, servedBy, server };
+}
+
+function configureApp(publicAppUrl: string) {
+  vi.doMock('$env/dynamic/public', () => ({ env: { PUBLIC_APP_URL: publicAppUrl } }));
+}
+
+function configureMcp(publicAppUrl: string | undefined) {
+  if (publicAppUrl === undefined) delete process.env.PUBLIC_APP_URL;
+  else process.env.PUBLIC_APP_URL = publicAppUrl;
+}
+
+describe('oauth discovery, walked the way a client walks it', () => {
+  const originalAppUrl = process.env.PUBLIC_APP_URL;
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.doUnmock('$env/dynamic/public');
+    configureMcp(originalAppUrl);
+  });
+
+  it.each([
+    ['apex', 'https://anomalia.so'],
+    ['www', 'https://www.anomalia.so']
+  ])(
+    'advertises an identifier that serves its own metadata, PUBLIC_APP_URL=%s',
+    async (_, configured) => {
+      configureMcp(undefined);
+      configureApp(configured);
+
+      const { identifier, servedBy } = await walkDiscovery();
+
+      expect(servedBy).toBe(identifier);
+    }
+  );
+
+  it.each([
+    ['apex', 'https://anomalia.so'],
+    ['www', 'https://www.anomalia.so']
+  ])('issues the identifier it advertised, PUBLIC_APP_URL=%s', async (_, configured) => {
+    configureMcp(undefined);
+    configureApp(configured);
+
+    const { identifier, server } = await walkDiscovery();
+
+    expect(server.issuer).toBe(identifier);
+  });
+
+  it('advertises endpoints on the origin it named as issuer', async () => {
+    configureMcp(undefined);
+    configureApp('https://anomalia.so');
+
+    const { identifier, server } = await walkDiscovery();
+
+    for (const endpoint of [
+      server.authorization_endpoint,
+      server.token_endpoint,
+      server.registration_endpoint
+    ]) {
+      expect(new URL(endpoint).origin).toBe(identifier);
+    }
+  });
+
+  it('keeps the whole walk on the dev server when PUBLIC_APP_URL is local', async () => {
+    configureMcp(LOCAL_ORIGIN);
+    configureApp(LOCAL_ORIGIN);
+
+    const { identifier, servedBy, server } = await walkDiscovery();
+
+    expect(identifier).toBe(LOCAL_ORIGIN);
+    expect(servedBy).toBe(LOCAL_ORIGIN);
+    expect(server.issuer).toBe(LOCAL_ORIGIN);
+    expect(new URL(server.token_endpoint).origin).toBe(LOCAL_ORIGIN);
+  });
+
+  it('issues the preview origin to a client that discovered it there', async () => {
+    configureApp('https://www.anomalia.so');
+
+    const server = await authorizationServerMetadata(PREVIEW_ORIGIN);
+
+    expect(server.issuer).toBe(PREVIEW_ORIGIN);
+    expect(new URL(server.authorization_endpoint).origin).toBe(PREVIEW_ORIGIN);
+  });
+});

--- a/src/lib/server/oauth.test.ts
+++ b/src/lib/server/oauth.test.ts
@@ -1,6 +1,10 @@
 import crypto from 'node:crypto';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { env } from '$env/dynamic/private';
+
+vi.mock('$env/dynamic/public', () => ({
+  env: { PUBLIC_APP_URL: 'https://www.anomalia.so' }
+}));
 
 // Firmare è fail-closed di proposito: senza `APP_SECRET` nessun token esce. Il segreto se lo dà
 // il test, o la suite è verde solo su chi ha un `.env` completo e rossa in CI.

--- a/src/lib/server/oauth.ts
+++ b/src/lib/server/oauth.ts
@@ -160,25 +160,6 @@ export function anonClient() {
 
 // ── Discovery URLs ───────────────────────────────────────────────
 
-/**
- * Identificativo dell'authorization server = **l'origin che serve davvero questo documento**.
- *
- * Qui prima si toglieva il `www.` e si annunciava l'apex. Il riferimento a RFC 8414 era giusto
- * (l'`issuer` dev'essere identico all'identificatore da cui il client costruisce l'URL di
- * discovery) ma applicato al contrario: l'apex `https://anomalia.so` non serve niente, Vercel
- * lo 308-redirecta a www a livello di *dominio*, cioè prima del routing del deployment —
- * nessun `vercel.json` può escludere `/.well-known/*` da quel redirect. I client OAuth/MCP che
- * non seguono i redirect in discovery (Smithery, per dirne uno) si fermano esattamente lì:
- *   {"code":"oauth/auth_server_discovery_http_error", "status":308}
- *
- * Quindi l'issuer sta sull'unico host che risponde 200: issuer, endpoint e host che serve i
- * metadata diventano lo stesso origin e la discovery non dipende più da un redirect.
- *
- * L'altra metà della coppia vive in anomalia (`authServerUrl()` in `lib/config.ts`, che
- * riempie `authorization_servers` nel documento RFC 9728 di mcp.anomalia.so): i due valori
- * devono restare identici byte per byte, o i client severi rifiutano i metadata. Si spostano
- * insieme, sempre.
- */
 export function issuerFor(url: URL): string {
   return appOrigin(url);
 }


### PR DESCRIPTION
## What?

A spec-compliant MCP client discovering `https://mcp.anomalia.so/mcp` reads **two** documents and
must find them consistent. Today it does not: the RFC 9728 metadata names `https://anomalia.so`,
that host answers **308**, and following the redirect yields `issuer: https://www.anomalia.so` —
which RFC 8414 §3.3 says must be byte-identical to the identifier the client started from. A
strict client rejects the metadata; a redirect-averse one never gets that far.

This PR adds the test that catches that disagreement, running the real handlers on both sides,
and removes the comments the test replaces.

**It does not change any production behaviour, because the defect is not in this repo's code** —
`authServerUrl()` here already returns www, on `dev` and on `main`. See *Why?* for what is
actually broken and who has to fix it.

## Why?

Two reasons the pair could drift without anything going red:

1. **Every URL in the chain returns 200 when poked by hand.** The failure is in the *relationship*
   between two documents, and nothing compared them. There were already two string-equals-string
   tests, one per side (`cli/lib/config.test.ts`, `src/lib/server/app-url.test.ts`), both green.
   Neither knows what the other asserts.
2. **The step that breaks it is invisible to every handler.** The apex → www 308 is a Vercel
   *domain* redirect, applied before deployment routing, so no `vercel.json` can exclude
   `/.well-known/*` from it and no handler-level test ever meets it.

The live walk, run against production today:

```
### step 1 — RFC 9728 protected-resource metadata
{"resource":"https://mcp.anomalia.so/mcp","authorization_servers":["https://anomalia.so"],
 "scopes_supported":["anomalia"],"bearer_methods_supported":["header"]}
  HTTP 200

### step 2/3 — the identifier it named, fetched without following redirects
  https://anomalia.so/.well-known/oauth-authorization-server -> HTTP 308,
  Location: https://www.anomalia.so/.well-known/oauth-authorization-server

### step 4 — following the redirect anyway
  issuer: https://www.anomalia.so
  authorization_endpoint: https://www.anomalia.so/oauth/authorize
```

### Where the identifier is produced — every place

| Place | What it produces |
|---|---|
| `cli/mcp/http-router.ts` | `authorization_servers` on the Vercel path (the rewrite target) |
| `cli/mcp/http-app.ts` | `authorization_servers` on the local Bun path |
| `cli/lib/config.ts` → `authServerUrl()` | the identifier itself: local `PUBLIC_APP_URL` wins, else `PRODUCTION_URL` = `https://www.anomalia.so` |
| `src/lib/server/oauth.ts` → `issuerFor()` / `endpointsFor()` | `issuer` and the three endpoints, both via `appOrigin(url)` |
| `src/lib/server/app-url.ts` → `appOrigin()` | request origin for localhost and `*.vercel.app`, request origin when the registrable host matches `PUBLIC_APP_URL` (apex and www are the same registrable host), else `PUBLIC_APP_URL` |
| `src/routes/.well-known/oauth-authorization-server/+server.ts` | the RFC 8414 document |

Grepping the bare apex string also turns it up in `README.md`, `cli/README.md`, `docs/api/*.md`,
the plugin manifests and the skills — all `homepage`/`curl` prose, none of it an OAuth
identifier. Left alone.

**On this repo the two sides already agree.** `authServerUrl()` returns www; the app served on
www issues `https://www.anomalia.so`. The new test proves it green.

### So what is broken

`mcp.anomalia.so` is not served by this repository. The Vercel project `anomalia-cli`
(`prj_oUOLCxXPSMiEggnTB2QqL0AcuFDd`) is linked to the **pre-monorepo** repo
`andreabuttarelli/anomalia-cli`, whose `authServerUrl()` still returns `'https://anomalia.so'` —
with a comment stating the *opposite* decision, "deliberately the apex" — and whose last
production deployment (`dpl_9E7evMpPiAJJDLY5UZjwLDu7GKx2`) predates the monorepo import by
sixteen days. The correct code has simply never been deployed there.

**The repair is to repoint that project at `anomaliaso/anomalia` with Root Directory `cli/mcp`**
(where `vercel.json` and `scripts/build-vercel.mjs` already live) and redeploy. That is a
dashboard action, not a line of code, and it is not in this PR. Until it happens production keeps
serving the old behaviour.

## How?

**www on both sides, not "make the apex serve the metadata".** Serving the document from the apex
would fix step 3 for redirect-averse clients, but that 308 is a domain-level redirect on the
Vercel project: removing it means moving the whole site's apex → www canonicalisation into the
app for the sake of one discovery document. www is already the only host that answers 200, so it
closes step 3 *and* step 4 at zero cost. One identifier, both sides.

**The test walks the algorithm, including the redirect.** The 308 is declared as data
(`VERCEL_DOMAIN_REDIRECTS`, verified with `curl`) and applied between the two documents — without
it the walk passes even with the apex, which is exactly why hand-testing never caught this. The
test then asserts the identifier serves its own metadata, that `issuer` is byte-identical, and
that the endpoints share that origin — under `PUBLIC_APP_URL` set to **both** apex and www, so
the pairing cannot depend on how the environment happens to be configured. Local dev walks
entirely on the dev server; a preview host issues its own origin.

**The app-side test imports `cli/lib/config.ts`, not `cli/mcp/*`.** The first draft imported
`routeMcpHttp` for maximum fidelity and added **32 `TS5097` errors** to the type-check: `cli/mcp`
uses `.ts` import specifiers (mandatory for Bun) that the app's `tsconfig` rejects. `cli/lib/config.ts`
has no imports at all, so it costs one file. The link it gives up — that the RFC 9728 document
really carries `authServerUrl()` — is closed on the CLI side instead, where both handlers can
actually run: `cli/mcp/http-app.test.ts` now demands `authorization_servers` equal
`[authServerUrl()]` from `handleMcpFetch` *and* from `routeMcpHttp`, where it previously only
demanded a non-empty array.

**Comments removed, not added.** Three blocks explained the same RFC 8414 constraint from three
places; none could fail, and two pointed at `021-app`, a repo that stopped existing at the
monorepo move. Per `AGENTS.md` the knowledge moves into the test, which does fail.

**Bonus, same area:** the two RFC 8414 assertions in `oauth.test.ts` read `PUBLIC_APP_URL` through
`appOrigin()`, so another worktree's dev server exported into the environment turned them red on
code nobody had touched. The public env is now pinned in the file, as `app-url.test.ts` and
`team-ignition.test.ts` already do.

## Testing?

Targeted only — the full suite and Playwright are delegated to CI (`.github/workflows/ci.yml`
runs `npx vitest run` and Playwright on every PR), on a machine where nine agents are running in
parallel and swap is full.

**Red first.** With `authServerUrl()` reverted to `'https://anomalia.so'` — i.e. the code that is
actually deployed on `mcp.anomalia.so` today — the new test fails 5 of 7, reproducing production
exactly:

```
 ❯ src/lib/server/oauth-discovery.test.ts (7 tests | 5 failed) 453ms
   × advertises an identifier that serves its own metadata, PUBLIC_APP_URL=apex
     → expected 'https://www.anomalia.so' to be 'https://anomalia.so'
   × advertises an identifier that serves its own metadata, PUBLIC_APP_URL=www
     → expected 'https://www.anomalia.so' to be 'https://anomalia.so'
   × issues the identifier it advertised, PUBLIC_APP_URL=apex
     → expected 'https://www.anomalia.so' to be 'https://anomalia.so'
   × issues the identifier it advertised, PUBLIC_APP_URL=www
     → expected 'https://www.anomalia.so' to be 'https://anomalia.so'
   × advertises endpoints on the origin it named as issuer
     → expected 'https://www.anomalia.so' to be 'https://anomalia.so'
```

**Green on this branch.**

```
$ npx vitest run src/lib/server/oauth-discovery.test.ts src/lib/server/oauth.test.ts src/lib/server/app-url.test.ts
 ✓ src/lib/server/app-url.test.ts (4 tests)
 ✓ src/lib/server/oauth.test.ts (12 tests)
 ✓ src/lib/server/oauth-discovery.test.ts (7 tests)
 Test Files  3 passed (3)
      Tests  23 passed (23)
```

Same three files forced into one worker (`--pool=threads --poolOptions.threads.singleThread`),
to rule out env leakage from the new file into its neighbours: **23 passed**.

```
$ cd cli && bun test
 41 pass / 0 fail / 110 expect() calls — 8 files
$ cd cli && bun run typecheck
 (clean)
$ git diff --check
 (clean)
```

**Type-check.** `npm run check` did **not** complete: killed after ~45 minutes with the machine at
load 25 and no summary line printed, and a bare `npx tsc --noEmit` behaved the same. So the touched
files were checked with a scoped `tsconfig` that `extends` the project's own and includes the
generated SvelteKit ambient types — it pulls in the full import graph and reports the app's
pre-existing errors, of which **zero** are in anything this PR touches:

```
errors in files I touched:            0
errors in cli/:                       0
errors in the route the test calls:   0
errors in app-url.ts:                 0
TS5097 anywhere:                      0   (32 before the import was narrowed)
total (all pre-existing, unrelated): 252
```

**What was NOT tested, and the risk.** The full `npm run test:unit` is left to CI. An earlier
complete run on this branch's predecessor was green except `live.test.ts`, which timed out at
120 s under load and passed 85/85 when re-run alone — the documented flake. No browser
verification: nothing here renders, and the coordinator asked that no dev server, Docker or
Playwright be started on this machine; none was. Production was walked with `curl` only, which
changes nothing.

**Not verifiable from here:** that repointing the Vercel project fixes production. It follows from
the two facts evidenced below (production serves the apex; the linked repo returns the apex) but
it is an inference until someone redeploys.

## Evidence (screenshots/videos)

No UI changes, so no screenshots.

<details>
<summary>Live production walk, before this PR (still true after it merges)</summary>

```
$ curl -s https://mcp.anomalia.so/.well-known/oauth-protected-resource
{"resource":"https://mcp.anomalia.so/mcp","authorization_servers":["https://anomalia.so"],
 "scopes_supported":["anomalia"],"bearer_methods_supported":["header"]}

$ curl -s -o /dev/null -w '%{http_code} -> %{redirect_url}\n' \
    https://anomalia.so/.well-known/oauth-authorization-server
308 -> https://www.anomalia.so/.well-known/oauth-authorization-server

$ curl -sL https://anomalia.so/.well-known/oauth-authorization-server
{"issuer":"https://www.anomalia.so", ...}
```

Identifier `https://anomalia.so`, issuer `https://www.anomalia.so`. RFC 8414 §3.3 violated, and a
client that does not follow redirects stops at the 308.
</details>

<details>
<summary>Why production disagrees with this repo — the deployment is another repository</summary>

`mcp.anomalia.so` is served by the Vercel project `anomalia-cli`:

```
list_projects → { "id": "prj_oUOLCxXPSMiEggnTB2QqL0AcuFDd", "name": "anomalia-cli",
                  "link": { "type": "github", "org": "andreabuttarelli", "repo": "anomalia-cli" } }
```

Its last `target: "production"` deployment is `dpl_9E7evMpPiAJJDLY5UZjwLDu7GKx2`,
`githubCommitRepo: "anomalia-cli"`, `githubCommitRef: "main"` — created 2026-08-12, sixteen days
before `6006a92 Move CLI, MCP and skills into the monorepo (#22)` (2026-08-28).

That repo's `lib/config.ts`, fetched live:

```
$ gh api repos/andreabuttarelli/anomalia-cli/contents/lib/config.ts --jq .content | base64 -d
...
 * OAuth authorization server identifier advertised to MCP clients — deliberately the **apex**,
 * unlike PRODUCTION_URL.
...
export function authServerUrl(): string {
  const app = appUrl();
  return isLocal(app) ? app : 'https://anomalia.so';
}
```

This monorepo, on `dev`, evaluated directly:

```
$ cd cli && VERCEL=1 bun -e "import {authServerUrl, appUrl} from './lib/config.ts'; \
    console.log('appUrl', appUrl()); console.log('authServerUrl', authServerUrl());"
appUrl https://www.anomalia.so
authServerUrl https://www.anomalia.so
```
</details>

<details>
<summary>The first draft of the test, and why it was narrowed</summary>

Importing `routeMcpHttp` into an app-side vitest pulls `cli/mcp/*` into the app's TypeScript
program, where its Bun-mandatory `.ts` specifiers are illegal:

```
$ npx tsc --noEmit   (first draft)
cli/mcp/http-app.ts(1,40): error TS5097: An import path can only end with a '.ts' extension
                            when 'allowImportingTsExtensions' is enabled.
... 32 such errors, all in cli/, all introduced by that one import
```

Nothing else in `src/` imports `cli/`, so all 32 were mine. The test now imports the
import-free `cli/lib/config.ts`, and the document-to-function link moved to the CLI's own suite.
</details>

<details>
<summary>The env-flaky assertions that were pinned</summary>

On an unmodified `oauth.test.ts`, with another worktree's dev server in the environment:

```
$ PUBLIC_APP_URL=http://localhost:5223 npx vitest run src/lib/server/oauth.test.ts
 ❯ src/lib/server/oauth.test.ts (12 tests | 2 failed)
   × names the host that served the document, apex-free and without trailing slash
     → expected 'http://localhost:5223' to be 'https://www.anomalia.so'
   × keeps every endpoint absolute and on the issuer origin
     → expected 'http://localhost:5223' to be 'https://www.anomalia.so'
```

After pinning the public env in the file, same command: **12 passed**.
</details>

## Anything Else?

- **No public changelog, on purpose.** Nothing a customer can see changes when this merges. The
  customer-visible line — connecting Anomalia from a browser-based AI client completes discovery
  instead of failing — belongs to the redeploy, and writing it now would claim a fix this PR does
  not ship. `changelog/2026-09-04-oauth-discovery-contract.md` says so explicitly.
- **Follow-up, and it is the actual fix:** repoint `anomalia-cli` on Vercel at
  `anomaliaso/anomalia`, Root Directory `cli/mcp`, and redeploy. Then re-run the walk above and
  add the public changelog line.
- **The redirect table is a fact about hosting, kept in the test as data.** If the apex → www
  redirect is ever removed, that one row is what has to change; the test says so by failing.
- **Known gap:** `authServerUrl()` hardcodes Anomalia's own www for any non-local `PUBLIC_APP_URL`,
  so a self-hosted MCP server would advertise `anomalia.so` as its authorization server.
  Deliberately left alone — collapsing it to `appUrl()` would make a stray `PUBLIC_APP_URL` in a
  Vercel dashboard able to reintroduce the apex, which is the failure this whole PR is about.
  Worth revisiting when self-hosted MCP is a real requirement.
- **`LESSONS.md`** gains the lesson this cost: when production contradicts the code you just read,
  ask Vercel which repo and which commit served that domain before diagnosing anything else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
