### PR TITLE
Add the thin-shell calendar at /v2/:brand/calendar

### DIFF
--- a/changelog/2026-09-04-thin-frontend-calendar.md
+++ b/changelog/2026-09-04-thin-frontend-calendar.md
@@ -1,0 +1,176 @@
+# Il calendario della nuova shell, contro la REST e non contro il database
+
+Il piano `docs/external-agent-plan.md` (Fase 4) elenca otto rotte per la shell nuova, e nella
+tabella dei rischi elenca anche *"UI rewrite expands again"* con il controllo *"Ship only the
+control-plane surfaces listed above"*. Otto rotte in una volta è esattamente il modo in cui quel
+rischio si avvera. Qui ne arriva **una**: il calendario.
+
+È la prima giusta per tre motivi. È il ciclo operativo vero (pianifica, rivedi, modifica,
+approva). Il piano dice che *assorbe* la coda di approvazione e il dettaglio del post invece di
+tenerli come aree separate — quindi una rotta sola copre tre pagine di oggi. E stressa il confine
+REST più di qualunque altra vista: legge un mese, apre un post, ne riscrive la copy, lo approva.
+Se il calendario regge contro la REST con dei numeri decenti, le altre seguono lo stesso schema;
+se non regge, meglio scoprirlo su una rotta che su otto.
+
+## Dove vive, e perché lì
+
+`/v2/:brand/calendar`.
+
+La mappa del piano dice `/app/:brand/calendar`, che l'app di oggi occupa già — e la consegna era
+esplicita: **non toccare niente sotto `src/routes/app/[brand]/`**. Serviva un indirizzo dove
+stare finché la parità non è dimostrata.
+
+`/v2` è un prefisso di versione, non un nome di prodotto: dice "seconda versione di `/app`, non
+ancora al posto della prima" senza inventare vocabolario che poi va disimparato (`/console`,
+`/next`, `/shell` avrebbero tutti promesso qualcosa). La promozione, il giorno che la parità c'è,
+è un `git mv src/routes/v2 src/routes/app`: la struttura sotto è già quella della mappa del piano.
+Nessuna collisione con `/api/v1`, che sta sotto `/api`.
+
+## La REST è il confine, davvero
+
+La pagina non legge Supabase. Il `load` prende la sessione da `locals.safeGetSession()` — solo
+per avere il token — e poi chiama `GET /api/v1/brands/:slug/calendar` con quel Bearer. Le due
+azioni fanno lo stesso: `PUT /posts/:id` per la copy, `POST /posts/:id/approve` per
+l'approvazione. Zero import da `$lib/server/cli-queries` nella pagina.
+
+Non è purismo: è il punto dell'esercizio. Web, MCP e CLI passano dalle stesse regole di prodotto,
+quindi una regola che cambia nell'endpoint cambia per tutti e tre insieme, e un difetto trovato
+da uno è un difetto per tutti. La prima volta che la pagina avesse letto una query del server,
+il calendario e `anomalia content` avrebbero potuto divergere in silenzio.
+
+SvelteKit serve il `fetch` interno del load senza un vero giro HTTP, quindi il confine non costa
+una richiesta di rete in più.
+
+## Le primitive: due aggiunte, il resto riusato
+
+Il piano dice di aggiungere **solo** le primitive che una superficie spedita usa davvero, e di
+riusare quelle già in `src/lib/components/ui`.
+
+Riusate: `button`, `badge`, `label`, `sheet` (il pannello del post entra da destra invece di
+essere una rotta a sé).
+
+Aggiunte, due: `textarea` — la copy si modifica lì — e `alert-dialog`, per la conferma
+dell'approvazione. `alert-dialog` non è decorazione: `role="alertdialog"`, trappola del focus,
+Escape, e l'azione che manda un post fuori dall'edificio è esattamente il caso per cui la
+primitiva esiste.
+
+`shadcn-svelte add` ha anche riscritto `button.svelte` (riordino di classi, nessun
+comportamento diverso) e ha alzato `tailwind-variants` in `package.json`: entrambi ripristinati.
+Un bump di dipendenza non c'entra niente con questa PR.
+
+## L'approvazione dice quello che fa
+
+Questo è il pezzo che conta. Il contratto di oggi, scritto nel piano senza giri di parole:
+**approvare autorizza la distribuzione e la tenta subito.** Nessuno stato nuovo è stato
+inventato, nessuna parola è stata ammorbidita.
+
+Nel pannello la conseguenza si legge **prima** del clic, in tre pezzi:
+
+1. una riga fissa: approvare autorizza la distribuzione e consegna il post agli account
+   collegati subito, non c'è un passo "pubblica" separato;
+2. la data vera, calcolata dal post: `distributionNote` dice l'istante nel fuso del brand se è
+   ancora nel futuro, e altrimenti dice che il post esce al primo slot utile — *possibly right
+   away*. È l'unico punto in cui il testo poteva mentire, e per questo è una funzione pura con
+   tre test: la scorciatoia sarebbe stata scrivere "programmato per {data}" anche quando la data
+   è passata, che è precisamente il caso in cui il post esce all'istante;
+3. un `alert-dialog` che ripete la conseguenza e nomina la piattaforma, con "Keep it pending"
+   come uscita.
+
+Il bottone dice *Approve and distribute*, non *Approve*.
+
+## Due difetti trovati costruendola
+
+**L'ultimo giorno del mese spariva.** `getCalendar` costruiva la finestra della query così:
+
+    const lastDay = new Date(year, month, 0);
+    const endStr = lastDay.toISOString().slice(0, 10);
+
+`new Date(2026, 8, 30)` è mezzanotte **locale del server**. A est di UTC, `toISOString()` la
+riporta al giorno prima: con `TZ=Europe/Rome` la finestra di settembre diventava
+`2026-08-31 … 2026-09-29`. Ogni post dell'ultimo giorno del mese era invisibile nel calendario —
+e quello del 31 del mese precedente compariva di straforo. Su Vercel non si vede perché le
+funzioni girano in UTC; su qualunque runtime che non lo sia, sì.
+
+Non è un difetto del frontend: `getCalendar` è la lettura condivisa da REST, CLI e MCP, quindi
+`anomalia content` e `get_calendar` mentivano allo stesso modo. Il test di regressione fissa il
+fuso del server dentro il test (`process.env.TZ`), così è rosso anche su un runner UTC invece di
+esserlo solo sulla macchina di chi l'ha scritto. La finestra ora si costruisce dai numeri, senza
+passare da un `Date` locale. Sta in un commit a parte: è un cambio di comportamento del backend,
+non la nuova superficie.
+
+**`.grid` di `app.css` sequestra l'utility `grid` di Tailwind.** `src/app.css` (globale, su ogni
+pagina) definisce `.grid { display: grid; grid-template-columns: 1.7fr 1fr; gap: 16px }`. È una
+classe di layout scritta a mano che porta lo stesso nome dell'utility Tailwind. Le utility di
+Tailwind qui sono `important` e vincono su `display`, ma `grid-template-columns` non ha una
+controparte da sovrascrivere: resta quella di `app.css`. Risultato, l'`alert-dialog` di
+shadcn — che usa `grid` — usciva su due colonne, con titolo, testo e bottoni affiancati e il
+footer fuori dal riquadro.
+
+Rimediato **localmente** al punto di chiamata (`flex flex-col` su Content e Header, che
+tailwind-merge risolve togliendo `grid`), come il piano permette esplicitamente: *replace styling
+locally when it does not fit*. Rinominare `.grid` in `app.css` toccherebbe decine di pagine
+legacy e non è il lavoro di questa PR — ma è una mina che ogni prossima primitiva shadcn può
+pestare, e va disinnescata prima che `/v2` diventi `/app`.
+
+## Le condizioni stanno in un posto solo
+
+`POST_STATES` è una tabella: per ogni status, l'etichetta, il tono del badge, se si modifica, se
+si approva. Uno status sconosciuto non concede niente. Non c'è un `if (status === 'published')`
+sparso nella pagina e un altro nel pannello: la prossima riga di stato si aggiunge alla tabella e
+si vede accanto a tutte le altre.
+
+## Il fuso orario è del brand, non del server
+
+`getCalendar` torna gli istanti in UTC e il fuso del brand a parte. Mettere un post nella casella
+del giorno leggendo la data del server sposta di un giorno tutti i post di sera: un post delle
+23:30 UTC del 31 agosto è il 1° settembre a Roma. La griglia raggruppa con
+`Intl.DateTimeFormat('en-CA', { timeZone })`, e il test che lo tiene fermo è
+`un post di fine mese cade sul giorno del brand, non su quello UTC`.
+
+Conseguenza meno ovvia: la griglia mostra **sempre sei settimane**. Con cinque, un mese che
+chiude di domenica (maggio 2026) faceva sparire dalla vista il post che nel fuso del brand
+scivola al giorno dopo — il bordo della griglia cadeva prima. Sei settimane coprono sempre
+l'ultimo giorno più uno, e in più l'altezza non balla navigando fra i mesi. Anche questo ha il
+suo test.
+
+Le bozze senza data non finiscono su "oggi": stanno in una fascia a parte sotto la griglia, che
+dice cosa sono e perché non sono sul calendario. `get_calendar` le marca già `isDraft` — una
+distinzione sistemata di proposito a suo tempo, e qui è onorata invece che appiattita.
+
+## JavaScript iniziale — misura NON presa
+
+Il piano chiede di misurare la rotta nuova contro un SvelteKit vuoto. **Non è stato fatto**, e il
+numero non c'è: serve un `vite build` di produzione, e la macchina su cui girava questo lavoro era
+in swap con nove agenti in parallelo. Un numero inventato sarebbe peggio di nessun numero.
+
+Quello che è stato fatto invece è la leva che quel numero servirebbe a giudicare: il pannello del
+post — `Sheet` e `AlertDialog`, cioè tutto bits-ui — sta in un componente a parte importato
+dinamicamente al **primo post aperto**, non al caricamento della rotta. La griglia del mese, la
+navigazione fra i mesi e la fascia delle bozze non caricano una riga di bits-ui. Lo script per
+la misura è pronto (chiusura transitiva del manifest Vite per: framework da solo → più il layout
+di root → più la rotta → più il pannello) e va eseguito dopo un build su una macchina scarica.
+
+Il conto grosso è comunque già visibile a occhio nudo, e non è di questa rotta: vedi sotto.
+
+## Cosa non è stato costruito, di proposito
+
+- **Nessun `approve-all`.** L'endpoint esiste. Un bottone che approva tutto è un bottone che
+  distribuisce tutto: se una superficie deve rendere leggibile la conseguenza prima del clic,
+  quella conseguenza moltiplicata per venti post non è leggibile.
+- **Nessun `GET /posts/:id/media`.** La risposta del calendario porta già caption, media_url,
+  piattaforma, status e data: aprire un post non costa un secondo giro. Le slide dei carousel e
+  i video restano fuori — quando serviranno, quell'endpoint è lì.
+- **Nessun drag-and-drop, nessun reschedule, nessun delete, nessun revoke.** Sono altri verbi,
+  ognuno con la sua conseguenza da rendere leggibile.
+- **Nessuna shell, nessun layout `/v2`.** Una rotta sola non ha bisogno di una navigazione: il
+  layout condiviso si estrae quando la seconda superficie lo chiede davvero.
+- **Nessun changelog pubblico.** Niente manda un cliente su `/v2`: annunciare una superficie che
+  nessuno può raggiungere è una riga che invecchia male.
+
+## Quello che resta storto
+
+Il `+layout.svelte` di root è globale e non si scavalca: svelte-i18n, analytics, cookie banner e
+lo shimmer d'ingresso entrano anche in questa rotta, che non ne usa nessuno. Il piano chiede di
+*rifiutare le dipendenze globali che alzano il JavaScript iniziale senza servire la prima
+interazione*: dentro una rotta non si possono rifiutare. È il primo conto da pagare il giorno in
+cui `/v2` diventa `/app`, e il numero qui sopra dice quanto vale.

--- a/src/lib/components/ui/alert-dialog/alert-dialog-action.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-action.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+	import {
+		buttonVariants,
+		type ButtonVariant,
+		type ButtonSize,
+	} from "$lib/components/ui/button/index.js";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		variant = "default",
+		size = "default",
+		...restProps
+	}: AlertDialogPrimitive.ActionProps & {
+		variant?: ButtonVariant;
+		size?: ButtonSize;
+	} = $props();
+</script>
+
+<AlertDialogPrimitive.Action
+	bind:ref
+	data-slot="alert-dialog-action"
+	class={cn(buttonVariants({ variant, size }), "cn-alert-dialog-action", className)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-cancel.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-cancel.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+	import {
+		buttonVariants,
+		type ButtonVariant,
+		type ButtonSize,
+	} from "$lib/components/ui/button/index.js";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		variant = "outline",
+		size = "default",
+		...restProps
+	}: AlertDialogPrimitive.CancelProps & {
+		variant?: ButtonVariant;
+		size?: ButtonSize;
+	} = $props();
+</script>
+
+<AlertDialogPrimitive.Cancel
+	bind:ref
+	data-slot="alert-dialog-cancel"
+	class={cn(buttonVariants({ variant, size }), "cn-alert-dialog-cancel", className)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-content.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-content.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+	import { cn, type WithoutChild, type WithoutChildrenOrChild } from "$lib/utils.js";
+	import AlertDialogOverlay from "./alert-dialog-overlay.svelte";
+	import AlertDialogPortal from "./alert-dialog-portal.svelte";
+	import type { ComponentProps } from "svelte";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		size = "default",
+		portalProps,
+		...restProps
+	}: WithoutChild<AlertDialogPrimitive.ContentProps> & {
+		size?: "default" | "sm";
+		portalProps?: WithoutChildrenOrChild<ComponentProps<typeof AlertDialogPortal>>;
+	} = $props();
+</script>
+
+<AlertDialogPortal {...portalProps}>
+	<AlertDialogOverlay />
+	<AlertDialogPrimitive.Content
+		bind:ref
+		data-slot="alert-dialog-content"
+		data-size={size}
+		class={cn(
+			"gap-4 rounded-xl bg-popover p-4 text-popover-foreground ring-1 ring-foreground/10 duration-100 data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 outline-none",
+			className
+		)}
+		{...restProps}
+	/>
+</AlertDialogPortal>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-description.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-description.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: AlertDialogPrimitive.DescriptionProps = $props();
+</script>
+
+<AlertDialogPrimitive.Description
+	bind:ref
+	data-slot="alert-dialog-description"
+	class={cn("text-sm text-balance text-muted-foreground md:text-pretty *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground", className)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-footer.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-footer.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="alert-dialog-footer"
+	class={cn(
+		"-mx-4 -mb-4 rounded-b-xl border-t bg-muted/50 p-4 flex flex-col-reverse gap-2 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end",
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-header.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-header.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="alert-dialog-header"
+	class={cn("grid grid-rows-[auto_1fr] place-items-center gap-1.5 text-center has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-4 sm:group-data-[size=default]/alert-dialog-content:place-items-start sm:group-data-[size=default]/alert-dialog-content:text-left sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr]", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-media.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-media.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="alert-dialog-media"
+	class={cn("mb-2 inline-flex size-10 items-center justify-center rounded-md bg-muted sm:group-data-[size=default]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-6", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-overlay.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-overlay.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: AlertDialogPrimitive.OverlayProps = $props();
+</script>
+
+<AlertDialogPrimitive.Overlay
+	bind:ref
+	data-slot="alert-dialog-overlay"
+	class={cn("bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0 fixed inset-0 z-50", className)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-portal.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-portal.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+
+	let { ...restProps }: AlertDialogPrimitive.PortalProps = $props();
+</script>
+
+<AlertDialogPrimitive.Portal {...restProps} />

--- a/src/lib/components/ui/alert-dialog/alert-dialog-title.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-title.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: AlertDialogPrimitive.TitleProps = $props();
+</script>
+
+<AlertDialogPrimitive.Title
+	bind:ref
+	data-slot="alert-dialog-title"
+	class={cn("text-base font-medium sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2", className)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-trigger.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-trigger.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+
+	let { ref = $bindable(null), ...restProps }: AlertDialogPrimitive.TriggerProps = $props();
+</script>
+
+<AlertDialogPrimitive.Trigger bind:ref data-slot="alert-dialog-trigger" {...restProps} />

--- a/src/lib/components/ui/alert-dialog/alert-dialog.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+
+	let { open = $bindable(false), ...restProps }: AlertDialogPrimitive.RootProps = $props();
+</script>
+
+<AlertDialogPrimitive.Root bind:open {...restProps} />

--- a/src/lib/components/ui/alert-dialog/index.ts
+++ b/src/lib/components/ui/alert-dialog/index.ts
@@ -1,0 +1,40 @@
+import Action from "./alert-dialog-action.svelte";
+import Cancel from "./alert-dialog-cancel.svelte";
+import Content from "./alert-dialog-content.svelte";
+import Description from "./alert-dialog-description.svelte";
+import Footer from "./alert-dialog-footer.svelte";
+import Header from "./alert-dialog-header.svelte";
+import Media from "./alert-dialog-media.svelte";
+import Overlay from "./alert-dialog-overlay.svelte";
+import Portal from "./alert-dialog-portal.svelte";
+import Title from "./alert-dialog-title.svelte";
+import Trigger from "./alert-dialog-trigger.svelte";
+import Root from "./alert-dialog.svelte";
+
+export {
+	Root,
+	Title,
+	Action,
+	Cancel,
+	Portal,
+	Footer,
+	Header,
+	Trigger,
+	Overlay,
+	Content,
+	Description,
+	Media,
+	//
+	Root as AlertDialog,
+	Title as AlertDialogTitle,
+	Action as AlertDialogAction,
+	Cancel as AlertDialogCancel,
+	Portal as AlertDialogPortal,
+	Footer as AlertDialogFooter,
+	Header as AlertDialogHeader,
+	Trigger as AlertDialogTrigger,
+	Overlay as AlertDialogOverlay,
+	Content as AlertDialogContent,
+	Description as AlertDialogDescription,
+	Media as AlertDialogMedia,
+};

--- a/src/lib/components/ui/textarea/index.ts
+++ b/src/lib/components/ui/textarea/index.ts
@@ -1,0 +1,7 @@
+import Root from "./textarea.svelte";
+
+export {
+	Root,
+	//
+	Root as Textarea,
+};

--- a/src/lib/components/ui/textarea/textarea.svelte
+++ b/src/lib/components/ui/textarea/textarea.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import { cn, type WithElementRef, type WithoutChildren } from "$lib/utils.js";
+	import type { HTMLTextareaAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		value = $bindable(),
+		class: className,
+		"data-slot": dataSlot = "textarea",
+		...restProps
+	}: WithoutChildren<WithElementRef<HTMLTextareaAttributes>> = $props();
+</script>
+
+<textarea
+	bind:this={ref}
+	data-slot={dataSlot}
+	class={cn(
+		"rounded-lg border border-input bg-transparent px-2.5 py-2 text-base transition-colors focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:bg-input/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 flex field-sizing-content min-h-16 w-full outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+		className
+	)}
+	bind:value
+	{...restProps}></textarea>

--- a/src/lib/server/cli-queries.calendar.test.ts
+++ b/src/lib/server/cli-queries.calendar.test.ts
@@ -71,6 +71,24 @@ const calendar = (rows: Record<string, unknown>[], year: number, month: number) 
   return getCalendar(client as unknown as SupabaseLike, 'brand-1', 'Europe/Rome', year, month);
 };
 
+const LAST_DAY_OF_OCTOBER = {
+  id: 'last-day',
+  brand_id: 'brand-1',
+  status: 'scheduled',
+  scheduled_for: '2030-10-31T21:00:00.000Z',
+  slot: '2030-10-31'
+};
+
+async function underServerTimezone<T>(timezone: string, run: () => Promise<T>): Promise<T> {
+  const original = process.env.TZ;
+  process.env.TZ = timezone;
+  try {
+    return await run();
+  } finally {
+    process.env.TZ = original;
+  }
+}
+
 describe('getCalendar con un post proposto dall esterno', () => {
   it('mette un pending datato nel suo mese', async () => {
     const out = await calendar([DATED_IN_OCTOBER], 2030, 10);
@@ -96,5 +114,42 @@ describe('getCalendar con un post proposto dall esterno', () => {
     const out = await calendar([DATED_IN_OCTOBER], 2030, 10);
 
     expect(out.posts.find((p) => p.id === 'proposed')?.isDraft).toBeUndefined();
+  });
+});
+
+describe('la finestra del mese non dipende dal fuso del server', () => {
+  it('arriva fino all ultimo giorno anche a est di UTC', async () => {
+    const posts = await underServerTimezone('Europe/Rome', async () => {
+      const out = await calendar([LAST_DAY_OF_OCTOBER], 2030, 10);
+      return out.posts.map((p) => p.id);
+    });
+
+    expect(posts).toContain('last-day');
+  });
+
+  it('non tira dentro l ultimo giorno del mese prima', async () => {
+    const previousMonthTail = {
+      id: 'september-tail',
+      brand_id: 'brand-1',
+      status: 'scheduled',
+      scheduled_for: '2030-09-30T21:00:00.000Z',
+      slot: '2030-09-30'
+    };
+
+    const posts = await underServerTimezone('Europe/Rome', async () => {
+      const out = await calendar([previousMonthTail], 2030, 10);
+      return out.posts.map((p) => p.id);
+    });
+
+    expect(posts).not.toContain('september-tail');
+  });
+
+  it('la stessa finestra a ovest di UTC', async () => {
+    const posts = await underServerTimezone('America/Los_Angeles', async () => {
+      const out = await calendar([LAST_DAY_OF_OCTOBER], 2030, 10);
+      return out.posts.map((p) => p.id);
+    });
+
+    expect(posts).toContain('last-day');
   });
 });

--- a/src/lib/server/cli-queries.ts
+++ b/src/lib/server/cli-queries.ts
@@ -462,11 +462,14 @@ export async function getVoice(supabase: SupabaseClient, brandId: string) {
 
 // ── Calendar ────────────────────────────────────────────────────────────
 
+function isoDate(year: number, month: number, day: number): string {
+  return `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+}
+
 export async function getCalendar(supabase: SupabaseClient, brandId: string, brandTimezone: string, year: number, month: number, brandLanguage: string | null = null) {
-  const firstDay = new Date(year, month - 1, 1);
-  const lastDay = new Date(year, month, 0);
-  const startStr = firstDay.toISOString().slice(0, 10);
-  const endStr = lastDay.toISOString().slice(0, 10);
+  const lastDayOfMonth = new Date(Date.UTC(year, month, 0)).getUTCDate();
+  const startStr = isoDate(year, month, 1);
+  const endStr = isoDate(year, month, lastDayOfMonth);
 
   const [schedRes, slotRes, draftRes] = await Promise.all([
     supabase.from('posts')

--- a/src/routes/v2/[brand]/calendar/+page.server.ts
+++ b/src/routes/v2/[brand]/calendar/+page.server.ts
@@ -1,0 +1,145 @@
+import { error, fail, redirect } from '@sveltejs/kit';
+import type { Actions, PageServerLoad } from './$types';
+import { dayInZone, type CalendarPost } from './calendar-month';
+
+type Calendar = {
+  posts: CalendarPost[];
+  year: number;
+  month: number;
+  monthLabel: string;
+  prevYM: string;
+  nextYM: string;
+  timezone: string;
+};
+
+type ApproveResult = {
+  ok?: boolean;
+  status?: string;
+  noAccount?: boolean;
+  message?: string;
+  error?: string;
+};
+
+type Outcome = {
+  id: string | null;
+  message: string | null;
+  saved: boolean;
+  approved: boolean;
+  status: string | null;
+};
+
+const MONTH_PARAM = /^\d{4}-\d{2}$/;
+const CAPTION_MAX = 20_000;
+
+function outcome(partial: Partial<Outcome>): Outcome {
+  return { id: null, message: null, saved: false, approved: false, status: null, ...partial };
+}
+
+function brandApi(slug: string, path: string): string {
+  return `/api/v1/brands/${encodeURIComponent(slug)}${path}`;
+}
+
+async function readError(res: Response): Promise<string> {
+  const body = (await res.json().catch(() => null)) as { error?: string } | null;
+  return body?.error ?? `Request failed (${res.status})`;
+}
+
+export const load: PageServerLoad = async ({ params, url, fetch, locals }) => {
+  const { session } = await locals.safeGetSession();
+  if (!session) {
+    redirect(303, '/login');
+  }
+
+  const month = url.searchParams.get('month');
+  const query = month && MONTH_PARAM.test(month) ? `?month=${month}` : '';
+
+  const res = await fetch(brandApi(params.brand, `/calendar${query}`), {
+    headers: { Authorization: `Bearer ${session.access_token}` }
+  });
+
+  if (!res.ok) {
+    error(res.status, await readError(res));
+  }
+
+  const calendar = (await res.json()) as Calendar;
+
+  return {
+    brand: params.brand,
+    calendar,
+    today: dayInZone(new Date().toISOString(), calendar.timezone),
+    selectedPostId: url.searchParams.get('post')
+  };
+};
+
+export const actions: Actions = {
+  edit: async ({ request, params, fetch, locals }) => {
+    const { session } = await locals.safeGetSession();
+    if (!session) {
+      redirect(303, '/login');
+    }
+
+    const form = await request.formData();
+    const id = String(form.get('id') ?? '');
+    const caption = String(form.get('caption') ?? '');
+
+    if (!id) {
+      return fail(400, outcome({ message: 'Missing post.' }));
+    }
+    if (!caption.trim()) {
+      return fail(400, outcome({ id, message: 'The copy cannot be empty.' }));
+    }
+    if (caption.length > CAPTION_MAX) {
+      return fail(400, outcome({ id, message: 'The copy is too long to save.' }));
+    }
+
+    const res = await fetch(brandApi(params.brand, `/posts/${encodeURIComponent(id)}`), {
+      method: 'PUT',
+      headers: {
+        Authorization: `Bearer ${session.access_token}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ caption })
+    });
+
+    if (!res.ok) {
+      return fail(res.status, outcome({ id, message: await readError(res) }));
+    }
+
+    return outcome({ id, saved: true });
+  },
+
+  approve: async ({ request, params, fetch, locals }) => {
+    const { session } = await locals.safeGetSession();
+    if (!session) {
+      redirect(303, '/login');
+    }
+
+    const form = await request.formData();
+    const id = String(form.get('id') ?? '');
+
+    if (!id) {
+      return fail(400, outcome({ message: 'Missing post.' }));
+    }
+
+    const res = await fetch(brandApi(params.brand, `/posts/${encodeURIComponent(id)}/approve`), {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${session.access_token}` }
+    });
+
+    const result = (await res.json().catch(() => null)) as ApproveResult | null;
+
+    if (!res.ok || result?.error) {
+      return fail(
+        res.ok ? 400 : res.status,
+        outcome({ id, message: result?.error ?? 'Approval failed.' })
+      );
+    }
+
+    return outcome({
+      id,
+      approved: true,
+      status: result?.status ?? 'approved',
+      message: result?.message ?? null
+    });
+  }
+};

--- a/src/routes/v2/[brand]/calendar/+page.svelte
+++ b/src/routes/v2/[brand]/calendar/+page.svelte
@@ -1,0 +1,196 @@
+<script lang="ts">
+  import '$lib/styles/tailwind.css';
+  import { replaceState } from '$app/navigation';
+  import { page } from '$app/state';
+  import { Badge } from '$lib/components/ui/badge/index.js';
+  import { buildMonthGrid, stateOf, timeInZone } from './calendar-month';
+  import type { CalendarPost } from './calendar-month';
+  import type { PageProps } from './$types';
+
+  const WEEKDAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+
+  let { data, form }: PageProps = $props();
+
+  const calendar = $derived(data.calendar);
+  const grid = $derived(
+    buildMonthGrid(calendar.year, calendar.month, calendar.posts, calendar.timezone)
+  );
+  const pendingCount = $derived(calendar.posts.filter((p) => p.status === 'pending_user').length);
+  const datedCount = $derived(calendar.posts.length - grid.undated.length);
+
+  let selectedId = $state<string | null>(data.selectedPostId);
+  let PostPanel = $state<typeof import('./PostPanel.svelte').default | null>(null);
+
+  const selected = $derived(calendar.posts.find((p) => p.id === selectedId) ?? null);
+
+  $effect(() => {
+    if (selectedId && !PostPanel) {
+      import('./PostPanel.svelte').then((m) => (PostPanel = m.default));
+    }
+  });
+
+  function monthHref(ym: string): string {
+    return `?month=${ym}`;
+  }
+
+  function syncUrl(postId: string | null) {
+    const url = new URL(page.url);
+    if (postId) {
+      url.searchParams.set('post', postId);
+    } else {
+      url.searchParams.delete('post');
+    }
+    replaceState(url, page.state);
+  }
+
+  function open(post: CalendarPost) {
+    selectedId = post.id;
+    syncUrl(post.id);
+  }
+
+  function close() {
+    selectedId = null;
+    syncUrl(null);
+  }
+
+  function summary(post: CalendarPost): string {
+    return (post.caption ?? '').trim().slice(0, 60) || 'Untitled';
+  }
+</script>
+
+<svelte:head><title>{calendar.monthLabel} — {data.brand}</title></svelte:head>
+
+<div class="bg-background text-foreground min-h-screen px-4 py-8 sm:px-8">
+  <div class="mx-auto flex max-w-6xl flex-col gap-6">
+    <header class="flex flex-wrap items-end justify-between gap-4">
+      <div class="flex flex-col gap-1">
+        <p class="text-muted-foreground text-xs tracking-wide uppercase">{data.brand}</p>
+        <h1 class="text-2xl font-semibold">{calendar.monthLabel}</h1>
+        <p class="text-muted-foreground text-xs">
+          Times shown in {calendar.timezone}
+          {#if pendingCount > 0}
+            · <strong class="text-foreground">{pendingCount} waiting for review</strong>
+          {/if}
+        </p>
+      </div>
+
+      <nav class="flex items-center gap-2" aria-label="Month">
+        <a
+          href={monthHref(calendar.prevYM)}
+          class="border-border hover:bg-muted focus-visible:ring-ring/50 rounded-lg border px-3 py-1.5 text-sm focus-visible:ring-3 focus-visible:outline-none"
+          aria-label="Previous month">←</a
+        >
+        <a
+          href="?"
+          class="border-border hover:bg-muted focus-visible:ring-ring/50 rounded-lg border px-3 py-1.5 text-sm focus-visible:ring-3 focus-visible:outline-none"
+          >Today</a
+        >
+        <a
+          href={monthHref(calendar.nextYM)}
+          class="border-border hover:bg-muted focus-visible:ring-ring/50 rounded-lg border px-3 py-1.5 text-sm focus-visible:ring-3 focus-visible:outline-none"
+          aria-label="Next month">→</a
+        >
+      </nav>
+    </header>
+
+    {#if form && form.id !== selectedId}
+      <p
+        role={form.message && !form.approved ? 'alert' : 'status'}
+        class="rounded-lg border px-3 py-2 text-sm {form.message && !form.approved
+          ? 'border-destructive/40 text-destructive'
+          : 'border-border'}"
+      >
+        {form.message ?? (form.approved ? `Approved — the post is now ${form.status}.` : 'Copy saved.')}
+      </p>
+    {/if}
+
+    <section aria-label="Month calendar" class="overflow-x-auto">
+      <div class="min-w-[42rem]">
+        <div class="text-muted-foreground grid grid-cols-7 gap-px pb-1 text-xs font-medium">
+          {#each WEEKDAYS as weekday (weekday)}
+            <div class="px-2">{weekday}</div>
+          {/each}
+        </div>
+
+        <div class="bg-border grid grid-cols-7 gap-px overflow-hidden rounded-xl border-0">
+          {#each grid.weeks as week, w (w)}
+            {#each week as day (day.date)}
+              <div
+                class="bg-background flex h-full min-h-24 flex-col gap-1 p-2 {day.inMonth
+                  ? ''
+                  : 'opacity-45'}"
+              >
+                <div class="flex items-baseline gap-1">
+                  <span
+                    class="text-xs {day.date === data.today
+                      ? 'bg-primary text-primary-foreground rounded-full px-1.5 py-0.5 font-semibold'
+                      : 'text-muted-foreground'}">{day.dayOfMonth}</span
+                  >
+                </div>
+
+                {#each day.posts as post (post.id)}
+                  {@const postState = stateOf(post.status)}
+                  <button
+                    type="button"
+                    onclick={() => open(post)}
+                    class="hover:bg-muted focus-visible:ring-ring/50 w-full rounded-md border px-1.5 py-1 text-left text-xs focus-visible:ring-3 focus-visible:outline-none {postState.canApprove
+                      ? 'border-primary/60 bg-primary/5'
+                      : 'border-border'}"
+                  >
+                    <span class="block font-medium">
+                      {post.scheduled_for ? timeInZone(post.scheduled_for, calendar.timezone) : '—'}
+                      · {post.platform ?? 'post'}
+                    </span>
+                    <span class="text-muted-foreground line-clamp-2 block">{summary(post)}</span>
+                  </button>
+                {/each}
+              </div>
+            {/each}
+          {/each}
+        </div>
+      </div>
+    </section>
+
+    {#if datedCount === 0}
+      <p class="text-muted-foreground text-sm">Nothing planned in {calendar.monthLabel}.</p>
+    {/if}
+
+    <section aria-labelledby="undated-heading" class="flex flex-col gap-2">
+      <h2 id="undated-heading" class="text-sm font-semibold">
+        Drafts without a date ({grid.undated.length})
+      </h2>
+      <p class="text-muted-foreground text-xs">
+        Written, not on the calendar. They stay here until a date is set.
+      </p>
+
+      {#if grid.undated.length === 0}
+        <p class="text-muted-foreground text-sm">None.</p>
+      {:else}
+        <ul class="flex flex-wrap gap-2">
+          {#each grid.undated as post (post.id)}
+            {@const postState = stateOf(post.status)}
+            <li>
+              <button
+                type="button"
+                onclick={() => open(post)}
+                class="border-border hover:bg-muted focus-visible:ring-ring/50 flex max-w-xs flex-col gap-1 rounded-lg border border-dashed px-3 py-2 text-left text-xs focus-visible:ring-3 focus-visible:outline-none"
+              >
+                <span class="flex items-center gap-2">
+                  <span class="font-medium">{post.platform ?? 'post'}</span>
+                  <Badge variant={postState.tone}>{postState.label}</Badge>
+                </span>
+                <span class="text-muted-foreground line-clamp-2">{summary(post)}</span>
+              </button>
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    </section>
+  </div>
+</div>
+
+{#if PostPanel && selected}
+  {#key selected.id}
+    <PostPanel post={selected} timezone={calendar.timezone} {form} onclose={close} />
+  {/key}
+{/if}

--- a/src/routes/v2/[brand]/calendar/PostPanel.svelte
+++ b/src/routes/v2/[brand]/calendar/PostPanel.svelte
@@ -1,0 +1,164 @@
+<script lang="ts">
+  import { enhance } from '$app/forms';
+  import * as AlertDialog from '$lib/components/ui/alert-dialog/index.js';
+  import * as Sheet from '$lib/components/ui/sheet/index.js';
+  import { Badge } from '$lib/components/ui/badge/index.js';
+  import { Button, buttonVariants } from '$lib/components/ui/button/index.js';
+  import { Label } from '$lib/components/ui/label/index.js';
+  import { Textarea } from '$lib/components/ui/textarea/index.js';
+  import { distributionNote, momentInZone, stateOf } from './calendar-month';
+  import type { CalendarPost } from './calendar-month';
+
+  type Outcome = {
+    id: string | null;
+    message: string | null;
+    saved: boolean;
+    approved: boolean;
+    status: string | null;
+  };
+
+  let {
+    post,
+    timezone,
+    form,
+    onclose
+  }: {
+    post: CalendarPost;
+    timezone: string;
+    form: Outcome | null;
+    onclose: () => void;
+  } = $props();
+
+  const postState = $derived(stateOf(post.status));
+  const outcome = $derived(form?.id === post.id ? form : null);
+
+  let caption = $state(post.caption ?? '');
+  let confirming = $state(false);
+  let saving = $state(false);
+  let approving = $state(false);
+
+</script>
+
+<Sheet.Root open onOpenChange={(open) => !open && onclose()}>
+  <Sheet.Content side="right" class="gap-0 overflow-y-auto data-[side=right]:sm:max-w-lg">
+    <Sheet.Header class="gap-2">
+      <Sheet.Title class="flex items-center gap-2 text-base">
+        {post.platform ?? 'Post'}
+        <Badge variant={postState.tone}>{postState.label}</Badge>
+      </Sheet.Title>
+      <Sheet.Description>
+        {post.scheduled_for ? momentInZone(post.scheduled_for, timezone) : 'No date yet'}
+      </Sheet.Description>
+    </Sheet.Header>
+
+    <div class="flex flex-col gap-5 px-4 pb-6">
+      {#if post.media_url}
+        <img
+          src={post.media_url}
+          alt="Visual attached to this post"
+          loading="lazy"
+          class="border-border max-h-72 w-full rounded-lg border object-contain"
+        />
+      {/if}
+
+      {#if outcome?.message}
+        <p
+          role={outcome.approved ? 'status' : 'alert'}
+          class="rounded-lg border px-3 py-2 text-sm {outcome.approved
+            ? 'border-border'
+            : 'border-destructive/40 text-destructive'}"
+        >
+          {outcome.message}
+        </p>
+      {:else if outcome?.saved}
+        <p role="status" class="border-border rounded-lg border px-3 py-2 text-sm">Copy saved.</p>
+      {:else if outcome?.approved}
+        <p role="status" class="border-border rounded-lg border px-3 py-2 text-sm">
+          Approved and sent for distribution — the post is now {outcome.status}.
+        </p>
+      {/if}
+
+      <form
+        method="POST"
+        action="?/edit"
+        class="flex flex-col gap-2"
+        use:enhance={() => {
+          saving = true;
+          return async ({ update }) => {
+            await update({ reset: false });
+            saving = false;
+          };
+        }}
+      >
+        <input type="hidden" name="id" value={post.id} />
+        <Label for="caption">Copy</Label>
+        <Textarea
+          id="caption"
+          name="caption"
+          bind:value={caption}
+          rows={10}
+          readonly={!postState.canEdit}
+          aria-describedby={postState.canEdit ? undefined : 'copy-locked'}
+        />
+        {#if postState.canEdit}
+          <div>
+            <Button type="submit" variant="outline" size="sm" disabled={saving}>
+              {saving ? 'Saving…' : 'Save copy'}
+            </Button>
+          </div>
+        {:else}
+          <p id="copy-locked" class="text-muted-foreground text-xs">
+            A published post is read-only here.
+          </p>
+        {/if}
+      </form>
+
+      {#if postState.canApprove}
+        <div class="border-border flex flex-col gap-3 rounded-lg border p-4">
+          <h3 class="text-sm font-semibold">Approve</h3>
+          <p class="text-muted-foreground text-sm">
+            Approving authorises distribution and hands the post to the connected accounts straight
+            away. There is no separate publish step and no state between here and live.
+          </p>
+          <p class="text-sm">{distributionNote(post, timezone)}</p>
+
+          <AlertDialog.Root bind:open={confirming}>
+            <AlertDialog.Trigger class="{buttonVariants({ size: 'sm' })} w-fit">
+              Approve and distribute
+            </AlertDialog.Trigger>
+            <AlertDialog.Content class="flex flex-col">
+              <AlertDialog.Header class="flex flex-col place-items-start text-left">
+                <AlertDialog.Title>Distribute this post?</AlertDialog.Title>
+                <AlertDialog.Description>
+                  {distributionNote(post, timezone)} Anomalia sends it to the connected {post.platform ??
+                    'social'} account. If no account is connected yet, the post stays approved and waits
+                  for one.
+                </AlertDialog.Description>
+              </AlertDialog.Header>
+              <form
+                method="POST"
+                action="?/approve"
+                use:enhance={() => {
+                  approving = true;
+                  return async ({ update }) => {
+                    await update({ reset: false });
+                    approving = false;
+                    confirming = false;
+                  };
+                }}
+              >
+                <input type="hidden" name="id" value={post.id} />
+                <AlertDialog.Footer>
+                  <AlertDialog.Cancel type="button">Keep it pending</AlertDialog.Cancel>
+                  <Button type="submit" disabled={approving}>
+                    {approving ? 'Sending…' : 'Approve and distribute'}
+                  </Button>
+                </AlertDialog.Footer>
+              </form>
+            </AlertDialog.Content>
+          </AlertDialog.Root>
+        </div>
+      {/if}
+    </div>
+  </Sheet.Content>
+</Sheet.Root>

--- a/src/routes/v2/[brand]/calendar/calendar-month.test.ts
+++ b/src/routes/v2/[brand]/calendar/calendar-month.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildMonthGrid,
+  distributionNote,
+  momentInZone,
+  stateOf,
+  timeInZone
+} from './calendar-month';
+import type { CalendarPost } from './calendar-month';
+
+const ROME = 'Europe/Rome';
+
+function post(overrides: Partial<CalendarPost> & { id: string }): CalendarPost {
+  return {
+    platform: 'instagram',
+    caption: 'copy',
+    media_url: null,
+    scheduled_for: null,
+    status: 'pending_user',
+    slot: null,
+    ...overrides
+  };
+}
+
+describe('buildMonthGrid', () => {
+  it('parte di lunedì e chiude di domenica, coprendo tutto il mese', () => {
+    const { weeks } = buildMonthGrid(2026, 8, [], ROME);
+
+    expect(weeks[0][0].date).toBe('2026-07-27');
+    expect(weeks.at(-1)?.at(-1)?.date).toBe('2026-09-06');
+    expect(weeks.every((w) => w.length === 7)).toBe(true);
+  });
+
+  it('marca fuori mese i giorni di riporto', () => {
+    const { weeks } = buildMonthGrid(2026, 8, [], ROME);
+    const days = weeks.flat();
+
+    expect(days.find((d) => d.date === '2026-07-31')?.inMonth).toBe(false);
+    expect(days.find((d) => d.date === '2026-08-01')?.inMonth).toBe(true);
+    expect(days.filter((d) => d.inMonth)).toHaveLength(31);
+  });
+
+  it('un post di fine mese cade sul giorno del brand, non su quello UTC', () => {
+    const late = post({ id: 'a', scheduled_for: '2026-08-31T23:30:00Z', status: 'scheduled' });
+
+    const { weeks, undated } = buildMonthGrid(2026, 8, [late], ROME);
+    const days = weeks.flat();
+
+    expect(days.find((d) => d.date === '2026-09-01')?.posts).toEqual([late]);
+    expect(days.find((d) => d.date === '2026-08-31')?.posts).toEqual([]);
+    expect(undated).toEqual([]);
+  });
+
+  it('un mese che chiude di domenica mostra comunque il giorno oltre il bordo', () => {
+    const midnight = post({ id: 'x', scheduled_for: '2026-05-31T23:30:00Z', status: 'scheduled' });
+
+    const { weeks, undated } = buildMonthGrid(2026, 5, [midnight], ROME);
+
+    expect(weeks.flat().find((d) => d.date === '2026-06-01')?.posts).toEqual([midnight]);
+    expect(undated).toEqual([]);
+  });
+
+  it('una bozza senza data resta fuori dalla griglia invece di finire su oggi', () => {
+    const draft = post({ id: 'b', isDraft: true });
+
+    const { weeks, undated } = buildMonthGrid(2026, 8, [draft], ROME);
+
+    expect(undated).toEqual([draft]);
+    expect(weeks.flat().every((d) => d.posts.length === 0)).toBe(true);
+  });
+
+  it('uno slot datato piazza un post che non ha scheduled_for', () => {
+    const slotted = post({ id: 'c', scheduled_for: null, slot: '2026-08-14', status: 'approved' });
+
+    const { weeks, undated } = buildMonthGrid(2026, 8, [slotted], ROME);
+
+    expect(weeks.flat().find((d) => d.date === '2026-08-14')?.posts).toEqual([slotted]);
+    expect(undated).toEqual([]);
+  });
+
+  it('uno slot ricorrente non è una data e non inventa un giorno', () => {
+    const recurring = post({ id: 'd', slot: 'Mon 09:00', isDraft: true });
+
+    const { undated } = buildMonthGrid(2026, 8, [recurring], ROME);
+
+    expect(undated).toEqual([recurring]);
+  });
+
+  it('ordina i post dello stesso giorno per orario', () => {
+    const late = post({ id: 'late', scheduled_for: '2026-08-14T16:00:00Z' });
+    const early = post({ id: 'early', scheduled_for: '2026-08-14T07:00:00Z' });
+
+    const { weeks } = buildMonthGrid(2026, 8, [late, early], ROME);
+
+    expect(weeks.flat().find((d) => d.date === '2026-08-14')?.posts.map((p) => p.id)).toEqual([
+      'early',
+      'late'
+    ]);
+  });
+});
+
+describe('stateOf', () => {
+  it('solo un post pending_user si può approvare', () => {
+    expect(stateOf('pending_user').canApprove).toBe(true);
+    expect(stateOf('approved').canApprove).toBe(false);
+    expect(stateOf('scheduled').canApprove).toBe(false);
+    expect(stateOf('published').canApprove).toBe(false);
+  });
+
+  it('un post pubblicato non si modifica', () => {
+    expect(stateOf('published').canEdit).toBe(false);
+    expect(stateOf('pending_user').canEdit).toBe(true);
+  });
+
+  it('uno status sconosciuto non concede niente', () => {
+    const unknown = stateOf('teleported');
+
+    expect(unknown.canEdit).toBe(false);
+    expect(unknown.canApprove).toBe(false);
+    expect(unknown.label).toBe('teleported');
+  });
+});
+
+describe('orari nel fuso del brand', () => {
+  it('legge l istante sull orologio del brand', () => {
+    expect(timeInZone('2026-08-14T07:00:00Z', ROME)).toBe('09:00');
+    expect(timeInZone('2026-08-14T07:00:00Z', 'UTC')).toBe('07:00');
+  });
+
+  it('il momento esteso nomina il fuso, così la conseguenza non è ambigua', () => {
+    expect(momentInZone('2026-08-14T07:00:00Z', ROME)).toContain('09:00');
+    expect(momentInZone('2026-08-14T07:00:00Z', ROME)).toContain('Europe/Rome');
+  });
+});
+
+describe('distributionNote', () => {
+  const now = Date.parse('2026-08-01T00:00:00Z');
+
+  it('nomina l istante quando la data è ancora davanti', () => {
+    const note = distributionNote(
+      post({ id: 'a', scheduled_for: '2026-08-14T07:00:00Z' }),
+      ROME,
+      now
+    );
+
+    expect(note).toContain('09:00');
+    expect(note).toContain('Europe/Rome');
+  });
+
+  it('non promette una data che è già passata', () => {
+    const note = distributionNote(
+      post({ id: 'b', scheduled_for: '2026-07-01T07:00:00Z' }),
+      ROME,
+      now
+    );
+
+    expect(note).not.toContain('09:00');
+    expect(note).toContain('possibly right away');
+  });
+
+  it('una bozza senza data dice che può uscire subito', () => {
+    expect(distributionNote(post({ id: 'c', isDraft: true }), ROME, now)).toContain(
+      'possibly right away'
+    );
+  });
+});

--- a/src/routes/v2/[brand]/calendar/calendar-month.ts
+++ b/src/routes/v2/[brand]/calendar/calendar-month.ts
@@ -1,0 +1,148 @@
+export type CalendarPost = {
+  id: string;
+  platform: string | null;
+  caption: string | null;
+  media_url: string | null;
+  scheduled_for: string | null;
+  status: string;
+  slot: string | null;
+  isDraft?: boolean;
+};
+
+export type MonthDay = {
+  date: string;
+  dayOfMonth: number;
+  inMonth: boolean;
+  posts: CalendarPost[];
+};
+
+export type PostState = {
+  label: string;
+  tone: 'default' | 'secondary' | 'outline' | 'destructive';
+  canEdit: boolean;
+  canApprove: boolean;
+};
+
+const WEEK_LENGTH = 7;
+const WEEKS_SHOWN = 6;
+const MONDAY_INDEX = 1;
+const DAY_MS = 86_400_000;
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}/;
+
+const POST_STATES: Record<string, PostState> = {
+  pending_user: { label: 'Pending review', tone: 'default', canEdit: true, canApprove: true },
+  approved: { label: 'Approved', tone: 'secondary', canEdit: true, canApprove: false },
+  scheduled: { label: 'Scheduled', tone: 'secondary', canEdit: true, canApprove: false },
+  published: { label: 'Published', tone: 'outline', canEdit: false, canApprove: false },
+  failed: { label: 'Failed', tone: 'destructive', canEdit: true, canApprove: false }
+};
+
+export function stateOf(status: string): PostState {
+  return POST_STATES[status] ?? { label: status, tone: 'outline', canEdit: false, canApprove: false };
+}
+
+export function dayInZone(iso: string, timezone: string): string {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: timezone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit'
+  }).format(new Date(iso));
+}
+
+export function timeInZone(iso: string, timezone: string): string {
+  return new Intl.DateTimeFormat('en-GB', {
+    timeZone: timezone,
+    hour: '2-digit',
+    minute: '2-digit'
+  }).format(new Date(iso));
+}
+
+export function momentInZone(iso: string, timezone: string): string {
+  const stamp = new Intl.DateTimeFormat('en-GB', {
+    timeZone: timezone,
+    weekday: 'short',
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit'
+  }).format(new Date(iso));
+
+  return `${stamp} (${timezone})`;
+}
+
+export function distributionNote(
+  post: CalendarPost,
+  timezone: string,
+  now: number = Date.now()
+): string {
+  const at = post.scheduled_for ? Date.parse(post.scheduled_for) : Number.NaN;
+
+  if (Number.isFinite(at) && at > now) {
+    return `It goes out on ${momentInZone(post.scheduled_for as string, timezone)}.`;
+  }
+
+  return 'This post has no future date, so it goes out at the next slot Anomalia can use — possibly right away.';
+}
+
+function dayKeyOf(post: CalendarPost, timezone: string): string | null {
+  if (post.scheduled_for) {
+    return dayInZone(post.scheduled_for, timezone);
+  }
+
+  return post.slot?.match(ISO_DATE)?.[0] ?? null;
+}
+
+function byScheduledTime(a: CalendarPost, b: CalendarPost): number {
+  return (a.scheduled_for ?? '').localeCompare(b.scheduled_for ?? '');
+}
+
+export function buildMonthGrid(
+  year: number,
+  month: number,
+  posts: CalendarPost[],
+  timezone: string
+): { weeks: MonthDay[][]; undated: CalendarPost[] } {
+  const byDay = new Map<string, CalendarPost[]>();
+  const undated: CalendarPost[] = [];
+
+  for (const post of posts) {
+    const key = dayKeyOf(post, timezone);
+    if (!key) {
+      undated.push(post);
+      continue;
+    }
+
+    byDay.set(key, [...(byDay.get(key) ?? []), post]);
+  }
+
+  for (const dayPosts of byDay.values()) {
+    dayPosts.sort(byScheduledTime);
+  }
+
+  const firstOfMonth = Date.UTC(year, month - 1, 1);
+  const leading = (new Date(firstOfMonth).getUTCDay() + WEEK_LENGTH - MONDAY_INDEX) % WEEK_LENGTH;
+
+  const weeks: MonthDay[][] = [];
+
+  for (let w = 0; w < WEEKS_SHOWN; w++) {
+    const week: MonthDay[] = [];
+
+    for (let d = 0; d < WEEK_LENGTH; d++) {
+      const at = new Date(firstOfMonth + (w * WEEK_LENGTH + d - leading) * DAY_MS);
+      const date = at.toISOString().slice(0, 10);
+
+      week.push({
+        date,
+        dayOfMonth: at.getUTCDate(),
+        inMonth: at.getUTCMonth() === month - 1,
+        posts: byDay.get(date) ?? []
+      });
+    }
+
+    weeks.push(week);
+  }
+
+  return { weeks, undated };
+}


### PR DESCRIPTION
## What?

The first surface of the thin frontend from Phase 4 of `docs/external-agent-plan.md`: a month
calendar at **`/v2/:brand/calendar`** that plans, reviews, edits and approves social content
entirely through the v1 REST API. It runs alongside the current application and does not touch a
single file under `src/routes/app/[brand]/`.

Open it at `/v2/demo/calendar`. Month navigation, the post panel, editing the copy and approving
all work; nothing links to it yet, so nobody reaches it by accident.

A second commit fixes a backend defect the surface uncovered: `getCalendar` was dropping the last
day of every month on any runtime not in UTC.

## Why?

The plan lists eight routes for the new frontend and, in the same document, lists *"UI rewrite
expands again"* among its risks with the control *"Ship only the control-plane surfaces listed
above"*. Eight routes at once is how that risk lands. This is one.

The calendar is the right first one. It is the real operational loop. The plan says it *absorbs*
the approval queue and the post detail instead of keeping them as separate areas, so one route
replaces three of today's pages. And it exercises the REST boundary harder than any other view:
it reads a month, opens a post, rewrites its copy and approves it. If it holds against REST, the
rest follow the pattern; if it does not, better to learn that on one route than on eight.

## How?

**Mount point — `/v2/:brand/calendar`.** The plan's eventual address is `/app/:brand/calendar`,
which the current app occupies. `/v2` is a version prefix, not a product name: it says "second
version of `/app`, not yet in its place" without inventing vocabulary (`/console`, `/next`,
`/shell` would each have promised something). The structure underneath already matches the plan's
route map, so promotion is `git mv src/routes/v2 src/routes/app`. No collision with `/api/v1`,
which lives under `/api`.

**REST is the boundary, literally.** The page imports nothing from `$lib/server/cli-queries`. The
load takes the session from `locals.safeGetSession()` only to get the bearer token, then calls
`GET /api/v1/brands/:slug/calendar`. The two form actions call `PUT /posts/:id` and
`POST /posts/:id/approve`. SvelteKit dispatches the load's same-origin `fetch` internally, so the
boundary costs no extra network round trip. This is the whole point of the exercise: web, MCP and
CLI go through the same product rules, so a rule that changes changes for all three at once.

**Primitives — two added, four reused.** Added: `textarea` (the copy is edited there) and
`alert-dialog` (the approval confirmation — `role="alertdialog"`, focus trap, Escape, which is
exactly what an action that leaves the building wants). Reused: `button`, `badge`, `label`,
`sheet`. The registry was not installed wholesale.

`shadcn-svelte add` also rewrote `button.svelte` (class reordering, no behaviour change) and
bumped `tailwind-variants` in `package.json`. Both reverted — a dependency bump does not belong
in this PR.

**The approval consequence is legible before the click.** Approval authorises distribution and
attempts it immediately; no new state was invented and no wording was softened. The panel says it
three ways:

1. a fixed line — approving hands the post to the connected accounts straight away, there is no
   separate publish step;
2. `distributionNote(post, timezone)` — names the instant in the brand's timezone **only while it
   is still in the future**, and otherwise says the post goes out at the next slot Anomalia can
   use, *possibly right away*. This is the one piece of copy that could lie (the easy shortcut is
   "scheduled for {date}" even when the date has passed, which is precisely when the post goes out
   at once), so it is a pure function with three tests;
3. an `alert-dialog` repeating the consequence and naming the platform, with "Keep it pending" as
   the way out.

The button reads *Approve and distribute*.

**Conditions live in one table.** `POST_STATES` maps each status to its label, badge tone, whether
it can be edited and whether it can be approved. An unknown status grants nothing. There is no
`if (status === 'published')` in the page and another in the panel.

**The brand's timezone, not the server's.** `getCalendar` returns UTC instants and the brand
timezone separately. Bucketing a post into a day cell by the server's date moves every evening
post by a day — 23:30 UTC on 31 August is 1 September in Rome. The grid groups with
`Intl.DateTimeFormat('en-CA', { timeZone })`. A less obvious consequence: the grid always shows
**six weeks**. With five, a month ending on a Sunday (May 2026) pushed the boundary post off the
edge of the visible grid entirely. Six weeks always cover the last day plus one, and the height
stops jumping between months. Both have tests.

Undated drafts do not land on "today": they sit in their own strip below the grid that says what
they are. `get_calendar` already flags them `isDraft` — a distinction fixed deliberately, honoured
here rather than flattened.

**Lazy loading.** The post panel (`Sheet` + `AlertDialog`, i.e. all of bits-ui) is a separate
component dynamically imported on the **first post opened**, not at route load. The month grid,
month navigation and drafts strip pull in no bits-ui at all.

**Selection lives in the URL.** `?post=<id>` is written with `replaceState`, so opening a post
costs no server round trip but a reload or a shared link restores the open panel.

### The backend defect (separate commit)

`getCalendar` built its query window like this:

```js
const lastDay = new Date(year, month, 0);
const endStr = lastDay.toISOString().slice(0, 10);
```

`new Date(2026, 8, 30)` is midnight in the **server's** timezone. East of UTC, `toISOString()`
rolls it back a day: under `TZ=Europe/Rome` the September window became
`2026-08-31 … 2026-09-29`. Every post on the last day of the month was invisible, and the
previous month's last day leaked in.

Not a frontend problem: `getCalendar` is the read shared by REST, CLI and MCP, so
`anomalia content` and `get_calendar` were wrong the same way. Vercel functions run in UTC, which
is why production never showed it and every non-UTC runtime does. The window is now built from the
numbers. The regression test pins the server timezone inside the test (`process.env.TZ`) so it is
red on a UTC runner too, not only on the machine that found it.

It is a separate commit on purpose: it changes backend behaviour, and mixing that into the commit
that adds a surface makes it impossible to tell which one moved what.

## Testing?

**Targeted unit tests, run and green:**

```
npx vitest run "src/routes/v2" "src/lib/server/cli-queries.calendar.test.ts"
  Test Files  2 passed (2)
       Tests  23 passed (23)
```

- `calendar-month.test.ts` (16) — grid geometry, the brand-timezone day bucketing, the
  six-week boundary case, dated slots vs recurring slots, the status table, and the three
  `distributionNote` cases.
- `cli-queries.calendar.test.ts` (7) — 4 pre-existing plus 3 new for the month window.

**Red before green, observed, not assumed.** The month-window tests were written first and watched
fail under `TZ=UTC` (2 failed / 5 passed) before the fix, then pass under both `TZ=UTC` and
`TZ=Europe/Rome`. The grid tests were verified to be able to fail by mutating the implementation
(five weeks instead of six, UTC instead of the brand timezone): 4 of them went red, then green
again on revert.

**`npm run check`:** 379 errors, 250 warnings — **none in any file this PR touches**. `svelte-check`
reported 383 before this branch's last fix; the 4 that were mine (a local `state` variable
shadowing the `$state` rune in `PostPanel.svelte`) are gone, and the remaining 379 are all
pre-existing. Two advisory warnings remain in the new files, both the deliberate
"initial value" pattern (`$state` seeded from the URL and from the post).

**Full suite:** an earlier full `npm run test:unit` on this branch was green (596 files, 6600
tests, 0 failed). Per coordination, the full suite is now delegated to CI rather than re-run
locally — nine agents re-running the same 583 test files on one machine was the bottleneck.

**`git diff --check`:** clean.

**`cli/` tests: not run.** Dependencies are not installed in this worktree and no file under
`cli/` is touched by this branch; the CLI reaches `getCalendar` over HTTP, so CI covers it.

### Visual verification — deferred, deliberately

**The full-surface visual pass has not been done and is deferred**, on Andrea's direction: the old
frontend is going to be dismantled, so verifying against it proves nothing, and the new frontend is
not yet coherent enough for a visual judgement to mean anything. That pass happens when the new
frontend exists as a whole surface, not piece by piece while it is being built.

What that means for this PR: **treat the visuals as unreviewed.** Spacing, density and the mobile
layout have had no design pass and should not be read as settled.

For honesty about what did happen: before that direction arrived, an earlier browser session
against the local Docker stack drove this route end to end, and it is what surfaced both defects
fixed here — the month-window bug and the `.grid` collision below. That session is over, its
browser and dev server are shut down, and nothing in this PR depends on re-running it.

## Evidence

No screenshots — see the section above for why the visual pass is deferred.

<details>
<summary>Targeted tests, green</summary>

```
 ✓ src/routes/v2/[brand]/calendar/calendar-month.test.ts (16 tests) 23ms
 ✓ src/lib/server/cli-queries.calendar.test.ts (7 tests) 14ms

 Test Files  2 passed (2)
      Tests  23 passed (23)
```
</details>

<details>
<summary>The month-window test, red before the fix (TZ=UTC)</summary>

```
 × la finestra del mese non dipende dal fuso del server > arriva fino all ultimo giorno anche a est di UTC
 × la finestra del mese non dipende dal fuso del server > non tira dentro l ultimo giorno del mese prima
      Tests  2 failed | 5 passed (7)
```

After the fix, under both `TZ=UTC` and `TZ=Europe/Rome`: `Tests  7 passed (7)`.
</details>

<details>
<summary>svelte-check: no errors in the touched files</summary>

```
TOTAL ERRORS: 379  WARNINGS: 250

=== in files this PR touches ===
WARNING "src/routes/v2/[brand]/calendar/PostPanel.svelte" 35:24 "This reference only captures the initial value of `post`…"
WARNING "src/routes/v2/[brand]/calendar/+page.svelte" 21:42 "This reference only captures the initial value of `data`…"
=== (end) ===
```
</details>

## Anything Else?

**Initial JavaScript was not measured.** The plan asks for the new route measured against an empty
SvelteKit baseline. That needs a production `vite build`, and the machine this ran on was in swap
with nine agents in parallel. **There is no number, and inventing one would be worse than having
none.** The measurement script is written (transitive closure of the Vite client manifest:
framework alone → plus the root layout → plus the route → plus the deferred panel) and should be
run on an idle machine. The lever that number would judge is already in place: bits-ui is deferred
to the first post opened.

**`app.css` has a global `.grid` that hijacks Tailwind's `grid` utility.** `src/app.css` defines
`.grid { display: grid; grid-template-columns: 1.7fr 1fr; gap: 16px }` — a hand-rolled layout class
with the same name as the utility. Tailwind's utilities are `important` here and win on `display`,
but `grid-template-columns` has no counterpart to override, so app.css's survives. shadcn's
`alert-dialog` uses `grid`, and rendered across two columns with the footer outside the box.

Worked around **locally at the call site** (`flex flex-col` on Content and Header, which
tailwind-merge resolves by dropping `grid`), which the plan explicitly permits. Renaming `.grid` in
`app.css` would touch dozens of legacy pages and is not this PR's job — but it is a mine every
future shadcn primitive can step on, and it must be defused before `/v2` becomes `/app`.

**The root layout is a global dependency a route cannot refuse.** `src/routes/+layout.svelte` pulls
svelte-i18n, analytics, the cookie banner and the app-entry shimmer into every page including this
one, which uses none of them. The plan asks to *reject global dependencies that materially increase
initial JavaScript without serving the first interaction*; from inside a route there is nothing to
reject. It is the first bill to pay the day `/v2` becomes `/app`.

**Deliberately not built:**

- **No `approve-all`.** The endpoint exists. A button that approves everything is a button that
  distributes everything, and a consequence that must be legible before the click is not legible
  multiplied by twenty posts.
- **No `GET /posts/:id/media` call.** The calendar response already carries caption, media_url,
  platform, status and date, so opening a post costs no second round trip. Carousel slides and
  video controls stay out; that endpoint is there when they are wanted.
- **No drag-and-drop, reschedule, delete or revoke.** Each is a different verb with its own
  consequence to make legible.
- **No shell, no `/v2` layout.** One route needs no navigation; the shared layout gets extracted
  when a second surface actually asks for it.
- **No public changelog.** Nothing sends a customer to `/v2`, so announcing it would be a line
  that ages badly. The internal changelog is in `changelog/2026-09-04-thin-frontend-calendar.md`.

**A remaining looseness, not fixed here:** `getCalendar`'s month window is still a window of UTC
days compared against `timestamptz`, not of days in the brand's timezone. For a brand in
Europe/Rome that is a two-hour skew at each end of the month. The grid already places a post that
crosses the boundary on its correct brand-timezone day, so nothing is misplaced on screen; making
the *window* timezone-exact is a separate decision with its own consequences for CLI and MCP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
