### PR TITLE
Resolve the address the people import dials

### DIFF
--- a/changelog/2026-09-04-people-import-ssrf.md
+++ b/changelog/2026-09-04-people-import-ssrf.md
@@ -1,0 +1,59 @@
+# L'import della foto di una persona passa dalla guardia condivisa
+
+`/app/onboarding/people/import` scarica la foto di un membro del team da un URL **esterno**,
+scelto durante l'analisi del sito del brand: l'URL non lo digita nessuno, lo propone il crawler
+sopra contenuto che non controlliamo. Aveva una copia propria della guardia SSRF — trenta righe di
+espressioni regolari su `URL.hostname` — e la copia era più debole dell'originale in cinque punti.
+
+## Cosa passava davvero
+
+La premessa da cui è partita l'indagine era che *ogni* letterale IPv6 passasse, perché
+`URL.hostname` conserva le parentesi quadre. È falsa: `isPrivateHost` le toglieva
+(`replace(/^\[|\]$/g, '')`), quindi `[fc00::1]`, `[::1]` e `[fe80::1]` erano rifiutati. Il test
+scritto per primo lo ha mostrato subito — quattro casi verdi su nove al primo giro. Quello che
+passava è più interessante, e sono cinque cose:
+
+1. **`http://[::ffff:127.0.0.1]/`** — `URL` normalizza l'esadecimale: `hostname` diventa
+   `[::ffff:7f00:1]`. Nessun pattern lo vede: né `/^127\./` (non è più in decimale) né `/^f[cd]/`.
+2. **`http://[2002:7f00:1::]/`** — 6to4, l'IPv4 sta nei due hextet centrali.
+3. **`http://[64:ff9b::7f00:1]/`** — NAT64, stessa storia in coda.
+4. **Un nome pubblico il cui DNS punta in casa.** `rebind.example.com → 127.0.0.1` è una stringa
+   innocua: nessun confronto di nomi potrà mai vederla. Questo è il buco che conta, ed è quello
+   che nessuna riga in più nella lista dei pattern avrebbe chiuso.
+5. **Il corpo bufferizzato prima di essere misurato.** `await res.arrayBuffer()` porta in memoria
+   *tutto* e poi confronta con `MAX_BYTES`: il tetto c'era e non serviva, perché la memoria è già
+   finita quando lo si applica.
+
+Il redirect veniva ricontrollato a ogni hop — quella parte era giusta — ma con la stessa guardia
+rotta, quindi le prime quattro forme rientravano dalla finestra.
+
+## Cosa è stato scartato
+
+**Allungare la lista dei pattern.** Sarebbe stato il diff più corto e la riparazione più fragile:
+una lista di prefissi vietati cresce una forma alla volta, e la forma nuova la si scopre dopo che
+è già passata. Le tre forme IPv6 qui sopra sono esattamente questo — scoperte una dopo l'altra.
+Nessuna lista di stringhe risolve il caso 4, che è quello serio.
+
+**Scrivere una guardia nuova, o correggere quella locale.** `safeFetchBytes` in `tool-guard.ts`
+esiste già, e fa le tre cose che servono: risolve l'host con `lookup(host, { all: true })` e
+giudica **l'indirizzo**, ricontrolla a **ogni** hop di redirect, e applica il tetto *mentre* il
+corpo scorre rifiutando invece di troncare (un JPEG tagliato è un asset corrotto salvato come se
+fosse intero). Tre chiamanti ci erano già stati portati sopra — `storeBrandLogoFromUrl`,
+`archiveImageToBucket`, `archiveMarketMedia`, PR #199. Questo è il quarto, con lo stesso metodo:
+la guardia locale sparisce, non viene riparata.
+
+## Cosa resta a carico di #225
+
+I letterali IPv6 in parentesi quadre oggi vengono rifiutati dal ramo *sbagliato*: `lookup('[fc00::1]')`
+risponde `ENOTFOUND` perché le parentesi non sono un nome, e la guardia risponde «Could not resolve
+that host». Il rifiuto è reale — i test lo dimostrano — ma arriva da una coincidenza, non dalla
+classificazione. La PR #225 (`fix/ipv6-mapped-private`) insegna a `isPrivateAddress` a leggere
+l'IPv4 che un IPv6 porta dentro, e da lì in poi le stesse sei forme sono rifiutate dal ramo giusto
+anche quando arrivano da un record AAAA vero, che `lookup` restituisce verbatim. Questa PR non
+dipende da quella e non la anticipa: i test qui sono sull'endpoint, quindi passano prima e dopo.
+
+## Cosa cambia per chi usa il prodotto
+
+Niente, salvo che l'import di una foto rifiuta un indirizzo non pubblico. `http://` resta
+ammesso — i siti brand vecchi servono ancora le foto del team in chiaro — e i redirect delle CDN
+social continuano a essere seguiti, che era la ragione per cui la guardia manuale esisteva.

--- a/src/lib/content/changelog/2026-09-04-people-import-ssrf.ts
+++ b/src/lib/content/changelog/2026-09-04-people-import-ssrf.ts
@@ -1,0 +1,12 @@
+import type { ChangelogEntry } from './index';
+
+const entry: ChangelogEntry = {
+  date: '2026-09-04',
+  title: 'Team photos found on your site are imported more carefully',
+  items: [
+    'When onboarding picks up a photo of someone from your website, the download now refuses any address that is not on the public internet, and keeps checking as the link forwards along.',
+    'An oversized photo is turned away while it downloads instead of after, so one bad link no longer slows the rest of the step down.'
+  ]
+};
+
+export default entry;

--- a/src/routes/app/onboarding/people/import/+server.ts
+++ b/src/routes/app/onboarding/people/import/+server.ts
@@ -1,55 +1,34 @@
 import type { RequestHandler } from './$types';
 import { canEnter } from '$lib/server/access';
 import { logOnboardingError } from '$lib/server/onboarding-errors';
+import { safeFetchBytes, SafeFetchError, type SafeFetchReason, type SafeFetchBytesResult } from '$lib/server/tool-guard';
 
 // Import a team member's photo from an EXTERNAL url (detected during brand analysis) into the
 // private brand-knowledge bucket — the same place manual uploads land — so a detected person can
-// be used as an image reference and persisted just like a manually-added one. SSRF-safe.
+// be used as an image reference and persisted just like a manually-added one.
+//
+// The URL comes from outside, so the fetch goes through the shared guard: it RESOLVES the host
+// instead of matching its name, re-checks every redirect hop (social CDNs almost always 302),
+// and refuses a body past the ceiling while it streams rather than after buffering it.
 const MAX_BYTES = 8 * 1024 * 1024;
 const TIMEOUT_MS = 12_000;
 const MAX_REDIRECTS = 5;
+const IMPORT_USER_AGENT = 'Mozilla/5.0 (compatible; DalNullaBot/1.0)';
 
-function isPrivateHost(host: string): boolean {
-  const h = host.toLowerCase().replace(/^\[|\]$/g, '');
-  return (
-    h === 'localhost' || h === '0.0.0.0' || h === '::1' ||
-    /^127\./.test(h) || /^10\./.test(h) || /^192\.168\./.test(h) ||
-    /^169\.254\./.test(h) || /^172\.(1[6-9]|2\d|3[01])\./.test(h) ||
-    /^f[cd]/.test(h) || /^fe[89ab]/.test(h)
-  );
-}
+// What the browser is told, per refusal — one row per reason, so a new one cannot be answered
+// with a message invented at the call site.
+const REFUSAL_BY_REASON: Record<SafeFetchReason, string> = {
+  not_public: 'Forbidden host',
+  too_large: 'Bad size',
+  fetch_failed: 'Fetch failed'
+};
 
-function assertPublicUrl(raw: string): URL {
-  const parsed = new URL(raw);
-  if (!['http:', 'https:'].includes(parsed.protocol) || isPrivateHost(parsed.hostname)) {
-    throw new Error('Forbidden host');
+function hostOf(raw: string): string {
+  try {
+    return new URL(raw).hostname;
+  } catch {
+    return '';
   }
-  return parsed;
-}
-
-// Social CDNs (IG/TikTok/X) almost always 302 — reject-all redirects dropped every thumb. Follow
-// redirects manually and re-check each hop so we never land on a private IP.
-async function fetchPublicImage(startUrl: string): Promise<Response> {
-  let current = startUrl;
-  for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
-    assertPublicUrl(current);
-    const res = await fetch(current, {
-      signal: AbortSignal.timeout(TIMEOUT_MS),
-      redirect: 'manual',
-      headers: {
-        'User-Agent': 'Mozilla/5.0 (compatible; DalNullaBot/1.0)',
-        Accept: 'image/avif,image/webp,image/apng,image/*,*/*;q=0.8'
-      }
-    });
-    if (res.status >= 300 && res.status < 400) {
-      const loc = res.headers.get('location');
-      if (!loc) throw new Error('Bad redirect');
-      current = new URL(loc, current).href;
-      continue;
-    }
-    return res;
-  }
-  throw new Error('Too many redirects');
 }
 
 function sniffImageExt(buf: Buffer, contentType: string): string | null {
@@ -74,29 +53,32 @@ export const POST: RequestHandler = async ({ request, locals: { supabase, safeGe
 
   const body = await request.json().catch(() => ({}));
   const raw = String(body?.url ?? '').trim();
-  let start: URL;
-  try {
-    start = assertPublicUrl(raw);
-  } catch {
-    return new Response('Forbidden host', { status: 400 });
-  }
+  const host = hostOf(raw);
 
-  let res: Response;
+  let fetched: SafeFetchBytesResult;
   try {
-    res = await fetchPublicImage(start.href);
+    fetched = await safeFetchBytes(raw, {
+      maxBytes: MAX_BYTES,
+      timeoutMs: TIMEOUT_MS,
+      maxRedirects: MAX_REDIRECTS,
+      userAgent: IMPORT_USER_AGENT
+    });
   } catch (e) {
-    await logOnboardingError(supabase, user.id, 'people_import', e, { host: start.hostname });
-    return new Response('Fetch failed', { status: 400 });
+    const reason: SafeFetchReason = e instanceof SafeFetchError ? e.reason : 'fetch_failed';
+    if (reason !== 'not_public') {
+      await logOnboardingError(supabase, user.id, 'people_import', e, { host });
+    }
+    return new Response(REFUSAL_BY_REASON[reason], { status: 400 });
   }
-  if (!res.ok) {
-    await logOnboardingError(supabase, user.id, 'people_import', `Fetch failed: HTTP ${res.status}`, { host: start.hostname });
+
+  if (!fetched.ok) {
+    await logOnboardingError(supabase, user.id, 'people_import', `Fetch failed: HTTP ${fetched.status}`, { host });
     return new Response('Fetch failed', { status: 400 });
   }
 
-  const contentType = res.headers.get('content-type') ?? '';
-  const buf = Buffer.from(await res.arrayBuffer());
-  if (buf.length === 0 || buf.length > MAX_BYTES) return new Response('Bad size', { status: 400 });
-  const ext = sniffImageExt(buf, contentType);
+  const buf = fetched.bytes;
+  if (buf.length === 0) return new Response('Bad size', { status: 400 });
+  const ext = sniffImageExt(buf, fetched.mime);
   if (!ext) return new Response('Not an image', { status: 400 });
 
   const path = `${user.id}/onboarding/${crypto.randomUUID()}.${ext}`;
@@ -104,7 +86,7 @@ export const POST: RequestHandler = async ({ request, locals: { supabase, safeGe
     .from('brand-knowledge')
     .upload(path, buf, { contentType: `image/${ext === 'jpg' ? 'jpeg' : ext}`, upsert: false });
   if (up.error) {
-    await logOnboardingError(supabase, user.id, 'people_import', up.error.message, { host: start.hostname, size: buf.length });
+    await logOnboardingError(supabase, user.id, 'people_import', up.error.message, { host, size: buf.length });
     return new Response(up.error.message, { status: 400 });
   }
 

--- a/src/routes/app/onboarding/people/import/server.test.ts
+++ b/src/routes/app/onboarding/people/import/server.test.ts
@@ -1,0 +1,155 @@
+/**
+ * L'endpoint importa la foto di una persona da un URL ESTERNO scelto durante l'analisi del brand:
+ * l'URL arriva da fuori, quindi la superficie che conta è il rifiuto.
+ *
+ * La guardia locale che c'era prima confrontava `URL.hostname` con delle espressioni regolari, e
+ * per un letterale IPv6 `hostname` conserva le parentesi quadre (`[fc00::1]`): nessun pattern
+ * poteva corrispondere, e ogni indirizzo IPv6 passava. I test qui sotto sono la prova che non
+ * passa più — e che il rifiuto vale anche per un nome pubblico il cui DNS punta in casa, che
+ * nessun confronto di stringhe potrà mai vedere.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('$env/dynamic/private', () => ({ env: {} }));
+vi.mock('node:dns/promises', () => ({ lookup: vi.fn() }));
+vi.mock('$lib/server/supabase-admin', () => ({ createAdminClient: () => ({}) }));
+vi.mock('$lib/server/access', () => ({ canEnter: vi.fn(async () => true) }));
+vi.mock('$lib/server/onboarding-errors', () => ({ logOnboardingError: vi.fn(async () => {}) }));
+
+import { lookup } from 'node:dns/promises';
+import { POST } from './+server';
+
+const PNG = Buffer.from('89504e470d0a1a0a0000000d49484452', 'hex');
+
+const PUBLIC_ADDRESS = '93.184.216.34';
+const LOOPBACK = '127.0.0.1';
+
+const IPV6_LITERALS = {
+  'unique-local': 'http://[fc00::1]/photo.png',
+  loopback: 'http://[::1]/photo.png',
+  'link-local': 'http://[fe80::1]/photo.png',
+  'IPv4-mapped': 'http://[::ffff:127.0.0.1]/photo.png',
+  '6to4': 'http://[2002:7f00:1::]/photo.png',
+  NAT64: 'http://[64:ff9b::7f00:1]/photo.png'
+};
+
+function resolvesTo(byHost: Record<string, string>) {
+  vi.mocked(lookup).mockImplementation((async (host: string) => {
+    const address = byHost[host];
+    if (!address) throw Object.assign(new Error('ENOTFOUND'), { code: 'ENOTFOUND' });
+    return [{ address, family: 4 }];
+  }) as never);
+}
+
+/** Ogni URL risponde con un PNG valido, così ciò che ferma la richiesta è solo la guardia. */
+function servesImageEverywhere(redirects: Record<string, string> = {}) {
+  const requested: string[] = [];
+
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: URL | string) => {
+      const url = String(input);
+      requested.push(url);
+
+      const location = redirects[url];
+      if (location) {
+        return new Response(null, { status: 302, headers: { location } });
+      }
+      return new Response(new Uint8Array(PNG), { status: 200, headers: { 'content-type': 'image/png' } });
+    })
+  );
+
+  return requested;
+}
+
+function storage() {
+  const uploaded: string[] = [];
+  return {
+    uploaded,
+    client: {
+      storage: {
+        from: () => ({
+          upload: async (path: string) => {
+            uploaded.push(path);
+            return { error: null };
+          },
+          createSignedUrl: async () => ({ data: { signedUrl: 'https://signed.test/a.png' } })
+        })
+      }
+    }
+  };
+}
+
+function post(url: string, supabase: unknown) {
+  return (POST as (event: unknown) => Promise<Response>)({
+    request: new Request('https://anomalia.test/app/onboarding/people/import', {
+      method: 'POST',
+      body: JSON.stringify({ url })
+    }),
+    locals: {
+      supabase,
+      safeGetSession: async () => ({ session: { user: { id: 'user-1' } }, user: { id: 'user-1' } })
+    }
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('POST /app/onboarding/people/import', () => {
+  it('archivia la foto quando l host risolve su un indirizzo pubblico', async () => {
+    resolvesTo({ 'cdn.example.com': PUBLIC_ADDRESS });
+    servesImageEverywhere();
+    const store = storage();
+
+    const res = await post('https://cdn.example.com/photo.png', store.client);
+
+    expect(res.status).toBe(200);
+    expect(store.uploaded).toHaveLength(1);
+  });
+
+  for (const [shape, url] of Object.entries(IPV6_LITERALS)) {
+    it(`rifiuta il letterale IPv6 ${shape} (${url})`, async () => {
+      resolvesTo({});
+      const requested = servesImageEverywhere();
+      const store = storage();
+
+      const res = await post(url, store.client);
+
+      expect(res.status).toBe(400);
+      expect(requested).toEqual([]);
+      expect(store.uploaded).toEqual([]);
+    });
+  }
+
+  it('rifiuta un nome pubblico il cui DNS punta sul loopback', async () => {
+    resolvesTo({ 'rebind.example.com': LOOPBACK });
+    const requested = servesImageEverywhere();
+    const store = storage();
+
+    const res = await post('https://rebind.example.com/photo.png', store.client);
+
+    expect(res.status).toBe(400);
+    expect(requested).toEqual([]);
+    expect(store.uploaded).toEqual([]);
+  });
+
+  it('rifiuta un redirect che cammina dentro la rete privata', async () => {
+    resolvesTo({ 'cdn.example.com': PUBLIC_ADDRESS, 'rebind.example.com': LOOPBACK });
+    const requested = servesImageEverywhere({
+      'https://cdn.example.com/photo.png': 'https://rebind.example.com/photo.png'
+    });
+    const store = storage();
+
+    const res = await post('https://cdn.example.com/photo.png', store.client);
+
+    expect(res.status).toBe(400);
+    expect(requested).toEqual(['https://cdn.example.com/photo.png']);
+    expect(store.uploaded).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What?

`/app/onboarding/people/import` — the endpoint that copies a team member's photo off the brand's
own website into the private knowledge bucket — kept a private copy of the SSRF guard: two dozen
lines of regular expressions matched against `URL.hostname`, and never a DNS resolution. This
replaces that copy with `safeFetchBytes`, the guard `storeBrandLogoFromUrl`, `archiveImageToBucket`
and `archiveMarketMedia` already use. The local `isPrivateHost` / `assertPublicUrl` /
`fetchPublicImage` trio is deleted rather than repaired.

## Why?

The URL is not typed by anyone. It is proposed by the crawler over a page we do not control, then
fetched server-side with our network position — which is the definition of a request forger. Five
things got past the local copy:

1. **`http://[::ffff:127.0.0.1]/`** — `URL` normalises the hexadecimal, so `hostname` is
   `[::ffff:7f00:1]`. Neither `/^127\./` (no longer decimal) nor `/^f[cd]/` matches it.
2. **`http://[2002:7f00:1::]/`** — 6to4; the IPv4 sits in the middle hextets.
3. **`http://[64:ff9b::7f00:1]/`** — NAT64; same address, different position.
4. **A public name whose DNS answers `127.0.0.1`.** This is the one that matters: the string is
   innocent, and no hostname comparison will ever see it. Adding rows to a pattern list does not
   close it.
5. **The body buffered before being measured.** `await res.arrayBuffer()` pulls the whole response
   into memory and *then* compares against `MAX_BYTES` — the ceiling was applied after the memory
   was already spent.

The redirect chain *was* re-checked per hop, which was right; it just re-applied the same broken
check, so the first four forms walked back in through a `302`.

**A correction to the report this came from.** The premise was that *every* IPv6 literal passed,
because `URL.hostname` keeps the square brackets. That is false: `isPrivateHost` stripped them
(`replace(/^\[|\]$/g, '')`), so `[fc00::1]`, `[::1]` and `[fe80::1]` were refused. The test written
first said so on its first run — four of nine cases were green before any fix.

## How?

No new guard was written. `safeFetchBytes` (in `tool-guard.ts`) already does the three things that
matter: it resolves the host with `lookup(host, { all: true })` and judges the **address**, it
re-checks **every** redirect hop, and it enforces the byte ceiling *while the body streams*,
rejecting rather than truncating — a cut JPEG is a corrupt asset stored as though it were whole.

Rejected alternative: **lengthening the pattern list**. It is the shortest diff and the most
fragile repair. A list of banned prefixes grows one form at a time and the new form is discovered
after it has already passed — the three IPv6 shapes above are exactly that, found one after
another. And no list of strings closes case 4.

The refusal messages the browser sees are now a `Record<SafeFetchReason, string>` next to the
model rather than an `if` per branch, so a new reason cannot be answered with a message invented
at the call site. The existing wording (`Forbidden host` / `Bad size` / `Fetch failed`) is
preserved; the only caller (`PeopleStep.svelte`) checks `res.ok` and never reads the body, so
nothing downstream depends on it. `http://` stays allowed — older brand sites still serve team
photos in the clear — and social-CDN redirects are still followed, which is why the manual walk
existed in the first place.

## Testing?

Written first, watched fail, then fixed — the new file is
`src/routes/app/onboarding/people/import/server.test.ts` (9 cases: the happy path, the six IPv6
literal shapes, DNS rebinding, and a redirect that walks into a private network).

Targeted only — this machine is saturated and CI already runs the full suite plus Playwright on
every PR:

- `npx vitest run src/routes/app/onboarding/people/import/server.test.ts` — **red first**:
  5 failed / 9. Then **green**: 9 passed / 9.
- `npx vitest run src/lib/server/tool-guard.test.ts src/lib/server/media-fetch-guard.test.ts` —
  22 passed, the guard and the three callers already on it are unaffected.

**Not run, deliberately**: the full unit suite, Playwright, Docker, a dev server. No browser
verification: this change has no UI surface — the only client (`PeopleStep.svelte`) reads
`res.ok` and is untouched.

## Evidence

<details>
<summary>Red — before the fix (5 failed / 9)</summary>

```
 ❯ src/routes/app/onboarding/people/import/server.test.ts (9 tests | 5 failed)
   × rifiuta il letterale IPv6 IPv4-mapped (http://[::ffff:127.0.0.1]/photo.png)
   × rifiuta il letterale IPv6 6to4 (http://[2002:7f00:1::]/photo.png)
   × rifiuta il letterale IPv6 NAT64 (http://[64:ff9b::7f00:1]/photo.png)
   × rifiuta un nome pubblico il cui DNS punta sul loopback
   × rifiuta un redirect che cammina dentro la rete privata

AssertionError: expected 200 to be 400
- Expected
+ Received
- 400
+ 200

 Test Files  1 failed (1)
      Tests  5 failed | 4 passed (9)
```

The four that were already green are the bracketed `fc00::` / `::1` / `fe80::` literals and the
happy path — the correction to the premise, visible in the run itself.
</details>

<details>
<summary>Green — after the fix (9 / 9)</summary>

```
 ✓ src/routes/app/onboarding/people/import/server.test.ts (9 tests) 10ms

 Test Files  1 passed (1)
      Tests  9 passed (9)
```
</details>

<details>
<summary>The guard and its existing callers, unchanged</summary>

```
$ npx vitest run src/lib/server/tool-guard.test.ts src/lib/server/media-fetch-guard.test.ts
 Test Files  2 passed (2)
      Tests  22 passed (22)
```
</details>

## Anything Else?

**The bracketed literals are still refused by the wrong branch.** `lookup('[fc00::1]')` answers
`ENOTFOUND` — brackets are not a hostname — so the refusal comes from *"Could not resolve that
host"*, not from the classifier. That is a coincidence with an expiry date. PR #225
(`fix/ipv6-mapped-private`) teaches `isPrivateAddress` to read the IPv4 an IPv6 carries inside it,
which is what makes those forms refusable when they arrive from a real AAAA record — `lookup`
hands those back verbatim. **This PR does not depend on #225 and does not anticipate it**: the
tests here assert on the endpoint's answer, so they are green before and after that merge.

**Still outside this PR**: `isUrlSafe` in `packages/site-analysis` — the *other* guard that
compares names instead of resolving addresses, with ~30 call sites. It is being handled separately
in `fix/site-analysis-resolves-addresses`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
