### PR TITLE
Take the strategy agent off the agent framework

### DIFF
--- a/changelog/2026-09-04-strategy-agent-off-the-kit.md
+++ b/changelog/2026-09-04-strategy-agent-off-the-kit.md
@@ -1,0 +1,59 @@
+# Lo strategy agent esce dal framework, secondo dei dodici
+
+Segue il week planner e usa la stessa ricetta, senza inventarne una nuova: era il punto —
+se il secondo avesse richiesto un'altra forma, la ricetta non sarebbe una ricetta.
+
+Perché questo per secondo: è quello che teneva ancora dentro il week planner. Il planner
+importa da qui `agentModel`, `withAgentFallback` e la matematica del budget, e finché
+`strategy-agent.ts` importava `$lib/server/harness` il planner ci arrivava lo stesso, in un
+passo in più.
+
+## Cosa fa il giro
+
+1. carica il contesto di fattibilità (prodotti e persone con foto, rubriche approvate) e il
+   budget del brand in dollari;
+2. costruisce system e prompt secondo il modo — `propose`, `propose_next_cycle`, `revise`,
+   `replan_week` — e apre un giro a strumenti con tetto di 80 step;
+3. dodici letture gratuite dentro il brand, `search_web` (max 12, a pagamento),
+   `draft_variants` (max 5, ognuna genera fino a tre varianti in parallelo e ne fa scegliere
+   una), `check_feasibility`, `repair_plan` (max 12), `finish`;
+4. si ferma dopo cinque step identici di fila;
+5. `finish` non chiude se il piano viola ancora la fattibilità;
+6. senza `finish` ma con una bozza esce in ripiego; senza niente solleva;
+7. scrive `agent_runs`, `ai_calls`, e restituisce piano, note, citazioni, costo e crediti.
+
+## Cosa nascondeva `harnessGenerateText`, qui
+
+Le stesse cinque aggiunte del week planner, e le stesse tre vive su `batch`: la traccia di
+sessione, il guardiano, la toppa al system. Ma qui il guardiano non è un dettaglio.
+
+`search_web` è una **ricerca a pagamento**, e `stewardWouldBlock` la blocca finché non è
+stata chiamata una lettura del brand. Il modello non riceve un errore — riceve
+`blocked_by: 'steward'`, `ran: false`, `next_tool: 'read_brand_studio'` — perché un errore
+lo farebbe ritentare, e ritentare una ricerca a pagamento costa. Sul week planner questa
+regola era inerte (nessuno dei suoi strumenti è una ricerca a pagamento riconosciuta); qui
+è la differenza fra un giro che legge il brand prima di pagare e uno che paga per scoprire
+quello che aveva già in casa. Tre test la tengono, ed è la ragione per cui il guardiano
+viene portato dietro invece di essere lasciato al framework.
+
+## L'arco che spariva
+
+Prima: `strategy-agent.ts → harness/index → harness/run → chat/model` e `→ chat/controller`
+(e da lì `$lib/agent/bridge/verdict`). Adesso quell'arco non esiste più da qui.
+
+Restano, misurati: `credits → scheduler → director → harness/index → …` — cioè
+`director.ts`, un altro dei dodici — e `credits → scheduler → agent-turns → chat/queue`,
+che è accoppiamento di infrastruttura e non del framework.
+
+## La tabella al posto dell'elenco
+
+Il guardiano in `nested-agents.test.ts` era un array di quattro nomi, e ogni PR della serie
+avrebbe dovuto toglierne uno: dodici PR in parallelo sulla stessa riga. Adesso è una
+tabella con una riga per orchestratore che dice chi guida il giro — `harness` o `sdk` — e
+ogni PR ne cambia una diversa. Le eccezioni stanno in un posto solo, accanto alla regola
+che le governa, e si vedono tutte insieme.
+
+## Cosa non cambia
+
+Il cliente non osserva niente: stesso piano, stesse righe in `agent_runs` e
+`agent_sessions`, una sola chiamata al giro. Nessun changelog pubblico.

--- a/src/lib/server/nested-agents.test.ts
+++ b/src/lib/server/nested-agents.test.ts
@@ -12,16 +12,58 @@ describe('niente agenti annidati sul GTM di produzione', () => {
 	});
 });
 
+// CHI GUIDA IL GIRO, un orchestratore per riga.
+//
+// `harness` = passa ancora da `harnessGenerateText`; `sdk` = guida `generateText` da sé e prende
+// la traccia dai moduli foglia. Gli orchestratori escono dal framework uno per PR, e una tabella
+// con una riga per file fa sì che due PR in parallelo tocchino righe diverse invece della stessa.
+const LOOP_DRIVER: Record<string, 'harness' | 'sdk'> = {
+	'image-agent.ts': 'harness',
+	'produce-agent.ts': 'harness',
+	'strategy-agent.ts': 'sdk',
+	'week-planner-agent.ts': 'harness'
+};
+
+const loopFiles = Object.keys(LOOP_DRIVER);
+
 describe('batch loops: cap USD restano su generateText', () => {
-	it.each(['image-agent.ts', 'strategy-agent.ts', 'week-planner-agent.ts', 'produce-agent.ts'])(
-		'%s usa harnessGenerateText e PER_RUN o deadline, non new HarnessAgent',
+	it.each(loopFiles)('%s ha un tetto e non è un HarnessAgent', (file) => {
+		const src = readFileSync(join(root, `lib/server/${file}`), 'utf8');
+		expect(src).not.toMatch(/new HarnessAgent\b/);
+		expect(src.includes('PER_RUN_USD_CAP') || src.includes('deadlineMs') || src.includes('deadlineReached')).toBe(
+			true
+		);
+	});
+
+	it.each(loopFiles.filter((f) => LOOP_DRIVER[f] === 'harness'))(
+		'%s passa ancora da harnessGenerateText',
 		(file) => {
 			const src = readFileSync(join(root, `lib/server/${file}`), 'utf8');
 			expect(src).toContain('harnessGenerateText');
-			expect(src).not.toMatch(/new HarnessAgent\b/);
-			expect(src.includes('PER_RUN_USD_CAP') || src.includes('deadlineMs') || src.includes('deadlineReached')).toBe(
-				true
-			);
+		}
+	);
+
+	// `harness/index` riesporta `harness/run`, che importa `chat/model` e `chat/controller`: chi
+	// prende la traccia dall'indice si porta dentro la chat e `$lib/agent` senza usarli. I moduli
+	// foglia non li toccano, e questo test è l'unica cosa che impedisce di «riordinare» l'import.
+	it.each(loopFiles.filter((f) => LOOP_DRIVER[f] === 'sdk'))(
+		'%s guida l\'SDK e prende la traccia dai moduli foglia',
+		(file) => {
+			const src = readFileSync(join(root, `lib/server/${file}`), 'utf8');
+			expect(src).toMatch(/await generateText\(/);
+			expect(src).not.toContain('harnessGenerateText(');
+			expect(src).not.toMatch(/from '\$lib\/server\/harness'/);
+			expect(src).toMatch(/from '\$lib\/server\/harness\/session'/);
+			expect(src).toMatch(/from '\$lib\/server\/harness\/persist'/);
+		}
+	);
+
+	it.each(['session.ts', 'persist.ts', 'pipeline.ts', 'steward.ts'])(
+		'harness/%s non importa la chat né $lib/agent',
+		(file) => {
+			const src = readFileSync(join(root, `lib/server/harness/${file}`), 'utf8');
+			expect(src).not.toMatch(/from '\$lib\/server\/chat\//);
+			expect(src).not.toMatch(/from '\$lib\/agent\//);
 		}
 	);
 });

--- a/src/lib/server/strategy-agent.loop.test.ts
+++ b/src/lib/server/strategy-agent.loop.test.ts
@@ -1,0 +1,537 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+/**
+ * CARATTERIZZAZIONE DEL GIRO DELLO STRATEGY AGENT.
+ *
+ * Stesso metodo del week planner: il comportamento di oggi è la specifica, e va fissato prima
+ * che l'orchestratore esca dal framework. Il punto di aggancio è `generateText` dell'SDK — il
+ * confine che sopravvive alla riscrittura — quindi questi test giudicano entrambe le
+ * implementazioni senza una riga di differenza.
+ *
+ * Qui, a differenza del week planner, il guardiano di sessione BLOCCA davvero: `search_web` è
+ * una ricerca a pagamento, e finché il brand non è stato letto la chiamata non parte.
+ */
+
+const {
+  generateText,
+  logAiCall,
+  persistAgentRun,
+  parallelVariants,
+  groundedText,
+  getCreditsUsage,
+  agentSessionWrites
+} = vi.hoisted(() => ({
+  generateText: vi.fn(),
+  logAiCall: vi.fn(),
+  persistAgentRun: vi.fn(),
+  parallelVariants: vi.fn(),
+  groundedText: vi.fn(),
+  getCreditsUsage: vi.fn(),
+  agentSessionWrites: [] as Array<Record<string, unknown>>
+}));
+
+vi.mock('$env/dynamic/private', () => ({ env: {} }));
+
+vi.mock('ai', async () => {
+  const actual = await vi.importActual<typeof import('ai')>('ai');
+  return { ...actual, generateText };
+});
+
+vi.mock('$lib/server/llm', async () => {
+  const actual = await vi.importActual<typeof import('$lib/server/llm')>('$lib/server/llm');
+  return {
+    ...actual,
+    llmDefaultModel: () => 'gemini-3.7-flash',
+    llmLanguageModel: () => ({ modelId: 'gemini-3.7-flash' })
+  };
+});
+
+vi.mock('$lib/server/ai-log', async () => {
+  const actual = await vi.importActual<typeof import('$lib/server/ai-log')>('$lib/server/ai-log');
+  return { ...actual, logAiCall };
+});
+
+vi.mock('$lib/server/agent-runs', () => ({ persistAgentRun }));
+
+vi.mock('$lib/server/brand-context', () => ({ genaiClient: () => ({}) }));
+
+vi.mock('$lib/server/xiaomi', () => ({
+  parallelVariants,
+  aiStructured: vi.fn(),
+  VARIANT_LENSES: ['contrarian', 'proof', 'community'],
+  CREATIVE_TEMPERATURE: 0.9,
+  PIN_GEMINI: {}
+}));
+
+vi.mock('$lib/server/research', async () => {
+  const actual = await vi.importActual<typeof import('$lib/server/research')>('$lib/server/research');
+  return { ...actual, groundedText };
+});
+
+vi.mock('$lib/server/credits', () => ({ getCreditsUsage }));
+
+vi.mock('$lib/server/rubrics', () => ({ loadApprovedRubrics: async () => [] }));
+
+vi.mock('$lib/server/strategy-agent-reads', () => ({
+  readBrandStudioForAgent: async () => ({ studio: 'brand kit' }),
+  readEditorialPlanForAgent: async () => ({ plan: 'active' }),
+  readGtmForAgent: async () => ({ gtm: 'phase 1' }),
+  readKnowledgeForAgent: async () => ({ docs: [] }),
+  readLeadsForAgent: async () => ({ leads: [] }),
+  readMediaForAgent: async () => ({ media: [] }),
+  readRubricsForAgent: async () => ({ rubrics: [] }),
+  readStrategyReportForAgent: async () => ({ report: 'none' })
+}));
+
+vi.mock('$lib/server/supabase-admin', () => ({
+  createAdminClient: () => ({
+    from: (table: string) => ({
+      insert: (row: Record<string, unknown>) => {
+        if (table === 'agent_sessions') agentSessionWrites.push({ op: 'insert', ...row });
+        return Promise.resolve({ error: null });
+      },
+      upsert: (row: Record<string, unknown>) => {
+        if (table === 'agent_sessions') agentSessionWrites.push({ op: 'upsert', ...row });
+        return Promise.resolve({ error: null });
+      },
+      select: () => ({
+        eq: () => ({
+          maybeSingle: async () => ({
+            data: { id: 'b1', plan: 'pro', activated_at: null, status: 'active' }
+          })
+        })
+      })
+    })
+  })
+}));
+
+import {
+  MAX_STRATEGY_DRAFTS,
+  MAX_STRATEGY_SEARCHES,
+  MAX_STRATEGY_STEPS,
+  STALL_STEP_THRESHOLD,
+  runStrategyAgent
+} from './strategy-agent';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyRec = Record<string, any>;
+
+/** Supabase finto: ogni catena risolve a `{ data: [] }`, ed è attendibile a qualunque punto. */
+function stubSupabase(): AnyRec {
+  const chain: AnyRec = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        if (prop === 'then') {
+          return (resolve: (v: unknown) => unknown) => Promise.resolve({ data: [], error: null }).then(resolve);
+        }
+        if (prop === 'maybeSingle' || prop === 'single') return async () => ({ data: null, error: null });
+        return () => chain;
+      }
+    }
+  );
+  return { from: () => chain };
+}
+
+const CADENCE = '3/week';
+
+function goodPlan(over: AnyRec = {}): AnyRec {
+  return {
+    strategy: 'Il banco di lavoro, quattro settimane',
+    cadence: CADENCE,
+    platform_mix: [{ platform: 'instagram', share: '100%', role: 'primary' }],
+    weeks: Array.from({ length: 4 }, (_, i) => ({
+      index: i,
+      theme: `Settimana ${i + 1}`,
+      focus: 'Gli strumenti del banco',
+      rationale: 'Perché è quello che si vede',
+      content_mix: [{ type: 'single_image', count: 3 }]
+    })),
+    ...over
+  };
+}
+
+type ScriptedCall = { tool: string; input?: unknown };
+type DriveRecord = {
+  prepared: AnyRec[];
+  calls: Array<{ tool: string; output: unknown }>;
+  system: string;
+  prompt: string;
+  toolNames: string[];
+};
+
+function drive(script: ScriptedCall[], record: DriveRecord) {
+  return async (options: AnyRec) => {
+    record.system = String(options.system ?? '');
+    record.prompt = String(options.prompt ?? '');
+    record.toolNames = Object.keys(options.tools ?? {});
+
+    const steps: AnyRec[] = [];
+    for (const entry of script) {
+      const prepared = (await options.prepareStep?.({ stepNumber: steps.length, steps })) ?? {};
+      record.prepared.push(prepared);
+
+      const impl = options.tools?.[entry.tool];
+      const output = impl ? await impl.execute(entry.input ?? {}, {}) : { error: 'no such tool' };
+      record.calls.push({ tool: entry.tool, output });
+
+      const toolCalls = [{ toolName: entry.tool, input: entry.input ?? {}, type: 'tool-call' }];
+      const toolResults = [{ toolName: entry.tool, output, type: 'tool-result' }];
+      const usage = { inputTokens: 100, outputTokens: 40 };
+      steps.push({ toolCalls, toolResults, text: '', usage });
+      await options.onStepFinish?.({ toolCalls, toolResults, text: '', usage });
+
+      const stops = (options.stopWhen ?? []) as Array<(a: AnyRec) => boolean | Promise<boolean>>;
+      const verdicts = await Promise.all(stops.map((s) => s({ steps, stepNumber: steps.length })));
+      if (verdicts.some(Boolean)) break;
+    }
+    return { text: '', totalUsage: { inputTokens: 100 * steps.length, outputTokens: 40 * steps.length }, steps };
+  };
+}
+
+function baseOpts(over: AnyRec = {}): AnyRec {
+  return {
+    supabase: stubSupabase(),
+    userId: 'u1',
+    brandId: 'b1',
+    profile: { name: 'Demo Brand', about: 'caffè' },
+    constraints: { allowedCadences: [CADENCE], platforms: ['instagram'], planTier: 'pro' },
+    mode: 'propose',
+    seedBrief: 'Il brand vende macinini.',
+    deadlineMs: 60_000,
+    ...over
+  };
+}
+
+function newRecord(): DriveRecord {
+  return { prepared: [], calls: [], system: '', prompt: '', toolNames: [] };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  agentSessionWrites.length = 0;
+  getCreditsUsage.mockResolvedValue({
+    remaining: 500,
+    used: 0,
+    quota: 500,
+    bonus: 0,
+    percent: 0,
+    periodStart: new Date(),
+    periodEnd: new Date()
+  });
+  parallelVariants.mockResolvedValue(goodPlan());
+  groundedText.mockResolvedValue({
+    text: 'risposta',
+    citations: [{ title: 'Fonte', uri: 'https://esempio.it/a' }]
+  });
+});
+
+describe('il tavolo dei tool offerto al modello', () => {
+  it('è esattamente questo elenco', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(
+      drive([{ tool: 'draft_variants', input: { brief: 'b' } }, { tool: 'finish', input: { notes: 'ok' } }], rec)
+    );
+
+    await runStrategyAgent(baseOpts() as never);
+
+    expect(rec.toolNames.sort()).toEqual(
+      [
+        'check_feasibility',
+        'draft_variants',
+        'finish',
+        'read_brand',
+        'read_brand_studio',
+        'read_competitors',
+        'read_editorial_plan',
+        'read_gtm',
+        'read_knowledge',
+        'read_leads',
+        'read_media',
+        'read_post_history',
+        'read_radar',
+        'read_rubrics',
+        'read_strategy_report',
+        'repair_plan',
+        'search_web'
+      ].sort()
+    );
+  });
+
+  it('il prompt di apertura dice di leggere il brand prima di pagare una ricerca', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(
+      drive([{ tool: 'draft_variants', input: { brief: 'b' } }, { tool: 'finish', input: { notes: 'ok' } }], rec)
+    );
+
+    await runStrategyAgent(baseOpts() as never);
+
+    expect(rec.prompt).toContain('before any paid search');
+    expect(rec.prompt).toContain('Il brand vende macinini.');
+  });
+});
+
+describe('il percorso che chiude', () => {
+  it('una bozza, un finish: una sola generazione di varianti', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(
+      drive(
+        [
+          { tool: 'read_brand_studio', input: {} },
+          { tool: 'draft_variants', input: { brief: 'quattro settimane' } },
+          { tool: 'check_feasibility', input: { plan: goodPlan() } },
+          { tool: 'finish', input: { notes: 'piano pronto' } }
+        ],
+        rec
+      )
+    );
+
+    const out = await runStrategyAgent(baseOpts() as never);
+
+    expect(parallelVariants).toHaveBeenCalledTimes(1);
+    expect(generateText).toHaveBeenCalledTimes(1);
+    expect(out.plan.weeks).toHaveLength(4);
+    expect(out.notes).toBe('piano pronto');
+    expect(out.credits).toBe(Math.round(out.costUsd * 100));
+    expect(rec.calls.find((c) => c.tool === 'check_feasibility')?.output).toMatchObject({ ok: true });
+    expect(rec.calls.find((c) => c.tool === 'finish')?.output).toMatchObject({ ok: true });
+  });
+
+  it('registra la corsa come `finished` e logga la chiamata riuscita', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(
+      drive([{ tool: 'draft_variants', input: { brief: 'b' } }, { tool: 'finish', input: { notes: 'ok' } }], rec)
+    );
+
+    await runStrategyAgent(baseOpts() as never);
+
+    expect(persistAgentRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        brandId: 'b1',
+        agent: 'strategy',
+        mode: 'propose',
+        status: 'finished',
+        finishedOk: true,
+        notes: 'ok'
+      })
+    );
+    expect(logAiCall).toHaveBeenCalledWith(
+      expect.objectContaining({ label: 'strategy-agent', ok: true, context: 'strategy-agent', brandId: 'b1' })
+    );
+  });
+
+  it('lascia una riga di sessione leggibile su agent_sessions', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(
+      drive([{ tool: 'draft_variants', input: { brief: 'b' } }, { tool: 'finish', input: { notes: 'ok' } }], rec)
+    );
+
+    await runStrategyAgent(baseOpts() as never);
+
+    const finishedRow = agentSessionWrites.find((r) => r.status === 'finished');
+    expect(finishedRow).toMatchObject({ agent: 'strategy', surface: 'batch', brand_id: 'b1', mode: 'propose' });
+    expect(Number(finishedRow?.event_count)).toBeGreaterThan(0);
+  });
+});
+
+describe('i tetti che proteggono il budget del giro', () => {
+  it('rifiuta la bozza oltre il tetto e non genera varianti una volta in più', async () => {
+    const rec = newRecord();
+    const script = Array.from({ length: MAX_STRATEGY_DRAFTS + 1 }, (_, i) => ({
+      tool: 'draft_variants',
+      input: { brief: `brief ${i}` }
+    }));
+    generateText.mockImplementation(drive(script, rec));
+
+    await runStrategyAgent(baseOpts() as never);
+
+    expect(parallelVariants).toHaveBeenCalledTimes(MAX_STRATEGY_DRAFTS);
+    expect(rec.calls[MAX_STRATEGY_DRAFTS].output).toMatchObject({ error: expect.stringContaining('budget') });
+  });
+
+  it('rifiuta la ricerca oltre il tetto e non interroga il web una volta in più', async () => {
+    const rec = newRecord();
+    const script = [
+      { tool: 'read_brand_studio', input: {} },
+      ...Array.from({ length: MAX_STRATEGY_SEARCHES + 1 }, (_, i) => ({
+        tool: 'search_web',
+        input: { query: `domanda ${i}` }
+      }))
+    ];
+    generateText.mockImplementation(drive(script, rec));
+
+    await expect(runStrategyAgent(baseOpts() as never)).rejects.toThrow(
+      'Strategy agent finished without a plan'
+    );
+
+    expect(groundedText).toHaveBeenCalledTimes(MAX_STRATEGY_SEARCHES);
+    const last = rec.calls[rec.calls.length - 1].output as AnyRec;
+    expect(last.error).toContain('budget exhausted');
+  });
+
+  it('si ferma dopo cinque step identici di fila', async () => {
+    const rec = newRecord();
+    const script = Array.from({ length: STALL_STEP_THRESHOLD + 6 }, () => ({
+      tool: 'read_gtm',
+      input: { which: 'both' }
+    }));
+    generateText.mockImplementation(drive(script, rec));
+
+    await expect(runStrategyAgent(baseOpts() as never)).rejects.toThrow();
+
+    expect(rec.calls).toHaveLength(STALL_STEP_THRESHOLD);
+  });
+
+  it('si ferma al tetto degli step', async () => {
+    const rec = newRecord();
+    const script = Array.from({ length: MAX_STRATEGY_STEPS + 5 }, (_, i) => ({
+      tool: 'read_knowledge',
+      input: { limit: (i % 50) + 1 }
+    }));
+    generateText.mockImplementation(drive(script, rec));
+
+    await expect(runStrategyAgent(baseOpts() as never)).rejects.toThrow();
+    expect(rec.calls.length).toBeLessThanOrEqual(MAX_STRATEGY_STEPS);
+  });
+});
+
+describe('il cancello di fattibilità', () => {
+  it('finish rifiuta un piano che viola ancora, e la corsa esce in ripiego', async () => {
+    const rec = newRecord();
+    const broken = goodPlan({ weeks: [{ index: 0, theme: '', focus: '', content_mix: [] }] });
+    parallelVariants.mockResolvedValue(broken);
+    generateText.mockImplementation(
+      drive([{ tool: 'draft_variants', input: { brief: 'b' } }, { tool: 'finish', input: { notes: 'chiudo' } }], rec)
+    );
+
+    const out = await runStrategyAgent(baseOpts() as never);
+
+    const finish = rec.calls.find((c) => c.tool === 'finish')?.output as AnyRec;
+    expect(finish.error).toBe('Plan still has feasibility violations');
+    expect(finish.violations.length).toBeGreaterThan(0);
+    expect(out.notes).toBe('Agent ended without finish; using last draft.');
+    expect(persistAgentRun).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'fallback', finishedOk: false, violations: expect.any(Array) })
+    );
+  });
+
+  it('senza nessun piano la corsa fallisce e viene registrata come fallita', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(drive([{ tool: 'read_brand_studio', input: {} }], rec));
+
+    await expect(runStrategyAgent(baseOpts() as never)).rejects.toThrow(
+      'Strategy agent finished without a plan'
+    );
+    expect(persistAgentRun).toHaveBeenCalledWith(expect.objectContaining({ status: 'failed', finishedOk: false }));
+  });
+
+  it('repair_plan rimette in piedi un piano rotto senza ripassare dal generatore', async () => {
+    const rec = newRecord();
+    parallelVariants.mockResolvedValue(goodPlan({ weeks: [{ index: 0, theme: '', focus: '', content_mix: [] }] }));
+    generateText.mockImplementation(
+      drive(
+        [
+          { tool: 'draft_variants', input: { brief: 'b' } },
+          { tool: 'repair_plan', input: { patch: goodPlan(), reason: 'settimane vuote' } },
+          { tool: 'finish', input: { notes: 'riparato' } }
+        ],
+        rec
+      )
+    );
+
+    const out = await runStrategyAgent(baseOpts() as never);
+
+    expect(parallelVariants).toHaveBeenCalledTimes(1);
+    expect(rec.calls[1].output).toMatchObject({ ok: true, reason: 'settimane vuote' });
+    expect(out.notes).toBe('riparato');
+  });
+});
+
+describe('le citazioni', () => {
+  it('quelle della ricerca finiscono nel risultato', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(
+      drive(
+        [
+          { tool: 'read_brand_studio', input: {} },
+          { tool: 'search_web', input: { query: 'quanto costa un macinino' } },
+          { tool: 'draft_variants', input: { brief: 'b' } },
+          { tool: 'finish', input: { notes: 'ok' } }
+        ],
+        rec
+      )
+    );
+
+    const out = await runStrategyAgent(baseOpts() as never);
+
+    expect(out.citations).toEqual([{ title: 'Fonte', uri: 'https://esempio.it/a' }]);
+  });
+});
+
+describe('il guardiano di sessione, che il framework applicava in silenzio', () => {
+  // Questa è la regola che sul week planner non esisteva: `search_web` è una ricerca a
+  // pagamento, e finché il brand non è stato letto la query NON parte. Il modello riceve
+  // un'istruzione, non un errore, perché un errore lo farebbe ritentare.
+  it('non lascia partire una ricerca a pagamento prima che il brand sia stato letto', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(
+      drive([{ tool: 'search_web', input: { query: 'subito al web' } }], rec)
+    );
+
+    await expect(runStrategyAgent(baseOpts() as never)).rejects.toThrow();
+
+    expect(groundedText).not.toHaveBeenCalled();
+    expect(rec.calls[0].output).toMatchObject({
+      blocked_by: 'steward',
+      code: 'search_before_brand',
+      ran: false,
+      next_tool: 'read_brand_studio'
+    });
+  });
+
+  it('dopo la lettura del brand la ricerca parte', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(
+      drive(
+        [
+          { tool: 'read_brand_studio', input: {} },
+          { tool: 'search_web', input: { query: 'adesso sì' } }
+        ],
+        rec
+      )
+    );
+
+    await expect(runStrategyAgent(baseOpts() as never)).rejects.toThrow();
+
+    expect(groundedText).toHaveBeenCalledTimes(1);
+    expect(rec.calls[1].output).toMatchObject({ text: 'risposta' });
+  });
+
+  it('avvisa nel system che la ricerca a pagamento è chiusa finché non si legge il brand', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(
+      drive([{ tool: 'read_gtm', input: {} }, { tool: 'read_gtm', input: { which: 'active' } }], rec)
+    );
+
+    await expect(runStrategyAgent(baseOpts() as never)).rejects.toThrow();
+
+    expect(String(rec.prepared[1].system)).toContain('read_brand_studio');
+  });
+});
+
+describe('il budget scritto nel system di ogni step', () => {
+  it('porta i contatori che il modello deve vedere', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(
+      drive([{ tool: 'draft_variants', input: { brief: 'b' } }, { tool: 'finish', input: { notes: 'ok' } }], rec)
+    );
+
+    await runStrategyAgent(baseOpts() as never);
+
+    const system = String(rec.prepared[0].system);
+    expect(system).toContain('searches_left=');
+    expect(system).toContain('drafts_left=');
+    expect(system).toContain('repairs_left=');
+    expect(system).toContain('time_left≈');
+  });
+});

--- a/src/lib/server/strategy-agent.ts
+++ b/src/lib/server/strategy-agent.ts
@@ -2,8 +2,11 @@ import { maxOutputTokensFor } from '$lib/server/ai-output-limits';
 import type { GoogleGenAI } from '@google/genai';
 import type { LanguageModel } from 'ai';
 import { llmDefaultModel, llmLanguageModel } from '$lib/server/llm';
-import { tool, stepCountIs, hasToolCall, type StopCondition } from 'ai';
-import { harnessGenerateText } from '$lib/server/harness';
+import { generateText, tool, stepCountIs, hasToolCall, type StopCondition } from 'ai';
+import { createHarnessSession } from '$lib/server/harness/session';
+import { persistHarnessSession } from '$lib/server/harness/persist';
+import { wrapTools } from '$lib/server/harness/pipeline';
+import { applyStewardPrepareStep, createSessionSteward } from '$lib/server/harness/steward';
 import { z } from 'zod';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { env } from '$env/dynamic/private';
@@ -781,9 +784,10 @@ async function runStrategyAgentInner(opts: StrategyAgentOpts): Promise<StrategyA
   let loopModel = agentModel();
 
   try {
-    await withAgentFallback('strategy-agent', (chosen, markDirty) => {
+    await withAgentFallback('strategy-agent', async (chosen, markDirty) => {
       loopModel = chosen;
-      return harnessGenerateText({
+
+      const session = createHarnessSession({
         brandId: opts.brandId,
         userId: opts.userId,
         agent: 'strategy',
@@ -791,55 +795,80 @@ async function runStrategyAgentInner(opts: StrategyAgentOpts): Promise<StrategyA
         model: loopModel.modelId,
         provider: loopModel.provider,
         surface: 'batch'
-      }, {
-        // Text-only reasoning → DeepSeek by default (see strategyAgentModel).
-        model: loopModel.model,
-        maxOutputTokens: maxOutputTokensFor(loopModel.provider),
-        system: baseSystem,
-        prompt: `${userPrompt}\n\nStart by reading stored brand context (read_brand_studio, read_gtm, read_editorial_plan, read_knowledge, read_media) before any paid search.`,
-        tools,
-        stopWhen: [hasToolCall('finish'), stepCountIs(MAX_STRATEGY_STEPS), stallStop, () => deadlineReached(t0, deadlineMs)],
-        temperature: 0.4,
-        prepareStep: () => {
-          const elapsed = Date.now() - t0;
-          const remainingSec = Math.max(0, Math.round((deadlineMs - elapsed) / 1000));
-          const stepSystem = appendBudgetToSystem(baseSystem, budget, remainingSec);
-          if (budget.usdRemaining <= 0 && (workingPlan || basePlan.weeks.length)) {
-            return { toolChoice: { type: 'tool' as const, toolName: 'finish' }, system: stepSystem };
-          }
-          return { system: stepSystem };
-        },
-        onStepFinish: ({ usage, toolCalls, toolResults, text }) => {
-          addStrategyStepCost(budget, usage, loopModel);
-          stallFingerprints.push(
-            stepFingerprint(
-              { cadence: workingPlan?.cadence, w0: workingPlan?.weeks?.[0]?.theme, s: budget.searchesLeft, d: budget.draftsLeft },
-              toolCalls?.map((tc) => ({ toolName: tc.toolName, input: 'input' in tc ? tc.input : undefined }))
-            )
-          );
-          stepNum += 1;
-          const entry: StrategyAgentStepLog = {
-            step: stepNum,
-            toolCalls: toolCalls?.map((tc) => ({ name: tc.toolName, input: 'input' in tc ? tc.input : undefined })),
-            toolResults: toolResults?.map((tr) => ({ name: tr.toolName, output: 'output' in tr ? tr.output : undefined })),
-            text: text?.trim() || undefined
-          };
-          stepLog.push(entry);
-          if (opts.verbose) {
-            console.log(`\n[strategy-agent] ══ step ${stepNum} ══`);
-            for (const tc of entry.toolCalls ?? []) {
-              console.log(`  → ${tc.name}`, JSON.stringify(tc.input, null, 2).slice(0, 1500));
-            }
-            for (const tr of entry.toolResults ?? []) {
-              console.log(`  ← ${tr.name}`, JSON.stringify(tr.output, null, 2).slice(0, 3000));
-            }
-            if (entry.text) console.log(`  · text: ${entry.text.slice(0, 400)}`);
-            console.log(
-              `  · budget: searches=${budget.searchesLeft} drafts=${budget.draftsLeft} repairs=${budget.repairsLeft} usd≈$${budget.usdRemaining.toFixed(2)}`
+      });
+      const prompt = `${userPrompt}\n\nStart by reading stored brand context (read_brand_studio, read_gtm, read_editorial_plan, read_knowledge, read_media) before any paid search.`;
+      session.captureRequest({ system: baseSystem, prompt });
+
+      const steward = createSessionSteward(session, Object.keys(tools));
+      const watchedTools = wrapTools(session, tools, {
+        before: [...(steward.pipeline().before ?? []), () => { markDirty(); }]
+      });
+
+      try {
+        const result = await generateText({
+          // Text-only reasoning → DeepSeek by default (see strategyAgentModel).
+          model: loopModel.model,
+          maxOutputTokens: maxOutputTokensFor(loopModel.provider),
+          system: baseSystem,
+          prompt,
+          allowSystemInMessages: true,
+          tools: watchedTools,
+          stopWhen: [hasToolCall('finish'), stepCountIs(MAX_STRATEGY_STEPS), stallStop, () => deadlineReached(t0, deadlineMs)],
+          temperature: 0.4,
+          prepareStep: () => {
+            const elapsed = Date.now() - t0;
+            const remainingSec = Math.max(0, Math.round((deadlineMs - elapsed) / 1000));
+            const stepSystem = appendBudgetToSystem(baseSystem, budget, remainingSec);
+            const step =
+              budget.usdRemaining <= 0 && (workingPlan || basePlan.weeks.length)
+                ? { toolChoice: { type: 'tool' as const, toolName: 'finish' }, system: stepSystem }
+                : { system: stepSystem };
+            const patched = applyStewardPrepareStep(session, steward, step, baseSystem) ?? {};
+            session.capturePrepareStep(patched);
+            return patched;
+          },
+          onStepFinish: ({ usage, toolCalls, toolResults, text }) => {
+            session.recordStep({ usage, toolCalls, text });
+            addStrategyStepCost(budget, usage, loopModel);
+            stallFingerprints.push(
+              stepFingerprint(
+                { cadence: workingPlan?.cadence, w0: workingPlan?.weeks?.[0]?.theme, s: budget.searchesLeft, d: budget.draftsLeft },
+                toolCalls?.map((tc) => ({ toolName: tc.toolName, input: 'input' in tc ? tc.input : undefined }))
+              )
             );
+            stepNum += 1;
+            const entry: StrategyAgentStepLog = {
+              step: stepNum,
+              toolCalls: toolCalls?.map((tc) => ({ name: tc.toolName, input: 'input' in tc ? tc.input : undefined })),
+              toolResults: toolResults?.map((tr) => ({ name: tr.toolName, output: 'output' in tr ? tr.output : undefined })),
+              text: text?.trim() || undefined
+            };
+            stepLog.push(entry);
+            if (opts.verbose) {
+              console.log(`\n[strategy-agent] ══ step ${stepNum} ══`);
+              for (const tc of entry.toolCalls ?? []) {
+                console.log(`  → ${tc.name}`, JSON.stringify(tc.input, null, 2).slice(0, 1500));
+              }
+              for (const tr of entry.toolResults ?? []) {
+                console.log(`  ← ${tr.name}`, JSON.stringify(tr.output, null, 2).slice(0, 3000));
+              }
+              if (entry.text) console.log(`  · text: ${entry.text.slice(0, 400)}`);
+              console.log(
+                `  · budget: searches=${budget.searchesLeft} drafts=${budget.draftsLeft} repairs=${budget.repairsLeft} usd≈$${budget.usdRemaining.toFixed(2)}`
+              );
+            }
           }
-        }
-      }, { before: [() => { markDirty(); }] });
+        });
+        session.recordAssistantText(result.text);
+        session.recordUsage(result.totalUsage ?? result.usage);
+        session.finish('finished');
+        return result;
+      } catch (e) {
+        session.finish('failed', e);
+        throw e;
+      } finally {
+        persistHarnessSession(session);
+      }
     });
   } catch (e) {
     loopOk = false;


### PR DESCRIPTION
## What?

The strategy agent — the orchestrator that proposes, revises and replans a brand's four-week
editorial plan — no longer runs its loop through the agent framework. It calls `generateText`
from the AI SDK directly, and the three things `harnessGenerateText` was silently adding on a
batch surface are now written at the call site, in the order they happen.

Second of twelve, deliberately the same shape as #224 (the week planner). If the second one had
needed a different form, there would be no recipe.

17 characterization tests were written **against the existing framework implementation** and
watched pass before anything moved. They hook `generateText`, not `harnessGenerateText`, so the
same tests grade both implementations. They pass on both.

`packages/agent-*` is untouched. Nothing is deleted.

## Why?

`packages/agent-*` (105,226 lines), `src/lib/agent` (23,909) and `src/lib/server/chat` (32,031)
are slated for deletion — 161,166 lines, about 31% of the repository. Deletion is blocked by
whoever still imports the framework, so the orchestrators come off it one at a time.

This one came second because **it is what still held the week planner in**. The planner imports
`agentModel`, `withAgentFallback` and the budget arithmetic from here; while `strategy-agent.ts`
imported `$lib/server/harness`, #224's win was one hop away from being undone. `harness/index`
re-exports `harness/run`, which imports `chat/model` and `chat/controller`, which imports
`$lib/agent/bridge/verdict`.

## How?

### What the orchestrator does

1. load the feasibility context (products and people with photos, approved rubrics) and the
   brand's dollar budget;
2. build system + prompt for the mode — `propose`, `propose_next_cycle`, `revise`,
   `replan_week` — and open an SDK tool loop capped at 80 steps;
3. twelve free reads inside the brand, `search_web` (max 12, paid), `draft_variants` (max 5, each
   generating up to three variants in parallel and picking one), `check_feasibility`,
   `repair_plan` (max 12), `finish`;
4. stop after five identical steps in a row;
5. `finish` refuses to close while the plan still violates feasibility;
6. no `finish` but a draft in hand → fall back; nothing at all → throw;
7. write `agent_runs`, `ai_calls`; return plan, notes, citations, cost and credits.

The framework wrapped step 2. Nothing else.

### The steward is load-bearing here, unlike on the week planner

`harnessGenerateText` appends five things; on `batch` three are live (session transcript, session
steward, per-step system patch) and two are declared `surface === 'chat'` and have never done
anything (shadow controller, forced first tool call).

On #224 the steward was mostly latent. Here it is not: `search_web` is a **paid** search, and
`stewardWouldBlock` refuses to let the query leave the building until a brand read has returned.
The model gets `blocked_by: 'steward'`, `ran: false`, `next_tool: 'read_brand_studio'` — never
`{ error }`, because models treat an error as an outage and retry, and retrying a paid search
costs money. Three tests hold that, and it is the reason the steward is carried over explicitly
rather than left behind with the wrapper.

### Where the transcript comes from now

`harness/session`, `harness/persist`, `harness/pipeline` and `harness/steward` — 1,030 lines —
import neither chat nor `$lib/agent`. `harness/index` does. Importing the four leaves keeps the
Usage page intact at zero cost, and these four are not in the 161,166 lines slated for deletion.

### The guard became a table, so twelve PRs stop fighting over one line

`nested-agents.test.ts` held a four-name array, and every PR in this series would have had to
remove one entry from it — twelve parallel branches editing the same line. It is now a table with
one row per orchestrator saying who drives the loop:

```ts
const LOOP_DRIVER: Record<string, 'harness' | 'sdk'> = {
  'image-agent.ts': 'harness',
  'produce-agent.ts': 'harness',
  'strategy-agent.ts': 'sdk',
  'week-planner-agent.ts': 'harness'
};
```

Each PR flips a different line. It also puts the exceptions in one place beside the rule that
governs them, which is what `AGENTS.md` asks for.

**Merge note:** this restructures the same block #224 edits, so one of the two will conflict on
`nested-agents.test.ts`. The resolution is mechanical — keep this table, set `week-planner-agent.ts`
to `'sdk'`. Merging #224 first makes it a one-line resolution.

### Commits

1. `d1416e1` — the 17 characterization tests, passing against the framework implementation.
2. `7ca9668` — the rewrite plus the guard table.
3. the internal changelog.

## Testing?

Targeted only. The full suite and Playwright are delegated to CI (`.github/workflows/ci.yml` runs
`npx vitest run` plus Playwright on every pull request); re-running 583 test files locally, on a
machine with nine agents on it, pays for the same work twice. `npm run check` was not run: this
PR touches no `.svelte` file and no shared type.

```
$ npx vitest run src/lib/server/strategy-agent.loop.test.ts \
    src/lib/server/nested-agents.test.ts \
    src/lib/server/week-planner-agent.test.ts

 ✓ src/lib/server/nested-agents.test.ts (15 tests) 5ms
 ✓ src/lib/server/strategy-agent.loop.test.ts (17 tests) 50ms
 ✓ src/lib/server/week-planner-agent.test.ts (8 tests) 2ms

 Test Files  3 passed (3)
      Tests  40 passed (40)
```

The 17 loop tests were run against the previous implementation first, at commit `d1416e1`, before
the rewrite existed:

```
 ✓ src/lib/server/strategy-agent.loop.test.ts (17 tests) 50ms
 Test Files  1 passed (1)
      Tests  17 passed (17)
```

Reproducible: `git checkout d1416e1 && npx vitest run src/lib/server/strategy-agent.loop.test.ts`.

### What the 17 pin

The exact tool table; the opening prompt; the caps on searches, drafts and repairs *and that none
of them pays a model one time more* (`expect(parallelVariants).toHaveBeenCalledTimes(1)`,
`toHaveBeenCalledTimes(MAX_STRATEGY_DRAFTS)`, `expect(groundedText).toHaveBeenCalledTimes(MAX_STRATEGY_SEARCHES)`);
the stall detector at five identical steps; the step cap; the feasibility gate refusing to finish;
the repair path that fixes a plan without going back to the generator; citations reaching the
result; the rows written to `agent_runs` and `agent_sessions`; and the three steward tests above.

### Schema

No new enum-ish value is written — `agent: 'strategy'`, `surface: 'batch'` and the status
vocabulary all come through unchanged code. `agent_sessions` and `agent_runs` were checked
against the live schema anyway and carry **no CHECK constraints** (`select conname, … from
pg_constraint where conrelid = 'public.agent_sessions'::regclass and contype = 'c'` → 0 rows;
same for `agent_runs`).

### Not tested, and why

- **No live run for this one.** #224's rewrite was exercised end to end against the local stack
  with a real model, before and after, and the loop it proves is the same loop with the same
  three additions — the diff here is the identical transformation applied to a second file. The
  machine is currently in swap and a second paid run would measure the machine, not the change.
  If a reviewer wants it, the script is one file and the run costs about $0.07.
- **`npm run eval:durability` was not run** — it costs real money and this machine is not a
  reliable bench right now. **It should be run before merging the series**, since these
  orchestrators persist work, which is exactly what those scenarios measure.
- **The `withAgentFallback` retry path is untested**, in both implementations:
  `agentFallbackModel()` returns `null` unconditionally, so the retry is unreachable. Unchanged.

<details>
<summary>Import graph, measured (transitive BFS resolving <code>$lib</code>, relative and <code>@anomalia/*</code>, 219 modules visited)</summary>

**Before**, `src/lib/server/strategy-agent.ts` reached chat in three hops through its own import:

```
strategy-agent.ts -> harness/index.ts -> harness/run.ts -> chat/model.ts
strategy-agent.ts -> harness/index.ts -> harness/run.ts -> chat/controller.ts
```

**After** — that edge is gone. What remains arrives through other files, each of which is its own
piece of work:

```
strategy-agent.ts -> credits.ts -> scheduler.ts -> director.ts -> harness/index.ts -> harness/run.ts -> chat/model.ts
strategy-agent.ts -> credits.ts -> scheduler.ts -> agent-turns.ts -> chat/queue.ts
```

`director.ts` is another of the twelve. The `credits → scheduler → agent-turns` chain is
infrastructure coupling, unrelated to the framework, and comes down with chat itself.
</details>

## Anything Else?

- **Still on the framework after this PR:** `director.ts`, `produce-agent.ts`, `seo-agent.ts`,
  `image-agent.ts`, `analytics-review-agent.ts`, `media-generator/agent.ts`,
  `media-generator/ugc-agent.ts`, `media-generator/ugc-plan-agent.ts`, `motion-video/agent.ts`,
  `sandbox.ts` — plus `agent-base.ts`, `craft-model.ts`, `harness-skills.ts`,
  `agent-kit-effects-store.ts` and all of chat. `packages/agent-*` is imported directly by 37
  non-test files in `src/lib`.

- **Two of the remaining ten are a different shape.** `media-generator/agent.ts` and
  `motion-video/agent.ts` use `harnessStreamText`, not `harnessGenerateText`. The wrapper does
  more there — it installs `onFinish`/`onError`/`onAbort` and snapshots the request before the
  stream starts, so a killed stream still leaves a transcript. The recipe holds in outline but
  those two need their own reading, and they should not be batched with the seven that are a
  straight swap.

- **`sandbox.ts` and `agent-base.ts` are not orchestrators** in this sense: they import
  `$lib/agent` / `@anomalia/agent-*` directly rather than driving a loop through the harness.
  Different problem, later PR.

- **The recipe** is in `changelog/2026-09-04-week-planner-off-the-kit.md`, and this PR is the
  evidence it transfers: the same eight steps, a second file, no new abstraction.

- **No public changelog**, deliberately. Same plan, same rows, one loop call — a customer cannot
  observe any difference. If a later one in this series *is* observable, that is a defect, not a
  feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
