### PR TITLE
Take the Director off the agent framework

### DIFF
--- a/changelog/2026-09-04-director-off-the-kit.md
+++ b/changelog/2026-09-04-director-off-the-kit.md
@@ -1,0 +1,53 @@
+# Il Director esce dal framework, terzo dei dodici
+
+Terzo giro con la stessa ricetta. È il primo dei tre a discostarsi in due punti, ed è per
+questo che valeva la pena prenderlo presto: se la forma regge su un orchestratore che
+manda immagini e che riprova su un altro provider, regge.
+
+## Cosa fa il giro
+
+Il Director è l'ultimo cancello prima della coda di approvazione: guarda il batch finito
+tutto insieme — didascalie e immagini renderizzate nello stesso messaggio — e ha quattro
+strumenti chiusi (verificare un'affermazione sul web, riscrivere una didascalia,
+rirenderizzare un'immagine con una nota da art director, segnalare un post) più `finish`.
+Otto step al massimo, un tetto per strumento (2 ricerche, 3 riscritture, 2 rirender), e
+non può pubblicare niente.
+
+## Le due differenze rispetto ai primi due
+
+**Parla per `messages`, non per `prompt`.** Le immagini stanno in un solo messaggio utente,
+ognuna dopo la propria etichetta. `captureRequest` prende i messaggi invece del prompt — è
+lo stesso metodo, con l'altro ramo.
+
+**Rifà la review per intero quando kie muore.** Perdere il Director perché kie è a corto di
+crediti è peggio che farlo girare su Gemini, quindi un fallimento riprova una volta,
+azzerando il log parziale. Ogni tentativo è una sessione sua, quindi due righe in
+`agent_sessions` — che è già quello che la pagina Usage mostrava, ma prima lo faceva il
+framework e non lo diceva nessuno. Adesso è scritto dove succede.
+
+## Il guardiano, e perché resta
+
+`director` non è fra gli agenti a cui il guardiano impone di leggere il brand prima di
+pagare una ricerca. Qui fa una cosa sola, e utile: `search_web` ha un tetto di due, e dalla
+terza chiamata torna un errore; dopo due errori di fila lo strumento esce dal tavolo,
+invece di lasciare il modello a bussare a una porta chiusa per i suoi otto step. Un test lo
+tiene.
+
+## L'arco che spariva
+
+Prima: `director.ts → harness/index → harness/run → chat/model` e `→ chat/controller`.
+Adesso non più da qui. Restano archi che passano da `content-preview → image-agent →
+harness/index` — cioè `image-agent.ts`, un altro dei dodici — e da `content-preview →
+credits → scheduler → agent-turns → chat/queue`, che è infrastruttura.
+
+## Il guardiano dell'import sta nel test dell'orchestratore
+
+Sul week planner e sullo strategy agent è finito in `nested-agents.test.ts`. Qui no: dodici
+PR in parallelo che modificano lo stesso file di guardia si accodano sulla stessa riga per
+niente. Il vincolo — «non tornare a `harness/index`» — vale per questo file, quindi vive
+nel test di questo file.
+
+## Cosa non cambia
+
+Il cliente non osserva niente: stesse revisioni, stessi tetti, stesse righe. Nessun
+changelog pubblico.

--- a/src/lib/server/director.loop.test.ts
+++ b/src/lib/server/director.loop.test.ts
@@ -1,0 +1,502 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+/**
+ * CARATTERIZZAZIONE DEL GIRO DEL DIRECTOR.
+ *
+ * Terzo dei dodici, stesso metodo: il comportamento di oggi è la specifica e va fissato prima
+ * che l'orchestratore esca dal framework, agganciando `generateText` dell'SDK — il confine che
+ * sopravvive alla riscrittura.
+ *
+ * Il Director è l'unico dei tre finora che parla al modello per `messages` invece che per
+ * `prompt`, perché gli allega le immagini renderizzate; ed è l'unico che riprova su un secondo
+ * provider quando il primo muore.
+ */
+
+const {
+  generateText,
+  logAiCall,
+  groundedText,
+  structured,
+  renderPreviewImages,
+  collectBatchReviewImages,
+  agentSessionWrites
+} = vi.hoisted(() => ({
+  generateText: vi.fn(),
+  logAiCall: vi.fn(),
+  groundedText: vi.fn(),
+  structured: vi.fn(),
+  renderPreviewImages: vi.fn(),
+  collectBatchReviewImages: vi.fn(),
+  agentSessionWrites: [] as Array<Record<string, unknown>>
+}));
+
+vi.mock('$env/dynamic/private', () => ({ env: { KIE_API_KEY: 'test-kie' } }));
+
+vi.mock('ai', async () => {
+  const actual = await vi.importActual<typeof import('ai')>('ai');
+  return { ...actual, generateText };
+});
+
+vi.mock('$lib/server/llm', async () => {
+  const actual = await vi.importActual<typeof import('$lib/server/llm')>('$lib/server/llm');
+  return {
+    ...actual,
+    llmConfigured: () => true,
+    llmDefaultModel: () => 'gemini-3.7-flash',
+    llmLanguageModel: () => ({ modelId: 'gemini-3.7-flash' })
+  };
+});
+
+vi.mock('./ai-log', async () => {
+  const actual = await vi.importActual<typeof import('./ai-log')>('./ai-log');
+  return { ...actual, logAiCall };
+});
+
+vi.mock('./research', () => ({ groundedText, structured }));
+
+vi.mock('./content-preview', () => ({
+  renderPreviewImages,
+  collectBatchReviewImages,
+  platformPlaybook: () => 'PLAYBOOK'
+}));
+
+vi.mock('./kie', () => ({
+  KIE_MODEL: 'grok-4-6',
+  KIE_GROK_NO_STORE: { store: false },
+  kieFetch: () => globalThis.fetch
+}));
+
+vi.mock('$lib/server/supabase-admin', () => ({
+  createAdminClient: () => ({
+    from: (table: string) => ({
+      insert: (row: Record<string, unknown>) => {
+        if (table === 'agent_sessions') agentSessionWrites.push({ op: 'insert', ...row });
+        return Promise.resolve({ error: null });
+      },
+      upsert: (row: Record<string, unknown>) => {
+        if (table === 'agent_sessions') agentSessionWrites.push({ op: 'upsert', ...row });
+        return Promise.resolve({ error: null });
+      },
+      select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: null }) }) })
+    })
+  })
+}));
+
+import { runDirector } from './director';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyRec = Record<string, any>;
+
+const MAX_STEPS = 8;
+const SEARCH_BUDGET = 2;
+const REWRITE_BUDGET = 3;
+const RERENDER_BUDGET = 2;
+
+function post(over: AnyRec = {}): AnyRec {
+  return {
+    platform: 'instagram',
+    format: 'single_image',
+    media: 'image',
+    caption: 'La ghiera del macinino non resta mai ferma.',
+    image_prompt: 'macine in acciaio su fondo crema',
+    imageUrl: 'https://cdn.example/a.png',
+    ...over
+  };
+}
+
+type ScriptedCall = { tool: string; input?: unknown };
+type DriveRecord = {
+  calls: Array<{ tool: string; output: unknown }>;
+  system: string;
+  messages: AnyRec[];
+  toolNames: string[];
+  providerOptions: AnyRec;
+};
+
+function drive(script: ScriptedCall[], record: DriveRecord, text = '') {
+  return async (options: AnyRec) => {
+    record.system = String(options.system ?? '');
+    record.messages = (options.messages ?? []) as AnyRec[];
+    record.toolNames = Object.keys(options.tools ?? {});
+    record.providerOptions = options.providerOptions ?? {};
+
+    const steps: AnyRec[] = [];
+    for (const entry of script) {
+      await options.prepareStep?.({ stepNumber: steps.length, steps });
+
+      const impl = options.tools?.[entry.tool];
+      const output = impl ? await impl.execute(entry.input ?? {}, {}) : { error: 'no such tool' };
+      record.calls.push({ tool: entry.tool, output });
+
+      const toolCalls = [{ toolName: entry.tool, input: entry.input ?? {}, type: 'tool-call' }];
+      const toolResults = [{ toolName: entry.tool, output, type: 'tool-result' }];
+      const usage = { inputTokens: 100, outputTokens: 40 };
+      steps.push({ toolCalls, toolResults, text: '', usage });
+      await options.onStepFinish?.({ toolCalls, toolResults, text: '', usage });
+
+      const stops = (options.stopWhen ?? []) as Array<(a: AnyRec) => boolean | Promise<boolean>>;
+      const verdicts = await Promise.all(stops.map((s) => s({ steps, stepNumber: steps.length })));
+      if (verdicts.some(Boolean)) break;
+    }
+    return { text, usage: { inputTokens: 900, outputTokens: 120 }, steps };
+  };
+}
+
+function baseOpts(over: AnyRec = {}): AnyRec {
+  return {
+    supabase: {},
+    userId: 'u1',
+    brandId: 'b1',
+    profile: { name: 'Demo Brand', visual_style: 'risografia', language: 'italiano' },
+    posts: [post()],
+    brief: 'La settimana del banco',
+    ...over
+  };
+}
+
+function newRecord(): DriveRecord {
+  return { calls: [], system: '', messages: [], toolNames: [], providerOptions: {} };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  agentSessionWrites.length = 0;
+  collectBatchReviewImages.mockResolvedValue([
+    { label: 'POST 0', inlineData: { mimeType: 'image/png', data: 'AAAA' } }
+  ]);
+  groundedText.mockResolvedValue({ text: 'risposta verificata', citations: [{ uri: 'https://esempio.it/a' }] });
+  structured.mockResolvedValue({ caption: 'Didascalia riscritta.' });
+  renderPreviewImages.mockResolvedValue(undefined);
+});
+
+describe('un batch vuoto', () => {
+  it('non chiama nessun modello', async () => {
+    generateText.mockImplementation(drive([], newRecord()));
+
+    const log = await runDirector(baseOpts({ posts: [] }) as never);
+
+    expect(log).toEqual({ steps: [], summary: '(empty batch)' });
+    expect(generateText).not.toHaveBeenCalled();
+  });
+});
+
+describe('quello che il modello riceve', () => {
+  it('offre esattamente questi tool', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(drive([{ tool: 'finish', input: { summary: 'tutto a posto' } }], rec));
+
+    await runDirector(baseOpts() as never);
+
+    expect(rec.toolNames.sort()).toEqual(
+      ['finish', 'flag_for_user', 'rerender_image', 'rewrite_caption', 'search_web'].sort()
+    );
+  });
+
+  it('allega ogni immagine dopo la sua etichetta, dentro un solo messaggio utente', async () => {
+    const rec = newRecord();
+    collectBatchReviewImages.mockResolvedValue([
+      { label: 'POST 0', inlineData: { mimeType: 'image/png', data: 'AAAA' } },
+      { label: 'POST 0 slide 2', inlineData: { mimeType: 'image/jpeg', data: 'BBBB' } }
+    ]);
+    generateText.mockImplementation(drive([{ tool: 'finish', input: { summary: 'ok' } }], rec));
+
+    await runDirector(baseOpts() as never);
+
+    expect(rec.messages).toHaveLength(1);
+    expect(rec.messages[0].role).toBe('user');
+    const content = rec.messages[0].content as AnyRec[];
+    expect(content[0].type).toBe('text');
+    expect(content[0].text).toContain('BATCH BRIEF: La settimana del banco');
+    expect(content[0].text).toContain('BRAND VISUAL BRIEF');
+    expect(content.slice(1)).toEqual([
+      { type: 'text', text: '[POST 0]' },
+      { type: 'image', image: 'data:image/png;base64,AAAA' },
+      { type: 'text', text: '[POST 0 slide 2]' },
+      { type: 'image', image: 'data:image/jpeg;base64,BBBB' }
+    ]);
+  });
+
+  it('dice a kie di non conservare gli item fra uno step e l altro', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(drive([{ tool: 'finish', input: { summary: 'ok' } }], rec));
+
+    await runDirector(baseOpts() as never);
+
+    expect(rec.providerOptions).toMatchObject({ openai: { store: false } });
+  });
+});
+
+describe('gli strumenti che cambiano il batch', () => {
+  it('rewrite_caption sostituisce la didascalia del post', async () => {
+    const rec = newRecord();
+    const opts = baseOpts();
+    generateText.mockImplementation(
+      drive(
+        [
+          { tool: 'rewrite_caption', input: { index: 0, instruction: 'togli la promessa' } },
+          { tool: 'finish', input: { summary: 'riscritta una didascalia' } }
+        ],
+        rec
+      )
+    );
+
+    const log = await runDirector(opts as never);
+
+    expect(opts.posts[0].caption).toBe('Didascalia riscritta.');
+    expect(rec.calls[0].output).toMatchObject({ ok: true });
+    expect(log.steps[0]).toMatchObject({ tool: 'rewrite_caption' });
+  });
+
+  it('una riscrittura fallita lascia la didascalia com era', async () => {
+    const rec = newRecord();
+    const opts = baseOpts();
+    const original = opts.posts[0].caption;
+    structured.mockResolvedValue({ caption: '   ' });
+    generateText.mockImplementation(
+      drive([{ tool: 'rewrite_caption', input: { index: 0, instruction: 'x' } }, { tool: 'finish', input: { summary: 'ok' } }], rec)
+    );
+
+    await runDirector(opts as never);
+
+    expect(opts.posts[0].caption).toBe(original);
+    expect(rec.calls[0].output).toMatchObject({ error: 'rewrite failed — caption unchanged' });
+  });
+
+  it('rerender_image appende la nota alla brief e rirenderizza', async () => {
+    const rec = newRecord();
+    const opts = baseOpts();
+    generateText.mockImplementation(
+      drive(
+        [
+          { tool: 'rerender_image', input: { index: 0, note: 'meno contrasto' } },
+          { tool: 'finish', input: { summary: 'ok' } }
+        ],
+        rec
+      )
+    );
+
+    await runDirector(opts as never);
+
+    expect(opts.posts[0].image_prompt).toContain('ART DIRECTOR NOTE (apply this): meno contrasto');
+    expect(renderPreviewImages).toHaveBeenCalledTimes(1);
+  });
+
+  it('rerender_image rifiuta un post di solo testo', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(
+      drive([{ tool: 'rerender_image', input: { index: 0, note: 'x' } }, { tool: 'finish', input: { summary: 'ok' } }], rec)
+    );
+
+    await runDirector(baseOpts({ posts: [post({ media: 'text' })] }) as never);
+
+    expect(rec.calls[0].output).toMatchObject({ error: 'bad index or text-only post' });
+    expect(renderPreviewImages).not.toHaveBeenCalled();
+  });
+
+  it('flag_for_user segna il post senza toccarne il contenuto', async () => {
+    const rec = newRecord();
+    const opts = baseOpts();
+    generateText.mockImplementation(
+      drive(
+        [
+          { tool: 'flag_for_user', input: { index: 0, reason: 'claim al limite' } },
+          { tool: 'finish', input: { summary: 'ok' } }
+        ],
+        rec
+      )
+    );
+
+    await runDirector(opts as never);
+
+    expect(opts.posts[0].__attention).toBe('claim al limite');
+    expect(rec.calls[0].output).toMatchObject({ ok: true });
+  });
+
+  it('un indice inesistente non rompe il giro', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(
+      drive([{ tool: 'flag_for_user', input: { index: 9, reason: 'x' } }, { tool: 'finish', input: { summary: 'ok' } }], rec)
+    );
+
+    await runDirector(baseOpts() as never);
+
+    expect(rec.calls[0].output).toMatchObject({ error: 'bad index' });
+  });
+});
+
+describe('i tetti per strumento', () => {
+  it('la ricerca si ferma al suo tetto e non interroga il web una volta in più', async () => {
+    const rec = newRecord();
+    const script = Array.from({ length: SEARCH_BUDGET + 1 }, (_, i) => ({
+      tool: 'search_web',
+      input: { query: `domanda ${i}` }
+    }));
+    generateText.mockImplementation(drive(script, rec));
+
+    await runDirector(baseOpts() as never);
+
+    expect(groundedText).toHaveBeenCalledTimes(SEARCH_BUDGET);
+    expect(rec.calls[SEARCH_BUDGET].output).toMatchObject({
+      error: 'budget exhausted for search_web — wrap up with finish()'
+    });
+  });
+
+  it('la riscrittura si ferma al suo tetto', async () => {
+    const rec = newRecord();
+    const script = Array.from({ length: REWRITE_BUDGET + 1 }, (_, i) => ({
+      tool: 'rewrite_caption',
+      input: { index: 0, instruction: `nota ${i}` }
+    }));
+    generateText.mockImplementation(drive(script, rec));
+
+    await runDirector(baseOpts() as never);
+
+    expect(structured).toHaveBeenCalledTimes(REWRITE_BUDGET);
+    expect(rec.calls[REWRITE_BUDGET].output).toMatchObject({
+      error: 'budget exhausted for rewrite_caption — wrap up with finish()'
+    });
+  });
+
+  it('il rirender si ferma al suo tetto', async () => {
+    const rec = newRecord();
+    const script = Array.from({ length: RERENDER_BUDGET + 1 }, (_, i) => ({
+      tool: 'rerender_image',
+      input: { index: 0, note: `nota ${i}` }
+    }));
+    generateText.mockImplementation(drive(script, rec));
+
+    await runDirector(baseOpts() as never);
+
+    expect(renderPreviewImages).toHaveBeenCalledTimes(RERENDER_BUDGET);
+    expect(rec.calls[RERENDER_BUDGET].output).toMatchObject({
+      error: 'budget exhausted for rerender_image — wrap up with finish()'
+    });
+  });
+
+  it('si ferma al tetto degli step', async () => {
+    const rec = newRecord();
+    const script = Array.from({ length: MAX_STEPS + 4 }, (_, i) => ({
+      tool: 'flag_for_user',
+      input: { index: 0, reason: `motivo ${i}` }
+    }));
+    generateText.mockImplementation(drive(script, rec));
+
+    await runDirector(baseOpts() as never);
+
+    expect(rec.calls).toHaveLength(MAX_STEPS);
+  });
+});
+
+describe('come si chiude', () => {
+  it('finish detta il riassunto', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(drive([{ tool: 'finish', input: { summary: '  Controllato tutto.  ' } }], rec));
+
+    const log = await runDirector(baseOpts() as never);
+
+    expect(log.summary).toBe('Controllato tutto.');
+  });
+
+  it('senza finish ripiega sulla prosa con cui il modello ha chiuso', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(drive([{ tool: 'flag_for_user', input: { index: 0, reason: 'x' } }], rec, 'Batch ok.'));
+
+    const log = await runDirector(baseOpts() as never);
+
+    expect(log.summary).toBe('Batch ok.');
+  });
+
+  it('senza finish e senza prosa lo dice', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(drive([{ tool: 'flag_for_user', input: { index: 0, reason: 'x' } }], rec, ''));
+
+    const log = await runDirector(baseOpts() as never);
+
+    expect(log.summary).toBe('Review ended at step budget.');
+  });
+});
+
+describe('il ripiego di provider, che è il punto del Director', () => {
+  it('se kie muore rifà la review su Gemini e azzera il log parziale', async () => {
+    const rec = newRecord();
+    generateText
+      .mockImplementationOnce(async (options: AnyRec) => {
+        await options.tools.flag_for_user.execute({ index: 0, reason: 'parziale' }, {});
+        throw new Error('kie out of credits');
+      })
+      .mockImplementationOnce(drive([{ tool: 'finish', input: { summary: 'rifatta su Gemini' } }], rec));
+
+    const log = await runDirector(baseOpts() as never);
+
+    expect(generateText).toHaveBeenCalledTimes(2);
+    expect(log.summary).toBe('rifatta su Gemini');
+    expect(log.steps.map((s) => s.tool)).toEqual(['finish']);
+    expect(logAiCall).toHaveBeenCalledWith(
+      expect.objectContaining({ label: 'director', ok: true, provider: 'llm', model: 'gemini-3.7-flash' })
+    );
+  });
+
+  it('ogni tentativo lascia la sua riga di sessione', async () => {
+    const rec = newRecord();
+    generateText
+      .mockImplementationOnce(async () => {
+        throw new Error('kie down');
+      })
+      .mockImplementationOnce(drive([{ tool: 'finish', input: { summary: 'ok' } }], rec));
+
+    await runDirector(baseOpts() as never);
+
+    const rows = agentSessionWrites.filter((r) => r.agent === 'director');
+    expect(rows.some((r) => r.status === 'failed' && r.provider === 'kie')).toBe(true);
+    expect(rows.some((r) => r.status === 'finished' && r.provider === 'llm')).toBe(true);
+  });
+
+  it('se anche Gemini muore il batch esce comunque, con la nota del fallimento', async () => {
+    generateText.mockImplementation(async () => {
+      throw new Error('tutto giù');
+    });
+
+    const log = await runDirector(baseOpts() as never);
+
+    expect(log.summary).toContain('(director failed: tutto giù');
+    expect(logAiCall).toHaveBeenCalledWith(expect.objectContaining({ label: 'director', ok: false }));
+  });
+});
+
+describe('il guardiano di sessione, che il framework applicava in silenzio', () => {
+  // Il tetto di `search_web` è 2: la terza e la quarta chiamata tornano un errore, e a quel
+  // punto il guardiano toglie lo strumento dal tavolo invece di lasciare che il modello continui
+  // a bussare a una porta chiusa. Il risultato che vede il modello è un'istruzione, non un
+  // errore, perché un errore lo farebbe ritentare.
+  it('toglie dal tavolo uno strumento che ha fallito due volte di fila', async () => {
+    const rec = newRecord();
+    const script = Array.from({ length: SEARCH_BUDGET + 3 }, (_, i) => ({
+      tool: 'search_web',
+      input: { query: `domanda ${i}` }
+    }));
+    generateText.mockImplementation(drive(script, rec));
+
+    await runDirector(baseOpts() as never);
+
+    expect(groundedText).toHaveBeenCalledTimes(SEARCH_BUDGET);
+    expect(rec.calls[SEARCH_BUDGET].output).toMatchObject({ error: expect.stringContaining('budget exhausted') });
+    expect(rec.calls[SEARCH_BUDGET + 1].output).toMatchObject({ error: expect.stringContaining('budget exhausted') });
+    expect(rec.calls[SEARCH_BUDGET + 2].output).toMatchObject({
+      blocked_by: 'steward',
+      code: 'error_retry',
+      ran: false,
+      do_not_retry: true
+    });
+  });
+
+  it('un tool che solleva davvero fa cadere il tentativo, e il Director ripiega sull altro provider', async () => {
+    const rec = newRecord();
+    groundedText.mockRejectedValue(new Error('rete giù'));
+    generateText.mockImplementation(drive([{ tool: 'search_web', input: { query: 'a' } }], rec));
+
+    const log = await runDirector(baseOpts() as never);
+
+    expect(generateText).toHaveBeenCalledTimes(2);
+    expect(log.summary).toContain('(director failed: rete giù');
+  });
+});

--- a/src/lib/server/director.loop.test.ts
+++ b/src/lib/server/director.loop.test.ts
@@ -82,6 +82,8 @@ vi.mock('$lib/server/supabase-admin', () => ({
   })
 }));
 
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { runDirector } from './director';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -167,6 +169,30 @@ beforeEach(() => {
   groundedText.mockResolvedValue({ text: 'risposta verificata', citations: [{ uri: 'https://esempio.it/a' }] });
   structured.mockResolvedValue({ caption: 'Didascalia riscritta.' });
   renderPreviewImages.mockResolvedValue(undefined);
+});
+
+// `harness/index` riesporta `harness/run`, che importa `chat/model` e `chat/controller`: chi
+// prende la traccia dall'indice si porta dentro la chat e `$lib/agent` senza usarli. I moduli
+// foglia non li toccano, e questo test è l'unica cosa che impedisce di «riordinare» l'import.
+describe('da dove arriva la traccia', () => {
+  const src = readFileSync(join(process.cwd(), 'src/lib/server/director.ts'), 'utf8');
+
+  it('il Director guida l SDK e non passa dall indice del framework', () => {
+    expect(src).toMatch(/await generateText\(/);
+    expect(src).not.toContain('harnessGenerateText(');
+    expect(src).not.toMatch(/from '\$lib\/server\/harness'/);
+    expect(src).toMatch(/from '\$lib\/server\/harness\/session'/);
+    expect(src).toMatch(/from '\$lib\/server\/harness\/persist'/);
+  });
+
+  it.each(['session.ts', 'persist.ts', 'pipeline.ts', 'steward.ts'])(
+    'harness/%s non importa la chat né $lib/agent',
+    (file) => {
+      const leaf = readFileSync(join(process.cwd(), `src/lib/server/harness/${file}`), 'utf8');
+      expect(leaf).not.toMatch(/from '\$lib\/server\/chat\//);
+      expect(leaf).not.toMatch(/from '\$lib\/agent\//);
+    }
+  );
 });
 
 describe('un batch vuoto', () => {

--- a/src/lib/server/director.ts
+++ b/src/lib/server/director.ts
@@ -1,8 +1,11 @@
 import { KIE_GROK_MAX_OUTPUT_TOKENS } from '$lib/server/ai-output-limits';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { createOpenAI } from '@ai-sdk/openai';
-import { tool, stepCountIs, hasToolCall, type LanguageModel } from 'ai';
-import { harnessGenerateText } from '$lib/server/harness';
+import { generateText, tool, stepCountIs, hasToolCall, type LanguageModel } from 'ai';
+import { createHarnessSession } from '$lib/server/harness/session';
+import { persistHarnessSession } from '$lib/server/harness/persist';
+import { wrapTools } from '$lib/server/harness/pipeline';
+import { applyStewardPrepareStep, createSessionSteward } from '$lib/server/harness/steward';
 import { z } from 'zod';
 import { env } from '$env/dynamic/private';
 import { llmConfigured, llmDefaultModel, llmLanguageModel } from '$lib/server/llm';
@@ -197,7 +200,7 @@ Generated images follow (cover + carousel slides when present). Labels mark POST
         })
       };
 
-      const run = (m: LanguageModel, runProvider: string, runModelId: string) => {
+      const run = async (m: LanguageModel, runProvider: string, runModelId: string) => {
         const content: Array<{ type: 'text'; text: string } | { type: 'image'; image: string }> = [
           { type: 'text', text: intro }
         ];
@@ -208,32 +211,57 @@ Generated images follow (cover + carousel slides when present). Labels mark POST
             image: `data:${p.inlineData.mimeType};base64,${p.inlineData.data}`
           });
         }
-        return harnessGenerateText(
-          {
-            brandId: opts.brandId,
-            userId: opts.userId,
-            agent: 'director',
-            mode: runProvider,
-            model: runModelId,
-            provider: runProvider,
-            surface: 'batch'
-          },
-          {
+
+        const messages = [{ role: 'user' as const, content }];
+        const session = createHarnessSession({
+          brandId: opts.brandId,
+          userId: opts.userId,
+          agent: 'director',
+          mode: runProvider,
+          model: runModelId,
+          provider: runProvider,
+          surface: 'batch'
+        });
+        session.captureRequest({ system: SYSTEM, messages });
+
+        const steward = createSessionSteward(session, Object.keys(tools));
+        const watchedTools = wrapTools(session, tools, steward.pipeline());
+
+        try {
+          const result = await generateText({
             model: m,
             // Runs on either kie Grok or the Gemini fallback — 64k on both.
             maxOutputTokens: KIE_GROK_MAX_OUTPUT_TOKENS,
             system: SYSTEM,
-            messages: [{ role: 'user', content }],
-            tools,
+            messages,
+            allowSystemInMessages: true,
+            tools: watchedTools,
             // kie has no server-side item store — without this every step after the first replays
             // `item_reference` and dies. `forceReasoning` è l'altra metà: senza, l'SDK butta le
             // reasoning part fra uno step e l'altro perché non riconosce `grok-*` dal nome, e su 8
             // step il Director rivaluta il batch da capo ogni volta. Ignorato dal ripiego Gemini.
             providerOptions: { openai: { ...KIE_GROK_NO_STORE } },
             // finish() is the intended exit; the step cap is the backstop when the model rambles.
-            stopWhen: [stepCountIs(MAX_STEPS), hasToolCall('finish')]
-          }
-        );
+            stopWhen: [stepCountIs(MAX_STEPS), hasToolCall('finish')],
+            prepareStep: () => {
+              const patched = applyStewardPrepareStep(session, steward, {}, SYSTEM) ?? {};
+              session.capturePrepareStep(patched);
+              return patched;
+            },
+            onStepFinish: (event) => {
+              session.recordStep(event);
+            }
+          });
+          session.recordAssistantText(result.text);
+          session.recordUsage(result.totalUsage ?? result.usage);
+          session.finish('finished');
+          return result;
+        } catch (e) {
+          session.finish('failed', e);
+          throw e;
+        } finally {
+          persistHarnessSession(session);
+        }
       };
 
       // The Director is the LAST gate before the approval queue. Losing it because kie is out of


### PR DESCRIPTION
## What?

The Director — the last gate before a finished batch reaches the client's approval queue — no
longer runs its loop through the agent framework. It calls `generateText` from the AI SDK
directly, and the three things `harnessGenerateText` was silently adding on a batch surface are
now written at the call site.

Third of twelve, same shape as #224 (week planner) and #231 (strategy agent). 22 characterization
tests were written **against the existing framework implementation** and watched pass before
anything moved; they hook `generateText`, not the wrapper, so the same tests grade both. They pass
on both.

`packages/agent-*` is untouched. Nothing is deleted.

## Why?

`packages/agent-*` (105,226 lines), `src/lib/agent` (23,909) and `src/lib/server/chat` (32,031)
are slated for deletion — about 31% of the repository. Deletion is blocked by whoever still
imports the framework, so the orchestrators come off it one at a time.

The Director was taken third for a reason: it is the first one that **departs from the recipe in
two places**. It talks to the model in `messages` rather than `prompt`, because it attaches the
rendered images to its review, and it runs the whole review a second time on another provider
when the first one dies. If the shape established by the first two only worked on orchestrators
shaped exactly like the first two, it would not be a recipe. It holds.

It also sits on `strategy-agent`'s remaining path into chat (`credits → scheduler → director →
harness/index`), so #231's win is only complete once this lands.

## How?

### What the orchestrator does

Reviews a finished batch as a whole — captions and rendered images in one multimodal message,
plus the brief — with a closed set of tools: `search_web` (verify a claim), `rewrite_caption`,
`rerender_image` (appends an art-director note and re-runs the QC pipeline), `flag_for_user`, and
`finish`. Eight steps maximum, per-tool budgets of 2 / 3 / 2, and it can never publish. Any
failure returns a partial log and the batch ships exactly as the pipeline produced it.

### What the framework was hiding

The same five additions; on `batch` three are live (session transcript, session steward, per-step
system patch) and two are declared `surface === 'chat'` and have never done anything here.

The Director passed **no** `prepareStep` and **no** `onStepFinish` of its own, so both were
entirely the wrapper's — that is exactly the kind of control flow this series is trying to make
visible. They are now four lines each, at the call site.

The steward earns one rule here. `director` is not in the framework's grounding list, so the
"read the brand before paying for search" rule is inert. What does fire: `search_web` is budgeted
at two, the third and fourth calls return an error, and after two consecutive errors the tool
comes off the table instead of the model knocking at a closed door for the rest of its eight
steps. One test holds it.

### The two departures, preserved rather than smoothed over

- **`messages`, not `prompt`.** `captureRequest` takes the messages branch. A test pins the exact
  content array: one text intro, then each image immediately after its own `[label]` text part.
- **Two attempts, two sessions.** `run()` is called again on Gemini when kie throws, so each
  attempt opens and persists its own session row. That is what the Usage page already showed —
  the framework did it, without saying so. Two tests pin it: the retry clears the partial log,
  and one row lands per attempt with the right provider.

### Where the transcript comes from now

`harness/session`, `harness/persist`, `harness/pipeline` and `harness/steward` — 1,030 lines —
import neither chat nor `$lib/agent`. `harness/index` does, because it re-exports `harness/run`.
Importing the four leaves removes the edge and keeps the Usage page intact at zero cost.

### The import guard lives in this file's own test

#224 and #231 put theirs in `nested-agents.test.ts`. This one does not: twelve parallel PRs
editing one shared guard file queue up on the same line for no benefit. The constraint — "do not
collapse back to `harness/index`" — is about this file, so it lives in this file's test. **This
PR therefore does not touch `nested-agents.test.ts` and cannot conflict with #224 or #231.**

### Commits

1. `3257aaa` — the 22 characterization tests, passing against the framework implementation.
2. `462d0a7` — the rewrite plus the import guard.
3. the internal changelog.

## Testing?

Targeted only. The full suite and Playwright are delegated to CI (`.github/workflows/ci.yml` runs
`npx vitest run` plus Playwright on every pull request). `npm run check` was not run: no `.svelte`
file and no shared type is touched.

```
$ npx vitest run src/lib/server/director.loop.test.ts src/lib/server/nested-agents.test.ts

 ✓ src/lib/server/nested-agents.test.ts (7 tests) 5ms
 ✓ src/lib/server/director.loop.test.ts (27 tests) 26ms

 Test Files  2 passed (2)
      Tests  34 passed (34)
```

The 22 loop tests were run against the previous implementation first, at commit `3257aaa`, before
the rewrite existed:

```
 ✓ src/lib/server/director.loop.test.ts (22 tests) 23ms
 Test Files  1 passed (1)
      Tests  22 passed (22)
```

Reproducible: `git checkout 3257aaa && npx vitest run src/lib/server/director.loop.test.ts`.
(The 27 above are the 22 plus the five new import guards, which only exist after the rewrite.)

### What the 22 pin

An empty batch returning `(empty batch)` **without calling a model at all**; the exact tool table;
the multimodal message layout; the kie `store: false` provider option; the caption rewrite landing
on the post, and leaving it untouched when the rewrite comes back blank; the art-director note
appended before a re-render; a text-only post refusing a re-render; `flag_for_user` marking
without touching content; a bad index not breaking the loop; each per-tool budget *and that none
of them pays a primitive one time more*; the step cap; `finish` versus the prose fallback versus
`Review ended at step budget.`; the kie→Gemini retry with its cleared log and its two session
rows; the batch shipping with `(director failed: …)` when both providers die; and the steward
taking a tool off the table after two consecutive failures.

### Schema

No new enum-ish value is written — `agent: 'director'`, `surface: 'batch'`, `mode` = the provider
name, and the status vocabulary all come through unchanged code. `agent_sessions` and `agent_runs`
were checked against the live schema and carry **no CHECK constraints** (`pg_constraint` with
`contype = 'c'` → 0 rows on both).

### Not tested, and why

- **No live run for this one.** #224's rewrite was exercised end to end against the local stack
  with a real model, before and after, and this is the same transformation applied to a third
  file. The machine is in swap; a paid run right now would measure the machine.
- **`npm run eval:durability` was not run** — real money, and this machine is not a reliable bench
  today. **It should be run before merging the series.**
- **The `KIE_API_KEY`-absent path** (`kieModel()` returning null so the run starts on Gemini) is
  not covered; the tests set a key so the retry path is reachable. Unchanged by this PR.

<details>
<summary>Import graph, measured (transitive BFS, 219 modules visited)</summary>

**Before**, `src/lib/server/director.ts` reached chat through its own import:

```
director.ts -> harness/index.ts -> harness/run.ts -> chat/model.ts
director.ts -> harness/index.ts -> harness/run.ts -> chat/controller.ts
```

**After** — that edge is gone. What remains arrives through other files, each its own piece of
work:

```
director.ts -> content-preview.ts -> content-preview/articles.ts -> image-agent.ts -> harness/index.ts -> ...
director.ts -> content-preview.ts -> content-preview/images.ts -> credits.ts -> scheduler.ts -> agent-turns.ts -> chat/queue.ts
```

`image-agent.ts` is another of the twelve. The `credits → scheduler → agent-turns` chain is
infrastructure coupling, unrelated to the framework.
</details>

## Anything Else?

- **Still on the framework after this PR:** `produce-agent.ts`, `seo-agent.ts`, `image-agent.ts`,
  `analytics-review-agent.ts`, `media-generator/agent.ts`, `media-generator/ugc-agent.ts`,
  `media-generator/ugc-plan-agent.ts`, `motion-video/agent.ts`, `sandbox.ts` — plus
  `agent-base.ts`, `craft-model.ts`, `harness-skills.ts`, `agent-kit-effects-store.ts` and all of
  chat.

- **Two of the rest are genuinely a different shape.** `media-generator/agent.ts` and
  `motion-video/agent.ts` use `harnessStreamText`, where the wrapper does more: it installs
  `onFinish` / `onError` / `onAbort` and snapshots the request *before* the stream starts, so a
  killed stream still leaves a transcript. The recipe holds in outline, but those two need their
  own reading and should not be batched with the straight swaps. Named here so nobody assumes the
  pattern is universal.

- **`sandbox.ts` and `agent-base.ts` are not orchestrators** in this sense — they import
  `$lib/agent` / `@anomalia/agent-*` directly rather than driving a loop. Different problem.

- **No public changelog**, deliberately. Same reviews, same budgets, same rows — a customer cannot
  observe any difference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
