### PR TITLE
Bring ads remix back from the pre-monorepo CLI

### DIFF
--- a/changelog/2026-09-04-absorb-legacy-cli.md
+++ b/changelog/2026-09-04-absorb-legacy-cli.md
@@ -1,0 +1,50 @@
+# Il vecchio repo `anomalia-cli` non serve più: c'era una cosa sola da riportare
+
+`andreabuttarelli/anomalia-cli` è il predecessore del monorepo. Serve ancora
+`mcp.anomalia.so` tramite il progetto Vercel `anomalia-cli`, e il suo ultimo deploy di
+produzione precede di sedici giorni l'importazione in `cli/` — quindi lì gira codice più
+vecchio di quello che sta qui. Prima di ricollegare il dominio (azione da dashboard, non
+codice: la PR #228 racconta perché) andava stabilito se quel repo custodisse ancora qualcosa.
+
+Censimento dei 103 file tracciati, contro i 111 di `cli/`:
+
+| insieme | quanti | esito |
+|---|---|---|
+| solo là | 6 | tutti scartati |
+| solo qua | 14 | niente da fare |
+| in entrambi, diversi | 39 | 38 vince `cli/`, 1 aveva qualcosa in più |
+
+**I 6 file solo là, uno per uno.** `mcp/api/_bundle.js`, `mcp/api/mcp.js`,
+`mcp/api/oauth-protected-resource.js` sono l'output di `scripts/build-vercel.mjs` committato:
+qui `cli/.gitignore` li ignora e li rigenera il build. `.claude-plugin/marketplace.json` e
+`.agents/plugins/marketplace.json` esistono già in questo repo, alla radice del monorepo e con
+i path del monorepo — è `cli/plugins/anomalia/plugin-skill.test.ts` a pretenderli lì.
+`.github/workflows/release.yml` è il predecessore di `cli-release.yml`, che ne è un
+sovrainsieme (stessi step, più il push del formula alla tap e gli artifact dei run manuali).
+L'unica cosa che il vecchio ha in più è la guardia che salta `npm publish` quando `NPM_TOKEN`
+è vuoto: non è portata di proposito, perché una release che non pubblica in silenzio è peggio
+di una che fallisce a voce alta.
+
+**Dei 39 diversi, 38 sono la stessa storia**: URL riscritti da `andreabuttarelli/anomalia-cli`
+a `anomaliaso/anomalia`, i tool MCP passati al registry dei contratti, il `consent`
+obbligatorio sulle persone reali, `authServerUrl()` corretto da apex a www. Tutto già qui.
+
+**Il trentanovesimo è l'unica cosa da riportare.** `commands/ads.ts` là ha il flag `--remix`,
+`mcp/tools/web.ts` là ha il tool `ads_remix`, `lib/api.ts` là ha `adsRemix`. Qui non ci sono
+mai stati: `git log -S adsRemix -- cli/` non trova niente, quindi non sono stati tolti — sono
+stati aggiunti al vecchio repo *dopo* l'importazione. Ma la rotta esiste qui,
+`src/routes/api/v1/brands/[slug]/ads/remix/+server.ts`, è documentata in
+`docs/api/08-ads-voice-gtm-misc.md`, e nessun client la sapeva chiamare.
+
+Riportata attraverso il registry (`ADS_REMIX` in `packages/api-contracts/src/ads.ts`), non
+ricopiando il tool a mano: il tool MCP esce generato, identico per nome, titolo, descrizione e
+campi a quello del vecchio repo, e la CLI chiama `callEndpoint` senza un metodo in più in
+`api.ts`. Un campo è stato corretto lungo la strada: il vecchio stampava `b.product`, mentre la
+rotta emette `productName` — là la colonna Product era vuota. Il fallback `visual_prompt`
+snake_case è sparito per lo stesso motivo, il server non lo emette.
+
+Il GET su `/ads/remix` (rileggere i brief senza rispenderli) è rimasto fuori: nel vecchio repo
+`getAdsRemix` esisteva in `api.ts` e non lo chiamava nessuno. Si aggiunge quando serve.
+
+Verificato catturando `tools/list` da `handleMcpFetch` prima e dopo: 82 → 83 tool, l'unico
+aggiunto è `ads_remix`, nessuno tolto o rinominato.

--- a/cli/README.md
+++ b/cli/README.md
@@ -82,6 +82,7 @@ anomalia content my-brand --status pending_user
 anomalia approve my-brand --all
 anomalia seo my-brand
 anomalia web my-brand generate --topic "..."
+anomalia ads my-brand --remix
 anomalia ai my-brand --message "..." --pipe
 ```
 
@@ -95,7 +96,7 @@ prefixes error instead of guessing.
 | Planning | `plan`, `weekly-plan`, `calendar`, `gtm` |
 | Brand | `studio`, `voice`, `people`, `products` |
 | Web | `seo`, `geo`, `keywords`, `web` |
-| Ads | `ads` — campaigns, spend, boost proposals, duplicate/delete (`--sync`, `--propose`, `--create`, `--approve`, `--pause`, `--resume`, `--duplicate`, `--delete`, `--reject`, `--ad` per singola creatività) |
+| Ads | `ads` — campaigns, spend, boost proposals, remix, duplicate/delete (`--sync`, `--propose`, `--remix`, `--create`, `--approve`, `--pause`, `--resume`, `--duplicate`, `--delete`, `--reject`, `--ad` per singola creatività) |
 | Insight | `dashboard`, `status`, `analytics` |
 | AI | `ai --message "..."` — natural language, full read/write access |
 

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -273,8 +273,9 @@ program
 
 program
   .command('ads <slug>')
-  .description('Ads via Zernio: list, propose boosts, approve spend, create standalone')
+  .description('Ads via Zernio: list, propose boosts, remix competitor ads, approve spend')
   .option('--propose', 'Crea proposte di boost dai post organici migliori')
+  .option('--remix', 'Remix competitor/trending ads → brief creativi in brand voice')
   .option('--approve <id>', 'Approva e lancia una campagna proposta (spende budget)')
   .option('--reject <id>', 'Rifiuta una proposta')
   .option('--duplicate <id>', 'Duplica una campagna live (copia in pausa, poi approva)')

--- a/cli/commands/ads.ts
+++ b/cli/commands/ads.ts
@@ -1,7 +1,21 @@
 import ora from 'ora';
 import { loadSession } from '../lib/auth.ts';
-import { api } from '../lib/api.ts';
-import { ok, warn, c, table } from '../lib/display.ts';
+import { api, callEndpoint } from '../lib/api.ts';
+import { ADS_REMIX } from '../lib/contracts/index.ts';
+import { ok, warn, c, table, section, info } from '../lib/display.ts';
+
+type RemixBrief = {
+  rank: number;
+  strategy: string;
+  keep?: string | null;
+  change?: string | null;
+  hook: string;
+  headline: string;
+  body?: string | null;
+  cta?: string | null;
+  productName?: string | null;
+  visualPrompt?: string | null;
+};
 
 export async function cmdAds(
   slug: string,
@@ -17,6 +31,7 @@ export async function cmdAds(
     sync?: boolean;
     budget?: string;
     create?: boolean;
+    remix?: boolean;
     platform?: string;
     name?: string;
     headline?: string;
@@ -32,6 +47,25 @@ export async function cmdAds(
     process.exit(1);
   }
   const token = session.access_token;
+
+  if (opts.remix) {
+    const spinner = ora('Remix ads: harvest + vision analysis…').start();
+    try {
+      const r = await callEndpoint<{ error?: string; briefs?: RemixBrief[] }>(ADS_REMIX, token, slug);
+      spinner.stop();
+      if (r.error) {
+        warn(r.error);
+        process.exit(1);
+      }
+      const briefs = [...(r.briefs ?? [])].sort((a, b) => a.rank - b.rank);
+      ok(`${briefs.length} remix brief${briefs.length === 1 ? '' : 's'}`);
+      printRemixBriefs(briefs);
+    } catch (e) {
+      spinner.fail(String(e));
+      process.exit(1);
+    }
+    return;
+  }
 
   if (opts.sync) {
     const spinner = ora('Sync ad accounts + metrics…').start();
@@ -213,4 +247,41 @@ export async function cmdAds(
     spinner.fail(String(e));
     process.exit(1);
   }
+}
+
+function printRemixBriefs(briefs: RemixBrief[]) {
+  if (!briefs.length) {
+    warn('Nessun brief. Controlla competitor ads / brand kit / catalogo prodotti.');
+    return;
+  }
+
+  section('Ads remix briefs');
+  table(
+    ['#', 'Hook', 'Headline', 'Product', 'Strategy'],
+    briefs.map((b) => [
+      b.rank,
+      truncate(b.hook, 36),
+      truncate(b.headline, 36),
+      truncate(b.productName ?? '—', 20),
+      truncate(b.strategy, 40),
+    ])
+  );
+
+  for (const b of briefs) {
+    console.log(`\n${c.bold(`#${b.rank}`)} ${c.dim(b.productName ?? '—')}`);
+    console.log(`  Hook      ${b.hook}`);
+    console.log(`  Headline  ${b.headline}`);
+    if (b.body) console.log(`  Body      ${b.body}`);
+    if (b.cta) console.log(`  CTA       ${b.cta}`);
+    console.log(`  Strategy  ${b.strategy}`);
+    if (b.keep) console.log(`  Keep      ${b.keep}`);
+    if (b.change) console.log(`  Change    ${b.change}`);
+    if (b.visualPrompt) info(`  Visual    ${b.visualPrompt}`);
+  }
+  console.log('');
+}
+
+function truncate(s: string, n: number): string {
+  const t = s.replace(/\s+/g, ' ').trim();
+  return t.length > n ? `${t.slice(0, n - 1)}…` : t;
 }

--- a/cli/docs/mcp.md
+++ b/cli/docs/mcp.md
@@ -97,7 +97,7 @@ Post and article ids accept **short unambiguous prefixes** from list results (sa
 | Posts | `list_posts`, `get_post`, `edit_post`, `approve_posts`, `regenerate_slide`, `make_video` |
 | Plans | `get_plan`, `propose_plan`, `plan_week`, `produce_week` |
 | Studio | `get_studio`, `add_note`, `research_competitors` |
-| Web | `get_seo`, `get_geo`, `generate_article`, `chat` |
+| Web | `get_seo`, `get_geo`, `generate_article`, `ads_remix`, `chat` |
 
 Full map: [`skills/anomalia/references/tools.md`](../skills/anomalia/references/tools.md).
 

--- a/cli/docs/quickref.md
+++ b/cli/docs/quickref.md
@@ -73,6 +73,7 @@ anomalia web <slug> generate --topic "..."   # Nuovo articolo
 anomalia web <slug> optimize|publish --id <id>
 anomalia ads <slug>                          # Campagne + metriche paid
 anomalia ads <slug> --propose                # Proposte boost dai top post
+anomalia ads <slug> --remix                  # Remix competitor ads → brief creativi
 anomalia ads <slug> --approve <id> [--budget N]
 anomalia ads <slug> --pause <id>             # Pausa campagna (tutte le creatività)
 anomalia ads <slug> --resume <id>            # Riattiva campagna

--- a/cli/lib/contracts/ads.ts
+++ b/cli/lib/contracts/ads.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+import type { BrandEndpoint } from './index';
+
+const RemixBrief = z.looseObject({
+  rank: z.number(),
+  strategy: z.string(),
+  keep: z.string().nullable().optional(),
+  change: z.string().nullable().optional(),
+  hook: z.string(),
+  headline: z.string(),
+  body: z.string().nullable().optional(),
+  cta: z.string().nullable().optional(),
+  productName: z.string().nullable().optional(),
+  visualPrompt: z.string().nullable().optional()
+});
+
+export const ADS_REMIX = {
+  tool: 'ads_remix',
+  title: 'Ads remix',
+  description:
+    'Harvest competitor/trending ads, analyze with vision, and return ranked remix briefs in ' +
+    'brand voice (hook, headline, body, CTA, product, visualPrompt). Replaces previous briefs. ' +
+    'Costs credits.',
+  method: 'POST',
+  pathUnderBrand: '/ads/remix',
+  input: z.object({}).strict(),
+  output: z.object({ ok: z.literal(true), briefs: z.array(RemixBrief) }),
+  failures: [
+    { error: 'no_competitor_ads', status: 400 },
+    { error: 'no_remix_briefs', status: 400 },
+    { error: 'ads_not_on_plan', status: 403 },
+    { error: 'credits_exhausted', status: 402 },
+    { error: 'Not found', status: 404 }
+  ],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/cli/lib/contracts/index.ts
+++ b/cli/lib/contracts/index.ts
@@ -1,4 +1,5 @@
 import type { z } from 'zod';
+import { ADS_REMIX } from './ads';
 import { GET_ARTICLE, UPDATE_ARTICLE } from './articles';
 import { CHECK_CONTENT } from './content';
 import { GET_CREATION_KIT } from './creation-kit';
@@ -82,6 +83,7 @@ export type ResourceEndpoint = EndpointShape & {
 export type BrandEndpoint = ResourcelessEndpoint | ResourceEndpoint;
 
 export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
+  ADS_REMIX,
   CHECK_CONTENT,
   CREATE_POST,
   CREATE_PRODUCT,
@@ -131,6 +133,7 @@ export function statusForFailure(endpoint: BrandEndpoint, error: string): number
 }
 
 export {
+  ADS_REMIX,
   CHECK_CONTENT,
   CREATE_POST,
   GET_ARTICLE,

--- a/cli/llms.txt
+++ b/cli/llms.txt
@@ -93,6 +93,7 @@ Note: `--id` accepts the short prefix printed in the tables.
 - `anomalia ads <slug>` — Ad campaigns, spend, metrics + boost candidates
 - `anomalia ads <slug> --sync` — Sync ad accounts + metrics
 - `anomalia ads <slug> --propose` — Propose boosts from top organic posts
+- `anomalia ads <slug> --remix` — Remix competitor/trending ads into ranked creative briefs
 - `anomalia ads <slug> --create --name "..." --headline "..." [--platform metaads|googleads] [--budget N]` — Create a standalone proposal
 - `anomalia ads <slug> --approve <id> [--budget N] [--goal ...]` — Approve + launch on Zernio
 - `anomalia ads <slug> --pause <id>` — Pause a campaign (all its creatives)

--- a/packages/api-contracts/src/ads.ts
+++ b/packages/api-contracts/src/ads.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+import type { BrandEndpoint } from './index';
+
+const RemixBrief = z.looseObject({
+  rank: z.number(),
+  strategy: z.string(),
+  keep: z.string().nullable().optional(),
+  change: z.string().nullable().optional(),
+  hook: z.string(),
+  headline: z.string(),
+  body: z.string().nullable().optional(),
+  cta: z.string().nullable().optional(),
+  productName: z.string().nullable().optional(),
+  visualPrompt: z.string().nullable().optional()
+});
+
+export const ADS_REMIX = {
+  tool: 'ads_remix',
+  title: 'Ads remix',
+  description:
+    'Harvest competitor/trending ads, analyze with vision, and return ranked remix briefs in ' +
+    'brand voice (hook, headline, body, CTA, product, visualPrompt). Replaces previous briefs. ' +
+    'Costs credits.',
+  method: 'POST',
+  pathUnderBrand: '/ads/remix',
+  input: z.object({}).strict(),
+  output: z.object({ ok: z.literal(true), briefs: z.array(RemixBrief) }),
+  failures: [
+    { error: 'no_competitor_ads', status: 400 },
+    { error: 'no_remix_briefs', status: 400 },
+    { error: 'ads_not_on_plan', status: 403 },
+    { error: 'credits_exhausted', status: 402 },
+    { error: 'Not found', status: 404 }
+  ],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/packages/api-contracts/src/index.test.ts
+++ b/packages/api-contracts/src/index.test.ts
@@ -248,6 +248,36 @@ describe('il registry degli endpoint di brand', () => {
     expect(byTool('update_article').method).toBe('POST');
   });
 
+  it('ads_remix è tornato: la rotta esiste, il client la sapeva chiamare, poi solo lui l ha persa', () => {
+    const remix = byTool('ads_remix');
+    expect(remix.method).toBe('POST');
+    expect(pathFor(remix, 'demo')).toBe('/api/v1/brands/demo/ads/remix');
+    expect(remix.destructive).toBe(false);
+    expect(statusForFailure(remix, 'ads_not_on_plan')).toBe(403);
+    expect(statusForFailure(remix, 'credits_exhausted')).toBe(402);
+    expect(statusForFailure(remix, 'no_competitor_ads')).toBe(400);
+  });
+
+  it('ads_remix promette brief classificati, non una lista di stringhe', () => {
+    const { output } = byTool('ads_remix');
+    expect(
+      output.safeParse({
+        ok: true,
+        briefs: [
+          {
+            rank: 1,
+            strategy: 'Riprendi hook-problema-soluzione',
+            hook: 'Stufo di risultati che non arrivano?',
+            headline: 'Il metodo che funziona',
+            productName: 'Kit Completo',
+            visualPrompt: 'Flat lay del kit'
+          }
+        ]
+      }).success
+    ).toBe(true);
+    expect(output.safeParse({ ok: true, briefs: ['un brief'] }).success).toBe(false);
+  });
+
   it('una response con outputSchema è un oggetto: MCP non sa trasportare un array', () => {
     for (const e of BRAND_ENDPOINTS) {
       if (!(e.output instanceof z.ZodObject)) continue;

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -1,4 +1,5 @@
 import type { z } from 'zod';
+import { ADS_REMIX } from './ads';
 import { GET_ARTICLE, UPDATE_ARTICLE } from './articles';
 import { CHECK_CONTENT } from './content';
 import { GET_CREATION_KIT } from './creation-kit';
@@ -82,6 +83,7 @@ export type ResourceEndpoint = EndpointShape & {
 export type BrandEndpoint = ResourcelessEndpoint | ResourceEndpoint;
 
 export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
+  ADS_REMIX,
   CHECK_CONTENT,
   CREATE_POST,
   CREATE_PRODUCT,
@@ -131,6 +133,7 @@ export function statusForFailure(endpoint: BrandEndpoint, error: string): number
 }
 
 export {
+  ADS_REMIX,
   CHECK_CONTENT,
   CREATE_POST,
   GET_ARTICLE,

--- a/src/lib/content/changelog/2026-09-04-ads-remix-back.ts
+++ b/src/lib/content/changelog/2026-09-04-ads-remix-back.ts
@@ -1,0 +1,10 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-04',
+  title: 'Remixing competitor ads is back in the CLI and for your agents',
+  items: [
+    'Run `anomalia ads <brand> --remix` again, or ask your agent for it: competitor and trending ads are analysed and come back as ranked creative briefs in your brand voice — hook, headline, body, CTA and a visual prompt.',
+    'The product each brief is built around now shows up instead of a dash.'
+  ]
+} satisfies ChangelogEntry;


### PR DESCRIPTION
## What?

A census of `andreabuttarelli/anomalia-cli` — the pre-monorepo repo that still serves
`mcp.anomalia.so` — against `cli/`, and the one thing it turned up that was worth moving:
**ads remix**. The CLI regains `anomalia ads <slug> --remix` and MCP regains the `ads_remix`
tool, both hitting `POST /api/v1/brands/:slug/ads/remix`, a route that already exists and is
already documented here but that no client could call.

Nothing else was brought over. The census, file by file, is in
`changelog/2026-09-04-absorb-legacy-cli.md`.

## Why?

The old repo's last production deployment predates the monorepo import by sixteen days, so
`mcp.anomalia.so` is serving code older than what lives here (PR #228 explains the concrete
damage: `authServerUrl()` there still returns the apex, which 308-redirects, which kills OAuth
discovery for a redirect-averse client). Before repointing that Vercel project — a dashboard
action, not code, and deliberately not in this PR — someone had to establish that the old repo
holds nothing this one lacks. It holds one thing, and now it doesn't.

## How?

### The census, in three sets

103 tracked files there, 111 under `cli/` here.

| set | count | outcome |
|---|---|---|
| only there | 6 | all discarded |
| only here | 14 | nothing to do |
| in both, different | 39 | 38 keep this repo's version, 1 had something extra |

**The 6 only-there files, and why each is discarded.** `mcp/api/_bundle.js`, `mcp/api/mcp.js`,
`mcp/api/oauth-protected-resource.js` are committed build output of `scripts/build-vercel.mjs`
— `cli/.gitignore` already ignores those paths here and the build regenerates them.
`.claude-plugin/marketplace.json` and `.agents/plugins/marketplace.json` already exist in this
repo at the monorepo root with monorepo paths; `cli/plugins/anomalia/plugin-skill.test.ts`
asserts they live there. `.github/workflows/release.yml` is the ancestor of `cli-release.yml`,
which is a superset of it — same steps, plus pushing the formula to the Homebrew tap and
uploading artifacts on manual runs. The only thing the old workflow has extra is a guard that
skips `npm publish` with a warning when `NPM_TOKEN` is empty; **deliberately not ported**,
because a release that silently doesn't publish is worse than one that fails loudly.

**38 of the 39 differing files** are the same four stories: repo URLs rewritten from
`andreabuttarelli/anomalia-cli` to `anomaliaso/anomalia`, MCP tools moved onto the contracts
registry (which is why `mcp/tools/*.ts` shrank), mandatory `consent` on real people, and
`authServerUrl()` corrected from apex to www. This repo wins all of them.

**The 39th is `ads` remix.** `commands/ads.ts` there has `--remix`, `mcp/tools/web.ts` there has
the `ads_remix` tool, `lib/api.ts` there has `adsRemix`/`getAdsRemix`. `git log -S adsRemix --
cli/` returns nothing, so this repo never had them — they were added over there *after* the
import. Meanwhile `src/routes/api/v1/brands/[slug]/ads/remix/+server.ts` is here and
`docs/api/08-ads-voice-gtm-misc.md` documents both verbs.

### Through the registry, not by hand

`ADS_REMIX` is a new entry in `packages/api-contracts/src/ads.ts` (mirrored into
`cli/lib/contracts/` by `sync-contracts.sh`). The MCP tool then comes out generated — no
hand-written registration — and the CLI calls `callEndpoint(ADS_REMIX, …)` instead of gaining
another method on `api.ts`. That is strictly less code than copying the old tool over, and it
is the idiom the rest of the registry already uses.

**One field corrected on the way in.** The old CLI printed `b.product`; the route emits
`productName`. The Product column was empty over there. The `visual_prompt` snake_case fallback
went too, for the same reason: the server never emits it.

**The GET was left out.** `getAdsRemix` (re-read the briefs without paying to regenerate them)
existed in the old `api.ts` with no caller — dead code, not a lost capability. It costs fifteen
lines the day someone wants it.

## Testing?

The test came first and was watched fail (`missing endpoint ads_remix`, 2 failed / 60 passed)
before the contract existed.

```
npx vitest run packages/api-contracts   →  4 files, 62 tests passed
cd cli && bun test                      →  51 pass, 0 fail (10 files)
cd cli && bun run typecheck             →  clean
npx vitest run src/lib/content/changelog →  3 tests passed
```

**Equivalence proven, not asserted**: `tools/list` was captured through `handleMcpFetch` before
and after, and diffed field by field.

<details>
<summary>tools/list before → after</summary>

```
before 82 after 83
added:   ads_remix
removed: (none)

{
 "name": "ads_remix",
 "title": "Ads remix",
 "description": "Harvest competitor/trending ads, analyze with vision, and return ranked remix
   briefs in brand voice (hook, headline, body, CTA, product, visualPrompt). Replaces previous
   briefs. Costs credits.",
 "properties": ["slug"],
 "required": ["slug"],
 "additionalProperties": false,
 "annotations": { "readOnlyHint": false, "destructiveHint": false }
}
```

Name, title, description, properties and required set match the old repo's hand-written tool
exactly. `additionalProperties: false` is the declared delta — registry inputs are `.strict()`.
</details>

**Not tested**: the remix run itself against a real brand. `POST /ads/remix` harvests
competitor ads and calls a vision model, so exercising it spends real credits on a real ad
account; the equivalence proof above is what stands in for it, and the route it now reaches is
unchanged by this PR.

## Evidence (screenshots/videos)

No UI change — this is CLI, MCP and contract surface only. The `tools/list` diff above is the
evidence for the MCP surface; the CLI evidence is the same registry entry driving
`callEndpoint`.

<details>
<summary>The census as run</summary>

```
$ comm -23 old.txt new.txt          # only in the old repo
.agents/plugins/marketplace.json
.claude-plugin/marketplace.json
.github/workflows/release.yml
mcp/api/_bundle.js
mcp/api/mcp.js
mcp/api/oauth-protected-resource.js

$ git log --oneline -S 'adsRemix' -- cli/
(no output — never existed here)
```
</details>

## Anything Else?

**The old repo is now superfluous as a source of code.** It is not yet superfluous as
infrastructure: the Vercel project `anomalia-cli`
(`prj_oUOLCxXPSMiEggnTB2QqL0AcuFDd`) is still linked to it and still answers
`mcp.anomalia.so`. Repointing that project at `anomaliaso/anomalia` with Root Directory
`cli/mcp` is the remaining step, and it is a dashboard action — per PR #228, and deliberately
out of scope here. After that, archiving the old repo loses nothing.

Public changelog included: a customer can notice `--remix` coming back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
