### PR TITLE
Resolve the address before the crawler dials it

### DIFF
--- a/changelog/2026-09-04-site-analysis-resolves-addresses.md
+++ b/changelog/2026-09-04-site-analysis-resolves-addresses.md
@@ -1,0 +1,101 @@
+# Il crawler risolve l'indirizzo prima di aprire il socket
+
+`isUrlSafe` in `packages/site-analysis/src/crawl.ts` confrontava **pattern di hostname** e non
+risolveva mai. Un nome pubblico il cui record DNS risponde `127.0.0.1` — o `169.254.169.254`, il
+metadata service — lo superava senza storie: la stringa è innocua, è la risposta del resolver a
+non esserlo. Nessuna riga in più in una lista di pattern può vedere quel caso, perché il pattern
+guarda il nome e il socket va all'indirizzo.
+
+Conta più di un difetto teorico perché il crawler apre socket verso indirizzi **che gli detta il
+materiale che sta leggendo**: la pagina dice dove sono le immagini, il `302` dice dove andare, il
+catalogo dice da dove leggere. E `isUrlSafe` ha ~30 punti di chiamata, parecchi dei quali ricevono
+URL scelti da un modello — quindi contenuto con prompt injection può nominarle.
+
+## Cosa è stato fatto
+
+Il package risolve l'indirizzo alle **otto porte da cui esce davvero**, tutte già `async`:
+`fetchPage` (URL iniziale e ogni hop di redirect), `loadPageHtml`, `extractColorsFromImage`,
+`defaultEntryProbe`, `resolveEntryUrl`, `fetchShopifyProducts`, `fetchWooCommerceProducts`.
+
+La guardia nuova è `isUrlSafeToFetch`: il pre-filtro di sempre, poi `lookup(host, { all: true })`
+e il giudizio **sull'indirizzo**. Tre proprietà che vanno dette perché non sono ovvie:
+
+- **Basta un solo record privato fra due** perché l'URL sia rifiutato. Un nome con un A pubblico e
+  un A privato sceglierebbe altrimenti quale usare al momento della connessione, e non è una
+  scelta nostra.
+- **Un nome che non risolve non si dialoga.** Se il resolver non sa dov'è, non lo sappiamo nemmeno
+  noi. È anche ciò che rifiuta i letterali IPv6 in parentesi quadre residui.
+- **Le parentesi quadre e la zone id si tolgono prima** del confronto: `[fc00::1]` e `fe80::1%eth0`
+  non sono indirizzi, ed entrambe le forme basterebbero a far mancare ogni pattern.
+
+`node:dns/promises` è stdlib, quindi il confine di `packages/no-app-imports.test.ts` regge senza
+toccare niente: il divieto è su `$lib` e `$env`, non sui builtin. Il test è nella suite mirata.
+
+## La tabella, e le righe che mancavano
+
+`lookup` restituisce i record **verbatim**, quindi un nome può consegnare un indirizzo in una
+forma che nessuno digiterebbe a mano. La tabella dei pattern era ferma alle forme che si digitano,
+e cinque passavano — provate rosse prima di essere chiuse:
+
+| Forma | Esempio |
+| --- | --- |
+| CGNAT | `100.64.0.1` |
+| multicast / riservati | `239.255.255.250` |
+| IPv4-compatible | `::169.254.169.254` |
+| 6to4 | `2002:7f00:1::` |
+| NAT64 | `64:ff9b::7f00:1` |
+
+Le due tabelle IPv4/IPv6 sono ora **una sola** funzione, `isPrivateAddress`, usata sia sul nome
+(quando è già un indirizzo scritto per esteso) sia su ciò che il resolver risponde: la riga nuova
+vale per entrambi i casi il giorno che si aggiunge, e nessuno dei due può restare indietro.
+
+6to4 e NAT64 sono rifiutati **in blocco**, per prefisso, invece di estrarne l'IPv4 e rimandarlo
+alle regole IPv4: sono due righe contro venticinque, e il relay 6to4 è tecnologia morta. Estrarre
+l'IPv4 embedded è quello che fa `isPrivateAddress` in `tool-guard.ts` con la PR #225 — vedi sotto
+perché non è stato copiato qui.
+
+## Cosa è stato scartato
+
+**Rendere `isUrlSafe` `async` e migrare tutti e ~30 i chiamanti.** È la riparazione che il
+committente aveva suggerito, ed è quella che chiude tutto insieme. Non è stata fatta, per una
+ragione che non è la pigrizia: `if (!isUrlSafe(u))` con un `await` dimenticato valuta una
+**Promise, che è truthy** — la guardia diventa un no-op silenzioso, in un punto di sicurezza,
+senza che niente diventi rosso. Fra i chiamanti ce ne sono dentro `.filter()` e `.some()` sincroni
+(`design-visual-refs`, `create-content-tools` ×3, `post-editor-tools`) e dentro funzioni sincrone
+che a loro volta cascano (`demo-account.normalizeHttpUrl`): trenta conversioni, in tredici file,
+in una PR che nessuno riesce a rivedere davvero. Il rapporto rischio/beneficio è pessimo.
+
+**Spostare `isPrivateAddress` di `tool-guard.ts` dentro il package** (app → package è la direzione
+lecita, e sarebbe l'unico modo di avere un classificatore solo). La PR #225 sta riscrivendo
+esattamente quella funzione in questo momento: spostarla adesso trasforma uno dei due merge in una
+risoluzione manuale di conflitti su codice di sicurezza. Si fa dopo, quando #225 è dentro.
+
+**Allungare la lista dei pattern e basta.** È il diff più corto e non chiude il caso che conta: il
+nome pubblico che risolve in casa.
+
+## Cosa resta scoperto, esplicitamente
+
+1. **I ~30 chiamanti applicativi di `isUrlSafe` continuano a confrontare nomi.** La maggior parte
+   filtra URL da consegnare a un generatore di immagini di terze parti (fal, kie) — lì il socket
+   lo apre il fornitore, dalla sua rete, e risolvere qui non prova niente su cosa dialogherà lui.
+   Ma quattro lo aprono davvero da noi e vanno migrati: `brand-analysis.fetchImageInlinePart`,
+   `design-render.toDataUri`, `youtube-thumbnail`, `prepublish-check.probeMediaUrl`. La strada per
+   quelli non è `isUrlSafeToFetch`: è `safeFetchBytes` di `tool-guard.ts`, che oltre a risolvere
+   ricontrolla ogni hop e applica il tetto di byte mentre il corpo scorre. Due (`studio-actions`,
+   `catalog-tools`) ci passano già a valle e sono di fatto coperti.
+2. **Due classificatori di indirizzi convivono**: questo e quello di `tool-guard.ts`. Convivevano
+   già; questa PR non peggiora la situazione ma non la risolve. L'unificazione è il seguito
+   naturale di #225.
+3. **`website-capture` passa l'URL a Browserless**, che lo scarica dalla sua rete. È una minaccia
+   diversa e non la tocca né questa guardia né l'altra.
+
+## Effetti collaterali da sapere
+
+Ogni pagina scaricata costa ora una `dns.lookup` in più. La risoluzione la fa `getaddrinfo` sul
+thread pool (default 4 thread), e il sistema operativo tiene la cache: un'analisi che legge la
+homepage più sei pagine interne dello stesso dominio fa una risoluzione vera e sei dalla cache.
+
+I test esistenti di `crawl.test.ts` chiamavano `loadPageHtml('https://example.com')` con `fetch`
+finto ma DNS vero: dopo questa modifica sarebbero diventati dipendenti dalla rete. Il resolver è
+ora finto anche lì, con una risposta pubblica fissa — quei test provano cosa fa il crawler con la
+risposta, non il resolver, e restano gli stessi con o senza rete.

--- a/packages/site-analysis/src/crawl-ssrf.test.ts
+++ b/packages/site-analysis/src/crawl-ssrf.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Il crawler apre socket verso indirizzi che gli detta il materiale che sta leggendo: la pagina
+ * dice dove sono le immagini, il redirect dice dove andare, il catalogo dice da dove leggere. La
+ * guardia che aveva confrontava NOMI, e un nome pubblico il cui record DNS risponde 127.0.0.1 è
+ * una stringa innocua: non c'è confronto di stringhe che possa vederlo.
+ *
+ * Qui si prova la sola cosa che conta — che il socket non si apra — su ognuna delle porte da cui
+ * il package esce davvero.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('node:dns/promises', () => ({ lookup: vi.fn() }));
+
+import { lookup } from 'node:dns/promises';
+import { extractColorsFromImage, fetchPage, fetchShopifyProducts, loadPageHtml } from './crawl';
+
+const PUBLIC_ADDRESS = '93.184.216.34';
+const LOOPBACK = '127.0.0.1';
+const METADATA = '169.254.169.254';
+
+const REBIND = 'https://rebind.example.com';
+const PUBLIC_SITE = 'https://example.com';
+
+function resolvesTo(byHost: Record<string, string>) {
+  vi.mocked(lookup).mockImplementation((async (host: string) => {
+    const address = byHost[host];
+    if (!address) throw Object.assign(new Error('ENOTFOUND'), { code: 'ENOTFOUND' });
+    return [{ address, family: address.includes(':') ? 6 : 4 }];
+  }) as never);
+}
+
+/** Ogni indirizzo risponde, così ciò che ferma la richiesta può essere solo la guardia. */
+function servesEverything(redirects: Record<string, string> = {}) {
+  const dialled: string[] = [];
+
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: URL | string) => {
+      const url = String(input);
+      dialled.push(url);
+
+      const location = redirects[url];
+      if (location) return new Response(null, { status: 302, headers: { location } });
+
+      return new Response('<html><body>' + 'x'.repeat(200) + '</body></html>', {
+        status: 200,
+        headers: { 'content-type': 'text/html' }
+      });
+    })
+  );
+
+  return dialled;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('il crawler non dialoga un nome pubblico che risolve in rete privata', () => {
+  it('fetchPage non apre il socket', async () => {
+    resolvesTo({ 'rebind.example.com': LOOPBACK });
+    const dialled = servesEverything();
+
+    expect(await fetchPage(`${REBIND}/`)).toBe('');
+    expect(dialled).toEqual([]);
+  });
+
+  it('fetchPage non segue un redirect che ci finisce dentro', async () => {
+    resolvesTo({ 'example.com': PUBLIC_ADDRESS, 'rebind.example.com': METADATA });
+    const dialled = servesEverything({ [`${PUBLIC_SITE}/`]: `${REBIND}/latest/meta-data/` });
+
+    expect(await fetchPage(`${PUBLIC_SITE}/`)).toBe('');
+    expect(dialled).toEqual([`${PUBLIC_SITE}/`]);
+  });
+
+  it('loadPageHtml non apre il socket', async () => {
+    resolvesTo({ 'rebind.example.com': LOOPBACK });
+    const dialled = servesEverything();
+
+    expect(await loadPageHtml(`${REBIND}/`)).toBe('');
+    expect(dialled).toEqual([]);
+  });
+
+  it('extractColorsFromImage non apre il socket', async () => {
+    resolvesTo({ 'rebind.example.com': LOOPBACK });
+    const dialled = servesEverything();
+
+    expect(await extractColorsFromImage(`${REBIND}/logo.png`)).toEqual([]);
+    expect(dialled).toEqual([]);
+  });
+
+  it('fetchShopifyProducts non apre il socket', async () => {
+    resolvesTo({ 'rebind.example.com': LOOPBACK });
+    const dialled = servesEverything();
+
+    expect(await fetchShopifyProducts(`${REBIND}/`)).toEqual([]);
+    expect(dialled).toEqual([]);
+  });
+});
+
+/**
+ * `lookup` restituisce i record VERBATIM, quindi un nome può consegnare un indirizzo in una di
+ * queste forme senza che nessuno lo abbia scritto a mano. La tabella dei pattern era ferma alle
+ * forme che si digitano.
+ */
+describe('le forme che un resolver può consegnare', () => {
+  const REFUSED = {
+    CGNAT: '100.64.0.1',
+    'multicast/riservati': '239.255.255.250',
+    'IPv4-mapped': '::ffff:127.0.0.1',
+    'IPv4-compatible': '::169.254.169.254',
+    '6to4': '2002:7f00:1::',
+    NAT64: '64:ff9b::7f00:1'
+  };
+
+  for (const [shape, address] of Object.entries(REFUSED)) {
+    it(`rifiuta ${shape} (${address})`, async () => {
+      resolvesTo({ 'rebind.example.com': address });
+      const dialled = servesEverything();
+
+      expect(await fetchPage(`${REBIND}/`)).toBe('');
+      expect(dialled).toEqual([]);
+    });
+  }
+
+  it('basta un solo record privato fra due perché il nome sia rifiutato', async () => {
+    vi.mocked(lookup).mockImplementation((async () => [
+      { address: PUBLIC_ADDRESS, family: 4 },
+      { address: LOOPBACK, family: 4 }
+    ]) as never);
+    const dialled = servesEverything();
+
+    expect(await fetchPage(`${REBIND}/`)).toBe('');
+    expect(dialled).toEqual([]);
+  });
+});
+
+describe('il crawler continua a leggere i siti veri', () => {
+  it('fetchPage legge un nome che risolve su un indirizzo pubblico', async () => {
+    resolvesTo({ 'example.com': PUBLIC_ADDRESS });
+    const dialled = servesEverything();
+
+    expect(await fetchPage(`${PUBLIC_SITE}/`)).toContain('<html>');
+    expect(dialled).toEqual([`${PUBLIC_SITE}/`]);
+  });
+
+  it('fetchPage segue un redirect verso un altro indirizzo pubblico', async () => {
+    resolvesTo({ 'example.com': PUBLIC_ADDRESS, 'cdn.example.net': PUBLIC_ADDRESS });
+    const dialled = servesEverything({ [`${PUBLIC_SITE}/`]: 'https://cdn.example.net/' });
+
+    expect(await fetchPage(`${PUBLIC_SITE}/`)).toContain('<html>');
+    expect(dialled).toEqual([`${PUBLIC_SITE}/`, 'https://cdn.example.net/']);
+  });
+
+  it('un nome che non risolve non si dialoga', async () => {
+    resolvesTo({});
+    const dialled = servesEverything();
+
+    expect(await fetchPage('https://nowhere.example/')).toBe('');
+    expect(dialled).toEqual([]);
+  });
+});

--- a/packages/site-analysis/src/crawl.test.ts
+++ b/packages/site-analysis/src/crawl.test.ts
@@ -1,4 +1,12 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
+
+// Le funzioni che scaricano risolvono l'indirizzo prima di aprire il socket. Qui non si prova il
+// resolver: si prova cosa fa il crawler con la risposta, quindi la risposta e' fissa e pubblica e
+// la suite resta la stessa con o senza rete. Il rifiuto su indirizzo privato sta in crawl-ssrf.
+vi.mock('node:dns/promises', () => ({
+    lookup: async () => [{ address: '93.184.216.34', family: 4 }]
+}));
+
 import { blockPageReason, classifyArchetype, discoverAnnouncementPages, discoverInternalPages, extractLogos, extractSocialHandles, harvestPageImages, isUrlSafe, loadPageHtml, matchTeamPhotos, resolveEntryUrl, svgToPng, type BrowserRenderer, type EntryProbe } from './crawl';
 
 const linksHtml = (hrefs: string[]) =>

--- a/packages/site-analysis/src/crawl.ts
+++ b/packages/site-analysis/src/crawl.ts
@@ -11,6 +11,7 @@
  * cambiano da prodotto a prodotto — un autopilota social vuole colori e font, un prodotto di lead
  * vuole sapere cosa NON fai e con che parole ne parlano i tuoi clienti. Due lettori, un raccoglitore.
  */
+import { lookup } from 'node:dns/promises';
 
 /** Il nome ridotto a token confrontabili: serve solo ad abbinare le foto del team ai nomi. */
 function slugify(value: string): string {
@@ -421,7 +422,7 @@ export const MAX_IMAGE_BYTES = 5 * 1024 * 1024; // 5MB — limite per immagini l
  * Graceful degradation: se vibrant non è disponibile o fallisce, restituisce [].
  */
 export async function extractColorsFromImage(imageUrl: string): Promise<string[]> {
-    if (!isUrlSafe(imageUrl)) return [];
+    if (!(await isUrlSafeToFetch(imageUrl))) return [];
 
     try {
         const response = await fetch(imageUrl, {
@@ -713,7 +714,11 @@ export function matchTeamPhotos(
 /** Lista di hostname bloccati per prevenire SSRF */
 const SSRF_BLOCKED_HOSTNAMES = ['localhost', '0.0.0.0', '[::1]'];
 
-/** Pattern IPv4 privati — matchano hostname come stringa */
+/**
+ * Gli indirizzi che non escono su internet. Una tabella sola, applicata sia al nome (quando è già
+ * un indirizzo scritto per esteso) sia a ciò che il resolver risponde: la riga nuova vale per
+ * entrambi i casi il giorno che si aggiunge, e nessuno dei due può restare indietro.
+ */
 const SSRF_PRIVATE_IP_PATTERNS = [
     /^127\./,
     /^10\./,
@@ -721,21 +726,44 @@ const SSRF_PRIVATE_IP_PATTERNS = [
     /^192\.168\./,
     /^169\.254\./,
     /^0\./,
+    /^100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\./,  // CGNAT (100.64/10)
+    /^(22[4-9]|2[3-5]\d)\./,                     // multicast e riservati (224.0.0.0+)
 ];
 
 /** Pattern IPv6 privati — copre mapped IPv4 (::ffff:), unique local (fc/fd), link-local (fe80) */
 const SSRF_PRIVATE_IPV6_PATTERNS = [
     /^::ffff:/i,      // IPv6-mapped IPv4 (es. ::ffff:127.0.0.1)
+    /^::\d/,          // IPv4-compatible (es. ::127.0.0.1)
     /^::$/,           // Unspecified address
     /^::1$/,          // Loopback senza brackets
     /^f[cd]/i,        // Unique local addresses (fc00::/7)
     /^fe[89ab]/i,     // Link-local addresses (fe80::/10)
+    /^2002:/i,        // 6to4 — porta un IPv4 dentro, e il relay è tecnologia morta
+    /^64:ff9b:/i,     // NAT64 — idem
 ];
 
 /**
- * Verifica che un URL non punti a risorse interne (SSRF protection).
- * Controlla hostname e pattern IP (IPv4 + IPv6) — usato sia per URL iniziali che per redirect,
- * e per ogni URL che arriva da fuori (es. le immagini di riferimento scelte dal chatbot).
+ * Dice se un indirizzo — non un nome — è fuori dalla rete pubblica.
+ *
+ * Le parentesi quadre e la zone id (`fe80::1%eth0`) si tolgono prima: nessuna delle due fa parte
+ * dell'indirizzo, ed entrambe basterebbero a far mancare ogni pattern.
+ */
+function isPrivateAddress(address: string): boolean {
+    const bare = address.trim().toLowerCase().replace(/^\[|\]$/g, '').split('%')[0];
+    return (
+        SSRF_PRIVATE_IP_PATTERNS.some(p => p.test(bare)) ||
+        SSRF_PRIVATE_IPV6_PATTERNS.some(p => p.test(bare))
+    );
+}
+
+/**
+ * Il PRE-FILTRO: dice se un URL è scritto in modo accettabile e non nomina apertamente un
+ * indirizzo interno. Non risolve niente, quindi NON basta da solo prima di aprire un socket —
+ * un nome pubblico il cui record DNS risponde `127.0.0.1` lo supera senza storie, perché la
+ * stringa è innocua: è la risposta del resolver a non esserlo.
+ *
+ * Chi sta per scaricare qualcosa usa `isUrlSafeToFetch`. Questa resta per chi filtra un elenco
+ * di URL senza dialogarli (le immagini di riferimento proposte a un modello, per esempio).
  */
 export function isUrlSafe(url: string): boolean {
     try {
@@ -743,16 +771,29 @@ export function isUrlSafe(url: string): boolean {
         if (!['http:', 'https:'].includes(parsed.protocol)) return false;
         const hostname = parsed.hostname.toLowerCase();
         if (SSRF_BLOCKED_HOSTNAMES.includes(hostname)) return false;
-        if (SSRF_PRIVATE_IP_PATTERNS.some(p => p.test(hostname))) return false;
 
-        // IPv6: rimuovi brackets per testare i pattern (URL.hostname li include per IPv6)
-        const bareHost = hostname.replace(/^\[|\]$/g, '');
-        if (SSRF_PRIVATE_IPV6_PATTERNS.some(p => p.test(bareHost))) return false;
-
-        return true;
+        return !isPrivateAddress(hostname);
     } catch {
         return false;
     }
+}
+
+/**
+ * La guardia da usare PRIMA DI APRIRE UN SOCKET: il pre-filtro, e poi l'indirizzo vero.
+ *
+ * `lookup(host, { all: true })` chiede al resolver ogni indirizzo dietro quel nome, e basta che
+ * uno solo sia interno perché l'URL sia rifiutato — un nome con due record, uno pubblico e uno
+ * privato, sceglierebbe altrimenti quale dei due usare al momento della connessione. Un nome che
+ * non risolve non si dialoga: se il resolver non sa dov'è, non lo sappiamo nemmeno noi.
+ */
+export async function isUrlSafeToFetch(url: string): Promise<boolean> {
+    if (!isUrlSafe(url)) return false;
+
+    const host = new URL(url).hostname.toLowerCase().replace(/^\[|\]$/g, '');
+    const addresses = await lookup(host, { all: true }).catch(() => []);
+    if (!addresses.length) return false;
+
+    return !addresses.some(a => isPrivateAddress(a.address));
 }
 
 // --- Fetch ---
@@ -763,8 +804,8 @@ export function isUrlSafe(url: string): boolean {
  * Gestione redirect manuale per validare SSRF su ogni hop.
  */
 export async function fetchPage(url: string): Promise<string> {
-    // Validazione SSRF sull'URL iniziale
-    if (!isUrlSafe(url)) return '';
+    // Validazione SSRF sull'URL iniziale: l'indirizzo, non il nome
+    if (!(await isUrlSafeToFetch(url))) return '';
 
     let currentUrl = url;
     let redirectCount = 0;
@@ -795,7 +836,7 @@ export async function fetchPage(url: string): Promise<string> {
                 const resolvedUrl = new URL(location, currentUrl).href;
 
                 // Validazione SSRF sul target del redirect
-                if (!isUrlSafe(resolvedUrl)) return '';
+                if (!(await isUrlSafeToFetch(resolvedUrl))) return '';
 
                 currentUrl = resolvedUrl;
                 redirectCount++;
@@ -890,7 +931,7 @@ const TLS_ERROR_CODES = new Set([
 ]);
 
 const defaultEntryProbe: EntryProbe = async (url) => {
-    if (!isUrlSafe(url)) return { tlsError: false, finalUrl: null };
+    if (!(await isUrlSafeToFetch(url))) return { tlsError: false, finalUrl: null };
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
     try {
@@ -930,7 +971,7 @@ export async function resolveEntryUrl(url: string, probe: EntryProbe = defaultEn
     if (!finalUrl) return url;
 
     try {
-        if (new URL(finalUrl).protocol === 'https:' && isUrlSafe(finalUrl)) return finalUrl;
+        if (new URL(finalUrl).protocol === 'https:' && (await isUrlSafeToFetch(finalUrl))) return finalUrl;
     } catch {
         return url;
     }
@@ -953,7 +994,7 @@ export async function loadPageHtml(
     onEscalate?: () => void,
     renderer: BrowserRenderer = noRenderer
 ): Promise<string> {
-    if (!isUrlSafe(url)) return '';
+    if (!(await isUrlSafeToFetch(url))) return '';
 
     // Una pagina di blocco non è il sito: meglio niente, così chi chiama lo dice all'utente
     // invece di far analizzare un errore 403 come se fosse il suo brand.
@@ -1036,7 +1077,7 @@ export async function fetchShopifyProducts(baseUrl: string): Promise<Array<{ nam
 
         // Validazione SSRF — l'origin deriva dall'URL utente che è già validato,
         // ma difesa in profondità per evitare bypass se chiamato da altri contesti
-        if (!isUrlSafe(`${origin}/products.json`)) return [];
+        if (!(await isUrlSafeToFetch(`${origin}/products.json`))) return [];
 
         const PER_PAGE = 250; // Max consentito da Shopify
         const MAX_PAGES = 10; // Limite sicurezza: max 2500 prodotti
@@ -1123,7 +1164,7 @@ export async function fetchWooCommerceProducts(baseUrl: string): Promise<Array<{
         const origin = new URL(baseUrl).origin;
 
         // Validazione SSRF — difesa in profondità
-        if (!isUrlSafe(`${origin}/wp-json/wc/store/v1/products`)) return [];
+        if (!(await isUrlSafeToFetch(`${origin}/wp-json/wc/store/v1/products`))) return [];
 
         const PER_PAGE = 100; // Max per WooCommerce Store API
         const MAX_PAGES = 10;

--- a/src/lib/content/changelog/2026-09-04-site-analysis-resolves-addresses.ts
+++ b/src/lib/content/changelog/2026-09-04-site-analysis-resolves-addresses.ts
@@ -1,0 +1,12 @@
+import type { ChangelogEntry } from './index';
+
+const entry: ChangelogEntry = {
+  date: '2026-09-04',
+  title: 'Reading a website checks where each address really leads',
+  items: [
+    'When we read your site — its pages, its images, its product catalogue — every address is now checked against where it actually leads, not just how it is written, and a link that leads somewhere off the public internet is dropped instead of followed.',
+    'The same check runs again each time a link forwards along, so a public address can no longer hand the crawler somewhere private on the way.'
+  ]
+};
+
+export default entry;


### PR DESCRIPTION
## What?

`isUrlSafe` in `packages/site-analysis/src/crawl.ts` compares **hostname patterns** and never
resolves anything. This adds `isUrlSafeToFetch` — the same pre-filter, then
`lookup(host, { all: true })` and a verdict on the **address** — and routes the eight places the
package actually opens a socket through it. It also completes the address table with five forms a
resolver can hand back and the old one let past.

It does **not** migrate `isUrlSafe`'s ~30 call sites; the "Anything Else?" section says exactly
what is left and why.

## Why?

A public name whose DNS record answers `127.0.0.1` — or `169.254.169.254`, the cloud metadata
endpoint — walks straight through a hostname comparison. The string is innocent; the resolver's
answer is not. No number of extra rows in a pattern list closes it, because the pattern reads the
name and the socket goes to the address.

That matters more here than in most places, because the crawler opens sockets toward addresses
**the material it is reading dictates**: the page says where the images are, the `302` says where
to go next, the catalogue says where to read from. And several of `isUrlSafe`'s callers receive
URLs chosen by a model, so prompt-injected content can name them.

### The census asked for

`grep -rn "isUrlSafe"` — 38 call sites, 8 in the package and 30 in the app:

**Package, all `async`, all dial — all eight migrated in this PR:**
`crawl.ts` — `extractColorsFromImage` (:424), `fetchPage` initial URL (:767) and every redirect
hop (:798), `defaultEntryProbe` (:893), `resolveEntryUrl` (:933), `loadPageHtml` (:956),
`fetchShopifyProducts` (:1039), `fetchWooCommerceProducts` (:1126).

**App, via the `brand-analysis.ts` re-export — none migrated here:**

| File | Sites | What the URL is for |
| --- | --- | --- |
| `agent/tools/create-content-tools.ts` | 9 | video/reference URLs for the generators; 3 inside sync `.filter()` |
| `server/demo-account.ts` | 3 | normalising a brand website; one inside a **sync** function |
| `server/design-render.ts` | 2 | **fetches** (`toDataUri`) |
| `server/design-compose.ts` | 2 | listing brand logo/favicon for a model |
| `server/design-visual-refs.ts` | 2 | listing competitor thumbs; one inside sync `.filter()` |
| `server/media-generator/agent.ts` | 2 | listing reference images for a model |
| `server/brand-analysis.ts` | 1 | **fetches** (`fetchImageInlinePart`) |
| `server/youtube-thumbnail.ts` | 1 | **fetches** |
| `server/prepublish-check.ts` | 1 | **fetches** (`probeMediaUrl`) |
| `server/website-capture.ts` | 1 | hands the URL to Browserless (fetched from *their* network) |
| `agent/tools/catalog-tools.ts` | 1 | already followed by `archiveImageToBucket` (on `safeFetchBytes`) |
| `agent/tools/post-editor-tools.ts` | 1 | inside a **sync** closure |
| `server/studio-actions.ts` | 1 | already followed by `storeBrandLogoFromUrl` (on `safeFetchBytes`) |

## How?

**The boundary held without being touched.** `packages/no-app-imports.test.ts` forbids `$lib` and
`$env`, not Node builtins — `node:dns/promises` is stdlib, so the package resolves for itself and
no port had to be declared, no dependency inverted, and nothing about the test changed. (It is in
the targeted run below, as required.)

Three properties of `isUrlSafeToFetch` worth stating because they are not obvious:

- **One private record among two is enough to refuse.** A name with a public A and a private A
  would otherwise pick which one to dial at connect time, and that is not our choice to leave open.
- **A name that does not resolve is not dialled.** If the resolver does not know where it is,
  neither do we. This is also what refuses leftover bracketed IPv6 literals.
- **Brackets and the zone id are stripped first** (`[fc00::1]`, `fe80::1%eth0`) — neither is part
  of an address, and either one alone is enough to make every pattern miss.

**The two pattern tables became one function**, `isPrivateAddress`, applied to the name (when it
is already a literal address) *and* to what the resolver answers — so a new row lands on both
cases the day it is written, and neither can fall behind.

**The five missing rows.** `lookup` returns records verbatim, so a name can deliver a form nobody
would ever type. Each was watched fail before it was closed: CGNAT (`100.64.0.1`), multicast
(`239.255.255.250`), IPv4-compatible (`::169.254.169.254`), 6to4 (`2002:7f00:1::`) and NAT64
(`64:ff9b::7f00:1`). 6to4 and NAT64 are refused **by prefix** rather than by extracting the
embedded IPv4 — two rows against twenty-five, and the 6to4 relay is dead technology.

### Rejected

**Making `isUrlSafe` async and migrating all ~30 callers** — the fix suggested in the report, and
the one that would improve every caller at once. Not laziness: `if (!isUrlSafe(u))` with a
forgotten `await` evaluates a **Promise, which is truthy**, so the guard silently becomes a no-op
in a security path with nothing red to show for it. Several callers sit inside sync `.filter()` /
`.some()` (`design-visual-refs`, `create-content-tools` ×3, `post-editor-tools`) and one cascades
out of a sync function (`demo-account.normalizeHttpUrl`). Thirty conversions across thirteen files
is not a diff anyone reviews properly, and the failure mode of getting one wrong is invisible.

**Moving `tool-guard.ts`'s `isPrivateAddress` into the package** — app→package is the legal
direction and it is the only way to end up with a single classifier. **PR #225 is rewriting exactly
that function right now**; moving it in parallel turns one of the two merges into a manual conflict
resolution over security code. It is the natural follow-up once #225 lands.

**Just adding rows to the pattern list** — shortest diff, does not close the case that matters.

## Testing?

Written first, watched fail, then fixed. New file:
`packages/site-analysis/src/crawl-ssrf.test.ts` (15 cases).

Targeted only — this machine is saturated and CI already runs the full suite plus Playwright on
every PR:

- `npx vitest run packages/site-analysis/src/crawl-ssrf.test.ts` — **red first**: 6 failed / 8
  (every dialling function opened the socket). After the fix, and with the five table rows added
  and watched fail separately: **15 passed**.
- `npx vitest run packages/site-analysis/src/crawl.test.ts` — the existing suite, still green.
- `npx vitest run packages/no-app-imports.test.ts` — **mandatory** for a `packages/` change; green,
  the boundary is untouched.
- `npx vitest run src/lib/server/chat/brand-studio-tools.test.ts src/lib/agent/tools/standalone-graphic.test.ts src/routes/start/preview/server.test.ts`
  — every app test that reaches `brand-analysis`: 49 passed.

Combined final run of the three package files: **131 passed**.

**Not run, deliberately**: the full unit suite, Playwright, Docker, a dev server, `eval:durability`
(no chat/prompt/tool/model path is touched). No browser verification: there is no UI surface — the
only observable change is which addresses the crawler refuses.

## Evidence

<details>
<summary>Red — the crawler dialled every one of them (6 failed / 8)</summary>

```
   × fetchPage non apre il socket
   × fetchPage non segue un redirect che ci finisce dentro
   × loadPageHtml non apre il socket
   × extractColorsFromImage non apre il socket
   × fetchShopifyProducts non apre il socket
   × un nome che non risolve non si dialoga

AssertionError: expected '<html><body>xxxxxxxxxxxxxxxxxxxxxxxxx…' to be ''
AssertionError: expected [ Array(1) ] to deeply equal []

 Test Files  1 failed (1)
      Tests  6 failed | 2 passed (8)
```
</details>

<details>
<summary>Red — the five resolver-delivered forms, with the new table rows removed</summary>

```
   × le forme che un resolver può consegnare > rifiuta CGNAT (100.64.0.1)
   × le forme che un resolver può consegnare > rifiuta multicast/riservati (239.255.255.250)
   × le forme che un resolver può consegnare > rifiuta IPv4-compatible (::169.254.169.254)
   × le forme che un resolver può consegnare > rifiuta 6to4 (2002:7f00:1::)
   × le forme che un resolver può consegnare > rifiuta NAT64 (64:ff9b::7f00:1)

 Test Files  1 failed (1)
      Tests  5 failed | 10 passed (15)
```

(`::ffff:127.0.0.1` was already covered by the existing `/^::ffff:/` row, so it stays green in
this run — the honest count is five new rows, not six.)
</details>

<details>
<summary>Green — package suite plus the boundary test</summary>

```
$ npx vitest run packages/site-analysis/src/crawl-ssrf.test.ts \
                packages/site-analysis/src/crawl.test.ts \
                packages/no-app-imports.test.ts
 Test Files  3 passed (3)
      Tests  131 passed (131)
```
</details>

<details>
<summary>Green — every app test that reaches brand-analysis</summary>

```
$ npx vitest run src/lib/server/chat/brand-studio-tools.test.ts \
                src/lib/agent/tools/standalone-graphic.test.ts \
                src/routes/start/preview/server.test.ts
 Test Files  3 passed (3)
      Tests  49 passed (49)
```
</details>

## Anything Else?

**What is still uncovered, explicitly.**

1. **The ~30 app callers of `isUrlSafe` still compare names.** Most of them filter URLs handed to a
   third-party image generator (fal, kie), where the socket is opened by the provider from its own
   network and resolving here proves nothing about what it will dial. But **four fetch for real
   from us and need migrating**: `brand-analysis.fetchImageInlinePart`, `design-render.toDataUri`,
   `youtube-thumbnail`, `prepublish-check.probeMediaUrl`. Their destination is not
   `isUrlSafeToFetch` — it is `safeFetchBytes` in `tool-guard.ts`, which also re-checks every
   redirect hop and enforces the byte ceiling while the body streams. Two more (`studio-actions`,
   `catalog-tools`) already flow into `safeFetchBytes` downstream and are effectively covered.
2. **Two address classifiers now coexist** — this one and `tool-guard.ts`'s. They coexisted before;
   this PR does not make it worse and does not fix it. Unification is the follow-up to #225.
3. **`website-capture` hands the URL to Browserless**, which fetches it from its own network. A
   different threat, untouched by either guard.

**A cost worth knowing.** Every page fetched now costs one extra `dns.lookup`. Resolution runs
through `getaddrinfo` on the thread pool (4 threads by default) and the OS caches: an analysis that
reads a homepage plus six internal pages of the same domain does one real resolution and six from
cache.

**A test-hygiene change that came with it.** `crawl.test.ts` called
`loadPageHtml('https://example.com')` with `fetch` stubbed but DNS real, which would have made
those tests network-dependent from this commit on. The resolver is now stubbed there too, with a
fixed public answer — those tests are about what the crawler does with the answer, not about the
resolver, and they now behave identically with or without a network.

**Sibling PR**: #230 (`fix/people-import-ssrf`) closes the other guard found alongside this one —
the private copy in `/app/onboarding/people/import`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
