### PR TITLE
Add the thin-shell post list at /v2/:brand/posts

### DIFF
--- a/changelog/2026-09-04-thin-frontend-posts.md
+++ b/changelog/2026-09-04-thin-frontend-posts.md
@@ -1,0 +1,68 @@
+# L'elenco dei post nel frontend sottile — `/v2/:brand/posts`
+
+La seconda superficie del frontend sottile, dopo il calendario. Elenca i post del brand con
+stato, piattaforme e data, si filtra per stato, e apre il singolo post in un pannello laterale
+dove si modifica la copy e si approva.
+
+## Perché esiste, visto che c'è il calendario
+
+Il calendario risponde a "cosa esce questo mese". Non risponde a "cosa è fallito", né a "cosa ho
+pubblicato finora": un post senza data non ha una casella, e uno di tre mesi fa è a tre click di
+navigazione. La lista è l'altro asse dello stesso dato — per stato invece che per giorno — ed è
+l'unico modo per vedere in un colpo la coda `failed`, che nel calendario è invisibile.
+
+## Cosa c'era prima
+
+`/app/:brand/posts` nel vecchio frontend. Verrà smantellato: `/v2` è il prefisso temporaneo
+finché `/app` è occupato, e la promozione finale sarà `git mv src/routes/v2 src/routes/app`.
+
+## Come è costruita
+
+**Legge dagli endpoint, non dal database.** Il `load` prende il token dalla sessione e chiama
+`GET /api/v1/brands/:slug` (per il fuso del brand) e `GET /api/v1/brands/:slug/posts?status=…`
+in parallelo. Le due azioni chiamano `PUT /posts/:id` e `POST /posts/:id/approve`. Nessun import
+da `$lib/server/cli-queries`: web, MCP e CLI passano dalle stesse regole di prodotto.
+
+**Il filtro sta nella URL, non in memoria.** `?status=failed` è un link: il server rifà la
+query e la pagina si ridisegna. Nessuno store, nessuna cache, nessuna sincronizzazione — l'unico
+stato client è quale pannello è aperto, e anche quello è scritto in `?post=<id>` con
+`replaceState`, così un reload o un link condiviso lo ripristinano.
+
+`filterFor` non si fida del parametro: uno stato che non è nella tabella torna ad `all`, così la
+URL non può inventare un filtro che l'API non conosce.
+
+**Le condizioni stanno in una tabella sola.** `POST_STATES` dice per ogni stato l'etichetta, il
+tono del badge, se si modifica e se si approva. Uno stato sconosciuto non concede niente. Le
+stesse righe generano i filtri (`STATUS_FILTERS`), quindi aggiungere uno stato è aggiungere una
+riga, non toccare tre punti.
+
+**Il fuso è quello del brand.** `whenLabel` formatta con `Intl.DateTimeFormat` sul timezone che
+arriva dall'API: le 23:30 UTC del 31 agosto sono il 1 settembre a Roma, e mostrare la data del
+server sposterebbe di un giorno ogni post serale. È lo stesso difetto che il calendario ha già
+pagato una volta, quindi qui c'è un test che lo pinna.
+
+## Cosa è stato scartato
+
+**Nessuna primitiva nuova.** Il pannello del calendario usa `textarea` e `alert-dialog` di
+shadcn. Qui il testo è un `<textarea>` con le classi dell'`input` esistente, e la conferma
+dell'approvazione è a due passi in linea (il bottone diventa "Yes, distribute it" / "Keep it
+pending"). Due ragioni: meno JavaScript sul primo render, e soprattutto nessuna collisione
+add/add con la PR del calendario, che aggiunge quegli stessi 14 file. Se la conferma in linea si
+rivelasse debole, il passaggio ad `alert-dialog` è un cambio di componente, non di flusso.
+
+**Nessuna utility `grid`.** `app.css` definisce un `.grid` globale (`grid-template-columns:
+1.7fr 1fr`) che dirotta chiunque usi la classe `grid` senza un `grid-cols-*` accanto. La lista è
+una colonna flex: il problema non si presenta invece di essere aggirato.
+
+**Nessuna chat, nessun link alla chat.** Le chat escono dal prodotto.
+
+**Nessuna paginazione.** `getPosts` risponde con i 50 più recenti per data di creazione; la
+pagina lo dice in fondo invece di fingere di mostrare tutto. Paginare vuol dire cambiare
+l'endpoint, e l'endpoint lo usano anche CLI e MCP: è un lavoro suo, non di questa superficie.
+
+## Debito noto
+
+Il pannello e la tabella degli stati sono un doppione di quelli in
+`src/routes/v2/[brand]/calendar/` (PR #229): le due PR sono indipendenti per non incatenare
+l'ordine di merge con nove agenti in parallelo. Quando entrambe sono su `dev`, la pulizia è
+spostare `post-state.ts` e `PostPanel.svelte` a `src/routes/v2/[brand]/` e ripuntare due import.

--- a/src/routes/v2/[brand]/posts/+page.server.ts
+++ b/src/routes/v2/[brand]/posts/+page.server.ts
@@ -1,0 +1,142 @@
+import { error, fail, redirect } from '@sveltejs/kit';
+import type { Actions, PageServerLoad } from './$types';
+import { filterFor, type PostRow } from './post-state';
+
+type BrandRead = {
+  brand: { name: string; slug: string; timezone: string };
+};
+
+type ApproveResult = {
+  ok?: boolean;
+  status?: string;
+  noAccount?: boolean;
+  message?: string;
+  error?: string;
+};
+
+type Outcome = {
+  id: string | null;
+  message: string | null;
+  saved: boolean;
+  approved: boolean;
+  status: string | null;
+};
+
+const CAPTION_MAX = 20_000;
+
+function outcome(partial: Partial<Outcome>): Outcome {
+  return { id: null, message: null, saved: false, approved: false, status: null, ...partial };
+}
+
+function brandApi(slug: string, path: string): string {
+  return `/api/v1/brands/${encodeURIComponent(slug)}${path}`;
+}
+
+async function readError(res: Response): Promise<string> {
+  const body = (await res.json().catch(() => null)) as { error?: string } | null;
+  return body?.error ?? `Request failed (${res.status})`;
+}
+
+export const load: PageServerLoad = async ({ params, url, fetch, locals }) => {
+  const { session } = await locals.safeGetSession();
+  if (!session) {
+    redirect(303, '/login');
+  }
+
+  const headers = { Authorization: `Bearer ${session.access_token}` };
+  const status = filterFor(url.searchParams.get('status'));
+
+  const [brandRes, postsRes] = await Promise.all([
+    fetch(brandApi(params.brand, ''), { headers }),
+    fetch(brandApi(params.brand, `/posts?status=${status}`), { headers })
+  ]);
+
+  if (!brandRes.ok) {
+    error(brandRes.status, await readError(brandRes));
+  }
+  if (!postsRes.ok) {
+    error(postsRes.status, await readError(postsRes));
+  }
+
+  const { brand } = (await brandRes.json()) as BrandRead;
+
+  return {
+    brand: { slug: params.brand, name: brand.name, timezone: brand.timezone },
+    status,
+    posts: (await postsRes.json()) as PostRow[],
+    selectedPostId: url.searchParams.get('post')
+  };
+};
+
+export const actions: Actions = {
+  edit: async ({ request, params, fetch, locals }) => {
+    const { session } = await locals.safeGetSession();
+    if (!session) {
+      redirect(303, '/login');
+    }
+
+    const form = await request.formData();
+    const id = String(form.get('id') ?? '');
+    const caption = String(form.get('caption') ?? '');
+
+    if (!id) {
+      return fail(400, outcome({ message: 'Missing post.' }));
+    }
+    if (!caption.trim()) {
+      return fail(400, outcome({ id, message: 'The copy cannot be empty.' }));
+    }
+    if (caption.length > CAPTION_MAX) {
+      return fail(400, outcome({ id, message: 'The copy is too long to save.' }));
+    }
+
+    const res = await fetch(brandApi(params.brand, `/posts/${encodeURIComponent(id)}`), {
+      method: 'PUT',
+      headers: {
+        Authorization: `Bearer ${session.access_token}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ caption })
+    });
+
+    if (!res.ok) {
+      return fail(res.status, outcome({ id, message: await readError(res) }));
+    }
+
+    return outcome({ id, saved: true });
+  },
+
+  approve: async ({ request, params, fetch, locals }) => {
+    const { session } = await locals.safeGetSession();
+    if (!session) {
+      redirect(303, '/login');
+    }
+
+    const form = await request.formData();
+    const id = String(form.get('id') ?? '');
+
+    if (!id) {
+      return fail(400, outcome({ message: 'Missing post.' }));
+    }
+
+    const res = await fetch(brandApi(params.brand, `/posts/${encodeURIComponent(id)}/approve`), {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${session.access_token}` }
+    });
+
+    const result = (await res.json().catch(() => null)) as ApproveResult | null;
+
+    if (!res.ok || result?.error) {
+      return fail(
+        res.ok ? 400 : res.status,
+        outcome({ id, message: result?.error ?? 'Approval failed.' })
+      );
+    }
+
+    return outcome({
+      id,
+      approved: true,
+      status: result?.status ?? 'approved',
+      message: result?.message ?? null
+    });
+  }
+};

--- a/src/routes/v2/[brand]/posts/+page.svelte
+++ b/src/routes/v2/[brand]/posts/+page.svelte
@@ -1,0 +1,119 @@
+<script lang="ts">
+  import '$lib/styles/tailwind.css';
+  import { replaceState } from '$app/navigation';
+  import { page } from '$app/state';
+  import { Badge } from '$lib/components/ui/badge/index.js';
+  import { platformsOf, stateOf, summarise, whenLabel, STATUS_FILTERS } from './post-state';
+  import type { PostRow } from './post-state';
+  import type { PageProps } from './$types';
+
+  let { data, form }: PageProps = $props();
+
+  const brand = $derived(data.brand);
+  const posts = $derived(data.posts);
+
+  let selectedId = $state<string | null>(data.selectedPostId);
+  let PostPanel = $state<typeof import('./PostPanel.svelte').default | null>(null);
+
+  const selected = $derived(posts.find((p) => p.id === selectedId) ?? null);
+
+  $effect(() => {
+    if (selectedId && !PostPanel) {
+      import('./PostPanel.svelte').then((m) => (PostPanel = m.default));
+    }
+  });
+
+  function syncUrl(postId: string | null) {
+    const url = new URL(page.url);
+    if (postId) {
+      url.searchParams.set('post', postId);
+    } else {
+      url.searchParams.delete('post');
+    }
+    replaceState(url, page.state);
+  }
+
+  function open(post: PostRow) {
+    selectedId = post.id;
+    syncUrl(post.id);
+  }
+
+  function close() {
+    selectedId = null;
+    syncUrl(null);
+  }
+
+  function filterHref(value: string): string {
+    return value === 'all' ? '?' : `?status=${value}`;
+  }
+</script>
+
+<svelte:head><title>Posts — {brand.name}</title></svelte:head>
+
+<div class="bg-background text-foreground min-h-screen px-4 py-8 sm:px-8">
+  <div class="mx-auto flex max-w-4xl flex-col gap-6">
+    <header class="flex flex-col gap-1">
+      <p class="text-muted-foreground text-xs tracking-wide uppercase">{brand.name}</p>
+      <h1 class="text-2xl font-semibold">Posts</h1>
+      <p class="text-muted-foreground text-xs">Times shown in {brand.timezone}</p>
+    </header>
+
+    <nav aria-label="Filter by status" class="flex flex-wrap gap-2">
+      {#each STATUS_FILTERS as filter (filter.value)}
+        <a
+          href={filterHref(filter.value)}
+          aria-current={data.status === filter.value ? 'page' : undefined}
+          class="focus-visible:ring-ring/50 rounded-lg border px-3 py-1.5 text-sm focus-visible:ring-3 focus-visible:outline-none {data.status ===
+          filter.value
+            ? 'border-primary bg-primary/10 font-medium'
+            : 'border-border hover:bg-muted'}">{filter.label}</a
+        >
+      {/each}
+    </nav>
+
+    {#if form && form.id !== selectedId}
+      <p
+        role={form.message && !form.approved ? 'alert' : 'status'}
+        class="rounded-lg border px-3 py-2 text-sm {form.message && !form.approved
+          ? 'border-destructive/40 text-destructive'
+          : 'border-border'}"
+      >
+        {form.message ??
+          (form.approved ? `Approved — the post is now ${form.status}.` : 'Copy saved.')}
+      </p>
+    {/if}
+
+    {#if posts.length === 0}
+      <p class="text-muted-foreground text-sm">Nothing here.</p>
+    {:else}
+      <ul class="border-border divide-border divide-y overflow-hidden rounded-xl border">
+        {#each posts as post (post.id)}
+          {@const postState = stateOf(post.status)}
+          <li>
+            <button
+              type="button"
+              onclick={() => open(post)}
+              class="hover:bg-muted focus-visible:ring-ring/50 flex w-full flex-col gap-1 px-4 py-3 text-left focus-visible:ring-3 focus-visible:outline-none"
+            >
+              <span class="flex flex-wrap items-center gap-2 text-xs">
+                <Badge variant={postState.tone}>{postState.label}</Badge>
+                <span class="font-medium">{platformsOf(post).join(' · ') || 'post'}</span>
+                <span class="text-muted-foreground">{whenLabel(post, brand.timezone)}</span>
+              </span>
+              <span class="line-clamp-2 text-sm">{summarise(post)}</span>
+            </button>
+          </li>
+        {/each}
+      </ul>
+      <p class="text-muted-foreground text-xs">
+        Showing the {posts.length} most recent. Older posts stay in the calendar.
+      </p>
+    {/if}
+  </div>
+</div>
+
+{#if PostPanel && selected}
+  {#key selected.id}
+    <PostPanel post={selected} timezone={brand.timezone} {form} onclose={close} />
+  {/key}
+{/if}

--- a/src/routes/v2/[brand]/posts/PostPanel.svelte
+++ b/src/routes/v2/[brand]/posts/PostPanel.svelte
@@ -1,0 +1,172 @@
+<script lang="ts">
+  import { enhance } from '$app/forms';
+  import * as Sheet from '$lib/components/ui/sheet/index.js';
+  import { Badge } from '$lib/components/ui/badge/index.js';
+  import { Button } from '$lib/components/ui/button/index.js';
+  import { Label } from '$lib/components/ui/label/index.js';
+  import { distributionNote, platformsOf, stateOf, whenLabel } from './post-state';
+  import type { PostRow } from './post-state';
+
+  type Outcome = {
+    id: string | null;
+    message: string | null;
+    saved: boolean;
+    approved: boolean;
+    status: string | null;
+  };
+
+  let {
+    post,
+    timezone,
+    form,
+    onclose
+  }: {
+    post: PostRow;
+    timezone: string;
+    form: Outcome | null;
+    onclose: () => void;
+  } = $props();
+
+  const postState = $derived(stateOf(post.status));
+  const outcome = $derived(form?.id === post.id ? form : null);
+
+  let caption = $state(post.caption ?? '');
+  let confirming = $state(false);
+  let saving = $state(false);
+  let approving = $state(false);
+</script>
+
+<Sheet.Root open onOpenChange={(open) => !open && onclose()}>
+  <Sheet.Content side="right" class="gap-0 overflow-y-auto data-[side=right]:sm:max-w-lg">
+    <Sheet.Header class="gap-2">
+      <Sheet.Title class="flex flex-wrap items-center gap-2 text-base">
+        {platformsOf(post).join(' · ') || 'Post'}
+        <Badge variant={postState.tone}>{postState.label}</Badge>
+      </Sheet.Title>
+      <Sheet.Description>{whenLabel(post, timezone)}</Sheet.Description>
+    </Sheet.Header>
+
+    <div class="flex flex-col gap-5 px-4 pb-6">
+      {#if post.media_url}
+        <img
+          src={post.media_url}
+          alt="Visual attached to this post"
+          loading="lazy"
+          class="border-border max-h-72 w-full rounded-lg border object-contain"
+        />
+      {/if}
+
+      {#if outcome?.message}
+        <p
+          role={outcome.approved ? 'status' : 'alert'}
+          class="rounded-lg border px-3 py-2 text-sm {outcome.approved
+            ? 'border-border'
+            : 'border-destructive/40 text-destructive'}"
+        >
+          {outcome.message}
+        </p>
+      {:else if outcome?.saved}
+        <p role="status" class="border-border rounded-lg border px-3 py-2 text-sm">Copy saved.</p>
+      {:else if outcome?.approved}
+        <p role="status" class="border-border rounded-lg border px-3 py-2 text-sm">
+          Approved and sent for distribution — the post is now {outcome.status}.
+        </p>
+      {/if}
+
+      <form
+        method="POST"
+        action="?/edit"
+        class="flex flex-col gap-2"
+        use:enhance={() => {
+          saving = true;
+          return async ({ update }) => {
+            await update({ reset: false });
+            saving = false;
+          };
+        }}
+      >
+        <input type="hidden" name="id" value={post.id} />
+        <Label for="caption">Copy</Label>
+        <textarea
+          id="caption"
+          name="caption"
+          bind:value={caption}
+          rows={10}
+          readonly={!postState.canEdit}
+          aria-describedby={postState.canEdit ? undefined : 'copy-locked'}
+          class="dark:bg-input/30 border-input focus-visible:border-ring focus-visible:ring-ring/50 field-sizing-content w-full min-w-0 rounded-lg border bg-transparent px-2.5 py-1.5 text-base outline-none focus-visible:ring-3 read-only:opacity-70 md:text-sm"
+        ></textarea>
+        {#if postState.canEdit}
+          <div>
+            <Button type="submit" variant="outline" size="sm" disabled={saving}>
+              {saving ? 'Saving…' : 'Save copy'}
+            </Button>
+          </div>
+        {:else}
+          <p id="copy-locked" class="text-muted-foreground text-xs">
+            A published post is read-only here.
+          </p>
+        {/if}
+      </form>
+
+      {#if post.published_url}
+        <a
+          href={post.published_url}
+          target="_blank"
+          rel="noreferrer"
+          class="text-sm underline underline-offset-4">See it live</a
+        >
+      {/if}
+
+      {#if postState.canApprove}
+        <div class="border-border flex flex-col gap-3 rounded-lg border p-4">
+          <h3 class="text-sm font-semibold">Approve</h3>
+          <p class="text-muted-foreground text-sm">
+            Approving authorises distribution and hands the post to the connected accounts straight
+            away. There is no separate publish step and no state between here and live.
+          </p>
+          <p class="text-sm">{distributionNote(post, timezone)}</p>
+
+          {#if !confirming}
+            <div>
+              <Button type="button" size="sm" onclick={() => (confirming = true)}>
+                Approve and distribute
+              </Button>
+            </div>
+          {:else}
+            <form
+              method="POST"
+              action="?/approve"
+              class="flex flex-col gap-3"
+              use:enhance={() => {
+                approving = true;
+                return async ({ update }) => {
+                  await update({ reset: false });
+                  approving = false;
+                  confirming = false;
+                };
+              }}
+            >
+              <input type="hidden" name="id" value={post.id} />
+              <p role="alert" class="text-sm">
+                Anomalia sends it to the connected {platformsOf(post).join(' and ') || 'social'} account.
+                If no account is connected yet, the post stays approved and waits for one.
+              </p>
+              <div class="flex flex-wrap gap-2">
+                <Button type="submit" size="sm" disabled={approving}>
+                  {approving ? 'Sending…' : 'Yes, distribute it'}
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onclick={() => (confirming = false)}>Keep it pending</Button
+                >
+              </div>
+            </form>
+          {/if}
+        </div>
+      {/if}
+    </div>
+  </Sheet.Content>
+</Sheet.Root>

--- a/src/routes/v2/[brand]/posts/post-state.test.ts
+++ b/src/routes/v2/[brand]/posts/post-state.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import {
+  distributionNote,
+  filterFor,
+  platformsOf,
+  stateOf,
+  summarise,
+  whenLabel,
+  type PostRow
+} from './post-state';
+
+const ROME = 'Europe/Rome';
+
+function post(over: Partial<PostRow> = {}): PostRow {
+  return {
+    id: 'p1',
+    platform: 'instagram',
+    platforms: null,
+    caption: null,
+    media_url: null,
+    slot: null,
+    scheduled_for: null,
+    status: 'pending_user',
+    published_url: null,
+    created_at: '2026-09-01T08:00:00Z',
+    ...over
+  };
+}
+
+describe('la tabella degli stati decide da sola cosa si puo fare', () => {
+  it('un post in attesa si modifica e si approva', () => {
+    expect(stateOf('pending_user')).toMatchObject({ canEdit: true, canApprove: true });
+  });
+
+  it('un post pubblicato non si tocca', () => {
+    expect(stateOf('published')).toMatchObject({ canEdit: false, canApprove: false });
+  });
+
+  it('uno stato sconosciuto non concede niente', () => {
+    expect(stateOf('quantum')).toEqual({
+      label: 'quantum',
+      tone: 'outline',
+      canEdit: false,
+      canApprove: false
+    });
+  });
+});
+
+describe('il filtro viene dalla URL e non si fida', () => {
+  it('accetta uno stato conosciuto', () => {
+    expect(filterFor('pending_user')).toBe('pending_user');
+  });
+
+  it('riporta ad all uno stato inventato', () => {
+    expect(filterFor('drop table posts')).toBe('all');
+  });
+
+  it('riporta ad all quando manca', () => {
+    expect(filterFor(null)).toBe('all');
+  });
+});
+
+describe('la data mostrata e quella del brand, non quella del server', () => {
+  it('le 23:30 UTC del 31 agosto sono il 1 settembre a Roma', () => {
+    const label = whenLabel(post({ scheduled_for: '2026-08-31T23:30:00Z' }), ROME);
+
+    expect(label).toContain('1 Sep');
+    expect(label).not.toContain('31 Aug');
+  });
+
+  it('senza orario resta il giorno dello slot', () => {
+    expect(whenLabel(post({ slot: '2026-09-10' }), ROME)).toContain('10 Sep');
+  });
+
+  it('senza data lo dice', () => {
+    expect(whenLabel(post(), ROME)).toBe('No date');
+  });
+});
+
+describe('le piattaforme di un post', () => {
+  it('la lista vince sul singolo', () => {
+    expect(platformsOf(post({ platform: 'instagram', platforms: ['linkedin', 'x'] }))).toEqual([
+      'linkedin',
+      'x'
+    ]);
+  });
+
+  it('senza lista resta il singolo', () => {
+    expect(platformsOf(post({ platform: 'instagram' }))).toEqual(['instagram']);
+  });
+
+  it('senza niente resta vuoto', () => {
+    expect(platformsOf(post({ platform: null }))).toEqual([]);
+  });
+});
+
+describe('cosa dice la riga quando la copy manca', () => {
+  it('una copy vuota non diventa una riga vuota', () => {
+    expect(summarise(post({ caption: '   ' }))).toBe('Untitled');
+  });
+
+  it('una copy lunga viene troncata', () => {
+    expect(summarise(post({ caption: 'x'.repeat(200) })).length).toBeLessThan(200);
+  });
+});
+
+describe('cosa succede davvero quando approvi', () => {
+  const now = Date.parse('2026-09-04T10:00:00Z');
+
+  it('una data futura viene nominata', () => {
+    const note = distributionNote(post({ scheduled_for: '2026-09-05T09:00:00Z' }), ROME, now);
+
+    expect(note).toContain('5 Sep');
+    expect(note).toContain(ROME);
+  });
+
+  it('una data passata non viene spacciata per programmata', () => {
+    const note = distributionNote(post({ scheduled_for: '2026-09-01T09:00:00Z' }), ROME, now);
+
+    expect(note).not.toContain('1 Sep');
+    expect(note).toContain('possibly right away');
+  });
+
+  it('senza data dice che esce al primo slot utile', () => {
+    expect(distributionNote(post(), ROME, now)).toContain('possibly right away');
+  });
+});

--- a/src/routes/v2/[brand]/posts/post-state.ts
+++ b/src/routes/v2/[brand]/posts/post-state.ts
@@ -1,0 +1,119 @@
+export type PostRow = {
+  id: string;
+  platform: string | null;
+  platforms: string[] | null;
+  caption: string | null;
+  media_url: string | null;
+  slot: string | null;
+  scheduled_for: string | null;
+  status: string;
+  published_url: string | null;
+  created_at: string;
+};
+
+export type PostState = {
+  label: string;
+  tone: 'default' | 'secondary' | 'outline' | 'destructive';
+  canEdit: boolean;
+  canApprove: boolean;
+};
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}/;
+const SUMMARY_MAX = 90;
+
+const POST_STATES: Record<string, PostState> = {
+  pending_user: { label: 'Pending review', tone: 'default', canEdit: true, canApprove: true },
+  approved: { label: 'Approved', tone: 'secondary', canEdit: true, canApprove: false },
+  scheduled: { label: 'Scheduled', tone: 'secondary', canEdit: true, canApprove: false },
+  published: { label: 'Published', tone: 'outline', canEdit: false, canApprove: false },
+  failed: { label: 'Failed', tone: 'destructive', canEdit: true, canApprove: false }
+};
+
+export const STATUS_FILTERS = [
+  { value: 'all', label: 'Everything' },
+  ...Object.entries(POST_STATES).map(([value, state]) => ({ value, label: state.label }))
+];
+
+export function stateOf(status: string): PostState {
+  return (
+    POST_STATES[status] ?? { label: status, tone: 'outline', canEdit: false, canApprove: false }
+  );
+}
+
+export function filterFor(status: string | null): string {
+  return status && status in POST_STATES ? status : 'all';
+}
+
+export function platformsOf(post: PostRow): string[] {
+  if (post.platforms?.length) {
+    return post.platforms;
+  }
+
+  return post.platform ? [post.platform] : [];
+}
+
+export function momentInZone(iso: string, timezone: string): string {
+  const stamp = new Intl.DateTimeFormat('en-GB', {
+    timeZone: timezone,
+    weekday: 'short',
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit'
+  }).format(new Date(iso));
+
+  return `${stamp} (${timezone})`;
+}
+
+function dayLabel(day: string): string {
+  return new Intl.DateTimeFormat('en-GB', {
+    timeZone: 'UTC',
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric'
+  }).format(new Date(`${day}T00:00:00Z`));
+}
+
+export function whenLabel(post: PostRow, timezone: string): string {
+  if (post.scheduled_for) {
+    return new Intl.DateTimeFormat('en-GB', {
+      timeZone: timezone,
+      day: 'numeric',
+      month: 'short',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit'
+    }).format(new Date(post.scheduled_for));
+  }
+
+  const day = post.slot?.match(ISO_DATE)?.[0];
+  if (day) {
+    return `${dayLabel(day)}, no time yet`;
+  }
+
+  return 'No date';
+}
+
+export function summarise(post: PostRow): string {
+  const copy = (post.caption ?? '').trim().replace(/\s+/g, ' ');
+  if (!copy) {
+    return 'Untitled';
+  }
+
+  return copy.length > SUMMARY_MAX ? `${copy.slice(0, SUMMARY_MAX)}…` : copy;
+}
+
+export function distributionNote(
+  post: PostRow,
+  timezone: string,
+  now: number = Date.now()
+): string {
+  const at = post.scheduled_for ? Date.parse(post.scheduled_for) : Number.NaN;
+
+  if (Number.isFinite(at) && at > now) {
+    return `It goes out on ${momentInZone(post.scheduled_for as string, timezone)}.`;
+  }
+
+  return 'This post has no future date, so it goes out at the next slot Anomalia can use — possibly right away.';
+}


### PR DESCRIPTION
## What?

The second surface of the thin frontend, after the calendar in #229: a post list at
**`/v2/:brand/posts`** that shows the brand's posts with status, platforms and date, filters by
status, and opens one in a side panel where the copy is edited and the post approved — all through
the v1 REST API. It runs alongside the current application and touches no file under
`src/routes/app/`.

Open it at `/v2/demo/posts`. Nothing links to it yet, so nobody reaches it by accident.

## Why?

The calendar answers *"what goes out this month"*. It does not answer *"what failed"* — a failed
post has no cell of its own, and a post with no date has no cell at all — and it does not answer
*"what did I publish"*, which is three months of month-navigation away.

The list is the same data on the other axis: **by status instead of by day**. It is the only view
where the `failed` queue is visible in one look, and the only one where "show me everything
pending" is a single click rather than a scan of thirty cells.

Two surfaces of eight, both shipped one at a time. `docs/external-agent-plan.md` lists *"UI rewrite
expands again"* as a risk with the control *"ship only the control-plane surfaces listed above"*;
one route per PR is how that control is actually applied.

## How?

**REST is the boundary, literally.** The page imports nothing from `$lib/server/cli-queries`. The
load takes the session only for the bearer token, then calls `GET /api/v1/brands/:slug` (for the
brand's timezone and name) and `GET /api/v1/brands/:slug/posts?status=…` in parallel. The two form
actions call `PUT /posts/:id` and `POST /posts/:id/approve`. SvelteKit dispatches the same-origin
`fetch` internally, so the boundary costs no extra network round trip — and web, MCP and CLI all
go through the same product rules.

**The filter is a link, not a store.** `?status=failed` is an `<a>`: the server redoes the query
and the page redraws. No client store, no cache, no synchronisation. The only client state is
which panel is open, and even that is written into `?post=<id>` with `replaceState`, so a reload
or a shared link restores it.

`filterFor` does not trust the parameter: a status that is not in the table falls back to `all`,
so the URL cannot invent a filter the API does not know.

**Conditions live in one table.** `POST_STATES` says, per status, the label, the badge tone,
whether the copy can be edited and whether the post can be approved. The **same rows** generate
the filter chips (`STATUS_FILTERS`), so adding a status is adding a row, not editing three places.
An unknown status grants nothing.

**The brand's timezone, not the server's.** `whenLabel` formats with `Intl.DateTimeFormat` on the
timezone the API returns. 23:30 UTC on 31 August is 1 September in Rome; formatting with the
server's date moves every evening post by a day. That is the same class of defect #229 paid for
once in `getCalendar`, so there is a test pinning it here rather than a comment about it.

**Lazy loading.** The panel (`Sheet`, i.e. all of bits-ui) is a separate component dynamically
imported on the **first post opened**, not at route load. The list, the filters and the empty
state pull in no bits-ui at all.

### What was deliberately not built

**No new shadcn primitive.** The calendar's panel uses `textarea` and `alert-dialog`. Here the copy
is a plain `<textarea>` carrying the existing `input` primitive's classes, and the approval
confirmation is a two-step inline one — the button becomes *"Yes, distribute it" / "Keep it
pending"*. Two reasons: less JavaScript on first render, and no add/add collision with #229, which
adds those same 14 files. If the inline confirmation proves too weak, moving to `alert-dialog` is
a component swap, not a flow change.

**No `grid` utility anywhere.** `app.css` ships a global `.grid { grid-template-columns: 1.7fr 1fr }`
that hijacks any element carrying the bare `grid` class without a `grid-cols-*` beside it. The list
is a flex column, so the collision does not arise instead of being worked around.

**No chat, and no link to one.**

**No pagination.** `getPosts` answers with the 50 most recent by creation date; the page says so at
the bottom instead of pretending to show everything. Paginating means changing an endpoint the CLI
and MCP also use — its own job, not this surface's.

## Testing?

**Targeted unit tests, run and green:**

```
npx vitest run "src/routes/v2"
 ✓ src/routes/v2/[brand]/posts/post-state.test.ts (17 tests) 12ms

 Test Files  1 passed (1)
      Tests  17 passed (17)
```

The 17 cover the status table (including an unknown status granting nothing), the URL filter
falling back to `all` on an invented value, the brand-timezone date label, the platform fallback,
the empty-copy row, and the three `distributionNote` cases.

**Red before green, observed.** The test file was written first and run before `post-state.ts`
existed:

```
 FAIL  src/routes/v2/[brand]/posts/post-state.test.ts
Error: Failed to load url ./post-state — Does the file exist?
 Test Files  1 failed (1)
      Tests  no tests
```

**`npm run check`:** `426 ERRORS 250 WARNINGS` on this branch — **zero of them in a file this PR
touches**. The only two lines mentioning `src/routes/v2/[brand]/posts/` are `WARNING`s, both the
deliberate "initial value" pattern (`$state` seeded once from the URL and from the post), the same
two #229 carries.

**Full suite: not run locally, delegated to CI.** `.github/workflows/ci.yml` runs the whole suite
plus Playwright on every PR, and nine agents re-running 583 test files on one machine is the
bottleneck this repo already identified.

### Visual verification — deferred, deliberately

**The visual pass has not been done and is deferred**, on Andrea's direction: the new frontend gets
judged when it is a whole surface, not piece by piece while it is being built. No dev server, no
Docker, no browser was started for this PR.

**Treat the visuals as unreviewed.** Spacing, density and the mobile layout have had no design pass
and should not be read as settled.

## Evidence

No screenshots — see above for why the visual pass is deferred.

<details>
<summary>Targeted tests, green</summary>

```
 RUN  v2.1.9 /Users/andreabuttarelli/Documents/GitHub/anomalia-wt/thin-frontend-posts

 ✓ src/routes/v2/[brand]/posts/post-state.test.ts (17 tests) 12ms

 Test Files  1 passed (1)
      Tests  17 passed (17)
   Duration  204ms
```
</details>

<details>
<summary>The same file, red before the implementation existed</summary>

```
 ❯ src/routes/v2/[brand]/posts/post-state.test.ts (0 test)

 FAIL  src/routes/v2/[brand]/posts/post-state.test.ts
Error: Failed to load url ./post-state (resolved id: ./post-state) in
.../src/routes/v2/[brand]/posts/post-state.test.ts. Does the file exist?

 Test Files  1 failed (1)
      Tests  no tests
```
</details>

<details>
<summary>svelte-check — every line naming a file of this PR</summary>

```
WARNING "src/routes/v2/[brand]/posts/PostPanel.svelte" 33:24 "This reference only captures the initial value of `post`…"
WARNING "src/routes/v2/[brand]/posts/+page.svelte" 15:42 "This reference only captures the initial value of `data`…"

COMPLETED 10291 FILES 426 ERRORS 250 WARNINGS 212 FILES_WITH_PROBLEMS
```

No `ERROR` line names a file this PR adds.
</details>

## Anything Else?

**Public changelog skipped on purpose.** Nothing links to `/v2` yet, so nothing changes for a
customer. The internal changelog is `changelog/2026-09-04-thin-frontend-posts.md`.

**Known duplication, and the cleanup.** `post-state.ts` and `PostPanel.svelte` restate what
`src/routes/v2/[brand]/calendar/` has in #229. The two PRs are deliberately independent — with nine
agents in flight, chaining merge order costs more than the duplication does. **When both are on
`dev`, the cleanup is one small commit**: move `post-state.ts` and `PostPanel.svelte` up to
`src/routes/v2/[brand]/` and repoint two imports in the calendar. Nothing else has to move.

**`/v2` is a version prefix, not a product name.** `/app` is occupied by the frontend being
dismantled; the structure under `v2/` already matches the plan's route map, so the promotion is
`git mv src/routes/v2 src/routes/app`.

**Untouched, on purpose:** the root `+layout.svelte` still loads svelte-i18n, analytics, the cookie
banner and the entry shimmer on `/v2`, which uses none of them. It is a global layout a route
cannot decline; fixing it is its own PR, and this one does not make it worse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
