### PR TITLE
Add the thin-shell brand overview at /v2/:brand

### DIFF
--- a/changelog/2026-09-04-thin-frontend-overview.md
+++ b/changelog/2026-09-04-thin-frontend-overview.md
@@ -1,0 +1,60 @@
+# La panoramica del brand nel frontend sottile — `/v2/:brand`
+
+La pagina d'ingresso del frontend sottile: quanti post aspettano l'approvazione, qual è il
+prossimo in uscita, e lo stato del brand in fatti. Da lì si va al calendario e all'elenco post.
+
+## Perché esiste
+
+Un frontend senza pagina d'ingresso costringe a conoscere le URL. E le tre domande che un utente
+si fa aprendo il prodotto sono sempre le stesse: *devo fare qualcosa? sta per uscire qualcosa?
+è tutto a posto?* Tre sezioni, tre risposte.
+
+## Cosa c'era prima
+
+La dashboard di `/app/:brand`, che risponde alle stesse domande dentro una decina di riquadri,
+grafici e scorciatoie. Verrà smantellata insieme al resto del vecchio frontend.
+
+## Come è costruita
+
+**Due letture, nessun database.** `GET /api/v1/brands/:slug` (il brand più i conteggi che
+`getBrandDetail` già calcola) e `GET /api/v1/brands/:slug/posts?status=scheduled`, in parallelo.
+Nessun import da `$lib/server`, nessuna azione: la pagina è di sola lettura.
+
+**`nextOut` è l'unica cosa che decide qualcosa**, e decide poco: il post programmato più vicino
+*nel futuro*. Scarta i passati e quelli senza data, e non inventa un "prossimo" quando non c'è —
+la scorciatoia facile (prendere il primo della lista) mostrerebbe un post di ieri come prossimo in
+uscita. Cinque test, uno per ogni modo di sbagliare.
+
+**Le date sono nel fuso del brand.** `momentInZone` sul timezone che arriva dall'API: le 23:30 UTC
+del 31 agosto sono il 1 settembre a Roma. Stesso difetto già pagato una volta nel calendario.
+
+## Cosa è stato scartato
+
+**Niente grafici, niente riquadri decorativi, niente chat.** Lo "stato del brand" è una lista di
+fatti — stato, piano, account collegati, piano editoriale attivo o no, programmati, pubblicati,
+fuso — e l'ultimo run dell'automazione con il suo errore se c'è stato. Un numero è un numero: non
+gli serve una card intorno.
+
+**Niente verdetti scritti qui.** La pagina non dice "senza account collegati non esce niente":
+mostra `Connected accounts: 0` e lascia parlare il dato. Una regola di prodotto scritta nel
+frontend è una regola che diverge dal server al primo cambiamento.
+
+**`GET /brands/:slug/doctor` non è stato usato**, pur essendo la risposta migliore a "è tutto a
+posto?": è read-only, senza AI e senza crediti, e calcola sul server esattamente il verdetto che
+qui servirebbe. Ma la sua prosa è in italiano e i suoi `fix` mandano a `/approvals` e a
+"Impostazioni → Piattaforme", cioè al frontend che stiamo smantellando. Metterla in una superficie
+inglese vorrebbe dire trascinarci dentro due lingue e il vecchio vocabolario. Quando il doctor
+parlerà la lingua dell'utente e indicherà le rotte nuove, questa sezione diventa una riga sola.
+
+**Niente `+layout.svelte` per `/v2`.** Servirebbe per la navigazione condivisa, ma nessuna delle
+tre superfici ne ha ancora abbastanza da condividere: due link in fondo alla panoramica bastano, e
+un layout scritto ora sarebbe scritto sulle prime tre rotte di otto.
+
+**Nessuna utility `grid`.** `app.css` ha un `.grid` globale (`grid-template-columns: 1.7fr 1fr`)
+che dirotta chiunque usi la classe `grid` senza un `grid-cols-*` accanto. Qui è tutto flex.
+
+## Debito noto
+
+`momentInZone` è un doppione di quello in `calendar/` (PR #229) e in `posts/` (PR #235): le PR
+sono indipendenti per non incatenare l'ordine di merge. Quando sono tutte su `dev`, la pulizia è
+un file solo in `src/routes/v2/[brand]/` e tre import ripuntati.

--- a/src/routes/v2/[brand]/+page.server.ts
+++ b/src/routes/v2/[brand]/+page.server.ts
@@ -1,0 +1,67 @@
+import { error, redirect } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+import { nextOut, type ScheduledPost } from './overview';
+
+type SchedulerRun = {
+  status: string;
+  posts_created: number | null;
+  created_at: string;
+  error: string | null;
+};
+
+type BrandRead = {
+  brand: { name: string; slug: string; status: string; plan: string | null; timezone: string };
+  pendingCount: number;
+  scheduledCount: number;
+  publishedCount: number;
+  accountCount: number;
+  plan: { id: string } | null;
+  runs: SchedulerRun[];
+};
+
+function brandApi(slug: string, path: string): string {
+  return `/api/v1/brands/${encodeURIComponent(slug)}${path}`;
+}
+
+async function readError(res: Response): Promise<string> {
+  const body = (await res.json().catch(() => null)) as { error?: string } | null;
+  return body?.error ?? `Request failed (${res.status})`;
+}
+
+export const load: PageServerLoad = async ({ params, fetch, locals }) => {
+  const { session } = await locals.safeGetSession();
+  if (!session) {
+    redirect(303, '/login');
+  }
+
+  const headers = { Authorization: `Bearer ${session.access_token}` };
+
+  const [brandRes, scheduledRes] = await Promise.all([
+    fetch(brandApi(params.brand, ''), { headers }),
+    fetch(brandApi(params.brand, '/posts?status=scheduled'), { headers })
+  ]);
+
+  if (!brandRes.ok) {
+    error(brandRes.status, await readError(brandRes));
+  }
+  if (!scheduledRes.ok) {
+    error(scheduledRes.status, await readError(scheduledRes));
+  }
+
+  const read = (await brandRes.json()) as BrandRead;
+  const scheduled = (await scheduledRes.json()) as ScheduledPost[];
+
+  return {
+    slug: params.brand,
+    brand: read.brand,
+    counts: {
+      pending: read.pendingCount,
+      scheduled: read.scheduledCount,
+      published: read.publishedCount,
+      accounts: read.accountCount
+    },
+    hasEditorialPlan: Boolean(read.plan),
+    lastRun: read.runs[0] ?? null,
+    next: nextOut(scheduled)
+  };
+};

--- a/src/routes/v2/[brand]/+page.svelte
+++ b/src/routes/v2/[brand]/+page.svelte
@@ -1,0 +1,108 @@
+<script lang="ts">
+  import '$lib/styles/tailwind.css';
+  import { momentInZone } from './overview';
+  import type { PageProps } from './$types';
+
+  let { data }: PageProps = $props();
+
+  const brand = $derived(data.brand);
+  const counts = $derived(data.counts);
+  const next = $derived(data.next);
+  const lastRun = $derived(data.lastRun);
+
+  const facts = $derived([
+    { label: 'Brand status', value: brand.status },
+    { label: 'Plan', value: brand.plan ?? 'none' },
+    { label: 'Connected accounts', value: String(counts.accounts) },
+    { label: 'Editorial plan', value: data.hasEditorialPlan ? 'active' : 'none' },
+    { label: 'Scheduled', value: String(counts.scheduled) },
+    { label: 'Published', value: String(counts.published) },
+    { label: 'Timezone', value: brand.timezone }
+  ]);
+
+  function summary(caption: string | null): string {
+    const copy = (caption ?? '').trim().replace(/\s+/g, ' ');
+    return copy.length > 120 ? `${copy.slice(0, 120)}…` : copy || 'Untitled';
+  }
+</script>
+
+<svelte:head><title>{brand.name}</title></svelte:head>
+
+<div class="bg-background text-foreground min-h-screen px-4 py-8 sm:px-8">
+  <div class="mx-auto flex max-w-3xl flex-col gap-8">
+    <header class="flex flex-col gap-1">
+      <p class="text-muted-foreground text-xs tracking-wide uppercase">{data.slug}</p>
+      <h1 class="text-2xl font-semibold">{brand.name}</h1>
+    </header>
+
+    <section aria-labelledby="waiting" class="flex flex-col gap-2">
+      <h2 id="waiting" class="text-sm font-semibold">Waiting for you</h2>
+      {#if counts.pending === 0}
+        <p class="text-muted-foreground text-sm">Nothing to approve.</p>
+      {:else}
+        <p class="text-3xl font-semibold">{counts.pending}</p>
+        <p class="text-sm">
+          <a href="/v2/{data.slug}/posts?status=pending_user" class="underline underline-offset-4">
+            {counts.pending === 1 ? 'Review it' : 'Review them'}
+          </a>
+        </p>
+      {/if}
+    </section>
+
+    <section aria-labelledby="next-out" class="flex flex-col gap-2">
+      <h2 id="next-out" class="text-sm font-semibold">Next out</h2>
+      {#if !next}
+        <p class="text-muted-foreground text-sm">Nothing scheduled.</p>
+      {:else}
+        <p class="text-sm">
+          <span class="font-medium">{next.platform ?? 'post'}</span> ·
+          {momentInZone(next.scheduled_for as string, brand.timezone)}
+        </p>
+        <p class="text-muted-foreground text-sm">{summary(next.caption)}</p>
+        <p class="text-sm">
+          <a href="/v2/{data.slug}/posts?post={next.id}" class="underline underline-offset-4"
+            >Open it</a
+          >
+        </p>
+      {/if}
+    </section>
+
+    <section aria-labelledby="state" class="flex flex-col gap-2">
+      <h2 id="state" class="text-sm font-semibold">Brand state</h2>
+      <dl class="border-border divide-border divide-y overflow-hidden rounded-xl border text-sm">
+        {#each facts as fact (fact.label)}
+          <div class="flex items-baseline justify-between gap-4 px-4 py-2">
+            <dt class="text-muted-foreground">{fact.label}</dt>
+            <dd>{fact.value}</dd>
+          </div>
+        {/each}
+      </dl>
+
+      {#if lastRun}
+        <p class="text-muted-foreground text-xs">
+          Last automation run: {lastRun.status}
+          {#if lastRun.posts_created}· {lastRun.posts_created} posts{/if}
+          · {momentInZone(lastRun.created_at, brand.timezone)}
+        </p>
+        {#if lastRun.error}
+          <p role="alert" class="text-destructive text-xs">{lastRun.error}</p>
+        {/if}
+      {:else}
+        <p class="text-muted-foreground text-xs">No automation run recorded yet.</p>
+      {/if}
+    </section>
+
+    <nav aria-label="Brand" class="flex flex-wrap gap-2">
+      <a
+        href="/v2/{data.slug}/calendar"
+        class="border-border hover:bg-muted focus-visible:ring-ring/50 rounded-lg border px-3 py-1.5 text-sm focus-visible:ring-3 focus-visible:outline-none"
+        >Calendar</a
+      >
+      <a
+        href="/v2/{data.slug}/posts"
+        class="border-border hover:bg-muted focus-visible:ring-ring/50 rounded-lg border px-3 py-1.5 text-sm focus-visible:ring-3 focus-visible:outline-none"
+        >Posts</a
+      >
+    </nav>
+  </div>
+</div>

--- a/src/routes/v2/[brand]/overview.test.ts
+++ b/src/routes/v2/[brand]/overview.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { momentInZone, nextOut, type ScheduledPost } from './overview';
+
+const ROME = 'Europe/Rome';
+const NOW = Date.parse('2026-09-04T10:00:00Z');
+
+function post(id: string, scheduled_for: string | null): ScheduledPost {
+  return { id, platform: 'instagram', caption: null, scheduled_for, status: 'scheduled' };
+}
+
+describe('il prossimo post in uscita', () => {
+  it('e il piu vicino nel futuro, non il primo della lista', () => {
+    const posts = [
+      post('later', '2026-09-20T09:00:00Z'),
+      post('soon', '2026-09-05T09:00:00Z'),
+      post('middle', '2026-09-10T09:00:00Z')
+    ];
+
+    expect(nextOut(posts, NOW)?.id).toBe('soon');
+  });
+
+  it('ignora quelli gia passati', () => {
+    const posts = [post('yesterday', '2026-09-03T09:00:00Z'), post('tomorrow', '2026-09-05T09:00:00Z')];
+
+    expect(nextOut(posts, NOW)?.id).toBe('tomorrow');
+  });
+
+  it('ignora quelli senza data', () => {
+    expect(nextOut([post('undated', null), post('dated', '2026-09-05T09:00:00Z')], NOW)?.id).toBe(
+      'dated'
+    );
+  });
+
+  it('non inventa un prossimo quando sono tutti passati', () => {
+    expect(nextOut([post('old', '2026-08-01T09:00:00Z')], NOW)).toBeNull();
+  });
+
+  it('non inventa un prossimo su una lista vuota', () => {
+    expect(nextOut([], NOW)).toBeNull();
+  });
+});
+
+describe('quando esce, detto nel fuso del brand', () => {
+  it('le 23:30 UTC del 31 agosto sono il 1 settembre a Roma', () => {
+    const label = momentInZone('2026-08-31T23:30:00Z', ROME);
+
+    expect(label).toContain('1 Sep');
+    expect(label).not.toContain('31 Aug');
+    expect(label).toContain(ROME);
+  });
+});

--- a/src/routes/v2/[brand]/overview.ts
+++ b/src/routes/v2/[brand]/overview.ts
@@ -1,0 +1,38 @@
+export type ScheduledPost = {
+  id: string;
+  platform: string | null;
+  caption: string | null;
+  scheduled_for: string | null;
+  status: string;
+};
+
+export function nextOut(posts: ScheduledPost[], now: number = Date.now()): ScheduledPost | null {
+  let soonest: ScheduledPost | null = null;
+  let soonestAt = Number.POSITIVE_INFINITY;
+
+  for (const post of posts) {
+    const at = post.scheduled_for ? Date.parse(post.scheduled_for) : Number.NaN;
+    if (!Number.isFinite(at) || at <= now || at >= soonestAt) {
+      continue;
+    }
+
+    soonest = post;
+    soonestAt = at;
+  }
+
+  return soonest;
+}
+
+export function momentInZone(iso: string, timezone: string): string {
+  const stamp = new Intl.DateTimeFormat('en-GB', {
+    timeZone: timezone,
+    weekday: 'short',
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit'
+  }).format(new Date(iso));
+
+  return `${stamp} (${timezone})`;
+}


### PR DESCRIPTION
## What?

The entry page of the thin frontend: **`/v2/:brand`**. Three sections — how many posts wait for
approval, which one goes out next, and the brand's state as a list of facts — plus two links to the
calendar (#229) and the post list (#235). Read-only: no form actions, no writes.

It runs alongside the current application and touches no file under `src/routes/app/`. Open it at
`/v2/demo`. Nothing links to it yet.

## Why?

A frontend without an entry page forces people to know its URLs — and with the calendar and the
post list both landing, `/v2/:brand` is currently a 404 between two working routes.

The three questions a user opens the product with are always the same: *do I have to do something?
is something about to go out? is everything all right?* Three sections, three answers, nothing
else. That is the whole brief, and the constraint that keeps it from becoming a dashboard again.

## How?

**Two reads, no database.** `GET /api/v1/brands/:slug` — which already returns the brand plus the
counts `getBrandDetail` computes (pending, scheduled, published, connected accounts, the active
editorial plan, the last scheduler runs) — and `GET /api/v1/brands/:slug/posts?status=scheduled`,
in parallel. Nothing is imported from `$lib/server`. No actions: the page only reads, so there is
no client state at all, not even a panel.

**`nextOut` is the only thing that decides anything, and it decides little:** the scheduled post
closest **in the future**. It drops the past ones and the undated ones, and returns `null` rather
than inventing a next. The easy shortcut — take the first of the list — shows yesterday's post as
the next one out, which is precisely the lie the section exists to avoid. Five tests, one per way
of getting it wrong.

**The brand's timezone, not the server's.** `momentInZone` formats with `Intl.DateTimeFormat` on
the timezone the API returns: 23:30 UTC on 31 August is 1 September in Rome. Same class of defect
`getCalendar` paid for once in #229.

### What was deliberately not built

**No charts, no decorative boxes, no chat.** The brand state is a `<dl>` of facts — status, plan,
connected accounts, editorial plan active or not, scheduled, published, timezone — and the last
automation run with its error if there was one. A number is a number; it does not need a card
around it.

**No verdicts written in the frontend.** The page does not say *"with no connected account nothing
can go out"*. It shows `Connected accounts: 0` and lets the number speak. A product rule written in
a component is a rule that diverges from the server at the first change.

**`GET /brands/:slug/doctor` was not used**, although it is the better answer to *"is everything all
right?"*: it is read-only, spends no AI and no credits, and computes on the server exactly the
verdict this page would want (the first gate each loop fails, and how to unlock it). Two things
stop it: its prose is **in Italian**, and its `fix` strings point at `/approvals` and *"Impostazioni
→ Piattaforme"* — the frontend being dismantled. Putting it on an English surface would drag two
languages and the old vocabulary in. When the doctor speaks the user's language and names the new
routes, this section collapses to one line.

**No `+layout.svelte` for `/v2`.** It would carry shared navigation, but three surfaces do not yet
have enough to share: two links at the foot of the overview are enough, and a layout written now
would be written against the first three routes of eight.

**No `grid` utility anywhere.** `app.css` ships a global `.grid { grid-template-columns: 1.7fr 1fr }`
that hijacks any element carrying the bare `grid` class without a `grid-cols-*` beside it.
Everything here is flex.

## Testing?

**Targeted unit tests, run and green:**

```
npx vitest run "src/routes/v2"
 ✓ src/routes/v2/[brand]/overview.test.ts (6 tests) 16ms

 Test Files  1 passed (1)
      Tests  6 passed (6)
```

Five on `nextOut` (soonest wins over list order, past ones ignored, undated ones ignored, null when
all are past, null on an empty list) and one pinning the brand-timezone label.

**Red before green, observed.** The test file was written and run before `overview.ts` existed:

```
 FAIL  src/routes/v2/[brand]/overview.test.ts
Error: Failed to load url ./overview — Does the file exist?
 Test Files  1 failed (1)
      Tests  no tests
```

**`npm run check`:** `430 ERRORS 248 WARNINGS` on this branch — **not one line naming a file this PR
adds**, neither error nor warning. `grep 'v2/\[brand\]'` over the full svelte-check output returns
nothing.

**Full suite: not run locally, delegated to CI.** `.github/workflows/ci.yml` runs the whole suite
plus Playwright on every PR.

### Visual verification — deferred, deliberately

**The visual pass has not been done and is deferred**, on Andrea's direction: the new frontend gets
judged when it is a whole surface, not piece by piece while it is being built. No dev server, no
Docker, no browser was started for this PR.

**Treat the visuals as unreviewed.** Spacing, density and the mobile layout have had no design pass.

## Evidence

No screenshots — see above for why the visual pass is deferred.

<details>
<summary>Targeted tests, green</summary>

```
 RUN  v2.1.9 /Users/andreabuttarelli/Documents/GitHub/anomalia-wt/thin-frontend-overview

 ✓ src/routes/v2/[brand]/overview.test.ts (6 tests) 16ms

 Test Files  1 passed (1)
      Tests  6 passed (6)
   Duration  215ms
```
</details>

<details>
<summary>The same file, red before the implementation existed</summary>

```
 ❯ src/routes/v2/[brand]/overview.test.ts (0 test)

 FAIL  src/routes/v2/[brand]/overview.test.ts
Error: Failed to load url ./overview (resolved id: ./overview) in
.../src/routes/v2/[brand]/overview.test.ts. Does the file exist?

 Test Files  1 failed (1)
      Tests  no tests
```
</details>

<details>
<summary>svelte-check — the whole run, and what it says about this PR's files</summary>

```
$ grep -E 'v2/\[brand\]' check.txt
(no output)

COMPLETED 10305 FILES 430 ERRORS 248 WARNINGS 214 FILES_WITH_PROBLEMS
```
</details>

## Anything Else?

**Public changelog skipped on purpose.** Nothing links to `/v2` yet, so nothing changes for a
customer. The internal changelog is `changelog/2026-09-04-thin-frontend-overview.md`.

**The two links at the foot go live with their PRs.** `/v2/:brand/calendar` is #229 and
`/v2/:brand/posts` is #235; until each lands, its link 404s. All three are heading for `dev`, and
this PR is independent of both — with nine agents in flight, chaining merge order costs more than a
dead link on an unlinked page does.

**Known duplication, and the cleanup.** `momentInZone` restates the one in `calendar/` (#229) and in
`posts/` (#235). When all three are on `dev`, the cleanup is one file in `src/routes/v2/[brand]/`
and three repointed imports.

**`/v2` is a version prefix, not a product name.** `/app` is occupied by the frontend being
dismantled; the structure under `v2/` already matches the plan's route map, so the promotion is
`git mv src/routes/v2 src/routes/app`.

**Untouched, on purpose:** the root `+layout.svelte` still loads svelte-i18n, analytics, the cookie
banner and the entry shimmer on `/v2`, which uses none of them. It is a global layout a route cannot
decline; fixing it is its own PR, and this one does not make it worse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
