### PR TITLE
Take the image agent off the agent framework

### DIFF
--- a/changelog/2026-09-04-image-agent-off-the-kit.md
+++ b/changelog/2026-09-04-image-agent-off-the-kit.md
@@ -1,0 +1,40 @@
+# L'image agent esce dal framework, quarto dei dodici
+
+Quarto giro, stessa ricetta. Questo era già mezzo pronto senza che nessuno lo avesse
+pensato apposta: `image-agent.test.ts` guida il giro con un finto `generateText` dall'inizio,
+cioè aggancia già il confine giusto. Quei quattordici test valgono su entrambe le
+implementazioni senza una riga di differenza, e sono stati la metà del lavoro.
+
+## Cosa mancava alla rete
+
+I test che c'erano guardano i contatori — il budget dei rendering, l'accumulo del costo per
+step, lo stallo a tre impronte, la toppa al system. Nessuno guardava il *tavolo*: quali
+strumenti il modello riceve davvero, che forma ha il messaggio, cosa risponde un tool
+quando il tetto è finito (invece di cosa risponde il contatore), cosa esce quando il giro
+non conclude niente, e cosa finisce in `agent_sessions`. Dieci test in più, e la
+caratterizzazione è completa.
+
+## Cosa nascondeva `harnessGenerateText`
+
+Le solite cinque aggiunte, le solite tre vive su `batch`. Qui il guardiano serve a una cosa
+precisa e cara: due `render_image` che tornano vuoti di fila e il renderer esce dal tavolo,
+invece di lasciare il modello a chiedere un'immagine a un generatore rotto per i suoi
+cinquanta step. Un rendering costa davvero, quindi non è contabilità.
+
+## Il `finally` che aveva già ragione
+
+`persistHarnessSession` si mette accanto al `logAiCall` che stava già lì, e per lo stesso
+motivo scritto nel commento sopra: una corsa che muore ha comunque pagato i rendering che
+aveva già lanciato, e tutt'e due le righe devono dirlo. Prima la traccia la salvava il
+`finally` del framework; adesso la salva questo, che è lo stesso posto.
+
+## L'arco che spariva
+
+Prima: `image-agent.ts → harness/index → harness/run → chat/model` e `→ chat/controller`.
+Adesso non più. Con questo se ne va anche l'ultimo arco che restava a `director.ts`, che ci
+arrivava per `content-preview → articles → image-agent`.
+
+## Cosa non cambia
+
+Il cliente non osserva niente: stesse immagini, stessi tetti, stesse righe. Nessun
+changelog pubblico.

--- a/src/lib/server/image-agent.loop.test.ts
+++ b/src/lib/server/image-agent.loop.test.ts
@@ -1,0 +1,354 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+/**
+ * CARATTERIZZAZIONE DEL GIRO DELL'IMAGE AGENT.
+ *
+ * Quarto dei dodici. `image-agent.test.ts` esercita già il giro attraverso un finto
+ * `generateText`, che è il confine giusto: quei test valgono su entrambe le implementazioni e
+ * restano il grosso della rete. Qui si aggiunge quello che nessuno guardava — l'elenco esatto
+ * degli strumenti, come è fatto il messaggio che il modello riceve, cosa scrivono i tetti al
+ * livello del tool (non del contatore), la riga di sessione, e il guardiano.
+ */
+
+const {
+  generateText,
+  logAiCall,
+  renderPostImage,
+  uploadPostImage,
+  publishLibraryImageAsPostMedia,
+  listBrandMedia,
+  resolveUserTurnMediaParts,
+  agentSessionWrites
+} = vi.hoisted(() => ({
+  generateText: vi.fn(),
+  logAiCall: vi.fn(),
+  renderPostImage: vi.fn(),
+  uploadPostImage: vi.fn(),
+  publishLibraryImageAsPostMedia: vi.fn(),
+  listBrandMedia: vi.fn(),
+  resolveUserTurnMediaParts: vi.fn(),
+  agentSessionWrites: [] as Array<Record<string, unknown>>
+}));
+
+vi.mock('$env/dynamic/private', () => ({
+  env: { GEMINI_API_KEY: 'test', LLM_API_KEY: 'test', LLM_DEFAULT_MODEL: 'gemini-3.7-flash' }
+}));
+
+vi.mock('ai', async () => {
+  const actual = await vi.importActual<typeof import('ai')>('ai');
+  return { ...actual, generateText };
+});
+
+vi.mock('$lib/media-parts', () => ({ resolveUserTurnMediaParts }));
+
+vi.mock('$lib/server/content-preview', () => ({
+  aspectRatioFor: () => '4:5',
+  extractVisualPlaybook: () => '',
+  loadBrandMoodImageUrls: async () => [],
+  loadCompetitorThumbUrls: async () => [],
+  renderPostImage,
+  uploadPostImage
+}));
+
+vi.mock('$lib/server/brand-media', () => ({
+  listBrandMedia,
+  loadLibraryMediaParts: async () => [{ inlineData: { mimeType: 'image/png', data: 'BBBB' } }],
+  publishLibraryImageAsPostMedia
+}));
+
+vi.mock('$lib/server/media-archive', () => ({ signKnowledgePaths: async () => [] }));
+vi.mock('$lib/server/people', () => ({ signPersonImages: async () => [] }));
+vi.mock('$lib/server/brand-context', () => ({ fetchImagePart: async () => null }));
+
+vi.mock('$lib/server/credits', () => ({
+  getCreditsUsage: async () => ({
+    remaining: 500,
+    used: 0,
+    quota: 500,
+    bonus: 0,
+    percent: 0,
+    periodStart: new Date(),
+    periodEnd: new Date()
+  })
+}));
+
+vi.mock('$lib/server/supabase-admin', () => ({
+  createAdminClient: () => ({
+    from: (table: string) => ({
+      insert: (row: Record<string, unknown>) => {
+        if (table === 'agent_sessions') agentSessionWrites.push({ op: 'insert', ...row });
+        return Promise.resolve({ error: null });
+      },
+      upsert: (row: Record<string, unknown>) => {
+        if (table === 'agent_sessions') agentSessionWrites.push({ op: 'upsert', ...row });
+        return Promise.resolve({ error: null });
+      },
+      select: () => ({
+        eq: () => ({
+          maybeSingle: async () => ({ data: { id: 'b1', plan: 'pro', activated_at: null, status: 'active' } })
+        })
+      })
+    })
+  })
+}));
+
+vi.mock('$lib/server/ai-log', async () => {
+  const actual = await vi.importActual<typeof import('$lib/server/ai-log')>('$lib/server/ai-log');
+  return { ...actual, logAiCall };
+});
+
+import { MAX_AGENT_INSPECTS, MAX_AGENT_RENDERS, MAX_AGENT_STEPS, runImageAgent } from './image-agent';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyRec = Record<string, any>;
+
+function stubSupabase(): AnyRec {
+  const chain: AnyRec = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        if (prop === 'then') {
+          return (resolve: (v: unknown) => unknown) => Promise.resolve({ data: [], error: null }).then(resolve);
+        }
+        if (prop === 'maybeSingle' || prop === 'single') return async () => ({ data: null, error: null });
+        return () => chain;
+      }
+    }
+  );
+  return { from: () => chain };
+}
+
+type ScriptedCall = { tool: string; input?: unknown };
+type DriveRecord = {
+  prepared: AnyRec[];
+  calls: Array<{ tool: string; output: unknown }>;
+  system: string;
+  messages: AnyRec[];
+  toolNames: string[];
+};
+
+function drive(script: ScriptedCall[], record: DriveRecord) {
+  return async (options: AnyRec) => {
+    record.system = String(options.system ?? '');
+    record.messages = (options.messages ?? []) as AnyRec[];
+    record.toolNames = Object.keys(options.tools ?? {});
+
+    const steps: AnyRec[] = [];
+    for (const entry of script) {
+      const prepared = (await options.prepareStep?.({ stepNumber: steps.length, steps })) ?? {};
+      record.prepared.push(prepared);
+
+      const impl = options.tools?.[entry.tool];
+      const output = impl ? await impl.execute(entry.input ?? {}, {}) : { error: 'no such tool' };
+      record.calls.push({ tool: entry.tool, output });
+
+      const toolCalls = [{ toolName: entry.tool, input: entry.input ?? {}, type: 'tool-call' }];
+      const toolResults = [{ toolName: entry.tool, output, type: 'tool-result' }];
+      const usage = { inputTokens: 100, outputTokens: 40 };
+      steps.push({ toolCalls, toolResults, text: '', usage });
+      await options.onStepFinish?.({ toolCalls, toolResults, text: '', usage });
+
+      const stops = (options.stopWhen ?? []) as Array<(a: AnyRec) => boolean | Promise<boolean>>;
+      const verdicts = await Promise.all(stops.map((s) => s({ steps, stepNumber: steps.length })));
+      if (verdicts.some(Boolean)) break;
+    }
+    return { text: '', totalUsage: { inputTokens: 100 * steps.length, outputTokens: 40 * steps.length }, steps };
+  };
+}
+
+function baseOpts(over: AnyRec = {}): AnyRec {
+  return {
+    supabase: stubSupabase(),
+    userId: 'u1',
+    brandId: 'b1',
+    brief: 'Macine in acciaio su fondo crema',
+    platform: 'instagram',
+    aspectRatio: '4:5',
+    deadlineMs: 60_000,
+    ...over
+  };
+}
+
+function newRecord(): DriveRecord {
+  return { prepared: [], calls: [], system: '', messages: [], toolNames: [] };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  agentSessionWrites.length = 0;
+  renderPostImage.mockResolvedValue('data:image/png;base64,AAAA');
+  uploadPostImage.mockResolvedValue('https://cdn.example/img.png');
+  publishLibraryImageAsPostMedia.mockResolvedValue({ publicUrl: 'https://cdn.example/lib.png' });
+  listBrandMedia.mockResolvedValue([]);
+  resolveUserTurnMediaParts.mockResolvedValue([]);
+});
+
+describe('quello che il modello riceve', () => {
+  it('offre esattamente questi tool', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(
+      drive([{ tool: 'finish', input: { imagePrompt: 'p', notes: 'n', imageUrl: 'https://cdn.example/img.png' } }], rec)
+    );
+
+    await runImageAgent(baseOpts() as never);
+
+    expect(rec.toolNames.sort()).toEqual(
+      ['finish', 'inspect_assets', 'render_image', 'search_assets', 'use_asset_as_is'].sort()
+    );
+  });
+
+  it('apre con la brief e allega i media che la brief stessa linka', async () => {
+    const rec = newRecord();
+    resolveUserTurnMediaParts.mockResolvedValue([
+      { type: 'image', image: 'data:image/png;base64,LINKED' }
+    ]);
+    generateText.mockImplementation(
+      drive([{ tool: 'finish', input: { imagePrompt: 'p', notes: 'n', imageUrl: 'https://cdn.example/img.png' } }], rec)
+    );
+
+    await runImageAgent(baseOpts() as never);
+
+    expect(resolveUserTurnMediaParts).toHaveBeenCalledWith('Macine in acciaio su fondo crema');
+    expect(rec.messages).toHaveLength(1);
+    const content = rec.messages[0].content as AnyRec[];
+    expect(content[0].text).toContain('Macine in acciaio su fondo crema');
+    expect(content[1]).toEqual({ type: 'image', image: 'data:image/png;base64,LINKED' });
+  });
+});
+
+describe('i tetti, visti dal tool e non dal contatore', () => {
+  it('il rirender si ferma al tetto e non paga un rendering in più', async () => {
+    const rec = newRecord();
+    const script = Array.from({ length: MAX_AGENT_RENDERS + 1 }, (_, i) => ({
+      tool: 'render_image',
+      input: { prompt: `prompt ${i}` }
+    }));
+    generateText.mockImplementation(drive(script, rec));
+
+    await runImageAgent(baseOpts() as never);
+
+    expect(renderPostImage).toHaveBeenCalledTimes(MAX_AGENT_RENDERS);
+    expect(rec.calls[MAX_AGENT_RENDERS].output).toMatchObject({ error: expect.stringContaining('budget') });
+  });
+
+  it('l ispezione si ferma al suo tetto', async () => {
+    const rec = newRecord();
+    listBrandMedia.mockResolvedValue([
+      { id: 'm1', title: 'Macine', kind: 'image', description: '', tags: [], path: 'p/1' }
+    ]);
+    const script = [
+      { tool: 'search_assets', input: { query: 'macine' } },
+      ...Array.from({ length: MAX_AGENT_INSPECTS + 1 }, () => ({
+        tool: 'inspect_assets',
+        input: { ids: ['library:m1'] }
+      }))
+    ];
+    generateText.mockImplementation(drive(script, rec));
+
+    await runImageAgent(baseOpts() as never);
+
+    const last = rec.calls[rec.calls.length - 1].output as AnyRec;
+    expect(last.error).toContain('budget');
+  });
+
+  it('si ferma al tetto degli step', async () => {
+    const rec = newRecord();
+    const script = Array.from({ length: MAX_AGENT_STEPS + 5 }, (_, i) => ({
+      tool: 'search_assets',
+      input: { query: `cerca ${i}` }
+    }));
+    generateText.mockImplementation(drive(script, rec));
+
+    await runImageAgent(baseOpts() as never);
+
+    expect(rec.calls.length).toBeLessThanOrEqual(MAX_AGENT_STEPS);
+  });
+});
+
+describe('la foto di libreria usata così com è', () => {
+  it('rifiuta un id che non è di libreria', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(
+      drive([{ tool: 'use_asset_as_is', input: { id: 'mood:x' } }], rec)
+    );
+
+    await runImageAgent(baseOpts() as never);
+
+    expect(rec.calls[0].output).toMatchObject({ error: 'id must be a library asset (library:...)' });
+    expect(publishLibraryImageAsPostMedia).not.toHaveBeenCalled();
+  });
+
+  it('pubblicata, diventa il risultato e la sorgente è la libreria', async () => {
+    const rec = newRecord();
+    listBrandMedia.mockResolvedValue([
+      { id: 'm1', title: 'Macine', kind: 'image', description: '', tags: [], path: 'p/1' }
+    ]);
+    generateText.mockImplementation(
+      drive(
+        [
+          { tool: 'search_assets', input: { query: 'macine' } },
+          { tool: 'use_asset_as_is', input: { id: 'library:m1' } }
+        ],
+        rec
+      )
+    );
+
+    const out = await runImageAgent(baseOpts() as never);
+
+    expect(rec.calls[1].output).toMatchObject({ ok: true, imageUrl: 'https://cdn.example/lib.png' });
+    expect(out.source).toBe('library');
+    expect(out.imageUrl).toBe('https://cdn.example/lib.png');
+  });
+});
+
+describe('quando il giro non conclude niente', () => {
+  it('torna la brief come prompt e lo dice nelle note', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(drive([{ tool: 'search_assets', input: { query: 'niente' } }], rec));
+
+    const out = await runImageAgent(baseOpts() as never);
+
+    expect(out.imageUrl).toBeUndefined();
+    expect(out.imagePrompt).toBe('Macine in acciaio su fondo crema');
+    expect(out.notes).toBe('Image agent finished without a result.');
+  });
+});
+
+describe('la traccia della corsa', () => {
+  it('lascia una riga di sessione leggibile su agent_sessions', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(
+      drive([{ tool: 'finish', input: { imagePrompt: 'p', notes: 'n', imageUrl: 'https://cdn.example/img.png' } }], rec)
+    );
+
+    await runImageAgent(baseOpts() as never);
+
+    const finishedRow = agentSessionWrites.find((r) => r.status === 'finished');
+    expect(finishedRow).toMatchObject({ agent: 'image', surface: 'batch', brand_id: 'b1', mode: 'instagram' });
+    expect(Number(finishedRow?.event_count)).toBeGreaterThan(0);
+  });
+});
+
+describe('il guardiano di sessione, che il framework applicava in silenzio', () => {
+  it('toglie dal tavolo il rendering dopo due fallimenti di fila', async () => {
+    const rec = newRecord();
+    renderPostImage.mockResolvedValue(null);
+    generateText.mockImplementation(
+      drive(
+        [
+          { tool: 'render_image', input: { prompt: 'a' } },
+          { tool: 'render_image', input: { prompt: 'b' } },
+          { tool: 'render_image', input: { prompt: 'c' } }
+        ],
+        rec
+      )
+    );
+
+    await runImageAgent(baseOpts() as never);
+
+    expect(rec.calls[0].output).toMatchObject({ error: 'render_image returned no image' });
+    expect(rec.calls[1].output).toMatchObject({ error: 'render_image returned no image' });
+    expect(rec.calls[2].output).toMatchObject({ blocked_by: 'steward', ran: false, do_not_retry: true });
+    expect(renderPostImage).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lib/server/image-agent.loop.test.ts
+++ b/src/lib/server/image-agent.loop.test.ts
@@ -97,6 +97,8 @@ vi.mock('$lib/server/ai-log', async () => {
   return { ...actual, logAiCall };
 });
 
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { MAX_AGENT_INSPECTS, MAX_AGENT_RENDERS, MAX_AGENT_STEPS, runImageAgent } from './image-agent';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -350,5 +352,19 @@ describe('il guardiano di sessione, che il framework applicava in silenzio', () 
     expect(rec.calls[1].output).toMatchObject({ error: 'render_image returned no image' });
     expect(rec.calls[2].output).toMatchObject({ blocked_by: 'steward', ran: false, do_not_retry: true });
     expect(renderPostImage).toHaveBeenCalledTimes(2);
+  });
+});
+// `harness/index` riesporta `harness/run`, che importa `chat/model` e `chat/controller`: chi
+// prende la traccia dall'indice si porta dentro la chat e `$lib/agent` senza usarli. I moduli
+// foglia non li toccano, e questo test è l'unica cosa che impedisce di «riordinare» l'import.
+describe('da dove arriva la traccia', () => {
+  const src = readFileSync(join(process.cwd(), 'src/lib/server/image-agent.ts'), 'utf8');
+
+  it('l image agent guida l SDK e non passa dall indice del framework', () => {
+    expect(src).toMatch(/await generateText\(/);
+    expect(src).not.toContain('harnessGenerateText(');
+    expect(src).not.toMatch(/from '\$lib\/server\/harness'/);
+    expect(src).toMatch(/from '\$lib\/server\/harness\/session'/);
+    expect(src).toMatch(/from '\$lib\/server\/harness\/persist'/);
   });
 });

--- a/src/lib/server/image-agent.ts
+++ b/src/lib/server/image-agent.ts
@@ -1,9 +1,12 @@
 import IMAGE_PROMPTS_GUIDE from '$lib/agent-docs/how/WRITE-IMAGE-PROMPTS.md?raw';
 import { GEMINI_MAX_OUTPUT_TOKENS } from '$lib/server/ai-output-limits';
 import type { GoogleGenAI } from '@google/genai';
-import { tool, stepCountIs, hasToolCall, type StopCondition } from 'ai';
+import { generateText, tool, stepCountIs, hasToolCall, type StopCondition } from 'ai';
 import { resolveUserTurnMediaParts } from '$lib/media-parts';
-import { harnessGenerateText } from '$lib/server/harness';
+import { createHarnessSession } from '$lib/server/harness/session';
+import { persistHarnessSession } from '$lib/server/harness/persist';
+import { wrapTools } from '$lib/server/harness/pipeline';
+import { applyStewardPrepareStep, createSessionSteward } from '$lib/server/harness/steward';
 import { z } from 'zod';
 import sharp from 'sharp';
 import type { SupabaseClient } from '@supabase/supabase-js';
@@ -734,54 +737,71 @@ async function runImageAgentInner(opts: ImageAgentOpts): Promise<ImageAgentResul
   // Images / clips linked in the brief itself — otherwise the model is blind to them.
   const briefMedia = await resolveUserTurnMediaParts(opts.brief);
   let loopError: string | undefined;
+  const messages = [
+    {
+      role: 'user' as const,
+      content: [
+        {
+          type: 'text' as const,
+          text: `Produce the best image for this brief. Start by searching assets relevant to: ${opts.brief.slice(0, 500)}`
+        },
+        // Any image or clip linked in the brief itself — otherwise the model is blind to it.
+        ...briefMedia
+      ]
+    }
+  ];
+  const session = createHarnessSession({
+    brandId: opts.brandId,
+    userId: opts.userId,
+    agent: 'image',
+    mode: opts.platform ?? 'standalone',
+    model: IMAGE_AGENT_MODEL(),
+    provider: 'llm',
+    surface: 'batch'
+  });
+  session.captureRequest({ system: baseSystem, messages });
+
+  const steward = createSessionSteward(session, Object.keys(tools));
+  const watchedTools = wrapTools(session, tools, steward.pipeline());
+
   try {
-    result = await harnessGenerateText({
-      brandId: opts.brandId,
-      userId: opts.userId,
-      agent: 'image',
-      mode: opts.platform ?? 'standalone',
-      model: IMAGE_AGENT_MODEL(),
-      provider: 'llm',
-      surface: 'batch'
-    }, {
+    result = await generateText({
       model: llmLanguageModel(),
       maxOutputTokens: GEMINI_MAX_OUTPUT_TOKENS,
       system: baseSystem,
-      messages: [
-        {
-          role: 'user',
-          content: [
-            {
-              type: 'text',
-              text: `Produce the best image for this brief. Start by searching assets relevant to: ${opts.brief.slice(0, 500)}`
-            },
-            // Any image or clip linked in the brief itself — otherwise the model is blind to it.
-            ...briefMedia
-          ]
-        }
-      ],
-      tools,
+      messages,
+      allowSystemInMessages: true,
+      tools: watchedTools,
       stopWhen: [hasToolCall('finish'), stepCountIs(MAX_AGENT_STEPS), stallStop],
       temperature: 0.35,
       prepareStep: () => {
         const elapsed = Date.now() - t0;
         const remainingSec = Math.max(0, Math.round((deadlineMs - elapsed) / 1000));
         const stepSystem = buildPrepareStepSystem(baseSystem, budget, maxRenders, maxInspects, remainingSec);
-        if (budget.usdRemaining <= 0 && outcome.best) {
-          return { toolChoice: { type: 'tool' as const, toolName: 'finish' }, system: stepSystem };
-        }
-        return { system: stepSystem };
+        const step =
+          budget.usdRemaining <= 0 && outcome.best
+            ? { toolChoice: { type: 'tool' as const, toolName: 'finish' }, system: stepSystem }
+            : { system: stepSystem };
+        const patched = applyStewardPrepareStep(session, steward, step, baseSystem) ?? {};
+        session.capturePrepareStep(patched);
+        return patched;
       },
-      onStepFinish: ({ usage }) => {
-        if (usage) addStepCost(budget, usage);
+      onStepFinish: (event) => {
+        session.recordStep(event);
+        if (event.usage) addStepCost(budget, event.usage);
         stallFingerprints.push(fingerprint(outcome.best, budget));
       }
     });
+    session.recordAssistantText(result.text);
+    session.recordUsage(result.totalUsage ?? result.usage);
+    session.finish('finished');
   } catch (e) {
+    session.finish('failed', e);
     loopOk = false;
     loopError = e instanceof Error ? e.message : String(e);
     throw e;
   } finally {
+    persistHarnessSession(session);
     const totalUsage = extractSdkUsage(result?.totalUsage);
     logAiCall({
       label: 'image-agent',

--- a/src/lib/server/nested-agents.test.ts
+++ b/src/lib/server/nested-agents.test.ts
@@ -18,7 +18,7 @@ describe('niente agenti annidati sul GTM di produzione', () => {
 // la traccia dai moduli foglia. Gli orchestratori escono dal framework uno per PR, e una tabella
 // con una riga per file fa sì che due PR in parallelo tocchino righe diverse invece della stessa.
 const LOOP_DRIVER: Record<string, 'harness' | 'sdk'> = {
-	'image-agent.ts': 'harness',
+	'image-agent.ts': 'sdk',
 	'produce-agent.ts': 'harness',
 	'strategy-agent.ts': 'sdk',
 	'week-planner-agent.ts': 'sdk'


### PR DESCRIPTION
## What?

The image agent — the loop that produces a post's image, searching brand assets, rendering,
inspecting and publishing a library photo as-is — no longer runs through the agent framework. It
calls `generateText` from the AI SDK directly, and the three things `harnessGenerateText` was
silently adding on a batch surface are written at the call site.

Fourth of twelve, same shape as #224, #231 and #232 (all merged). Ten new characterization tests
were written **against the existing framework implementation** and watched pass before anything
moved; the fourteen already in `image-agent.test.ts` did the rest.

`packages/agent-*` is untouched. Nothing is deleted.

## Why?

`packages/agent-*` (105,226 lines), `src/lib/agent` (23,909) and `src/lib/server/chat` (32,031)
are slated for deletion — about 31% of the repository. Deletion is blocked by whoever still
imports the framework, so the orchestrators come off it one at a time.

This one also closes the loose end #232 left: after the Director came off the framework, its
remaining route into `chat/model` and `chat/controller` ran `content-preview → articles →
image-agent → harness/index`. With this PR **neither file reaches chat's model or controller at
all** any more.

## How?

### It was already half-done, by accident

`image-agent.test.ts` has driven this loop through a fake `generateText` since before this series
existed — which is exactly the boundary the recipe asks for. Those fourteen tests grade both
implementations without a line of difference, and they pass on both. That is most of the safety
net, for free.

### What the net was missing

The existing tests watch the *counters*: the render budget helper, per-step cost accumulation, the
stall threshold, the prepare-step system patch. Nothing watched the *table*: which tools the model
is actually handed, the shape of the message, what a **tool** returns when its budget is spent (as
opposed to what the counter returns), what comes back when the loop concludes nothing, and what
lands in `agent_sessions`. Ten tests close that, and the characterization is complete.

### What the framework was hiding

The same five additions; on `batch` three are live (session transcript, session steward, per-step
system patch) and two are declared `surface === 'chat'` and have never done anything here.

The steward earns its keep on one rule: two `render_image` calls that come back empty in a row and
the renderer leaves the table, instead of the model asking a broken generator for a picture for
the rest of its fifty steps. A render costs real money, so this is not bookkeeping. One test holds
it.

### The finally block that was already right

`persistHarnessSession` joins the `logAiCall` that was already there, for the reason its own
comment gives: a run that throws still spent whatever it rendered, so both rows have to say so.
The transcript used to be saved by the framework's finally; now it is saved by this one, which is
the same place.

### Where the transcript comes from now

`harness/session`, `harness/persist`, `harness/pipeline` and `harness/steward` — 1,030 lines —
import neither chat nor `$lib/agent`. `harness/index` does, because it re-exports `harness/run`.

### Commits

1. `8d54db2` — the ten characterization tests, passing against the framework implementation.
2. the rewrite plus the `LOOP_DRIVER` row flip.
3. the internal changelog.

The guard in `nested-agents.test.ts` is a **one-line change** (`'image-agent.ts': 'harness'` →
`'sdk'`) — that table was introduced in #231 precisely so the twelve PRs in this series stop
queueing up on the same line, and it has now paid for itself twice on rebase.

## Testing?

Targeted only. The full suite and Playwright are delegated to CI (`.github/workflows/ci.yml` runs
both on every pull request). `npm run check` was not run: no `.svelte` file and no shared type is
touched.

```
$ npx vitest run src/lib/server/nested-agents.test.ts \
    src/lib/server/image-agent.loop.test.ts \
    src/lib/server/image-agent.test.ts

 Test Files  3 passed (3)
      Tests  40 passed (40)
```

The ten loop tests were run against the previous implementation first, at commit `8d54db2`, before
the rewrite existed:

```
 ✓ src/lib/server/image-agent.loop.test.ts (10 tests) 41ms
 ✓ src/lib/server/image-agent.test.ts (14 tests) 17ms
 Test Files  2 passed (2)
      Tests  24 passed (24)
```

Reproducible: `git checkout 8d54db2 && npx vitest run src/lib/server/image-agent.loop.test.ts src/lib/server/image-agent.test.ts`.

### What the ten pin

The exact tool table; the single user message carrying the brief plus any media the brief itself
links (`resolveUserTurnMediaParts`); the render cap seen from the tool *and that it does not pay
for one render more*; the inspect cap; the step cap; `use_asset_as_is` refusing a non-library id
and, on success, making the result `source: 'library'`; the empty run returning the brief as its
own prompt with `Image agent finished without a result.`; the `agent_sessions` row; and the
steward taking the renderer off the table after two empty renders.

### Schema

No new enum-ish value is written — `agent: 'image'`, `surface: 'batch'`, `mode` = the platform,
and the status vocabulary all come through unchanged code. `agent_sessions` and `agent_runs` carry
**no CHECK constraints** (checked against the live schema via `pg_constraint`, `contype = 'c'` → 0
rows on both).

### Not tested, and why

- **No live run for this one.** #224's rewrite was exercised end to end against the local stack
  with a real model, before and after; this is the same transformation applied to a fourth file,
  and the machine is currently in swap.
- **`npm run eval:durability` was not run** — real money, unreliable bench today. **It should be
  run before the series is considered finished.**

<details>
<summary>Import graph, measured (transitive BFS, 219 modules visited)</summary>

**Before**: `image-agent.ts -> harness/index.ts -> harness/run.ts -> chat/model.ts` (and
`chat/controller.ts`, and through it `$lib/agent/bridge/verdict`).

**After**: neither is reachable. What remains is one infrastructure chain, unrelated to the
framework and untouched here:

```
image-agent.ts -> credits.ts -> scheduler.ts -> agent-turns.ts -> chat/queue.ts
image-agent.ts -> credits.ts -> scheduler.ts -> agent-turns.ts -> team-ignition.ts -> chat/persistence.ts
```
</details>

## Anything Else?

- **Series status.** Off the framework: week planner (#224), strategy agent (#231), Director
  (#232), image agent (this). Still on it: `produce-agent.ts`, `seo-agent.ts`,
  `analytics-review-agent.ts`, `media-generator/agent.ts`, `media-generator/ugc-agent.ts`,
  `media-generator/ugc-plan-agent.ts`, `motion-video/agent.ts`, `sandbox.ts` — plus
  `agent-base.ts`, `craft-model.ts`, `harness-skills.ts`, `agent-kit-effects-store.ts` and all of
  chat.

- **Two of the rest are a different shape.** `media-generator/agent.ts` and
  `motion-video/agent.ts` use `harnessStreamText`, where the wrapper installs
  `onFinish`/`onError`/`onAbort` and snapshots the request *before* the stream starts, so a killed
  stream still leaves a transcript. The recipe holds in outline but those need their own reading.

- **No public changelog**, deliberately. Same images, same budgets, same rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
