### PR TITLE
Generate sixteen more MCP tools from the registry

### DIFF
--- a/changelog/2026-09-04-registry-sixteen-tools.md
+++ b/changelog/2026-09-04-registry-sixteen-tools.md
@@ -66,15 +66,21 @@ la differenza. Il primo giro del test l'aveva vista, ed era rumore.
 | 3 | **non sono una chiamata HTTP**: leggono e scrivono `~/.config/anomalia/session.json` | `login`, `logout`, `whoami` |
 | 3 | **non sono una chiamata sola**: `get_status` ne fa due e ricompone, `produce_week` risolve prima il draft, `edit_post` rimodella la risposta in `{ok, id, patch}` | `get_status`, `produce_week`, `edit_post` |
 | 3 | **il percorso non sta sotto `/brands/:slug/`**, o è il brand stesso: `list_brands` è `/api/v1/brands`, `get_dashboard` è la radice del brand e `pathUnderBrand` è per contratto un sotto-percorso, `chat` non parla JSON su una rotta normale | `list_brands`, `get_dashboard`, `chat` |
-| 3 | **`DELETE` con `:id` su una risorsa**: derivabili adesso che il registry sa sostituire un id (PR #218), ma sono un gruppo a sé e vanno in una PR separata | `delete_person`, `delete_competitor`, `delete_document` |
+| 3 | **`DELETE` con `:id` su una risorsa**: derivabili, ma **non equivalenti**. Il generatore non usa l'`id` dichiarato dal contratto: lo sostituisce con `resourceId(resource)`, che è `z.string().min(1)` risolto per prefisso. Oggi questi tre chiedono un UUID stretto; migrandoli, un prefisso qualsiasi basterebbe a cancellare — su un'operazione distruttiva — e la loro descrizione (`"Delete a studio person by UUID."`) diventerebbe falsa. È un cambio di prodotto, non una migrazione | `delete_person`, `delete_competitor`, `delete_document` |
 
 13 + 4 + 4 + 3 + 3 + 3 + 3 = **33**. Con i 16 migrati fa 49, che è il numero da cui si partiva.
 
-I tre `DELETE` sono l'unico gruppo che si scioglierebbe oggi senza inventare niente:
+Sui tre `DELETE` vale la pena essere espliciti, perché sulla carta sembravano i più facili.
 `delete_person` e `delete_competitor` hanno già la loro risorsa in `BRAND_RESOURCES`,
-`delete_document` ne vuole una nuova. Sono la PR successiva.
+`delete_document` ne vorrebbe una nuova: due righe. Il problema non è quello. È che
+`delete_product`, già nel registry, accetta un prefisso, mentre questi tre pretendono un UUID —
+e il generatore non lascia scegliere: sovrascrive l'`id` del contratto con il suo. Portarli su
+significa allargare tre cancellazioni, non spostarle. **Vale la pena farlo** — l'incoerenza fra
+`delete_product` e `delete_person` la paga chi usa i tool — ma è una decisione di prodotto con
+un changelog pubblico, e va presa, non nascosta dentro un refactor che promette di non cambiare
+niente.
 
-Gli altri no. Il blocco dei 17 che rimodellano l'input non si scioglie con un campo in più: si
+Gli altri blocchi non si sciolgono affatto. Il blocco dei 17 che rimodellano l'input non si scioglie con un campo in più: si
 scioglierebbe con un meccanismo per dichiarare *costanti di body invisibili all'input schema*,
 che è un'astrazione nuova per un caso solo — o meglio, per il caso che quei tool esistano
 perché una rotta sola fa cinque cose diverse a seconda di `action`. La cosa giusta lì è

--- a/changelog/2026-09-04-registry-sixteen-tools.md
+++ b/changelog/2026-09-04-registry-sixteen-tools.md
@@ -1,0 +1,81 @@
+# Sedici tool MCP smettono di essere scritti a mano
+
+Il registry (`packages/api-contracts/src/`, specchiato in `cli/lib/contracts/`) genera i tool
+MCP da una dichiarazione sola; tutto il resto è `server.registerTool(...)` ricopiato a mano, con
+il contratto della rotta scritto in tre posti — la rotta, `lib/api.ts`, il tool. Su `dev` erano
+**36 generati su 85 tool**: 49 a mano.
+
+Questa PR ne porta su **16**. Restano 33 a mano, e sotto c'è il motivo di ciascuno.
+
+## Cosa è passato
+
+| gruppo | tool |
+|---|---|
+| letture | `get_analytics`, `get_gtm`, `get_voice`, `list_products` |
+| piano editoriale | `propose_plan`, `revise_plan`, `approve_plan`, `discard_plan` |
+| SEO/GEO/keywords | `seo_action`, `geo_action`, `refresh_keywords` |
+| studio | `update_brand_kit`, `update_voice`, `add_competitor`, `research_competitors`, `sync_history` |
+
+Il criterio è uno: **una sola chiamata, sotto `/brands/:slug/`, e l'input del tool è già il
+body (o la query) della rotta**. Dove il tool rimodella qualcosa prima di partire, non passa.
+
+## Cosa è servito aggiungere al registry
+
+Una riga sola: `openWorld?: boolean` in `EndpointShape`, emesso come `openWorldHint: true`.
+`research_competitors` e `sync_history` lo dichiaravano a mano e senza quel campo la migrazione
+li avrebbe fatti sembrare tool che non escono da Anomalia — una perdita di informazione per il
+client, non una migrazione. È lo stesso genere di campo di `destructive`, che c'era già.
+
+`PUT` era già nell'unione dei metodi (PR #220), quindi `update_brand_kit` è passato senza
+toccare niente.
+
+## Come è stata provata l'equivalenza
+
+Non a parole: `tools/list` catturato attraverso `handleMcpFetch` prima e dopo, confrontato campo
+per campo su tutti e 85 i tool.
+
+```
+before 85 after 85
+added: []      removed: []
+tools with any delta: 16
+```
+
+I 16 delta sono **solo** i due dichiarati:
+
+- `additionalProperties: null → false`, perché gli input del registry sono `.strict()`. Un campo
+  che nessuno ha dichiarato viene rifiutato invece di essere scartato in silenzio.
+- `destructiveHint: false` che compare sulle quattro letture: il generatore lo emette sempre,
+  la versione a mano lo ometteva. `readOnlyHint` resta `true`.
+
+Il confronto vive come test, non come nota: `cli/mcp/migrated-writes.test.ts` porta la forma di
+ogni tool com'era **prima**, catturata da `tools/list`, e fallisce se un titolo cambia, una
+descrizione viene riscritta o un campo sparisce. `cli/mcp/read-tools.test.ts` fa lo stesso per
+le letture ed è stato esteso con le quattro nuove.
+
+Un dettaglio: `required` è confrontato ordinato. Il registry mette `slug` in coda, la versione a
+mano lo metteva in testa; in JSON Schema `required` è un insieme, e nessun client può osservare
+la differenza. Il primo giro del test l'aveva vista, ed era rumore.
+
+## I 33 che restano, e cosa li blocca
+
+| quanti | blocco | tool |
+|---|---|---|
+| 13 | **l'input del tool non è il body della rotta**: il tool aggiunge una costante (`kind: 'real'`, `action: 'generate'`) o rinomina un campo (`week` → `week_index`). Dichiararla nel registry vorrebbe dire farla comparire fra le properties del tool — cioè cambiare la forma pubblica, che è esattamente ciò che una migrazione non deve fare | `add_note`, `add_person`, `generate_person`, `set_colors`, `save_brief`, `replan_week`, `plan_week`, `generate_article`, `optimize_article`, `publish_article`, `unpublish_article`, `delete_article`, `ads_action` |
+| 4 | stesso blocco, su `/posts/:id/media`: quattro tool diversi che si distinguono solo per il letterale `action` | `regenerate_post_media`, `regenerate_slide`, `reorder_slides`, `make_video` |
+| 4 | **distruttivi sul mondo esterno**: pubblicano davvero su account veri. Sulla carta derivabili, ma la prova che il diff di `tools/list` fornisce riguarda la forma, non l'effetto — e l'effetto qui non si verifica senza pubblicare. `approve_posts` è `approve_post` moltiplicato per tutti i pending, stessa ragione | `approve_post`, `publish_post`, `reject_post`, `approve_posts` |
+| 3 | **non sono una chiamata HTTP**: leggono e scrivono `~/.config/anomalia/session.json` | `login`, `logout`, `whoami` |
+| 3 | **non sono una chiamata sola**: `get_status` ne fa due e ricompone, `produce_week` risolve prima il draft, `edit_post` rimodella la risposta in `{ok, id, patch}` | `get_status`, `produce_week`, `edit_post` |
+| 3 | **il percorso non sta sotto `/brands/:slug/`**, o è il brand stesso: `list_brands` è `/api/v1/brands`, `get_dashboard` è la radice del brand e `pathUnderBrand` è per contratto un sotto-percorso, `chat` non parla JSON su una rotta normale | `list_brands`, `get_dashboard`, `chat` |
+| 3 | **`DELETE` con `:id` su una risorsa**: derivabili adesso che il registry sa sostituire un id (PR #218), ma sono un gruppo a sé e vanno in una PR separata | `delete_person`, `delete_competitor`, `delete_document` |
+
+13 + 4 + 4 + 3 + 3 + 3 + 3 = **33**. Con i 16 migrati fa 49, che è il numero da cui si partiva.
+
+I tre `DELETE` sono l'unico gruppo che si scioglierebbe oggi senza inventare niente:
+`delete_person` e `delete_competitor` hanno già la loro risorsa in `BRAND_RESOURCES`,
+`delete_document` ne vuole una nuova. Sono la PR successiva.
+
+Gli altri no. Il blocco dei 17 che rimodellano l'input non si scioglie con un campo in più: si
+scioglierebbe con un meccanismo per dichiarare *costanti di body invisibili all'input schema*,
+che è un'astrazione nuova per un caso solo — o meglio, per il caso che quei tool esistano
+perché una rotta sola fa cinque cose diverse a seconda di `action`. La cosa giusta lì è
+spaccare la rotta, non insegnare al registry a nasconderci dentro un letterale.

--- a/changelog/2026-09-04-registry-sixteen-tools.md
+++ b/changelog/2026-09-04-registry-sixteen-tools.md
@@ -3,7 +3,7 @@
 Il registry (`packages/api-contracts/src/`, specchiato in `cli/lib/contracts/`) genera i tool
 MCP da una dichiarazione sola; tutto il resto è `server.registerTool(...)` ricopiato a mano, con
 il contratto della rotta scritto in tre posti — la rotta, `lib/api.ts`, il tool. Su `dev` erano
-**36 generati su 85 tool**: 49 a mano.
+**39 generati su 88 tool**: 49 a mano.
 
 Questa PR ne porta su **16**. Restano 33 a mano, e sotto c'è il motivo di ciascuno.
 
@@ -32,10 +32,10 @@ toccare niente.
 ## Come è stata provata l'equivalenza
 
 Non a parole: `tools/list` catturato attraverso `handleMcpFetch` prima e dopo, confrontato campo
-per campo su tutti e 85 i tool.
+per campo su tutti e 88 i tool.
 
 ```
-before 85 after 85
+before 88 after 88
 added: []      removed: []
 tools with any delta: 16
 ```

--- a/cli/lib/contracts/index.ts
+++ b/cli/lib/contracts/index.ts
@@ -11,8 +11,12 @@ import {
   LIST_WEB_FIXES,
 } from './evidence';
 import {
+  APPROVE_PLAN,
+  DISCARD_PLAN,
   PLAN_CADENCES,
   PLAN_CYCLE_WEEKS,
+  PROPOSE_PLAN,
+  REVISE_PLAN,
   SAVE_PLAN,
   SAVE_WEEK_SEEDS,
 } from './plans';
@@ -28,14 +32,19 @@ import {
 } from './posts';
 import {
   GET_ADS,
+  GET_ANALYTICS,
   GET_GEO,
+  GET_GTM,
   GET_KEYWORDS,
   GET_PLAN,
   GET_SEO,
   GET_STUDIO,
+  GET_VOICE,
   GET_WEEKLY_PLAN,
-  LIST_ARTICLES
+  LIST_ARTICLES,
+  LIST_PRODUCTS
 } from './reads';
+import { GEO_ACTION, REFRESH_KEYWORDS, SEO_ACTION } from './search';
 import {
   CREATE_SHARE,
   LIST_SHARES,
@@ -43,13 +52,18 @@ import {
   SHARED_VIEW_TYPES,
 } from './shares';
 import {
+  ADD_COMPETITOR,
   CREATE_PRODUCT,
   DELETE_PRODUCT,
   GET_BIO,
+  RESEARCH_COMPETITORS,
   SET_BIO,
+  SYNC_HISTORY,
+  UPDATE_BRAND_KIT,
   UPDATE_COMPETITOR,
   UPDATE_PERSON,
-  UPDATE_PRODUCT
+  UPDATE_PRODUCT,
+  UPDATE_VOICE
 } from './studio';
 
 export type EndpointFailure = { readonly error: string; readonly status: number };
@@ -75,6 +89,7 @@ type EndpointShape = {
   readonly output: z.ZodType;
   readonly failures: readonly EndpointFailure[];
   readonly destructive: boolean;
+  readonly openWorld?: boolean;
 };
 
 export type ResourcelessEndpoint = EndpointShape & {
@@ -90,7 +105,9 @@ export type ResourceEndpoint = EndpointShape & {
 export type BrandEndpoint = ResourcelessEndpoint | ResourceEndpoint;
 
 export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
+  ADD_COMPETITOR,
   ADS_REMIX,
+  APPROVE_PLAN,
   BILLING_PORTAL_LINK,
   CHECKOUT_LINK,
   CHECK_CONTENT,
@@ -98,37 +115,51 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   CREATE_PRODUCT,
   CREATE_SHARE,
   DELETE_PRODUCT,
+  DISCARD_PLAN,
+  GEO_ACTION,
   GET_ADS,
+  GET_ANALYTICS,
   GET_ARTICLE,
   GET_AUDIT_FINDINGS,
   GET_BIO,
   GET_CALENDAR,
   GET_CREATION_KIT,
   GET_GEO,
+  GET_GTM,
   GET_KEYWORDS,
   GET_PLAN,
   GET_POST,
   GET_SEO,
   GET_STUDIO,
+  GET_VOICE,
   GET_WEEKLY_PLAN,
   IMPORT_MEDIA_URL,
   LIST_ARTICLES,
   LIST_AUDIT_CITATIONS,
   LIST_MEDIA,
   LIST_POSTS,
+  LIST_PRODUCTS,
   LIST_SHARES,
   LIST_WEB_AUDITS,
   LIST_WEB_FIXES,
+  PROPOSE_PLAN,
+  REFRESH_KEYWORDS,
   RENDER_POST,
   RESCHEDULE_POST,
+  RESEARCH_COMPETITORS,
+  REVISE_PLAN,
   REVOKE_SHARE,
   SAVE_PLAN,
   SAVE_WEEK_SEEDS,
+  SEO_ACTION,
   SET_BIO,
+  SYNC_HISTORY,
   UPDATE_ARTICLE,
+  UPDATE_BRAND_KIT,
   UPDATE_COMPETITOR,
   UPDATE_PERSON,
   UPDATE_PRODUCT,
+  UPDATE_VOICE,
 ];
 
 export function pathFor(endpoint: ResourcelessEndpoint, slug: string): string;
@@ -176,22 +207,32 @@ export {
 } from './evidence';
 export {
   GET_ADS,
+  GET_ANALYTICS,
   GET_GEO,
+  GET_GTM,
   GET_KEYWORDS,
   GET_PLAN,
   GET_SEO,
   GET_STUDIO,
+  GET_VOICE,
   GET_WEEKLY_PLAN,
-  LIST_ARTICLES
+  LIST_ARTICLES,
+  LIST_PRODUCTS
 };
+export { GEO_ACTION, REFRESH_KEYWORDS, SEO_ACTION } from './search';
 export {
+  ADD_COMPETITOR,
   CREATE_PRODUCT,
   DELETE_PRODUCT,
   GET_BIO,
+  RESEARCH_COMPETITORS,
   SET_BIO,
+  SYNC_HISTORY,
+  UPDATE_BRAND_KIT,
   UPDATE_COMPETITOR,
   UPDATE_PERSON,
-  UPDATE_PRODUCT
+  UPDATE_PRODUCT,
+  UPDATE_VOICE
 } from './studio';
 export {
   CREATE_SHARE,
@@ -211,7 +252,16 @@ export type {
 export { KIT_FORMATS } from './creation-kit';
 export type { GetCreationKitInput, GetCreationKitResult } from './creation-kit';
 export type { CreatePostInput, CreatePostResult } from './posts';
-export { PLAN_CADENCES, PLAN_CYCLE_WEEKS, SAVE_PLAN, SAVE_WEEK_SEEDS };
+export {
+  APPROVE_PLAN,
+  DISCARD_PLAN,
+  PLAN_CADENCES,
+  PLAN_CYCLE_WEEKS,
+  PROPOSE_PLAN,
+  REVISE_PLAN,
+  SAVE_PLAN,
+  SAVE_WEEK_SEEDS
+};
 export type { SavePlanInput, SavePlanResult, SaveWeekSeedsInput, SaveWeekSeedsResult } from './plans';
 export type { CreateProductInput, CreateProductResult } from './studio';
 export type { CreateShareInput, CreateShareResult, SharedViewType } from './shares';

--- a/cli/lib/contracts/plans.ts
+++ b/cli/lib/contracts/plans.ts
@@ -170,3 +170,54 @@ export const SAVE_WEEK_SEEDS = {
   ],
   destructive: false
 } satisfies BrandEndpoint;
+
+const NoInput = z.object({}).strict();
+const Ok = z.object({ ok: z.literal(true) });
+
+export const PROPOSE_PLAN = {
+  tool: 'propose_plan',
+  title: 'Propose editorial plan',
+  description: 'Generate the first / a new editorial plan proposal.',
+  method: 'POST',
+  pathUnderBrand: '/editorial-plan/propose',
+  input: NoInput,
+  output: z.object({ ok: z.literal(true), plan: z.unknown() }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const REVISE_PLAN = {
+  tool: 'revise_plan',
+  title: 'Revise editorial plan',
+  description: 'Request a revision of the proposed plan with feedback.',
+  method: 'POST',
+  pathUnderBrand: '/editorial-plan/revise',
+  input: z.object({ feedback: z.string().min(1) }).strict(),
+  output: z.object({ ok: z.literal(true), plan: z.unknown() }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const APPROVE_PLAN = {
+  tool: 'approve_plan',
+  title: 'Approve editorial plan',
+  description: 'Approve the proposed editorial plan.',
+  method: 'POST',
+  pathUnderBrand: '/editorial-plan/approve',
+  input: NoInput,
+  output: Ok,
+  failures: [],
+  destructive: true
+} satisfies BrandEndpoint;
+
+export const DISCARD_PLAN = {
+  tool: 'discard_plan',
+  title: 'Discard editorial plan',
+  description: 'Discard the proposed editorial plan.',
+  method: 'POST',
+  pathUnderBrand: '/editorial-plan/discard',
+  input: NoInput,
+  output: Ok,
+  failures: [],
+  destructive: true
+} satisfies BrandEndpoint;

--- a/cli/lib/contracts/reads.ts
+++ b/cli/lib/contracts/reads.ts
@@ -195,3 +195,90 @@ export const LIST_ARTICLES = {
   failures: [],
   destructive: false
 } satisfies BrandEndpoint;
+
+export const GET_ANALYTICS = {
+  tool: 'get_analytics',
+  title: 'Analytics',
+  description: 'Brand analytics: totals, engagement, recent activity.',
+  method: 'GET',
+  pathUnderBrand: '/analytics',
+  input: NoInput,
+  output: z.looseObject({
+    total: z.number(),
+    scheduled: z.number(),
+    pending: z.number(),
+    failed: z.number(),
+    platforms: z.array(z.tuple([z.string(), z.number()])),
+    upcomingPosts: z.array(JsonObject),
+    recentActivity: z.array(JsonObject),
+    socialPerformance: z.array(JsonObject),
+    topPosts: z.array(JsonObject),
+    products: z.number(),
+    accounts: z.number()
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const GET_GTM = {
+  tool: 'get_gtm',
+  title: 'GTM roadmap',
+  description: 'View the go-to-market roadmap for a brand.',
+  method: 'GET',
+  pathUnderBrand: '/gtm',
+  input: NoInput,
+  output: z.object({
+    gtm: JsonObject.nullable(),
+    proposed: JsonObject.nullable(),
+    proposedFeedback: z.string().nullable(),
+    currentPhase: z.number().nullable(),
+    phaseStatuses: z.array(z.enum(['done', 'now', 'next'])),
+    horizons: z.array(z.string()),
+    studioPct: z.number()
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const GET_VOICE = {
+  tool: 'get_voice',
+  title: 'Voice rules',
+  description: 'View brand voice framework and platform rules.',
+  method: 'GET',
+  pathUnderBrand: '/voice',
+  input: NoInput,
+  output: z.object({
+    platforms: z.array(z.string()),
+    voiceMode: z.string(),
+    voiceFramework: JsonObject,
+    platformRules: z.record(z.string(), JsonObject),
+    avoid: z.array(z.string()),
+    platformInstructions: z.record(z.string(), z.string()),
+    studioPct: z.number()
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const LIST_PRODUCTS = {
+  tool: 'list_products',
+  title: 'List products',
+  description: 'List products in the brand catalog.',
+  method: 'GET',
+  pathUnderBrand: '/products',
+  input: NoInput,
+  output: z.object({
+    products: z.array(
+      z.looseObject({
+        id: z.string(),
+        title: z.string(),
+        kind: z.string(),
+        pricing: z.string().nullable(),
+        imageCount: z.number(),
+        featured: z.boolean()
+      })
+    )
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/cli/lib/contracts/search.ts
+++ b/cli/lib/contracts/search.ts
@@ -1,0 +1,59 @@
+import { z } from 'zod';
+import type { BrandEndpoint } from './index';
+
+export const SEO_ACTION = {
+  tool: 'seo_action',
+  title: 'SEO action',
+  description:
+    'Run SEO actions: run (tech audit), plan, more (append initiatives), asset, article. For asset/article pass initiativeId.',
+  method: 'POST',
+  pathUnderBrand: '/seo',
+  input: z
+    .object({
+      action: z.enum(['run', 'plan', 'more', 'asset', 'article']),
+      initiativeId: z.string().optional(),
+      guidance: z.string().optional().describe('Optional guidance when action=more')
+    })
+    .strict(),
+  output: z.looseObject({
+    ok: z.boolean().optional(),
+    error: z.string().optional(),
+    grade: z.string().optional(),
+    initiatives: z.number().optional(),
+    added: z.number().optional(),
+    generated: z.number().optional(),
+    articleId: z.string().optional(),
+    techScore: z.number().nullable().optional()
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const GEO_ACTION = {
+  tool: 'geo_action',
+  title: 'GEO action',
+  description: 'Run GEO citation audit or generate fix artifacts.',
+  method: 'POST',
+  pathUnderBrand: '/geo',
+  input: z.object({ action: z.enum(['audit', 'fix']) }).strict(),
+  output: z.looseObject({
+    ok: z.boolean().optional(),
+    techScore: z.number().nullable().optional(),
+    shareOfVoice: z.number().optional(),
+    generated: z.number().optional()
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const REFRESH_KEYWORDS = {
+  tool: 'refresh_keywords',
+  title: 'Refresh keywords',
+  description: 'Regenerate keyword research for the brand.',
+  method: 'POST',
+  pathUnderBrand: '/keywords',
+  input: z.object({}).strict(),
+  output: z.object({ ok: z.literal(true), keywords: z.number() }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/cli/lib/contracts/studio.ts
+++ b/cli/lib/contracts/studio.ts
@@ -200,3 +200,104 @@ export const SET_BIO = {
   ],
   destructive: false
 } satisfies BrandEndpoint;
+
+export const UPDATE_BRAND_KIT = {
+  tool: 'update_brand_kit',
+  title: 'Update brand kit',
+  description: 'Update brand kit fields (about, category, audience, style, language).',
+  method: 'PUT',
+  pathUnderBrand: '/studio/kit',
+  input: z
+    .object({
+      about: z.string().optional(),
+      category: z.string().optional(),
+      target_audience: z.string().optional(),
+      brand_style: z.string().optional(),
+      language: z.string().optional()
+    })
+    .strict(),
+  output: Ok,
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const UPDATE_VOICE = {
+  tool: 'update_voice',
+  title: 'Update voice',
+  description:
+    'Patch brand voice fields (mood, tone, register, avoid list, platform instructions).',
+  method: 'POST',
+  pathUnderBrand: '/voice/update',
+  input: z
+    .object({
+      mood: z.string().optional(),
+      tone: z.string().optional(),
+      register: z.number().optional(),
+      emotion: z.string().optional(),
+      character: z.string().optional(),
+      syntax: z.string().optional(),
+      avoid: z.array(z.string()).optional(),
+      platform_instructions: z.record(z.string(), z.string()).optional()
+    })
+    .strict(),
+  output: Ok,
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const ADD_COMPETITOR = {
+  tool: 'add_competitor',
+  title: 'Add competitor',
+  description: 'Add a competitor to the studio.',
+  method: 'POST',
+  pathUnderBrand: '/studio/competitors',
+  input: z
+    .object({
+      name: z.string().min(1),
+      website: z.string().optional(),
+      rationale: z.string().optional()
+    })
+    .strict(),
+  output: z.object({
+    ok: z.literal(true),
+    competitor: z.looseObject({
+      id: z.string(),
+      name: z.string(),
+      website: z.string().nullable(),
+      kind: z.string(),
+      source: z.string()
+    })
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const RESEARCH_COMPETITORS = {
+  tool: 'research_competitors',
+  title: 'Research competitors',
+  description: 'Run AI competitor research and add findings to the studio.',
+  method: 'POST',
+  pathUnderBrand: '/studio/competitors/research',
+  input: z.object({}).strict(),
+  output: z.object({ ok: z.literal(true), found: z.number(), added: z.number() }),
+  failures: [],
+  destructive: false,
+  openWorld: true
+} satisfies BrandEndpoint;
+
+export const SYNC_HISTORY = {
+  tool: 'sync_history',
+  title: 'Sync social history',
+  description: 'Sync historical social posts into the studio.',
+  method: 'POST',
+  pathUnderBrand: '/studio/history/sync',
+  input: z.object({}).strict(),
+  output: z.looseObject({
+    synced: z.number(),
+    noAccounts: z.boolean().optional(),
+    errors: z.array(z.string()).optional()
+  }),
+  failures: [],
+  destructive: false,
+  openWorld: true
+} satisfies BrandEndpoint;

--- a/cli/mcp/migrated-writes.test.ts
+++ b/cli/mcp/migrated-writes.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, test } from 'bun:test';
+import { BRAND_ENDPOINTS } from '../lib/contracts/index.ts';
+import { handleMcpFetch } from './http-app.ts';
+
+const SLUG = { type: 'string', minLength: 1, description: 'Brand URL slug' };
+
+const NOT_DESTRUCTIVE = { readOnlyHint: false, destructiveHint: false };
+const DESTRUCTIVE = { readOnlyHint: false, destructiveHint: true };
+const OPEN_WORLD = { readOnlyHint: false, destructiveHint: false, openWorldHint: true };
+
+// Ogni riga è la forma che il tool aveva scritto a mano, catturata da tools/list prima della
+// migrazione. Una descrizione riscritta o un campo perso qui è una regressione, non una
+// migrazione: chi ha già l'integrazione non deve accorgersi di niente.
+const MIGRATED_WRITES = [
+  {
+    name: 'propose_plan',
+    title: 'Propose editorial plan',
+    description: 'Generate the first / a new editorial plan proposal.',
+    properties: { slug: SLUG },
+    required: ['slug'],
+    annotations: NOT_DESTRUCTIVE,
+  },
+  {
+    name: 'revise_plan',
+    title: 'Revise editorial plan',
+    description: 'Request a revision of the proposed plan with feedback.',
+    properties: { slug: SLUG, feedback: { type: 'string', minLength: 1 } },
+    required: ['slug', 'feedback'],
+    annotations: NOT_DESTRUCTIVE,
+  },
+  {
+    name: 'approve_plan',
+    title: 'Approve editorial plan',
+    description: 'Approve the proposed editorial plan.',
+    properties: { slug: SLUG },
+    required: ['slug'],
+    annotations: DESTRUCTIVE,
+  },
+  {
+    name: 'discard_plan',
+    title: 'Discard editorial plan',
+    description: 'Discard the proposed editorial plan.',
+    properties: { slug: SLUG },
+    required: ['slug'],
+    annotations: DESTRUCTIVE,
+  },
+  {
+    name: 'refresh_keywords',
+    title: 'Refresh keywords',
+    description: 'Regenerate keyword research for the brand.',
+    properties: { slug: SLUG },
+    required: ['slug'],
+    annotations: NOT_DESTRUCTIVE,
+  },
+  {
+    name: 'seo_action',
+    title: 'SEO action',
+    description:
+      'Run SEO actions: run (tech audit), plan, more (append initiatives), asset, article. For asset/article pass initiativeId.',
+    properties: {
+      slug: SLUG,
+      action: { type: 'string', enum: ['run', 'plan', 'more', 'asset', 'article'] },
+      initiativeId: { type: 'string' },
+      guidance: { type: 'string', description: 'Optional guidance when action=more' },
+    },
+    required: ['slug', 'action'],
+    annotations: NOT_DESTRUCTIVE,
+  },
+  {
+    name: 'geo_action',
+    title: 'GEO action',
+    description: 'Run GEO citation audit or generate fix artifacts.',
+    properties: { slug: SLUG, action: { type: 'string', enum: ['audit', 'fix'] } },
+    required: ['slug', 'action'],
+    annotations: NOT_DESTRUCTIVE,
+  },
+  {
+    name: 'update_brand_kit',
+    title: 'Update brand kit',
+    description: 'Update brand kit fields (about, category, audience, style, language).',
+    properties: {
+      slug: SLUG,
+      about: { type: 'string' },
+      category: { type: 'string' },
+      target_audience: { type: 'string' },
+      brand_style: { type: 'string' },
+      language: { type: 'string' },
+    },
+    required: ['slug'],
+    annotations: NOT_DESTRUCTIVE,
+  },
+  {
+    name: 'update_voice',
+    title: 'Update voice',
+    description:
+      'Patch brand voice fields (mood, tone, register, avoid list, platform instructions).',
+    properties: {
+      slug: SLUG,
+      mood: { type: 'string' },
+      tone: { type: 'string' },
+      register: { type: 'number' },
+      emotion: { type: 'string' },
+      character: { type: 'string' },
+      syntax: { type: 'string' },
+      avoid: { type: 'array', items: { type: 'string' } },
+      platform_instructions: {
+        type: 'object',
+        propertyNames: { type: 'string' },
+        additionalProperties: { type: 'string' },
+      },
+    },
+    required: ['slug'],
+    annotations: NOT_DESTRUCTIVE,
+  },
+  {
+    name: 'add_competitor',
+    title: 'Add competitor',
+    description: 'Add a competitor to the studio.',
+    properties: {
+      slug: SLUG,
+      name: { type: 'string', minLength: 1 },
+      website: { type: 'string' },
+      rationale: { type: 'string' },
+    },
+    required: ['slug', 'name'],
+    annotations: NOT_DESTRUCTIVE,
+  },
+  {
+    name: 'research_competitors',
+    title: 'Research competitors',
+    description: 'Run AI competitor research and add findings to the studio.',
+    properties: { slug: SLUG },
+    required: ['slug'],
+    annotations: OPEN_WORLD,
+  },
+  {
+    name: 'sync_history',
+    title: 'Sync social history',
+    description: 'Sync historical social posts into the studio.',
+    properties: { slug: SLUG },
+    required: ['slug'],
+    annotations: OPEN_WORLD,
+  },
+] as const;
+
+type Tool = {
+  name: string;
+  title?: string;
+  description?: string;
+  inputSchema?: {
+    properties?: Record<string, unknown>;
+    required?: string[];
+    additionalProperties?: boolean;
+  };
+  annotations?: Record<string, unknown>;
+};
+
+async function rpc(method: string, params: unknown, id = 1) {
+  const res = await handleMcpFetch(
+    new Request('http://localhost/mcp', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json, text/event-stream' },
+      body: JSON.stringify({ jsonrpc: '2.0', id, method, params }),
+    }),
+  );
+  return (await res.json()) as { result?: Record<string, unknown> };
+}
+
+async function tools(): Promise<Tool[]> {
+  await rpc('initialize', {
+    protocolVersion: '2024-11-05',
+    capabilities: {},
+    clientInfo: { name: 'test', version: '0.0.1' },
+  });
+  const listed = await rpc('tools/list', {}, 2);
+  return (listed.result?.tools ?? []) as Tool[];
+}
+
+const find = (all: Tool[], name: string): Tool => {
+  const tool = all.find((t) => t.name === name);
+  if (!tool) throw new Error(`tool ${name} non registrato`);
+  return tool;
+};
+
+describe('le scritture migrate sul registry', () => {
+  test('restano identiche dall’esterno: titolo, descrizione, campi, obbligatori', async () => {
+    const all = await tools();
+
+    for (const expected of MIGRATED_WRITES) {
+      const tool = find(all, expected.name);
+
+      expect(tool.title, expected.name).toBe(expected.title);
+      expect(tool.description, expected.name).toBe(expected.description);
+      expect(tool.inputSchema?.properties, expected.name).toEqual(expected.properties);
+      // `required` è un insieme in JSON Schema: il registry lo emette con slug in coda, la
+      // versione a mano lo emetteva in testa. Ordinati, o il test fallisce su una differenza
+      // che nessun client può osservare.
+      expect([...(tool.inputSchema?.required ?? [])].sort(), expected.name).toEqual(
+        [...expected.required].sort(),
+      );
+    }
+  });
+
+  test('un tool che tocca il mondo fuori continua a dirlo', async () => {
+    const all = await tools();
+
+    for (const expected of MIGRATED_WRITES) {
+      expect(find(all, expected.name).annotations, expected.name).toEqual(expected.annotations);
+    }
+  });
+
+  test('rifiutano un campo che nessuno ha dichiarato, invece di scartarlo in silenzio', async () => {
+    const all = await tools();
+
+    for (const { name } of MIGRATED_WRITES) {
+      expect(find(all, name).inputSchema?.additionalProperties, name).toBe(false);
+    }
+  });
+
+  test('sono dichiarate nel registry, non registrate a mano', () => {
+    const declared = BRAND_ENDPOINTS.map((e) => e.tool);
+
+    for (const { name } of MIGRATED_WRITES) {
+      expect(declared, name).toContain(name);
+    }
+  });
+});

--- a/cli/mcp/read-tools.test.ts
+++ b/cli/mcp/read-tools.test.ts
@@ -64,6 +64,34 @@ const MIGRATED_READS = [
     },
     required: ['slug'],
   },
+  {
+    name: 'get_analytics',
+    title: 'Analytics',
+    description: 'Brand analytics: totals, engagement, recent activity.',
+    properties: { slug: SLUG_PROPERTY },
+    required: ['slug'],
+  },
+  {
+    name: 'get_gtm',
+    title: 'GTM roadmap',
+    description: 'View the go-to-market roadmap for a brand.',
+    properties: { slug: SLUG_PROPERTY },
+    required: ['slug'],
+  },
+  {
+    name: 'get_voice',
+    title: 'Voice rules',
+    description: 'View brand voice framework and platform rules.',
+    properties: { slug: SLUG_PROPERTY },
+    required: ['slug'],
+  },
+  {
+    name: 'list_products',
+    title: 'List products',
+    description: 'List products in the brand catalog.',
+    properties: { slug: SLUG_PROPERTY },
+    required: ['slug'],
+  },
 ] as const;
 
 type Tool = {

--- a/cli/mcp/tools/brand-content.ts
+++ b/cli/mcp/tools/brand-content.ts
@@ -24,6 +24,7 @@ function registerDeclaredEndpoints(server: McpServer) {
         annotations: {
           readOnlyHint: endpoint.method === 'GET',
           destructiveHint: endpoint.destructive,
+          ...(endpoint.openWorld ? { openWorldHint: true } : {}),
         },
       },
       async ({ slug: brandSlug, ...input }) =>
@@ -90,72 +91,7 @@ export function registerBrandTools(server: McpServer) {
       }),
   );
 
-  server.registerTool(
-    'get_analytics',
-    {
-      title: 'Analytics',
-      description: 'Brand analytics: totals, engagement, recent activity.',
-      inputSchema: z.object({ slug }),
-      annotations: { readOnlyHint: true },
-    },
-    async ({ slug }) => withAuth((token) => api.getAnalytics(token, slug)),
-  );
-
-  server.registerTool(
-    'get_gtm',
-    {
-      title: 'GTM roadmap',
-      description: 'View the go-to-market roadmap for a brand.',
-      inputSchema: z.object({ slug }),
-      annotations: { readOnlyHint: true },
-    },
-    async ({ slug }) => withAuth((token) => api.getGtm(token, slug)),
-  );
-
-  server.registerTool(
-    'get_voice',
-    {
-      title: 'Voice rules',
-      description: 'View brand voice framework and platform rules.',
-      inputSchema: z.object({ slug }),
-      annotations: { readOnlyHint: true },
-    },
-    async ({ slug }) => withAuth((token) => api.getVoice(token, slug)),
-  );
-
-  server.registerTool(
-    'update_voice',
-    {
-      title: 'Update voice',
-      description: 'Patch brand voice fields (mood, tone, register, avoid list, platform instructions).',
-      inputSchema: z.object({
-        slug,
-        mood: z.string().optional(),
-        tone: z.string().optional(),
-        register: z.number().optional(),
-        emotion: z.string().optional(),
-        character: z.string().optional(),
-        syntax: z.string().optional(),
-        avoid: z.array(z.string()).optional(),
-        platform_instructions: z.record(z.string(), z.string()).optional(),
-      }),
-      annotations: { readOnlyHint: false, destructiveHint: false },
-    },
-    async ({ slug, ...data }) => withAuth((token) => api.updateVoice(token, slug, data)),
-  );
-
-  server.registerTool(
-    'list_products',
-    {
-      title: 'List products',
-      description: 'List products in the brand catalog.',
-      inputSchema: z.object({ slug }),
-      annotations: { readOnlyHint: true },
-    },
-    async ({ slug }) => withAuth((token) => api.listProducts(token, slug)),
-  );
-
-  server.registerTool(
+            server.registerTool(
     'approve_posts',
     {
       title: 'Approve all pending posts',

--- a/cli/mcp/tools/plan.ts
+++ b/cli/mcp/tools/plan.ts
@@ -6,54 +6,7 @@ import { withAuth } from '../util.ts';
 const slug = z.string().min(1).describe('Brand URL slug');
 
 export function registerPlanTools(server: McpServer) {
-  server.registerTool(
-    'propose_plan',
-    {
-      title: 'Propose editorial plan',
-      description: 'Generate the first / a new editorial plan proposal.',
-      inputSchema: z.object({ slug }),
-      annotations: { readOnlyHint: false, destructiveHint: false },
-    },
-    async ({ slug }) => withAuth((token) => api.proposePlan(token, slug)),
-  );
-
-  server.registerTool(
-    'revise_plan',
-    {
-      title: 'Revise editorial plan',
-      description: 'Request a revision of the proposed plan with feedback.',
-      inputSchema: z.object({
-        slug,
-        feedback: z.string().min(1),
-      }),
-      annotations: { readOnlyHint: false, destructiveHint: false },
-    },
-    async ({ slug, feedback }) => withAuth((token) => api.revisePlan(token, slug, feedback)),
-  );
-
-  server.registerTool(
-    'approve_plan',
-    {
-      title: 'Approve editorial plan',
-      description: 'Approve the proposed editorial plan.',
-      inputSchema: z.object({ slug }),
-      annotations: { readOnlyHint: false, destructiveHint: true },
-    },
-    async ({ slug }) => withAuth((token) => api.approvePlan(token, slug)),
-  );
-
-  server.registerTool(
-    'discard_plan',
-    {
-      title: 'Discard editorial plan',
-      description: 'Discard the proposed editorial plan.',
-      inputSchema: z.object({ slug }),
-      annotations: { readOnlyHint: false, destructiveHint: true },
-    },
-    async ({ slug }) => withAuth((token) => api.discardPlan(token, slug)),
-  );
-
-  server.registerTool(
+          server.registerTool(
     'save_brief',
     {
       title: 'Save week brief',

--- a/cli/mcp/tools/studio.ts
+++ b/cli/mcp/tools/studio.ts
@@ -6,25 +6,7 @@ import { withAuth } from '../util.ts';
 const slug = z.string().min(1).describe('Brand URL slug');
 
 export function registerStudioTools(server: McpServer) {
-  server.registerTool(
-    'update_brand_kit',
-    {
-      title: 'Update brand kit',
-      description: 'Update brand kit fields (about, category, audience, style, language).',
-      inputSchema: z.object({
-        slug,
-        about: z.string().optional(),
-        category: z.string().optional(),
-        target_audience: z.string().optional(),
-        brand_style: z.string().optional(),
-        language: z.string().optional(),
-      }),
-      annotations: { readOnlyHint: false, destructiveHint: false },
-    },
-    async ({ slug, ...data }) => withAuth((token) => api.updateBrandKit(token, slug, data)),
-  );
-
-  server.registerTool(
+    server.registerTool(
     'set_colors',
     {
       title: 'Set brand colors',
@@ -142,24 +124,7 @@ export function registerStudioTools(server: McpServer) {
     async ({ slug, id }) => withAuth((token) => api.deletePerson(token, slug, id)),
   );
 
-  server.registerTool(
-    'add_competitor',
-    {
-      title: 'Add competitor',
-      description: 'Add a competitor to the studio.',
-      inputSchema: z.object({
-        slug,
-        name: z.string().min(1),
-        website: z.string().optional(),
-        rationale: z.string().optional(),
-      }),
-      annotations: { readOnlyHint: false, destructiveHint: false },
-    },
-    async ({ slug, name, website, rationale }) =>
-      withAuth((token) => api.addCompetitor(token, slug, { name, website, rationale })),
-  );
-
-  server.registerTool(
+    server.registerTool(
     'delete_competitor',
     {
       title: 'Delete competitor',
@@ -173,25 +138,4 @@ export function registerStudioTools(server: McpServer) {
     async ({ slug, id }) => withAuth((token) => api.deleteCompetitor(token, slug, id)),
   );
 
-  server.registerTool(
-    'research_competitors',
-    {
-      title: 'Research competitors',
-      description: 'Run AI competitor research and add findings to the studio.',
-      inputSchema: z.object({ slug }),
-      annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
-    },
-    async ({ slug }) => withAuth((token) => api.researchCompetitors(token, slug)),
-  );
-
-  server.registerTool(
-    'sync_history',
-    {
-      title: 'Sync social history',
-      description: 'Sync historical social posts into the studio.',
-      inputSchema: z.object({ slug }),
-      annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
-    },
-    async ({ slug }) => withAuth((token) => api.syncHistory(token, slug)),
-  );
-}
+    }

--- a/cli/mcp/tools/web.ts
+++ b/cli/mcp/tools/web.ts
@@ -6,50 +6,7 @@ import { resolveArticleId, withAuth } from '../util.ts';
 const slug = z.string().min(1).describe('Brand URL slug');
 
 export function registerWebTools(server: McpServer) {
-  server.registerTool(
-    'seo_action',
-    {
-      title: 'SEO action',
-      description:
-        'Run SEO actions: run (tech audit), plan, more (append initiatives), asset, article. For asset/article pass initiativeId.',
-      inputSchema: z.object({
-        slug,
-        action: z.enum(['run', 'plan', 'more', 'asset', 'article']),
-        initiativeId: z.string().optional(),
-        guidance: z.string().optional().describe('Optional guidance when action=more'),
-      }),
-      annotations: { readOnlyHint: false, destructiveHint: false },
-    },
-    async ({ slug, action, initiativeId, guidance }) =>
-      withAuth((token) => api.seoAction(token, slug, { action, initiativeId, guidance })),
-  );
-
-  server.registerTool(
-    'geo_action',
-    {
-      title: 'GEO action',
-      description: 'Run GEO citation audit or generate fix artifacts.',
-      inputSchema: z.object({
-        slug,
-        action: z.enum(['audit', 'fix']),
-      }),
-      annotations: { readOnlyHint: false, destructiveHint: false },
-    },
-    async ({ slug, action }) => withAuth((token) => api.geoAction(token, slug, action)),
-  );
-
-  server.registerTool(
-    'refresh_keywords',
-    {
-      title: 'Refresh keywords',
-      description: 'Regenerate keyword research for the brand.',
-      inputSchema: z.object({ slug }),
-      annotations: { readOnlyHint: false, destructiveHint: false },
-    },
-    async ({ slug }) => withAuth((token) => api.refreshKeywords(token, slug)),
-  );
-
-  server.registerTool(
+        server.registerTool(
     'generate_article',
     {
       title: 'Generate article',

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -11,8 +11,12 @@ import {
   LIST_WEB_FIXES,
 } from './evidence';
 import {
+  APPROVE_PLAN,
+  DISCARD_PLAN,
   PLAN_CADENCES,
   PLAN_CYCLE_WEEKS,
+  PROPOSE_PLAN,
+  REVISE_PLAN,
   SAVE_PLAN,
   SAVE_WEEK_SEEDS,
 } from './plans';
@@ -28,14 +32,19 @@ import {
 } from './posts';
 import {
   GET_ADS,
+  GET_ANALYTICS,
   GET_GEO,
+  GET_GTM,
   GET_KEYWORDS,
   GET_PLAN,
   GET_SEO,
   GET_STUDIO,
+  GET_VOICE,
   GET_WEEKLY_PLAN,
-  LIST_ARTICLES
+  LIST_ARTICLES,
+  LIST_PRODUCTS
 } from './reads';
+import { GEO_ACTION, REFRESH_KEYWORDS, SEO_ACTION } from './search';
 import {
   CREATE_SHARE,
   LIST_SHARES,
@@ -43,13 +52,18 @@ import {
   SHARED_VIEW_TYPES,
 } from './shares';
 import {
+  ADD_COMPETITOR,
   CREATE_PRODUCT,
   DELETE_PRODUCT,
   GET_BIO,
+  RESEARCH_COMPETITORS,
   SET_BIO,
+  SYNC_HISTORY,
+  UPDATE_BRAND_KIT,
   UPDATE_COMPETITOR,
   UPDATE_PERSON,
-  UPDATE_PRODUCT
+  UPDATE_PRODUCT,
+  UPDATE_VOICE
 } from './studio';
 
 export type EndpointFailure = { readonly error: string; readonly status: number };
@@ -75,6 +89,7 @@ type EndpointShape = {
   readonly output: z.ZodType;
   readonly failures: readonly EndpointFailure[];
   readonly destructive: boolean;
+  readonly openWorld?: boolean;
 };
 
 export type ResourcelessEndpoint = EndpointShape & {
@@ -90,7 +105,9 @@ export type ResourceEndpoint = EndpointShape & {
 export type BrandEndpoint = ResourcelessEndpoint | ResourceEndpoint;
 
 export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
+  ADD_COMPETITOR,
   ADS_REMIX,
+  APPROVE_PLAN,
   BILLING_PORTAL_LINK,
   CHECKOUT_LINK,
   CHECK_CONTENT,
@@ -98,37 +115,51 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   CREATE_PRODUCT,
   CREATE_SHARE,
   DELETE_PRODUCT,
+  DISCARD_PLAN,
+  GEO_ACTION,
   GET_ADS,
+  GET_ANALYTICS,
   GET_ARTICLE,
   GET_AUDIT_FINDINGS,
   GET_BIO,
   GET_CALENDAR,
   GET_CREATION_KIT,
   GET_GEO,
+  GET_GTM,
   GET_KEYWORDS,
   GET_PLAN,
   GET_POST,
   GET_SEO,
   GET_STUDIO,
+  GET_VOICE,
   GET_WEEKLY_PLAN,
   IMPORT_MEDIA_URL,
   LIST_ARTICLES,
   LIST_AUDIT_CITATIONS,
   LIST_MEDIA,
   LIST_POSTS,
+  LIST_PRODUCTS,
   LIST_SHARES,
   LIST_WEB_AUDITS,
   LIST_WEB_FIXES,
+  PROPOSE_PLAN,
+  REFRESH_KEYWORDS,
   RENDER_POST,
   RESCHEDULE_POST,
+  RESEARCH_COMPETITORS,
+  REVISE_PLAN,
   REVOKE_SHARE,
   SAVE_PLAN,
   SAVE_WEEK_SEEDS,
+  SEO_ACTION,
   SET_BIO,
+  SYNC_HISTORY,
   UPDATE_ARTICLE,
+  UPDATE_BRAND_KIT,
   UPDATE_COMPETITOR,
   UPDATE_PERSON,
   UPDATE_PRODUCT,
+  UPDATE_VOICE,
 ];
 
 export function pathFor(endpoint: ResourcelessEndpoint, slug: string): string;
@@ -176,22 +207,32 @@ export {
 } from './evidence';
 export {
   GET_ADS,
+  GET_ANALYTICS,
   GET_GEO,
+  GET_GTM,
   GET_KEYWORDS,
   GET_PLAN,
   GET_SEO,
   GET_STUDIO,
+  GET_VOICE,
   GET_WEEKLY_PLAN,
-  LIST_ARTICLES
+  LIST_ARTICLES,
+  LIST_PRODUCTS
 };
+export { GEO_ACTION, REFRESH_KEYWORDS, SEO_ACTION } from './search';
 export {
+  ADD_COMPETITOR,
   CREATE_PRODUCT,
   DELETE_PRODUCT,
   GET_BIO,
+  RESEARCH_COMPETITORS,
   SET_BIO,
+  SYNC_HISTORY,
+  UPDATE_BRAND_KIT,
   UPDATE_COMPETITOR,
   UPDATE_PERSON,
-  UPDATE_PRODUCT
+  UPDATE_PRODUCT,
+  UPDATE_VOICE
 } from './studio';
 export {
   CREATE_SHARE,
@@ -211,7 +252,16 @@ export type {
 export { KIT_FORMATS } from './creation-kit';
 export type { GetCreationKitInput, GetCreationKitResult } from './creation-kit';
 export type { CreatePostInput, CreatePostResult } from './posts';
-export { PLAN_CADENCES, PLAN_CYCLE_WEEKS, SAVE_PLAN, SAVE_WEEK_SEEDS };
+export {
+  APPROVE_PLAN,
+  DISCARD_PLAN,
+  PLAN_CADENCES,
+  PLAN_CYCLE_WEEKS,
+  PROPOSE_PLAN,
+  REVISE_PLAN,
+  SAVE_PLAN,
+  SAVE_WEEK_SEEDS
+};
 export type { SavePlanInput, SavePlanResult, SaveWeekSeedsInput, SaveWeekSeedsResult } from './plans';
 export type { CreateProductInput, CreateProductResult } from './studio';
 export type { CreateShareInput, CreateShareResult, SharedViewType } from './shares';

--- a/packages/api-contracts/src/plans.ts
+++ b/packages/api-contracts/src/plans.ts
@@ -170,3 +170,54 @@ export const SAVE_WEEK_SEEDS = {
   ],
   destructive: false
 } satisfies BrandEndpoint;
+
+const NoInput = z.object({}).strict();
+const Ok = z.object({ ok: z.literal(true) });
+
+export const PROPOSE_PLAN = {
+  tool: 'propose_plan',
+  title: 'Propose editorial plan',
+  description: 'Generate the first / a new editorial plan proposal.',
+  method: 'POST',
+  pathUnderBrand: '/editorial-plan/propose',
+  input: NoInput,
+  output: z.object({ ok: z.literal(true), plan: z.unknown() }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const REVISE_PLAN = {
+  tool: 'revise_plan',
+  title: 'Revise editorial plan',
+  description: 'Request a revision of the proposed plan with feedback.',
+  method: 'POST',
+  pathUnderBrand: '/editorial-plan/revise',
+  input: z.object({ feedback: z.string().min(1) }).strict(),
+  output: z.object({ ok: z.literal(true), plan: z.unknown() }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const APPROVE_PLAN = {
+  tool: 'approve_plan',
+  title: 'Approve editorial plan',
+  description: 'Approve the proposed editorial plan.',
+  method: 'POST',
+  pathUnderBrand: '/editorial-plan/approve',
+  input: NoInput,
+  output: Ok,
+  failures: [],
+  destructive: true
+} satisfies BrandEndpoint;
+
+export const DISCARD_PLAN = {
+  tool: 'discard_plan',
+  title: 'Discard editorial plan',
+  description: 'Discard the proposed editorial plan.',
+  method: 'POST',
+  pathUnderBrand: '/editorial-plan/discard',
+  input: NoInput,
+  output: Ok,
+  failures: [],
+  destructive: true
+} satisfies BrandEndpoint;

--- a/packages/api-contracts/src/reads.ts
+++ b/packages/api-contracts/src/reads.ts
@@ -195,3 +195,90 @@ export const LIST_ARTICLES = {
   failures: [],
   destructive: false
 } satisfies BrandEndpoint;
+
+export const GET_ANALYTICS = {
+  tool: 'get_analytics',
+  title: 'Analytics',
+  description: 'Brand analytics: totals, engagement, recent activity.',
+  method: 'GET',
+  pathUnderBrand: '/analytics',
+  input: NoInput,
+  output: z.looseObject({
+    total: z.number(),
+    scheduled: z.number(),
+    pending: z.number(),
+    failed: z.number(),
+    platforms: z.array(z.tuple([z.string(), z.number()])),
+    upcomingPosts: z.array(JsonObject),
+    recentActivity: z.array(JsonObject),
+    socialPerformance: z.array(JsonObject),
+    topPosts: z.array(JsonObject),
+    products: z.number(),
+    accounts: z.number()
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const GET_GTM = {
+  tool: 'get_gtm',
+  title: 'GTM roadmap',
+  description: 'View the go-to-market roadmap for a brand.',
+  method: 'GET',
+  pathUnderBrand: '/gtm',
+  input: NoInput,
+  output: z.object({
+    gtm: JsonObject.nullable(),
+    proposed: JsonObject.nullable(),
+    proposedFeedback: z.string().nullable(),
+    currentPhase: z.number().nullable(),
+    phaseStatuses: z.array(z.enum(['done', 'now', 'next'])),
+    horizons: z.array(z.string()),
+    studioPct: z.number()
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const GET_VOICE = {
+  tool: 'get_voice',
+  title: 'Voice rules',
+  description: 'View brand voice framework and platform rules.',
+  method: 'GET',
+  pathUnderBrand: '/voice',
+  input: NoInput,
+  output: z.object({
+    platforms: z.array(z.string()),
+    voiceMode: z.string(),
+    voiceFramework: JsonObject,
+    platformRules: z.record(z.string(), JsonObject),
+    avoid: z.array(z.string()),
+    platformInstructions: z.record(z.string(), z.string()),
+    studioPct: z.number()
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const LIST_PRODUCTS = {
+  tool: 'list_products',
+  title: 'List products',
+  description: 'List products in the brand catalog.',
+  method: 'GET',
+  pathUnderBrand: '/products',
+  input: NoInput,
+  output: z.object({
+    products: z.array(
+      z.looseObject({
+        id: z.string(),
+        title: z.string(),
+        kind: z.string(),
+        pricing: z.string().nullable(),
+        imageCount: z.number(),
+        featured: z.boolean()
+      })
+    )
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/packages/api-contracts/src/search.ts
+++ b/packages/api-contracts/src/search.ts
@@ -1,0 +1,59 @@
+import { z } from 'zod';
+import type { BrandEndpoint } from './index';
+
+export const SEO_ACTION = {
+  tool: 'seo_action',
+  title: 'SEO action',
+  description:
+    'Run SEO actions: run (tech audit), plan, more (append initiatives), asset, article. For asset/article pass initiativeId.',
+  method: 'POST',
+  pathUnderBrand: '/seo',
+  input: z
+    .object({
+      action: z.enum(['run', 'plan', 'more', 'asset', 'article']),
+      initiativeId: z.string().optional(),
+      guidance: z.string().optional().describe('Optional guidance when action=more')
+    })
+    .strict(),
+  output: z.looseObject({
+    ok: z.boolean().optional(),
+    error: z.string().optional(),
+    grade: z.string().optional(),
+    initiatives: z.number().optional(),
+    added: z.number().optional(),
+    generated: z.number().optional(),
+    articleId: z.string().optional(),
+    techScore: z.number().nullable().optional()
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const GEO_ACTION = {
+  tool: 'geo_action',
+  title: 'GEO action',
+  description: 'Run GEO citation audit or generate fix artifacts.',
+  method: 'POST',
+  pathUnderBrand: '/geo',
+  input: z.object({ action: z.enum(['audit', 'fix']) }).strict(),
+  output: z.looseObject({
+    ok: z.boolean().optional(),
+    techScore: z.number().nullable().optional(),
+    shareOfVoice: z.number().optional(),
+    generated: z.number().optional()
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const REFRESH_KEYWORDS = {
+  tool: 'refresh_keywords',
+  title: 'Refresh keywords',
+  description: 'Regenerate keyword research for the brand.',
+  method: 'POST',
+  pathUnderBrand: '/keywords',
+  input: z.object({}).strict(),
+  output: z.object({ ok: z.literal(true), keywords: z.number() }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/packages/api-contracts/src/studio.ts
+++ b/packages/api-contracts/src/studio.ts
@@ -200,3 +200,104 @@ export const SET_BIO = {
   ],
   destructive: false
 } satisfies BrandEndpoint;
+
+export const UPDATE_BRAND_KIT = {
+  tool: 'update_brand_kit',
+  title: 'Update brand kit',
+  description: 'Update brand kit fields (about, category, audience, style, language).',
+  method: 'PUT',
+  pathUnderBrand: '/studio/kit',
+  input: z
+    .object({
+      about: z.string().optional(),
+      category: z.string().optional(),
+      target_audience: z.string().optional(),
+      brand_style: z.string().optional(),
+      language: z.string().optional()
+    })
+    .strict(),
+  output: Ok,
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const UPDATE_VOICE = {
+  tool: 'update_voice',
+  title: 'Update voice',
+  description:
+    'Patch brand voice fields (mood, tone, register, avoid list, platform instructions).',
+  method: 'POST',
+  pathUnderBrand: '/voice/update',
+  input: z
+    .object({
+      mood: z.string().optional(),
+      tone: z.string().optional(),
+      register: z.number().optional(),
+      emotion: z.string().optional(),
+      character: z.string().optional(),
+      syntax: z.string().optional(),
+      avoid: z.array(z.string()).optional(),
+      platform_instructions: z.record(z.string(), z.string()).optional()
+    })
+    .strict(),
+  output: Ok,
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const ADD_COMPETITOR = {
+  tool: 'add_competitor',
+  title: 'Add competitor',
+  description: 'Add a competitor to the studio.',
+  method: 'POST',
+  pathUnderBrand: '/studio/competitors',
+  input: z
+    .object({
+      name: z.string().min(1),
+      website: z.string().optional(),
+      rationale: z.string().optional()
+    })
+    .strict(),
+  output: z.object({
+    ok: z.literal(true),
+    competitor: z.looseObject({
+      id: z.string(),
+      name: z.string(),
+      website: z.string().nullable(),
+      kind: z.string(),
+      source: z.string()
+    })
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const RESEARCH_COMPETITORS = {
+  tool: 'research_competitors',
+  title: 'Research competitors',
+  description: 'Run AI competitor research and add findings to the studio.',
+  method: 'POST',
+  pathUnderBrand: '/studio/competitors/research',
+  input: z.object({}).strict(),
+  output: z.object({ ok: z.literal(true), found: z.number(), added: z.number() }),
+  failures: [],
+  destructive: false,
+  openWorld: true
+} satisfies BrandEndpoint;
+
+export const SYNC_HISTORY = {
+  tool: 'sync_history',
+  title: 'Sync social history',
+  description: 'Sync historical social posts into the studio.',
+  method: 'POST',
+  pathUnderBrand: '/studio/history/sync',
+  input: z.object({}).strict(),
+  output: z.looseObject({
+    synced: z.number(),
+    noAccounts: z.boolean().optional(),
+    errors: z.array(z.string()).optional()
+  }),
+  failures: [],
+  destructive: false,
+  openWorld: true
+} satisfies BrandEndpoint;


### PR DESCRIPTION
## What?

Sixteen MCP tools stop being hand-written and start being generated from the endpoint registry
(`packages/api-contracts/src/`, mirrored into `cli/lib/contracts/`). Registry coverage goes from
**39 of 88 tools to 55 of 88**; hand-written drops from 49 to 33.

| group | tools |
|---|---|
| reads | `get_analytics`, `get_gtm`, `get_voice`, `list_products` |
| editorial plan | `propose_plan`, `revise_plan`, `approve_plan`, `discard_plan` |
| SEO/GEO/keywords | `seo_action`, `geo_action`, `refresh_keywords` |
| studio | `update_brand_kit`, `update_voice`, `add_competitor`, `research_competitors`, `sync_history` |

**No tool is added, removed, renamed, or loses a field.** From a client's side the only visible
change is that these sixteen now reject an undeclared input field instead of dropping it in
silence.

## Why?

Adding an endpoint currently means writing its contract three times — the route, `lib/api.ts`,
and a `server.registerTool(...)` block — and the three drift silently, because nothing compares
them. The registry is the one declaration that produces the tool; every block deleted here is
one copy that can no longer go stale.

The remaining 33 are not oversights. Each one is blocked by something specific, listed below,
and the sum is exactly 49 — the number this repo started with.

## How?

**The criterion for moving a tool is one sentence**: one call, under `/brands/:slug/`, and the
tool's input is already the route's body or query. A tool that reshapes anything before calling
— adds a literal, renames a field, resolves an id first, recomposes the response — does not
qualify, because expressing that reshape in the registry would change the tool's public shape,
which is precisely what a migration must not do.

**One field was added to the registry**: `openWorld?: boolean` on `EndpointShape`, emitted as
`openWorldHint: true`. `research_competitors` and `sync_history` declared it by hand; generating
them without it would have told clients those tools never leave Anomalia. It is the same kind of
field as `destructive`, which was already there — not a new mechanism.

`PUT` needed nothing: it entered the method union in #220, so `update_brand_kit` moved for free.

**Rejected alternative — teaching the registry to hold constant body fields.** Thirteen of the
blocked tools differ from their route only by a literal (`kind: 'real'`, `action: 'generate'`).
A `body` field on the contract, merged in but hidden from the input schema, would move all
thirteen. It was not built: it is a new mechanism serving one situation, and that situation is
that one route does five different things depending on `action`. The right fix there is to split
the route, not to teach the registry to smuggle a literal.

**A new contract file, `search.ts`**, holds `SEO_ACTION`, `GEO_ACTION`, `REFRESH_KEYWORDS` —
they are writes, and `reads.ts` (where their GET siblings live) is named for what it holds.

## Testing?

Re-run after rebasing onto `dev` at `85fd9d4`. `dev` moved twice during this work (#221 through
#237), and both times the conflict was the same one the repo documents:

```
cd cli && bun test                     →  56 pass, 0 fail (11 files)
cd cli && bun run typecheck            →  clean
npx vitest run packages/api-contracts  →  5 files, 68 tests passed
npx vitest run packages                →  34 files, 468 tests passed (pre-rebase run)
```

an alphabetically ordered union of the `BRAND_ENDPOINTS` lines (`ADS_REMIX` from #233, then
`BILLING_PORTAL_LINK`/`CHECKOUT_LINK` from #237), followed by `sync-contracts.sh` — the mirror
in `cli/lib/contracts/` is never edited by hand. After each resolution:
`grep -c 'export const BRAND_ENDPOINTS'` is **1**, the array is sorted, has no duplicates, and
holds 55 entries. The equivalence capture below was re-run from scratch against each new base
rather than reused — the numbers here are from the final one.

`bash cli/scripts/sync-contracts.sh` was re-run after every edit to
`packages/api-contracts/src/`; `cli/lib/contracts.test.ts` compares the two trees byte for byte
and is green.

### Equivalence proven, not asserted

`tools/list` was captured through `handleMcpFetch` before and after and compared field by field
across **all 88 tools** — name, title, description, property set, required set,
`additionalProperties`, annotations.

<details>
<summary>Before → after, full diff</summary>

```
before 88 after 88
added: []
removed: []
tools with any delta: 16

{"name":"add_competitor","additionalProperties":[null,false]}
{"name":"approve_plan","additionalProperties":[null,false]}
{"name":"discard_plan","additionalProperties":[null,false]}
{"name":"geo_action","additionalProperties":[null,false]}
{"name":"get_analytics","additionalProperties":[null,false],
  "annotations":[{"readOnlyHint":true},{"readOnlyHint":true,"destructiveHint":false}]}
{"name":"get_gtm","additionalProperties":[null,false],
  "annotations":[{"readOnlyHint":true},{"readOnlyHint":true,"destructiveHint":false}]}
{"name":"get_voice","additionalProperties":[null,false],
  "annotations":[{"readOnlyHint":true},{"readOnlyHint":true,"destructiveHint":false}]}
{"name":"list_products","additionalProperties":[null,false],
  "annotations":[{"readOnlyHint":true},{"readOnlyHint":true,"destructiveHint":false}]}
{"name":"propose_plan","additionalProperties":[null,false]}
{"name":"refresh_keywords","additionalProperties":[null,false]}
{"name":"research_competitors","additionalProperties":[null,false]}
{"name":"revise_plan","additionalProperties":[null,false]}
{"name":"seo_action","additionalProperties":[null,false]}
{"name":"sync_history","additionalProperties":[null,false]}
{"name":"update_brand_kit","additionalProperties":[null,false]}
{"name":"update_voice","additionalProperties":[null,false]}
```

Both deltas are the declared ones: `additionalProperties: false` because registry inputs are
`.strict()`, and `destructiveHint: false` appearing on the four reads because the generator
always emits it. `readOnlyHint` stays `true`. `research_competitors` and `sync_history` keep
`openWorldHint: true`.
</details>

The comparison lives as a test, not as a note in this description:
`cli/mcp/migrated-writes.test.ts` carries the shape each tool had **before**, captured from
`tools/list`, and fails on a rewritten description or a dropped field.
`cli/mcp/read-tools.test.ts` does the same for reads and was extended with the four new ones.
Both were watched fail first (3 failures: the two "declared in the registry" assertions and the
`additionalProperties` one) — the shape assertions passed against the hand-written tools, which
is what proves the tables are a faithful capture and not a description of the destination.

`required` is compared sorted. The registry puts `slug` last, the hand-written version put it
first; JSON Schema `required` is a set and no client can observe the difference. The first run
flagged it, and it was noise.

**Not tested**: nothing calls these sixteen endpoints for real in this PR. `callEndpoint` was
read against each `api.ts` method it replaces — same path, same verb, same body — and the one
behavioural difference found is that a POST with no input now sends `"{}"` instead of no body at
all. Every route involved (`/editorial-plan/propose|approve|discard`, `/keywords`,
`/studio/competitors/research`, `/studio/history/sync`) was checked and none of them reads the
request body.

## Evidence (screenshots/videos)

No UI. The `tools/list` diff above is the evidence, and the two test files are its permanent
form.

## Anything Else?

**The 33 that stay hand-written, and what blocks each:**

| count | blocker | tools |
|---|---|---|
| 13 | the tool's input is not the route's body: it adds a literal or renames a field | `add_note`, `add_person`, `generate_person`, `set_colors`, `save_brief`, `replan_week`, `plan_week`, `generate_article`, `optimize_article`, `publish_article`, `unpublish_article`, `delete_article`, `ads_action` |
| 4 | same, on `/posts/:id/media` — four tools that differ only by the `action` literal | `regenerate_post_media`, `regenerate_slide`, `reorder_slides`, `make_video` |
| 4 | destructive against real accounts; the `tools/list` diff proves shape, not effect | `approve_post`, `publish_post`, `reject_post`, `approve_posts` |
| 3 | not an HTTP call — they read and write `~/.config/anomalia/session.json` | `login`, `logout`, `whoami` |
| 3 | not one call: two round-trips, or a reshaped response | `get_status`, `produce_week`, `edit_post` |
| 3 | the path is not under `/brands/:slug/`, or is the brand itself | `list_brands`, `get_dashboard`, `chat` |
| 3 | `DELETE` on a `:id` resource — derivable, but **not equivalent**: the generator overrides the contract's `id` with `resourceId(resource)`, a prefix-resolved `min(1)` string, so a strict UUID on a destructive delete would become a prefix and the tool description ("by UUID") would become false | `delete_person`, `delete_competitor`, `delete_document` |

13 + 4 + 4 + 3 + 3 + 3 + 3 = **33**, and 33 + 16 = 49.

`approve_posts` is not in the three tools the brief named, but it is `approve_post` fanned out
over every pending post — same real-world effect, same missing proof — so it stays with them.

The three `DELETE`s deserve a word, because on paper they looked like the easiest group.
`delete_person` and `delete_competitor` already have their resource in `BRAND_RESOURCES` and
`delete_document` would want one new row — two lines. That is not the problem. The problem is
that the generator does not use the `id` a contract declares: it overrides it with
`resourceId(resource)`, the prefix-resolved `z.string().min(1)` that `delete_product` already
uses. Moving these three would therefore **widen three destructive deletes** from a strict UUID
to any unambiguous prefix, and make their own descriptions ("Delete a studio person by UUID.")
false.

That is worth doing — the inconsistency between `delete_product` and `delete_person` is paid by
whoever uses the tools — but it is a product decision with a public changelog, not something to
hide inside a refactor that promises to change nothing. It is written up rather than shipped
here; say the word and it is a small PR.

**No public changelog.** Name, title, description and fields are identical; a customer cannot
notice this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
