### PR TITLE
Take the produce agent off the agent framework

### DIFF
--- a/changelog/2026-09-04-produce-agent-off-the-kit.md
+++ b/changelog/2026-09-04-produce-agent-off-the-kit.md
@@ -1,0 +1,38 @@
+# Il produce agent esce dal framework, quinto dei dodici
+
+Primo file della serie con **due** giri dentro: lo scrittore (`produce`) e il giudice
+(`produce_reviewer`), che si passano il batch fino a quattro volte — scrivi, renderizza,
+fai guardare, e se il giudice dice di no si ricomincia con il suo feedback in coda alla
+stessa conversazione.
+
+Due giri vogliono due sessioni, due `logAiCall`, due tavoli di strumenti. Il framework li
+teneva insieme per conto suo; adesso lo dice il file.
+
+## Cosa nascondeva `harnessGenerateText`
+
+Le solite cinque aggiunte, le solite tre vive su `batch`. Qui il guardiano fa una cosa che
+sul week planner non poteva fare e sullo strategy agent faceva: `produce` è fra gli agenti
+che devono ancorarsi al brand prima di pagare una ricerca, quindi `search_web` non parte
+finché `read_brand_studio` non è tornato. Il giudice invece non è in quell'elenco, e la sua
+ricerca parte subito — ed è giusto, perché non ha un tavolo di letture del brand da
+chiamare prima. Due comportamenti diversi nello stesso file, tutti e due tenuti da un test.
+
+Il giudice non passava nessun `prepareStep`: era interamente del framework. Adesso sono
+quattro righe, scritte dove serve.
+
+## Il ripiego che resta per round
+
+Se kie muore, **quel round** si rifà su Gemini — non l'intero ciclo. Quindi un round
+fallito lascia due righe in `agent_sessions` (una `failed` su kie, una `finished` su llm) e
+il ciclo prosegue da lì. Era già così; adesso si vede.
+
+## L'arco che spariva
+
+Prima: `produce-agent.ts → harness/index → harness/run → chat/model` e `→ chat/controller`.
+Adesso non più da qui. Ne resta uno per `content-preview → articles → image-agent →
+harness/index`, che sparisce con l'image agent (PR #237).
+
+## Cosa non cambia
+
+Il cliente non osserva niente: stesse didascalie, stessi round, stesse righe. Nessun
+changelog pubblico.

--- a/src/lib/server/nested-agents.test.ts
+++ b/src/lib/server/nested-agents.test.ts
@@ -19,7 +19,7 @@ describe('niente agenti annidati sul GTM di produzione', () => {
 // con una riga per file fa sì che due PR in parallelo tocchino righe diverse invece della stessa.
 const LOOP_DRIVER: Record<string, 'harness' | 'sdk'> = {
 	'image-agent.ts': 'sdk',
-	'produce-agent.ts': 'harness',
+	'produce-agent.ts': 'sdk',
 	'seo-agent.ts': 'sdk',
 	'strategy-agent.ts': 'sdk',
 	'week-planner-agent.ts': 'sdk'

--- a/src/lib/server/produce-agent.loop.test.ts
+++ b/src/lib/server/produce-agent.loop.test.ts
@@ -1,0 +1,482 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+/**
+ * CARATTERIZZAZIONE DEI DUE GIRI DEL PRODUCE AGENT.
+ *
+ * Quinto dei dodici, ed è il primo con DUE giri nello stesso file: il writer (`produce`) e il
+ * giudice (`produce_reviewer`), che si passano il batch fino a quattro volte. Il metodo è lo
+ * stesso — si aggancia `generateText` dell'SDK, il confine che sopravvive alla riscrittura — ma
+ * qui il finto modello deve rispondere in modo diverso a seconda di chi lo chiama.
+ */
+
+const {
+  generateText,
+  logAiCall,
+  persistAgentRun,
+  renderPreviewImages,
+  collectBatchReviewImages,
+  groundedText,
+  loadOwnPostHistory,
+  agentSessionWrites
+} = vi.hoisted(() => ({
+  generateText: vi.fn(),
+  logAiCall: vi.fn(),
+  persistAgentRun: vi.fn(),
+  renderPreviewImages: vi.fn(),
+  collectBatchReviewImages: vi.fn(),
+  groundedText: vi.fn(),
+  loadOwnPostHistory: vi.fn(),
+  agentSessionWrites: [] as Array<Record<string, unknown>>
+}));
+
+vi.mock('$env/dynamic/private', () => ({ env: { KIE_API_KEY: 'test-kie' } }));
+
+vi.mock('ai', async () => {
+  const actual = await vi.importActual<typeof import('ai')>('ai');
+  return { ...actual, generateText };
+});
+
+vi.mock('$lib/server/llm', async () => {
+  const actual = await vi.importActual<typeof import('$lib/server/llm')>('$lib/server/llm');
+  return {
+    ...actual,
+    llmConfigured: () => true,
+    llmDefaultModel: () => 'gemini-3.7-flash',
+    llmLanguageModel: () => ({ modelId: 'gemini-3.7-flash' })
+  };
+});
+
+vi.mock('$lib/server/ai-log', async () => {
+  const actual = await vi.importActual<typeof import('$lib/server/ai-log')>('$lib/server/ai-log');
+  return { ...actual, logAiCall };
+});
+
+vi.mock('$lib/server/agent-runs', async () => {
+  const actual = await vi.importActual<typeof import('$lib/server/agent-runs')>('$lib/server/agent-runs');
+  return { ...actual, persistAgentRun };
+});
+
+vi.mock('$lib/server/kie', () => ({
+  KIE_MODEL: 'grok-4-6',
+  KIE_GROK_NO_STORE: { store: false },
+  kieFetch: () => globalThis.fetch
+}));
+
+vi.mock('$lib/server/research', async () => {
+  const actual = await vi.importActual<typeof import('$lib/server/research')>('$lib/server/research');
+  return { ...actual, groundedText };
+});
+
+vi.mock('$lib/server/own-post-history', () => ({ loadOwnPostHistory }));
+
+vi.mock('$lib/server/brand-context', () => ({
+  fetchImagePart: async () => null,
+  genaiClient: () => ({}),
+  makeGenaiClient: () => ({})
+}));
+
+vi.mock('$lib/server/market-references', () => ({
+  ensureMarketReferences: async () => [],
+  formatMarketBrief: () => 'MARKET'
+}));
+
+vi.mock('$lib/server/thematic-calendar', () => ({ upcomingTimelyHooks: async () => '' }));
+
+vi.mock('$lib/server/strategy-agent-reads', () => ({
+  readBrandStudioForAgent: async () => ({ studio: 'brand kit' }),
+  readEditorialPlanForAgent: async () => ({ plan: 'active' }),
+  readGtmForAgent: async () => ({ gtm: 'phase 1' }),
+  readKnowledgeForAgent: async () => ({ docs: [] }),
+  readLeadsForAgent: async () => ({ leads: [] }),
+  readMediaForAgent: async () => ({ media: [] }),
+  readRubricsForAgent: async () => ({ rubrics: [] }),
+  readStrategyReportForAgent: async () => ({ report: 'none' }),
+  readVisualInsightsForAgent: async () => ''
+}));
+
+vi.mock('$lib/server/supabase-admin', () => ({
+  createAdminClient: () => ({
+    from: (table: string) => ({
+      insert: (row: Record<string, unknown>) => {
+        if (table === 'agent_sessions') agentSessionWrites.push({ op: 'insert', ...row });
+        return Promise.resolve({ error: null });
+      },
+      upsert: (row: Record<string, unknown>) => {
+        if (table === 'agent_sessions') agentSessionWrites.push({ op: 'upsert', ...row });
+        return Promise.resolve({ error: null });
+      },
+      select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: null }) }) })
+    })
+  })
+}));
+
+vi.mock('$lib/server/content-preview', async () => {
+  const actual =
+    await vi.importActual<typeof import('$lib/server/content-preview')>('$lib/server/content-preview');
+  return { ...actual, renderPreviewImages, collectBatchReviewImages };
+});
+
+import { PRODUCE_AGENT_MAX_STEPS, PRODUCE_MAX_ROUNDS, runProduceAgentLoop } from './produce-agent';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyRec = Record<string, any>;
+
+function stubSupabase(): AnyRec {
+  const chain: AnyRec = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        if (prop === 'then') {
+          return (resolve: (v: unknown) => unknown) => Promise.resolve({ data: [], error: null }).then(resolve);
+        }
+        if (prop === 'maybeSingle' || prop === 'single') return async () => ({ data: null, error: null });
+        return () => chain;
+      }
+    }
+  );
+  return { from: () => chain };
+}
+
+const SEED = {
+  id: 's1',
+  platform: 'instagram',
+  platforms: ['instagram'],
+  format: 'single_image',
+  media: 'image' as const,
+  day: 'Monday',
+  time: '09:00',
+  angle: 'la ghiera che non resta ferma',
+  pillar: 'strumenti',
+  subject: 'macine',
+  setting: 'banco',
+  props: '',
+  product: '',
+  person: ''
+};
+
+const STRATEGY = {
+  theme: 'Il banco di lavoro',
+  rationale: 'Gli strumenti raccontano il mestiere',
+  doDont: 'DO concreto. DON\'T slogan.',
+  seeds: [SEED]
+};
+
+const CRAFT = {
+  index: 0,
+  caption: 'Le macine piane da 64mm, e perché la ghiera non resta mai ferma.',
+  image_prompt: 'macine in acciaio su fondo crema, risografia',
+  justification: 'lo strumento è il contenuto'
+};
+
+type ScriptedCall = { tool: string; input?: unknown };
+type TurnRecord = {
+  agent: string;
+  system: string;
+  messages: AnyRec[];
+  toolNames: string[];
+  calls: Array<{ tool: string; output: unknown }>;
+};
+
+const turns: TurnRecord[] = [];
+
+/** Un giro dell'SDK. `agent` è dedotto dal tavolo: solo il giudice ha `approve`. */
+function drive(script: ScriptedCall[], text = '') {
+  return async (options: AnyRec) => {
+    const toolNames = Object.keys(options.tools ?? {});
+    const rec: TurnRecord = {
+      agent: toolNames.includes('approve') ? 'produce_reviewer' : 'produce',
+      system: String(options.system ?? ''),
+      messages: (options.messages ?? []) as AnyRec[],
+      toolNames,
+      calls: []
+    };
+    turns.push(rec);
+
+    const steps: AnyRec[] = [];
+    for (const entry of script) {
+      await options.prepareStep?.({ stepNumber: steps.length, steps });
+
+      const impl = options.tools?.[entry.tool];
+      const output = impl ? await impl.execute(entry.input ?? {}, {}) : { error: 'no such tool' };
+      rec.calls.push({ tool: entry.tool, output });
+
+      const toolCalls = [{ toolName: entry.tool, input: entry.input ?? {}, type: 'tool-call' }];
+      const toolResults = [{ toolName: entry.tool, output, type: 'tool-result' }];
+      const usage = { inputTokens: 100, outputTokens: 40 };
+      steps.push({ toolCalls, toolResults, text: '', usage });
+      await options.onStepFinish?.({ toolCalls, toolResults, text: '', usage });
+
+      const stops = (options.stopWhen ?? []) as Array<(a: AnyRec) => boolean | Promise<boolean>>;
+      const verdicts = await Promise.all(stops.map((s) => s({ steps, stepNumber: steps.length })));
+      if (verdicts.some(Boolean)) break;
+    }
+    return {
+      text,
+      totalUsage: { inputTokens: 100 * steps.length, outputTokens: 40 * steps.length },
+      steps,
+      response: { messages: [] }
+    };
+  };
+}
+
+const writerSubmits = () =>
+  drive([
+    { tool: 'submit_batch', input: { posts: [CRAFT], batch_justification: 'crescita organica' } },
+    { tool: 'finish', input: { notes: 'fatto' } }
+  ]);
+
+const reviewerApproves = () => drive([{ tool: 'approve', input: { summary: 'buono' } }]);
+const reviewerRejects = (feedback: string) =>
+  drive([{ tool: 'request_changes', input: { summary: 'no', feedback } }]);
+
+function baseOpts(over: AnyRec = {}): AnyRec {
+  return {
+    supabase: stubSupabase(),
+    userId: 'u1',
+    brandId: 'b1',
+    profile: { name: 'Demo Brand' },
+    strategy: STRATEGY,
+    prefs: {},
+    timezone: 'Europe/Rome',
+    deadlineMs: 60_000,
+    ...over
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  turns.length = 0;
+  agentSessionWrites.length = 0;
+  renderPreviewImages.mockResolvedValue(undefined);
+  collectBatchReviewImages.mockResolvedValue([
+    { label: 'POST 0', inlineData: { mimeType: 'image/png', data: 'AAAA' } }
+  ]);
+  groundedText.mockResolvedValue({ text: 'risposta', citations: [{ uri: 'https://esempio.it/a' }] });
+  loadOwnPostHistory.mockResolvedValue([]);
+});
+
+describe('il giro completo, scritto e approvato', () => {
+  it('scrive, renderizza, fa giudicare e chiude in un round', async () => {
+    generateText.mockImplementationOnce(writerSubmits()).mockImplementationOnce(reviewerApproves());
+
+    const out = await runProduceAgentLoop(baseOpts() as never);
+
+    expect(generateText).toHaveBeenCalledTimes(2);
+    expect(turns.map((t) => t.agent)).toEqual(['produce', 'produce_reviewer']);
+    expect(renderPreviewImages).toHaveBeenCalledTimes(1);
+    expect(out?.approved).toBe(true);
+    expect(out?.rounds).toBe(1);
+    expect(out?.posts?.[0].caption).toBe(CRAFT.caption);
+  });
+
+  it('registra una corsa e logga entrambe le chiamate', async () => {
+    generateText.mockImplementationOnce(writerSubmits()).mockImplementationOnce(reviewerApproves());
+
+    await runProduceAgentLoop(baseOpts() as never);
+
+    expect(logAiCall).toHaveBeenCalledWith(expect.objectContaining({ label: 'produce-agent', context: 'produce-agent' }));
+    expect(logAiCall).toHaveBeenCalledWith(
+      expect.objectContaining({ label: 'produce-reviewer', context: 'produce-reviewer' })
+    );
+    expect(persistAgentRun).toHaveBeenCalledWith(
+      expect.objectContaining({ brandId: 'b1', agent: 'produce', finishedOk: true })
+    );
+  });
+
+  it('lascia una riga di sessione per lo scrittore e una per il giudice', async () => {
+    generateText.mockImplementationOnce(writerSubmits()).mockImplementationOnce(reviewerApproves());
+
+    await runProduceAgentLoop(baseOpts() as never);
+
+    const rows = agentSessionWrites.filter((r) => r.status === 'finished');
+    expect(rows.some((r) => r.agent === 'produce' && r.surface === 'batch')).toBe(true);
+    expect(rows.some((r) => r.agent === 'produce_reviewer' && r.surface === 'batch')).toBe(true);
+  });
+});
+
+describe('i due tavoli', () => {
+  it('lo scrittore ha submit_batch e finish, il giudice approve e request_changes', async () => {
+    generateText.mockImplementationOnce(writerSubmits()).mockImplementationOnce(reviewerApproves());
+
+    await runProduceAgentLoop(baseOpts() as never);
+
+    const writer = turns[0];
+    expect(writer.toolNames).toContain('submit_batch');
+    expect(writer.toolNames).toContain('finish');
+    expect(writer.toolNames).toContain('read_brand_studio');
+    expect(writer.toolNames).toContain('search_web');
+    expect(writer.toolNames).not.toContain('approve');
+
+    const reviewer = turns[1];
+    expect(reviewer.toolNames.sort()).toEqual(['approve', 'request_changes', 'search_web'].sort());
+  });
+
+  it('il giudice riceve ogni immagine dopo la sua etichetta', async () => {
+    generateText.mockImplementationOnce(writerSubmits()).mockImplementationOnce(reviewerApproves());
+
+    await runProduceAgentLoop(baseOpts() as never);
+
+    const content = turns[1].messages[0].content as AnyRec[];
+    expect(content[0].type).toBe('text');
+    expect(content.slice(1)).toEqual([
+      { type: 'text', text: '[POST 0]' },
+      { type: 'image', image: 'data:image/png;base64,AAAA' }
+    ]);
+  });
+
+  it('il budget delle ricerche è scritto nel system di ogni step dello scrittore', async () => {
+    let stepSystem = '';
+    generateText
+      .mockImplementationOnce(async (options: AnyRec) => {
+        stepSystem = String((await options.prepareStep?.({ stepNumber: 0, steps: [] }))?.system ?? '');
+        await options.tools.submit_batch.execute({ posts: [CRAFT], batch_justification: 'x' }, {});
+        return { text: '', totalUsage: {}, steps: [], response: { messages: [] } };
+      })
+      .mockImplementationOnce(reviewerApproves());
+
+    await runProduceAgentLoop(baseOpts() as never);
+
+    expect(stepSystem).toContain('searches_used=0/');
+    expect(stepSystem).toContain('remaining_sec≈');
+  });
+});
+
+describe('il rimpallo fra scrittore e giudice', () => {
+  it('un rifiuto rimanda allo scrittore, e la seconda approvazione chiude in due round', async () => {
+    generateText
+      .mockImplementationOnce(writerSubmits())
+      .mockImplementationOnce(reviewerRejects('gli hashtag sono generici'))
+      .mockImplementationOnce(writerSubmits())
+      .mockImplementationOnce(reviewerApproves());
+
+    const out = await runProduceAgentLoop(baseOpts() as never);
+
+    expect(generateText).toHaveBeenCalledTimes(4);
+    expect(out?.rounds).toBe(2);
+    expect(out?.approved).toBe(true);
+    expect(renderPreviewImages).toHaveBeenCalledTimes(2);
+  });
+
+  it('quattro rifiuti di fila spediscono comunque, non approvato', async () => {
+    for (let i = 0; i < PRODUCE_MAX_ROUNDS; i++) {
+      generateText.mockImplementationOnce(writerSubmits()).mockImplementationOnce(reviewerRejects('ancora no'));
+    }
+
+    const out = await runProduceAgentLoop(baseOpts() as never);
+
+    expect(out?.rounds).toBe(PRODUCE_MAX_ROUNDS);
+    expect(out?.approved).toBe(false);
+    expect(out?.posts).toHaveLength(1);
+  });
+
+  it('uno scrittore che non consegna fa ripiegare sul percorso legacy', async () => {
+    generateText.mockImplementationOnce(drive([{ tool: 'read_brand_studio', input: {} }]));
+
+    const out = await runProduceAgentLoop(baseOpts() as never);
+
+    expect(out).toBeNull();
+    expect(renderPreviewImages).not.toHaveBeenCalled();
+  });
+
+  it('un giudice senza verdetto esplicito approva, per non bloccare il batch', async () => {
+    generateText
+      .mockImplementationOnce(writerSubmits())
+      .mockImplementationOnce(drive([{ tool: 'search_web', input: { query: 'x' } }], 'niente da dire'));
+
+    const out = await runProduceAgentLoop(baseOpts() as never);
+
+    expect(out?.approved).toBe(true);
+    expect(out?.reviewSummary).toBe('niente da dire');
+  });
+});
+
+describe('il ripiego di provider', () => {
+  it('se kie muore lo scrittore rifà il round su Gemini', async () => {
+    generateText
+      .mockImplementationOnce(async () => {
+        throw new Error('kie out of credits');
+      })
+      .mockImplementationOnce(writerSubmits())
+      .mockImplementationOnce(reviewerApproves());
+
+    const out = await runProduceAgentLoop(baseOpts() as never);
+
+    expect(generateText).toHaveBeenCalledTimes(3);
+    expect(out?.approved).toBe(true);
+    const rows = agentSessionWrites.filter((r) => r.agent === 'produce');
+    expect(rows.some((r) => r.status === 'failed' && r.provider === 'kie')).toBe(true);
+    expect(rows.some((r) => r.status === 'finished' && r.provider === 'llm')).toBe(true);
+  });
+});
+
+describe('i tetti', () => {
+  it('lo scrittore si ferma al tetto degli step', async () => {
+    const script = Array.from({ length: PRODUCE_AGENT_MAX_STEPS + 5 }, (_, i) => ({
+      tool: 'read_knowledge',
+      input: { limit: (i % 20) + 1 }
+    }));
+    generateText.mockImplementationOnce(drive(script));
+
+    const out = await runProduceAgentLoop(baseOpts() as never);
+
+    expect(out).toBeNull();
+    expect(turns[0].calls.length).toBeLessThanOrEqual(PRODUCE_AGENT_MAX_STEPS);
+  });
+});
+
+describe('il guardiano di sessione, che il framework applicava in silenzio', () => {
+  // `produce` è fra gli agenti che devono ancorarsi al brand prima di pagare una ricerca:
+  // `search_web` non parte finché `read_brand_studio` non è tornato.
+  it('non lascia partire una ricerca a pagamento prima che il brand sia stato letto', async () => {
+    generateText.mockImplementationOnce(
+      drive([
+        { tool: 'search_web', input: { query: 'subito al web' } },
+        { tool: 'submit_batch', input: { posts: [CRAFT], batch_justification: 'x' } },
+        { tool: 'finish', input: { notes: 'ok' } }
+      ])
+    ).mockImplementationOnce(reviewerApproves());
+
+    await runProduceAgentLoop(baseOpts() as never);
+
+    expect(groundedText).not.toHaveBeenCalled();
+    expect(turns[0].calls[0].output).toMatchObject({
+      blocked_by: 'steward',
+      code: 'search_before_brand',
+      ran: false,
+      next_tool: 'read_brand_studio'
+    });
+  });
+
+  it('dopo la lettura del brand la ricerca parte', async () => {
+    generateText.mockImplementationOnce(
+      drive([
+        { tool: 'read_brand_studio', input: {} },
+        { tool: 'search_web', input: { query: 'adesso sì' } },
+        { tool: 'submit_batch', input: { posts: [CRAFT], batch_justification: 'x' } },
+        { tool: 'finish', input: { notes: 'ok' } }
+      ])
+    ).mockImplementationOnce(reviewerApproves());
+
+    await runProduceAgentLoop(baseOpts() as never);
+
+    expect(groundedText).toHaveBeenCalledTimes(1);
+  });
+
+  // Il giudice NON è fra quegli agenti: la sua ricerca parte subito, ed è giusto così — non ha
+  // un tavolo di letture del brand da chiamare prima.
+  it('il giudice può cercare subito', async () => {
+    generateText
+      .mockImplementationOnce(writerSubmits())
+      .mockImplementationOnce(
+        drive([
+          { tool: 'search_web', input: { query: 'verifica' } },
+          { tool: 'approve', input: { summary: 'ok' } }
+        ])
+      );
+
+    await runProduceAgentLoop(baseOpts() as never);
+
+    expect(groundedText).toHaveBeenCalledTimes(1);
+    expect(turns[1].calls[0].output).not.toMatchObject({ blocked_by: 'steward' });
+  });
+});

--- a/src/lib/server/produce-agent.ts
+++ b/src/lib/server/produce-agent.ts
@@ -8,7 +8,11 @@ import {
   type LanguageModel,
   type ModelMessage
 } from 'ai';
-import { harnessGenerateText } from '$lib/server/harness';
+import { generateText } from 'ai';
+import { createHarnessSession } from '$lib/server/harness/session';
+import { persistHarnessSession } from '$lib/server/harness/persist';
+import { wrapTools } from '$lib/server/harness/pipeline';
+import { applyStewardPrepareStep, createSessionSteward } from '$lib/server/harness/steward';
 import { z } from 'zod';
 import { env } from '$env/dynamic/private';
 import { fetchImagePart } from '$lib/server/brand-context';
@@ -657,22 +661,29 @@ ${CAPTION_FAILURE_MODES}
 ${ownerEditPairsBlock(opts.prefs)}${winners}${visuals}Seeds (${opts.strategy.seeds.length}):
 ${seedBrief(opts.strategy)}`;
 
+  const session = createHarnessSession({
+    brandId: opts.brandId,
+    userId: opts.userId,
+    agent: 'produce',
+    mode: opts.provider,
+    model: opts.modelId,
+    provider: opts.provider,
+    surface: 'batch'
+  });
+  session.captureRequest({ system: baseSystem, messages: opts.messages });
+
+  const steward = createSessionSteward(session, Object.keys(tools));
+  const watchedTools = wrapTools(session, tools, steward.pipeline());
+
   let result;
   try {
-    result = await harnessGenerateText({
-      brandId: opts.brandId,
-      userId: opts.userId,
-      agent: 'produce',
-      mode: opts.provider,
-      model: opts.modelId,
-      provider: opts.provider,
-      surface: 'batch'
-    }, {
+    result = await generateText({
       model: opts.model,
       maxOutputTokens: maxOutputTokensFor(opts.provider),
       system: baseSystem,
       messages: opts.messages,
-      tools,
+      allowSystemInMessages: true,
+      tools: watchedTools,
       stopWhen: [hasToolCall('finish'), stepCountIs(PRODUCE_AGENT_MAX_STEPS)],
       // Su kie/Grok la temperatura non arriva comunque: `forceReasoning` (dentro KIE_GROK_NO_STORE)
       // la toglie dalla richiesta, ed è un bene misurato — il campionamento di default di kie/Grok
@@ -682,11 +693,16 @@ ${seedBrief(opts.strategy)}`;
       providerOptions: opts.provider === 'kie' ? { openai: { ...KIE_GROK_NO_STORE } } : undefined,
       prepareStep: () => {
         const remaining = Math.max(0, Math.round((opts.deadlineMs - (Date.now() - t0)) / 1000));
-        return {
+        const step = {
           system: `${baseSystem}\n\n[budget] searches_used=${searches}/${SEARCH_BUDGET}; submitted=${!!submitted.current}; remaining_sec≈${remaining}`
         };
+        const patched = applyStewardPrepareStep(session, steward, step, baseSystem) ?? {};
+        session.capturePrepareStep(patched);
+        return patched;
       },
-      onStepFinish: ({ toolCalls, toolResults, text }) => {
+      onStepFinish: (event) => {
+        session.recordStep(event);
+        const { toolCalls, toolResults, text } = event;
         steps.push({
           step: steps.length + 1,
           toolCalls: toolCalls?.map((c) => ({ name: c.toolName, input: c.input })),
@@ -698,7 +714,14 @@ ${seedBrief(opts.strategy)}`;
         });
       }
     });
+    session.recordAssistantText(result.text);
+    session.recordUsage(result.totalUsage ?? result.usage);
+    session.finish('finished');
+  } catch (e) {
+    session.finish('failed', e);
+    throw e;
   } finally {
+    persistHarnessSession(session);
     logAiCall({
       label: 'produce-agent',
       provider: opts.provider,
@@ -833,6 +856,7 @@ Rendered images (if any) follow this text. Labels (POST i / POST i slide j) are 
 Approve only if these assets would help the brand grow organically AND pass hashtag/Reddit hygiene; otherwise request_changes with concrete feedback.`;
 
   let result;
+  let session: ReturnType<typeof createHarnessSession> | undefined;
   try {
     const imageContent: Array<
       { type: 'text'; text: string } | { type: 'image'; image: string }
@@ -844,7 +868,8 @@ Approve only if these assets would help the brand grow organically AND pass hash
         image: `data:${p.inlineData.mimeType};base64,${p.inlineData.data}`
       });
     }
-    result = await harnessGenerateText({
+    const messages = [{ role: 'user' as const, content: imageContent }];
+    session = createHarnessSession({
       brandId: opts.brandId,
       userId: opts.userId,
       agent: 'produce_reviewer',
@@ -852,17 +877,25 @@ Approve only if these assets would help the brand grow organically AND pass hash
       model: opts.modelId,
       provider: opts.provider,
       surface: 'batch'
-    }, {
+    });
+    session.captureRequest({ system: REVIEWER_SYSTEM, messages });
+
+    const steward = createSessionSteward(session, Object.keys(tools));
+    const watchedTools = wrapTools(session, tools, steward.pipeline());
+    const reviewerSession = session;
+
+    result = await generateText({
       model: opts.model,
       maxOutputTokens: maxOutputTokensFor(opts.provider),
       system: REVIEWER_SYSTEM,
-      messages: [
-        {
-          role: 'user',
-          content: imageContent
-        }
-      ],
-      tools,
+      messages,
+      allowSystemInMessages: true,
+      tools: watchedTools,
+      prepareStep: () => {
+        const patched = applyStewardPrepareStep(reviewerSession, steward, {}, REVIEWER_SYSTEM) ?? {};
+        reviewerSession.capturePrepareStep(patched);
+        return patched;
+      },
       stopWhen: [
         hasToolCall('approve'),
         hasToolCall('request_changes'),
@@ -875,7 +908,9 @@ Approve only if these assets would help the brand grow organically AND pass hash
       // giudizio: il verdetto è ancorato alle immagini e alle regole, non alla temperatura.
       temperature: opts.provider === 'kie' ? undefined : 0.3,
       providerOptions: opts.provider === 'kie' ? { openai: { ...KIE_GROK_NO_STORE } } : undefined,
-      onStepFinish: ({ toolCalls, toolResults, text }) => {
+      onStepFinish: (event) => {
+        reviewerSession.recordStep(event);
+        const { toolCalls, toolResults, text } = event;
         steps.push({
           step: steps.length + 1,
           toolCalls: toolCalls?.map((c) => ({ name: c.toolName, input: c.input })),
@@ -884,7 +919,14 @@ Approve only if these assets would help the brand grow organically AND pass hash
         });
       }
     });
+    session.recordAssistantText(result.text);
+    session.recordUsage(result.totalUsage ?? result.usage);
+    session.finish('finished');
+  } catch (e) {
+    session?.finish('failed', e);
+    throw e;
   } finally {
+    if (session) persistHarnessSession(session);
     logAiCall({
       label: 'produce-reviewer',
       provider: opts.provider,


### PR DESCRIPTION
## What?

The produce agent — the writer/reviewer pair that turns approved seeds into captions and image
briefs — no longer runs its loops through the agent framework. Both call `generateText` from the
AI SDK directly, and the three things `harnessGenerateText` was silently adding on a batch surface
are written at each call site.

Fifth of twelve, same shape as #224, #231, #232 (merged) and #237. This is the **first file with
two loops in it**, and it holds without changing the recipe.

15 characterization tests were written **against the existing framework implementation** and
watched pass before anything moved. They hook `generateText`, not the wrapper, so the same tests
grade both. They pass on both.

`packages/agent-*` is untouched.

## Why?

`packages/agent-*` (105,226 lines), `src/lib/agent` (23,909) and `src/lib/server/chat` (32,031)
are slated for deletion — about 31% of the repository. Deletion is blocked by whoever still
imports the framework.

The produce agent is on the weekly autopilot's critical path: it is what actually writes the
captions a customer approves. It was named in the original brief as one of the two natural first
cuts; it comes fifth instead because the four before it established the pattern on simpler shapes,
and this one has two loops, a per-round provider retry and a four-round writer↔reviewer bounce.

## How?

### What the orchestrator does

Up to four rounds. Each round: the **writer** researches (twelve free brand reads plus a budgeted
`search_web`), calls `submit_batch` with one craft per seed, and `finish`es. The crafts become
posts, the images are rendered, and the **reviewer** looks at captions and rendered images
together and calls `approve` or `request_changes`. A rejection appends the feedback to the same
conversation and goes round again. Four rejections and the batch ships unapproved; a writer that
never submits returns `null` and the caller falls back to the legacy path.

### What the framework was hiding

The same five additions; on `batch` three are live and two are declared `surface === 'chat'`.

The reviewer passed **no** `prepareStep` at all — it was entirely the wrapper's. That is precisely
the control flow this series exists to make visible; it is four lines now, where the loop is.

The steward is carried because it does **two different things in this one file**:

- `produce` is in the framework's grounding list, so the writer's `search_web` does not leave the
  building until `read_brand_studio` has returned. The model gets `blocked_by: 'steward'`,
  `next_tool: 'read_brand_studio'`, never `{ error }` — an error reads as an outage and gets
  retried, and a retried paid search costs money.
- `produce_reviewer` is **not** in that list, so the reviewer may search immediately. Correct: it
  has no brand-read table to call first.

Two tests hold the first, one holds the second. Had the steward been dropped, the writer would
start paying for searches before reading the brand and nothing would have failed.

### The retry is per round, not per cycle

A kie failure re-runs **that round** on Gemini, so a failed round leaves two `agent_sessions` rows
(one `failed` on kie, one `finished` on llm) and the cycle continues. That was already true; now
the file says so.

### Where the transcript comes from now

`harness/session`, `harness/persist`, `harness/pipeline` and `harness/steward` — 1,030 lines —
import neither chat nor `$lib/agent`. `harness/index` does, because it re-exports `harness/run`.

### Commits

1. `8c109bd` — the 15 characterization tests, passing against the framework implementation.
2. the rewrite of both loops plus the `LOOP_DRIVER` row flip (one line).
3. the internal changelog.

## Testing?

Targeted only. The full suite and Playwright are delegated to CI. `npm run check` was not run: no
`.svelte` file and no shared type is touched.

```
$ npx vitest run src/lib/server/nested-agents.test.ts \
    src/lib/server/produce-agent.loop.test.ts \
    src/lib/server/produce-agent.test.ts \
    src/lib/server/produce-approved.test.ts

 Test Files  4 passed (4)
      Tests  38 passed (38)
```

The 15 loop tests were run against the previous implementation first, at commit `8c109bd`, before
the rewrite existed:

```
 ✓ src/lib/server/produce-agent.loop.test.ts (15 tests)
 Test Files  1 passed (1)
      Tests  15 passed (15)
```

Reproducible: `git checkout 8c109bd && npx vitest run src/lib/server/produce-agent.loop.test.ts`.

### What the 15 pin

The full round — write, render, review, close; the two tool tables and that only the reviewer
holds `approve`/`request_changes`; the reviewer's multimodal message with each image after its
label; the search budget written into the writer's per-step system; a rejection sending the batch
back for a second round (and a second render); four rejections shipping anyway, unapproved; a
writer that never submits returning `null` without rendering anything; a reviewer with no explicit
verdict approving so the batch is never blocked forever; the kie→Gemini retry of a single round
with its two session rows; the step cap; and the three steward tests above.

### Schema

No new enum-ish value is written — `agent: 'produce'` / `'produce_reviewer'`, `surface: 'batch'`,
`mode` = the provider, and the status vocabulary all come through unchanged code. `agent_sessions`
and `agent_runs` carry **no CHECK constraints** (checked against the live schema, `pg_constraint`
with `contype = 'c'` → 0 rows on both).

### Not tested, and why

- **No live run for this one.** #224's rewrite was exercised end to end against the local stack
  with a real model, before and after; this is the same transformation applied to a fifth file,
  and the machine is in swap.
- **`npm run eval:durability` was not run** — real money, unreliable bench today. It should be run
  before the series is considered finished, and this orchestrator is the strongest argument for
  it: it persists work across four rounds.

<details>
<summary>Import graph, measured (transitive BFS, 219 modules visited)</summary>

**Before**: `produce-agent.ts -> harness/index.ts -> harness/run.ts -> chat/model.ts` (and
`chat/controller.ts`, and through it `$lib/agent/bridge/verdict`).

**After**: that edge is gone. One indirect path remains, and it is #237's to close:

```
produce-agent.ts -> content-preview.ts -> content-preview/articles.ts -> image-agent.ts -> harness/index.ts -> ...
```

Plus the usual infrastructure chains through `credits → scheduler → agent-turns → chat/queue` and
`brand-context → design-* → motion-video → chat/artifacts`, unrelated to the framework.
</details>

## Anything Else?

- **Series status.** Merged: week planner (#224), strategy agent (#231), Director (#232). Open:
  image agent (#237), produce agent (this). Still on the framework: `seo-agent.ts`,
  `analytics-review-agent.ts`, `media-generator/agent.ts`, `media-generator/ugc-agent.ts`,
  `media-generator/ugc-plan-agent.ts`, `motion-video/agent.ts`, `sandbox.ts` — plus
  `agent-base.ts`, `craft-model.ts`, `harness-skills.ts`, `agent-kit-effects-store.ts` and chat.

- **`nested-agents.test.ts` is a one-line change.** The `LOOP_DRIVER` table introduced in #231
  exists so the twelve PRs in this series stop queueing on the same line; it has now paid for
  itself three times on rebase.

- **Two of the rest are a different shape.** `media-generator/agent.ts` and
  `motion-video/agent.ts` use `harnessStreamText`, where the wrapper installs
  `onFinish`/`onError`/`onAbort` and snapshots the request *before* the stream starts. Those need
  their own reading.

- **No public changelog**, deliberately. Same captions, same rounds, same rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
