### PR TITLE
Take the SEO agent off the agent framework

### DIFF
--- a/changelog/2026-09-04-seo-agent-off-the-kit.md
+++ b/changelog/2026-09-04-seo-agent-off-the-kit.md
@@ -1,0 +1,26 @@
+# Il SEO agent esce dal framework, sesto dei dodici
+
+Sesto giro, stessa ricetta, nessuna variazione: `harnessGenerateText` via, `generateText`
+dell'SDK al suo posto, e le tre aggiunte vive su `batch` — traccia di sessione, guardiano,
+toppa al system di ogni step — scritte dove il giro succede.
+
+Una particolarità che vale la pena scrivere: **questo agente non solleva mai.** Se il
+modello esplode, il `catch` registra il fallimento e la funzione torna `null`, perché una
+review SEO che fallisce non deve portarsi dietro chi l'ha chiamata. La riscrittura non lo
+tocca, ma adesso si vede che la sessione viene chiusa come `failed` e salvata prima che
+quel `catch` faccia il suo lavoro.
+
+Il guardiano resta per la regola che qui morde: gli strumenti `dfs_*` sono ricerche a
+pagamento, e due fallimenti di fila sullo stesso strumento lo tolgono dal tavolo. `seo` non
+è fra gli agenti che devono ancorarsi al brand prima di cercare — non ha un tavolo di
+letture del brand da chiamare — quindi quella regola qui non si applica, ed è giusto così.
+
+## L'arco che spariva
+
+Prima: `seo-agent.ts → harness/index → harness/run → chat/model` e `→ chat/controller`.
+Adesso non più da qui.
+
+## Cosa non cambia
+
+Il cliente non osserva niente: stessa valutazione, stesse iniziative, stesse righe. Nessun
+changelog pubblico.

--- a/src/lib/server/nested-agents.test.ts
+++ b/src/lib/server/nested-agents.test.ts
@@ -20,6 +20,7 @@ describe('niente agenti annidati sul GTM di produzione', () => {
 const LOOP_DRIVER: Record<string, 'harness' | 'sdk'> = {
 	'image-agent.ts': 'harness',
 	'produce-agent.ts': 'harness',
+	'seo-agent.ts': 'sdk',
 	'strategy-agent.ts': 'sdk',
 	'week-planner-agent.ts': 'sdk'
 };

--- a/src/lib/server/seo-agent.loop.test.ts
+++ b/src/lib/server/seo-agent.loop.test.ts
@@ -284,3 +284,18 @@ describe('il budget scritto nel system di ogni step', () => {
     expect(String(rec.prepared[0].system)).toContain('time_left≈');
   });
 });
+
+// `harness/index` riesporta `harness/run`, che importa `chat/model` e `chat/controller`: chi
+// prende la traccia dall'indice si porta dentro la chat e `$lib/agent` senza usarli. I moduli
+// foglia non li toccano, e questo test è l'unica cosa che impedisce di «riordinare» l'import.
+describe('da dove arriva la traccia', () => {
+  it('il seo agent guida l SDK e non passa dall indice del framework', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { join } = await import('node:path');
+    const src = readFileSync(join(process.cwd(), 'src/lib/server/seo-agent.ts'), 'utf8');
+    expect(src).toMatch(/await generateText\(/);
+    expect(src).not.toContain('harnessGenerateText(');
+    expect(src).not.toMatch(/from '\$lib\/server\/harness'/);
+    expect(src).toMatch(/from '\$lib\/server\/harness\/session'/);
+  });
+});

--- a/src/lib/server/seo-agent.loop.test.ts
+++ b/src/lib/server/seo-agent.loop.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+/**
+ * CARATTERIZZAZIONE DEL GIRO DEL SEO AGENT.
+ *
+ * Sesto dei dodici, stesso metodo: si aggancia `generateText` dell'SDK, il confine che
+ * sopravvive alla riscrittura, e si fissa il comportamento di oggi prima di toccarlo.
+ */
+
+const { generateText, logAiCall, persistAgentRun, fetchUsdBudget, agentSessionWrites } = vi.hoisted(
+  () => ({
+    generateText: vi.fn(),
+    logAiCall: vi.fn(),
+    persistAgentRun: vi.fn(),
+    fetchUsdBudget: vi.fn(),
+    agentSessionWrites: [] as Array<Record<string, unknown>>
+  })
+);
+
+vi.mock('$env/dynamic/private', () => ({ env: {} }));
+
+vi.mock('ai', async () => {
+  const actual = await vi.importActual<typeof import('ai')>('ai');
+  return { ...actual, generateText };
+});
+
+vi.mock('$lib/server/llm', async () => {
+  const actual = await vi.importActual<typeof import('$lib/server/llm')>('$lib/server/llm');
+  return {
+    ...actual,
+    llmDefaultModel: () => 'gemini-3.7-flash',
+    llmLanguageModel: () => ({ modelId: 'gemini-3.7-flash' })
+  };
+});
+
+vi.mock('$lib/server/ai-log', async () => {
+  const actual = await vi.importActual<typeof import('$lib/server/ai-log')>('$lib/server/ai-log');
+  return { ...actual, logAiCall };
+});
+
+vi.mock('$lib/server/agent-runs', () => ({ persistAgentRun }));
+
+vi.mock('$lib/server/strategy-agent', async () => {
+  const actual = await vi.importActual<typeof import('$lib/server/strategy-agent')>('$lib/server/strategy-agent');
+  return { ...actual, fetchUsdBudget };
+});
+
+vi.mock('$lib/server/dataforseo-tools', () => ({ createDataForSeoTools: () => ({}) }));
+
+vi.mock('$lib/server/seo-metrics', () => ({ buildSeoMetrics: async () => ({ metrics: 'none' }) }));
+
+vi.mock('$lib/server/supabase-admin', () => ({
+  createAdminClient: () => ({
+    from: (table: string) => ({
+      insert: (row: Record<string, unknown>) => {
+        if (table === 'agent_sessions') agentSessionWrites.push({ op: 'insert', ...row });
+        return Promise.resolve({ error: null });
+      },
+      upsert: (row: Record<string, unknown>) => {
+        if (table === 'agent_sessions') agentSessionWrites.push({ op: 'upsert', ...row });
+        return Promise.resolve({ error: null });
+      },
+      select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: null }) }) })
+    })
+  })
+}));
+
+import { MAX_SEO_AGENT_STEPS, runSeoAgent, seoAgentEnabled } from './seo-agent';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyRec = Record<string, any>;
+
+function stubSupabase(): AnyRec {
+  const chain: AnyRec = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        if (prop === 'then') {
+          return (resolve: (v: unknown) => unknown) => Promise.resolve({ data: [], error: null }).then(resolve);
+        }
+        if (prop === 'maybeSingle' || prop === 'single') return async () => ({ data: null, error: null });
+        return () => chain;
+      }
+    }
+  );
+  return { from: () => chain };
+}
+
+const FINISH_INPUT = {
+  notes: 'Grounded in the latest audit.',
+  evaluation: { grade: 'B', summary: 'Solid base', strengths: ['brand'], weaknesses: ['thin pages'] },
+  initiatives: [
+    {
+      type: 'blog' as const,
+      title: 'Come si regola la macina',
+      targetQuery: 'regolare macina espresso',
+      rationale: 'query reale, zero copertura',
+      effort: 'low' as const,
+      impact: 'high' as const
+    }
+  ]
+};
+
+type ScriptedCall = { tool: string; input?: unknown };
+type DriveRecord = {
+  prepared: AnyRec[];
+  calls: Array<{ tool: string; output: unknown }>;
+  system: string;
+  prompt: string;
+  toolNames: string[];
+};
+
+function drive(script: ScriptedCall[], record: DriveRecord) {
+  return async (options: AnyRec) => {
+    record.system = String(options.system ?? '');
+    record.prompt = String(options.prompt ?? '');
+    record.toolNames = Object.keys(options.tools ?? {});
+
+    const steps: AnyRec[] = [];
+    for (const entry of script) {
+      const prepared = (await options.prepareStep?.({ stepNumber: steps.length, steps })) ?? {};
+      record.prepared.push(prepared);
+
+      const impl = options.tools?.[entry.tool];
+      const output = impl ? await impl.execute(entry.input ?? {}, {}) : { error: 'no such tool' };
+      record.calls.push({ tool: entry.tool, output });
+
+      const toolCalls = [{ toolName: entry.tool, input: entry.input ?? {}, type: 'tool-call' }];
+      const toolResults = [{ toolName: entry.tool, output, type: 'tool-result' }];
+      const usage = { inputTokens: 100, outputTokens: 40 };
+      steps.push({ toolCalls, toolResults, text: '', usage });
+      await options.onStepFinish?.({ toolCalls, toolResults, text: '', usage });
+
+      const stops = (options.stopWhen ?? []) as Array<(a: AnyRec) => boolean | Promise<boolean>>;
+      const verdicts = await Promise.all(stops.map((s) => s({ steps, stepNumber: steps.length })));
+      if (verdicts.some(Boolean)) break;
+    }
+    return { text: '', totalUsage: { inputTokens: 100 * steps.length, outputTokens: 40 * steps.length }, steps };
+  };
+}
+
+function baseOpts(over: AnyRec = {}): AnyRec {
+  return {
+    supabase: stubSupabase(),
+    brand: { id: 'b1', name: 'Demo Brand', website: 'https://demo.example' },
+    deadlineMs: 60_000,
+    ...over
+  };
+}
+
+function newRecord(): DriveRecord {
+  return { prepared: [], calls: [], system: '', prompt: '', toolNames: [] };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  agentSessionWrites.length = 0;
+  fetchUsdBudget.mockResolvedValue(5);
+});
+
+describe('acceso di default', () => {
+  it('si spegne solo con SEO_AGENT_ENABLED=false', () => {
+    expect(seoAgentEnabled()).toBe(true);
+  });
+});
+
+describe('il tavolo dei tool offerto al modello', () => {
+  it('è esattamente questo elenco, più quelli di DataForSEO', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(drive([{ tool: 'finish', input: FINISH_INPUT }], rec));
+
+    await runSeoAgent(baseOpts() as never);
+
+    expect(rec.toolNames.sort()).toEqual(
+      ['finish', 'read_existing_plan', 'read_gsc_summary', 'read_latest_audit', 'read_seo_metrics'].sort()
+    );
+  });
+
+  it('il prompt cambia col modo: `more` chiede iniziative nuove e distinte', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(drive([{ tool: 'finish', input: FINISH_INPUT }], rec));
+
+    await runSeoAgent(baseOpts({ mode: 'more', count: 4 }) as never);
+
+    expect(rec.prompt).toContain('4 NEW initiatives distinct from the existing plan');
+  });
+
+  it('in modo `plan` chiede una valutazione aggiornata', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(drive([{ tool: 'finish', input: FINISH_INPUT }], rec));
+
+    await runSeoAgent(baseOpts() as never);
+
+    expect(rec.prompt).toContain('updated evaluation and prioritized initiatives');
+  });
+});
+
+describe('il percorso che chiude', () => {
+  it('finish restituisce valutazione e iniziative normalizzate', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(
+      drive([{ tool: 'read_latest_audit', input: {} }, { tool: 'finish', input: FINISH_INPUT }], rec)
+    );
+
+    const out = await runSeoAgent(baseOpts() as never);
+
+    expect(generateText).toHaveBeenCalledTimes(1);
+    expect(out?.evaluation.grade).toBe('B');
+    expect(out?.initiatives).toHaveLength(1);
+    expect(out?.initiatives[0].targetQuery).toBe('regolare macina espresso');
+    expect(rec.calls[1].output).toMatchObject({ ok: true });
+  });
+
+  it('registra la corsa come `finished` e logga la chiamata riuscita', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(drive([{ tool: 'finish', input: FINISH_INPUT }], rec));
+
+    await runSeoAgent(baseOpts() as never);
+
+    expect(persistAgentRun).toHaveBeenCalledWith(
+      expect.objectContaining({ brandId: 'b1', agent: 'seo', mode: 'plan', status: 'finished', finishedOk: true })
+    );
+    expect(logAiCall).toHaveBeenCalledWith(expect.objectContaining({ label: 'seoAgent', ok: true }));
+  });
+
+  it('lascia una riga di sessione leggibile su agent_sessions', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(drive([{ tool: 'finish', input: FINISH_INPUT }], rec));
+
+    await runSeoAgent(baseOpts() as never);
+
+    const finishedRow = agentSessionWrites.find((r) => r.status === 'finished');
+    expect(finishedRow).toMatchObject({ agent: 'seo', surface: 'batch', brand_id: 'b1', mode: 'plan' });
+  });
+});
+
+describe('quando non chiude', () => {
+  it('senza finish la corsa è fallita e non torna niente', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(drive([{ tool: 'read_latest_audit', input: {} }], rec));
+
+    const out = await runSeoAgent(baseOpts() as never);
+
+    expect(out).toBeNull();
+    expect(persistAgentRun).toHaveBeenCalledWith(
+      expect.objectContaining({ agent: 'seo', status: 'failed', finishedOk: false })
+    );
+    expect(logAiCall).toHaveBeenCalledWith(expect.objectContaining({ label: 'seoAgent', ok: false }));
+  });
+
+  it('un modello che esplode non propaga: la corsa torna null', async () => {
+    generateText.mockImplementation(async () => {
+      throw new Error('gateway giù');
+    });
+
+    const out = await runSeoAgent(baseOpts() as never);
+
+    expect(out).toBeNull();
+    expect(logAiCall).toHaveBeenCalledWith(expect.objectContaining({ label: 'seoAgent', ok: false, error: 'gateway giù' }));
+  });
+
+  it('si ferma al tetto degli step', async () => {
+    const rec = newRecord();
+    const script = Array.from({ length: MAX_SEO_AGENT_STEPS + 5 }, (_, i) => ({
+      tool: 'read_seo_metrics',
+      input: { note: `giro ${i}` }
+    }));
+    generateText.mockImplementation(drive(script, rec));
+
+    await runSeoAgent(baseOpts() as never);
+
+    expect(rec.calls.length).toBeLessThanOrEqual(MAX_SEO_AGENT_STEPS);
+  });
+});
+
+describe('il budget scritto nel system di ogni step', () => {
+  it('porta i contatori e il tempo che resta', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(drive([{ tool: 'finish', input: FINISH_INPUT }], rec));
+
+    await runSeoAgent(baseOpts() as never);
+
+    expect(String(rec.prepared[0].system)).toContain('usd_remaining≈');
+    expect(String(rec.prepared[0].system)).toContain('time_left≈');
+  });
+});

--- a/src/lib/server/seo-agent.ts
+++ b/src/lib/server/seo-agent.ts
@@ -1,7 +1,10 @@
 import { swallow } from '$lib/server/swallow';
 import { maxOutputTokensFor } from '$lib/server/ai-output-limits';
-import { tool, stepCountIs, hasToolCall, type StopCondition } from 'ai';
-import { harnessGenerateText } from '$lib/server/harness';
+import { generateText, tool, stepCountIs, hasToolCall, type StopCondition } from 'ai';
+import { createHarnessSession } from '$lib/server/harness/session';
+import { persistHarnessSession } from '$lib/server/harness/persist';
+import { wrapTools } from '$lib/server/harness/pipeline';
+import { applyStewardPrepareStep, createSessionSteward } from '$lib/server/harness/steward';
 import { z } from 'zod';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { randomUUID } from 'node:crypto';
@@ -385,35 +388,51 @@ ${mode === 'more' ? `Propose ${opts.count ?? 4} NEW initiatives only.` : 'Propos
   let loopError: string | undefined;
 
   try {
-    await withAgentFallback('seoAgent', (chosen, markDirty) => {
+    await withAgentFallback('seoAgent', async (chosen, markDirty) => {
       loopModel = chosen;
-      return harnessGenerateText({
+
+      const session = createHarnessSession({
         brandId: String(opts.brand.id),
         agent: 'seo',
         mode,
         model: loopModel.modelId,
         provider: loopModel.provider,
         surface: 'batch'
-      }, {
+      });
+      const prompt =
+        mode === 'more'
+          ? `Research with DataForSEO, then finish with ${opts.count ?? 4} NEW initiatives distinct from the existing plan.`
+          : `Review this brand's SEO with DataForSEO tools, then finish with an updated evaluation and prioritized initiatives.`;
+      session.captureRequest({ system: baseSystem, prompt });
+
+      const steward = createSessionSteward(session, Object.keys(tools));
+      const watchedTools = wrapTools(session, tools, {
+        before: [...(steward.pipeline().before ?? []), () => { markDirty(); }]
+      });
+
+      try {
+        const result = await generateText({
         model: loopModel.model,
         maxOutputTokens: maxOutputTokensFor(loopModel.provider),
         system: baseSystem,
-        prompt:
-          mode === 'more'
-            ? `Research with DataForSEO, then finish with ${opts.count ?? 4} NEW initiatives distinct from the existing plan.`
-            : `Review this brand's SEO with DataForSEO tools, then finish with an updated evaluation and prioritized initiatives.`,
-        tools,
+        prompt,
+        allowSystemInMessages: true,
+        tools: watchedTools,
         stopWhen: [hasToolCall('finish'), stepCountIs(MAX_SEO_AGENT_STEPS), stallStop, () => deadlineReached(t0, deadlineMs)],
         temperature: 0.35,
         prepareStep: () => {
           const remainingSec = Math.max(0, Math.round((deadlineMs - (Date.now() - t0)) / 1000));
           const stepSystem = appendBudgetToSystem(baseSystem, budget, remainingSec);
-          if (budget.usdRemaining <= 0 && state.finished) {
-            return { toolChoice: { type: 'tool' as const, toolName: 'finish' }, system: stepSystem };
-          }
-          return { system: stepSystem };
+          const step =
+            budget.usdRemaining <= 0 && state.finished
+              ? { toolChoice: { type: 'tool' as const, toolName: 'finish' }, system: stepSystem }
+              : { system: stepSystem };
+          const patched = applyStewardPrepareStep(session, steward, step, baseSystem) ?? {};
+          session.capturePrepareStep(patched);
+          return patched;
         },
         onStepFinish: ({ usage, toolCalls, toolResults, text }) => {
+          session.recordStep({ usage, toolCalls, text });
           addStrategyStepCost(budget, usage, loopModel);
           // Approximate DFS spend so the USD cap bites before runaway history calls.
           const dfsCalls = (toolCalls ?? []).filter((tc) => String(tc.toolName).startsWith('dfs_')).length;
@@ -433,7 +452,17 @@ ${mode === 'more' ? `Propose ${opts.count ?? 4} NEW initiatives only.` : 'Propos
           }
           void toolResults;
         }
-      }, { before: [() => { markDirty(); }] });
+        });
+        session.recordAssistantText(result.text);
+        session.recordUsage(result.totalUsage ?? result.usage);
+        session.finish('finished');
+        return result;
+      } catch (e) {
+        session.finish('failed', e);
+        throw e;
+      } finally {
+        persistHarnessSession(session);
+      }
     });
   } catch (e) {
     loopOk = false;


### PR DESCRIPTION
## What?

The SEO agent — the loop that reviews a brand's SEO against DataForSEO and Search Console, then
commits an evaluation and a prioritised initiative list — no longer runs through the agent
framework. It calls `generateText` from the AI SDK directly, and the three things
`harnessGenerateText` was silently adding on a batch surface are written at the call site.

Sixth of twelve. 11 characterization tests were written **against the existing framework
implementation** and watched pass before anything moved; they hook `generateText`, not the
wrapper, so the same tests grade both. They pass on both.

`packages/agent-*` is untouched.

## Why?

`packages/agent-*` (105,226 lines), `src/lib/agent` (23,909) and `src/lib/server/chat` (32,031)
are slated for deletion — about 31% of the repository. Deletion is blocked by whoever still
imports the framework, so the orchestrators come off it one at a time. This is one of the last
three straight swaps; the two after it are the streaming pair, which are a different shape.

## How?

Same recipe as #224, #231, #232 (merged), #237 and #239. The wrapper goes; the session transcript,
the session steward and the per-step system patch are written where the loop is. The two other
things `harnessGenerateText` adds are declared `surface === 'chat'` and have never done anything
here.

**One thing worth naming: this agent never throws.** A model that dies is caught, logged as a
failed run, and the function returns `null`, because a failed SEO review must not take its caller
down. The rewrite does not change that; it makes visible that the session is closed as `failed`
and persisted *before* that catch does its work. A test pins it.

**The steward is kept for the rule that bites here.** The `dfs_*` tools are paid lookups, and two
consecutive failures on one takes it off the table rather than letting the model keep paying. The
grounding rule ("read the brand before searching") correctly does **not** apply: `seo` is not in
the framework's grounding list, and it has no brand-read table to call first.

### Commits

1. the 11 characterization tests, passing against the framework implementation.
2. the rewrite, the import guard, the `LOOP_DRIVER` row, and the internal changelog.

## Testing?

Targeted only. The full suite and Playwright are delegated to CI. `npm run check` was not run: no
`.svelte` file and no shared type is touched.

```
$ npx vitest run src/lib/server/seo-agent.loop.test.ts
 Test Files  1 passed (1)
      Tests  12 passed (12)      # 11 loop tests + the import guard

$ npx vitest run src/lib/server/nested-agents.test.ts
 Test Files  1 passed (1)
      Tests  17 passed (17)
```

Against the previous implementation, before the rewrite existed: `11 passed (11)` — the twelfth is
the import guard, which can only pass afterwards.

### What the 11 pin

The exact tool table plus whatever DataForSEO contributes; the prompt changing with the mode
(`more` asks for N new initiatives distinct from the existing plan, `plan` asks for an updated
evaluation); `finish` returning a normalised evaluation and initiatives; the rows written to
`agent_runs` and `agent_sessions`; a run that never finishes returning `null` and logging
`ok: false`; a model that explodes not propagating; the step cap; and the budget written into the
per-step system.

### Schema

No new enum-ish value is written — `agent: 'seo'`, `surface: 'batch'`, `mode` ∈ the existing
`plan|review|more`, and the status vocabulary all come through unchanged code. `agent_sessions`
and `agent_runs` carry **no CHECK constraints** (checked against the live schema).

### Not tested, and why

- **No live run.** #224's rewrite was exercised end to end against the local stack with a real
  model, before and after; this is the same transformation on a sixth file, and the machine is in
  swap.
- **`npm run eval:durability` was not run** — real money, unreliable bench today. It should be run
  before the series is called finished.

<details>
<summary>Import graph, measured (transitive BFS, 222 modules visited)</summary>

**Before**: `seo-agent.ts -> harness/index.ts -> harness/run.ts -> chat/model.ts` (and
`chat/controller.ts`).

**After**: that edge is gone. What remains routes through `image-agent.ts`, which #237 closes:

```
seo-agent.ts -> strategy-agent.ts -> editorial-plan.ts -> content-preview.ts -> content-preview/articles.ts -> image-agent.ts -> harness/index.ts -> ...
```
</details>

## Anything Else?

- **Series status.** Merged: #224 week planner, #231 strategy agent, #232 Director. Open: #237
  image agent, #239 produce agent, this. Left: `analytics-review-agent.ts`,
  `media-generator/ugc-plan-agent.ts` (straight swaps), `media-generator/agent.ts` and
  `motion-video/agent.ts` (streaming — different shape), plus `media-generator/ugc-agent.ts`,
  `sandbox.ts`, `agent-base.ts`, `craft-model.ts`, `harness-skills.ts`,
  `agent-kit-effects-store.ts` and chat.

- **`nested-agents.test.ts` is a one-line addition**, thanks to the `LOOP_DRIVER` table from #231.

- **No public changelog**, deliberately. Same evaluation, same initiatives, same rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
