### PR TITLE
Take the analytics review agent off the agent framework

### DIFF
--- a/changelog/2026-09-04-analytics-review-off-the-kit.md
+++ b/changelog/2026-09-04-analytics-review-off-the-kit.md
@@ -1,0 +1,26 @@
+# L'analytics review agent esce dal framework, settimo dei dodici
+
+Settimo giro, stessa ricetta. Questo è l'agente con il tavolo più largo della serie: legge
+le performance vere e poi propone aggiustamenti al GTM, revisioni al piano editoriale,
+riscrive post in coda, li rischedula, corregge articoli in bozza e scrive lezioni nella
+memoria del brand.
+
+Proprio per questo i test di caratterizzazione guardano il **giro**, non le scritture: quelle
+hanno già i loro test, e rifarli qui sarebbe una seconda definizione che diverge dalla prima
+al primo campo aggiunto. Quello che serviva fissare era cosa il modello riceve (il tavolo
+esatto, la disciplina sull'evidenza, il digest, la guida dell'owner), come si chiude, cosa
+finisce in `agent_runs` e `agent_sessions`, e cosa succede quando non si chiude.
+
+Come il SEO agent, **non solleva mai**: un modello che muore viene catturato, registrato
+come corsa fallita, e la funzione torna `null`. Una review che fallisce non deve portarsi
+dietro il cron che l'ha chiamata.
+
+## L'arco che spariva
+
+Prima: `analytics-review-agent.ts → harness/index → harness/run → chat/model` e `→
+chat/controller`. Adesso non più da qui.
+
+## Cosa non cambia
+
+Il cliente non osserva niente: stesse proposte, stesse note, stesse righe. Nessun changelog
+pubblico.

--- a/src/lib/server/analytics-review-agent.loop.test.ts
+++ b/src/lib/server/analytics-review-agent.loop.test.ts
@@ -1,0 +1,302 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+/**
+ * CARATTERIZZAZIONE DEL GIRO DELL'ANALYTICS REVIEW AGENT.
+ *
+ * Settimo dei dodici, stesso metodo: si aggancia `generateText` dell'SDK — il confine che
+ * sopravvive alla riscrittura — e si fissa il comportamento di oggi prima di toccarlo.
+ *
+ * È l'agente con il tavolo più largo della serie: propone, riscrive e rischedula cose vere.
+ * Qui non si esercitano quelle scritture (hanno i loro test); si esercita il GIRO che le guida.
+ */
+
+const { generateText, logAiCall, persistAgentRun, fetchUsdBudget, agentSessionWrites } = vi.hoisted(
+  () => ({
+    generateText: vi.fn(),
+    logAiCall: vi.fn(),
+    persistAgentRun: vi.fn(),
+    fetchUsdBudget: vi.fn(),
+    agentSessionWrites: [] as Array<Record<string, unknown>>
+  })
+);
+
+vi.mock('$env/dynamic/private', () => ({ env: {} }));
+
+vi.mock('ai', async () => {
+  const actual = await vi.importActual<typeof import('ai')>('ai');
+  return { ...actual, generateText };
+});
+
+vi.mock('$lib/server/llm', async () => {
+  const actual = await vi.importActual<typeof import('$lib/server/llm')>('$lib/server/llm');
+  return {
+    ...actual,
+    llmDefaultModel: () => 'gemini-3.7-flash',
+    llmLanguageModel: () => ({ modelId: 'gemini-3.7-flash' })
+  };
+});
+
+vi.mock('$lib/server/ai-log', async () => {
+  const actual = await vi.importActual<typeof import('$lib/server/ai-log')>('$lib/server/ai-log');
+  return { ...actual, logAiCall };
+});
+
+vi.mock('$lib/server/agent-runs', () => ({ persistAgentRun }));
+
+vi.mock('$lib/server/strategy-agent', async () => {
+  const actual = await vi.importActual<typeof import('$lib/server/strategy-agent')>('$lib/server/strategy-agent');
+  return { ...actual, fetchUsdBudget };
+});
+
+vi.mock('$lib/server/brand-context', () => ({ genaiClient: () => ({}) }));
+
+vi.mock('$lib/server/seo-metrics', () => ({ buildSeoMetrics: async () => ({}) }));
+
+vi.mock('$lib/server/supabase-admin', () => ({
+  createAdminClient: () => ({
+    from: (table: string) => ({
+      insert: (row: Record<string, unknown>) => {
+        if (table === 'agent_sessions') agentSessionWrites.push({ op: 'insert', ...row });
+        return Promise.resolve({ error: null });
+      },
+      upsert: (row: Record<string, unknown>) => {
+        if (table === 'agent_sessions') agentSessionWrites.push({ op: 'upsert', ...row });
+        return Promise.resolve({ error: null });
+      },
+      select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: null }) }) })
+    })
+  })
+}));
+
+import { MAX_ANALYTICS_REVIEW_STEPS, runAnalyticsReviewAgent } from './analytics-review-agent';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyRec = Record<string, any>;
+
+function stubSupabase(): AnyRec {
+  const chain: AnyRec = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        if (prop === 'then') {
+          return (resolve: (v: unknown) => unknown) => Promise.resolve({ data: [], error: null }).then(resolve);
+        }
+        if (prop === 'maybeSingle' || prop === 'single') return async () => ({ data: null, error: null });
+        return () => chain;
+      }
+    }
+  );
+  return { from: () => chain };
+}
+
+type ScriptedCall = { tool: string; input?: unknown };
+type DriveRecord = {
+  prepared: AnyRec[];
+  calls: Array<{ tool: string; output: unknown }>;
+  system: string;
+  prompt: string;
+  toolNames: string[];
+};
+
+function drive(script: ScriptedCall[], record: DriveRecord) {
+  return async (options: AnyRec) => {
+    record.system = String(options.system ?? '');
+    record.prompt = String(options.prompt ?? '');
+    record.toolNames = Object.keys(options.tools ?? {});
+
+    const steps: AnyRec[] = [];
+    for (const entry of script) {
+      const prepared = (await options.prepareStep?.({ stepNumber: steps.length, steps })) ?? {};
+      record.prepared.push(prepared);
+
+      const impl = options.tools?.[entry.tool];
+      const output = impl ? await impl.execute(entry.input ?? {}, {}) : { error: 'no such tool' };
+      record.calls.push({ tool: entry.tool, output });
+
+      const toolCalls = [{ toolName: entry.tool, input: entry.input ?? {}, type: 'tool-call' }];
+      const toolResults = [{ toolName: entry.tool, output, type: 'tool-result' }];
+      const usage = { inputTokens: 100, outputTokens: 40 };
+      steps.push({ toolCalls, toolResults, text: '', usage });
+      await options.onStepFinish?.({ toolCalls, toolResults, text: '', usage });
+
+      const stops = (options.stopWhen ?? []) as Array<(a: AnyRec) => boolean | Promise<boolean>>;
+      const verdicts = await Promise.all(stops.map((s) => s({ steps, stepNumber: steps.length })));
+      if (verdicts.some(Boolean)) break;
+    }
+    return { text: '', totalUsage: { inputTokens: 100 * steps.length, outputTokens: 40 * steps.length }, steps };
+  };
+}
+
+function baseOpts(over: AnyRec = {}): AnyRec {
+  return {
+    supabase: stubSupabase(),
+    userId: 'u1',
+    brand: { id: 'b1', name: 'Demo Brand', slug: 'demo', timezone: 'Europe/Rome', content_prefs: {} },
+    deadlineMs: 60_000,
+    ...over
+  };
+}
+
+function newRecord(): DriveRecord {
+  return { prepared: [], calls: [], system: '', prompt: '', toolNames: [] };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  agentSessionWrites.length = 0;
+  fetchUsdBudget.mockResolvedValue(4);
+});
+
+describe('il tavolo dei tool offerto al modello', () => {
+  it('è esattamente questo elenco', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(drive([{ tool: 'finish', input: { notes: 'nulla da cambiare' } }], rec));
+
+    await runAnalyticsReviewAgent(baseOpts() as never);
+
+    expect(rec.toolNames.sort()).toEqual(
+      [
+        'adjust_active_week',
+        'finish',
+        'propose_editorial_revision',
+        'propose_gtm_adjustment',
+        'read_performance',
+        'read_plans',
+        'remember_lesson',
+        'reschedule_pending_post',
+        'revise_draft_article',
+        'rewrite_pending_post'
+      ].sort()
+    );
+  });
+
+  it('il system porta la disciplina sull evidenza e il digest', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(drive([{ tool: 'finish', input: { notes: 'ok' } }], rec));
+
+    await runAnalyticsReviewAgent(baseOpts() as never);
+
+    expect(rec.system).toContain('EVIDENCE DISCIPLINE');
+    expect(rec.system).toContain('Current digest:');
+    expect(rec.system).toContain('Demo Brand');
+  });
+
+  it('la guida dell owner finisce nel system quando c è', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(drive([{ tool: 'finish', input: { notes: 'ok' } }], rec));
+
+    await runAnalyticsReviewAgent(baseOpts({ guidance: 'guarda i salvataggi, non le impression' }) as never);
+
+    expect(rec.system).toContain('Owner guidance: guarda i salvataggi, non le impression');
+  });
+});
+
+describe('il percorso che chiude', () => {
+  it('finish restituisce le note e il conto delle azioni', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(
+      drive([{ tool: 'read_performance', input: {} }, { tool: 'finish', input: { notes: '  Niente da cambiare.  ' } }], rec)
+    );
+
+    const out = await runAnalyticsReviewAgent(baseOpts() as never);
+
+    expect(generateText).toHaveBeenCalledTimes(1);
+    expect(out?.notes).toBe('Niente da cambiare.');
+    expect(out?.actions).toEqual([]);
+    expect(rec.calls[1].output).toMatchObject({ ok: true, actions: 0 });
+  });
+
+  it('registra la corsa come `finished` e logga la chiamata riuscita', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(drive([{ tool: 'finish', input: { notes: 'ok' } }], rec));
+
+    await runAnalyticsReviewAgent(baseOpts() as never);
+
+    expect(persistAgentRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        brandId: 'b1',
+        agent: 'analytics_review',
+        mode: 'weekly',
+        status: 'finished',
+        finishedOk: true
+      })
+    );
+    expect(logAiCall).toHaveBeenCalledWith(expect.objectContaining({ label: 'analyticsReviewAgent', ok: true }));
+  });
+
+  it('lascia una riga di sessione leggibile su agent_sessions', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(drive([{ tool: 'finish', input: { notes: 'ok' } }], rec));
+
+    await runAnalyticsReviewAgent(baseOpts() as never);
+
+    const finishedRow = agentSessionWrites.find((r) => r.status === 'finished');
+    expect(finishedRow).toMatchObject({
+      agent: 'analytics_review',
+      surface: 'batch',
+      brand_id: 'b1',
+      mode: 'weekly'
+    });
+  });
+
+  it('il modo scelto dal chiamante arriva alla riga di corsa', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(drive([{ tool: 'finish', input: { notes: 'ok' } }], rec));
+
+    await runAnalyticsReviewAgent(baseOpts({ mode: 'monthly' }) as never);
+
+    expect(persistAgentRun).toHaveBeenCalledWith(expect.objectContaining({ mode: 'monthly' }));
+  });
+});
+
+describe('quando non chiude', () => {
+  it('senza finish e senza azioni la corsa è fallita e non torna niente', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(drive([{ tool: 'read_performance', input: {} }], rec));
+
+    const out = await runAnalyticsReviewAgent(baseOpts() as never);
+
+    expect(out).toBeNull();
+    expect(persistAgentRun).toHaveBeenCalledWith(
+      expect.objectContaining({ agent: 'analytics_review', status: 'failed', finishedOk: false })
+    );
+  });
+
+  it('un modello che esplode non propaga', async () => {
+    generateText.mockImplementation(async () => {
+      throw new Error('gateway giù');
+    });
+
+    const out = await runAnalyticsReviewAgent(baseOpts() as never);
+
+    expect(out).toBeNull();
+    expect(logAiCall).toHaveBeenCalledWith(
+      expect.objectContaining({ label: 'analyticsReviewAgent', ok: false, error: 'gateway giù' })
+    );
+  });
+
+  it('si ferma al tetto degli step', async () => {
+    const rec = newRecord();
+    const script = Array.from({ length: MAX_ANALYTICS_REVIEW_STEPS + 5 }, (_, i) => ({
+      tool: 'read_plans',
+      input: { note: `giro ${i}` }
+    }));
+    generateText.mockImplementation(drive(script, rec));
+
+    await runAnalyticsReviewAgent(baseOpts() as never);
+
+    expect(rec.calls.length).toBeLessThanOrEqual(MAX_ANALYTICS_REVIEW_STEPS);
+  });
+});
+
+describe('il budget scritto nel system di ogni step', () => {
+  it('porta i contatori e il tempo che resta', async () => {
+    const rec = newRecord();
+    generateText.mockImplementation(drive([{ tool: 'finish', input: { notes: 'ok' } }], rec));
+
+    await runAnalyticsReviewAgent(baseOpts() as never);
+
+    expect(String(rec.prepared[0].system)).toContain('usd_remaining≈');
+    expect(String(rec.prepared[0].system)).toContain('time_left≈');
+  });
+});

--- a/src/lib/server/analytics-review-agent.loop.test.ts
+++ b/src/lib/server/analytics-review-agent.loop.test.ts
@@ -300,3 +300,18 @@ describe('il budget scritto nel system di ogni step', () => {
     expect(String(rec.prepared[0].system)).toContain('time_left≈');
   });
 });
+
+// `harness/index` riesporta `harness/run`, che importa `chat/model` e `chat/controller`: chi
+// prende la traccia dall'indice si porta dentro la chat e `$lib/agent` senza usarli. I moduli
+// foglia non li toccano, e questo test è l'unica cosa che impedisce di «riordinare» l'import.
+describe('da dove arriva la traccia', () => {
+  it('l analytics review guida l SDK e non passa dall indice del framework', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { join } = await import('node:path');
+    const src = readFileSync(join(process.cwd(), 'src/lib/server/analytics-review-agent.ts'), 'utf8');
+    expect(src).toMatch(/await generateText\(/);
+    expect(src).not.toContain('harnessGenerateText(');
+    expect(src).not.toMatch(/from '\$lib\/server\/harness'/);
+    expect(src).toMatch(/from '\$lib\/server\/harness\/session'/);
+  });
+});

--- a/src/lib/server/analytics-review-agent.ts
+++ b/src/lib/server/analytics-review-agent.ts
@@ -1,7 +1,11 @@
 import { swallow } from '$lib/server/swallow';
 import { maxOutputTokensFor } from '$lib/server/ai-output-limits';
 import { tool, stepCountIs, hasToolCall, type StopCondition } from 'ai';
-import { harnessGenerateText } from '$lib/server/harness';
+import { generateText } from 'ai';
+import { createHarnessSession } from '$lib/server/harness/session';
+import { persistHarnessSession } from '$lib/server/harness/persist';
+import { wrapTools } from '$lib/server/harness/pipeline';
+import { applyStewardPrepareStep, createSessionSteward } from '$lib/server/harness/steward';
 import { z } from 'zod';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { env } from '$env/dynamic/private';
@@ -787,9 +791,10 @@ ${digest.slice(0, 6000)}`;
   let loopError: string | undefined;
 
   try {
-    await withAgentFallback('analyticsReviewAgent', (chosen, markDirty) => {
+    await withAgentFallback('analyticsReviewAgent', async (chosen, markDirty) => {
       loopModel = chosen;
-      return harnessGenerateText({
+
+      const session = createHarnessSession({
         brandId,
         userId: opts.userId,
         agent: 'analytics_review',
@@ -797,13 +802,24 @@ ${digest.slice(0, 6000)}`;
         model: loopModel.modelId,
         provider: loopModel.provider,
         surface: 'batch'
-      }, {
+      });
+      const prompt =
+        'Review this brand\'s analytics and adapt strategy, editorial plan, and upcoming content where the evidence is clear. Prefer proposals for GTM/editorial; edit pending/scheduled posts and draft articles directly when useful. Finish with notes.';
+      session.captureRequest({ system: baseSystem, prompt });
+
+      const steward = createSessionSteward(session, Object.keys(tools));
+      const watchedTools = wrapTools(session, tools, {
+        before: [...(steward.pipeline().before ?? []), () => { markDirty(); }]
+      });
+
+      try {
+        const result = await generateText({
         model: loopModel.model,
         maxOutputTokens: maxOutputTokensFor(loopModel.provider),
         system: baseSystem,
-        prompt:
-          'Review this brand\'s analytics and adapt strategy, editorial plan, and upcoming content where the evidence is clear. Prefer proposals for GTM/editorial; edit pending/scheduled posts and draft articles directly when useful. Finish with notes.',
-        tools,
+        prompt,
+        allowSystemInMessages: true,
+        tools: watchedTools,
         stopWhen: [
           hasToolCall('finish'),
           stepCountIs(MAX_ANALYTICS_REVIEW_STEPS),
@@ -813,9 +829,13 @@ ${digest.slice(0, 6000)}`;
         temperature: 0.35,
         prepareStep: () => {
           const remainingSec = Math.max(0, Math.round((deadlineMs - (Date.now() - t0)) / 1000));
-          return { system: appendBudgetToSystem(baseSystem, budget, remainingSec) };
+          const step = { system: appendBudgetToSystem(baseSystem, budget, remainingSec) };
+          const patched = applyStewardPrepareStep(session, steward, step, baseSystem) ?? {};
+          session.capturePrepareStep(patched);
+          return patched;
         },
         onStepFinish: ({ usage, toolCalls, text }) => {
+          session.recordStep({ usage, toolCalls, text });
           addStrategyStepCost(budget, usage, loopModel);
           stallFingerprints.push(
             stepFingerprint(
@@ -831,7 +851,17 @@ ${digest.slice(0, 6000)}`;
             );
           }
         }
-      }, { before: [() => { markDirty(); }] });
+        });
+        session.recordAssistantText(result.text);
+        session.recordUsage(result.totalUsage ?? result.usage);
+        session.finish('finished');
+        return result;
+      } catch (e) {
+        session.finish('failed', e);
+        throw e;
+      } finally {
+        persistHarnessSession(session);
+      }
     });
   } catch (e) {
     loopOk = false;


### PR DESCRIPTION
## What?

The analytics review agent — the loop that reads a brand's real performance and adapts strategy,
plan and upcoming content — no longer runs through the agent framework. It calls `generateText`
from the AI SDK directly, and the three things `harnessGenerateText` was silently adding on a
batch surface are written at the call site.

Seventh of twelve. 11 characterization tests were written **against the existing framework
implementation** and watched pass before anything moved; they hook `generateText`, not the
wrapper, so the same tests grade both. They pass on both.

`packages/agent-*` is untouched.

## Why?

`packages/agent-*` (105,226 lines), `src/lib/agent` (23,909) and `src/lib/server/chat` (32,031)
are slated for deletion. Deletion is blocked by whoever still imports the framework. After this
PR, the only orchestrators left on it are the two UGC ones.

## How?

Same recipe as #224, #231, #232, #237 (merged), #239 and #240. The wrapper goes; the session
transcript, the session steward and the per-step system patch are written where the loop is. The
other two additions are declared `surface === 'chat'` and have never done anything here.

**Like the SEO agent, this one never throws.** A model that dies is caught, logged as a failed
run, and `null` is returned, because a failed review must not take the cron that called it down.
The rewrite makes visible that the session is closed as `failed` and persisted *before* that catch
runs. A test pins it.

**The tests grade the loop, not the writes.** This agent has the widest table in the series — it
proposes GTM adjustments and editorial revisions, rewrites and reschedules pending posts, revises
draft articles and writes brand memories. Those writes have their own tests; re-asserting them
here would be a second definition that diverges from the first at the next field added. What
needed pinning was what the model receives and how the loop closes.

## Testing?

Targeted only. The full suite and Playwright are delegated to CI. `npm run check` was not run: no
`.svelte` file and no shared type is touched.

```
$ npx vitest run src/lib/server/analytics-review-agent.loop.test.ts
 Test Files  1 passed (1)
      Tests  12 passed (12)      # 11 loop tests + the import guard
```

Against the previous implementation, before the rewrite existed: `11 passed (11)` — the twelfth is
the import guard, which can only pass afterwards.

### What the 11 pin

The exact tool table (ten tools); the evidence-discipline block and the digest reaching the system
prompt; owner guidance when present; `finish` returning trimmed notes and the action count; the
rows written to `agent_runs` and `agent_sessions` carrying the caller's mode; a run with no finish
and no actions returning `null` and logging `ok: false`; a model that explodes not propagating;
the step cap; and the budget written into the per-step system.

### Schema

No new enum-ish value is written — `agent: 'analytics_review'`, `surface: 'batch'`, `mode` = the
caller's (`weekly`/`monthly`), and the status vocabulary all come through unchanged code.
`agent_sessions` and `agent_runs` carry **no CHECK constraints** (checked against the live schema).

### Not tested, and why

- **No live run.** Same transformation as #224, which was exercised end to end against the local
  stack with a real model before and after; the machine is in swap.
- **`npm run eval:durability` was not run** — real money, unreliable bench today.

## Anything Else?

- **⚠️ The four harness leaf modules must survive the chat teardown.** Every orchestrator in this
  series takes its Usage-page transcript from `harness/session`, `harness/persist`,
  `harness/pipeline` and `harness/steward` — 1,030 lines that import neither chat nor
  `$lib/agent`, and are **not** part of the 161,166 lines slated for deletion. Non-test importers
  today: `week-planner-agent.ts`, `strategy-agent.ts`, `director.ts`, `analytics-review-agent.ts`
  (plus `image-agent.ts`, `produce-agent.ts` and `seo-agent.ts` in the open PRs), and
  `chat/controller.ts`. Deleting `src/lib/server/harness/` wholesale alongside chat would take the
  autopilot's transcripts with it. Only `harness/run.ts` and `harness/index.ts` are chat-coupled,
  and they become unreferenced once this series lands.

- **Series status.** Merged: #224 week planner, #231 strategy agent, #232 Director, #237 image
  agent. Open: #239 produce agent, #240 SEO agent, this. Left after these:
  `media-generator/ugc-agent.ts` and `media-generator/ugc-plan-agent.ts` — both **content
  generation, to be rewritten off the framework, not removed**.

- **No public changelog**, deliberately. Same proposals, same notes, same rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
