### PR TITLE
Take the last two orchestrators off the agent framework

### DIFF
--- a/changelog/2026-09-04-craft-model-off-the-kit.md
+++ b/changelog/2026-09-04-craft-model-off-the-kit.md
@@ -1,0 +1,23 @@
+# La fabbrica dei modelli di resa esce da `$lib/agent`
+
+`craft-model.ts` decide su cosa gira una resa: un motion video e una clip UGC, due cose che
+**sopravvivono** alla cancellazione del framework. Per farlo chiedeva il modello di ripiego a
+`harnessSdkModel()`, che vive in `$lib/agent/bridge/adapters.ts`.
+
+Quella funzione è lunga **cinque righe** e usa solo il centralino (`llmApiKey`,
+`llmModelForPicker`, `llmLanguageModel`). Il file che la ospita ne è lungo 514 e importa la
+chat (`chat/agent-files`), il sandbox di Vercel e kie. Cioè: la scelta del modello per due
+capacità generative che restano dipendeva, per cinque righe, da un file che deve sparire.
+
+Adesso quelle cinque righe stanno in `craft-model.ts`, con un nome che dice cosa fanno
+(`routedModel`) e quattro prove che tengono la scaletta: la scappatoia del mestiere vince su
+tutto, senza scappatoia decide il centralino, senza chiave resta il default dichiarato, e una
+scappatoia fatta di soli spazi non conta come scelta. `craft-model.ts` non importa più
+`$lib/agent`.
+
+`harnessSdkModel` resta dov'è, con il suo test: serve ancora alla chat, e sparisce con lei.
+
+## Cosa non cambia
+
+Nessuna differenza osservabile: stessa scaletta, stesso modello scelto in tutti e tre i casi.
+Nessun changelog pubblico.

--- a/src/lib/server/craft-model.test.ts
+++ b/src/lib/server/craft-model.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+/**
+ * La fabbrica che decide su cosa gira una resa — motion video e clip UGC, due cose che
+ * SOPRAVVIVONO alla cancellazione del framework.
+ *
+ * Prima chiedeva il modello di ripiego a `$lib/agent/bridge/adapters`: cinque righe dentro un
+ * file da 514 che importa la chat e il sandbox. Queste tre prove tengono la scaletta — forzato,
+ * centralino, default — e il test qui sotto tiene l'import fuori da `$lib/agent`.
+ */
+
+const { llmApiKey } = vi.hoisted(() => ({ llmApiKey: vi.fn() }));
+
+vi.mock('$env/dynamic/private', () => ({ env: {} }));
+
+vi.mock('$lib/server/llm', () => ({
+  llmApiKey,
+  llmDefaultModel: () => 'gemini-3.7-flash',
+  llmModelForPicker: () => 'anthropic/claude-opus-5',
+  llmLanguageModel: (id?: string) => ({ modelId: id })
+}));
+
+import { craftAgentModel } from './craft-model';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  llmApiKey.mockReturnValue('key');
+});
+
+describe('craftAgentModel', () => {
+  it('la scappatoia del mestiere vince su tutto', () => {
+    expect(craftAgentModel({ envModel: '  kie/grok-4-6  ' })).toMatchObject({
+      modelId: 'kie/grok-4-6',
+      provider: 'llm'
+    });
+  });
+
+  it('senza scappatoia prende quello che serve il centralino', () => {
+    expect(craftAgentModel({ envModel: undefined })).toMatchObject({
+      modelId: 'anthropic/claude-opus-5',
+      provider: 'llm'
+    });
+  });
+
+  it('senza chiave il centralino non serve niente e resta il default dichiarato', () => {
+    llmApiKey.mockReturnValue(undefined);
+    expect(craftAgentModel({ envModel: undefined })).toMatchObject({
+      modelId: 'gemini-3.7-flash',
+      provider: 'llm'
+    });
+  });
+
+  it('una scappatoia fatta di soli spazi non conta come scelta', () => {
+    expect(craftAgentModel({ envModel: '   ' })).toMatchObject({ modelId: 'anthropic/claude-opus-5' });
+  });
+});
+
+describe('da dove prende il modello', () => {
+  it('non importa più da $lib/agent', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { join } = await import('node:path');
+    const src = readFileSync(join(process.cwd(), 'src/lib/server/craft-model.ts'), 'utf8');
+    expect(src).not.toMatch(/from '\$lib\/agent\//);
+  });
+});

--- a/src/lib/server/craft-model.ts
+++ b/src/lib/server/craft-model.ts
@@ -8,8 +8,7 @@
  */
 import { env } from '$env/dynamic/private';
 import type { LanguageModel } from 'ai';
-import { harnessSdkModel } from '$lib/agent/bridge/adapters';
-import { llmDefaultModel, llmLanguageModel } from '$lib/server/llm';
+import { llmApiKey, llmDefaultModel, llmLanguageModel, llmModelForPicker } from '$lib/server/llm';
 
 export type CraftAgentModel = {
 	model: LanguageModel;
@@ -24,9 +23,22 @@ export function craftAgentModel(opts: {
 	const forced = opts.envModel?.trim();
 	if (forced) return { model: llmLanguageModel(forced), modelId: forced, provider: 'llm' };
 
-	const routed = harnessSdkModel();
+	const routed = routedModel();
 	if (routed) return routed;
 
 	const id = llmDefaultModel();
+	return { model: llmLanguageModel(id), modelId: id, provider: 'llm' };
+}
+
+/**
+ * Il modello che il centralino serve quando nessuno ha forzato niente.
+ *
+ * Cinque righe che stavano dentro `$lib/agent/bridge/adapters`, un file da 514 righe che tira
+ * dentro la chat e il sandbox: la resa di un motion e di una clip UGC — due cose che restano —
+ * dipendevano da lui per scegliere su cosa girare. Qui usano solo il centralino.
+ */
+function routedModel(): CraftAgentModel | null {
+	if (!llmApiKey()) return null;
+	const id = llmModelForPicker(null);
 	return { model: llmLanguageModel(id), modelId: id, provider: 'llm' };
 }


### PR DESCRIPTION
## What?

The last two orchestrators — `media-generator/agent.ts` and `motion-video/agent.ts` — come off
the agent framework. Both call `streamText` from the AI SDK directly, and both drop from
`surface: 'chat'` to `surface: 'batch'`, **which I measured before changing rather than reasoned
about**.

It also carries the `craft-model` rescue from the previous revision of this PR.

**No orchestrator is left on the framework.** `harnessGenerateText` / `harnessStreamText` now have
exactly two callers in the whole repository, both chat routes.

## Why?

These two were the only agents in the series declaring `surface: 'chat'`, which switched on the
two wrapper additions that were inert everywhere else: the shadow controller and the forced first
tool call. #246 said this needed a decision. Here is the measurement that made it.

### The forced first tool call never fires

It passes three gates in order: `surface === 'chat'`, then `acceptsForcedToolChoice(model)` (an id
matching `/grok/i`), then `isHeavyProductionAsk(last user text)`. **The second gate is shut.**

```
=== MODEL IDS ACTUALLY RESOLVED ===
media-generator model  : google/gemini-3.8-flash
motion-video model     : google/gemini-3.8-flash
llmModelForPicker(null): google/gemini-3.8-flash
MOTION_VIDEO_MODEL env : (unset)
CHAT_CONTROLLER env    : (unset)
grok?  media: false  motion: false

=== forcedFirstStepTools WITH THE ACTUAL MODEL IDS ===
media-generator: fires on 0/12 prompts
motion-video:    fires on 0/12 prompts

=== forcedFirstStepTools IF THE MODEL WERE GROK ===
fires on 5/12 prompts
```

Twelve realistic requests ("fammi un video…", "genera 3 immagini…", "più contrasto", "togli il
logo", "non fare nessun video, solo la copertina", "ciao"…). The regex discriminates perfectly —
5 of 12 — and **nothing ever reaches it**. Grok enters this repository through the **kie** provider
(`createOpenAI` on `api.kie.ai/grok/v1`, `provider: 'kie'`), which is the Director's and produce's
road, not this one. The gateway path these two use resolves to Gemini.

The shadow controller needs `CHAT_CONTROLLER=shadow`, which is set nowhere and referenced only
inside `chat/controller.ts`.

### And if it had fired, it would have been a defect

`FORCED_STEP_EXCLUDE` drops `ask_user_questions` from the forced step, because in a chat turn that
tool would end the turn. **Motion video has that tool.** Forcing a tool while removing the agent's
only way to ask a clarifying question is the defect wearing the protection's face — on an agent
that is not a chat turn and whose loop already ends on `finish`.

So `surface: 'batch'`, which is also simply true: both are generators invoked by code with the
request already decided.

## How?

Same recipe as the nine before — session transcript, session steward, per-step system patch, all
written at the call site. Streaming needs three more things the wrapper did silently, now visible:

- the **snapshot before the stream**, so a killed turn still leaves system and messages;
- `onError` and `onAbort` closing the session as `failed` / `aborted` instead of leaving it
  `running` forever.

`motion-video` composes its existing `prepareStep` (the reference-frame patch) with the steward's,
and its tool table is hoisted to a `const` so it can be wrapped — mechanical, no reordering of the
tools themselves.

### Commits

1. `5b1da43` — free `craft-model` from `$lib/agent/bridge/adapters` (5 lines, 514-line chat-coupled host), with its first-ever test file.
2. `84fde41` — both streaming loops onto the SDK, `surface: 'batch'`, guard tests, changelog.

## Testing?

Targeted only; full suite and Playwright delegated to CI. `npm run check` not run — no `.svelte`,
no shared type.

```
$ npx vitest run src/lib/server/motion-video/ src/lib/server/media-generator/ \
    src/lib/server/craft-model.test.ts \
    src/lib/server/streaming-agents-off-the-kit.test.ts \
    src/lib/server/nested-agents.test.ts

 Test Files  30 passed (30)
      Tests  228 passed (228)
```

The measurement above is reproducible: it ran the real `forcedFirstStepTools`,
`isHeavyProductionAsk`, `llmDefaultModel` and `craftAgentModel` under vite-node against this
worktree's config.

## Anything Else?

### ✅ What you asked me to verify: `harness/run.ts` and `harness/index.ts` are free

After this PR, the only callers of `harnessGenerateText` / `harnessStreamText` / `attachHarness`
in the whole repository, outside `src/lib/server/harness/` itself, are **two chat routes**:

```
src/routes/api/v1/chat/respond/run/+server.ts
src/routes/app/[brand]/chat/+server.ts
```

Both belong to the chat teardown. `harness/run.ts` and `harness/index.ts` can go with them, and
`isHeavyProductionAsk` (plus its test) goes with `harness/run.ts` — it has no other runtime caller.

**The four leaf modules must stay**: `harness/session`, `harness/persist`, `harness/pipeline`,
`harness/steward` — 1,030 lines, no chat and no `$lib/agent` imports, and eleven orchestrators now
take their Usage-page transcript from them.

### ❌ `packages/agent-*` is NOT detachable yet — and the blocker is not mine

I measured before opening the deletion PR, and it would break the build. `@anomalia/agent-*` is
still imported by 18 files in `src/lib/agent`, 4 in `src/lib/server/chat`,
`src/lib/server/agent-kit-effects-store.ts`, `src/lib/server/sandbox.ts`, and four client libs
(`chat-model-policy`, `chat-tiers`, `models/catalog`, `thread-cursor`). I checked the last five:
**none has a consumer outside chat / `src/lib/agent` / agent-lab**, so they all die with the chat
teardown. Deletion becomes a clean one-shot the moment that lands, and I will open it then.

### ⚠️ Two cross-boundary risks for the chat teardown

1. **`agent-base.ts` is shared with the surviving generators.** Motion video, the media generator
   and the UGC producer all build on `createAgentBase`, which imports `chat/agents`, `chat/model`,
   `chat/goal`, and `$lib/agent/tools/{sandbox,goal,artifact}-tools`. Removing chat without a plan
   for those takes goals, artifacts and the sandbox away from three generators that must survive.
   Same shape as the three rescues already done (`brand-context-tools`, `media-library-tools`,
   `harnessSdkModel`) but larger, and it is a product-scope question — do the generators keep
   goals and artifacts? — not a mechanical move. **I did not touch it.**
2. **`agent-turns.ts` imports `chat/queue.ts`, and `credits.ts → scheduler.ts → agent-turns.ts`.**
   Every orchestrator reaches chat through that chain. If `chat/queue.ts` is deleted without
   fixing `agent-turns.ts` first, `credits.ts` breaks and with it every agent in the product, not
   just chat. Same for `design-render-chromium → motion-video/still-artifacts → chat/artifacts`.

### No public changelog

Same images, same videos, same rows — a customer cannot observe any difference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
