### PR TITLE
Add the materials library to the thin frontend

### DIFF
--- a/changelog/2026-09-04-thin-frontend-materials.md
+++ b/changelog/2026-09-04-thin-frontend-materials.md
@@ -1,0 +1,102 @@
+# La libreria media nel frontend sottile — `/v2/:brand/materials`
+
+La terza superficie del frontend sottile, dopo il calendario (#229) e l'elenco dei post (#235).
+È "Materiali" nel mockup della barra laterale: la libreria di ciò che il brand possiede già —
+foto, render, esport — con anteprime, filtro per tipo, ricerca testuale e apertura del singolo
+elemento in un pannello laterale.
+
+## Perché esiste
+
+Il resto di `/v2` mostra cosa esce. Nessuna superficie mostra cosa c'è. È l'asset che decide se
+un post costa zero o costa un render: `create_post` accetta `media_ids`, e un id preso dalla
+libreria riusa un'immagine invece di pagarne una nuova. Senza una pagina che mostri quegli id,
+l'unico modo per conoscerli è `list_media` da CLI — cioè la libreria esiste per gli agenti e non
+per la persona che deve dire "usa quella".
+
+Il pannello quindi mostra l'id per esteso, in monospace, selezionabile. Non è un dettaglio
+tecnico lasciato scoperto: è la ragione per cui si apre un elemento.
+
+## Cosa c'era prima
+
+`/app/:brand/...` nel vecchio frontend. `/v2` è il prefisso temporaneo finché `/app` è occupato;
+la promozione finale sarà `git mv src/routes/v2 src/routes/app`.
+
+## Come è costruita
+
+**Legge da un endpoint, non dal database.** Il `load` prende il token dalla sessione e chiama in
+parallelo `GET /api/v1/brands/:slug` (per nome e fuso del brand) e
+`GET /api/v1/brands/:slug/media` (`LIST_MEDIA`). Nessun import da `$lib/server/brand-media`: web,
+MCP e CLI passano dalle stesse regole.
+
+**Sola lettura.** `POST /media` esiste (`IMPORT_MEDIA_URL`: importa da una URL pubblica) ma è un
+flusso di scrittura con i suoi errori — `media_unavailable`, dimensioni, mime rifiutati — e non
+è quello che questa superficie deve risolvere. Nessun upload, nessuna modifica, nessuna
+cancellazione: la libreria si riempie da upload, render e agenti.
+
+**Il filtro sta nella URL.** `?kind=video` è un link, `?q=menu` è una `<form method="GET">`. Il
+server rifà la query e la pagina si ridisegna. Nessuno store, nessuna cache. L'unico stato
+client è quale pannello è aperto, scritto in `?item=<id>` con `replaceState` così che un reload o
+un link condiviso lo ripristinino.
+
+`kindFor` non si fida del parametro: un tipo che non è nella tabella torna ad `all`.
+
+**Il filtro per tipo è lato server, ma non è una query.** `LIST_MEDIA` accetta `query` e `limit`,
+non `kind`: il tipo non è filtrabile dall'API. Le due strade erano aggiungere un parametro
+all'endpoint — che usano anche CLI e MCP — o filtrare le righe già arrivate. La seconda, in
+`load`, perché la prima è lavoro dell'endpoint e non di questa pagina, e perché `ofKind` su una
+lista che l'API già limita non è una query mascherata: è la stessa scelta di `filterFor` in #235,
+un parametro di URL che non può inventare uno stato che l'API non conosce.
+
+**La ricerca invece passa davvero dall'API.** `?q=` diventa `?query=` su `LIST_MEDIA`, che cerca
+su titolo, descrizione e tag. Duplicare quella ricerca nel frontend avrebbe voluto dire due
+definizioni di "corrisponde", divergenti al primo cambio.
+
+**Il fuso è quello del brand.** `addedOn` formatta `created_at` con `Intl.DateTimeFormat` sul
+timezone che arriva dall'API: le 23:30 UTC del 31 agosto sono il 1 settembre a Roma. Un test lo
+pinna, come in #229 e #235.
+
+## Cosa non si può mostrare, e perché non è stato inventato
+
+`LIST_MEDIA` restituisce dieci campi: `id`, `kind`, `mime`, `width`, `height`, `title`,
+`description`, `tags`, `signed_url`, `created_at`. La riga in `brand_media` ne ha molti di più —
+`source`, `bytes`, `duration_seconds`, `times_used`, `last_used_at`, `suggested_use`,
+`when_to_use`, `how_to_use`, `where_to_use`, `subjects`, `colors`, `mood`, `catalog_status`.
+
+Sono esattamente le cose che questa pagina vorrebbe: **quante volte un asset è già stato usato**
+(per non ripubblicare la stessa foto), **quando l'ultima volta**, e le indicazioni d'uso che
+l'AI ha già scritto catalogando il file. Nessuna passa dall'endpoint, quindi nessuna è mostrata.
+Allargare `LIST_MEDIA` è un cambio di contratto che tocca anche CLI e MCP: è un PR suo.
+
+Un `signed_url` nullo non diventa un'anteprima rotta — il pannello lo dice.
+
+## Cosa è stato scartato
+
+**Nessuna primitiva nuova da `shadcn-svelte`.** Solo `sheet` e `badge`, già in
+`src/lib/components/ui/`. La ricerca è un `<input type="search">` con le classi dell'`input`
+esistente: `shadcn-svelte add` ha già riscritto `button.svelte` e alzato `tailwind-variants` due
+volte, e non c'è niente qui che lo giustifichi.
+
+**Nessuna utility `grid`.** `app.css` definisce un `.grid` globale
+(`grid-template-columns: 1.7fr 1fr`) che dirotta chiunque scriva la classe. La griglia di
+anteprime è `flex flex-wrap` con larghezza fissa per elemento: il problema non si presenta
+invece di essere aggirato.
+
+**Nessun `<video>` nella griglia.** Un elemento video per riquadro significa una richiesta di
+rete per riquadro al primo render. In griglia un video è un riquadro con la sua etichetta; il
+player esiste solo nel pannello, che è a import dinamico e quindi non entra nel bundle iniziale.
+
+**Nessuna paginazione.** `LIST_MEDIA` accetta `limit` (max 200) ma non un cursore: paginare
+davvero vuol dire cambiare l'endpoint. La pagina dice quanti ne mostra invece di fingere di
+mostrarli tutti.
+
+**Nessuna chat, nessun link alla chat.**
+
+**Nessuna barra laterale.** Le cinque voci del mockup sono un layout condiviso, e due delle
+cinque non esistono ancora: un link che darebbe 404 non si mette. Il layout arriva quando le
+superfici ci sono tutte.
+
+## Debito noto
+
+Nessuno nuovo. `media-kind.ts` non duplica niente di `post-state.ts`: sono due tabelle diverse
+su due domini diversi. Resta aperto il doppione già noto fra #229, #235 e #236 (`PostPanel`,
+`POST_STATES`, `momentInZone`), che questa PR non tocca perché non usa nessuno dei tre.

--- a/src/routes/v2/[brand]/materials/+page.server.ts
+++ b/src/routes/v2/[brand]/materials/+page.server.ts
@@ -1,0 +1,53 @@
+import { error, redirect } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+import { kindFor, ofKind, type MediaRow } from './media-kind';
+
+type BrandRead = {
+  brand: { name: string; slug: string; timezone: string };
+};
+
+const QUERY_MAX = 200;
+
+function brandApi(slug: string, path: string): string {
+  return `/api/v1/brands/${encodeURIComponent(slug)}${path}`;
+}
+
+async function readError(res: Response): Promise<string> {
+  const body = (await res.json().catch(() => null)) as { error?: string } | null;
+  return body?.error ?? `Request failed (${res.status})`;
+}
+
+export const load: PageServerLoad = async ({ params, url, fetch, locals }) => {
+  const { session } = await locals.safeGetSession();
+  if (!session) {
+    redirect(303, '/login');
+  }
+
+  const headers = { Authorization: `Bearer ${session.access_token}` };
+  const kind = kindFor(url.searchParams.get('kind'));
+  const query = (url.searchParams.get('q') ?? '').trim().slice(0, QUERY_MAX);
+  const search = query ? `?query=${encodeURIComponent(query)}` : '';
+
+  const [brandRes, mediaRes] = await Promise.all([
+    fetch(brandApi(params.brand, ''), { headers }),
+    fetch(brandApi(params.brand, `/media${search}`), { headers })
+  ]);
+
+  if (!brandRes.ok) {
+    error(brandRes.status, await readError(brandRes));
+  }
+  if (!mediaRes.ok) {
+    error(mediaRes.status, await readError(mediaRes));
+  }
+
+  const { brand } = (await brandRes.json()) as BrandRead;
+  const { media } = (await mediaRes.json()) as { media: MediaRow[] };
+
+  return {
+    brand: { slug: params.brand, name: brand.name, timezone: brand.timezone },
+    kind,
+    query,
+    media: ofKind(media, kind),
+    selectedMediaId: url.searchParams.get('item')
+  };
+};

--- a/src/routes/v2/[brand]/materials/+page.svelte
+++ b/src/routes/v2/[brand]/materials/+page.svelte
@@ -1,0 +1,154 @@
+<script lang="ts">
+  import '$lib/styles/tailwind.css';
+  import { replaceState } from '$app/navigation';
+  import { page } from '$app/state';
+  import { Badge } from '$lib/components/ui/badge/index.js';
+  import { KIND_FILTERS, addedOn, labelOf } from './media-kind';
+  import type { MediaRow } from './media-kind';
+  import type { PageProps } from './$types';
+
+  let { data }: PageProps = $props();
+
+  const brand = $derived(data.brand);
+  const media = $derived(data.media);
+
+  let selectedId = $state<string | null>(data.selectedMediaId);
+  let MediaPanel = $state<typeof import('./MediaPanel.svelte').default | null>(null);
+
+  const selected = $derived(media.find((m) => m.id === selectedId) ?? null);
+
+  $effect(() => {
+    if (selectedId && !MediaPanel) {
+      import('./MediaPanel.svelte').then((m) => (MediaPanel = m.default));
+    }
+  });
+
+  function syncUrl(mediaId: string | null) {
+    const url = new URL(page.url);
+    if (mediaId) {
+      url.searchParams.set('item', mediaId);
+    } else {
+      url.searchParams.delete('item');
+    }
+    replaceState(url, page.state);
+  }
+
+  function open(item: MediaRow) {
+    selectedId = item.id;
+    syncUrl(item.id);
+  }
+
+  function close() {
+    selectedId = null;
+    syncUrl(null);
+  }
+
+  function filterHref(value: string): string {
+    const params = new URLSearchParams();
+    if (value !== 'all') {
+      params.set('kind', value);
+    }
+    if (data.query) {
+      params.set('q', data.query);
+    }
+    return `?${params}`;
+  }
+</script>
+
+<svelte:head><title>Materials — {brand.name}</title></svelte:head>
+
+<div class="bg-background text-foreground min-h-screen px-4 py-8 sm:px-8">
+  <div class="mx-auto flex max-w-5xl flex-col gap-6">
+    <header class="flex flex-col gap-1">
+      <p class="text-muted-foreground text-xs tracking-wide uppercase">{brand.name}</p>
+      <h1 class="text-2xl font-semibold">Materials</h1>
+      <p class="text-muted-foreground text-xs">
+        Everything the brand can reuse in a post. Read-only here — assets arrive from uploads,
+        renders and agents.
+      </p>
+    </header>
+
+    <div class="flex flex-wrap items-center justify-between gap-3">
+      <nav aria-label="Filter by type" class="flex flex-wrap gap-2">
+        {#each KIND_FILTERS as filter (filter.value)}
+          <a
+            href={filterHref(filter.value)}
+            aria-current={data.kind === filter.value ? 'page' : undefined}
+            class="focus-visible:ring-ring/50 rounded-lg border px-3 py-1.5 text-sm focus-visible:ring-3 focus-visible:outline-none {data.kind ===
+            filter.value
+              ? 'border-primary bg-primary/10 font-medium'
+              : 'border-border hover:bg-muted'}">{filter.label}</a
+          >
+        {/each}
+      </nav>
+
+      <form method="GET" class="flex items-center gap-2">
+        {#if data.kind !== 'all'}
+          <input type="hidden" name="kind" value={data.kind} />
+        {/if}
+        <label class="sr-only" for="q">Search materials</label>
+        <input
+          id="q"
+          name="q"
+          type="search"
+          value={data.query}
+          placeholder="Search title, description, tags"
+          class="dark:bg-input/30 border-input focus-visible:border-ring focus-visible:ring-ring/50 w-56 rounded-lg border bg-transparent px-2.5 py-1.5 text-sm outline-none focus-visible:ring-3"
+        />
+        <button
+          type="submit"
+          class="border-border hover:bg-muted focus-visible:ring-ring/50 rounded-lg border px-3 py-1.5 text-sm focus-visible:ring-3 focus-visible:outline-none"
+          >Search</button
+        >
+      </form>
+    </div>
+
+    {#if media.length === 0}
+      <p class="text-muted-foreground text-sm">
+        {data.query ? `Nothing matches “${data.query}”.` : 'The library is empty.'}
+      </p>
+    {:else}
+      <ul class="flex flex-wrap gap-3">
+        {#each media as item (item.id)}
+          <li class="w-[calc(50%-0.375rem)] sm:w-40">
+            <button
+              type="button"
+              onclick={() => open(item)}
+              class="border-border hover:bg-muted focus-visible:ring-ring/50 flex w-full flex-col overflow-hidden rounded-xl border text-left focus-visible:ring-3 focus-visible:outline-none"
+            >
+              <span class="bg-muted flex h-32 w-full items-center justify-center overflow-hidden">
+                {#if item.kind === 'image' && item.signed_url}
+                  <img
+                    src={item.signed_url}
+                    alt={labelOf(item)}
+                    loading="lazy"
+                    decoding="async"
+                    class="h-full w-full object-cover"
+                  />
+                {:else}
+                  <span class="text-muted-foreground text-xs">{item.kind}</span>
+                {/if}
+              </span>
+              <span class="flex flex-col gap-1 px-2.5 py-2">
+                <span class="line-clamp-2 text-sm font-medium">{labelOf(item)}</span>
+                <span class="text-muted-foreground flex items-center gap-1.5 text-xs">
+                  <Badge variant="outline">{item.kind}</Badge>
+                  {addedOn(item, brand.timezone)}
+                </span>
+              </span>
+            </button>
+          </li>
+        {/each}
+      </ul>
+      <p class="text-muted-foreground text-xs">
+        {media.length} shown. The library returns the newest first.
+      </p>
+    {/if}
+  </div>
+</div>
+
+{#if MediaPanel && selected}
+  {#key selected.id}
+    <MediaPanel item={selected} timezone={brand.timezone} onclose={close} />
+  {/key}
+{/if}

--- a/src/routes/v2/[brand]/materials/MediaPanel.svelte
+++ b/src/routes/v2/[brand]/materials/MediaPanel.svelte
@@ -1,0 +1,84 @@
+<script lang="ts">
+  import * as Sheet from '$lib/components/ui/sheet/index.js';
+  import { Badge } from '$lib/components/ui/badge/index.js';
+  import { addedOn, labelOf, shapeOf } from './media-kind';
+  import type { MediaRow } from './media-kind';
+
+  let {
+    item,
+    timezone,
+    onclose
+  }: {
+    item: MediaRow;
+    timezone: string;
+    onclose: () => void;
+  } = $props();
+
+  const shape = $derived(shapeOf(item));
+</script>
+
+<Sheet.Root open onOpenChange={(open) => !open && onclose()}>
+  <Sheet.Content side="right" class="gap-0 overflow-y-auto data-[side=right]:sm:max-w-lg">
+    <Sheet.Header class="gap-2">
+      <Sheet.Title class="flex flex-wrap items-center gap-2 text-base">
+        {labelOf(item)}
+        <Badge variant="outline">{item.kind}</Badge>
+      </Sheet.Title>
+      <Sheet.Description>Added {addedOn(item, timezone)}</Sheet.Description>
+    </Sheet.Header>
+
+    <div class="flex flex-col gap-5 px-4 pb-6">
+      {#if !item.signed_url}
+        <p class="text-muted-foreground text-sm">
+          No preview available — the file is in the library but Anomalia could not sign a link for
+          it right now.
+        </p>
+      {:else if item.kind === 'video'}
+        <!-- svelte-ignore a11y_media_has_caption -->
+        <video
+          src={item.signed_url}
+          controls
+          preload="metadata"
+          class="border-border max-h-96 w-full rounded-lg border"
+        ></video>
+      {:else}
+        <img
+          src={item.signed_url}
+          alt={labelOf(item)}
+          loading="lazy"
+          class="border-border max-h-96 w-full rounded-lg border object-contain"
+        />
+      {/if}
+
+      {#if item.description}
+        <p class="text-sm">{item.description}</p>
+      {/if}
+
+      {#if item.tags?.length}
+        <ul class="flex flex-wrap gap-1.5">
+          {#each item.tags as tag (tag)}
+            <li><Badge variant="secondary">{tag}</Badge></li>
+          {/each}
+        </ul>
+      {/if}
+
+      <dl class="text-muted-foreground flex flex-col gap-1 text-xs">
+        {#if item.mime}
+          <div class="flex gap-2"><dt class="w-20">Format</dt>
+            <dd class="text-foreground">{item.mime}</dd></div>
+        {/if}
+        {#if shape}
+          <div class="flex gap-2"><dt class="w-20">Size</dt>
+            <dd class="text-foreground">{shape}</dd></div>
+        {/if}
+        <div class="flex gap-2"><dt class="w-20">Id</dt>
+          <dd class="text-foreground font-mono break-all">{item.id}</dd></div>
+      </dl>
+
+      <p class="text-muted-foreground text-xs">
+        An agent reuses this asset by passing its id to create_post, instead of paying for a new
+        render.
+      </p>
+    </div>
+  </Sheet.Content>
+</Sheet.Root>

--- a/src/routes/v2/[brand]/materials/media-kind.test.ts
+++ b/src/routes/v2/[brand]/materials/media-kind.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { addedOn, kindFor, labelOf, ofKind, shapeOf, type MediaRow } from './media-kind';
+
+const ROME = 'Europe/Rome';
+
+function media(over: Partial<MediaRow> = {}): MediaRow {
+  return {
+    id: 'm1',
+    kind: 'image',
+    mime: 'image/png',
+    width: null,
+    height: null,
+    title: null,
+    description: null,
+    tags: null,
+    signed_url: null,
+    created_at: '2026-09-01T08:00:00Z',
+    ...over
+  };
+}
+
+describe('il filtro per tipo viene dalla URL e non si fida', () => {
+  it('accetta un tipo conosciuto', () => {
+    expect(kindFor('video')).toBe('video');
+  });
+
+  it('riporta ad all un tipo inventato', () => {
+    expect(kindFor('drop table brand_media')).toBe('all');
+  });
+
+  it('riporta ad all quando manca', () => {
+    expect(kindFor(null)).toBe('all');
+  });
+});
+
+describe('la libreria mostrata e quella filtrata, non tutta', () => {
+  const library = [media({ id: 'a' }), media({ id: 'b', kind: 'video' }), media({ id: 'c' })];
+
+  it('un tipo tiene solo il suo', () => {
+    expect(ofKind(library, 'video').map((m) => m.id)).toEqual(['b']);
+  });
+
+  it('all non toglie niente', () => {
+    expect(ofKind(library, 'all')).toHaveLength(3);
+  });
+
+  it('un tipo senza elementi non inventa una griglia', () => {
+    expect(ofKind([media({ kind: 'video' })], 'image')).toEqual([]);
+  });
+});
+
+describe('come si chiama un asset che non ha un nome', () => {
+  it('il titolo vince', () => {
+    expect(labelOf(media({ title: 'Menu autunno' }))).toBe('Menu autunno');
+  });
+
+  it('un titolo di soli spazi non diventa una riga vuota', () => {
+    expect(labelOf(media({ title: '   ', mime: 'image/webp' }))).toBe('image/webp');
+  });
+
+  it('senza titolo e senza mime resta il tipo', () => {
+    expect(labelOf(media({ title: null, mime: null, kind: 'video' }))).toBe('video');
+  });
+});
+
+describe('le misure si mostrano solo se ci sono davvero', () => {
+  it('con entrambe le misure', () => {
+    expect(shapeOf(media({ width: 1080, height: 1350 }))).toBe('1080×1350');
+  });
+
+  it('con una sola misura non si inventa la seconda', () => {
+    expect(shapeOf(media({ width: 1080, height: null }))).toBeNull();
+  });
+});
+
+describe('la data mostrata e quella del brand, non quella del server', () => {
+  it('le 23:30 UTC del 31 agosto sono il 1 settembre a Roma', () => {
+    expect(addedOn(media({ created_at: '2026-08-31T23:30:00Z' }), ROME)).toContain('1 Sep');
+  });
+});

--- a/src/routes/v2/[brand]/materials/media-kind.ts
+++ b/src/routes/v2/[brand]/materials/media-kind.ts
@@ -1,0 +1,48 @@
+export type MediaRow = {
+  id: string;
+  kind: string;
+  mime: string | null;
+  width: number | null;
+  height: number | null;
+  title: string | null;
+  description: string | null;
+  tags: string[] | null;
+  signed_url: string | null;
+  created_at: string;
+};
+
+const MEDIA_KINDS: Record<string, string> = {
+  image: 'Images',
+  video: 'Videos'
+};
+
+export const KIND_FILTERS = [
+  { value: 'all', label: 'Everything' },
+  ...Object.entries(MEDIA_KINDS).map(([value, label]) => ({ value, label }))
+];
+
+export function kindFor(kind: string | null): string {
+  return kind && kind in MEDIA_KINDS ? kind : 'all';
+}
+
+export function ofKind(media: MediaRow[], kind: string): MediaRow[] {
+  return kind === 'all' ? media : media.filter((m) => m.kind === kind);
+}
+
+export function labelOf(item: MediaRow): string {
+  const title = (item.title ?? '').trim();
+  return title || (item.mime ?? item.kind);
+}
+
+export function shapeOf(item: MediaRow): string | null {
+  return item.width && item.height ? `${item.width}×${item.height}` : null;
+}
+
+export function addedOn(item: MediaRow, timezone: string): string {
+  return new Intl.DateTimeFormat('en-GB', {
+    timeZone: timezone,
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric'
+  }).format(new Date(item.created_at));
+}


### PR DESCRIPTION
## What?

Adds `/v2/:brand/materials` — "Materiali" in the new sidebar mockup. It is the brand's media
library: a grid of previews, a filter by type, a free-text search, and a side panel that opens
one asset and shows its preview, description, tags, format, dimensions and full id.

Read-only. It calls `GET /api/v1/brands/:slug/media` (`LIST_MEDIA`) and the brand read for name
and timezone. Nothing on the page writes.

Third surface of the thin frontend, after the calendar (#229) and the post list (#235).

## Why?

The rest of `/v2` shows what goes out. Nothing shows what the brand already owns.

That matters for money, not for completeness: `create_post` accepts `media_ids`, and an id taken
from the library reuses an asset instead of paying for a new render. Today the only way to see
those ids is `anomalia`'s `list_media` from a terminal — so the library exists for agents and not
for the person who has to say "use that one". The panel prints the id in monospace for exactly
that reason.

It is also on the critical path: `/app` is not being dismantled until `/v2` covers it, and
~52,000 lines of chat code wait behind that.

## How?

**Reads an endpoint, never the database.** The `load` takes the token from the session and calls
`GET /api/v1/brands/:slug` and `GET /api/v1/brands/:slug/media` in parallel. No import from
`$lib/server/brand-media`: web, MCP and CLI go through the same product rules.

**Read-only on purpose.** `POST /media` exists (`IMPORT_MEDIA_URL`, import from a public URL) but
it is a write flow with its own failures — `media_unavailable`, rejected mime, size — and that is
not what this surface has to solve. No upload, no edit, no delete. I did not add an endpoint.

**The filters live in the URL.** `?kind=video` is a link; `?q=menu` is a `<form method="GET">`.
The server redoes the query and the page redraws. The only client state is which panel is open,
and that is written to `?item=<id>` with `replaceState`, so a reload or a shared link restores it.
`kindFor` does not trust the parameter: a type outside the table falls back to `all`.

**The type filter narrows rows in `load`, it is not a query.** `LIST_MEDIA` takes `query` and
`limit`, not `kind`. The two options were to add a parameter to an endpoint the CLI and MCP also
use, or to filter the rows already returned. I took the second: widening the contract is that
endpoint's PR, not this page's. Search, by contrast, does go to the API (`?q=` becomes `?query=`),
because duplicating "matches" in the frontend would mean two definitions that diverge on the first
change.

**The clock is the brand's.** `addedOn` formats `created_at` with `Intl.DateTimeFormat` on the
timezone the API returns. 23:30 UTC on 31 August is 1 September in Rome; a test pins it, as in
#229 and #235.

### Rejected

- **No new `shadcn-svelte` primitives.** Only `sheet` and `badge`, already in
  `src/lib/components/ui/`. The search box is an `<input type="search">` wearing the existing
  input classes. `shadcn-svelte add` has rewritten `button.svelte` and bumped `tailwind-variants`
  twice in this repo; nothing here justified the risk.
- **No `grid` utility.** `app.css` has a global `.grid` (`grid-template-columns: 1.7fr 1fr`) that
  hijacks anyone who writes the class. The preview grid is `flex flex-wrap` with a fixed width per
  tile.
- **No `<video>` in the grid** — one video element per tile is one network request per tile on
  first render. In the grid a video is a labelled tile; the player lives only in the panel, which
  is dynamically imported and therefore absent from the initial bundle.
- **No pagination.** `LIST_MEDIA` takes `limit` (max 200) but no cursor. The page says how many it
  shows instead of pretending to show everything.
- **No chat, and no link to chat.**
- **No sidebar.** The mockup's five entries are a shared layout and two of the five do not exist
  yet. A link that would 404 does not go in.

### What I wanted to show and could not

`LIST_MEDIA` returns ten fields: `id`, `kind`, `mime`, `width`, `height`, `title`, `description`,
`tags`, `signed_url`, `created_at`. The `brand_media` row carries far more — `times_used`,
`last_used_at`, `bytes`, `duration_seconds`, `source`, and the AI catalogue's `suggested_use` /
`when_to_use` / `how_to_use` / `where_to_use`.

Those are exactly what this page wants: **how often an asset has already been used** (so the same
photo does not go out twice) and **when it last was**. None of them cross the endpoint, so none of
them are shown. Widening `LIST_MEDIA` is a contract change that also touches the CLI and MCP — its
own PR.

A null `signed_url` does not become a broken preview: the panel says so.

## Testing?

`npx vitest run materials/media-kind` — **12 passed**. Written first and watched fail (`Failed to
load url ./media-kind … Does the file exist?`) before the module existed.

They pin the things that have already gone wrong once on this surface family: a URL-supplied
filter that must not invent a type the API does not know, a brand-timezone date that must not
show the server's day, and a title of only spaces that must not render an empty row.

`npm run check`: **419 errors, 253 warnings** — **zero errors in the files this PR adds**. The one
warning on `materials/+page.svelte` (`state_referenced_locally`, 15:42) is the identical line
already merged in `posts/+page.svelte`.

Full suite not run here (CI runs it, plus Playwright, on this PR).

**Visual verification is deferred to the complete frontend.** No dev server, no browser and no
Playwright were run for this PR: `/v2` has no sidebar and no entry point yet, so there is nothing
to navigate to it from and no honest screenshot to take. The whole of `/v2` gets one visual pass
when the five surfaces exist and a layout links them.

## Evidence (screenshots/videos)

None. See the paragraph above — the surface is not reachable from anywhere in the app yet, so a
screenshot would be of a URL typed by hand and would prove less than it appears to.

<details>
<summary>Red before green</summary>

```
 FAIL  src/routes/v2/[brand]/materials/media-kind.test.ts
Error: Failed to load url ./media-kind (resolved id: ./media-kind) in
  .../src/routes/v2/[brand]/materials/media-kind.test.ts. Does the file exist?
 Test Files  1 failed (1)
```
</details>

<details>
<summary>Green</summary>

```
 ✓ src/routes/v2/[brand]/materials/media-kind.test.ts (12 tests) 12ms
 Test Files  1 passed (1)
      Tests  12 passed (12)
```
</details>

## Anything Else?

**No public changelog.** Nothing in the product links to `/v2` yet, so a customer cannot reach
this page and a release note would announce something they cannot find. The internal changelog is
`changelog/2026-09-04-thin-frontend-materials.md`. The public one goes in when `/v2` gets its
entry point.

**No new duplication.** `media-kind.ts` shares nothing with `post-state.ts` — different table,
different domain. The known triplication between #229, #235 and #236 (`PostPanel`, `POST_STATES`,
`momentInZone`) is untouched here because this surface uses none of the three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
