### PR TITLE
Add the editorial plan to the thin frontend

### DIFF
--- a/changelog/2026-09-04-thin-frontend-strategy.md
+++ b/changelog/2026-09-04-thin-frontend-strategy.md
@@ -1,0 +1,83 @@
+# Il piano editoriale nel frontend sottile — `/v2/:brand/strategy`
+
+La quarta superficie del frontend sottile, dopo calendario (#229), post (#235) e materiali
+(#247). È "Strategia" nel mockup: il piano editoriale attivo — la scommessa, la voce, dove esce,
+le quattro settimane del ciclo — più le poche cose dello studio su cui il piano è costruito.
+
+Sola lettura.
+
+## Perché esiste
+
+Il calendario dice *quando*, i post dicono *cosa*. Nessuna superficie dice *perché quello*. Il
+piano editoriale è la risposta che l'agente si è dato e a cui obbedisce ogni settimana: se la
+settimana 3 produce carousel invece di reel è perché `content_mix` lo dice, e senza una pagina
+che lo mostri quel comportamento sembra un capriccio del modello.
+
+C'è anche una cosa che solo qui si vede: il campo `brief` di una settimana. È il testo che
+l'utente ha scritto per sovrascrivere il tema ("settimana del lancio"), e il pianificatore lo
+passa verbatim al batch. Se non compare da nessuna parte, nessuno sa che è stato registrato.
+
+## Come è costruita
+
+**Due letture, non tre.** `GET /api/v1/brands/:slug/editorial-plan` (`GET_PLAN`) e
+`GET /api/v1/brands/:slug/studio` (`GET_STUDIO`), in parallelo con la lettura del brand.
+
+`GET_WEEKLY_PLAN` è stato letto e scartato: `getWeeklyPlan` interroga la stessa riga
+`editorial_plans` di `getEditorialPlan` e ne restituisce un sottoinsieme — `weeks` ridotte a
+`{index, theme, status}` invece delle otto chiavi complete, e la stessa `cadence`, `strategy`,
+`platform_mix`. Le sue due aggiunte non servono qui: `posts` non è filtrato per settimana (sono
+gli ultimi 50 post del brand, cioè esattamente ciò che mostra `/v2/:brand/posts`), e `seeds` è
+l'output grezzo del pianificatore. La quota c'è già in `editorial-plan` come `{used, remaining}`.
+Una terza richiesta per dati che si hanno già è latenza pagata per niente.
+
+**Il `jsonb` non è un tipo.** `GET_PLAN` dichiara `plan` e `proposed` come oggetti opachi, e a
+ragione: la riga la scrive un modello contro uno schema, non un `CHECK` del database. Quindi
+`plan-shape.ts` non si fida di niente — `weeks` che non è un array non viene iterato, un tema che
+manca ripiega su `title` e poi su "Week 2", una `cadence` numerica non finisce in pagina, una
+voce di `content_mix` senza `type` viene saltata invece di stampare `undefined 3`. Sono i modi in
+cui una pagina che legge jsonb muore, e sono in un test.
+
+**Le condizioni stanno in una tabella sola.** `WEEK_STATES` dice per ogni stato l'etichetta e il
+tono del badge; uno stato che il modello si è inventato passa attraverso col suo nome e tono
+neutro invece di rompere il badge.
+
+**`share` è testo, non un numero.** Lo schema di `platform_mix` lo descrive come
+«`'40%'` o `'2/week'`»: è prosa del modello. Non c'è nessuna percentuale da calcolare e nessuna
+barra da disegnare — si mostra com'è.
+
+**Nessuno stato client.** Niente pannello, niente filtri, niente `replaceState`: la pagina è una
+lettura sola e non ha nulla da ricordare.
+
+## Cosa non si può mostrare, e perché non è stato inventato
+
+**Quanto del piano è stato eseguito.** La pagina mostra le quattro settimane e quale è quella
+corrente, ma non quanti post ciascuna settimana ha davvero prodotto. `getWeeklyPlan` restituisce
+`posts` senza legarli alla settimana (nessun filtro su `editorial_week`, nessun raggruppamento),
+e i post hanno `pillar` e `format` ma non l'indice di settimana. Legarli vorrebbe dire scrivere
+in questa pagina una regola che decide quale post appartiene a quale settimana — cioè logica di
+dominio nel frontend, che è esattamente la cosa da non fare. Serve un endpoint che lo dica.
+
+**Il piano GTM.** `plan.gtm` esiste con `stage`, `summary`, `platform_recs[]` e `plays[]`, ed è
+la parte più interessante per un brand a zero. Non è mostrato: è una superficie sua, e mostrarne
+un riassunto senza le raccomandazioni per piattaforma direbbe meno di quanto confonde.
+
+**Accettare o rifiutare la proposta.** `SAVE_PLAN` esiste. Se c'è un piano proposto la pagina lo
+mostra con il riepilogo delle modifiche e lo dice — ma decidere è un'azione con conseguenze
+(sostituisce il piano attivo, e da lì scende tutta la produzione), e questa PR è una lettura.
+
+## Cosa è stato scartato
+
+**Nessuna primitiva nuova.** Solo `badge`, già presente. Nessun `card`, nessun `tabs`: sono
+sezioni con un titolo, e `shadcn-svelte add` ha già riscritto `button.svelte` due volte in questo
+repository.
+
+**Nessuna utility `grid`.** `app.css` ha un `.grid` globale (`grid-template-columns: 1.7fr 1fr`).
+Tutto è flex.
+
+**Nessun import dinamico.** Non c'è niente da rimandare: la pagina non ha pannelli e il suo
+JavaScript è quello di SvelteKit più un badge.
+
+**Nessuna chat, nessun link alla chat.**
+
+**Nessuna barra laterale.** Le cinque voci del mockup sono un layout condiviso e non tutte le
+superfici esistono. Un link che darebbe 404 non si mette.

--- a/src/routes/v2/[brand]/strategy/+page.server.ts
+++ b/src/routes/v2/[brand]/strategy/+page.server.ts
@@ -1,0 +1,83 @@
+import { error, redirect } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+import { listOf, type PlanBlob } from './plan-shape';
+
+type BrandRead = {
+  brand: { name: string; slug: string; timezone: string };
+};
+
+type PlanRead = {
+  plan: PlanBlob | null;
+  proposed: PlanBlob | null;
+  proposedFeedback: string | null;
+  currentWeek: number | null;
+  quota: { used: number; remaining: number };
+};
+
+type StudioRead = {
+  kit: PlanBlob | null;
+  products: unknown[];
+  documents: unknown[];
+  people: unknown[];
+  competitors: unknown[];
+  targetPlatforms: string[];
+  language: string;
+  studioPct: number;
+};
+
+function brandApi(slug: string, path: string): string {
+  return `/api/v1/brands/${encodeURIComponent(slug)}${path}`;
+}
+
+async function readError(res: Response): Promise<string> {
+  const body = (await res.json().catch(() => null)) as { error?: string } | null;
+  return body?.error ?? `Request failed (${res.status})`;
+}
+
+export const load: PageServerLoad = async ({ params, fetch, locals }) => {
+  const { session } = await locals.safeGetSession();
+  if (!session) {
+    redirect(303, '/login');
+  }
+
+  const headers = { Authorization: `Bearer ${session.access_token}` };
+
+  const [brandRes, planRes, studioRes] = await Promise.all([
+    fetch(brandApi(params.brand, ''), { headers }),
+    fetch(brandApi(params.brand, '/editorial-plan'), { headers }),
+    fetch(brandApi(params.brand, '/studio'), { headers })
+  ]);
+
+  if (!brandRes.ok) {
+    error(brandRes.status, await readError(brandRes));
+  }
+  if (!planRes.ok) {
+    error(planRes.status, await readError(planRes));
+  }
+  if (!studioRes.ok) {
+    error(studioRes.status, await readError(studioRes));
+  }
+
+  const { brand } = (await brandRes.json()) as BrandRead;
+  const editorial = (await planRes.json()) as PlanRead;
+  const studio = (await studioRes.json()) as StudioRead;
+
+  return {
+    brand: { slug: params.brand, name: brand.name },
+    plan: editorial.plan,
+    proposed: editorial.proposed,
+    proposedFeedback: editorial.proposedFeedback,
+    currentWeek: editorial.currentWeek,
+    quota: editorial.quota,
+    truth: {
+      pillars: listOf(studio.kit, 'content_pillars'),
+      platforms: studio.targetPlatforms,
+      language: studio.language,
+      completeness: studio.studioPct,
+      products: studio.products.length,
+      people: studio.people.length,
+      competitors: studio.competitors.length,
+      documents: studio.documents.length
+    }
+  };
+};

--- a/src/routes/v2/[brand]/strategy/+page.svelte
+++ b/src/routes/v2/[brand]/strategy/+page.svelte
@@ -1,0 +1,182 @@
+<script lang="ts">
+  import '$lib/styles/tailwind.css';
+  import { Badge } from '$lib/components/ui/badge/index.js';
+  import { listOf, pairsOf, platformsOf, stateOf, textOf, weeksOf } from './plan-shape';
+  import type { PageProps } from './$types';
+
+  let { data }: PageProps = $props();
+
+  const plan = $derived(data.plan);
+  const weeks = $derived(weeksOf(plan, data.currentWeek));
+  const voice = $derived(plan ? pairsOf(plan) : []);
+  const platforms = $derived(plan ? platformsOf(plan) : []);
+  const strategy = $derived(textOf(plan, 'strategy'));
+  const cadence = $derived(textOf(plan, 'cadence'));
+  const changes = $derived(listOf(data.proposed, 'changes_summary'));
+  const truth = $derived(data.truth);
+</script>
+
+<svelte:head><title>Strategy — {data.brand.name}</title></svelte:head>
+
+<div class="bg-background text-foreground min-h-screen px-4 py-8 sm:px-8">
+  <div class="mx-auto flex max-w-3xl flex-col gap-8">
+    <header class="flex flex-col gap-1">
+      <p class="text-muted-foreground text-xs tracking-wide uppercase">{data.brand.name}</p>
+      <h1 class="text-2xl font-semibold">Strategy</h1>
+      <p class="text-muted-foreground text-xs">
+        {#if cadence}{cadence} · {/if}{data.quota.used} posts used this month, {data.quota
+          .remaining} left
+      </p>
+    </header>
+
+    {#if !plan}
+      <p class="border-border rounded-xl border px-4 py-3 text-sm">
+        No active editorial plan. Anomalia writes one during onboarding and rewrites it every
+        cycle — until then there is nothing here to read.
+      </p>
+    {:else}
+      {#if strategy}
+        <section aria-labelledby="bet" class="flex flex-col gap-2">
+          <h2 id="bet" class="text-sm font-semibold">The bet</h2>
+          <p class="text-sm leading-relaxed">{strategy}</p>
+        </section>
+      {/if}
+
+      {#if voice.length > 0}
+        <section aria-labelledby="voice" class="flex flex-col gap-2">
+          <h2 id="voice" class="text-sm font-semibold">Voice</h2>
+          <dl class="flex flex-wrap gap-x-8 gap-y-2 text-sm">
+            {#each voice as pair (pair.label)}
+              <div class="flex flex-col">
+                <dt class="text-muted-foreground text-xs">{pair.label}</dt>
+                <dd>{pair.value}</dd>
+              </div>
+            {/each}
+          </dl>
+        </section>
+      {/if}
+
+      {#if platforms.length > 0}
+        <section aria-labelledby="where" class="flex flex-col gap-2">
+          <h2 id="where" class="text-sm font-semibold">Where it goes</h2>
+          <ul class="border-border divide-border divide-y rounded-xl border">
+            {#each platforms as row (row.platform)}
+              <li class="flex flex-wrap items-baseline gap-x-3 gap-y-1 px-4 py-3 text-sm">
+                <span class="font-medium">{row.platform}</span>
+                {#if row.share}<Badge variant="outline">{row.share}</Badge>{/if}
+                {#if row.role}<span class="text-muted-foreground">{row.role}</span>{/if}
+              </li>
+            {/each}
+          </ul>
+        </section>
+      {/if}
+
+      <section aria-labelledby="weeks" class="flex flex-col gap-2">
+        <h2 id="weeks" class="text-sm font-semibold">The cycle</h2>
+        {#if weeks.length === 0}
+          <p class="text-muted-foreground text-sm">The plan carries no weeks.</p>
+        {:else}
+          <ol class="border-border divide-border divide-y rounded-xl border">
+            {#each weeks as week (week.index)}
+              {@const state = stateOf(week.status)}
+              <li class="flex flex-col gap-1 px-4 py-3 {week.current ? 'bg-primary/5' : ''}">
+                <div class="flex flex-wrap items-center gap-2 text-xs">
+                  <span class="text-muted-foreground">{week.label}</span>
+                  <Badge variant={state.tone}>{state.label}</Badge>
+                  {#if week.current}
+                    <span class="text-primary font-medium">Now</span>
+                  {/if}
+                </div>
+                <p class="text-sm font-medium">{week.theme}</p>
+                {#if week.focus}
+                  <p class="text-muted-foreground text-sm">{week.focus}</p>
+                {/if}
+                {#if week.mix}
+                  <p class="text-muted-foreground text-xs">{week.mix}</p>
+                {/if}
+                {#if week.brief}
+                  <p class="text-sm">
+                    <span class="text-muted-foreground text-xs">Your brief — </span>{week.brief}
+                  </p>
+                {/if}
+              </li>
+            {/each}
+          </ol>
+        {/if}
+      </section>
+    {/if}
+
+    {#if data.proposed}
+      <section aria-labelledby="proposed" class="border-border flex flex-col gap-2 rounded-xl border p-4">
+        <h2 id="proposed" class="text-sm font-semibold">A new plan is waiting</h2>
+        <p class="text-sm leading-relaxed">{textOf(data.proposed, 'strategy')}</p>
+        {#if changes.length > 0}
+          <ul class="text-muted-foreground flex list-disc flex-col gap-1 pl-5 text-sm">
+            {#each changes as change (change)}
+              <li>{change}</li>
+            {/each}
+          </ul>
+        {/if}
+        {#if data.proposedFeedback}
+          <p class="text-muted-foreground text-xs">Your feedback: {data.proposedFeedback}</p>
+        {/if}
+        <p class="text-muted-foreground text-xs">
+          Accepting or rejecting it is not done from here yet.
+        </p>
+      </section>
+    {/if}
+
+    <section aria-labelledby="truth" class="flex flex-col gap-3">
+      <h2 id="truth" class="text-sm font-semibold">What the plan is built on</h2>
+
+      {#if truth.pillars.length > 0}
+        <div class="flex flex-col gap-1.5">
+          <p class="text-muted-foreground text-xs">Content pillars</p>
+          <ul class="flex flex-wrap gap-1.5">
+            {#each truth.pillars as pillar (pillar)}
+              <li><Badge variant="secondary">{pillar}</Badge></li>
+            {/each}
+          </ul>
+        </div>
+      {/if}
+
+      {#if truth.platforms.length > 0}
+        <div class="flex flex-col gap-1.5">
+          <p class="text-muted-foreground text-xs">Selected platforms</p>
+          <ul class="flex flex-wrap gap-1.5">
+            {#each truth.platforms as platform (platform)}
+              <li><Badge variant="outline">{platform}</Badge></li>
+            {/each}
+          </ul>
+        </div>
+      {/if}
+
+      <dl class="text-muted-foreground flex flex-wrap gap-x-8 gap-y-2 text-sm">
+        <div class="flex flex-col">
+          <dt class="text-xs">Language</dt>
+          <dd class="text-foreground">{truth.language}</dd>
+        </div>
+        <div class="flex flex-col">
+          <dt class="text-xs">Products</dt>
+          <dd class="text-foreground">{truth.products}</dd>
+        </div>
+        <div class="flex flex-col">
+          <dt class="text-xs">People</dt>
+          <dd class="text-foreground">{truth.people}</dd>
+        </div>
+        <div class="flex flex-col">
+          <dt class="text-xs">Competitors</dt>
+          <dd class="text-foreground">{truth.competitors}</dd>
+        </div>
+        <div class="flex flex-col">
+          <dt class="text-xs">Documents</dt>
+          <dd class="text-foreground">{truth.documents}</dd>
+        </div>
+        <div class="flex flex-col">
+          <dt class="text-xs">Studio filled</dt>
+          <dd class="text-foreground">{truth.completeness}%</dd>
+        </div>
+      </dl>
+    </section>
+  </div>
+</div>

--- a/src/routes/v2/[brand]/strategy/plan-shape.test.ts
+++ b/src/routes/v2/[brand]/strategy/plan-shape.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest';
+import { listOf, mixOf, pairsOf, platformsOf, stateOf, textOf, weeksOf } from './plan-shape';
+
+describe('le settimane arrivano da un jsonb che nessuno controlla', () => {
+  it('un piano senza settimane non diventa una lista rotta', () => {
+    expect(weeksOf(null, null)).toEqual([]);
+    expect(weeksOf({ weeks: null }, null)).toEqual([]);
+    expect(weeksOf({ weeks: 'four' }, null)).toEqual([]);
+  });
+
+  it('il tema manca e ci si accontenta del titolo', () => {
+    const [week] = weeksOf({ weeks: [{ title: 'Lancio' }] }, null);
+
+    expect(week.theme).toBe('Lancio');
+  });
+
+  it('senza tema e senza titolo la settimana si nomina da sola', () => {
+    const [week] = weeksOf({ weeks: [{}] }, null);
+
+    expect(week.theme).toBe('Week 1');
+  });
+
+  it("l'indice mostrato parte da uno, non da zero", () => {
+    const weeks = weeksOf({ weeks: [{}, {}] }, null);
+
+    expect(weeks.map((w) => w.label)).toEqual(['Week 1', 'Week 2']);
+  });
+
+  it('la settimana corrente e una sola', () => {
+    const weeks = weeksOf({ weeks: [{}, {}, {}, {}] }, 2);
+
+    expect(weeks.filter((w) => w.current).map((w) => w.index)).toEqual([2]);
+  });
+
+  it('senza settimana corrente non se ne accende nessuna', () => {
+    expect(weeksOf({ weeks: [{}, {}] }, null).some((w) => w.current)).toBe(false);
+  });
+});
+
+describe('lo stato di una settimana decide come si legge', () => {
+  it('done e chiuso', () => {
+    expect(stateOf('done')).toMatchObject({ label: 'Done', tone: 'secondary' });
+  });
+
+  it('uno stato inventato dal modello non rompe il badge', () => {
+    expect(stateOf('vibes')).toEqual({ label: 'vibes', tone: 'outline' });
+  });
+
+  it('senza stato resta upcoming', () => {
+    expect(stateOf(undefined).label).toBe('Upcoming');
+  });
+});
+
+describe('il mix di contenuti si legge in una riga', () => {
+  it('tipo e quantita in ordine di arrivo', () => {
+    expect(mixOf({ content_mix: [{ type: 'reel', count: 3 }, { type: 'carousel', count: 2 }] })).toBe(
+      '3 reel · 2 carousel'
+    );
+  });
+
+  it('un mix assente non stampa un separatore solitario', () => {
+    expect(mixOf({})).toBe('');
+    expect(mixOf({ content_mix: [] })).toBe('');
+    expect(mixOf({ content_mix: 'three reels' })).toBe('');
+  });
+
+  it('una voce senza tipo viene saltata invece di stampare undefined', () => {
+    expect(mixOf({ content_mix: [{ count: 3 }, { type: 'reel', count: 1 }] })).toBe('1 reel');
+  });
+});
+
+describe('la voce del brand si mostra solo dove esiste', () => {
+  it('le quattro voci in ordine fisso', () => {
+    const pairs = pairsOf({ voice: { mood: 'warm', tone: 'direct', goal: 'trust', personality: 'host' } });
+
+    expect(pairs.map((p) => p.label)).toEqual(['Mood', 'Tone', 'Goal', 'Personality']);
+  });
+
+  it('una voce vuota non diventa una riga vuota', () => {
+    expect(pairsOf({ voice: { mood: 'warm', tone: '  ', goal: null } })).toEqual([
+      { label: 'Mood', value: 'warm' }
+    ]);
+  });
+
+  it('senza voce non si mostra la sezione', () => {
+    expect(pairsOf({})).toEqual([]);
+    expect(pairsOf({ voice: 'friendly' })).toEqual([]);
+  });
+});
+
+describe('il mix di piattaforme e testo del modello, non un numero', () => {
+  it('piattaforma, quota e ruolo passano cosi come sono', () => {
+    expect(
+      platformsOf({ platform_mix: [{ platform: 'instagram', share: '2/week', role: 'discovery' }] })
+    ).toEqual([{ platform: 'instagram', share: '2/week', role: 'discovery' }]);
+  });
+
+  it('una riga senza piattaforma viene saltata', () => {
+    expect(platformsOf({ platform_mix: [{ share: '40%' }] })).toEqual([]);
+  });
+
+  it('un mix assente resta una lista vuota', () => {
+    expect(platformsOf({ platform_mix: null })).toEqual([]);
+  });
+});
+
+describe('i pilastri arrivano dallo studio, e non sempre arrivano', () => {
+  it('una lista di stringhe passa', () => {
+    expect(listOf({ content_pillars: ['dietro le quinte', 'ricette'] }, 'content_pillars')).toEqual([
+      'dietro le quinte',
+      'ricette'
+    ]);
+  });
+
+  it('un brand mai analizzato non ha pilastri', () => {
+    expect(listOf(null, 'content_pillars')).toEqual([]);
+    expect(listOf({}, 'content_pillars')).toEqual([]);
+  });
+
+  it('un pilastro vuoto non diventa un badge vuoto', () => {
+    expect(listOf({ content_pillars: ['ricette', '   ', ''] }, 'content_pillars')).toEqual([
+      'ricette'
+    ]);
+  });
+
+  it('un jsonb che non e una lista non viene iterato', () => {
+    expect(listOf({ content_pillars: 'ricette, dietro le quinte' }, 'content_pillars')).toEqual([]);
+  });
+});
+
+describe('un campo di testo del piano non e garantito che sia testo', () => {
+  it('la strategia scritta si legge', () => {
+    expect(textOf({ strategy: 'Portare il locale online' }, 'strategy')).toBe(
+      'Portare il locale online'
+    );
+  });
+
+  it('un piano assente non stampa undefined', () => {
+    expect(textOf(null, 'strategy')).toBe('');
+  });
+
+  it('un numero al posto di una frase non finisce in pagina', () => {
+    expect(textOf({ cadence: 3 }, 'cadence')).toBe('');
+  });
+});

--- a/src/routes/v2/[brand]/strategy/plan-shape.ts
+++ b/src/routes/v2/[brand]/strategy/plan-shape.ts
@@ -1,0 +1,106 @@
+export type PlanBlob = Record<string, unknown>;
+
+export type WeekRow = {
+  index: number;
+  label: string;
+  theme: string;
+  focus: string;
+  brief: string;
+  mix: string;
+  status: string;
+  current: boolean;
+};
+
+export type WeekState = {
+  label: string;
+  tone: 'default' | 'secondary' | 'outline';
+};
+
+export type Pair = { label: string; value: string };
+
+export type PlatformRow = { platform: string; share: string; role: string };
+
+const WEEK_STATES: Record<string, WeekState> = {
+  upcoming: { label: 'Upcoming', tone: 'outline' },
+  planned: { label: 'Planned', tone: 'default' },
+  done: { label: 'Done', tone: 'secondary' }
+};
+
+const VOICE_LABELS: Pair[] = [
+  { label: 'Mood', value: 'mood' },
+  { label: 'Tone', value: 'tone' },
+  { label: 'Goal', value: 'goal' },
+  { label: 'Personality', value: 'personality' }
+];
+
+function rows(value: unknown): PlanBlob[] {
+  return Array.isArray(value) ? (value.filter((v) => v && typeof v === 'object') as PlanBlob[]) : [];
+}
+
+function text(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+export function stateOf(status: unknown): WeekState {
+  const key = text(status) || 'upcoming';
+  return WEEK_STATES[key] ?? { label: key, tone: 'outline' };
+}
+
+export function mixOf(week: PlanBlob): string {
+  return rows(week.content_mix)
+    .map((entry) => {
+      const type = text(entry.type);
+      return type ? `${entry.count ?? 0} ${type}` : '';
+    })
+    .filter(Boolean)
+    .join(' · ');
+}
+
+export function weeksOf(plan: PlanBlob | null, currentWeek: number | null): WeekRow[] {
+  if (!plan) {
+    return [];
+  }
+
+  return rows(plan.weeks).map((week, index) => ({
+    index,
+    label: `Week ${index + 1}`,
+    theme: text(week.theme) || text(week.title) || `Week ${index + 1}`,
+    focus: text(week.focus),
+    brief: text(week.brief),
+    mix: mixOf(week),
+    status: text(week.status) || 'upcoming',
+    current: index === currentWeek
+  }));
+}
+
+export function pairsOf(plan: PlanBlob): Pair[] {
+  const voice = plan.voice;
+  if (!voice || typeof voice !== 'object' || Array.isArray(voice)) {
+    return [];
+  }
+
+  const spoken = voice as PlanBlob;
+
+  return VOICE_LABELS.map(({ label, value }) => ({ label, value: text(spoken[value]) })).filter(
+    (pair) => pair.value !== ''
+  );
+}
+
+export function platformsOf(plan: PlanBlob): PlatformRow[] {
+  return rows(plan.platform_mix)
+    .map((entry) => ({
+      platform: text(entry.platform),
+      share: text(entry.share),
+      role: text(entry.role)
+    }))
+    .filter((entry) => entry.platform !== '');
+}
+
+export function textOf(blob: PlanBlob | null, key: string): string {
+  return blob ? text(blob[key]) : '';
+}
+
+export function listOf(blob: PlanBlob | null, key: string): string[] {
+  const value = blob?.[key];
+  return Array.isArray(value) ? value.map((entry) => text(entry)).filter(Boolean) : [];
+}


### PR DESCRIPTION
## What?

Adds `/v2/:brand/strategy` — "Strategia" in the new sidebar mockup. It shows the brand's active
editorial plan, read-only: the strategy statement, the voice (mood / tone / goal / personality),
the platform mix with each platform's share and job, and the four weeks of the cycle with the
current one marked. Under it, the studio facts the plan was built on — content pillars, selected
platforms, language, and how many products, people, competitors and documents the brand has
given Anomalia.

If a revised plan is waiting, the page says so and shows its strategy plus the change summary.

Fourth surface of the thin frontend, after the calendar (#229), the post list (#235) and the
materials library (#247).

## Why?

The calendar answers *when*. The post list answers *what*. Nothing answers *why that*.

The editorial plan is the answer the agent gave itself and then obeys every week. When week 3
produces carousels instead of reels it is because `content_mix` says so — and with no page
showing it, that behaviour reads as the model being erratic.

One thing is visible only here: a week's `brief`. That is the text the user wrote to override the
theme ("launch week"), and the batch planner passes it to the planner verbatim. If it appears
nowhere, nobody knows it was recorded.

And it is on the critical path: `/app` is not dismantled until `/v2` covers it.

## How?

**Two reads, not three.** `GET /api/v1/brands/:slug/editorial-plan` (`GET_PLAN`) and
`GET /api/v1/brands/:slug/studio` (`GET_STUDIO`), in parallel with the brand read. No import from
`$lib/server/cli-queries` — web, MCP and CLI go through the same rules.

**`GET_WEEKLY_PLAN` was read and deliberately skipped.** `getWeeklyPlan` queries the same
`editorial_plans` row as `getEditorialPlan` and returns a subset of it: `weeks` flattened to
`{index, theme, status}` instead of the full eight keys, and the same `cadence`, `strategy` and
`platform_mix`. Its two additions do not help here — `posts` is not week-scoped (it is the
brand's last 50 posts, which is exactly what `/v2/:brand/posts` already shows) and `seeds` is the
planner's raw output. The quota is already in `editorial-plan` as `{used, remaining}`. A third
request for data I already have is latency paid for nothing.

**The jsonb is not a type.** `GET_PLAN` types `plan` and `proposed` as opaque objects, correctly:
a model writes that row against a JSON schema, not against a DB constraint. So `plan-shape.ts`
trusts none of it — a `weeks` that is not an array is not iterated, a missing theme falls back to
`title` and then to a generated `Week 2`, a numeric `cadence` never reaches the page, and a
`content_mix` entry without a `type` is skipped instead of rendering `undefined 3`.

**One table for the exceptions.** `WEEK_STATES` holds label and badge tone per status; a status
the model invented passes through under its own name with a neutral tone rather than breaking the
badge.

**`share` is prose, not a number.** The `platform_mix` schema describes it as "e.g. '40%' or
'2/week'". There is no percentage to compute and no bar to draw — it is shown as written.

**No client state at all.** No panel, no filters, no `replaceState`: the page is a single read
with nothing to remember.

### What I wanted to show and could not

- **How much of the plan actually shipped.** The page shows the four weeks and which one is
  current, but not how many posts each week produced. `getWeeklyPlan` returns `posts` without
  binding them to a week (no `editorial_week` filter, no grouping), and a post row carries
  `pillar` and `format` but no week index. Binding them would mean writing, in this page, the
  rule that decides which post belongs to which week — domain logic in the frontend, which is
  exactly what this frontend must not have. It needs an endpoint that says it.
- **The GTM plan.** `plan.gtm` exists with `stage`, `summary`, `platform_recs[]` and `plays[]`,
  and it is the most interesting part for a brand at zero. Not shown: it is its own surface, and
  a summary without the per-platform recommendations would confuse more than it says.
- **Accepting or rejecting the proposal.** `SAVE_PLAN` exists. When a proposal is pending the
  page shows it and says plainly that deciding is not done from here yet — deciding replaces the
  active plan and all production descends from it, and this PR is a read.

### Rejected

- **No new `shadcn-svelte` primitives** — only `badge`, already present. No `card`, no `tabs`:
  these are sections with a heading. `shadcn-svelte add` has rewritten `button.svelte` twice in
  this repo.
- **No `grid` utility** — `app.css` has a global `.grid` (`grid-template-columns: 1.7fr 1fr`).
  Everything is flex.
- **No dynamic import** — there is nothing to defer; the page has no panel.
- **No chat, and no link to chat.**
- **No sidebar** — the mockup's five entries are a shared layout and not every surface exists. A
  link that would 404 does not go in.

## Testing?

`npx vitest run strategy/plan-shape` — **25 passed**. Written first and watched fail (`Failed to
load url ./plan-shape … Does the file exist?`) before the module existed.

They pin how this page dies: a plan whose `weeks` is a string, a week with no theme, a
`content_mix` entry with no type, a `voice` that is a string instead of an object, a
`platform_mix` row with no platform, a `content_pillars` that is prose instead of a list. Every
one of those is a shape a model can emit into that column today.

`npm run check`: **744 errors, 34 warnings** — **zero errors and zero warnings in the files this
PR adds**. (The absolute number differs from the materials PR's 419 because the two worktrees sit
on different `dev` commits; the top offenders are `src/lib/content/changelog/legacy.ts`,
`rubrics-feasibility.test.ts` and `scripts/db-migrate.mjs`, all pre-existing and untouched here.)

Full suite not run here — CI runs it, plus Playwright, on this PR.

**Visual verification is deferred to the complete frontend.** No dev server, no browser and no
Playwright were run for this PR. `/v2` still has no sidebar and no entry point, so nothing in the
app navigates here yet. The whole of `/v2` gets one visual pass when the five surfaces exist and
a layout links them.

## Evidence (screenshots/videos)

None, for the reason above: the surface is not reachable from anywhere in the app, so a
screenshot would be of a hand-typed URL and would prove less than it appears to.

<details>
<summary>Red before green</summary>

```
 FAIL  src/routes/v2/[brand]/strategy/plan-shape.test.ts
Error: Failed to load url ./plan-shape (resolved id: ./plan-shape) in
  .../src/routes/v2/[brand]/strategy/plan-shape.test.ts. Does the file exist?
 Test Files  1 failed (1)
      Tests  no tests
```
</details>

<details>
<summary>Green</summary>

```
 ✓ src/routes/v2/[brand]/strategy/plan-shape.test.ts (25 tests) 3ms
 Test Files  1 passed (1)
      Tests  25 passed (25)
```
</details>

## Anything Else?

**No public changelog.** Nothing in the product links to `/v2` yet, so a customer cannot reach
this page. The internal changelog is `changelog/2026-09-04-thin-frontend-strategy.md`. The public
one goes in when `/v2` gets its entry point.

**No new duplication.** `plan-shape.ts` shares nothing with `post-state.ts` or `media-kind.ts`.
The known triplication between #229, #235 and #236 (`PostPanel`, `POST_STATES`, `momentInZone`)
is untouched — this surface uses none of the three.

**Follow-up worth its own ticket:** an endpoint that binds posts to their editorial week would
turn the week list from a plan into a plan-versus-reality view, which is what the page wants to
be.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
