### PR TITLE
Move billing to the org, one org at a time

### DIFF
--- a/changelog/2026-09-04-org-billing-migrate-script.md
+++ b/changelog/2026-09-04-org-billing-migrate-script.md
@@ -1,0 +1,53 @@
+# Lo strumento per spostare la fatturazione sull'org, un'org alla volta
+
+Il codice per la fatturazione a livello di organizzazione è tutto in `dev` (#202, #210, #212,
+#216), ma nessuna org è ancora migrata: `organizations.stripe_customer_id` è vuoto ovunque, quindi
+ogni lettura passa dal ramo di fallback verso il brand e per i clienti non è cambiato niente.
+Questo è il ferro per fare il passaggio vero — il ticket #191.
+
+`scripts/migrate-org-billing.ts` copia sull'org i valori Stripe del brand che paga:
+`stripe_customer_id`, `stripe_subscription_id`, `plan`, `activated_at`. **Stripe non viene mai
+chiamato**: l'org riusa lo stesso identico customer e la stessa identica subscription che il brand
+ha già, che è ciò che rende il passaggio reversibile. Le colonne del brand non vengono toccate:
+restano a rispondere finché una migration successiva non le rimuove (decisione #185).
+
+**Dry-run per default.** Senza flag non scrive niente e stampa, org per org, cosa farebbe. `--apply`
+**pretende** `--org <id>`: il rollout è una org alla volta con una verifica in mezzo (decisione
+#192), e migrarne novanta con un comando non è una cosa che questo script sappia fare. `--verify`
+ricontrolla i punti (a) e (b) della checklist — che org e brand pagante dicano gli stessi valori, e
+che pool di crediti ne esca — e dichiara nell'output che (c) il portale che si apre e (d) l'azione
+AI che passa il gate restano da fare a mano.
+
+Chi paga si riconosce da **due** condizioni, `stripe_subscription_id` valorizzato **e** piano nella
+lista dei paganti: la migration 0104 azzera il piano alla cancellazione lasciando l'id, quindi
+nessuna delle due da sola distingue una subscription viva da una morta. È la stessa coppia di
+condizioni che usa `payingOrgId` in `src/lib/server/org.ts`, non una terza definizione.
+
+**Casi che si fermano invece di indovinare:** un'org con due brand paganti non viene migrata, viene
+segnalata come conflitto e lo script esce con codice 1. Non dovrebbe esistere — nessun cliente ha
+più di una subscription attiva — ma se esiste, quale delle due subscription diventa quella dell'org
+è una domanda per una persona, non per uno script.
+
+**`activated_at` viaggia con gli altri tre** anche se oggi non lo legge nessuno: un'org pagante
+prende il periodo da Stripe, e finché le colonne del brand ci sono `resolveOrgBilling` ripiega
+sulla data del brand pagante. È una colonna in più in un UPDATE che sta già avvenendo, ed è ciò che
+impedisce all'ancora del piano free di spostarsi in silenzio sul mese solare il giorno in cui
+quelle colonne spariranno.
+
+**Scartato: collassare le org multiple dei fondatori.** Il testo di #191 lo chiedeva, ma è
+antecedente alla decisione #203, che ha stabilito che il multi-org va preservato e che ogni org
+resta indipendente. Lo script non collassa niente.
+
+**Scartato: un guard "eseguito come comando" nello stesso file.** Sotto `vite-node` il path dello
+script non arriva mai in `process.argv` (ci arrivano i flag, non il file), quindi il guard non può
+funzionare — e senza guard un test che importa il modulo avvia un comando che sa scrivere su una
+riga di fatturazione. La logica pura sta in `scripts/org-billing-plan.ts`, il comando la importa:
+niente guard da azzeccare, e la parte che decide cosa viene scritto è testabile da sola.
+
+**Quello che il primo dry-run vero ha trovato:** la migration `20260903190000_org_billing_schema.sql`
+**non è applicata** in produzione. Lo script si è fermato su
+`column organizations.stripe_subscription_id does not exist`, e `node scripts/schema-drift-check.mjs`
+lo conferma con sette divergenze. Il codice in `dev` nomina già quelle colonne: finché la migration
+non viene applicata a mano, in produzione la risoluzione dell'org fallisce e il gate dei crediti
+ricade in fail-open — lo stesso silenzio di una settimana che #161 ha chiuso e che #205 rende
+rumoroso.

--- a/scripts/migrate-org-billing.ts
+++ b/scripts/migrate-org-billing.ts
@@ -1,0 +1,168 @@
+/**
+ * Move an organization's billing from its paying brand up to the org row (#191).
+ *
+ *   npx vite-node --config scripts/vite-node.config.ts scripts/migrate-org-billing.ts
+ *   …                                                 scripts/migrate-org-billing.ts --org <id> --apply
+ *   …                                                 scripts/migrate-org-billing.ts --verify [--org <id>]
+ *
+ * Writes ONLY to `organizations`, and only the four billing columns. Stripe is never called: the
+ * org reuses the very customer and subscription its brand already has, which is what makes this
+ * reversible — the brand columns stay as they are and keep answering until a later migration
+ * drops them.
+ *
+ * Dry run by default. `--apply` needs `--org`, because the rollout is one org at a time with a
+ * check in between; migrating 90-odd rows in one command is not a thing this script can do.
+ */
+import { isPaying, planForOrg, type BillingValues, type BrandRow, type OrgRow } from './org-billing-plan';
+
+// The server modules are pulled in from inside main(): importing them drags SvelteKit's env and
+// the i18n bundle along, and `planForOrg` — the part that decides what gets written to a real
+// billing row — is a pure function that should be testable without any of it.
+type AdminClient = Awaited<ReturnType<typeof adminClient>>;
+const adminClient = async () =>
+  (await import('../src/lib/server/supabase-admin')).createAdminClient();
+
+// ── the runner ───────────────────────────────────────────────────────────────────
+
+const SELECT =
+  'id, name, stripe_customer_id, stripe_subscription_id, plan, activated_at, ' +
+  'brands(id, name, plan, stripe_customer_id, stripe_subscription_id, activated_at)';
+
+function arg(flag: string): string | undefined {
+  const i = process.argv.indexOf(flag);
+  return i === -1 ? undefined : process.argv[i + 1];
+}
+
+function requireEnv() {
+  const missing = ['PUBLIC_SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY'].filter(
+    (k) => !process.env[k]
+  );
+  if (missing.length === 0) return;
+  console.error(
+    `Missing ${missing.join(' and ')}.\n` +
+      'This script needs the service role: RLS hides other people\'s orgs from the anon key, so ' +
+      'it would read an empty database and report that nothing needs migrating.\n' +
+      '  npx vite-node --config scripts/vite-node.config.ts scripts/migrate-org-billing.ts'
+  );
+  process.exit(2);
+}
+
+async function loadOrgs(db: AdminClient, orgId?: string) {
+  const q = db.from('organizations').select(SELECT).order('created_at', { ascending: true });
+  const { data, error } = await (orgId ? q.eq('id', orgId) : q);
+  if (error) throw new Error(`reading organizations: ${error.message}`);
+  return (data ?? []) as unknown as OrgRow[];
+}
+
+const label = (o: OrgRow) => `${o.id.slice(0, 8)} ${o.name ?? '(no name)'}`;
+
+async function report(orgs: OrgRow[], apply: boolean, db: AdminClient) {
+  const counts = { migrate: 0, done: 0, skip: 0, conflict: 0 };
+
+  for (const org of orgs) {
+    const plan = planForOrg(org);
+    counts[plan.kind]++;
+
+    if (plan.kind === 'skip') {
+      console.log(`  skip      ${label(org)} — ${plan.reason}`);
+      continue;
+    }
+    if (plan.kind === 'done') {
+      console.log(`  done      ${label(org)} — already migrated`);
+      continue;
+    }
+    if (plan.kind === 'conflict') {
+      console.log(`  CONFLICT  ${label(org)} — ${plan.brandIds.length} paying brands: ${plan.brandIds.join(', ')}`);
+      console.log('            not migrating: pick the right subscription by hand first.');
+      continue;
+    }
+
+    const v = plan.values;
+    console.log(`  migrate   ${label(org)} — from brand ${plan.brandName ?? plan.brandId}`);
+    console.log(`            customer=${v.stripe_customer_id} subscription=${v.stripe_subscription_id} plan=${v.plan} activated_at=${v.activated_at}`);
+
+    if (!apply) continue;
+    const { error } = await db.from('organizations').update(v).eq('id', org.id);
+    if (error) throw new Error(`writing org ${org.id}: ${error.message}`);
+    console.log('            written.');
+  }
+
+  console.log(
+    `\n${orgs.length} orgs — ${counts.migrate} to migrate, ${counts.done} already done, ` +
+      `${counts.skip} skipped, ${counts.conflict} conflicts`
+  );
+  if (counts.conflict > 0) process.exitCode = 1;
+}
+
+async function verify(orgs: OrgRow[], db: AdminClient) {
+  for (const org of orgs) {
+    const paying = (org.brands ?? []).filter(isPaying)[0];
+    if (!org.stripe_customer_id && !paying) {
+      console.log(`  skip      ${label(org)} — free, nothing to verify`);
+      continue;
+    }
+
+    const same =
+      !!paying &&
+      org.stripe_customer_id === paying.stripe_customer_id &&
+      org.stripe_subscription_id === paying.stripe_subscription_id &&
+      org.plan === paying.plan;
+    console.log(`  ${same ? '(a) ok    ' : '(a) MISMATCH'} ${label(org)}`);
+    if (!same) {
+      console.log(`            org   customer=${org.stripe_customer_id} subscription=${org.stripe_subscription_id} plan=${org.plan}`);
+      console.log(`            brand customer=${paying?.stripe_customer_id} subscription=${paying?.stripe_subscription_id} plan=${paying?.plan}`);
+      process.exitCode = 1;
+    }
+
+    const brand = paying ?? org.brands?.[0];
+    if (!brand) continue;
+    const { getCreditsUsage } = await import('../src/lib/server/credits');
+    const usage = await getCreditsUsage(db as never, {
+      id: brand.id,
+      plan: org.plan ?? brand.plan,
+      activated_at: org.activated_at ?? brand.activated_at,
+      status: 'active'
+    });
+    console.log(
+      `  (b)       pool ${usage.used}/${usage.quota} credits (${usage.percent}% used, ${usage.remaining} left), ` +
+        `period ${usage.periodStart.toISOString().slice(0, 10)} → ${usage.periodEnd.toISOString().slice(0, 10)}`
+    );
+  }
+  console.log('\n(c) billing portal opens and (d) an AI action passes the gate are NOT checked here — do those in the browser.');
+}
+
+async function main() {
+  requireEnv();
+  const orgId = arg('--org');
+  const apply = process.argv.includes('--apply');
+  const wantVerify = process.argv.includes('--verify');
+
+  if (apply && !orgId) {
+    console.error(
+      '--apply needs --org <id>: the rollout is one org at a time, verified before the next.\n' +
+        'Run without --apply first to see what a given org would get.'
+    );
+    process.exit(2);
+  }
+
+  const db = await adminClient();
+  const orgs = await loadOrgs(db, orgId);
+  if (orgs.length === 0) {
+    console.error(orgId ? `No org ${orgId}.` : 'No organizations.');
+    process.exit(1);
+  }
+
+  if (wantVerify) {
+    console.log(`verify — ${orgs.length} org(s)\n`);
+    await verify(orgs, db);
+    return;
+  }
+
+  console.log(`${apply ? 'APPLY' : 'dry run — nothing is written'} — ${orgs.length} org(s)\n`);
+  await report(orgs, apply, db);
+}
+
+main().catch((e) => {
+  console.error(e instanceof Error ? e.message : e);
+  process.exit(1);
+});

--- a/scripts/org-billing-plan.test.ts
+++ b/scripts/org-billing-plan.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import { planForOrg } from './org-billing-plan';
+
+const PAYING = {
+  id: 'b-pay',
+  name: 'Paying',
+  plan: 'pro',
+  stripe_customer_id: 'cus_1',
+  stripe_subscription_id: 'sub_1',
+  activated_at: '2026-01-15T00:00:00Z'
+};
+
+const FREE = {
+  id: 'b-free',
+  name: 'Free',
+  plan: null,
+  stripe_customer_id: null,
+  stripe_subscription_id: null,
+  activated_at: null
+};
+
+function org(brands: unknown[], own: Record<string, unknown> = {}) {
+  return {
+    id: 'org-1',
+    name: 'Org',
+    stripe_customer_id: null,
+    stripe_subscription_id: null,
+    plan: null,
+    activated_at: null,
+    ...own,
+    brands
+  } as never;
+}
+
+describe('planForOrg', () => {
+  it('copies the paying brand up to the org', () => {
+    const plan = planForOrg(org([FREE, PAYING]));
+
+    expect(plan).toEqual({
+      kind: 'migrate',
+      brandId: 'b-pay',
+      brandName: 'Paying',
+      values: {
+        stripe_customer_id: 'cus_1',
+        stripe_subscription_id: 'sub_1',
+        plan: 'pro',
+        activated_at: '2026-01-15T00:00:00Z'
+      }
+    });
+  });
+
+  it('skips an org with no paying brand', () => {
+    expect(planForOrg(org([FREE]))).toEqual({
+      kind: 'skip',
+      reason: 'no paying brand — stays free'
+    });
+  });
+
+  it('skips an org with no brands at all', () => {
+    expect(planForOrg(org([]))).toEqual({
+      kind: 'skip',
+      reason: 'no brands'
+    });
+  });
+
+  // 0104 clears the plan on cancellation but keeps the subscription id: both conditions are
+  // what tells a live subscription from a dead one.
+  it('does not treat a cancelled subscription as paying', () => {
+    const cancelled = { ...PAYING, plan: null };
+    expect(planForOrg(org([cancelled]))).toEqual({
+      kind: 'skip',
+      reason: 'no paying brand — stays free'
+    });
+  });
+
+  it('does not treat a paid plan without a subscription as paying', () => {
+    const noSub = { ...PAYING, stripe_subscription_id: null };
+    expect(planForOrg(org([noSub]))).toEqual({
+      kind: 'skip',
+      reason: 'no paying brand — stays free'
+    });
+  });
+
+  it('refuses to choose when two brands of the org pay', () => {
+    const second = { ...PAYING, id: 'b-pay-2', name: 'Second', stripe_subscription_id: 'sub_2' };
+    expect(planForOrg(org([PAYING, second]))).toEqual({
+      kind: 'conflict',
+      brandIds: ['b-pay', 'b-pay-2']
+    });
+  });
+
+  it('reports an already-migrated org instead of rewriting it', () => {
+    const already = org([PAYING], {
+      stripe_customer_id: 'cus_1',
+      stripe_subscription_id: 'sub_1',
+      plan: 'pro'
+    });
+    expect(planForOrg(already)).toEqual({ kind: 'done' });
+  });
+
+  // Idempotence has to survive a *partial* row too: re-running must finish the job, not skip it.
+  it('re-migrates an org whose row is only half written', () => {
+    const half = org([PAYING], { stripe_customer_id: 'cus_1' });
+    expect(planForOrg(half)).toMatchObject({ kind: 'migrate', brandId: 'b-pay' });
+  });
+});

--- a/scripts/org-billing-plan.ts
+++ b/scripts/org-billing-plan.ts
@@ -1,0 +1,78 @@
+/**
+ * What an organization's billing row needs, decided from its own row and its brands.
+ *
+ * Lives apart from the command in migrate-org-billing.ts on purpose: this is the part that
+ * decides what gets written to a real billing row, so it is a pure function a test can hold
+ * without the command's env, its Supabase client, or its side effects.
+ */
+import { PAID_PLAN_IDS } from '../src/lib/plans';
+
+export type BrandRow = {
+  id: string;
+  name: string | null;
+  plan: string | null;
+  stripe_customer_id: string | null;
+  stripe_subscription_id: string | null;
+  activated_at: string | null;
+};
+
+export type OrgRow = {
+  id: string;
+  name: string | null;
+  stripe_customer_id: string | null;
+  stripe_subscription_id: string | null;
+  plan: string | null;
+  activated_at: string | null;
+  brands: BrandRow[];
+};
+
+export type BillingValues = {
+  stripe_customer_id: string | null;
+  stripe_subscription_id: string | null;
+  plan: string | null;
+  activated_at: string | null;
+};
+
+export type OrgPlan =
+  | { kind: 'migrate'; brandId: string; brandName: string | null; values: BillingValues }
+  | { kind: 'skip'; reason: string }
+  | { kind: 'conflict'; brandIds: string[] }
+  | { kind: 'done' };
+
+export const isPaying = (b: BrandRow) =>
+  !!b.stripe_subscription_id && (PAID_PLAN_IDS as readonly string[]).includes(String(b.plan));
+
+/**
+ * What this org needs, from its own row and its brands. Same two conditions `payingOrgId` uses in
+ * src/lib/server/org.ts — a cancelled subscription keeps its id and loses its plan (0104), so
+ * neither alone tells a live subscription from a dead one.
+ *
+ * `activated_at` rides along even though nothing reads it today (a paying org takes its period
+ * from Stripe, and until the brand columns are dropped `resolveOrgBilling` falls back to the
+ * paying brand's). It is one column in an UPDATE that is already happening, and it is what keeps
+ * the free-plan anchor from quietly moving to the calendar month on the day those columns go.
+ */
+export function planForOrg(org: OrgRow): OrgPlan {
+  const brands = org.brands ?? [];
+  if (brands.length === 0) return { kind: 'skip', reason: 'no brands' };
+
+  const paying = brands.filter(isPaying);
+  if (paying.length > 1) return { kind: 'conflict', brandIds: paying.map((b) => b.id) };
+  if (paying.length === 0) return { kind: 'skip', reason: 'no paying brand — stays free' };
+
+  const brand = paying[0];
+  const values: BillingValues = {
+    stripe_customer_id: brand.stripe_customer_id,
+    stripe_subscription_id: brand.stripe_subscription_id,
+    plan: brand.plan,
+    activated_at: brand.activated_at
+  };
+
+  const settled =
+    org.stripe_customer_id === values.stripe_customer_id &&
+    org.stripe_subscription_id === values.stripe_subscription_id &&
+    org.plan === values.plan;
+  if (settled) return { kind: 'done' };
+
+  return { kind: 'migrate', brandId: brand.id, brandName: brand.name, values };
+}


### PR DESCRIPTION
## What?

`scripts/migrate-org-billing.ts` — the tool that performs the last step of the org-level billing
migration (#191): copying the paying brand's Stripe values up onto its organization
(`stripe_customer_id`, `stripe_subscription_id`, `plan`, `activated_at`).

It is **dry run by default** and prints, org by org, what it would do. `--apply` refuses to run
without `--org <id>`. `--verify` re-checks a migrated org. Stripe is never called and the brand
columns are never touched.

## Why?

All the code is merged (#202, #210, #212, #216) but **no organization is migrated**:
`organizations.stripe_customer_id` is empty everywhere, so every read takes the brand fallback and
nothing has changed for any customer. The switch itself still has to happen, against real billing
rows, and the decisions governing it (#185, #192, #203) call for one org at a time with a check in
between — which is a procedure, not a SQL statement typed under pressure.

## How?

- **Who is paying** is decided by two conditions, `stripe_subscription_id` present **and** plan in
  `PAID_PLAN_IDS` — the same pair `payingOrgId` uses in `src/lib/server/org.ts`, imported rather
  than restated. Migration 0104 clears the plan on cancellation and keeps the id, so neither
  condition alone separates a live subscription from a dead one.
- **Nothing is guessed.** An org with two paying brands is reported as a conflict and skipped, and
  the run exits 1. It should not exist — no customer holds two subscriptions — but if it does,
  which subscription becomes the org's is a question for a person.
- **Idempotent, including half-written rows:** an org whose three values already match is reported
  as done; one that got only part of the way is migrated again.
- **`activated_at` rides along.** Nothing reads it today (a paying org takes its period from
  Stripe, and `resolveOrgBilling` falls back to the paying brand's date while the brand columns
  exist). It is one column in an UPDATE that is already happening, and it is what stops the
  free-plan anchor from quietly moving to the calendar month the day those columns are dropped.
- **The pure decision lives in its own module** (`scripts/org-billing-plan.ts`). Under `vite-node`
  the script path never reaches `process.argv` — the flags do, the filename does not — so a
  "run as a command" guard cannot work, and without one a test importing the module would start a
  command that can write to a billing row. Splitting it removes the guard and leaves the part that
  decides what gets written testable on its own.
- **Deliberately not done: collapsing the founders' multiple orgs.** #191's text asks for it, but
  that text predates #203, which settled that multi-org is preserved and each org stays
  independent. Nothing is collapsed.

## Testing?

8 unit tests on the decision logic, written first and watched fail. Green is not the evidence —
three mutations are:

| mutation | test that caught it |
|---|---|
| drop the paid-plan condition from `isPaying` | *does not treat a cancelled subscription as paying* |
| remove the two-paying-brands guard | *refuses to choose when two brands of the org pay* |
| treat "has a customer id" as migrated | *re-migrates an org whose row is only half written* |

The dry run was executed for real against production (read-only). `--apply` was never run.
`typecheck-runtime.mjs` was not run — it is killed under load on this machine; the CI `test` job
covers it.

## Evidence

<details><summary>The real dry run, and what it found</summary>

```
$ node --env-file-if-exists=.env vite-node.mjs --config scripts/vite-node.config.ts \
    scripts/migrate-org-billing.ts
reading organizations: column organizations.stripe_subscription_id does not exist
exit=1

$ node scripts/schema-drift-check.mjs
    assenti nel database: organizations.plan, organizations.activated_at,
                          organizations.stripe_subscription_id, credit_grants.org_id, org_usage
ROSSO — 7 divergenze. Le migration si applicano a mano: i deploy di questo repo non lo fanno.
```
</details>

## Anything Else?

**Blocking, and bigger than this PR: `supabase/migrations/20260903190000_org_billing_schema.sql`
is not applied in production.** The dry run stopped on the missing column and
`schema-drift-check.mjs` confirms seven divergences. The code merged into `dev` already names those
columns and calls `org_billing_period` / `sum_org_ai_cost_usd`, so until the migration is applied
by hand, in production the org lookup fails and `gateCreditsCore` takes its fail-open branch —
the same silence #161 closed and #205 makes audible. Apply it before `dev` reaches `main`.

**The procedure, once the migration is applied:**

1. Run the dry run with no flags and read the whole list.
2. Migrate your own free orgs first — structural canaries: they exercise the write and the reads
   without touching a paying customer.
3. Before the first paying org, exercise the paid path in Stripe **test mode** (decision #192):
   portal, plan change, webhook on an active subscription.
4. Then one paying org at a time: `--org <id> --apply`, then `--org <id> --verify`, then the two
   halves the script cannot check — the billing portal opens, and an AI action passes the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RgPP6gw4d7xW7Y92vJJrPZ
