### PR TITLE
Add the results page to the thin frontend

### DIFF
--- a/changelog/2026-09-04-thin-frontend-results.md
+++ b/changelog/2026-09-04-thin-frontend-results.md
@@ -1,0 +1,96 @@
+# I risultati nel frontend sottile — `/v2/:brand/results`
+
+La quinta superficie del frontend sottile, dopo calendario (#229), post (#235), materiali (#247)
+e strategia (#248). È "Risultati" nel mockup: quanto è uscito, come è andato, cosa non è uscito
+e perché.
+
+Sola lettura.
+
+## Perché esiste
+
+Anomalia produce e pubblica da sola. La domanda che resta è una: *sta funzionando?* Senza una
+risposta, l'autopilot è un abbonamento a fiducia cieca — e il momento in cui la fiducia si rompe
+non è il post mediocre, è il post che non è mai uscito e di cui nessuno ha saputo niente.
+
+Per questo la sezione "Delivery" c'è anche quando è vuota: dire «0 falliti» è un'informazione, non
+mostrarla lascia il dubbio.
+
+## Cosa mostra, e da dove viene ogni numero
+
+**`GET /api/v1/brands/:slug/analytics`** — è il grosso della pagina:
+
+- le tessere in alto: pubblicati, programmati, in attesa di revisione, visualizzazioni;
+- la tabella per piattaforma: post, views, likes, comments, shares, sommati da
+  `social_post_history.metrics`, cioè da quello che le piattaforme hanno restituito;
+- "What worked": i sei post migliori per punteggio pesato, con miniatura e link al vivo;
+- "Delivery": il totale, i falliti, e le righe di `publish_logs` che portano un errore.
+
+**`GET /api/v1/brands/:slug/seo`** e **`GET /api/v1/brands/:slug/geo`** — una striscia sola in
+fondo, e solo se hanno misurato qualcosa.
+
+## La regola che decide cosa si vede
+
+`shown()`. Prende una lista di `{label, value}` e tiene solo le voci il cui valore **è un
+numero**. `SeoMetrics` ha undici campi e sono tutti `number | null`: un brand senza sito, o con un
+audit che non è mai girato, li ha nulli quasi tutti. La scelta era fra mostrare "—" undici volte e
+non mostrare la voce. Non mostrarla: una tessera vuota promette un numero che non esiste, e la
+somma di undici promesse vuote è una pagina che sembra rotta.
+
+Uno zero misurato **resta**, perché zero backlink è un fatto. Il filtro è sul tipo, non sulla
+verità: `typeof value === 'number'`. Se l'intera striscia è vuota, la sezione non si disegna.
+
+## Cosa non si può mostrare, e perché non è stato inventato
+
+**L'andamento nel tempo.** `/seo` restituisce `metrics.trend[]` e `/geo` un `trend[]`, quindi il
+dato per una sparkline c'è. Ma per la parte social — quella che conta, e l'unica che ogni brand
+ha — non c'è: `getAnalytics` somma `social_post_history` su tutta la storia e restituisce un
+totale, senza finestra e senza confronto. Un grafico del solo SEO accanto a numeri social senza
+grafico direbbe che il SEO è la cosa importante, che è il contrario di come sta il prodotto.
+
+**La copertura per periodo.** Nessun numero di questa pagina ha una finestra temporale: sono
+totali da sempre. `getAnalytics` non accetta né `from` né `to`. Un "questo mese" richiede un
+parametro sull'endpoint, che usano anche CLI e MCP: è un PR suo, non questa pagina.
+
+**Il grado SEO.** `plan.evaluation.grade` esiste ma è una lettera, non un numero, e `shown()`
+tratta numeri. Aggiungere un secondo meccanismo per un solo valore avrebbe raddoppiato le regole
+di "cosa si mostra" — la cosa che questa pagina ha esattamente un modo di decidere.
+
+**`/web/audits` non è stato chiamato.** È l'indice storico degli audit
+(`{id, at, tech_score, share_of_voice, citability_score, binding_constraint, citation_count,
+finding_count}`): per lo stato attuale non aggiunge niente che `/seo` e `/geo` non diano già, e
+per la storia servirebbe il grafico che (vedi sopra) non si può fare onestamente. Una quarta
+richiesta a ogni caricamento per dati duplicati non si paga.
+
+## Una nota sui numeri web
+
+I nove cron che alimentano `brand_geo_audits`, `brand_seo_plans` e le tabelle dei backlink sono
+in corso di spegnimento (`kill/seo-geo-pages`, non ancora mergiato al momento di questa PR: su
+`dev` girano ancora tutti e nove). Se quel PR entra, la striscia "Web" continua a mostrare
+l'ultimo audit disponibile e si ferma lì. È il comportamento giusto — sono dati storici veri, e
+`shown()` li fa sparire da sé quando non ce ne sono — ma va saputo, perché un numero fermo
+sembra un difetto se non si sa che la sorgente è stata spenta di proposito.
+
+## Il contratto che manca
+
+`/analytics` è una rotta viva senza voce in `BRAND_ENDPOINTS`: non ha `tool`, non ha schema di
+output, e quindi non esiste per MCP. È l'unico dei sei endpoint letti dalle superfici `/v2` in
+questa condizione. Questa PR non lo aggiunge — un contratto nuovo è una superficie MCP nuova, con
+il suo nome di tool e la sua descrizione, e non si decide di sfuggita mentre si scrive una pagina.
+Ma è la ragione per cui i tipi di lettura stanno scritti a mano in `+page.server.ts` invece di
+arrivare dallo schema, ed è il motivo per cui vale la pena aprirlo.
+
+## Cosa è stato scartato
+
+**Nessuna libreria di grafici.** Non c'è un grafico, quindi non c'è niente da installare. Il
+primo bundle di questa pagina è SvelteKit più un badge.
+
+**Nessuna primitiva nuova.** Solo `badge`.
+
+**Nessuna utility `grid`.** `app.css` ha un `.grid` globale
+(`grid-template-columns: 1.7fr 1fr`). Tessere e tabelle sono flex.
+
+**Nessuno stato client.** Nessun filtro, nessun pannello, nessun `replaceState`.
+
+**Nessuna chat, nessun link alla chat.**
+
+**Nessuna barra laterale.** Un link che darebbe 404 non si mette.

--- a/src/routes/v2/[brand]/results/+page.server.ts
+++ b/src/routes/v2/[brand]/results/+page.server.ts
@@ -1,0 +1,96 @@
+import { error, redirect } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+import { failuresOf, shown, type ActivityRow, type PlatformRow, type TopPost } from './tally';
+
+type BrandRead = {
+  brand: { name: string; slug: string; timezone: string };
+};
+
+type Analytics = {
+  total: number;
+  scheduled: number;
+  pending: number;
+  failed: number;
+  socialPerformance: PlatformRow[];
+  topPosts: TopPost[];
+  recentActivity: ActivityRow[];
+  accounts: number;
+};
+
+type SeoRead = {
+  metrics: {
+    traffic: number | null;
+    organicKeywords: number | null;
+    keywordsTop10: number | null;
+    domainRating: number | null;
+    referringDomains: number | null;
+    backlinks: number | null;
+  };
+};
+
+type GeoRead = {
+  audit: { tech_score: number | null; share_of_voice: number | null } | null;
+  citability: { score?: number } | null;
+};
+
+function brandApi(slug: string, path: string): string {
+  return `/api/v1/brands/${encodeURIComponent(slug)}${path}`;
+}
+
+async function readError(res: Response): Promise<string> {
+  const body = (await res.json().catch(() => null)) as { error?: string } | null;
+  return body?.error ?? `Request failed (${res.status})`;
+}
+
+export const load: PageServerLoad = async ({ params, fetch, locals }) => {
+  const { session } = await locals.safeGetSession();
+  if (!session) {
+    redirect(303, '/login');
+  }
+
+  const headers = { Authorization: `Bearer ${session.access_token}` };
+
+  const [brandRes, analyticsRes, seoRes, geoRes] = await Promise.all([
+    fetch(brandApi(params.brand, ''), { headers }),
+    fetch(brandApi(params.brand, '/analytics'), { headers }),
+    fetch(brandApi(params.brand, '/seo'), { headers }),
+    fetch(brandApi(params.brand, '/geo'), { headers })
+  ]);
+
+  if (!brandRes.ok) {
+    error(brandRes.status, await readError(brandRes));
+  }
+  if (!analyticsRes.ok) {
+    error(analyticsRes.status, await readError(analyticsRes));
+  }
+
+  const { brand } = (await brandRes.json()) as BrandRead;
+  const analytics = (await analyticsRes.json()) as Analytics;
+
+  const seo = seoRes.ok ? ((await seoRes.json()) as SeoRead) : null;
+  const geo = geoRes.ok ? ((await geoRes.json()) as GeoRead) : null;
+
+  return {
+    brand: { slug: params.brand, name: brand.name, timezone: brand.timezone },
+    counts: {
+      total: analytics.total,
+      scheduled: analytics.scheduled,
+      pending: analytics.pending,
+      failed: analytics.failed,
+      accounts: analytics.accounts
+    },
+    platforms: analytics.socialPerformance,
+    topPosts: analytics.topPosts,
+    failures: failuresOf(analytics.recentActivity),
+    web: shown([
+      { label: 'Organic traffic', value: seo?.metrics.traffic },
+      { label: 'Ranking keywords', value: seo?.metrics.organicKeywords },
+      { label: 'In the top 10', value: seo?.metrics.keywordsTop10 },
+      { label: 'Domain rating', value: seo?.metrics.domainRating },
+      { label: 'Referring domains', value: seo?.metrics.referringDomains },
+      { label: 'Backlinks', value: seo?.metrics.backlinks },
+      { label: 'AI share of voice', value: geo?.audit?.share_of_voice },
+      { label: 'Citability', value: geo?.citability?.score }
+    ])
+  };
+};

--- a/src/routes/v2/[brand]/results/+page.svelte
+++ b/src/routes/v2/[brand]/results/+page.svelte
@@ -1,0 +1,174 @@
+<script lang="ts">
+  import '$lib/styles/tailwind.css';
+  import { Badge } from '$lib/components/ui/badge/index.js';
+  import { METRIC_LABELS, compact, reachOf } from './tally';
+  import type { TopPost } from './tally';
+  import type { PageProps } from './$types';
+
+  let { data }: PageProps = $props();
+
+  const reach = $derived(reachOf(data.platforms));
+
+  const headline = $derived([
+    { label: 'Published', value: compact(reach.posts) },
+    { label: 'Scheduled', value: compact(data.counts.scheduled) },
+    { label: 'Awaiting review', value: compact(data.counts.pending) },
+    { label: 'Views', value: compact(reach.views) }
+  ]);
+
+  function scoreOf(post: TopPost): string {
+    return METRIC_LABELS.map(({ key, label }) => ({ label, value: post.metrics[key] }))
+      .filter((m) => typeof m.value === 'number')
+      .map((m) => `${compact(m.value)} ${m.label.toLowerCase()}`)
+      .join(' · ');
+  }
+
+  function excerpt(caption: string | null): string {
+    const copy = (caption ?? '').trim().replace(/\s+/g, ' ');
+    return copy.length > 80 ? `${copy.slice(0, 80)}…` : copy || 'Untitled';
+  }
+
+  function dayOf(iso: string): string {
+    return new Intl.DateTimeFormat('en-GB', {
+      timeZone: data.brand.timezone,
+      day: 'numeric',
+      month: 'short'
+    }).format(new Date(iso));
+  }
+</script>
+
+<svelte:head><title>Results — {data.brand.name}</title></svelte:head>
+
+<div class="bg-background text-foreground min-h-screen px-4 py-8 sm:px-8">
+  <div class="mx-auto flex max-w-4xl flex-col gap-8">
+    <header class="flex flex-col gap-1">
+      <p class="text-muted-foreground text-xs tracking-wide uppercase">{data.brand.name}</p>
+      <h1 class="text-2xl font-semibold">Results</h1>
+      <p class="text-muted-foreground text-xs">
+        Everything below is measured, not estimated. Platform numbers come from the accounts
+        themselves — {data.counts.accounts} connected.
+      </p>
+    </header>
+
+    <section aria-label="Headline numbers" class="flex flex-wrap gap-3">
+      {#each headline as tile (tile.label)}
+        <div class="border-border flex min-w-36 flex-1 flex-col gap-1 rounded-xl border px-4 py-3">
+          <span class="text-muted-foreground text-xs">{tile.label}</span>
+          <span class="text-2xl font-semibold">{tile.value}</span>
+        </div>
+      {/each}
+    </section>
+
+    <section aria-labelledby="platforms" class="flex flex-col gap-2">
+      <h2 id="platforms" class="text-sm font-semibold">By platform</h2>
+      {#if data.platforms.length === 0}
+        <p class="text-muted-foreground text-sm">
+          Nothing published yet, so there is nothing to measure.
+        </p>
+      {:else}
+        <ul class="border-border divide-border divide-y rounded-xl border">
+          {#each data.platforms as row (row.platform)}
+            <li class="flex flex-col gap-1 px-4 py-3">
+              <span class="flex items-baseline gap-2 text-sm">
+                <span class="font-medium">{row.platform || 'unknown'}</span>
+                <span class="text-muted-foreground text-xs">{row.posts} published</span>
+              </span>
+              <span class="text-muted-foreground flex flex-wrap gap-x-4 gap-y-1 text-xs">
+                {#each METRIC_LABELS as metric (metric.key)}
+                  <span
+                    ><span class="text-foreground font-medium"
+                      >{compact(row.totals[metric.key] ?? 0)}</span
+                    >
+                    {metric.label.toLowerCase()}</span
+                  >
+                {/each}
+              </span>
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    </section>
+
+    {#if data.topPosts.length > 0}
+      <section aria-labelledby="best" class="flex flex-col gap-2">
+        <h2 id="best" class="text-sm font-semibold">What worked</h2>
+        <ul class="border-border divide-border divide-y rounded-xl border">
+          {#each data.topPosts as post (post.id)}
+            <li class="flex items-start gap-3 px-4 py-3">
+              {#if post.thumbnail_url}
+                <img
+                  src={post.thumbnail_url}
+                  alt=""
+                  loading="lazy"
+                  decoding="async"
+                  class="border-border h-14 w-14 shrink-0 rounded-lg border object-cover"
+                />
+              {/if}
+              <div class="flex min-w-0 flex-col gap-1">
+                <span class="flex flex-wrap items-center gap-2 text-xs">
+                  <Badge variant="outline">{post.platform ?? 'post'}</Badge>
+                  {#if post.published_at}
+                    <span class="text-muted-foreground">{dayOf(post.published_at)}</span>
+                  {/if}
+                </span>
+                <span class="line-clamp-2 text-sm">{excerpt(post.caption)}</span>
+                <span class="text-muted-foreground text-xs">{scoreOf(post)}</span>
+                {#if post.url}
+                  <a
+                    href={post.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    class="text-xs underline underline-offset-4">See it live</a
+                  >
+                {/if}
+              </div>
+            </li>
+          {/each}
+        </ul>
+      </section>
+    {/if}
+
+    <section aria-labelledby="delivery" class="flex flex-col gap-2">
+      <h2 id="delivery" class="text-sm font-semibold">Delivery</h2>
+      <p class="text-muted-foreground text-sm">
+        {data.counts.total} posts in the brand, {data.counts.failed} of them failed to go out.
+      </p>
+      {#if data.failures.length > 0}
+        <ul class="border-destructive/40 divide-border divide-y rounded-xl border">
+          {#each data.failures as failure (failure.id)}
+            <li class="flex flex-col gap-1 px-4 py-3 text-sm">
+              <span class="flex flex-wrap items-center gap-2 text-xs">
+                <Badge variant="destructive">{failure.status}</Badge>
+                <span class="font-medium">{failure.platform ?? 'unknown'}</span>
+                <span class="text-muted-foreground">{dayOf(failure.created_at)}</span>
+              </span>
+              <span class="line-clamp-1">{excerpt(failure.caption)}</span>
+              {#if failure.error}
+                <span class="text-destructive text-xs">{failure.error}</span>
+              {/if}
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    </section>
+
+    {#if data.web.length > 0}
+      <section aria-labelledby="web" class="flex flex-col gap-2">
+        <h2 id="web" class="text-sm font-semibold">Web</h2>
+        <ul class="flex flex-wrap gap-3">
+          {#each data.web as metric (metric.label)}
+            <li
+              class="border-border flex min-w-32 flex-col gap-1 rounded-xl border px-3 py-2 text-sm"
+            >
+              <span class="text-muted-foreground text-xs">{metric.label}</span>
+              <span class="font-semibold">{metric.value}</span>
+            </li>
+          {/each}
+        </ul>
+        <p class="text-muted-foreground text-xs">
+          Only the figures the last audit actually measured are listed.
+        </p>
+      </section>
+    {/if}
+  </div>
+</div>

--- a/src/routes/v2/[brand]/results/tally.test.ts
+++ b/src/routes/v2/[brand]/results/tally.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { compact, failuresOf, reachOf, shown, type ActivityRow, type PlatformRow } from './tally';
+
+function row(over: Partial<PlatformRow> = {}): PlatformRow {
+  return {
+    platform: 'instagram',
+    posts: 1,
+    totals: { views: 0, likes: 0, comments: 0, shares: 0 },
+    ...over
+  };
+}
+
+function log(over: Partial<ActivityRow> = {}): ActivityRow {
+  return {
+    id: 'l1',
+    post_id: null,
+    platform: 'instagram',
+    status: 'scheduled',
+    caption: null,
+    error: null,
+    created_at: '2026-09-01T08:00:00Z',
+    ...over
+  };
+}
+
+describe('la copertura e la somma delle piattaforme, non di una', () => {
+  it('somma ogni metrica e i post', () => {
+    const total = reachOf([
+      row({ posts: 3, totals: { views: 1000, likes: 40, comments: 5, shares: 2 } }),
+      row({ platform: 'linkedin', posts: 2, totals: { views: 500, likes: 10, comments: 1, shares: 0 } })
+    ]);
+
+    expect(total).toEqual({ posts: 5, views: 1500, likes: 50, comments: 6, shares: 2 });
+  });
+
+  it('nessuna piattaforma non e NaN', () => {
+    expect(reachOf([])).toEqual({ posts: 0, views: 0, likes: 0, comments: 0, shares: 0 });
+  });
+
+  it('una metrica mancante vale zero, non undefined', () => {
+    const total = reachOf([row({ totals: { views: 10 } as PlatformRow['totals'] })]);
+
+    expect(total.likes).toBe(0);
+    expect(total.views).toBe(10);
+  });
+});
+
+describe('un numero grande si legge, non si conta', () => {
+  it('sotto il migliaio resta intero', () => {
+    expect(compact(0)).toBe('0');
+    expect(compact(950)).toBe('950');
+  });
+
+  it('sopra il migliaio si accorcia', () => {
+    expect(compact(18432)).toBe('18.4K');
+    expect(compact(1200000)).toBe('1.2M');
+  });
+});
+
+describe('cosa conta come consegna fallita', () => {
+  it('lo stato failed conta', () => {
+    expect(failuresOf([log({ status: 'failed' })])).toHaveLength(1);
+  });
+
+  it("un errore registrato conta anche se lo stato non dice failed", () => {
+    expect(failuresOf([log({ status: 'retrying', error: 'token expired' })])).toHaveLength(1);
+  });
+
+  it('una consegna riuscita non conta', () => {
+    expect(failuresOf([log({ status: 'scheduled' }), log({ status: 'canceled' })])).toEqual([]);
+  });
+});
+
+describe('si mostrano i numeri che ci sono, non quelli che si vorrebbero', () => {
+  it('una metrica assente non diventa una tessera vuota', () => {
+    expect(shown([{ label: 'Traffic', value: null }, { label: 'Keywords', value: 12 }])).toEqual([
+      { label: 'Keywords', value: '12' }
+    ]);
+  });
+
+  it('uno zero misurato e un numero, e resta', () => {
+    expect(shown([{ label: 'Backlinks', value: 0 }])).toEqual([{ label: 'Backlinks', value: '0' }]);
+  });
+
+  it('i numeri grandi arrivano gia accorciati', () => {
+    expect(shown([{ label: 'Traffic', value: 18432 }])).toEqual([
+      { label: 'Traffic', value: '18.4K' }
+    ]);
+  });
+
+  it('niente da mostrare e una lista vuota, non una sezione vuota', () => {
+    expect(shown([{ label: 'Traffic', value: null }])).toEqual([]);
+  });
+});

--- a/src/routes/v2/[brand]/results/tally.ts
+++ b/src/routes/v2/[brand]/results/tally.ts
@@ -1,0 +1,63 @@
+export type Totals = { views: number; likes: number; comments: number; shares: number };
+
+export type PlatformRow = { platform: string; posts: number; totals: Totals };
+
+export type ActivityRow = {
+  id: string;
+  post_id: string | null;
+  platform: string | null;
+  status: string;
+  caption: string | null;
+  error: string | null;
+  created_at: string;
+};
+
+export type TopPost = {
+  id: string;
+  platform: string | null;
+  caption: string | null;
+  thumbnail_url: string | null;
+  url: string | null;
+  published_at: string | null;
+  metrics: Record<string, number>;
+};
+
+export type Reach = Totals & { posts: number };
+
+export type Entry = { label: string; value: number | null | undefined };
+
+const COMPACT = new Intl.NumberFormat('en', { notation: 'compact', maximumFractionDigits: 1 });
+
+export const METRIC_LABELS: Array<{ key: keyof Totals; label: string }> = [
+  { key: 'views', label: 'Views' },
+  { key: 'likes', label: 'Likes' },
+  { key: 'comments', label: 'Comments' },
+  { key: 'shares', label: 'Shares' }
+];
+
+export function compact(value: number): string {
+  return COMPACT.format(value);
+}
+
+export function reachOf(rows: PlatformRow[]): Reach {
+  return rows.reduce<Reach>(
+    (total, row) => ({
+      posts: total.posts + (row.posts ?? 0),
+      views: total.views + (row.totals?.views ?? 0),
+      likes: total.likes + (row.totals?.likes ?? 0),
+      comments: total.comments + (row.totals?.comments ?? 0),
+      shares: total.shares + (row.totals?.shares ?? 0)
+    }),
+    { posts: 0, views: 0, likes: 0, comments: 0, shares: 0 }
+  );
+}
+
+export function failuresOf(rows: ActivityRow[]): ActivityRow[] {
+  return rows.filter((row) => row.status === 'failed' || Boolean(row.error));
+}
+
+export function shown(entries: Entry[]): Array<{ label: string; value: string }> {
+  return entries
+    .filter((entry): entry is { label: string; value: number } => typeof entry.value === 'number')
+    .map((entry) => ({ label: entry.label, value: compact(entry.value) }));
+}


### PR DESCRIPTION
## What?

Adds `/v2/:brand/results` — "Risultati" in the new sidebar mockup. Read-only.

Four headline tiles (published, scheduled, awaiting review, views), a per-platform table of
posts / views / likes / comments / shares, the six posts that actually worked with their
thumbnails and links, a delivery section that names the posts that failed to go out and why, and
a compact web strip from the last SEO/GEO audit.

Fifth surface of the thin frontend, after the calendar (#229), the post list (#235), the
materials library (#247) and the editorial plan (#248).

## Why?

Anomalia produces and publishes on its own. The one question left is whether it is working.
Without an answer, the autopilot is a subscription to blind faith.

And the moment faith breaks is not the mediocre post — it is the post that never went out and
that nobody was told about. That is why the delivery section renders even when it is empty:
"0 failed" is information; omitting it leaves doubt.

On the critical path: `/app` is not dismantled until `/v2` covers it.

## How?

**Where each number comes from.**

`GET /api/v1/brands/:slug/analytics` carries the page: the headline tiles, the per-platform
table (summed from `social_post_history.metrics`, i.e. what the platforms themselves returned),
the six top posts by weighted score, and the `publish_logs` rows behind delivery.

`GET .../seo` and `GET .../geo` feed one strip at the bottom, and only when they measured
something.

**`shown()` is the rule that decides what appears.** It takes `{label, value}` entries and keeps
only those whose value **is a number**. `SeoMetrics` has eleven fields and every one is
`number | null`; a brand with no site, or whose audit never ran, has almost all of them null. The
choice was eleven em-dashes or no tile. No tile — an empty tile promises a number that does not
exist, and eleven empty promises is a page that looks broken.

A **measured zero stays**, because zero backlinks is a fact. The filter is on the type, not on
truthiness: `typeof value === 'number'`. When the whole strip is empty the section does not
render at all.

**A brand without a website does not get a 500.** Only the brand read and `/analytics` are
fatal; `/seo` and `/geo` failing is treated as "nothing measured" and the strip disappears. The
social numbers are the ones every brand has, and they must not be hostage to a web audit.

**No client state**: no filters, no panel, no `replaceState`.

### What I wanted to show and could not

- **A trend over time.** `/seo` returns `metrics.trend[]` and `/geo` returns a `trend[]`, so the
  data for a sparkline exists there. It does not exist for the social side — `getAnalytics` sums
  `social_post_history` over all history and returns one total, with no window and no comparison.
  Charting only SEO next to unplotted social numbers would say SEO is the important one, which is
  the opposite of where the product stands.
- **Any per-period figure.** No number on this page has a time window; they are all-time totals.
  `getAnalytics` accepts neither `from` nor `to`. A "this month" needs a parameter on an endpoint
  the CLI and MCP also use — its own PR.
- **The SEO grade.** `plan.evaluation.grade` exists, but it is a letter and `shown()` handles
  numbers. Adding a second mechanism for a single value would double the rules for "what gets
  shown", which is the one thing this page decides exactly one way.
- **`/web/audits` was deliberately not called.** It is the historical audit index
  (`{id, at, tech_score, share_of_voice, citability_score, binding_constraint, citation_count,
  finding_count}`). For the present state it adds nothing `/seo` and `/geo` do not already give,
  and for history it would need the chart that (above) cannot be drawn honestly. A fourth request
  on every load for duplicated data is not worth paying.

### Two things a reviewer should know

**The web numbers may be frozen.** The nine crons feeding `brand_geo_audits`, `brand_seo_plans`
and the backlink tables are being switched off in `kill/seo-geo-pages` (not merged when this PR
was opened — all nine still run on `dev`). If that lands, the web strip keeps showing the last
available audit and stops there. That is the right behaviour — real historical data, and
`shown()` makes it disappear on its own once there is none — but a frozen number looks like a
defect if you do not know the source was turned off on purpose.

**`/analytics` has no contract.** It is a live route with no entry in `BRAND_ENDPOINTS`: no
`tool`, no output schema, therefore invisible to MCP. It is the only one of the six endpoints the
`/v2` surfaces read that is in this state. This PR does not add it — a new contract is a new MCP
surface, with its own tool name and description, and that is not decided in passing while writing
a page. It is why the read types are hand-written in `+page.server.ts` instead of coming from the
schema, and it is why the contract is worth opening.

### Rejected

- **No charting library.** There is no chart, so there is nothing to install. This page's initial
  bundle is SvelteKit plus a badge.
- **No new `shadcn-svelte` primitives** — only `badge`.
- **No `grid` utility** — `app.css` has a global `.grid` (`grid-template-columns: 1.7fr 1fr`).
  Tiles and tables are flex.
- **No chat, and no link to chat.**
- **No sidebar** — a link that would 404 does not go in.

## Testing?

`npx vitest run results/tally` — **12 passed**. Written first and watched fail (`Failed to load
url ./tally … Does the file exist?`) before the module existed.

They pin the decisions, not the rendering: that reach is the sum across platforms and not one of
them, that a missing metric counts as zero rather than `NaN`, that a delivery counts as failed
when the status says so **or** when a row carries an error (`publish_logs.status` is free text —
`failed`, `scheduled`, `canceled` are all written by hand), and that `shown()` drops a null but
keeps a measured zero.

`npm run check`: **627 errors, 235 warnings** — **zero errors in the files this PR adds**.

Full suite not run here — CI runs it, plus Playwright, on this PR.

**Visual verification is deferred to the complete frontend.** No dev server, no browser and no
Playwright were run for this PR. `/v2` still has no sidebar and no entry point, so nothing in the
app navigates here. The whole of `/v2` gets one visual pass when the surfaces exist and a layout
links them.

### CI note

`src/lib/page-modal-tiers.test.ts` > "ogni rotta del brand è classificata" is failing on `dev`
itself (run 33866574444, sha b869dbb1): `workbench-paths.ts` still classifies `agent-lab`, which
b6eead1 deleted from `src/routes/app/[brand]/`. The failure diff is one line, `- "agent-lab"`.
This branch touches nothing under `src/routes/app` or `workbench-paths.ts`; the fix belongs to
the PR that removed the route.

## Evidence (screenshots/videos)

None, for the reason above: the surface is not reachable from anywhere in the app, so a
screenshot would be of a hand-typed URL and would prove less than it appears to.

<details>
<summary>Red before green</summary>

```
 FAIL  src/routes/v2/[brand]/results/tally.test.ts
Error: Failed to load url ./tally (resolved id: ./tally) in
  .../src/routes/v2/[brand]/results/tally.test.ts. Does the file exist?
 Test Files  1 failed (1)
      Tests  no tests
```
</details>

<details>
<summary>Green</summary>

```
 ✓ src/routes/v2/[brand]/results/tally.test.ts (12 tests) 3ms
 Test Files  1 passed (1)
      Tests  12 passed (12)
```
</details>

## Anything Else?

**No public changelog.** Nothing in the product links to `/v2` yet, so a customer cannot reach
this page. The internal changelog is `changelog/2026-09-04-thin-frontend-results.md`. The public
one goes in when `/v2` gets its entry point.

**No new duplication.** `tally.ts` shares nothing with `post-state.ts`, `media-kind.ts` or
`plan-shape.ts`. The known triplication between #229, #235 and #236 (`PostPanel`, `POST_STATES`,
`momentInZone`) is untouched — this surface uses none of the three.

**Two follow-ups worth their own tickets:** a contract for `/analytics`, and a window parameter
on it. The second turns every number here from all-time into something you can compare, which is
the difference between a scoreboard and a report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
