### PR TITLE
Drop the deleted agent-lab route from the path list

### DIFF
--- a/changelog/2026-09-04-workbench-paths-agent-lab.md
+++ b/changelog/2026-09-04-workbench-paths-agent-lab.md
@@ -1,0 +1,15 @@
+# La lista delle rotte nominava una rotta cancellata
+
+`agent-lab` è stato eliminato con la #245, ma `workbench-paths.ts` continuava a elencarlo fra le
+rotte escluse dalla modal. `page-modal-tiers.test.ts` confronta quella lista con le rotte che
+esistono davvero sul disco, quindi è diventato rosso **su `dev`** — e con lui la CI di ogni PR
+aperta, che a quel punto sembrava rotta per colpa propria.
+
+Il test faceva esattamente il suo mestiere: è la ragione per cui esiste. Qui si toglie la riga.
+
+## E due rimandi scaduti
+
+`billing/contract.ts` e `billing/contract.test.ts` spiegavano il proprio meccanismo per analogia
+con `agent-lab/shell.test.ts`, un file che non c'è più. Un commento che rimanda a qualcosa di
+cancellato è peggio di nessun commento: manda a cercare una cosa che non si trova. Entrambi
+descrivono adesso quello che fanno senza appoggiarsi a un esempio esterno.

--- a/src/lib/billing/contract.test.ts
+++ b/src/lib/billing/contract.test.ts
@@ -4,9 +4,8 @@ import { describe, expect, it } from 'vitest';
 
 /**
  * IL TEST-GUARDIA: contract.ts deve restare importabile dal client (pagine/component che
- * costruiscono un upsell UI, non solo dal server). Legge il file come TESTO (come
- * src/routes/app/[brand]/agent-lab/shell.test.ts fa per una pagina) e fallisce se ci trova un
- * import server-only.
+ * costruiscono un upsell UI, non solo dal server). Legge il file come TESTO e fallisce se ci
+ * trova un import server-only.
  */
 const source = readFileSync(fileURLToPath(new URL('./contract.ts', import.meta.url)), 'utf-8');
 

--- a/src/lib/billing/contract.ts
+++ b/src/lib/billing/contract.ts
@@ -5,8 +5,7 @@
 // server-only, unchanged, just wrapped behind this same shape. A server-side selector picks one.
 //
 // This file must stay importable from the browser: no server-only imports, no secrets, no
-// payment-provider SDK — enforced by contract.test.ts the same way
-// src/routes/app/[brand]/agent-lab/shell.test.ts guards a page shell, by reading it as text.
+// payment-provider SDK — enforced by contract.test.ts, which reads this file as text.
 
 export type QuotaKind = 'credits' | 'posts';
 

--- a/src/lib/workbench-paths.ts
+++ b/src/lib/workbench-paths.ts
@@ -294,8 +294,7 @@ export const BRAND_PAGE_ROUTES = [
   'site/edit/[id]', // editor articolo a tutta larghezza (isArticleEdit) + dinamica
   'media-generator', // canvas full-bleed col composer pinnato (isMediaWorkbench)
   'motion-video', //   idem
-  'ugc-creator', //   idem
-  'agent-lab' // banco di prova SOLO dev (404 in prod): mai nel rail, non ha senso nella modal
+  'ugc-creator' //   idem
 ] as const;
 
 /** Rotte del brand ospitate nella modal. */


### PR DESCRIPTION
## What?

`workbench-paths.ts` still listed `agent-lab` among the routes excluded from the modal, but PR #245 deleted that route. One line removed, plus two comments in `src/lib/billing/contract.{ts,test.ts}` that explained themselves by pointing at `agent-lab/shell.test.ts` — a file that no longer exists.

## Why?

`page-modal-tiers.test.ts` compares the declared list against the routes actually present on disk. It went red **on `dev` itself**, so the CI of every open PR was failing for a reason that had nothing to do with those PRs. Two separate agents hit it today and correctly refused to smuggle the fix into their own diffs.

The test did exactly the job it exists for: it noticed that a declaration and reality had parted ways. Nothing about it needed changing.

## How?

The entry is deleted rather than the assertion loosened — the route is gone, so the exclusion has nothing left to exclude.

For the two comments: a pointer to a deleted file is worse than no pointer, because it sends the reader looking for something that cannot be found. Both now describe what they do without leaning on an external example. No behaviour changes.

## Testing?

Red observed first, on `origin/dev`:

```
AssertionError: expected [ '.', 'ads/[channel]/new', …(60) ]
                to deeply equal [ '.', 'ads/[channel]/new', …(61) ]
-   "agent-lab",
 Test Files  1 failed (1)
      Tests  1 failed | 12 passed (13)
```

Green after:

```
npx vitest run src/lib/billing/contract.test.ts src/lib/page-modal-tiers.test.ts
 Test Files  2 passed (2)
      Tests  16 passed (16)
```

`git grep agent-lab -- src` returns only `src/lib/agent/README.md` and a line in `bridge/adapters.ts`, both of which belong to the chat teardown in flight and are being removed there.

Full suite and Playwright delegated to CI. No visual verification: this touches a route list and two comments, with no UI surface of its own.

## Evidence

The failure diff is the single line `- "agent-lab"`, quoted above; there is nothing else to show for a one-entry deletion.

## Anything Else?

The general shape is worth noting while several deletions are in flight: a route can be removed and leave a *declaration about it* behind, and the declaration is not always in the same folder. This one lived in `src/lib`, three directories away from the route it named.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY