### PR TITLE
Read the search numbers from MCP: gsc, ranks, backlinks

### DIFF
--- a/changelog/2026-09-04-measurement-web-metrics.md
+++ b/changelog/2026-09-04-measurement-web-metrics.md
@@ -1,0 +1,58 @@
+# Search Console, posizionamenti e backlink diventano tool MCP
+
+Tre letture di misurazione entrano nel registry degli endpoint
+(`packages/api-contracts/src/web-metrics.ts`): `get_gsc`, `get_ranks`, `get_backlinks`. Da lì il
+tool MCP e il metodo del client CLI nascono da soli, senza una riga di `registerTool` scritta a
+mano e senza un tipo ricopiato.
+
+## Perché esiste
+
+Anomalia sta diventando un'interfaccia headless per agenti esterni via MCP. Un agente che non può
+leggere i numeri non può decidere niente: `get_seo` e `get_geo` rispondono sull'ultimo audit, ma
+la performance di ricerca vera — clic, impression, posizione media, la posizione di una keyword
+oggi rispetto a ieri, chi ci linka — stava dietro tre rotte che nessun tool esponeva. Erano
+documentate in `docs/api/07` e raggiungibili con `curl`, cioè da un umano, non da un agente.
+
+## Cosa c'era prima
+
+Le rotte esistono da tempo e non cambiano: `GET /gsc`, `GET /ranks`, `GET /backlinks`. Cambia
+solo che adesso sono dichiarate, quindi generate.
+
+## Come è costruito
+
+Un file nuovo per famiglia, come `search.ts` in #238: `web-metrics.ts` tiene le tre misure del
+web e non si mescola a `reads.ts`, che è pieno di stato del brand.
+
+L'`output` è descritto sul serio, non `z.any()`. Le tre forme sono state lette dalle funzioni che
+le producono (`loadGscSummary`, `loadRankBoard`, `loadBacklinkNetworkSummary`) e riconosciute
+nelle risposte già documentate in `docs/api/07`. Le due decisioni che non erano ovvie:
+
+- **`partnerName` è opzionale sui piazzamenti.** È un arricchimento best-effort: la query dei nomi
+  parte solo se ci sono partner da nominare. Dichiararlo obbligatorio avrebbe reso l'output falso
+  su una rete vuota.
+- **`connected` di GSC non è deducibile dai numeri.** Zero clic con `connected: false` significa
+  "mai collegato", con `connected: true` significa "collegato e a zero". Un agente che non
+  distingue i due casi propone la cosa sbagliata, quindi il campo è obbligatorio e c'è un test che
+  lo tiene.
+
+## L'equivalenza, provata
+
+`tools/list` catturato attraverso `handleMcpFetch` prima e dopo: **88 → 91**, tre aggiunti, zero
+rimossi, zero modificati. Nessun tool esistente cambia nome, titolo, descrizione, insieme delle
+proprietà o dei campi obbligatori.
+
+La prova permanente non è quel confronto ma una legge nuova in `cli/mcp/read-tools.test.ts`: per
+**ogni** endpoint del registry deve esistere in `tools/list` un tool con lo stesso titolo, la
+stessa descrizione, `readOnlyHint` uguale a `method === 'GET'` e `destructiveHint` uguale a
+`destructive`. Vale per i 58 di oggi e per quelli che arriveranno. È stata vista fallire
+sopprimendo `get_gsc` nel generatore.
+
+## Chiave di sola lettura
+
+Tutte e tre sono `GET`, `destructive: false`, e una API key di sola lettura le raggiunge — non per
+gentilezza delle rotte ma per costruzione: `resolveCaller` in `cli-auth.ts` nega la scrittura una
+volta sola, e il criterio è il metodo (`request.method !== 'GET'`). Nessuna delle tre chiama
+`gateAiAction` o `checkApiKeyWriteAccess`: non spendono crediti.
+
+`POST /backlinks` invece spende crediti (`gateAiAction`) ed è rimasto fuori: qui entrano solo
+letture.

--- a/cli/lib/contracts/index.ts
+++ b/cli/lib/contracts/index.ts
@@ -45,6 +45,7 @@ import {
   LIST_PRODUCTS
 } from './reads';
 import { GEO_ACTION, REFRESH_KEYWORDS, SEO_ACTION } from './search';
+import { GET_BACKLINKS, GET_GSC, GET_RANKS } from './web-metrics';
 import {
   CREATE_SHARE,
   LIST_SHARES,
@@ -121,14 +122,17 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   GET_ANALYTICS,
   GET_ARTICLE,
   GET_AUDIT_FINDINGS,
+  GET_BACKLINKS,
   GET_BIO,
   GET_CALENDAR,
   GET_CREATION_KIT,
   GET_GEO,
+  GET_GSC,
   GET_GTM,
   GET_KEYWORDS,
   GET_PLAN,
   GET_POST,
+  GET_RANKS,
   GET_SEO,
   GET_STUDIO,
   GET_VOICE,
@@ -220,6 +224,7 @@ export {
   LIST_PRODUCTS
 };
 export { GEO_ACTION, REFRESH_KEYWORDS, SEO_ACTION } from './search';
+export { GET_BACKLINKS, GET_GSC, GET_RANKS } from './web-metrics';
 export {
   ADD_COMPETITOR,
   CREATE_PRODUCT,

--- a/cli/lib/contracts/web-metrics.ts
+++ b/cli/lib/contracts/web-metrics.ts
@@ -1,0 +1,117 @@
+import { z } from 'zod';
+import type { BrandEndpoint } from './index';
+
+const NoInput = z.object({}).strict();
+
+const SearchRow = z.object({
+  clicks: z.number(),
+  impressions: z.number(),
+  position: z.number()
+});
+
+export const GET_GSC = {
+  tool: 'get_gsc',
+  title: 'Search Console',
+  description:
+    'Google Search Console over the last 28 days: clicks, impressions, top queries and pages, and whether the property is connected.',
+  method: 'GET',
+  pathUnderBrand: '/gsc',
+  input: NoInput,
+  output: z.object({
+    connected: z.boolean(),
+    configured: z.boolean(),
+    siteUrl: z.string().nullable(),
+    syncedAt: z.string().nullable(),
+    lastError: z.string().nullable(),
+    clicks28d: z.number(),
+    impressions28d: z.number(),
+    topQueries: z.array(SearchRow.extend({ query: z.string() })),
+    topPages: z.array(SearchRow.extend({ page: z.string() }))
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const GET_RANKS = {
+  tool: 'get_ranks',
+  title: 'Rank tracking',
+  description:
+    'Tracked keywords with their current Google position, the previous one, the move between them, the ranking URL and whether an AI Overview showed.',
+  method: 'GET',
+  pathUnderBrand: '/ranks',
+  input: NoInput,
+  output: z.object({
+    keywords: z.array(
+      z.object({
+        id: z.string(),
+        keyword: z.string(),
+        locale: z.string(),
+        device: z.string(),
+        source: z.string(),
+        active: z.boolean(),
+        position: z.number().nullable(),
+        prevPosition: z.number().nullable(),
+        delta: z.number().nullable(),
+        url: z.string().nullable(),
+        checkedAt: z.string().nullable(),
+        hasAiOverview: z.boolean()
+      })
+    )
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+const BacklinkPlacement = z.object({
+  id: z.string(),
+  sourceBrandId: z.string(),
+  sourceArticleId: z.string().nullable(),
+  targetBrandId: z.string(),
+  targetArticleId: z.string().nullable(),
+  targetUrl: z.string(),
+  anchorText: z.string().nullable(),
+  status: z.string(),
+  createdAt: z.string(),
+  partnerName: z.string().nullable().optional()
+});
+
+export const GET_BACKLINKS = {
+  tool: 'get_backlinks',
+  title: 'Backlink network',
+  description:
+    'Backlink network: links given and received, open give/receive opportunities, and whether the network is unlocked for this brand (Starter or above, plus opt-in).',
+  method: 'GET',
+  pathUnderBrand: '/backlinks',
+  input: NoInput,
+  output: z.object({
+    enabled: z.boolean(),
+    planAllowed: z.boolean(),
+    unlocked: z.boolean(),
+    outgoing: z.array(BacklinkPlacement),
+    incoming: z.array(BacklinkPlacement),
+    opportunities: z.array(
+      z.object({
+        id: z.string(),
+        direction: z.enum(['give', 'receive']),
+        partnerBrandId: z.string(),
+        partnerBrandName: z.string(),
+        partnerArticleId: z.string().nullable(),
+        partnerUrl: z.string(),
+        partnerTitle: z.string().nullable(),
+        relevance: z.number(),
+        suggestedAnchor: z.string().nullable(),
+        rationale: z.string().nullable(),
+        status: z.string(),
+        createdAt: z.string()
+      })
+    ),
+    stats: z.object({
+      outgoingCount: z.number(),
+      incomingCount: z.number(),
+      openGive: z.number(),
+      openReceive: z.number()
+    })
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/cli/mcp/read-tools.test.ts
+++ b/cli/mcp/read-tools.test.ts
@@ -159,6 +159,19 @@ describe('le letture migrate sul registry', () => {
     }
   });
 
+  test('ogni endpoint del registry esiste in tools/list come lo dichiara', async () => {
+    const all = await tools();
+
+    for (const endpoint of BRAND_ENDPOINTS) {
+      const tool = find(all, endpoint.tool);
+
+      expect(tool.title, endpoint.tool).toBe(endpoint.title);
+      expect(tool.description, endpoint.tool).toBe(endpoint.description);
+      expect(tool.annotations?.readOnlyHint, endpoint.tool).toBe(endpoint.method === 'GET');
+      expect(tool.annotations?.destructiveHint, endpoint.tool).toBe(endpoint.destructive);
+    }
+  });
+
   test('nessuna di esse è dichiarata due volte', async () => {
     const names = (await tools()).map((t) => t.name);
 

--- a/cli/plugins/anomalia/skills/anomalia/references/tools.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/tools.md
@@ -225,6 +225,9 @@ one with the most clicks in the last seven days.
 | `list_audit_citations` | (MCP only) |
 | `list_web_fixes` | (MCP only) |
 | `get_keywords` / `refresh_keywords` | `anomalia keywords <slug> [refresh]` |
+| `get_gsc` | (MCP only) |
+| `get_ranks` | (MCP only) |
+| `get_backlinks` | (MCP only) |
 | `list_articles` / `generate_article` / `optimize_article` | `anomalia web <slug> …` |
 | `get_article` / `update_article` | (MCP only) |
 | `publish_article` / `unpublish_article` / `delete_article` | `anomalia web <slug> publish\|…` |
@@ -234,6 +237,17 @@ one with the most clicks in the last seven days.
 `get_seo` and `get_geo` answer on the **latest** audit. The four web tools let you trace a claim
 back to what was actually measured, without paying for a new audit. All four are reads: they call
 no model, spend no credits and write nothing.
+
+`get_gsc`, `get_ranks` and `get_backlinks` are the measured side of the same brand. `get_gsc`
+reads Google Search Console over the last 28 days — clicks, impressions, top queries and top
+pages — and says whether the property is connected at all: `connected: false` means there is
+nothing to read yet, not that the brand ranks nowhere. `get_ranks` returns the tracked keywords
+with `position`, `prevPosition` and `delta` (positive = moved up), the ranking URL, and
+`hasAiOverview` for the ones where Google answered on its own. `get_backlinks` returns links
+given and received plus the open give/receive opportunities, and `unlocked` tells you whether
+the network is usable — it needs Starter or above **and** the brand's opt-in, so `planAllowed`
+and `enabled` say which of the two is missing. All three are reads: no model, no credits, no
+writes.
 
 `list_web_audits` is the index of every audit, newest first — `id`, `at`, `tech_score`,
 `share_of_voice`, `citability_score`, `binding_constraint`, and how many citations and findings

--- a/cli/skills/anomalia/references/tools.md
+++ b/cli/skills/anomalia/references/tools.md
@@ -225,6 +225,9 @@ one with the most clicks in the last seven days.
 | `list_audit_citations` | (MCP only) |
 | `list_web_fixes` | (MCP only) |
 | `get_keywords` / `refresh_keywords` | `anomalia keywords <slug> [refresh]` |
+| `get_gsc` | (MCP only) |
+| `get_ranks` | (MCP only) |
+| `get_backlinks` | (MCP only) |
 | `list_articles` / `generate_article` / `optimize_article` | `anomalia web <slug> …` |
 | `get_article` / `update_article` | (MCP only) |
 | `publish_article` / `unpublish_article` / `delete_article` | `anomalia web <slug> publish\|…` |
@@ -234,6 +237,17 @@ one with the most clicks in the last seven days.
 `get_seo` and `get_geo` answer on the **latest** audit. The four web tools let you trace a claim
 back to what was actually measured, without paying for a new audit. All four are reads: they call
 no model, spend no credits and write nothing.
+
+`get_gsc`, `get_ranks` and `get_backlinks` are the measured side of the same brand. `get_gsc`
+reads Google Search Console over the last 28 days — clicks, impressions, top queries and top
+pages — and says whether the property is connected at all: `connected: false` means there is
+nothing to read yet, not that the brand ranks nowhere. `get_ranks` returns the tracked keywords
+with `position`, `prevPosition` and `delta` (positive = moved up), the ranking URL, and
+`hasAiOverview` for the ones where Google answered on its own. `get_backlinks` returns links
+given and received plus the open give/receive opportunities, and `unlocked` tells you whether
+the network is usable — it needs Starter or above **and** the brand's opt-in, so `planAllowed`
+and `enabled` say which of the two is missing. All three are reads: no model, no credits, no
+writes.
 
 `list_web_audits` is the index of every audit, newest first — `id`, `at`, `tech_score`,
 `share_of_voice`, `citability_score`, `binding_constraint`, and how many citations and findings

--- a/docs/api/07-growth-seo-geo.md
+++ b/docs/api/07-growth-seo-geo.md
@@ -451,6 +451,8 @@ curl -s -X POST "https://anomalia.so/api/v1/brands/mio-brand/keywords" \
 
 ## `GET /api/v1/brands/:slug/backlinks`
 
+Tool MCP: `get_backlinks`.
+
 Riepilogo della backlink network: piazzamenti in uscita/entrata, opportunità open e statistiche.
 
 **Query params**: nessuno
@@ -815,6 +817,8 @@ curl -s "https://anomalia.so/api/v1/brands/mio-brand/articles/mio-articolo" \
 
 ## `GET /api/v1/brands/:slug/gsc`
 
+Tool MCP: `get_gsc`.
+
 Riepilogo Google Search Console: stato connessione + metriche aggregate 28 giorni (top query e pagine, max 20 ciascuna).
 
 **Query params**: nessuno
@@ -879,6 +883,8 @@ curl -s -X POST "https://anomalia.so/api/v1/brands/mio-brand/gsc" \
 ---
 
 ## `GET /api/v1/brands/:slug/ranks`
+
+Tool MCP: `get_ranks`.
 
 Rank board: keyword tracciate attive con posizione attuale, precedente e delta.
 

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -45,6 +45,7 @@ import {
   LIST_PRODUCTS
 } from './reads';
 import { GEO_ACTION, REFRESH_KEYWORDS, SEO_ACTION } from './search';
+import { GET_BACKLINKS, GET_GSC, GET_RANKS } from './web-metrics';
 import {
   CREATE_SHARE,
   LIST_SHARES,
@@ -121,14 +122,17 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   GET_ANALYTICS,
   GET_ARTICLE,
   GET_AUDIT_FINDINGS,
+  GET_BACKLINKS,
   GET_BIO,
   GET_CALENDAR,
   GET_CREATION_KIT,
   GET_GEO,
+  GET_GSC,
   GET_GTM,
   GET_KEYWORDS,
   GET_PLAN,
   GET_POST,
+  GET_RANKS,
   GET_SEO,
   GET_STUDIO,
   GET_VOICE,
@@ -220,6 +224,7 @@ export {
   LIST_PRODUCTS
 };
 export { GEO_ACTION, REFRESH_KEYWORDS, SEO_ACTION } from './search';
+export { GET_BACKLINKS, GET_GSC, GET_RANKS } from './web-metrics';
 export {
   ADD_COMPETITOR,
   CREATE_PRODUCT,

--- a/packages/api-contracts/src/web-metrics.test.ts
+++ b/packages/api-contracts/src/web-metrics.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+import { GET_BACKLINKS, GET_GSC, GET_RANKS } from './web-metrics';
+import { BRAND_ENDPOINTS } from './index';
+
+const WEB_METRICS = [GET_GSC, GET_RANKS, GET_BACKLINKS];
+
+describe('il contratto delle misure del web', () => {
+  it('espone solo letture: un numero non si sposta passando da qui', () => {
+    for (const endpoint of WEB_METRICS) {
+      expect(endpoint.method, endpoint.tool).toBe('GET');
+      expect(endpoint.destructive, endpoint.tool).toBe(false);
+    }
+  });
+
+  it('è registrato, o il tool MCP non nasce', () => {
+    for (const endpoint of WEB_METRICS) {
+      expect(BRAND_ENDPOINTS, endpoint.tool).toContain(endpoint);
+    }
+  });
+
+  it('non chiede niente oltre al brand, e rifiuta il resto', () => {
+    for (const endpoint of WEB_METRICS) {
+      expect(endpoint.input.safeParse({}).success, endpoint.tool).toBe(true);
+      expect(endpoint.input.safeParse({ campo_che_non_esiste: 'x' }).success, endpoint.tool).toBe(false);
+    }
+  });
+
+  it('gsc distingue "mai collegato" da "collegato e a zero"', () => {
+    const disconnected = {
+      connected: false,
+      configured: true,
+      siteUrl: null,
+      syncedAt: null,
+      lastError: null,
+      clicks28d: 0,
+      impressions28d: 0,
+      topQueries: [],
+      topPages: []
+    };
+    expect(GET_GSC.output.safeParse(disconnected).success).toBe(true);
+    expect(GET_GSC.output.safeParse({ ...disconnected, connected: true, siteUrl: 'https://x.it' }).success).toBe(true);
+    const { connected: _omitted, ...senzaStato } = disconnected;
+    expect(GET_GSC.output.safeParse(senzaStato).success).toBe(false);
+  });
+
+  it('una query di gsc porta clic, impression e posizione media', () => {
+    const row = { query: 'crm agenzie', clicks: 12, impressions: 340, position: 4.2 };
+    expect(GET_GSC.output.safeParse({
+      connected: true,
+      configured: true,
+      siteUrl: 'https://x.it',
+      syncedAt: '2026-09-01T08:00:00Z',
+      lastError: null,
+      clicks28d: 12,
+      impressions28d: 340,
+      topQueries: [row],
+      topPages: [{ page: 'https://x.it/a', clicks: 12, impressions: 340, position: 4.2 }]
+    }).success).toBe(true);
+    expect(GET_GSC.output.safeParse({
+      connected: true,
+      configured: true,
+      siteUrl: null,
+      syncedAt: null,
+      lastError: null,
+      clicks28d: 0,
+      impressions28d: 0,
+      topQueries: [{ query: 'crm agenzie', clicks: 12 }],
+      topPages: []
+    }).success).toBe(false);
+  });
+
+  it('una keyword mai controllata resta una riga, con la posizione a null', () => {
+    const tracked = {
+      id: 'kw-1',
+      keyword: 'crm agenzie',
+      locale: 'it-IT',
+      device: 'desktop',
+      source: 'manual',
+      active: true,
+      position: null,
+      prevPosition: null,
+      delta: null,
+      url: null,
+      checkedAt: null,
+      hasAiOverview: false
+    };
+    expect(GET_RANKS.output.safeParse({ keywords: [tracked] }).success).toBe(true);
+    expect(GET_RANKS.output.safeParse({ keywords: [{ ...tracked, position: 3, prevPosition: 7, delta: 4 }] }).success).toBe(true);
+    expect(GET_RANKS.output.safeParse({ keywords: [{ id: 'kw-1', keyword: 'x' }] }).success).toBe(false);
+  });
+
+  it('backlinks dice se la rete è sbloccata, non solo cosa contiene', () => {
+    const empty = {
+      enabled: false,
+      planAllowed: false,
+      unlocked: false,
+      outgoing: [],
+      incoming: [],
+      opportunities: [],
+      stats: { outgoingCount: 0, incomingCount: 0, openGive: 0, openReceive: 0 }
+    };
+    expect(GET_BACKLINKS.output.safeParse(empty).success).toBe(true);
+    const { unlocked: _omitted, ...senzaVerdetto } = empty;
+    expect(GET_BACKLINKS.output.safeParse(senzaVerdetto).success).toBe(false);
+  });
+
+  it('un piazzamento arriva anche senza il nome del partner, che è un arricchimento', () => {
+    const placement = {
+      id: 'p-1',
+      sourceBrandId: 'b-1',
+      sourceArticleId: null,
+      targetBrandId: 'b-2',
+      targetArticleId: null,
+      targetUrl: 'https://altro.it/post',
+      anchorText: null,
+      status: 'live',
+      createdAt: '2026-09-01T08:00:00Z'
+    };
+    const summary = {
+      enabled: true,
+      planAllowed: true,
+      unlocked: true,
+      outgoing: [placement],
+      incoming: [{ ...placement, partnerName: 'Altro Brand' }],
+      opportunities: [
+        {
+          id: 'o-1',
+          direction: 'give',
+          partnerBrandId: 'b-2',
+          partnerBrandName: 'Altro Brand',
+          partnerArticleId: null,
+          partnerUrl: 'https://altro.it/post',
+          partnerTitle: null,
+          relevance: 0.8,
+          suggestedAnchor: null,
+          rationale: null,
+          status: 'open',
+          createdAt: '2026-09-01T08:00:00Z'
+        }
+      ],
+      stats: { outgoingCount: 1, incomingCount: 1, openGive: 1, openReceive: 0 }
+    };
+    expect(GET_BACKLINKS.output.safeParse(summary).success).toBe(true);
+    expect(
+      GET_BACKLINKS.output.safeParse({
+        ...summary,
+        opportunities: [{ ...summary.opportunities[0], direction: 'sideways' }]
+      }).success
+    ).toBe(false);
+  });
+});

--- a/packages/api-contracts/src/web-metrics.ts
+++ b/packages/api-contracts/src/web-metrics.ts
@@ -1,0 +1,117 @@
+import { z } from 'zod';
+import type { BrandEndpoint } from './index';
+
+const NoInput = z.object({}).strict();
+
+const SearchRow = z.object({
+  clicks: z.number(),
+  impressions: z.number(),
+  position: z.number()
+});
+
+export const GET_GSC = {
+  tool: 'get_gsc',
+  title: 'Search Console',
+  description:
+    'Google Search Console over the last 28 days: clicks, impressions, top queries and pages, and whether the property is connected.',
+  method: 'GET',
+  pathUnderBrand: '/gsc',
+  input: NoInput,
+  output: z.object({
+    connected: z.boolean(),
+    configured: z.boolean(),
+    siteUrl: z.string().nullable(),
+    syncedAt: z.string().nullable(),
+    lastError: z.string().nullable(),
+    clicks28d: z.number(),
+    impressions28d: z.number(),
+    topQueries: z.array(SearchRow.extend({ query: z.string() })),
+    topPages: z.array(SearchRow.extend({ page: z.string() }))
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const GET_RANKS = {
+  tool: 'get_ranks',
+  title: 'Rank tracking',
+  description:
+    'Tracked keywords with their current Google position, the previous one, the move between them, the ranking URL and whether an AI Overview showed.',
+  method: 'GET',
+  pathUnderBrand: '/ranks',
+  input: NoInput,
+  output: z.object({
+    keywords: z.array(
+      z.object({
+        id: z.string(),
+        keyword: z.string(),
+        locale: z.string(),
+        device: z.string(),
+        source: z.string(),
+        active: z.boolean(),
+        position: z.number().nullable(),
+        prevPosition: z.number().nullable(),
+        delta: z.number().nullable(),
+        url: z.string().nullable(),
+        checkedAt: z.string().nullable(),
+        hasAiOverview: z.boolean()
+      })
+    )
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+const BacklinkPlacement = z.object({
+  id: z.string(),
+  sourceBrandId: z.string(),
+  sourceArticleId: z.string().nullable(),
+  targetBrandId: z.string(),
+  targetArticleId: z.string().nullable(),
+  targetUrl: z.string(),
+  anchorText: z.string().nullable(),
+  status: z.string(),
+  createdAt: z.string(),
+  partnerName: z.string().nullable().optional()
+});
+
+export const GET_BACKLINKS = {
+  tool: 'get_backlinks',
+  title: 'Backlink network',
+  description:
+    'Backlink network: links given and received, open give/receive opportunities, and whether the network is unlocked for this brand (Starter or above, plus opt-in).',
+  method: 'GET',
+  pathUnderBrand: '/backlinks',
+  input: NoInput,
+  output: z.object({
+    enabled: z.boolean(),
+    planAllowed: z.boolean(),
+    unlocked: z.boolean(),
+    outgoing: z.array(BacklinkPlacement),
+    incoming: z.array(BacklinkPlacement),
+    opportunities: z.array(
+      z.object({
+        id: z.string(),
+        direction: z.enum(['give', 'receive']),
+        partnerBrandId: z.string(),
+        partnerBrandName: z.string(),
+        partnerArticleId: z.string().nullable(),
+        partnerUrl: z.string(),
+        partnerTitle: z.string().nullable(),
+        relevance: z.number(),
+        suggestedAnchor: z.string().nullable(),
+        rationale: z.string().nullable(),
+        status: z.string(),
+        createdAt: z.string()
+      })
+    ),
+    stats: z.object({
+      outgoingCount: z.number(),
+      incomingCount: z.number(),
+      openGive: z.number(),
+      openReceive: z.number()
+    })
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/src/lib/content/changelog/2026-09-04-measurement-web-metrics.ts
+++ b/src/lib/content/changelog/2026-09-04-measurement-web-metrics.ts
@@ -1,0 +1,14 @@
+import type { ChangelogEntry } from './index';
+
+const entry: ChangelogEntry = {
+  date: '2026-09-04',
+  title: 'Your AI assistant can read your search numbers',
+  items: [
+    'Search Console is readable by your assistant: 28-day clicks and impressions, top queries and top pages, and whether the property is connected at all.',
+    'Tracked keywords come with their position today, the position before, the move between them, and whether Google answered with an AI Overview.',
+    'The backlink network is readable too — links given, links received, open opportunities, and whether the network is unlocked for your plan.',
+    'All three are reads: they cost no credits and change nothing.'
+  ]
+};
+
+export default entry;


### PR DESCRIPTION
## What?

Three measurement reads stop being reachable only by `curl` and become MCP tools, generated from
the endpoint registry: **`get_gsc`**, **`get_ranks`**, **`get_backlinks`**. A new contract file,
`packages/api-contracts/src/web-metrics.ts`, declares them with a real `output` — not `z.any()` —
mirrored into `cli/lib/contracts/` by `sync-contracts.sh`.

Registry coverage goes from **55 to 58** endpoints; `tools/list` goes from **88 to 91** tools. No
existing tool changes, is renamed, or disappears.

The PR also adds one law to `cli/mcp/read-tools.test.ts`: every entry in `BRAND_ENDPOINTS` must
appear in `tools/list` with the title, description and annotations the contract declares. It
covers the 58 of today and every endpoint added after, so the next family does not need its own
captured table.

## Why?

Anomalia is becoming a headless interface for external agents over MCP, and an agent that cannot
read the numbers cannot decide anything. Measurement was half-invisible: `get_seo` and `get_geo`
answer on the latest audit, but the numbers that say whether the work is working — clicks and
impressions from Search Console, where a tracked keyword sits today versus yesterday, who links
to the brand — lived behind three routes that no tool exposed. Documented in `docs/api/07`,
reachable with a bearer token: that is an interface for a human, not for an agent.

## How?

**A new file per family**, the precedent set by `search.ts` in #238. `web-metrics.ts` holds the
three web measurements and does not mix into `reads.ts`, which is full of brand state.

**The output is read, not guessed.** Each shape comes from the function that builds it —
`loadGscSummary`, `loadRankBoard`, `loadBacklinkNetworkSummary` — and was checked against the
responses already documented in `docs/api/07`. Two decisions were not obvious:

- **`partnerName` is optional on a placement.** The name lookup is best-effort and only runs when
  there are partners to name. Declaring it required would make the contract lie on an empty
  network.
- **GSC's `connected` is required.** Zero clicks with `connected: false` means "never connected";
  with `connected: true` it means "connected and flat". An agent that cannot tell them apart
  proposes the wrong thing. A test holds the distinction.

**Rejected alternative — one measurement doc and one giant contract file.** Eight measurement
endpoints in one file, one PR, one changelog. It would have been faster to write and impossible
to review, and it would have collided with itself on `index.ts` three times over. The endpoints
are split by family instead: this is web/SEO; market and brand-state follow in their own PRs.

**No new `docs/api/` file.** All three routes were already documented in `07-growth-seo-geo.md`,
shape included — the docs get the one line the repo already uses to name a tool
(`Tool MCP: \`get_gsc\`.`), nothing more.

## Testing?

```
npx vitest run packages/api-contracts   →  6 files, 84 tests passed
cd cli && bun test                      →  57 pass, 0 fail (11 files)
cd cli && bun run typecheck             →  clean
node scripts/typecheck-runtime.mjs      →  ok (311 pre-existing non-fatal errors ignored)
npm run check                           →  347 errors, all pre-existing; none in the files touched
```

`bash cli/scripts/sync-contracts.sh` was run after every edit under
`packages/api-contracts/src/`; `cli/lib/contracts.test.ts` compares the two trees byte for byte
and is green. `grep -c 'export const BRAND_ENDPOINTS' packages/api-contracts/src/index.ts` is
**1**, the array is sorted and has no duplicates.

**Red before green, twice.** `web-metrics.test.ts` was written first and failed on the missing
module; the new law in `read-tools.test.ts` was watched fail by suppressing `get_gsc` in the
generator loop (`error: tool get_gsc non registrato`).

**Not tested**: nothing calls the three endpoints for real here. The routes are untouched — this
PR only declares what they already return.

**Read-only API keys reach all three, and that is not a per-route courtesy.** `resolveCaller` in
`src/lib/server/cli-auth.ts` denies a read-only key once, on the method:

```ts
if (request.method !== 'GET' && request.method !== 'HEAD') {
  const denied = checkApiKeyWriteAccess(...);
  if (denied) return { error: denied };
}
```

All three are `GET`. None of the three GET handlers calls `gateAiAction` or
`checkApiKeyWriteAccess` — **they spend no credits**.

## Evidence (screenshots/videos)

No UI.

<details>
<summary><code>tools/list</code> through <code>handleMcpFetch</code>, before → after</summary>

```
before 88 after 91
added: ['get_backlinks', 'get_gsc', 'get_ranks']
removed: []
changed: []

{"name": "get_gsc", "title": "Search Console",
 "description": "Google Search Console over the last 28 days: clicks, impressions, top queries and pages, and whether the property is connected.",
 "properties": ["slug"], "required": ["slug"], "additionalProperties": false,
 "annotations": {"readOnlyHint": true, "destructiveHint": false}}

{"name": "get_ranks", "title": "Rank tracking",
 "description": "Tracked keywords with their current Google position, the previous one, the move between them, the ranking URL and whether an AI Overview showed.",
 "properties": ["slug"], "required": ["slug"], "additionalProperties": false,
 "annotations": {"readOnlyHint": true, "destructiveHint": false}}

{"name": "get_backlinks", "title": "Backlink network",
 "description": "Backlink network: links given and received, open give/receive opportunities, and whether the network is unlocked for this brand (Starter or above, plus opt-in).",
 "properties": ["slug"], "required": ["slug"], "additionalProperties": false,
 "annotations": {"readOnlyHint": true, "destructiveHint": false}}
```

Captured by driving `handleMcpFetch` with `initialize` + `tools/list` and comparing name, title,
description, property set, required set, `additionalProperties` and annotations, tool by tool.
`changed: []` is the whole claim: the other 88 are byte-identical.
</details>

<details>
<summary>The new law, watched fail</summary>

```
error: tool get_gsc non registrato
      at find (cli/mcp/read-tools.test.ts:128:24)
(fail) le letture migrate sul registry > ogni endpoint del registry esiste in tools/list come lo dichiara

 4 pass
 1 fail
```
</details>

## Anything Else?

**`POST /backlinks` stayed out, on purpose.** It calls `gateAiAction` and bills credits. Only
reads are in this round; a tool that promises a free read and charges instead would be the worst
defect of this batch.

**What comes next, in its own PR:** market measurement (`market/field`, `radar/diagnose`,
`ideas`) and brand state (`doctor`, `goals`). The census behind the split: 92 route files under
`src/routes/api/v1/brands/[slug]/`, 46 route paths covered by the registry before this PR, 45
uncovered — of which exactly eight are measurement reads.

**Left out and why.** `/agent-sessions` is agent-run telemetry, measurement-adjacent and a real
candidate, but its payload is a redacted transcript blob that would be `z.unknown()` in practice,
and the sandbox agents that write it are being removed in parallel. `/rubrics`, `/publishing` and
`/articles` are state and content, not measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
