### PR TITLE
Remove the TopbarCta neutral variant, now unused

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -30,6 +30,21 @@ decisiva e` chiedere una foto AI (percorso vecchio) e vedere lo stesso errore. M
 LOGICA con i test (il caricamento si mocka) e nel browser verifica quello che il difetto riguardava
 — quale tool viene scelto, quali righe nascono — senza pretendere che il file arrivi in Storage.
 
+### 77 test leggono un sorgente con `readFileSync`: cancellarlo non rompe nessun import
+Un censimento del codice morto fatto sul grafo degli import non li vede: questi test non importano
+niente di cio` che controllano, leggono il **testo** del file e ci asseriscono sopra. Cancelli il
+sorgente, nessun import si spezza, il grafo tace — e la CI diventa rossa. Peggio: il nome del test
+non dice cosa copre. Oggi `topbar-cta.test.ts` asseriva sul pannello del desktop agentico, e nessuna
+suite scelta «per area» lo avrebbe mai caricato; `dev` e` diventata rossa tre volte, in mano a due
+agenti diversi. Stessa forma per le liste che classificano le rotte per **stringa**
+(`workbench-paths.ts`, `settings/platforms.ts`): un grep sui simboli non le trova mai — e` la
+rottura di `agent-lab`. Segnale: un test rosso su un file che non hai toccato, che non importa nulla
+di cio` che hai cancellato. Mossa, prima di ogni PR di cancellazione:
+`npx vitest run $(git grep -ln "readFileSync" -- 'src/**/*.test.ts') > /tmp/src-read.log 2>&1`
+(poi `tail -5` sul file: `| tail` diretto bufferizza e il watchdog a 600s ti uccide), piu` un grep
+del **nome nudo** di ogni percorso cancellato — senza estensione e senza `$lib`, perche` e` cosi`
+che quelle liste lo nominano.
+
 ### Il worktree nuovo ha bisogno di `npm ci` — e ancora dopo ogni rebase su dev
 Un worktree parte senza `node_modules`, e `vite.config.ts` muore subito (`Cannot find package '@sentry/sveltekit'`). Ma il caso insidioso è l'altro: dopo aver ribasato su dev che ha accolto PR nuove, il `node_modules` installato col vecchio lockfile produce guasti **deterministici e fuori posto** — v. `extractUserText is not a function` in un test di immagini: il codice era giusto, le dipendenze vecchie. Segnale: un errore `X is not a function` su codice mai toccato, in un worktree ribasato. Mossa: `npm ci` nel worktree, sempre, dopo il rebase.
 

--- a/changelog/2026-09-04-variante-neutral-senza-utenti.md
+++ b/changelog/2026-09-04-variante-neutral-senza-utenti.md
@@ -1,0 +1,42 @@
+# La variante `neutral` di TopbarCta non ha piu' nessuno
+
+69 righe fra `TopbarCta.svelte` e `PageTopBar.svelte`.
+
+## Cosa spariva
+
+- `TopbarCta.svelte`: `variant?: 'primary' | 'ghost' | 'neutral'` torna a due valori, via
+  la riga `class:neutral={...}` e le cinque regole `.topbar-cta.neutral*`.
+- `PageTopBar.svelte`: le cinque regole `:global(.topbar-cta.neutral*)` che la
+  rivestivano dentro la topbar.
+
+## Perche' e' morta
+
+`4cdcdb1` ha tolto il pannello del desktop agentico da
+`src/routes/app/[brand]/chat/[thread]/+page.svelte`. Era **l'unico** posto che passasse
+`variant="neutral"`. Dopo quella rimozione l'unica occorrenza rimasta in tutto il repo
+stava in `topbar-cta.test.ts`, che asseriva sul markup del pannello appena cancellato —
+un test rimasto senza soggetto, che la #262 elimina. Tolto il test, la variante non ha
+piu' **nessun** riferimento.
+
+`TopbarCta` resta viva e molto usata (agents, backlinks, competitors, geo, gtm,
+keywords, seo, site): muoiono solo `neutral` e il suo vestito.
+
+## Come l'ho provato, e la trappola che ci sta sotto
+
+Un `grep` di `variant="neutral"` su tutto `src` non trova nessun consumatore.
+
+Ma il punto vero e' un altro, ed e' una lezione che oggi ha fatto diventare rossa `dev`
+tre volte: **77 test in `src` leggono un sorgente con `readFileSync` e asseriscono sul
+suo testo, senza importarne un simbolo.** Cancellare quel sorgente non rompe nessun
+import: un censimento fatto sul grafo degli import non se ne accorge, e il guasto arriva
+in CI. Peggio, il nome del test non dice cosa controlla — `topbar-cta.test.ts` asseriva
+sul pannello del desktop agentico, e nessuna suite scelta «per area» lo avrebbe caricato.
+
+Da qui in avanti il cancello prima di ogni cancellazione e' questo:
+
+```
+npx vitest run $(git grep -ln "readFileSync" -- 'src/**/*.test.ts') > /tmp/src-read.log 2>&1
+```
+
+Qui: **79 file, 1.116 test, verdi** — e `ui-tokens.test.ts`, che sta in quel gruppo,
+copre anche i token CSS che queste regole usavano.

--- a/src/lib/components/PageTopBar.svelte
+++ b/src/lib/components/PageTopBar.svelte
@@ -736,39 +736,6 @@
     pointer-events: none;
     transform: none;
   }
-  .page-topbar-actions :global(.topbar-cta.neutral) {
-    gap: 6px;
-    border: 1px solid var(--line);
-    padding: 7px 10px;
-    font-size: 12px;
-    font-weight: 550;
-    color: var(--ink-soft);
-    background: transparent;
-    box-shadow: none;
-    transform: none;
-  }
-  .page-topbar-actions :global(.topbar-cta.neutral:hover:not(:disabled)) {
-    color: var(--ink);
-    background: var(--paper-2);
-    border-color: var(--line-2);
-    box-shadow: none;
-    transform: none;
-  }
-  .page-topbar-actions :global(.topbar-cta.neutral:active:not(:disabled)) {
-    background: var(--paper-3);
-    box-shadow: none;
-    transform: none;
-  }
-  .page-topbar-actions :global(.topbar-cta.neutral:focus-visible) {
-    outline: 2px solid var(--ink);
-    outline-offset: 2px;
-  }
-  .page-topbar-actions :global(.topbar-cta.neutral:disabled) {
-    opacity: 0.72;
-    cursor: not-allowed;
-    pointer-events: none;
-    transform: none;
-  }
   .page-topbar-actions :global(.topbar-cta-spin),
   .page-topbar-actions :global(.spin) {
     width: 14px;

--- a/src/lib/components/TopbarCta.svelte
+++ b/src/lib/components/TopbarCta.svelte
@@ -17,7 +17,7 @@
     disabled?: boolean;
     type?: 'submit' | 'button';
     title?: string;
-    variant?: 'primary' | 'ghost' | 'neutral';
+    variant?: 'primary' | 'ghost';
     /** Lucide (or compatible) icon — shown when not busy; spinner replaces it while loading. */
     Icon?: Component<{ class?: string; strokeWidth?: number | string; 'aria-hidden'?: boolean | 'true' | 'false' }>;
     class?: string;
@@ -32,7 +32,6 @@
   class="topbar-cta {className}"
   class:is-busy={busy}
   class:ghost={variant === 'ghost'}
-  class:neutral={variant === 'neutral'}
   {type}
   disabled={locked}
   aria-busy={busy}
@@ -90,17 +89,6 @@
     box-shadow: none;
   }
 
-  .topbar-cta.neutral {
-    gap: 6px;
-    padding: 7px 10px;
-    font-size: 12px;
-    font-weight: 550;
-    color: var(--ink-soft);
-    background: transparent;
-    border: 1px solid var(--line);
-    box-shadow: none;
-  }
-
   .topbar-cta:hover:not(:disabled):not(.is-busy) {
     transform: translateY(-1px);
     background: color-mix(in srgb, var(--accent) 88%, #000);
@@ -111,14 +99,6 @@
 
   .topbar-cta.ghost:hover:not(:disabled):not(.is-busy) {
     background: color-mix(in srgb, var(--accent) 14%, var(--paper));
-    box-shadow: none;
-  }
-
-  .topbar-cta.neutral:hover:not(:disabled):not(.is-busy) {
-    transform: none;
-    color: var(--ink);
-    background: var(--paper-2);
-    border-color: var(--line-2);
     box-shadow: none;
   }
 
@@ -135,19 +115,9 @@
     box-shadow: none;
   }
 
-  .topbar-cta.neutral:active:not(:disabled):not(.is-busy) {
-    transform: none;
-    background: var(--paper-3);
-    box-shadow: none;
-  }
-
   .topbar-cta:focus-visible {
     outline: 2px solid color-mix(in srgb, var(--accent) 55%, #fff);
     outline-offset: 2px;
-  }
-
-  .topbar-cta.neutral:focus-visible {
-    outline-color: var(--ink);
   }
 
   .topbar-cta:disabled,
@@ -184,11 +154,6 @@
   .topbar-cta.ghost .topbar-cta-spin {
     border-color: color-mix(in srgb, var(--accent) 30%, transparent);
     border-top-color: var(--accent);
-  }
-
-  .topbar-cta.neutral .topbar-cta-spin {
-    border-color: color-mix(in srgb, var(--ink) 22%, transparent);
-    border-top-color: var(--ink);
   }
 
   @keyframes topbar-cta-spin {


### PR DESCRIPTION
## What?

The `neutral` variant of `TopbarCta` and its styling, 69 lines across two components:

- `TopbarCta.svelte` — `variant?: 'primary' | 'ghost' | 'neutral'` goes back to two values, plus the `class:neutral={…}` line and the five `.topbar-cta.neutral*` rules.
- `PageTopBar.svelte` — the five `:global(.topbar-cta.neutral*)` rules that dressed it inside the topbar.

`TopbarCta` itself stays and is widely used — agents, backlinks, competitors, geo, gtm, keywords, seo, site. Only `neutral` and its clothes die.

**Stacked on #262**, which removes the test that was the variant's last reference. Based on `fix/topbar-cta-after-desktop` so the diff here is only the variant; retarget to `dev` once #262 lands.

## Why?

`4cdcdb1` removed the agent desktop panel from `src/routes/app/[brand]/chat/[thread]/+page.svelte`, the only place that ever passed `variant="neutral"`. After that commit the sole remaining occurrence anywhere in the repo was inside `topbar-cta.test.ts` — a test asserting on markup the same commit had just deleted. #262 removes that test. With it gone, the variant has **no reference at all**: not a consumer, not a test, nothing.

A variant with no caller is worse than unused code in a leaf file. It sits in a shared component's public prop type, so the next person picking a topbar style sees three options and has to work out that one of them was for a screen that no longer exists.

## How?

Straight deletion, no refactor: the union member, the class binding, and the ten CSS rules keyed on `.neutral`. Nothing else in either component moves.

Rejected alternative: keeping `neutral` "in case a future page wants a quiet topbar button". That is the defensive keep `CLAUDE.md` rejects — complexity paid today for a contingency that never arrives. `ghost` already covers a low-emphasis action, and the variant is one `git show` away if a page ever needs it back.

## Testing?

The gate that matters here is **not** the import graph, and that is the point of this PR.

**77 test files in `src` read a source with `readFileSync` and assert on its text without importing a single symbol from it.** Delete what one of them reads and no import breaks — an importer census sees nothing, and the failure surfaces in CI. Worse, the test name does not say what it covers: `topbar-cta.test.ts` asserted on the agent desktop panel, so no suite picked "by area" would ever have loaded it. That is exactly how `dev` went red today.

So the check run here is the whole set:

```
npx vitest run $(git grep -ln "readFileSync" -- 'src/**/*.test.ts') \
  cli/lib/contracts.test.ts packages/no-app-imports.test.ts \
  scripts/self-host-compose.test.ts scripts/vercel-install.test.ts
```

- **79 files, 1116 tests, all green.** `ui-tokens.test.ts` is inside that set, so the CSS custom properties these rules referenced are covered too.
- Full suite plus Playwright runs here in CI.
- Not run: browser verification. No rendered surface changes — every removed rule is keyed on a class no element ever receives, because no caller passes the variant that sets it.

## Evidence

<details><summary>No consumer passes the variant</summary>

```
$ git grep -rn 'variant="neutral"' -- src
(nothing, once #262 removes topbar-cta.test.ts)
```

The four `'neutral'` hits left in `src` are an unrelated brand-voice tone enum (`operational-strategy.ts`, `voice/+page.svelte`).
</details>

<details><summary>The source-reading gate, green</summary>

```
 Test Files  79 passed (79)
      Tests  1116 passed (1116)
```
</details>

<details><summary>Why the importer census could not have caught this</summary>

```
$ git grep -ln "readFileSync" -- 'src/**/*.test.ts' | wc -l
77
```

Each of these asserts on file *text*. `topbar-cta.test.ts` read three paths — the chat thread page, `TopbarCta.svelte`, `PageTopBar.svelte` — and imported nothing from any of them.
</details>

## Anything Else?

**This gate is now part of the deletion series.** I re-ran it against all four code-touching PRs already open (#253, #254, #256, #260) after this was pointed out: **1125 tests green on every one of them**, and a bare-name grep of all 106 deleted paths across those branches finds none of them named inside a source-reading test. None of those PRs is at risk from this failure mode.

The same shape applies to the route-classification lists (`workbench-paths.ts`, `settings/platforms.ts`) that name paths as **strings** — a symbol grep never finds them. That is the `agent-lab` breakage #253 fixes, and it is why the census greps the bare name, without extension and without `$lib`.

No migration and no table is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY