### PR TITLE
Read the market from MCP: field watch, radar diagnosis, idea bank

### DIFF
--- a/changelog/2026-09-04-measurement-market.md
+++ b/changelog/2026-09-04-measurement-market.md
@@ -1,0 +1,51 @@
+# Campo, radar e banco idee diventano tool MCP
+
+Tre letture entrano nel registry (`packages/api-contracts/src/market.ts`): `get_market_field`,
+`diagnose_radar`, `list_ideas`. Il tool MCP e il metodo del client CLI nascono dalla dichiarazione,
+non da un `registerTool` scritto a mano.
+
+## Perché esiste
+
+Un agente esterno che non vede il campo lavora al buio: propone senza sapere cosa gira, e quando
+il Radar non trova niente non ha modo di scoprire perché. Le tre rotte esistono da tempo — due
+non erano nemmeno documentate in `docs/api/`, quindi erano raggiungibili solo da chi aveva letto
+il codice.
+
+## Cosa c'era prima
+
+`GET /market/field`, `GET /radar/diagnose`, `GET /ideas`: invariate. Cambia solo che adesso sono
+dichiarate.
+
+## Le due cose che non erano ovvie
+
+**`diagnose_radar` esce di casa, e lo dice.** È una lettura — niente AI, niente crediti, niente
+scritture — ma fa una richiesta di rete per fonte configurata, e per questo la rotta ha
+`maxDuration: 300`. Nel contratto è `openWorld: true`, che il generatore emette come
+`openWorldHint: true`: un client che vede solo `readOnlyHint` la tratterebbe come una lettura
+locale e istantanea, e non lo è. La descrizione lo ripete a parole, perché l'annotazione la legge
+il client e la descrizione la legge il modello.
+
+**I post del campo hanno campi opzionali, e non è pigrizia.** La rotta fa
+`{ ...(postById.get(id) ?? {}), query, relevance, discoveredAt, teardown }`: se la riga di
+`market_posts` non c'è più, l'oggetto esce con i soli quattro campi che il mapper scrive sempre.
+Dichiarare `platform` obbligatorio avrebbe reso il contratto falso proprio nel caso in cui serve
+capire cosa è successo.
+
+`list_ideas` senza `status` non restituisce tutto: restituisce solo `new` + `shortlisted`
+(`unusedOnly`). È scritto nella descrizione del tool, perché un agente che chiede "le idee" e ne
+riceve un sottoinsieme senza saperlo conclude che il banco è vuoto.
+
+## L'equivalenza, provata
+
+`tools/list` catturato attraverso `handleMcpFetch` prima e dopo: **90 → 93**, tre aggiunti, zero
+rimossi, zero modificati. La base è 90 e non 91 (#263 aveva lasciato 91) perché nel frattempo lo
+smantellamento della chat ha tolto il tool `chat` da `dev`.
+
+## Chiave di sola lettura
+
+Tutte e tre `GET`, `destructive: false`. La chiave di sola lettura le raggiunge per costruzione:
+`resolveCaller` nega la scrittura una volta sola e il criterio è il metodo. Nessuna delle tre
+chiama `gateAiAction`.
+
+**`POST /market/field` è rimasto fuori**: quella sì spende crediti (ricerche su più piattaforme e
+un teardown per ogni post nuovo). Qui entrano solo letture.

--- a/cli/lib/contracts/index.ts
+++ b/cli/lib/contracts/index.ts
@@ -44,6 +44,7 @@ import {
   LIST_ARTICLES,
   LIST_PRODUCTS
 } from './reads';
+import { DIAGNOSE_RADAR, GET_MARKET_FIELD, LIST_IDEAS } from './market';
 import { GEO_ACTION, REFRESH_KEYWORDS, SEO_ACTION } from './search';
 import { GET_BACKLINKS, GET_GSC, GET_RANKS } from './web-metrics';
 import {
@@ -116,6 +117,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   CREATE_PRODUCT,
   CREATE_SHARE,
   DELETE_PRODUCT,
+  DIAGNOSE_RADAR,
   DISCARD_PLAN,
   GEO_ACTION,
   GET_ADS,
@@ -130,6 +132,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   GET_GSC,
   GET_GTM,
   GET_KEYWORDS,
+  GET_MARKET_FIELD,
   GET_PLAN,
   GET_POST,
   GET_RANKS,
@@ -140,6 +143,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   IMPORT_MEDIA_URL,
   LIST_ARTICLES,
   LIST_AUDIT_CITATIONS,
+  LIST_IDEAS,
   LIST_MEDIA,
   LIST_POSTS,
   LIST_PRODUCTS,
@@ -223,6 +227,7 @@ export {
   LIST_ARTICLES,
   LIST_PRODUCTS
 };
+export { DIAGNOSE_RADAR, GET_MARKET_FIELD, IDEA_STATUSES, IDEAS_DEFAULT, IDEAS_MAX, LIST_IDEAS, MARKET_FIELD_DEFAULT, MARKET_FIELD_MAX } from './market';
 export { GEO_ACTION, REFRESH_KEYWORDS, SEO_ACTION } from './search';
 export { GET_BACKLINKS, GET_GSC, GET_RANKS } from './web-metrics';
 export {

--- a/cli/lib/contracts/market.ts
+++ b/cli/lib/contracts/market.ts
@@ -1,0 +1,168 @@
+import { z } from 'zod';
+import type { BrandEndpoint } from './index';
+
+export const MARKET_FIELD_DEFAULT = 20;
+export const MARKET_FIELD_MAX = 50;
+export const IDEAS_DEFAULT = 50;
+export const IDEAS_MAX = 200;
+
+export const IDEA_STATUSES = ['new', 'shortlisted', 'used', 'archived'] as const;
+
+const limitUpTo = (max: number, fallback: number) =>
+  z.coerce
+    .number()
+    .int()
+    .min(1)
+    .max(max)
+    .optional()
+    .describe(`How many to return, ${fallback} by default, ${max} at most`);
+
+const FieldTopics = z.object({
+  queries: z.array(z.string()),
+  hashtags: z.array(z.string())
+});
+
+const FieldPlaybook = z.object({
+  summary: z.string(),
+  hooks: z.array(z.object({ pattern: z.string(), example: z.string() })),
+  tones: z.array(z.string()),
+  fieldRagebait: z.number(),
+  moves: z.array(
+    z.object({ move: z.string(), why: z.string(), howToAdapt: z.string(), ragebait: z.number() })
+  ),
+  avoid: z.array(z.string()),
+  postsSeen: z.number(),
+  updatedAt: z.string()
+});
+
+const FieldTeardown = z.object({
+  market_post_id: z.string(),
+  tone_of_voice: z.string().nullable(),
+  communication: z.string().nullable(),
+  format: z.string().nullable(),
+  hook_type: z.string().nullable(),
+  spread_strategy: z.array(z.string()),
+  ragebait: z.number(),
+  ragebait_levers: z.array(z.string()),
+  why_it_spread: z.string().nullable(),
+  transferable: z.array(z.string()),
+  avoid: z.string().nullable()
+});
+
+export const GET_MARKET_FIELD = {
+  tool: 'get_market_field',
+  title: 'Field watch',
+  description:
+    "What moves in the brand's field: the topics being watched, the playbook distilled from them, and the catalogued posts with the teardown of why each one spread.",
+  method: 'GET',
+  pathUnderBrand: '/market/field',
+  input: z.object({ limit: limitUpTo(MARKET_FIELD_MAX, MARKET_FIELD_DEFAULT) }).strict(),
+  output: z.object({
+    topics: FieldTopics.nullable(),
+    playbook: FieldPlaybook.nullable(),
+    updatedAt: z.string().nullable(),
+    posts: z.array(
+      z.object({
+        id: z.string().optional(),
+        platform: z.string().nullable().optional(),
+        url: z.string().nullable().optional(),
+        account_key: z.string().nullable().optional(),
+        content: z.string().nullable().optional(),
+        media_type: z.string().nullable().optional(),
+        engagement: z.number().nullable().optional(),
+        published_at: z.string().nullable().optional(),
+        query: z.string().nullable(),
+        relevance: z.number().nullable(),
+        discoveredAt: z.string().nullable(),
+        teardown: FieldTeardown.nullable()
+      })
+    )
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const DIAGNOSE_RADAR = {
+  tool: 'diagnose_radar',
+  title: 'Radar diagnosis',
+  description:
+    'Why Radar finds nothing: fetches every configured source live and reports, per source, how many items came back or why it was skipped — source off, plan, platform toggle, endpoint error. Reads only, spends no credits, and can take seconds per source.',
+  method: 'GET',
+  pathUnderBrand: '/radar/diagnose',
+  input: z.object({}).strict(),
+  output: z.object({
+    enabled: z.boolean(),
+    plan: z.string().nullable(),
+    proLeads: z.boolean(),
+    scrapecreatorsConfigured: z.boolean(),
+    platforms: z.record(z.string(), z.boolean()),
+    engagePlatforms: z.array(z.string()),
+    sources: z.array(
+      z.object({
+        kind: z.string(),
+        value: z.string(),
+        active: z.boolean(),
+        allowedByPlan: z.boolean(),
+        enabled: z.boolean(),
+        platform: z.string().nullable(),
+        items: z.number(),
+        windowHours: z.number().optional(),
+        sample: z.array(z.object({ title: z.string(), url: z.string() })).optional(),
+        skipped: z.string().optional(),
+        error: z.string().optional()
+      })
+    ),
+    note: z.string()
+  }),
+  failures: [],
+  destructive: false,
+  openWorld: true
+} satisfies BrandEndpoint;
+
+export const LIST_IDEAS = {
+  tool: 'list_ideas',
+  title: 'Idea bank',
+  description:
+    'Disruptive ideas saved for this brand. Omit status for the ones still usable (new and shortlisted); pass all, or one status, to see the rest.',
+  method: 'GET',
+  pathUnderBrand: '/ideas',
+  input: z
+    .object({
+      status: z
+        .enum([...IDEA_STATUSES, 'all'])
+        .optional()
+        .describe('Omit for unused ideas only'),
+      limit: limitUpTo(IDEAS_MAX, IDEAS_DEFAULT)
+    })
+    .strict(),
+  output: z.object({
+    ideas: z.array(
+      z.object({
+        id: z.string(),
+        brand_id: z.string(),
+        user_id: z.string().nullable(),
+        title: z.string(),
+        idea: z.string(),
+        device: z.string().nullable(),
+        why_it_contrasts: z.string().nullable(),
+        who_it_annoys: z.string().nullable(),
+        format: z.string().nullable(),
+        score: z.number().nullable(),
+        surface: z.string().nullable(),
+        agent: z.string().nullable(),
+        thread_id: z.string().nullable(),
+        status: z.enum(IDEA_STATUSES),
+        used_post_id: z.string().nullable(),
+        used_at: z.string().nullable(),
+        last_shown_at: z.string().nullable(),
+        shown_count: z.number(),
+        tags: z.array(z.string()),
+        created_at: z.string(),
+        updated_at: z.string()
+      })
+    ),
+    count: z.number()
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/cli/plugins/anomalia/skills/anomalia/references/tools.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/tools.md
@@ -232,6 +232,28 @@ one with the most clicks in the last seven days.
 | `get_article` / `update_article` | (MCP only) |
 | `publish_article` / `unpublish_article` / `delete_article` | `anomalia web <slug> publish\|…` |
 | `get_ads` / `ads_action` | `anomalia ads <slug> [--propose\|--create\|--approve\|--pause\|--resume\|--duplicate\|--delete\|--reject] [--ad <adId>]` |
+| `get_market_field` | (MCP only) |
+| `diagnose_radar` | (MCP only) |
+| `list_ideas` | (MCP only) |
+
+`get_market_field` is what the brand's field is doing, not what the brand is doing: the topics
+being watched, the playbook distilled from them, and the catalogued posts each with a teardown —
+tone, format, hook, what made it spread, what is transferable and what to avoid. `limit` caps the
+posts (20 by default, 50 at most). A field never watched answers with `topics`, `playbook` and
+`updatedAt` at `null`: that is a state, not an error, and it means the weekly pass has not run
+for this brand yet.
+
+`diagnose_radar` answers "why does Radar find nothing". It fetches every configured source live
+and reports, per source, how many items came back — or `skipped` (source off, plan, platform
+toggle) or `error` (the endpoint failed). It spends no credits and writes nothing, but it does
+leave the building: one network request per source, so it can take seconds. Dynamic keyword
+searches are not probed here.
+
+`list_ideas` is the brand's idea bank — the disruptive ideas agents saved while working. Omit
+`status` and you get only the ones still usable (`new` and `shortlisted`); pass `all`, or one of
+`new` / `shortlisted` / `used` / `archived`, for the rest. `limit` is 50 by default, 200 at most.
+Each idea carries the contrast `device` it uses, `why_it_contrasts` and `who_it_annoys` — an idea
+that annoys nobody is not one.
 
 `get_seo` and `get_geo` answer on the **latest** audit. The four web tools let you trace a claim
 back to what was actually measured, without paying for a new audit. All four are reads: they call

--- a/cli/skills/anomalia/references/tools.md
+++ b/cli/skills/anomalia/references/tools.md
@@ -232,6 +232,28 @@ one with the most clicks in the last seven days.
 | `get_article` / `update_article` | (MCP only) |
 | `publish_article` / `unpublish_article` / `delete_article` | `anomalia web <slug> publish\|…` |
 | `get_ads` / `ads_action` | `anomalia ads <slug> [--propose\|--create\|--approve\|--pause\|--resume\|--duplicate\|--delete\|--reject] [--ad <adId>]` |
+| `get_market_field` | (MCP only) |
+| `diagnose_radar` | (MCP only) |
+| `list_ideas` | (MCP only) |
+
+`get_market_field` is what the brand's field is doing, not what the brand is doing: the topics
+being watched, the playbook distilled from them, and the catalogued posts each with a teardown —
+tone, format, hook, what made it spread, what is transferable and what to avoid. `limit` caps the
+posts (20 by default, 50 at most). A field never watched answers with `topics`, `playbook` and
+`updatedAt` at `null`: that is a state, not an error, and it means the weekly pass has not run
+for this brand yet.
+
+`diagnose_radar` answers "why does Radar find nothing". It fetches every configured source live
+and reports, per source, how many items came back — or `skipped` (source off, plan, platform
+toggle) or `error` (the endpoint failed). It spends no credits and writes nothing, but it does
+leave the building: one network request per source, so it can take seconds. Dynamic keyword
+searches are not probed here.
+
+`list_ideas` is the brand's idea bank — the disruptive ideas agents saved while working. Omit
+`status` and you get only the ones still usable (`new` and `shortlisted`); pass `all`, or one of
+`new` / `shortlisted` / `used` / `archived`, for the rest. `limit` is 50 by default, 200 at most.
+Each idea carries the contrast `device` it uses, `why_it_contrasts` and `who_it_annoys` — an idea
+that annoys nobody is not one.
 
 `get_seo` and `get_geo` answer on the **latest** audit. The four web tools let you trace a claim
 back to what was actually measured, without paying for a new audit. All four are reads: they call

--- a/docs/api/01-overview.md
+++ b/docs/api/01-overview.md
@@ -63,6 +63,7 @@ Gli endpoint che spendono AI richiedono **piano a pagamento + crediti** e scope 
 | `POST /brands/:slug/geo` | Audit/fix GEO |
 | `POST /brands/:slug/keywords` | Rigenera keyword research |
 | `POST /brands/:slug/backlinks` | Rigenera opportunità backlink |
+| `POST /brands/:slug/market/field` | Passata field watch (scopri → smonta → distilla) |
 | `POST /brands/:slug/studio/competitors/research` | Ricerca competitor AI |
 | `POST /brands/:slug/studio/people` (kind `ai`) | Ritratti AI |
 | `POST /brands/:slug/ads/remix` | Remix brief da ad competitor |
@@ -98,7 +99,7 @@ checkout. Restano scope `write`: il link porta anche a un bottone di disdetta.
 | [05 — Editorial plan](05-editorial-plan.md) | Propose, approve, discard, revise, update, save-brief, replan-week |
 | [06 — Weekly plan](06-weekly-plan.md) | Plan, produce, render, save |
 | [07 — Growth: SEO/GEO/web](07-growth-seo-geo.md) | SEO, GEO, keywords, backlinks, web, articles, GSC, ranks, library, video review |
-| [08 — Ads, voice, GTM e gestione](08-ads-voice-gtm-misc.md) | Ads, remix, voice, GTM, rubrics, products, api-keys |
+| [08 — Ads, voice, GTM e gestione](08-ads-voice-gtm-misc.md) | Ads, remix, voice, GTM, rubrics, products, api-keys, ideas, field watch, radar diagnose |
 
 ## Note
 

--- a/docs/api/08-ads-voice-gtm-misc.md
+++ b/docs/api/08-ads-voice-gtm-misc.md
@@ -1,6 +1,7 @@
 # API — 08 · Ads, voice, GTM e gestione
 
-Ads (campagne + remix), voice framework, piano GTM, rubriche, prodotti, API key.
+Ads (campagne + remix), voice framework, piano GTM, rubriche, prodotti, API key, banco
+idee, field watch e diagnosi del Radar.
 Errori comuni di auth: vedi [01-overview](01-overview.md).
 
 ## `GET /api/v1/brands/:slug/ads`
@@ -788,6 +789,8 @@ curl -s -X DELETE "https://anomalia.so/api/v1/brands/mio-brand/api-keys/KEY_ID" 
 
 ## `GET /api/v1/brands/:slug/ideas`
 
+Tool MCP: `list_ideas`.
+
 Il banco delle idee dirompenti del brand — quello che gli agenti salvano mentre lavorano
 (`save_disruptive_idea`). Nessuna chiamata AI: lettura pura.
 
@@ -858,4 +861,151 @@ Richiede una key con scope `write`.
 curl -s -X POST "https://anomalia.so/api/v1/brands/mio-brand/ideas" \
   -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
   -d '{"title":"La maglia che brucia","idea":"Brucia una maglia low-cost, marchio mai inquadrato","device":"destroy_the_alternative","who_it_annoys":"Chi vende fast fashion"}'
+```
+
+---
+
+## `GET /api/v1/brands/:slug/market/field`
+
+Tool MCP: `get_market_field`.
+
+Cosa si muove nel **campo** del brand: i topic osservati, il playbook distillato da quello che
+gira, e i post catalogati con il loro teardown — perché quel post ha girato, e cosa se ne può
+portare via. Lettura pura: nessuna chiamata AI, nessun credito. La passata che riempie queste
+tabelle è il `POST` sotto, di norma fatto dal cron.
+
+**Query**
+
+| Param | Default | Note |
+|---|---|---|
+| `limit` | `20` | quanti post del campo, max 50 |
+
+**Response** `200`:
+
+```json
+{
+  "topics": { "queries": ["crm per agenzie"], "hashtags": ["#agencylife"] },
+  "playbook": {
+    "summary": "Il campo apre con un costo e chiude con un invito a dissentire",
+    "hooks": [{ "pattern": "numero + categoria", "example": "3 cose che le agenzie sbagliano" }],
+    "tones": ["esperto seccato"],
+    "fieldRagebait": 4,
+    "moves": [{ "move": "chiama la categoria per nome", "why": "…", "howToAdapt": "…", "ragebait": 3 }],
+    "avoid": ["callout con nome"],
+    "postsSeen": 42,
+    "updatedAt": "2026-09-01T08:00:00Z"
+  },
+  "updatedAt": "2026-09-01T08:00:00Z",
+  "posts": [
+    {
+      "id": "…",
+      "platform": "threads",
+      "url": "https://www.threads.net/@tizio/post/…",
+      "account_key": "threads:tizio",
+      "content": "…",
+      "media_type": "text",
+      "engagement": 1820,
+      "published_at": "2026-08-30T18:00:00Z",
+      "query": "crm per agenzie",
+      "relevance": 0.72,
+      "discoveredAt": "2026-08-31T04:00:00Z",
+      "teardown": {
+        "market_post_id": "…",
+        "tone_of_voice": "amico che ti avverte",
+        "communication": "prima persona, frasi corte",
+        "format": "lista numerata",
+        "hook_type": "promessa di un errore da evitare",
+        "spread_strategy": ["chiama in causa una categoria per nome"],
+        "ragebait": 4,
+        "ragebait_levers": ["hot take contro il consenso"],
+        "why_it_spread": "dice ad alta voce una cosa che tutti pensano",
+        "transferable": ["aprire con il costo reale"],
+        "avoid": null
+      }
+    }
+  ]
+}
+```
+
+Un campo mai osservato risponde `200` con `topics`, `playbook` e `updatedAt` a `null` e `posts`
+vuoto: è uno stato, non un errore. `teardown` è `null` finché il post non è stato smontato.
+
+**Esempio**:
+
+```bash
+curl -s "https://anomalia.so/api/v1/brands/mio-brand/market/field?limit=10" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+---
+
+## `GET /api/v1/brands/:slug/radar/diagnose`
+
+Tool MCP: `diagnose_radar`.
+
+L'autodiagnosi delle fonti Radar: **interroga ogni sorgente configurata dal vivo** e dice, per
+ognuna, quanti item sono tornati o perché è stata saltata — spenta, esclusa dal piano, piattaforma
+disattivata in Settings, o endpoint in errore. È la risposta a «perché il Radar non trova niente».
+
+Nessuna chiamata AI, nessun credito, nessuna scrittura, niente in coda. Ma esce di casa: fa una
+richiesta di rete per fonte, quindi può metterci secondi (`maxDuration` 300). Le ricerche
+dinamiche per keyword non vengono sondate qui — costano un credito di scraping ciascuna e sono
+già registrate per scansione in `radar_searches`.
+
+**Query params**: nessuno
+
+**Response** `200`:
+
+```json
+{
+  "enabled": true,
+  "plan": "pro",
+  "proLeads": true,
+  "scrapecreatorsConfigured": true,
+  "platforms": { "reddit": true, "threads": true, "x": false },
+  "engagePlatforms": ["reddit", "threads", "x", "linkedin"],
+  "sources": [
+    {
+      "kind": "rss",
+      "value": "https://esempio.it/feed",
+      "active": true,
+      "allowedByPlan": true,
+      "enabled": true,
+      "platform": null,
+      "items": 12,
+      "windowHours": 48,
+      "sample": [{ "title": "…", "url": "https://esempio.it/articolo" }]
+    },
+    {
+      "kind": "reddit",
+      "value": "r/agency",
+      "active": false,
+      "allowedByPlan": true,
+      "enabled": true,
+      "platform": "reddit",
+      "items": 0,
+      "skipped": "source is off"
+    },
+    {
+      "kind": "rss",
+      "value": "https://rotto.it/feed",
+      "active": true,
+      "allowedByPlan": true,
+      "enabled": true,
+      "platform": null,
+      "items": 0,
+      "error": "HTTP 503"
+    }
+  ],
+  "note": "Dynamic keyword searches are reported per scan in radar_searches, not probed here."
+}
+```
+
+Una fonte porta sempre `items`; `skipped` ed `error` si escludono a vicenda e spiegano lo zero.
+
+**Esempio**:
+
+```bash
+curl -s "https://anomalia.so/api/v1/brands/mio-brand/radar/diagnose" \
+  -H "Authorization: Bearer $TOKEN"
 ```

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -15,7 +15,7 @@ integrazioni esterne via API key — request, response, query params, body, erro
 | [05 — Editorial plan](05-editorial-plan.md) | `/editorial-plan` + `propose` `approve` `discard` `revise` `update` `save-brief` `replan-week` |
 | [06 — Weekly plan](06-weekly-plan.md) | `/weekly-plan` + `plan` `produce` `render` `save` |
 | [07 — Growth: SEO/GEO/web](07-growth-seo-geo.md) | `/seo`, `/geo`, `/web/audits`, `/web/fixes`, `/keywords`, `/backlinks`, `/web`, `/articles`, `/gsc`, `/ranks`, `/library/scan` |
-| [08 — Ads, voice, GTM e gestione](08-ads-voice-gtm-misc.md) | `/ads`, `/ads/remix`, `/voice`, `/gtm`, `/rubrics`, `/products`, `/api-keys` |
+| [08 — Ads, voice, GTM e gestione](08-ads-voice-gtm-misc.md) | `/ads`, `/ads/remix`, `/voice`, `/gtm`, `/rubrics`, `/products`, `/api-keys`, `/ideas`, `/market/field`, `/radar/diagnose` |
 | [09 — Connections](09-connections.md) | `/connections`, `/connections/catalog`, `/connections/:id/complete`, `/connections/:id` |
 | [10 — Shares](10-shares.md) | `/shares`, `/shares/revoke`, e la rotta pubblica `/share/:token` |
 | [11 — Billing](11-billing.md) | `/billing/portal`, `/billing/checkout` — link Stripe che l'agente consegna all'umano |

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -44,6 +44,7 @@ import {
   LIST_ARTICLES,
   LIST_PRODUCTS
 } from './reads';
+import { DIAGNOSE_RADAR, GET_MARKET_FIELD, LIST_IDEAS } from './market';
 import { GEO_ACTION, REFRESH_KEYWORDS, SEO_ACTION } from './search';
 import { GET_BACKLINKS, GET_GSC, GET_RANKS } from './web-metrics';
 import {
@@ -116,6 +117,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   CREATE_PRODUCT,
   CREATE_SHARE,
   DELETE_PRODUCT,
+  DIAGNOSE_RADAR,
   DISCARD_PLAN,
   GEO_ACTION,
   GET_ADS,
@@ -130,6 +132,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   GET_GSC,
   GET_GTM,
   GET_KEYWORDS,
+  GET_MARKET_FIELD,
   GET_PLAN,
   GET_POST,
   GET_RANKS,
@@ -140,6 +143,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   IMPORT_MEDIA_URL,
   LIST_ARTICLES,
   LIST_AUDIT_CITATIONS,
+  LIST_IDEAS,
   LIST_MEDIA,
   LIST_POSTS,
   LIST_PRODUCTS,
@@ -223,6 +227,7 @@ export {
   LIST_ARTICLES,
   LIST_PRODUCTS
 };
+export { DIAGNOSE_RADAR, GET_MARKET_FIELD, IDEA_STATUSES, IDEAS_DEFAULT, IDEAS_MAX, LIST_IDEAS, MARKET_FIELD_DEFAULT, MARKET_FIELD_MAX } from './market';
 export { GEO_ACTION, REFRESH_KEYWORDS, SEO_ACTION } from './search';
 export { GET_BACKLINKS, GET_GSC, GET_RANKS } from './web-metrics';
 export {

--- a/packages/api-contracts/src/market.test.ts
+++ b/packages/api-contracts/src/market.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest';
+import { DIAGNOSE_RADAR, GET_MARKET_FIELD, IDEAS_MAX, LIST_IDEAS, MARKET_FIELD_MAX } from './market';
+import { BRAND_ENDPOINTS } from './index';
+
+const MARKET = [GET_MARKET_FIELD, DIAGNOSE_RADAR, LIST_IDEAS];
+
+describe('il contratto delle misure del mercato', () => {
+  it('espone solo letture: guardare il campo non lo cambia', () => {
+    for (const endpoint of MARKET) {
+      expect(endpoint.method, endpoint.tool).toBe('GET');
+      expect(endpoint.destructive, endpoint.tool).toBe(false);
+    }
+  });
+
+  it('è registrato, o il tool MCP non nasce', () => {
+    for (const endpoint of MARKET) {
+      expect(BRAND_ENDPOINTS, endpoint.tool).toContain(endpoint);
+    }
+  });
+
+  it('rifiuta un parametro che non dichiara invece di scartarlo in silenzio', () => {
+    for (const endpoint of MARKET) {
+      expect(endpoint.input.safeParse({ campo_che_non_esiste: 'x' }).success, endpoint.tool).toBe(false);
+    }
+  });
+
+  it('la diagnosi del radar esce di casa, e lo dichiara', () => {
+    expect(DIAGNOSE_RADAR.openWorld).toBe(true);
+    expect(GET_MARKET_FIELD.openWorld).toBeUndefined();
+    expect(LIST_IDEAS.openWorld).toBeUndefined();
+  });
+
+  it.each([
+    ['get_market_field', GET_MARKET_FIELD, MARKET_FIELD_MAX],
+    ['list_ideas', LIST_IDEAS, IDEAS_MAX]
+  ] as const)('%s dichiara il tetto che la rotta applica in silenzio', (_tool, endpoint, max) => {
+    expect(endpoint.input.safeParse({ limit: max }).success).toBe(true);
+    expect(endpoint.input.safeParse({ limit: max + 1 }).success).toBe(false);
+    expect(endpoint.input.safeParse({ limit: 0 }).success).toBe(false);
+  });
+
+  it('legge il limite dalla query string, dove arriva come stringa', () => {
+    const parsed = GET_MARKET_FIELD.input.safeParse({ limit: '5' });
+    expect(parsed.success && parsed.data).toEqual({ limit: 5 });
+  });
+
+  it('un campo mai osservato risponde comunque, a vuoto invece che con un errore', () => {
+    expect(
+      GET_MARKET_FIELD.output.safeParse({ topics: null, playbook: null, updatedAt: null, posts: [] }).success
+    ).toBe(true);
+  });
+
+  it('un post del campo porta il suo teardown, e il teardown può mancare', () => {
+    const post = {
+      id: 'mp-1',
+      platform: 'threads',
+      url: 'https://threads.net/x',
+      account_key: 'threads:tizio',
+      content: 'un post',
+      media_type: 'text',
+      engagement: 420,
+      published_at: '2026-09-01T08:00:00Z',
+      query: 'crm agenzie',
+      relevance: 0.7,
+      discoveredAt: '2026-09-02T08:00:00Z',
+      teardown: null
+    };
+    expect(GET_MARKET_FIELD.output.safeParse({ topics: null, playbook: null, updatedAt: null, posts: [post] }).success).toBe(true);
+
+    const teardown = {
+      market_post_id: 'mp-1',
+      tone_of_voice: 'amico che ti avverte',
+      communication: 'prima persona, frasi corte',
+      format: 'lista numerata',
+      hook_type: 'promessa di un errore da evitare',
+      spread_strategy: ['chiama in causa una categoria'],
+      ragebait: 4,
+      ragebait_levers: ['hot take'],
+      why_it_spread: 'dice una cosa che nessuno dice',
+      transferable: ['aprire con il costo'],
+      avoid: null
+    };
+    expect(
+      GET_MARKET_FIELD.output.safeParse({ topics: null, playbook: null, updatedAt: null, posts: [{ ...post, teardown }] }).success
+    ).toBe(true);
+    expect(
+      GET_MARKET_FIELD.output.safeParse({ topics: null, playbook: null, updatedAt: null, posts: [{ query: 'x', relevance: 1 }] }).success
+    ).toBe(false);
+  });
+
+  it('una fonte del radar dice quanti item ha trovato, o perché non ne ha trovati', () => {
+    const base = {
+      enabled: true,
+      plan: 'pro',
+      proLeads: true,
+      scrapecreatorsConfigured: true,
+      platforms: { reddit: true },
+      engagePlatforms: ['reddit'],
+      note: 'x'
+    };
+    const found = { kind: 'rss', value: 'https://x.it/feed', active: true, allowedByPlan: true, enabled: true, platform: null, items: 3 };
+    expect(DIAGNOSE_RADAR.output.safeParse({ ...base, sources: [found] }).success).toBe(true);
+    expect(
+      DIAGNOSE_RADAR.output.safeParse({ ...base, sources: [{ ...found, items: 0, skipped: 'source is off' }] }).success
+    ).toBe(true);
+    expect(
+      DIAGNOSE_RADAR.output.safeParse({ ...base, sources: [{ ...found, items: 0, error: 'HTTP 503' }] }).success
+    ).toBe(true);
+    const { items: _omitted, ...senzaConto } = found;
+    expect(DIAGNOSE_RADAR.output.safeParse({ ...base, sources: [senzaConto] }).success).toBe(false);
+  });
+
+  it('senza status il banco idee dà le non usate, e "all" è un valore accettato', () => {
+    expect(LIST_IDEAS.input.safeParse({}).success).toBe(true);
+    expect(LIST_IDEAS.input.safeParse({ status: 'all' }).success).toBe(true);
+    expect(LIST_IDEAS.input.safeParse({ status: 'shortlisted' }).success).toBe(true);
+    expect(LIST_IDEAS.input.safeParse({ status: 'boh' }).success).toBe(false);
+  });
+
+  it('un idea porta la leva del contrasto e chi infastidisce, o non è un idea disruptive', () => {
+    const idea = {
+      id: 'i-1',
+      brand_id: 'b-1',
+      user_id: null,
+      title: 'Titolo',
+      idea: 'Il corpo',
+      device: 'taboo_number',
+      why_it_contrasts: 'dice il prezzo',
+      who_it_annoys: 'i concorrenti',
+      format: 'carousel',
+      score: 8,
+      surface: 'cli',
+      agent: null,
+      thread_id: null,
+      status: 'new',
+      used_post_id: null,
+      used_at: null,
+      last_shown_at: null,
+      shown_count: 0,
+      tags: [],
+      created_at: '2026-09-01T08:00:00Z',
+      updated_at: '2026-09-01T08:00:00Z'
+    };
+    expect(LIST_IDEAS.output.safeParse({ ideas: [idea], count: 1 }).success).toBe(true);
+    const { who_it_annoys: _omitted, ...mutilata } = idea;
+    expect(LIST_IDEAS.output.safeParse({ ideas: [mutilata], count: 1 }).success).toBe(false);
+  });
+});

--- a/packages/api-contracts/src/market.ts
+++ b/packages/api-contracts/src/market.ts
@@ -1,0 +1,168 @@
+import { z } from 'zod';
+import type { BrandEndpoint } from './index';
+
+export const MARKET_FIELD_DEFAULT = 20;
+export const MARKET_FIELD_MAX = 50;
+export const IDEAS_DEFAULT = 50;
+export const IDEAS_MAX = 200;
+
+export const IDEA_STATUSES = ['new', 'shortlisted', 'used', 'archived'] as const;
+
+const limitUpTo = (max: number, fallback: number) =>
+  z.coerce
+    .number()
+    .int()
+    .min(1)
+    .max(max)
+    .optional()
+    .describe(`How many to return, ${fallback} by default, ${max} at most`);
+
+const FieldTopics = z.object({
+  queries: z.array(z.string()),
+  hashtags: z.array(z.string())
+});
+
+const FieldPlaybook = z.object({
+  summary: z.string(),
+  hooks: z.array(z.object({ pattern: z.string(), example: z.string() })),
+  tones: z.array(z.string()),
+  fieldRagebait: z.number(),
+  moves: z.array(
+    z.object({ move: z.string(), why: z.string(), howToAdapt: z.string(), ragebait: z.number() })
+  ),
+  avoid: z.array(z.string()),
+  postsSeen: z.number(),
+  updatedAt: z.string()
+});
+
+const FieldTeardown = z.object({
+  market_post_id: z.string(),
+  tone_of_voice: z.string().nullable(),
+  communication: z.string().nullable(),
+  format: z.string().nullable(),
+  hook_type: z.string().nullable(),
+  spread_strategy: z.array(z.string()),
+  ragebait: z.number(),
+  ragebait_levers: z.array(z.string()),
+  why_it_spread: z.string().nullable(),
+  transferable: z.array(z.string()),
+  avoid: z.string().nullable()
+});
+
+export const GET_MARKET_FIELD = {
+  tool: 'get_market_field',
+  title: 'Field watch',
+  description:
+    "What moves in the brand's field: the topics being watched, the playbook distilled from them, and the catalogued posts with the teardown of why each one spread.",
+  method: 'GET',
+  pathUnderBrand: '/market/field',
+  input: z.object({ limit: limitUpTo(MARKET_FIELD_MAX, MARKET_FIELD_DEFAULT) }).strict(),
+  output: z.object({
+    topics: FieldTopics.nullable(),
+    playbook: FieldPlaybook.nullable(),
+    updatedAt: z.string().nullable(),
+    posts: z.array(
+      z.object({
+        id: z.string().optional(),
+        platform: z.string().nullable().optional(),
+        url: z.string().nullable().optional(),
+        account_key: z.string().nullable().optional(),
+        content: z.string().nullable().optional(),
+        media_type: z.string().nullable().optional(),
+        engagement: z.number().nullable().optional(),
+        published_at: z.string().nullable().optional(),
+        query: z.string().nullable(),
+        relevance: z.number().nullable(),
+        discoveredAt: z.string().nullable(),
+        teardown: FieldTeardown.nullable()
+      })
+    )
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const DIAGNOSE_RADAR = {
+  tool: 'diagnose_radar',
+  title: 'Radar diagnosis',
+  description:
+    'Why Radar finds nothing: fetches every configured source live and reports, per source, how many items came back or why it was skipped — source off, plan, platform toggle, endpoint error. Reads only, spends no credits, and can take seconds per source.',
+  method: 'GET',
+  pathUnderBrand: '/radar/diagnose',
+  input: z.object({}).strict(),
+  output: z.object({
+    enabled: z.boolean(),
+    plan: z.string().nullable(),
+    proLeads: z.boolean(),
+    scrapecreatorsConfigured: z.boolean(),
+    platforms: z.record(z.string(), z.boolean()),
+    engagePlatforms: z.array(z.string()),
+    sources: z.array(
+      z.object({
+        kind: z.string(),
+        value: z.string(),
+        active: z.boolean(),
+        allowedByPlan: z.boolean(),
+        enabled: z.boolean(),
+        platform: z.string().nullable(),
+        items: z.number(),
+        windowHours: z.number().optional(),
+        sample: z.array(z.object({ title: z.string(), url: z.string() })).optional(),
+        skipped: z.string().optional(),
+        error: z.string().optional()
+      })
+    ),
+    note: z.string()
+  }),
+  failures: [],
+  destructive: false,
+  openWorld: true
+} satisfies BrandEndpoint;
+
+export const LIST_IDEAS = {
+  tool: 'list_ideas',
+  title: 'Idea bank',
+  description:
+    'Disruptive ideas saved for this brand. Omit status for the ones still usable (new and shortlisted); pass all, or one status, to see the rest.',
+  method: 'GET',
+  pathUnderBrand: '/ideas',
+  input: z
+    .object({
+      status: z
+        .enum([...IDEA_STATUSES, 'all'])
+        .optional()
+        .describe('Omit for unused ideas only'),
+      limit: limitUpTo(IDEAS_MAX, IDEAS_DEFAULT)
+    })
+    .strict(),
+  output: z.object({
+    ideas: z.array(
+      z.object({
+        id: z.string(),
+        brand_id: z.string(),
+        user_id: z.string().nullable(),
+        title: z.string(),
+        idea: z.string(),
+        device: z.string().nullable(),
+        why_it_contrasts: z.string().nullable(),
+        who_it_annoys: z.string().nullable(),
+        format: z.string().nullable(),
+        score: z.number().nullable(),
+        surface: z.string().nullable(),
+        agent: z.string().nullable(),
+        thread_id: z.string().nullable(),
+        status: z.enum(IDEA_STATUSES),
+        used_post_id: z.string().nullable(),
+        used_at: z.string().nullable(),
+        last_shown_at: z.string().nullable(),
+        shown_count: z.number(),
+        tags: z.array(z.string()),
+        created_at: z.string(),
+        updated_at: z.string()
+      })
+    ),
+    count: z.number()
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/src/lib/content/changelog/2026-09-04-measurement-market.ts
+++ b/src/lib/content/changelog/2026-09-04-measurement-market.ts
@@ -1,0 +1,14 @@
+import type { ChangelogEntry } from './index';
+
+const entry: ChangelogEntry = {
+  date: '2026-09-04',
+  title: 'Your assistant can see the field, and why Radar is quiet',
+  items: [
+    'Field watch is readable by your assistant: the topics being watched, the playbook distilled from them, and each catalogued post with the teardown of why it spread.',
+    'Radar can now diagnose itself on request — every source is fetched live and reports what it found, or why it found nothing: switched off, not on your plan, platform disabled, or the source itself failing.',
+    'The idea bank is readable too, with the contrast each idea uses and who it is meant to annoy.',
+    'All three are reads: they cost no credits and change nothing. The Radar check does contact every source, so it takes a few seconds.'
+  ]
+};
+
+export default entry;


### PR DESCRIPTION
## What?

Three market-measurement reads become MCP tools, generated from the endpoint registry:
**`get_market_field`**, **`diagnose_radar`**, **`list_ideas`**. A new contract file,
`packages/api-contracts/src/market.ts`, declares them with a real `output`, mirrored into
`cli/lib/contracts/` by `sync-contracts.sh`.

Registry coverage goes from **58 to 61** endpoints; `tools/list` goes from **90 to 93**. No
existing tool changes, is renamed, or disappears.

`GET /market/field` and `GET /radar/diagnose` had **no page in `docs/api/`** at all. They get one
each in `08-ads-voice-gtm-misc.md`, with the full response shape.

## Why?

Anomalia is becoming a headless interface for external agents over MCP, and measurement is half
the product. An agent that cannot see the field proposes in the dark — it has no idea what is
moving, what made a post spread, or which hook the field is opening with. And when Radar returns
nothing, the agent cannot tell an empty week from a source that is switched off, off-plan, or
returning 503: without the diagnosis, "nothing found" reads as "nothing to find".

## How?

**A file per family**, the precedent set by `search.ts` in #238. `market.ts` holds the field
watch, the radar self-test and the idea bank.

**`diagnose_radar` declares `openWorld: true`.** It is a read — no model, no credits, no writes —
but it makes one network request per configured source, which is why the route carries
`maxDuration: 300`. The generator emits that as `openWorldHint: true`. A client that saw only
`readOnlyHint` would treat a multi-second walk over external feeds as a local read; the
description repeats it in words, because the annotation is for the client and the description is
for the model.

**The field posts carry optional columns, and that is not laziness.** The route builds each entry
as `{ ...(postById.get(id) ?? {}), query, relevance, discoveredAt, teardown }`. When the
`market_posts` row is gone, the object comes out with only the four fields the mapper always
writes. Declaring `platform` required would make the contract false in exactly the case where
someone is trying to work out what happened.

**`list_ideas` without `status` is not "everything".** The route sets `unusedOnly`, so it returns
`new` + `shortlisted` only. That is in the tool description: an agent that asks for "the ideas",
gets a subset and is not told, concludes the bank is empty.

**Rejected alternative — a new numbered `docs/api/12`.** Two of these three routes needed
documentation and the third already had a section in `08`. A new file would have split one family
across two documents and claimed a number that a parallel branch may also be claiming. They went
where the third already lived, and `08`'s intro line and both index tables name them.

## Testing?

```
npx vitest run packages/api-contracts   →  7 files, 96 tests passed
cd cli && bun test                      →  57 pass, 0 fail (11 files)
cd cli && bun run typecheck             →  clean
node scripts/typecheck-runtime.mjs      →  ok (311 pre-existing non-fatal errors ignored)
npm run check                           →  347 errors, all pre-existing; zero in the files touched
```

`bash cli/scripts/sync-contracts.sh` was run after every edit under
`packages/api-contracts/src/`; `cli/lib/contracts.test.ts` compares the two trees byte for byte
and is green. `grep -c 'export const BRAND_ENDPOINTS' packages/api-contracts/src/index.ts` is
**1**, the array is sorted and has no duplicates.

**Red before green.** `market.test.ts` was written first and failed on the missing module, then
failed a second time for a real reason: the first wiring pass inserted `GET_MARKET_FIELD` into
the `./reads` import block instead of the array, and the test caught it —
`expected [ …(57) ] to include { tool: 'get_market_field' }`.

**Not tested**: nothing calls the three endpoints for real here. The routes are untouched; this
PR only declares what they already return, and the shapes were read from `runFieldWatch`,
`radarDiagnose` and `listDisruptiveIdeas` rather than guessed.

**Read-only API keys reach all three, by construction.** `resolveCaller` in
`src/lib/server/cli-auth.ts` denies a read-only key once, on the method — all three are `GET`.
None of the three GET handlers calls `gateAiAction` or `checkApiKeyWriteAccess`: **they spend no
credits.**

## Evidence (screenshots/videos)

No UI.

<details>
<summary><code>tools/list</code> through <code>handleMcpFetch</code>, before → after</summary>

```
before 90 after 93
added: ['diagnose_radar', 'get_market_field', 'list_ideas']
removed: []
changed: []

{"name": "get_market_field", "title": "Field watch",
 "description": "What moves in the brand's field: the topics being watched, the playbook distilled from them, and the catalogued posts with the teardown of why each one spread.",
 "properties": ["limit", "slug"], "required": ["slug"], "additionalProperties": false,
 "annotations": {"readOnlyHint": true, "destructiveHint": false}}

{"name": "diagnose_radar", "title": "Radar diagnosis",
 "description": "Why Radar finds nothing: fetches every configured source live and reports, per source, how many items came back or why it was skipped — source off, plan, platform toggle, endpoint error. Reads only, spends no credits, and can take seconds per source.",
 "properties": ["slug"], "required": ["slug"], "additionalProperties": false,
 "annotations": {"readOnlyHint": true, "destructiveHint": false, "openWorldHint": true}}

{"name": "list_ideas", "title": "Idea bank",
 "description": "Disruptive ideas saved for this brand. Omit status for the ones still usable (new and shortlisted); pass all, or one status, to see the rest.",
 "properties": ["limit", "slug", "status"], "required": ["slug"], "additionalProperties": false,
 "annotations": {"readOnlyHint": true, "destructiveHint": false}}
```

Captured by driving `handleMcpFetch` with `initialize` + `tools/list`, comparing name, title,
description, property set, required set, `additionalProperties` and annotations tool by tool.
`changed: []` is the claim: the other 90 are byte-identical. The baseline is **90**, not the 91
#263 left behind — the chat dismantling removed the `chat` tool from `dev` in between.
</details>

## Anything Else?

**`POST /market/field` stayed out, on purpose.** It calls `gateAiAction` and bills credits — a
pass searches several platforms and runs a teardown per new post. Only reads are in this round.

**Rebased onto `dev` after #263 merged.** The conflict was the documented one plus a second: the
skill's tool table had lost the `chat` row on `dev` while this branch still carried it. Resolution
kept the three new rows and dropped `chat`, then re-ran `sync-plugin-skill.sh`. After the rebase
`BRAND_ENDPOINTS` holds **61** entries, sorted, no duplicates, and
`grep -c 'export const BRAND_ENDPOINTS'` is **1**. The registry-wide `tools/list` law added in
#263 now covers these three too, and `cd cli && bun test` runs it.

**Still uncovered, measurement-wise:** `doctor` and `goals`, coming in the third PR of the set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
