### PR TITLE
Read the brand's health from MCP: doctor and goals

### DIFF
--- a/changelog/2026-09-04-measurement-brand-state.md
+++ b/changelog/2026-09-04-measurement-brand-state.md
@@ -1,0 +1,48 @@
+# La diagnosi del brand e gli obiettivi diventano tool MCP
+
+Due letture entrano nel registry (`packages/api-contracts/src/brand-state.ts`): `diagnose_brand`
+e `get_goals`. Chiudono il giro cominciato con #263 (web/SEO) e proseguito con #265 (mercato): le
+otto letture di misurazione scoperte dal censimento sono ora tutte dichiarate, e
+`BRAND_ENDPOINTS` passa da 55 a 63.
+
+## Perché esiste
+
+`diagnose_brand` è la domanda che un agente esterno si pone per prima quando non succede niente:
+non «cosa è andato storto» ma «quale cancello non passo». La rotta esiste da tempo e nessun tool
+la esponeva, quindi l'unico modo di leggerla era `curl` — cioè un umano.
+
+`get_goals` è l'altra metà: la modalità obiettivo lascia uno stato (che la chat mostra) e una
+storia (che nessuno leggeva). Il riepilogo è il punto — quanti obiettivi si chiudono al primo
+colpo, quante riprese automatiche costano, per quale ragione le catene si fermano — perché è da
+lì che si capisce se il tetto dei giri è generoso, stretto, o non lo tocca mai nessuno.
+
+## Le due cose che non erano ovvie
+
+**`notCovered` è obbligatorio nell'output, non decorativo.** La diagnosi copre tre cicli su nove.
+Un agente che legge `loops: []` senza sapere cosa è escluso conclude che il prodotto sta girando.
+C'è un test che rifiuta l'output senza `notCovered`, ed è l'unico modo per impedire che il campo
+venga tolto come ridondante.
+
+**Il parametro si chiama `thread`, non `threadId`.** `callEndpoint` passa le chiavi dell'input
+come query params tali e quali, e la rotta legge `url.searchParams.get('thread')`. Un contratto
+con `threadId` avrebbe generato un tool che accetta il campo, lo manda, e viene ignorato in
+silenzio: il filtro non filtra e l'agente non se ne accorge. Un test lo tiene fermo.
+
+## L'equivalenza, provata
+
+`tools/list` catturato attraverso `handleMcpFetch` prima e dopo il rebase su `dev`: **93 → 95**,
+due aggiunti, zero rimossi, zero modificati. La base sale a 93 perché nel frattempo sono entrati
+#263 (web/SEO) e #265 (mercato); scende di uno rispetto alla somma perché lo smantellamento della
+chat ha tolto il tool `chat`.
+
+## Il rischio dichiarato
+
+`/goals` legge da `src/lib/server/chat/goal-log.ts`, e la chat è in smantellamento in parallelo.
+Se la modalità obiettivo viene rimossa, questo endpoint va rimosso con lei: il contratto non è un
+motivo per tenerla in vita. Al momento della scrittura la rotta, il modulo e le tabelle
+(`chat_goals`, `chat_goal_events`) sono tutti presenti su `dev`.
+
+## Chiave di sola lettura
+
+Entrambe `GET`, `destructive: false`, nessuna chiama `gateAiAction`. La chiave di sola lettura le
+raggiunge per costruzione: `resolveCaller` nega la scrittura una volta sola, sul metodo.

--- a/cli/lib/contracts/brand-state.ts
+++ b/cli/lib/contracts/brand-state.ts
@@ -1,0 +1,122 @@
+import { z } from 'zod';
+import type { BrandEndpoint } from './index';
+
+export const GOALS_DEFAULT = 20;
+export const GOALS_MAX = 100;
+
+export const DOCTOR_GATE_STATUSES = ['pass', 'fail', 'unknown'] as const;
+export const DOCTOR_LOOP_STATUSES = ['ok', 'blocked', 'waiting', 'failing', 'unknown'] as const;
+export const GOAL_STATUSES = ['open', 'met', 'handed_back', 'abandoned'] as const;
+export const GOAL_CRITERION_STATUSES = ['open', 'done', 'dropped'] as const;
+
+export const DIAGNOSE_BRAND = {
+  tool: 'diagnose_brand',
+  title: 'Brand doctor',
+  description:
+    'Why this brand receives nothing from the AI. Per recurring cycle: the FIRST gate it fails, what has to happen for that gate to pass, and the last recorded outcome. Says which cycles it does not cover.',
+  method: 'GET',
+  pathUnderBrand: '/doctor',
+  input: z.object({}).strict(),
+  output: z.object({
+    brand: z.object({
+      name: z.string().nullable(),
+      slug: z.string().nullable(),
+      plan: z.string().nullable()
+    }),
+    generatedAt: z.string(),
+    headline: z.string(),
+    loops: z.array(
+      z.object({
+        loop: z.string(),
+        schedule: z.string(),
+        status: z.enum(DOCTOR_LOOP_STATUSES),
+        blockedBy: z.string().nullable(),
+        gates: z.array(
+          z.object({
+            id: z.string(),
+            status: z.enum(DOCTOR_GATE_STATUSES),
+            detail: z.string(),
+            fix: z.string().optional()
+          })
+        ),
+        lastRun: z
+          .object({ at: z.string(), outcome: z.string(), reason: z.string().nullable() })
+          .nullable()
+      })
+    ),
+    notCovered: z.array(z.string())
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const GET_GOALS = {
+  tool: 'get_goals',
+  title: 'Chat goals',
+  description:
+    'Goal mode, measured: how many goals were met on the first pass, how many went back to the person, how many automatic laps were spent, and the reason each chain stopped — plus the goals themselves with their diary.',
+  method: 'GET',
+  pathUnderBrand: '/goals',
+  input: z
+    .object({
+      limit: z.coerce
+        .number()
+        .int()
+        .min(1)
+        .max(GOALS_MAX)
+        .optional()
+        .describe(`How many goals, ${GOALS_DEFAULT} by default, ${GOALS_MAX} at most`),
+      thread: z.string().min(1).optional().describe('Only the goals of one conversation')
+    })
+    .strict(),
+  output: z.object({
+    brand: z.string(),
+    summary: z.object({
+      goals: z.number(),
+      open: z.number(),
+      met: z.number(),
+      handed_back: z.number(),
+      abandoned: z.number(),
+      met_first_pass: z.number(),
+      laps: z.number(),
+      stopped_by: z.record(z.string(), z.number()),
+      criteria_done: z.number(),
+      criteria_dropped: z.number(),
+      criteria_open: z.number()
+    }),
+    goals: z.array(
+      z.object({
+        id: z.string(),
+        statement: z.string(),
+        status: z.enum(GOAL_STATUSES),
+        source: z.string(),
+        laps: z.number(),
+        criteria: z.array(
+          z.object({
+            id: z.string(),
+            text: z.string(),
+            status: z.enum(GOAL_CRITERION_STATUSES),
+            note: z.string().nullable().optional()
+          })
+        ),
+        created_at: z.string(),
+        closed_at: z.string().nullable(),
+        closing_note: z.string().nullable(),
+        events: z.array(
+          z.object({
+            kind: z.string(),
+            reason: z.string().nullable(),
+            actor: z.string(),
+            progress: z.string(),
+            closed_now: z.number(),
+            laps: z.number(),
+            queued: z.boolean().nullable(),
+            at: z.string()
+          })
+        )
+      })
+    )
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/cli/lib/contracts/index.ts
+++ b/cli/lib/contracts/index.ts
@@ -44,6 +44,7 @@ import {
   LIST_ARTICLES,
   LIST_PRODUCTS
 } from './reads';
+import { DIAGNOSE_BRAND, GET_GOALS } from './brand-state';
 import { DIAGNOSE_RADAR, GET_MARKET_FIELD, LIST_IDEAS } from './market';
 import { GEO_ACTION, REFRESH_KEYWORDS, SEO_ACTION } from './search';
 import { GET_BACKLINKS, GET_GSC, GET_RANKS } from './web-metrics';
@@ -117,6 +118,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   CREATE_PRODUCT,
   CREATE_SHARE,
   DELETE_PRODUCT,
+  DIAGNOSE_BRAND,
   DIAGNOSE_RADAR,
   DISCARD_PLAN,
   GEO_ACTION,
@@ -129,6 +131,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   GET_CALENDAR,
   GET_CREATION_KIT,
   GET_GEO,
+  GET_GOALS,
   GET_GSC,
   GET_GTM,
   GET_KEYWORDS,
@@ -227,6 +230,16 @@ export {
   LIST_ARTICLES,
   LIST_PRODUCTS
 };
+export {
+  DIAGNOSE_BRAND,
+  DOCTOR_GATE_STATUSES,
+  DOCTOR_LOOP_STATUSES,
+  GET_GOALS,
+  GOALS_DEFAULT,
+  GOALS_MAX,
+  GOAL_CRITERION_STATUSES,
+  GOAL_STATUSES
+} from './brand-state';
 export { DIAGNOSE_RADAR, GET_MARKET_FIELD, IDEA_STATUSES, IDEAS_DEFAULT, IDEAS_MAX, LIST_IDEAS, MARKET_FIELD_DEFAULT, MARKET_FIELD_MAX } from './market';
 export { GEO_ACTION, REFRESH_KEYWORDS, SEO_ACTION } from './search';
 export { GET_BACKLINKS, GET_GSC, GET_RANKS } from './web-metrics';

--- a/cli/plugins/anomalia/skills/anomalia/references/tools.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/tools.md
@@ -19,6 +19,8 @@ All tools take a brand `slug` when brand-scoped. Ids accept short unambiguous pr
 | `get_status` | `anomalia status <slug>` |
 | `get_analytics` | `anomalia analytics <slug>` |
 | `get_calendar` | `anomalia calendar <slug> [--month YYYY-MM]` |
+| `diagnose_brand` | (MCP only) |
+| `get_goals` | (MCP only) |
 | `get_gtm` | `anomalia gtm <slug>` |
 | `get_voice` / `update_voice` | `anomalia voice <slug>` |
 | `list_products` | (studio / products views) |
@@ -38,6 +40,18 @@ All tools take a brand `slug` when brand-scoped. Ids accept short unambiguous pr
 | `regenerate_slide` | `anomalia post <slug> <id> slide --index N --instruction "…"` |
 | `reorder_slides` | `anomalia post <slug> <id> reorder --order "0,2,1"` |
 | `make_video` | `anomalia post <slug> <id> video …` |
+
+`diagnose_brand` answers "why is nothing happening". For each recurring cycle — publishing,
+autopilot, analytics review — it names the FIRST gate the brand fails (`blockedBy`), what the
+data says (`detail`), what unblocks it (`fix`, present only on a failing gate), and the last
+recorded outcome. Read `notCovered` before concluding anything: it lists the cycles this
+diagnosis does not look at, so "no blocks" never means "the whole product is working". No model,
+no credits, no writes.
+
+`get_goals` is goal mode measured rather than described: `summary` says how many goals were met
+on the first pass, how many went back to the person, how many automatic laps were spent, and
+`stopped_by` says why the chains stopped. Each goal carries its criteria and its diary. `limit`
+is 20 by default and 100 at most; `thread` narrows to one conversation.
 
 `get_creation_kit` is what you read BEFORE writing. Required: `slug`, `goal` (one line saying
 what the post has to do), `platforms` (comma-separated) and `format` (`single_image`, `carousel`,

--- a/cli/skills/anomalia/references/tools.md
+++ b/cli/skills/anomalia/references/tools.md
@@ -19,6 +19,8 @@ All tools take a brand `slug` when brand-scoped. Ids accept short unambiguous pr
 | `get_status` | `anomalia status <slug>` |
 | `get_analytics` | `anomalia analytics <slug>` |
 | `get_calendar` | `anomalia calendar <slug> [--month YYYY-MM]` |
+| `diagnose_brand` | (MCP only) |
+| `get_goals` | (MCP only) |
 | `get_gtm` | `anomalia gtm <slug>` |
 | `get_voice` / `update_voice` | `anomalia voice <slug>` |
 | `list_products` | (studio / products views) |
@@ -38,6 +40,18 @@ All tools take a brand `slug` when brand-scoped. Ids accept short unambiguous pr
 | `regenerate_slide` | `anomalia post <slug> <id> slide --index N --instruction "…"` |
 | `reorder_slides` | `anomalia post <slug> <id> reorder --order "0,2,1"` |
 | `make_video` | `anomalia post <slug> <id> video …` |
+
+`diagnose_brand` answers "why is nothing happening". For each recurring cycle — publishing,
+autopilot, analytics review — it names the FIRST gate the brand fails (`blockedBy`), what the
+data says (`detail`), what unblocks it (`fix`, present only on a failing gate), and the last
+recorded outcome. Read `notCovered` before concluding anything: it lists the cycles this
+diagnosis does not look at, so "no blocks" never means "the whole product is working". No model,
+no credits, no writes.
+
+`get_goals` is goal mode measured rather than described: `summary` says how many goals were met
+on the first pass, how many went back to the person, how many automatic laps were spent, and
+`stopped_by` says why the chains stopped. Each goal carries its criteria and its diary. `limit`
+is 20 by default and 100 at most; `thread` narrows to one conversation.
 
 `get_creation_kit` is what you read BEFORE writing. Required: `slug`, `goal` (one line saying
 what the post has to do), `platforms` (comma-separated) and `format` (`single_image`, `carousel`,

--- a/docs/api/01-overview.md
+++ b/docs/api/01-overview.md
@@ -93,7 +93,7 @@ checkout. Restano scope `write`: il link porta anche a un bottone di disdetta.
 
 | Pagina | Area |
 |---|---|
-| [02 — Brand core](02-brands-core.md) | `brands`, detail, analytics, calendar, bio, publishing, tick |
+| [02 — Brand core](02-brands-core.md) | `brands`, detail, analytics, calendar, bio, publishing, tick, doctor, goals |
 | [03 — Posts](03-posts.md) | Lista, edit, approve, publish, reschedule, render, media, revoke |
 | [04 — Studio](04-studio.md) | Kit, colors, memory, people, documents, competitors, history sync |
 | [05 — Editorial plan](05-editorial-plan.md) | Propose, approve, discard, revise, update, save-brief, replan-week |

--- a/docs/api/02-brands-core.md
+++ b/docs/api/02-brands-core.md
@@ -1,6 +1,7 @@
 # API — 02 · Brand core
 
-Endpoint per listare brand, leggere il dettaglio, analytics, calendario, bio e publishing.
+Endpoint per listare brand, leggere il dettaglio, analytics, calendario, bio, publishing,
+diagnosi del brand e obiettivi della chat.
 Errori comuni di auth: vedi [01-overview](01-overview.md).
 
 ## `GET /api/v1/brands`
@@ -455,4 +456,135 @@ curl -s -X POST "https://anomalia.so/api/v1/brands/mio-brand/media" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"url":"https://cdn.example.com/render/final.png","title":"Chiusura campagna"}'
+```
+
+---
+
+## `GET /api/v1/brands/:slug/doctor`
+
+Tool MCP: `diagnose_brand`.
+
+Perché questo brand non riceve niente dall'AI. Per ogni ciclo ricorrente coperto (pubblicazione,
+autopilot, analytics review): il **primo** cancello che non passa, cosa deve succedere perché
+passi, e l'ultimo esito registrato in `loop_ticks`. Lettura pura: nessuna scrittura, nessuna AI,
+nessun credito.
+
+`notCovered` non è un dettaglio: dichiara i cicli che questa diagnosi **non** guarda, così un
+«nessun blocco» non viene letto come «tutto il prodotto sta funzionando».
+
+**Query params**: nessuno
+
+**Response** `200`:
+
+```json
+{
+  "brand": { "name": "Demo Brand", "slug": "demo", "plan": "pro" },
+  "generatedAt": "2026-09-04T08:00:00Z",
+  "headline": "publishing: nessun post approvato in attesa → approva un post",
+  "loops": [
+    {
+      "loop": "publishing",
+      "schedule": "ogni 15 minuti",
+      "status": "blocked",
+      "blockedBy": "has_approved_posts",
+      "gates": [
+        { "id": "plan_allows", "status": "pass", "detail": "Piano pro" },
+        {
+          "id": "has_approved_posts",
+          "status": "fail",
+          "detail": "0 post approvati in attesa",
+          "fix": "Approva un post pendente"
+        }
+      ],
+      "lastRun": { "at": "2026-09-04T07:45:00Z", "outcome": "skipped", "reason": "nothing_to_publish" }
+    }
+  ],
+  "notCovered": ["seo", "geo", "radar", "field", "blog", "ads", "weekly_recap"]
+}
+```
+
+`status` di un ciclo: `ok` · `blocked` (un cancello lo esclude) · `waiting` (passa i cancelli ma
+non è ancora il suo turno) · `failing` · `unknown`. `status` di un cancello: `pass` · `fail` ·
+`unknown`; `fix` c'è solo su `fail`. `blockedBy` è l'id del primo cancello fallito, `null` quando
+non ce n'è.
+
+**Esempio**:
+
+```bash
+curl -s "https://anomalia.so/api/v1/brands/mio-brand/doctor" -H "Authorization: Bearer $TOKEN"
+```
+
+---
+
+## `GET /api/v1/brands/:slug/goals`
+
+Tool MCP: `get_goals`.
+
+La storia della modalità obiettivo, e il riepilogo che risponde alla domanda vera su una funzione
+nuova: **funziona?** Non quanti obiettivi ci sono, ma quanti si chiudono al primo colpo, quanti
+tornano alla persona, quante riprese automatiche sono costati e per quale ragione le catene si
+fermano. Lettura pura: nessuna scrittura, nessuna AI, nessun credito.
+
+**Query**
+
+| Param | Default | Note |
+|---|---|---|
+| `limit` | `20` | quanti obiettivi, max 100 |
+| `thread` | *(tutti)* | solo gli obiettivi di una conversazione |
+
+**Response** `200`:
+
+```json
+{
+  "brand": "mio-brand",
+  "summary": {
+    "goals": 3,
+    "open": 1,
+    "met": 1,
+    "handed_back": 1,
+    "abandoned": 0,
+    "met_first_pass": 1,
+    "laps": 2,
+    "stopped_by": { "out_of_time": 1 },
+    "criteria_done": 4,
+    "criteria_dropped": 1,
+    "criteria_open": 2
+  },
+  "goals": [
+    {
+      "id": "…",
+      "statement": "Pubblica tre post questa settimana",
+      "status": "met",
+      "source": "user",
+      "laps": 0,
+      "criteria": [{ "id": "c1", "text": "primo post", "status": "done", "note": null }],
+      "created_at": "2026-09-01T08:00:00Z",
+      "closed_at": "2026-09-01T09:00:00Z",
+      "closing_note": null,
+      "events": [
+        {
+          "kind": "opened",
+          "reason": null,
+          "actor": "user",
+          "progress": "0/3",
+          "closed_now": 0,
+          "laps": 0,
+          "queued": null,
+          "at": "2026-09-01T08:00:00Z"
+        }
+      ]
+    }
+  ]
+}
+```
+
+`status` di un obiettivo: `open` · `met` · `handed_back` · `abandoned`. `status` di un criterio:
+`open` · `done` · `dropped`. `laps` sono le riprese automatiche consumate — la voce di spesa
+della funzione.
+
+**Esempio**:
+
+```bash
+curl -s "https://anomalia.so/api/v1/brands/mio-brand/goals?limit=50" \
+  -H "Authorization: Bearer $TOKEN"
 ```

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -9,7 +9,7 @@ integrazioni esterne via API key — request, response, query params, body, erro
 | Pagina | Endpoint |
 |---|---|
 | [01 — Overview](01-overview.md) | Auth (JWT/API key), errori comuni, gate crediti, convenzioni |
-| [02 — Brand core](02-brands-core.md) | `GET /brands`, `GET /brands/:slug`, `/analytics`, `/calendar`, `/bio`, `/publishing`, `/tick` |
+| [02 — Brand core](02-brands-core.md) | `GET /brands`, `GET /brands/:slug`, `/analytics`, `/calendar`, `/bio`, `/publishing`, `/tick`, `/doctor`, `/goals` |
 | [03 — Posts](03-posts.md) | `/posts` (list/edit/delete), `/approve`, `/publish`, `/reschedule`, `/render`, `/media`, `/revoke`, `/approve-all` |
 | [04 — Studio](04-studio.md) | `/studio`, `/kit`, `/colors`, `/memory`, `/people`, `/documents`, `/competitors`, `/history/sync`, `/people/:id` |
 | [05 — Editorial plan](05-editorial-plan.md) | `/editorial-plan` + `propose` `approve` `discard` `revise` `update` `save-brief` `replan-week` |

--- a/packages/api-contracts/src/brand-state.test.ts
+++ b/packages/api-contracts/src/brand-state.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+import { DIAGNOSE_BRAND, GET_GOALS, GOALS_MAX } from './brand-state';
+import { BRAND_ENDPOINTS } from './index';
+
+const BRAND_STATE = [DIAGNOSE_BRAND, GET_GOALS];
+
+const GATE = { id: 'has_active_plan', status: 'fail', detail: 'Nessun piano attivo', fix: 'Approva un piano' };
+const LOOP = {
+  loop: 'publishing',
+  schedule: 'ogni 15 minuti',
+  status: 'blocked',
+  blockedBy: 'has_active_plan',
+  gates: [GATE],
+  lastRun: null
+};
+const DIAGNOSIS = {
+  brand: { name: 'Demo Brand', slug: 'demo', plan: 'pro' },
+  generatedAt: '2026-09-04T08:00:00Z',
+  headline: 'publishing: Nessun piano attivo → Approva un piano',
+  loops: [LOOP],
+  notCovered: ['seo', 'geo']
+};
+
+describe('il contratto dello stato del brand', () => {
+  it('espone solo letture: una diagnosi non cura, racconta', () => {
+    for (const endpoint of BRAND_STATE) {
+      expect(endpoint.method, endpoint.tool).toBe('GET');
+      expect(endpoint.destructive, endpoint.tool).toBe(false);
+    }
+  });
+
+  it('è registrato, o il tool MCP non nasce', () => {
+    for (const endpoint of BRAND_STATE) {
+      expect(BRAND_ENDPOINTS, endpoint.tool).toContain(endpoint);
+    }
+  });
+
+  it('rifiuta un parametro che non dichiara invece di scartarlo in silenzio', () => {
+    for (const endpoint of BRAND_STATE) {
+      expect(endpoint.input.safeParse({ campo_che_non_esiste: 'x' }).success, endpoint.tool).toBe(false);
+    }
+  });
+
+  it('nessuna delle due esce di casa: sono due letture del database', () => {
+    for (const endpoint of BRAND_STATE) {
+      expect(endpoint.openWorld, endpoint.tool).toBeUndefined();
+    }
+  });
+
+  it('la diagnosi dice quale cancello ferma il ciclo, non solo che è fermo', () => {
+    expect(DIAGNOSE_BRAND.output.safeParse(DIAGNOSIS).success).toBe(true);
+    const { blockedBy: _omitted, ...senzaColpevole } = LOOP;
+    expect(DIAGNOSE_BRAND.output.safeParse({ ...DIAGNOSIS, loops: [senzaColpevole] }).success).toBe(false);
+  });
+
+  it('un ciclo che gira ha blockedBy a null, e nessun cancello con un rimedio', () => {
+    const ok = {
+      ...DIAGNOSIS,
+      headline: 'Nessun blocco rilevato sui cicli coperti da questa diagnosi.',
+      loops: [
+        {
+          ...LOOP,
+          status: 'ok',
+          blockedBy: null,
+          gates: [{ id: 'has_active_plan', status: 'pass', detail: 'Piano attivo' }],
+          lastRun: { at: '2026-09-04T07:00:00Z', outcome: 'published', reason: null }
+        }
+      ]
+    };
+    expect(DIAGNOSE_BRAND.output.safeParse(ok).success).toBe(true);
+  });
+
+  it('la diagnosi dichiara cosa NON copre, o un "nessun blocco" si legge come "tutto ok"', () => {
+    const { notCovered: _omitted, ...senzaPerimetro } = DIAGNOSIS;
+    expect(DIAGNOSE_BRAND.output.safeParse(senzaPerimetro).success).toBe(false);
+  });
+
+  it('gli obiettivi dichiarano il tetto che la rotta applica in silenzio', () => {
+    expect(GET_GOALS.input.safeParse({ limit: GOALS_MAX }).success).toBe(true);
+    expect(GET_GOALS.input.safeParse({ limit: GOALS_MAX + 1 }).success).toBe(false);
+    expect(GET_GOALS.input.safeParse({ limit: 0 }).success).toBe(false);
+  });
+
+  it('gli obiettivi si filtrano per conversazione, e il parametro si chiama come nella query', () => {
+    expect(GET_GOALS.input.safeParse({ thread: 'th-1' }).success).toBe(true);
+    expect(GET_GOALS.input.safeParse({ threadId: 'th-1' }).success).toBe(false);
+  });
+
+  it('il riepilogo degli obiettivi risponde a "funziona?", non a "quanti sono"', () => {
+    const summary = {
+      goals: 3,
+      open: 1,
+      met: 1,
+      handed_back: 1,
+      abandoned: 0,
+      met_first_pass: 1,
+      laps: 2,
+      stopped_by: { out_of_time: 1 },
+      criteria_done: 4,
+      criteria_dropped: 1,
+      criteria_open: 2
+    };
+    const goal = {
+      id: 'g-1',
+      statement: 'Pubblica tre post',
+      status: 'met',
+      source: 'user',
+      laps: 0,
+      criteria: [{ id: 'c1', text: 'primo post', status: 'done', note: null }],
+      created_at: '2026-09-01T08:00:00Z',
+      closed_at: '2026-09-01T09:00:00Z',
+      closing_note: null,
+      events: [
+        { kind: 'opened', reason: null, actor: 'user', progress: '0/1', closed_now: 0, laps: 0, queued: null, at: '2026-09-01T08:00:00Z' }
+      ]
+    };
+    expect(GET_GOALS.output.safeParse({ brand: 'demo', summary, goals: [goal] }).success).toBe(true);
+
+    const { met_first_pass: _omitted, ...senzaPrimoColpo } = summary;
+    expect(GET_GOALS.output.safeParse({ brand: 'demo', summary: senzaPrimoColpo, goals: [] }).success).toBe(false);
+    expect(
+      GET_GOALS.output.safeParse({ brand: 'demo', summary, goals: [{ ...goal, status: 'boh' }] }).success
+    ).toBe(false);
+  });
+});

--- a/packages/api-contracts/src/brand-state.ts
+++ b/packages/api-contracts/src/brand-state.ts
@@ -1,0 +1,122 @@
+import { z } from 'zod';
+import type { BrandEndpoint } from './index';
+
+export const GOALS_DEFAULT = 20;
+export const GOALS_MAX = 100;
+
+export const DOCTOR_GATE_STATUSES = ['pass', 'fail', 'unknown'] as const;
+export const DOCTOR_LOOP_STATUSES = ['ok', 'blocked', 'waiting', 'failing', 'unknown'] as const;
+export const GOAL_STATUSES = ['open', 'met', 'handed_back', 'abandoned'] as const;
+export const GOAL_CRITERION_STATUSES = ['open', 'done', 'dropped'] as const;
+
+export const DIAGNOSE_BRAND = {
+  tool: 'diagnose_brand',
+  title: 'Brand doctor',
+  description:
+    'Why this brand receives nothing from the AI. Per recurring cycle: the FIRST gate it fails, what has to happen for that gate to pass, and the last recorded outcome. Says which cycles it does not cover.',
+  method: 'GET',
+  pathUnderBrand: '/doctor',
+  input: z.object({}).strict(),
+  output: z.object({
+    brand: z.object({
+      name: z.string().nullable(),
+      slug: z.string().nullable(),
+      plan: z.string().nullable()
+    }),
+    generatedAt: z.string(),
+    headline: z.string(),
+    loops: z.array(
+      z.object({
+        loop: z.string(),
+        schedule: z.string(),
+        status: z.enum(DOCTOR_LOOP_STATUSES),
+        blockedBy: z.string().nullable(),
+        gates: z.array(
+          z.object({
+            id: z.string(),
+            status: z.enum(DOCTOR_GATE_STATUSES),
+            detail: z.string(),
+            fix: z.string().optional()
+          })
+        ),
+        lastRun: z
+          .object({ at: z.string(), outcome: z.string(), reason: z.string().nullable() })
+          .nullable()
+      })
+    ),
+    notCovered: z.array(z.string())
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const GET_GOALS = {
+  tool: 'get_goals',
+  title: 'Chat goals',
+  description:
+    'Goal mode, measured: how many goals were met on the first pass, how many went back to the person, how many automatic laps were spent, and the reason each chain stopped — plus the goals themselves with their diary.',
+  method: 'GET',
+  pathUnderBrand: '/goals',
+  input: z
+    .object({
+      limit: z.coerce
+        .number()
+        .int()
+        .min(1)
+        .max(GOALS_MAX)
+        .optional()
+        .describe(`How many goals, ${GOALS_DEFAULT} by default, ${GOALS_MAX} at most`),
+      thread: z.string().min(1).optional().describe('Only the goals of one conversation')
+    })
+    .strict(),
+  output: z.object({
+    brand: z.string(),
+    summary: z.object({
+      goals: z.number(),
+      open: z.number(),
+      met: z.number(),
+      handed_back: z.number(),
+      abandoned: z.number(),
+      met_first_pass: z.number(),
+      laps: z.number(),
+      stopped_by: z.record(z.string(), z.number()),
+      criteria_done: z.number(),
+      criteria_dropped: z.number(),
+      criteria_open: z.number()
+    }),
+    goals: z.array(
+      z.object({
+        id: z.string(),
+        statement: z.string(),
+        status: z.enum(GOAL_STATUSES),
+        source: z.string(),
+        laps: z.number(),
+        criteria: z.array(
+          z.object({
+            id: z.string(),
+            text: z.string(),
+            status: z.enum(GOAL_CRITERION_STATUSES),
+            note: z.string().nullable().optional()
+          })
+        ),
+        created_at: z.string(),
+        closed_at: z.string().nullable(),
+        closing_note: z.string().nullable(),
+        events: z.array(
+          z.object({
+            kind: z.string(),
+            reason: z.string().nullable(),
+            actor: z.string(),
+            progress: z.string(),
+            closed_now: z.number(),
+            laps: z.number(),
+            queued: z.boolean().nullable(),
+            at: z.string()
+          })
+        )
+      })
+    )
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -44,6 +44,7 @@ import {
   LIST_ARTICLES,
   LIST_PRODUCTS
 } from './reads';
+import { DIAGNOSE_BRAND, GET_GOALS } from './brand-state';
 import { DIAGNOSE_RADAR, GET_MARKET_FIELD, LIST_IDEAS } from './market';
 import { GEO_ACTION, REFRESH_KEYWORDS, SEO_ACTION } from './search';
 import { GET_BACKLINKS, GET_GSC, GET_RANKS } from './web-metrics';
@@ -117,6 +118,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   CREATE_PRODUCT,
   CREATE_SHARE,
   DELETE_PRODUCT,
+  DIAGNOSE_BRAND,
   DIAGNOSE_RADAR,
   DISCARD_PLAN,
   GEO_ACTION,
@@ -129,6 +131,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   GET_CALENDAR,
   GET_CREATION_KIT,
   GET_GEO,
+  GET_GOALS,
   GET_GSC,
   GET_GTM,
   GET_KEYWORDS,
@@ -227,6 +230,16 @@ export {
   LIST_ARTICLES,
   LIST_PRODUCTS
 };
+export {
+  DIAGNOSE_BRAND,
+  DOCTOR_GATE_STATUSES,
+  DOCTOR_LOOP_STATUSES,
+  GET_GOALS,
+  GOALS_DEFAULT,
+  GOALS_MAX,
+  GOAL_CRITERION_STATUSES,
+  GOAL_STATUSES
+} from './brand-state';
 export { DIAGNOSE_RADAR, GET_MARKET_FIELD, IDEA_STATUSES, IDEAS_DEFAULT, IDEAS_MAX, LIST_IDEAS, MARKET_FIELD_DEFAULT, MARKET_FIELD_MAX } from './market';
 export { GEO_ACTION, REFRESH_KEYWORDS, SEO_ACTION } from './search';
 export { GET_BACKLINKS, GET_GSC, GET_RANKS } from './web-metrics';

--- a/src/lib/content/changelog/2026-09-04-measurement-brand-state.ts
+++ b/src/lib/content/changelog/2026-09-04-measurement-brand-state.ts
@@ -1,0 +1,13 @@
+import type { ChangelogEntry } from './index';
+
+const entry: ChangelogEntry = {
+  date: '2026-09-04',
+  title: 'Ask your assistant why nothing is happening',
+  items: [
+    'Your assistant can now run the brand doctor: for each recurring cycle it names the first thing blocking you and what unblocks it — and says which cycles it is not looking at.',
+    'Goal mode history is readable too: how many goals were met on the first try, how many came back to you, and why a chain stopped.',
+    'Both are reads: they cost no credits and change nothing.'
+  ]
+};
+
+export default entry;


### PR DESCRIPTION
## What?

The last two measurement reads become MCP tools, generated from the endpoint registry:
**`diagnose_brand`** (`GET /doctor`) and **`get_goals`** (`GET /goals`). A new contract file,
`packages/api-contracts/src/brand-state.ts`, declares them with a real `output`, mirrored into
`cli/lib/contracts/` by `sync-contracts.sh`.

Registry coverage goes from **61 to 63** endpoints; `tools/list` goes from **93 to 95**. No
existing tool changes, is renamed, or disappears.

Neither route had a page in `docs/api/`. They get one each in `02-brands-core.md`, with the full
response shape and the meaning of every status value.

This closes the set opened by #263 (web/SEO) and #265 (market): the eight measurement reads the
census found uncovered are now all declared.

## Why?

The first question an external agent asks when nothing is happening is not "what broke" but
"which gate am I failing". `GET /doctor` has answered that for a while — per recurring cycle, the
first gate the brand fails and what unblocks it — and no tool sat in front of it, so the only way
to read it was `curl`: an interface for a human.

`GET /goals` is the other half. Goal mode leaves a state, which the chat already shows, and a
history, which nobody read. The summary is the point: not how many goals exist, but how many
close on the first pass, how many automatic laps they cost, and why the chains stop. That is what
says whether the four-lap ceiling is generous, tight, or never touched.

## How?

**A file per family**, the precedent set by `search.ts` in #238. `brand-state.ts` holds the two.

**`notCovered` is required in the doctor's output, not decorative.** The diagnosis covers three
cycles out of nine and says so. An agent that reads `loops` with no blocks and does not know what
was excluded concludes the whole product is running. A test refuses an output without the field —
which is the only thing that stops someone deleting it later as redundant.

**The goals filter is `thread`, not `threadId`.** `callEndpoint` turns input keys into query
params verbatim, and the route reads `url.searchParams.get('thread')`. Naming it `threadId` would
have produced a tool that accepts the field, sends it, and has it silently ignored: a filter that
does not filter, with no error to notice. A test pins the name.

**Status values are enums, not `z.string()`.** A loop is `ok` / `blocked` / `waiting` / `failing`
/ `unknown`, a gate is `pass` / `fail` / `unknown`, a goal is `open` / `met` / `handed_back` /
`abandoned`. An agent branching on these needs the closed set, and a widened one would go
unnoticed; the contract fails instead.

**Rejected alternative — a new numbered `docs/api/` file for the measurement family.** It would
have split brand-health reads away from `/analytics` and `/calendar`, which are the same kind of
thing, and claimed a number a parallel branch may also want. They went into `02-brands-core.md`,
whose intro line and both index tables now name them.

## Testing?

```
npx vitest run packages/api-contracts   →  8 files, 106 tests passed
npx vitest run src/lib/content/changelog →  3 tests passed
cd cli && bun test                      →  57 pass, 0 fail (11 files)
cd cli && bun run typecheck             →  clean
node scripts/typecheck-runtime.mjs      →  ok (559 pre-existing non-fatal errors ignored)
npm run check                           →  340 errors, all pre-existing; none in the files touched
```

`bash cli/scripts/sync-contracts.sh` was run after every edit under
`packages/api-contracts/src/`; `cli/lib/contracts.test.ts` compares the two trees byte for byte
and is green. `grep -c 'export const BRAND_ENDPOINTS' packages/api-contracts/src/index.ts` is
**1**, the array is sorted and has no duplicates.

**Red before green.** `brand-state.test.ts` was written first and failed on the missing module,
then went green with the contract. The registry-wide law added in #263 — every `BRAND_ENDPOINTS`
entry must appear in `tools/list` with its declared title, description and annotations — covers
these two automatically; `cd cli && bun test` runs it.

**Not tested**: nothing calls the two endpoints for real here. The routes are untouched; the
shapes were read from `brandDoctor`, `loadGoalHistory` and `summarizeGoals` rather than guessed.

**Read-only API keys reach both, by construction.** `resolveCaller` in
`src/lib/server/cli-auth.ts` denies a read-only key once, on the method — both are `GET`. Neither
handler calls `gateAiAction` or `checkApiKeyWriteAccess`: **they spend no credits.**

## Evidence (screenshots/videos)

No UI.

<details>
<summary><code>tools/list</code> through <code>handleMcpFetch</code>, before → after</summary>

```
before 93 after 95
added: ['diagnose_brand', 'get_goals']
removed: []
changed: []

{"name": "diagnose_brand", "title": "Brand doctor",
 "description": "Why this brand receives nothing from the AI. Per recurring cycle: the FIRST gate it fails, what has to happen for that gate to pass, and the last recorded outcome. Says which cycles it does not cover.",
 "properties": ["slug"], "required": ["slug"], "additionalProperties": false,
 "annotations": {"readOnlyHint": true, "destructiveHint": false}}

{"name": "get_goals", "title": "Chat goals",
 "description": "Goal mode, measured: how many goals were met on the first pass, how many went back to the person, how many automatic laps were spent, and the reason each chain stopped — plus the goals themselves with their diary.",
 "properties": ["limit", "slug", "thread"], "required": ["slug"], "additionalProperties": false,
 "annotations": {"readOnlyHint": true, "destructiveHint": false}}
```

Captured after rebasing onto `dev` with #263 and #265 already in. The baseline is **93**, one
below the arithmetic sum, because the chat dismantling removed the `chat` tool in between.
`removed: []` and `changed: []` are the claim — the other 93 are byte-identical.
</details>

## Anything Else?

**A dependency worth naming: `/goals` reads `src/lib/server/chat/goal-log.ts`, and the chat is
being dismantled in parallel.** If goal mode goes, this endpoint goes with it — the contract is
not a reason to keep it alive. At the time of writing the route, the module and the tables
(`chat_goals`, `chat_goal_events`) are all present on `dev`, and the `chat` tool disappearing
from `tools/list` between #263 and this PR is the visible edge of that work.

**Rebased onto `dev` twice** — after #263 and after #265 — both times resolving `index.ts` as an
alphabetically ordered union of `BRAND_ENDPOINTS`, then `sync-contracts.sh`. The array holds
**63** entries, sorted, no duplicates, and `grep -c 'export const BRAND_ENDPOINTS'` is **1**.

**The census behind the three PRs.** 92 `+server.ts` files under
`src/routes/api/v1/brands/[slug]/`; 46 route paths covered by the registry before #263, 45
uncovered. Of those 45, exactly eight are measurement reads — `gsc`, `ranks`, `backlinks`
(#263), `market/field`, `radar/diagnose`, `ideas` (#265), `doctor`, `goals` (here). Nothing else
in the uncovered set is a measurement: `/agent-sessions` is agent-run telemetry whose payload is
a redacted transcript blob and whose writers are being removed; `/rubrics`, `/publishing`,
`/articles`, `/connections`, `/api-keys` and `/webhook` are state, content or configuration.

**Every credit-spending sibling stayed out**: `POST /backlinks`, `POST /market/field`. Only reads
are in this set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
