### PR TITLE
Ignore the local agent config and the manual probe output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,4 +88,8 @@ AGENT-CHAT-*.md
 /mcp.json
 /.mcp.json
 .mimocode/
+.codex/
 vite.config.ts.timestamp-*.mjs
+
+# Prove locali: immagini e file generati per verificare a mano, mai da committare.
+.probe/


### PR DESCRIPTION
## What?

Two entries in `.gitignore`: `.codex/` and `.probe/`.

## Why?

`.codex/` holds an agent tool's local configuration — endpoints and vendor project ids, different on every machine. The file sits directly under a comment that already lists exactly this kind of thing (`opencode.json`, `mimocode.jsonc`, `.mcp.json`, `.mimocode/`); it was simply never added.

`.probe/` is where manual verification output lands: rendered images kept just long enough to look at them. This afternoon four PNGs from a brand-style comparison were sitting **staged for commit** in the main checkout because nothing excluded them. Nobody wants them in the history, and the only thing standing between them and a commit was somebody noticing.

## How?

`.codex/` goes inside the existing agent-config block, next to its siblings, rather than at the end — the comment above it already says why those lines exist, and repeating the reason would be the kind of comment this repo removes.

`.probe/` gets its own line and its own one-line reason, because it is a different category: not configuration, but throwaway output.

Neither pattern matches anything tracked, so nothing is removed from the index by this change.

## Testing?

```
$ git check-ignore -q .codex/ && echo ignored
ignored
$ git check-ignore -q .probe/ && echo ignored
ignored
$ git ls-files .codex .probe
(no output — nothing tracked was covered)
```

No application code is touched. Full suite delegated to CI.

## Evidence

Before, in the main checkout:

```
A  .codex/config.toml
A  .probe/transwiki-acquerello-con-brand-style-full.png
A  .probe/transwiki-acquerello-con-brand-style.png
A  .probe/transwiki-acquerello-senza-brand-style-full.png
A  .probe/transwiki-acquerello-senza-brand-style.png
```

All five staged, none of them wanted.

## Anything Else?

`.env*` was considered and left out. `.env` and `.env.local` are already covered further up, and a broad `.env*` would also swallow `.env.example`, which is tracked on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY