### PR TITLE
Restore the brand home route so /app/[brand] resolves

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -853,3 +853,40 @@ nomina e il database non ha. Va eseguito **dopo ogni migration scritta e prima d
 tocca il database** — non solo quando qualcosa è già rotto. Un `select` di colonne che potrebbero
 non esistere non è mai «non può fallire»: o si legge `error`, o il difetto arriva travestito da
 colpa di chi chiama.
+
+## Una rotta SvelteKit esiste perché esiste un file di pagina
+
+**Segnale.** Una pagina risponde `Not found` per tutti, e lo stack punta a `resolve()` dentro
+`@sveltejs/kit`, non a codice tuo:
+
+```
+Error: Not found: /app/anomalia
+    at resolve (node_modules/@sveltejs/kit/src/runtime/server/respond.js:711:13)
+```
+
+Nel `git log` recente c'è una PR che parlava d'altro — un cookie, un redirect, un ordine di
+esecuzione — e che, fra le altre cose, ha **cancellato** un `+page.server.ts`.
+
+**Cosa succede.** SvelteKit costruisce il manifest dai file. Senza né `+page.server.ts` né
+`+page.svelte` la rotta non esiste, e il 404 nasce prima che parta un solo `load` — layout
+compreso. Un rimando spostato «in cima al layout» non viene mai raggiunto: il guscio non entra
+nemmeno in scena. È capitato a `/app/[brand]`: la home del brand è rimasta irraggiungibile per
+tutti mentre i quattro test del rimando restavano verdi, perché provavano il `load` del layout e
+il 404 avviene prima di lui.
+
+**La mossa.** Svuotare una pagina del suo contenuto e lasciarci solo un `redirect` è legittimo;
+**cancellare il file no**, perché toglie la rotta. Quando una pagina diventa un rimando, il file
+resta e la ragione per cui resta si scrive dentro — è l'unica cosa che il prossimo lettore vede
+prima di ricancellarlo. E la proprietà si fissa in un test che legge la cartella dal disco
+(`readdirSync`, come gli altri 71 di questo repo), non nel `load`: quel test è l'unico che può
+fallire per la ragione giusta. Munirlo del negativo, o passa a vuoto — qui una cartella di solo
+endpoint (`credits/`, con un `+server.ts` e basta) che **non** deve risultare una pagina.
+
+**Il corollario, se due rimandi sembrano uno di troppo.** Le due strade del server non si
+comportano allo stesso modo, e la differenza decide chi vince: per una richiesta di pagina
+(`server/page/index.js`) i `load` partono in parallelo ma i risultati si consumano **in ordine di
+nodo**, quindi vince il layout; per la `__data.json` di una navigazione dal client
+(`server/data/index.js`) è un `Promise.all` che rilancia il `Redirect` appena arriva, quindi vince
+**il primo che rigetta**. Un rimando piazzato nella pagina chiude la risposta mentre il layout è
+ancora dentro le sue query, e il `cookies.set` del layout trova la risposta già generata. Prima di
+dichiarare ridondante una guardia, leggi quale delle due strade la esercita.

--- a/changelog/2026-09-04-la-home-del-brand-e-una-rotta.md
+++ b/changelog/2026-09-04-la-home-del-brand-e-una-rotta.md
@@ -1,0 +1,51 @@
+# `/app/[brand]` rispondeva 404: la rotta non esisteva più
+
+La #269 ha corretto due difetti veri della home del brand — il percorso relativo che usciva dal
+brand e la corsa fra il rimando e il cookie dell'ultimo brand — spostando il rimando in cima a
+`+layout.server.ts`. Quella parte è giusta e resta. Insieme, però, ha **cancellato**
+`src/routes/app/[brand]/+page.server.ts`, e senza né `+page.server.ts` né `+page.svelte`
+SvelteKit non ha una rotta da servire:
+
+```
+Error: Not found: /app/anomalia
+    at resolve (node_modules/@sveltejs/kit/src/runtime/server/respond.js:711:13)
+```
+
+Il 404 nasce in `resolve()`, **prima** che parta un solo `load`. Il rimando messo nel layout non
+viene mai raggiunto: la home del brand era irraggiungibile per tutti, e il sintomo non somigliava
+alla causa.
+
+## Cosa misura la correzione
+
+`npx svelte-kit sync` genera i `$types` leggendo i file delle rotte. Prima:
+`.svelte-kit/types/src/routes/app/[brand]/$types.d.ts` non nominava `PageServerLoad` nemmeno una
+volta — non c'era una pagina. Dopo, due volte. È SvelteKit stesso a dire se la rotta esiste.
+
+## I due rimandi non sono uno di troppo
+
+Letto il runtime installato (`@sveltejs/kit` 2.63.1), le due strade fanno cose diverse:
+
+- **Richiesta di pagina** (`server/page/index.js:253-281`): i `load` partono in parallelo, ma i
+  risultati si consumano **in ordine di nodo** (`await server_promises[i]`), e i layout vengono
+  prima della foglia. Vince il rimando del **layout**.
+- **Navigazione dal client** (`server/data/index.js:99-104`, la `__data.json`): `Promise.all` e
+  `throw error` immediato su un `Redirect` — vince **il primo che rigetta**, non il primo indice.
+  È qui che stava la corsa della #269: il rimando nella pagina era sincrono, chiudeva la risposta,
+  e il layout arrivava dopo alla riga del cookie con la risposta già generata
+  (`respond.js:731-738` sostituisce `cookies.set` con un lancio).
+
+Il rimando in cima al layout parte prima di qualunque `await`, quindi su entrambe le strade rigetta
+per primo e il layout non arriva mai a scrivere il cookie: la corsa non esiste. Il `+page.server.ts`
+esiste **perché la rotta esista** — il suo `load` oggi non scatta mai, ed è la rete se un domani
+quella guardia si spostasse. Il rimando qui è assoluto: `./workbench` si risolve contro un URL
+senza barra finale e atterra su `/app/workbench`, che non è la rotta di nessuno.
+
+## Il test che mancava
+
+`home-redirect.test.ts` provava il `load` del layout, e il `load` del layout non si accorge di un
+404 che avviene prima di lui: i quattro test erano verdi mentre la home era rotta per tutti. Il
+file ne guadagna due, che leggono la cartella dal disco:
+
+- `/app/[brand]` contiene un file di pagina — è la proprietà che è saltata;
+- una cartella di solo endpoint (`credits/`, che ha un `+server.ts` e basta) **non** ne contiene —
+  il controllo sa dire di no, quindi il primo non passa a vuoto.

--- a/src/lib/content/changelog/2026-09-04-brand-home-opens-again.ts
+++ b/src/lib/content/changelog/2026-09-04-brand-home-opens-again.ts
@@ -1,0 +1,11 @@
+import type { ChangelogEntry } from './index';
+
+const entry: ChangelogEntry = {
+  date: '2026-09-04',
+  title: 'A brand home page opens again',
+  items: [
+    'Opening a brand from the sidebar, a link or a bookmark landed on a "Not found" page instead of the brand. It now goes straight to the workbench, as it did before.'
+  ]
+};
+
+export default entry;

--- a/src/routes/app/[brand]/+page.server.ts
+++ b/src/routes/app/[brand]/+page.server.ts
@@ -1,0 +1,17 @@
+import { redirect } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+
+/**
+ * Questo file esiste perché la rotta esista. SvelteKit costruisce il manifest dai file: senza una
+ * pagina qui, `/app/<slug>` non è una rotta e il 404 nasce in `resolve()` prima che parta un solo
+ * `load` — quindi il rimando in cima al layout non viene mai raggiunto. Cancellarlo ha già tolto
+ * la home del brand a tutti (#269), e il sintomo — «Not found» — non somiglia alla causa.
+ *
+ * A rimandare per davvero è il layout, che nell'ordine dei nodi viene prima di questa pagina.
+ * Questo `load` è la rete: se un domani quella guardia non scattasse, la home rimanda comunque.
+ * Assoluto e non `./workbench`, che si risolve contro un URL senza barra finale e atterra su
+ * `/app/workbench` — la rotta di nessuno.
+ */
+export const load: PageServerLoad = ({ params }) => {
+  redirect(302, `/app/${encodeURIComponent(params.brand)}/workbench`);
+};

--- a/src/routes/app/[brand]/home-redirect.test.ts
+++ b/src/routes/app/[brand]/home-redirect.test.ts
@@ -1,3 +1,6 @@
+import { readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it, vi } from 'vitest';
 
 /**
@@ -59,5 +62,27 @@ describe('la home del brand rimanda al workbench del brand', () => {
 	it('una rotta figlia non viene rimandata', async () => {
 		const { redirected } = await loadLayout('/app/demo/calendar', 'demo');
 		expect(redirected?.location).not.toBe('/app/demo/workbench');
+	});
+});
+
+/**
+ * Il redirect nel layout non basta a far esistere la rotta. SvelteKit costruisce il manifest
+ * dai file: senza né `+page.server.ts` né `+page.svelte`, `/app/<slug>` non è una rotta, e il
+ * 404 nasce in `resolve()` PRIMA che un solo `load` parta — layout compreso. Un test sul solo
+ * `load` del layout resta verde mentre la home è irraggiungibile per tutti: è già successo.
+ */
+const brandRouteDir = fileURLToPath(new URL('.', import.meta.url));
+
+function pageFilesIn(dir: string): string[] {
+	return readdirSync(join(brandRouteDir, dir)).filter((f) => f === '+page.server.ts' || f === '+page.svelte');
+}
+
+describe('/app/[brand] è una rotta, non solo un guscio', () => {
+	it('ha un file di pagina, altrimenti il 404 arriva prima del layout', () => {
+		expect(pageFilesIn('.')).not.toEqual([]);
+	});
+
+	it('il controllo sa dire di no: una cartella di solo endpoint non ha pagina', () => {
+		expect(pageFilesIn('credits')).toEqual([]);
 	});
 });


### PR DESCRIPTION
## What?

Restores `src/routes/app/[brand]/+page.server.ts`, deleted by #269, so that `/app/[brand]` is a
route again. It holds a single redirect to the brand's workbench, built with an **absolute** path
from `params.brand`. The redirect that #269 put at the top of `+layout.server.ts` is untouched —
that part was right.

`home-redirect.test.ts` gains the property that was missing, plus its negative control.

## Why?

`/app/<any brand>` answered 404 on `dev`, for everybody:

```
Error: Not found: /app/anomalia
    at resolve (node_modules/@sveltejs/kit/src/runtime/server/respond.js:711:13)
```

SvelteKit builds its manifest from files. With neither `+page.server.ts` nor `+page.svelte`,
`/app/<slug>` is not a route at all, and the 404 is raised inside `resolve()` **before a single
`load` runs** — the layout included. So the redirect #269 moved into the layout was never reached:
the shell never entered the scene. Opening a brand from the sidebar, from a link or from a
bookmark landed on "Not found".

## How?

**Measured, not deduced.** Two questions had to be settled: does the route exist, and is the
second redirect redundant?

*Does the route exist* — `npx svelte-kit sync` generates `$types` by reading the route files, so
SvelteKit itself answers. Before: `.svelte-kit/types/src/routes/app/[brand]/$types.d.ts` did not
name `PageServerLoad` once. After: twice.

*Which redirect actually fires* — read from the installed runtime (`@sveltejs/kit` 2.63.1), the
two server paths behave differently:

| path | orchestration | who wins |
|---|---|---|
| page request (`server/page/index.js:253-281`) | loads start in parallel, results consumed **in node order** (`await server_promises[i]`), layouts before the leaf | the **layout** redirect |
| client navigation `__data.json` (`server/data/index.js:99-104`) | `Promise.all`, `throw error` immediately on a `Redirect` | the **first to reject**, not the first index |

That second row is exactly where #269's cookie race lived: a redirect thrown from the page closed
the response while the layout was still inside its queries, and the layout then reached
`cookies.set` with the response already generated (`respond.js:731-738` replaces `cookies.set`
with a throw). The layout guard redirects **before any `await`**, so it rejects first on both
paths and never reaches the cookie write. The race is gone on both.

So the two are not one too many, and they are not symmetric: the layout redirect is the one that
runs; `+page.server.ts` exists **so the route exists**, and its `load` is the net if that guard
ever moves. It stays a redirect rather than an empty `+page.svelte` — same one file, and a blank
page would be a worse regression than a redirect.

The path is absolute on purpose: `./workbench` resolves against a URL with no trailing slash and
lands on `/app/workbench`, nobody's route — the other half of what #269 was fixing.

The reason the file cannot be deleted is written inside the file, because that is the only thing
the next reader sees before deleting it again.

## Testing?

Test first, red observed, then the fix — the four existing tests were **green** the whole time the
home was unreachable, because they exercise the layout's `load` and the 404 happens before it. The
honest way to pin route existence without a browser is to read the directory from disk, the same
shape as the 71 `readFileSync` tests already in this repo.

<details>
<summary>The red, before the fix</summary>

```
 ❯ src/routes/app/[brand]/home-redirect.test.ts (6 tests | 1 failed) 1493ms
   × /app/[brand] è una rotta, non solo un guscio > ha un file di pagina, altrimenti il 404 arriva prima del layout
     → expected [] to not deeply equal []

 FAIL  src/routes/app/[brand]/home-redirect.test.ts > /app/[brand] è una rotta, non solo un guscio > ha un file di pagina, altrimenti il 404 arriva prima del layout
AssertionError: expected [] to not deeply equal []
 ❯ src/routes/app/[brand]/home-redirect.test.ts:82:32
     82|   expect(pageFilesIn('.')).not.toEqual([]);

 Test Files  1 failed (1)
      Tests  1 failed | 5 passed (6)
```

The negative control was green throughout: `credits/` holds only a `+server.ts`, and the check
says so — a scan that stops finding anything must fail, not pass.
</details>

<details>
<summary>Green, after the fix</summary>

```
$ npx vitest run "src/routes/app/[brand]"
 ✓ src/routes/app/[brand]/home-redirect.test.ts (6 tests) 1422ms
 Test Files  5 passed (5)
      Tests  20 passed (20)

$ node scripts/typecheck-runtime.mjs
typecheck-runtime: ok (ignored 306 non-fatal type error(s))
```
</details>

<details>
<summary>SvelteKit's own verdict on route existence</summary>

```
$ npx svelte-kit sync && grep -c PageServerLoad '.svelte-kit/types/src/routes/app/[brand]/$types.d.ts'
0      # before
2      # after
```
</details>

**Full suite**: `7046 passed | 13 failed | 11 skipped`. The 13 are pre-existing on `origin/dev`
and untouched by this diff — `src/hooks.server.test.ts` and three files under
`src/lib/agent/bridge/` (`extractUserText is not a function`, `extractUserImages is not a
function`, `TypeError: Invalid URL`). They fail identically in isolation, so it is not
full-suite interference; the branch does not make them worse and does not fix them.

**Not tested**: no browser. Docker, Playwright and a dev server were explicitly out of scope for
this change, so there is no screenshot of the brand home loading. What is proven is that SvelteKit
now has the route and that the redirect target is the right absolute path; what is not proven from
here is the rendered workbench. Risk is low — the diff adds one route file and two assertions —
but the browser gate is genuinely not green, and this note says so instead of implying otherwise.

## Evidence (screenshots/videos)

None: no UI was changed, and no browser was run. The CLI evidence is in the collapsed blocks above,
each captioned with what it measures.

## Anything Else?

The lesson went into `LESSONS.md`, because it is general and will cost again: **a SvelteKit route
exists because a page file exists.** Emptying a page of its content and leaving only a redirect is
legitimate; deleting the file is not, because it removes the route and the 404 arrives before any
`load`. The symptom (`Not found` in `resolve()`) looks nothing like the cause (a file deleted in a
PR that was about cookies).

The corollary is in there too, since it is the part that makes "is this guard redundant?"
answerable: the page path and the `__data.json` path pick a different winner, so a guard that looks
dead on one is the only one that runs on the other.

Both changelogs are in the same commit — internal `changelog/2026-09-04-la-home-del-brand-e-una-rotta.md`,
public `A brand home page opens again`, since the home was unreachable for every customer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
