### PR TITLE
Give /v2 a shell, and a way in

### DIFF
--- a/changelog/2026-09-04-v2-shell.md
+++ b/changelog/2026-09-04-v2-shell.md
@@ -1,0 +1,59 @@
+# Il guscio di `/v2`: una barra laterale sola, e un modo per arrivarci
+
+Sotto `/v2/[brand]` c'erano cinque superfici e nessuna cosa che le tenesse insieme. La barra
+laterale del mockup viveva **dentro** la dashboard, quindi calendario, materiali, strategia e
+risultati disegnavano ognuno il proprio intorno e nessuno di loro aveva un modo per tornare
+indietro. E niente in tutta l'applicazione portava a `/v2`: ci si arrivava digitando l'URL, cioè
+nessuno ci arrivava.
+
+## La barra laterale sale di un livello
+
+`+layout.svelte` prende la barra così com'era. Il nome del brand e il contatore dei post da
+approvare li legge `+layout.server.ts` da `/api/v1/brands/:slug` — la stessa chiamata che faceva
+la dashboard, ma fatta dal guscio, che è chi ha bisogno di saperlo su ogni pagina. La voce attiva
+non è più scritta a mano («Home»): viene dal `pathname`, perché un guscio non sa su quale pagina
+sta.
+
+Lo spostamento è il primo commit e non cambia niente: stesse voci, stessi href, stessi test verdi
+prima e dopo. Il secondo commit cambia senza spostare.
+
+## Cinque voci, e la regola che le tiene oneste
+
+La nav descriveva il mondo del giorno in cui era stata scritta: Materiali, Strategia e Risultati
+disegnati come righe spente perché le pagine non esistevano ancora, e Calendario e Post come due
+voci per la stessa superficie da quando la #259 ha trasformato `/posts` in un redirect.
+
+Ora sono cinque, tutte link, una sola per il calendario. La lista è dato in `nav.ts`, e un test
+tiene la regola che le righe spente esprimevano a mano: **un percorso entra nella nav il giorno
+che ha un `+page.svelte`**. Il test fallisce su una voce che risponderebbe 404 — è la stessa cosa
+che diceva il commento, ma non invecchia.
+
+Scartato: tenere le voci disabilitate «per completezza». Una riga spenta accanto a una pagina che
+esiste è solo una nav che ha smesso di essere aggiornata.
+
+## Il punto d'ingresso
+
+Una voce sola in coda alla barra laterale del **vecchio** `/app`, in entrambe le nav (`navTeam` e
+legacy): `New interface · preview`. Due `[...groups, v2Preview]` e un oggetto — si toglie con una
+riga il giorno che serve, e chi la usa la trova senza sapere che `/v2` esiste.
+
+Non è tradotta, e non per pigrizia: `/v2` non lo è. Etichettarla in quattro lingue la farebbe
+sembrare finita, e finita non è. Il giorno che sostituisce questo guscio, il guscio se ne va e la
+voce con lui.
+
+Scartato: `/v2` senza brand che rimanda all'ultimo aperto (`LAST_BRAND_COOKIE`). È un file in
+meno da toccare, ma risolve il problema sbagliato — fa funzionare un URL che nessuno digiterebbe,
+invece di far trovare la superficie a chi non sa che c'è.
+
+## Il debito che resta, e non è di questa PR
+
+Il `+layout.svelte` di root è globale e una rotta non può rifiutarlo: svelte-i18n, analytics,
+cookie banner e lo shimmer d'ingresso si caricano anche su `/v2`, che non usa nessuno dei quattro.
+È JavaScript pagato su ogni pagina della superficie che nasce per essere leggera. Va risolto, ma
+è un lavoro suo: qui non è stato peggiorato.
+
+E `+layout.server.ts` chiama `/api/v1/brands/:slug` che la dashboard e la vista lista del
+calendario chiamano già: una richiesta in più al primo caricamento di quelle due. Il carico
+client-side non la ripete (il load dipende da `params.brand`, che non cambia navigando dentro il
+brand). Toglierla vorrebbe dire far leggere alle pagine i dati del layout con `await parent()`, e
+legare le pagine al guscio: non ora, per una richiesta.

--- a/src/lib/content/changelog/2026-09-04-v2-preview.ts
+++ b/src/lib/content/changelog/2026-09-04-v2-preview.ts
@@ -1,0 +1,9 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-04',
+  title: 'A preview of the new interface',
+  items: [
+    'The sidebar now carries a “New interface · preview” entry: five screens — home, materials, strategy, calendar, results — rebuilt to be fast and quiet. It is still being built, and the rest of the app is unchanged.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/routes/app/[brand]/+layout.svelte
+++ b/src/routes/app/[brand]/+layout.svelte
@@ -317,8 +317,22 @@
     ];
   }
 
+  // L'ingresso alla nuova interfaccia. Non è tradotta perché `/v2` non lo è: è in costruzione, e
+  // l'etichetta lo dice invece di farla passare per finita. Il giorno che sostituisce questo
+  // guscio, il guscio se ne va e questa voce con lui.
+  const v2Preview = $derived<NavGroup>({
+    items: [
+      {
+        href: `/v2/${data.brand.slug}`,
+        label: 'New interface · preview',
+        icon: Sparkles,
+        key: 'v2-preview'
+      }
+    ]
+  });
+
   const sidebarGroups = $derived.by(() => {
-    if (navTeam) return teamSidebarGroups();
+    if (navTeam) return [...teamSidebarGroups(), v2Preview];
     // Il tipo è quello del componente, non ricopiato a mano: la copia era andata alla deriva
     // (icon opzionale vs obbligatoria) e falliva solo all'assegnazione qui sotto.
     // `app.home.workbench.title` è la stessa chiave della pillola in topbar e del titolo della
@@ -418,7 +432,7 @@
       });
     }
 
-    return groups;
+    return [...groups, v2Preview];
   });
 
 

--- a/src/routes/v2/[brand]/+layout.server.ts
+++ b/src/routes/v2/[brand]/+layout.server.ts
@@ -1,0 +1,22 @@
+import { error, redirect } from '@sveltejs/kit';
+import type { LayoutServerLoad } from './$types';
+
+export const load: LayoutServerLoad = async ({ params, fetch, locals }) => {
+  const { session } = await locals.safeGetSession();
+  if (!session) {
+    redirect(303, '/login');
+  }
+
+  const res = await fetch(`/api/v1/brands/${encodeURIComponent(params.brand)}`, {
+    headers: { Authorization: `Bearer ${session.access_token}` }
+  });
+
+  if (!res.ok) {
+    const body = (await res.json().catch(() => null)) as { error?: string } | null;
+    error(res.status, body?.error ?? `Request failed (${res.status})`);
+  }
+
+  const read = (await res.json()) as { brand: { name: string }; pendingCount: number };
+
+  return { slug: params.brand, brandName: read.brand.name, pendingCount: read.pendingCount };
+};

--- a/src/routes/v2/[brand]/+layout.svelte
+++ b/src/routes/v2/[brand]/+layout.svelte
@@ -2,26 +2,12 @@
   import '$lib/styles/tailwind.css';
   import { page } from '$app/state';
   import { Badge } from '$lib/components/ui/badge/index.js';
+  import { navFor } from './nav';
   import type { LayoutProps } from './$types';
 
   let { data, children }: LayoutProps = $props();
 
-  const base = $derived(`/v2/${data.slug}`);
-
-  // Le voci senza `href` non sono link: la pagina non esiste ancora, e un 404 è peggio di una
-  // riga spenta. Quando la superficie arriva, qui cambia solo l'href.
-  const NAV = $derived([
-    { label: 'Home', href: base, badge: 0 },
-    { label: 'Materials', href: null, badge: 0 },
-    { label: 'Strategy', href: null, badge: 0 },
-    { label: 'Calendar', href: `${base}/calendar`, badge: data.pendingCount },
-    { label: 'Posts', href: `${base}/posts`, badge: 0 },
-    { label: 'Results', href: null, badge: 0 }
-  ]);
-
-  function isCurrent(href: string): boolean {
-    return href === base ? page.url.pathname === base : page.url.pathname.startsWith(href);
-  }
+  const nav = $derived(navFor(data.slug, page.url.pathname, data.pendingCount));
 </script>
 
 <div class="bg-background text-foreground flex min-h-screen flex-col sm:flex-row">
@@ -29,30 +15,19 @@
     <p class="truncate text-base font-semibold">{data.brandName}</p>
 
     <nav aria-label="Brand" class="flex flex-wrap gap-1 sm:flex-col">
-      {#each NAV as item (item.label)}
-        {#if item.href}
-          <a
-            href={item.href}
-            aria-current={isCurrent(item.href) ? 'page' : undefined}
-            class="hover:bg-muted focus-visible:ring-ring/50 flex items-center gap-2 rounded-lg px-3 py-1.5 text-sm focus-visible:ring-3 focus-visible:outline-none {isCurrent(
-              item.href
-            )
-              ? 'bg-muted font-medium'
-              : ''}"
-          >
-            <span>{item.label}</span>
-            {#if item.badge > 0}
-              <Badge variant="default">{item.badge}</Badge>
-            {/if}
-          </a>
-        {:else}
-          <span
-            aria-disabled="true"
-            title="Not built yet"
-            class="text-muted-foreground/60 flex items-center rounded-lg px-3 py-1.5 text-sm"
-            >{item.label}</span
-          >
-        {/if}
+      {#each nav as item (item.label)}
+        <a
+          href={item.href}
+          aria-current={item.current ? 'page' : undefined}
+          class="hover:bg-muted focus-visible:ring-ring/50 flex items-center gap-2 rounded-lg px-3 py-1.5 text-sm focus-visible:ring-3 focus-visible:outline-none {item.current
+            ? 'bg-muted font-medium'
+            : ''}"
+        >
+          <span>{item.label}</span>
+          {#if item.badge > 0}
+            <Badge variant="default">{item.badge}</Badge>
+          {/if}
+        </a>
       {/each}
     </nav>
   </aside>

--- a/src/routes/v2/[brand]/+layout.svelte
+++ b/src/routes/v2/[brand]/+layout.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+  import '$lib/styles/tailwind.css';
+  import { page } from '$app/state';
+  import { Badge } from '$lib/components/ui/badge/index.js';
+  import type { LayoutProps } from './$types';
+
+  let { data, children }: LayoutProps = $props();
+
+  const base = $derived(`/v2/${data.slug}`);
+
+  // Le voci senza `href` non sono link: la pagina non esiste ancora, e un 404 è peggio di una
+  // riga spenta. Quando la superficie arriva, qui cambia solo l'href.
+  const NAV = $derived([
+    { label: 'Home', href: base, badge: 0 },
+    { label: 'Materials', href: null, badge: 0 },
+    { label: 'Strategy', href: null, badge: 0 },
+    { label: 'Calendar', href: `${base}/calendar`, badge: data.pendingCount },
+    { label: 'Posts', href: `${base}/posts`, badge: 0 },
+    { label: 'Results', href: null, badge: 0 }
+  ]);
+
+  function isCurrent(href: string): boolean {
+    return href === base ? page.url.pathname === base : page.url.pathname.startsWith(href);
+  }
+</script>
+
+<div class="bg-background text-foreground flex min-h-screen flex-col sm:flex-row">
+  <aside class="border-border flex flex-col gap-4 border-b p-4 sm:w-56 sm:border-r sm:border-b-0">
+    <p class="truncate text-base font-semibold">{data.brandName}</p>
+
+    <nav aria-label="Brand" class="flex flex-wrap gap-1 sm:flex-col">
+      {#each NAV as item (item.label)}
+        {#if item.href}
+          <a
+            href={item.href}
+            aria-current={isCurrent(item.href) ? 'page' : undefined}
+            class="hover:bg-muted focus-visible:ring-ring/50 flex items-center gap-2 rounded-lg px-3 py-1.5 text-sm focus-visible:ring-3 focus-visible:outline-none {isCurrent(
+              item.href
+            )
+              ? 'bg-muted font-medium'
+              : ''}"
+          >
+            <span>{item.label}</span>
+            {#if item.badge > 0}
+              <Badge variant="default">{item.badge}</Badge>
+            {/if}
+          </a>
+        {:else}
+          <span
+            aria-disabled="true"
+            title="Not built yet"
+            class="text-muted-foreground/60 flex items-center rounded-lg px-3 py-1.5 text-sm"
+            >{item.label}</span
+          >
+        {/if}
+      {/each}
+    </nav>
+  </aside>
+
+  <div class="flex min-w-0 flex-1 flex-col">{@render children()}</div>
+</div>

--- a/src/routes/v2/[brand]/+page.svelte
+++ b/src/routes/v2/[brand]/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import '$lib/styles/tailwind.css';
   import { Badge } from '$lib/components/ui/badge/index.js';
   import McpGuide from './McpGuide.svelte';
   import { attentionLine } from './dashboard';
@@ -10,17 +9,6 @@
   const brand = $derived(data.brand);
   const facts = $derived(data.facts);
 
-  // Le voci senza `href` non sono link: la pagina non esiste ancora, e un 404 è peggio di una
-  // riga spenta. Quando la superficie arriva, qui cambia solo l'href.
-  const NAV = $derived([
-    { label: 'Home', href: `/v2/${data.slug}`, badge: 0 },
-    { label: 'Materials', href: null, badge: 0 },
-    { label: 'Strategy', href: null, badge: 0 },
-    { label: 'Calendar', href: `/v2/${data.slug}/calendar`, badge: facts.pending },
-    { label: 'Posts', href: `/v2/${data.slug}/posts`, badge: 0 },
-    { label: 'Results', href: null, badge: 0 }
-  ]);
-
   const TILES = $derived([
     { label: 'Published', value: facts.published },
     { label: 'Scheduled', value: facts.scheduled },
@@ -30,172 +18,139 @@
 
 <svelte:head><title>{brand.name}</title></svelte:head>
 
-<div class="bg-background text-foreground flex min-h-screen flex-col sm:flex-row">
-  <aside class="border-border flex flex-col gap-4 border-b p-4 sm:w-56 sm:border-r sm:border-b-0">
-    <p class="truncate text-base font-semibold">{brand.name}</p>
+<main class="flex min-w-0 flex-1 flex-col gap-6 px-4 py-6 sm:px-8">
+  <McpGuide />
 
-    <nav aria-label="Brand" class="flex flex-wrap gap-1 sm:flex-col">
-      {#each NAV as item (item.label)}
-        {#if item.href}
-          <a
-            href={item.href}
-            aria-current={item.label === 'Home' ? 'page' : undefined}
-            class="hover:bg-muted focus-visible:ring-ring/50 flex items-center gap-2 rounded-lg px-3 py-1.5 text-sm focus-visible:ring-3 focus-visible:outline-none {item.label ===
-            'Home'
-              ? 'bg-muted font-medium'
-              : ''}"
+  <header class="flex flex-wrap items-start justify-between gap-3">
+    <div class="flex flex-col gap-0.5">
+      <h1 class="text-2xl font-semibold">To do</h1>
+      <p class="text-muted-foreground text-sm">{attentionLine(data.todos.length)}</p>
+    </div>
+
+    <details class="relative">
+      <summary
+        class="border-border hover:bg-muted focus-visible:ring-ring/50 cursor-pointer list-none rounded-lg border px-3 py-1.5 text-sm focus-visible:ring-3 focus-visible:outline-none"
+        >Share</summary
+      >
+      <div
+        class="border-border bg-card absolute right-0 z-10 mt-2 flex w-80 flex-col gap-3 rounded-xl border p-3 text-sm shadow-lg"
+      >
+        <p class="text-muted-foreground text-xs">
+          A read-only snapshot of this month for the client: what went out, what is planned, and
+          the reach. No actions, no setup, no account.
+        </p>
+
+        <form method="POST" action="?/share">
+          <button
+            type="submit"
+            class="border-border hover:bg-muted focus-visible:ring-ring/50 w-full rounded-lg border px-3 py-1.5 focus-visible:ring-3 focus-visible:outline-none"
+            >Create a client link</button
           >
-            <span>{item.label}</span>
-            {#if item.badge > 0}
-              <Badge variant="default">{item.badge}</Badge>
-            {/if}
-          </a>
-        {:else}
-          <span
-            aria-disabled="true"
-            title="Not built yet"
-            class="text-muted-foreground/60 flex items-center rounded-lg px-3 py-1.5 text-sm"
-            >{item.label}</span
-          >
+        </form>
+
+        {#if form?.message}
+          <p role="alert" class="text-destructive text-xs">{form.message}</p>
         {/if}
-      {/each}
-    </nav>
-  </aside>
 
-  <main class="flex min-w-0 flex-1 flex-col gap-6 px-4 py-6 sm:px-8">
-    <McpGuide />
-
-    <header class="flex flex-wrap items-start justify-between gap-3">
-      <div class="flex flex-col gap-0.5">
-        <h1 class="text-2xl font-semibold">To do</h1>
-        <p class="text-muted-foreground text-sm">{attentionLine(data.todos.length)}</p>
-      </div>
-
-      <details class="relative">
-        <summary
-          class="border-border hover:bg-muted focus-visible:ring-ring/50 cursor-pointer list-none rounded-lg border px-3 py-1.5 text-sm focus-visible:ring-3 focus-visible:outline-none"
-          >Share</summary
-        >
-        <div
-          class="border-border bg-card absolute right-0 z-10 mt-2 flex w-80 flex-col gap-3 rounded-xl border p-3 text-sm shadow-lg"
-        >
-          <p class="text-muted-foreground text-xs">
-            A read-only snapshot of this month for the client: what went out, what is planned, and
-            the reach. No actions, no setup, no account.
+        {#if form?.revoked}
+          <p role="status" class="text-muted-foreground text-xs">
+            Revoked. It now answers like a link that never existed.
           </p>
+        {/if}
 
-          <form method="POST" action="?/share">
-            <button
-              type="submit"
-              class="border-border hover:bg-muted focus-visible:ring-ring/50 w-full rounded-lg border px-3 py-1.5 focus-visible:ring-3 focus-visible:outline-none"
-              >Create a client link</button
-            >
-          </form>
+        {#if form?.url}
+          <label class="flex flex-col gap-1 text-xs">
+            <span>Copy it now — it is shown once.</span>
+            <input
+              readonly
+              value={form.url}
+              onfocus={(e) => e.currentTarget.select()}
+              class="border-border bg-background w-full rounded-md border px-2 py-1 font-mono text-xs"
+            />
+          </label>
+        {/if}
 
-          {#if form?.message}
-            <p role="alert" class="text-destructive text-xs">{form.message}</p>
-          {/if}
-
-          {#if form?.revoked}
-            <p role="status" class="text-muted-foreground text-xs">
-              Revoked. It now answers like a link that never existed.
-            </p>
-          {/if}
-
-          {#if form?.url}
-            <label class="flex flex-col gap-1 text-xs">
-              <span>Copy it now — it is shown once.</span>
-              <input
-                readonly
-                value={form.url}
-                onfocus={(e) => e.currentTarget.select()}
-                class="border-border bg-background w-full rounded-md border px-2 py-1 font-mono text-xs"
-              />
-            </label>
-          {/if}
-
-          {#if data.liveShares.length > 0}
-            <ul class="flex flex-col gap-1 text-xs">
-              {#each data.liveShares as share (share.id)}
-                <li class="flex items-center justify-between gap-2">
-                  <span class="text-muted-foreground"
-                    >Link of {new Date(share.created_at).toLocaleDateString()}</span
-                  >
-                  <form method="POST" action="?/revoke">
-                    <input type="hidden" name="id" value={share.id} />
-                    <button type="submit" class="text-destructive underline underline-offset-4"
-                      >Revoke</button
-                    >
-                  </form>
-                </li>
-              {/each}
-            </ul>
-          {/if}
-        </div>
-      </details>
-    </header>
-
-    <section aria-label="To do" class="flex flex-col gap-2">
-      {#if data.todos.length === 0}
-        <p class="text-muted-foreground text-sm">Nothing needs you right now.</p>
-      {:else}
-        {#each data.todos as todo (todo.id)}
-          <article
-            class="border-border bg-card flex flex-wrap items-center justify-between gap-3 rounded-xl border px-4 py-3"
-          >
-            <div class="flex min-w-0 flex-col">
-              <p class="font-medium">{todo.title}</p>
-              <p class="text-muted-foreground text-sm">{todo.detail}</p>
-            </div>
-            {#if todo.action}
-              <a
-                href={todo.action.href}
-                class="border-border hover:bg-muted focus-visible:ring-ring/50 flex-none rounded-lg border px-3 py-1.5 text-sm focus-visible:ring-3 focus-visible:outline-none"
-                >{todo.action.label}</a
-              >
-            {/if}
-          </article>
-        {/each}
-      {/if}
-    </section>
-
-    <section aria-labelledby="next-out" class="flex flex-col gap-2">
-      <h2 id="next-out" class="text-muted-foreground text-sm">Next out</h2>
-
-      {#if data.upcoming.length === 0}
-        <p class="text-muted-foreground text-sm">Nothing dated ahead.</p>
-      {:else}
-        <ul class="divide-border flex flex-col divide-y">
-          {#each data.upcoming as row (row.id)}
-            <li>
-              <a
-                href="/v2/{data.slug}/posts?post={row.id}"
-                class="hover:bg-muted focus-visible:ring-ring/50 flex flex-wrap items-baseline gap-x-3 gap-y-1 rounded-md px-1 py-2 text-sm focus-visible:ring-3 focus-visible:outline-none"
-              >
-                <span class="text-muted-foreground w-16 flex-none">{row.day}</span>
-                <span class="text-muted-foreground w-20 flex-none truncate text-xs"
-                  >{row.platform}</span
+        {#if data.liveShares.length > 0}
+          <ul class="flex flex-col gap-1 text-xs">
+            {#each data.liveShares as share (share.id)}
+              <li class="flex items-center justify-between gap-2">
+                <span class="text-muted-foreground"
+                  >Link of {new Date(share.created_at).toLocaleDateString()}</span
                 >
-                <span class="min-w-0 flex-1 truncate font-medium">{row.title}</span>
-                <Badge variant={row.state.tone}>{row.state.label}</Badge>
-              </a>
-            </li>
-          {/each}
-        </ul>
-      {/if}
-    </section>
+                <form method="POST" action="?/revoke">
+                  <input type="hidden" name="id" value={share.id} />
+                  <button type="submit" class="text-destructive underline underline-offset-4"
+                    >Revoke</button
+                  >
+                </form>
+              </li>
+            {/each}
+          </ul>
+        {/if}
+      </div>
+    </details>
+  </header>
 
-    <section aria-label="Numbers" class="flex flex-wrap gap-3">
-      {#each TILES as tile (tile.label)}
-        <div
-          class="border-border bg-card flex min-w-36 flex-1 flex-col gap-1 rounded-xl border px-4 py-3"
+  <section aria-label="To do" class="flex flex-col gap-2">
+    {#if data.todos.length === 0}
+      <p class="text-muted-foreground text-sm">Nothing needs you right now.</p>
+    {:else}
+      {#each data.todos as todo (todo.id)}
+        <article
+          class="border-border bg-card flex flex-wrap items-center justify-between gap-3 rounded-xl border px-4 py-3"
         >
-          <span class="text-muted-foreground text-xs">{tile.label}</span>
-          <span class="text-2xl font-semibold">{tile.value}</span>
-        </div>
+          <div class="flex min-w-0 flex-col">
+            <p class="font-medium">{todo.title}</p>
+            <p class="text-muted-foreground text-sm">{todo.detail}</p>
+          </div>
+          {#if todo.action}
+            <a
+              href={todo.action.href}
+              class="border-border hover:bg-muted focus-visible:ring-ring/50 flex-none rounded-lg border px-3 py-1.5 text-sm focus-visible:ring-3 focus-visible:outline-none"
+              >{todo.action.label}</a
+            >
+          {/if}
+        </article>
       {/each}
-    </section>
+    {/if}
+  </section>
 
-    <p class="text-muted-foreground text-xs">Times shown in {brand.timezone}</p>
-  </main>
-</div>
+  <section aria-labelledby="next-out" class="flex flex-col gap-2">
+    <h2 id="next-out" class="text-muted-foreground text-sm">Next out</h2>
+
+    {#if data.upcoming.length === 0}
+      <p class="text-muted-foreground text-sm">Nothing dated ahead.</p>
+    {:else}
+      <ul class="divide-border flex flex-col divide-y">
+        {#each data.upcoming as row (row.id)}
+          <li>
+            <a
+              href="/v2/{data.slug}/posts?post={row.id}"
+              class="hover:bg-muted focus-visible:ring-ring/50 flex flex-wrap items-baseline gap-x-3 gap-y-1 rounded-md px-1 py-2 text-sm focus-visible:ring-3 focus-visible:outline-none"
+            >
+              <span class="text-muted-foreground w-16 flex-none">{row.day}</span>
+              <span class="text-muted-foreground w-20 flex-none truncate text-xs"
+                >{row.platform}</span
+              >
+              <span class="min-w-0 flex-1 truncate font-medium">{row.title}</span>
+              <Badge variant={row.state.tone}>{row.state.label}</Badge>
+            </a>
+          </li>
+        {/each}
+      </ul>
+    {/if}
+  </section>
+
+  <section aria-label="Numbers" class="flex flex-wrap gap-3">
+    {#each TILES as tile (tile.label)}
+      <div
+        class="border-border bg-card flex min-w-36 flex-1 flex-col gap-1 rounded-xl border px-4 py-3"
+      >
+        <span class="text-muted-foreground text-xs">{tile.label}</span>
+        <span class="text-2xl font-semibold">{tile.value}</span>
+      </div>
+    {/each}
+  </section>
+
+  <p class="text-muted-foreground text-xs">Times shown in {brand.timezone}</p>
+</main>

--- a/src/routes/v2/[brand]/calendar/+page.svelte
+++ b/src/routes/v2/[brand]/calendar/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import '$lib/styles/tailwind.css';
   import { goto } from '$app/navigation';
   import { page } from '$app/state';
   import { Badge } from '$lib/components/ui/badge/index.js';

--- a/src/routes/v2/[brand]/materials/+page.svelte
+++ b/src/routes/v2/[brand]/materials/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import '$lib/styles/tailwind.css';
   import { replaceState } from '$app/navigation';
   import { page } from '$app/state';
   import { Badge } from '$lib/components/ui/badge/index.js';

--- a/src/routes/v2/[brand]/nav.test.ts
+++ b/src/routes/v2/[brand]/nav.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { existsSync } from 'node:fs';
+import { NAV_PATHS, navFor } from './nav';
+
+const nav = (pathname: string, pending = 0) => navFor('demo', pathname, pending);
+const labels = (pathname: string) => nav(pathname).map((item) => item.label);
+const current = (pathname: string) => nav(pathname).filter((i) => i.current).map((i) => i.label);
+
+describe('la barra laterale', () => {
+  it('ha le cinque voci del mockup, e una sola per il calendario', () => {
+    expect(labels('/v2/demo')).toEqual(['Home', 'Materials', 'Strategy', 'Calendar', 'Results']);
+  });
+
+  it('non porta a una pagina che non esiste', () => {
+    expect(NAV_PATHS.length).toBe(5);
+
+    for (const path of NAV_PATHS) {
+      expect(`${path} → +page.svelte`).toBe(
+        existsSync(`src/routes/v2/[brand]${path}/+page.svelte`)
+          ? `${path} → +page.svelte`
+          : `${path} → 404`
+      );
+    }
+  });
+
+  it('accende la voce della pagina aperta', () => {
+    expect(current('/v2/demo/calendar')).toEqual(['Calendar']);
+    expect(current('/v2/demo/materials')).toEqual(['Materials']);
+  });
+
+  it('accende Home solo sulla home', () => {
+    expect(current('/v2/demo')).toEqual(['Home']);
+    expect(current('/v2/demo/results')).toEqual(['Results']);
+  });
+
+  it('non confonde una rotta che comincia allo stesso modo', () => {
+    expect(current('/v2/demo/calendar-archive')).toEqual([]);
+  });
+
+  it('mette il conteggio da approvare solo sul calendario', () => {
+    const badges = nav('/v2/demo', 4).map((item) => [item.label, item.badge]);
+
+    expect(badges).toEqual([
+      ['Home', 0],
+      ['Materials', 0],
+      ['Strategy', 0],
+      ['Calendar', 4],
+      ['Results', 0]
+    ]);
+  });
+});

--- a/src/routes/v2/[brand]/nav.ts
+++ b/src/routes/v2/[brand]/nav.ts
@@ -1,0 +1,30 @@
+const CALENDAR = '/calendar';
+
+// L'ordine del mockup. Una voce entra qui il giorno che la sua pagina esiste: un link che dà 404
+// è peggio di una superficie che manca, perché la fa sembrare rotta invece che non ancora scritta.
+const NAV = [
+  { label: 'Home', path: '' },
+  { label: 'Materials', path: '/materials' },
+  { label: 'Strategy', path: '/strategy' },
+  { label: 'Calendar', path: CALENDAR },
+  { label: 'Results', path: '/results' }
+];
+
+export const NAV_PATHS = NAV.map((item) => item.path);
+
+export type NavEntry = { label: string; href: string; badge: number; current: boolean };
+
+export function navFor(slug: string, pathname: string, pending: number): NavEntry[] {
+  const base = `/v2/${slug}`;
+
+  return NAV.map(({ label, path }) => {
+    const href = `${base}${path}`;
+
+    return {
+      label,
+      href,
+      badge: path === CALENDAR ? pending : 0,
+      current: path ? pathname === href || pathname.startsWith(`${href}/`) : pathname === base
+    };
+  });
+}

--- a/src/routes/v2/[brand]/results/+page.svelte
+++ b/src/routes/v2/[brand]/results/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import '$lib/styles/tailwind.css';
   import { Badge } from '$lib/components/ui/badge/index.js';
   import { METRIC_LABELS, compact, reachOf } from './tally';
   import type { TopPost } from './tally';

--- a/src/routes/v2/[brand]/strategy/+page.svelte
+++ b/src/routes/v2/[brand]/strategy/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import '$lib/styles/tailwind.css';
   import { Badge } from '$lib/components/ui/badge/index.js';
   import { listOf, pairsOf, platformsOf, stateOf, textOf, weeksOf } from './plan-shape';
   import type { PageProps } from './$types';


### PR DESCRIPTION
## What?

`/v2/[brand]` had five surfaces and nothing holding them together. This adds the shell:

- **`+layout.svelte`** — the sidebar from the mockup, moved out of the dashboard page where it lived, so every v2 surface now has it. `+layout.server.ts` reads the brand name and the pending count from `/api/v1/brands/:slug`.
- **Five entries, all live** — Home, Materials, Strategy, Calendar, Results. `Posts` is gone (since #259 it is a redirect to `calendar?view=list`, so it was a second entry for the same page), and the three rows that were drawn spent because their pages did not exist are now links, because the pages exist.
- **A way in** — one entry at the tail of the old `/app` sidebar: `New interface · preview`.

## Why?

Every page redrawing its own surroundings is the reason `/v2` cannot replace `/app`: from the calendar there was no way back to the dashboard, and from anywhere in the product there was no way to `/v2` at all except typing the URL. A surface nobody can reach gets no feedback, and a surface with no feedback does not get finished.

## How?

**Three commits, and the middle one is the point.** The move is `78654cd` — same entries, same hrefs, nothing else; the existing 106 v2 tests are green before and after. The change is `1f451af` — the entry list, and nothing moved. In this repo one commit moves without changing and another changes without moving, and here it paid: the only thing the move could not carry over was the active entry, which the dashboard hardcoded as "Home" and a layout has to read from the `pathname`.

**The nav is data, in `nav.ts`, so a test can hold the rule.** The spent rows carried a comment saying a link that 404s is worse than a row that is off. `nav.test.ts` says the same thing as a test that fails: every path in the nav must have a `+page.svelte`. That is what would have caught `/posts`, which has only a `+server.ts`. The scan asserts `NAV_PATHS.length` first, so a nav that scanned nothing fails instead of passing.

**The entry point is in the old sidebar, not a `/v2` redirect.** Both were on the table. `/v2` without a brand resolving through `LAST_BRAND_COOKIE` is one new file and touches nothing shared — but it makes an URL work that nobody would type. It solves the wrong half. The sidebar entry is two `[...groups, v2Preview]` spreads and one object in `src/routes/app/[brand]/+layout.svelte` (both the `navTeam` and the legacy branch), removable in a line, and it is the only version where somebody finds it without being told.

**It is not localised, deliberately.** The rest of that nav goes through `$_()`. `/v2` itself is English-only hardcoded, and adding a key to four locale catalogues to label a preview would make it look finished. The label says `preview`. When `/v2` replaces this shell, the shell goes and the entry goes with it.

**Constraints held**: no domain logic in the shell (it reads `/api/v1/brands/:slug` and renders), no client state (active entry and view come from the URL), no chat and no link to it, flex only — never Tailwind's `grid`, which `app.css` hijacks globally. No new dependency, no `shadcn-svelte add`: `Badge` was already imported by the page the sidebar came from. `$lib/styles/tailwind.css` is now imported once by the shell instead of by each of the five pages.

**No modal pages in the new shell, and that is a decision, not an omission.** The layout hosts the sidebar and the content at **full width**; every surface is its own route with its own shareable URL. Nothing under `src/routes/v2` imports `PageModal` or opens a page inside a window, and nothing should: the old shell's modal system — `workbench-paths.ts`, `BRAND_MODAL_ROUTES`, the sixteen files that read it — dies with `/app` and does not follow.

The one thing that is not a page is the post detail: `?post=<id>` on the calendar opens `PostPanel` as a right-hand `Sheet`, which Andrea asked for by name. The line to hold is the difference between the two — that is a **detail panel inside the page that governs it**, with its state in the URL and the back button closing it, not a whole page served in a window. Materials has the same shape at `?item=<id>`.

## Testing?

**Verification in a browser is deferred — it was not done, and nothing below stands in for it.** No dev server, no Docker, no Playwright, no screenshot. The layout renders on every v2 page and its visual behaviour (the sidebar on a narrow viewport, the active entry after a client-side navigation, the pending badge) has not been looked at by a human or a browser. That check is still owed.

What did run, with real numbers:

```
node scripts/typecheck-runtime.mjs   → ok (308 pre-existing non-fatal errors, 0 in the touched files)
npx vitest run "src/routes/v2"       → 8 files, 112 tests passed
npx vitest run src/lib/content/changelog → 3 tests passed
npx vitest run "src/routes/app/[brand]/home-redirect.test.ts" → 6 tests passed
npx vitest run $(git grep -ln "readFileSync" -- 'src/**/*.test.ts')  → 69 files, 957 tests passed
```

The last one is the one that matters for a PR that moves files: 69 test files assert on the text of a file at a path, and a moved file is exactly how they go red.

`npm run test:unit` in full was **not** run (it costs the machine, and CI runs it).

The new test was watched fail before it passed, on the property and not on a missing import:

```
 ❯ src/routes/v2/[brand]/nav.test.ts (6 tests | 3 failed)
   × ha le cinque voci del mockup, e una sola per il calendario
     → expected [ 'Home', 'Materials', …(4) ] to deeply equal [ 'Home', 'Materials', …(3) ]
         "Calendar",
       + "Posts",
         "Results",
   × non porta a una pagina che non esiste
     → expected 6 to be 5
   × mette il conteggio da approvare solo sul calendario
```

## Evidence

None. There are no screenshots because the app was not started — see **Testing?**. The evidence this PR can offer is the test output above, and it is not a substitute for looking at the page.

## Anything Else?

**Known debt, not introduced here and not fixed here.** The root `+layout.svelte` is global and a route cannot refuse it: svelte-i18n, analytics, the cookie banner and the entry shimmer load on `/v2` too, which uses none of the four. It is initial JavaScript paid on every page of the surface that exists to be light. It is its own piece of work; this PR does not make it worse.

**One extra request on first load.** `+layout.server.ts` calls `/api/v1/brands/:slug`, which the dashboard and the calendar's list view already call. Client-side navigation does not repeat it (the load depends on `params.brand`, which does not change inside a brand). Removing it would mean pages reading the layout's data through `await parent()` and being tied to the shell — not for one request.

**What `/v2` still lacks before it can replace `/app`**, none of it in scope here: no brand switcher and no way out of the brand (the shell knows one brand and has no route back to a brand list), no settings or connectors surface, no account or sign-out, no error or 404 page of its own (it falls back to the app-wide one, which is drawn in the old shell's language), and the dashboard still links "Next out" through `/posts?post=`, which works only because #259 left the redirect in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY

