### PR TITLE
Correct the stale test count and record the local-red lesson

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,7 +193,8 @@ no stories.
 
 ## Agent evaluation, before anything that matters (a rule, not a habit)
 
-Unit tests (5200, all green) verify that the **code is well built**. They have never prevented a
+Unit tests (~7.000, green in CI — check the CI log before believing a local red: see
+LESSONS.md) verify that the **code is well built**. They have never prevented a
 single quality defect, because they run on a fake model and a fake database: brand context
 arrived empty, attachments were rejected by a constraint, the model resolved to the wrong one,
 and a read crossed every brand of the user — **green suite for everyone**.

--- a/LESSONS.md
+++ b/LESSONS.md
@@ -33,6 +33,14 @@ LOGICA con i test (il caricamento si mocka) e nel browser verifica quello che il
 ### Il worktree nuovo ha bisogno di `npm ci` — e ancora dopo ogni rebase su dev
 Un worktree parte senza `node_modules`, e `vite.config.ts` muore subito (`Cannot find package '@sentry/sveltekit'`). Ma il caso insidioso è l'altro: dopo aver ribasato su dev che ha accolto PR nuove, il `node_modules` installato col vecchio lockfile produce guasti **deterministici e fuori posto** — v. `extractUserText is not a function` in un test di immagini: il codice era giusto, le dipendenze vecchie. Segnale: un errore `X is not a function` su codice mai toccato, in un worktree ribasato. Mossa: `npm ci` nel worktree, sempre, dopo il rebase.
 
+**E prima di credere a un rosso locale, guarda la CI.** Lo stesso `extractUserText`/
+`extractUserImages` è tornato il 4/9 su `dev`: quei simboli non erano codice nostro ma una patch
+`patch-package`, tolta perché non applicava più alla versione installata. In locale i test
+falliscono davvero; **sulla CI passano** (verificato nel log della run, non dedotto). Segnale: un
+rosso locale su file che nessuna PR ha toccato, mentre la CI è verde. Mossa: leggere il log della
+CI PRIMA di cancellare il test — il soggetto è vivo, è l'installazione locale a essere fuori
+posto, e cancellarlo butta via copertura che funziona.
+
 ### Il worktree nuovo ha bisogno anche del `.env`
 Dopo il `npm ci` la suite parte ma cade su 40+ test con `SUPABASE_SERVICE_ROLE_KEY not configured`: Vitest carica l'env dal `.env` del worktree, che non c'è. Segnale: errori di env mancante in un worktree fresco, deterministici, su file che passano nel checkout principale. Mossa: `cp ../anomalia/.env .` alla creazione del worktree, accanto al `npm ci`.
 

--- a/changelog/2026-09-04-conta-test-scaduta.md
+++ b/changelog/2026-09-04-conta-test-scaduta.md
@@ -1,0 +1,22 @@
+# La conta dei test in CLAUDE.md era ferma a 5200
+
+Sono ~7.000. Una cifra che nessuno aggiorna smette di essere un'informazione: chi la legge non
+sa più se il numero descrive la suite o l'anno scorso.
+
+## E il rosso locale che non è un rosso
+
+Nello stesso conteggio sono emersi 13 test rossi in locale su `dev` — `hooks.server`, e tre file
+sotto `src/lib/agent/bridge/` con `extractUserText is not a function`, `extractUserImages is not
+a function`, `Invalid URL`. Sembravano il segno di uno smantellamento che aveva cancellato
+qualcosa di vivo.
+
+Non lo erano. Quei simboli non sono codice nostro: arrivavano da una patch `patch-package` su
+`@ai-sdk/harness-pi`, rimossa perché non applicava più alla versione installata (v.
+`2026-09-04-patch-scadute.md`). In locale l'installazione non li ha; **sulla CI quei due file
+passano** — `pi-stream.test.ts` ✓ 4 test, `harness-pi-images.test.ts` ✓ 5 test, suite a 7.028
+passati e zero falliti. `hooks.server.test.ts` passa anche in locale, da solo: era interferenza
+fra test in parallelo.
+
+Cancellare quei test perché rossi in locale avrebbe buttato via copertura funzionante. La lezione
+— guardare la CI prima di credere a un rosso locale — è finita in `LESSONS.md`, accanto a quella
+sul `node_modules` stantio che nomina già gli stessi simboli e che da sola non è bastata.


### PR DESCRIPTION
## What?

Two lines of documentation, and the reason they matter.

`CLAUDE.md` claimed **"Unit tests (5200, all green)"**. There are about **7,000**. The line now says so, and points at the CI log rather than a local run.

`LESSONS.md` gains the discriminator that was missing: **check CI before believing a local red.**

## Why?

A stale count is not a small thing here: it is the sentence an agent reads to decide whether the suite is trustworthy. Nobody had updated it, so it had stopped being information.

The prompt for this was a report of **13 red tests on `dev`** — `hooks.server.test.ts` and three files under `src/lib/agent/bridge/` failing with `extractUserText is not a function`, `extractUserImages is not a function` and `Invalid URL`. The shape said "the chat teardown deleted something live, and only a test noticed".

**It did not.** The investigation, in order:

1. Those symbols are not our code. They come from `@ai-sdk/harness-pi`.
2. They never existed upstream — they were added by a `patch-package` patch (`patches/@ai-sdk+harness-pi+1.0.89.patch`), which another agent removed today because it no longer applied to the installed version (see `changelog/2026-09-04-patch-scadute.md`).
3. The locally installed build genuinely lacks them: `grep -c extractUserImages node_modules/@ai-sdk/harness-pi/dist/index.js` → `0`.
4. **On CI those same files pass.** From the PR #266 run log, not inferred:
   ```
   ✓ src/lib/agent/bridge/pi-stream.test.ts (4 tests)
   ✓ src/lib/agent/bridge/harness-pi-images.test.ts (5 tests)
   Test Files  615 passed | 3 skipped (618)
   Tests       7028 passed | 11 skipped (7039)
   ```
5. `hooks.server.test.ts` passes locally too, on its own — that one was interference between tests running in parallel.

So no code was deleted that anything still needed, and **deleting those tests because they were locally red would have thrown away coverage that CI proves works**. That is the trap worth writing down, because `LESSONS.md` already had an entry naming these exact symbols (the stale-`node_modules` one) and it was not enough on its own: it tells you to run `npm ci`, not how to tell a real red from an environmental one.

## How?

- `CLAUDE.md`: the count, plus a pointer to check the CI log before trusting a local red.
- `LESSONS.md`: a paragraph under the existing `node_modules` entry with the signal (*a local red on files no PR touched, while CI is green*) and the move (*read the CI log before deleting the test*).
- One internal changelog entry recording the diagnosis so the next person does not repeat it.

## Testing?

Documentation only — no code, no test, no behaviour changes. The evidence that mattered is the CI log quoted above.

## Evidence (screenshots/videos)

Not applicable: no UI, no runtime code.

## Anything Else?

**Worth someone's attention, but not mine to fix here:** `harness-pi-images.test.ts` and `pi-stream.test.ts` now only pass in an environment that no longer matches `patches/` and the lockfile — the patch that provided their subject is gone. They are green on CI today and genuinely red on a normal local install, which makes them a poor guard. That belongs to whoever owns the dependency cleanup that removed the patches, not to the chat teardown.

Nothing in this PR is related to the chat removal; it is opened separately so it can land on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
