### PR TITLE
Restore all three patches: they were applying all along

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -898,3 +898,26 @@ nodo**, quindi vince il layout; per la `__data.json` di una navigazione dal clie
 **il primo che rigetta**. Un rimando piazzato nella pagina chiude la risposta mentre il layout è
 ancora dentro le sue query, e il `cookies.set` del layout trova la risposta già generata. Prima di
 dichiarare ridondante una guardia, leggi quale delle due strade la esercita.
+
+## Una patch «scaduta» può esserlo solo sulla tua macchina
+
+**Segnale.** `patch-package` dice `Patch was made for version: X / Installed version: Y`, con Y più
+nuova. Sembra ovvio: la dipendenza è andata avanti, la patch è da buttare.
+
+**Cosa succede.** In questo repo ci sono due lockfile: `package-lock.json`, tracciato, che la CI usa
+con `npm ci`, e `bun.lock`, non tracciato, che vive sulla macchina di chi ha lanciato `bun install`.
+Divergono. Il primo pinnava `@ai-sdk/harness@1.0.87` — esattamente la versione della patch — mentre
+bun aveva risolto la 1.0.101. La patch era **viva per tutti tranne che lì**, e cancellarla ha fatto
+diventare rossa la CI e ha tolto due comportamenti veri: le scritture in blocco di `writeSkills`
+(6,9 secondi di attesa) e la conservazione delle parti immagine nell'adattatore pi, che senza patch
+**degrada in silenzio** invece di fallire.
+
+**Mossa.** Prima di dichiarare scaduta una patch, leggi la versione nel lockfile **tracciato**, non
+quella in `node_modules`. Se coincide con quella della patch, la patch è viva e il problema è
+l'install che hai davanti.
+
+**Corollario, e qui è il punto.** Tre errori nello stesso blocco sembravano tre conferme
+indipendenti: due dicevano «la patch non applica», il terzo «il pacchetto non c'è». Erano tre
+sintomi di **una causa sola** — l'albero di `node_modules` rotto — e nessuno dei tre parlava delle
+patch. Dopo un `npm install` pulito applicano tutte e tre. Più errori insieme invitano a
+concludere; guarda invece se hanno un antenato comune.

--- a/changelog/2026-09-04-patch-erano-vive.md
+++ b/changelog/2026-09-04-patch-erano-vive.md
@@ -1,0 +1,44 @@
+# Le patch non erano scadute: era l'install a essere sbagliato
+
+La #268 ha rimosso tutte e tre le patch sostenendo che non applicavano più. Per due su tre
+era falso, e la prova stava nel lockfile che la CI usa davvero:
+
+```
+node_modules/@ai-sdk/harness    -> 1.0.87
+node_modules/@ai-sdk/harness-pi -> 1.0.89
+```
+
+Esattamente le versioni che le patch prendono di mira. Con `npm ci` applicavano entrambe, pulite.
+
+Il `Installed version: 1.0.101` che appariva nell'errore veniva da **bun**, che risolveva versioni
+più nuove perché `bun.lock` — non tracciato — è divergente da `package-lock.json`. Una diagnosi
+fatta su un install locale e generalizzata a tutti: il sintomo era vero sulla macchina di chi
+guardava, la conclusione no.
+
+## Cosa si era perso
+
+- `@ai-sdk/harness` manda in una sola volta le scritture di `writeSkills`: quattordici file a
+  ~450ms l'uno erano 6,9 secondi prima che l'agente potesse rispondere.
+- `@ai-sdk/harness-pi` conserva le parti immagine attraverso l'adattatore pi. Senza, un `URL`
+  attraversa `Object.entries` come oggetto vuoto e viene scartato in silenzio: **il modello
+  riceve solo il testo `[attached: url]`**, e le immagini spariscono senza un errore.
+
+La seconda è la peggiore delle due, perché non fallisce: degrada.
+
+## Nemmeno la terza era morta
+
+`@earendil-works+pi-ai+0.74.2.patch` sembrava orfana: `patch-package` diceva *«Patch file found
+for package pi-ai which is not present»*, cioè il pacchetto non c'è. Non c'era **in
+quell'albero**. Dopo un `npm install` pulito `@earendil-works/pi-ai` è al suo posto, la patch
+applica, e i tre test di `pi-stream.test.ts` che senza di essa leggono `error` invece di `stop`
+tornano verdi.
+
+Tre errori diversi nello stesso blocco di output, tutti e tre prodotti dallo stesso
+`node_modules` rotto. Li ho letti come tre conferme indipendenti della stessa conclusione, e
+invece erano tre sintomi di un'unica causa che non c'entrava niente con le patch.
+
+## La lezione
+
+Quando `patch-package` si lamenta, la domanda non è «la patch è scaduta?» ma **«quale install me
+lo sta dicendo?»**. In un repo con due lockfile, uno tracciato e uno no, la risposta cambia la
+conclusione — e più errori nello stesso blocco possono avere una causa sola, a monte di tutti.

--- a/patches/@ai-sdk+harness+1.0.87.patch
+++ b/patches/@ai-sdk+harness+1.0.87.patch
@@ -1,0 +1,143 @@
+diff --git a/node_modules/@ai-sdk/harness/dist/utils/index.js b/node_modules/@ai-sdk/harness/dist/utils/index.js
+index c6dc6e3..8618175 100644
+--- a/node_modules/@ai-sdk/harness/dist/utils/index.js
++++ b/node_modules/@ai-sdk/harness/dist/utils/index.js
+@@ -548,6 +548,13 @@ async function writeSkills({
+     command: `mkdir -p ${shellQuote(rootDir)}`,
+     abortSignal
+   });
++  // anomalia: ogni writeTextFile e` un round-trip nella sandbox — due, in realta`: `mkdir -p` del
++  // padre, poi il file. In fila costavano ~450ms l'uno: 14 file = 6.9 secondi prima che la chat
++  // potesse rispondere. Qui i file partono TUTTI INSIEME, in un solo comando: le cartelle in una
++  // `mkdir -p` sola, i contenuti via base64 (nessun problema di quoting, il markdown puo`
++  // contenere qualunque cosa). Il fallback per riga esiste perche' `writeSkills` e` codice
++  // generico: una sandbox senza `base64` deve continuare a funzionare, piu` lenta ma giusta.
++  const writes = [];
+   for (const skill of skills) {
+     const name = validateSkillName({
+       name: skill.name,
+@@ -555,10 +562,9 @@ async function writeSkills({
+       message: invalidSkillNameMessage
+     });
+     const skillDir = path2.posix.join(rootDir, name);
+-    await sandbox.writeTextFile({
++    writes.push({
+       path: path2.posix.join(skillDir, "SKILL.md"),
+-      content: renderSkillFile({ skill, trailingNewline }),
+-      abortSignal
++      content: renderSkillFile({ skill, trailingNewline })
+     });
+     for (const file of (_b = skill.files) != null ? _b : []) {
+       const filePath = normalizeSkillFilePath({
+@@ -567,13 +573,108 @@ async function writeSkills({
+         mode: filePathMode,
+         message: invalidSkillFilePathMessage
+       });
+-      await sandbox.writeTextFile({
++      writes.push({
+         path: path2.posix.join(skillDir, filePath),
+-        content: file.content,
+-        abortSignal
++        content: file.content
+       });
+     }
+   }
++  const writeOneByOne = (list) =>
++    Promise.all(
++      list.map((w) => sandbox.writeTextFile({ path: w.path, content: w.content, abortSignal }))
++    );
++  if (writes.length === 0) {
++    return;
++  }
++  // Un comando solo sarebbe il minimo dei round-trip, ma bash rifiuta un argomento oltre
++  // MAX_ARG_STRLEN (128KB): «argument list too long», e si finiva nel fallback senza accorgersene.
++  // Quindi si spezza sotto quella soglia, con margine, e i pezzi partono insieme.
++  const MAX_SCRIPT_BYTES = 96 * 1024;
++  const encoded = writes.map((w) => ({
++    path: w.path,
++    content: w.content,
++    line: `printf %s ${shellQuote(Buffer.from(w.content, "utf8").toString("base64"))} | base64 -d > ${shellQuote(w.path)}`
++  }));
++  const dirs = [...new Set(writes.map((w) => path2.posix.dirname(w.path)))];
++  const chunks = [];
++  let current = [];
++  let size = 0;
++  for (const e of encoded) {
++    // Un singolo file oltre la soglia non stara` mai in un comando: va per la sua strada.
++    if (e.line.length > MAX_SCRIPT_BYTES) {
++      chunks.push([e]);
++      continue;
++    }
++    if (size + e.line.length > MAX_SCRIPT_BYTES && current.length > 0) {
++      chunks.push(current);
++      current = [];
++      size = 0;
++    }
++    current.push(e);
++    size += e.line.length + 4;
++  }
++  if (current.length > 0) {
++    chunks.push(current);
++  }
++  const runChunk = async (chunk, withDirs) => {
++    const script = [
++      ...withDirs ? [`mkdir -p ${dirs.map(shellQuote).join(" ")}`] : [],
++      ...chunk.map((e) => e.line)
++    ].join(" && ");
++    if (script.length > MAX_SCRIPT_BYTES) {
++      await writeOneByOne(chunk);
++      return;
++    }
++    try {
++      const result = await sandbox.run({ command: script, abortSignal });
++      if (result != null && typeof result === "object" && "exitCode" in result && result.exitCode !== 0) {
++        throw new Error(`writeSkills batch exited ${result.exitCode}`);
++      }
++    } catch {
++      await writeOneByOne(chunk);
++    }
++  };
++  // Le skill NON cambiano fra un turno e l'altro, e la sandbox del brand vive fra i turni:
++  // riscriverle ogni volta e` lavoro gia` fatto. Il marcatore porta l'impronta del contenuto e sta
++  // DENTRO la cartella delle skill, quindi una sandbox nuova non ce l'ha e una modifica lo
++  // invalida. Sta qui, e non nel chiamante, perche' non passare le skill all'agent le toglierebbe
++  // anche dal catalogo del modello: qui si salta la SCRITTURA, non la dichiarazione.
++  const identity = fingerprintSkillWrites(writes);
++  const markerPath = path2.posix.join(rootDir, ".harness-skills-id");
++  try {
++    const seen = await sandbox.run({
++      command: `cat ${shellQuote(markerPath)} 2>/dev/null || true`,
++      abortSignal
++    });
++    const stdout = seen != null && typeof seen === "object" && "stdout" in seen ? String(seen.stdout) : "";
++    if (stdout.trim() === identity) {
++      return;
++    }
++  } catch {
++    // Non sapere se ci sono non e` una ragione per non scriverle.
++  }
++  // Le cartelle prima, poi tutti i pezzi insieme.
++  await sandbox.run({ command: `mkdir -p ${dirs.map(shellQuote).join(" ")}`, abortSignal });
++  await Promise.all(chunks.map((chunk) => runChunk(chunk, false)));
++  // Il marcatore per ULTIMO: se una scrittura fallisce non deve restare scritto che ci sono.
++  await sandbox
++    .run({ command: `printf %s ${shellQuote(identity)} > ${shellQuote(markerPath)}`, abortSignal })
++    .catch(() => {});
++}
++function fingerprintSkillWrites(writes) {
++  const payload = writes
++    .map((w) => `${w.path}\0${w.content}`)
++    .sort()
++    .join("\0\0");
++  // FNV-1a: serve a dire "e` cambiato", non a resistere a un avversario.
++  let h1 = 2166136261;
++  let h2 = 2166136261 ^ payload.length;
++  for (let i = 0; i < payload.length; i++) {
++    const c = payload.charCodeAt(i);
++    h1 = Math.imul(h1 ^ c, 16777619);
++    h2 = Math.imul(h2 ^ (c + i), 16777619);
++  }
++  return `${(h1 >>> 0).toString(16)}${(h2 >>> 0).toString(16)}`;
+ }
+ function validateSkillName({
+   name,

--- a/patches/@ai-sdk+harness-pi+1.0.89.patch
+++ b/patches/@ai-sdk+harness-pi+1.0.89.patch
@@ -1,0 +1,149 @@
+diff --git a/node_modules/@ai-sdk/harness-pi/dist/index.js b/node_modules/@ai-sdk/harness-pi/dist/index.js
+index 258bb62..f47ea6a 100644
+--- a/node_modules/@ai-sdk/harness-pi/dist/index.js
++++ b/node_modules/@ai-sdk/harness-pi/dist/index.js
+@@ -967,16 +967,60 @@ function extractUserText(prompt) {
+   }
+   const parts = [];
+   for (const part of content) {
+-    if (part.type !== "text") {
+-      throw new HarnessCapabilityUnsupportedError({
+-        message: `pi: only text user-message parts are supported; got '${part.type}'.`,
+-        harnessId: HARNESS_ID
+-      });
++    if (part.type === "text") {
++      parts.push(part.text);
+     }
+-    parts.push(part.text);
+   }
+   return parts.join("\n\n");
+ }
++const MAX_USER_IMAGES = 8;
++async function toImageContent(image, mediaType) {
++  if (typeof image === "string") {
++    if (image.startsWith("data:")) {
++      const comma = image.indexOf(",");
++      if (comma < 0) return null;
++      const header = image.slice(5, comma);
++      return {
++        type: "image",
++        data: image.slice(comma + 1),
++        mimeType: mediaType || header.split(";")[0] || "image/png"
++      };
++    }
++    if (!/^https?:\/\//i.test(image)) return null;
++    const res = await fetch(image, { signal: AbortSignal.timeout(15e3) });
++    if (!res.ok) return null;
++    const buf = await res.arrayBuffer();
++    return {
++      type: "image",
++      data: Buffer.from(buf).toString("base64"),
++      mimeType: mediaType || res.headers.get("content-type")?.split(";")[0] || "image/png"
++    };
++  }
++  if (image instanceof Uint8Array) {
++    return {
++      type: "image",
++      data: Buffer.from(image).toString("base64"),
++      mimeType: mediaType || "image/png"
++    };
++  }
++  if (image instanceof URL) {
++    return toImageContent(image.toString(), mediaType);
++  }
++  return null;
++}
++async function extractUserImages(prompt) {
++  if (typeof prompt === "string") return [];
++  const { content } = prompt;
++  if (typeof content === "string") return [];
++  const images = [];
++  for (const part of content) {
++    if (images.length >= MAX_USER_IMAGES) break;
++    if (part.type !== "image") continue;
++    const img = await toImageContent(part.image, part.mediaType);
++    if (img) images.push(img);
++  }
++  return images;
++}
+ function serializeToolOutput(output) {
+   if (typeof output === "string") {
+     return output;
+@@ -1060,6 +1104,22 @@ function finishStep(state) {
+     }
+   ];
+ }
++function closeOpenStepForTerminal(state) {
++  if (!state.stepOpen) return [];
++  state.stepOpen = false;
++  state.pendingStepToolCallIds.clear();
++  return [
++    {
++      type: "finish-step",
++      finishReason: { unified: "other", raw: void 0 },
++      usage: {
++        inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
++        outputTokens: { total: 0, text: 0, reasoning: 0 }
++      },
++      harnessMetadata: { pi: { inferredStep: true } }
++    }
++  ];
++}
+ function finishPiApprovalStep(state, toolCallId) {
+   state.stepOpen = true;
+   state.pendingStepToolCallIds.delete(toolCallId);
+@@ -2407,6 +2467,7 @@ async function createPiSession(input) {
+     if (stopped) {
+       throw new Error("Pi session has been stopped.");
+     }
++    const userImages = turnOpts.images?.length ? turnOpts.images : void 0;
+     const userTools = turnOpts.tools;
+     currentEmit = turnOpts.emit;
+     const turnAbortController = new AbortController();
+@@ -2483,7 +2544,7 @@ async function createPiSession(input) {
+           }
+         });
+         try {
+-          await session.prompt(turnOpts.text);
++          await session.prompt(turnOpts.text, userImages ? { images: userImages } : void 0);
+           if (terminalError) {
+             if (suspending && isAbortError(terminalError)) return;
+             currentEmit?.({ type: "error", error: new Error(terminalError) });
+@@ -2507,6 +2568,9 @@ async function createPiSession(input) {
+               reasoning: void 0
+             }
+           };
++          for (const part of closeOpenStepForTerminal(translatorState)) {
++            currentEmit?.(part);
++          }
+           currentEmit?.({
+             type: "finish",
+             finishReason,
+@@ -2514,6 +2578,9 @@ async function createPiSession(input) {
+           });
+         } catch (err) {
+           if (suspending && isAbortError(err)) return;
++          for (const part of closeOpenStepForTerminal(translatorState)) {
++            currentEmit?.(part);
++          }
+           currentEmit?.({ type: "error", error: err });
+         } finally {
+           unsubErr();
+@@ -2593,6 +2660,7 @@ async function createPiSession(input) {
+       }
+       return runTurn({
+         text: extractUserText(promptOpts.prompt),
++        images: await extractUserImages(promptOpts.prompt),
+         tools: promptOpts.tools ?? [],
+         instructions: promptOpts.instructions,
+         emit: promptOpts.emit,
+@@ -3079,6 +3147,8 @@ var pi = createPi();
+ export {
+   VERSION,
+   createPi,
++  extractUserText,
++  extractUserImages,
+   pi
+ };
+ //# sourceMappingURL=index.js.map
+\ No newline at end of file

--- a/patches/@earendil-works+pi-ai+0.74.2.patch
+++ b/patches/@earendil-works+pi-ai+0.74.2.patch
@@ -1,0 +1,47 @@
+diff --git a/node_modules/@earendil-works/pi-ai/dist/providers/openai-completions.js b/node_modules/@earendil-works/pi-ai/dist/providers/openai-completions.js
+index 4f2e1d5..8f81d10 100644
+--- a/node_modules/@earendil-works/pi-ai/dist/providers/openai-completions.js
++++ b/node_modules/@earendil-works/pi-ai/dist/providers/openai-completions.js
+@@ -305,9 +305,12 @@ export const streamOpenAICompletions = (model, context, options) => {
+             if (output.stopReason === "error") {
+                 throw new Error(output.errorMessage || "Provider returned an error stop reason");
+             }
+-            if (!hasFinishReason) {
++            if (!hasFinishReason && output.content.length === 0 && compat.supportsFinishReason !== false) {
+                 throw new Error("Stream ended without finish_reason");
+             }
++            if (!hasFinishReason) {
++                output.stopReason = output.content.some((block) => block.type === "toolCall") ? "toolUse" : "stop";
++            }
+             stream.push({ type: "done", reason: output.stopReason, message: output });
+             stream.end();
+         }
+@@ -888,6 +891,7 @@ function detectCompat(model) {
+         supportsDeveloperRole: !isNonStandard,
+         supportsReasoningEffort: !isGrok && !isZai && !isMoonshot && !isTogether && !isCloudflareAiGateway,
+         supportsUsageInStreaming: true,
++        supportsFinishReason: !(provider === "openrouter" || baseUrl.includes("openrouter.ai")),
+         maxTokensField: useMaxTokens ? "max_tokens" : "max_completion_tokens",
+         requiresToolResultName: false,
+         requiresAssistantAfterToolResult: false,
+@@ -924,6 +928,7 @@ function getCompat(model) {
+         supportsDeveloperRole: model.compat.supportsDeveloperRole ?? detected.supportsDeveloperRole,
+         supportsReasoningEffort: model.compat.supportsReasoningEffort ?? detected.supportsReasoningEffort,
+         supportsUsageInStreaming: model.compat.supportsUsageInStreaming ?? detected.supportsUsageInStreaming,
++        supportsFinishReason: model.compat.supportsFinishReason ?? detected.supportsFinishReason,
+         maxTokensField: model.compat.maxTokensField ?? detected.maxTokensField,
+         requiresToolResultName: model.compat.requiresToolResultName ?? detected.requiresToolResultName,
+         requiresAssistantAfterToolResult: model.compat.requiresAssistantAfterToolResult ?? detected.requiresAssistantAfterToolResult,
+diff --git a/node_modules/@earendil-works/pi-ai/dist/types.d.ts b/node_modules/@earendil-works/pi-ai/dist/types.d.ts
+index 4527475..7cd1c1f 100644
+--- a/node_modules/@earendil-works/pi-ai/dist/types.d.ts
++++ b/node_modules/@earendil-works/pi-ai/dist/types.d.ts
+@@ -313,6 +313,8 @@ export interface OpenAICompletionsCompat {
+     supportsReasoningEffort?: boolean;
+     /** Whether the provider supports `stream_options: { include_usage: true }` for token usage in streaming responses. Default: true. */
+     supportsUsageInStreaming?: boolean;
++    /** Whether streamed responses include `finish_reason`. Default: true. */
++    supportsFinishReason?: boolean;
+     /** Which field to use for max tokens. Default: auto-detected from URL. */
+     maxTokensField?: "max_completion_tokens" | "max_tokens";
+     /** Whether tool results require the `name` field. Default: auto-detected from URL. */


### PR DESCRIPTION
## What?

Restores every file PR #268 deleted from `patches/`. All three apply cleanly and the nine bridge tests that depend on them pass.

## Why?

#268 is mine, it is merged, **its CI check is `FAILURE`, and its reasoning was wrong on all three counts.**

The argument was that `patch-package` reported a newer installed version than each patch targets, so the patches were stale. The versions CI actually installs say otherwise:

```
package-lock.json:
  node_modules/@ai-sdk/harness    -> 1.0.87
  node_modules/@ai-sdk/harness-pi -> 1.0.89
```

Exactly the versions the patches target. The `Installed version: 1.0.101` in the error came from **bun**, resolving past the untracked `bun.lock`, which has drifted from the tracked `package-lock.json`. The symptom was real on one machine; the conclusion was not.

The third patch looked different and was not: `Patch file found for package pi-ai which is not present` means the package was missing **from that tree**. After a clean `npm install`, `@earendil-works/pi-ai` is there and the patch applies.

Three errors in one block read as three independent confirmations. They were three symptoms of one cause — a broken `node_modules` — and none of them was about patches.

## What the deletion cost

- **`@ai-sdk/harness`** — `writeSkills` sent fourteen sandbox writes one at a time, ~450ms each: 6.9 seconds of silence before an agent could answer. The patch batches them.
- **`@ai-sdk/harness-pi`** — image parts survive the pi adapter. Without it a `URL` crosses `Object.entries` as an empty object and is dropped silently: the model receives only the text `[attached: url]`. **This one degrades instead of failing**, which is why nothing caught it.
- **`@earendil-works/pi-ai`** — a completed OpenRouter stream that omits `finish_reason` reads as `error` instead of `stop`.

## How?

The three files come back exactly as they were, taken from the commit before #268's merge. No `package.json` change.

The `changelog/` entry and the `LESSONS.md` addition record the discriminator, because the next person will see the same output: **when patch-package complains, the question is not "is the patch stale?" but "which install is telling me?"** — and, in a repo carrying one tracked lockfile and one untracked, several errors at once may share an ancestor rather than confirm each other.

## Testing?

Red first, on `dev` as it stands today:

```
 Test Files  1 failed | 1 passed (2)
      Tests  3 failed | 6 passed (9)
  × accepts a completed response whose provider omits finish_reason
    → expected 'error' to be 'stop'
```

Green with the patches restored:

```
$ npx patch-package
@ai-sdk/harness@1.0.87 ✔
@ai-sdk/harness-pi@1.0.89 ✔
@earendil-works/pi-ai@0.74.2 ✔

$ npx vitest run src/lib/agent/bridge/harness-pi-images.test.ts src/lib/agent/bridge/pi-stream.test.ts
 Test Files  2 passed (2)
      Tests  9 passed (9)
```

Full suite delegated to CI, which is the environment whose install was the point all along.

## Evidence

`#268` merged with `test=FAILURE`. That is the whole evidence, and it should have blocked the merge.

## Anything Else?

Two things worth carrying:

The `bun.lock` in this repo is untracked and has drifted from `package-lock.json`. Anyone running `bun install` gets a different dependency tree from CI, and today that difference produced a confident, wrong diagnosis plus a merged PR that broke the build. Either track it and keep the two in step, or stop using it here.

And the `harness-pi` patch is the kind of guard worth naming: without it nothing errors, images just quietly stop reaching the model. A test is the only thing standing between that and a silent regression, which is exactly why deleting the patch did not look dangerous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY