### PR TITLE
Let an agent choose which model draws and which one films

### DIFF
--- a/changelog/2026-09-04-agent-media-models.md
+++ b/changelog/2026-09-04-agent-media-models.md
@@ -1,0 +1,98 @@
+# I modelli media si scelgono da fuori, e la scelta viene validata
+
+Anomalia sta diventando un'interfaccia headless per agenti esterni. Le impostazioni erano
+l'ultimo pezzo che imponeva il browser: un cliente che voleva cambiare il modello con cui si
+generano le immagini doveva aprire una pagina. Ora può dirlo al proprio agente.
+
+Due tool nuovi, generati dal registry (`get_media_models`, `set_media_model`), su
+`GET`/`PUT /api/v1/brands/:slug/settings/models`. `tools/list` passa da **95 a 97**, e il diff è
+solo additivo: nessun tool esistente cambia titolo, descrizione o annotazioni.
+
+## Perché una coppia e non solo la scrittura
+
+I modelli disponibili non sono una lista fissa: per **immagini** vengono da
+`IMAGE_MODEL_CHOICES` (`src/lib/image-models.ts`), per i **video** da `videoModelsForRole`
+(`src/lib/video-models.ts`), e cambiano per mestiere. Aleph riscrive una clip e non ne genera
+una; Kling V3 Turbo anima una foto e non parte dal testo. Un tool che accetta una stringa libera
+lascia l'agente salvare un modello che quel mestiere non fa, e il guasto si scopre al primo
+render fallito — lontano da dove è stato causato.
+
+La lettura serve a **scegliere**: per ogni mestiere torna la scelta corrente e gli id ammessi.
+Ma la validazione sta nella **scrittura**, perché è l'unico punto che non si può saltare: un
+agente esterno può chiamare `PUT` senza aver letto niente, e in quel caso risponde
+`model_not_for_slot` (400) con l'elenco `allowed` di ciò che sarebbe passato. Niente viene
+salvato.
+
+`slot` è uno `z.enum` a compile time — i sei mestieri sono una tabella scritta a mano e stabile.
+`model` **non** lo è, ed è una scelta: un enum piatto di tutti gli id direbbe all'agente che
+`runway/aleph` va bene per `imageModel`, che è falso. L'insieme ammesso dipende dallo slot, e
+quella è una cosa che uno schema piatto non sa esprimere. Quindi lo dice la rotta, con la lista.
+
+## Dove è salvata la preferenza (e cosa non ha un posto)
+
+Su `brands.content_prefs`, jsonb, sotto le sei chiavi che `MEDIA_MODEL_SLOTS` già dichiara:
+`imageModel`, `imageRefineModel`, `videoModel`, `videoImageModel`, `videoRefineModel`,
+`videoMotionModel`. **Nessuna migration**: la colonna c'è dal `0011`, e i sei slot ci scrivono
+già dal browser.
+
+Il **motion video programmatico** (Remotion/TSX) è la casistica che Andrea ha nominato e che
+**non ha un posto dove salvare una preferenza**: il modello che scrive il TSX viene da
+`motionAgentModel()` → `craftAgentModel({ envModel: env.MOTION_VIDEO_MODEL })`, cioè una
+variabile d'ambiente di piattaforma o il default del catalogo chat. Non è una preferenza di
+brand, e inventarne una colonna sarebbe una decisione di prodotto travestita da endpoint —
+soprattutto in un repo dove il deploy non applica le migration. È scritto nella doc e nella
+skill, non implementato.
+
+Fuori anche `brands.chat_default_tier`: esiste come colonna e come funzione
+(`setChatDefaultTier`), ma **nessuna UI la chiama** oggi, e il catalogo chat è in mezzo allo
+smantellamento di `src/lib/server/chat/`. Esporre da qui un campo che nessuno scrive
+significherebbe congelare una forma che sta cambiando.
+
+## La regola sta in un posto solo
+
+`updateMediaModel` (l'azione del form) e la rotta `PUT` sono due chiamanti della stessa cosa: un
+modello è salvabile solo se sa fare il mestiere in cui viene salvato, e una durata che il nuovo
+modello non regge va riportata dentro il suo tetto (30s esistono su Seedance 2.5, non su Grok).
+Scritta due volte sarebbe divergente al primo modello nuovo, e la metà non aggiornata salverebbe
+preferenze che il renderer scarta.
+
+Estratta in `chooseMediaModel` (`src/lib/server/media-model-prefs.ts`): l'azione del form ora la
+chiama invece di ripetere il clamp inline, e il commento stantio che descriveva la versione a uno
+slot solo è andato via con lui.
+
+## I due elenchi che non possono divergere
+
+`packages/api-contracts` non può importare `$lib` (`packages/no-app-imports.test.ts` lo
+impedisce), quindi i sei nomi vivono anche nel contratto, come `MEDIA_MODEL_SLOT_IDS`. Un
+mestiere aggiunto di là e non di qua sarebbe modificabile dal browser e invisibile a
+`set_media_model`, in silenzio.
+
+Il guardiano è un test in `src/lib/media-model-slots.test.ts` che confronta i due elenchi. È
+stato visto fallire aggiungendo un settimo slot finto al contratto, prima di essere lasciato
+verde.
+
+## Cosa è stato visto rosso
+
+- il contratto, prima che il file esistesse;
+- `chooseMediaModel`, prima che esistesse;
+- la rotta: tolta la validazione e tolto il re-clamp, esattamente due test cadono
+  (`model_not_for_slot` e la durata) e dieci restano verdi;
+- il guardiano dei due elenchi, con un settimo slot finto;
+- **la chiave di sola lettura**: `resolveCaller` blocca ogni non-GET sul metodo, una volta, per
+  tutte le rotte. Non c'era un test. Ora c'è, e togliendo quelle quattro righe da `cli-auth.ts`
+  diventa rosso.
+
+## Cosa resta fuori, e perché
+
+- **`api-keys`** — un agente che si conia le proprie credenziali è una scala di privilegi: la
+  chiave nuova nasce con lo scope che chiede, e uno scope di scrittura ottenuto da una sessione
+  di sola lettura annulla il confine che `resolveCaller` difende.
+- **`danger`** — cancella il brand e disdice l'abbonamento Stripe. Irreversibile e senza una
+  conferma che un agente possa dare al posto di una persona.
+- **OAuth dei connettori** (`connected-accounts`, `connectors`, `search-console`, `facebook`,
+  `linkedin`) — il consenso a un provider terzo lo dà un umano su una pagina del provider. Un
+  tool può al massimo consegnare il link, mai attraversarlo. La disconnessione è l'altra metà
+  della stessa cosa e resta con lei.
+- **`billing`** — già coperto, e nel modo giusto: `create_checkout_link` e
+  `create_billing_portal_link` (PR #223) **mintano una URL e la restituiscono**. L'agente
+  consegna la porta; la persona la attraversa su Stripe.

--- a/cli/lib/contracts/index.ts
+++ b/cli/lib/contracts/index.ts
@@ -46,6 +46,7 @@ import {
 } from './reads';
 import { DIAGNOSE_BRAND, GET_GOALS } from './brand-state';
 import { DIAGNOSE_RADAR, GET_MARKET_FIELD, LIST_IDEAS } from './market';
+import { GET_MEDIA_MODELS, SET_MEDIA_MODEL } from './media-models';
 import { GEO_ACTION, REFRESH_KEYWORDS, SEO_ACTION } from './search';
 import { GET_BACKLINKS, GET_GSC, GET_RANKS } from './web-metrics';
 import {
@@ -136,6 +137,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   GET_GTM,
   GET_KEYWORDS,
   GET_MARKET_FIELD,
+  GET_MEDIA_MODELS,
   GET_PLAN,
   GET_POST,
   GET_RANKS,
@@ -164,6 +166,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   SAVE_WEEK_SEEDS,
   SEO_ACTION,
   SET_BIO,
+  SET_MEDIA_MODEL,
   SYNC_HISTORY,
   UPDATE_ARTICLE,
   UPDATE_BRAND_KIT,
@@ -241,6 +244,13 @@ export {
   GOAL_STATUSES
 } from './brand-state';
 export { DIAGNOSE_RADAR, GET_MARKET_FIELD, IDEA_STATUSES, IDEAS_DEFAULT, IDEAS_MAX, LIST_IDEAS, MARKET_FIELD_DEFAULT, MARKET_FIELD_MAX } from './market';
+export {
+  GET_MEDIA_MODELS,
+  MEDIA_MODEL_JOBS,
+  MEDIA_MODEL_SLOT_IDS,
+  SET_MEDIA_MODEL
+} from './media-models';
+export type { MediaModelSlotId } from './media-models';
 export { GEO_ACTION, REFRESH_KEYWORDS, SEO_ACTION } from './search';
 export { GET_BACKLINKS, GET_GSC, GET_RANKS } from './web-metrics';
 export {

--- a/cli/lib/contracts/media-models.ts
+++ b/cli/lib/contracts/media-models.ts
@@ -1,0 +1,93 @@
+import { z } from 'zod';
+import type { BrandEndpoint } from './index';
+
+/**
+ * I mestieri che un brand puo' affidare a modelli diversi. La tabella che li governa vive
+ * nell'app (`$lib/media-model-slots`) insieme al dialetto di ogni provider; qui stanno i soli
+ * due fatti che l'API deve dire a un agente: come si chiama lo slot, e che lavoro fa.
+ *
+ * Un test dell'app tiene i due elenchi allineati: un mestiere aggiunto di la' e non di qua
+ * sarebbe un tool che non lo sa offrire, in silenzio.
+ */
+export const MEDIA_MODEL_SLOT_IDS = [
+  'imageModel',
+  'imageRefineModel',
+  'videoModel',
+  'videoImageModel',
+  'videoRefineModel',
+  'videoMotionModel'
+] as const;
+
+export type MediaModelSlotId = (typeof MEDIA_MODEL_SLOT_IDS)[number];
+
+export const MEDIA_MODEL_JOBS: Record<MediaModelSlotId, string> = {
+  imageModel: 'Draws a post image from a prompt.',
+  imageRefineModel: 'Redraws an image that already exists, keeping what it shows.',
+  videoModel: 'Makes a clip from words alone, with no starting frame.',
+  videoImageModel: 'Animates one still that already exists, usually the rendered cover.',
+  videoRefineModel: 'Rewrites a clip that already exists, keeping its movement.',
+  videoMotionModel: 'Takes the movement from a guide video and applies it to a subject in a still.'
+};
+
+const slot = z.enum(MEDIA_MODEL_SLOT_IDS).describe('Which job the model is chosen for');
+
+const Choice = z.object({ id: z.string(), label: z.string() });
+
+export const GET_MEDIA_MODELS = {
+  tool: 'get_media_models',
+  title: 'Media models',
+  description:
+    'Which model draws and which model films for this brand, one job at a time, with the ' +
+    'models each job actually accepts. Read it before set_media_model: a model that cannot do ' +
+    'a job is refused, and this is where the accepted ids come from. A null model means the ' +
+    'brand made no choice and the platform default renders.',
+  method: 'GET',
+  pathUnderBrand: '/settings/models',
+  input: z.object({}).strict(),
+  output: z.object({
+    brand: z.string(),
+    slots: z.array(
+      z.object({
+        slot: z.enum(MEDIA_MODEL_SLOT_IDS),
+        job: z.string(),
+        model: z.string().nullable(),
+        choices: z.array(Choice)
+      })
+    )
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const SET_MEDIA_MODEL = {
+  tool: 'set_media_model',
+  title: 'Choose a media model',
+  description:
+    'Pin the model that serves one job for this brand — image generation, image refinement, ' +
+    'video from text, animating a still, video refinement, motion transfer. Only the models ' +
+    'that job accepts are taken: anything else comes back as model_not_for_slot with the list ' +
+    'that would have been accepted. Send model: null to drop the choice and go back to the ' +
+    'platform default. Calls no model and spends no credits; it takes effect on the next render.',
+  method: 'PUT',
+  pathUnderBrand: '/settings/models',
+  input: z
+    .object({
+      slot,
+      model: z
+        .string()
+        .min(1)
+        .nullable()
+        .describe('A model id from get_media_models for this slot, or null to clear the choice')
+    })
+    .strict(),
+  output: z.object({
+    ok: z.literal(true),
+    slot: z.enum(MEDIA_MODEL_SLOT_IDS),
+    model: z.string().nullable()
+  }),
+  failures: [
+    { error: 'model_not_for_slot', status: 400 },
+    { error: 'update_failed', status: 500 }
+  ],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/cli/plugins/anomalia/skills/anomalia/SKILL.md
+++ b/cli/plugins/anomalia/skills/anomalia/SKILL.md
@@ -86,6 +86,13 @@ time; `update_person` and `update_competitor` fix a role or a wrong website. The
 fields you send, leave every other column as it was, and cost nothing. `update_person` can never
 attest consent: a real person's face stays withheld from every generator until the operator
 states, in their own words, that they have it.
+**Choose which model draws and which films** → `get_media_models` lists the six jobs (image
+generation, image refinement, video from text, animating a still, video refinement, motion
+transfer) with the models each one accepts; `set_media_model` pins one. A model that cannot do
+that job is refused with the list that would have been taken, so read before you write. `null`
+gives the job back to the platform default. No credits, no model call; it applies to the next
+render.
+
 **Hand over a payment link** → `create_checkout_link` (pick a plan and pay) or
 `create_billing_portal_link` (invoices, card, plan change, **cancel**). You mint the URL and give
 it to the account owner; they complete it on Stripe. Never pay, never switch a plan, never cancel

--- a/cli/plugins/anomalia/skills/anomalia/references/tools.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/tools.md
@@ -228,6 +228,33 @@ their own words.
 pastes it on the profile by hand. `get_bio` also returns the short link worth putting there — the
 one with the most clicks in the last seven days.
 
+## Media models
+
+| MCP | CLI |
+|-----|-----|
+| `get_media_models` | (MCP only) |
+| `set_media_model` | (MCP only) |
+
+Six jobs a brand can hand to different models: `imageModel` (draw an image), `imageRefineModel`
+(redraw one that exists), `videoModel` (clip from words alone), `videoImageModel` (animate a
+still), `videoRefineModel` (rewrite a clip, keeping its movement), `videoMotionModel` (take
+movement from a guide video). They are not rungs of one ladder — a model that animates a photo
+may have no video input at all, so each job offers only the models that do it.
+
+`get_media_models` returns, per job, the current choice and the ids that job accepts.
+`set_media_model` takes `slot` and `model`; a model that job cannot do comes back as
+`model_not_for_slot` (400) with the list that would have been accepted, and nothing is saved.
+`model: null` drops the choice and the platform default renders again. `model` is always
+required — there is no way to leave it unsaid.
+
+Neither call spends credits or runs a model. The choice applies to the next render, not to
+anything already produced. It is stored on the brand, so it is the same for everyone working on
+that brand.
+
+The motion video written in code (Remotion/TSX) has no model choice of its own: it is a program
+rendered in a VM, not a generative model, and no per-brand preference exists for the model that
+writes it.
+
 ## SEO / GEO / blog / ads / AI
 
 | MCP | CLI |

--- a/cli/skills/anomalia/SKILL.md
+++ b/cli/skills/anomalia/SKILL.md
@@ -86,6 +86,13 @@ time; `update_person` and `update_competitor` fix a role or a wrong website. The
 fields you send, leave every other column as it was, and cost nothing. `update_person` can never
 attest consent: a real person's face stays withheld from every generator until the operator
 states, in their own words, that they have it.
+**Choose which model draws and which films** → `get_media_models` lists the six jobs (image
+generation, image refinement, video from text, animating a still, video refinement, motion
+transfer) with the models each one accepts; `set_media_model` pins one. A model that cannot do
+that job is refused with the list that would have been taken, so read before you write. `null`
+gives the job back to the platform default. No credits, no model call; it applies to the next
+render.
+
 **Hand over a payment link** → `create_checkout_link` (pick a plan and pay) or
 `create_billing_portal_link` (invoices, card, plan change, **cancel**). You mint the URL and give
 it to the account owner; they complete it on Stripe. Never pay, never switch a plan, never cancel

--- a/cli/skills/anomalia/references/tools.md
+++ b/cli/skills/anomalia/references/tools.md
@@ -228,6 +228,33 @@ their own words.
 pastes it on the profile by hand. `get_bio` also returns the short link worth putting there — the
 one with the most clicks in the last seven days.
 
+## Media models
+
+| MCP | CLI |
+|-----|-----|
+| `get_media_models` | (MCP only) |
+| `set_media_model` | (MCP only) |
+
+Six jobs a brand can hand to different models: `imageModel` (draw an image), `imageRefineModel`
+(redraw one that exists), `videoModel` (clip from words alone), `videoImageModel` (animate a
+still), `videoRefineModel` (rewrite a clip, keeping its movement), `videoMotionModel` (take
+movement from a guide video). They are not rungs of one ladder — a model that animates a photo
+may have no video input at all, so each job offers only the models that do it.
+
+`get_media_models` returns, per job, the current choice and the ids that job accepts.
+`set_media_model` takes `slot` and `model`; a model that job cannot do comes back as
+`model_not_for_slot` (400) with the list that would have been accepted, and nothing is saved.
+`model: null` drops the choice and the platform default renders again. `model` is always
+required — there is no way to leave it unsaid.
+
+Neither call spends credits or runs a model. The choice applies to the next render, not to
+anything already produced. It is stored on the brand, so it is the same for everyone working on
+that brand.
+
+The motion video written in code (Remotion/TSX) has no model choice of its own: it is a program
+rendered in a VM, not a generative model, and no per-brand preference exists for the model that
+writes it.
+
 ## SEO / GEO / blog / ads / AI
 
 | MCP | CLI |

--- a/docs/api/12-settings-models.md
+++ b/docs/api/12-settings-models.md
@@ -1,0 +1,91 @@
+# API — 12 · Impostazioni: modelli media
+
+Due endpoint sotto `/api/v1/brands/:slug/settings/models`, che sono i tool MCP
+`get_media_models` e `set_media_model`. Servono la stessa cosa che Settings → Images & video
+mostra nel browser: **quale modello disegna e quale gira**, per questo brand.
+
+Errori comuni di auth: vedi [01-overview](01-overview.md).
+
+## I sei mestieri
+
+Non sono gradini della stessa scala. Un modello che anima una foto può non avere alcun ingresso
+video, e allora `videoRefineModel` per lui non è "peggio" — non esiste. Ogni mestiere offre
+soltanto i modelli che quel mestiere lo fanno davvero.
+
+| slot | mestiere |
+|---|---|
+| `imageModel` | disegna l'immagine di un post da un prompt |
+| `imageRefineModel` | ridisegna un'immagine che esiste già, tenendo ciò che mostra |
+| `videoModel` | gira una clip dalle sole parole, senza fotogramma di partenza |
+| `videoImageModel` | anima una immagine che esiste già (di solito la cover renderizzata) |
+| `videoRefineModel` | riscrive una clip che esiste già, tenendone il movimento |
+| `videoMotionModel` | prende il movimento da un video guida e lo applica a un soggetto in una immagine |
+
+La tabella che li governa è `src/lib/media-model-slots.ts`; i cataloghi per mestiere vengono da
+`src/lib/image-models.ts` e `src/lib/video-models.ts`. La preferenza è salvata sul brand, in
+`brands.content_prefs`, sotto la chiave omonima allo slot — non esiste una colonna dedicata e
+questa PR non ne ha creata una.
+
+Il **motion video scritto in codice** (Remotion/TSX) non è qui: è un programma renderizzato in
+una VM, non un modello generativo, e non ha oggi nessuna preferenza per brand.
+
+## `GET /api/v1/brands/:slug/settings/models`
+
+Sola lettura: nessun modello chiamato, nessun credito.
+
+**Response** `200`:
+
+```json
+{
+  "brand": "demo",
+  "slots": [
+    {
+      "slot": "imageModel",
+      "job": "Draws a post image from a prompt.",
+      "model": "gpt-image-2",
+      "choices": [
+        { "id": "nano-banana-2-lite", "label": "Nano Banana 2 Lite" },
+        { "id": "gpt-image-2", "label": "GPT Image 2" }
+      ]
+    }
+  ]
+}
+```
+
+`model: null` vuol dire che il brand non ha scelto: renderizza il default di piattaforma. Un id
+salvato che quel mestiere **non fa più** (il catalogo è cambiato) torna anch'esso `null`: il
+renderer lo scarta già, e mostrarlo qui farebbe credere che sia in vigore.
+
+## `PUT /api/v1/brands/:slug/settings/models`
+
+**Body**:
+
+```json
+{ "slot": "videoRefineModel", "model": "runway/aleph" }
+```
+
+`slot` è uno dei sei; `model` è obbligatorio e può essere `null` per togliere la scelta e tornare
+al default di piattaforma. Nessun modello chiamato, nessun credito: vale dal render successivo.
+
+**Response** `200`: `{ "ok": true, "slot": "videoRefineModel", "model": "runway/aleph" }`
+
+**Errori**
+
+| status | error | quando |
+|---|---|---|
+| `400` | `invalid_input` | `slot` non è uno dei sei, o il body non è quello dichiarato |
+| `400` | `model_not_for_slot` | il modello esiste ma non sa fare quel mestiere — il body porta `allowed` con gli id che sarebbero stati accettati |
+| `403` | `API key is read-only` | chiave senza scope `write` (imposto in `resolveCaller`, non per rotta) |
+| `500` | `update_failed` | la scrittura su `brands` è fallita |
+
+La validazione sta nella **scrittura**, non nella lettura: un agente esterno può chiamare `PUT`
+direttamente senza aver letto niente, e una preferenza salvata con un modello che quel mestiere
+non fa sarebbe un guasto scoperto al primo render fallito, lontano da dove è stato causato.
+
+## Cambiare il modello video ritocca la durata
+
+Il tetto di durata è una capacità del modello: 30s esistono su Seedance 2.5, non su Grok. Se il
+brand aveva salvato una durata che il nuovo `videoModel` non regge, la scrittura la riporta
+dentro il tetto — altrimenti resterebbe una scelta che nessun render riesce più a onorare, e
+Settings mostrerebbe un valore insalvabile. La regola vive in `chooseMediaModel`
+(`src/lib/server/media-model-prefs.ts`), che è lo stesso codice che usa il form del browser.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -19,6 +19,7 @@ integrazioni esterne via API key — request, response, query params, body, erro
 | [09 — Connections](09-connections.md) | `/connections`, `/connections/catalog`, `/connections/:id/complete`, `/connections/:id` |
 | [10 — Shares](10-shares.md) | `/shares`, `/shares/revoke`, e la rotta pubblica `/share/:token` |
 | [11 — Billing](11-billing.md) | `/billing/portal`, `/billing/checkout` — link Stripe che l'agente consegna all'umano |
+| [12 — Impostazioni: modelli media](12-settings-models.md) | `/settings/models` — quale modello disegna e quale gira, per brand |
 
 ## Regole di manutenzione
 

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -46,6 +46,7 @@ import {
 } from './reads';
 import { DIAGNOSE_BRAND, GET_GOALS } from './brand-state';
 import { DIAGNOSE_RADAR, GET_MARKET_FIELD, LIST_IDEAS } from './market';
+import { GET_MEDIA_MODELS, SET_MEDIA_MODEL } from './media-models';
 import { GEO_ACTION, REFRESH_KEYWORDS, SEO_ACTION } from './search';
 import { GET_BACKLINKS, GET_GSC, GET_RANKS } from './web-metrics';
 import {
@@ -136,6 +137,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   GET_GTM,
   GET_KEYWORDS,
   GET_MARKET_FIELD,
+  GET_MEDIA_MODELS,
   GET_PLAN,
   GET_POST,
   GET_RANKS,
@@ -164,6 +166,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   SAVE_WEEK_SEEDS,
   SEO_ACTION,
   SET_BIO,
+  SET_MEDIA_MODEL,
   SYNC_HISTORY,
   UPDATE_ARTICLE,
   UPDATE_BRAND_KIT,
@@ -241,6 +244,13 @@ export {
   GOAL_STATUSES
 } from './brand-state';
 export { DIAGNOSE_RADAR, GET_MARKET_FIELD, IDEA_STATUSES, IDEAS_DEFAULT, IDEAS_MAX, LIST_IDEAS, MARKET_FIELD_DEFAULT, MARKET_FIELD_MAX } from './market';
+export {
+  GET_MEDIA_MODELS,
+  MEDIA_MODEL_JOBS,
+  MEDIA_MODEL_SLOT_IDS,
+  SET_MEDIA_MODEL
+} from './media-models';
+export type { MediaModelSlotId } from './media-models';
 export { GEO_ACTION, REFRESH_KEYWORDS, SEO_ACTION } from './search';
 export { GET_BACKLINKS, GET_GSC, GET_RANKS } from './web-metrics';
 export {

--- a/packages/api-contracts/src/media-models.test.ts
+++ b/packages/api-contracts/src/media-models.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import {
+  GET_MEDIA_MODELS,
+  MEDIA_MODEL_JOBS,
+  MEDIA_MODEL_SLOT_IDS,
+  SET_MEDIA_MODEL
+} from './media-models';
+import { BRAND_ENDPOINTS, statusForFailure } from './index';
+
+describe('i modelli media come contratto', () => {
+  it('stanno nel registry, o nessun agente li vede', () => {
+    for (const endpoint of [GET_MEDIA_MODELS, SET_MEDIA_MODEL]) {
+      expect(BRAND_ENDPOINTS, endpoint.tool).toContain(endpoint);
+    }
+  });
+
+  it('ogni mestiere si spiega da solo, senza aprire il browser', () => {
+    for (const slot of MEDIA_MODEL_SLOT_IDS) {
+      expect(MEDIA_MODEL_JOBS[slot].length, slot).toBeGreaterThan(20);
+    }
+  });
+
+  it('la scrittura accetta i sei mestieri e nessun altro nome', () => {
+    expect(SET_MEDIA_MODEL.input.safeParse({ slot: 'imageModel', model: 'x' }).success).toBe(true);
+    expect(SET_MEDIA_MODEL.input.safeParse({ slot: 'imageMdoel', model: 'x' }).success).toBe(false);
+  });
+
+  it('svuotare uno slot è dire null, non una stringa vuota che sembra una scelta', () => {
+    expect(SET_MEDIA_MODEL.input.safeParse({ slot: 'imageModel', model: null }).success).toBe(true);
+    expect(SET_MEDIA_MODEL.input.safeParse({ slot: 'imageModel', model: '' }).success).toBe(false);
+  });
+
+  it('un modello che quel mestiere non sa fare è colpa di chi chiama: 400, non 500', () => {
+    expect(statusForFailure(SET_MEDIA_MODEL, 'model_not_for_slot')).toBe(400);
+  });
+
+  it('la lettura porta, per ogni mestiere, le scelte valide da cui pescare', () => {
+    const parsed = GET_MEDIA_MODELS.output.safeParse({
+      brand: 'demo',
+      slots: [
+        {
+          slot: 'imageModel',
+          job: MEDIA_MODEL_JOBS.imageModel,
+          model: null,
+          choices: [{ id: 'nano-banana-pro', label: 'Nano Banana Pro' }]
+        }
+      ]
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('non promette un modello dove non c è scelta: null è un valore, non un buco', () => {
+    const withModel = GET_MEDIA_MODELS.output.safeParse({
+      brand: 'demo',
+      slots: [{ slot: 'imageModel', job: 'x', model: 'nano-banana-pro', choices: [] }]
+    });
+    expect(withModel.success).toBe(true);
+    const missing = GET_MEDIA_MODELS.output.safeParse({
+      brand: 'demo',
+      slots: [{ slot: 'imageModel', job: 'x', choices: [] }]
+    });
+    expect(missing.success).toBe(false);
+  });
+});

--- a/packages/api-contracts/src/media-models.ts
+++ b/packages/api-contracts/src/media-models.ts
@@ -1,0 +1,93 @@
+import { z } from 'zod';
+import type { BrandEndpoint } from './index';
+
+/**
+ * I mestieri che un brand puo' affidare a modelli diversi. La tabella che li governa vive
+ * nell'app (`$lib/media-model-slots`) insieme al dialetto di ogni provider; qui stanno i soli
+ * due fatti che l'API deve dire a un agente: come si chiama lo slot, e che lavoro fa.
+ *
+ * Un test dell'app tiene i due elenchi allineati: un mestiere aggiunto di la' e non di qua
+ * sarebbe un tool che non lo sa offrire, in silenzio.
+ */
+export const MEDIA_MODEL_SLOT_IDS = [
+  'imageModel',
+  'imageRefineModel',
+  'videoModel',
+  'videoImageModel',
+  'videoRefineModel',
+  'videoMotionModel'
+] as const;
+
+export type MediaModelSlotId = (typeof MEDIA_MODEL_SLOT_IDS)[number];
+
+export const MEDIA_MODEL_JOBS: Record<MediaModelSlotId, string> = {
+  imageModel: 'Draws a post image from a prompt.',
+  imageRefineModel: 'Redraws an image that already exists, keeping what it shows.',
+  videoModel: 'Makes a clip from words alone, with no starting frame.',
+  videoImageModel: 'Animates one still that already exists, usually the rendered cover.',
+  videoRefineModel: 'Rewrites a clip that already exists, keeping its movement.',
+  videoMotionModel: 'Takes the movement from a guide video and applies it to a subject in a still.'
+};
+
+const slot = z.enum(MEDIA_MODEL_SLOT_IDS).describe('Which job the model is chosen for');
+
+const Choice = z.object({ id: z.string(), label: z.string() });
+
+export const GET_MEDIA_MODELS = {
+  tool: 'get_media_models',
+  title: 'Media models',
+  description:
+    'Which model draws and which model films for this brand, one job at a time, with the ' +
+    'models each job actually accepts. Read it before set_media_model: a model that cannot do ' +
+    'a job is refused, and this is where the accepted ids come from. A null model means the ' +
+    'brand made no choice and the platform default renders.',
+  method: 'GET',
+  pathUnderBrand: '/settings/models',
+  input: z.object({}).strict(),
+  output: z.object({
+    brand: z.string(),
+    slots: z.array(
+      z.object({
+        slot: z.enum(MEDIA_MODEL_SLOT_IDS),
+        job: z.string(),
+        model: z.string().nullable(),
+        choices: z.array(Choice)
+      })
+    )
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const SET_MEDIA_MODEL = {
+  tool: 'set_media_model',
+  title: 'Choose a media model',
+  description:
+    'Pin the model that serves one job for this brand — image generation, image refinement, ' +
+    'video from text, animating a still, video refinement, motion transfer. Only the models ' +
+    'that job accepts are taken: anything else comes back as model_not_for_slot with the list ' +
+    'that would have been accepted. Send model: null to drop the choice and go back to the ' +
+    'platform default. Calls no model and spends no credits; it takes effect on the next render.',
+  method: 'PUT',
+  pathUnderBrand: '/settings/models',
+  input: z
+    .object({
+      slot,
+      model: z
+        .string()
+        .min(1)
+        .nullable()
+        .describe('A model id from get_media_models for this slot, or null to clear the choice')
+    })
+    .strict(),
+  output: z.object({
+    ok: z.literal(true),
+    slot: z.enum(MEDIA_MODEL_SLOT_IDS),
+    model: z.string().nullable()
+  }),
+  failures: [
+    { error: 'model_not_for_slot', status: 400 },
+    { error: 'update_failed', status: 500 }
+  ],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/src/lib/content/changelog/2026-09-04-agent-media-models.ts
+++ b/src/lib/content/changelog/2026-09-04-agent-media-models.ts
@@ -1,0 +1,13 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-04',
+  title: 'Tell your AI which model draws and which one films',
+  items: [
+    'Claude, Cursor and any connected AI client can now read and change the models your brand uses — image generation, image refinement, video from text, animating a still, video refinement, motion transfer — without opening Anomalia.',
+    'Your AI sees the models each job actually accepts before it picks one, so it never proposes a model that job cannot run.',
+    'A model that cannot do the job is refused with the list that would have worked, instead of being saved and failing at the next render.',
+    'Clearing a choice hands the job back to the platform default.',
+    'Changing the video model now keeps your clip length inside what that model supports, so a saved length never becomes unusable.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/media-model-slots.test.ts
+++ b/src/lib/media-model-slots.test.ts
@@ -12,6 +12,7 @@ import {
   KLING_3_VIDEO_MODEL,
   KLING_TURBO_I2V_MODEL
 } from '$lib/video-models';
+import { MEDIA_MODEL_SLOT_IDS } from '@anomalia/api-contracts';
 
 describe('media model slots', () => {
   it('offers at least one model in every slot', () => {
@@ -45,5 +46,12 @@ describe('media model slots', () => {
   it('does not answer for a slot that does not exist', () => {
     expect(mediaModelSlot('videoVibesModel')).toBeUndefined();
     expect(mediaModelSlot('')).toBeUndefined();
+  });
+
+  it('is the same list the API contract offers, or a slot exists that no agent can reach', () => {
+    // Il contratto non puo' importare `$lib`, quindi i sei nomi vivono anche li'. Questo test e'
+    // cio' che impedisce ai due elenchi di divergere in silenzio: un mestiere aggiunto qui e non
+    // di la' resterebbe modificabile dal browser e invisibile a `set_media_model`.
+    expect([...MEDIA_MODEL_SLOT_IDS]).toEqual(MEDIA_MODEL_SLOTS.map((s) => s.id));
   });
 });

--- a/src/lib/server/cli-auth.test.ts
+++ b/src/lib/server/cli-auth.test.ts
@@ -136,3 +136,54 @@ describe('authenticate — prodotto chiuso', () => {
     expect(res.user?.id).toBe('user-1');
   });
 });
+
+/**
+ * Lo scope di scrittura di una chiave è imposto UNA volta, in `resolveCaller`, sul metodo: ogni
+ * rotta che muta è un non-GET, quindi il metodo è l'intero controllo. È la ragione per cui una
+ * rotta nuova non deve ricordarsi di nulla — ma è anche il motivo per cui, se quella riga sparisse,
+ * sparirebbe per tutte insieme. Questo test è la prova che c'è.
+ */
+describe('una chiave di sola lettura', () => {
+  const RAW_KEY = 'anomalia_live_sololetturatest';
+
+  async function callWithKey(method: string) {
+    const rows: Record<string, unknown>[] = [];
+    vi.resetModules();
+    vi.doMock('$env/dynamic/private', () => ({ env: { SUPABASE_SERVICE_ROLE_KEY: 'service-role' } }));
+    vi.doMock('@supabase/supabase-js', () => ({
+      createClient: () => createTestSupabase({ api_keys: rows }).client
+    }));
+
+    const { authenticate, hashApiKey } = await import('./cli-auth');
+    rows.push({
+      id: 'key-1',
+      user_id: 'user-1',
+      name: 'read only',
+      key_hash: await hashApiKey(RAW_KEY),
+      permissions: { brand_ids: '*', scopes: ['read'] }
+    });
+
+    return authenticate(
+      new Request('https://x/api/v1/brands/demo/settings/models', {
+        method,
+        headers: { authorization: `Bearer ${RAW_KEY}` }
+      })
+    );
+  }
+
+  it('legge senza ostacoli', async () => {
+    const res = await callWithKey('GET');
+
+    expect(res.error).toBeUndefined();
+    expect(res.apiKey?.id).toBe('key-1');
+  });
+
+  it('non scrive: ogni metodo che muta è 403 prima ancora di entrare in una rotta', async () => {
+    for (const method of ['POST', 'PUT', 'DELETE']) {
+      const res = await callWithKey(method);
+
+      expect(res.error?.status, method).toBe(403);
+      expect(await res.error!.json(), method).toEqual({ error: 'API key is read-only' });
+    }
+  });
+});

--- a/src/lib/server/media-model-prefs.test.ts
+++ b/src/lib/server/media-model-prefs.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// `$lib/server/video` legge l'env per il modello di ripiego: fuori dal runtime SvelteKit non
+// esiste, e senza questo mock il modulo non si carica nemmeno.
+vi.mock('$env/dynamic/private', () => ({ env: {} }));
+
+import { chooseMediaModel } from './media-model-prefs';
+import { mediaModelSlot } from '$lib/media-model-slots';
+import { GPT_IMAGE_2_MODEL } from '$lib/image-models';
+import { ALEPH_REFINE_MODEL, GROK_IMAGINE_VIDEO_MODEL, SEEDANCE_25_MODEL } from '$lib/video-models';
+
+const slot = (id: string) => mediaModelSlot(id)!;
+
+describe('la scelta di un modello per un mestiere', () => {
+  it('salva il modello sotto la chiave di quel mestiere', () => {
+    const { prefs } = chooseMediaModel({}, slot('imageModel'), GPT_IMAGE_2_MODEL);
+    expect(prefs).toEqual({ imageModel: GPT_IMAGE_2_MODEL });
+  });
+
+  it('rifiuta un modello che quel mestiere non sa fare, e dice quali erano ammessi', () => {
+    const refused = chooseMediaModel({}, slot('videoRefineModel'), GROK_IMAGINE_VIDEO_MODEL);
+    expect(refused.prefs).toBeUndefined();
+    expect(refused.allowed).toContain(ALEPH_REFINE_MODEL);
+    expect(refused.allowed).not.toContain(GROK_IMAGINE_VIDEO_MODEL);
+  });
+
+  it('svuotare uno slot toglie la chiave invece di salvare una stringa vuota', () => {
+    const { prefs } = chooseMediaModel({ imageModel: GPT_IMAGE_2_MODEL, language: 'it' }, slot('imageModel'), null);
+    expect(prefs).toEqual({ language: 'it' });
+  });
+
+  it('non tocca le altre preferenze del brand', () => {
+    const { prefs } = chooseMediaModel(
+      { videoInstructions: 'parla piano', imageModel: 'x' },
+      slot('videoModel'),
+      SEEDANCE_25_MODEL
+    );
+    expect(prefs).toEqual({
+      videoInstructions: 'parla piano',
+      imageModel: 'x',
+      videoModel: SEEDANCE_25_MODEL
+    });
+  });
+
+  it('riporta la durata dentro il tetto del nuovo modello, invece di lasciarla insalvabile', () => {
+    // 30s vive solo su Seedance 2.5; scegliendo Grok il tetto scende a 15 e una durata salvata
+    // che il modello non regge farebbe fallire il render, non il salvataggio.
+    const { prefs } = chooseMediaModel(
+      { videoModel: SEEDANCE_25_MODEL, videoDuration: 30 },
+      slot('videoModel'),
+      GROK_IMAGINE_VIDEO_MODEL
+    );
+    expect(prefs?.videoDuration).toBeLessThanOrEqual(15);
+  });
+
+  it('non ritocca la durata quando a cambiare è un altro mestiere', () => {
+    const { prefs } = chooseMediaModel(
+      { videoModel: SEEDANCE_25_MODEL, videoDuration: 30 },
+      slot('imageModel'),
+      GPT_IMAGE_2_MODEL
+    );
+    expect(prefs?.videoDuration).toBe(30);
+  });
+});

--- a/src/lib/server/media-model-prefs.ts
+++ b/src/lib/server/media-model-prefs.ts
@@ -1,0 +1,56 @@
+import { slotAccepts, slotChoices, type MediaModelSlot } from '$lib/media-model-slots';
+import { clampVideoDuration, isKnownVideoModel, videoDurationOptions } from '$lib/server/video';
+
+type Prefs = Record<string, unknown>;
+
+export type MediaModelChoice =
+  | { prefs: Prefs; allowed?: undefined }
+  | { prefs?: undefined; allowed: string[] };
+
+/**
+ * Le preferenze del brand dopo aver messo QUESTO modello in QUESTO mestiere.
+ *
+ * Sta qui e non dentro l'azione del form perche' i chiamanti sono due — il browser e i tool
+ * dell'API — e la regola e' una: un modello e' salvabile solo se sa fare il lavoro in cui viene
+ * salvato, e una durata che il nuovo modello non regge va riportata dentro il suo tetto. Scritta
+ * due volte divergerebbe al primo cambio, e la meta' non aggiornata salverebbe una preferenza che
+ * il renderer poi scarta: il modo piu' silenzioso di non funzionare.
+ */
+export function chooseMediaModel(
+  current: Prefs | null | undefined,
+  slot: MediaModelSlot,
+  model: string | null
+): MediaModelChoice {
+  const prefs: Prefs = { ...(current ?? {}) };
+
+  if (model === null) {
+    delete prefs[slot.pref];
+    return { prefs };
+  }
+
+  if (!slotAccepts(slot, model)) {
+    return { allowed: slotChoices(slot).map((c) => c.id) };
+  }
+
+  prefs[slot.pref] = model;
+
+  if (slot.pref === 'videoModel' && typeof prefs.videoDuration === 'number') {
+    prefs.videoDuration = nearestAllowedDuration(prefs.videoDuration, model);
+  }
+
+  return { prefs };
+}
+
+/**
+ * Il tetto di un modello puo' essere piu' basso di quello del modello precedente (30s su Seedance
+ * 2.5 contro i 15s di Grok): senza questo passaggio la durata salvata resterebbe una scelta che
+ * nessun render riesce piu' a onorare, e Settings mostrerebbe un valore che non si puo' salvare.
+ */
+function nearestAllowedDuration(seconds: number, model: string): number {
+  const known = isKnownVideoModel(model) ? model : null;
+  const clamped = clampVideoDuration(seconds, known);
+  const allowed = videoDurationOptions(known);
+  if (!allowed.length || allowed.includes(clamped)) return clamped;
+
+  return allowed.reduce((best, s) => (Math.abs(s - clamped) < Math.abs(best - clamped) ? s : best));
+}

--- a/src/lib/server/studio-actions.ts
+++ b/src/lib/server/studio-actions.ts
@@ -279,38 +279,25 @@ export const studioActions: Actions = {
     });
   },
 
-  // Which kie video model generates clips (Settings → Video). Duration options and the render
-  // clamp follow this model's caps. Empty = platform env default (Grok Imagine today).
   // Quale modello serve quale mestiere (Settings -> Images & video). Una sola azione per tutti e
   // sei gli slot: la regola che un modello deve saper fare il lavoro in cui viene salvato vale
   // ovunque, e scritta sei volte divergerebbe al primo cambio.
   updateMediaModel: async ({ request, params, locals: { supabase } }) => {
     return withBrand(supabase, params.brand, async (brand) => {
       const fd = await request.formData();
-      const { mediaModelSlot, slotAccepts } = await import('$lib/media-model-slots');
+      const { mediaModelSlot } = await import('$lib/media-model-slots');
       const slot = mediaModelSlot(fd.get('slot'));
       if (!slot) return fail(400, { error: 'Unknown model slot' });
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const prefs: Record<string, any> = { ...(brand.content_prefs ?? {}) };
-      const raw = String(fd.get('model') ?? '').trim();
-      if (!raw) delete prefs[slot.pref];
-      else if (!slotAccepts(slot, raw)) return fail(400, { error: 'Unknown model for this slot' });
-      else prefs[slot.pref] = raw;
-
-      // Re-clamp a stored length that the previous model allowed but this one does not (e.g. 30s
-      // on Seedance 2.5 -> Grok's 15s ceiling), so Settings never shows an unsavable value.
-      if (slot.pref === 'videoModel' && typeof prefs.videoDuration === 'number') {
-        const { isKnownVideoModel, clampVideoDuration, videoDurationOptions } = await import('$lib/server/video');
-        const model = isKnownVideoModel(prefs.videoModel) ? prefs.videoModel : null;
-        prefs.videoDuration = clampVideoDuration(prefs.videoDuration, model);
-        const allowed = videoDurationOptions(model);
-        if (!allowed.includes(prefs.videoDuration) && allowed.length) {
-          prefs.videoDuration = allowed.reduce((best, s) =>
-            Math.abs(s - prefs.videoDuration) < Math.abs(best - prefs.videoDuration) ? s : best
-          );
-        }
-      }
+      // La regola sta in `chooseMediaModel`, non qui: il browser e i tool dell'API la chiamano
+      // entrambi, e scritta due volte divergerebbe al primo modello nuovo.
+      const { chooseMediaModel } = await import('$lib/server/media-model-prefs');
+      const { prefs } = chooseMediaModel(
+        brand.content_prefs as Record<string, unknown> | null,
+        slot,
+        String(fd.get('model') ?? '').trim() || null
+      );
+      if (!prefs) return fail(400, { error: 'Unknown model for this slot' });
 
       const { error } = await supabase.from('brands').update({ content_prefs: prefs }).eq('id', brand.id);
       if (error) return fail(400, { error: error.message });

--- a/src/routes/api/v1/brands/[slug]/settings/models/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/settings/models/+server.ts
@@ -1,0 +1,89 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { authenticate, loadBrandForUser, checkApiKeyWriteAccess } from '$lib/server/cli-auth';
+import {
+  MEDIA_MODEL_JOBS,
+  MEDIA_MODEL_SLOT_IDS,
+  SET_MEDIA_MODEL,
+  statusForFailure
+} from '@anomalia/api-contracts';
+import { mediaModelSlot, slotAccepts, slotChoices } from '$lib/media-model-slots';
+import { chooseMediaModel } from '$lib/server/media-model-prefs';
+
+// Quale modello disegna e quale gira, per questo brand — la stessa cosa che Settings → Images &
+// video mostra nel browser, servita agli agenti esterni.
+//
+// La lettura esiste perché la scrittura sia possibile: i modelli ammessi cambiano per mestiere
+// (Aleph riscrive una clip e non ne genera una; Turbo anima una foto e non parte dal testo), e un
+// agente che non li vede tira a indovinare. La validazione però NON sta qui: sta nella scrittura,
+// che è l'unico punto che non si può saltare.
+
+export const GET: RequestHandler = async ({ request, params }) => {
+  const { supabase, error, apiKey } = await authenticate(request);
+  if (error) return error;
+
+  const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
+  if (brandError) return brandError;
+
+  const prefs = (brand.content_prefs ?? {}) as Record<string, unknown>;
+
+  return json({
+    brand: brand.slug,
+    slots: MEDIA_MODEL_SLOT_IDS.map((id) => {
+      const slot = mediaModelSlot(id)!;
+      const stored = String(prefs[slot.pref] ?? '').trim();
+
+      return {
+        slot: id,
+        job: MEDIA_MODEL_JOBS[id],
+        // Un modello salvato che quel mestiere non fa più non è una scelta: il renderer lo scarta
+        // già, e mostrarlo qui farebbe credere all'agente che sia in vigore.
+        model: stored && slotAccepts(slot, stored) ? stored : null,
+        choices: slotChoices(slot)
+      };
+    })
+  });
+};
+
+export const PUT: RequestHandler = async ({ request, params }) => {
+  const { supabase, error, apiKey } = await authenticate(request);
+  if (error) return error;
+
+  const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
+  if (brandError) return brandError;
+  const writeDenied = checkApiKeyWriteAccess(apiKey);
+  if (writeDenied) return writeDenied;
+
+  const parsed = SET_MEDIA_MODEL.input.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return json({ error: 'invalid_input', details: parsed.error.issues }, { status: 400 });
+  }
+
+  const slot = mediaModelSlot(parsed.data.slot)!;
+  const { prefs, allowed } = chooseMediaModel(
+    brand.content_prefs as Record<string, unknown> | null,
+    slot,
+    parsed.data.model
+  );
+
+  if (!prefs) {
+    return json(
+      { error: 'model_not_for_slot', slot: parsed.data.slot, allowed },
+      { status: statusForFailure(SET_MEDIA_MODEL, 'model_not_for_slot') }
+    );
+  }
+
+  const { error: updateError } = await supabase
+    .from('brands')
+    .update({ content_prefs: prefs })
+    .eq('id', brand.id);
+
+  if (updateError) {
+    return json(
+      { error: 'update_failed', detail: updateError.message },
+      { status: statusForFailure(SET_MEDIA_MODEL, 'update_failed') }
+    );
+  }
+
+  return json({ ok: true, slot: parsed.data.slot, model: parsed.data.model });
+};

--- a/src/routes/api/v1/brands/[slug]/settings/models/server.test.ts
+++ b/src/routes/api/v1/brands/[slug]/settings/models/server.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('$env/dynamic/private', () => ({ env: {} }));
+vi.mock('$lib/server/cli-auth', () => ({
+  authenticate: vi.fn(),
+  loadBrandForUser: vi.fn(),
+  checkApiKeyWriteAccess: vi.fn(() => null)
+}));
+
+import { GET, PUT } from './+server';
+import { authenticate, loadBrandForUser, checkApiKeyWriteAccess } from '$lib/server/cli-auth';
+import { GPT_IMAGE_2_MODEL } from '$lib/image-models';
+import { ALEPH_REFINE_MODEL, GROK_IMAGINE_VIDEO_MODEL, SEEDANCE_25_MODEL } from '$lib/video-models';
+
+type Row = Record<string, unknown>;
+
+function fakeSupabase(updateError: { message: string } | null = null) {
+  const updates: Row[] = [];
+  const client = {
+    from() {
+      const q = {
+        update(row: Row) {
+          updates.push(row);
+          return q;
+        },
+        eq: async () => ({ error: updateError })
+      };
+      return q;
+    }
+  };
+  return { client, updates };
+}
+
+let supabase: ReturnType<typeof fakeSupabase>;
+
+const brand = (content_prefs: Row | null) => ({ id: 'brand-1', slug: 'demo', content_prefs });
+
+const url = 'https://example.test/api/v1/brands/demo/settings/models';
+
+const read = () =>
+  (GET as (e: unknown) => Promise<Response>)({
+    request: new Request(url),
+    params: { slug: 'demo' }
+  });
+
+const write = (body: unknown) =>
+  (PUT as (e: unknown) => Promise<Response>)({
+    request: new Request(url, { method: 'PUT', body: JSON.stringify(body) }),
+    params: { slug: 'demo' }
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  supabase = fakeSupabase();
+  vi.mocked(authenticate).mockResolvedValue({ supabase: supabase.client, apiKey: null, error: null } as never);
+  vi.mocked(loadBrandForUser).mockResolvedValue({ brand: brand(null), error: null } as never);
+  vi.mocked(checkApiKeyWriteAccess).mockReturnValue(null as never);
+});
+
+describe('GET /api/v1/brands/:slug/settings/models', () => {
+  it('elenca i sei mestieri con le scelte che ciascuno accetta davvero', async () => {
+    const body = await (await read()).json();
+
+    expect(body.brand).toBe('demo');
+    expect(body.slots.map((s: Row) => s.slot)).toEqual([
+      'imageModel',
+      'imageRefineModel',
+      'videoModel',
+      'videoImageModel',
+      'videoRefineModel',
+      'videoMotionModel'
+    ]);
+
+    const refine = body.slots.find((s: Row) => s.slot === 'videoRefineModel');
+    expect(refine.choices.map((c: Row) => c.id)).toEqual([ALEPH_REFINE_MODEL]);
+  });
+
+  it('senza una scelta del brand risponde null, non un modello che nessuno ha scelto', async () => {
+    const body = await (await read()).json();
+
+    expect(body.slots.every((s: Row) => s.model === null)).toBe(true);
+  });
+
+  it('riporta la scelta del brand quando c è', async () => {
+    vi.mocked(loadBrandForUser).mockResolvedValue({
+      brand: brand({ imageModel: GPT_IMAGE_2_MODEL }),
+      error: null
+    } as never);
+
+    const body = await (await read()).json();
+
+    expect(body.slots.find((s: Row) => s.slot === 'imageModel').model).toBe(GPT_IMAGE_2_MODEL);
+  });
+
+  it('non spaccia per attiva una preferenza che il mestiere non sa più fare', async () => {
+    // Un catalogo cambia; un id salvato che ha perso il ruolo il renderer lo scarta già.
+    vi.mocked(loadBrandForUser).mockResolvedValue({
+      brand: brand({ videoRefineModel: GROK_IMAGINE_VIDEO_MODEL }),
+      error: null
+    } as never);
+
+    const body = await (await read()).json();
+
+    expect(body.slots.find((s: Row) => s.slot === 'videoRefineModel').model).toBeNull();
+  });
+});
+
+describe('PUT /api/v1/brands/:slug/settings/models', () => {
+  it('salva il modello sotto il mestiere scelto', async () => {
+    const res = await write({ slot: 'imageModel', model: GPT_IMAGE_2_MODEL });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, slot: 'imageModel', model: GPT_IMAGE_2_MODEL });
+    expect(supabase.updates[0]).toEqual({ content_prefs: { imageModel: GPT_IMAGE_2_MODEL } });
+  });
+
+  it('rifiuta un modello che quel mestiere non fa, e dice quali erano ammessi', async () => {
+    const res = await write({ slot: 'videoRefineModel', model: GROK_IMAGINE_VIDEO_MODEL });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('model_not_for_slot');
+    expect(body.allowed).toEqual([ALEPH_REFINE_MODEL]);
+    expect(supabase.updates).toEqual([]);
+  });
+
+  it('rifiuta un mestiere che non esiste, invece di scartarlo in silenzio', async () => {
+    const res = await write({ slot: 'videoVibesModel', model: GPT_IMAGE_2_MODEL });
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('invalid_input');
+    expect(supabase.updates).toEqual([]);
+  });
+
+  it('null toglie la scelta e lascia intatto il resto delle preferenze', async () => {
+    vi.mocked(loadBrandForUser).mockResolvedValue({
+      brand: brand({ imageModel: GPT_IMAGE_2_MODEL, language: 'it' }),
+      error: null
+    } as never);
+
+    const res = await write({ slot: 'imageModel', model: null });
+
+    expect(res.status).toBe(200);
+    expect(supabase.updates[0]).toEqual({ content_prefs: { language: 'it' } });
+  });
+
+  it('riporta la durata dentro il tetto del modello appena scelto', async () => {
+    vi.mocked(loadBrandForUser).mockResolvedValue({
+      brand: brand({ videoModel: SEEDANCE_25_MODEL, videoDuration: 30 }),
+      error: null
+    } as never);
+
+    await write({ slot: 'videoModel', model: GROK_IMAGINE_VIDEO_MODEL });
+
+    const prefs = supabase.updates[0].content_prefs as Row;
+    expect(prefs.videoDuration as number).toBeLessThanOrEqual(15);
+  });
+
+  it('si ferma prima di scrivere se la chiave è di sola lettura', async () => {
+    vi.mocked(checkApiKeyWriteAccess).mockReturnValue(
+      new Response('read only', { status: 403 }) as never
+    );
+
+    const res = await write({ slot: 'imageModel', model: GPT_IMAGE_2_MODEL });
+
+    expect(res.status).toBe(403);
+    expect(supabase.updates).toEqual([]);
+  });
+
+  it('si ferma prima di scrivere se il brand non è del chiamante', async () => {
+    vi.mocked(loadBrandForUser).mockResolvedValue({
+      brand: null,
+      error: new Response('not found', { status: 404 })
+    } as never);
+
+    const res = await write({ slot: 'imageModel', model: GPT_IMAGE_2_MODEL });
+
+    expect(res.status).toBe(404);
+    expect(supabase.updates).toEqual([]);
+  });
+
+  it('riporta il fallimento della scrittura come il 500 dichiarato', async () => {
+    supabase = fakeSupabase({ message: 'connection reset' });
+    vi.mocked(authenticate).mockResolvedValue({ supabase: supabase.client, apiKey: null, error: null } as never);
+
+    const res = await write({ slot: 'imageModel', model: GPT_IMAGE_2_MODEL });
+
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('update_failed');
+  });
+});


### PR DESCRIPTION
## What?

Two new registry-generated tools let an external agent read and change **which model draws and which model films** for a brand, without opening the browser: `get_media_models` (GET `/api/v1/brands/:slug/settings/models`) and `set_media_model` (PUT, same path).

Six jobs, the ones `MEDIA_MODEL_SLOTS` already governs: `imageModel`, `imageRefineModel`, `videoModel`, `videoImageModel`, `videoRefineModel`, `videoMotionModel`. The preference is stored where it already lives — `brands.content_prefs` — so **no migration**, and the browser form and the API tool are now two callers of one function.

`tools/list` goes from **95 to 97**. Field-by-field comparison of every existing tool: nothing changed, nothing disappeared.

## Why?

Anomalia is becoming a headless interface for external agents. Settings were the last piece that still required a person at a keyboard: a customer who wanted a different image model had to open a page. Andrea asked for this one by name — "i settings hanno poi i tools dedicati in modo che l'ai possa modificare es quale modello usare per image generation, image refine, motion video, video motion".

## How?

**A pair, and the validation lives in the write.** The available models are not a fixed list: images come from `IMAGE_MODEL_CHOICES`, videos from `videoModelsForRole`, and the accepted set **differs per job** — Aleph rewrites a clip and cannot generate one; Kling V3 Turbo animates a photo and cannot start from text. `get_media_models` exists so an agent can *choose*. But the refusal lives in `set_media_model`, because that is the only point that cannot be skipped: an external agent can call `PUT` having read nothing, and a preference saved with a model that job cannot run is a fault discovered at the next failed render, far from where it was caused. A bad model answers `model_not_for_slot` (400) carrying `allowed`, and saves nothing.

**Why `slot` is an enum and `model` is not.** `slot` is a compile-time `z.enum` — six values, a hand-written table, stable. `model` deliberately is not: a flat enum of every id would advertise `runway/aleph` as valid for `imageModel`, which is false. Per-slot validity is not expressible in a flat schema, so the route validates against the real catalog and returns the list. Rejected alternative: duplicating ~15 model ids into the contracts package, which would put a second copy of a churning table (`video-models.ts`) behind `sync-contracts.sh` on every model addition, for a check the route has to do anyway.

**One rule, one place.** `updateMediaModel` (the form action) carried the "a model must be able to do the job it is saved into" check *and* the clip-length re-clamp inline. A second caller made that a divergence waiting to happen, so both now route through `chooseMediaModel` (`src/lib/server/media-model-prefs.ts`). That is a separate, behaviour-preserving commit.

**The two lists that cannot diverge.** `packages/api-contracts` cannot import `$lib` (`packages/no-app-imports.test.ts`), so the six names live in the contract too. A test in `src/lib/media-model-slots.test.ts` compares them: a job added on one side only would be editable from the browser and invisible to `set_media_model`, in silence.

## Testing?

Red before green for every new test, with real output.

- **contract** — written and run before `media-models.ts` existed: `Failed to load url ./media-models`. Then green.
- **`chooseMediaModel`** — same, module missing first. Then green.
- **the route** — implementation existed first, so it was proven by removing the logic: with the `slotAccepts` guard and the duration re-clamp deleted, **exactly 2 of 12 fail** (`model_not_for_slot`, the duration) and 10 stay green. Restored, 12/12.
- **the two-list guard** — proven by adding a seventh fake slot to the contract: `expected [ 'imageModel', …(6) ] to deeply equal [ 'imageModel', …(5) ]`. Reverted.
- **read-only API key** — the brief asked to verify `resolveCaller` instead of trusting it. There was no test. There is now, exercising the real `authenticate` with a seeded `api_keys` row: GET passes, POST/PUT/DELETE are 403 `API key is read-only`. Proven by deleting those four lines from `cli-auth.ts` → red. Restored.

Commands run (the ones CI runs; `npm run check` is not one of them):

| command | result |
|---|---|
| `npx vitest run packages/api-contracts` | 9 files, 113 tests, pass |
| `cd cli && bun test` | 57 tests, 0 fail |
| `cd cli && bun run typecheck` | clean |
| `node scripts/typecheck-runtime.mjs` | ok |
| affected app tests (slots, prefs, cli-auth, route, changelog, no-app-imports) | 6 files, 129 tests, pass |

**Not tested:** no browser verification, no Docker, no dev server, no Playwright — the brief forbade all of them for this task. The full `npm run test:unit` was not run either (also forbidden); CI runs it.

**Risk:** the route writes the whole `content_prefs` blob back, exactly as the form action has always done, so a concurrent write from the browser to a different key can lose a race. That is pre-existing behaviour, not introduced here, and both callers now share the same code path.

## Evidence

`tools/list` through `handleMcpFetch`, captured on `origin/dev` and on this branch, compared object by object:

<details>
<summary>Before → after: 95 → 97, additive only</summary>

```
$ diff <(names before) <(names after)
41a42
> get_media_models
86a88
> set_media_model

$ full-object comparison
new:     ['get_media_models', 'set_media_model']
gone:    []
changed: []
```

</details>

<details>
<summary>The route's failure path, from the test run</summary>

```
PUT { slot: 'videoRefineModel', model: 'grok-imagine-video-1-5-preview' }
→ 400 { error: 'model_not_for_slot', slot: 'videoRefineModel', allowed: ['runway/aleph'] }
  (nothing written)
```

</details>

<details>
<summary>Red, then green: the route with its validation removed</summary>

```
× PUT … > rifiuta un modello che quel mestiere non fa, e dice quali erano ammessi
× PUT … > riporta la durata dentro il tetto del modello appena scelto
   Tests  2 failed | 10 passed (12)
```

</details>

No UI change: this PR adds no page and touches no component.

## Anything Else?

**Where each preference is stored, and what has nowhere to go.**

Everything here lands in `brands.content_prefs` (jsonb, since `0011`) under the six keys `MEDIA_MODEL_SLOTS` already declares. Nothing new in the schema, no migration written, none needed.

Two things were deliberately left out because they have **no per-brand place to be saved**, and inventing a column is a product decision — especially in a repo whose deploys do not run migrations:

- **Programmatic motion video (Remotion/TSX)** — Andrea named it. The model that writes the TSX comes from `motionAgentModel()` → `craftAgentModel({ envModel: env.MOTION_VIDEO_MODEL })`: a platform env var, or the chat catalogue default. It is a program rendered in a VM, not a generative model, and there is no brand preference to expose. Said so in the docs and the skill rather than adding a column.
- **`brands.chat_default_tier`** — the column exists and `setChatDefaultTier()` exists, but **no UI or route calls it today**, and the chat model catalogue is mid-teardown in another branch. Exposing a field nobody writes would freeze a shape that is still moving.

**What stays out of MCP, and why** (the rest of the settings census travels with the next PRs):

- **`api-keys`** — an agent that mints its own credentials is a privilege ladder: a new key is born with whatever scope it asks for, and a write scope obtained from a read-only session cancels the boundary `resolveCaller` defends.
- **`danger`** — deletes the brand and cancels the Stripe subscription. Irreversible, and the confirmation is not one an agent can give on a person's behalf.
- **Connector OAuth** (`connected-accounts`, `connectors`, `search-console`, `facebook`, `linkedin`) — consent to a third party is given by a human on the third party's page. A tool can hand over the link; it must never walk through it. Disconnecting is the same act in reverse and stays with it.
- **Billing** — already covered, and correctly: `create_checkout_link` and `create_billing_portal_link` (#223) **mint a Stripe URL and hand it back**. The agent delivers the door; the person walks through it. Nothing here duplicates them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
