### PR TITLE
Let an agent set the timezone, platforms, hashtags and tone

### DIFF
--- a/changelog/2026-09-04-agent-brand-settings.md
+++ b/changelog/2026-09-04-agent-brand-settings.md
@@ -1,0 +1,95 @@
+# Come lavora il brand si cambia da fuori, con le conseguenze scritte
+
+Secondo giro sulle impostazioni headless, dopo i modelli media. Quattro pagine di Settings che
+erano quattro form separati diventano una coppia di tool: `get_brand_settings` e
+`set_brand_settings`, su `GET`/`PUT /api/v1/brands/:slug/settings/brand`.
+
+`tools/list` passa da **97 a 99**, additivo: `new: [get_brand_settings, set_brand_settings]`,
+`gone: []`, `changed: []` sul confronto oggetto per oggetto.
+
+## Un tool solo con quattro campi, non quattro tool
+
+Fuso, piattaforme, hashtag ed esempi di voce vivono tutti sul brand e si cambiano spesso insieme.
+Un `PUT` che tocca solo i campi nominati è la forma che `update_product` e `update_brand_kit` già
+usano qui, e risparmia tre giri di rete a un agente che sistema il brand in una volta.
+
+`destructive: false` per tutti e quattro, e non è una svista: nessuno di questi campi cancella
+niente. Il punto è verificato sotto — un post già programmato non si sposta e non si annulla.
+
+Fuori dalla scrittura la **lingua** dei post (`content_prefs.language`): la scrive già
+`update_brand_kit`, e due scrittori per lo stesso campo sono una divergenza in attesa.
+
+## Le due conseguenze, misurate e messe nella descrizione
+
+Sono la ragione per cui questa PR ha richiesto di leggere il percorso di pubblicazione prima di
+scrivere una riga.
+
+**Il fuso non sposta i post che hanno già un orario.** `posts.scheduled_for` è un `timestamptz`
+(`0004_content_plans_posts.sql`), cioè un istante assoluto. La conversione da orario locale a UTC
+avviene **una volta sola**, alla scrittura della riga (`wallClockToUtc` / `nextOccurrence` in
+`src/lib/server/schedule.ts`), e nessuno la ricalcola dopo — `setTimezone` fa un `update` su
+`brands` e invalida la cache della nav, e basta. Cambiare fuso non muove niente in assoluto: muove
+l'ora locale con cui quell'istante si legge. 18:00 a Roma = 16:00 UTC = 12:00 a New York.
+
+**Togliere una piattaforma non annulla i post già programmati su di essa.**
+`brands.target_platforms` è un ingresso di produzione — lo leggono `planner-inputs.ts` e
+`scheduler.ts` per decidere per cosa scrivere i post NUOVI. `publish.ts` non lo legge affatto:
+costruisce i bersagli da `post.platforms ?? [post.platform]` e l'unico cancello è un
+`social_accounts` attivo.
+
+Entrambe stanno nella `description` del tool, non solo nella doc. È l'unica cosa che un agente
+legge prima di chiamare, e un agente che sposta il calendario di un cliente senza saperlo è
+peggio di un tool che non esiste.
+
+## La trappola che la lettura rende visibile
+
+`target_platforms` **non** è validata contro gli account collegati — né dal form, né dal tool
+della chat, né dall'onboarding. Si può bersagliare una piattaforma dove non c'è dove pubblicare: i
+post vengono prodotti e restano in `approved` con `noAccount`, e nessuno lo dice.
+
+Quindi `get_brand_settings` porta `connected_platforms` e la scrittura risponde con
+`without_account`. Non è decorazione: è la differenza fra una configurazione sbagliata che si
+scopre subito e una che si scopre quando manca un post.
+
+Non ho aggiunto una validazione che RIFIUTA la piattaforma senza account: bersagliarla prima di
+collegarla è un ordine di lavoro legittimo (l'onboarding fa esattamente così), e rifiutarlo
+romperebbe il flusso normale. Dire che succede è la cosa giusta; impedirlo no.
+
+## Il fuso ora si valida, e per tutti e due i chiamanti
+
+`setTimezone` accettava **qualunque stringa non vuota**. Dal browser non poteva sbagliare — il
+`<select>` offre quindici zone — ma la colonna decide l'ora locale di ogni slot futuro, e una
+stringa che non è un fuso non fallisce al salvataggio: fallisce dopo, quando qualcosa prova a
+calcolare un orario.
+
+`isKnownTimezone` sta in `$lib/brand-fields.ts`, che esiste letteralmente per questo («chi scrive
+uno di questi campi passa da qui, o sta introducendo la seconda versione della stessa regola»), e
+la chiamano sia la rotta sia il form. Chiede a `Intl` invece di tenere un elenco: così gli alias
+storici (`Asia/Calcutta`) restano validi e nessuno deve aggiornare una lista quando IANA ne
+aggiunge una.
+
+## I due elenchi di piattaforme
+
+Stessa forma dei model slot: il contratto non può importare `$lib`, quindi `TARGET_PLATFORMS` vive
+anche lì, e un test in `src/lib/platforms.test.ts` — il file che è già la legge del vocabolario
+delle piattaforme — lo confronta con `PLATFORM_KEYS`. Visto fallire aggiungendo `myspace` al
+contratto.
+
+`twitter` non è nell'elenco di proposito: è un alias storico di `x`, e un tool che offre due nomi
+per la stessa piattaforma insegna quello sbagliato.
+
+## Una cosa che lo schema non poteva fare
+
+`input` deve restare un `ZodObject` puro: la registrazione MCP ci aggiunge `slug` con `.extend`, e
+un `.refine` (per "almeno un campo") lo trasformerebbe in qualcosa che `.extend` non ha — cioè un
+crash a runtime su `tools/list`, non un errore di compilazione. Quindi il conteggio dei campi lo
+fa la rotta, con `no_fields` dichiarato nel contratto. C'è un test che tiene ferma la proprietà.
+
+## Cosa è stato visto rosso
+
+- il contratto, prima che il file esistesse;
+- `isKnownTimezone`, prima che esistesse (`ReferenceError`);
+- la rotta: tolte la validazione del fuso, la guardia `no_fields`, la normalizzazione degli
+  hashtag, la deduplica delle piattaforme e il calcolo di `without_account`, **cadono esattamente
+  5 test su 17** e 12 restano verdi;
+- il guardiano dei due elenchi di piattaforme, con `myspace` aggiunto al contratto.

--- a/cli/lib/contracts/brand-settings.ts
+++ b/cli/lib/contracts/brand-settings.ts
@@ -1,0 +1,105 @@
+import { z } from 'zod';
+import type { BrandEndpoint } from './index';
+
+/**
+ * Le piattaforme su cui il prodotto lavora. L'elenco vero e' `PLATFORM_KEYS`
+ * (`$lib/components/platform-meta`), che il contratto non puo' importare: un test dell'app tiene
+ * i due allineati. `twitter` non e' qui di proposito — e' un alias storico di `x`, e un tool che
+ * offre due nomi per la stessa piattaforma insegna il nome sbagliato.
+ */
+export const TARGET_PLATFORMS = [
+  'instagram',
+  'tiktok',
+  'facebook',
+  'linkedin',
+  'x',
+  'threads',
+  'youtube',
+  'bluesky',
+  'reddit'
+] as const;
+
+export type TargetPlatform = (typeof TARGET_PLATFORMS)[number];
+
+const platform = z.enum(TARGET_PLATFORMS);
+
+const hashtags = z
+  .partialRecord(platform, z.array(z.string()))
+  .describe('Hashtags per platform. When set for a platform, the AI uses ONLY these');
+
+const voiceExamples = z
+  .array(z.string())
+  .describe('Real past posts of the brand, one per entry, that the AI imitates for tone');
+
+export const GET_BRAND_SETTINGS = {
+  tool: 'get_brand_settings',
+  title: 'Brand settings',
+  description:
+    'How this brand works: posting timezone, the platforms it publishes to (with the ones that ' +
+    'actually have a connected account), the hashtags it allows per platform, and the past posts ' +
+    'the AI imitates for tone. Read it before set_brand_settings — it carries the platform ' +
+    'vocabulary and shows which targets have nowhere to publish yet.',
+  method: 'GET',
+  pathUnderBrand: '/settings/brand',
+  input: z.object({}).strict(),
+  output: z.object({
+    brand: z.string(),
+    timezone: z.string(),
+    platforms: z.array(z.string()),
+    platform_choices: z.array(z.string()),
+    connected_platforms: z.array(z.string()),
+    hashtags: z.record(z.string(), z.array(z.string())),
+    voice_examples: z.array(z.string())
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const SET_BRAND_SETTINGS = {
+  tool: 'set_brand_settings',
+  title: 'Change how the brand works',
+  description:
+    'Change the posting timezone, the target platforms, the per-platform hashtags, or the voice ' +
+    'examples. Only the fields you send change. `hashtags` and `voice_examples` REPLACE the whole ' +
+    'list, so send the full list you want, not a delta; `[]` and `{}` clear one. Calls no model ' +
+    'and spends no credits. ' +
+    'Two consequences worth knowing before you call it. Changing `timezone` does NOT move posts ' +
+    'that already have a time: they keep firing at the same absolute instant, so their local hour ' +
+    'shifts by the offset difference — a post set for 18:00 in Rome reads as 12:00 once the brand ' +
+    'moves to New York. Only new scheduling uses the new zone. Removing a platform from ' +
+    '`platforms` does NOT cancel posts already scheduled on it: the target list decides what NEW ' +
+    'posts are made for, never what publishes, and an existing post still goes out while its ' +
+    'account is connected.',
+  method: 'PUT',
+  pathUnderBrand: '/settings/brand',
+  input: z
+    .object({
+      timezone: z
+        .string()
+        .min(1)
+        .optional()
+        .describe('IANA zone, e.g. "Europe/Rome". Decides the local hour of every future slot'),
+      platforms: z
+        .array(platform)
+        .optional()
+        .describe('Platforms new posts are made for. An empty list leaves the planner no target'),
+      hashtags: hashtags.optional(),
+      voice_examples: voiceExamples.optional()
+    })
+    .strict(),
+  output: z.object({
+    ok: z.literal(true),
+    timezone: z.string(),
+    platforms: z.array(z.string()),
+    hashtags: z.record(z.string(), z.array(z.string())),
+    voice_examples: z.array(z.string()),
+    /** Piattaforme scelte che non hanno dove pubblicare: i post per loro restano fermi. */
+    without_account: z.array(z.string())
+  }),
+  failures: [
+    { error: 'no_fields', status: 400 },
+    { error: 'unknown_timezone', status: 400 },
+    { error: 'update_failed', status: 500 }
+  ],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/cli/lib/contracts/index.ts
+++ b/cli/lib/contracts/index.ts
@@ -45,6 +45,7 @@ import {
   LIST_PRODUCTS
 } from './reads';
 import { DIAGNOSE_BRAND, GET_GOALS } from './brand-state';
+import { GET_BRAND_SETTINGS, SET_BRAND_SETTINGS } from './brand-settings';
 import { DIAGNOSE_RADAR, GET_MARKET_FIELD, LIST_IDEAS } from './market';
 import { GET_MEDIA_MODELS, SET_MEDIA_MODEL } from './media-models';
 import { GEO_ACTION, REFRESH_KEYWORDS, SEO_ACTION } from './search';
@@ -129,6 +130,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   GET_AUDIT_FINDINGS,
   GET_BACKLINKS,
   GET_BIO,
+  GET_BRAND_SETTINGS,
   GET_CALENDAR,
   GET_CREATION_KIT,
   GET_GEO,
@@ -166,6 +168,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   SAVE_WEEK_SEEDS,
   SEO_ACTION,
   SET_BIO,
+  SET_BRAND_SETTINGS,
   SET_MEDIA_MODEL,
   SYNC_HISTORY,
   UPDATE_ARTICLE,
@@ -233,6 +236,12 @@ export {
   LIST_ARTICLES,
   LIST_PRODUCTS
 };
+export {
+  GET_BRAND_SETTINGS,
+  SET_BRAND_SETTINGS,
+  TARGET_PLATFORMS
+} from './brand-settings';
+export type { TargetPlatform } from './brand-settings';
 export {
   DIAGNOSE_BRAND,
   DOCTOR_GATE_STATUSES,

--- a/cli/plugins/anomalia/skills/anomalia/SKILL.md
+++ b/cli/plugins/anomalia/skills/anomalia/SKILL.md
@@ -86,6 +86,13 @@ time; `update_person` and `update_competitor` fix a role or a wrong website. The
 fields you send, leave every other column as it was, and cost nothing. `update_person` can never
 attest consent: a real person's face stays withheld from every generator until the operator
 states, in their own words, that they have it.
+**Change how the brand works** → `get_brand_settings` then `set_brand_settings`: posting
+timezone, target platforms, hashtags per platform, voice examples. Only the fields you send
+change, and lists replace rather than merge. Two things to tell the person: changing the timezone
+does not move posts that already have a time (their local hour shifts instead), and removing a
+platform does not cancel posts already scheduled on it. If a target platform has no connected
+account the write says so in `without_account` — its posts will be produced and then wait.
+
 **Choose which model draws and which films** → `get_media_models` lists the six jobs (image
 generation, image refinement, video from text, animating a still, video refinement, motion
 transfer) with the models each one accepts; `set_media_model` pins one. A model that cannot do

--- a/cli/plugins/anomalia/skills/anomalia/references/tools.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/tools.md
@@ -228,6 +228,34 @@ their own words.
 pastes it on the profile by hand. `get_bio` also returns the short link worth putting there — the
 one with the most clicks in the last seven days.
 
+## Brand settings
+
+| MCP | CLI |
+|-----|-----|
+| `get_brand_settings` | (MCP only) |
+| `set_brand_settings` | (MCP only) |
+
+How the brand works: posting `timezone`, target `platforms`, `hashtags` per platform, and
+`voice_examples` (real past posts the AI imitates for tone). `set_brand_settings` changes only the
+fields you send; `hashtags` and `voice_examples` **replace** the whole list, so send the full list,
+not a delta — `{}` and `[]` clear one.
+
+Two consequences to say out loud before you change either of the first two:
+
+- **Timezone.** A post that already has a time does not move. It keeps firing at the same absolute
+  instant, so its local hour shifts by the offset difference — 18:00 in Rome reads as 12:00 once
+  the brand moves to New York. Only new scheduling uses the new zone.
+- **Platforms.** The target list decides what NEW posts are made for, never what publishes.
+  Removing a platform does not cancel posts already scheduled on it: they still go out while their
+  account is connected.
+
+`get_brand_settings` also returns `connected_platforms`, and the write answers with
+`without_account`. Targeting a platform with no connected account is allowed and silent otherwise:
+posts for it are produced and then sit unpublished until an account exists. Say so when it happens.
+
+An unknown IANA zone is refused (`unknown_timezone`), and so is a platform outside the list —
+`twitter` is not a name here, it is `x`. The post language lives on `update_brand_kit`, not here.
+
 ## Media models
 
 | MCP | CLI |

--- a/cli/skills/anomalia/SKILL.md
+++ b/cli/skills/anomalia/SKILL.md
@@ -86,6 +86,13 @@ time; `update_person` and `update_competitor` fix a role or a wrong website. The
 fields you send, leave every other column as it was, and cost nothing. `update_person` can never
 attest consent: a real person's face stays withheld from every generator until the operator
 states, in their own words, that they have it.
+**Change how the brand works** → `get_brand_settings` then `set_brand_settings`: posting
+timezone, target platforms, hashtags per platform, voice examples. Only the fields you send
+change, and lists replace rather than merge. Two things to tell the person: changing the timezone
+does not move posts that already have a time (their local hour shifts instead), and removing a
+platform does not cancel posts already scheduled on it. If a target platform has no connected
+account the write says so in `without_account` — its posts will be produced and then wait.
+
 **Choose which model draws and which films** → `get_media_models` lists the six jobs (image
 generation, image refinement, video from text, animating a still, video refinement, motion
 transfer) with the models each one accepts; `set_media_model` pins one. A model that cannot do

--- a/cli/skills/anomalia/references/tools.md
+++ b/cli/skills/anomalia/references/tools.md
@@ -228,6 +228,34 @@ their own words.
 pastes it on the profile by hand. `get_bio` also returns the short link worth putting there — the
 one with the most clicks in the last seven days.
 
+## Brand settings
+
+| MCP | CLI |
+|-----|-----|
+| `get_brand_settings` | (MCP only) |
+| `set_brand_settings` | (MCP only) |
+
+How the brand works: posting `timezone`, target `platforms`, `hashtags` per platform, and
+`voice_examples` (real past posts the AI imitates for tone). `set_brand_settings` changes only the
+fields you send; `hashtags` and `voice_examples` **replace** the whole list, so send the full list,
+not a delta — `{}` and `[]` clear one.
+
+Two consequences to say out loud before you change either of the first two:
+
+- **Timezone.** A post that already has a time does not move. It keeps firing at the same absolute
+  instant, so its local hour shifts by the offset difference — 18:00 in Rome reads as 12:00 once
+  the brand moves to New York. Only new scheduling uses the new zone.
+- **Platforms.** The target list decides what NEW posts are made for, never what publishes.
+  Removing a platform does not cancel posts already scheduled on it: they still go out while their
+  account is connected.
+
+`get_brand_settings` also returns `connected_platforms`, and the write answers with
+`without_account`. Targeting a platform with no connected account is allowed and silent otherwise:
+posts for it are produced and then sit unpublished until an account exists. Say so when it happens.
+
+An unknown IANA zone is refused (`unknown_timezone`), and so is a platform outside the list —
+`twitter` is not a name here, it is `x`. The post language lives on `update_brand_kit`, not here.
+
 ## Media models
 
 | MCP | CLI |

--- a/docs/api/13-settings-brand.md
+++ b/docs/api/13-settings-brand.md
@@ -1,0 +1,103 @@
+# API — 13 · Impostazioni: come lavora il brand
+
+Due endpoint sotto `/api/v1/brands/:slug/settings/brand`, cioè i tool MCP `get_brand_settings` e
+`set_brand_settings`. Coprono quattro pagine di Settings che erano quattro form separati: fuso di
+pubblicazione, piattaforme bersaglio, hashtag per piattaforma, esempi di voce.
+
+Errori comuni di auth: vedi [01-overview](01-overview.md).
+
+## Dove è salvata ogni cosa
+
+| campo | colonna |
+|---|---|
+| `timezone` | `brands.timezone` |
+| `platforms` | `brands.target_platforms` (array; elenco vuoto → `null`) |
+| `hashtags` | `brands.content_prefs.platformHashtags` |
+| `voice_examples` | `brands.content_prefs.voiceExamples` |
+
+Nessuna migration: sono tutte colonne che il browser scrive già.
+
+La **lingua** dei post non è qui: vive su `content_prefs.language` e la scrive `update_brand_kit`.
+Due scrittori per lo stesso campo sono una divergenza in attesa.
+
+## `GET /api/v1/brands/:slug/settings/brand`
+
+Sola lettura: nessun modello, nessun credito.
+
+```json
+{
+  "brand": "demo",
+  "timezone": "Europe/Rome",
+  "platforms": ["instagram", "reddit"],
+  "platform_choices": ["instagram", "tiktok", "facebook", "linkedin", "x", "threads", "youtube", "bluesky", "reddit"],
+  "connected_platforms": ["instagram"],
+  "hashtags": { "instagram": ["#caffe", "#milano"] },
+  "voice_examples": ["Un post vero del brand."]
+}
+```
+
+`connected_platforms` è la parte che non si trova altrove. `target_platforms` **non** è validata
+contro gli account collegati: si può bersagliare una piattaforma dove non c'è dove pubblicare, e i
+post prodotti per lei restano in `approved` con `noAccount` finché un account non esiste
+(`src/lib/server/publish.ts`). Senza questo campo, un agente non ha modo di accorgersene.
+
+## `PUT /api/v1/brands/:slug/settings/brand`
+
+**Body** — tutti i campi facoltativi, ma almeno uno:
+
+```json
+{
+  "timezone": "America/New_York",
+  "platforms": ["instagram", "linkedin"],
+  "hashtags": { "instagram": ["#caffe"] },
+  "voice_examples": ["Un post vero del brand."]
+}
+```
+
+`hashtags` e `voice_examples` **sostituiscono** l'intera lista: si manda quella completa, non una
+differenza. `{}` e `[]` la cancellano. Gli hashtag passano dallo stesso ripulitore del form
+(`normalizeHashtags`): un `#` solo davanti, niente spazi o punteggiatura dentro, deduplicati, tetto
+a 30.
+
+**Response** `200`:
+
+```json
+{
+  "ok": true,
+  "timezone": "America/New_York",
+  "platforms": ["instagram", "linkedin"],
+  "hashtags": { "instagram": ["#caffe"] },
+  "voice_examples": ["Un post vero del brand."],
+  "without_account": ["linkedin"]
+}
+```
+
+**Errori**
+
+| status | error | quando |
+|---|---|---|
+| `400` | `invalid_input` | una piattaforma fuori elenco, un campo non dichiarato, un tipo sbagliato |
+| `400` | `no_fields` | body valido ma vuoto: non è una scrittura |
+| `400` | `unknown_timezone` | stringa che `Intl` non risolve come fuso |
+| `403` | `API key is read-only` | chiave senza scope `write` |
+| `500` | `update_failed` | la scrittura su `brands` è fallita |
+
+## Le due conseguenze che il tool dichiara
+
+Sono nella `description` del tool, non solo qui: è l'unica cosa che un agente legge prima di
+chiamare.
+
+**Il fuso non sposta i post che hanno già un orario.** `posts.scheduled_for` è un `timestamptz`,
+cioè un istante assoluto: la conversione da orario locale a UTC avviene **una volta**, quando la
+riga viene creata o rischedulata (`wallClockToUtc` / `nextOccurrence` in
+`src/lib/server/schedule.ts`). Nessuno la ricalcola dopo. Cambiare il fuso quindi non muove niente
+in assoluto — muove l'**ora locale** con cui quell'istante si legge: un post fissato per le 18:00 a
+Roma (16:00 UTC) diventa le 12:00 a New York. Solo le programmazioni successive usano il fuso
+nuovo.
+
+**Togliere una piattaforma non annulla i post già programmati su di essa.**
+`brands.target_platforms` è un ingresso di **produzione**: lo leggono il planner
+(`planner-inputs.ts`) e il produttore (`scheduler.ts`) per decidere per quali piattaforme scrivere
+i post NUOVI. Il percorso di pubblicazione non la legge affatto — `publish.ts` costruisce i
+bersagli dalla riga del post (`post.platforms` / `post.platform`) e l'unico cancello è l'esistenza
+di un `social_accounts` attivo. Un post già programmato esce lo stesso.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -20,6 +20,7 @@ integrazioni esterne via API key — request, response, query params, body, erro
 | [10 — Shares](10-shares.md) | `/shares`, `/shares/revoke`, e la rotta pubblica `/share/:token` |
 | [11 — Billing](11-billing.md) | `/billing/portal`, `/billing/checkout` — link Stripe che l'agente consegna all'umano |
 | [12 — Impostazioni: modelli media](12-settings-models.md) | `/settings/models` — quale modello disegna e quale gira, per brand |
+| [13 — Impostazioni: come lavora il brand](13-settings-brand.md) | `/settings/brand` — fuso, piattaforme, hashtag, esempi di voce |
 
 ## Regole di manutenzione
 

--- a/packages/api-contracts/src/brand-settings.test.ts
+++ b/packages/api-contracts/src/brand-settings.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { GET_BRAND_SETTINGS, SET_BRAND_SETTINGS, TARGET_PLATFORMS } from './brand-settings';
+import { BRAND_ENDPOINTS, statusForFailure } from './index';
+
+describe('le impostazioni di brand come contratto', () => {
+  it('stanno nel registry, o nessun agente le vede', () => {
+    for (const endpoint of [GET_BRAND_SETTINGS, SET_BRAND_SETTINGS]) {
+      expect(BRAND_ENDPOINTS, endpoint.tool).toContain(endpoint);
+    }
+  });
+
+  it('cambia solo i campi che nomini: sono tutti facoltativi', () => {
+    expect(SET_BRAND_SETTINGS.input.safeParse({ timezone: 'Europe/Rome' }).success).toBe(true);
+    expect(SET_BRAND_SETTINGS.input.safeParse({ voice_examples: [] }).success).toBe(true);
+  });
+
+  it('una richiesta vuota non è una scrittura: 400 dichiarato, non un 200 che non fa niente', () => {
+    // Lo schema resta un ZodObject puro — la registrazione MCP ci aggiunge `slug` con `.extend`,
+    // e un `.refine` lo trasformerebbe in qualcosa che `.extend` non ha. Quindi il conteggio dei
+    // campi lo fa la rotta, e il fallimento è dichiarato qui.
+    expect(statusForFailure(SET_BRAND_SETTINGS, 'no_fields')).toBe(400);
+    expect(typeof SET_BRAND_SETTINGS.input.extend).toBe('function');
+  });
+
+  it('accetta solo le piattaforme su cui il prodotto lavora', () => {
+    expect(SET_BRAND_SETTINGS.input.safeParse({ platforms: ['instagram', 'linkedin'] }).success).toBe(true);
+    expect(SET_BRAND_SETTINGS.input.safeParse({ platforms: ['myspace'] }).success).toBe(false);
+    expect(TARGET_PLATFORMS).toContain('instagram');
+  });
+
+  it('togliere ogni piattaforma è una scelta, non un errore di battitura', () => {
+    expect(SET_BRAND_SETTINGS.input.safeParse({ platforms: [] }).success).toBe(true);
+  });
+
+  it('un fuso che non esiste è colpa di chi chiama, e ha un errore suo', () => {
+    expect(statusForFailure(SET_BRAND_SETTINGS, 'unknown_timezone')).toBe(400);
+  });
+
+  it('gli hashtag sono per piattaforma, non una lista sola', () => {
+    const ok = SET_BRAND_SETTINGS.input.safeParse({ hashtags: { instagram: ['#caffe'] } });
+    expect(ok.success).toBe(true);
+    expect(SET_BRAND_SETTINGS.input.safeParse({ hashtags: { myspace: ['#x'] } }).success).toBe(false);
+  });
+
+  it('la lettura porta le scelte ammesse e quelle che non hanno dove pubblicare', () => {
+    const parsed = GET_BRAND_SETTINGS.output.safeParse({
+      brand: 'demo',
+      timezone: 'Europe/Rome',
+      platforms: ['instagram', 'reddit'],
+      platform_choices: [...TARGET_PLATFORMS],
+      connected_platforms: ['instagram'],
+      hashtags: { instagram: ['#caffe'] },
+      voice_examples: ['Un post vero del brand.']
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('dice cosa succede a un fuso cambiato e a una piattaforma tolta, o l agente non lo sa', () => {
+    // Un post gia' programmato non si sposta e non si annulla: sono le due conseguenze che
+    // rendono questi due campi diversi da una preferenza qualunque, e vivono nella descrizione
+    // perche' e' l'unica cosa che l'agente legge prima di chiamare.
+    expect(SET_BRAND_SETTINGS.description).toMatch(/does NOT move posts/);
+    expect(SET_BRAND_SETTINGS.description).toMatch(/does NOT cancel posts/);
+  });
+
+  it('twitter non e un nome che il prodotto insegna: si chiama x', () => {
+    expect(TARGET_PLATFORMS).not.toContain('twitter');
+    expect(SET_BRAND_SETTINGS.input.safeParse({ platforms: ['twitter'] }).success).toBe(false);
+  });
+});

--- a/packages/api-contracts/src/brand-settings.ts
+++ b/packages/api-contracts/src/brand-settings.ts
@@ -1,0 +1,105 @@
+import { z } from 'zod';
+import type { BrandEndpoint } from './index';
+
+/**
+ * Le piattaforme su cui il prodotto lavora. L'elenco vero e' `PLATFORM_KEYS`
+ * (`$lib/components/platform-meta`), che il contratto non puo' importare: un test dell'app tiene
+ * i due allineati. `twitter` non e' qui di proposito — e' un alias storico di `x`, e un tool che
+ * offre due nomi per la stessa piattaforma insegna il nome sbagliato.
+ */
+export const TARGET_PLATFORMS = [
+  'instagram',
+  'tiktok',
+  'facebook',
+  'linkedin',
+  'x',
+  'threads',
+  'youtube',
+  'bluesky',
+  'reddit'
+] as const;
+
+export type TargetPlatform = (typeof TARGET_PLATFORMS)[number];
+
+const platform = z.enum(TARGET_PLATFORMS);
+
+const hashtags = z
+  .partialRecord(platform, z.array(z.string()))
+  .describe('Hashtags per platform. When set for a platform, the AI uses ONLY these');
+
+const voiceExamples = z
+  .array(z.string())
+  .describe('Real past posts of the brand, one per entry, that the AI imitates for tone');
+
+export const GET_BRAND_SETTINGS = {
+  tool: 'get_brand_settings',
+  title: 'Brand settings',
+  description:
+    'How this brand works: posting timezone, the platforms it publishes to (with the ones that ' +
+    'actually have a connected account), the hashtags it allows per platform, and the past posts ' +
+    'the AI imitates for tone. Read it before set_brand_settings — it carries the platform ' +
+    'vocabulary and shows which targets have nowhere to publish yet.',
+  method: 'GET',
+  pathUnderBrand: '/settings/brand',
+  input: z.object({}).strict(),
+  output: z.object({
+    brand: z.string(),
+    timezone: z.string(),
+    platforms: z.array(z.string()),
+    platform_choices: z.array(z.string()),
+    connected_platforms: z.array(z.string()),
+    hashtags: z.record(z.string(), z.array(z.string())),
+    voice_examples: z.array(z.string())
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const SET_BRAND_SETTINGS = {
+  tool: 'set_brand_settings',
+  title: 'Change how the brand works',
+  description:
+    'Change the posting timezone, the target platforms, the per-platform hashtags, or the voice ' +
+    'examples. Only the fields you send change. `hashtags` and `voice_examples` REPLACE the whole ' +
+    'list, so send the full list you want, not a delta; `[]` and `{}` clear one. Calls no model ' +
+    'and spends no credits. ' +
+    'Two consequences worth knowing before you call it. Changing `timezone` does NOT move posts ' +
+    'that already have a time: they keep firing at the same absolute instant, so their local hour ' +
+    'shifts by the offset difference — a post set for 18:00 in Rome reads as 12:00 once the brand ' +
+    'moves to New York. Only new scheduling uses the new zone. Removing a platform from ' +
+    '`platforms` does NOT cancel posts already scheduled on it: the target list decides what NEW ' +
+    'posts are made for, never what publishes, and an existing post still goes out while its ' +
+    'account is connected.',
+  method: 'PUT',
+  pathUnderBrand: '/settings/brand',
+  input: z
+    .object({
+      timezone: z
+        .string()
+        .min(1)
+        .optional()
+        .describe('IANA zone, e.g. "Europe/Rome". Decides the local hour of every future slot'),
+      platforms: z
+        .array(platform)
+        .optional()
+        .describe('Platforms new posts are made for. An empty list leaves the planner no target'),
+      hashtags: hashtags.optional(),
+      voice_examples: voiceExamples.optional()
+    })
+    .strict(),
+  output: z.object({
+    ok: z.literal(true),
+    timezone: z.string(),
+    platforms: z.array(z.string()),
+    hashtags: z.record(z.string(), z.array(z.string())),
+    voice_examples: z.array(z.string()),
+    /** Piattaforme scelte che non hanno dove pubblicare: i post per loro restano fermi. */
+    without_account: z.array(z.string())
+  }),
+  failures: [
+    { error: 'no_fields', status: 400 },
+    { error: 'unknown_timezone', status: 400 },
+    { error: 'update_failed', status: 500 }
+  ],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -45,6 +45,7 @@ import {
   LIST_PRODUCTS
 } from './reads';
 import { DIAGNOSE_BRAND, GET_GOALS } from './brand-state';
+import { GET_BRAND_SETTINGS, SET_BRAND_SETTINGS } from './brand-settings';
 import { DIAGNOSE_RADAR, GET_MARKET_FIELD, LIST_IDEAS } from './market';
 import { GET_MEDIA_MODELS, SET_MEDIA_MODEL } from './media-models';
 import { GEO_ACTION, REFRESH_KEYWORDS, SEO_ACTION } from './search';
@@ -129,6 +130,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   GET_AUDIT_FINDINGS,
   GET_BACKLINKS,
   GET_BIO,
+  GET_BRAND_SETTINGS,
   GET_CALENDAR,
   GET_CREATION_KIT,
   GET_GEO,
@@ -166,6 +168,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   SAVE_WEEK_SEEDS,
   SEO_ACTION,
   SET_BIO,
+  SET_BRAND_SETTINGS,
   SET_MEDIA_MODEL,
   SYNC_HISTORY,
   UPDATE_ARTICLE,
@@ -233,6 +236,12 @@ export {
   LIST_ARTICLES,
   LIST_PRODUCTS
 };
+export {
+  GET_BRAND_SETTINGS,
+  SET_BRAND_SETTINGS,
+  TARGET_PLATFORMS
+} from './brand-settings';
+export type { TargetPlatform } from './brand-settings';
 export {
   DIAGNOSE_BRAND,
   DOCTOR_GATE_STATUSES,

--- a/src/lib/brand-fields.test.ts
+++ b/src/lib/brand-fields.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { normalizeHashtags, normalizeWebsite, sanitizeBrandColors } from './brand-fields';
+import {
+  isKnownTimezone,
+  normalizeHashtags,
+  normalizeWebsite,
+  sanitizeBrandColors
+} from './brand-fields';
 
 /**
  * Queste tre funzioni esistono per una ragione sola: il form dello Studio e i tool della chat
@@ -50,5 +55,27 @@ describe('normalizeHashtags', () => {
   it('si ferma a 30: un solo campo non può diventare un muro di tag', () => {
     const many = Array.from({ length: 50 }, (_, i) => `#t${i}`).join(' ');
     expect(normalizeHashtags(many)).toHaveLength(30);
+  });
+});
+
+describe('il fuso orario del brand', () => {
+  it('accetta una zona IANA vera', () => {
+    expect(isKnownTimezone('Europe/Rome')).toBe(true);
+    expect(isKnownTimezone('America/New_York')).toBe(true);
+  });
+
+  it('accetta anche gli alias storici, che restano fusi validi', () => {
+    // `Asia/Calcutta` non è nell'elenco moderno ma ICU lo risolve: rifiutarlo direbbe "non
+    // esiste" a un brand che ce l'ha salvato da anni.
+    expect(isKnownTimezone('Asia/Calcutta')).toBe(true);
+  });
+
+  it('rifiuta ciò che non è un fuso, invece di salvarlo e romperlo dopo', () => {
+    // La colonna decide l'ora locale di ogni slot futuro: una stringa qualunque non fallisce al
+    // salvataggio, fallisce quando il calendario prova a calcolare un orario.
+    expect(isKnownTimezone('Europe/Atlantide')).toBe(false);
+    expect(isKnownTimezone('CET+1')).toBe(false);
+    expect(isKnownTimezone('')).toBe(false);
+    expect(isKnownTimezone('   ')).toBe(false);
   });
 });

--- a/src/lib/brand-fields.ts
+++ b/src/lib/brand-fields.ts
@@ -52,3 +52,25 @@ export function normalizeHashtags(raw: string): string[] {
   }
   return out;
 }
+
+/**
+ * Un fuso che il runtime sa risolvere davvero.
+ *
+ * La colonna `brands.timezone` decide l'ora locale di ogni slot futuro: una stringa che non e' un
+ * fuso non fallisce al salvataggio, fallisce piu' tardi, quando qualcosa prova a calcolare un
+ * orario. Il `<select>` del browser ne offre quindici e non puo' sbagliare; un tool che riceve una
+ * stringa da un agente si'.
+ *
+ * Chiedere a `Intl` invece di tenere un elenco: cosi' gli alias storici (`Asia/Calcutta`) restano
+ * validi, e nessuno deve aggiornare una lista quando IANA ne aggiunge uno.
+ */
+export function isKnownTimezone(value: unknown): boolean {
+  const tz = String(value ?? '').trim();
+  if (!tz) return false;
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: tz });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/content/changelog/2026-09-04-agent-brand-settings.ts
+++ b/src/lib/content/changelog/2026-09-04-agent-brand-settings.ts
@@ -1,0 +1,13 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-04',
+  title: 'Your AI can set the posting timezone, platforms, hashtags and tone',
+  items: [
+    'Claude, Cursor and any connected AI client can now read and change how your brand works — posting timezone, which platforms it posts to, the hashtags allowed per platform, and the past posts it copies your tone from.',
+    'Before it changes the timezone, your AI is told what that does: posts that already have a time keep going out at the same moment, so their local hour shifts. Nothing on your calendar is silently moved.',
+    'Removing a platform no longer needs a warning from you: your AI knows it does not cancel posts already scheduled there.',
+    'If you target a platform with no connected account, you now hear about it instead of finding out when a post never goes out.',
+    'A timezone that is not a real timezone is refused, in the app as well as through your AI — it used to be saved and only break later.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/platforms.test.ts
+++ b/src/lib/platforms.test.ts
@@ -5,6 +5,8 @@ import { RADAR_PLATFORM_KEYS } from './plans';
 import { CAROUSEL_PLATFORMS } from './server/content-preview';
 import { VIDEO_PLATFORMS } from './server/market-trends';
 import { DISCOVERY_PLATFORMS } from './server/market-discovery';
+import { PLATFORM_KEYS } from './components/platform-meta';
+import { TARGET_PLATFORMS } from '@anomalia/api-contracts';
 
 const VOCAB: readonly string[] = Object.values(PLATFORM_IDS);
 
@@ -64,5 +66,13 @@ describe('every set draws its ids from the vocabulary', () => {
     for (const id of members) {
       expect(VOCAB).toContain(id);
     }
+  });
+});
+
+describe('le piattaforme che un agente puo scegliere', () => {
+  it('sono esattamente quelle su cui il prodotto lavora', () => {
+    // Il contratto non puo' importare `$lib`, quindi l'elenco vive anche li'. Una piattaforma
+    // aggiunta qui e non di la' sarebbe selezionabile dal browser e rifiutata dal tool.
+    expect([...TARGET_PLATFORMS]).toEqual(PLATFORM_KEYS);
   });
 });

--- a/src/lib/server/settings-actions.ts
+++ b/src/lib/server/settings-actions.ts
@@ -10,6 +10,7 @@ import { emailLocale } from '$lib/server/email-i18n';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { RequestEvent } from '@sveltejs/kit';
 import { isChatTier, isGatewayModelTier } from '$lib/chat-tiers';
+import { isKnownTimezone } from '$lib/brand-fields';
 import { invalidateBrandNav } from '$lib/server/nav-cache';
 import { readUploadImage } from '$lib/server/raster-image';
 import { createAdminClient } from '$lib/server/supabase-admin';
@@ -204,7 +205,7 @@ export async function setChatDefaultTier({ request, params, locals: { supabase }
 export async function setTimezone({ request, params, locals: { supabase } }: Ev) {
   const data = await request.formData();
   const tz = String(data.get('timezone') ?? '').trim();
-  if (!tz) return { error: 'Pick a timezone' };
+  if (!isKnownTimezone(tz)) return { error: 'Pick a timezone' };
   const { error } = await supabase.from('brands').update({ timezone: tz }).eq('slug', params.brand!);
   if (error) return { error: error.message };
   invalidateBrandNav(params.brand!);

--- a/src/routes/api/v1/brands/[slug]/settings/brand/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/settings/brand/+server.ts
@@ -1,0 +1,129 @@
+import { json } from '@sveltejs/kit';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { RequestHandler } from './$types';
+import { authenticate, loadBrandForUser, checkApiKeyWriteAccess } from '$lib/server/cli-auth';
+import { SET_BRAND_SETTINGS, TARGET_PLATFORMS, statusForFailure } from '@anomalia/api-contracts';
+import { isKnownTimezone, normalizeHashtags } from '$lib/brand-fields';
+
+type Prefs = Record<string, unknown>;
+
+// Come lavora il brand: fuso di pubblicazione, piattaforme bersaglio, hashtag per piattaforma,
+// esempi di voce. Sono le impostazioni che un cliente cambia davvero, e finora esistevano solo
+// dietro quattro form diversi.
+//
+// La lettura porta anche le piattaforme che hanno un account collegato. Non è decorazione:
+// `target_platforms` non è validata contro gli account, quindi un agente può bersagliare una
+// piattaforma dove non c'è dove pubblicare, e i post per lei restano fermi in `approved` senza
+// che nessuno lo dica.
+
+async function connectedPlatforms(supabase: SupabaseClient, brandId: string): Promise<string[]> {
+  const { data } = await supabase
+    .from('social_accounts')
+    .select('platform')
+    .eq('brand_id', brandId)
+    .eq('status', 'active');
+
+  return [...new Set((data ?? []).map((row) => String(row.platform ?? '').toLowerCase()))].filter(Boolean);
+}
+
+const storedHashtags = (prefs: Prefs): Record<string, string[]> =>
+  (prefs.platformHashtags as Record<string, string[]>) ?? {};
+
+const storedExamples = (prefs: Prefs): string[] => (prefs.voiceExamples as string[]) ?? [];
+
+export const GET: RequestHandler = async ({ request, params }) => {
+  const { supabase, error, apiKey } = await authenticate(request);
+  if (error) return error;
+
+  const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
+  if (brandError) return brandError;
+
+  const prefs = (brand.content_prefs ?? {}) as Prefs;
+
+  return json({
+    brand: brand.slug,
+    timezone: brand.timezone,
+    platforms: brand.target_platforms ?? [],
+    platform_choices: [...TARGET_PLATFORMS],
+    connected_platforms: await connectedPlatforms(supabase, brand.id),
+    hashtags: storedHashtags(prefs),
+    voice_examples: storedExamples(prefs)
+  });
+};
+
+export const PUT: RequestHandler = async ({ request, params }) => {
+  const { supabase, error, apiKey } = await authenticate(request);
+  if (error) return error;
+
+  const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
+  if (brandError) return brandError;
+  const writeDenied = checkApiKeyWriteAccess(apiKey);
+  if (writeDenied) return writeDenied;
+
+  const parsed = SET_BRAND_SETTINGS.input.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return json({ error: 'invalid_input', details: parsed.error.issues }, { status: 400 });
+  }
+
+  const input = parsed.data;
+  if (Object.keys(input).length === 0) {
+    return json({ error: 'no_fields' }, { status: statusForFailure(SET_BRAND_SETTINGS, 'no_fields') });
+  }
+
+  if (input.timezone !== undefined && !isKnownTimezone(input.timezone)) {
+    return json(
+      { error: 'unknown_timezone', timezone: input.timezone },
+      { status: statusForFailure(SET_BRAND_SETTINGS, 'unknown_timezone') }
+    );
+  }
+
+  const prefs: Prefs = { ...((brand.content_prefs ?? {}) as Prefs) };
+
+  if (input.hashtags !== undefined) {
+    const map: Record<string, string[]> = {};
+    for (const [platform, tags] of Object.entries(input.hashtags)) {
+      // Lo stesso ripulitore del form: uno `#` solo, niente spazi dentro, deduplicati, tetto a 30.
+      const clean = normalizeHashtags((tags ?? []).join(' '));
+      if (clean.length) map[platform] = clean;
+    }
+    if (Object.keys(map).length) prefs.platformHashtags = map;
+    else delete prefs.platformHashtags;
+  }
+
+  if (input.voice_examples !== undefined) {
+    const examples = input.voice_examples.map((line) => String(line ?? '').trim()).filter(Boolean);
+    if (examples.length) prefs.voiceExamples = examples;
+    else delete prefs.voiceExamples;
+  }
+
+  const platforms = input.platforms ? [...new Set(input.platforms)] : undefined;
+
+  const patch = {
+    ...(input.timezone !== undefined ? { timezone: input.timezone } : {}),
+    // Elenco vuoto = nessun bersaglio, salvato come null: è la forma che ogni lettore già gestisce.
+    ...(platforms !== undefined ? { target_platforms: platforms.length ? platforms : null } : {}),
+    ...(input.hashtags !== undefined || input.voice_examples !== undefined
+      ? { content_prefs: prefs }
+      : {})
+  };
+
+  const { error: updateError } = await supabase.from('brands').update(patch).eq('id', brand.id);
+  if (updateError) {
+    return json(
+      { error: 'update_failed', detail: updateError.message },
+      { status: statusForFailure(SET_BRAND_SETTINGS, 'update_failed') }
+    );
+  }
+
+  const saved = platforms ?? brand.target_platforms ?? [];
+  const connected = await connectedPlatforms(supabase, brand.id);
+
+  return json({
+    ok: true,
+    timezone: input.timezone ?? brand.timezone,
+    platforms: saved,
+    hashtags: storedHashtags(prefs),
+    voice_examples: storedExamples(prefs),
+    without_account: saved.filter((p: string) => !connected.includes(p))
+  });
+};

--- a/src/routes/api/v1/brands/[slug]/settings/brand/server.test.ts
+++ b/src/routes/api/v1/brands/[slug]/settings/brand/server.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('$lib/server/cli-auth', () => ({
+  authenticate: vi.fn(),
+  loadBrandForUser: vi.fn(),
+  checkApiKeyWriteAccess: vi.fn(() => null)
+}));
+
+import { GET, PUT } from './+server';
+import { authenticate, loadBrandForUser, checkApiKeyWriteAccess } from '$lib/server/cli-auth';
+
+type Row = Record<string, unknown>;
+
+function fakeSupabase(accounts: Row[] = [], updateError: { message: string } | null = null) {
+  const updates: Row[] = [];
+  const client = {
+    from(table: string) {
+      if (table === 'social_accounts') {
+        const q = {
+          select: () => q,
+          eq(_col: string, _val: unknown) {
+            return _col === 'status' ? Promise.resolve({ data: accounts }) : q;
+          }
+        };
+        return q;
+      }
+      const q = {
+        update(row: Row) {
+          updates.push(row);
+          return q;
+        },
+        eq: async () => ({ error: updateError })
+      };
+      return q;
+    }
+  };
+  return { client, updates };
+}
+
+let supabase: ReturnType<typeof fakeSupabase>;
+
+const BRAND = {
+  id: 'brand-1',
+  slug: 'demo',
+  timezone: 'Europe/Rome',
+  target_platforms: ['instagram'],
+  content_prefs: null as Row | null
+};
+
+const brandWith = (patch: Partial<typeof BRAND>) => ({ ...BRAND, ...patch });
+
+const url = 'https://example.test/api/v1/brands/demo/settings/brand';
+
+const read = () =>
+  (GET as (e: unknown) => Promise<Response>)({ request: new Request(url), params: { slug: 'demo' } });
+
+const write = (body: unknown) =>
+  (PUT as (e: unknown) => Promise<Response>)({
+    request: new Request(url, { method: 'PUT', body: JSON.stringify(body) }),
+    params: { slug: 'demo' }
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  supabase = fakeSupabase([{ platform: 'instagram' }]);
+  vi.mocked(authenticate).mockResolvedValue({ supabase: supabase.client, apiKey: null, error: null } as never);
+  vi.mocked(loadBrandForUser).mockResolvedValue({ brand: BRAND, error: null } as never);
+  vi.mocked(checkApiKeyWriteAccess).mockReturnValue(null as never);
+});
+
+describe('GET /api/v1/brands/:slug/settings/brand', () => {
+  it('porta il fuso, le piattaforme scelte e il vocabolario ammesso', async () => {
+    const body = await (await read()).json();
+
+    expect(body.timezone).toBe('Europe/Rome');
+    expect(body.platforms).toEqual(['instagram']);
+    expect(body.platform_choices).toContain('linkedin');
+  });
+
+  it('dice quali piattaforme hanno davvero un account, non solo quali sono bersaglio', async () => {
+    // Bersagliare una piattaforma senza account non è un errore, ma i post per lei restano fermi:
+    // se il tool non lo dice, nessuno lo scopre finché non manca un post.
+    vi.mocked(loadBrandForUser).mockResolvedValue({
+      brand: brandWith({ target_platforms: ['instagram', 'reddit'] }),
+      error: null
+    } as never);
+
+    const body = await (await read()).json();
+
+    expect(body.platforms).toEqual(['instagram', 'reddit']);
+    expect(body.connected_platforms).toEqual(['instagram']);
+  });
+
+  it('un brand senza preferenze risponde con liste vuote, non con null', async () => {
+    const body = await (await read()).json();
+
+    expect(body.hashtags).toEqual({});
+    expect(body.voice_examples).toEqual([]);
+  });
+});
+
+describe('PUT /api/v1/brands/:slug/settings/brand', () => {
+  it('cambia solo i campi nominati', async () => {
+    const res = await write({ timezone: 'America/New_York' });
+
+    expect(res.status).toBe(200);
+    expect(supabase.updates[0]).toEqual({ timezone: 'America/New_York' });
+  });
+
+  it('rifiuta un fuso che non esiste invece di romperlo al primo calcolo di orario', async () => {
+    const res = await write({ timezone: 'Europe/Atlantide' });
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('unknown_timezone');
+    expect(supabase.updates).toEqual([]);
+  });
+
+  it('una richiesta senza campi è 400 dichiarato, non un 200 che non fa niente', async () => {
+    const res = await write({});
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('no_fields');
+    expect(supabase.updates).toEqual([]);
+  });
+
+  it('rifiuta una piattaforma che il prodotto non serve', async () => {
+    const res = await write({ platforms: ['myspace'] });
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('invalid_input');
+    expect(supabase.updates).toEqual([]);
+  });
+
+  it('togliere ogni piattaforma salva null, la forma che ogni lettore già gestisce', async () => {
+    await write({ platforms: [] });
+
+    expect(supabase.updates[0]).toEqual({ target_platforms: null });
+  });
+
+  it('non salva la stessa piattaforma due volte', async () => {
+    await write({ platforms: ['instagram', 'instagram', 'linkedin'] });
+
+    expect(supabase.updates[0]).toEqual({ target_platforms: ['instagram', 'linkedin'] });
+  });
+
+  it('avverte quando una piattaforma scelta non ha dove pubblicare', async () => {
+    const body = await (await write({ platforms: ['instagram', 'reddit'] })).json();
+
+    expect(body.without_account).toEqual(['reddit']);
+  });
+
+  it('ripulisce gli hashtag con lo stesso ripulitore del form', async () => {
+    await write({ hashtags: { instagram: ['caffe speciale', '#Caffe'] } });
+
+    const prefs = supabase.updates[0].content_prefs as Row;
+    expect(prefs.platformHashtags).toEqual({ instagram: ['#caffe', '#speciale'] });
+  });
+
+  it('una mappa vuota toglie gli hashtag invece di salvarne una vuota', async () => {
+    vi.mocked(loadBrandForUser).mockResolvedValue({
+      brand: brandWith({ content_prefs: { platformHashtags: { instagram: ['#x'] }, language: 'it' } }),
+      error: null
+    } as never);
+
+    await write({ hashtags: {} });
+
+    expect(supabase.updates[0].content_prefs).toEqual({ language: 'it' });
+  });
+
+  it('scarta le righe vuote fra gli esempi di voce', async () => {
+    await write({ voice_examples: ['Un post vero.', '   ', ''] });
+
+    const prefs = supabase.updates[0].content_prefs as Row;
+    expect(prefs.voiceExamples).toEqual(['Un post vero.']);
+  });
+
+  it('non tocca le altre preferenze del brand', async () => {
+    vi.mocked(loadBrandForUser).mockResolvedValue({
+      brand: brandWith({ content_prefs: { imageModel: 'gpt-image-2', language: 'it' } }),
+      error: null
+    } as never);
+
+    await write({ voice_examples: ['Un post vero.'] });
+
+    expect(supabase.updates[0].content_prefs).toEqual({
+      imageModel: 'gpt-image-2',
+      language: 'it',
+      voiceExamples: ['Un post vero.']
+    });
+  });
+
+  it('si ferma prima di scrivere se la chiave è di sola lettura', async () => {
+    vi.mocked(checkApiKeyWriteAccess).mockReturnValue(new Response('read only', { status: 403 }) as never);
+
+    const res = await write({ timezone: 'America/New_York' });
+
+    expect(res.status).toBe(403);
+    expect(supabase.updates).toEqual([]);
+  });
+
+  it('si ferma prima di scrivere se il brand non è del chiamante', async () => {
+    vi.mocked(loadBrandForUser).mockResolvedValue({
+      brand: null,
+      error: new Response('not found', { status: 404 })
+    } as never);
+
+    const res = await write({ timezone: 'America/New_York' });
+
+    expect(res.status).toBe(404);
+    expect(supabase.updates).toEqual([]);
+  });
+
+  it('riporta il fallimento della scrittura come il 500 dichiarato', async () => {
+    supabase = fakeSupabase([], { message: 'connection reset' });
+    vi.mocked(authenticate).mockResolvedValue({ supabase: supabase.client, apiKey: null, error: null } as never);
+
+    const res = await write({ timezone: 'America/New_York' });
+
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('update_failed');
+  });
+});


### PR DESCRIPTION
## What?

Four Settings pages that were four separate forms become one pair of registry-generated tools: `get_brand_settings` (GET `/api/v1/brands/:slug/settings/brand`) and `set_brand_settings` (PUT, same path). They cover the posting **timezone**, the target **platforms**, the per-platform **hashtags**, and the **voice examples** the AI imitates for tone.

Everything lands on columns the browser already writes — `brands.timezone`, `brands.target_platforms`, `brands.content_prefs.platformHashtags`, `brands.content_prefs.voiceExamples`. **No migration.**

`tools/list` goes from **97 to 99**. Object-by-object comparison of every existing tool: `new: [get_brand_settings, set_brand_settings]`, `gone: []`, `changed: []`.

The PR also closes a real gap it found on the way: `setTimezone` accepted any non-empty string.

## Why?

These are the settings a customer actually changes, and after the media models they are the closest thing to what was asked for by name. Anomalia is becoming a headless interface: a person should be able to tell their agent "post in New York time, drop Reddit, use these hashtags on Instagram" and have it happen.

## How?

**One tool with four optional fields, not four tools.** They all live on the brand and get changed together. A `PUT` that touches only the named fields is the shape `update_product` and `update_brand_kit` already use here, and it saves an agent three round trips when it tidies a brand in one go. The post **language** is deliberately not writable here — `update_brand_kit` already owns that field, and two writers for one column is a divergence waiting.

**`destructive: false` on all four, and that is a finding, not an assumption.** Before writing a line I traced what these two columns actually do:

- **Timezone.** `posts.scheduled_for` is a `timestamptz` (`0004_content_plans_posts.sql`) — an absolute instant. The local→UTC conversion happens **once**, when the row is written (`wallClockToUtc` / `nextOccurrence`, `src/lib/server/schedule.ts`), and nothing recomputes it afterwards. Changing the timezone moves nothing in absolute time; it moves the **local hour** that instant reads as: 18:00 in Rome = 16:00 UTC = 12:00 in New York. Only new scheduling uses the new zone.
- **Platforms.** `brands.target_platforms` is a **production-time** input — read by `planner-inputs.ts` and `scheduler.ts` to decide what NEW posts are made for. `publish.ts` never reads it: it builds targets from `post.platforms ?? [post.platform]`, and the only gate is an active `social_accounts` row. Removing a platform does not cancel posts already scheduled on it.

Both sentences are in the tool's `description`, not only in the docs, and a test holds them there. That is the only text an agent reads before calling, and an agent that shifts a customer's calendar without knowing is worse than a tool that does not exist.

**The trap the read makes visible.** `target_platforms` is not validated against connected accounts anywhere — not the form, not the chat tool, not onboarding. You can target a platform with nowhere to publish; posts get produced and then sit at `approved` with `noAccount`, silently. So the read returns `connected_platforms` and the write answers with `without_account`. I did **not** add a refusal: targeting before connecting is a legitimate order of work (onboarding does exactly that), so saying it happens is right and preventing it is not.

**A schema constraint worth knowing.** `input` must stay a plain `ZodObject`: MCP registration adds `slug` with `.extend`, and a `.refine` for "at least one field" would turn it into something without `.extend` — a runtime crash on `tools/list`, not a compile error. So the field count is checked in the route with `no_fields` declared in the contract, and a test pins the property.

**Two platform lists, one law.** Same shape as the model slots: the contract cannot import `$lib`, so `TARGET_PLATFORMS` lives there too, and `src/lib/platforms.test.ts` — already this repo's platform-vocabulary law — compares it with `PLATFORM_KEYS`. `twitter` is deliberately absent: it is a historical alias for `x`, and a tool offering two names for one platform teaches the wrong one.

**The timezone gap, fixed for both callers.** `isKnownTimezone` goes in `$lib/brand-fields.ts`, the file whose own docblock says a field is cleaned in one place or you are writing the second version of the rule. Route and form both call it. It asks `Intl` instead of keeping a list, so historical aliases (`Asia/Calcutta`) stay valid and nobody maintains a list when IANA adds a zone.

## Testing?

Red before green, with real output.

- **contract** — run before `brand-settings.ts` existed. Then green.
- **`isKnownTimezone`** — run before it existed: `ReferenceError: isKnownTimezone is not defined`. Then green.
- **the route** — proven by removing the load-bearing logic (timezone validation, the `no_fields` guard, hashtag normalization, platform dedupe, the `without_account` computation): **exactly 5 of 17 fail**, 12 stay green. Restored, 17/17.
- **the platform guard** — proven by adding `myspace` to the contract's list: red. Reverted.

| command | result |
|---|---|
| `npx vitest run packages/api-contracts` | 10 files, 123 tests, pass |
| `cd cli && bun test` | 57 tests, 0 fail |
| `cd cli && bun run typecheck` | clean |
| `node scripts/typecheck-runtime.mjs` | ok |
| affected app tests (platforms, brand-fields, both settings routes, changelog, no-app-imports) | 149 tests, pass |

**Not tested:** no browser, Docker, dev server or Playwright — forbidden for this task. The full `npm run test:unit` was not run either; CI runs it.

**Risk:** the write reads `content_prefs`, patches it, and writes the whole blob back — the same thing every form action here has always done, so a concurrent write to a different key can lose a race. Pre-existing, not introduced. Also: `setTimezone` now refuses a value it used to accept. The browser `<select>` only ever offered valid zones, so no existing path can hit it; a brand row already holding a bad value is unaffected until someone tries to save it again.

## Evidence

<details>
<summary>tools/list through handleMcpFetch, on origin/dev and on this branch</summary>

```
new:     ['get_brand_settings', 'set_brand_settings']
gone:    []
changed: []
count:   97 → 99
```

The hashtag map teaches the vocabulary through the schema, not through prose:

```json
"hashtags": {
  "type": "object",
  "propertyNames": { "type": "string", "enum": ["instagram","tiktok","facebook","linkedin","x","threads","youtube","bluesky","reddit"] },
  "additionalProperties": { "type": "array", "items": { "type": "string" } }
}
```

</details>

<details>
<summary>Red, then green: the route with its logic removed</summary>

```
× rifiuta un fuso che non esiste invece di romperlo al primo calcolo di orario
× una richiesta senza campi è 400 dichiarato, non un 200 che non fa niente
× non salva la stessa piattaforma due volte
× avverte quando una piattaforma scelta non ha dove pubblicare
× ripulisce gli hashtag con lo stesso ripulitore del form
   Tests  5 failed | 12 passed (17)
```

</details>

<details>
<summary>The write's answer, from the test run</summary>

```
PUT { platforms: ['instagram', 'reddit'] }   (only instagram has an active account)
→ 200 { ok: true, platforms: ['instagram','reddit'], without_account: ['reddit'], … }

PUT { timezone: 'Europe/Atlantide' }  → 400 { error: 'unknown_timezone' }   (nothing written)
PUT { }                               → 400 { error: 'no_fields' }          (nothing written)
PUT { platforms: ['myspace'] }        → 400 { error: 'invalid_input' }      (nothing written)
```

</details>

No UI change: this PR adds no page and touches no component.

## Anything Else?

**Census decisions carried into this PR** (the reasons, not just the verdicts):

- **`ads` — read yes, write no.** A spend cap is somebody else's money: raising it is spending it by proxy, and unlike a Stripe link there is not even a hosted page acting as witness. A `get_ads_settings` is worth having — an agent planning campaigns needs to know the limits it is inside — and it is not in this PR. If `brands.ads_settings` turns out to hold fields that are *not* money (format preferences, targeting, exclusions), those are ordinary configuration and can be writable; that separation has to be looked at on the column, not assumed.
- **`profile` — out.** It is the user's, not the brand's, and the registry is brand-scoped. Exposing it there would bend the scoping for one case.
- **`appearance` — out, nothing to expose.** It lives only in `localStorage`; there is no server state.
- **`usage`, `publishing`, `ads/accounts` — reads only.** They are mirrors of state.

**A defect found during the census, not fixed here.** `src/routes/app/[brand]/settings/referrals` calls `ensureReferralCode` during `load` — a page load that INSERTs a row. A read that writes is a trap independent of this work: it means a GET has a side effect, it fires on every visit, and anything that prefetches that route creates data. Recording it here so whoever meets it finds it written down.

**A column outliving what used it.** `brands.chat_default_tier` has a column (`20260902180000_chat_model_default.sql`) and a setter (`setChatDefaultTier` in `settings-actions.ts`), and **no UI or route calls either** — confirmed by repo-wide grep. With the chat catalogue mid-teardown, this is a removal candidate once the chats are out, not something to expose. Flagging it so it does not quietly survive for years.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
