### PR TITLE
Let an agent switch the recurring jobs, and say what that costs

### DIFF
--- a/changelog/2026-09-04-agent-automations.md
+++ b/changelog/2026-09-04-agent-automations.md
@@ -1,0 +1,86 @@
+# I lavori ricorrenti si accendono da fuori, e accendere dice che costa
+
+Terzo giro sulle impostazioni headless. `get_automations` e `set_automation`, su
+`GET`/`PUT /api/v1/brands/:slug/settings/automations`. `tools/list`: **97 → 99**, additivo,
+`changed: []` sul confronto oggetto per oggetto.
+
+## Perché nove lavori e non l'interruttore dell'autopilot
+
+La pagina `settings/autopilot` sembra un booleano. Non lo è: chiama
+`setJobEnabled(admin, { jobKey: 'autopilot' })`, e `autopilot` è **una riga di `ROSTER_JOBS`, che
+ne ha nove**. Esiste già `brandRoster()` che per ciascuno restituisce `enabled`, `cadence`,
+`state`, `reason`, `lastRunAt`, `servedAt`, `behind`, e la pagina `/agents` li accende tutti.
+
+Esporne uno solo quando la funzione condivisa ne accetta nove sarebbe una scelta arbitraria che
+qualcuno avrebbe dovuto disfare. Nessun codice nuovo per gli altri otto: sono la stessa chiamata.
+
+## La parte che decide la forma del tool: accendere impegna denaro
+
+Questi lavori girano **da soli** e chiamano modelli AI a ogni giro. Un agente esterno che ne
+accende uno non cambia una preferenza — impegna crediti del cliente, ripetutamente, senza che
+nessuno lo riguardi. È meno visibile di un pagamento proprio perché non c'è nessuna schermata a
+fare da testimone.
+
+Il precedente è di oggi: il cron delle routine dei custom agents faceva 288 esecuzioni AI al
+giorno ed è stato spento perché qualcuno è andato a contarle. Un tool che accende senza dire il
+costo prepara quella situazione, con la differenza che l'avremmo costruita noi.
+
+Quindi:
+
+- la `description` di `set_automation` dichiara che accendere è una decisione di spesa, che il
+  lavoro girerà da solo alla sua cadenza, e che **spegnere non spende niente**. Tre test tengono
+  lì quelle frasi: se sparisce la frase, sparisce l'avvertimento;
+- la risposta di chi accende porta `spends_on_every_run` e `cadence`, così ciò che è stato
+  impegnato resta scritto nel turno, non solo nella descrizione letta prima;
+- `enabled` non ha default: accendere e spegnere sono due gesti espliciti.
+
+**`openWorld` non è impostato, e non è una svista.** In questo registry `openWorld` vuol dire
+"esce su internet" (`diagnose_radar`, `research_competitors`, `sync_history`). `set_automation`
+cambia una riga nel nostro database: usare quel flag per dire "costa" sarebbe un'annotazione che
+mente su cosa il tool fa — lo stesso errore dell'enum piatto sui modelli. Il registry non sa
+esprimere "impegna spesa futura"; lo dicono la descrizione e la risposta.
+
+## Il costo per lavoro: non esiste, e il tool lo dice invece di tacere
+
+Sono andato a vedere se `ai_calls` permettesse una somma per lavoro. **No**, e per quattro ragioni
+indipendenti:
+
+1. `ai_calls` non ha nessuna colonna che nomini il loop. `context` è testo libero per call site
+   (`'design/compose'`, `'produce-agent'`, `'tool=…'`), mai una chiave del roster.
+2. Le `label` sono **condivise fra lavori**: `director` / `directorRewrite` stanno sia in
+   `autopilot` sia in `radar_recap`; `createSingleContent` sta sia in `autopilot` sia nella
+   creazione manuale dal browser. Un `CASE WHEN label IN (…)` attribuirebbe male.
+3. `strategy_review` non è isolabile affatto: gira come un turno di chat nel thread dell'agente
+   proprietario, indistinguibile da un turno digitato da una persona.
+4. `loop_ticks` — l'unica tabella che nomina il loop — non ha né costo né chiave di join verso
+   `ai_calls`. E gli aggregati PostgREST sono disattivati su questo progetto (`0158_provider_spend`
+   esiste proprio per questo), quindi anche volendo servirebbe una funzione SQL nuova.
+
+Al posto di un numero inventato, il tool porta `runs_30d`: **quante volte il lavoro ha davvero
+girato**. I giri `skipped` non contano — un gate li ha fermati prima di spendere, e contarli
+direbbe "questo ti costa" di qualcosa che non è costato; i `failed` contano, perché possono aver
+già speso prima di fallire. Con `cadence`, è quello che serve per descrivere l'impegno.
+
+E la `description` della lettura **dice** che il costo per lavoro non è attribuibile, invece di
+lasciare che l'assenza sembri una dimenticanza. Un test lo tiene fermo, e verifica anche che
+nell'output non compaia un campo `spend_usd`.
+
+Per avere davvero il costo servirebbe una colonna `loop` su `ai_calls` scritta da ogni call site
+dentro ogni tick: una migration più un'instrumentazione diffusa. È una decisione, non un dettaglio
+di questo endpoint, e in questo repo le migration non le applica il deploy.
+
+## Una fonte sola per il testo dei lavori
+
+`ROSTER_JOB_BLURBS` era privato e lo leggeva solo `rosterForPrompt`. Ora c'è `jobBlurb(key)`
+esportata, con dentro il ripiego sul nome, e la usano sia il prompt sia il tool: un lavoro nuovo
+entra in tutti e due senza che nessuno se ne ricordi. Il contratto **non** ricopia i testi — solo
+le nove chiavi, che un test confronta con `ROSTER_JOBS`.
+
+## Cosa è stato visto rosso
+
+- il contratto, prima di essere nel registry;
+- il guardiano delle nove chiavi, con un `made_up_job` aggiunto al contratto;
+- `jobRunCounts`: tolti il filtro sugli esiti e quello sulla finestra, cadono i due test che li
+  pretendono;
+- la rotta: tolti il conteggio, il gate del piano, `spends_on_every_run` e la gestione del
+  fallimento dell'interruttore, **cadono 5 test su 12** e 7 restano verdi.

--- a/cli/lib/contracts/automations.ts
+++ b/cli/lib/contracts/automations.ts
@@ -1,0 +1,92 @@
+import { z } from 'zod';
+import type { BrandEndpoint } from './index';
+
+/**
+ * I lavori ricorrenti inclusi nel prodotto. L'elenco vero e' `ROSTER_JOBS`
+ * (`$lib/server/job-roster`), che il contratto non puo' importare: un test dell'app tiene i due
+ * allineati. Il testo di cosa fa ciascuno NON e' qui — arriva dalla rotta, da `jobBlurb`, che e'
+ * la stessa fonte del prompt di onboarding.
+ */
+export const AUTOMATION_JOBS = [
+  'autopilot',
+  'analytics_review',
+  'weekly_recap',
+  'seo',
+  'geo',
+  'radar_recap',
+  'market_refs',
+  'strategy_review',
+  'library'
+] as const;
+
+export type AutomationJob = (typeof AUTOMATION_JOBS)[number];
+
+export const AUTOMATION_CADENCES = ['daily', 'weekly', 'monthly'] as const;
+export const AUTOMATION_STATES = ['off', 'ok', 'skipped', 'failed', 'never'] as const;
+
+const job = z.enum(AUTOMATION_JOBS).describe('Which recurring job');
+
+const Job = z.object({
+  job: z.enum(AUTOMATION_JOBS),
+  what: z.string(),
+  cadence: z.enum(AUTOMATION_CADENCES),
+  enabled: z.boolean(),
+  state: z.enum(AUTOMATION_STATES),
+  reason: z.string().nullable(),
+  last_run_at: z.string().nullable(),
+  behind: z.boolean(),
+  /** Quante volte ha davvero girato negli ultimi 30 giorni: i giri fermati da un gate non contano. */
+  runs_30d: z.number()
+});
+
+export const GET_AUTOMATIONS = {
+  tool: 'get_automations',
+  title: 'Recurring jobs',
+  description:
+    'The recurring jobs included with the product and whether this brand runs them: what each ' +
+    'one does, how often, whether it is on, how it went last time, and how many times it ' +
+    'actually ran in the last 30 days. Read it before set_automation — `runs_30d` with `cadence` ' +
+    'is how you tell what turning one on commits the brand to. What it CANNOT tell you is the ' +
+    'money: AI spend is recorded per call, with no column naming the job that made it, so no ' +
+    'clean read attributes dollars to one automation. The brand-wide bill is on the usage page.',
+  method: 'GET',
+  pathUnderBrand: '/settings/automations',
+  input: z.object({}).strict(),
+  output: z.object({
+    brand: z.string(),
+    plan: z.string().nullable(),
+    /** Senza un piano a pagamento nessuno di questi parte, per quanti se ne accendano. */
+    scheduled_work_allowed: z.boolean(),
+    jobs: z.array(Job)
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const SET_AUTOMATION = {
+  tool: 'set_automation',
+  title: 'Turn a recurring job on or off',
+  description:
+    'Turn one recurring job on or off for this brand. ' +
+    'Turning one ON is a spending decision, not a preference: from that moment the job runs BY ' +
+    'ITSELF on its cadence, and every run calls AI models and spends the brand’s credits, with ' +
+    'nobody looking. Say which job, how often it will run, and that it spends — before you turn ' +
+    'it on, and to the person whose credits they are. Turning one OFF spends nothing and is the ' +
+    'safe direction: it takes effect at the next tick and destroys nothing. ' +
+    'A brand without a paid plan runs none of them, however many are on. The call itself calls ' +
+    'no model and spends no credits.',
+  method: 'PUT',
+  pathUnderBrand: '/settings/automations',
+  input: z.object({ job, enabled: z.boolean().describe('true starts it running by itself') }).strict(),
+  output: z.object({
+    ok: z.literal(true),
+    job: z.enum(AUTOMATION_JOBS),
+    enabled: z.boolean(),
+    cadence: z.enum(AUTOMATION_CADENCES),
+    /** Ripetuto nella risposta di chi ACCENDE: cosa e' stato impegnato resta scritto nel turno. */
+    spends_on_every_run: z.boolean(),
+    scheduled_work_allowed: z.boolean()
+  }),
+  failures: [{ error: 'toggle_failed', status: 500 }],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/cli/lib/contracts/index.ts
+++ b/cli/lib/contracts/index.ts
@@ -1,5 +1,6 @@
 import type { z } from 'zod';
 import { ADS_REMIX } from './ads';
+import { GET_AUTOMATIONS, SET_AUTOMATION } from './automations';
 import { BILLING_PORTAL_LINK, CHECKOUT_LINK } from './billing';
 import { GET_ARTICLE, UPDATE_ARTICLE } from './articles';
 import { CHECK_CONTENT } from './content';
@@ -127,6 +128,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   GET_ADS,
   GET_ANALYTICS,
   GET_ARTICLE,
+  GET_AUTOMATIONS,
   GET_AUDIT_FINDINGS,
   GET_BACKLINKS,
   GET_BIO,
@@ -167,6 +169,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   SAVE_PLAN,
   SAVE_WEEK_SEEDS,
   SEO_ACTION,
+  SET_AUTOMATION,
   SET_BIO,
   SET_BRAND_SETTINGS,
   SET_MEDIA_MODEL,
@@ -282,6 +285,14 @@ export {
   REVOKE_SHARE,
   SHARED_VIEW_TYPES,
 };
+export {
+  AUTOMATION_CADENCES,
+  AUTOMATION_JOBS,
+  AUTOMATION_STATES,
+  GET_AUTOMATIONS,
+  SET_AUTOMATION
+} from './automations';
+export type { AutomationJob } from './automations';
 export { BILLING_PORTAL_LINK, CHECKOUT_LINK };
 export type { BillingPortalLinkResult, CheckoutLinkInput, CheckoutLinkResult } from './billing';
 export type { CheckContentInput, CheckContentResult } from './content';

--- a/cli/plugins/anomalia/skills/anomalia/SKILL.md
+++ b/cli/plugins/anomalia/skills/anomalia/SKILL.md
@@ -93,6 +93,13 @@ does not move posts that already have a time (their local hour shifts instead), 
 platform does not cancel posts already scheduled on it. If a target platform has no connected
 account the write says so in `without_account` — its posts will be produced and then wait.
 
+**Turn a recurring job on or off** → `get_automations` lists the nine included jobs with their
+cadence, state and `runs_30d`; `set_automation` flips one. Turning one ON commits the brand to
+recurring AI spend with nobody watching, so say which job, how often, and that it spends before
+you do it. Turning one OFF is free and safe. There is no per-job cost figure — spend is not
+attributable to one job — so describe the commitment with cadence and `runs_30d`, and never
+invent a number.
+
 **Choose which model draws and which films** → `get_media_models` lists the six jobs (image
 generation, image refinement, video from text, animating a still, video refinement, motion
 transfer) with the models each one accepts; `set_media_model` pins one. A model that cannot do

--- a/cli/plugins/anomalia/skills/anomalia/references/tools.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/tools.md
@@ -256,6 +256,33 @@ posts for it are produced and then sit unpublished until an account exists. Say 
 An unknown IANA zone is refused (`unknown_timezone`), and so is a platform outside the list —
 `twitter` is not a name here, it is `x`. The post language lives on `update_brand_kit`, not here.
 
+## Recurring jobs
+
+| MCP | CLI |
+|-----|-----|
+| `get_automations` | (MCP only) |
+| `set_automation` | (MCP only) |
+
+The nine jobs included with the product — `autopilot`, `analytics_review`, `weekly_recap`, `seo`,
+`geo`, `radar_recap`, `market_refs`, `strategy_review`, `library` — with what each does, its
+cadence, whether it is on, how it went last time, whether it is behind, and `runs_30d`: how many
+times it actually ran in the last 30 days (runs a gate stopped are not counted, because they spent
+nothing).
+
+**Turning one ON is a spending decision, not a preference.** From that moment the job runs by
+itself on its cadence, and every run calls AI models and spends the brand's credits, with nobody
+looking. Before you turn one on, say which job it is, how often it will run, and that it spends —
+to the person whose credits they are. Turning one OFF spends nothing, takes effect at the next
+tick, and destroys nothing: it is the safe direction, so do not make it hard.
+
+`get_automations` deliberately does **not** report a cost per job, and that is not an omission to
+work around: AI spend is logged per call with no column naming the job, and the same labels are
+shared between jobs, so any per-job figure would be invented. Use `runs_30d` with `cadence` to
+describe the commitment, and point at the usage page for the brand-wide bill.
+
+A brand without a paid plan runs none of them however many are on — `scheduled_work_allowed` says
+so. The calls themselves spend no credits.
+
 ## Media models
 
 | MCP | CLI |

--- a/cli/skills/anomalia/SKILL.md
+++ b/cli/skills/anomalia/SKILL.md
@@ -93,6 +93,13 @@ does not move posts that already have a time (their local hour shifts instead), 
 platform does not cancel posts already scheduled on it. If a target platform has no connected
 account the write says so in `without_account` — its posts will be produced and then wait.
 
+**Turn a recurring job on or off** → `get_automations` lists the nine included jobs with their
+cadence, state and `runs_30d`; `set_automation` flips one. Turning one ON commits the brand to
+recurring AI spend with nobody watching, so say which job, how often, and that it spends before
+you do it. Turning one OFF is free and safe. There is no per-job cost figure — spend is not
+attributable to one job — so describe the commitment with cadence and `runs_30d`, and never
+invent a number.
+
 **Choose which model draws and which films** → `get_media_models` lists the six jobs (image
 generation, image refinement, video from text, animating a still, video refinement, motion
 transfer) with the models each one accepts; `set_media_model` pins one. A model that cannot do

--- a/cli/skills/anomalia/references/tools.md
+++ b/cli/skills/anomalia/references/tools.md
@@ -256,6 +256,33 @@ posts for it are produced and then sit unpublished until an account exists. Say 
 An unknown IANA zone is refused (`unknown_timezone`), and so is a platform outside the list —
 `twitter` is not a name here, it is `x`. The post language lives on `update_brand_kit`, not here.
 
+## Recurring jobs
+
+| MCP | CLI |
+|-----|-----|
+| `get_automations` | (MCP only) |
+| `set_automation` | (MCP only) |
+
+The nine jobs included with the product — `autopilot`, `analytics_review`, `weekly_recap`, `seo`,
+`geo`, `radar_recap`, `market_refs`, `strategy_review`, `library` — with what each does, its
+cadence, whether it is on, how it went last time, whether it is behind, and `runs_30d`: how many
+times it actually ran in the last 30 days (runs a gate stopped are not counted, because they spent
+nothing).
+
+**Turning one ON is a spending decision, not a preference.** From that moment the job runs by
+itself on its cadence, and every run calls AI models and spends the brand's credits, with nobody
+looking. Before you turn one on, say which job it is, how often it will run, and that it spends —
+to the person whose credits they are. Turning one OFF spends nothing, takes effect at the next
+tick, and destroys nothing: it is the safe direction, so do not make it hard.
+
+`get_automations` deliberately does **not** report a cost per job, and that is not an omission to
+work around: AI spend is logged per call with no column naming the job, and the same labels are
+shared between jobs, so any per-job figure would be invented. Use `runs_30d` with `cadence` to
+describe the commitment, and point at the usage page for the brand-wide bill.
+
+A brand without a paid plan runs none of them however many are on — `scheduled_work_allowed` says
+so. The calls themselves spend no credits.
+
 ## Media models
 
 | MCP | CLI |

--- a/docs/api/14-settings-automations.md
+++ b/docs/api/14-settings-automations.md
@@ -1,0 +1,117 @@
+# API — 14 · Impostazioni: i lavori ricorrenti
+
+Due endpoint sotto `/api/v1/brands/:slug/settings/automations`, cioè i tool MCP
+`get_automations` e `set_automation`. Sono l'interruttore che la pagina `/agents` mostra nel
+browser, per tutti e nove i lavori del roster — non solo per l'autopilot.
+
+Errori comuni di auth: vedi [01-overview](01-overview.md).
+
+## I nove lavori
+
+`ROSTER_JOBS` (`src/lib/server/job-roster.ts`): `autopilot`, `analytics_review`, `weekly_recap`,
+`seo`, `geo`, `radar_recap`, `market_refs`, `strategy_review`, `library`. Il testo di cosa fa
+ciascuno arriva da `jobBlurb`, che è la stessa fonte del prompt di onboarding: un lavoro nuovo
+entra da solo in tutti e due.
+
+Lo stato è salvato come **rifiuto**, non come booleano: `brand_job_optouts` ha una riga solo per i
+lavori spenti. Nessuna migration qui.
+
+## Accendere è una decisione di spesa
+
+È la cosa che questi due endpoint devono dire più forte di ogni altra.
+
+Un lavoro acceso gira **da solo**, alla sua cadenza, e ogni giro chiama modelli AI e spende i
+crediti del brand — senza che nessuno lo riguardi. Non c'è nessuna schermata di pagamento a fare
+da testimone, e questo lo rende meno visibile di un acquisto, non meno costoso. La `description`
+di `set_automation` lo dichiara, e un test tiene lì quella frase.
+
+Spegnere invece non spende niente, vale dal tick successivo e non distrugge nulla: è la direzione
+che protegge, e resta facile.
+
+`destructive` è `false` — non si distrugge niente — e **`openWorld` non è impostato**. In questo
+registry `openWorld` vuol dire "esce su internet" (`diagnose_radar`, `research_competitors`,
+`sync_history`): usarlo per dire "costa" sarebbe un'annotazione che mente su cosa il tool fa. La
+spesa la dicono la descrizione e la risposta, non un flag preso in prestito.
+
+## `GET /api/v1/brands/:slug/settings/automations`
+
+Sola lettura: nessun modello, nessun credito.
+
+```json
+{
+  "brand": "demo",
+  "plan": "pro",
+  "scheduled_work_allowed": true,
+  "jobs": [
+    {
+      "job": "seo",
+      "what": "SEO agent — weekly site review: grade, issues, and growth initiatives.",
+      "cadence": "weekly",
+      "enabled": true,
+      "state": "ok",
+      "reason": null,
+      "last_run_at": "2026-09-01T04:12:00.000Z",
+      "behind": false,
+      "runs_30d": 4
+    }
+  ]
+}
+```
+
+`scheduled_work_allowed` è `scheduledWorkAllowed(plan)`: senza piano a pagamento nessuno di questi
+parte, per quanti se ne accendano, e ogni tick registra `skipped/no_plan`.
+
+## Il costo per lavoro non esiste, e il tool lo dice
+
+`get_automations` **non** riporta dollari per lavoro. Non è una dimenticanza:
+
+- `ai_calls` non ha nessuna colonna che nomini il loop. Le colonne sono `label`, `provider`,
+  `model`, `cost_usd`, `context`, `brand_id`, `thread_id`… e `context` è testo libero per call
+  site (`'design/compose'`, `'produce-agent'`, `'tool=…'`), mai una chiave del roster.
+- Le `label` sono **condivise fra lavori**: `director` / `directorRewrite` stanno sia in
+  `autopilot` sia in `radar_recap`; `createSingleContent` sta sia in `autopilot` sia nella
+  creazione manuale di un post dal browser. Una ricostruzione `CASE WHEN label IN (…)`
+  attribuirebbe male, non attribuirebbe.
+- `strategy_review` non è isolabile affatto: gira come un normale turno di chat nel thread
+  dell'agente proprietario, indistinguibile da un turno digitato da una persona.
+- `loop_ticks` è l'unica tabella che nomina il loop per brand, e non ha né costo né una chiave di
+  join verso `ai_calls`. Un join per finestra temporale sarebbe un'approssimazione, non
+  un'attribuzione.
+
+Quindi il tool porta `runs_30d` — **quante volte il lavoro ha davvero girato** — che è il dato che
+esiste. I giri fermati da un gate (`skipped`) non contano: non hanno chiamato nessun modello, e
+contarli direbbe "questo ti costa" di qualcosa che non è costato. Un giro `failed` invece conta,
+perché può aver già speso prima di fallire.
+
+Per avere un costo per lavoro servirebbe una colonna `loop` su `ai_calls`, scritta da ogni call
+site dentro il percorso di ogni tick. È una migration più un'instrumentazione diffusa: una
+decisione, non un dettaglio di questo endpoint.
+
+## `PUT /api/v1/brands/:slug/settings/automations`
+
+**Body**: `{ "job": "seo", "enabled": true }` — entrambi obbligatori. `enabled` non ha default:
+accendere e spegnere devono essere due gesti espliciti.
+
+**Response** `200`:
+
+```json
+{
+  "ok": true,
+  "job": "seo",
+  "enabled": true,
+  "cadence": "weekly",
+  "spends_on_every_run": true,
+  "scheduled_work_allowed": true
+}
+```
+
+`spends_on_every_run` ripete nella risposta ciò che è stato impegnato: resta scritto nel turno
+dell'agente, non solo nella descrizione che ha letto prima di chiamare.
+
+**Errori**
+
+| status | error | quando |
+|---|---|---|
+| `400` | `invalid_input` | `job` fuori dai nove, `enabled` mancante, campo non dichiarato |
+| `403` | `API key is read-only` | chiave senza scope `write` |
+| `500` | `toggle_failed` | la scrittura su `brand_job_optouts` è fallita (spesso: migration non applicata) |

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -21,6 +21,7 @@ integrazioni esterne via API key — request, response, query params, body, erro
 | [11 — Billing](11-billing.md) | `/billing/portal`, `/billing/checkout` — link Stripe che l'agente consegna all'umano |
 | [12 — Impostazioni: modelli media](12-settings-models.md) | `/settings/models` — quale modello disegna e quale gira, per brand |
 | [13 — Impostazioni: come lavora il brand](13-settings-brand.md) | `/settings/brand` — fuso, piattaforme, hashtag, esempi di voce |
+| [14 — Impostazioni: lavori ricorrenti](14-settings-automations.md) | `/settings/automations` — i nove lavori del roster e il loro interruttore |
 
 ## Regole di manutenzione
 

--- a/packages/api-contracts/src/automations.test.ts
+++ b/packages/api-contracts/src/automations.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import { AUTOMATION_JOBS, GET_AUTOMATIONS, SET_AUTOMATION } from './automations';
+import { BRAND_ENDPOINTS, statusForFailure } from './index';
+
+describe('i lavori ricorrenti come contratto', () => {
+  it('stanno nel registry, o nessun agente li vede', () => {
+    for (const endpoint of [GET_AUTOMATIONS, SET_AUTOMATION]) {
+      expect(BRAND_ENDPOINTS, endpoint.tool).toContain(endpoint);
+    }
+  });
+
+  it('accetta solo i lavori che esistono', () => {
+    expect(SET_AUTOMATION.input.safeParse({ job: 'seo', enabled: true }).success).toBe(true);
+    expect(SET_AUTOMATION.input.safeParse({ job: 'chat', enabled: true }).success).toBe(false);
+    expect(AUTOMATION_JOBS).toContain('autopilot');
+  });
+
+  it('accendere e spegnere sono lo stesso tool: `enabled` è obbligatorio, non implicito', () => {
+    expect(SET_AUTOMATION.input.safeParse({ job: 'seo' }).success).toBe(false);
+  });
+
+  /**
+   * QUESTO è il test che conta. Accendere un lavoro impegna crediti del cliente a ogni giro
+   * futuro, senza che nessuno lo riguardi — ed è meno visibile di un pagamento, perché non c'è
+   * nessuna schermata a fare da testimone. La descrizione è l'unica cosa che un agente legge
+   * prima di chiamare: se la frase sparisce, sparisce l'avvertimento.
+   */
+  it('dice che accendere spende, e che spegnere no', () => {
+    expect(SET_AUTOMATION.description).toMatch(/spending decision/);
+    expect(SET_AUTOMATION.description).toMatch(/every run calls AI models and spends/);
+    expect(SET_AUTOMATION.description).toMatch(/Turning one OFF spends nothing/);
+  });
+
+  it('non promette un costo per lavoro che il database non sa attribuire', () => {
+    // `ai_calls` non ha nessuna colonna che nomini il loop, e le label sono condivise fra lavori
+    // (`director` sta sia in autopilot sia in radar_recap). Un numero inventato qui sarebbe
+    // peggio del silenzio: un agente deciderebbe su una cifra falsa.
+    expect(GET_AUTOMATIONS.description).toMatch(/no clean read attributes dollars/);
+    expect(Object.keys(GET_AUTOMATIONS.output.shape)).not.toContain('spend_usd');
+  });
+
+  it('porta invece quanto ha girato davvero, che è il dato che esiste', () => {
+    const parsed = GET_AUTOMATIONS.output.safeParse({
+      brand: 'demo',
+      plan: 'pro',
+      scheduled_work_allowed: true,
+      jobs: [
+        {
+          job: 'seo',
+          what: 'SEO agent — weekly site review.',
+          cadence: 'weekly',
+          enabled: true,
+          state: 'ok',
+          reason: null,
+          last_run_at: '2026-09-01T00:00:00.000Z',
+          behind: false,
+          runs_30d: 4
+        }
+      ]
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('la risposta di chi accende riscrive cosa è stato impegnato', () => {
+    const parsed = SET_AUTOMATION.output.safeParse({
+      ok: true,
+      job: 'seo',
+      enabled: true,
+      cadence: 'weekly',
+      spends_on_every_run: true,
+      scheduled_work_allowed: true
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('un interruttore che non si scrive è un guasto nostro, non di chi chiama', () => {
+    expect(statusForFailure(SET_AUTOMATION, 'toggle_failed')).toBe(500);
+  });
+
+  it('non finge di raggiungere il mondo fuori: cambia una riga, non chiama un provider', () => {
+    // `openWorld` in questo registry vuol dire "esce su internet" (radar/diagnose, la ricerca
+    // competitor, sync_history). Usarlo per dire "costa" sarebbe un'annotazione che mente.
+    expect(SET_AUTOMATION.openWorld).toBeUndefined();
+    expect(SET_AUTOMATION.destructive).toBe(false);
+  });
+});

--- a/packages/api-contracts/src/automations.ts
+++ b/packages/api-contracts/src/automations.ts
@@ -1,0 +1,92 @@
+import { z } from 'zod';
+import type { BrandEndpoint } from './index';
+
+/**
+ * I lavori ricorrenti inclusi nel prodotto. L'elenco vero e' `ROSTER_JOBS`
+ * (`$lib/server/job-roster`), che il contratto non puo' importare: un test dell'app tiene i due
+ * allineati. Il testo di cosa fa ciascuno NON e' qui — arriva dalla rotta, da `jobBlurb`, che e'
+ * la stessa fonte del prompt di onboarding.
+ */
+export const AUTOMATION_JOBS = [
+  'autopilot',
+  'analytics_review',
+  'weekly_recap',
+  'seo',
+  'geo',
+  'radar_recap',
+  'market_refs',
+  'strategy_review',
+  'library'
+] as const;
+
+export type AutomationJob = (typeof AUTOMATION_JOBS)[number];
+
+export const AUTOMATION_CADENCES = ['daily', 'weekly', 'monthly'] as const;
+export const AUTOMATION_STATES = ['off', 'ok', 'skipped', 'failed', 'never'] as const;
+
+const job = z.enum(AUTOMATION_JOBS).describe('Which recurring job');
+
+const Job = z.object({
+  job: z.enum(AUTOMATION_JOBS),
+  what: z.string(),
+  cadence: z.enum(AUTOMATION_CADENCES),
+  enabled: z.boolean(),
+  state: z.enum(AUTOMATION_STATES),
+  reason: z.string().nullable(),
+  last_run_at: z.string().nullable(),
+  behind: z.boolean(),
+  /** Quante volte ha davvero girato negli ultimi 30 giorni: i giri fermati da un gate non contano. */
+  runs_30d: z.number()
+});
+
+export const GET_AUTOMATIONS = {
+  tool: 'get_automations',
+  title: 'Recurring jobs',
+  description:
+    'The recurring jobs included with the product and whether this brand runs them: what each ' +
+    'one does, how often, whether it is on, how it went last time, and how many times it ' +
+    'actually ran in the last 30 days. Read it before set_automation — `runs_30d` with `cadence` ' +
+    'is how you tell what turning one on commits the brand to. What it CANNOT tell you is the ' +
+    'money: AI spend is recorded per call, with no column naming the job that made it, so no ' +
+    'clean read attributes dollars to one automation. The brand-wide bill is on the usage page.',
+  method: 'GET',
+  pathUnderBrand: '/settings/automations',
+  input: z.object({}).strict(),
+  output: z.object({
+    brand: z.string(),
+    plan: z.string().nullable(),
+    /** Senza un piano a pagamento nessuno di questi parte, per quanti se ne accendano. */
+    scheduled_work_allowed: z.boolean(),
+    jobs: z.array(Job)
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const SET_AUTOMATION = {
+  tool: 'set_automation',
+  title: 'Turn a recurring job on or off',
+  description:
+    'Turn one recurring job on or off for this brand. ' +
+    'Turning one ON is a spending decision, not a preference: from that moment the job runs BY ' +
+    'ITSELF on its cadence, and every run calls AI models and spends the brand’s credits, with ' +
+    'nobody looking. Say which job, how often it will run, and that it spends — before you turn ' +
+    'it on, and to the person whose credits they are. Turning one OFF spends nothing and is the ' +
+    'safe direction: it takes effect at the next tick and destroys nothing. ' +
+    'A brand without a paid plan runs none of them, however many are on. The call itself calls ' +
+    'no model and spends no credits.',
+  method: 'PUT',
+  pathUnderBrand: '/settings/automations',
+  input: z.object({ job, enabled: z.boolean().describe('true starts it running by itself') }).strict(),
+  output: z.object({
+    ok: z.literal(true),
+    job: z.enum(AUTOMATION_JOBS),
+    enabled: z.boolean(),
+    cadence: z.enum(AUTOMATION_CADENCES),
+    /** Ripetuto nella risposta di chi ACCENDE: cosa e' stato impegnato resta scritto nel turno. */
+    spends_on_every_run: z.boolean(),
+    scheduled_work_allowed: z.boolean()
+  }),
+  failures: [{ error: 'toggle_failed', status: 500 }],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -1,5 +1,6 @@
 import type { z } from 'zod';
 import { ADS_REMIX } from './ads';
+import { GET_AUTOMATIONS, SET_AUTOMATION } from './automations';
 import { BILLING_PORTAL_LINK, CHECKOUT_LINK } from './billing';
 import { GET_ARTICLE, UPDATE_ARTICLE } from './articles';
 import { CHECK_CONTENT } from './content';
@@ -127,6 +128,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   GET_ADS,
   GET_ANALYTICS,
   GET_ARTICLE,
+  GET_AUTOMATIONS,
   GET_AUDIT_FINDINGS,
   GET_BACKLINKS,
   GET_BIO,
@@ -167,6 +169,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   SAVE_PLAN,
   SAVE_WEEK_SEEDS,
   SEO_ACTION,
+  SET_AUTOMATION,
   SET_BIO,
   SET_BRAND_SETTINGS,
   SET_MEDIA_MODEL,
@@ -282,6 +285,14 @@ export {
   REVOKE_SHARE,
   SHARED_VIEW_TYPES,
 };
+export {
+  AUTOMATION_CADENCES,
+  AUTOMATION_JOBS,
+  AUTOMATION_STATES,
+  GET_AUTOMATIONS,
+  SET_AUTOMATION
+} from './automations';
+export type { AutomationJob } from './automations';
 export { BILLING_PORTAL_LINK, CHECKOUT_LINK };
 export type { BillingPortalLinkResult, CheckoutLinkInput, CheckoutLinkResult } from './billing';
 export type { CheckContentInput, CheckContentResult } from './content';

--- a/src/lib/content/changelog/2026-09-04-agent-automations.ts
+++ b/src/lib/content/changelog/2026-09-04-agent-automations.ts
@@ -1,0 +1,12 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-04',
+  title: 'Your AI can switch the recurring jobs on and off',
+  items: [
+    'Claude, Cursor and any connected AI client can now see all nine included jobs — the content producer, the performance review, the weekly recap, SEO, AI visibility, the radar digest, competitor watch, strategy review and the library curator — with how often each runs, how it went last time, and how many times it actually ran in the last month.',
+    'Your AI can turn each one on or off, and it is told that switching one on commits you to recurring AI spend — so it asks you first instead of quietly starting work you pay for.',
+    'Switching one off is free and takes effect on the next run.',
+    'You are told when a job cannot run at all because your plan does not include scheduled work, instead of it silently doing nothing.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/job-roster.test.ts
+++ b/src/lib/server/job-roster.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { AUTOMATION_CADENCES, AUTOMATION_JOBS, AUTOMATION_STATES } from '@anomalia/api-contracts';
 import type { SupabaseClient } from '@supabase/supabase-js';
 
 // jobPausedForBrand legge il piano e gli opt-out con il client admin, e registra il salto in
@@ -18,6 +19,7 @@ vi.mock('$lib/server/loop-ticks', () => ({
 
 import {
   brandRoster,
+  jobRunCounts,
   clearJobRosterCache,
   jobEnabledForBrand,
   jobPausedForBrand,
@@ -247,5 +249,82 @@ describe('rosterForPrompt — la squadra nel prompt viene dal registro, non da u
     const jobs = [...ROSTER_JOBS, { key: 'made_up_job', cadence: 'daily' } as unknown as RosterJob];
     const text = rosterForPrompt(jobs);
     expect(text).toContain('- made_up_job (daily): made_up_job'); // blurb assente → cade sul nome
+  });
+});
+
+describe('il roster che un agente puo comandare', () => {
+  it('e esattamente quello che il prodotto fa girare', () => {
+    // Il contratto non puo' importare `$lib`, quindi l'elenco vive anche li'. Un lavoro aggiunto
+    // qui e non di la' sarebbe accendibile dal browser e invisibile a `set_automation`; uno
+    // aggiunto solo di la' sarebbe un tool che accende qualcosa che non gira.
+    expect([...AUTOMATION_JOBS]).toEqual(ROSTER_JOBS.map((j) => j.key));
+  });
+
+  it('ogni cadenza e ogni stato che il roster produce e un valore che il contratto dichiara', () => {
+    for (const job of ROSTER_JOBS) {
+      expect(AUTOMATION_CADENCES, job.key).toContain(job.cadence);
+    }
+    expect([...AUTOMATION_STATES].sort()).toEqual(['failed', 'never', 'off', 'ok', 'skipped']);
+  });
+});
+
+describe('jobRunCounts — quante volte un lavoro ha davvero girato', () => {
+  function ticksAdmin(rows: { loop: string; outcome: string }[] | null, throws = false) {
+    const filters = { loop: [] as string[], outcome: [] as string[], since: '' };
+    const q: Record<string, unknown> = {};
+    Object.assign(q, {
+      select: () => q,
+      eq: () => q,
+      in: (col: string, vals: string[]) => {
+        if (col === 'outcome') filters.outcome = vals;
+        else filters.loop = vals;
+        return q;
+      },
+      gte: (_col: string, val: string) => {
+        filters.since = val;
+        return q;
+      },
+      limit: () => (throws ? Promise.reject(new Error('no table')) : Promise.resolve({ data: rows }))
+    });
+    return {
+      admin: { from: () => q } as unknown as SupabaseClient,
+      filters
+    };
+  }
+
+  it('conta un lavoro per volta, non tutti insieme', async () => {
+    const { admin } = ticksAdmin([
+      { loop: 'seo', outcome: 'ok' },
+      { loop: 'seo', outcome: 'failed' },
+      { loop: 'geo', outcome: 'ok' }
+    ]);
+    const counts = await jobRunCounts(admin, 'b1', '2026-08-05T00:00:00.000Z');
+    expect(counts.get('seo')).toBe(2);
+    expect(counts.get('geo')).toBe(1);
+  });
+
+  it('non conta un giro fermato da un gate: non ha speso niente', async () => {
+    // Contare gli `skipped` direbbe «questo lavoro ti costa» di un lavoro che non ha mai
+    // chiamato un modello — e la cifra servirebbe proprio a decidere se accenderlo.
+    const { admin, filters } = ticksAdmin([]);
+    await jobRunCounts(admin, 'b1', '2026-08-05T00:00:00.000Z');
+    expect(filters.outcome).toEqual(['ok', 'failed']);
+  });
+
+  it('guarda solo dentro la finestra che le viene chiesta', async () => {
+    const { admin, filters } = ticksAdmin([]);
+    await jobRunCounts(admin, 'b1', '2026-08-05T00:00:00.000Z');
+    expect(filters.since).toBe('2026-08-05T00:00:00.000Z');
+  });
+
+  it('un lavoro che non ha mai girato non compare, e vale zero', async () => {
+    const { admin } = ticksAdmin([{ loop: 'seo', outcome: 'ok' }]);
+    const counts = await jobRunCounts(admin, 'b1', '2026-08-05T00:00:00.000Z');
+    expect(counts.get('library') ?? 0).toBe(0);
+  });
+
+  it('la tabella assente non porta giù la lettura: zero conteggi, non un errore', async () => {
+    const { admin } = ticksAdmin(null, true);
+    await expect(jobRunCounts(admin, 'b1', '2026-08-05T00:00:00.000Z')).resolves.toEqual(new Map());
   });
 });

--- a/src/lib/server/job-roster.ts
+++ b/src/lib/server/job-roster.ts
@@ -102,11 +102,15 @@ const ROSTER_JOB_BLURBS: Partial<Record<string, string>> = {
   library: 'Library curator — monthly refresh of the indexed site content.'
 };
 
+/** Cosa fa un lavoro, in inglese. Chiave senza blurb → il suo nome, cosi' un lavoro nuovo entra
+ * da solo sia nel prompt sia nel tool che lo elenca. */
+export function jobBlurb(key: string): string {
+  return ROSTER_JOB_BLURBS[key] ?? key;
+}
+
 /** UNA fonte (ROSTER_JOBS), mai una lista ricopiata dentro un prompt. Il parametro è per i test. */
 export function rosterForPrompt(jobs: readonly RosterJob[] = ROSTER_JOBS): string {
-  return jobs
-    .map((j) => `- ${j.key} (${j.cadence}): ${ROSTER_JOB_BLURBS[j.key] ?? j.key}`)
-    .join('\n');
+  return jobs.map((j) => `- ${j.key} (${j.cadence}): ${jobBlurb(j.key)}`).join('\n');
 }
 
 // Map in memoria + TTL corto: un tick scorre decine di brand e chiederebbe "questo lavoro è
@@ -348,6 +352,49 @@ export async function brandRoster(admin: SupabaseClient, brandId: string): Promi
       behind: enabled && (!servedAt || Date.now() - Date.parse(servedAt) > CADENCE_GRACE_MS[job.cadence])
     };
   });
+}
+
+/** Quanto indietro guarda `jobRunCounts`. Un mese copre anche il lavoro mensile, una volta. */
+export const RUN_WINDOW_DAYS = 30;
+
+/** Tetto della lettura: nove lavori per trenta giorni non ci arrivano, e un brand impazzito non
+ * trascina giù la pagina che lo sta guardando. */
+const RUN_ROWS_MAX = 1000;
+
+/**
+ * Quante volte ogni lavoro ha DAVVERO girato nella finestra.
+ *
+ * `skipped` non conta: un gate lo ha fermato prima di spendere, e contarlo direbbe "questo lavoro
+ * ti costa" di un lavoro che non ha mai chiamato un modello. `ok` e `failed` invece hanno provato,
+ * e un tentativo fallito può aver già speso.
+ *
+ * Non è il COSTO, ed è tutto ciò che il database sa dire: `ai_calls` non ha nessuna colonna che
+ * nomini il loop, e le label sono condivise fra lavori diversi (`director` sta sia in autopilot
+ * sia in radar_recap), quindi nessuna somma per lavoro sarebbe vera.
+ */
+export async function jobRunCounts(
+  admin: SupabaseClient,
+  brandId: string,
+  sinceIso: string
+): Promise<Map<string, number>> {
+  const counts = new Map<string, number>();
+  try {
+    const res = await admin
+      .from('loop_ticks')
+      .select('loop, outcome')
+      .eq('brand_id', brandId)
+      .in('loop', [...ROSTER_JOB_KEYS])
+      .in('outcome', ['ok', 'failed'])
+      .gte('created_at', sinceIso)
+      .limit(RUN_ROWS_MAX);
+    for (const row of (res?.data ?? []) as { loop: unknown }[]) {
+      const loop = String(row.loop);
+      counts.set(loop, (counts.get(loop) ?? 0) + 1);
+    }
+  } catch {
+    return counts;
+  }
+  return counts;
 }
 
 /**

--- a/src/routes/api/v1/brands/[slug]/settings/automations/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/settings/automations/+server.ts
@@ -1,0 +1,102 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { authenticate, loadBrandForUser, checkApiKeyWriteAccess } from '$lib/server/cli-auth';
+import { createAdminClient } from '$lib/server/supabase-admin';
+import { SET_AUTOMATION, statusForFailure } from '@anomalia/api-contracts';
+import {
+  ROSTER_JOBS,
+  RUN_WINDOW_DAYS,
+  brandRoster,
+  jobBlurb,
+  jobRunCounts,
+  scheduledWorkAllowed,
+  setJobEnabled
+} from '$lib/server/job-roster';
+
+// I lavori ricorrenti inclusi nel prodotto, e l'interruttore di ciascuno.
+//
+// Il client admin serve perché `brand_job_optouts` e `loop_ticks` sono territorio service-role;
+// l'autorizzazione l'ha già fatta `loadBrandForUser` sul client dell'utente — stesso schema di
+// `/doctor`.
+//
+// Accendere impegna crediti a ogni giro futuro, quindi la lettura porta `runs_30d`: quante volte
+// il lavoro ha DAVVERO girato. Non porta dollari, e non è una dimenticanza — `ai_calls` non ha
+// nessuna colonna che nomini il loop, e le sue label sono condivise fra lavori diversi, quindi
+// una cifra per lavoro sarebbe inventata.
+
+const windowStart = () =>
+  new Date(Date.now() - RUN_WINDOW_DAYS * 24 * 60 * 60 * 1000).toISOString();
+
+const cadenceOf = (key: string) => ROSTER_JOBS.find((j) => j.key === key)!.cadence;
+
+export const GET: RequestHandler = async ({ request, params }) => {
+  const { supabase, error, apiKey } = await authenticate(request);
+  if (error) return error;
+
+  const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
+  if (brandError) return brandError;
+
+  const admin = createAdminClient();
+  const [roster, runs] = await Promise.all([
+    brandRoster(admin, brand.id),
+    jobRunCounts(admin, brand.id, windowStart())
+  ]);
+
+  return json({
+    brand: brand.slug,
+    plan: brand.plan,
+    scheduled_work_allowed: scheduledWorkAllowed(brand.plan),
+    jobs: roster.map((row) => ({
+      job: row.key,
+      what: jobBlurb(row.key),
+      cadence: row.cadence,
+      enabled: row.enabled,
+      state: row.state,
+      reason: row.reason,
+      last_run_at: row.lastRunAt,
+      behind: row.behind,
+      runs_30d: runs.get(row.key) ?? 0
+    }))
+  });
+};
+
+export const PUT: RequestHandler = async ({ request, params }) => {
+  const { supabase, user, error, apiKey } = await authenticate(request);
+  if (error) return error;
+
+  const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
+  if (brandError) return brandError;
+  const writeDenied = checkApiKeyWriteAccess(apiKey);
+  if (writeDenied) return writeDenied;
+
+  const parsed = SET_AUTOMATION.input.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return json({ error: 'invalid_input', details: parsed.error.issues }, { status: 400 });
+  }
+
+  const { job, enabled } = parsed.data;
+  const res = await setJobEnabled(createAdminClient(), {
+    brandId: brand.id,
+    jobKey: job,
+    enabled,
+    userId: user?.id ?? null
+  });
+
+  if (!res.ok) {
+    return json(
+      { error: 'toggle_failed', detail: res.error },
+      { status: statusForFailure(SET_AUTOMATION, 'toggle_failed') }
+    );
+  }
+
+  return json({
+    ok: true,
+    job,
+    enabled,
+    cadence: cadenceOf(job),
+    // Ripetuto nella risposta di chi accende: ciò che è stato impegnato resta scritto nel turno,
+    // non solo nella descrizione che l'agente ha letto prima.
+    spends_on_every_run: enabled,
+    scheduled_work_allowed: scheduledWorkAllowed(brand.plan)
+  });
+};

--- a/src/routes/api/v1/brands/[slug]/settings/automations/server.test.ts
+++ b/src/routes/api/v1/brands/[slug]/settings/automations/server.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('$lib/server/cli-auth', () => ({
+  authenticate: vi.fn(),
+  loadBrandForUser: vi.fn(),
+  checkApiKeyWriteAccess: vi.fn(() => null)
+}));
+vi.mock('$lib/server/supabase-admin', () => ({ createAdminClient: () => ({}) }));
+
+const roster = vi.fn();
+const runs = vi.fn();
+const toggle = vi.fn();
+
+vi.mock('$lib/server/job-roster', async (original) => {
+  const actual = await original<typeof import('$lib/server/job-roster')>();
+  return {
+    ...actual,
+    brandRoster: (...args: unknown[]) => roster(...args),
+    jobRunCounts: (...args: unknown[]) => runs(...args),
+    setJobEnabled: (...args: unknown[]) => toggle(...args)
+  };
+});
+
+import { GET, PUT } from './+server';
+import { authenticate, loadBrandForUser, checkApiKeyWriteAccess } from '$lib/server/cli-auth';
+
+const ROW = {
+  key: 'seo',
+  cadence: 'weekly',
+  enabled: true,
+  state: 'ok',
+  reason: null,
+  lastRunAt: '2026-09-01T00:00:00.000Z',
+  servedAt: '2026-09-01T00:00:00.000Z',
+  behind: false
+};
+
+const BRAND = { id: 'brand-1', slug: 'demo', plan: 'pro' };
+
+const url = 'https://example.test/api/v1/brands/demo/settings/automations';
+
+const read = () =>
+  (GET as (e: unknown) => Promise<Response>)({ request: new Request(url), params: { slug: 'demo' } });
+
+const write = (body: unknown) =>
+  (PUT as (e: unknown) => Promise<Response>)({
+    request: new Request(url, { method: 'PUT', body: JSON.stringify(body) }),
+    params: { slug: 'demo' }
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  roster.mockResolvedValue([ROW]);
+  runs.mockResolvedValue(new Map([['seo', 4]]));
+  toggle.mockResolvedValue({ ok: true });
+  vi.mocked(authenticate).mockResolvedValue({ supabase: {}, user: { id: 'u1' }, apiKey: null, error: null } as never);
+  vi.mocked(loadBrandForUser).mockResolvedValue({ brand: BRAND, error: null } as never);
+  vi.mocked(checkApiKeyWriteAccess).mockReturnValue(null as never);
+});
+
+describe('GET /api/v1/brands/:slug/settings/automations', () => {
+  it('dice di ogni lavoro cosa fa, ogni quanto, e quante volte ha girato', async () => {
+    const body = await (await read()).json();
+
+    expect(body.jobs[0]).toMatchObject({
+      job: 'seo',
+      cadence: 'weekly',
+      enabled: true,
+      state: 'ok',
+      runs_30d: 4
+    });
+    expect(body.jobs[0].what).toContain('SEO');
+  });
+
+  it('un lavoro che non ha mai girato vale zero, non manca', async () => {
+    runs.mockResolvedValue(new Map());
+
+    const body = await (await read()).json();
+
+    expect(body.jobs[0].runs_30d).toBe(0);
+  });
+
+  it('guarda indietro trenta giorni, non da sempre', async () => {
+    await read();
+
+    const since = Date.parse(runs.mock.calls[0][2] as string);
+    const days = (Date.now() - since) / 86_400_000;
+    expect(days).toBeGreaterThan(29.9);
+    expect(days).toBeLessThan(30.1);
+  });
+
+  it('dice se su questo piano i lavori partono, invece di lasciarlo indovinare', async () => {
+    vi.mocked(loadBrandForUser).mockResolvedValue({
+      brand: { ...BRAND, plan: 'free' },
+      error: null
+    } as never);
+
+    const body = await (await read()).json();
+
+    expect(body.scheduled_work_allowed).toBe(false);
+  });
+
+  it('non chiama nessun modello e non spende', async () => {
+    await read();
+
+    expect(toggle).not.toHaveBeenCalled();
+  });
+});
+
+describe('PUT /api/v1/brands/:slug/settings/automations', () => {
+  it('accende il lavoro chiesto e riscrive cosa è stato impegnato', async () => {
+    const res = await write({ job: 'seo', enabled: true });
+
+    expect(res.status).toBe(200);
+    expect(toggle).toHaveBeenCalledWith({}, { brandId: 'brand-1', jobKey: 'seo', enabled: true, userId: 'u1' });
+    expect(await res.json()).toEqual({
+      ok: true,
+      job: 'seo',
+      enabled: true,
+      cadence: 'weekly',
+      spends_on_every_run: true,
+      scheduled_work_allowed: true
+    });
+  });
+
+  it('spegnere non impegna niente, e lo dice', async () => {
+    const body = await (await write({ job: 'seo', enabled: false })).json();
+
+    expect(body.enabled).toBe(false);
+    expect(body.spends_on_every_run).toBe(false);
+  });
+
+  it('rifiuta un lavoro che non esiste, invece di scrivere un opt-out orfano', async () => {
+    const res = await write({ job: 'chat', enabled: true });
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('invalid_input');
+    expect(toggle).not.toHaveBeenCalled();
+  });
+
+  it('rifiuta una richiesta che non dice se accendere o spegnere', async () => {
+    const res = await write({ job: 'seo' });
+
+    expect(res.status).toBe(400);
+    expect(toggle).not.toHaveBeenCalled();
+  });
+
+  it('si ferma prima di scrivere se la chiave è di sola lettura', async () => {
+    vi.mocked(checkApiKeyWriteAccess).mockReturnValue(new Response('read only', { status: 403 }) as never);
+
+    const res = await write({ job: 'seo', enabled: true });
+
+    expect(res.status).toBe(403);
+    expect(toggle).not.toHaveBeenCalled();
+  });
+
+  it('si ferma prima di scrivere se il brand non è del chiamante', async () => {
+    vi.mocked(loadBrandForUser).mockResolvedValue({
+      brand: null,
+      error: new Response('not found', { status: 404 })
+    } as never);
+
+    const res = await write({ job: 'seo', enabled: true });
+
+    expect(res.status).toBe(404);
+    expect(toggle).not.toHaveBeenCalled();
+  });
+
+  it('riporta il fallimento dell interruttore come il 500 dichiarato', async () => {
+    toggle.mockResolvedValue({ ok: false, error: 'db' });
+
+    const res = await write({ job: 'seo', enabled: true });
+
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('toggle_failed');
+  });
+});


### PR DESCRIPTION
## What?

`get_automations` and `set_automation` (GET/PUT `/api/v1/brands/:slug/settings/automations`) put the **nine recurring jobs included with the product** — `autopilot`, `analytics_review`, `weekly_recap`, `seo`, `geo`, `radar_recap`, `market_refs`, `strategy_review`, `library` — in front of an external agent: what each does, its cadence, whether it is on, how it went last time, whether it is behind, and how many times it actually ran in the last 30 days.

State lives where it already lives: `brand_job_optouts`, a row per job that is **off**. **No migration.**

`tools/list` goes from **99 to 101**. Object-by-object comparison of every existing tool: `new: [get_automations, set_automation]`, `gone: []`, `changed: []`.

## Why?

`settings/autopilot` looks like a boolean. It is not: it calls `setJobEnabled(admin, { jobKey: 'autopilot' })`, and `autopilot` is **one row of `ROSTER_JOBS`, which has nine**. `brandRoster()` already returns all nine with their state, and `/agents` already toggles all nine. Exposing one of them would be an arbitrary line someone would later have to undo — and the other eight cost no new code, because they are the same call.

## How?

### Turning a job on is a spending decision, and the tool says so

These jobs run **by themselves** and call AI models on every run. An agent that switches one on is not changing a preference — it is committing the customer's credits, repeatedly, with nobody looking. It is less visible than a payment precisely because there is no checkout screen acting as witness.

There is a fresh precedent in this repo: the custom-agent routine cron was doing **288 AI executions a day** and was switched off because somebody went and counted them. A tool that switches things on without saying what it costs sets that up again — except we would have built it.

So:

- `set_automation`'s description states that turning one on is a spending decision, that the job will run by itself on its cadence, and that **turning one off spends nothing**. Three tests hold those sentences in place: if the sentence goes, the warning goes.
- The write echoes `cadence` and `spends_on_every_run`, so what was committed stays written in the agent's turn, not only in the description it read beforehand.
- `enabled` has no default. Switching on and switching off are two explicit gestures.
- Switching **off** is left easy: it spends nothing, applies at the next tick, destroys nothing.

### `openWorld` stays unset — deliberately

In this registry `openWorld` means *reaches the internet* (`diagnose_radar`, `research_competitors`, `sync_history`). `set_automation` flips a row in our own database. Using that flag to mean "this costs money" would be an annotation that lies about what the tool does — the same mistake as a flat model enum. The registry has no way to express *commits future spend*; the description and the response carry it instead. That is the honest option, and it is stated rather than silently chosen.

### Per-job cost does not exist, and the read says so instead of staying quiet

I went to check whether `ai_calls` could be summed per job. **It cannot**, for four independent reasons:

1. `ai_calls` has no column naming the loop. `context` is free-text per call site (`'design/compose'`, `'produce-agent'`, `'tool=…'`), never a roster key.
2. Labels are **shared between jobs**: `director` / `directorRewrite` belong to both `autopilot` and `radar_recap`; `createSingleContent` belongs to both `autopilot` and manual post creation from the browser. A `CASE WHEN label IN (…)` reconstruction would misattribute, not attribute.
3. `strategy_review` cannot be isolated at all — it runs as an ordinary chat turn in the owner agent's thread, indistinguishable from one a person typed.
4. `loop_ticks`, the only table naming the loop, has neither a cost column nor a join key to `ai_calls`. And PostgREST aggregates are disabled on this project (`0158_provider_spend` exists for that reason), so even then a new SQL function would be needed.

Rather than inventing a number, the read carries `runs_30d` — **how many times the job actually ran**. Runs a gate stopped (`skipped`) are not counted: they never called a model, and counting them would say "this costs you" of something that cost nothing. `failed` runs are counted, because they may have spent before failing. With `cadence`, that is what describes the commitment.

And `get_automations`'s description **states** that per-job cost is not attributable, so its absence does not read as an oversight. A test pins that sentence and also asserts no `spend_usd` field appears in the output.

Getting a real figure would need a `loop` column on `ai_calls` written by every call site inside every tick: a migration plus diffuse instrumentation. That is a decision, not a detail of this endpoint, and deploys here do not run migrations.

### One source for the job text

`ROSTER_JOB_BLURBS` was private, read only by `rosterForPrompt`. It is now `jobBlurb(key)` with the fallback inside it, used by both the onboarding prompt and the tool — a new job enters both without anyone remembering to. The contract copies **no** text, only the nine keys, and a test compares them with `ROSTER_JOBS`.

## Testing?

Red before green, with real output.

- **contract** — red before it was in the registry.
- **the nine-key guard** — proven by adding `made_up_job` to the contract: red. Reverted.
- **`jobRunCounts`** — proven by removing the outcome filter and the window filter: the two tests that demand them fail.
- **the route** — proven by removing the run count, the plan gate, `spends_on_every_run` and the toggle-failure handling: **exactly 5 of 12 fail**, 7 stay green. Restored, 12/12.

| command | result |
|---|---|
| `npx vitest run packages/api-contracts` | 132 tests, pass |
| `cd cli && bun test` | 57 tests, 0 fail |
| `cd cli && bun run typecheck` | clean |
| `node scripts/typecheck-runtime.mjs` | ok |
| affected app tests (job-roster, all three settings routes, changelog, no-app-imports) | 164 tests, pass |

**Not tested:** no browser, Docker, dev server or Playwright — forbidden for this task. The full `npm run test:unit` was not run; CI runs it.

**Risk:** `set_automation` writes through the admin client, as the `/agents` page does; authorisation happens first on the user's client via `loadBrandForUser`, the same shape `/doctor` uses. `runs_30d` is capped at 1000 rows — nine jobs over thirty days do not reach it, and a runaway brand cannot drag down the read that is looking at it.

## Evidence

<details>
<summary>tools/list through handleMcpFetch, origin/dev vs this branch (after rebase)</summary>

```
new:     ['get_automations', 'set_automation']
gone:    []
changed: []
count:   99 → 101

set_automation annotations: {'readOnlyHint': False, 'destructiveHint': False}
```

</details>

<details>
<summary>Red, then green: the route with its logic removed</summary>

```
× GET … > dice di ogni lavoro cosa fa, ogni quanto, e quante volte ha girato
× GET … > un lavoro che non ha mai girato vale zero, non manca
× GET … > dice se su questo piano i lavori partono, invece di lasciarlo indovinare
× PUT … > spegnere non impegna niente, e lo dice
× PUT … > riporta il fallimento dell interruttore come il 500 dichiarato
   Tests  5 failed | 7 passed (12)
```

</details>

<details>
<summary>What the write answers</summary>

```
PUT { job: 'seo', enabled: true }
→ { ok: true, job: 'seo', enabled: true, cadence: 'weekly',
    spends_on_every_run: true, scheduled_work_allowed: true }

PUT { job: 'seo', enabled: false }
→ spends_on_every_run: false

PUT { job: 'chat', enabled: true } → 400 invalid_input   (no opt-out written)
PUT { job: 'seo' }                 → 400 invalid_input   (no default for enabled)
```

</details>

No UI change: this PR adds no page and touches no component.

## Anything Else?

**A brand on a free plan runs none of these**, however many are on — every tick records `skipped/no_plan`. The read returns `scheduled_work_allowed` so an agent does not have to infer it from a silent absence of runs.

**What a per-job cost would actually take**, if it is ever wanted: a `loop` (or `job_key`) column on `ai_calls`, set at every `logAiCall` / `aiStructured` call site inside each tick's execution path, plus a SQL aggregate because PostgREST aggregates are off here. Retrofitting it from labels is not an option — `autopilot` and `radar_recap` share `director`, and `autopilot` shares `createSingleContent` with manual creation from the browser, so a reconstruction would move money between jobs and between a job and manual use.

**Still flagged from the earlier census**, unchanged: `brands.chat_default_tier` has a column and a setter and no caller — a removal candidate once the chats are out; and `settings/referrals` calls `ensureReferralCode` during `load`, a page load that INSERTs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
