### PR TITLE
Share the plan and the whole workspace by public link

### DIFF
--- a/changelog/2026-09-04-shares-strategy-workspace.md
+++ b/changelog/2026-09-04-shares-strategy-workspace.md
@@ -1,0 +1,73 @@
+# Un link pubblico che porta il lavoro, non l'app
+
+La richiesta era «rendere `/app/[brand]/*` visibile a chi ha un link pubblico»: il cliente finale
+deve poter vedere il lavoro senza un account. La forma però non poteva essere quella letterale.
+
+## Cosa NON è stato fatto, e perché
+
+Non si è aperto l'albero dell'app sotto token. Sotto `/app/[brand]` vivono 96 pagine, e fra queste
+`settings/api-keys` (le chiavi API), `settings/danger` (`DELETE FROM brands` più la disdetta),
+`settings/demo-account` e `settings/blog-integrations` (segreti nel Vault), oltre a billing, team,
+account collegati e consumi. Un link su quell'albero consegna credenziali e tasto di cancellazione
+a chiunque lo riceva o lo inoltri.
+
+Anche potendo elencare le pagine ammesse, l'elenco sarebbe di **esclusioni**: la pagina aggiunta il
+mese prossimo sarebbe pubblica per difetto, a meno che qualcuno si ricordi di escluderla. Nessuno
+si ricorda. E c'è un secondo motivo, tecnico: ogni pagina carica attraverso
+`+layout.server.ts` → `event.parent()` e interroga tabelle vive con `locals.supabase`. Renderle
+anonime vuol dire o la chiave di servizio (ogni confine RLS che salta insieme) o una sessione
+finta. Entrambe hanno un raggio d'azione più largo delle 96 pagine.
+
+## Cosa è stato fatto
+
+Esteso il meccanismo della PR #221 — snapshot congelato, token con impronta, revoca e scadenza —
+con due tipi di vista in più:
+
+- **`strategy`** — il lavoro concordato: la strategia editoriale, il ritmo, il mix di piattaforme,
+  le settimane (data, tema, focus, stato) e la fase GTM che governa il mese chiesto con i suoi
+  obiettivi (`kpi` → `target`). Solo i piani **attivi**: una proposta è una conversazione ancora
+  aperta con chi decide, e `revision_feedback` ne è letteralmente il testo. Restano fuori
+  `rationale`, `brief` e `products` di ogni settimana — gli appunti di chi pianifica, non il piano
+  — insieme a `voice`, `changes_summary`, `reply` e ogni `actual`/`metric`/`value` dei goal.
+- **`workspace`** — un link solo invece di quattro: dashboard, calendario, report e strategia
+  dietro schede. Non è una vista in più, è la **somma esatta** delle altre: ogni sezione è lo
+  snapshot che quella vista consegnerebbe da sola, quindi non può mostrare un campo che uno dei
+  link singoli non mostrerebbe già. Un test lo verifica chiave per chiave.
+
+`buildDashboard` si è spezzato in `composeDashboard` (puro) più il wrapper che fa le query, così
+il workspace legge calendario e storia **una volta sola** invece di quattro.
+
+La fase GTM è scelta dal **mese chiesto**, non dall'orologio. Presa dal clock, uno snapshot
+congelato a settembre mostrerebbe una fase decisa dall'istante della creazione anziché dal mese di
+cui il link parla — e non si proverebbe senza toccare il tempo.
+
+## Come si impedisce che l'elenco si allarghi da solo
+
+Una cosa diventa pubblica solo attraversando **quattro porte**, tutte deliberate:
+
+1. `SHARED_VIEW_TYPES` nel contratto — l'enum che l'endpoint valida (`view: 'settings'` è un 400).
+2. Il builder in `SNAPSHOT_BUILDERS`, che nomina campo per campo cosa copia. È un
+   `Record<SharedViewType, …>`: un tipo senza builder non compila.
+3. Il vincolo `check (view_type in (…))` su `shared_views`.
+4. La pagina `/share/[token]`, che deve saperla disegnare.
+
+La rotta pubblica non ha nessun percorso dentro l'albero dell'app: legge una tabella sola e una
+colonna sola. Una pagina aggiunta domani non attraversa nessuna delle quattro, quindi resta
+invisibile **senza che nessuno debba ricordarsene**.
+
+La terza porta è l'unica che TypeScript non copre, ed era già divergita: `dashboard` stava nel
+contratto e non nel check, e ci volle una seconda migration. In produzione quella divergenza è un
+`23514` che nessuno sa leggere. Ora un test legge le migration, estrae l'ultimo
+`view_type in (…)` e lo confronta con l'enum — e diventa rosso prima del deploy. È stato visto
+fallire: allargato il contratto senza la migration, la suite è andata rossa; scritta la migration,
+è tornata verde.
+
+Un secondo test tiene che sotto `src/routes/share/` viva **una** rotta sola, `[token]`: un secondo
+punto d'ingresso pubblico aggiunto per distrazione fa fallire la suite invece di esistere in
+silenzio.
+
+## Migration da applicare
+
+`supabase/migrations/20260904210000_shared_views_strategy_workspace.sql` allarga il check a
+`strategy` e `workspace`. **Non applicata**: questo repo non esegue migration al deploy. Senza,
+la creazione dei due nuovi tipi viene rifiutata da Postgres — le viste già esistenti non cambiano.

--- a/cli/lib/contracts/shares.ts
+++ b/cli/lib/contracts/shares.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { BrandEndpoint } from './index';
 
-export const SHARED_VIEW_TYPES = ['calendar', 'dashboard', 'monthly_report'] as const;
+export const SHARED_VIEW_TYPES = ['calendar', 'dashboard', 'monthly_report', 'strategy', 'workspace'] as const;
 
 export type SharedViewType = (typeof SHARED_VIEW_TYPES)[number];
 
@@ -37,7 +37,7 @@ export const CREATE_SHARE = {
       view: z
         .enum(SHARED_VIEW_TYPES)
         .describe(
-          'calendar = the month plan; dashboard = the month at a glance (what went out, what is planned, reach); monthly_report = what that month published'
+          'calendar = the month plan; dashboard = the month at a glance (what went out, what is planned, reach); monthly_report = what that month published; strategy = the agreed plan behind it (statement, cadence, platforms, weeks, current phase); workspace = all of the above behind one link'
         ),
       month: MONTH.optional(),
       expires_in_days: z.coerce

--- a/cli/plugins/anomalia/skills/anomalia/SKILL.md
+++ b/cli/plugins/anomalia/skills/anomalia/SKILL.md
@@ -102,7 +102,7 @@ costs no credits, which is the point: whoever ran out is who needs it.
 **Approve pending posts** → `list_posts` (status pending) → optional `get_post` → `approve_posts`.
 
 **Send a client the calendar, the month at a glance, or the month's results** → `create_share`
-(`view`: `calendar`, `dashboard` or `monthly_report`). It returns a link they open with no account, showing a frozen snapshot of that
+(`view`: `calendar`, `dashboard`, `monthly_report`, `strategy` or `workspace` — `workspace` puts all four behind one link). It returns a link they open with no account, showing a frozen snapshot of that
 view and nothing else. The token is in the response **once** — hand over the `url` immediately.
 `list_shares` shows what is out there, `revoke_share` turns one off without touching anyone's
 access to the brand.

--- a/cli/plugins/anomalia/skills/anomalia/references/tools.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/tools.md
@@ -144,7 +144,7 @@ It never looks at pixels — judging an image or a video is a separate, explicit
 | `revoke_share` | (MCP only) |
 
 `create_share` freezes one view as a snapshot and returns a link a client opens with no account.
-Required: `slug`, `view` (`calendar`, `dashboard` or `monthly_report`). Optional: `month` (`YYYY-MM`, default
+Required: `slug`, `view` (`calendar`, `dashboard`, `monthly_report`, `strategy` or `workspace`). Optional: `month` (`YYYY-MM`, default
 the current month on the brand clock) and `expires_in_days` (1–365; without it the link lasts
 until revoked).
 

--- a/cli/skills/anomalia/SKILL.md
+++ b/cli/skills/anomalia/SKILL.md
@@ -102,7 +102,7 @@ costs no credits, which is the point: whoever ran out is who needs it.
 **Approve pending posts** → `list_posts` (status pending) → optional `get_post` → `approve_posts`.
 
 **Send a client the calendar, the month at a glance, or the month's results** → `create_share`
-(`view`: `calendar`, `dashboard` or `monthly_report`). It returns a link they open with no account, showing a frozen snapshot of that
+(`view`: `calendar`, `dashboard`, `monthly_report`, `strategy` or `workspace` — `workspace` puts all four behind one link). It returns a link they open with no account, showing a frozen snapshot of that
 view and nothing else. The token is in the response **once** — hand over the `url` immediately.
 `list_shares` shows what is out there, `revoke_share` turns one off without touching anyone's
 access to the brand.

--- a/cli/skills/anomalia/references/tools.md
+++ b/cli/skills/anomalia/references/tools.md
@@ -144,7 +144,7 @@ It never looks at pixels — judging an image or a video is a separate, explicit
 | `revoke_share` | (MCP only) |
 
 `create_share` freezes one view as a snapshot and returns a link a client opens with no account.
-Required: `slug`, `view` (`calendar`, `dashboard` or `monthly_report`). Optional: `month` (`YYYY-MM`, default
+Required: `slug`, `view` (`calendar`, `dashboard`, `monthly_report`, `strategy` or `workspace`). Optional: `month` (`YYYY-MM`, default
 the current month on the brand clock) and `expires_in_days` (1–365; without it the link lasts
 until revoked).
 

--- a/docs/api/10-shares.md
+++ b/docs/api/10-shares.md
@@ -31,7 +31,7 @@ Crea il link. Richiede una API key con scope `write`.
 
 | Campo | Obbligatorio | Note |
 |---|---|---|
-| `view` | sì | `calendar`, `dashboard` o `monthly_report` |
+| `view` | sì | `calendar`, `dashboard`, `monthly_report`, `strategy` o `workspace` |
 | `month` | no | `YYYY-MM`. Senza, il mese corrente sull'orologio del brand |
 | `expires_in_days` | no | 1–365. Senza, il link vale finché non viene revocato |
 
@@ -140,9 +140,44 @@ builder che esistono già, quindi non ha una terza allowlist da tenere allineata
 Ogni top post: `platform`, `caption`, `thumbnail_url`, `url`, `published_at`, `views`, `likes`,
 `comments`, `shares`.
 
+**`strategy`** — `brand_name`, `timezone`, `month`, `month_label`, `statement`, `cadence`,
+`platforms[]`, `weeks[]`, `objective`, `horizon`, `phase`.
+Ogni piattaforma: `platform`, `share`, `role`. Ogni settimana: `week_start`, `theme`, `focus`,
+`status`. La fase è quella che governa il **mese chiesto** (non quella di oggi): `name`,
+`objective`, `goals[]` con `kpi` e `target`.
+Solo i piani **attivi**: una proposta è una conversazione ancora aperta con chi decide, non
+lavoro concordato — e `revision_feedback` è letteralmente il testo di quella conversazione.
+Restano fuori `rationale`, `brief` e `products` di ogni settimana (gli appunti di chi pianifica),
+`voice`, `changes_summary`, `reply` e ogni `actual`/`metric`/`value` dei goal.
+
+**`workspace`** — `brand_name`, `timezone`, `month`, `month_label`, più `dashboard`, `calendar`,
+`report` e `strategy`, ognuno **esattamente** lo snapshot della vista corrispondente. Un link
+solo invece di quattro. Non è una vista in più ma la loro somma: non può mostrare un campo che
+uno dei link singoli non mostrerebbe già, e un test lo verifica chiave per chiave.
+
 Non escono mai: id di post, brand o riga; prompt e `image_prompt`; `qc`, `needs_attention`,
 `attention_reason`; token di approvazione; connettori, note interne, costi, impostazioni, membri;
 lo slug del brand e la provenienza dei dati.
+
+## Perché non basta aprire le pagine di `/app/[brand]` sotto token
+
+Sotto `/app/[brand]` vivono 96 pagine, e fra queste `settings/api-keys`, `settings/danger`,
+`settings/demo-account` e `settings/blog-integrations`: chiavi API, `DELETE FROM brands` e
+segreti nel Vault. Un elenco di **esclusioni** si dimentica alla prima pagina aggiunta, e la
+pagina aggiunta sarebbe pubblica per difetto.
+
+Qui vale il contrario. La rotta pubblica non ha nessun percorso dentro l'albero dell'app: legge
+una tabella sola e una colonna sola. Una pagina aggiunta domani non attraversa **nessuna** delle
+quattro porte che rendono pubblica una cosa, e resta invisibile senza che nessuno se ne ricordi:
+
+1. `SHARED_VIEW_TYPES` in `packages/api-contracts/src/shares.ts` — l'enum che l'endpoint valida.
+2. Il builder in `SNAPSHOT_BUILDERS`, che nomina campo per campo cosa copia. È un
+   `Record<SharedViewType, …>`: un tipo senza builder non compila.
+3. Il vincolo `check (view_type in (…))` su `shared_views`. È l'unica delle quattro che
+   TypeScript non copre, ed è già divergita una volta (`dashboard` nel contratto, assente nel
+   check): ora un test confronta la migration con l'enum e la suite diventa rossa prima del
+   deploy.
+4. La pagina `/share/[token]`, che deve saperla disegnare.
 
 ## Fuori da questa versione
 

--- a/packages/api-contracts/src/shares.test.ts
+++ b/packages/api-contracts/src/shares.test.ts
@@ -3,9 +3,18 @@ import { CREATE_SHARE, LIST_SHARES, REVOKE_SHARE, SHARED_VIEW_TYPES } from './sh
 
 describe('il contratto delle viste pubbliche', () => {
   it('dichiara solo le viste che esistono davvero', () => {
-    expect([...SHARED_VIEW_TYPES]).toEqual(['calendar', 'dashboard', 'monthly_report']);
+    expect([...SHARED_VIEW_TYPES]).toEqual(['calendar', 'dashboard', 'monthly_report', 'strategy', 'workspace']);
     expect(CREATE_SHARE.input.safeParse({ view: 'proposal' }).success).toBe(false);
   });
+
+  // Le pagine sotto /app/[brand] non sono viste condivisibili: indovinarne il nome non apre
+  // niente, perché diventare pubblici passa da questo enum e da altre tre porte deliberate.
+  it.each(['settings', 'api-keys', 'billing', 'team', 'knowledge', 'agents', 'usage', 'danger'])(
+    'rifiuta %s: una pagina dell app non è una vista pubblica',
+    (guessed) => {
+      expect(CREATE_SHARE.input.safeParse({ view: guessed }).success).toBe(false);
+    }
+  );
 
   it('accetta un mese YYYY-MM e rifiuta qualunque altra forma', () => {
     expect(CREATE_SHARE.input.safeParse({ view: 'calendar', month: '2026-09' }).success).toBe(true);

--- a/packages/api-contracts/src/shares.ts
+++ b/packages/api-contracts/src/shares.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { BrandEndpoint } from './index';
 
-export const SHARED_VIEW_TYPES = ['calendar', 'dashboard', 'monthly_report'] as const;
+export const SHARED_VIEW_TYPES = ['calendar', 'dashboard', 'monthly_report', 'strategy', 'workspace'] as const;
 
 export type SharedViewType = (typeof SHARED_VIEW_TYPES)[number];
 
@@ -37,7 +37,7 @@ export const CREATE_SHARE = {
       view: z
         .enum(SHARED_VIEW_TYPES)
         .describe(
-          'calendar = the month plan; dashboard = the month at a glance (what went out, what is planned, reach); monthly_report = what that month published'
+          'calendar = the month plan; dashboard = the month at a glance (what went out, what is planned, reach); monthly_report = what that month published; strategy = the agreed plan behind it (statement, cadence, platforms, weeks, current phase); workspace = all of the above behind one link'
         ),
       month: MONTH.optional(),
       expires_in_days: z.coerce

--- a/src/lib/content/changelog/2026-09-04-share-the-work.ts
+++ b/src/lib/content/changelog/2026-09-04-share-the-work.ts
@@ -1,0 +1,11 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-04',
+  title: 'Show a client the work without giving them an account',
+  items: [
+    'A public link can now carry the plan behind the work: the editorial strategy, the cadence, the platform mix, the weeks ahead and the goals of the phase you are in.',
+    'One link can now hold everything a client should see — this month, the calendar, the results and the plan — behind tabs, instead of four separate links.',
+    'A shared link stays read-only and carries only what a client should read: no settings, no keys, no costs, no internal notes, no team data. Expiring it or revoking it still closes it for good.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/shared-views.test.ts
+++ b/src/lib/server/shared-views.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const getCalendar = vi.fn();
@@ -11,6 +14,12 @@ import {
   REPORT_POST_FIELDS,
   REPORT_SNAPSHOT_FIELDS,
   SHARE_SNAPSHOT_VERSION,
+  STRATEGY_GOAL_FIELDS,
+  STRATEGY_PHASE_FIELDS,
+  STRATEGY_PLATFORM_FIELDS,
+  STRATEGY_SNAPSHOT_FIELDS,
+  WORKSPACE_SNAPSHOT_FIELDS,
+  STRATEGY_WEEK_FIELDS,
   SharedViewsNotMigrated,
   buildSnapshot,
   createSharedView,
@@ -407,5 +416,238 @@ describe('la lista e la revoca', () => {
     const shares = fakeTable({ data: null, error: null });
 
     await expect(revokeSharedView(fakeSupabase({ shared_views: shares }), 'brand-1', 'share-di-un-altro')).resolves.toBeNull();
+  });
+});
+
+describe('lo snapshot della strategia', () => {
+  const AN_EDITORIAL_PLAN_WITH_EVERYTHING = {
+    id: 'plan-1',
+    brand_id: 'brand-1',
+    status: 'active',
+    strategy: 'La strategia che il cliente legge',
+    cadence: '3/week',
+    platform_mix: [{ platform: 'linkedin', share: '60%', role: 'autorità' }],
+    weeks: [
+      {
+        index: 0,
+        week_start: '2026-09-07',
+        theme: 'Lancio',
+        focus: 'Presentare il prodotto',
+        status: 'planned',
+        rationale: 'ragionamento interno',
+        brief: 'il brief che ha scritto l operatore',
+        products: ['SKU interno'],
+        content_mix: [{ type: 'reel', count: 3 }]
+      }
+    ],
+    voice: { mood: 'interno', tone: 'interno', goal: 'interno', personality: 'interno' },
+    revision_feedback: 'il feedback della revisione',
+    changes_summary: ['cambio interno'],
+    source: 'agent',
+    parent_id: 'plan-0'
+  };
+
+  const A_GTM_PLAN_WITH_EVERYTHING = {
+    id: 'gtm-1',
+    brand_id: 'brand-1',
+    status: 'active',
+    horizon: '6m',
+    objective: 'Vendere di più',
+    phases: [
+      {
+        index: 0,
+        name: 'Fase passata',
+        objective: 'passato',
+        rationale: 'ragionamento interno gtm',
+        start_date: '2026-06-01',
+        end_date: '2026-08-31',
+        goals: [{ kpi: 'lead', target: '100', why: 'perché interno', actual: '42', metric: 'leads', value: 42 }],
+        platform_weights: [{ platform: 'linkedin', percent: 100 }],
+        pillars: ['pilastro']
+      },
+      {
+        index: 1,
+        name: 'Fase corrente',
+        objective: 'crescere',
+        rationale: 'ragionamento interno gtm',
+        start_date: '2026-09-01',
+        end_date: '2026-11-30',
+        goals: [{ kpi: 'lead', target: '200', why: 'perché interno', actual: '10', metric: 'leads', value: 10 }],
+        platform_weights: [{ platform: 'linkedin', percent: 100 }],
+        pillars: ['pilastro']
+      }
+    ],
+    revision_feedback: 'il feedback della revisione gtm',
+    reply: 'risposta interna',
+    changes_summary: ['cambio interno gtm'],
+    parent_id: 'gtm-0'
+  };
+
+  function strategySupabase(editorial: Row | null, gtm: Row | null) {
+    return fakeSupabase({
+      editorial_plans: fakeTable({ data: editorial, error: null }),
+      gtm_plans: fakeTable({ data: gtm, error: null })
+    });
+  }
+
+  it('porta solo i campi dichiarati, in cima e dentro ogni parte', async () => {
+    const { snapshot } = await buildSnapshot(
+      strategySupabase(AN_EDITORIAL_PLAN_WITH_EVERYTHING, A_GTM_PLAN_WITH_EVERYTHING),
+      BRAND,
+      'strategy',
+      '2026-09'
+    );
+
+    expect(Object.keys(snapshot).sort()).toEqual([...STRATEGY_SNAPSHOT_FIELDS].sort());
+    expect(Object.keys((snapshot.weeks as Row[])[0]).sort()).toEqual([...STRATEGY_WEEK_FIELDS].sort());
+    expect(Object.keys((snapshot.platforms as Row[])[0]).sort()).toEqual([...STRATEGY_PLATFORM_FIELDS].sort());
+    expect(Object.keys(snapshot.phase as Row).sort()).toEqual([...STRATEGY_PHASE_FIELDS].sort());
+    expect(Object.keys(((snapshot.phase as Row).goals as Row[])[0]).sort()).toEqual([...STRATEGY_GOAL_FIELDS].sort());
+  });
+
+  it('non fa uscire brief, revisioni, ragionamenti interni né identificatori', async () => {
+    const { snapshot } = await buildSnapshot(
+      strategySupabase(AN_EDITORIAL_PLAN_WITH_EVERYTHING, A_GTM_PLAN_WITH_EVERYTHING),
+      BRAND,
+      'strategy',
+      '2026-09'
+    );
+    const serialized = JSON.stringify(snapshot);
+
+    for (const secret of [
+      'ragionamento interno',
+      'il brief che ha scritto l operatore',
+      'SKU interno',
+      'il feedback della revisione',
+      'cambio interno',
+      'risposta interna',
+      'perché interno',
+      'plan-1',
+      'plan-0',
+      'gtm-1',
+      'gtm-0',
+      'brand-1'
+    ]) {
+      expect(serialized, secret).not.toContain(secret);
+    }
+  });
+
+  it('legge solo il piano attivo: una proposta non è lavoro concordato', async () => {
+    const editorial = fakeTable({ data: AN_EDITORIAL_PLAN_WITH_EVERYTHING, error: null });
+    const gtm = fakeTable({ data: A_GTM_PLAN_WITH_EVERYTHING, error: null });
+
+    await buildSnapshot(fakeSupabase({ editorial_plans: editorial, gtm_plans: gtm }), BRAND, 'strategy', '2026-09');
+
+    expect(argsOf(editorial, 'eq')).toEqual([
+      ['brand_id', 'brand-1'],
+      ['status', 'active']
+    ]);
+    expect(argsOf(gtm, 'eq')).toEqual([
+      ['brand_id', 'brand-1'],
+      ['status', 'active']
+    ]);
+  });
+
+  it('mostra la fase che governa il mese chiesto, non la prima della lista', async () => {
+    const { snapshot } = await buildSnapshot(
+      strategySupabase(AN_EDITORIAL_PLAN_WITH_EVERYTHING, A_GTM_PLAN_WITH_EVERYTHING),
+      BRAND,
+      'strategy',
+      '2026-09'
+    );
+
+    expect((snapshot.phase as Row).name).toBe('Fase corrente');
+  });
+
+  it('senza piano attivo resta vuoto invece di rompersi', async () => {
+    const { snapshot } = await buildSnapshot(strategySupabase(null, null), BRAND, 'strategy', '2026-09');
+
+    expect(snapshot.statement).toBeNull();
+    expect(snapshot.weeks).toEqual([]);
+    expect(snapshot.platforms).toEqual([]);
+    expect(snapshot.phase).toBeNull();
+    expect(Object.keys(snapshot).sort()).toEqual([...STRATEGY_SNAPSHOT_FIELDS].sort());
+  });
+
+  it('dice che la migration manca invece di far passare un errore Postgres', async () => {
+    const supabase = fakeSupabase({ editorial_plans: fakeTable({ data: null, error: MISSING_TABLE }) });
+
+    await expect(buildSnapshot(supabase, BRAND, 'strategy', '2026-09')).rejects.toBeInstanceOf(SharedViewsNotMigrated);
+  });
+});
+
+describe('lo snapshot del workspace', () => {
+  function workspaceSupabase() {
+    return fakeSupabase({
+      social_post_history: fakeTable({ data: [A_HISTORY_ROW_WITH_EVERYTHING], error: null }),
+      editorial_plans: fakeTable({ data: null, error: null }),
+      gtm_plans: fakeTable({ data: null, error: null })
+    });
+  }
+
+  it('porta solo i campi dichiarati in cima', async () => {
+    const { snapshot } = await buildSnapshot(workspaceSupabase(), BRAND, 'workspace', '2026-09');
+
+    expect(Object.keys(snapshot).sort()).toEqual([...WORKSPACE_SNAPSHOT_FIELDS].sort());
+  });
+
+  it('ogni sezione è esattamente lo snapshot della sua vista: non può mostrare di più', async () => {
+    const { snapshot } = await buildSnapshot(workspaceSupabase(), BRAND, 'workspace', '2026-09');
+
+    expect(Object.keys(snapshot.calendar as Row).sort()).toEqual([...CALENDAR_SNAPSHOT_FIELDS].sort());
+    expect(Object.keys(snapshot.report as Row).sort()).toEqual([...REPORT_SNAPSHOT_FIELDS].sort());
+    expect(Object.keys(snapshot.dashboard as Row).sort()).toEqual([...DASHBOARD_SNAPSHOT_FIELDS].sort());
+    expect(Object.keys(snapshot.strategy as Row).sort()).toEqual([...STRATEGY_SNAPSHOT_FIELDS].sort());
+  });
+
+  it('non fa uscire prompt, qc, note interne o identificatori privati', async () => {
+    const { snapshot } = await buildSnapshot(workspaceSupabase(), BRAND, 'workspace', '2026-09');
+    const serialized = JSON.stringify(snapshot);
+
+    for (const secret of ['un prompt interno', 'borderline', 'token-di-approvazione', 'nota interna', 'post-1', 'brand-1', 'plan-1', 'zernio']) {
+      expect(serialized, secret).not.toContain(secret);
+    }
+  });
+
+  it('non ripete le query: il calendario e la storia si leggono una volta sola', async () => {
+    const history = fakeTable({ data: [A_HISTORY_ROW_WITH_EVERYTHING], error: null });
+    await buildSnapshot(
+      fakeSupabase({
+        social_post_history: history,
+        editorial_plans: fakeTable({ data: null, error: null }),
+        gtm_plans: fakeTable({ data: null, error: null })
+      }),
+      BRAND,
+      'workspace',
+      '2026-09'
+    );
+
+    expect(getCalendar).toHaveBeenCalledTimes(1);
+    expect(argsOf(history, 'select').length).toBe(1);
+  });
+});
+
+// Le porte che una pagina aggiunta domani deve attraversare per diventare pubblica. Sono
+// deliberate e separate: il contratto, il builder, il vincolo SQL, la superficie pubblica.
+// Questi test tengono le ultime due allineate alla prima — l'unica che TypeScript non copre.
+describe('l elenco di ciò che è pubblico non si allarga da solo', () => {
+  const repoRoot = fileURLToPath(new URL('../../../', import.meta.url));
+
+  it('il vincolo SQL su view_type dice esattamente quello che dice il contratto', () => {
+    const dir = join(repoRoot, 'supabase/migrations');
+    const declared = readdirSync(dir)
+      .filter((name) => name.endsWith('.sql'))
+      .sort()
+      .flatMap((name) => [...readFileSync(join(dir, name), 'utf8').matchAll(/view_type\s+in\s*\(([^)]*)\)/g)])
+      .at(-1);
+
+    expect(declared, 'nessuna migration dichiara i tipi di shared_views').toBeTruthy();
+
+    const allowed = [...(declared as RegExpMatchArray)[1].matchAll(/'([a-z_]+)'/g)].map((m) => m[1]);
+    expect(allowed.sort()).toEqual([...SHARED_VIEW_TYPES].sort());
+  });
+
+  it('sotto /share vive una rotta sola: il token, e niente altro', () => {
+    expect(readdirSync(join(repoRoot, 'src/routes/share'))).toEqual(['[token]']);
   });
 });

--- a/src/lib/server/shared-views.ts
+++ b/src/lib/server/shared-views.ts
@@ -34,6 +34,26 @@ export const DASHBOARD_SNAPSHOT_FIELDS = ['brand_name', 'timezone', 'month', 'mo
 export const REPORT_POST_FIELDS = ['platform', 'caption', 'thumbnail_url', 'url', 'published_at', ...METRIC_FIELDS] as const;
 export const REPORT_SNAPSHOT_FIELDS = ['brand_name', 'timezone', 'month', 'month_label', 'published', 'totals', 'platforms', 'top_posts'] as const;
 
+export const STRATEGY_GOAL_FIELDS = ['kpi', 'target'] as const;
+export const STRATEGY_PHASE_FIELDS = ['name', 'objective', 'goals'] as const;
+export const STRATEGY_WEEK_FIELDS = ['week_start', 'theme', 'focus', 'status'] as const;
+export const STRATEGY_PLATFORM_FIELDS = ['platform', 'share', 'role'] as const;
+export const STRATEGY_SNAPSHOT_FIELDS = [
+  'brand_name',
+  'timezone',
+  'month',
+  'month_label',
+  'statement',
+  'cadence',
+  'platforms',
+  'weeks',
+  'objective',
+  'horizon',
+  'phase'
+] as const;
+
+export const WORKSPACE_SNAPSHOT_FIELDS = ['brand_name', 'timezone', 'month', 'month_label', 'dashboard', 'calendar', 'report', 'strategy'] as const;
+
 export class SharedViewsNotMigrated extends Error {
   constructor() {
     super(`shared_views is missing — apply supabase/migrations/${MIGRATION_FILE} before using public client links`);
@@ -265,6 +285,136 @@ async function buildDashboard(
   return composeDashboard(calendar, report);
 }
 
+type PlanPhase = {
+  name?: string;
+  objective?: string;
+  start_date?: string | null;
+  end_date?: string | null;
+  goals?: { kpi?: string; target?: string }[];
+};
+
+/**
+ * La fase che governa il mese CHIESTO, non quella di oggi.
+ *
+ *   fasi:  |── giugno..agosto ──|── settembre..novembre ──|
+ *   mese chiesto: 2026-09  ────────────────▲  questa
+ *
+ * Presa dall'orologio, uno snapshot congelato a settembre mostrerebbe la fase di dicembre a chi
+ * apre il link a dicembre — tranne che lo snapshot è congelato, quindi mostrerebbe una fase decisa
+ * dal momento della creazione e non dal mese di cui parla il link. Dal mese, invece, è la stessa
+ * risposta per chiunque, sempre, e si prova senza toccare il clock.
+ */
+function phaseForMonth(phases: PlanPhase[], month: string): PlanPhase | null {
+  const reference = Date.parse(`${month}-01T00:00:00Z`);
+
+  return (
+    phases.find((phase) => {
+      if (!phase.start_date) return false;
+      if (Date.parse(`${phase.start_date}T00:00:00Z`) > reference) return false;
+      return !phase.end_date || Date.parse(`${phase.end_date}T23:59:59Z`) >= reference;
+    }) ?? null
+  );
+}
+
+/**
+ * Il lavoro concordato: cosa facciamo, con che ritmo, su quali piattaforme e verso quale obiettivo.
+ *
+ * Solo i piani ATTIVI. Una proposta è una conversazione ancora aperta fra noi e chi decide, non
+ * qualcosa da consegnare a un cliente — e `revision_feedback` è letteralmente il testo di quella
+ * conversazione. Restano fuori anche `rationale`, `brief` e `products` di ogni settimana: sono
+ * gli appunti di chi pianifica, non il piano.
+ */
+async function buildStrategy(
+  supabase: SupabaseClient,
+  brand: SharedViewBrand,
+  month: string
+): Promise<SharedViewSnapshot> {
+  const [editorial, gtm] = await Promise.all([
+    supabase
+      .from('editorial_plans')
+      .select('strategy, cadence, platform_mix, weeks')
+      .eq('brand_id', brand.id)
+      .eq('status', 'active')
+      .maybeSingle(),
+    supabase
+      .from('gtm_plans')
+      .select('objective, horizon, phases')
+      .eq('brand_id', brand.id)
+      .eq('status', 'active')
+      .maybeSingle()
+  ]);
+
+  if (editorial.error) raise(editorial.error);
+  if (gtm.error) raise(gtm.error);
+
+  const plan = (editorial.data ?? {}) as Record<string, unknown>;
+  const gtmPlan = (gtm.data ?? {}) as Record<string, unknown>;
+
+  const weeks = (Array.isArray(plan.weeks) ? plan.weeks : []) as Record<string, unknown>[];
+  const mix = (Array.isArray(plan.platform_mix) ? plan.platform_mix : []) as Record<string, unknown>[];
+  const phase = phaseForMonth((Array.isArray(gtmPlan.phases) ? gtmPlan.phases : []) as PlanPhase[], month);
+
+  return {
+    brand_name: brand.name,
+    timezone: brand.timezone,
+    month,
+    month_label: monthLabel(month),
+    statement: (plan.strategy as string | null) ?? null,
+    cadence: (plan.cadence as string | null) ?? null,
+    platforms: mix.map((entry) => ({
+      platform: (entry.platform as string | null) ?? null,
+      share: (entry.share as string | null) ?? null,
+      role: (entry.role as string | null) ?? null
+    })),
+    weeks: weeks.map((week) => ({
+      week_start: (week.week_start as string | null) ?? null,
+      theme: (week.theme as string | null) ?? null,
+      focus: (week.focus as string | null) ?? null,
+      status: (week.status as string | null) ?? null
+    })),
+    objective: (gtmPlan.objective as string | null) ?? null,
+    horizon: (gtmPlan.horizon as string | null) ?? null,
+    phase: phase
+      ? {
+          name: phase.name ?? null,
+          objective: phase.objective ?? null,
+          goals: (phase.goals ?? []).map((goal) => ({ kpi: goal.kpi ?? null, target: goal.target ?? null }))
+        }
+      : null
+  };
+}
+
+/**
+ * Un link solo per tutto quello che il cliente può vedere, invece di quattro da tenere insieme.
+ *
+ * Non è una vista in più: è la somma esatta delle altre. Ogni sezione È lo snapshot che quella
+ * vista consegnerebbe da sola, quindi il workspace non può mostrare un campo che uno dei link
+ * singoli non mostrerebbe già — e un test lo verifica chiave per chiave. Le query si fanno una
+ * volta e la dashboard si compone da calendario e report, che sono già qui.
+ */
+async function buildWorkspace(
+  supabase: SupabaseClient,
+  brand: SharedViewBrand,
+  month: string
+): Promise<SharedViewSnapshot> {
+  const [calendar, report, strategy] = await Promise.all([
+    buildCalendar(supabase, brand, month),
+    buildMonthlyReport(supabase, brand, month),
+    buildStrategy(supabase, brand, month)
+  ]);
+
+  return {
+    brand_name: brand.name,
+    timezone: calendar.timezone,
+    month,
+    month_label: calendar.month_label,
+    dashboard: composeDashboard(calendar, report),
+    calendar,
+    report,
+    strategy
+  };
+}
+
 /** L'unica tabella dei tipi di vista: aggiungerne uno è una riga qui più il suo builder. */
 const SNAPSHOT_BUILDERS: Record<
   SharedViewType,
@@ -272,7 +422,9 @@ const SNAPSHOT_BUILDERS: Record<
 > = {
   calendar: buildCalendar,
   dashboard: buildDashboard,
-  monthly_report: buildMonthlyReport
+  monthly_report: buildMonthlyReport,
+  strategy: buildStrategy,
+  workspace: buildWorkspace
 };
 
 export async function buildSnapshot(

--- a/src/lib/server/shared-views.ts
+++ b/src/lib/server/shared-views.ts
@@ -108,6 +108,10 @@ function shareStatus(row: { expires_at: string | null; revoked_at: string | null
   return 'live';
 }
 
+function monthLabel(month: string): string {
+  return new Date(`${month}-01T00:00:00Z`).toLocaleDateString('en-US', { month: 'long', year: 'numeric', timeZone: 'UTC' });
+}
+
 function monthBounds(month: string): { start: string; end: string } {
   const [year, index] = month.split('-').map(Number);
   return {
@@ -213,17 +217,11 @@ async function buildMonthlyReport(
     .sort((a, b) => engagementScore(b) - engagementScore(a))
     .slice(0, TOP_POSTS);
 
-  const monthLabel = new Date(`${month}-01T00:00:00Z`).toLocaleDateString('en-US', {
-    month: 'long',
-    year: 'numeric',
-    timeZone: 'UTC'
-  });
-
   return {
     brand_name: brand.name,
     timezone: brand.timezone,
     month,
-    month_label: monthLabel,
+    month_label: monthLabel(month),
     published: rows.length,
     totals,
     platforms: [...byPlatform.values()].sort((a, b) => b.published - a.published),
@@ -238,6 +236,22 @@ async function buildMonthlyReport(
  * cosa esce, il report mensile sa cosa è uscito e quanto ha coperto. Una terza allowlist qui
  * sarebbe una terza cosa da tenere allineata a `posts`.
  */
+function composeDashboard(calendar: SharedViewSnapshot, report: SharedViewSnapshot): SharedViewSnapshot {
+  const posts = calendar.posts as { status: string }[];
+  const planned = posts.filter((post) => post.status !== 'published');
+
+  return {
+    brand_name: calendar.brand_name,
+    timezone: calendar.timezone,
+    month: calendar.month,
+    month_label: calendar.month_label,
+    published: report.published,
+    planned: planned.length,
+    reach: (report.totals as Record<string, number>).views,
+    upcoming: planned.slice(0, UPCOMING_SHOWN)
+  };
+}
+
 async function buildDashboard(
   supabase: SupabaseClient,
   brand: SharedViewBrand,
@@ -248,19 +262,7 @@ async function buildDashboard(
     buildMonthlyReport(supabase, brand, month)
   ]);
 
-  const posts = calendar.posts as { status: string }[];
-  const planned = posts.filter((post) => post.status !== 'published');
-
-  return {
-    brand_name: brand.name,
-    timezone: calendar.timezone,
-    month,
-    month_label: calendar.month_label,
-    published: report.published,
-    planned: planned.length,
-    reach: (report.totals as Record<string, number>).views,
-    upcoming: planned.slice(0, UPCOMING_SHOWN)
-  };
+  return composeDashboard(calendar, report);
 }
 
 /** L'unica tabella dei tipi di vista: aggiungerne uno è una riga qui più il suo builder. */

--- a/src/routes/share/[token]/+page.svelte
+++ b/src/routes/share/[token]/+page.svelte
@@ -2,10 +2,31 @@
   let { data } = $props();
 
   const snapshot = $derived(data.snapshot as Record<string, any>);
-  const isCalendar = $derived(data.view === 'calendar');
-  const isDashboard = $derived(data.view === 'dashboard');
 
   const METRICS = ['views', 'likes', 'comments', 'shares'] as const;
+
+  const TITLES: Record<string, string> = {
+    calendar: 'Content calendar',
+    dashboard: 'This month',
+    monthly_report: 'Monthly report',
+    strategy: 'The plan'
+  };
+
+  // Il workspace è la somma delle altre viste, non una vista in più: ogni scheda legge la sezione
+  // che quella vista consegnerebbe da sola. Cambiare scheda non chiede niente al server — lo
+  // snapshot è già tutto qui, e non c'è niente da chiedere: un link pubblico non scrive mai.
+  const TABS = ['dashboard', 'calendar', 'monthly_report', 'strategy'] as const;
+  const SECTION: Record<(typeof TABS)[number], string> = {
+    dashboard: 'dashboard',
+    calendar: 'calendar',
+    monthly_report: 'report',
+    strategy: 'strategy'
+  };
+
+  const isWorkspace = $derived(data.view === 'workspace');
+  let tab = $state<(typeof TABS)[number]>('dashboard');
+  const view = $derived(isWorkspace ? tab : (data.view as string));
+  const section = $derived(isWorkspace ? (snapshot[SECTION[tab]] as Record<string, any>) : snapshot);
 
   function day(post: { scheduled_for: string | null; slot: string | null }): string {
     const raw = post.scheduled_for ?? post.slot ?? '';
@@ -21,99 +42,136 @@
     return parsed.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
   }
 
+  function weekDay(start: string | null): string {
+    if (!start) return '';
+    const parsed = new Date(`${start}T00:00:00Z`);
+    if (Number.isNaN(parsed.getTime())) return start;
+    return parsed.toLocaleDateString(undefined, { day: 'numeric', month: 'short', timeZone: 'UTC' });
+  }
+
   const number = (n: unknown) => Number(n ?? 0).toLocaleString();
 
-  const TITLES: Record<string, string> = {
-    calendar: 'Content calendar',
-    dashboard: 'This month',
-    monthly_report: 'Monthly report'
-  };
+  const emptyStrategy = (s: Record<string, any>) =>
+    !s.statement && !s.objective && !s.phase && s.weeks.length === 0 && s.platforms.length === 0;
 </script>
 
-<svelte:head>
-  <title>{snapshot.brand_name} — {snapshot.month_label}</title>
-  <meta name="robots" content="noindex, nofollow" />
-</svelte:head>
+{#snippet postList(list: Record<string, any>[])}
+  <ol class="calendar">
+    {#each list as post, i (i)}
+      <li>
+        <div class="when">
+          <span class="date">{day(post)}</span>
+          <span class="hour">{time(post)}</span>
+        </div>
+        <div class="what">
+          <div class="meta">
+            <span class="platform">{post.platform ?? '—'}</span>
+            <span class="status status-{post.status}">{post.status}</span>
+          </div>
+          {#if post.caption}<p class="caption">{post.caption}</p>{/if}
+        </div>
+        {#if post.media_url}
+          <img class="thumb" src={post.media_url} alt="" loading="lazy" />
+        {/if}
+      </li>
+    {/each}
+  </ol>
+{/snippet}
 
-<main>
-  <header>
-    <p class="eyebrow">{snapshot.brand_name}</p>
-    <h1>{TITLES[data.view] ?? 'Monthly report'}</h1>
-    <p class="sub">{snapshot.month_label}</p>
-  </header>
-
-  {#if isDashboard}
+{#snippet body(which: string, s: Record<string, any>)}
+  {#if which === 'dashboard'}
     <section class="tiles">
-      <div class="tile"><span class="n">{number(snapshot.published)}</span><span class="l">published</span></div>
-      <div class="tile"><span class="n">{number(snapshot.planned)}</span><span class="l">planned</span></div>
-      <div class="tile"><span class="n">{number(snapshot.reach)}</span><span class="l">reach</span></div>
+      <div class="tile"><span class="n">{number(s.published)}</span><span class="l">published</span></div>
+      <div class="tile"><span class="n">{number(s.planned)}</span><span class="l">planned</span></div>
+      <div class="tile"><span class="n">{number(s.reach)}</span><span class="l">reach</span></div>
     </section>
 
     <h2>Next out</h2>
-    {#if snapshot.upcoming.length === 0}
+    {#if s.upcoming.length === 0}
       <p class="empty">Nothing planned for the rest of this month.</p>
     {:else}
-      <ol class="calendar">
-        {#each snapshot.upcoming as post, i (i)}
-          <li>
-            <div class="when">
-              <span class="date">{day(post)}</span>
-              <span class="hour">{time(post)}</span>
-            </div>
-            <div class="what">
-              <div class="meta">
-                <span class="platform">{post.platform ?? '—'}</span>
-                <span class="status status-{post.status}">{post.status}</span>
-              </div>
-              {#if post.caption}<p class="caption">{post.caption}</p>{/if}
-            </div>
-            {#if post.media_url}
-              <img class="thumb" src={post.media_url} alt="" loading="lazy" />
-            {/if}
-          </li>
-        {/each}
-      </ol>
+      {@render postList(s.upcoming)}
     {/if}
-  {:else if isCalendar}
-    {#if snapshot.posts.length === 0}
+  {:else if which === 'calendar'}
+    {#if s.posts.length === 0}
       <p class="empty">Nothing planned for this month yet.</p>
     {:else}
-      <ol class="calendar">
-        {#each snapshot.posts as post, i (i)}
-          <li>
-            <div class="when">
-              <span class="date">{day(post)}</span>
-              <span class="hour">{time(post)}</span>
-            </div>
-            <div class="what">
-              <div class="meta">
-                <span class="platform">{post.platform ?? '—'}</span>
-                <span class="status status-{post.status}">{post.status}</span>
+      {@render postList(s.posts)}
+    {/if}
+  {:else if which === 'strategy'}
+    {#if emptyStrategy(s)}
+      <p class="empty">The plan is not published yet.</p>
+    {:else}
+      {#if s.statement}<p class="statement">{s.statement}</p>{/if}
+
+      {#if s.objective || s.cadence || s.horizon}
+        <dl class="facts">
+          {#if s.objective}<div><dt>Objective</dt><dd>{s.objective}</dd></div>{/if}
+          {#if s.horizon}<div><dt>Horizon</dt><dd>{s.horizon}</dd></div>{/if}
+          {#if s.cadence}<div><dt>Cadence</dt><dd>{s.cadence}</dd></div>{/if}
+        </dl>
+      {/if}
+
+      {#if s.phase}
+        <h2>This phase</h2>
+        <p class="statement">{s.phase.name ?? ''}{s.phase.objective ? ` — ${s.phase.objective}` : ''}</p>
+        {#if s.phase.goals.length}
+          <table>
+            <thead><tr><th>Goal</th><th>Target</th></tr></thead>
+            <tbody>
+              {#each s.phase.goals as goal, i (i)}
+                <tr><td>{goal.kpi ?? '—'}</td><td>{goal.target ?? '—'}</td></tr>
+              {/each}
+            </tbody>
+          </table>
+        {/if}
+      {/if}
+
+      {#if s.platforms.length}
+        <h2>Platforms</h2>
+        <table>
+          <thead><tr><th>Platform</th><th>Share</th><th>Role</th></tr></thead>
+          <tbody>
+            {#each s.platforms as row, i (i)}
+              <tr><td>{row.platform ?? '—'}</td><td>{row.share ?? '—'}</td><td class="role">{row.role ?? '—'}</td></tr>
+            {/each}
+          </tbody>
+        </table>
+      {/if}
+
+      {#if s.weeks.length}
+        <h2>Weeks</h2>
+        <ol class="calendar">
+          {#each s.weeks as w, i (i)}
+            <li>
+              <div class="when">
+                <span class="date">{weekDay(w.week_start) || `Week ${i + 1}`}</span>
+                <span class="hour">{w.status ?? ''}</span>
               </div>
-              {#if post.caption}<p class="caption">{post.caption}</p>{/if}
-            </div>
-            {#if post.media_url}
-              <img class="thumb" src={post.media_url} alt="" loading="lazy" />
-            {/if}
-          </li>
-        {/each}
-      </ol>
+              <div class="what">
+                <div class="meta"><span class="platform">{w.theme ?? '—'}</span></div>
+                {#if w.focus}<p class="caption">{w.focus}</p>{/if}
+              </div>
+            </li>
+          {/each}
+        </ol>
+      {/if}
     {/if}
   {:else}
     <section class="tiles">
-      <div class="tile"><span class="n">{number(snapshot.published)}</span><span class="l">published</span></div>
+      <div class="tile"><span class="n">{number(s.published)}</span><span class="l">published</span></div>
       {#each METRICS as metric (metric)}
-        <div class="tile"><span class="n">{number(snapshot.totals[metric])}</span><span class="l">{metric}</span></div>
+        <div class="tile"><span class="n">{number(s.totals[metric])}</span><span class="l">{metric}</span></div>
       {/each}
     </section>
 
-    {#if snapshot.platforms.length}
+    {#if s.platforms.length}
       <table>
         <thead>
           <tr><th>Platform</th><th>Posts</th>{#each METRICS as metric (metric)}<th>{metric}</th>{/each}</tr>
         </thead>
         <tbody>
-          {#each snapshot.platforms as row (row.platform)}
+          {#each s.platforms as row (row.platform)}
             <tr>
               <td>{row.platform}</td>
               <td>{number(row.published)}</td>
@@ -124,10 +182,10 @@
       </table>
     {/if}
 
-    {#if snapshot.top_posts.length}
+    {#if s.top_posts.length}
       <h2>Best performing</h2>
       <ol class="tops">
-        {#each snapshot.top_posts as post, i (i)}
+        {#each s.top_posts as post, i (i)}
           <li>
             {#if post.thumbnail_url}<img class="thumb" src={post.thumbnail_url} alt="" loading="lazy" />{/if}
             <div class="what">
@@ -144,6 +202,29 @@
       <p class="empty">No published posts recorded for this month.</p>
     {/if}
   {/if}
+{/snippet}
+
+<svelte:head>
+  <title>{snapshot.brand_name} — {snapshot.month_label}</title>
+  <meta name="robots" content="noindex, nofollow" />
+</svelte:head>
+
+<main>
+  <header>
+    <p class="eyebrow">{snapshot.brand_name}</p>
+    <h1>{TITLES[view] ?? 'Monthly report'}</h1>
+    <p class="sub">{snapshot.month_label}</p>
+  </header>
+
+  {#if isWorkspace}
+    <nav class="tabs">
+      {#each TABS as name (name)}
+        <button type="button" class:on={name === tab} onclick={() => (tab = name)}>{TITLES[name]}</button>
+      {/each}
+    </nav>
+  {/if}
+
+  {@render body(view, section)}
 
   <footer>Snapshot taken {new Date(data.created_at).toLocaleDateString()}.</footer>
 </main>
@@ -176,8 +257,56 @@
     margin: 0.25rem 0 2rem;
     color: #52525b;
   }
+  .tabs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    margin: 0 0 2rem;
+  }
+  .tabs button {
+    font: inherit;
+    font-size: 0.82rem;
+    padding: 0.35rem 0.8rem;
+    border: 1px solid #e4e4e7;
+    border-radius: 999px;
+    background: #fff;
+    color: #52525b;
+    cursor: pointer;
+  }
+  .tabs button.on {
+    background: #18181b;
+    border-color: #18181b;
+    color: #fafafa;
+  }
   .empty {
     color: #71717a;
+  }
+  .statement {
+    margin: 0 0 1.5rem;
+    font-size: 1rem;
+    line-height: 1.6;
+    white-space: pre-wrap;
+  }
+  .facts {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr));
+    gap: 0.75rem;
+    margin: 0 0 1rem;
+  }
+  .facts div {
+    padding: 0.9rem 1rem;
+    border: 1px solid #e4e4e7;
+    border-radius: 0.75rem;
+  }
+  .facts dt {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #71717a;
+  }
+  .facts dd {
+    margin: 0.2rem 0 0;
+    font-size: 0.95rem;
   }
   ol {
     list-style: none;
@@ -283,6 +412,10 @@
   td:first-child {
     text-align: left;
     text-transform: capitalize;
+  }
+  td.role {
+    text-align: left;
+    text-transform: none;
   }
   th {
     color: #71717a;

--- a/supabase/migrations/20260904210000_shared_views_strategy_workspace.sql
+++ b/supabase/migrations/20260904210000_shared_views_strategy_workspace.sql
@@ -1,0 +1,22 @@
+-- Due tipi in più: la strategia concordata e il workspace che li tiene tutti dietro un link solo.
+--
+-- Questo check è UNA delle quattro porte che una cosa deve attraversare per diventare pubblica —
+-- il contratto (`SHARED_VIEW_TYPES`), il builder (`SNAPSHOT_BUILDERS`, che TypeScript esige
+-- completo), questo vincolo e la pagina che la disegna. Nessuna è automatica, ed è il punto: una
+-- pagina aggiunta sotto /app/[brand] il mese prossimo non attraversa nessuna delle quattro, quindi
+-- non diventa pubblica per distrazione.
+--
+-- Questa riga e `SHARED_VIEW_TYPES` sono le due che possono divergere in silenzio: TypeScript non
+-- legge SQL, e la divergenza si presenta in produzione come un 23514 che nessuno sa leggere. È già
+-- successo con `dashboard`. Ora un test le confronta (`shared-views.test.ts`, "il vincolo SQL su
+-- view_type dice esattamente quello che dice il contratto") e la suite diventa rossa prima del
+-- deploy.
+--
+-- Niente tocca le righe esistenti: i link già consegnati valgono, col loro snapshot e la loro
+-- versione.
+alter table public.shared_views
+  drop constraint if exists shared_views_view_type_check;
+
+alter table public.shared_views
+  add constraint shared_views_view_type_check
+  check (view_type in ('calendar', 'dashboard', 'monthly_report', 'strategy', 'workspace'));


### PR DESCRIPTION
## What?

A public share link can now carry two more things: **`strategy`** — the agreed plan behind the
work — and **`workspace`** — dashboard, calendar, monthly report and strategy behind a single
link with tabs, instead of four separate links.

This extends the mechanism merged in #221 (frozen snapshot, hashed token, revoke, expiry). It
does **not** open `/app/[brand]/*` to anonymous visitors, and the "Why?" says why.

Two commits: a pure refactor (`composeDashboard`, `monthLabel` extracted, 30 existing tests
unchanged and green before and after) and the feature.

## Why?

The request was «rendere `/app/[brand]/*` visibile a tutte le persone che hanno un link
pubblico»: a client should see the work without an account. The literal shape is unsafe and
unstable.

**Unsafe.** 96 pages live under `/app/[brand]`, among them `settings/api-keys` (the brand's API
keys), `settings/danger` (`DELETE FROM brands` plus the subscription cancellation),
`settings/demo-account` and `settings/blog-integrations` (client secrets and access tokens in
Supabase Vault), plus billing, team, connected accounts and usage. A link over that tree hands
credentials and a delete button to whoever receives it — or forwards it.

**Unstable.** An allowlist of *exclusions* fails open: the page added next month is public unless
somebody remembers to exclude it. Nobody remembers. And technically every page loads through
`+layout.server.ts` → `event.parent()` and queries live tables with `locals.supabase`; serving
them anonymously means either the service key (every RLS boundary gone at once) or a forged
session. Both have a wider blast radius than the 96 pages.

So the surface stays declarative: the public route reads **one table and one column**, and what a
client sees is what an allowlist copied at creation time.

## How?

**`strategy`** — `statement`, `cadence`, `platforms[]` (platform/share/role), `weeks[]`
(week_start/theme/focus/status), `objective`, `horizon`, `phase` (name/objective/goals with
kpi+target). **Active plans only**: a proposal is a conversation still open with whoever decides,
and `revision_feedback` is literally its text. Left out: each week's `rationale`, `brief` and
`products` (the planner's notes, not the plan), plus `voice`, `changes_summary`, `reply` and every
goal's `actual`/`metric`/`value`.

The GTM phase is picked from the **month asked for**, not the clock. Taken from the clock, a
snapshot frozen in September would show a phase decided by the instant of creation rather than by
the month the link is about — and it could not be tested without moving time.

**`workspace`** — not one more view but the **exact sum** of the others: each section *is* the
snapshot that view would hand over alone, so it cannot show a field one of the single links would
not already show. A test verifies it key by key. `buildDashboard` was split into a pure
`composeDashboard` plus the wrapper that queries, so the workspace reads the calendar and the
history **once**, not four times.

**Rejected alternative — routes under token.** Reaching the real pages read-only was considered
and dropped for the reasons in "Why?". The decision criterion was: which list fails closed?

### How a page added next month stays private

Four gates, all deliberate, and a thing is public only after passing all of them:

1. `SHARED_VIEW_TYPES` in `packages/api-contracts/src/shares.ts` — the enum the endpoint
   validates. `{"view":"settings"}` is a 400 before anything is written.
2. The builder in `SNAPSHOT_BUILDERS`, naming field by field what it copies. It is a
   `Record<SharedViewType, …>`: a type without a builder does not compile.
3. The `check (view_type in (…))` constraint on `shared_views`.
4. The `/share/[token]` page, which has to know how to draw it.

The public route has **no path into the app tree at all** — a new page passes none of the four and
stays invisible without anyone having to remember.

Gate 3 is the only one TypeScript cannot see, and it **has already drifted**: `dashboard` was in
the contract and missing from the check, which took a second migration to fix. In production that
divergence is a `23514` nobody can read. A new test reads the migrations, extracts the last
`view_type in (…)` and compares it with the enum.

## Testing?

Run: `npx vitest run packages/api-contracts src/lib/server/shared-views.test.ts "src/routes/share" "src/routes/api/v1/brands/[slug]/shares" src/lib/content/changelog` → **183 passed**, and
`node scripts/typecheck-runtime.mjs` → **ok**. The Svelte page compiles with zero warnings.

Not tested: no browser run, no local Docker stack, no migration applied anywhere. The public page
is exercised through its server load and its compiler output, not through a rendered DOM.

Every new test was watched fail first. The ones that matter are negative, and they were also
**mutated to prove they bite** — a test that cannot fail is a declaration, not a defence.

<details>
<summary>Red before green — the 10 new snapshot tests</summary>

```
 Test Files  1 failed (1)
      Tests  10 failed | 26 passed (36)

 × lo snapshot della strategia > porta solo i campi dichiarati, in cima e dentro ogni parte
 × lo snapshot della strategia > non fa uscire brief, revisioni, ragionamenti interni né identificatori
 × lo snapshot della strategia > legge solo il piano attivo: una proposta non è lavoro concordato
 × lo snapshot della strategia > mostra la fase che governa il mese chiesto, non la prima della lista
 × lo snapshot della strategia > senza piano attivo resta vuoto invece di rompersi
 × lo snapshot del workspace > porta solo i campi dichiarati in cima
 × lo snapshot del workspace > ogni sezione è esattamente lo snapshot della sua vista: non può mostrare di più
 × lo snapshot del workspace > non fa uscire prompt, qc, note interne o identificatori privati
 × lo snapshot del workspace > non ripete le query: il calendario e la storia si leggono una volta sola

TypeError: SNAPSHOT_BUILDERS[view] is not a function
```
</details>

<details>
<summary>Red before green — the contract/SQL parity guard (the answer to "what about the page added next month")</summary>

Contract widened, migration not yet written:

```
 × il vincolo SQL su view_type dice esattamente quello che dice il contratto
AssertionError: expected [ 'calendar', 'dashboard', …(1) ] to deeply equal [ 'calendar', 'dashboard', …(3) ]

  Array [
    "calendar",
    "dashboard",
    "monthly_report",
-   "strategy",
-   "workspace",
  ]
```

Migration written → green. This is the gate that stops the SQL allowlist and the contract from
drifting again.
</details>

<details>
<summary>Mutation — the leakage test bites</summary>

`rationale` and `brief` added back to the week mapping:

```
 × lo snapshot della strategia > non fa uscire brief, revisioni, ragionamenti interni né identificatori
AssertionError: ragionamento interno: expected '{"brand_name":"Demo Brand",…' not to contain 'ragionamento interno'
Received: …"weeks":[{"week_start":"2026-09-07","theme":"Lancio","rationale":"ragionamento interno",
          "brief":"il brief che ha scritto l operatore",…
```
</details>

<details>
<summary>Mutation — revoke and expiry bite (they cover every view type, old and new)</summary>

`liveShare` with the revoke check removed:

```
exit=1
 × GET /share/:token > revocato, scaduto e mai esistito rispondono nello stesso identico modo
   → expected true to be false
 × leggere una vista condivisa dal token > revocato, scaduto e mai esistito sono la stessa risposta
   → expected [ { view: 'calendar', …(3) }, …(2) ] to deeply equal [ null, null, null ]
```

`liveShare` with the expiry check removed:

```
exit=1
 × GET /share/:token > revocato, scaduto e mai esistito rispondono nello stesso identico modo
   → expected true to be false
 × leggere una vista condivisa dal token > revocato, scaduto e mai esistito sono la stessa risposta
   → expected [ null, …(2) ] to deeply equal [ null, null, null ]
```
</details>

<details>
<summary>Guessing a page name gets a 400, not a link</summary>

New in `packages/api-contracts/src/shares.test.ts`:

```
✓ rifiuta settings: una pagina dell app non è una vista pubblica
✓ rifiuta api-keys: una pagina dell app non è una vista pubblica
✓ rifiuta billing / team / knowledge / agents / usage / danger
```

Plus the existing endpoint test: an unknown `view` is a 400 **before any write**, and a second
new test asserts `src/routes/share/` holds exactly one route — `[token]` — so a second public
entry point added by accident fails the suite instead of existing quietly.
</details>

<details>
<summary>Green, after</summary>

```
 Test Files  13 passed (13)
      Tests  183 passed (183)

typecheck-runtime: ok (ignored 313 non-fatal type error(s))
```
</details>

## Evidence (screenshots/videos)

None. No UI surface creates shares — they are made from the CLI, MCP and API only — and no
browser verification was run for this change, as instructed. The public page's rendering is
covered by the compiler (zero warnings) and by the server-side tests of what it receives.

## Anything Else?

**A migration must be applied — it is not applied here.**
`supabase/migrations/20260904210000_shared_views_strategy_workspace.sql` widens the check
constraint to `strategy` and `workspace`. This repo does not run migrations on deploy. Until it
is applied, creating the two new view types is rejected by Postgres; every existing link keeps
working, untouched.

**Deferred.** The `workspace` tabs are client-side state on a fully loaded snapshot: no deep link
to a tab, no `?tab=` in the URL. Nothing on the page writes, so there is nothing to lose on a
reload. Add it if a client asks to send someone straight to the calendar.

**Not addressed here.** There is still no browser surface to create or revoke a share; it is CLI,
MCP and API only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
