### PR TITLE
Let an agent say what is missing to publish, and hand over the connect link

### DIFF
--- a/changelog/2026-09-04-agent-social-connect.md
+++ b/changelog/2026-09-04-agent-social-connect.md
@@ -1,0 +1,75 @@
+# Un agente esterno può dire cosa manca per pubblicare, e consegnare la porta
+
+Un agente esterno poteva scrivere un post per Instagram e non poteva fare niente perché
+Instagram fosse collegato. Nessuno dei 63 endpoint del registry nominava account o piattaforme
+social: il post veniva prodotto, restava fermo, e l'agente non aveva modo né di accorgersene né
+di dire alla persona cosa fare. Era il buco che rompeva il ciclo principale del prodotto.
+
+Due tool, non uno e non quattro.
+
+`list_social_accounts` (`GET /social/accounts`) risponde alla domanda che oggi non aveva
+risposta: **su cosa questo brand pubblica davvero**. Una riga per account — piattaforma, handle,
+stato — più `connected_platforms` (almeno un account attivo), `broken_platforms` (la riga c'è ma
+nessuna è viva: scaduta, revocata, scollegata), `can_connect`, `slots` e `manage_url`.
+`broken_platforms` è la cosa che nessun'altra superficie mostra, ed è quasi sempre la risposta a
+«perché questo post non è uscito».
+
+`create_social_connect_link` (`POST /social/connect`) conia l'URL che **una persona** apre per
+autorizzare una piattaforma, e si ferma lì.
+
+## La forma, che è quella del billing
+
+L'agente conia il link, l'umano lo attraversa. Nessun agente esegue un OAuth, tiene un token o
+scollega un account. Il consenso a una piattaforma terza lo dà una persona.
+
+L'URL coniato è la nostra `/app/<slug>/settings/connect/<platform>`, **non** l'URL OAuth di
+Zernio. Scartato quest'ultimo per tre motivi, ognuno sufficiente da solo: coniarlo richiede di
+creare il profilo Zernio del brand (una scrittura verso un terzo, innescata da una chiave API);
+scade e si usa una volta sola, quindi un umano che clicca dieci minuti dopo trova un errore; e
+porta un token nell'indirizzo, che è esattamente ciò che non deve attraversare questo confine.
+Con la pagina nostra il consenso lo dà qualcuno già dentro con la propria login, e qui non
+transita nessun segreto — il che rende il link, a differenza di quello di billing, **non** una
+credenziale.
+
+## Quello che non abbiamo esposto
+
+**Non c'è un tool per scollegare, di proposito.** È la stessa azione al contrario e per un agente
+è peggio: togliere un account ferma le pubblicazioni programmate senza che nessuno se ne accorga
+finché non manca un post. Non serviva nemmeno aggiungere un link: `manage_url` è già nella
+risposta di entrambi i tool, ed è la porta dove una persona scollega. Esposto come URL da
+attraversare, costo zero, nessuna nuova superficie.
+
+## Non due risposte alla stessa domanda
+
+`get_brand_settings` (PR #277) restituiva già `connected_platforms`, con una `connectedPlatforms()`
+privata dentro la sua rotta. Due letture separate della stessa cosa divergono al primo
+cambiamento, e un agente che sente due risposte diverse non sa a quale credere: la lettura è stata
+estratta in `$lib/server/social-connections.ts` e **entrambe le rotte la usano**. `settings/brand`
+non ha cambiato di una virgola quello che risponde — i suoi 17 test lo tengono — ma adesso il suo
+`connected_platforms` e quello di `list_social_accounts` vengono letteralmente dalla stessa
+lettura. La differenza fra i due tool resta reale e dichiarata: uno è il riassunto per
+piattaforma dentro le impostazioni, l'altro è la verità per account, e l'unico posto dove un
+collegamento rotto si vede.
+
+## Scelte minori, che però hanno una ragione
+
+- **Il vocabolario delle piattaforme è `TARGET_PLATFORMS`**, quello che già esisteva in
+  `packages/api-contracts/src/brand-settings.ts`. Non riscritto: importato. `twitter` resta fuori,
+  perché è l'alias storico di `x` e due nomi per la stessa piattaforma insegnano quello sbagliato.
+- **Due rifiuti separati, non uno generico.** `plan_cannot_connect` (piano che non collega
+  account) e `account_limit` (posti finiti) sono due problemi con due rimedi diversi: il primo
+  porta `activate_url`, il secondo `manage_url`. Un solo errore li avrebbe confusi.
+- **Il tetto blocca una piattaforma nuova, non una riautorizzazione.** Se l'account è già suo il
+  posto è già occupato, e rifiutare avrebbe lasciato un account scaduto senza modo di tornare vivo.
+- **Nessun `zernio_account_id` nella risposta.** Non serve a niente che un agente possa fare, e un
+  identificatore esposto invita a credere che ci si possa agire sopra.
+- **Nessun comando CLI**, come per i link di billing: sono tool MCP e basta.
+
+## Come è verificato
+
+I test che contano sono i negativi, e sono stati scritti prima: una chiave di sola lettura non
+conia link; nessun campo che somigli a una credenziale attraversa il confine, né nel contratto né
+nella risposta reale di una rotta a cui si passano righe con `access_token` e `zernio_account_id`;
+una piattaforma non supportata viene rifiutata con l'elenco di quelle ammesse. `tools/list`
+catturato prima e dopo attraverso `handleMcpFetch`: 99 → 101, due aggiunti, nessuno rimosso e
+nessuno dei 99 esistenti diverso di un campo.

--- a/cli/lib/contracts/index.ts
+++ b/cli/lib/contracts/index.ts
@@ -50,6 +50,7 @@ import { GET_BRAND_SETTINGS, SET_BRAND_SETTINGS } from './brand-settings';
 import { DIAGNOSE_RADAR, GET_MARKET_FIELD, LIST_IDEAS } from './market';
 import { GET_MEDIA_MODELS, SET_MEDIA_MODEL } from './media-models';
 import { GEO_ACTION, REFRESH_KEYWORDS, SEO_ACTION } from './search';
+import { LIST_SOCIAL_ACCOUNTS, SOCIAL_CONNECT_LINK } from './social';
 import { GET_BACKLINKS, GET_GSC, GET_RANKS } from './web-metrics';
 import {
   CREATE_SHARE,
@@ -157,6 +158,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   LIST_POSTS,
   LIST_PRODUCTS,
   LIST_SHARES,
+  LIST_SOCIAL_ACCOUNTS,
   LIST_WEB_AUDITS,
   LIST_WEB_FIXES,
   PROPOSE_PLAN,
@@ -173,6 +175,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   SET_BIO,
   SET_BRAND_SETTINGS,
   SET_MEDIA_MODEL,
+  SOCIAL_CONNECT_LINK,
   SYNC_HISTORY,
   UPDATE_ARTICLE,
   UPDATE_BRAND_KIT,
@@ -293,6 +296,7 @@ export {
   SET_AUTOMATION
 } from './automations';
 export type { AutomationJob } from './automations';
+export { LIST_SOCIAL_ACCOUNTS, SOCIAL_CONNECT_LINK } from './social';
 export { BILLING_PORTAL_LINK, CHECKOUT_LINK };
 export type { BillingPortalLinkResult, CheckoutLinkInput, CheckoutLinkResult } from './billing';
 export type { CheckContentInput, CheckContentResult } from './content';

--- a/cli/lib/contracts/social.ts
+++ b/cli/lib/contracts/social.ts
@@ -1,0 +1,112 @@
+import { z } from 'zod';
+import type { BrandEndpoint } from './index';
+import { TARGET_PLATFORMS } from './brand-settings';
+
+/**
+ * Il collegamento SOCIAL, che non è `/connections` (quello è Composio: Drive, Notion, GitHub,
+ * Gmail). Qui si parla degli account su cui il prodotto pubblica davvero.
+ *
+ * La forma è quella già scelta per il billing, e non cambia: **l'agente conia il link, l'umano lo
+ * attraversa.** Nessun agente esegue un OAuth, tiene un token o scollega un account per conto di
+ * qualcuno. Il consenso a una piattaforma terza lo dà una persona, sulla pagina di quella
+ * piattaforma; all'agente serve sapere cosa manca e consegnare la porta giusta.
+ *
+ * A differenza del link di billing, questo URL NON è una credenziale: è una pagina della nostra
+ * app, che chiede la sua login. Chi non è già dentro come proprietario del brand non ci fa niente.
+ */
+
+const platform = z.enum(TARGET_PLATFORMS);
+
+const AccountSchema = z.object({
+  platform: z.string(),
+  username: z.string().nullable(),
+  display_name: z.string().nullable(),
+  profile_url: z.string().nullable(),
+  status: z
+    .string()
+    .describe('`active` pubblica. Ogni altro valore no: la riga esiste ma il post resterebbe fermo'),
+  connected_at: z.string().nullable()
+});
+
+const SlotsSchema = z.object({
+  used: z.number().int(),
+  limit: z.number().int().describe('Quanti account il piano di questo brand ammette. 0 = nessuno')
+});
+
+const ManageUrlSchema = z
+  .string()
+  .describe(
+    'Pagina dove una persona sincronizza o SCOLLEGA un account. Non esiste un tool per scollegare: ' +
+      'togliere un account ferma le pubblicazioni programmate senza che nessuno se ne accorga ' +
+      'finché non manca un post, quindi è un passo che si attraversa, non si esegue'
+  );
+
+export const LIST_SOCIAL_ACCOUNTS = {
+  tool: 'list_social_accounts',
+  title: 'Connected social accounts',
+  description:
+    'The social accounts this brand can publish to, one row each: platform, the handle it actually ' +
+    'posts as, and whether it still works. Read it before promising anything will go out — a ' +
+    'target platform with no active account produces posts that sit forever. It also says whether ' +
+    'the plan allows connecting at all and how many slots are left, which is what decides if ' +
+    'create_social_connect_link can help. get_brand_settings carries the same connected_platforms ' +
+    'summary for the platform vocabulary; this is the account-level truth behind it, and the only ' +
+    'place a broken connection shows up. Calls no model and spends no credits.',
+  method: 'GET',
+  pathUnderBrand: '/social/accounts',
+  input: z.object({}).strict(),
+  output: z.object({
+    brand: z.string(),
+    accounts: z.array(AccountSchema),
+    connected_platforms: z
+      .array(z.string())
+      .describe('Piattaforme con almeno un account attivo: le uniche su cui un post esce davvero'),
+    broken_platforms: z
+      .array(z.string())
+      .describe('Ha un account ma nessuno attivo: scaduto, revocato o scollegato. Va riautorizzato'),
+    platform_choices: z.array(z.string()),
+    can_connect: z.boolean().describe('Falso su free/trial e sui piani che non collegano account'),
+    slots: SlotsSchema,
+    manage_url: ManageUrlSchema
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const SOCIAL_CONNECT_LINK = {
+  tool: 'create_social_connect_link',
+  title: 'Social connect link',
+  description:
+    'Mint the link a HUMAN opens to authorise one social platform for this brand, and stop there. ' +
+    'You never run the OAuth, never see a token and never connect anything: the person clicks, ' +
+    'signs in on that platform, and the account appears. The URL is a page of our own app behind ' +
+    'their login, not a credential — but it is useless to anyone who cannot already reach the ' +
+    'brand, so hand it over and let them go. Call list_social_accounts first: this refuses when ' +
+    'the plan connects no accounts (plan_cannot_connect) or every slot is taken (account_limit), ' +
+    'and those are two different problems with two different remedies. Minting a link for a ' +
+    'platform that is already connected is allowed and returns already_connected: it is how a ' +
+    'expired account gets re-authorised, or a second account added. Calls no model and spends no ' +
+    'credits: it works precisely when credits are gone.',
+  method: 'POST',
+  pathUnderBrand: '/social/connect',
+  input: z
+    .object({
+      platform: platform.describe('The platform to authorise, from platform_choices')
+    })
+    .strict(),
+  output: z.object({
+    ok: z.literal(true),
+    platform: z.string(),
+    url: z.string().describe('Give it to the person who owns the brand. Opening it yourself does nothing'),
+    already_connected: z
+      .boolean()
+      .describe('Ha già un account attivo su questa piattaforma: il link riautorizza o ne aggiunge uno'),
+    slots: SlotsSchema,
+    manage_url: ManageUrlSchema
+  }),
+  failures: [
+    { error: 'plan_cannot_connect', status: 409 },
+    { error: 'account_limit', status: 409 }
+  ],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/cli/plugins/anomalia/skills/anomalia/references/tools.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/tools.md
@@ -251,7 +251,9 @@ Two consequences to say out loud before you change either of the first two:
 
 `get_brand_settings` also returns `connected_platforms`, and the write answers with
 `without_account`. Targeting a platform with no connected account is allowed and silent otherwise:
-posts for it are produced and then sit unpublished until an account exists. Say so when it happens.
+posts for it are produced and then sit unpublished until an account exists. Say so when it happens,
+and reach for `list_social_accounts` — it reads the same accounts and is the only place that says
+*why* a platform is missing.
 
 An unknown IANA zone is refused (`unknown_timezone`), and so is a platform outside the list —
 `twitter` is not a name here, it is `x`. The post language lives on `update_brand_kit`, not here.
@@ -407,6 +409,44 @@ Refusals name the field: `article_not_found` (an article of another brand includ
 `translation_locked` (a translation's locale is its identity) and `article_published` — what is
 live is never edited in place. To correct a published article: `unpublish_article`,
 `update_article`, `publish_article`.
+## Social accounts
+
+| MCP | CLI |
+|-----|-----|
+| `list_social_accounts` | (MCP only) |
+| `create_social_connect_link` | (MCP only) |
+
+Where the brand actually publishes, and how a platform gets connected. This is **not**
+`connections` / `list_integrations_tools`: those are Composio (Drive, Notion, GitHub, Gmail).
+These two are the social accounts a post goes out on.
+
+`list_social_accounts` returns one row per account — `platform`, `username`, `status` — plus
+`connected_platforms` (at least one **active** account: the only ones a post leaves from),
+`broken_platforms` (an account exists but none is active — expired, revoked, disconnected),
+`can_connect`, `slots` (`used` / `limit` for the plan) and `manage_url`. `broken_platforms` is the
+one thing no other tool shows, and it is usually the answer to "why hasn't this published?": the
+post is scheduled, the platform is targeted, and the account stopped working weeks ago.
+
+`create_social_connect_link` takes a `platform` and answers with the **URL a person opens** to
+authorise it. You never run the OAuth, never see a token, never connect anything: you hand the URL
+over and stop. Unlike a billing link it is not a credential — it is a page of our own app behind
+their login — but it is only useful to someone who can already reach the brand. Minting a link for
+a platform that is already connected is fine and comes back with `already_connected: true`: that
+is how an expired account gets re-authorised or a second one added.
+
+`platform` must be one of `platform_choices` — the same vocabulary as `set_brand_settings`, and
+`twitter` is not in it, it is `x`. An unknown name is refused with `invalid_input` and the allowed
+list in `platform_choices`.
+
+Two refusals mean two different remedies: `plan_cannot_connect` (409) is a free, trial, paused or
+export-only brand that connects no accounts at all — the body carries `activate_url`, which is
+where the person starts; `account_limit` (409) is a plan whose slots are full, and the remedy is
+`manage_url`, where they remove one. Neither call spends credits or touches a model.
+
+**There is no tool to disconnect an account, on purpose.** Removing one stops scheduled
+publishing without anyone noticing until a post fails to go out, and that is not a step an agent
+takes on someone's behalf. `manage_url` is where a person does it.
+
 ## Billing links
 
 | MCP | CLI |

--- a/cli/skills/anomalia/references/tools.md
+++ b/cli/skills/anomalia/references/tools.md
@@ -251,7 +251,9 @@ Two consequences to say out loud before you change either of the first two:
 
 `get_brand_settings` also returns `connected_platforms`, and the write answers with
 `without_account`. Targeting a platform with no connected account is allowed and silent otherwise:
-posts for it are produced and then sit unpublished until an account exists. Say so when it happens.
+posts for it are produced and then sit unpublished until an account exists. Say so when it happens,
+and reach for `list_social_accounts` — it reads the same accounts and is the only place that says
+*why* a platform is missing.
 
 An unknown IANA zone is refused (`unknown_timezone`), and so is a platform outside the list —
 `twitter` is not a name here, it is `x`. The post language lives on `update_brand_kit`, not here.
@@ -407,6 +409,44 @@ Refusals name the field: `article_not_found` (an article of another brand includ
 `translation_locked` (a translation's locale is its identity) and `article_published` — what is
 live is never edited in place. To correct a published article: `unpublish_article`,
 `update_article`, `publish_article`.
+## Social accounts
+
+| MCP | CLI |
+|-----|-----|
+| `list_social_accounts` | (MCP only) |
+| `create_social_connect_link` | (MCP only) |
+
+Where the brand actually publishes, and how a platform gets connected. This is **not**
+`connections` / `list_integrations_tools`: those are Composio (Drive, Notion, GitHub, Gmail).
+These two are the social accounts a post goes out on.
+
+`list_social_accounts` returns one row per account — `platform`, `username`, `status` — plus
+`connected_platforms` (at least one **active** account: the only ones a post leaves from),
+`broken_platforms` (an account exists but none is active — expired, revoked, disconnected),
+`can_connect`, `slots` (`used` / `limit` for the plan) and `manage_url`. `broken_platforms` is the
+one thing no other tool shows, and it is usually the answer to "why hasn't this published?": the
+post is scheduled, the platform is targeted, and the account stopped working weeks ago.
+
+`create_social_connect_link` takes a `platform` and answers with the **URL a person opens** to
+authorise it. You never run the OAuth, never see a token, never connect anything: you hand the URL
+over and stop. Unlike a billing link it is not a credential — it is a page of our own app behind
+their login — but it is only useful to someone who can already reach the brand. Minting a link for
+a platform that is already connected is fine and comes back with `already_connected: true`: that
+is how an expired account gets re-authorised or a second one added.
+
+`platform` must be one of `platform_choices` — the same vocabulary as `set_brand_settings`, and
+`twitter` is not in it, it is `x`. An unknown name is refused with `invalid_input` and the allowed
+list in `platform_choices`.
+
+Two refusals mean two different remedies: `plan_cannot_connect` (409) is a free, trial, paused or
+export-only brand that connects no accounts at all — the body carries `activate_url`, which is
+where the person starts; `account_limit` (409) is a plan whose slots are full, and the remedy is
+`manage_url`, where they remove one. Neither call spends credits or touches a model.
+
+**There is no tool to disconnect an account, on purpose.** Removing one stops scheduled
+publishing without anyone noticing until a post fails to go out, and that is not a step an agent
+takes on someone's behalf. `manage_url` is where a person does it.
+
 ## Billing links
 
 | MCP | CLI |

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -50,6 +50,7 @@ import { GET_BRAND_SETTINGS, SET_BRAND_SETTINGS } from './brand-settings';
 import { DIAGNOSE_RADAR, GET_MARKET_FIELD, LIST_IDEAS } from './market';
 import { GET_MEDIA_MODELS, SET_MEDIA_MODEL } from './media-models';
 import { GEO_ACTION, REFRESH_KEYWORDS, SEO_ACTION } from './search';
+import { LIST_SOCIAL_ACCOUNTS, SOCIAL_CONNECT_LINK } from './social';
 import { GET_BACKLINKS, GET_GSC, GET_RANKS } from './web-metrics';
 import {
   CREATE_SHARE,
@@ -157,6 +158,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   LIST_POSTS,
   LIST_PRODUCTS,
   LIST_SHARES,
+  LIST_SOCIAL_ACCOUNTS,
   LIST_WEB_AUDITS,
   LIST_WEB_FIXES,
   PROPOSE_PLAN,
@@ -173,6 +175,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   SET_BIO,
   SET_BRAND_SETTINGS,
   SET_MEDIA_MODEL,
+  SOCIAL_CONNECT_LINK,
   SYNC_HISTORY,
   UPDATE_ARTICLE,
   UPDATE_BRAND_KIT,
@@ -293,6 +296,7 @@ export {
   SET_AUTOMATION
 } from './automations';
 export type { AutomationJob } from './automations';
+export { LIST_SOCIAL_ACCOUNTS, SOCIAL_CONNECT_LINK } from './social';
 export { BILLING_PORTAL_LINK, CHECKOUT_LINK };
 export type { BillingPortalLinkResult, CheckoutLinkInput, CheckoutLinkResult } from './billing';
 export type { CheckContentInput, CheckContentResult } from './content';

--- a/packages/api-contracts/src/social.test.ts
+++ b/packages/api-contracts/src/social.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import { TARGET_PLATFORMS } from './brand-settings';
+import { LIST_SOCIAL_ACCOUNTS, SOCIAL_CONNECT_LINK } from './social';
+
+describe('il vocabolario delle piattaforme', () => {
+  it('è quello del prodotto, non una copia scritta qui', () => {
+    const parsed = SOCIAL_CONNECT_LINK.input.safeParse({ platform: 'instagram' });
+
+    expect(parsed.success).toBe(true);
+    for (const platform of TARGET_PLATFORMS) {
+      expect(SOCIAL_CONNECT_LINK.input.safeParse({ platform }).success, platform).toBe(true);
+    }
+  });
+
+  it('rifiuta una piattaforma che il prodotto non pubblica, e dice quali sono ammesse', () => {
+    const parsed = SOCIAL_CONNECT_LINK.input.safeParse({ platform: 'myspace' });
+
+    expect(parsed.success).toBe(false);
+    const allowed = parsed.error?.issues.flatMap((i) =>
+      'values' in i ? (i.values as string[]) : []
+    );
+    expect(allowed).toEqual([...TARGET_PLATFORMS]);
+  });
+
+  it("rifiuta `twitter`: è l'alias storico di `x`, e due nomi insegnano quello sbagliato", () => {
+    expect(SOCIAL_CONNECT_LINK.input.safeParse({ platform: 'twitter' }).success).toBe(false);
+  });
+});
+
+describe('la coppia leggi-e-conia', () => {
+  it('la lettura è una GET e non è distruttiva', () => {
+    expect(LIST_SOCIAL_ACCOUNTS.method).toBe('GET');
+    expect(LIST_SOCIAL_ACCOUNTS.destructive).toBe(false);
+  });
+
+  it('coniare un link non è distruttivo: non collega e non scollega niente', () => {
+    expect(SOCIAL_CONNECT_LINK.method).toBe('POST');
+    expect(SOCIAL_CONNECT_LINK.destructive).toBe(false);
+  });
+
+  it('non vive sotto /connections, che è Composio e non ha niente a che vedere', () => {
+    expect(LIST_SOCIAL_ACCOUNTS.pathUnderBrand.startsWith('/social/')).toBe(true);
+    expect(SOCIAL_CONNECT_LINK.pathUnderBrand.startsWith('/social/')).toBe(true);
+  });
+
+  it('non accetta campi non dichiarati invece di scartarli in silenzio', () => {
+    expect(SOCIAL_CONNECT_LINK.input.safeParse({ platform: 'x', token: 'abc' }).success).toBe(false);
+    expect(LIST_SOCIAL_ACCOUNTS.input.safeParse({ platform: 'x' }).success).toBe(false);
+  });
+});
+
+describe('nessun segreto attraversa il confine', () => {
+  const forbidden = /token|secret|credential|access|refresh|password|cookie|zernio/i;
+
+  it('la lettura non dichiara un solo campo che somigli a una credenziale', () => {
+    const account = LIST_SOCIAL_ACCOUNTS.output.shape.accounts.element.shape;
+
+    for (const field of Object.keys(account)) {
+      expect(forbidden.test(field), field).toBe(false);
+    }
+    for (const field of Object.keys(LIST_SOCIAL_ACCOUNTS.output.shape)) {
+      expect(forbidden.test(field), field).toBe(false);
+    }
+  });
+
+  it('il link coniato non porta con sé nessun campo credenziale', () => {
+    for (const field of Object.keys(SOCIAL_CONNECT_LINK.output.shape)) {
+      expect(forbidden.test(field), field).toBe(false);
+    }
+  });
+
+  it('scarta ogni chiave in più che una rotta si lasciasse sfuggire', () => {
+    const leaked = LIST_SOCIAL_ACCOUNTS.output.safeParse({
+      brand: 'demo',
+      accounts: [
+        {
+          platform: 'instagram',
+          username: 'demo',
+          display_name: 'Demo',
+          profile_url: null,
+          status: 'active',
+          connected_at: '2026-09-04T00:00:00.000Z',
+          access_token: 'ig-secret'
+        }
+      ],
+      connected_platforms: ['instagram'],
+      broken_platforms: [],
+      platform_choices: [...TARGET_PLATFORMS],
+      can_connect: true,
+      slots: { used: 1, limit: 3 },
+      manage_url: 'https://anomalia.so/app/demo/settings/connected-accounts'
+    });
+
+    expect(leaked.success).toBe(true);
+    expect(JSON.stringify(leaked.data)).not.toContain('ig-secret');
+  });
+});
+
+describe('i rifiuti che un agente deve saper leggere', () => {
+  it('dice che il piano non collega account, invece di consegnare una porta chiusa', () => {
+    expect(SOCIAL_CONNECT_LINK.failures).toContainEqual({
+      error: 'plan_cannot_connect',
+      status: 409
+    });
+  });
+
+  it('dice che i posti sono finiti, che è un altro problema e un altro rimedio', () => {
+    expect(SOCIAL_CONNECT_LINK.failures).toContainEqual({ error: 'account_limit', status: 409 });
+  });
+});

--- a/packages/api-contracts/src/social.ts
+++ b/packages/api-contracts/src/social.ts
@@ -1,0 +1,112 @@
+import { z } from 'zod';
+import type { BrandEndpoint } from './index';
+import { TARGET_PLATFORMS } from './brand-settings';
+
+/**
+ * Il collegamento SOCIAL, che non è `/connections` (quello è Composio: Drive, Notion, GitHub,
+ * Gmail). Qui si parla degli account su cui il prodotto pubblica davvero.
+ *
+ * La forma è quella già scelta per il billing, e non cambia: **l'agente conia il link, l'umano lo
+ * attraversa.** Nessun agente esegue un OAuth, tiene un token o scollega un account per conto di
+ * qualcuno. Il consenso a una piattaforma terza lo dà una persona, sulla pagina di quella
+ * piattaforma; all'agente serve sapere cosa manca e consegnare la porta giusta.
+ *
+ * A differenza del link di billing, questo URL NON è una credenziale: è una pagina della nostra
+ * app, che chiede la sua login. Chi non è già dentro come proprietario del brand non ci fa niente.
+ */
+
+const platform = z.enum(TARGET_PLATFORMS);
+
+const AccountSchema = z.object({
+  platform: z.string(),
+  username: z.string().nullable(),
+  display_name: z.string().nullable(),
+  profile_url: z.string().nullable(),
+  status: z
+    .string()
+    .describe('`active` pubblica. Ogni altro valore no: la riga esiste ma il post resterebbe fermo'),
+  connected_at: z.string().nullable()
+});
+
+const SlotsSchema = z.object({
+  used: z.number().int(),
+  limit: z.number().int().describe('Quanti account il piano di questo brand ammette. 0 = nessuno')
+});
+
+const ManageUrlSchema = z
+  .string()
+  .describe(
+    'Pagina dove una persona sincronizza o SCOLLEGA un account. Non esiste un tool per scollegare: ' +
+      'togliere un account ferma le pubblicazioni programmate senza che nessuno se ne accorga ' +
+      'finché non manca un post, quindi è un passo che si attraversa, non si esegue'
+  );
+
+export const LIST_SOCIAL_ACCOUNTS = {
+  tool: 'list_social_accounts',
+  title: 'Connected social accounts',
+  description:
+    'The social accounts this brand can publish to, one row each: platform, the handle it actually ' +
+    'posts as, and whether it still works. Read it before promising anything will go out — a ' +
+    'target platform with no active account produces posts that sit forever. It also says whether ' +
+    'the plan allows connecting at all and how many slots are left, which is what decides if ' +
+    'create_social_connect_link can help. get_brand_settings carries the same connected_platforms ' +
+    'summary for the platform vocabulary; this is the account-level truth behind it, and the only ' +
+    'place a broken connection shows up. Calls no model and spends no credits.',
+  method: 'GET',
+  pathUnderBrand: '/social/accounts',
+  input: z.object({}).strict(),
+  output: z.object({
+    brand: z.string(),
+    accounts: z.array(AccountSchema),
+    connected_platforms: z
+      .array(z.string())
+      .describe('Piattaforme con almeno un account attivo: le uniche su cui un post esce davvero'),
+    broken_platforms: z
+      .array(z.string())
+      .describe('Ha un account ma nessuno attivo: scaduto, revocato o scollegato. Va riautorizzato'),
+    platform_choices: z.array(z.string()),
+    can_connect: z.boolean().describe('Falso su free/trial e sui piani che non collegano account'),
+    slots: SlotsSchema,
+    manage_url: ManageUrlSchema
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const SOCIAL_CONNECT_LINK = {
+  tool: 'create_social_connect_link',
+  title: 'Social connect link',
+  description:
+    'Mint the link a HUMAN opens to authorise one social platform for this brand, and stop there. ' +
+    'You never run the OAuth, never see a token and never connect anything: the person clicks, ' +
+    'signs in on that platform, and the account appears. The URL is a page of our own app behind ' +
+    'their login, not a credential — but it is useless to anyone who cannot already reach the ' +
+    'brand, so hand it over and let them go. Call list_social_accounts first: this refuses when ' +
+    'the plan connects no accounts (plan_cannot_connect) or every slot is taken (account_limit), ' +
+    'and those are two different problems with two different remedies. Minting a link for a ' +
+    'platform that is already connected is allowed and returns already_connected: it is how a ' +
+    'expired account gets re-authorised, or a second account added. Calls no model and spends no ' +
+    'credits: it works precisely when credits are gone.',
+  method: 'POST',
+  pathUnderBrand: '/social/connect',
+  input: z
+    .object({
+      platform: platform.describe('The platform to authorise, from platform_choices')
+    })
+    .strict(),
+  output: z.object({
+    ok: z.literal(true),
+    platform: z.string(),
+    url: z.string().describe('Give it to the person who owns the brand. Opening it yourself does nothing'),
+    already_connected: z
+      .boolean()
+      .describe('Ha già un account attivo su questa piattaforma: il link riautorizza o ne aggiunge uno'),
+    slots: SlotsSchema,
+    manage_url: ManageUrlSchema
+  }),
+  failures: [
+    { error: 'plan_cannot_connect', status: 409 },
+    { error: 'account_limit', status: 409 }
+  ],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/src/lib/content/changelog/2026-09-04-agent-social-connect.ts
+++ b/src/lib/content/changelog/2026-09-04-agent-social-connect.ts
@@ -1,0 +1,12 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-04',
+  title: 'Your agent can tell you what is missing before a post can go out',
+  items: [
+    'Your agent can now list the social accounts your brand publishes to, and say which ones stopped working — an expired account is usually why a scheduled post never went out.',
+    'Ask your agent to connect a platform and it hands you the link to authorise it. You open it and sign in: an agent never runs the login and never sees your account credentials.',
+    'It says up front when your plan connects no accounts, or when every slot is taken — two different problems, with the right page for each.',
+    'Disconnecting an account stays yours alone: your agent points you at the page, and never removes one for you.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/social-connections.ts
+++ b/src/lib/server/social-connections.ts
@@ -1,0 +1,82 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { accountLimit, canConnectSocials } from '$lib/server/plans';
+
+/**
+ * Lo stato del collegamento social di un brand, letto una volta sola.
+ *
+ * Esiste perché la stessa domanda — "su quali piattaforme questo brand pubblica davvero?" — la
+ * fanno due tool (`get_brand_settings` e `list_social_accounts`) e la rotta che conia il link. Con
+ * tre letture separate le tre risposte divergono al primo cambiamento, e un agente che ne sente
+ * due diverse non sa più a quale credere.
+ *
+ * `active` è l'unico stato che pubblica. Gli altri valori che il sync deposita (`disconnected`, e
+ * quelli che una piattaforma può restituire scaduti o revocati) non vengono enumerati qui: la
+ * riga c'è ma nessuna è attiva, e questo basta a dire che la piattaforma va riautorizzata.
+ */
+
+const ACTIVE = 'active';
+
+export type SocialAccount = {
+  platform: string;
+  username: string | null;
+  display_name: string | null;
+  profile_url: string | null;
+  status: string;
+  connected_at: string | null;
+};
+
+export type SocialConnections = {
+  accounts: SocialAccount[];
+  connected: string[];
+  broken: string[];
+  canConnect: boolean;
+  slots: { used: number; limit: number };
+};
+
+type BrandRef = { id: string; plan: string | null; status: string | null };
+
+const norm = (value: unknown): string => String(value ?? '').toLowerCase().trim();
+
+const unique = (platforms: string[]): string[] => [...new Set(platforms)].filter(Boolean);
+
+export async function socialConnections(
+  supabase: SupabaseClient,
+  brand: BrandRef
+): Promise<SocialConnections> {
+  const { data } = await supabase
+    .from('social_accounts')
+    .select('platform, username, display_name, profile_url, status, connected_at')
+    .eq('brand_id', brand.id)
+    .order('connected_at', { ascending: true });
+
+  const accounts: SocialAccount[] = (data ?? []).map((row) => ({
+    platform: norm(row.platform),
+    username: row.username ?? null,
+    display_name: row.display_name ?? null,
+    profile_url: row.profile_url ?? null,
+    status: norm(row.status) || ACTIVE,
+    connected_at: row.connected_at ?? null
+  }));
+
+  const connected = unique(accounts.filter((a) => a.status === ACTIVE).map((a) => a.platform));
+  const broken = unique(accounts.map((a) => a.platform)).filter((p) => !connected.includes(p));
+
+  return {
+    accounts,
+    connected,
+    broken,
+    canConnect: canConnectSocials(brand.plan, brand.status),
+    slots: {
+      used: accounts.filter((a) => a.status === ACTIVE).length,
+      limit: accountLimit(brand.plan)
+    }
+  };
+}
+
+/** Dove una persona collega una piattaforma. Non è un OAuth: è una pagina dietro la sua login. */
+export const connectPath = (slug: string, platform: string): string =>
+  `/app/${encodeURIComponent(slug)}/settings/connect/${encodeURIComponent(platform)}`;
+
+/** Dove una persona sincronizza o scollega. Nessun tool scollega: si attraversa, non si esegue. */
+export const managePath = (slug: string): string =>
+  `/app/${encodeURIComponent(slug)}/settings/connected-accounts`;

--- a/src/routes/api/v1/brands/[slug]/settings/brand/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/settings/brand/+server.ts
@@ -1,9 +1,9 @@
 import { json } from '@sveltejs/kit';
-import type { SupabaseClient } from '@supabase/supabase-js';
 import type { RequestHandler } from './$types';
 import { authenticate, loadBrandForUser, checkApiKeyWriteAccess } from '$lib/server/cli-auth';
 import { SET_BRAND_SETTINGS, TARGET_PLATFORMS, statusForFailure } from '@anomalia/api-contracts';
 import { isKnownTimezone, normalizeHashtags } from '$lib/brand-fields';
+import { socialConnections } from '$lib/server/social-connections';
 
 type Prefs = Record<string, unknown>;
 
@@ -14,17 +14,9 @@ type Prefs = Record<string, unknown>;
 // La lettura porta anche le piattaforme che hanno un account collegato. Non è decorazione:
 // `target_platforms` non è validata contro gli account, quindi un agente può bersagliare una
 // piattaforma dove non c'è dove pubblicare, e i post per lei restano fermi in `approved` senza
-// che nessuno lo dica.
-
-async function connectedPlatforms(supabase: SupabaseClient, brandId: string): Promise<string[]> {
-  const { data } = await supabase
-    .from('social_accounts')
-    .select('platform')
-    .eq('brand_id', brandId)
-    .eq('status', 'active');
-
-  return [...new Set((data ?? []).map((row) => String(row.platform ?? '').toLowerCase()))].filter(Boolean);
-}
+// che nessuno lo dica. L'elenco viene dalla stessa lettura di `list_social_accounts`, che è dove
+// si vede anche PERCHÉ una piattaforma non è collegata: due tool che rispondono alla stessa
+// domanda devono leggerla nello stesso posto, o divergono al primo cambiamento.
 
 const storedHashtags = (prefs: Prefs): Record<string, string[]> =>
   (prefs.platformHashtags as Record<string, string[]>) ?? {};
@@ -45,7 +37,7 @@ export const GET: RequestHandler = async ({ request, params }) => {
     timezone: brand.timezone,
     platforms: brand.target_platforms ?? [],
     platform_choices: [...TARGET_PLATFORMS],
-    connected_platforms: await connectedPlatforms(supabase, brand.id),
+    connected_platforms: (await socialConnections(supabase, brand)).connected,
     hashtags: storedHashtags(prefs),
     voice_examples: storedExamples(prefs)
   });
@@ -116,7 +108,7 @@ export const PUT: RequestHandler = async ({ request, params }) => {
   }
 
   const saved = platforms ?? brand.target_platforms ?? [];
-  const connected = await connectedPlatforms(supabase, brand.id);
+  const { connected } = await socialConnections(supabase, brand);
 
   return json({
     ok: true,

--- a/src/routes/api/v1/brands/[slug]/settings/brand/server.test.ts
+++ b/src/routes/api/v1/brands/[slug]/settings/brand/server.test.ts
@@ -18,9 +18,8 @@ function fakeSupabase(accounts: Row[] = [], updateError: { message: string } | n
       if (table === 'social_accounts') {
         const q = {
           select: () => q,
-          eq(_col: string, _val: unknown) {
-            return _col === 'status' ? Promise.resolve({ data: accounts }) : q;
-          }
+          eq: () => q,
+          order: async () => ({ data: accounts })
         };
         return q;
       }

--- a/src/routes/api/v1/brands/[slug]/social/accounts/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/social/accounts/+server.ts
@@ -1,0 +1,37 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { authenticate, loadBrandForUser } from '$lib/server/cli-auth';
+import { appOrigin } from '$lib/server/app-url';
+import { managePath, socialConnections } from '$lib/server/social-connections';
+import { TARGET_PLATFORMS } from '@anomalia/api-contracts';
+
+/**
+ * Su cosa questo brand pubblica davvero. `get_brand_settings` porta lo stesso elenco di
+ * `connected_platforms` — dalla stessa lettura, quindi non possono divergere — ma solo qui si vede
+ * l'account: l'handle, e se ha smesso di funzionare. Un account scaduto è la ragione per cui un
+ * post programmato non esce, ed è invisibile a chiunque guardi solo le piattaforme bersaglio.
+ *
+ * Non passa di qui nessun token: la riga in `social_accounts` non ne contiene, le credenziali
+ * stanno da Zernio, e l'id Zernio dell'account non esce perché non serve a niente che un agente
+ * possa fare.
+ */
+export const GET: RequestHandler = async ({ request, params, url }) => {
+  const { supabase, error, apiKey } = await authenticate(request);
+  if (error) return error;
+
+  const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
+  if (brandError) return brandError;
+
+  const state = await socialConnections(supabase, brand);
+
+  return json({
+    brand: brand.slug,
+    accounts: state.accounts,
+    connected_platforms: state.connected,
+    broken_platforms: state.broken,
+    platform_choices: [...TARGET_PLATFORMS],
+    can_connect: state.canConnect,
+    slots: state.slots,
+    manage_url: `${appOrigin(url)}${managePath(brand.slug)}`
+  });
+};

--- a/src/routes/api/v1/brands/[slug]/social/accounts/server.test.ts
+++ b/src/routes/api/v1/brands/[slug]/social/accounts/server.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('$lib/server/cli-auth', () => ({
+  authenticate: vi.fn(),
+  loadBrandForUser: vi.fn()
+}));
+vi.mock('$lib/server/app-url', () => ({ appOrigin: () => 'https://anomalia.test' }));
+
+import { GET } from './+server';
+import { authenticate, loadBrandForUser } from '$lib/server/cli-auth';
+
+type Row = Record<string, unknown>;
+
+function fakeSupabase(accounts: Row[]) {
+  const q = {
+    select: () => q,
+    eq: () => q,
+    order: async () => ({ data: accounts })
+  };
+  return { from: () => q };
+}
+
+const BRAND = { id: 'brand-1', slug: 'demo', plan: 'pro', status: 'active' };
+
+const IG = {
+  platform: 'Instagram',
+  username: 'demo.brand',
+  display_name: 'Demo Brand',
+  profile_url: 'https://instagram.com/demo.brand',
+  status: 'active',
+  connected_at: '2026-08-01T10:00:00.000Z'
+};
+
+const url = 'https://anomalia.test/api/v1/brands/demo/social/accounts';
+
+const read = (accounts: Row[] = [IG], brand: Row = BRAND) => {
+  vi.mocked(authenticate).mockResolvedValue({
+    supabase: fakeSupabase(accounts),
+    apiKey: undefined,
+    error: null
+  } as never);
+  vi.mocked(loadBrandForUser).mockResolvedValue({ brand, error: null } as never);
+
+  return (GET as (e: unknown) => Promise<Response>)({
+    request: new Request(url),
+    params: { slug: 'demo' },
+    url: new URL(url)
+  }).then(async (res) => ({ res, body: await res.json() }));
+};
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('GET /api/v1/brands/:slug/social/accounts', () => {
+  it("dice su quale handle pubblica, non solo che la piattaforma c'è", async () => {
+    const { body } = await read();
+
+    expect(body.accounts).toEqual([
+      {
+        platform: 'instagram',
+        username: 'demo.brand',
+        display_name: 'Demo Brand',
+        profile_url: 'https://instagram.com/demo.brand',
+        status: 'active',
+        connected_at: '2026-08-01T10:00:00.000Z'
+      }
+    ]);
+    expect(body.connected_platforms).toEqual(['instagram']);
+  });
+
+  it('separa una piattaforma rotta da una che non è mai stata collegata', async () => {
+    // Il caso che oggi nessuno vede: la riga c'è, il post è programmato, e non esce.
+    const { body } = await read([{ ...IG, status: 'expired' }]);
+
+    expect(body.connected_platforms).toEqual([]);
+    expect(body.broken_platforms).toEqual(['instagram']);
+  });
+
+  it('non chiama rotta una piattaforma che ha anche un solo account vivo', async () => {
+    const { body } = await read([
+      { ...IG, status: 'disconnected', username: 'vecchio' },
+      { ...IG, username: 'nuovo' }
+    ]);
+
+    expect(body.connected_platforms).toEqual(['instagram']);
+    expect(body.broken_platforms).toEqual([]);
+  });
+
+  it('dice che un piano free non collega niente, prima che qualcuno provi', async () => {
+    const { body } = await read([], { ...BRAND, plan: null, status: 'trial' });
+
+    expect(body.can_connect).toBe(false);
+    expect(body.slots).toEqual({ used: 0, limit: 0 });
+  });
+
+  it('conta solo gli account attivi contro il tetto del piano', async () => {
+    const { body } = await read([IG, { ...IG, platform: 'tiktok', status: 'disconnected' }]);
+
+    expect(body.slots.used).toBe(1);
+    expect(body.slots.limit).toBeGreaterThan(0);
+  });
+
+  it('porta il vocabolario delle piattaforme e la porta dove si scollega', async () => {
+    const { body } = await read();
+
+    expect(body.platform_choices).toContain('linkedin');
+    expect(body.manage_url).toBe(
+      'https://anomalia.test/app/demo/settings/connected-accounts'
+    );
+  });
+
+  it('non fa uscire un token, un id Zernio o qualunque altra credenziale', async () => {
+    const { body } = await read([
+      { ...IG, access_token: 'ig-secret', zernio_account_id: 'zern-1' }
+    ]);
+
+    expect(JSON.stringify(body)).not.toContain('ig-secret');
+    expect(JSON.stringify(body)).not.toContain('zern-1');
+    expect(JSON.stringify(body)).not.toMatch(/token|secret|zernio/i);
+  });
+
+  it('risponde esattamente quello che il contratto dichiara, niente di più', async () => {
+    const { LIST_SOCIAL_ACCOUNTS } = await import('@anomalia/api-contracts');
+    const { body } = await read();
+
+    expect(LIST_SOCIAL_ACCOUNTS.output.strict().safeParse(body).success).toBe(true);
+  });
+});

--- a/src/routes/api/v1/brands/[slug]/social/connect/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/social/connect/+server.ts
@@ -1,0 +1,78 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { authenticate, checkApiKeyWriteAccess, loadBrandForUser } from '$lib/server/cli-auth';
+import { appOrigin } from '$lib/server/app-url';
+import { connectPath, managePath, socialConnections } from '$lib/server/social-connections';
+import { SOCIAL_CONNECT_LINK, TARGET_PLATFORMS, statusForFailure } from '@anomalia/api-contracts';
+
+/**
+ * Conia la porta, non la attraversa.
+ *
+ * L'URL è la nostra pagina `/settings/connect/:platform`, che chiede la login della persona e da
+ * lì manda all'OAuth della piattaforma. È deliberatamente quella e non l'URL OAuth di Zernio:
+ * quello va coniato creando il profilo Zernio del brand, scade, si usa una volta sola, e porta un
+ * token nell'indirizzo — tre buoni motivi perché non passi mai da un agente. Così invece il
+ * consenso lo dà una persona già dentro, e qui non transita nessun segreto.
+ *
+ * I due rifiuti sono separati di proposito: un piano che non collega account e un piano pieno
+ * chiedono due rimedi diversi, e un solo errore generico li avrebbe confusi.
+ */
+export const POST: RequestHandler = async ({ request, params, url }) => {
+  const { supabase, error, apiKey } = await authenticate(request);
+  if (error) return error;
+
+  const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
+  if (brandError) return brandError;
+
+  const readOnly = checkApiKeyWriteAccess(apiKey);
+  if (readOnly) return readOnly;
+
+  const parsed = SOCIAL_CONNECT_LINK.input.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return json(
+      {
+        error: 'invalid_input',
+        details: parsed.error.issues,
+        platform_choices: [...TARGET_PLATFORMS]
+      },
+      { status: 400 }
+    );
+  }
+
+  const { platform } = parsed.data;
+  const origin = appOrigin(url);
+  const manageUrl = `${origin}${managePath(brand.slug)}`;
+  const state = await socialConnections(supabase, brand);
+
+  if (!state.canConnect) {
+    return json(
+      {
+        error: 'plan_cannot_connect',
+        plan: brand.plan,
+        brand_status: brand.status,
+        activate_url: `${origin}/app/${encodeURIComponent(brand.slug)}/activate`
+      },
+      { status: statusForFailure(SOCIAL_CONNECT_LINK, 'plan_cannot_connect') }
+    );
+  }
+
+  const alreadyConnected = state.connected.includes(platform);
+
+  // Un posto pieno blocca una piattaforma NUOVA. Riautorizzarne una già collegata no: il posto è
+  // già suo, e rifiutarlo lascerebbe un account scaduto senza modo di tornare vivo.
+  if (!alreadyConnected && state.slots.used >= state.slots.limit) {
+    return json(
+      { error: 'account_limit', slots: state.slots, manage_url: manageUrl },
+      { status: statusForFailure(SOCIAL_CONNECT_LINK, 'account_limit') }
+    );
+  }
+
+  return json({
+    ok: true,
+    platform,
+    url: `${origin}${connectPath(brand.slug, platform)}`,
+    already_connected: alreadyConnected,
+    slots: state.slots,
+    manage_url: manageUrl
+  });
+};

--- a/src/routes/api/v1/brands/[slug]/social/connect/server.test.ts
+++ b/src/routes/api/v1/brands/[slug]/social/connect/server.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { json } from '@sveltejs/kit';
+
+vi.mock('$lib/server/cli-auth', () => ({
+  authenticate: vi.fn(),
+  loadBrandForUser: vi.fn(),
+  checkApiKeyWriteAccess: vi.fn(() => undefined)
+}));
+vi.mock('$lib/server/app-url', () => ({ appOrigin: () => 'https://anomalia.test' }));
+
+import { POST } from './+server';
+import { authenticate, loadBrandForUser, checkApiKeyWriteAccess } from '$lib/server/cli-auth';
+
+type Row = Record<string, unknown>;
+
+function fakeSupabase(accounts: Row[]) {
+  const q = {
+    select: () => q,
+    eq: () => q,
+    order: async () => ({ data: accounts })
+  };
+  return { from: () => q };
+}
+
+const BRAND = { id: 'brand-1', slug: 'demo', plan: 'pro', status: 'active' };
+
+const IG = {
+  platform: 'instagram',
+  username: 'demo.brand',
+  display_name: 'Demo Brand',
+  profile_url: null,
+  status: 'active',
+  connected_at: '2026-08-01T10:00:00.000Z'
+};
+
+const url = 'https://anomalia.test/api/v1/brands/demo/social/connect';
+
+const mint = (body: unknown, accounts: Row[] = [], brand: Row = BRAND) => {
+  vi.mocked(authenticate).mockResolvedValue({
+    supabase: fakeSupabase(accounts),
+    apiKey: undefined,
+    error: null
+  } as never);
+  vi.mocked(loadBrandForUser).mockResolvedValue({ brand, error: null } as never);
+
+  return (POST as (e: unknown) => Promise<Response>)({
+    request: new Request(url, { method: 'POST', body: JSON.stringify(body) }),
+    params: { slug: 'demo' },
+    url: new URL(url)
+  }).then(async (res) => ({ res, body: await res.json() }));
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(checkApiKeyWriteAccess).mockReturnValue(undefined);
+});
+
+describe('POST /api/v1/brands/:slug/social/connect', () => {
+  it('consegna la porta e non attraversa niente: nessun redirect, nessun OAuth', async () => {
+    const { res, body } = await mint({ platform: 'instagram' });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('location')).toBeNull();
+    expect(body.ok).toBe(true);
+    expect(body.url).toBe('https://anomalia.test/app/demo/settings/connect/instagram');
+    expect(body.already_connected).toBe(false);
+  });
+
+  it('conia lo stesso link per riautorizzare una piattaforma già collegata, e lo dice', async () => {
+    const { res, body } = await mint({ platform: 'instagram' }, [IG]);
+
+    expect(res.status).toBe(200);
+    expect(body.already_connected).toBe(true);
+  });
+
+  it('rifiuta una piattaforma che il prodotto non pubblica, dicendo quali sono ammesse', async () => {
+    const { res, body } = await mint({ platform: 'myspace' });
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('invalid_input');
+    expect(body.platform_choices).toContain('instagram');
+    expect(body.platform_choices).not.toContain('myspace');
+  });
+
+  it("rifiuta `twitter`: è l'alias storico di `x`, e la porta giusta ha un nome solo", async () => {
+    const { res, body } = await mint({ platform: 'twitter' });
+
+    expect(res.status).toBe(400);
+    expect(body.platform_choices).toContain('x');
+  });
+
+  it('rifiuta un piano che non collega account, invece di mandare qualcuno a un muro', async () => {
+    const { res, body } = await mint({ platform: 'instagram' }, [], {
+      ...BRAND,
+      plan: null,
+      status: 'trial'
+    });
+
+    expect(res.status).toBe(409);
+    expect(body.error).toBe('plan_cannot_connect');
+    expect(body.activate_url).toBe('https://anomalia.test/app/demo/activate');
+  });
+
+  it('rifiuta quando i posti del piano sono finiti, che è un altro rimedio', async () => {
+    const full = Array.from({ length: 50 }, (_, i) => ({ ...IG, username: `a${i}` }));
+
+    const { res, body } = await mint({ platform: 'tiktok' }, full);
+
+    expect(res.status).toBe(409);
+    expect(body.error).toBe('account_limit');
+    expect(body.slots.used).toBeGreaterThanOrEqual(body.slots.limit);
+    expect(body.manage_url).toBe('https://anomalia.test/app/demo/settings/connected-accounts');
+  });
+
+  it('una chiave di sola lettura non conia niente', async () => {
+    vi.mocked(checkApiKeyWriteAccess).mockReturnValue(
+      json({ error: 'API key is read-only' }, { status: 403 })
+    );
+
+    const { res, body } = await mint({ platform: 'instagram' });
+
+    expect(res.status).toBe(403);
+    expect(body.url).toBeUndefined();
+  });
+
+  it('non restituisce un token, un id Zernio o qualunque altra credenziale', async () => {
+    const { body } = await mint({ platform: 'instagram' }, [
+      { ...IG, access_token: 'ig-secret', zernio_account_id: 'zern-1' }
+    ]);
+
+    expect(JSON.stringify(body)).not.toContain('ig-secret');
+    expect(JSON.stringify(body)).not.toContain('zern-1');
+    expect(JSON.stringify(body)).not.toMatch(/token|secret|zernio/i);
+  });
+
+  it('risponde esattamente quello che il contratto dichiara, niente di più', async () => {
+    const { SOCIAL_CONNECT_LINK } = await import('@anomalia/api-contracts');
+    const { body } = await mint({ platform: 'linkedin' });
+
+    expect(SOCIAL_CONNECT_LINK.output.strict().safeParse(body).success).toBe(true);
+  });
+});


### PR DESCRIPTION
## What?

Two MCP tools let an external agent deal with social accounts, which until now it could not
touch at all:

| Tool | Endpoint | What it does |
|------|----------|--------------|
| `list_social_accounts` | `GET /api/v1/brands/:slug/social/accounts` | One row per connected account — platform, handle, status — plus `connected_platforms`, `broken_platforms`, `can_connect`, `slots`, `manage_url` |
| `create_social_connect_link` | `POST /api/v1/brands/:slug/social/connect` | Given a platform, returns the URL **a person** opens to authorise it. Performs nothing |

`tools/list` goes 101 → 103. Nothing existing is removed or altered.

A supporting refactor lands first, in its own commit: the "which platforms are connected" read
moves out of the `settings/brand` route into `$lib/server/social-connections.ts`, and both routes
now call it. `get_brand_settings` returns exactly what it returned before.

## Why?

An external agent could write a post for Instagram and could do nothing to get Instagram
connected. Not one of the 63 registry endpoints named an account, a connection or a social
platform — `/connections*` is Composio (Drive, Notion, GitHub, Gmail), a different thing that
merely sounds the same. So the post was produced, it sat in `approved` forever, and the agent
could neither notice nor tell the person what to do. That is the main product loop, broken at
its first step.

`broken_platforms` is the half nobody could see at all: an account that expired or was revoked
still has a row, the platform is still targeted, and posts keep being scheduled onto a dead
connection. No surface said so.

## How?

**The shape is the one already settled for billing: the agent mints the link, the human walks
through it.** No agent runs an OAuth, holds a token, or disconnects on someone's behalf. Consent
to a third-party platform is given by a person, on that platform's page.

**The minted URL is our own `/app/<slug>/settings/connect/<platform>`, not Zernio's OAuth URL.**
The Zernio URL was rejected on three independent grounds: minting it requires creating the
brand's Zernio profile (a write to a third party, triggered by an API key); it is single-use and
expires, so a human clicking ten minutes later hits an error; and it carries a token in the
address, which is exactly what must not cross this boundary. Ours requires the person's own
login — which also means, unlike a billing link, it is *not* a credential.

**No duplicate answer to the same question.** PR #277 already shipped `connected_platforms` on
`get_brand_settings`, from a private `connectedPlatforms()` inside that route. Rather than write
a second reader that would drift from it, the read was extracted and both routes call it — so
the two tools' `connected_platforms` are now literally the same read. The tools stay distinct on
purpose and say so in their descriptions: `get_brand_settings` carries the platform-level summary
next to the settings it belongs to; `list_social_accounts` is the account-level truth behind it,
and the only place a broken connection appears.

**The platform vocabulary is `TARGET_PLATFORMS`**, imported from
`packages/api-contracts/src/brand-settings.ts` where it already lived — not rewritten. `twitter`
stays out: it is the historical alias of `x`, and two names for one platform teach the wrong one.

**Two refusals, not one generic error**, because they need different remedies:
`plan_cannot_connect` (409) carries `activate_url`; `account_limit` (409) carries `manage_url`.
The cap blocks a *new* platform but never a re-authorisation — the slot is already that account's,
and refusing would leave an expired account with no way back.

### Disconnection: deliberately not exposed

It is the same act in reverse and worse for an agent: removing an account stops scheduled
publishing with nobody noticing until a post fails to go out. It also needed no new surface —
`manage_url` is already in both responses, and it *is* the disconnect door, crossed by a human at
zero cost. Both tool descriptions and the skill say why there is no tool.

### Also considered and rejected

- **Extending `get_brand_settings` instead of adding a read.** It would load a settings tool with
  connection state, and the write tool would still need a companion read to call first.
- **A CLI command.** Billing links are MCP-only for the same reason; nothing asked for one.
- **Returning `zernio_account_id`.** It enables nothing an agent can do, and an exposed
  identifier invites the belief that it can be acted on.

## Testing?

The negative tests were written first and watched fail. CI runs `typecheck-runtime.mjs`, the full
`vitest run` and Playwright.

```
$ npx vitest run packages/api-contracts
 Test Files  12 passed (12)
      Tests  152 passed (152)

$ cd cli && bun test
 57 pass / 0 fail / 589 expect() calls   (11 files)

$ node scripts/typecheck-runtime.mjs
typecheck-runtime: ok (ignored 313 non-fatal type error(s))

$ npx vitest run src/routes/api/v1 src/lib/platforms.test.ts src/lib/content/changelog
 Test Files  27 passed (27)
      Tests  318 passed (318)
```

All four re-run after rebasing onto `dev` at `f8f34b1`, which had itself just gained
`get_automations` / `set_automation` — hence the 101 baseline.

`cd cli && bun run typecheck` leaves one error, `cli.ts(317,9) TS2554` on `program.parse()`. It
reproduces identically on a pristine `origin/dev` checkout with the same `node_modules`, and
`cli.ts` is not in this diff — it is local `commander` resolution, not this branch.

**Not tested:** no real OAuth was run and no account was actually connected. The route under the
minted URL (`settings/connect/[platform]`) is untouched by this PR; what is new stops at handing
over its address. Risk: if that page's path ever changes, the minted link breaks — which is why
the path is built in one place (`connectPath` / `managePath`) rather than spelled out per caller.

## Evidence

### `tools/list` through `handleMcpFetch`, captured before and after — not estimated

<details><summary>Full diff, every existing tool compared field by field</summary>

```
tools/list  dev: 101  branch: 103
added  : ['create_social_connect_link', 'list_social_accounts']
removed: []
changed: []

create_social_connect_link | readOnly=False | destructive=False | required=['platform','slug'] | addlProps=False
list_social_accounts       | readOnly=True  | destructive=False | required=['slug']            | addlProps=False
```

`changed` is a deep equality over the whole tool object (title, description, input schema,
annotations) for every name present in both captures. Nothing existing moved.

</details>

### The negative tests, real output

<details><summary><code>npx vitest run …/social packages/api-contracts/src/social.test.ts --reporter=verbose</code></summary>

```
✓ .../social/connect/server.test.ts > una chiave di sola lettura non conia niente
✓ .../social/connect/server.test.ts > non restituisce un token, un id Zernio o qualunque altra credenziale
✓ .../social/connect/server.test.ts > rifiuta una piattaforma che il prodotto non pubblica, dicendo quali sono ammesse
✓ .../social/connect/server.test.ts > rifiuta `twitter`: è l'alias storico di `x`, e la porta giusta ha un nome solo
✓ .../social/connect/server.test.ts > rifiuta un piano che non collega account, invece di mandare qualcuno a un muro
✓ .../social/connect/server.test.ts > rifiuta quando i posti del piano sono finiti, che è un altro rimedio
✓ .../social/connect/server.test.ts > risponde esattamente quello che il contratto dichiara, niente di più
✓ .../social/accounts/server.test.ts > non fa uscire un token, un id Zernio o qualunque altra credenziale
✓ .../social/accounts/server.test.ts > separa una piattaforma rotta da una che non è mai stata collegata
✓ .../social/accounts/server.test.ts > risponde esattamente quello che il contratto dichiara, niente di più
✓ packages/api-contracts/src/social.test.ts > rifiuta una piattaforma che il prodotto non pubblica, e dice quali sono ammesse
✓ packages/api-contracts/src/social.test.ts > la lettura non dichiara un solo campo che somigli a una credenziale
✓ packages/api-contracts/src/social.test.ts > il link coniato non porta con sé nessun campo credenziale
✓ packages/api-contracts/src/social.test.ts > scarta ogni chiave in più che una rotta si lasciasse sfuggire

 Test Files  3 passed (3)
      Tests  29 passed (29)
```

The two "no credentials" route tests are not assertions about the schema: they feed the fake
client rows carrying `access_token: 'ig-secret'` and `zernio_account_id: 'zern-1'`, then assert
neither string — nor anything matching `/token|secret|zernio/i` — appears anywhere in the
serialised response. The two "esattamente quello che il contratto dichiara" tests parse the real
response through `output.strict()`, so an extra key added later fails the build rather than
leaking quietly.

</details>

### The read, against the case that used to be invisible

<details><summary>An expired account is <code>broken</code>, not <code>connected</code></summary>

```js
// row: { platform: 'Instagram', username: 'demo.brand', status: 'expired' }
{ connected_platforms: [], broken_platforms: ['instagram'] }

// two accounts, one dead one alive → the platform is not broken
{ connected_platforms: ['instagram'], broken_platforms: [] }

// free/trial brand
{ can_connect: false, slots: { used: 0, limit: 0 } }
```

</details>

No UI changed, so there are no screenshots: both surfaces are API endpoints reached by MCP.

## Anything Else?

- **The registry has no test that every `BRAND_ENDPOINT` has a route behind it.** A tool declared
  with no route would 404 at call time and nothing would catch it before a user did. Both routes
  here are covered by their own tests, so this is not a gap in this PR — but it is one worth
  closing separately.
- **`social_accounts.status` is free text** (`text not null default 'active'`). This code never
  enumerates the failure values: `active` publishes, and a platform with rows but none active is
  broken. That deliberately avoids adding a second copy of the `['expired','error','disconnected']`
  list that already sits inline in `src/routes/app/[brand]/+layout.server.ts` — but those two
  places still ought to share one definition eventually.
- **`already_connected: true` is a hint, not a gate.** Minting a link for a live platform is
  allowed on purpose: it is how a second account gets added and how an expired one is re-authorised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
