### PR TITLE
Graft the MCP guide and the post panel into /app

### DIFF
--- a/changelog/2026-09-04-mcp-guide-e-pannello-post.md
+++ b/changelog/2026-09-04-mcp-guide-e-pannello-post.md
@@ -1,0 +1,68 @@
+# Le due cose che `/v2` aveva e `/app` no
+
+`/v2` si cancella: il calendario a doppia vista, i materiali, la strategia e i risultati
+esistono già in `/app`, e tenerne due copie era il costo senza il beneficio. Tre cose però
+non c'erano, e prima di cancellare vanno recuperate. Qui ce ne sono due (il link pubblico
+condivisibile lo sta estendendo un altro agente, partendo da #221).
+
+## La guida MCP, in cima alla home
+
+Collegare il proprio agente è la prima cosa che il prodotto chiede di fare, e una guida che
+vive dietro un link non la apre nessuno. Sta **sopra** il blocco `{#await}` della panoramica,
+non dentro: aspettare le ~30 query di `loadHomeOverview` vorrebbe dire mostrarla al secondo
+giro d'occhio, quando la pagina si è già riempita d'altro.
+
+È un `<details>` nativo, aperto, che si chiude e resta chiuso finché la pagina vive. **Non**
+prova a indovinare se un agente è già collegato, e il motivo è scritto nel componente: oggi
+non esiste nessun segnale per saperlo — l'MCP remoto autentica con un JWT Supabase
+indistinguibile da un login del browser, l'OAuth non tiene una tabella di client (il
+`client_id` *è* la registrazione, firmata), e `api_keys.last_used_at` è per utente e non
+viene mai toccato dal percorso MCP. Fingere «collegato» sarebbe peggio che chiedere un click.
+
+Rispetto alla versione di `/v2` cambiano due cose: le classi Tailwind coi token di `/v2`
+diventano la palette del guscio (`--paper`, `--ink`, `--line`) — due palette nella stessa
+pagina si vedono — e il testo passa da `svelte-i18n`, con le chiavi `app.mcpGuide.*` nei
+quattro cataloghi. `/v2` era in inglese perché era un'anteprima; `/app` no.
+
+## Il pannello del post, dentro il calendario
+
+`?post=<id>` apre uno `Sheet` a destra: anteprima (video, carosello, immagine), la copia
+comune e le riscritture per piattaforma, e l'approvazione con la sua conferma.
+
+Prima quel parametro **rimandava** a `/app/<slug>/posts/<id>/preview` — un deep link legacy
+delle anteprime in chat. Adesso apre il pannello. La scheda completa non sparisce: il pannello
+ha un link verso di lei, o quelle cinque rotte (`preview`, `details`, `edit`, `analytics`,
+`boost`) resterebbero senza nessuno che ci porta.
+
+Le due azioni (`editPost`, `approvePost`) passano dagli endpoint invece che da Supabase, come
+faceva `/v2`. Non è una preferenza di stile: dietro `approve` c'è la coda di distribuzione, e
+riscriverla nel `+page.server.ts` vorrebbe dire tenerne due versioni. Anche il dettaglio arriva
+da `/posts/:id/media`, dove le URL dei media sono già firmate.
+
+`captionPatch` è uscito dal `+page.server.ts` e vive in `$lib/post-caption.ts` con sette test.
+Non per simmetria: SvelteKit non lascia esportare altro che `load`/`actions` da un
+`+page.server.ts`, quindi lì dentro sarebbe stato codice non testabile — e ha due casi che si
+sbagliano in silenzio. Il primo: se il form non manda nessun campo `caption_<platform>`,
+`platform_captions` non deve comparire nel patch, o cancellerebbe riscritture salvate da
+qualcun altro. Il secondo: una riscrittura svuotata a mano non è una riscrittura vuota — è la
+richiesta di tornare alla copia comune, e salvata come stringa vuota farebbe uscire un post
+senza testo su quella piattaforma.
+
+## La vista del calendario sta nell'URL
+
+`let view = $state<'month' | 'list'>('month')` diventa `?view=list`, letto dal server con
+`viewFor` (lo stesso di `/v2`, già sotto test). Un calendario in lista adesso si manda a un
+collega, e il tasto indietro torna a com'era. Il toggle passa da due `<button>` a due `<a>`:
+funziona anche prima dell'idratazione.
+
+`view` è entrato anche nella `variant` della cache di pagina, insieme a `post`: due viste
+diverse non devono condividere una entry.
+
+## Cosa NON è localizzato, e perché
+
+`PostPanel` resta in inglese. Le sue etichette non stanno tutte nel componente: `stateOf`,
+`captionFields`, `whenLabel` e `distributionNote` vivono in `$lib/post-state.ts` e le
+restituiscono già formate, con 27 test inchiodati a quelle stringhe. Tradurre il pannello
+significa cambiare la forma di quel modulo, e non è una cosa da fare di striscio in una PR
+che ne sposta un'altra. La guida MCP invece è stata tradotta: dodici stringhe e nessun modulo
+sotto.

--- a/src/lib/components/McpGuide.svelte
+++ b/src/lib/components/McpGuide.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-  // La guida sta in cima alla dashboard, non dietro un link: collegare il proprio agente è la
-  // prima cosa che il prodotto chiede di fare, e una guida che vive altrove non la fa nessuno.
+  // La guida sta in cima alla home del brand, non dietro un link: collegare il proprio agente è
+  // la prima cosa che il prodotto chiede di fare, e una guida che vive altrove non la apre
+  // nessuno.
   //
   // È un <details> nativo, e resta aperto finché non lo chiude chi legge. NON prova a indovinare
   // se un agente è già collegato: oggi non esiste nessun segnale per saperlo — l'MCP remoto
@@ -8,6 +9,8 @@
   // tabella di client (il client_id È la registrazione, firmata) e `api_keys.last_used_at` è
   // per utente e non viene mai toccato dal percorso MCP. Fingere «collegato» sarebbe peggio che
   // chiedere un click.
+
+  import { _ } from 'svelte-i18n';
 
   const MCP_URL = 'https://mcp.anomalia.so/mcp';
 
@@ -24,24 +27,9 @@
 anomalia login`;
 
   const STEPS = [
-    {
-      id: 'remote',
-      title: 'Any MCP host — Claude, Cursor, ChatGPT',
-      note: 'Paste into the host’s MCP config. It asks you to sign in the first time (OAuth); after that every call carries your token.',
-      snippet: REMOTE_CONFIG
-    },
-    {
-      id: 'plugin',
-      title: 'Claude Code — the plugin',
-      note: 'Bundles the same remote MCP plus the Anomalia skill. On Codex: codex plugin marketplace add anomaliaso/anomalia',
-      snippet: PLUGIN
-    },
-    {
-      id: 'cli',
-      title: 'Terminal, or a host that cannot send a Bearer header',
-      note: 'The CLI login writes the session the local stdio MCP server reads.',
-      snippet: CLI
-    }
+    { id: 'remote', key: 'host', snippet: REMOTE_CONFIG },
+    { id: 'plugin', key: 'plugin', snippet: PLUGIN },
+    { id: 'cli', key: 'cli', snippet: CLI }
   ];
 
   let copied = $state<string | null>(null);
@@ -58,43 +46,130 @@ anomalia login`;
   }
 </script>
 
-<details
-  open
-  class="border-border bg-card overflow-hidden rounded-xl border [&[open]_.chevron]:rotate-90"
->
-  <summary
-    class="hover:bg-muted focus-visible:ring-ring/50 flex cursor-pointer list-none items-center gap-2 px-4 py-3 text-sm focus-visible:ring-3 focus-visible:outline-none"
-  >
-    <span class="chevron text-muted-foreground transition-transform" aria-hidden="true">›</span>
-    <span class="font-semibold">Connect your agent</span>
-    <span class="text-muted-foreground">Drive this brand from Claude, Cursor or ChatGPT</span>
+<details open class="mcp">
+  <summary>
+    <span class="chev" aria-hidden="true">›</span>
+    <strong>{$_('app.mcpGuide.title')}</strong>
+    <span class="muted">{$_('app.mcpGuide.subtitle')}</span>
   </summary>
 
-  <div class="border-border flex flex-col gap-4 border-t px-4 py-4">
+  <div class="body">
     {#each STEPS as step (step.id)}
-      <section class="flex flex-col gap-1.5">
-        <h3 class="text-sm font-medium">{step.title}</h3>
-        <p class="text-muted-foreground text-xs">{step.note}</p>
-        <div class="border-border bg-background flex items-start gap-2 rounded-lg border p-2">
-          <pre
-            class="min-w-0 flex-1 overflow-x-auto text-xs leading-relaxed"><code>{step.snippet}</code></pre>
-          <button
-            type="button"
-            onclick={() => copy(step.id, step.snippet)}
-            class="border-border hover:bg-muted focus-visible:ring-ring/50 flex-none rounded-md border px-2 py-1 text-xs focus-visible:ring-3 focus-visible:outline-none"
-          >
-            {copied === step.id ? 'Copied' : 'Copy'}
+      <section>
+        <h3>{$_(`app.mcpGuide.${step.key}Title`)}</h3>
+        <p class="muted">{$_(`app.mcpGuide.${step.key}Note`)}</p>
+        <div class="snippet">
+          <pre><code>{step.snippet}</code></pre>
+          <button type="button" onclick={() => copy(step.id, step.snippet)}>
+            {copied === step.id ? $_('app.mcpGuide.copied') : $_('app.mcpGuide.copy')}
           </button>
         </div>
       </section>
     {/each}
 
-    <p class="text-muted-foreground text-xs">
-      The remote server is <code>{MCP_URL}</code> and needs an
-      <code>Authorization: Bearer</code> header — a 401 without one is the correct answer, not a
-      fault. If your host registers a custom-scheme OAuth callback and the connection is refused,
-      use the CLI plus the local stdio server instead.
-      <a href="/docs/mcp" class="underline underline-offset-4">Full setup</a>.
+    <p class="muted foot">
+      {$_('app.mcpGuide.note', { values: { url: MCP_URL } })}
+      <a href="/docs/mcp">{$_('app.mcpGuide.docs')}</a>
     </p>
   </div>
 </details>
+
+<style>
+  /* La palette è quella del guscio (`--paper`, `--ink`, `--line`): la guida arriva da /v2, che
+     aveva i suoi token, e due palette nella stessa pagina si vedono. */
+  .mcp {
+    border: 1px solid var(--line);
+    border-radius: 14px;
+    background: var(--paper);
+    overflow: hidden;
+    margin-bottom: 20px;
+  }
+  summary {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 14px;
+    cursor: pointer;
+    list-style: none;
+    font-size: 13.5px;
+  }
+  summary::-webkit-details-marker {
+    display: none;
+  }
+  summary:hover {
+    background: var(--paper-2);
+  }
+  .chev {
+    color: var(--ink-faint);
+    transition: transform 140ms ease;
+  }
+  .mcp[open] .chev {
+    transform: rotate(90deg);
+  }
+  .muted {
+    color: var(--ink-soft);
+  }
+  .body {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    border-top: 1px solid var(--line);
+    padding: 16px 14px;
+  }
+  section {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+  }
+  h3 {
+    margin: 0;
+    font-size: 13.5px;
+    font-weight: 600;
+    color: var(--ink);
+  }
+  p {
+    margin: 0;
+    font-size: 12.5px;
+    line-height: 1.5;
+  }
+  .snippet {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    background: var(--paper-2);
+    padding: 8px;
+    margin-top: 3px;
+  }
+  /* Il blocco scorre da solo: la pagina non deve mai scorrere in orizzontale per un comando. */
+  pre {
+    flex: 1;
+    min-width: 0;
+    margin: 0;
+    overflow-x: auto;
+    font-size: 12px;
+    line-height: 1.55;
+  }
+  button {
+    flex: none;
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    background: var(--paper);
+    color: var(--ink-soft);
+    padding: 4px 8px;
+    font-size: 12px;
+    cursor: pointer;
+  }
+  button:hover {
+    color: var(--ink);
+  }
+  .foot {
+    font-size: 11.5px;
+  }
+  .foot a {
+    color: var(--accent);
+    text-decoration: underline;
+    text-underline-offset: 3px;
+  }
+</style>

--- a/src/lib/components/McpGuide.svelte
+++ b/src/lib/components/McpGuide.svelte
@@ -1,0 +1,100 @@
+<script lang="ts">
+  // La guida sta in cima alla dashboard, non dietro un link: collegare il proprio agente è la
+  // prima cosa che il prodotto chiede di fare, e una guida che vive altrove non la fa nessuno.
+  //
+  // È un <details> nativo, e resta aperto finché non lo chiude chi legge. NON prova a indovinare
+  // se un agente è già collegato: oggi non esiste nessun segnale per saperlo — l'MCP remoto
+  // autentica con un JWT Supabase indistinguibile da un login del browser, l'OAuth non tiene una
+  // tabella di client (il client_id È la registrazione, firmata) e `api_keys.last_used_at` è
+  // per utente e non viene mai toccato dal percorso MCP. Fingere «collegato» sarebbe peggio che
+  // chiedere un click.
+
+  const MCP_URL = 'https://mcp.anomalia.so/mcp';
+
+  const REMOTE_CONFIG = `{
+  "mcpServers": {
+    "anomalia": { "url": "${MCP_URL}" }
+  }
+}`;
+
+  const PLUGIN = `/plugin marketplace add anomaliaso/anomalia
+/plugin install anomalia@anomalia`;
+
+  const CLI = `curl -sSL https://raw.githubusercontent.com/anomaliaso/anomalia/main/cli/scripts/install.sh | bash
+anomalia login`;
+
+  const STEPS = [
+    {
+      id: 'remote',
+      title: 'Any MCP host — Claude, Cursor, ChatGPT',
+      note: 'Paste into the host’s MCP config. It asks you to sign in the first time (OAuth); after that every call carries your token.',
+      snippet: REMOTE_CONFIG
+    },
+    {
+      id: 'plugin',
+      title: 'Claude Code — the plugin',
+      note: 'Bundles the same remote MCP plus the Anomalia skill. On Codex: codex plugin marketplace add anomaliaso/anomalia',
+      snippet: PLUGIN
+    },
+    {
+      id: 'cli',
+      title: 'Terminal, or a host that cannot send a Bearer header',
+      note: 'The CLI login writes the session the local stdio MCP server reads.',
+      snippet: CLI
+    }
+  ];
+
+  let copied = $state<string | null>(null);
+
+  // Fuori da https e localhost la clipboard non c'è: il testo resta selezionabile nel blocco,
+  // quindi il fallimento è silenzioso e non un errore che finisce in Sentry.
+  async function copy(step: string, snippet: string) {
+    try {
+      await navigator.clipboard.writeText(snippet);
+      copied = step;
+    } catch {
+      copied = null;
+    }
+  }
+</script>
+
+<details
+  open
+  class="border-border bg-card overflow-hidden rounded-xl border [&[open]_.chevron]:rotate-90"
+>
+  <summary
+    class="hover:bg-muted focus-visible:ring-ring/50 flex cursor-pointer list-none items-center gap-2 px-4 py-3 text-sm focus-visible:ring-3 focus-visible:outline-none"
+  >
+    <span class="chevron text-muted-foreground transition-transform" aria-hidden="true">›</span>
+    <span class="font-semibold">Connect your agent</span>
+    <span class="text-muted-foreground">Drive this brand from Claude, Cursor or ChatGPT</span>
+  </summary>
+
+  <div class="border-border flex flex-col gap-4 border-t px-4 py-4">
+    {#each STEPS as step (step.id)}
+      <section class="flex flex-col gap-1.5">
+        <h3 class="text-sm font-medium">{step.title}</h3>
+        <p class="text-muted-foreground text-xs">{step.note}</p>
+        <div class="border-border bg-background flex items-start gap-2 rounded-lg border p-2">
+          <pre
+            class="min-w-0 flex-1 overflow-x-auto text-xs leading-relaxed"><code>{step.snippet}</code></pre>
+          <button
+            type="button"
+            onclick={() => copy(step.id, step.snippet)}
+            class="border-border hover:bg-muted focus-visible:ring-ring/50 flex-none rounded-md border px-2 py-1 text-xs focus-visible:ring-3 focus-visible:outline-none"
+          >
+            {copied === step.id ? 'Copied' : 'Copy'}
+          </button>
+        </div>
+      </section>
+    {/each}
+
+    <p class="text-muted-foreground text-xs">
+      The remote server is <code>{MCP_URL}</code> and needs an
+      <code>Authorization: Bearer</code> header — a 401 without one is the correct answer, not a
+      fault. If your host registers a custom-scheme OAuth callback and the connection is refused,
+      use the CLI plus the local stdio server instead.
+      <a href="/docs/mcp" class="underline underline-offset-4">Full setup</a>.
+    </p>
+  </div>
+</details>

--- a/src/lib/components/PostPanel.svelte
+++ b/src/lib/components/PostPanel.svelte
@@ -1,0 +1,202 @@
+<script lang="ts">
+  import { enhance } from '$app/forms';
+  import * as Sheet from '$lib/components/ui/sheet/index.js';
+  import { Badge } from '$lib/components/ui/badge/index.js';
+  import { Button } from '$lib/components/ui/button/index.js';
+  import { Label } from '$lib/components/ui/label/index.js';
+  import { Textarea } from '$lib/components/ui/textarea/index.js';
+  import {
+    captionFields,
+    distributionNote,
+    extrasOf,
+    platformsOf,
+    previewOf,
+    stateOf,
+    whenLabel
+  } from '$lib/post-state';
+  import type { PostDetail } from '$lib/post-state';
+
+  type Outcome = {
+    id: string | null;
+    message: string | null;
+    saved: boolean;
+    approved: boolean;
+    status: string | null;
+  };
+
+  let {
+    id,
+    detail,
+    timezone,
+    form,
+    onclose
+  }: {
+    id: string;
+    detail: PostDetail;
+    timezone: string;
+    form: Outcome | null;
+    onclose: () => void;
+  } = $props();
+
+  const postState = $derived(stateOf(detail.status));
+  const outcome = $derived(form?.id === id ? form : null);
+  const preview = $derived(previewOf(detail));
+  const captions = $derived(captionFields(detail));
+  const extras = $derived(extrasOf(detail));
+
+  let confirming = $state(false);
+  let saving = $state(false);
+  let approving = $state(false);
+</script>
+
+<Sheet.Root open onOpenChange={(open) => !open && onclose()}>
+  <Sheet.Content side="right" class="gap-0 overflow-y-auto data-[side=right]:sm:max-w-lg">
+    <Sheet.Header class="gap-2">
+      <Sheet.Title class="flex flex-wrap items-center gap-2 text-base">
+        {platformsOf(detail).join(' · ') || 'Post'}
+        <Badge variant={postState.tone}>{postState.label}</Badge>
+      </Sheet.Title>
+      <Sheet.Description>{whenLabel(detail, timezone)}</Sheet.Description>
+    </Sheet.Header>
+
+    <div class="flex flex-col gap-5 px-4 pb-6">
+      {#if preview.kind === 'video'}
+        <!-- svelte-ignore a11y_media_has_caption -->
+        <video
+          src={preview.urls[0]}
+          poster={detail.video_thumbnail_url ?? undefined}
+          controls
+          playsinline
+          preload="metadata"
+          class="border-border max-h-96 w-full rounded-lg border bg-black"
+        ></video>
+      {:else if preview.kind === 'carousel'}
+        <div class="flex snap-x gap-2 overflow-x-auto pb-1">
+          {#each preview.urls as url, index (url)}
+            <img
+              src={url}
+              alt="Slide {index + 1}"
+              loading="lazy"
+              class="border-border h-72 w-auto shrink-0 snap-start rounded-lg border object-contain"
+            />
+          {/each}
+        </div>
+      {:else if preview.kind === 'image'}
+        <img
+          src={preview.urls[0]}
+          alt="Visual attached to this post"
+          loading="lazy"
+          class="border-border max-h-96 w-full rounded-lg border object-contain"
+        />
+      {/if}
+
+      {#each extras as extra (extra.label)}
+        <div class="flex flex-col gap-1">
+          <p class="text-muted-foreground text-xs font-medium">{extra.label}</p>
+          <p class="text-sm break-words whitespace-pre-wrap">{extra.value}</p>
+        </div>
+      {/each}
+
+      {#if outcome?.message}
+        <p
+          role={outcome.approved ? 'status' : 'alert'}
+          class="rounded-lg border px-3 py-2 text-sm {outcome.approved
+            ? 'border-border'
+            : 'border-destructive/40 text-destructive'}"
+        >
+          {outcome.message}
+        </p>
+      {:else if outcome?.saved}
+        <p role="status" class="border-border rounded-lg border px-3 py-2 text-sm">Copy saved.</p>
+      {:else if outcome?.approved}
+        <p role="status" class="border-border rounded-lg border px-3 py-2 text-sm">
+          Approved and sent for distribution — the post is now {outcome.status}.
+        </p>
+      {/if}
+
+      <form
+        method="POST"
+        action="?/edit"
+        class="flex flex-col gap-4"
+        use:enhance={() => {
+          saving = true;
+          return async ({ update }) => {
+            await update({ reset: false });
+            saving = false;
+          };
+        }}
+      >
+        <input type="hidden" name="id" value={id} />
+
+        {#each captions as field (field.name)}
+          <div class="flex flex-col gap-2">
+            <Label for={field.name}>{field.label}</Label>
+            <Textarea
+              id={field.name}
+              name={field.name}
+              value={field.value}
+              rows={10}
+              readonly={!postState.canEdit}
+              aria-describedby={postState.canEdit ? undefined : 'copy-locked'}
+            />
+          </div>
+        {/each}
+
+        {#if postState.canEdit}
+          <div>
+            <Button type="submit" variant="outline" size="sm" disabled={saving}>
+              {saving ? 'Saving…' : 'Save copy'}
+            </Button>
+          </div>
+        {:else}
+          <p id="copy-locked" class="text-muted-foreground text-xs">
+            A published post is read-only here.
+          </p>
+        {/if}
+      </form>
+
+      {#if postState.canApprove}
+        <div class="border-border flex flex-col gap-3 rounded-lg border p-4">
+          <h3 class="text-sm font-semibold">Approve</h3>
+          <p class="text-sm">{distributionNote(detail, timezone)}</p>
+
+          {#if !confirming}
+            <div>
+              <Button type="button" size="sm" onclick={() => (confirming = true)}>
+                Approve and distribute
+              </Button>
+            </div>
+          {:else}
+            <form
+              method="POST"
+              action="?/approve"
+              class="flex flex-col gap-3"
+              use:enhance={() => {
+                approving = true;
+                return async ({ update }) => {
+                  await update({ reset: false });
+                  approving = false;
+                  confirming = false;
+                };
+              }}
+            >
+              <input type="hidden" name="id" value={id} />
+              <p role="alert" class="text-sm">
+                Anomalia sends it to the connected {platformsOf(detail).join(' and ') || 'social'} account.
+                If no account is connected yet, the post stays approved and waits for one.
+              </p>
+              <div class="flex flex-wrap gap-2">
+                <Button type="submit" size="sm" disabled={approving}>
+                  {approving ? 'Sending…' : 'Yes, distribute it'}
+                </Button>
+                <Button type="button" variant="outline" size="sm" onclick={() => (confirming = false)}
+                  >Keep it pending</Button
+                >
+              </div>
+            </form>
+          {/if}
+        </div>
+      {/if}
+    </div>
+  </Sheet.Content>
+</Sheet.Root>

--- a/src/lib/components/PostPanel.svelte
+++ b/src/lib/components/PostPanel.svelte
@@ -28,12 +28,17 @@
     id,
     detail,
     timezone,
+    fullHref,
     form,
     onclose
   }: {
     id: string;
     detail: PostDetail;
     timezone: string;
+    /** La scheda completa del post (anteprima, dettagli, analisi, boost): il pannello e' la
+     *  lettura rapida, non il suo sostituto, e senza questo link quelle cinque rotte non le
+     *  raggiungerebbe piu' nessuno. */
+    fullHref: string;
     form: Outcome | null;
     onclose: () => void;
   } = $props();
@@ -116,7 +121,7 @@
 
       <form
         method="POST"
-        action="?/edit"
+        action="?/editPost"
         class="flex flex-col gap-4"
         use:enhance={() => {
           saving = true;
@@ -155,6 +160,12 @@
         {/if}
       </form>
 
+      <a
+        href={fullHref}
+        class="text-muted-foreground text-xs underline underline-offset-4"
+        data-sveltekit-preload-data="off">Open the full post</a
+      >
+
       {#if postState.canApprove}
         <div class="border-border flex flex-col gap-3 rounded-lg border p-4">
           <h3 class="text-sm font-semibold">Approve</h3>
@@ -169,7 +180,7 @@
           {:else}
             <form
               method="POST"
-              action="?/approve"
+              action="?/approvePost"
               class="flex flex-col gap-3"
               use:enhance={() => {
                 approving = true;

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -3688,6 +3688,20 @@
       "talkTo": "Talk to {name}",
       "agentOffer": "Nothing here yet — {name} can take care of it. Open the chat."
     },
+    "mcpGuide": {
+      "title": "Connect your agent",
+      "subtitle": "Drive this brand from Claude, Cursor or ChatGPT",
+      "hostTitle": "Any MCP host — Claude, Cursor, ChatGPT",
+      "hostNote": "Paste this into the host's MCP config. It asks you to sign in the first time (OAuth); after that every call carries your token.",
+      "pluginTitle": "Claude Code — the plugin",
+      "pluginNote": "Bundles the same remote server plus the Anomalia skill. On Codex: codex plugin marketplace add anomaliaso/anomalia",
+      "cliTitle": "Terminal, or a host that cannot send a Bearer header",
+      "cliNote": "The CLI login writes the session the local stdio server reads.",
+      "copy": "Copy",
+      "copied": "Copied",
+      "note": "The remote server is {url} and needs an Authorization: Bearer header — a 401 without one is the correct answer, not a fault. If your host registers a custom-scheme OAuth callback and the connection is refused, use the CLI and the local server instead.",
+      "docs": "Full setup"
+    },
     "strategySetup": {
       "title": "Set up your Anomalia flow",
       "body": "Three steps, in order — Studio, Strategy, Editorial plan. Each one feeds the next, and every future post follows them.",

--- a/src/lib/i18n/locales/es.json
+++ b/src/lib/i18n/locales/es.json
@@ -3775,6 +3775,20 @@
       "talkTo": "Habla con {name}",
       "agentOffer": "Aún no hay nada aquí — {name} puede encargarse. Abre el chat."
     },
+    "mcpGuide": {
+      "title": "Conecta tu agente",
+      "subtitle": "Maneja esta marca desde Claude, Cursor o ChatGPT",
+      "hostTitle": "Cualquier host MCP — Claude, Cursor, ChatGPT",
+      "hostNote": "Pégalo en la configuración MCP del host. La primera vez pide iniciar sesión (OAuth); después cada llamada lleva tu token.",
+      "pluginTitle": "Claude Code — el plugin",
+      "pluginNote": "Incluye el mismo servidor remoto y la skill de Anomalia. En Codex: codex plugin marketplace add anomaliaso/anomalia",
+      "cliTitle": "Terminal, o un host que no puede enviar una cabecera Bearer",
+      "cliNote": "El login de la CLI escribe la sesión que lee el servidor local.",
+      "copy": "Copiar",
+      "copied": "Copiado",
+      "note": "El servidor remoto es {url} y necesita una cabecera Authorization: Bearer — un 401 sin ella es la respuesta correcta, no un fallo. Si tu host registra un callback OAuth con esquema propio y la conexión se rechaza, usa la CLI y el servidor local.",
+      "docs": "Configuración completa"
+    },
     "strategySetup": {
       "title": "Configura tu flujo de anomalías",
       "body": "Tres pasos en orden: estudio, estrategia y plan editorial. Cada uno alimenta al siguiente y cada publicación futura los sigue.",

--- a/src/lib/i18n/locales/fr.json
+++ b/src/lib/i18n/locales/fr.json
@@ -3775,6 +3775,20 @@
       "talkTo": "Parler à {name}",
       "agentOffer": "Rien ici pour l’instant — {name} peut s’en charger. Ouvrez le chat."
     },
+    "mcpGuide": {
+      "title": "Connectez votre agent",
+      "subtitle": "Pilotez cette marque depuis Claude, Cursor ou ChatGPT",
+      "hostTitle": "N'importe quel hôte MCP — Claude, Cursor, ChatGPT",
+      "hostNote": "Collez ceci dans la configuration MCP de l'hôte. Il demande de se connecter la première fois (OAuth) ; ensuite chaque appel porte votre jeton.",
+      "pluginTitle": "Claude Code — le plugin",
+      "pluginNote": "Réunit le même serveur distant et la compétence Anomalia. Sur Codex : codex plugin marketplace add anomaliaso/anomalia",
+      "cliTitle": "Terminal, ou un hôte incapable d'envoyer un en-tête Bearer",
+      "cliNote": "La connexion via la CLI écrit la session que lit le serveur local.",
+      "copy": "Copier",
+      "copied": "Copié",
+      "note": "Le serveur distant est {url} et exige un en-tête Authorization: Bearer — un 401 sans cet en-tête est la bonne réponse, pas une panne. Si votre hôte enregistre un rappel OAuth à schéma personnalisé et que la connexion est refusée, utilisez la CLI et le serveur local.",
+      "docs": "Configuration complète"
+    },
     "strategySetup": {
       "title": "Configurez votre flux Anomalia",
       "body": "Trois étapes, dans l'ordre — Studio, Stratégie, Plan éditorial. Chacune alimente la suivante, et chaque futur post les suit.",

--- a/src/lib/i18n/locales/it.json
+++ b/src/lib/i18n/locales/it.json
@@ -3689,6 +3689,20 @@
       "talkTo": "Parla con {name}",
       "agentOffer": "Qui non c’è ancora nulla — se ne può occupare {name}. Apri la chat."
     },
+    "mcpGuide": {
+      "title": "Collega il tuo agente",
+      "subtitle": "Guida questo brand da Claude, Cursor o ChatGPT",
+      "hostTitle": "Qualsiasi host MCP — Claude, Cursor, ChatGPT",
+      "hostNote": "Incolla nella configurazione MCP dell'host. La prima volta chiede di accedere (OAuth); dopo, ogni chiamata porta con sé il tuo token.",
+      "pluginTitle": "Claude Code — il plugin",
+      "pluginNote": "Contiene lo stesso server remoto più la skill di Anomalia. Su Codex: codex plugin marketplace add anomaliaso/anomalia",
+      "cliTitle": "Terminale, o un host che non sa mandare un header Bearer",
+      "cliNote": "Il login della CLI scrive la sessione che il server locale legge.",
+      "copy": "Copia",
+      "copied": "Copiato",
+      "note": "Il server remoto è {url} e vuole un header Authorization: Bearer — un 401 senza quello è la risposta giusta, non un guasto. Se il tuo host registra un callback OAuth con schema custom e la connessione viene rifiutata, usa la CLI e il server locale.",
+      "docs": "Guida completa"
+    },
     "strategySetup": {
       "title": "Imposta il flusso di Anomalia",
       "body": "Tre passi, in ordine — Studio, Strategia, Piano editoriale. Ognuno alimenta il successivo, e ogni contenuto futuro li seguirà.",

--- a/src/lib/post-caption.test.ts
+++ b/src/lib/post-caption.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { captionPatch, CAPTION_MAX } from './post-caption';
+
+const form = (entries: Record<string, string>) => {
+  const f = new FormData();
+  for (const [k, v] of Object.entries(entries)) f.append(k, v);
+  return f;
+};
+
+describe('la copia che il pannello salva', () => {
+  it('salva la copia comune quando non ci sono riscritture', () => {
+    expect(captionPatch(form({ caption: 'Ciao' }))).toEqual({ caption: 'Ciao' });
+  });
+
+  it('rifiuta una copia vuota invece di svuotare il post', () => {
+    expect(captionPatch(form({ caption: '   ' }))).toBe('The copy cannot be empty.');
+  });
+
+  it('rifiuta una copia più lunga di quanto la colonna regga', () => {
+    expect(captionPatch(form({ caption: 'a'.repeat(CAPTION_MAX + 1) }))).toBe(
+      'The copy is too long to save.'
+    );
+  });
+
+  it('raccoglie le riscritture per piattaforma dai campi caption_<platform>', () => {
+    expect(
+      captionPatch(form({ caption: 'Base', caption_instagram: 'IG', caption_x: 'X' }))
+    ).toEqual({ caption: 'Base', platform_captions: { instagram: 'IG', x: 'X' } });
+  });
+
+  /**
+   * Una riscrittura svuotata NON è una riscrittura vuota: è la richiesta di tornare alla copia
+   * comune. Se finisse nel patch come stringa vuota, quella piattaforma pubblicherebbe niente.
+   */
+  it('toglie la riscrittura svuotata invece di salvarla vuota', () => {
+    expect(captionPatch(form({ caption: 'Base', caption_instagram: '  ' }))).toEqual({
+      caption: 'Base',
+      platform_captions: null
+    });
+  });
+
+  it('non tocca le riscritture se il form non ne manda nessuna', () => {
+    const patch = captionPatch(form({ caption: 'Base', id: 'post-1' }));
+    expect(patch).not.toHaveProperty('platform_captions');
+  });
+
+  it('dice quale piattaforma è troppo lunga, non solo che qualcosa lo è', () => {
+    expect(
+      captionPatch(form({ caption: 'Base', caption_tiktok: 'a'.repeat(CAPTION_MAX + 1) }))
+    ).toBe('The copy for tiktok is too long to save.');
+  });
+});

--- a/src/lib/post-caption.ts
+++ b/src/lib/post-caption.ts
@@ -1,0 +1,47 @@
+/** Quanto testo la copia di un post regge prima che salvarla sia un errore, non una svista. */
+export const CAPTION_MAX = 20_000;
+
+const PLATFORM_CAPTION = /^caption_(.+)$/;
+
+/**
+ * Dal form del pannello alla patch per `PUT /api/v1/brands/:slug/posts/:id`, oppure il messaggio
+ * da mostrare a chi ha scritto.
+ *
+ * `platform_captions` compare SOLO se il form ha mandato almeno un campo `caption_<platform>`:
+ * un form che non li manda (perché il post ha una copia sola) non deve cancellare riscritture
+ * che qualcun altro ha salvato. E una riscrittura svuotata a mano non è una riscrittura vuota —
+ * è la richiesta di tornare alla copia comune.
+ */
+export function captionPatch(form: FormData): Record<string, unknown> | string {
+  const caption = String(form.get('caption') ?? '');
+  if (!caption.trim()) {
+    return 'The copy cannot be empty.';
+  }
+  if (caption.length > CAPTION_MAX) {
+    return 'The copy is too long to save.';
+  }
+
+  const overrides: Record<string, string> = {};
+  let sawOverride = false;
+
+  for (const [key, value] of form.entries()) {
+    const platform = PLATFORM_CAPTION.exec(key)?.[1];
+    if (!platform || typeof value !== 'string') {
+      continue;
+    }
+    if (value.length > CAPTION_MAX) {
+      return `The copy for ${platform} is too long to save.`;
+    }
+
+    sawOverride = true;
+    if (value.trim()) {
+      overrides[platform] = value.trim();
+    }
+  }
+
+  if (!sawOverride) {
+    return { caption };
+  }
+
+  return { caption, platform_captions: Object.keys(overrides).length ? overrides : null };
+}

--- a/src/lib/post-state.test.ts
+++ b/src/lib/post-state.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect } from 'vitest';
+import {
+  captionFields,
+  distributionNote,
+  extrasOf,
+  filterFor,
+  platformsOf,
+  previewOf,
+  stateOf,
+  summarise,
+  viewFor,
+  whenLabel,
+  type PostDetail,
+  type PostRow
+} from './post-state';
+
+const ROME = 'Europe/Rome';
+
+function post(over: Partial<PostRow> = {}): PostRow {
+  return {
+    id: 'p1',
+    platform: 'instagram',
+    platforms: null,
+    caption: null,
+    media_url: null,
+    slot: null,
+    scheduled_for: null,
+    status: 'pending_user',
+    published_url: null,
+    created_at: '2026-09-01T08:00:00Z',
+    ...over
+  };
+}
+
+describe('la tabella degli stati decide da sola cosa si puo fare', () => {
+  it('un post in attesa si modifica e si approva', () => {
+    expect(stateOf('pending_user')).toMatchObject({ canEdit: true, canApprove: true });
+  });
+
+  it('un post pubblicato non si tocca', () => {
+    expect(stateOf('published')).toMatchObject({ canEdit: false, canApprove: false });
+  });
+
+  it('uno stato sconosciuto non concede niente', () => {
+    expect(stateOf('quantum')).toEqual({
+      label: 'quantum',
+      tone: 'outline',
+      canEdit: false,
+      canApprove: false
+    });
+  });
+});
+
+describe('il filtro viene dalla URL e non si fida', () => {
+  it('accetta uno stato conosciuto', () => {
+    expect(filterFor('pending_user')).toBe('pending_user');
+  });
+
+  it('riporta ad all uno stato inventato', () => {
+    expect(filterFor('drop table posts')).toBe('all');
+  });
+
+  it('riporta ad all quando manca', () => {
+    expect(filterFor(null)).toBe('all');
+  });
+});
+
+describe('la data mostrata e quella del brand, non quella del server', () => {
+  it('le 23:30 UTC del 31 agosto sono il 1 settembre a Roma', () => {
+    const label = whenLabel(post({ scheduled_for: '2026-08-31T23:30:00Z' }), ROME);
+
+    expect(label).toContain('1 Sep');
+    expect(label).not.toContain('31 Aug');
+  });
+
+  it('senza orario resta il giorno dello slot', () => {
+    expect(whenLabel(post({ slot: '2026-09-10' }), ROME)).toContain('10 Sep');
+  });
+
+  it('senza data lo dice', () => {
+    expect(whenLabel(post(), ROME)).toBe('No date');
+  });
+});
+
+describe('le piattaforme di un post', () => {
+  it('la lista vince sul singolo', () => {
+    expect(platformsOf(post({ platform: 'instagram', platforms: ['linkedin', 'x'] }))).toEqual([
+      'linkedin',
+      'x'
+    ]);
+  });
+
+  it('senza lista resta il singolo', () => {
+    expect(platformsOf(post({ platform: 'instagram' }))).toEqual(['instagram']);
+  });
+
+  it('senza niente resta vuoto', () => {
+    expect(platformsOf(post({ platform: null }))).toEqual([]);
+  });
+});
+
+describe('cosa dice la riga quando la copy manca', () => {
+  it('una copy vuota non diventa una riga vuota', () => {
+    expect(summarise(post({ caption: '   ' }))).toBe('Untitled');
+  });
+
+  it('una copy lunga viene troncata', () => {
+    expect(summarise(post({ caption: 'x'.repeat(200) })).length).toBeLessThan(200);
+  });
+});
+
+describe('cosa succede davvero quando approvi', () => {
+  const now = Date.parse('2026-09-04T10:00:00Z');
+
+  it('una data futura viene nominata', () => {
+    const note = distributionNote(post({ scheduled_for: '2026-09-05T09:00:00Z' }), ROME, now);
+
+    expect(note).toContain('5 Sep');
+    expect(note).toContain(ROME);
+  });
+
+  it('una data passata non viene spacciata per programmata', () => {
+    const note = distributionNote(post({ scheduled_for: '2026-09-01T09:00:00Z' }), ROME, now);
+
+    expect(note).not.toContain('1 Sep');
+    expect(note).toContain('possibly right away');
+  });
+
+  it('senza data dice che esce al primo slot utile', () => {
+    expect(distributionNote(post(), ROME, now)).toContain('possibly right away');
+  });
+});
+
+describe('la vista sta nell URL, e il default è il calendario', () => {
+  it('accetta solo le viste che esistono', () => {
+    expect(viewFor('list')).toBe('list');
+    expect(viewFor('calendar')).toBe('calendar');
+  });
+
+  it('ricade sul calendario quando il parametro manca o è inventato', () => {
+    expect(viewFor(null)).toBe('calendar');
+    expect(viewFor('gantt')).toBe('calendar');
+  });
+});
+
+function detail(over: Partial<PostDetail> = {}): PostDetail {
+  return {
+    status: 'pending_user',
+    platform: 'instagram',
+    caption: null,
+    scheduled_for: null,
+    media_url: null,
+    ...over
+  };
+}
+
+describe('l anteprima mostra quello che c e, non quello che ci si aspetta', () => {
+  it('senza media non mostra nulla', () => {
+    expect(previewOf(detail())).toEqual({ kind: 'none', urls: [] });
+  });
+
+  it('una sola immagine', () => {
+    expect(previewOf(detail({ media_url: 'https://cdn/a.png' }))).toEqual({
+      kind: 'image',
+      urls: ['https://cdn/a.png']
+    });
+  });
+
+  it('un video si riconosce dal flag, non dall estensione', () => {
+    expect(previewOf(detail({ media_url: 'https://cdn/clip.mp4', is_video: true }))).toEqual({
+      kind: 'video',
+      urls: ['https://cdn/clip.mp4']
+    });
+  });
+
+  it('il carosello mostra le slide, non la copertina', () => {
+    const preview = previewOf(
+      detail({
+        media_url: 'https://cdn/cover.png',
+        is_carousel: true,
+        slides: [
+          { index: 0, url: 'https://cdn/1.png' },
+          { index: 1, url: null },
+          { index: 2, url: 'https://cdn/3.png' }
+        ]
+      })
+    );
+
+    expect(preview).toEqual({ kind: 'carousel', urls: ['https://cdn/1.png', 'https://cdn/3.png'] });
+  });
+
+  it('un carosello ancora senza slide renderizzate ricade sulla copertina', () => {
+    expect(previewOf(detail({ media_url: 'https://cdn/cover.png', is_carousel: true }))).toEqual({
+      kind: 'image',
+      urls: ['https://cdn/cover.png']
+    });
+  });
+});
+
+describe('le caption modificabili sono quelle che il post ha davvero', () => {
+  it('senza override c è solo la caption principale', () => {
+    expect(captionFields(detail({ caption: 'ciao' }))).toEqual([
+      { name: 'caption', label: 'Caption', value: 'ciao' }
+    ]);
+  });
+
+  it('una casella per piattaforma, in ordine stabile', () => {
+    const fields = captionFields(
+      detail({ caption: 'lunga', platform_captions: { x: 'corta', threads: 'media' } })
+    );
+
+    expect(fields.map((f) => f.name)).toEqual(['caption', 'caption_threads', 'caption_x']);
+    expect(fields[2].value).toBe('corta');
+  });
+});
+
+describe('il resto del testo che esce si vede, ma non si modifica', () => {
+  it('salta i campi vuoti e tiene l ordine della tabella', () => {
+    expect(extrasOf(detail({ title: 'Titolo', subreddit: 'r/x', first_comment: '  ' }))).toEqual([
+      { label: 'Title', value: 'Titolo' },
+      { label: 'Subreddit', value: 'r/x' }
+    ]);
+  });
+});

--- a/src/lib/post-state.ts
+++ b/src/lib/post-state.ts
@@ -1,0 +1,199 @@
+export type PostRow = {
+  id: string;
+  platform: string | null;
+  platforms?: string[] | null;
+  caption: string | null;
+  media_url: string | null;
+  slot: string | null;
+  scheduled_for: string | null;
+  status: string;
+  published_url?: string | null;
+  created_at?: string;
+  isDraft?: boolean;
+};
+
+type Named = { platform: string | null; platforms?: string[] | null };
+
+type Timing = { scheduled_for: string | null; slot?: string | null };
+
+export type PostState = {
+  label: string;
+  tone: 'default' | 'secondary' | 'outline' | 'destructive';
+  canEdit: boolean;
+  canApprove: boolean;
+};
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}/;
+const SUMMARY_MAX = 90;
+
+const POST_STATES: Record<string, PostState> = {
+  pending_user: { label: 'Pending review', tone: 'default', canEdit: true, canApprove: true },
+  approved: { label: 'Approved', tone: 'secondary', canEdit: true, canApprove: false },
+  scheduled: { label: 'Scheduled', tone: 'secondary', canEdit: true, canApprove: false },
+  published: { label: 'Published', tone: 'outline', canEdit: false, canApprove: false },
+  failed: { label: 'Failed', tone: 'destructive', canEdit: true, canApprove: false }
+};
+
+export const STATUS_FILTERS = [
+  { value: 'all', label: 'Everything' },
+  ...Object.entries(POST_STATES).map(([value, state]) => ({ value, label: state.label }))
+];
+
+export function stateOf(status: string): PostState {
+  return (
+    POST_STATES[status] ?? { label: status, tone: 'outline', canEdit: false, canApprove: false }
+  );
+}
+
+export function filterFor(status: string | null): string {
+  return status && status in POST_STATES ? status : 'all';
+}
+
+export function platformsOf(post: Named): string[] {
+  if (post.platforms?.length) {
+    return post.platforms;
+  }
+
+  return post.platform ? [post.platform] : [];
+}
+
+export function momentInZone(iso: string, timezone: string): string {
+  const stamp = new Intl.DateTimeFormat('en-GB', {
+    timeZone: timezone,
+    weekday: 'short',
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit'
+  }).format(new Date(iso));
+
+  return `${stamp} (${timezone})`;
+}
+
+function dayLabel(day: string): string {
+  return new Intl.DateTimeFormat('en-GB', {
+    timeZone: 'UTC',
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric'
+  }).format(new Date(`${day}T00:00:00Z`));
+}
+
+export function whenLabel(post: Timing, timezone: string): string {
+  if (post.scheduled_for) {
+    return new Intl.DateTimeFormat('en-GB', {
+      timeZone: timezone,
+      day: 'numeric',
+      month: 'short',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit'
+    }).format(new Date(post.scheduled_for));
+  }
+
+  const day = post.slot?.match(ISO_DATE)?.[0];
+  if (day) {
+    return `${dayLabel(day)}, no time yet`;
+  }
+
+  return 'No date';
+}
+
+export function summarise(post: PostRow): string {
+  const copy = (post.caption ?? '').trim().replace(/\s+/g, ' ');
+  if (!copy) {
+    return 'Untitled';
+  }
+
+  return copy.length > SUMMARY_MAX ? `${copy.slice(0, SUMMARY_MAX)}…` : copy;
+}
+
+export function distributionNote(
+  post: Timing,
+  timezone: string,
+  now: number = Date.now()
+): string {
+  const at = post.scheduled_for ? Date.parse(post.scheduled_for) : Number.NaN;
+
+  if (Number.isFinite(at) && at > now) {
+    return `It goes out on ${momentInZone(post.scheduled_for as string, timezone)}.`;
+  }
+
+  return 'This post has no future date, so it goes out at the next slot Anomalia can use — possibly right away.';
+}
+
+export type PostDetail = {
+  status: string;
+  platform: string | null;
+  platforms?: string[] | null;
+  caption: string | null;
+  scheduled_for: string | null;
+  slot?: string | null;
+  platform_captions?: Record<string, string> | null;
+  title?: string | null;
+  first_comment?: string | null;
+  link_url?: string | null;
+  subreddit?: string | null;
+  media_url: string | null;
+  video_thumbnail_url?: string | null;
+  is_video?: boolean;
+  is_carousel?: boolean;
+  slides?: { index: number; url: string | null }[] | null;
+};
+
+export type Preview = { kind: 'none' | 'image' | 'carousel' | 'video'; urls: string[] };
+
+export type CaptionField = { name: string; label: string; value: string };
+
+export const VIEWS = { calendar: 'Calendar', list: 'List' } as const;
+
+export type View = keyof typeof VIEWS;
+
+const DEFAULT_VIEW: View = 'calendar';
+
+const EXTRA_FIELDS = [
+  { key: 'title', label: 'Title' },
+  { key: 'first_comment', label: 'First comment' },
+  { key: 'link_url', label: 'Link' },
+  { key: 'subreddit', label: 'Subreddit' }
+] as const;
+
+export function viewFor(value: string | null): View {
+  return value && value in VIEWS ? (value as View) : DEFAULT_VIEW;
+}
+
+export function previewOf(detail: PostDetail): Preview {
+  const slides = (detail.slides ?? []).map((s) => s.url).filter((url): url is string => !!url);
+
+  if (detail.is_carousel && slides.length) {
+    return { kind: 'carousel', urls: slides };
+  }
+  if (!detail.media_url) {
+    return { kind: 'none', urls: [] };
+  }
+
+  return { kind: detail.is_video ? 'video' : 'image', urls: [detail.media_url] };
+}
+
+export function captionFields(detail: PostDetail): CaptionField[] {
+  const overrides = Object.entries(detail.platform_captions ?? {}).sort(([a], [b]) =>
+    a.localeCompare(b)
+  );
+
+  return [
+    { name: 'caption', label: 'Caption', value: detail.caption ?? '' },
+    ...overrides.map(([platform, text]) => ({
+      name: `caption_${platform}`,
+      label: `Caption on ${platform}`,
+      value: text
+    }))
+  ];
+}
+
+export function extrasOf(detail: PostDetail): { label: string; value: string }[] {
+  return EXTRA_FIELDS.flatMap(({ key, label }) => {
+    const value = detail[key];
+    return typeof value === 'string' && value.trim() ? [{ label, value }] : [];
+  });
+}

--- a/src/routes/app/[brand]/calendar/+page.server.ts
+++ b/src/routes/app/[brand]/calendar/+page.server.ts
@@ -17,6 +17,50 @@ import {
 import { founderVideoBudget, listVideoRequests } from '$lib/server/video-requests';
 import { createAdminClient } from '$lib/server/supabase-admin';
 import { cachedBrandPage } from '$lib/server/page-cache';
+import { viewFor, type PostDetail } from '$lib/post-state';
+import { captionPatch } from '$lib/post-caption';
+
+/** Il risultato che `PostPanel` legge: `id` dice a quale post appartiene, e senza quello il
+ *  pannello mostrerebbe l'esito di un'altra riga. */
+type PanelOutcome = {
+  id: string | null;
+  message: string | null;
+  saved: boolean;
+  approved: boolean;
+  status: string | null;
+};
+
+function panelOutcome(partial: Partial<PanelOutcome>): PanelOutcome {
+  return { id: null, message: null, saved: false, approved: false, status: null, ...partial };
+}
+
+function brandApi(slug: string, path: string): string {
+  return `/api/v1/brands/${encodeURIComponent(slug)}${path}`;
+}
+
+async function readError(res: Response): Promise<string> {
+  const body = (await res.json().catch(() => null)) as { error?: string } | null;
+  return body?.error ?? `Request failed (${res.status})`;
+}
+
+/**
+ * Il dettaglio del post aperto nel pannello. Passa dall'endpoint invece che da Supabase perche'
+ * la' le URL dei media sono gia' firmate: rifarlo qui vorrebbe dire riscrivere quella firma.
+ */
+async function readPostDetail(
+  fetcher: typeof fetch,
+  token: string,
+  slug: string,
+  id: string
+): Promise<PostDetail | null> {
+  const res = await fetcher(brandApi(slug, `/posts/${encodeURIComponent(id)}/media`), {
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  if (!res.ok) return null;
+
+  const detail = (await res.json()) as PostDetail & { error?: string };
+  return detail.error ? null : detail;
+}
 
 function parseIds(form: FormData, key = 'ids'): string[] {
   return String(form.get(key) ?? '')
@@ -77,6 +121,7 @@ export const load: PageServerLoad = async (event) => {
   const { supabase } = event.locals;
   const url = event.url;
   const { brand } = await event.parent();
+  const { session } = await event.locals.safeGetSession();
 
   // Outside the cached callback on purpose: this is a fire-and-forget reconciliation, not part
   // of the payload, and burying it inside would mean a cache hit silently skips it — a
@@ -96,11 +141,7 @@ export const load: PageServerLoad = async (event) => {
     const status = url.searchParams.get('status') ?? '';
     const filter = FILTERABLE.has(status) ? status : '';
     const rowFilter = url.searchParams.get('row') ?? '';
-    // Legacy deep link from chat previews — posts now have a dedicated dashboard.
-    const focusPostId = url.searchParams.get('post');
-    if (focusPostId) {
-      throw redirect(303, `/app/${brand.slug}/posts/${focusPostId}/preview`);
-    }
+    const selectedId = url.searchParams.get('post');
 
     const monthStart = new Date(Date.UTC(year, month - 1, 1));
     const monthEnd = new Date(Date.UTC(year, month, 0));
@@ -312,12 +353,81 @@ export const load: PageServerLoad = async (event) => {
       prevYM: `${prev.getUTCFullYear()}-${pad(prev.getUTCMonth() + 1)}`,
       nextYM: `${next.getUTCFullYear()}-${pad(next.getUTCMonth() + 1)}`,
       currentYM: `${today.year}-${pad(today.month)}`,
-      isCurrentMonth: year === today.year && month === today.month
+      isCurrentMonth: year === today.year && month === today.month,
+      // La vista sta nell'URL, non nel client: un calendario in lista si manda a un collega.
+      view: viewFor(url.searchParams.get('view')),
+      selectedId,
+      detail:
+        selectedId && session
+          ? await readPostDetail(event.fetch, session.access_token, brand.slug, selectedId)
+          : null
     };
-  }, [url.searchParams.get('m'), url.searchParams.get('status'), url.searchParams.get('row'), url.searchParams.get('post')].join('|'));
+  }, ['m', 'status', 'row', 'post', 'view'].map((k) => url.searchParams.get(k)).join('|'));
 };
 
 export const actions: Actions = {
+  /**
+   * Le due azioni del pannello. Passano dagli endpoint invece che da Supabase perche' `approve`
+   * non e' un `update`: dietro c'e' la coda di distribuzione, e riscriverla qui vorrebbe dire
+   * tenerne due versioni.
+   */
+  editPost: async ({ request, params, fetch, locals }) => {
+    const { session } = await locals.safeGetSession();
+    if (!session) redirect(303, '/login');
+
+    const form = await request.formData();
+    const id = String(form.get('id') ?? '');
+    if (!id) return fail(400, panelOutcome({ message: 'Missing post.' }));
+
+    const patch = captionPatch(form);
+    if (typeof patch === 'string') return fail(400, panelOutcome({ id, message: patch }));
+
+    const res = await fetch(brandApi(params.brand, `/posts/${encodeURIComponent(id)}`), {
+      method: 'PUT',
+      headers: {
+        Authorization: `Bearer ${session.access_token}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(patch)
+    });
+
+    if (!res.ok) return fail(res.status, panelOutcome({ id, message: await readError(res) }));
+
+    return panelOutcome({ id, saved: true });
+  },
+
+  approvePost: async ({ request, params, fetch, locals }) => {
+    const { session } = await locals.safeGetSession();
+    if (!session) redirect(303, '/login');
+
+    const form = await request.formData();
+    const id = String(form.get('id') ?? '');
+    if (!id) return fail(400, panelOutcome({ message: 'Missing post.' }));
+
+    const res = await fetch(brandApi(params.brand, `/posts/${encodeURIComponent(id)}/approve`), {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${session.access_token}` }
+    });
+
+    const result = (await res.json().catch(() => null)) as
+      | { status?: string; message?: string; error?: string }
+      | null;
+
+    if (!res.ok || result?.error) {
+      return fail(
+        res.ok ? 400 : res.status,
+        panelOutcome({ id, message: result?.error ?? 'Approval failed.' })
+      );
+    }
+
+    return panelOutcome({
+      id,
+      approved: true,
+      status: result?.status ?? 'approved',
+      message: result?.message ?? null
+    });
+  },
+
   updateCaption: async ({ request, locals: { supabase, user } }) => {
     const data = await request.formData();
     const id = String(data.get('id') ?? '');

--- a/src/routes/app/[brand]/calendar/+page.svelte
+++ b/src/routes/app/[brand]/calendar/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { enhance } from '$app/forms';
   import { goto } from '$app/navigation';
+  import { page } from '$app/state';
   import PageHead from '$lib/components/PageHead.svelte';
   import CreateContentModal from '$lib/components/CreateContentModal.svelte';
   import { captionViolations } from '$lib/platform-limits';
@@ -105,10 +106,38 @@
   };
 
   // Mese (grid) vs Lista (chronological) — same data, two read layouts. Month is the default.
-  let view = $state<'month' | 'list'>('month');
+  // La vista sta nell'URL: un calendario in lista si manda a un collega, e il tasto indietro
+  // torna a com'era.
+  const view = $derived(data.view as 'month' | 'list');
 
+  /** Lo stesso URL con dei parametri cambiati: filtri e mese restano dove sono. */
+  function hrefWith(patch: Record<string, string | null>): string {
+    const url = new URL(page.url);
+    for (const [key, value] of Object.entries(patch)) {
+      if (value === null) url.searchParams.delete(key);
+      else url.searchParams.set(key, value);
+    }
+    return `${url.pathname}${url.search}`;
+  }
+
+  // Il post si apre nel pannello a destra, sopra il calendario: `?post=<id>`, quindi
+  // condivisibile e chiudibile col tasto indietro. La scheda completa resta a un link dentro.
   function postHref(id: string) {
-    return `/app/${brand.slug}/posts/${id}/preview`;
+    return hrefWith({ post: id });
+  }
+  const fullPostHref = $derived(
+    data.selectedId ? `/app/${brand.slug}/posts/${data.selectedId}/preview` : ''
+  );
+
+  let PostPanel = $state<typeof import('$lib/components/PostPanel.svelte').default | null>(null);
+  $effect(() => {
+    if (data.detail && !PostPanel) {
+      void import('$lib/components/PostPanel.svelte').then((m) => (PostPanel = m.default));
+    }
+  });
+
+  function closePanel() {
+    void goto(hrefWith({ post: null }), { noScroll: true, keepFocus: true });
   }
 
   // "Crea contenuto" — same single user-briefed create modal as Content.
@@ -477,8 +506,12 @@
 
       <div class="cal-tools">
         <div class="vtoggle">
-          <button type="button" class:on={view === 'month'} onclick={() => (view = 'month')}>{$_('app.calendar.viewMonth')}</button>
-          <button type="button" class:on={view === 'list'} onclick={() => (view = 'list')}>{$_('app.calendar.viewList')}</button>
+          <a href={hrefWith({ view: null })} class:on={view === 'month'} data-sveltekit-noscroll
+            >{$_('app.calendar.viewMonth')}</a
+          >
+          <a href={hrefWith({ view: 'list' })} class:on={view === 'list'} data-sveltekit-noscroll
+            >{$_('app.calendar.viewList')}</a
+          >
         </div>
       </div>
     </div>
@@ -756,6 +789,19 @@
   {/if}
 </div>
 
+{#if PostPanel && data.detail && data.selectedId}
+  {#key data.selectedId}
+    <PostPanel
+      id={data.selectedId}
+      detail={data.detail}
+      timezone={data.timezone}
+      fullHref={fullPostHref}
+      {form}
+      onclose={closePanel}
+    />
+  {/key}
+{/if}
+
 <style>
   .cal-page {
     display: flex;
@@ -815,9 +861,10 @@
 
   .cal-tools { margin-left: auto; display: flex; align-items: center; gap: 10px; flex-shrink: 0; }
   .vtoggle { display: inline-flex; border: 1px solid var(--line-2); border-radius: 10px; overflow: hidden; }
-  .vtoggle button { padding: 7px 14px; font-size: 13px; font-weight: 600; background: var(--paper);
-    color: var(--ink-soft); border: none; cursor: pointer; font-family: inherit; }
-  .vtoggle button.on { background: rgba(var(--accent-rgb), 0.1); color: var(--accent); }
+  .vtoggle a { padding: 7px 14px; font-size: 13px; font-weight: 600; background: var(--paper);
+    color: var(--ink-soft); border: none; cursor: pointer; font-family: inherit;
+    text-decoration: none; }
+  .vtoggle a.on { background: rgba(var(--accent-rgb), 0.1); color: var(--accent); }
 
   /* Text badge replacing the 📝 blog emoji everywhere a blog article shows up. */
   .blog-label { font-size: 9px; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase; line-height: 1; }

--- a/src/routes/app/[brand]/workbench/+page.svelte
+++ b/src/routes/app/[brand]/workbench/+page.svelte
@@ -1,12 +1,18 @@
 <script lang="ts">
   import { _ } from 'svelte-i18n';
   import HomeWorkbench from '$lib/components/HomeWorkbench.svelte';
+  import McpGuide from '$lib/components/McpGuide.svelte';
   import WorkbenchPageShimmer from '$lib/components/WorkbenchPageShimmer.svelte';
 
   let { data } = $props();
 </script>
 
 <svelte:head><title>Anomalia — {$_('app.home.workbench.title')}</title></svelte:head>
+
+<!-- Sopra il blocco `{#await}`, non dentro: collegare il proprio agente è la prima cosa da fare,
+     e non dipende dalle ~30 query della panoramica. Aspettarle vorrebbe dire mostrarla al
+     secondo giro d'occhio, quando la pagina si è già riempita d'altro. -->
+<McpGuide />
 
 <!-- `extras` non si passa di proposito: erano i badge differiti del layout, e qui dentro
      non ci sono. Servivano solo come sovrascrittura anticipata — `overview` porta già


### PR DESCRIPTION
## What?

Porta dentro `/app` le due cose che `/v2` aveva e `/app` no, prima di cancellare `/v2`:

1. **la guida di connessione MCP**, in cima alla home del brand (`/app/<slug>/workbench`);
2. **il pannello del post**, `?post=<id>`, dentro il calendario — uno `Sheet` a destra con
   anteprima, copia (comune e per piattaforma) e approvazione.

Passando, **la vista del calendario esce da `$state` ed entra nell'URL** (`?view=list`).

Il **link pubblico condivisibile** non è qui: lo sta estendendo un altro agente a partire da
#221, e `shared-views.ts` / `src/routes/share/` non sono stati toccati.

## Why?

`/v2` si cancella — il calendario a doppia vista, i materiali, la strategia e i risultati
esistono già in `/app`, e tenerne due copie era il costo senza il beneficio. Ma tre cose non
avevano un equivalente, e cancellare prima di recuperarle vorrebbe dire riscriverle dalla
storia di git.

**La guida MCP in cima**: collegare il proprio agente è la prima cosa che il prodotto chiede
di fare. Una guida che vive dietro un link non la apre nessuno.

**Il pannello**: oggi `?post=<id>` sul calendario **rimanda** a `/posts/<id>/preview` — un deep
link legacy delle anteprime in chat. Per leggere un post e approvarlo si perdeva il calendario.

**La vista nell'URL**: un calendario in lista si manda a un collega, e il tasto indietro deve
tornare a com'era. È anche la regola che vale per tutto il resto — i filtri stanno nell'URL,
non nel client — e `?status=`, `?m=`, `?row=` la rispettavano già: `view` era l'eccezione.

## How?

**Due commit**: il primo *sposta* i tre file da `/v2` a `$lib` senza cambiarli (solo
`./post-state` → `$lib/post-state`), il secondo *cambia* senza spostare. Così si vede cosa è
arrivato e cosa è stato adattato.

**La guida sta sopra il blocco `{#await}`**, non dentro. Aspettare le ~30 query di
`loadHomeOverview` vorrebbe dire mostrarla al secondo giro d'occhio, quando la pagina si è già
riempita d'altro.

Due adattamenti rispetto a `/v2`: le classi Tailwind coi token di `/v2` (`bg-card`,
`text-muted-foreground`) diventano la palette del guscio (`--paper`, `--ink`, `--line`) — due
palette nella stessa pagina si vedono — e il testo passa da `svelte-i18n` con le chiavi
`app.mcpGuide.*` nei **quattro** cataloghi. `/v2` era in inglese perché era dichiarata
anteprima; `/app` non lo è.

La guida **non** prova a indovinare se un agente è già collegato, e il motivo resta scritto nel
componente: non esiste nessun segnale per saperlo — l'MCP remoto autentica con un JWT Supabase
indistinguibile da un login del browser, l'OAuth non tiene una tabella di client (il
`client_id` *è* la registrazione, firmata) e `api_keys.last_used_at` è per utente e non viene
mai toccato dal percorso MCP.

**Il pannello non sostituisce la scheda del post.** `PostPanel` ha una prop nuova, `fullHref`,
e un link verso `/posts/<id>/preview`: senza, le cinque rotte del dettaglio (`preview`,
`details`, `edit`, `analytics`, `boost`) resterebbero senza nessuno che ci porta. Il calendario
era il loro unico ingresso.

**Le due azioni passano dagli endpoint**, non da Supabase come il resto di quel
`+page.server.ts`. Non è gusto: dietro `approve` c'è la coda di distribuzione, e riscriverla
qui vorrebbe dire tenerne due versioni; il dettaglio arriva da `/posts/:id/media`, dove le URL
dei media sono già firmate — rifarlo in locale significherebbe riscrivere quella firma. Si
chiamano `editPost`/`approvePost` per non collidere con `updateCaption` e le altre otto azioni
già presenti.

**`captionPatch` è uscito dal `+page.server.ts`** e vive in `$lib/post-caption.ts`. SvelteKit
non lascia esportare altro che `load`/`actions` da un `+page.server.ts`, quindi lì sarebbe
stato codice non testabile — e ha due casi che si sbagliano in silenzio, ora entrambi sotto
test:

- se il form non manda **nessun** campo `caption_<platform>`, `platform_captions` non deve
  comparire nel patch: comparire come `null` cancellerebbe riscritture salvate da qualcun altro;
- una riscrittura **svuotata a mano** non è una riscrittura vuota — è la richiesta di tornare
  alla copia comune. Salvata come stringa vuota, quella piattaforma pubblicherebbe niente.

**La cache di pagina**: `view` è entrato nella `variant` insieme a `post`. Due viste diverse non
devono condividere una entry — la stessa regola che il `variant` già applicava a `m`, `status`
e `row`.

**Il toggle passa da due `<button>` a due `<a>`**: funziona anche prima dell'idratazione.

## Testing?

**La verifica in browser è rimandata**: niente Docker, niente dev server, niente Playwright,
nessuna verifica visiva. Va fatta prima del merge — la lista in *Anything Else?*.

| Comando | Esito |
|---|---|
| `node scripts/typecheck-runtime.mjs` | `ok (ignored 306 non-fatal type error(s))` |
| `npx vitest run $(git grep -ln "readFileSync\|readdirSync\|existsSync" -- 'src/**/*.test.ts')` | **73 file, 973 test, verdi** |
| `npx vitest run src/lib/post-caption.test.ts src/lib/post-state.test.ts` | **34 test verdi** (7 nuovi + 27 arrivati da `/v2`) |

**Rosso prima del verde**, con l'output vero — il test di `captionPatch` è stato scritto prima
del modulo:

```
Error: Failed to load url ./post-caption (resolved id: ./post-caption) in
  …/src/lib/post-caption.test.ts. Does the file exist?
 Test Files  1 failed (1)
      Tests  no tests
```

e dopo il modulo:

```
 ✓ src/lib/post-caption.test.ts (7 tests) 2ms
 ✓ src/lib/post-state.test.ts (27 tests) 22ms
      Tests  34 passed (34)
```

**Non testato, e perché**: `PostPanel` e `McpGuide` sono componenti — qui non si montano
componenti nei test, e la logica che avrebbero avuto dentro sta nei due moduli puri sotto
(`post-state.ts`, `post-caption.ts`), che sono testati. Il giro completo (aprire, salvare,
approvare) è verifica in browser, ed è rimandata. Non ho eseguito la suite intera (rossi noti su
`dev` non miei) né l'eval (questa PR non tocca chat, prompt, tool o modello).

**Rischi**:

- `form` sul calendario è ora l'unione di **dieci** azioni. `PostPanel` guarda `form?.id === id`,
  quindi l'esito di `updateCaption` o `deletePost` non gli arriva addosso — ma è il punto da
  guardare per primo se qualcosa si comporta male.
- il dettaglio del post entra nella cache di pagina (45 s). È corretto — ogni richiesta mutante
  del brand svuota le sue entry, per `hooks.server.ts` — ma è una strada nuova per quel dato.

## Evidence

Nessuno screenshot: la verifica visiva è rimandata e non voglio farla sembrare fatta.

<details>
<summary>Cosa succede oggi e cosa succederà, sullo stesso URL</summary>

```
/app/<slug>/calendar?post=abc

PRIMA   → 303 verso /app/<slug>/posts/abc/preview
           (il calendario si perde; per tornare, il tasto indietro)

DOPO    → il calendario resta, si apre lo Sheet a destra:
           anteprima · copia comune · copia per piattaforma · approva
           + "Open the full post" → /app/<slug>/posts/abc/preview
```
</details>

<details>
<summary>La vista, prima e dopo</summary>

```
PRIMA   let view = $state<'month' | 'list'>('month')
        due <button> che scrivono nella variabile
        → l'URL non cambia, il link non si condivide, indietro non torna

DOPO    const view = $derived(data.view)          // dal server, via viewFor()
        due <a href="?view=list"> / <a href="?…">  // niente `view` = mese
        → condivisibile, e nella variant della cache
```
</details>

## Anything Else?

**Da guardare nella verifica in browser:**

- aprire un post dal mese e dalla lista, salvare la copia, salvare una riscrittura per
  piattaforma, svuotarne una e riaprire il pannello (è il caso che il test copre in astratto);
- approvare, e leggere il messaggio di esito **dentro** il pannello giusto se prima si è usata
  un'altra azione della pagina (cancellazione, approva-settimana);
- il tasto indietro sul pannello e sul cambio vista;
- `?view=list&post=<id>` incollato a freddo;
- la guida MCP: aperta al primo arrivo, il tasto Copia fuori da https (deve fallire in silenzio,
  non lanciare), e in una lingua diversa dall'inglese.

**Debito dichiarato:**

- **`PostPanel` resta in inglese.** Non per pigrizia: le sue etichette non stanno tutte nel
  componente — `stateOf`, `captionFields`, `whenLabel` e `distributionNote` vivono in
  `$lib/post-state.ts` e le restituiscono già formate, con **27 test inchiodati a quelle
  stringhe**. Tradurlo vuol dire cambiare la forma di quel modulo, e non è una cosa da fare di
  striscio in una PR che ne sposta un altro. La guida MCP invece è tradotta: dodici stringhe e
  nessun modulo sotto.
- **La gerarchia del mockup sulla home** (le cose che richiedono attenzione in cima, con quante
  sono; poi le prossime uscite; poi i numeri) non è in questa PR: `HomeWorkbench` è un
  componente grande e ridisegnarlo mentre gli si mette una guida sopra mescolerebbe due
  diagnosi. Va fatto, e va fatto guardando il mockup accanto.
- Sul calendario ora si può modificare una copia **in due posti**: l'editor inline che c'era e
  il pannello. Non è un difetto oggi (scrivono la stessa colonna), ma è una duplicazione da
  risolvere nello sfoltimento.

**Prossima PR**: la cancellazione di `src/routes/v2/` (31 file) e della nota pubblica che ne
annunciava l'anteprima.

**Changelog**: interno (`changelog/2026-09-04-mcp-guide-e-pannello-post.md`). Il pubblico va
scritto **qui**, non con la sidebar: «la guida per collegare il tuo agente è in cima alla home,
e i post si aprono e si approvano senza lasciare il calendario» è una notizia. Lo aggiungo se
lo volete in questa PR o nella prossima — dirmi quale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
