### PR TITLE
Let an agent point Radar at new places

### DIFF
--- a/changelog/2026-09-04-agent-radar-settings.md
+++ b/changelog/2026-09-04-agent-radar-settings.md
@@ -1,0 +1,63 @@
+# Il Radar si punta da fuori, e il piano lo dice prima del 403
+
+Quarto giro sulle impostazioni headless. Quattro tool: `get_radar`, `set_radar_platform`,
+`add_radar_source`, `remove_radar_source`. `tools/list`: **99 → 103**, additivo, `changed: []`.
+
+## Perché la lettura non è di cortesia
+
+Due cose, qui, un agente non le può indovinare, e sono esattamente quelle che decidono se una
+scrittura riesce:
+
+- **il piano**. `threads`, `x`, `linkedin` (piattaforme) e `threads_query`, `x_community`,
+  `linkedin_query` (tipi di fonte) sono del piano Pro. Sotto, `get_radar` li segna `plan_locked` e
+  i write rispondono `plan_required`;
+- **il tetto**. `radarSourceLimit(plan)` limita quante fonti un brand può avere. `get_radar` porta
+  `source_limit` e `sources_used`; oltre, l'aggiunta risponde `source_limit` nominando il tetto.
+
+Un enum più corto per i tipi Pro sarebbe stato sbagliato: il piano è un fatto del runtime, non
+della forma della richiesta, e togliere quei nomi dallo schema significherebbe che un agente su
+Starter non può nemmeno sapere che esistono. Stanno nel vocabolario, e il rifiuto è dichiarato.
+
+## Niente id: la coppia che aggiunge è la coppia che toglie
+
+`(brand_id, kind, value)` è già la chiave unica sul database. Quindi `remove_radar_source` prende
+`(kind, value)` — l'unica cosa che un agente ha in mano subito dopo aver aggiunto una fonte — e
+non c'è nessun id da ricordare né un giro di rete per scoprirlo.
+
+È un `POST` a `/sources/remove` e non un `DELETE`: il client generato dal registry non manda un
+corpo su `DELETE`, e inventare una risorsa con `:id` avrebbe voluto dire una riga in
+`BRAND_RESOURCES`, un risolutore di prefissi e un metodo nuovo nel client — machinery per un id
+che il dominio non usa.
+
+## Il difetto che questa scelta ha reso visibile
+
+Un subreddit si scrive `r/coffee` e si **conserva** `coffee`: l'azione del form lo normalizzava
+inline, in aggiunta. Con una rimozione per coppia, normalizzare solo da un lato sarebbe stato un
+guasto silenzioso preciso: `remove('r/coffee')` non trova `coffee`, e la risposta dice «tolta»
+senza aver tolto niente.
+
+`radarSourceValue(kind, value)` sta in `$lib/server/radar.ts` e la chiamano tutti e tre i punti
+che scrivono — aggiunta, rimozione, form del browser. Un test dice esattamente questo: le due
+strade convergono sullo stesso valore.
+
+Nella stessa pagina c'era anche l'elenco dei tipi validi ricopiato a mano — la **quarta** copia,
+dopo `RADAR_BASE_KINDS`, `RADAR_PRO_LEAD_KINDS` e il tipo `RadarSourceKind`. Sostituito con
+l'unione dei due, che è ciò che era già.
+
+## Una fonte che c'è già non è un errore
+
+`added: false`, niente cambia, 200. Deliberatamente non un 409: un agente che riprova dopo un
+timeout non deve vedere un fallimento per una cosa che è nello stato giusto.
+
+## `destructive` per caso, non per famiglia
+
+`remove_radar_source` è l'unico dei quattro con `destructive: true`: cancella una riga che non
+torna. Aggiungere una fonte, accendere e spegnere una piattaforma non distruggono niente —
+spegnere restringe cosa il Radar trova e non tocca né le fonti né i risultati già trovati.
+
+## Cosa è stato visto rosso
+
+- il contratto, prima di essere nel registry;
+- il guardiano del vocabolario, con `mastodon` aggiunto alle piattaforme del contratto;
+- le rotte: tolti la normalizzazione, il gate del piano, il controllo della URL RSS, il tetto e il
+  404 della rimozione, **cadono 9 test su 16** e 7 restano verdi.

--- a/cli/lib/contracts/index.ts
+++ b/cli/lib/contracts/index.ts
@@ -49,6 +49,12 @@ import { DIAGNOSE_BRAND, GET_GOALS } from './brand-state';
 import { GET_BRAND_SETTINGS, SET_BRAND_SETTINGS } from './brand-settings';
 import { DIAGNOSE_RADAR, GET_MARKET_FIELD, LIST_IDEAS } from './market';
 import { GET_MEDIA_MODELS, SET_MEDIA_MODEL } from './media-models';
+import {
+  ADD_RADAR_SOURCE,
+  GET_RADAR,
+  REMOVE_RADAR_SOURCE,
+  SET_RADAR_PLATFORM
+} from './radar';
 import { GEO_ACTION, REFRESH_KEYWORDS, SEO_ACTION } from './search';
 import { GET_BACKLINKS, GET_GSC, GET_RANKS } from './web-metrics';
 import {
@@ -112,6 +118,7 @@ export type BrandEndpoint = ResourcelessEndpoint | ResourceEndpoint;
 
 export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   ADD_COMPETITOR,
+  ADD_RADAR_SOURCE,
   ADS_REMIX,
   APPROVE_PLAN,
   BILLING_PORTAL_LINK,
@@ -144,6 +151,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   GET_MEDIA_MODELS,
   GET_PLAN,
   GET_POST,
+  GET_RADAR,
   GET_RANKS,
   GET_SEO,
   GET_STUDIO,
@@ -161,6 +169,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   LIST_WEB_FIXES,
   PROPOSE_PLAN,
   REFRESH_KEYWORDS,
+  REMOVE_RADAR_SOURCE,
   RENDER_POST,
   RESCHEDULE_POST,
   RESEARCH_COMPETITORS,
@@ -171,6 +180,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   SEO_ACTION,
   SET_AUTOMATION,
   SET_BIO,
+  SET_RADAR_PLATFORM,
   SET_BRAND_SETTINGS,
   SET_MEDIA_MODEL,
   SYNC_HISTORY,
@@ -263,6 +273,17 @@ export {
   SET_MEDIA_MODEL
 } from './media-models';
 export type { MediaModelSlotId } from './media-models';
+export {
+  ADD_RADAR_SOURCE,
+  GET_RADAR,
+  RADAR_BASE_SOURCE_KINDS,
+  RADAR_PLATFORMS,
+  RADAR_PRO_SOURCE_KINDS,
+  RADAR_SOURCE_KINDS,
+  REMOVE_RADAR_SOURCE,
+  SET_RADAR_PLATFORM
+} from './radar';
+export type { RadarPlatform, RadarSourceKindName } from './radar';
 export { GEO_ACTION, REFRESH_KEYWORDS, SEO_ACTION } from './search';
 export { GET_BACKLINKS, GET_GSC, GET_RANKS } from './web-metrics';
 export {

--- a/cli/lib/contracts/radar.ts
+++ b/cli/lib/contracts/radar.ts
@@ -1,0 +1,157 @@
+import { z } from 'zod';
+import type { BrandEndpoint } from './index';
+
+/**
+ * Le piattaforme che il Radar puo' battere e i tipi di fonte che un brand puo' aggiungere.
+ * Gli elenchi veri sono `RADAR_PLATFORM_KEYS`, `RADAR_BASE_KINDS` e `RADAR_PRO_LEAD_KINDS`
+ * (`$lib/plans`), che il contratto non puo' importare: un test dell'app tiene i tre allineati.
+ *
+ * I `PRO` sono separati dai `BASE` perche' la differenza non e' di gusto: sono le fonti che un
+ * piano inferiore non puo' avere, e un tool che le offre a tutti insegna un 403.
+ */
+export const RADAR_PLATFORMS = ['gnews', 'reddit', 'threads', 'x', 'linkedin'] as const;
+
+export const RADAR_BASE_SOURCE_KINDS = ['gnews_query', 'rss', 'subreddit', 'reddit_query'] as const;
+export const RADAR_PRO_SOURCE_KINDS = ['threads_query', 'x_community', 'linkedin_query'] as const;
+export const RADAR_SOURCE_KINDS = [
+  ...RADAR_BASE_SOURCE_KINDS,
+  ...RADAR_PRO_SOURCE_KINDS
+] as const;
+
+export type RadarPlatform = (typeof RADAR_PLATFORMS)[number];
+export type RadarSourceKindName = (typeof RADAR_SOURCE_KINDS)[number];
+
+const platform = z.enum(RADAR_PLATFORMS).describe('Which platform Radar may search');
+const kind = z.enum(RADAR_SOURCE_KINDS).describe('What sort of source this is');
+
+const value = z
+  .string()
+  .min(1)
+  .describe(
+    'The query, the feed URL, or the subreddit name. rss must be an http(s) URL; a subreddit is ' +
+      'stored without its "r/"'
+  );
+
+const PLAN_REQUIRED: { error: string; status: number } = { error: 'plan_required', status: 403 };
+
+export const GET_RADAR = {
+  tool: 'get_radar',
+  title: 'Radar sources',
+  description:
+    'Where Radar looks for this brand: which platforms are on, which sources are configured, ' +
+    'and — the part you cannot guess — which source kinds this plan is allowed to use and how ' +
+    'many sources are left. Threads, X and LinkedIn belong to the Pro plan: on a lower plan they ' +
+    'read as locked here and adding one comes back plan_required.',
+  method: 'GET',
+  pathUnderBrand: '/settings/radar',
+  input: z.object({}).strict(),
+  output: z.object({
+    brand: z.string(),
+    plan: z.string().nullable(),
+    platforms: z.array(
+      z.object({
+        platform: z.enum(RADAR_PLATFORMS),
+        enabled: z.boolean(),
+        plan_locked: z.boolean()
+      })
+    ),
+    sources: z.array(
+      z.object({
+        id: z.string(),
+        kind: z.enum(RADAR_SOURCE_KINDS),
+        value: z.string(),
+        lang: z.string().nullable(),
+        active: z.boolean()
+      })
+    ),
+    allowed_kinds: z.array(z.string()),
+    source_limit: z.number(),
+    sources_used: z.number()
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const SET_RADAR_PLATFORM = {
+  tool: 'set_radar_platform',
+  title: 'Turn a Radar platform on or off',
+  description:
+    'Switch one platform on or off for this brand’s Radar. Turning one off narrows what Radar ' +
+    'finds; it deletes no source and no result already found. Threads, X and LinkedIn need the ' +
+    'Pro plan and answer plan_required below it. Calls no model and spends no credits.',
+  method: 'PUT',
+  pathUnderBrand: '/settings/radar',
+  input: z.object({ platform, enabled: z.boolean() }).strict(),
+  output: z.object({
+    ok: z.literal(true),
+    platform: z.enum(RADAR_PLATFORMS),
+    enabled: z.boolean()
+  }),
+  failures: [PLAN_REQUIRED, { error: 'update_failed', status: 500 }],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const ADD_RADAR_SOURCE = {
+  tool: 'add_radar_source',
+  title: 'Add a Radar source',
+  description:
+    'Add one place for Radar to watch: a Google News query, an RSS feed, a subreddit, a Reddit / ' +
+    'Threads / X / LinkedIn search. A source already there is left as it is rather than ' +
+    'duplicated — the pair (kind, value) is its identity, and it is what remove_radar_source ' +
+    'takes. Read get_radar first: the plan decides which kinds are allowed (plan_required) and ' +
+    'how many sources fit (source_limit). Adding a source calls no model and spends no credits, ' +
+    'but Radar reads it on every run from then on.',
+  method: 'POST',
+  pathUnderBrand: '/settings/radar/sources',
+  input: z
+    .object({
+      kind,
+      value,
+      lang: z
+        .string()
+        .max(5)
+        .optional()
+        .describe('Language hint, e.g. "it" or "en". "auto" by default')
+    })
+    .strict(),
+  output: z.object({
+    ok: z.literal(true),
+    kind: z.enum(RADAR_SOURCE_KINDS),
+    value: z.string(),
+    lang: z.string(),
+    /** Falso quando la fonte c'era gia': niente e' cambiato, e non e' un errore. */
+    added: z.boolean(),
+    sources_used: z.number(),
+    source_limit: z.number()
+  }),
+  failures: [
+    PLAN_REQUIRED,
+    { error: 'source_limit', status: 403 },
+    { error: 'invalid_value', status: 400 },
+    { error: 'insert_failed', status: 500 }
+  ],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const REMOVE_RADAR_SOURCE = {
+  tool: 'remove_radar_source',
+  title: 'Remove a Radar source',
+  description:
+    'Delete one source, named by the same (kind, value) pair that added it. It does not come ' +
+    'back, and Radar stops reading it. What it already found stays. A pair that is not there ' +
+    'answers not_found rather than reporting a success that removed nothing.',
+  method: 'POST',
+  pathUnderBrand: '/settings/radar/sources/remove',
+  input: z.object({ kind, value }).strict(),
+  output: z.object({
+    ok: z.literal(true),
+    kind: z.enum(RADAR_SOURCE_KINDS),
+    value: z.string(),
+    sources_used: z.number()
+  }),
+  failures: [
+    { error: 'not_found', status: 404 },
+    { error: 'delete_failed', status: 500 }
+  ],
+  destructive: true
+} satisfies BrandEndpoint;

--- a/cli/plugins/anomalia/skills/anomalia/SKILL.md
+++ b/cli/plugins/anomalia/skills/anomalia/SKILL.md
@@ -100,6 +100,12 @@ you do it. Turning one OFF is free and safe. There is no per-job cost figure —
 attributable to one job — so describe the commitment with cadence and `runs_30d`, and never
 invent a number.
 
+**Point Radar at a new place** → `get_radar` shows the platforms, the configured sources, the
+kinds this plan allows and how many sources are left; `add_radar_source` / `remove_radar_source`
+change them, naming a source by its `(kind, value)` pair. Threads, X and LinkedIn are Pro-only and
+answer `plan_required` below it, so read before you write. A source already there comes back
+`added: false` rather than failing.
+
 **Choose which model draws and which films** → `get_media_models` lists the six jobs (image
 generation, image refinement, video from text, animating a still, video refinement, motion
 transfer) with the models each one accepts; `set_media_model` pins one. A model that cannot do

--- a/cli/plugins/anomalia/skills/anomalia/references/tools.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/tools.md
@@ -283,6 +283,32 @@ describe the commitment, and point at the usage page for the brand-wide bill.
 A brand without a paid plan runs none of them however many are on — `scheduled_work_allowed` says
 so. The calls themselves spend no credits.
 
+## Radar sources
+
+| MCP | CLI |
+|-----|-----|
+| `get_radar` | (MCP only) |
+| `set_radar_platform` | (MCP only) |
+| `add_radar_source` | (MCP only) |
+| `remove_radar_source` | (MCP only) |
+
+Where Radar looks: which platforms are on (`gnews`, `reddit`, `threads`, `x`, `linkedin`) and
+which sources are configured (`gnews_query`, `rss`, `subreddit`, `reddit_query`, plus
+`threads_query`, `x_community`, `linkedin_query`).
+
+**Read `get_radar` first.** It carries the two things you cannot guess: `allowed_kinds` for this
+plan, and `source_limit` against `sources_used`. Threads, X and LinkedIn belong to the **Pro**
+plan — below it they read as `plan_locked` and both writes answer `plan_required` (403). Past the
+limit, `add_radar_source` answers `source_limit` (403) and names the ceiling.
+
+A source is identified by the pair **(kind, value)** — there is no id to remember, and it is what
+`remove_radar_source` takes. Adding one that is already there is not an error: nothing changes and
+`added: false` says so. `rss` must be an http(s) URL; a subreddit is stored without its `r/`, and
+both writes normalise it the same way, so `r/coffee` and `coffee` are the same source.
+
+Adding a source spends no credits by itself, but Radar reads it on every run from then on.
+Removing one is permanent and stops Radar reading it; what it already found stays.
+
 ## Media models
 
 | MCP | CLI |

--- a/cli/skills/anomalia/SKILL.md
+++ b/cli/skills/anomalia/SKILL.md
@@ -100,6 +100,12 @@ you do it. Turning one OFF is free and safe. There is no per-job cost figure —
 attributable to one job — so describe the commitment with cadence and `runs_30d`, and never
 invent a number.
 
+**Point Radar at a new place** → `get_radar` shows the platforms, the configured sources, the
+kinds this plan allows and how many sources are left; `add_radar_source` / `remove_radar_source`
+change them, naming a source by its `(kind, value)` pair. Threads, X and LinkedIn are Pro-only and
+answer `plan_required` below it, so read before you write. A source already there comes back
+`added: false` rather than failing.
+
 **Choose which model draws and which films** → `get_media_models` lists the six jobs (image
 generation, image refinement, video from text, animating a still, video refinement, motion
 transfer) with the models each one accepts; `set_media_model` pins one. A model that cannot do

--- a/cli/skills/anomalia/references/tools.md
+++ b/cli/skills/anomalia/references/tools.md
@@ -283,6 +283,32 @@ describe the commitment, and point at the usage page for the brand-wide bill.
 A brand without a paid plan runs none of them however many are on — `scheduled_work_allowed` says
 so. The calls themselves spend no credits.
 
+## Radar sources
+
+| MCP | CLI |
+|-----|-----|
+| `get_radar` | (MCP only) |
+| `set_radar_platform` | (MCP only) |
+| `add_radar_source` | (MCP only) |
+| `remove_radar_source` | (MCP only) |
+
+Where Radar looks: which platforms are on (`gnews`, `reddit`, `threads`, `x`, `linkedin`) and
+which sources are configured (`gnews_query`, `rss`, `subreddit`, `reddit_query`, plus
+`threads_query`, `x_community`, `linkedin_query`).
+
+**Read `get_radar` first.** It carries the two things you cannot guess: `allowed_kinds` for this
+plan, and `source_limit` against `sources_used`. Threads, X and LinkedIn belong to the **Pro**
+plan — below it they read as `plan_locked` and both writes answer `plan_required` (403). Past the
+limit, `add_radar_source` answers `source_limit` (403) and names the ceiling.
+
+A source is identified by the pair **(kind, value)** — there is no id to remember, and it is what
+`remove_radar_source` takes. Adding one that is already there is not an error: nothing changes and
+`added: false` says so. `rss` must be an http(s) URL; a subreddit is stored without its `r/`, and
+both writes normalise it the same way, so `r/coffee` and `coffee` are the same source.
+
+Adding a source spends no credits by itself, but Radar reads it on every run from then on.
+Removing one is permanent and stops Radar reading it; what it already found stays.
+
 ## Media models
 
 | MCP | CLI |

--- a/docs/api/15-settings-radar.md
+++ b/docs/api/15-settings-radar.md
@@ -1,0 +1,83 @@
+# API — 15 · Impostazioni: le fonti del Radar
+
+Quattro endpoint sotto `/api/v1/brands/:slug/settings/radar`, cioè i tool MCP `get_radar`,
+`set_radar_platform`, `add_radar_source` e `remove_radar_source`.
+
+Errori comuni di auth: vedi [01-overview](01-overview.md).
+
+## Dove è salvato cosa
+
+| cosa | dove |
+|---|---|
+| interruttori delle piattaforme | `brands.content_prefs.radar.platforms` |
+| fonti | `brand_news_sources` (`kind`, `value`, `lang`, `active`), unico su `(brand_id, kind, value)` |
+
+Nessuna migration: sono la colonna e la tabella che la pagina Settings → Radar scrive già.
+
+## Il piano decide, e la lettura lo dice prima
+
+`threads`, `x` e `linkedin` (piattaforme) e `threads_query`, `x_community`, `linkedin_query`
+(tipi di fonte) appartengono al piano **Pro** (`hasProRadarLeads`). Sotto, `get_radar` li segna
+`plan_locked` e i due write rispondono `plan_required` (403).
+
+Il numero di fonti ha un tetto per piano (`radarSourceLimit`): `get_radar` porta `source_limit` e
+`sources_used`, e `add_radar_source` risponde `source_limit` (403) nominando il tetto.
+
+Sono le due cose che un agente non può indovinare, ed è la ragione per cui la lettura esiste.
+
+## `GET /api/v1/brands/:slug/settings/radar`
+
+```json
+{
+  "brand": "demo",
+  "plan": "starter",
+  "platforms": [{ "platform": "threads", "enabled": false, "plan_locked": true }],
+  "sources": [{ "id": "…", "kind": "subreddit", "value": "coffee", "lang": "auto", "active": true }],
+  "allowed_kinds": ["gnews_query", "rss", "subreddit", "reddit_query"],
+  "source_limit": 10,
+  "sources_used": 1
+}
+```
+
+## `PUT /api/v1/brands/:slug/settings/radar`
+
+**Body**: `{ "platform": "reddit", "enabled": true }`. Spegnere restringe cosa il Radar trova; non
+cancella nessuna fonte e nessun risultato già trovato.
+
+Errori: `invalid_input` (400), `plan_required` (403), `update_failed` (500).
+
+## `POST /api/v1/brands/:slug/settings/radar/sources`
+
+**Body**: `{ "kind": "subreddit", "value": "r/coffee", "lang": "it" }` — `lang` facoltativo
+(`auto` di default).
+
+Una fonte che c'è già **non** è un errore: niente cambia e `added: false` lo dice. È
+deliberatamente diverso da un 409: un agente che riprova dopo un timeout non deve vedere un
+fallimento per una cosa che è nello stato giusto.
+
+Errori: `invalid_input` (400), `invalid_value` (400 — un `rss` che non è una URL, o un valore
+vuoto dopo la normalizzazione), `plan_required` (403), `source_limit` (403), `insert_failed` (500).
+
+## `POST /api/v1/brands/:slug/settings/radar/sources/remove`
+
+**Body**: `{ "kind": "subreddit", "value": "r/coffee" }`.
+
+È un `POST` e non un `DELETE` per una ragione precisa: la fonte si nomina con la coppia
+`(kind, value)` — la stessa chiave unica che l'ha creata, e l'unica cosa che un agente ha in mano
+subito dopo averla aggiunta — e il client generato dal registry non manda un corpo su `DELETE`.
+Nessun id da ricordare, nessun giro di rete per scoprirlo.
+
+Una coppia che non esiste risponde `not_found` (404), non un successo che non ha tolto niente.
+
+`destructive: true`: è l'unico dei quattro.
+
+## La normalizzazione che le due strade devono condividere
+
+Un subreddit si scrive `r/coffee` e si conserva `coffee`. Normalizzarlo solo in aggiunta
+lascerebbe una rimozione per `r/coffee` senza corrispondenza: la fonte resterebbe lì mentre la
+risposta dice che è stata tolta.
+
+`radarSourceValue(kind, value)` (`src/lib/server/radar.ts`) è quel passaggio, e lo chiamano tutti
+e tre i punti che scrivono: l'aggiunta, la rimozione e l'azione del form del browser. La pagina
+teneva anche un elenco dei tipi validi ricopiato a mano — la quarta copia — ora sostituito da
+`RADAR_BASE_KINDS + RADAR_PRO_LEAD_KINDS`.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -22,6 +22,7 @@ integrazioni esterne via API key — request, response, query params, body, erro
 | [12 — Impostazioni: modelli media](12-settings-models.md) | `/settings/models` — quale modello disegna e quale gira, per brand |
 | [13 — Impostazioni: come lavora il brand](13-settings-brand.md) | `/settings/brand` — fuso, piattaforme, hashtag, esempi di voce |
 | [14 — Impostazioni: lavori ricorrenti](14-settings-automations.md) | `/settings/automations` — i nove lavori del roster e il loro interruttore |
+| [15 — Impostazioni: fonti del Radar](15-settings-radar.md) | `/settings/radar` — piattaforme e fonti che il Radar guarda |
 
 ## Regole di manutenzione
 

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -49,6 +49,12 @@ import { DIAGNOSE_BRAND, GET_GOALS } from './brand-state';
 import { GET_BRAND_SETTINGS, SET_BRAND_SETTINGS } from './brand-settings';
 import { DIAGNOSE_RADAR, GET_MARKET_FIELD, LIST_IDEAS } from './market';
 import { GET_MEDIA_MODELS, SET_MEDIA_MODEL } from './media-models';
+import {
+  ADD_RADAR_SOURCE,
+  GET_RADAR,
+  REMOVE_RADAR_SOURCE,
+  SET_RADAR_PLATFORM
+} from './radar';
 import { GEO_ACTION, REFRESH_KEYWORDS, SEO_ACTION } from './search';
 import { GET_BACKLINKS, GET_GSC, GET_RANKS } from './web-metrics';
 import {
@@ -112,6 +118,7 @@ export type BrandEndpoint = ResourcelessEndpoint | ResourceEndpoint;
 
 export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   ADD_COMPETITOR,
+  ADD_RADAR_SOURCE,
   ADS_REMIX,
   APPROVE_PLAN,
   BILLING_PORTAL_LINK,
@@ -144,6 +151,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   GET_MEDIA_MODELS,
   GET_PLAN,
   GET_POST,
+  GET_RADAR,
   GET_RANKS,
   GET_SEO,
   GET_STUDIO,
@@ -161,6 +169,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   LIST_WEB_FIXES,
   PROPOSE_PLAN,
   REFRESH_KEYWORDS,
+  REMOVE_RADAR_SOURCE,
   RENDER_POST,
   RESCHEDULE_POST,
   RESEARCH_COMPETITORS,
@@ -171,6 +180,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   SEO_ACTION,
   SET_AUTOMATION,
   SET_BIO,
+  SET_RADAR_PLATFORM,
   SET_BRAND_SETTINGS,
   SET_MEDIA_MODEL,
   SYNC_HISTORY,
@@ -263,6 +273,17 @@ export {
   SET_MEDIA_MODEL
 } from './media-models';
 export type { MediaModelSlotId } from './media-models';
+export {
+  ADD_RADAR_SOURCE,
+  GET_RADAR,
+  RADAR_BASE_SOURCE_KINDS,
+  RADAR_PLATFORMS,
+  RADAR_PRO_SOURCE_KINDS,
+  RADAR_SOURCE_KINDS,
+  REMOVE_RADAR_SOURCE,
+  SET_RADAR_PLATFORM
+} from './radar';
+export type { RadarPlatform, RadarSourceKindName } from './radar';
 export { GEO_ACTION, REFRESH_KEYWORDS, SEO_ACTION } from './search';
 export { GET_BACKLINKS, GET_GSC, GET_RANKS } from './web-metrics';
 export {

--- a/packages/api-contracts/src/radar.test.ts
+++ b/packages/api-contracts/src/radar.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ADD_RADAR_SOURCE,
+  GET_RADAR,
+  RADAR_PRO_SOURCE_KINDS,
+  RADAR_SOURCE_KINDS,
+  REMOVE_RADAR_SOURCE,
+  SET_RADAR_PLATFORM
+} from './radar';
+import { BRAND_ENDPOINTS, statusForFailure } from './index';
+
+const ALL = [GET_RADAR, SET_RADAR_PLATFORM, ADD_RADAR_SOURCE, REMOVE_RADAR_SOURCE];
+
+describe('il Radar come contratto', () => {
+  it('sta tutto nel registry, o nessun agente lo vede', () => {
+    for (const endpoint of ALL) {
+      expect(BRAND_ENDPOINTS, endpoint.tool).toContain(endpoint);
+    }
+  });
+
+  it('accetta solo le piattaforme e i tipi di fonte che il Radar conosce', () => {
+    expect(SET_RADAR_PLATFORM.input.safeParse({ platform: 'reddit', enabled: true }).success).toBe(true);
+    expect(SET_RADAR_PLATFORM.input.safeParse({ platform: 'instagram', enabled: true }).success).toBe(false);
+    expect(ADD_RADAR_SOURCE.input.safeParse({ kind: 'rss', value: 'https://x.test/f' }).success).toBe(true);
+    expect(ADD_RADAR_SOURCE.input.safeParse({ kind: 'newsletter', value: 'x' }).success).toBe(false);
+  });
+
+  it('non accetta una fonte senza valore: sarebbe una riga che non guarda niente', () => {
+    expect(ADD_RADAR_SOURCE.input.safeParse({ kind: 'subreddit', value: '' }).success).toBe(false);
+  });
+
+  /**
+   * I tipi Pro stanno NELLO schema — un agente su un piano inferiore deve poterli nominare per
+   * sapere che esistono — ma il piano è un fatto del runtime, non della forma della richiesta:
+   * per questo il rifiuto è un fallimento dichiarato e non un enum più corto.
+   */
+  it('i tipi del piano Pro esistono nel vocabolario e il rifiuto è dichiarato', () => {
+    for (const k of RADAR_PRO_SOURCE_KINDS) {
+      expect(RADAR_SOURCE_KINDS, k).toContain(k);
+      expect(ADD_RADAR_SOURCE.input.safeParse({ kind: k, value: 'q' }).success, k).toBe(true);
+    }
+    expect(statusForFailure(ADD_RADAR_SOURCE, 'plan_required')).toBe(403);
+    expect(statusForFailure(SET_RADAR_PLATFORM, 'plan_required')).toBe(403);
+  });
+
+  it('il tetto delle fonti è un rifiuto dichiarato, non un 500 a sorpresa', () => {
+    expect(statusForFailure(ADD_RADAR_SOURCE, 'source_limit')).toBe(403);
+    expect(statusForFailure(ADD_RADAR_SOURCE, 'invalid_value')).toBe(400);
+  });
+
+  it('togliere una fonte è distruttivo e lo dichiara; aggiungerla no', () => {
+    expect(REMOVE_RADAR_SOURCE.destructive).toBe(true);
+    expect(ADD_RADAR_SOURCE.destructive).toBe(false);
+    expect(SET_RADAR_PLATFORM.destructive).toBe(false);
+  });
+
+  it('togliere una fonte che non c è è 404, non un successo che non ha tolto niente', () => {
+    expect(statusForFailure(REMOVE_RADAR_SOURCE, 'not_found')).toBe(404);
+  });
+
+  it('la coppia che aggiunge è la stessa che toglie', () => {
+    // Non c'è un id da ricordare: `(kind, value)` è già la chiave unica sul database, ed è
+    // l'unica cosa che un agente ha in mano subito dopo aver aggiunto una fonte.
+    expect(Object.keys(REMOVE_RADAR_SOURCE.input.shape).sort()).toEqual(['kind', 'value']);
+  });
+
+  it('la lettura dice cosa il piano permette, non solo cosa è già configurato', () => {
+    const parsed = GET_RADAR.output.safeParse({
+      brand: 'demo',
+      plan: 'starter',
+      platforms: [{ platform: 'threads', enabled: false, plan_locked: true }],
+      sources: [{ id: 's1', kind: 'subreddit', value: 'coffee', lang: 'auto', active: true }],
+      allowed_kinds: ['gnews_query', 'rss', 'subreddit', 'reddit_query'],
+      source_limit: 10,
+      sources_used: 1
+    });
+    expect(parsed.success).toBe(true);
+  });
+});

--- a/packages/api-contracts/src/radar.ts
+++ b/packages/api-contracts/src/radar.ts
@@ -1,0 +1,157 @@
+import { z } from 'zod';
+import type { BrandEndpoint } from './index';
+
+/**
+ * Le piattaforme che il Radar puo' battere e i tipi di fonte che un brand puo' aggiungere.
+ * Gli elenchi veri sono `RADAR_PLATFORM_KEYS`, `RADAR_BASE_KINDS` e `RADAR_PRO_LEAD_KINDS`
+ * (`$lib/plans`), che il contratto non puo' importare: un test dell'app tiene i tre allineati.
+ *
+ * I `PRO` sono separati dai `BASE` perche' la differenza non e' di gusto: sono le fonti che un
+ * piano inferiore non puo' avere, e un tool che le offre a tutti insegna un 403.
+ */
+export const RADAR_PLATFORMS = ['gnews', 'reddit', 'threads', 'x', 'linkedin'] as const;
+
+export const RADAR_BASE_SOURCE_KINDS = ['gnews_query', 'rss', 'subreddit', 'reddit_query'] as const;
+export const RADAR_PRO_SOURCE_KINDS = ['threads_query', 'x_community', 'linkedin_query'] as const;
+export const RADAR_SOURCE_KINDS = [
+  ...RADAR_BASE_SOURCE_KINDS,
+  ...RADAR_PRO_SOURCE_KINDS
+] as const;
+
+export type RadarPlatform = (typeof RADAR_PLATFORMS)[number];
+export type RadarSourceKindName = (typeof RADAR_SOURCE_KINDS)[number];
+
+const platform = z.enum(RADAR_PLATFORMS).describe('Which platform Radar may search');
+const kind = z.enum(RADAR_SOURCE_KINDS).describe('What sort of source this is');
+
+const value = z
+  .string()
+  .min(1)
+  .describe(
+    'The query, the feed URL, or the subreddit name. rss must be an http(s) URL; a subreddit is ' +
+      'stored without its "r/"'
+  );
+
+const PLAN_REQUIRED: { error: string; status: number } = { error: 'plan_required', status: 403 };
+
+export const GET_RADAR = {
+  tool: 'get_radar',
+  title: 'Radar sources',
+  description:
+    'Where Radar looks for this brand: which platforms are on, which sources are configured, ' +
+    'and — the part you cannot guess — which source kinds this plan is allowed to use and how ' +
+    'many sources are left. Threads, X and LinkedIn belong to the Pro plan: on a lower plan they ' +
+    'read as locked here and adding one comes back plan_required.',
+  method: 'GET',
+  pathUnderBrand: '/settings/radar',
+  input: z.object({}).strict(),
+  output: z.object({
+    brand: z.string(),
+    plan: z.string().nullable(),
+    platforms: z.array(
+      z.object({
+        platform: z.enum(RADAR_PLATFORMS),
+        enabled: z.boolean(),
+        plan_locked: z.boolean()
+      })
+    ),
+    sources: z.array(
+      z.object({
+        id: z.string(),
+        kind: z.enum(RADAR_SOURCE_KINDS),
+        value: z.string(),
+        lang: z.string().nullable(),
+        active: z.boolean()
+      })
+    ),
+    allowed_kinds: z.array(z.string()),
+    source_limit: z.number(),
+    sources_used: z.number()
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const SET_RADAR_PLATFORM = {
+  tool: 'set_radar_platform',
+  title: 'Turn a Radar platform on or off',
+  description:
+    'Switch one platform on or off for this brand’s Radar. Turning one off narrows what Radar ' +
+    'finds; it deletes no source and no result already found. Threads, X and LinkedIn need the ' +
+    'Pro plan and answer plan_required below it. Calls no model and spends no credits.',
+  method: 'PUT',
+  pathUnderBrand: '/settings/radar',
+  input: z.object({ platform, enabled: z.boolean() }).strict(),
+  output: z.object({
+    ok: z.literal(true),
+    platform: z.enum(RADAR_PLATFORMS),
+    enabled: z.boolean()
+  }),
+  failures: [PLAN_REQUIRED, { error: 'update_failed', status: 500 }],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const ADD_RADAR_SOURCE = {
+  tool: 'add_radar_source',
+  title: 'Add a Radar source',
+  description:
+    'Add one place for Radar to watch: a Google News query, an RSS feed, a subreddit, a Reddit / ' +
+    'Threads / X / LinkedIn search. A source already there is left as it is rather than ' +
+    'duplicated — the pair (kind, value) is its identity, and it is what remove_radar_source ' +
+    'takes. Read get_radar first: the plan decides which kinds are allowed (plan_required) and ' +
+    'how many sources fit (source_limit). Adding a source calls no model and spends no credits, ' +
+    'but Radar reads it on every run from then on.',
+  method: 'POST',
+  pathUnderBrand: '/settings/radar/sources',
+  input: z
+    .object({
+      kind,
+      value,
+      lang: z
+        .string()
+        .max(5)
+        .optional()
+        .describe('Language hint, e.g. "it" or "en". "auto" by default')
+    })
+    .strict(),
+  output: z.object({
+    ok: z.literal(true),
+    kind: z.enum(RADAR_SOURCE_KINDS),
+    value: z.string(),
+    lang: z.string(),
+    /** Falso quando la fonte c'era gia': niente e' cambiato, e non e' un errore. */
+    added: z.boolean(),
+    sources_used: z.number(),
+    source_limit: z.number()
+  }),
+  failures: [
+    PLAN_REQUIRED,
+    { error: 'source_limit', status: 403 },
+    { error: 'invalid_value', status: 400 },
+    { error: 'insert_failed', status: 500 }
+  ],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const REMOVE_RADAR_SOURCE = {
+  tool: 'remove_radar_source',
+  title: 'Remove a Radar source',
+  description:
+    'Delete one source, named by the same (kind, value) pair that added it. It does not come ' +
+    'back, and Radar stops reading it. What it already found stays. A pair that is not there ' +
+    'answers not_found rather than reporting a success that removed nothing.',
+  method: 'POST',
+  pathUnderBrand: '/settings/radar/sources/remove',
+  input: z.object({ kind, value }).strict(),
+  output: z.object({
+    ok: z.literal(true),
+    kind: z.enum(RADAR_SOURCE_KINDS),
+    value: z.string(),
+    sources_used: z.number()
+  }),
+  failures: [
+    { error: 'not_found', status: 404 },
+    { error: 'delete_failed', status: 500 }
+  ],
+  destructive: true
+} satisfies BrandEndpoint;

--- a/src/lib/content/changelog/2026-09-04-agent-radar-settings.ts
+++ b/src/lib/content/changelog/2026-09-04-agent-radar-settings.ts
@@ -1,0 +1,12 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-04',
+  title: 'Your AI can point Radar at new places',
+  items: [
+    'Claude, Cursor and any connected AI client can now see where Radar looks for your brand — which platforms are on and which news queries, feeds, subreddits and searches it watches — and add or remove them.',
+    'Your AI is told up front which sources your plan allows and how many you have left, so it stops proposing sources you cannot use.',
+    'Adding a source you already have no longer looks like a failure: nothing changes and it says so.',
+    'Removing a source now works whether you write a subreddit as “r/coffee” or “coffee” — before, only one of the two forms matched what was saved.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/plans.test.ts
+++ b/src/lib/plans.test.ts
@@ -15,6 +15,10 @@ import {
   CHAT_CONTEXT_CAP_TOKENS,
   leadEngagePlatforms,
   radarSourceLimit,
+  isRadarKindAllowed,
+  RADAR_BASE_KINDS,
+  RADAR_PRO_LEAD_KINDS,
+  RADAR_PLATFORM_KEYS,
   RADAR_SOURCE_LIMITS,
   visiblePlans,
   planByKey,
@@ -24,6 +28,11 @@ import {
   VIDEO_COST_USD_HD,
   VIDEO_COST_CREDITS
 } from './plans';
+import {
+  RADAR_BASE_SOURCE_KINDS,
+  RADAR_PLATFORMS,
+  RADAR_PRO_SOURCE_KINDS
+} from '@anomalia/api-contracts';
 
 describe('Go plan helpers', () => {
   it('recognises go as a plan key and a paid tier', () => {
@@ -206,6 +215,27 @@ describe('Go plan helpers', () => {
     }
     for (const p of PLANS) {
       expect(Object.keys(p).filter((k) => /^apiValue/.test(k))).toEqual([]);
+    }
+  });
+});
+
+describe('il vocabolario del Radar che un agente puo usare', () => {
+  it('e esattamente quello del prodotto: piattaforme e tipi di fonte', () => {
+    // Il contratto non puo' importare `$lib`, quindi i tre elenchi vivono anche li'. Uno che
+    // diverge sarebbe un tool che offre una fonte che il salvataggio rifiuta, o che ne nasconde
+    // una che esiste.
+    expect([...RADAR_PLATFORMS]).toEqual([...RADAR_PLATFORM_KEYS]);
+    expect([...RADAR_BASE_SOURCE_KINDS]).toEqual([...RADAR_BASE_KINDS]);
+    expect([...RADAR_PRO_SOURCE_KINDS]).toEqual([...RADAR_PRO_LEAD_KINDS]);
+  });
+
+  it('i tipi che il piano Pro sblocca sono gli stessi che il gate sblocca', () => {
+    for (const kind of RADAR_PRO_SOURCE_KINDS) {
+      expect(isRadarKindAllowed(kind, 'starter'), kind).toBe(false);
+      expect(isRadarKindAllowed(kind, 'pro'), kind).toBe(true);
+    }
+    for (const kind of RADAR_BASE_SOURCE_KINDS) {
+      expect(isRadarKindAllowed(kind, 'go'), kind).toBe(true);
     }
   });
 });

--- a/src/lib/server/radar.test.ts
+++ b/src/lib/server/radar.test.ts
@@ -6,7 +6,8 @@ import {
   sourceKindPlatform,
   radarBacklogExceeded,
   RADAR_PENDING_BACKLOG_CAP,
-  radarDigestHtml
+  radarDigestHtml,
+  radarSourceValue
 } from './radar';
 import { communityKeyOf, renderCommunityProfile, renderVocabularyDigest } from './community-profile';
 
@@ -245,3 +246,21 @@ describe('radarDigestHtml (la mail porta la merce: testo pronto + link diretto)'
   });
 });
 
+
+describe('radarSourceValue — la forma salvata è la forma cercata', () => {
+  it('conserva un subreddit senza il suo "r/"', () => {
+    expect(radarSourceValue('subreddit', 'r/coffee')).toBe('coffee');
+    expect(radarSourceValue('subreddit', 'R/Coffee/')).toBe('Coffee');
+  });
+
+  it('aggiungere e togliere convergono sullo stesso valore', () => {
+    // È il punto: senza questa funzione la rimozione di «r/coffee» non troverebbe «coffee», e
+    // risponderebbe «tolta» senza aver tolto niente.
+    expect(radarSourceValue('subreddit', 'r/coffee')).toBe(radarSourceValue('subreddit', 'coffee'));
+  });
+
+  it('non tocca gli altri tipi, dove "r/" non vuol dire niente', () => {
+    expect(radarSourceValue('rss', ' https://x.test/feed ')).toBe('https://x.test/feed');
+    expect(radarSourceValue('gnews_query', ' r/coffee shops ')).toBe('r/coffee shops');
+  });
+});

--- a/src/lib/server/radar.ts
+++ b/src/lib/server/radar.ts
@@ -109,6 +109,19 @@ export type RadarPrefs = {
   platforms?: Partial<Record<RadarPlatformKey, boolean>>;
 };
 
+/**
+ * La forma in cui una fonte viene SALVATA, che deve essere la stessa con cui viene cercata.
+ *
+ * Un subreddit si scrive «r/coffee» e si conserva «coffee»: normalizzarlo solo in aggiunta
+ * lascerebbe una rimozione per «r/coffee» senza corrispondenza, e la fonte resterebbe li' mentre
+ * la risposta dice che e' stata tolta. `(brand_id, kind, value)` e' la chiave unica: se le due
+ * strade non concordano sul valore, non concordano sulla riga.
+ */
+export function radarSourceValue(kind: string, value: unknown): string {
+  const v = String(value ?? '').trim();
+  return kind === 'subreddit' ? v.replace(/^r\//i, '').replace(/\/+$/, '') : v;
+}
+
 /** Map a brand_news_sources.kind onto its platform master toggle (rss has none — always custom). */
 export function sourceKindPlatform(kind: string): RadarPlatformKey | null {
   switch (kind) {

--- a/src/routes/api/v1/brands/[slug]/settings/radar/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/settings/radar/+server.ts
@@ -1,0 +1,89 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { authenticate, loadBrandForUser, checkApiKeyWriteAccess } from '$lib/server/cli-auth';
+import { SET_RADAR_PLATFORM, statusForFailure } from '@anomalia/api-contracts';
+import { radarPlatformEnabled, radarPrefsOf } from '$lib/server/radar';
+import {
+  RADAR_PLATFORM_KEYS,
+  hasProRadarLeads,
+  radarAllowedKinds,
+  radarSourceLimit
+} from '$lib/server/plans';
+
+// Dove il Radar guarda, per questo brand. La lettura porta ciò che il piano PERMETTE, non solo
+// ciò che è già configurato: Threads, X e LinkedIn appartengono al piano Pro, e un agente che non
+// lo sa scopre il confine con un 403 invece di leggerlo prima.
+
+const PRO_ONLY = ['threads', 'x', 'linkedin'];
+
+export const GET: RequestHandler = async ({ request, params }) => {
+  const { supabase, error, apiKey } = await authenticate(request);
+  if (error) return error;
+
+  const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
+  if (brandError) return brandError;
+
+  const { data: sources } = await supabase
+    .from('brand_news_sources')
+    .select('id, kind, value, lang, active')
+    .eq('brand_id', brand.id)
+    .order('created_at', { ascending: true });
+
+  const prefs = radarPrefsOf(brand.content_prefs as Record<string, unknown> | null);
+  const rows = sources ?? [];
+
+  return json({
+    brand: brand.slug,
+    plan: brand.plan,
+    platforms: RADAR_PLATFORM_KEYS.map((platform) => ({
+      platform,
+      enabled: radarPlatformEnabled(prefs, platform, brand.plan),
+      plan_locked: PRO_ONLY.includes(platform) && !hasProRadarLeads(brand.plan)
+    })),
+    sources: rows,
+    allowed_kinds: [...radarAllowedKinds(brand.plan)],
+    source_limit: radarSourceLimit(brand.plan),
+    sources_used: rows.length
+  });
+};
+
+export const PUT: RequestHandler = async ({ request, params }) => {
+  const { supabase, error, apiKey } = await authenticate(request);
+  if (error) return error;
+
+  const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
+  if (brandError) return brandError;
+  const writeDenied = checkApiKeyWriteAccess(apiKey);
+  if (writeDenied) return writeDenied;
+
+  const parsed = SET_RADAR_PLATFORM.input.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return json({ error: 'invalid_input', details: parsed.error.issues }, { status: 400 });
+  }
+
+  const { platform, enabled } = parsed.data;
+  if (PRO_ONLY.includes(platform) && !hasProRadarLeads(brand.plan)) {
+    return json(
+      { error: 'plan_required', platform, plan: brand.plan },
+      { status: statusForFailure(SET_RADAR_PLATFORM, 'plan_required') }
+    );
+  }
+
+  const prefs = ((brand.content_prefs ?? {}) as Record<string, unknown>);
+  const radar = { ...((prefs.radar as Record<string, unknown>) ?? {}) };
+  radar.platforms = { ...((radar.platforms as Record<string, boolean>) ?? {}), [platform]: enabled };
+
+  const { error: updateError } = await supabase
+    .from('brands')
+    .update({ content_prefs: { ...prefs, radar } })
+    .eq('id', brand.id);
+
+  if (updateError) {
+    return json(
+      { error: 'update_failed', detail: updateError.message },
+      { status: statusForFailure(SET_RADAR_PLATFORM, 'update_failed') }
+    );
+  }
+
+  return json({ ok: true, platform, enabled });
+};

--- a/src/routes/api/v1/brands/[slug]/settings/radar/server.test.ts
+++ b/src/routes/api/v1/brands/[slug]/settings/radar/server.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('$lib/server/cli-auth', () => ({
+  authenticate: vi.fn(),
+  loadBrandForUser: vi.fn(),
+  checkApiKeyWriteAccess: vi.fn(() => null)
+}));
+
+import { GET, PUT } from './+server';
+import { POST as ADD } from './sources/+server';
+import { POST as REMOVE } from './sources/remove/+server';
+import { authenticate, loadBrandForUser, checkApiKeyWriteAccess } from '$lib/server/cli-auth';
+
+type Row = Record<string, unknown>;
+
+function fakeSupabase(sources: Row[] = [], failures: { insert?: string; delete?: string; update?: string } = {}) {
+  const inserted: Row[] = [];
+  const deleted: string[] = [];
+  const updated: Row[] = [];
+  const client = {
+    from(table: string) {
+      if (table === 'brand_news_sources') {
+        const q: Record<string, unknown> = {};
+        Object.assign(q, {
+          select: () => q,
+          order: async () => ({ data: sources }),
+          eq: (col: string, val: string) => {
+            if (col === 'id') deleted.push(val);
+            return q;
+          },
+          insert: async (row: Row) => {
+            inserted.push(row);
+            return { error: failures.insert ? { message: failures.insert } : null };
+          },
+          delete: () => ({
+            eq: (_c: string, id: string) => ({
+              eq: async () => {
+                deleted.push(id);
+                return { error: failures.delete ? { message: failures.delete } : null };
+              }
+            })
+          }),
+          then: (resolve: (v: unknown) => unknown) => resolve({ data: sources })
+        });
+        return q;
+      }
+      const b: Record<string, unknown> = {};
+      Object.assign(b, {
+        update: (row: Row) => {
+          updated.push(row);
+          return b;
+        },
+        eq: async () => ({ error: failures.update ? { message: failures.update } : null })
+      });
+      return b;
+    }
+  };
+  return { client, inserted, deleted, updated };
+}
+
+let supabase: ReturnType<typeof fakeSupabase>;
+
+const BRAND = { id: 'brand-1', slug: 'demo', plan: 'pro', content_prefs: null as Row | null };
+const brandWith = (patch: Partial<typeof BRAND>) => ({ ...BRAND, ...patch });
+
+const base = 'https://example.test/api/v1/brands/demo/settings/radar';
+const call = (h: unknown, path: string, method: string, body?: unknown) =>
+  (h as (e: unknown) => Promise<Response>)({
+    request: new Request(`${base}${path}`, {
+      method,
+      ...(body === undefined ? {} : { body: JSON.stringify(body) })
+    }),
+    params: { slug: 'demo' }
+  });
+
+const read = () => call(GET, '', 'GET');
+const setPlatform = (b: unknown) => call(PUT, '', 'PUT', b);
+const add = (b: unknown) => call(ADD, '/sources', 'POST', b);
+const remove = (b: unknown) => call(REMOVE, '/sources/remove', 'POST', b);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  supabase = fakeSupabase();
+  vi.mocked(authenticate).mockResolvedValue({ supabase: supabase.client, apiKey: null, error: null } as never);
+  vi.mocked(loadBrandForUser).mockResolvedValue({ brand: BRAND, error: null } as never);
+  vi.mocked(checkApiKeyWriteAccess).mockReturnValue(null as never);
+});
+
+function withSources(rows: Row[], brand: Partial<typeof BRAND> = {}) {
+  supabase = fakeSupabase(rows);
+  vi.mocked(authenticate).mockResolvedValue({ supabase: supabase.client, apiKey: null, error: null } as never);
+  vi.mocked(loadBrandForUser).mockResolvedValue({ brand: brandWith(brand), error: null } as never);
+}
+
+describe('GET /settings/radar', () => {
+  it('dice cosa il piano permette, non solo cosa è configurato', async () => {
+    withSources([], { plan: 'starter' });
+
+    const body = await (await read()).json();
+
+    expect(body.allowed_kinds).toEqual(['gnews_query', 'rss', 'subreddit', 'reddit_query']);
+    const threads = body.platforms.find((p: Row) => p.platform === 'threads');
+    expect(threads).toMatchObject({ plan_locked: true, enabled: false });
+  });
+
+  it('su Pro le piattaforme dei lead non sono bloccate', async () => {
+    const body = await (await read()).json();
+
+    expect(body.platforms.find((p: Row) => p.platform === 'threads').plan_locked).toBe(false);
+  });
+
+  it('conta le fonti usate contro il tetto del piano', async () => {
+    withSources([{ id: 's1', kind: 'subreddit', value: 'coffee', lang: 'auto', active: true }]);
+
+    const body = await (await read()).json();
+
+    expect(body.sources_used).toBe(1);
+    expect(body.source_limit).toBeGreaterThan(0);
+  });
+});
+
+describe('PUT /settings/radar', () => {
+  it('accende una piattaforma senza toccare le altre preferenze', async () => {
+    withSources([], { content_prefs: { language: 'it', radar: { platforms: { gnews: false } } } });
+
+    const res = await setPlatform({ platform: 'reddit', enabled: true });
+
+    expect(res.status).toBe(200);
+    expect(supabase.updated[0]).toEqual({
+      content_prefs: { language: 'it', radar: { platforms: { gnews: false, reddit: true } } }
+    });
+  });
+
+  it('su un piano inferiore le piattaforme dei lead sono un rifiuto dichiarato', async () => {
+    withSources([], { plan: 'starter' });
+
+    const res = await setPlatform({ platform: 'linkedin', enabled: true });
+
+    expect(res.status).toBe(403);
+    expect((await res.json()).error).toBe('plan_required');
+    expect(supabase.updated).toEqual([]);
+  });
+
+  it('rifiuta una piattaforma che il Radar non batte', async () => {
+    const res = await setPlatform({ platform: 'instagram', enabled: true });
+
+    expect(res.status).toBe(400);
+    expect(supabase.updated).toEqual([]);
+  });
+});
+
+describe('POST /settings/radar/sources', () => {
+  it('salva un subreddit senza il suo "r/"', async () => {
+    const res = await add({ kind: 'subreddit', value: 'r/coffee' });
+
+    expect(res.status).toBe(200);
+    expect(supabase.inserted[0]).toMatchObject({ kind: 'subreddit', value: 'coffee', lang: 'auto' });
+  });
+
+  it('una fonte che c è già non è un errore e non viene duplicata', async () => {
+    withSources([{ id: 's1', kind: 'subreddit', value: 'coffee' }]);
+
+    const body = await (await add({ kind: 'subreddit', value: 'r/coffee' })).json();
+
+    expect(body.added).toBe(false);
+    expect(supabase.inserted).toEqual([]);
+  });
+
+  it('un feed RSS che non è una URL è colpa di chi chiama', async () => {
+    const res = await add({ kind: 'rss', value: 'il mio blog' });
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('invalid_value');
+    expect(supabase.inserted).toEqual([]);
+  });
+
+  it('un tipo che il piano non ha è 403 con il piano nella risposta', async () => {
+    withSources([], { plan: 'starter' });
+
+    const res = await add({ kind: 'x_community', value: 'coffee' });
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toMatchObject({ error: 'plan_required', kind: 'x_community', plan: 'starter' });
+    expect(supabase.inserted).toEqual([]);
+  });
+
+  it('oltre il tetto del piano si ferma, e dice quanto è il tetto', async () => {
+    const many = Array.from({ length: 50 }, (_, i) => ({ id: `s${i}`, kind: 'rss', value: `https://x.test/${i}` }));
+    withSources(many, { plan: 'go' });
+
+    const res = await add({ kind: 'rss', value: 'https://new.test/f' });
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe('source_limit');
+    expect(body.limit).toBeGreaterThan(0);
+    expect(supabase.inserted).toEqual([]);
+  });
+
+  it('si ferma prima di scrivere se la chiave è di sola lettura', async () => {
+    vi.mocked(checkApiKeyWriteAccess).mockReturnValue(new Response('read only', { status: 403 }) as never);
+
+    const res = await add({ kind: 'rss', value: 'https://x.test/f' });
+
+    expect(res.status).toBe(403);
+    expect(supabase.inserted).toEqual([]);
+  });
+});
+
+describe('POST /settings/radar/sources/remove', () => {
+  it('toglie la fonte nominata dalla stessa coppia che l ha aggiunta', async () => {
+    withSources([{ id: 's1', kind: 'subreddit', value: 'coffee' }]);
+
+    const res = await remove({ kind: 'subreddit', value: 'r/coffee' });
+
+    expect(res.status).toBe(200);
+    expect(supabase.deleted).toContain('s1');
+  });
+
+  it('una coppia che non c è è 404, non un successo che non ha tolto niente', async () => {
+    withSources([{ id: 's1', kind: 'subreddit', value: 'coffee' }]);
+
+    const res = await remove({ kind: 'subreddit', value: 'tea' });
+
+    expect(res.status).toBe(404);
+    expect((await res.json()).error).toBe('not_found');
+    expect(supabase.deleted).toEqual([]);
+  });
+
+  it('non tocca la fonte di un altro tipo con lo stesso valore', async () => {
+    withSources([
+      { id: 's1', kind: 'subreddit', value: 'coffee' },
+      { id: 's2', kind: 'gnews_query', value: 'coffee' }
+    ]);
+
+    await remove({ kind: 'gnews_query', value: 'coffee' });
+
+    expect(supabase.deleted).toEqual(['s2']);
+  });
+
+  it('si ferma prima di cancellare se la chiave è di sola lettura', async () => {
+    vi.mocked(checkApiKeyWriteAccess).mockReturnValue(new Response('read only', { status: 403 }) as never);
+
+    const res = await remove({ kind: 'subreddit', value: 'coffee' });
+
+    expect(res.status).toBe(403);
+    expect(supabase.deleted).toEqual([]);
+  });
+});

--- a/src/routes/api/v1/brands/[slug]/settings/radar/sources/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/settings/radar/sources/+server.ts
@@ -1,0 +1,74 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { authenticate, loadBrandForUser, checkApiKeyWriteAccess } from '$lib/server/cli-auth';
+import { ADD_RADAR_SOURCE, statusForFailure } from '@anomalia/api-contracts';
+import { radarSourceValue } from '$lib/server/radar';
+import { isRadarKindAllowed, radarSourceLimit } from '$lib/server/plans';
+
+// POST /api/v1/brands/:slug/settings/radar/sources — una fonte in più da guardare.
+//
+// Tre cancelli, e nessuno è opzionale: il tipo deve essere permesso dal piano, il valore deve
+// avere la forma che quel tipo richiede, e il brand deve avere ancora posto. Una fonte che c'è
+// già non è un errore: l'upsert la lascia com'è, e `added: false` lo dice.
+
+export const POST: RequestHandler = async ({ request, params }) => {
+  const { supabase, error, apiKey } = await authenticate(request);
+  if (error) return error;
+
+  const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
+  if (brandError) return brandError;
+  const writeDenied = checkApiKeyWriteAccess(apiKey);
+  if (writeDenied) return writeDenied;
+
+  const parsed = ADD_RADAR_SOURCE.input.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return json({ error: 'invalid_input', details: parsed.error.issues }, { status: 400 });
+  }
+
+  const { kind } = parsed.data;
+  const value = radarSourceValue(kind, parsed.data.value);
+  const lang = (parsed.data.lang ?? 'auto').slice(0, 5) || 'auto';
+  const fail = (name: string, extra: Record<string, unknown> = {}) =>
+    json({ error: name, ...extra }, { status: statusForFailure(ADD_RADAR_SOURCE, name) });
+
+  if (!isRadarKindAllowed(kind, brand.plan)) {
+    return fail('plan_required', { kind, plan: brand.plan });
+  }
+  if (!value) {
+    return fail('invalid_value', { kind, reason: 'empty after normalisation' });
+  }
+  if (kind === 'rss' && !/^https?:\/\//i.test(value)) {
+    return fail('invalid_value', { kind, reason: 'rss must be an http(s) URL' });
+  }
+
+  const limit = radarSourceLimit(brand.plan);
+  const { data: existing } = await supabase
+    .from('brand_news_sources')
+    .select('id, kind, value')
+    .eq('brand_id', brand.id);
+
+  const rows = existing ?? [];
+  const already = rows.some((r) => r.kind === kind && r.value === value);
+  if (!already && rows.length >= limit) {
+    return fail('source_limit', { limit, sources_used: rows.length, plan: brand.plan });
+  }
+
+  if (!already) {
+    const { error: insertError } = await supabase
+      .from('brand_news_sources')
+      .insert({ brand_id: brand.id, kind, value, lang });
+    if (insertError) {
+      return fail('insert_failed', { detail: insertError.message });
+    }
+  }
+
+  return json({
+    ok: true,
+    kind,
+    value,
+    lang,
+    added: !already,
+    sources_used: rows.length + (already ? 0 : 1),
+    source_limit: limit
+  });
+};

--- a/src/routes/api/v1/brands/[slug]/settings/radar/sources/remove/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/settings/radar/sources/remove/+server.ts
@@ -1,0 +1,61 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { authenticate, loadBrandForUser, checkApiKeyWriteAccess } from '$lib/server/cli-auth';
+import { REMOVE_RADAR_SOURCE, statusForFailure } from '@anomalia/api-contracts';
+import { radarSourceValue } from '$lib/server/radar';
+
+// POST /api/v1/brands/:slug/settings/radar/sources/remove — una fonte in meno.
+//
+// È un POST e non un DELETE perché la fonte si nomina con la coppia `(kind, value)` — la stessa
+// chiave unica che l'ha creata, e l'unica cosa che un agente ha in mano subito dopo averla
+// aggiunta — e il client del registry non manda un corpo su DELETE.
+//
+// Il valore passa dallo STESSO normalizzatore dell'aggiunta: `r/coffee` e `coffee` sono la stessa
+// fonte, e senza quel passaggio la rimozione risponderebbe "tolta" senza aver tolto niente.
+
+export const POST: RequestHandler = async ({ request, params }) => {
+  const { supabase, error, apiKey } = await authenticate(request);
+  if (error) return error;
+
+  const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
+  if (brandError) return brandError;
+  const writeDenied = checkApiKeyWriteAccess(apiKey);
+  if (writeDenied) return writeDenied;
+
+  const parsed = REMOVE_RADAR_SOURCE.input.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return json({ error: 'invalid_input', details: parsed.error.issues }, { status: 400 });
+  }
+
+  const { kind } = parsed.data;
+  const value = radarSourceValue(kind, parsed.data.value);
+
+  const { data: rows } = await supabase
+    .from('brand_news_sources')
+    .select('id, kind, value')
+    .eq('brand_id', brand.id);
+
+  const all = rows ?? [];
+  const match = all.find((r) => r.kind === kind && r.value === value);
+  if (!match) {
+    return json(
+      { error: 'not_found', kind, value },
+      { status: statusForFailure(REMOVE_RADAR_SOURCE, 'not_found') }
+    );
+  }
+
+  const { error: deleteError } = await supabase
+    .from('brand_news_sources')
+    .delete()
+    .eq('id', match.id)
+    .eq('brand_id', brand.id);
+
+  if (deleteError) {
+    return json(
+      { error: 'delete_failed', detail: deleteError.message },
+      { status: statusForFailure(REMOVE_RADAR_SOURCE, 'delete_failed') }
+    );
+  }
+
+  return json({ ok: true, kind, value, sources_used: all.length - 1 });
+};

--- a/src/routes/app/[brand]/settings/radar/+page.server.ts
+++ b/src/routes/app/[brand]/settings/radar/+page.server.ts
@@ -3,9 +3,18 @@ import type { PageServerLoad, Actions } from './$types';
 import {
   radarPrefsOf,
   radarPlatformEnabled,
+  radarSourceValue,
   type RadarPlatformKey
 } from '$lib/server/radar';
-import { RADAR_PLATFORM_KEYS } from '$lib/plans';
+import {
+  RADAR_BASE_KINDS,
+  RADAR_PLATFORM_KEYS,
+  RADAR_PRO_LEAD_KINDS,
+  type RadarSourceKind
+} from '$lib/plans';
+
+/** Un elenco solo dei tipi validi: quello ricopiato qui dentro era la quarta copia. */
+const RADAR_ALL_KINDS: readonly RadarSourceKind[] = [...RADAR_BASE_KINDS, ...RADAR_PRO_LEAD_KINDS];
 import { radarSourceLimit, isRadarKindAllowed, hasProRadarLeads } from '$lib/server/plans';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -72,12 +81,7 @@ export const actions: Actions = {
     const kind = String(fd.get('kind') ?? '');
     const value = String(fd.get('value') ?? '').trim();
     const lang = String(fd.get('lang') ?? 'auto').slice(0, 5) || 'auto';
-    if (
-      !['gnews_query', 'rss', 'subreddit', 'threads_query', 'x_community', 'reddit_query', 'linkedin_query'].includes(
-        kind
-      ) ||
-      !value
-    ) {
+    if (!RADAR_ALL_KINDS.includes(kind as RadarSourceKind) || !value) {
       return fail(400, { error: 'Invalid source' });
     }
     if (!isRadarKindAllowed(kind, brand.plan)) {
@@ -94,7 +98,7 @@ export const actions: Actions = {
       {
         brand_id: brand.id,
         kind,
-        value: kind === 'subreddit' ? value.replace(/^r\//, '').replace(/\/+$/, '') : value,
+        value: radarSourceValue(kind, value),
         lang
       },
       { onConflict: 'brand_id,kind,value', ignoreDuplicates: true }


### PR DESCRIPTION
## What?

Four registry-generated tools put Radar's configuration in front of an external agent: `get_radar` (GET `/settings/radar`), `set_radar_platform` (PUT, same path), `add_radar_source` (POST `/settings/radar/sources`) and `remove_radar_source` (POST `/settings/radar/sources/remove`).

State lives where it already lives — `brands.content_prefs.radar.platforms` for the toggles, `brand_news_sources` for the sources. **No migration.**

`tools/list` goes from **101 to 105**. Object-by-object comparison of every existing tool: `new: [add_radar_source, get_radar, remove_radar_source, set_radar_platform]`, `gone: []`, `changed: []`.

The PR also closes a defect the new shape exposed: the `r/` stripping for subreddits lived only on the add path.

## Why?

Radar decides what the brand ever hears about. Pointing it at a new subreddit, feed or search is the kind of thing a person says out loud — "watch r/espresso too" — and until now it meant opening a page.

## How?

### The read is not a courtesy — it carries what decides whether a write succeeds

Two facts an agent cannot guess:

- **the plan.** `threads`, `x`, `linkedin` (platforms) and `threads_query`, `x_community`, `linkedin_query` (source kinds) are Pro-only (`hasProRadarLeads`). Below it, `get_radar` marks them `plan_locked` and both writes answer `plan_required` (403).
- **the ceiling.** `radarSourceLimit(plan)` caps how many sources a brand may have. The read carries `source_limit` against `sources_used`; past it, adding answers `source_limit` (403) and names the ceiling.

A shorter enum for the Pro kinds would have been the wrong fix: the plan is a **runtime** fact, not a shape of the request, and removing those names from the schema would mean a Starter brand's agent cannot even learn they exist. They stay in the vocabulary; the refusal is a declared failure.

### No id — the pair that adds is the pair that removes

`(brand_id, kind, value)` is already the unique key on the table. So `remove_radar_source` takes `(kind, value)`, which is the only thing an agent holds right after adding a source: no id to remember, no round trip to discover one.

It is a `POST` to `/sources/remove` rather than a `DELETE` because the registry's generated client sends no body on `DELETE`, and inventing an `:id` resource would have meant a row in `BRAND_RESOURCES`, a prefix resolver and a new client method — machinery for an identifier the domain does not use.

### The defect that choice exposed

A subreddit is written `r/coffee` and **stored** `coffee`. The form action stripped it inline, on the add path only. With removal by pair, one-sided normalisation is a precise silent failure: `remove('r/coffee')` does not match `coffee`, and the answer says removed while nothing was.

`radarSourceValue(kind, value)` now lives in `$lib/server/radar.ts` and all three writers call it — add, remove, and the browser form. A test says exactly that: both paths converge on the same value.

The same page also kept a hand-copied list of valid kinds — the **fourth** copy, after `RADAR_BASE_KINDS`, `RADAR_PRO_LEAD_KINDS` and the `RadarSourceKind` type. Replaced by the union of the two that already existed.

### A source that is already there is not an error

`added: false`, nothing changes, 200. Deliberately not a 409: an agent retrying after a timeout should not see a failure for something that is in the right state.

### `destructive` per case, not per family

`remove_radar_source` is the only one of the four with `destructive: true` — it deletes a row that does not come back. Adding a source, and switching a platform on or off, destroy nothing: switching off narrows what Radar finds and touches neither the sources nor what was already found.

## Testing?

Red before green, with real output.

- **contract** — red before it was in the registry.
- **the vocabulary guard** — proven by adding `mastodon` to the contract's platforms: red. Reverted.
- **the routes** — proven by removing the normalisation, the plan gate, the RSS URL check, the ceiling and the removal's 404: **exactly 9 of 16 fail**, 7 stay green. Restored, 16/16.

| command | result |
|---|---|
| `npx vitest run packages/api-contracts` | 149 tests, pass |
| `cd cli && bun test` | 57 tests, 0 fail |
| `cd cli && bun run typecheck` | clean |
| `node scripts/typecheck-runtime.mjs` | ok |
| affected app tests (plans, radar, all settings routes, changelog, no-app-imports) | 203 tests, pass |

`node_modules/@anomalia/api-contracts` in this worktree resolves to **this worktree's** `packages/api-contracts` (verified with `realpathSync`), so the contract tests and the `tools/list` capture ran against this branch, not a stale copy.

**Not tested:** no browser, Docker, dev server or Playwright — forbidden for this task. The full `npm run test:unit` was not run; CI runs it.

**Risk:** the plan gate is re-applied on the write and not trusted from the read, so a stale read cannot be used to get past it. `add_radar_source` reads the brand's existing sources to count them and to detect a duplicate; that is one query and the row count is bounded by `source_limit`.

## Evidence

<details>
<summary>tools/list through handleMcpFetch, origin/dev vs this branch</summary>

```
new:     ['add_radar_source', 'get_radar', 'remove_radar_source', 'set_radar_platform']
gone:    []
changed: []
count:   101 → 105

remove_radar_source annotations: {'readOnlyHint': False, 'destructiveHint': True}
```

</details>

<details>
<summary>Red, then green: the routes with their logic removed</summary>

```
× GET  … > dice cosa il piano permette, non solo cosa è configurato
× PUT  … > su un piano inferiore le piattaforme dei lead sono un rifiuto dichiarato
× POST … > salva un subreddit senza il suo "r/"
× POST … > una fonte che c è già non è un errore e non viene duplicata
× POST … > un feed RSS che non è una URL è colpa di chi chiama
× POST … > un tipo che il piano non ha è 403 con il piano nella risposta
× POST … > oltre il tetto del piano si ferma, e dice quanto è il tetto
× POST … /remove > toglie la fonte nominata dalla stessa coppia che l ha aggiunta
× POST … /remove > una coppia che non c è è 404, non un successo che non ha tolto niente
   Tests  9 failed | 7 passed (16)
```

</details>

<details>
<summary>What the writes answer</summary>

```
POST /sources { kind: 'subreddit', value: 'r/coffee' }
→ stored as value: 'coffee', added: true

POST /sources { kind: 'subreddit', value: 'r/coffee' }   (again)
→ 200, added: false, nothing inserted

POST /sources { kind: 'rss', value: 'il mio blog' }      → 400 invalid_value
POST /sources { kind: 'x_community', value: 'coffee' }   → 403 plan_required (plan: starter)
POST /sources over the ceiling                            → 403 source_limit (limit named)
POST /sources/remove { kind: 'subreddit', value: 'tea' }  → 404 not_found
```

</details>

No UI change beyond the settings page now calling the shared normaliser and kind list; no component touched.

## Anything Else?

**The `r/` stripping exists in six other places** (`manual-posting.ts`, `platform-hygiene.ts` ×2, `produce-agent.ts` ×2, `radar.ts`'s own seeding). I deliberately did **not** unify them: they are different key paths — a subreddit to post into, a handle to clean — and the only ones that must agree are the writers of `brand_news_sources`, which now do. Worth a look on its own, not smuggled into this PR.

**Deliberately left out:** toggling a source's `active` flag. The column exists and the browser uses it to pause a source without deleting it; an agent can remove and re-add, and adding a fifth tool for a pause button is not worth the surface until someone asks.

**Still flagged from the census**, unchanged: `brands.chat_default_tier` has a column and a setter and no caller; `settings/referrals` calls `ensureReferralCode` during `load`, a page load that INSERTs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
