### PR TITLE
Prove every declared endpoint has its route

### DIFF
--- a/changelog/2026-09-04-contratti-senza-rotta.md
+++ b/changelog/2026-09-04-contratti-senza-rotta.md
@@ -1,0 +1,98 @@
+# Un contratto senza rotta era un tool che rispondeva 404
+
+## Cosa non veniva verificato
+
+`packages/api-contracts/src/index.ts` dichiara `BRAND_ENDPOINTS`. Da quella lista si
+generano **da soli** il metodo del client CLI e il tool MCP: aggiungere una entry
+basta perche' il tool compaia in `tools/list` e venga offerto a ogni agente esterno.
+
+Niente verificava che dietro a quella entry ci fosse davvero una rotta.
+
+Un contratto scritto senza il suo `+server.ts` — o con un `pathUnderBrand` che non
+combacia col percorso del file — produceva un tool perfettamente formato: nome,
+titolo, descrizione, schema di input. L'agente lo vedeva, lo sceglieva, lo chiamava,
+e prendeva **404**. Nessuno dei guardiani lo intercettava: il typecheck non guarda il
+filesystem, i test dei contratti (142, tutti verdi) verificano forma e coerenza degli
+schema, la CI esegue entrambi e si dichiara contenta.
+
+Lo stesso valeva per il verbo. Un contratto `POST` su una rotta che esporta solo `GET`
+e' la stessa 404, con una diagnosi peggiore: la rotta *esiste*, quindi il sospetto
+cade sull'autenticazione o sul brand, non sul registry.
+
+Il rischio cresce con la lista, e cresce in fretta: fra la scrittura di questo test e il
+rebase prima della PR, `BRAND_ENDPOINTS` e' passato da 69 a 75 entry — sei aggiunte da
+altri agenti in poche ore. E' esattamente il regime in cui una entry senza rotta passa
+inosservata fino a quando non la chiama un cliente.
+
+## Il guardiano
+
+`src/routes/api/v1/brands/[slug]/registry.test.ts`, due asserzioni:
+
+1. ogni entry di `BRAND_ENDPOINTS` ha il suo `+server.ts` su disco;
+2. quel file esporta il verbo che il contratto dichiara.
+
+Il percorso su disco non e' ricostruito a mano: e' **l'inverso esatto di `pathFor`**.
+Si passa alla funzione il nome della cartella dinamica al posto del valore, e l'URL
+che torna e' gia' il percorso.
+
+```
+pathFor(GET_POST, '[slug]', '[id]')  ->  /api/v1/brands/%5Bslug%5D/posts/%5Bid%5D
+decodificato                         ->  /api/v1/brands/[slug]/posts/[id]
++ '/+server.ts'                      ->  src/routes/api/v1/brands/[slug]/posts/[id]/+server.ts
+```
+
+Cosi' `RESOURCE_SEGMENT` non compare mai nel test: se domani `:id` diventa altro, il
+test segue da solo invece di diventare rosso per il motivo sbagliato.
+
+Il rosso e' stato visto davvero, con tre contratti finti aggiunti e poi tolti:
+
+```
+"ghost_report -> src/routes/api/v1/brands/[slug]/ghost/report/+server.ts non esiste"
+"ghost_slide -> src/routes/api/v1/brands/[slug]/posts/[id]/slides/+server.ts non esiste"
+"doctor_write -> src/routes/api/v1/brands/[slug]/doctor/+server.ts non esporta POST"
+```
+
+Il messaggio dice **quale** tool e **quale** percorso, che e' l'unica forma utile:
+chi legge la CI non ha il registry davanti.
+
+Su `dev` allo stato attuale passa pulito: nessun endpoint dichiarato oggi e' scoperto.
+
+## Undici test della CLI che non eseguiva nessuno
+
+Stesso difetto della PR #283, altra cartella. `cli/lib/*.test.ts`, `cli/mcp/*.test.ts`
+e `cli/plugins/anomalia/plugin-skill.test.ts` — 11 file, 57 test — erano fuori
+dall'`include` di vitest. Giravano solo lanciando `bun test` dentro `cli/` a mano.
+Fra questi c'e' `cli/lib/contracts.test.ts`, che sorveglia il **mirror** dei contratti
+dentro la CLI: il guardiano del disallineamento era a sua volta non sorvegliato.
+
+Sono scritti per `bun:test`, non per vitest. Riscriverli non serve: le due API
+coincidono su `describe` / `test` / `it` / `expect`, quindi basta un alias
+`'bun:test' -> 'vitest'` nella config di test. Nove file su undici sono passati
+subito; gli altri due usavano `import.meta.dir`, che esiste solo in Bun, ed e'
+diventato `fileURLToPath(new URL(..., import.meta.url))` — che vale in tutti e due.
+`bun test` dentro `cli/` continua a passare identico: 57 test, 0 fail.
+
+## Il limite che resta, ed e' dichiarato
+
+Le dipendenze della CLI **non** sono dichiarate nella `package.json` di root. Sotto
+vitest i test risolvono da li', e il quadro e' questo:
+
+| pacchetto | root | `cli/package.json` |
+|---|---|---|
+| `ora` | assente | `^8.1.1` |
+| `cli-table3` | assente | `^0.6.5` |
+| `commander` | 4.1.1 (transitiva di `seek-bzip`) | `^12.1.0` |
+| `chalk` | 4.1.2 (dev, CJS) | `^5.3.0` |
+
+Oggi non fa danno perche' nessuno degli 11 test arriva a toccarli: `ora` sta nei
+`cli/commands/*`, `chalk` e `cli-table3` in `cli/lib/display.ts`, `commander` in
+`cli.ts`, e nessuno di quei moduli entra nel grafo dei test. Ma e' un equilibrio
+che dipende da **quali file si importano**, non da una garanzia: il primo test che
+tocchera' `display.ts` fallira' in CI con un pacchetto mancante, e sembrera' un bug
+del test invece che un buco nelle dipendenze.
+
+L'alternativa pulita e' un passo di CI dedicato — `bun install && bun test` dentro
+`cli/`, col runtime per cui quei test sono scritti e con le versioni giuste. E' una
+modifica a `.github/workflows/ci.yml` e richiede anche un lockfile committato per
+`cli/`, che oggi non c'e'. Resta proposta, non fatta: eseguirli con le versioni
+sbagliate e' comunque meglio che non eseguirli, ma non e' il traguardo.

--- a/cli/lib/contracts.test.ts
+++ b/cli/lib/contracts.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, test } from 'bun:test';
 import { existsSync, readdirSync, readFileSync } from 'fs';
 import { join } from 'path';
+import { fileURLToPath } from 'url';
 import { z } from 'zod';
 import { pathFor, type ResourceEndpoint } from './contracts/index.ts';
 
-const ROOT = join(import.meta.dir, '..');
+const ROOT = fileURLToPath(new URL('../', import.meta.url));
 const CANONICAL = join(ROOT, '..', 'packages', 'api-contracts', 'src');
 const MIRROR = join(ROOT, 'lib', 'contracts');
 

--- a/cli/plugins/anomalia/plugin-skill.test.ts
+++ b/cli/plugins/anomalia/plugin-skill.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, test } from 'bun:test';
 import { existsSync, readdirSync, readFileSync, statSync } from 'fs';
 import { join } from 'path';
+import { fileURLToPath } from 'url';
 
-const ROOT = join(import.meta.dir, '..', '..');
+const ROOT = fileURLToPath(new URL('../../', import.meta.url));
 const CANONICAL = join(ROOT, 'skills', 'anomalia');
 const PLUGIN = join(ROOT, 'plugins', 'anomalia', 'skills', 'anomalia');
 

--- a/src/routes/api/v1/brands/[slug]/registry.test.ts
+++ b/src/routes/api/v1/brands/[slug]/registry.test.ts
@@ -1,0 +1,63 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { BRAND_ENDPOINTS, pathFor, type BrandEndpoint } from '@anomalia/api-contracts';
+
+/**
+ * IL REGISTRY PROMETTE, LE ROTTE MANTENGONO. Ogni entry di BRAND_ENDPOINTS diventa da sola un
+ * metodo del client CLI e un tool MCP: un contratto senza il suo `+server.ts`, o con un
+ * `pathUnderBrand` che non combacia col percorso su disco, produce un tool ben formato che
+ * compare in `tools/list`, viene offerto a ogni agente esterno e risponde 404.
+ *
+ * Il percorso su disco è l'inverso esatto di `pathFor`: gli si passa il nome della cartella
+ * dinamica al posto del valore, e l'URL che torna È il percorso.
+ *
+ *   pathFor(GET_POST, '[slug]', '[id]')  ->  /api/v1/brands/%5Bslug%5D/posts/%5Bid%5D
+ *   decodificato                         ->  /api/v1/brands/[slug]/posts/[id]
+ *   + '/+server.ts'                      ->  src/routes/api/v1/brands/[slug]/posts/[id]/+server.ts
+ *
+ * Così RESOURCE_SEGMENT non è mai scritto qui: se domani `:id` diventa altro, il test lo segue.
+ */
+
+const SLUG_DIR = '[slug]';
+const ID_DIR = '[id]';
+const REPO_ROOT = fileURLToPath(new URL('../../../../../../', import.meta.url));
+
+function routeFile(endpoint: BrandEndpoint): string {
+  const url =
+    endpoint.resource === undefined
+      ? pathFor(endpoint, SLUG_DIR)
+      : pathFor(endpoint, SLUG_DIR, ID_DIR);
+
+  return `src/routes${url.split('/').map(decodeURIComponent).join('/')}/+server.ts`;
+}
+
+function exportsVerb(source: string, verb: string): boolean {
+  const declared = new RegExp(`^export\\s+(const|let|var|(async\\s+)?function)\\s+${verb}\\b`, 'm');
+  const listed = new RegExp(`^export\\s*\\{[^}]*\\b${verb}\\b`, 'm');
+
+  return declared.test(source) || listed.test(source);
+}
+
+describe('BRAND_ENDPOINTS', () => {
+  it('ogni contratto ha la sua rotta su disco', () => {
+    const missing = BRAND_ENDPOINTS
+      .filter((e) => !existsSync(join(REPO_ROOT, routeFile(e))))
+      .map((e) => `${e.tool} -> ${routeFile(e)} non esiste`);
+
+    expect(missing).toEqual([]);
+  });
+
+  it('ogni rotta esporta il verbo che il contratto dichiara', () => {
+    const wrongVerb = BRAND_ENDPOINTS
+      .filter((e) => {
+        const file = join(REPO_ROOT, routeFile(e));
+
+        return existsSync(file) && !exportsVerb(readFileSync(file, 'utf8'), e.method);
+      })
+      .map((e) => `${e.tool} -> ${routeFile(e)} non esporta ${e.method}`);
+
+    expect(wrongVerb).toEqual([]);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -85,8 +85,13 @@ export default defineConfig({
       'packages/*/src/**/*.{test,spec}.{js,ts}',
       'packages/*.{test,spec}.{js,ts}',
       'scripts/**/*.{test,spec}.{js,ts}',
-      'docker/**/*.{test,spec}.{js,mjs,ts}'
+      'docker/**/*.{test,spec}.{js,mjs,ts}',
+      // I test della CLI sono scritti per `bun:test` e giravano solo se qualcuno lanciava
+      // `bun test` dentro `cli/` a mano: nessun runner li vedeva, CI compresa. L'alias li fa
+      // girare qui senza riscriverli — le due API coincidono su describe/test/it/expect.
+      'cli/**/*.{test,spec}.{js,ts}'
     ],
+    alias: { 'bun:test': 'vitest' },
     hookTimeout: 30_000
   }
 });


### PR DESCRIPTION
## What?

Two guardians that did not exist.

**1. Every entry of `BRAND_ENDPOINTS` must have a route.** A new test,
`src/routes/api/v1/brands/[slug]/registry.test.ts`, asserts for each of the 75
declared endpoints that the corresponding `+server.ts` exists on disk and that it
exports the verb the contract declares.

**2. The CLI's 11 test files now run.** `cli/lib/*.test.ts`, `cli/mcp/*.test.ts` and
`cli/plugins/anomalia/plugin-skill.test.ts` — 57 tests — were outside vitest's
`include` and executed only if someone typed `bun test` inside `cli/` by hand. They
now run in the repo suite, and still pass under `bun test` unchanged.

No endpoint currently declared on `dev` is uncovered: the test is green on the
current state.

## Why?

`packages/api-contracts/src/index.ts` is a registry from which the CLI client method
and the MCP tool are generated **by themselves**. Adding an entry is enough for the
tool to appear in `tools/list` and be offered to every external agent.

Nothing verified there was a route behind that entry. A contract written without its
`+server.ts` — or with a `pathUnderBrand` that does not match the file path —
produced a perfectly formed tool: name, title, description, input schema. The agent
saw it, chose it, called it, and got **404**. None of the guardians caught it: the
typecheck does not look at the filesystem, the contract tests (142, all green) verify
the shape and coherence of the schemas, and CI runs both and declares itself happy.

The same held for the verb. A `POST` contract on a route that exports only `GET` is
the same 404 with a worse diagnosis: the route *exists*, so suspicion falls on auth
or on the brand, not on the registry.

The risk grows with the list, and it grows fast: between writing this test and
rebasing before opening the PR, `BRAND_ENDPOINTS` went from 69 to 75 entries — six
additions by other agents in a few hours.

For the CLI tests the argument is PR #283's, one folder over: a test nobody runs is
not a guardian. Among the eleven is `cli/lib/contracts.test.ts`, which watches the
**mirror** of the contracts inside the CLI — the guardian of drift was itself
unwatched.

## How?

**The disk path is the exact inverse of `pathFor`, not a rule rewritten by hand.**
The dynamic folder name is passed where the value goes, and the URL that comes back
is already the path:

```
pathFor(GET_POST, '[slug]', '[id]')  ->  /api/v1/brands/%5Bslug%5D/posts/%5Bid%5D
decoded per segment                  ->  /api/v1/brands/[slug]/posts/[id]
+ '/+server.ts'                      ->  src/routes/api/v1/brands/[slug]/posts/[id]/+server.ts
```

`RESOURCE_SEGMENT` therefore never appears in the test. If `:id` becomes something
else tomorrow, the test follows on its own instead of going red for the wrong reason.

**Rejected**: importing each route module and reading its runtime exports. It would be
stronger, but it drags 95 server modules with `$env` and Supabase into the test, is
slow, and fails for reasons that have nothing to do with the registry. A regex over
the source covers every export form actually present (`export const`, `export
function`, `export { … }`).

**Where it lives**: under `src/`, colocated with the routes it guards, alongside the 44
tests already sitting in `src/routes/`. Not inside `packages/api-contracts/`, because
`packages/no-app-imports.test.ts` forbids a package from reaching into the app, and
this test has to see both sides.

**For the CLI tests**: `include` extended plus a `'bun:test' -> 'vitest'` alias. The two
APIs agree on `describe` / `test` / `it` / `expect`, so nothing was rewritten. Nine of
eleven files passed immediately; the other two used `import.meta.dir`, which exists
only in Bun, and now derive the path from `import.meta.url`, which holds under both
runtimes.

**Rejected**: a CI step running `bun test` inside `cli/`. It is the cleaner road — the
runtime those tests were written for, with the right dependency versions — but it is a
change to `.github/workflows/ci.yml` and also needs a committed lockfile for `cli/`,
which does not exist today. Left as a proposal, see *Anything Else?*.

## Testing?

**The red was actually seen.** Three fake contracts added to `BRAND_ENDPOINTS`, the test
run, the message read, the contracts removed:

```
- Expected
+ Received

- Array []
+ Array [
+   "ghost_report -> src/routes/api/v1/brands/[slug]/ghost/report/+server.ts non esiste",
+   "ghost_slide -> src/routes/api/v1/brands/[slug]/posts/[id]/slides/+server.ts non esiste",
+ ]

- Array []
+ Array [
+   "doctor_write -> src/routes/api/v1/brands/[slug]/doctor/+server.ts non esporta POST",
+ ]
```

The message names **which** tool and **which** path — the only useful form: whoever reads
CI does not have the registry in front of them. `ghost_slide` also proves the
`RESOURCE_SEGMENT` case (`/posts/:id/slides` -> `posts/[id]/slides`), and `doctor_write`
the verb case: the route exists and exports only `GET`.

**No false positives.** Green on the current state of `dev`, before and after the rebase
onto `d15191c` (which brought in the Radar-sources endpoints from #285/#287).

**Not tested**: that a route without a contract is dead code — the reverse direction is
out of scope here.

## Evidence

<details>
<summary>The new test, green after the rebase (with the api-contracts suite and the CLI tests)</summary>

```
 ✓ src/routes/api/v1/brands/[slug]/registry.test.ts (2 tests) 11ms
 ✓ cli/lib/contracts.test.ts (2 tests) 47ms
 ✓ cli/plugins/anomalia/plugin-skill.test.ts (2 tests) 4ms
 ✓ cli/mcp/create-post.test.ts (16 tests) 914ms
 ...
 Test Files  31 passed (31)
      Tests  254 passed (254)
```
</details>

<details>
<summary>Full suite — the one failure is a missing local env var, which CI provides</summary>

```
 Test Files  1 failed | 633 passed | 3 skipped (637)
      Tests  7217 passed | 11 skipped (7228)

 FAIL  src/hooks.server.test.ts
TypeError: Invalid URL
 ❯ src/hooks.server.ts:17:35
     17| const SESSION_COOKIE_NAME = `sb-${new URL(publicEnv.PUBLIC_SUPABASE_UR…
```

With CI's own values it passes, so the red is the environment, not the change:

```
$ PUBLIC_SUPABASE_URL=http://localhost:54321 PUBLIC_SUPABASE_ANON_KEY=ci-placeholder-anon-key \
    npx vitest run src/hooks.server.test.ts
 Test Files  1 passed (1)
```
</details>

<details>
<summary>`bun test` inside `cli/` still passes identically</summary>

```
bun test v1.3.14
 57 pass
 0 fail
 580 expect() calls
Ran 57 tests across 11 files. [605.00ms]
```
</details>

<details>
<summary>Runtime type gate</summary>

```
$ node scripts/typecheck-runtime.mjs
typecheck-runtime: ok (ignored 313 non-fatal type error(s))
```
</details>

No UI change, so no screenshots.

## Anything Else?

**The CLI dependencies are not declared at root, and that is a debt this PR does not
pay.** Under vitest the CLI tests resolve from the root `node_modules`:

| package | root | `cli/package.json` |
|---|---|---|
| `ora` | absent | `^8.1.1` |
| `cli-table3` | absent | `^0.6.5` |
| `commander` | 4.1.1 (transitive of `seek-bzip`) | `^12.1.0` |
| `chalk` | 4.1.2 (dev, CJS) | `^5.3.0` |

It does no harm today because none of the eleven tests reaches them: `ora` lives in
`cli/commands/*`, `chalk` and `cli-table3` in `cli/lib/display.ts`, `commander` in
`cli.ts`, and none of those modules enters the tests' import graph. But the balance
depends on **which files get imported**, not on a guarantee: the first test that touches
`display.ts` will fail in CI with a missing package, and it will look like a bug in the
test rather than a hole in the dependencies.

**The clean alternative, deliberately not done here**: a CI step `bun install && bun test`
inside `cli/`, with the runtime those tests were written for and the right versions. It
needs `oven-sh/setup-bun`, a committed lockfile for `cli/`, and a change to
`.github/workflows/ci.yml` — worth deciding on its own, not smuggled in here. Running
them with the wrong versions still beats not running them, but it is not the finish line.

**Possible next step for the registry**: the reverse direction — a route under
`/api/v1/brands/[slug]/` with no contract behind it. Some are legitimately UI-only
(`tick`, `publishing`, `webhook`), so it would need a declared exception list, which is
a different discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
