### PR TITLE
Let an agent set the blog up, categories and authors included

### DIFF
--- a/changelog/2026-09-04-agent-blog-settings.md
+++ b/changelog/2026-09-04-agent-blog-settings.md
@@ -1,0 +1,82 @@
+# Il blog si configura da fuori, con le conseguenze di ogni cancellazione scritte
+
+Quinto e ultimo giro sulle impostazioni headless. Quattro tool — `get_blog_settings`,
+`set_blog_settings`, `add_blog_term`, `remove_blog_term` — su `/settings/blog` e
+`/settings/blog/terms`. `tools/list`: **107 → 111**, additivo, `changed: []`.
+
+Coprono tre pagine di Settings che erano tre form separati: `blog-appearance`, `blog-categories`,
+`blog-authors`.
+
+## La cosa che mancava a `update_article`
+
+`update_article` accetta già `category_id`, `author_id` e `tag_ids`, e verifica che appartengano
+al brand. Ma **nessun tool poteva crearne uno**: un agente poteva archiviare un articolo sotto una
+categoria esistente e non sotto una nuova. `add_blog_term` chiude quel buco, e la lettura porta
+gli id che `update_article` vuole.
+
+## Una tabella per tre liste, non tre catene di `if`
+
+Categoria, tag e autore hanno la stessa forma — nome, slug derivato, unico per brand — e
+differiscono in due punti: i campi in più che accettano (`description`; `bio` e `role`; niente) e
+**cosa lasciano dietro quando si cancellano**.
+
+`BLOG_TERMS` è quella differenza, in un posto solo:
+
+| voce | vincolo | cosa resta |
+|---|---|---|
+| categoria | `brand_articles.category_id … set null` | gli articoli restano, senza categoria |
+| tag | `brand_article_tags.tag_id … cascade` | il tag sparisce da ogni articolo che lo aveva |
+| autore | `brand_articles.author_id … set null` | gli articoli restano, senza firma |
+
+Sono tre conseguenze diverse e sono nella descrizione di `remove_blog_term`, che un test tiene
+lì: un agente deve poterle riferire *prima* di eseguire. Il conto degli articoli toccati si fa
+prima della cancellazione — dopo, la riga che lo permetteva non esiste più — e torna come
+`articles_affected`.
+
+## Ridurre o rifiutare: due scelte diverse, e il perché
+
+- **`articles_per_week` viene ridotta** al tetto del piano. È quello che fa già il form del
+  browser, e due comportamenti per lo stesso campo sarebbero una divergenza. Ma un agente che non
+  rilegge crederebbe di aver salvato il numero chiesto: la risposta riporta `config` e la
+  descrizione dice di rileggerlo.
+- **una lingua che il blog non serve viene rifiutata** (`unknown_locale`). Scartarla in silenzio
+  lascerebbe l'agente convinto di aver acceso una traduzione che non esiste.
+- **un campo mandato alla lista sbagliata viene rifiutato** (`field_not_for_term`), non ignorato:
+  una `bio` su un tag non è un refuso da assorbire, è una biografia che l'agente crede di aver
+  scritto.
+- **uno slug già preso è 409**, non un 500 col messaggio Postgres del vincolo unico che il codice
+  attuale lascia passare a schermo.
+
+## Una regola per campo, e due chiamanti
+
+`customizationPatchFromFormData` costruiva le tredici regole di `blog_config` inline, per il form.
+L'API ha bisogno di una patch **parziale**: reimplementarle sarebbe stato tredici regole in due
+copie, e la divergenza non si vede come un errore — si vede come un colore leggermente sbagliato
+sul sito pubblico.
+
+Ora c'è `BLOG_CONFIG_FIELDS`, una riga per campo, e `blogConfigPatch(input, plan, current)` che
+applica solo i campi presenti. Il form ci passa tutti e tredici (un salvataggio da form è un
+rimpiazzo completo, e una casella non spuntata è `false`), i tool solo quelli nominati.
+
+Il vincolo incrociato — le lingue extra non possono contenere quella di default — si applica dopo
+il passaggio per campo, su ciò che vale DOPO la patch: senza `current`, cambiare solo `locales`
+lascerebbe il blog a tradursi verso se stesso.
+
+Nello stesso file lo slugify era ricopiato **tre volte**, una per azione. Ora è `blogTermSlug`, e
+la usano le tre azioni del form più le due rotte.
+
+## Cosa resta fuori, e non è una dimenticanza
+
+L'**icona del blog** e l'**avatar di un autore** si impostano solo caricando un file: passano da
+`readUploadImage`, hanno un tetto di 2 MB, finiscono nello Storage. Un campo che li accettasse
+come stringa farebbe salvare una URL che nessuno ha verificato. Un test verifica che quei campi
+non esistano negli schemi, e la descrizione lo dice invece di lasciarlo scoprire.
+
+## Cosa è stato visto rosso
+
+- il contratto, prima di essere nel registry;
+- `blogConfigPatch`: tolti il controllo del colore, quello del font, il tetto della cadenza e il
+  vincolo incrociato sulle lingue, cadono 6 test — **fra cui due che esistevano già per il form**,
+  che è la prova che le due strade ora condividono davvero la stessa regola;
+- le rotte: tolti `no_fields`, il rifiuto della lingua, lo slug vuoto, lo slug già preso, il campo
+  fuori lista, il 404 e il conteggio, **cadono 10 test su 19** e 9 restano verdi.

--- a/cli/lib/contracts/blog-settings.ts
+++ b/cli/lib/contracts/blog-settings.ts
@@ -1,0 +1,197 @@
+import { z } from 'zod';
+import type { BrandEndpoint } from './index';
+
+export const BLOG_FONTS = ['sans', 'serif', 'rounded', 'mono'] as const;
+export const BLOG_LAYOUTS = ['navbar', 'sidebar'] as const;
+
+/**
+ * I tre elenchi del blog che un brand puo' comporre. `category` e `author` sono riferimenti che un
+ * articolo tiene (`category_id`, `author_id`); `tag` e' una relazione molti-a-molti. La differenza
+ * conta solo quando si cancella, ed e' scritta nella descrizione di `remove_blog_term`.
+ */
+export const BLOG_TERM_KINDS = ['category', 'tag', 'author'] as const;
+export type BlogTermKind = (typeof BLOG_TERM_KINDS)[number];
+
+const term = z.enum(BLOG_TERM_KINDS).describe('Which list the entry belongs to');
+
+const NavbarLink = z.object({ label: z.string(), url: z.string() });
+
+const BlogConfig = z.object({
+  enabled: z.boolean(),
+  title: z.string().nullable(),
+  description: z.string().nullable(),
+  accent: z.string(),
+  font: z.string(),
+  layout: z.string(),
+  show_blog_link: z.boolean(),
+  humanizer_enabled: z.boolean(),
+  backlink_network: z.boolean(),
+  style_instructions: z.string().nullable(),
+  articles_per_week: z.number().nullable(),
+  default_locale: z.string().nullable(),
+  locales: z.array(z.string()),
+  navbar_links: z.array(NavbarLink),
+  icon_url: z.string().nullable()
+});
+
+export const GET_BLOG_SETTINGS = {
+  tool: 'get_blog_settings',
+  title: 'Blog settings',
+  description:
+    'How the brand’s blog looks and how it writes: the public site’s name, colour, font and ' +
+    'layout, the style brief the AI follows, how many articles a week it produces, the ' +
+    'languages, and the categories, tags and authors an article can be filed under. Read it ' +
+    'before set_blog_settings and before add_blog_term — it carries the fonts, layouts and ' +
+    'locales that are accepted, and the plan’s ceiling on articles per week and on extra ' +
+    'languages.',
+  method: 'GET',
+  pathUnderBrand: '/settings/blog',
+  input: z.object({}).strict(),
+  output: z.object({
+    brand: z.string(),
+    plan: z.string().nullable(),
+    config: BlogConfig,
+    limits: z.object({
+      articles_per_week_max: z.number(),
+      translation_languages: z.number(),
+      custom_domain: z.boolean()
+    }),
+    choices: z.object({
+      fonts: z.array(z.string()),
+      layouts: z.array(z.string()),
+      locales: z.array(z.string())
+    }),
+    categories: z.array(
+      z.object({ id: z.string(), name: z.string(), slug: z.string(), description: z.string().nullable() })
+    ),
+    tags: z.array(z.object({ id: z.string(), name: z.string(), slug: z.string() })),
+    authors: z.array(
+      z.object({
+        id: z.string(),
+        name: z.string(),
+        slug: z.string(),
+        role: z.string().nullable(),
+        bio: z.string().nullable(),
+        avatar_url: z.string().nullable()
+      })
+    )
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const SET_BLOG_SETTINGS = {
+  tool: 'set_blog_settings',
+  title: 'Change the blog settings',
+  description:
+    'Change how the blog looks and how it writes. Only the fields you send change; every other ' +
+    'one keeps its value. `articles_per_week` is CLAMPED to the plan’s ceiling rather than ' +
+    'refused, and the answer says what was actually saved — read it back instead of assuming ' +
+    'your number was taken. `locales` and `navbar_links` replace their whole list. Turning ' +
+    '`enabled` off takes the public blog down; it deletes no article. The blog icon and an ' +
+    'author’s avatar are images and cannot be set here. Calls no model and spends no credits.',
+  method: 'PUT',
+  pathUnderBrand: '/settings/blog',
+  input: z
+    .object({
+      enabled: z.boolean().optional().describe('Whether the public blog is live'),
+      title: z.string().nullable().optional().describe('Site name, 80 chars; null falls back to the brand name'),
+      description: z.string().nullable().optional().describe('Site description, 300 chars'),
+      accent: z.string().optional().describe('Six-digit hex, e.g. "#7c5cff"'),
+      font: z.enum(BLOG_FONTS).optional(),
+      layout: z.enum(BLOG_LAYOUTS).optional(),
+      show_blog_link: z.boolean().optional().describe('Show the Blog link in the main site nav'),
+      humanizer_enabled: z.boolean().optional().describe('Run the humanising pass over generated articles'),
+      backlink_network: z.boolean().optional().describe('Take part in the cross-brand backlink network'),
+      style_instructions: z
+        .string()
+        .nullable()
+        .optional()
+        .describe('Free-text brief the article generator follows, 1500 chars'),
+      articles_per_week: z
+        .number()
+        .nullable()
+        .optional()
+        .describe('Cadence; clamped to the plan ceiling. null returns to the plan default'),
+      default_locale: z
+        .string()
+        .nullable()
+        .optional()
+        .describe('Language the bare blog URL lands on, from choices.locales'),
+      locales: z
+        .array(z.string())
+        .optional()
+        .describe('Extra languages articles are translated into. Replaces the whole list'),
+      navbar_links: z.array(NavbarLink).optional().describe('Up to 6 custom nav links. Replaces the whole list')
+    })
+    .strict(),
+  output: z.object({ ok: z.literal(true), config: BlogConfig }),
+  failures: [
+    { error: 'no_fields', status: 400 },
+    { error: 'unknown_locale', status: 400 },
+    { error: 'update_failed', status: 500 }
+  ],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const ADD_BLOG_TERM = {
+  tool: 'add_blog_term',
+  title: 'Add a blog category, tag or author',
+  description:
+    'Create one entry an article can be filed under. The URL slug is derived from the name and ' +
+    'must be unique for the brand: a name that slugs to one already there answers ' +
+    'slug_taken rather than creating a second. `description` belongs to a category; `bio` and ' +
+    '`role` to an author; a tag takes only a name. An author’s avatar is an image and cannot be ' +
+    'set here — the author is created without one.',
+  method: 'POST',
+  pathUnderBrand: '/settings/blog/terms',
+  input: z
+    .object({
+      term,
+      name: z.string().min(1).describe('What it is called; the slug is derived from it'),
+      description: z.string().optional().describe('Category only, 300 chars'),
+      bio: z.string().optional().describe('Author only, 500 chars'),
+      role: z.string().optional().describe('Author only, e.g. "writer" or "editor", 30 chars')
+    })
+    .strict(),
+  output: z.object({
+    ok: z.literal(true),
+    term: z.enum(BLOG_TERM_KINDS),
+    id: z.string(),
+    name: z.string(),
+    slug: z.string()
+  }),
+  failures: [
+    { error: 'field_not_for_term', status: 400 },
+    { error: 'empty_slug', status: 400 },
+    { error: 'slug_taken', status: 409 },
+    { error: 'insert_failed', status: 500 }
+  ],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const REMOVE_BLOG_TERM = {
+  tool: 'remove_blog_term',
+  title: 'Remove a blog category, tag or author',
+  description:
+    'Delete one entry. No article is deleted, but each kind leaves a different mark, so say ' +
+    'which before you do it: removing a CATEGORY leaves its articles filed under nothing; ' +
+    'removing a TAG takes that tag off every article that carried it; removing an AUTHOR clears ' +
+    'the byline on their articles. It does not come back, and the articles keep no record of ' +
+    'what was removed.',
+  method: 'POST',
+  pathUnderBrand: '/settings/blog/terms/remove',
+  input: z.object({ term, id: z.string().min(1).describe('Row id, verbatim from get_blog_settings') }).strict(),
+  output: z.object({
+    ok: z.literal(true),
+    term: z.enum(BLOG_TERM_KINDS),
+    id: z.string(),
+    /** Quanti articoli restano senza quella voce: la conseguenza, contata, non promessa. */
+    articles_affected: z.number()
+  }),
+  failures: [
+    { error: 'not_found', status: 404 },
+    { error: 'delete_failed', status: 500 }
+  ],
+  destructive: true
+} satisfies BrandEndpoint;

--- a/cli/lib/contracts/index.ts
+++ b/cli/lib/contracts/index.ts
@@ -46,6 +46,12 @@ import {
   LIST_PRODUCTS
 } from './reads';
 import { DIAGNOSE_BRAND, GET_GOALS } from './brand-state';
+import {
+  ADD_BLOG_TERM,
+  GET_BLOG_SETTINGS,
+  REMOVE_BLOG_TERM,
+  SET_BLOG_SETTINGS
+} from './blog-settings';
 import { GET_BRAND_SETTINGS, SET_BRAND_SETTINGS } from './brand-settings';
 import { DIAGNOSE_RADAR, GET_MARKET_FIELD, LIST_IDEAS } from './market';
 import { GET_MEDIA_MODELS, SET_MEDIA_MODEL } from './media-models';
@@ -118,6 +124,7 @@ export type ResourceEndpoint = EndpointShape & {
 export type BrandEndpoint = ResourcelessEndpoint | ResourceEndpoint;
 
 export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
+  ADD_BLOG_TERM,
   ADD_COMPETITOR,
   ADD_RADAR_SOURCE,
   ADS_REMIX,
@@ -136,10 +143,11 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   GET_ADS,
   GET_ANALYTICS,
   GET_ARTICLE,
-  GET_AUTOMATIONS,
   GET_AUDIT_FINDINGS,
+  GET_AUTOMATIONS,
   GET_BACKLINKS,
   GET_BIO,
+  GET_BLOG_SETTINGS,
   GET_BRAND_SETTINGS,
   GET_CALENDAR,
   GET_CREATION_KIT,
@@ -171,6 +179,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   LIST_WEB_FIXES,
   PROPOSE_PLAN,
   REFRESH_KEYWORDS,
+  REMOVE_BLOG_TERM,
   REMOVE_RADAR_SOURCE,
   RENDER_POST,
   RESCHEDULE_POST,
@@ -182,9 +191,10 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   SEO_ACTION,
   SET_AUTOMATION,
   SET_BIO,
-  SET_RADAR_PLATFORM,
+  SET_BLOG_SETTINGS,
   SET_BRAND_SETTINGS,
   SET_MEDIA_MODEL,
+  SET_RADAR_PLATFORM,
   SOCIAL_CONNECT_LINK,
   SYNC_HISTORY,
   UPDATE_ARTICLE,
@@ -318,6 +328,16 @@ export {
 } from './automations';
 export type { AutomationJob } from './automations';
 export { LIST_SOCIAL_ACCOUNTS, SOCIAL_CONNECT_LINK } from './social';
+export {
+  ADD_BLOG_TERM,
+  BLOG_FONTS,
+  BLOG_LAYOUTS,
+  BLOG_TERM_KINDS,
+  GET_BLOG_SETTINGS,
+  REMOVE_BLOG_TERM,
+  SET_BLOG_SETTINGS
+} from './blog-settings';
+export type { BlogTermKind } from './blog-settings';
 export { BILLING_PORTAL_LINK, CHECKOUT_LINK };
 export type { BillingPortalLinkResult, CheckoutLinkInput, CheckoutLinkResult } from './billing';
 export type { CheckContentInput, CheckContentResult } from './content';

--- a/cli/plugins/anomalia/skills/anomalia/SKILL.md
+++ b/cli/plugins/anomalia/skills/anomalia/SKILL.md
@@ -106,6 +106,13 @@ change them, naming a source by its `(kind, value)` pair. Threads, X and LinkedI
 answer `plan_required` below it, so read before you write. A source already there comes back
 `added: false` rather than failing.
 
+**Set up the blog** → `get_blog_settings` shows how it looks, how it writes, the accepted fonts,
+layouts and locales, the plan's ceilings, and the categories, tags and authors; `set_blog_settings`
+changes it, and `add_blog_term` / `remove_blog_term` maintain the three lists. `articles_per_week`
+is clamped to the plan, so read back what was saved. Before removing a term, say what it leaves
+behind: a category leaves its articles unfiled, a tag comes off every article, an author leaves no
+byline.
+
 **Choose which model draws and which films** → `get_media_models` lists the six jobs (image
 generation, image refinement, video from text, animating a still, video refinement, motion
 transfer) with the models each one accepts; `set_media_model` pins one. A model that cannot do

--- a/cli/plugins/anomalia/skills/anomalia/references/tools.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/tools.md
@@ -311,6 +311,40 @@ both writes normalise it the same way, so `r/coffee` and `coffee` are the same s
 Adding a source spends no credits by itself, but Radar reads it on every run from then on.
 Removing one is permanent and stops Radar reading it; what it already found stays.
 
+## Blog settings
+
+| MCP | CLI |
+|-----|-----|
+| `get_blog_settings` | (MCP only) |
+| `set_blog_settings` | (MCP only) |
+| `add_blog_term` | (MCP only) |
+| `remove_blog_term` | (MCP only) |
+
+How the blog looks (name, colour, font, layout, nav links, whether it is live) and how it writes
+(style brief, articles per week, languages, humanising pass), plus the categories, tags and
+authors an article can be filed under.
+
+**Read `get_blog_settings` first.** It carries `choices` (the fonts, layouts and locales that are
+accepted) and `limits` (the plan's ceiling on articles per week, how many extra languages it
+allows, whether a custom domain is available).
+
+`set_blog_settings` changes only the fields you send. `articles_per_week` is **clamped** to the
+plan ceiling rather than refused, so read `config` back from the answer instead of assuming your
+number was taken. A locale the blog does not serve is refused (`unknown_locale`) rather than
+dropped. `locales` and `navbar_links` replace their whole list.
+
+`add_blog_term` takes `term`: `category`, `tag` or `author`. The slug is derived from the name and
+must be unique for the brand — a clash answers `slug_taken` (409), not a second row. `description`
+belongs to a category, `bio` and `role` to an author; sending one to the wrong list is refused
+(`field_not_for_term`), not ignored.
+
+`remove_blog_term` deletes no article, but each kind leaves a different mark — say which before
+you do it: a **category** leaves its articles filed under nothing, a **tag** comes off every
+article that carried it, an **author** leaves their articles with no byline. The answer counts
+`articles_affected`.
+
+The blog icon and an author's avatar are images and cannot be set through these tools.
+
 ## Media models
 
 | MCP | CLI |

--- a/cli/skills/anomalia/SKILL.md
+++ b/cli/skills/anomalia/SKILL.md
@@ -106,6 +106,13 @@ change them, naming a source by its `(kind, value)` pair. Threads, X and LinkedI
 answer `plan_required` below it, so read before you write. A source already there comes back
 `added: false` rather than failing.
 
+**Set up the blog** → `get_blog_settings` shows how it looks, how it writes, the accepted fonts,
+layouts and locales, the plan's ceilings, and the categories, tags and authors; `set_blog_settings`
+changes it, and `add_blog_term` / `remove_blog_term` maintain the three lists. `articles_per_week`
+is clamped to the plan, so read back what was saved. Before removing a term, say what it leaves
+behind: a category leaves its articles unfiled, a tag comes off every article, an author leaves no
+byline.
+
 **Choose which model draws and which films** → `get_media_models` lists the six jobs (image
 generation, image refinement, video from text, animating a still, video refinement, motion
 transfer) with the models each one accepts; `set_media_model` pins one. A model that cannot do

--- a/cli/skills/anomalia/references/tools.md
+++ b/cli/skills/anomalia/references/tools.md
@@ -311,6 +311,40 @@ both writes normalise it the same way, so `r/coffee` and `coffee` are the same s
 Adding a source spends no credits by itself, but Radar reads it on every run from then on.
 Removing one is permanent and stops Radar reading it; what it already found stays.
 
+## Blog settings
+
+| MCP | CLI |
+|-----|-----|
+| `get_blog_settings` | (MCP only) |
+| `set_blog_settings` | (MCP only) |
+| `add_blog_term` | (MCP only) |
+| `remove_blog_term` | (MCP only) |
+
+How the blog looks (name, colour, font, layout, nav links, whether it is live) and how it writes
+(style brief, articles per week, languages, humanising pass), plus the categories, tags and
+authors an article can be filed under.
+
+**Read `get_blog_settings` first.** It carries `choices` (the fonts, layouts and locales that are
+accepted) and `limits` (the plan's ceiling on articles per week, how many extra languages it
+allows, whether a custom domain is available).
+
+`set_blog_settings` changes only the fields you send. `articles_per_week` is **clamped** to the
+plan ceiling rather than refused, so read `config` back from the answer instead of assuming your
+number was taken. A locale the blog does not serve is refused (`unknown_locale`) rather than
+dropped. `locales` and `navbar_links` replace their whole list.
+
+`add_blog_term` takes `term`: `category`, `tag` or `author`. The slug is derived from the name and
+must be unique for the brand — a clash answers `slug_taken` (409), not a second row. `description`
+belongs to a category, `bio` and `role` to an author; sending one to the wrong list is refused
+(`field_not_for_term`), not ignored.
+
+`remove_blog_term` deletes no article, but each kind leaves a different mark — say which before
+you do it: a **category** leaves its articles filed under nothing, a **tag** comes off every
+article that carried it, an **author** leaves their articles with no byline. The answer counts
+`articles_affected`.
+
+The blog icon and an author's avatar are images and cannot be set through these tools.
+
 ## Media models
 
 | MCP | CLI |

--- a/docs/api/16-settings-blog.md
+++ b/docs/api/16-settings-blog.md
@@ -1,0 +1,90 @@
+# API — 16 · Impostazioni: il blog
+
+Quattro endpoint sotto `/api/v1/brands/:slug/settings/blog`, cioè i tool MCP `get_blog_settings`,
+`set_blog_settings`, `add_blog_term` e `remove_blog_term`. Coprono tre pagine di Settings:
+`blog-appearance`, `blog-categories`, `blog-authors`.
+
+Errori comuni di auth: vedi [01-overview](01-overview.md).
+
+## Dove è salvato cosa
+
+| cosa | dove |
+|---|---|
+| aspetto e cadenza | `brands.blog_config` (jsonb) |
+| categorie | `blog_categories` (`name`, `slug`, `description`, unico su `(brand_id, slug)`) |
+| tag | `blog_tags` (`name`, `slug`, unico su `(brand_id, slug)`) |
+| autori | `blog_authors` (`name`, `slug`, `bio`, `role`, `avatar_url`, unico su `(brand_id, slug)`) |
+
+Nessuna migration.
+
+Le chiavi del jsonb sono in camelCase da quando la pagina esiste; l'API parla snake_case come il
+resto del registry. La corrispondenza è una tabella sola dentro la rotta.
+
+## Cosa NON si può fare da qui
+
+L'**icona del blog** (`blog_config.iconUrl`) e l'**avatar di un autore** (`blog_authors.avatar_url`)
+si impostano solo caricando un file: passano da `readUploadImage`, hanno un tetto di 2 MB e
+finiscono nello Storage. Un campo che li accettasse come stringa farebbe salvare una URL che
+nessuno ha verificato, quindi non esiste. Un autore creato da qui nasce senza avatar.
+
+## `GET /api/v1/brands/:slug/settings/blog`
+
+Porta tre cose che un agente non può indovinare:
+
+- `choices` — i font (`FONT_KEYS`), i layout, e le 26 lingue di `BLOG_LOCALES`;
+- `limits` — `articles_per_week_max` (`blogArticlesPerWeekMax`), `translation_languages`
+  (0 sotto Pro), `custom_domain`;
+- le tre liste con i loro id, che sono ciò che `update_article` usa per `category_id`,
+  `author_id` e `tag_ids`.
+
+`articles_per_week` e `default_locale` tornano `null` quando il brand **non ha scelto**: il
+default del piano esiste, ma spacciarlo per una scelta fatta farebbe credere a un agente che il
+brand abbia deciso qualcosa che non ha deciso.
+
+## `PUT /api/v1/brands/:slug/settings/blog`
+
+Tutti i campi facoltativi, almeno uno. `locales` e `navbar_links` **sostituiscono** l'intera lista.
+
+Due comportamenti da leggere insieme, perché sono deliberatamente diversi:
+
+- **`articles_per_week` viene RIDOTTA** al tetto del piano, non rifiutata. È ciò che fa il form del
+  browser, e due comportamenti diversi per lo stesso campo sarebbero una divergenza. La risposta
+  riporta `config`, e la descrizione del tool dice di rileggerlo: un agente che non lo fa crede di
+  aver salvato il numero che ha chiesto.
+- **una lingua che il blog non serve viene RIFIUTATA** (`unknown_locale`, 400), non scartata.
+  Scartarla lascerebbe l'agente convinto di aver acceso una traduzione che non esiste.
+
+Errori: `invalid_input` (400), `no_fields` (400), `unknown_locale` (400), `update_failed` (500).
+
+## `POST /api/v1/brands/:slug/settings/blog/terms`
+
+**Body**: `{ "term": "category" | "tag" | "author", "name": "...", … }`.
+
+Lo slug è **derivato** dal nome (accenti tolti, minuscolo, trattini) e deve essere unico per il
+brand: un nome che produce uno slug già presente risponde `slug_taken` (409) invece di appoggiarsi
+al vincolo del database e restituire un 500 con dentro un messaggio Postgres.
+
+`description` appartiene a una categoria, `bio` e `role` a un autore, un tag prende solo il nome.
+Un campo mandato alla lista sbagliata è `field_not_for_term` (400): scartarlo lascerebbe l'agente
+convinto di aver scritto una biografia che non esiste.
+
+Errori: `invalid_input` (400), `field_not_for_term` (400), `empty_slug` (400), `slug_taken` (409),
+`insert_failed` (500).
+
+## `POST /api/v1/brands/:slug/settings/blog/terms/remove`
+
+**Body**: `{ "term": "...", "id": "..." }` — l'id verbatim da `get_blog_settings`.
+
+Nessun articolo viene cancellato, ma **ognuna delle tre lascia un segno diverso**, ed è la ragione
+per cui la tabella `BLOG_TERMS` esiste in un posto solo:
+
+| voce | vincolo | cosa resta |
+|---|---|---|
+| categoria | `brand_articles.category_id … on delete set null` | gli articoli restano, senza categoria |
+| tag | `brand_article_tags.tag_id … on delete cascade` | il tag sparisce da ogni articolo che lo aveva |
+| autore | `brand_articles.author_id … on delete set null` | gli articoli restano, senza firma |
+
+Il conto degli articoli toccati si fa **prima** della cancellazione — dopo, la riga che lo
+permetteva non esiste più — e torna come `articles_affected`.
+
+`destructive: true`: è l'unico dei quattro.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -23,6 +23,7 @@ integrazioni esterne via API key — request, response, query params, body, erro
 | [13 — Impostazioni: come lavora il brand](13-settings-brand.md) | `/settings/brand` — fuso, piattaforme, hashtag, esempi di voce |
 | [14 — Impostazioni: lavori ricorrenti](14-settings-automations.md) | `/settings/automations` — i nove lavori del roster e il loro interruttore |
 | [15 — Impostazioni: fonti del Radar](15-settings-radar.md) | `/settings/radar` — piattaforme e fonti che il Radar guarda |
+| [16 — Impostazioni: il blog](16-settings-blog.md) | `/settings/blog` — aspetto, cadenza, lingue, categorie, tag, autori |
 
 ## Regole di manutenzione
 

--- a/packages/api-contracts/src/blog-settings.test.ts
+++ b/packages/api-contracts/src/blog-settings.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ADD_BLOG_TERM,
+  BLOG_FONTS,
+  BLOG_TERM_KINDS,
+  GET_BLOG_SETTINGS,
+  REMOVE_BLOG_TERM,
+  SET_BLOG_SETTINGS
+} from './blog-settings';
+import { BRAND_ENDPOINTS, statusForFailure } from './index';
+
+const ALL = [GET_BLOG_SETTINGS, SET_BLOG_SETTINGS, ADD_BLOG_TERM, REMOVE_BLOG_TERM];
+
+describe('le impostazioni del blog come contratto', () => {
+  it('stanno tutte nel registry, o nessun agente le vede', () => {
+    for (const endpoint of ALL) {
+      expect(BRAND_ENDPOINTS, endpoint.tool).toContain(endpoint);
+    }
+  });
+
+  it('cambia solo i campi nominati, e una richiesta vuota è un rifiuto dichiarato', () => {
+    expect(SET_BLOG_SETTINGS.input.safeParse({ title: 'Il blog' }).success).toBe(true);
+    expect(statusForFailure(SET_BLOG_SETTINGS, 'no_fields')).toBe(400);
+  });
+
+  it('accetta solo i font e i layout che il sito sa rendere', () => {
+    expect(SET_BLOG_SETTINGS.input.safeParse({ font: 'serif' }).success).toBe(true);
+    expect(SET_BLOG_SETTINGS.input.safeParse({ font: 'comic-sans' }).success).toBe(false);
+    expect(SET_BLOG_SETTINGS.input.safeParse({ layout: 'carousel' }).success).toBe(false);
+    expect(BLOG_FONTS).toContain('sans');
+  });
+
+  it('la cadenza si azzera con null, non con una stringa vuota', () => {
+    expect(SET_BLOG_SETTINGS.input.safeParse({ articles_per_week: null }).success).toBe(true);
+    expect(SET_BLOG_SETTINGS.input.safeParse({ articles_per_week: '3' }).success).toBe(false);
+  });
+
+  /**
+   * La cadenza viene RIDOTTA al tetto del piano invece di essere rifiutata — è ciò che fa il form
+   * del browser, e due comportamenti diversi per lo stesso campo sarebbero una divergenza. Ma un
+   * agente che non rilegge crederebbe di aver salvato il numero che ha chiesto: per questo la
+   * risposta riporta la configurazione, e la descrizione dice di rileggerla.
+   */
+  it('dice che la cadenza viene ridotta al tetto, non rifiutata', () => {
+    expect(SET_BLOG_SETTINGS.description).toMatch(/CLAMPED to the plan/);
+    expect(Object.keys(SET_BLOG_SETTINGS.output.shape)).toContain('config');
+  });
+
+  it('dice cosa lascia dietro ogni cancellazione, che è diversa per ognuna', () => {
+    // Categoria e autore staccano un riferimento; un tag sparisce da ogni articolo che lo aveva.
+    // Sono tre conseguenze diverse, e l'agente le deve poter riferire prima di eseguire.
+    expect(REMOVE_BLOG_TERM.description).toMatch(/CATEGORY leaves its articles filed under nothing/);
+    expect(REMOVE_BLOG_TERM.description).toMatch(/TAG takes that tag off every article/);
+    expect(REMOVE_BLOG_TERM.description).toMatch(/AUTHOR clears\s+the byline/);
+  });
+
+  it('cancellare è distruttivo, creare e configurare no', () => {
+    expect(REMOVE_BLOG_TERM.destructive).toBe(true);
+    expect(ADD_BLOG_TERM.destructive).toBe(false);
+    expect(SET_BLOG_SETTINGS.destructive).toBe(false);
+  });
+
+  it('conosce le tre liste e nessun’altra', () => {
+    for (const kind of BLOG_TERM_KINDS) {
+      expect(ADD_BLOG_TERM.input.safeParse({ term: kind, name: 'x' }).success, kind).toBe(true);
+    }
+    expect(ADD_BLOG_TERM.input.safeParse({ term: 'series', name: 'x' }).success).toBe(false);
+    expect(ADD_BLOG_TERM.input.safeParse({ term: 'tag', name: '' }).success).toBe(false);
+  });
+
+  it('uno slug già preso è un conflitto, non un secondo record silenzioso', () => {
+    expect(statusForFailure(ADD_BLOG_TERM, 'slug_taken')).toBe(409);
+    expect(statusForFailure(ADD_BLOG_TERM, 'empty_slug')).toBe(400);
+    expect(statusForFailure(ADD_BLOG_TERM, 'field_not_for_term')).toBe(400);
+  });
+
+  it('non promette di poter caricare immagini da qui', () => {
+    // Icona del blog e avatar di un autore sono file: un campo che li accettasse come stringa
+    // farebbe salvare una URL che nessuno ha verificato.
+    expect(Object.keys(SET_BLOG_SETTINGS.input.shape)).not.toContain('icon_url');
+    expect(Object.keys(ADD_BLOG_TERM.input.shape)).not.toContain('avatar_url');
+    expect(ADD_BLOG_TERM.description).toMatch(/avatar is an image and cannot be/);
+  });
+
+  it('la lettura porta i limiti del piano, non solo la configurazione', () => {
+    const parsed = GET_BLOG_SETTINGS.output.safeParse({
+      brand: 'demo',
+      plan: 'starter',
+      config: {
+        enabled: true,
+        title: null,
+        description: null,
+        accent: '#111111',
+        font: 'sans',
+        layout: 'navbar',
+        show_blog_link: true,
+        humanizer_enabled: true,
+        backlink_network: true,
+        style_instructions: null,
+        articles_per_week: null,
+        default_locale: 'it',
+        locales: [],
+        navbar_links: [],
+        icon_url: null
+      },
+      limits: { articles_per_week_max: 8, translation_languages: 0, custom_domain: true },
+      choices: { fonts: [...BLOG_FONTS], layouts: ['navbar', 'sidebar'], locales: ['it', 'en'] },
+      categories: [{ id: 'c1', name: 'Caffè', slug: 'caffe', description: null }],
+      tags: [{ id: 't1', name: 'Espresso', slug: 'espresso' }],
+      authors: [{ id: 'a1', name: 'Ada', slug: 'ada', role: 'writer', bio: null, avatar_url: null }]
+    });
+    expect(parsed.success).toBe(true);
+  });
+});

--- a/packages/api-contracts/src/blog-settings.ts
+++ b/packages/api-contracts/src/blog-settings.ts
@@ -1,0 +1,197 @@
+import { z } from 'zod';
+import type { BrandEndpoint } from './index';
+
+export const BLOG_FONTS = ['sans', 'serif', 'rounded', 'mono'] as const;
+export const BLOG_LAYOUTS = ['navbar', 'sidebar'] as const;
+
+/**
+ * I tre elenchi del blog che un brand puo' comporre. `category` e `author` sono riferimenti che un
+ * articolo tiene (`category_id`, `author_id`); `tag` e' una relazione molti-a-molti. La differenza
+ * conta solo quando si cancella, ed e' scritta nella descrizione di `remove_blog_term`.
+ */
+export const BLOG_TERM_KINDS = ['category', 'tag', 'author'] as const;
+export type BlogTermKind = (typeof BLOG_TERM_KINDS)[number];
+
+const term = z.enum(BLOG_TERM_KINDS).describe('Which list the entry belongs to');
+
+const NavbarLink = z.object({ label: z.string(), url: z.string() });
+
+const BlogConfig = z.object({
+  enabled: z.boolean(),
+  title: z.string().nullable(),
+  description: z.string().nullable(),
+  accent: z.string(),
+  font: z.string(),
+  layout: z.string(),
+  show_blog_link: z.boolean(),
+  humanizer_enabled: z.boolean(),
+  backlink_network: z.boolean(),
+  style_instructions: z.string().nullable(),
+  articles_per_week: z.number().nullable(),
+  default_locale: z.string().nullable(),
+  locales: z.array(z.string()),
+  navbar_links: z.array(NavbarLink),
+  icon_url: z.string().nullable()
+});
+
+export const GET_BLOG_SETTINGS = {
+  tool: 'get_blog_settings',
+  title: 'Blog settings',
+  description:
+    'How the brand’s blog looks and how it writes: the public site’s name, colour, font and ' +
+    'layout, the style brief the AI follows, how many articles a week it produces, the ' +
+    'languages, and the categories, tags and authors an article can be filed under. Read it ' +
+    'before set_blog_settings and before add_blog_term — it carries the fonts, layouts and ' +
+    'locales that are accepted, and the plan’s ceiling on articles per week and on extra ' +
+    'languages.',
+  method: 'GET',
+  pathUnderBrand: '/settings/blog',
+  input: z.object({}).strict(),
+  output: z.object({
+    brand: z.string(),
+    plan: z.string().nullable(),
+    config: BlogConfig,
+    limits: z.object({
+      articles_per_week_max: z.number(),
+      translation_languages: z.number(),
+      custom_domain: z.boolean()
+    }),
+    choices: z.object({
+      fonts: z.array(z.string()),
+      layouts: z.array(z.string()),
+      locales: z.array(z.string())
+    }),
+    categories: z.array(
+      z.object({ id: z.string(), name: z.string(), slug: z.string(), description: z.string().nullable() })
+    ),
+    tags: z.array(z.object({ id: z.string(), name: z.string(), slug: z.string() })),
+    authors: z.array(
+      z.object({
+        id: z.string(),
+        name: z.string(),
+        slug: z.string(),
+        role: z.string().nullable(),
+        bio: z.string().nullable(),
+        avatar_url: z.string().nullable()
+      })
+    )
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const SET_BLOG_SETTINGS = {
+  tool: 'set_blog_settings',
+  title: 'Change the blog settings',
+  description:
+    'Change how the blog looks and how it writes. Only the fields you send change; every other ' +
+    'one keeps its value. `articles_per_week` is CLAMPED to the plan’s ceiling rather than ' +
+    'refused, and the answer says what was actually saved — read it back instead of assuming ' +
+    'your number was taken. `locales` and `navbar_links` replace their whole list. Turning ' +
+    '`enabled` off takes the public blog down; it deletes no article. The blog icon and an ' +
+    'author’s avatar are images and cannot be set here. Calls no model and spends no credits.',
+  method: 'PUT',
+  pathUnderBrand: '/settings/blog',
+  input: z
+    .object({
+      enabled: z.boolean().optional().describe('Whether the public blog is live'),
+      title: z.string().nullable().optional().describe('Site name, 80 chars; null falls back to the brand name'),
+      description: z.string().nullable().optional().describe('Site description, 300 chars'),
+      accent: z.string().optional().describe('Six-digit hex, e.g. "#7c5cff"'),
+      font: z.enum(BLOG_FONTS).optional(),
+      layout: z.enum(BLOG_LAYOUTS).optional(),
+      show_blog_link: z.boolean().optional().describe('Show the Blog link in the main site nav'),
+      humanizer_enabled: z.boolean().optional().describe('Run the humanising pass over generated articles'),
+      backlink_network: z.boolean().optional().describe('Take part in the cross-brand backlink network'),
+      style_instructions: z
+        .string()
+        .nullable()
+        .optional()
+        .describe('Free-text brief the article generator follows, 1500 chars'),
+      articles_per_week: z
+        .number()
+        .nullable()
+        .optional()
+        .describe('Cadence; clamped to the plan ceiling. null returns to the plan default'),
+      default_locale: z
+        .string()
+        .nullable()
+        .optional()
+        .describe('Language the bare blog URL lands on, from choices.locales'),
+      locales: z
+        .array(z.string())
+        .optional()
+        .describe('Extra languages articles are translated into. Replaces the whole list'),
+      navbar_links: z.array(NavbarLink).optional().describe('Up to 6 custom nav links. Replaces the whole list')
+    })
+    .strict(),
+  output: z.object({ ok: z.literal(true), config: BlogConfig }),
+  failures: [
+    { error: 'no_fields', status: 400 },
+    { error: 'unknown_locale', status: 400 },
+    { error: 'update_failed', status: 500 }
+  ],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const ADD_BLOG_TERM = {
+  tool: 'add_blog_term',
+  title: 'Add a blog category, tag or author',
+  description:
+    'Create one entry an article can be filed under. The URL slug is derived from the name and ' +
+    'must be unique for the brand: a name that slugs to one already there answers ' +
+    'slug_taken rather than creating a second. `description` belongs to a category; `bio` and ' +
+    '`role` to an author; a tag takes only a name. An author’s avatar is an image and cannot be ' +
+    'set here — the author is created without one.',
+  method: 'POST',
+  pathUnderBrand: '/settings/blog/terms',
+  input: z
+    .object({
+      term,
+      name: z.string().min(1).describe('What it is called; the slug is derived from it'),
+      description: z.string().optional().describe('Category only, 300 chars'),
+      bio: z.string().optional().describe('Author only, 500 chars'),
+      role: z.string().optional().describe('Author only, e.g. "writer" or "editor", 30 chars')
+    })
+    .strict(),
+  output: z.object({
+    ok: z.literal(true),
+    term: z.enum(BLOG_TERM_KINDS),
+    id: z.string(),
+    name: z.string(),
+    slug: z.string()
+  }),
+  failures: [
+    { error: 'field_not_for_term', status: 400 },
+    { error: 'empty_slug', status: 400 },
+    { error: 'slug_taken', status: 409 },
+    { error: 'insert_failed', status: 500 }
+  ],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const REMOVE_BLOG_TERM = {
+  tool: 'remove_blog_term',
+  title: 'Remove a blog category, tag or author',
+  description:
+    'Delete one entry. No article is deleted, but each kind leaves a different mark, so say ' +
+    'which before you do it: removing a CATEGORY leaves its articles filed under nothing; ' +
+    'removing a TAG takes that tag off every article that carried it; removing an AUTHOR clears ' +
+    'the byline on their articles. It does not come back, and the articles keep no record of ' +
+    'what was removed.',
+  method: 'POST',
+  pathUnderBrand: '/settings/blog/terms/remove',
+  input: z.object({ term, id: z.string().min(1).describe('Row id, verbatim from get_blog_settings') }).strict(),
+  output: z.object({
+    ok: z.literal(true),
+    term: z.enum(BLOG_TERM_KINDS),
+    id: z.string(),
+    /** Quanti articoli restano senza quella voce: la conseguenza, contata, non promessa. */
+    articles_affected: z.number()
+  }),
+  failures: [
+    { error: 'not_found', status: 404 },
+    { error: 'delete_failed', status: 500 }
+  ],
+  destructive: true
+} satisfies BrandEndpoint;

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -46,6 +46,12 @@ import {
   LIST_PRODUCTS
 } from './reads';
 import { DIAGNOSE_BRAND, GET_GOALS } from './brand-state';
+import {
+  ADD_BLOG_TERM,
+  GET_BLOG_SETTINGS,
+  REMOVE_BLOG_TERM,
+  SET_BLOG_SETTINGS
+} from './blog-settings';
 import { GET_BRAND_SETTINGS, SET_BRAND_SETTINGS } from './brand-settings';
 import { DIAGNOSE_RADAR, GET_MARKET_FIELD, LIST_IDEAS } from './market';
 import { GET_MEDIA_MODELS, SET_MEDIA_MODEL } from './media-models';
@@ -118,6 +124,7 @@ export type ResourceEndpoint = EndpointShape & {
 export type BrandEndpoint = ResourcelessEndpoint | ResourceEndpoint;
 
 export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
+  ADD_BLOG_TERM,
   ADD_COMPETITOR,
   ADD_RADAR_SOURCE,
   ADS_REMIX,
@@ -136,10 +143,11 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   GET_ADS,
   GET_ANALYTICS,
   GET_ARTICLE,
-  GET_AUTOMATIONS,
   GET_AUDIT_FINDINGS,
+  GET_AUTOMATIONS,
   GET_BACKLINKS,
   GET_BIO,
+  GET_BLOG_SETTINGS,
   GET_BRAND_SETTINGS,
   GET_CALENDAR,
   GET_CREATION_KIT,
@@ -171,6 +179,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   LIST_WEB_FIXES,
   PROPOSE_PLAN,
   REFRESH_KEYWORDS,
+  REMOVE_BLOG_TERM,
   REMOVE_RADAR_SOURCE,
   RENDER_POST,
   RESCHEDULE_POST,
@@ -182,9 +191,10 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   SEO_ACTION,
   SET_AUTOMATION,
   SET_BIO,
-  SET_RADAR_PLATFORM,
+  SET_BLOG_SETTINGS,
   SET_BRAND_SETTINGS,
   SET_MEDIA_MODEL,
+  SET_RADAR_PLATFORM,
   SOCIAL_CONNECT_LINK,
   SYNC_HISTORY,
   UPDATE_ARTICLE,
@@ -318,6 +328,16 @@ export {
 } from './automations';
 export type { AutomationJob } from './automations';
 export { LIST_SOCIAL_ACCOUNTS, SOCIAL_CONNECT_LINK } from './social';
+export {
+  ADD_BLOG_TERM,
+  BLOG_FONTS,
+  BLOG_LAYOUTS,
+  BLOG_TERM_KINDS,
+  GET_BLOG_SETTINGS,
+  REMOVE_BLOG_TERM,
+  SET_BLOG_SETTINGS
+} from './blog-settings';
+export type { BlogTermKind } from './blog-settings';
 export { BILLING_PORTAL_LINK, CHECKOUT_LINK };
 export type { BillingPortalLinkResult, CheckoutLinkInput, CheckoutLinkResult } from './billing';
 export type { CheckContentInput, CheckContentResult } from './content';

--- a/src/lib/content/changelog/2026-09-04-agent-blog-settings.ts
+++ b/src/lib/content/changelog/2026-09-04-agent-blog-settings.ts
@@ -1,0 +1,13 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-04',
+  title: 'Your AI can set the blog up, categories and authors included',
+  items: [
+    'Claude, Cursor and any connected AI client can now change how your blog looks and writes — its name, colour, font, layout, nav links, style brief, how many articles a week, and which languages — without opening Anomalia.',
+    'It can also create and remove your categories, tags and authors, so a new article can be filed under something that did not exist yet.',
+    'Before removing one, your AI is told what it leaves behind: a category leaves its articles unfiled, a tag comes off every article that carried it, an author leaves their articles without a byline. No article is ever deleted.',
+    'Asking for more articles a week than your plan allows no longer fails — it saves the most your plan permits and tells you what was saved.',
+    'A language your blog does not support is now refused outright, instead of being quietly dropped while you think the translation is on.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/blog-settings.test.ts
+++ b/src/lib/server/blog-settings.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { customizationPatchFromFormData, parseBlogConfig } from './blog-settings';
+import { blogConfigPatch, customizationPatchFromFormData, parseBlogConfig } from './blog-settings';
 
 function fd(entries: Record<string, string>): FormData {
   const form = new FormData();
@@ -74,5 +74,54 @@ describe('parseBlogConfig', () => {
   it('defaults backlinkNetwork to on', () => {
     expect(parseBlogConfig({}, 'starter').backlinkNetwork).toBe(true);
     expect(parseBlogConfig({ backlinkNetwork: false }, 'starter').backlinkNetwork).toBe(false);
+  });
+});
+
+describe('blogConfigPatch — una regola per campo, due chiamanti', () => {
+  it('tocca solo i campi nominati', () => {
+    expect(blogConfigPatch({ title: 'Il blog' })).toEqual({ title: 'Il blog' });
+    expect(blogConfigPatch({})).toEqual({});
+  });
+
+  it('rifiuta un colore che non è un esadecimale, ripiegando sul default', () => {
+    expect(blogConfigPatch({ accent: 'rosso' }).accent).toBe('#111111');
+    expect(blogConfigPatch({ accent: '#7C5CFF' }).accent).toBe('#7C5CFF');
+  });
+
+  it('un font che il sito non sa rendere torna a sans', () => {
+    expect(blogConfigPatch({ font: 'comic-sans' }).font).toBe('sans');
+    expect(blogConfigPatch({ font: 'serif' }).font).toBe('serif');
+  });
+
+  it('riduce la cadenza al tetto del piano invece di rifiutarla', () => {
+    // Un salvataggio che fallisce per un numero troppo alto è peggio di uno che salva il massimo
+    // consentito: è la stessa scelta che il form fa già.
+    const go = blogConfigPatch({ articlesPerWeek: 999 }, 'go').articlesPerWeek as number;
+    const pro = blogConfigPatch({ articlesPerWeek: 999 }, 'pro').articlesPerWeek as number;
+    expect(go).toBeLessThan(pro);
+    expect(blogConfigPatch({ articlesPerWeek: null }, 'go').articlesPerWeek).toBeNull();
+  });
+
+  it('scarta una lingua che il blog non serve', () => {
+    expect(blogConfigPatch({ locales: ['it', 'klingon', 'it'] }).locales).toEqual(['it']);
+    expect(blogConfigPatch({ defaultLocale: 'klingon' }).defaultLocale).toBeNull();
+  });
+
+  it('le lingue in più non contengono quella di default, nemmeno quella già salvata', () => {
+    // La regola è incrociata: senza `current`, cambiare solo `locales` lascerebbe la lingua di
+    // default dentro l'elenco delle traduzioni, e il blog si tradurrebbe verso se stesso.
+    expect(blogConfigPatch({ defaultLocale: 'it', locales: ['it', 'en'] }).locales).toEqual(['en']);
+    expect(blogConfigPatch({ locales: ['it', 'en'] }, null, { defaultLocale: 'it' }).locales).toEqual(['en']);
+  });
+
+  it('tiene al massimo sei link di navigazione, e solo quelli completi', () => {
+    const links = blogConfigPatch({
+      navbarLinks: [
+        { label: 'Home', url: 'https://x.test' },
+        { label: '', url: 'https://y.test' },
+        { label: 'Solo etichetta', url: '' }
+      ]
+    }).navbarLinks as unknown[];
+    expect(links).toEqual([{ label: 'Home', url: 'https://x.test' }]);
   });
 });

--- a/src/lib/server/blog-settings.ts
+++ b/src/lib/server/blog-settings.ts
@@ -282,61 +282,168 @@ export async function toggleBlog({ request, params, locals: { supabase } }: Ev) 
 }
 
 /** Parse blog appearance form fields into a blog_config patch. */
+/**
+ * UNA regola per campo di `blog_config`, e un chiamante solo che le applica.
+ *
+ * Il form del browser salva TUTTO insieme (una casella non spuntata non arriva, quindi assente
+ * vuol dire `false`); i tool dell'API cambiano solo i campi nominati. Sono due chiamanti, non due
+ * regole: se la pulizia di `accent` vivesse in due posti, il form rifiuterebbe un colore che il
+ * tool accetta, e nessuno lo scoprirebbe finché il sito non esce sbagliato.
+ *
+ * Ogni voce riceve il valore grezzo e il piano, e restituisce ciò che va scritto nel jsonb.
+ */
+const str = (v: unknown, max: number): string => String(v ?? '').trim().slice(0, max);
+
+const BLOG_CONFIG_FIELDS: Record<string, (v: unknown, plan?: string | null) => unknown> = {
+  enabled: (v) => v === true,
+  title: (v) => str(v, 80) || null,
+  description: (v) => str(v, 300) || null,
+  accent: (v) => (/^#[0-9a-f]{6}$/i.test(str(v, 7)) ? str(v, 7) : '#111111'),
+  font: (v) => (FONT_KEYS.includes(str(v, 20)) ? str(v, 20) : 'sans'),
+  layout: (v) => (str(v, 20) === 'sidebar' ? 'sidebar' : 'navbar'),
+  showBlogLink: (v) => v === true,
+  humanizerEnabled: (v) => v === true,
+  backlinkNetwork: (v) => v === true,
+  styleInstructions: (v) => str(v, 1500) || null,
+  // Ridotta al tetto del piano invece che rifiutata: alzare il piano poi la libera, e un salvataggio
+  // che fallisce per un numero troppo alto è peggio di uno che salva il massimo consentito.
+  articlesPerWeek: (v, plan) =>
+    v === null || v === undefined || v === ''
+      ? null
+      : Math.max(0, Math.min(blogArticlesPerWeekMax(plan), Math.round(Number(v) || 0))),
+  defaultLocale: (v) => {
+    const l = str(v, 10).toLowerCase();
+    return isBlogLocale(l) ? l : null;
+  },
+  locales: (v) => {
+    const raw = Array.isArray(v) ? v : [];
+    return raw
+      .map((x) => String(x).trim().toLowerCase())
+      .filter((x, i, arr) => isBlogLocale(x) && arr.indexOf(x) === i);
+  },
+  navbarLinks: (v) => {
+    const raw = Array.isArray(v) ? v : [];
+    return raw
+      .map((l) => ({ label: str((l as { label?: unknown })?.label, 60), url: str((l as { url?: unknown })?.url, 300) }))
+      .filter((l) => l.label && l.url)
+      .slice(0, 6);
+  }
+};
+
+export const BLOG_CONFIG_KEYS = Object.keys(BLOG_CONFIG_FIELDS);
+
+/**
+ * La patch pulita per i soli campi presenti in `input`.
+ *
+ * `locales` non può contenere la lingua di default — sono le lingue IN PIÙ — e la regola è
+ * incrociata, quindi si applica dopo il passaggio per campo, su ciò che vale DOPO la patch.
+ */
+export function blogConfigPatch(
+  input: Record<string, unknown>,
+  plan?: string | null,
+  current: Record<string, unknown> = {}
+): Record<string, unknown> {
+  const patch: Record<string, unknown> = {};
+  for (const [key, clean] of Object.entries(BLOG_CONFIG_FIELDS)) {
+    if (key in input) patch[key] = clean(input[key], plan);
+  }
+
+  if (Array.isArray(patch.locales)) {
+    const fallback = 'defaultLocale' in patch ? patch.defaultLocale : current.defaultLocale;
+    patch.locales = (patch.locales as string[]).filter((l) => l !== fallback);
+  }
+
+  return patch;
+}
+
+/**
+ * Lo slug di una voce del blog, derivato dal nome. Era ricopiato dentro tre azioni del form:
+ * tre copie della stessa riga, che al primo cambio (una lettera accentata trattata diversamente)
+ * avrebbero prodotto tre slug diversi per lo stesso nome.
+ */
+export function blogTermSlug(name: string, max: number): string {
+  return String(name ?? '')
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, max);
+}
+
+/**
+ * Le tre liste sotto cui un articolo si archivia, e in COSA differiscono.
+ *
+ * La differenza che conta è l'ultima colonna: cancellare non cancella mai un articolo, ma lascia
+ * un segno diverso per ognuna — una categoria e un autore staccano un riferimento (`on delete set
+ * null`), un tag sparisce dalla tabella di mezzo (`on delete cascade`). Tre righe qui invece di
+ * tre `if` sparsi: la prossima lista è una riga, e le conseguenze si leggono insieme.
+ */
+export const BLOG_TERMS = {
+  category: {
+    table: 'blog_categories',
+    nameMax: 80,
+    slugMax: 70,
+    extras: ['description'] as const,
+    extraMax: { description: 300 } as Record<string, number>,
+    refTable: 'brand_articles',
+    refColumn: 'category_id'
+  },
+  tag: {
+    table: 'blog_tags',
+    nameMax: 50,
+    slugMax: 50,
+    extras: [] as const,
+    extraMax: {} as Record<string, number>,
+    refTable: 'brand_article_tags',
+    refColumn: 'tag_id'
+  },
+  author: {
+    table: 'blog_authors',
+    nameMax: 100,
+    slugMax: 70,
+    extras: ['bio', 'role'] as const,
+    extraMax: { bio: 500, role: 30 } as Record<string, number>,
+    refTable: 'brand_articles',
+    refColumn: 'author_id'
+  }
+} as const;
+
+export type BlogTerm = keyof typeof BLOG_TERMS;
+
 export function customizationPatchFromFormData(
   fd: FormData,
   plan?: string | null
 ): Record<string, unknown> {
-  const title = String(fd.get('title') ?? '')
-    .trim()
-    .slice(0, 80);
-  const description = String(fd.get('description') ?? '')
-    .trim()
-    .slice(0, 300);
-  const accent = String(fd.get('accent') ?? '').trim();
-  const font = String(fd.get('font') ?? 'sans').trim();
-  const styleInstructions = String(fd.get('styleInstructions') ?? '')
-    .trim()
-    .slice(0, 1500);
-  const apwRaw = String(fd.get('articlesPerWeek') ?? '').trim();
-  const weekMax = blogArticlesPerWeekMax(plan);
-  const articlesPerWeek =
-    apwRaw === '' ? null : Math.max(0, Math.min(weekMax, Math.round(Number(apwRaw) || 0)));
-  const layout = String(fd.get('layout') ?? 'navbar').trim() === 'sidebar' ? 'sidebar' : 'navbar';
-  // Unchecked checkboxes are omitted from FormData — treat missing as false.
-  const showBlogLink = fd.get('showBlogLink') === 'true';
-  const humanizerEnabled = fd.get('humanizerEnabled') === 'true';
-  const backlinkNetwork = fd.get('backlinkNetwork') === 'true';
-  // Blog locales. defaultLocale is what the bare blog URL redirects to; `locales` are the extra
-  // languages articles get translated into. The plan clamp lives in resolveBlogLocales (applied on
-  // READ too), so a downgrade stops serving the extras without destroying the user's choice.
-  const defaultLocaleRaw = String(fd.get('defaultLocale') ?? '').trim().toLowerCase();
-  const defaultLocale = isBlogLocale(defaultLocaleRaw) ? defaultLocaleRaw : null;
-  const locales = fd
-    .getAll('locales')
-    .map((v) => String(v).trim().toLowerCase())
-    .filter((v, i, arr) => isBlogLocale(v) && v !== defaultLocale && arr.indexOf(v) === i);
-
   const navbarLinks: Array<{ label: string; url: string }> = [];
   for (let i = 0; i < 6; i++) {
-    const label = String(fd.get(`nav_label_${i}`) ?? '').trim();
-    const url = String(fd.get(`nav_url_${i}`) ?? '').trim();
-    if (label && url) navbarLinks.push({ label, url });
+    navbarLinks.push({
+      label: String(fd.get(`nav_label_${i}`) ?? ''),
+      url: String(fd.get(`nav_url_${i}`) ?? '')
+    });
   }
-  return {
-    title: title || null,
-    description: description || null,
-    accent: /^#[0-9a-f]{6}$/i.test(accent) ? accent : '#111111',
-    font: FONT_KEYS.includes(font) ? font : 'sans',
-    styleInstructions: styleInstructions || null,
-    articlesPerWeek,
-    defaultLocale,
-    locales,
-    layout,
-    showBlogLink,
-    navbarLinks,
-    humanizerEnabled,
-    backlinkNetwork
-  };
+  const apwRaw = String(fd.get('articlesPerWeek') ?? '').trim();
+  const defaultLocale = String(fd.get('defaultLocale') ?? '');
+
+  // Il form salva tutto insieme: ogni campo è presente, e una casella non spuntata è `false`.
+  return blogConfigPatch(
+    {
+      title: fd.get('title'),
+      description: fd.get('description'),
+      accent: fd.get('accent'),
+      font: fd.get('font') ?? 'sans',
+      styleInstructions: fd.get('styleInstructions'),
+      articlesPerWeek: apwRaw === '' ? null : apwRaw,
+      layout: fd.get('layout') ?? 'navbar',
+      showBlogLink: fd.get('showBlogLink') === 'true',
+      humanizerEnabled: fd.get('humanizerEnabled') === 'true',
+      backlinkNetwork: fd.get('backlinkNetwork') === 'true',
+      defaultLocale,
+      locales: fd.getAll('locales'),
+      navbarLinks
+    },
+    plan
+  );
 }
 
 export async function saveCustomization({ request, params, locals: { supabase } }: Ev) {
@@ -389,13 +496,7 @@ export async function createCategory({ request, params, locals: { supabase } }: 
     .trim()
     .slice(0, 80);
   if (!name) return fail(400, { error: 'name_required' });
-  const slug = name
-    .toLowerCase()
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .slice(0, 70);
+  const slug = blogTermSlug(name, 70);
   const description =
     String(fd.get('description') ?? '')
       .trim()
@@ -428,13 +529,7 @@ export async function createTag({ request, params, locals: { supabase } }: Ev) {
     .trim()
     .slice(0, 50);
   if (!name) return fail(400, { error: 'name_required' });
-  const slug = name
-    .toLowerCase()
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .slice(0, 50);
+  const slug = blogTermSlug(name, 50);
   const { error } = await createAdminClient()
     .from('blog_tags')
     .insert({ brand_id: brand.id, name, slug });
@@ -468,13 +563,7 @@ export async function createAuthor({
     .trim()
     .slice(0, 100);
   if (!name) return fail(400, { error: 'name_required' });
-  const slug = name
-    .toLowerCase()
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .slice(0, 70);
+  const slug = blogTermSlug(name, 70);
   const bio =
     String(fd.get('bio') ?? '')
       .trim()

--- a/src/routes/api/v1/brands/[slug]/settings/blog/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/settings/blog/+server.ts
@@ -1,0 +1,158 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { authenticate, loadBrandForUser, checkApiKeyWriteAccess } from '$lib/server/cli-auth';
+import { SET_BLOG_SETTINGS, statusForFailure } from '@anomalia/api-contracts';
+import { blogConfigPatch, parseBlogConfig, patchBlogConfig } from '$lib/server/blog-settings';
+import { FONT_KEYS } from '$lib/server/blog-site';
+import { BLOG_LOCALES, isBlogLocale } from '$lib/server/blog-locales';
+import {
+  blogArticlesPerWeekMax,
+  blogTranslationLanguages,
+  hasBlogCustomDomain
+} from '$lib/server/plans';
+import { createAdminClient } from '$lib/server/supabase-admin';
+
+// Come si vede e come scrive il blog del brand. La configurazione vive in `brands.blog_config`
+// (jsonb), le tre liste in tabelle loro. Il client admin serve solo per quelle tre letture, che
+// sono service-role; l'autorizzazione l'ha già fatta `loadBrandForUser`.
+
+// I nomi delle chiavi jsonb sono in camelCase da quando la pagina esiste; l'API parla snake_case
+// come il resto del registry. La corrispondenza sta qui, una volta, e non in venti punti.
+const FIELD_KEYS: Record<string, string> = {
+  enabled: 'enabled',
+  title: 'title',
+  description: 'description',
+  accent: 'accent',
+  font: 'font',
+  layout: 'layout',
+  show_blog_link: 'showBlogLink',
+  humanizer_enabled: 'humanizerEnabled',
+  backlink_network: 'backlinkNetwork',
+  style_instructions: 'styleInstructions',
+  articles_per_week: 'articlesPerWeek',
+  default_locale: 'defaultLocale',
+  locales: 'locales',
+  navbar_links: 'navbarLinks'
+};
+
+type Cfg = Record<string, unknown>;
+
+function view(cfg: Cfg, plan: string | null) {
+  const parsed = parseBlogConfig(cfg, plan);
+  return {
+    enabled: parsed.enabled,
+    title: parsed.title || null,
+    description: parsed.description || null,
+    accent: parsed.accent,
+    font: parsed.font,
+    layout: parsed.layout,
+    show_blog_link: parsed.showBlogLink,
+    humanizer_enabled: parsed.humanizerEnabled,
+    backlink_network: parsed.backlinkNetwork,
+    style_instructions: parsed.styleInstructions || null,
+    articles_per_week: cfg.articlesPerWeek == null ? null : parsed.articlesPerWeek,
+    // `defaultLocale` è sempre risolto (ripiega su una lingua vera); qui interessa se il brand
+    // ne ha SCELTA una, e le lingue extra sono già ridotte al permesso del piano.
+    default_locale: typeof cfg.defaultLocale === 'string' ? parsed.locales.defaultLocale : null,
+    locales: parsed.locales.extraLocales,
+    navbar_links: parsed.navbarLinks,
+    icon_url: parsed.iconUrl
+  };
+}
+
+async function lists(brandId: string) {
+  const admin = createAdminClient();
+  const [categories, tags, authors] = await Promise.all([
+    admin.from('blog_categories').select('id, name, slug, description').eq('brand_id', brandId).order('sort_order'),
+    admin.from('blog_tags').select('id, name, slug').eq('brand_id', brandId).order('name'),
+    admin.from('blog_authors').select('id, name, slug, role, bio, avatar_url').eq('brand_id', brandId).order('name')
+  ]);
+  return {
+    categories: categories.data ?? [],
+    tags: tags.data ?? [],
+    authors: authors.data ?? []
+  };
+}
+
+async function currentConfig(brandId: string): Promise<Cfg> {
+  const { data } = await createAdminClient()
+    .from('brands')
+    .select('blog_config')
+    .eq('id', brandId)
+    .maybeSingle();
+  return (data?.blog_config ?? {}) as Cfg;
+}
+
+export const GET: RequestHandler = async ({ request, params }) => {
+  const { supabase, error, apiKey } = await authenticate(request);
+  if (error) return error;
+
+  const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
+  if (brandError) return brandError;
+
+  const [cfg, rows] = await Promise.all([currentConfig(brand.id), lists(brand.id)]);
+
+  return json({
+    brand: brand.slug,
+    plan: brand.plan,
+    config: view(cfg, brand.plan),
+    limits: {
+      articles_per_week_max: blogArticlesPerWeekMax(brand.plan),
+      translation_languages: blogTranslationLanguages(brand.plan),
+      custom_domain: hasBlogCustomDomain(brand.plan)
+    },
+    choices: { fonts: FONT_KEYS, layouts: ['navbar', 'sidebar'], locales: [...BLOG_LOCALES] },
+    ...rows
+  });
+};
+
+export const PUT: RequestHandler = async ({ request, params }) => {
+  const { supabase, error, apiKey } = await authenticate(request);
+  if (error) return error;
+
+  const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
+  if (brandError) return brandError;
+  const writeDenied = checkApiKeyWriteAccess(apiKey);
+  if (writeDenied) return writeDenied;
+
+  const parsed = SET_BLOG_SETTINGS.input.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return json({ error: 'invalid_input', details: parsed.error.issues }, { status: 400 });
+  }
+
+  const input = parsed.data as Record<string, unknown>;
+  if (Object.keys(input).length === 0) {
+    return json({ error: 'no_fields' }, { status: statusForFailure(SET_BLOG_SETTINGS, 'no_fields') });
+  }
+
+  // Una lingua che il blog non serve viene RIFIUTATA qui invece di essere scartata in silenzio:
+  // scartarla lascerebbe l'agente convinto di aver acceso una traduzione che non esiste.
+  const wanted = [
+    ...(typeof input.default_locale === 'string' ? [input.default_locale] : []),
+    ...(Array.isArray(input.locales) ? (input.locales as string[]) : [])
+  ];
+  const unknown = wanted.filter((l) => !isBlogLocale(String(l).toLowerCase()));
+  if (unknown.length) {
+    return json(
+      { error: 'unknown_locale', unknown, allowed: [...BLOG_LOCALES] },
+      { status: statusForFailure(SET_BLOG_SETTINGS, 'unknown_locale') }
+    );
+  }
+
+  const current = await currentConfig(brand.id);
+  const inner: Cfg = {};
+  for (const [apiKeyName, cfgKey] of Object.entries(FIELD_KEYS)) {
+    if (apiKeyName in input) inner[cfgKey] = input[apiKeyName];
+  }
+
+  const patch = blogConfigPatch(inner, brand.plan, current);
+  const { error: updateError } = await patchBlogConfig(brand.id, patch);
+  if (updateError) {
+    return json(
+      { error: 'update_failed', detail: updateError.message },
+      { status: statusForFailure(SET_BLOG_SETTINGS, 'update_failed') }
+    );
+  }
+
+  return json({ ok: true, config: view({ ...current, ...patch }, brand.plan) });
+};

--- a/src/routes/api/v1/brands/[slug]/settings/blog/server.test.ts
+++ b/src/routes/api/v1/brands/[slug]/settings/blog/server.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('$lib/server/cli-auth', () => ({
+  authenticate: vi.fn(),
+  loadBrandForUser: vi.fn(),
+  checkApiKeyWriteAccess: vi.fn(() => null)
+}));
+
+const tables = vi.hoisted(() => ({
+  current: {} as Record<string, Record<string, unknown>[]>,
+  inserted: [] as Record<string, unknown>[],
+  deleted: [] as string[],
+  patched: [] as Record<string, unknown>[],
+  insertFails: null as string | null,
+  deleteFails: null as string | null
+}));
+
+vi.mock('$lib/server/supabase-admin', () => ({
+  createAdminClient: () => ({
+    from(table: string) {
+      const rows = tables.current[table] ?? [];
+      const q: Record<string, unknown> = {};
+      Object.assign(q, {
+        select: () => q,
+        order: async () => ({ data: rows }),
+        eq: () => q,
+        maybeSingle: async () => ({ data: rows[0] ?? null }),
+        single: async () => ({
+          data: tables.insertFails ? null : { id: 'new-1' },
+          error: tables.insertFails ? { message: tables.insertFails } : null
+        }),
+        insert: (row: Record<string, unknown>) => {
+          tables.inserted.push({ table, ...row });
+          return q;
+        },
+        delete: () => {
+          const d: Record<string, unknown> = {};
+          Object.assign(d, {
+            eq: (col: string, val: string) => {
+              if (col === 'id') tables.deleted.push(val);
+              return d;
+            },
+            then: (r: (v: unknown) => unknown) =>
+              r({ error: tables.deleteFails ? { message: tables.deleteFails } : null })
+          });
+          return d;
+        },
+        then: (r: (v: unknown) => unknown) => r({ data: rows })
+      });
+      return q;
+    }
+  })
+}));
+
+vi.mock('$lib/server/blog-settings', async (original) => {
+  const actual = await original<typeof import('$lib/server/blog-settings')>();
+  return {
+    ...actual,
+    patchBlogConfig: async (_id: string, patch: Record<string, unknown>) => {
+      tables.patched.push(patch);
+      return { error: null };
+    }
+  };
+});
+
+import { GET, PUT } from './+server';
+import { POST as ADD } from './terms/+server';
+import { POST as REMOVE } from './terms/remove/+server';
+import { authenticate, loadBrandForUser, checkApiKeyWriteAccess } from '$lib/server/cli-auth';
+
+const BRAND = { id: 'brand-1', slug: 'demo', plan: 'pro' };
+
+const base = 'https://example.test/api/v1/brands/demo/settings/blog';
+const call = (h: unknown, path: string, method: string, body?: unknown) =>
+  (h as (e: unknown) => Promise<Response>)({
+    request: new Request(`${base}${path}`, {
+      method,
+      ...(body === undefined ? {} : { body: JSON.stringify(body) })
+    }),
+    params: { slug: 'demo' }
+  });
+
+const read = () => call(GET, '', 'GET');
+const write = (b: unknown) => call(PUT, '', 'PUT', b);
+const add = (b: unknown) => call(ADD, '/terms', 'POST', b);
+const remove = (b: unknown) => call(REMOVE, '/terms/remove', 'POST', b);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  tables.current = { brands: [{ blog_config: {} }] };
+  tables.inserted = [];
+  tables.deleted = [];
+  tables.patched = [];
+  tables.insertFails = null;
+  tables.deleteFails = null;
+  vi.mocked(authenticate).mockResolvedValue({ supabase: {}, apiKey: null, error: null } as never);
+  vi.mocked(loadBrandForUser).mockResolvedValue({ brand: BRAND, error: null } as never);
+  vi.mocked(checkApiKeyWriteAccess).mockReturnValue(null as never);
+});
+
+describe('GET /settings/blog', () => {
+  it('porta i limiti del piano e le scelte ammesse, non solo la configurazione', async () => {
+    const body = await (await read()).json();
+
+    expect(body.limits.articles_per_week_max).toBeGreaterThan(0);
+    expect(body.choices.fonts).toContain('serif');
+    expect(body.choices.layouts).toEqual(['navbar', 'sidebar']);
+    expect(body.choices.locales).toContain('it');
+  });
+
+  it('senza una cadenza scelta risponde null, non il default del piano spacciato per scelta', async () => {
+    const body = await (await read()).json();
+
+    expect(body.config.articles_per_week).toBeNull();
+  });
+
+  it('senza una lingua scelta non ne inventa una', async () => {
+    const body = await (await read()).json();
+
+    expect(body.config.default_locale).toBeNull();
+  });
+});
+
+describe('PUT /settings/blog', () => {
+  it('cambia solo i campi nominati', async () => {
+    const res = await write({ title: 'Il blog del caffè' });
+
+    expect(res.status).toBe(200);
+    expect(tables.patched[0]).toEqual({ title: 'Il blog del caffè' });
+  });
+
+  it('una richiesta senza campi è 400 dichiarato', async () => {
+    const res = await write({});
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('no_fields');
+    expect(tables.patched).toEqual([]);
+  });
+
+  it('rifiuta un font che il sito non sa rendere, invece di ripiegare in silenzio', async () => {
+    const res = await write({ font: 'comic-sans' });
+
+    expect(res.status).toBe(400);
+    expect(tables.patched).toEqual([]);
+  });
+
+  it('rifiuta una lingua che il blog non serve e dice quali erano ammesse', async () => {
+    // Scartarla lascerebbe l'agente convinto di aver acceso una traduzione che non esiste.
+    const res = await write({ locales: ['it', 'klingon'] });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('unknown_locale');
+    expect(body.unknown).toEqual(['klingon']);
+    expect(tables.patched).toEqual([]);
+  });
+
+  it('riduce la cadenza al tetto del piano e riporta ciò che ha salvato', async () => {
+    const body = await (await write({ articles_per_week: 999 })).json();
+
+    const saved = tables.patched[0].articlesPerWeek as number;
+    expect(saved).toBeLessThan(999);
+    expect(body.config.articles_per_week).toBe(saved);
+  });
+
+  it('si ferma prima di scrivere se la chiave è di sola lettura', async () => {
+    vi.mocked(checkApiKeyWriteAccess).mockReturnValue(new Response('read only', { status: 403 }) as never);
+
+    const res = await write({ title: 'x' });
+
+    expect(res.status).toBe(403);
+    expect(tables.patched).toEqual([]);
+  });
+});
+
+describe('POST /settings/blog/terms', () => {
+  it('deriva lo slug dal nome, accenti compresi', async () => {
+    const body = await (await add({ term: 'category', name: 'Caffè Speciale' })).json();
+
+    expect(body.slug).toBe('caffe-speciale');
+    expect(tables.inserted[0]).toMatchObject({ table: 'blog_categories', slug: 'caffe-speciale' });
+  });
+
+  it('un nome che si riduce a niente non diventa una riga senza slug', async () => {
+    const res = await add({ term: 'tag', name: '???' });
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('empty_slug');
+    expect(tables.inserted).toEqual([]);
+  });
+
+  it('uno slug già preso è 409, non una seconda riga', async () => {
+    tables.current.blog_tags = [{ id: 't1' }];
+
+    const res = await add({ term: 'tag', name: 'Espresso' });
+
+    expect(res.status).toBe(409);
+    expect((await res.json()).error).toBe('slug_taken');
+    expect(tables.inserted).toEqual([]);
+  });
+
+  it('rifiuta un campo che quella lista non ha, invece di scartarlo', async () => {
+    const res = await add({ term: 'tag', name: 'Espresso', bio: 'una biografia' });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('field_not_for_term');
+    expect(body.accepts).toEqual([]);
+    expect(tables.inserted).toEqual([]);
+  });
+
+  it('un autore prende bio e ruolo, una categoria la descrizione', async () => {
+    await add({ term: 'author', name: 'Ada', bio: 'Scrive di caffè', role: 'editor' });
+    expect(tables.inserted[0]).toMatchObject({
+      table: 'blog_authors',
+      bio: 'Scrive di caffè',
+      role: 'editor'
+    });
+
+    tables.inserted = [];
+    await add({ term: 'category', name: 'Guide', description: 'Come si fa' });
+    expect(tables.inserted[0]).toMatchObject({ table: 'blog_categories', description: 'Come si fa' });
+  });
+
+  it('non scrive un avatar: è un file, e da qui non passa', async () => {
+    const res = await add({ term: 'author', name: 'Ada', avatar_url: 'https://x.test/a.png' });
+
+    expect(res.status).toBe(400);
+    expect(tables.inserted).toEqual([]);
+  });
+});
+
+describe('POST /settings/blog/terms/remove', () => {
+  it('conta gli articoli toccati PRIMA di cancellare', async () => {
+    tables.current.blog_categories = [{ id: 'c1' }];
+    tables.current.brand_articles = [{ id: 'a1' }, { id: 'a2' }];
+
+    const body = await (await remove({ term: 'category', id: 'c1' })).json();
+
+    expect(body.articles_affected).toBe(2);
+    expect(tables.deleted).toContain('c1');
+  });
+
+  it('una voce che non è del brand è 404, non una cancellazione altrui', async () => {
+    tables.current.blog_categories = [];
+
+    const res = await remove({ term: 'category', id: 'c1' });
+
+    expect(res.status).toBe(404);
+    expect(tables.deleted).toEqual([]);
+  });
+
+  it('un tag si conta sulla tabella di mezzo, non sugli articoli', async () => {
+    tables.current.blog_tags = [{ id: 't1' }];
+    tables.current.brand_article_tags = [{ id: 'x1' }];
+
+    const body = await (await remove({ term: 'tag', id: 't1' })).json();
+
+    expect(body.articles_affected).toBe(1);
+  });
+
+  it('si ferma prima di cancellare se la chiave è di sola lettura', async () => {
+    vi.mocked(checkApiKeyWriteAccess).mockReturnValue(new Response('read only', { status: 403 }) as never);
+
+    const res = await remove({ term: 'category', id: 'c1' });
+
+    expect(res.status).toBe(403);
+    expect(tables.deleted).toEqual([]);
+  });
+});

--- a/src/routes/api/v1/brands/[slug]/settings/blog/terms/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/settings/blog/terms/+server.ts
@@ -1,0 +1,72 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { authenticate, loadBrandForUser, checkApiKeyWriteAccess } from '$lib/server/cli-auth';
+import { ADD_BLOG_TERM, statusForFailure } from '@anomalia/api-contracts';
+import { BLOG_TERMS, blogTermSlug } from '$lib/server/blog-settings';
+import { createAdminClient } from '$lib/server/supabase-admin';
+
+// POST /api/v1/brands/:slug/settings/blog/terms — una categoria, un tag o un autore in più.
+//
+// Le tre liste hanno la stessa forma (nome → slug derivato, unico per brand) e differiscono solo
+// per i campi in più che accettano. La tabella `BLOG_TERMS` è quella differenza, in un posto solo.
+
+export const POST: RequestHandler = async ({ request, params }) => {
+  const { supabase, error, apiKey } = await authenticate(request);
+  if (error) return error;
+
+  const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
+  if (brandError) return brandError;
+  const writeDenied = checkApiKeyWriteAccess(apiKey);
+  if (writeDenied) return writeDenied;
+
+  const parsed = ADD_BLOG_TERM.input.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return json({ error: 'invalid_input', details: parsed.error.issues }, { status: 400 });
+  }
+
+  const { term, name, ...extras } = parsed.data;
+  const spec = BLOG_TERMS[term];
+  const fail = (e: string, extra: Record<string, unknown> = {}) =>
+    json({ error: e, ...extra }, { status: statusForFailure(ADD_BLOG_TERM, e) });
+
+  // Un campo mandato alla lista sbagliata viene RIFIUTATO, non scartato: salvarlo altrove o
+  // ignorarlo lascerebbe l'agente convinto di aver scritto una biografia che non esiste.
+  const stray = Object.keys(extras).filter(
+    (k) => extras[k as keyof typeof extras] !== undefined && !(spec.extras as readonly string[]).includes(k)
+  );
+  if (stray.length) {
+    return fail('field_not_for_term', { term, stray, accepts: [...spec.extras] });
+  }
+
+  const cleanName = String(name).trim().slice(0, spec.nameMax);
+  const slug = blogTermSlug(cleanName, spec.slugMax);
+  if (!slug) return fail('empty_slug', { name: cleanName });
+
+  const admin = createAdminClient();
+  const { data: clash } = await admin
+    .from(spec.table)
+    .select('id')
+    .eq('brand_id', brand.id)
+    .eq('slug', slug)
+    .maybeSingle();
+  if (clash) return fail('slug_taken', { term, slug, id: clash.id });
+
+  const row: Record<string, unknown> = { brand_id: brand.id, name: cleanName, slug };
+  for (const key of spec.extras) {
+    const value = extras[key as keyof typeof extras];
+    if (value === undefined) continue;
+    row[key] = String(value).trim().slice(0, spec.extraMax[key] ?? 300) || null;
+  }
+
+  const { data: created, error: insertError } = await admin
+    .from(spec.table)
+    .insert(row)
+    .select('id')
+    .single();
+
+  if (insertError || !created) {
+    return fail('insert_failed', { detail: insertError?.message });
+  }
+
+  return json({ ok: true, term, id: created.id, name: cleanName, slug });
+};

--- a/src/routes/api/v1/brands/[slug]/settings/blog/terms/remove/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/settings/blog/terms/remove/+server.ts
@@ -1,0 +1,64 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { authenticate, loadBrandForUser, checkApiKeyWriteAccess } from '$lib/server/cli-auth';
+import { REMOVE_BLOG_TERM, statusForFailure } from '@anomalia/api-contracts';
+import { BLOG_TERMS } from '$lib/server/blog-settings';
+import { createAdminClient } from '$lib/server/supabase-admin';
+
+// POST /api/v1/brands/:slug/settings/blog/terms/remove — una voce in meno.
+//
+// Nessun articolo viene cancellato, ma ognuna delle tre lascia un segno diverso: categoria e
+// autore staccano un riferimento (`on delete set null`), un tag sparisce dalla tabella di mezzo
+// (`on delete cascade`). Il conto degli articoli toccati si fa PRIMA della cancellazione — dopo,
+// la riga che lo permetteva non esiste più — e torna nella risposta: la conseguenza contata, non
+// promessa.
+
+export const POST: RequestHandler = async ({ request, params }) => {
+  const { supabase, error, apiKey } = await authenticate(request);
+  if (error) return error;
+
+  const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
+  if (brandError) return brandError;
+  const writeDenied = checkApiKeyWriteAccess(apiKey);
+  if (writeDenied) return writeDenied;
+
+  const parsed = REMOVE_BLOG_TERM.input.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return json({ error: 'invalid_input', details: parsed.error.issues }, { status: 400 });
+  }
+
+  const { term, id } = parsed.data;
+  const spec = BLOG_TERMS[term];
+  const admin = createAdminClient();
+
+  const { data: row } = await admin
+    .from(spec.table)
+    .select('id')
+    .eq('id', id)
+    .eq('brand_id', brand.id)
+    .maybeSingle();
+
+  if (!row) {
+    return json(
+      { error: 'not_found', term, id },
+      { status: statusForFailure(REMOVE_BLOG_TERM, 'not_found') }
+    );
+  }
+
+  const { data: affected } = await admin.from(spec.refTable).select('id').eq(spec.refColumn, id);
+
+  const { error: deleteError } = await admin
+    .from(spec.table)
+    .delete()
+    .eq('id', id)
+    .eq('brand_id', brand.id);
+
+  if (deleteError) {
+    return json(
+      { error: 'delete_failed', detail: deleteError.message },
+      { status: statusForFailure(REMOVE_BLOG_TERM, 'delete_failed') }
+    );
+  }
+
+  return json({ ok: true, term, id, articles_affected: (affected ?? []).length });
+};


### PR DESCRIPTION
## What?

Four registry-generated tools cover the three blog settings pages — `blog-appearance`, `blog-categories`, `blog-authors`: `get_blog_settings` (GET `/settings/blog`), `set_blog_settings` (PUT, same path), `add_blog_term` (POST `/settings/blog/terms`) and `remove_blog_term` (POST `/settings/blog/terms/remove`).

Everything lands where it already lives — `brands.blog_config` (jsonb), `blog_categories`, `blog_tags`, `blog_authors`. **No migration.**

`tools/list` goes from **107 to 111**. Object-by-object comparison of every existing tool: `new: [add_blog_term, get_blog_settings, remove_blog_term, set_blog_settings]`, `gone: []`, `changed: []`.

## Why?

`update_article` already accepts `category_id`, `author_id` and `tag_ids` and checks they belong to the brand. But **nothing could create one**: an agent could file an article under an existing category and not under a new one. And the whole look of the public blog — name, colour, font, layout, cadence, languages — needed a browser.

## How?

### One rule per field, two callers

`customizationPatchFromFormData` built the thirteen `blog_config` rules inline, for the form. The API needs a **partial** patch. Reimplementing them would be thirteen rules in two copies, and that divergence does not surface as an error — it surfaces as a slightly wrong colour on the public site.

`BLOG_CONFIG_FIELDS` is one row per field; `blogConfigPatch(input, plan, current)` applies only the fields present. The form passes all thirteen (a form save is a full replace, and an unticked checkbox means `false`), the tools only what they were given. The cross-field rule — extra languages cannot contain the default one — runs after the per-field pass, on what holds **after** the patch; without `current`, changing only `locales` would leave the blog translating into itself.

The slugify was copied **three times** in the same file, once per action. It is `blogTermSlug` now, used by the three form actions and both routes.

### One table for three lists, not three chains of `if`

Category, tag and author share a shape — name, derived slug, unique per brand — and differ in two places: the extra fields they take, and **what they leave behind when deleted**. `BLOG_TERMS` is that difference, in one place:

| term | constraint | what is left |
|---|---|---|
| category | `brand_articles.category_id … set null` | articles stay, filed under nothing |
| tag | `brand_article_tags.tag_id … cascade` | the tag comes off every article that carried it |
| author | `brand_articles.author_id … set null` | articles stay, with no byline |

Those three sentences are in `remove_blog_term`'s description and a test holds them there: an agent has to be able to say what will happen *before* it runs. The count of affected articles is taken **before** the delete — afterwards the row that allowed it is gone — and comes back as `articles_affected`.

### Clamp or refuse — the same decision made twice, differently, on purpose

- **`articles_per_week` is clamped** to the plan ceiling. That is what the browser form already does, and two behaviours for one field would be a divergence. But an agent that does not re-read would believe it saved the number it asked for, so the answer carries `config` and the description says to read it back.
- **A locale the blog does not serve is refused** (`unknown_locale`), not dropped. Dropping it would leave the caller believing a translation is on.
- **A field sent to the wrong list is refused** (`field_not_for_term`), not ignored: a `bio` on a tag is not a typo to absorb, it is a biography someone thinks they wrote.
- **A taken slug is a 409**, not the raw Postgres unique-violation 500 the current form code lets through to the screen.

### What stays out, and why it is not an omission

The **blog icon** and an **author's avatar** are set only by uploading a file — they go through `readUploadImage`, cap at 2 MB and land in Storage. A field accepting them as a string would save a URL nobody verified. A test asserts those fields do not exist in either schema, and the descriptions say so rather than leaving it to be discovered.

## Testing?

Red before green, with real output.

- **contract** — red before it was in the registry.
- **`blogConfigPatch`** — proven by removing the accent check, the font check, the cadence ceiling and the cross-field locale rule: 6 tests fail, **two of which pre-date this PR and belong to the form** — which is the proof that both paths now share one rule rather than two copies that agree today.
- **the routes** — proven by removing `no_fields`, the locale refusal, the empty-slug guard, the slug clash, the wrong-field refusal, the 404 and the affected count: **exactly 10 of 19 fail**, 9 stay green. Restored, 19/19.

| command | result |
|---|---|
| `npx vitest run packages/api-contracts` | 172 tests, pass |
| `cd cli && bun test` | 57 tests, 0 fail |
| `cd cli && bun run typecheck` | clean |
| `node scripts/typecheck-runtime.mjs` | ok |
| affected app tests (blog-settings, all settings routes, changelog, no-app-imports) | 194 tests, pass |

`node_modules/@anomalia/api-contracts` resolves to **this worktree's** `packages/api-contracts` (checked with `realpathSync`), so the contract tests and the `tools/list` capture ran against this branch.

**Not tested:** no browser, Docker, dev server or Playwright — forbidden for this task. The full `npm run test:unit` was not run; CI runs it.

**Risk:** `patchBlogConfig` reads `blog_config`, merges and writes the whole jsonb back — pre-existing behaviour, so a concurrent write to a different key can lose a race. The three list reads and the term writes use the admin client because those tables are service-role; authorisation happens first on the user's client through `loadBrandForUser`, the shape `/doctor` uses.

**Rebase note:** the registry conflicted with two branches merged meanwhile (radar, social). Resolved as an alphabetically ordered union of `BRAND_ENDPOINTS`; `grep -c "export const BRAND_ENDPOINTS"` returns 1, and the tools capture below was taken **after** the rebase, against current `dev`.

## Evidence

<details>
<summary>tools/list through handleMcpFetch, origin/dev vs this branch (after rebase)</summary>

```
new:     ['add_blog_term', 'get_blog_settings', 'remove_blog_term', 'set_blog_settings']
gone:    []
changed: []
count:   107 → 111

remove_blog_term annotations: {'readOnlyHint': False, 'destructiveHint': True}
```

</details>

<details>
<summary>Red, then green: the routes with their logic removed</summary>

```
× GET  … > senza una cadenza scelta risponde null, non il default del piano spacciato per scelta
× GET  … > senza una lingua scelta non ne inventa una
× PUT  … > una richiesta senza campi è 400 dichiarato
× PUT  … > rifiuta una lingua che il blog non serve e dice quali erano ammesse
× POST … /terms > un nome che si riduce a niente non diventa una riga senza slug
× POST … /terms > uno slug già preso è 409, non una seconda riga
× POST … /terms > rifiuta un campo che quella lista non ha, invece di scartarlo
× POST … /remove > conta gli articoli toccati PRIMA di cancellare
× POST … /remove > una voce che non è del brand è 404, non una cancellazione altrui
× POST … /remove > un tag si conta sulla tabella di mezzo, non sugli articoli
   Tests  10 failed | 9 passed (19)
```

</details>

<details>
<summary>Red on the shared field table — including the form's own tests</summary>

```
× customizationPatchFromFormData > falls back to default accent when invalid     ← pre-existing
× customizationPatchFromFormData > clamps articlesPerWeek to the plan max        ← pre-existing
× blogConfigPatch > rifiuta un colore che non è un esadecimale …
× blogConfigPatch > un font che il sito non sa rendere torna a sans
× blogConfigPatch > riduce la cadenza al tetto del piano invece di rifiutarla
× blogConfigPatch > le lingue in più non contengono quella di default …
   Tests  6 failed | 7 passed (13)
```

</details>

<details>
<summary>What the writes answer</summary>

```
PUT   { articles_per_week: 999 }        → 200, saved the plan max, config echoed
PUT   { locales: ['it','klingon'] }     → 400 unknown_locale, unknown: ['klingon'], nothing written
PUT   { font: 'comic-sans' }            → 400 invalid_input
PUT   { }                               → 400 no_fields

POST  /terms { term:'category', name:'Caffè Speciale' } → slug 'caffe-speciale'
POST  /terms { term:'tag', name:'???' }                 → 400 empty_slug
POST  /terms { term:'tag', name:'Espresso' } (taken)    → 409 slug_taken
POST  /terms { term:'tag', name:'x', bio:'…' }          → 400 field_not_for_term, accepts: []
POST  /terms/remove { term:'category', id:'c1' }        → articles_affected: 2
POST  /terms/remove { term:'category', id:'unknown' }   → 404 not_found
```

</details>

No UI change: no page added, no component touched.

## Anything Else?

**`blog_config.backlinkNetwork` may be dead.** It is written by the form and round-tripped, and I could not find it consumed by `blog-generate.ts`, `blog-site.ts`, `blog-month.ts` or `blog-locales.ts`. It is exposed here because the browser exposes it and dropping it would be a silent behaviour change, but it is worth confirming whether anything still reads it.

**Not exposed:** `blog-domain` (custom domain) and `blog-integrations` (Shopify/Webflow/Wix). The first calls the Vercel domain API and is a DNS-level change; the second stores OAuth credentials in Supabase Vault. Both are the connector-consent line already drawn: a tool can hand over a link, never walk through it.

**Still flagged from the census**, unchanged: `brands.chat_default_tier` has a column and a setter and no caller; `settings/referrals` calls `ensureReferralCode` during `load`, a page load that INSERTs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
