### PR TITLE
Let an external agent search the brand's knowledge

### DIFF
--- a/changelog/2026-09-04-search-knowledge-per-agenti-esterni.md
+++ b/changelog/2026-09-04-search-knowledge-per-agenti-esterni.md
@@ -1,0 +1,62 @@
+# `search_knowledge` — l'agente esterno interroga la conoscenza del brand
+
+## Cosa c'era prima
+
+L'agente interno cercava dentro i documenti del brand con `searchKnowledge`
+(`src/lib/server/knowledge.ts`): FTS su `brand_doc_chunks`, e in fusione RRF con i vicini
+vettoriali quando le parole chiave non bastano. Da fuori, via MCP, quella capacità non esisteva:
+i 115 tool del registry toccavano la conoscenza solo con `get_studio`, che elenca i documenti —
+dice **quali** ci sono, non cosa contengono.
+
+Un agente esterno che doveva scrivere qualcosa di fondato aveva due sole strade: chiedere
+`get_studio` e ricevere il `content_text` di ogni documento (l'intero corpus riversato nella
+finestra), oppure inventare.
+
+## Cosa cambia
+
+Una rotta sola, `GET /api/v1/brands/:slug/knowledge/search`, sopra la `searchKnowledge` che
+esisteva già. Nessuna riscrittura della ricerca: la rotta risolve il brand, passa la domanda e
+formatta i passi.
+
+Il tool MCP `search_knowledge` nasce dal registry (`packages/api-contracts/src/knowledge.ts`),
+come tutti gli altri.
+
+## Le due domande decise prima di progettare
+
+**Costa?** Quasi mai, e mai un modello generativo. `searchKnowledge` interroga prima l'FTS —
+Postgres puro, zero chiamate. Un embedding della domanda parte **solo** quando l'FTS restituisce
+meno risultati del `limit`; è un embedding corto, non una generazione, e finisce in `ai_calls`
+come `knowledge-embed`.
+
+Per questo la rotta **non** passa da `gateAiAction`: il corpus è già stato indicizzato — e pagato —
+al momento dell'ingestione. Mettere un cancello a crediti su una lettura significherebbe che un
+brand a secco non può più leggere quello che ha già pagato per indicizzare. Il prezzo è comunque
+dichiarato nella descrizione del tool, che è l'unica documentazione che un modello legge prima di
+chiamare.
+
+**Quanto restituisce?** Un chunk nasce a ~800 token (~3.200 caratteri). Otto chunk interi sono
+~25.000 caratteri per una domanda sola. Due tetti, entrambi nel contratto e verificati da un test:
+
+- `KNOWLEDGE_HITS_DEFAULT = 6`, `KNOWLEDGE_HITS_MAX = 20` — `limit` sopra il tetto è rifiutato da
+  zod prima di partire, e la rotta lo riapplica per chi chiama in HTTP diretto;
+- `KNOWLEDGE_EXCERPT_CHARS = 1500` per passo, con `truncated: true` quando c'è dell'altro. Il
+  `documentId` dice dove andarlo a prendere.
+
+## L'isolamento fra brand, e perché ha un test dedicato
+
+Sul percorso a chiave API `authenticate` restituisce il **client di servizio**: la RLS non
+protegge niente. L'unico filtro è `p_brand` dentro `search_brand_chunks`, e il brand arriva da
+`loadBrandForUser`, mai da un parametro di chi chiama.
+
+Questo repo ha già avuto una lettura che attraversava tutti i brand di un utente con la suite
+verde, quindi il test è scritto per fallire davvero: il finto Supabase imita il SQL vero
+(filtra per `p_brand`) ed è seminato con due brand. Il test cerca **il contenuto esatto** del
+documento dell'altro brand e pretende zero risultati; un secondo test verifica che ogni RPC parta
+con il brand risolto dallo slug anche quando chi chiama prova a passarne un altro.
+
+## Cosa è stato scartato
+
+- **`documentIds` come parametro.** `searchKnowledge` lo accetta, ma un agente esterno non ha
+  modo di sapere quali id gli servono prima di aver cercato. Si aggiunge quando serve davvero.
+- **Restituire il chunk intero.** Il passo tagliato più il `documentId` costano meno del corpus
+  intero e dicono la stessa cosa.

--- a/cli/lib/contracts/index.ts
+++ b/cli/lib/contracts/index.ts
@@ -49,6 +49,7 @@ import { DIAGNOSE_BRAND, GET_GOALS } from './brand-state';
 import { GET_BRAND_SETTINGS, SET_BRAND_SETTINGS } from './brand-settings';
 import { DIAGNOSE_RADAR, GET_MARKET_FIELD, LIST_IDEAS } from './market';
 import { GET_MEDIA_MODELS, SET_MEDIA_MODEL } from './media-models';
+import { SEARCH_KNOWLEDGE } from './knowledge';
 import {
   ADD_RADAR_SOURCE,
   GET_RADAR,
@@ -179,6 +180,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   REVOKE_SHARE,
   SAVE_PLAN,
   SAVE_WEEK_SEEDS,
+  SEARCH_KNOWLEDGE,
   SEO_ACTION,
   SET_AUTOMATION,
   SET_BIO,
@@ -287,6 +289,14 @@ export {
   SET_RADAR_PLATFORM
 } from './radar';
 export type { RadarPlatform, RadarSourceKindName } from './radar';
+export {
+  KNOWLEDGE_COLLECTIONS,
+  KNOWLEDGE_EXCERPT_CHARS,
+  KNOWLEDGE_HITS_DEFAULT,
+  KNOWLEDGE_HITS_MAX,
+  SEARCH_KNOWLEDGE
+} from './knowledge';
+export type { KnowledgeCollection } from './knowledge';
 export { GEO_ACTION, REFRESH_KEYWORDS, SEO_ACTION } from './search';
 export { GET_BACKLINKS, GET_GSC, GET_RANKS } from './web-metrics';
 export {

--- a/cli/lib/contracts/knowledge.ts
+++ b/cli/lib/contracts/knowledge.ts
@@ -1,0 +1,69 @@
+import { z } from 'zod';
+import type { BrandEndpoint } from './index';
+
+export const KNOWLEDGE_HITS_DEFAULT = 6;
+export const KNOWLEDGE_HITS_MAX = 20;
+
+/**
+ * Il tetto per passo. Un chunk nasce a ~800 token: otto interi sono ~25.000 caratteri riversati
+ * nella finestra di chi ha fatto una domanda sola. `truncated` dice che c'è dell'altro, e
+ * `documentId` dice dove andarlo a prendere.
+ */
+export const KNOWLEDGE_EXCERPT_CHARS = 1500;
+
+/** Lo stesso elenco chiuso di `COLLECTIONS` in `$lib/server/knowledge` — un test tiene i due allineati. */
+export const KNOWLEDGE_COLLECTIONS = [
+  'brand',
+  'product',
+  'commercial',
+  'legal',
+  'operations',
+  'research'
+] as const;
+
+export type KnowledgeCollection = (typeof KNOWLEDGE_COLLECTIONS)[number];
+
+export const SEARCH_KNOWLEDGE = {
+  tool: 'search_knowledge',
+  title: 'Search brand knowledge',
+  description:
+    "Ask the brand's own documents a question and get back the passages that answer it, each with the document and heading it came from. " +
+    'Hybrid retrieval over what is already indexed: keywords first, and a single embedding of the question only when keywords come up short — no credits are spent and nothing is written. ' +
+    `Each passage is cut at ${KNOWLEDGE_EXCERPT_CHARS} characters (\`truncated\` says when there is more); \`limit\` is ${KNOWLEDGE_HITS_DEFAULT} by default and ${KNOWLEDGE_HITS_MAX} at most. ` +
+    'Narrow with `collection` when you know the shelf. An empty `hits` means the indexed corpus has no answer — which is not the same as the brand not knowing it, because a document still queued has nothing to find.',
+  method: 'GET',
+  pathUnderBrand: '/knowledge/search',
+  input: z
+    .object({
+      query: z.string().min(1).describe("The question, phrased in the brand's own language"),
+      limit: z.coerce
+        .number()
+        .int()
+        .min(1)
+        .max(KNOWLEDGE_HITS_MAX)
+        .optional()
+        .describe(`How many passages, ${KNOWLEDGE_HITS_DEFAULT} by default, ${KNOWLEDGE_HITS_MAX} at most`),
+      collection: z
+        .enum(KNOWLEDGE_COLLECTIONS)
+        .optional()
+        .describe('Restrict to one shelf of the corpus')
+    })
+    .strict(),
+  output: z.object({
+    query: z.string(),
+    count: z.number(),
+    hits: z.array(
+      z.object({
+        chunkId: z.string(),
+        documentId: z.string(),
+        title: z.string(),
+        headingPath: z.string(),
+        excerpt: z.string(),
+        truncated: z.boolean(),
+        score: z.number()
+      })
+    )
+  }),
+  failures: [{ error: 'query_required', status: 400 }],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/cli/plugins/anomalia/skills/anomalia/references/tools.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/tools.md
@@ -228,6 +228,26 @@ their own words.
 pastes it on the profile by hand. `get_bio` also returns the short link worth putting there — the
 one with the most clicks in the last seven days.
 
+## Knowledge
+
+| MCP | CLI |
+|-----|-----|
+| `search_knowledge` | (MCP only) |
+
+`search_knowledge` asks the brand's OWN documents a question and returns the passages that answer
+it — not a list of files. Every hit carries where it came from (`documentId`, `title`,
+`headingPath`, `chunkId`), so a claim can be attributed instead of asserted. Retrieval is hybrid
+over what is already indexed: keywords first, one embedding of the question only when keywords
+come up short. No credits, no writes.
+
+Passages are cut at 1500 characters and `truncated` says when there is more; `limit` is 6 by
+default and 20 at most, so ask a narrow question several times rather than a wide one once.
+`collection` narrows to a shelf: `brand`, `product`, `commercial`, `legal`, `operations`,
+`research`.
+
+Empty `hits` is not the same as "the brand does not know this": a document that was uploaded but
+never processed has nothing to find. `get_studio` lists what exists.
+
 ## Brand settings
 
 | MCP | CLI |

--- a/cli/skills/anomalia/references/tools.md
+++ b/cli/skills/anomalia/references/tools.md
@@ -228,6 +228,26 @@ their own words.
 pastes it on the profile by hand. `get_bio` also returns the short link worth putting there — the
 one with the most clicks in the last seven days.
 
+## Knowledge
+
+| MCP | CLI |
+|-----|-----|
+| `search_knowledge` | (MCP only) |
+
+`search_knowledge` asks the brand's OWN documents a question and returns the passages that answer
+it — not a list of files. Every hit carries where it came from (`documentId`, `title`,
+`headingPath`, `chunkId`), so a claim can be attributed instead of asserted. Retrieval is hybrid
+over what is already indexed: keywords first, one embedding of the question only when keywords
+come up short. No credits, no writes.
+
+Passages are cut at 1500 characters and `truncated` says when there is more; `limit` is 6 by
+default and 20 at most, so ask a narrow question several times rather than a wide one once.
+`collection` narrows to a shelf: `brand`, `product`, `commercial`, `legal`, `operations`,
+`research`.
+
+Empty `hits` is not the same as "the brand does not know this": a document that was uploaded but
+never processed has nothing to find. `get_studio` lists what exists.
+
 ## Brand settings
 
 | MCP | CLI |

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -49,6 +49,7 @@ import { DIAGNOSE_BRAND, GET_GOALS } from './brand-state';
 import { GET_BRAND_SETTINGS, SET_BRAND_SETTINGS } from './brand-settings';
 import { DIAGNOSE_RADAR, GET_MARKET_FIELD, LIST_IDEAS } from './market';
 import { GET_MEDIA_MODELS, SET_MEDIA_MODEL } from './media-models';
+import { SEARCH_KNOWLEDGE } from './knowledge';
 import {
   ADD_RADAR_SOURCE,
   GET_RADAR,
@@ -179,6 +180,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   REVOKE_SHARE,
   SAVE_PLAN,
   SAVE_WEEK_SEEDS,
+  SEARCH_KNOWLEDGE,
   SEO_ACTION,
   SET_AUTOMATION,
   SET_BIO,
@@ -287,6 +289,14 @@ export {
   SET_RADAR_PLATFORM
 } from './radar';
 export type { RadarPlatform, RadarSourceKindName } from './radar';
+export {
+  KNOWLEDGE_COLLECTIONS,
+  KNOWLEDGE_EXCERPT_CHARS,
+  KNOWLEDGE_HITS_DEFAULT,
+  KNOWLEDGE_HITS_MAX,
+  SEARCH_KNOWLEDGE
+} from './knowledge';
+export type { KnowledgeCollection } from './knowledge';
 export { GEO_ACTION, REFRESH_KEYWORDS, SEO_ACTION } from './search';
 export { GET_BACKLINKS, GET_GSC, GET_RANKS } from './web-metrics';
 export {

--- a/packages/api-contracts/src/knowledge.test.ts
+++ b/packages/api-contracts/src/knowledge.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import {
+  KNOWLEDGE_COLLECTIONS,
+  KNOWLEDGE_EXCERPT_CHARS,
+  KNOWLEDGE_HITS_DEFAULT,
+  KNOWLEDGE_HITS_MAX,
+  SEARCH_KNOWLEDGE
+} from './knowledge';
+import { BRAND_ENDPOINTS } from './index';
+
+describe('il contratto della ricerca nella conoscenza', () => {
+  it('è registrato, o il tool MCP non nasce', () => {
+    expect(BRAND_ENDPOINTS).toContain(SEARCH_KNOWLEDGE);
+  });
+
+  it('è una lettura: cercare non cambia il corpus', () => {
+    expect(SEARCH_KNOWLEDGE.method).toBe('GET');
+    expect(SEARCH_KNOWLEDGE.destructive).toBe(false);
+    expect(SEARCH_KNOWLEDGE.openWorld).toBeUndefined();
+  });
+
+  it('la domanda è obbligatoria, e vuota non passa', () => {
+    expect(SEARCH_KNOWLEDGE.input.safeParse({}).success).toBe(false);
+    expect(SEARCH_KNOWLEDGE.input.safeParse({ query: '' }).success).toBe(false);
+    expect(SEARCH_KNOWLEDGE.input.safeParse({ query: 'quanto dura la garanzia' }).success).toBe(true);
+  });
+
+  it('dichiara il tetto che la rotta applica in silenzio', () => {
+    expect(SEARCH_KNOWLEDGE.input.safeParse({ query: 'x', limit: KNOWLEDGE_HITS_MAX }).success).toBe(true);
+    expect(SEARCH_KNOWLEDGE.input.safeParse({ query: 'x', limit: KNOWLEDGE_HITS_MAX + 1 }).success).toBe(false);
+    expect(SEARCH_KNOWLEDGE.input.safeParse({ query: 'x', limit: 0 }).success).toBe(false);
+  });
+
+  it('accetta solo le collezioni che il corpus conosce', () => {
+    for (const collection of KNOWLEDGE_COLLECTIONS) {
+      expect(SEARCH_KNOWLEDGE.input.safeParse({ query: 'x', collection }).success, collection).toBe(true);
+    }
+    expect(SEARCH_KNOWLEDGE.input.safeParse({ query: 'x', collection: 'inventata' }).success).toBe(false);
+  });
+
+  it('rifiuta un parametro che non dichiara invece di scartarlo in silenzio', () => {
+    expect(SEARCH_KNOWLEDGE.input.safeParse({ query: 'x', brand_id: 'altro' }).success).toBe(false);
+  });
+
+  /**
+   * La descrizione è l'unica documentazione che un modello esterno legge prima di chiamare.
+   * Se non dice il prezzo e il tetto, li scopre riempiendosi la finestra.
+   */
+  it('la descrizione dice il prezzo e il tetto, perché è tutto ciò che il modello legge', () => {
+    expect(SEARCH_KNOWLEDGE.description).toContain('no credits');
+    expect(SEARCH_KNOWLEDGE.description).toContain(String(KNOWLEDGE_EXCERPT_CHARS));
+    expect(SEARCH_KNOWLEDGE.description).toContain(String(KNOWLEDGE_HITS_MAX));
+  });
+
+  it('il campo di ogni passo dice da dove viene, o la citazione non è verificabile', () => {
+    const hit = SEARCH_KNOWLEDGE.output.safeParse({
+      query: 'garanzia',
+      count: 1,
+      hits: [
+        {
+          chunkId: 'c1',
+          documentId: 'd1',
+          title: 'Condizioni',
+          headingPath: 'Garanzia',
+          excerpt: '24 mesi',
+          truncated: false,
+          score: 1
+        }
+      ]
+    });
+
+    expect(hit.success).toBe(true);
+  });
+
+  it('il default sta sotto il tetto', () => {
+    expect(KNOWLEDGE_HITS_DEFAULT).toBeLessThanOrEqual(KNOWLEDGE_HITS_MAX);
+  });
+});

--- a/packages/api-contracts/src/knowledge.ts
+++ b/packages/api-contracts/src/knowledge.ts
@@ -1,0 +1,69 @@
+import { z } from 'zod';
+import type { BrandEndpoint } from './index';
+
+export const KNOWLEDGE_HITS_DEFAULT = 6;
+export const KNOWLEDGE_HITS_MAX = 20;
+
+/**
+ * Il tetto per passo. Un chunk nasce a ~800 token: otto interi sono ~25.000 caratteri riversati
+ * nella finestra di chi ha fatto una domanda sola. `truncated` dice che c'è dell'altro, e
+ * `documentId` dice dove andarlo a prendere.
+ */
+export const KNOWLEDGE_EXCERPT_CHARS = 1500;
+
+/** Lo stesso elenco chiuso di `COLLECTIONS` in `$lib/server/knowledge` — un test tiene i due allineati. */
+export const KNOWLEDGE_COLLECTIONS = [
+  'brand',
+  'product',
+  'commercial',
+  'legal',
+  'operations',
+  'research'
+] as const;
+
+export type KnowledgeCollection = (typeof KNOWLEDGE_COLLECTIONS)[number];
+
+export const SEARCH_KNOWLEDGE = {
+  tool: 'search_knowledge',
+  title: 'Search brand knowledge',
+  description:
+    "Ask the brand's own documents a question and get back the passages that answer it, each with the document and heading it came from. " +
+    'Hybrid retrieval over what is already indexed: keywords first, and a single embedding of the question only when keywords come up short — no credits are spent and nothing is written. ' +
+    `Each passage is cut at ${KNOWLEDGE_EXCERPT_CHARS} characters (\`truncated\` says when there is more); \`limit\` is ${KNOWLEDGE_HITS_DEFAULT} by default and ${KNOWLEDGE_HITS_MAX} at most. ` +
+    'Narrow with `collection` when you know the shelf. An empty `hits` means the indexed corpus has no answer — which is not the same as the brand not knowing it, because a document still queued has nothing to find.',
+  method: 'GET',
+  pathUnderBrand: '/knowledge/search',
+  input: z
+    .object({
+      query: z.string().min(1).describe("The question, phrased in the brand's own language"),
+      limit: z.coerce
+        .number()
+        .int()
+        .min(1)
+        .max(KNOWLEDGE_HITS_MAX)
+        .optional()
+        .describe(`How many passages, ${KNOWLEDGE_HITS_DEFAULT} by default, ${KNOWLEDGE_HITS_MAX} at most`),
+      collection: z
+        .enum(KNOWLEDGE_COLLECTIONS)
+        .optional()
+        .describe('Restrict to one shelf of the corpus')
+    })
+    .strict(),
+  output: z.object({
+    query: z.string(),
+    count: z.number(),
+    hits: z.array(
+      z.object({
+        chunkId: z.string(),
+        documentId: z.string(),
+        title: z.string(),
+        headingPath: z.string(),
+        excerpt: z.string(),
+        truncated: z.boolean(),
+        score: z.number()
+      })
+    )
+  }),
+  failures: [{ error: 'query_required', status: 400 }],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/src/lib/content/changelog/2026-09-04-search-brand-knowledge.ts
+++ b/src/lib/content/changelog/2026-09-04-search-brand-knowledge.ts
@@ -1,0 +1,10 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-04',
+  title: 'Your agent can now read what your brand knows',
+  items: [
+    'Claude, ChatGPT or Cursor can ask your brand documents a question and get back the passages that answer it, each with the document and heading it came from — so a claim can be checked, not just believed.',
+    'Searching your knowledge costs no credits and changes nothing.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/routes/api/v1/brands/[slug]/knowledge/search/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/knowledge/search/+server.ts
@@ -1,0 +1,52 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { authenticate, loadBrandForUser } from '$lib/server/cli-auth';
+import { searchKnowledge, COLLECTIONS, type Collection } from '$lib/server/knowledge';
+import {
+  KNOWLEDGE_EXCERPT_CHARS,
+  KNOWLEDGE_HITS_DEFAULT,
+  KNOWLEDGE_HITS_MAX
+} from '@anomalia/api-contracts';
+
+// Interrogare la conoscenza del brand come faceva l'agente interno: la stessa `searchKnowledge`
+// (FTS, e un embedding della domanda solo quando le parole chiave non bastano), esposta a chi
+// lavora da fuori. Nessun modello generativo, nessun credito, nessuna scrittura — quindi niente
+// `gateAiAction`: chi ha finito i crediti può ancora leggere quello che ha già pagato per indicizzare.
+//
+// L'isolamento non passa dalla RLS: sul percorso a chiave API `authenticate` restituisce il client
+// di servizio. Il brand viene da `loadBrandForUser`, mai da un parametro di chi chiama.
+
+export const GET: RequestHandler = async ({ request, params, url }) => {
+  const { supabase, error, apiKey } = await authenticate(request);
+  if (error) return error;
+
+  const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
+  if (brandError) return brandError;
+
+  const query = (url.searchParams.get('query') ?? '').trim();
+  if (!query) return json({ error: 'query_required' }, { status: 400 });
+
+  const requested = Number(url.searchParams.get('limit'));
+  const limit = Number.isFinite(requested) && requested > 0
+    ? Math.min(KNOWLEDGE_HITS_MAX, Math.round(requested))
+    : KNOWLEDGE_HITS_DEFAULT;
+
+  const asked = url.searchParams.get('collection');
+  const collection = COLLECTIONS.includes(asked as Collection) ? (asked as Collection) : null;
+
+  const hits = await searchKnowledge(supabase, brand.id, query, { limit, collection });
+
+  return json({
+    query,
+    count: hits.length,
+    hits: hits.map((hit) => ({
+      chunkId: hit.chunkId,
+      documentId: hit.documentId,
+      title: hit.title,
+      headingPath: hit.headingPath,
+      excerpt: hit.content.slice(0, KNOWLEDGE_EXCERPT_CHARS),
+      truncated: hit.content.length > KNOWLEDGE_EXCERPT_CHARS,
+      score: hit.score
+    }))
+  });
+};

--- a/src/routes/api/v1/brands/[slug]/knowledge/search/server.test.ts
+++ b/src/routes/api/v1/brands/[slug]/knowledge/search/server.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('$lib/server/cli-auth', () => ({
+  authenticate: vi.fn(),
+  loadBrandForUser: vi.fn()
+}));
+
+import { GET } from './+server';
+import { authenticate, loadBrandForUser } from '$lib/server/cli-auth';
+import { COLLECTIONS } from '$lib/server/knowledge';
+import { KNOWLEDGE_COLLECTIONS, KNOWLEDGE_EXCERPT_CHARS, KNOWLEDGE_HITS_MAX } from '@anomalia/api-contracts';
+
+type Chunk = {
+  id: string;
+  brand_id: string;
+  document_id: string;
+  heading_path: string | null;
+  content: string;
+  title: string | null;
+  collection?: string | null;
+};
+
+/**
+ * Il finto Supabase imita le due RPC come le scrive il SQL vero: filtrano per `p_brand`, e la
+ * ricerca testuale su `content`. Un fake che restituisce quello che gli dici non dimostra
+ * l'isolamento — questo sì, perché il corpus in memoria contiene due brand.
+ */
+function fakeSupabase(chunks: Chunk[]) {
+  const calls: { fn: string; args: Record<string, unknown> }[] = [];
+
+  const matching = (args: Record<string, unknown>) => {
+    const needle = String(args.p_query ?? '').toLowerCase();
+    const collection = args.p_collection as string | null;
+    return chunks
+      .filter((c) => c.brand_id === args.p_brand)
+      .filter((c) => !collection || c.collection === collection)
+      .filter((c) => !needle || c.content.toLowerCase().includes(needle))
+      .slice(0, Number(args.p_limit ?? 8))
+      .map((c) => ({
+        id: c.id,
+        document_id: c.document_id,
+        heading_path: c.heading_path,
+        content: c.content,
+        score: 1,
+        title: c.title
+      }));
+  };
+
+  return {
+    calls,
+    rpc: async (fn: string, args: Record<string, unknown>) => {
+      calls.push({ fn, args });
+      if (fn === 'search_brand_chunks') return { data: matching(args), error: null };
+      return { data: [], error: null };
+    }
+  };
+}
+
+const OWN: Chunk = {
+  id: 'chunk-own',
+  brand_id: 'brand-1',
+  document_id: 'doc-own',
+  heading_path: 'Garanzia',
+  content: 'La garanzia del macinacaffè dura 24 mesi.',
+  title: 'Condizioni'
+};
+
+const FOREIGN: Chunk = {
+  id: 'chunk-foreign',
+  brand_id: 'brand-2',
+  document_id: 'doc-foreign',
+  heading_path: 'Segreti',
+  content: 'Il margine riservato del concorrente è del 62 percento.',
+  title: 'Listino interno'
+};
+
+let supabase: ReturnType<typeof fakeSupabase>;
+
+function signedIn(chunks: Chunk[] = [OWN, FOREIGN]) {
+  supabase = fakeSupabase(chunks);
+  vi.mocked(authenticate).mockResolvedValue({
+    supabase,
+    user: { id: 'user-1' },
+    apiKey: undefined,
+    error: null
+  } as never);
+  vi.mocked(loadBrandForUser).mockResolvedValue({
+    brand: { id: 'brand-1', slug: 'demo', name: 'Demo Brand' },
+    error: null
+  } as never);
+}
+
+function call(query: Record<string, string>, slug = 'demo') {
+  const url = new URL(`https://anomalia.test/api/v1/brands/${slug}/knowledge/search`);
+  for (const [k, v] of Object.entries(query)) url.searchParams.set(k, v);
+  return (GET as (event: unknown) => Promise<Response>)({
+    request: new Request(url),
+    params: { slug },
+    url
+  }).then(async (res) => ({ res, body: await res.json() }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('GET /knowledge/search', () => {
+  it('la ricerca non attraversa i brand: il documento di un altro non esce nemmeno cercandone il contenuto esatto', async () => {
+    signedIn();
+
+    const { res, body } = await call({ query: 'margine riservato del concorrente' });
+
+    expect(res.status).toBe(200);
+    expect(body.hits).toEqual([]);
+    expect(JSON.stringify(body)).not.toContain('62 percento');
+    expect(JSON.stringify(body)).not.toContain('doc-foreign');
+  });
+
+  it('interroga sempre il brand risolto dallo slug, mai uno scelto da chi chiama', async () => {
+    signedIn();
+
+    await call({ query: 'garanzia', brand_id: 'brand-2', p_brand: 'brand-2' });
+
+    for (const { args } of supabase.calls) {
+      expect(args.p_brand).toBe('brand-1');
+    }
+  });
+
+  it('restituisce i passi del proprio brand con la provenienza', async () => {
+    signedIn();
+
+    const { body } = await call({ query: 'garanzia' });
+
+    expect(body.hits).toHaveLength(1);
+    expect(body.hits[0]).toMatchObject({
+      chunkId: 'chunk-own',
+      documentId: 'doc-own',
+      title: 'Condizioni',
+      headingPath: 'Garanzia',
+      truncated: false
+    });
+    expect(body.hits[0].excerpt).toContain('24 mesi');
+    expect(body.count).toBe(1);
+  });
+
+  it('taglia un passo lungo invece di rovesciarlo nella finestra di chi chiede', async () => {
+    const long = { ...OWN, content: `${'a'.repeat(KNOWLEDGE_EXCERPT_CHARS + 500)} garanzia` };
+    signedIn([long]);
+
+    const { body } = await call({ query: 'garanzia' });
+
+    expect(body.hits[0].excerpt.length).toBe(KNOWLEDGE_EXCERPT_CHARS);
+    expect(body.hits[0].truncated).toBe(true);
+  });
+
+  it('rifiuta una domanda vuota invece di cercare il nulla', async () => {
+    signedIn();
+
+    const { res, body } = await call({ query: '  ' });
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('query_required');
+  });
+
+  it('applica il tetto dichiarato anche se chi chiama ne chiede di più', async () => {
+    signedIn();
+
+    await call({ query: 'garanzia', limit: '500' });
+
+    const [{ args }] = supabase.calls;
+    expect(Number(args.p_limit)).toBeLessThanOrEqual(KNOWLEDGE_HITS_MAX * 3);
+  });
+
+  it('scarta una collezione che non esiste invece di passarla al database', async () => {
+    signedIn();
+
+    await call({ query: 'garanzia', collection: 'inventata' });
+
+    expect(supabase.calls[0].args.p_collection).toBeNull();
+  });
+
+  it('le collezioni dichiarate nel contratto sono quelle che il corpus conosce', () => {
+    expect([...KNOWLEDGE_COLLECTIONS]).toEqual([...COLLECTIONS]);
+  });
+});


### PR DESCRIPTION
## What?

An external agent (Claude, ChatGPT, Cursor) can now ask a brand's own documents a question and get back the passages that answer it, each carrying the document, title and heading it came from.

One new MCP tool, `search_knowledge`, generated from the registry, over one new route `GET /api/v1/brands/:slug/knowledge/search`. The retrieval itself is not new: the route sits on top of `searchKnowledge` in `src/lib/server/knowledge.ts`, unchanged.

`tools/list` goes from 115 to 116 tools. No existing tool changed a single field.

## Why?

Anomalia is handing reasoning and writing to the customer's own model and keeping the storing, validating, rendering, publishing and measuring. That trade only works if the external model can see what the brand knows.

Today it cannot. Of the 115 registry tools, the only one that touches knowledge is `get_studio`, and it answers with `documents: z.array(JsonObject)` — a list of files. It says **which** documents exist, never what is inside them. An external agent writing a post had two options: pull `get_studio` and take the `content_text` of every document (the whole corpus into its window), or make things up.

The internal agent never had that problem: `searchKnowledge` was wired into its tools. This PR gives the same thing to the outside.

## How?

**Route over the existing search, not a second search.** `searchKnowledge` already does FTS on `brand_doc_chunks` and fuses in vector neighbours with RRF when keyword recall is thin. The route resolves the brand, passes the question, shapes the hits. That is all it does.

**Cost — asked before designing, and it decided the gate.** Keyword retrieval is `search_brand_chunks`, pure Postgres, zero API calls. An embedding of the question fires **only** when FTS returns fewer rows than `limit`; it is a short embedding, not a generation, and it lands in `ai_calls` as `knowledge-embed`.

So the route deliberately does **not** call `gateAiAction`. The corpus was embedded — and paid for — at ingest time. Putting a credit gate on the read would mean a brand out of credits can no longer read what it already paid to index. The cost is instead declared in the tool description, which is the only documentation a model reads before calling.

**Payload — the second design question, also answered in the contract.** A chunk is born at ~800 tokens (~3,200 characters). Eight whole chunks is ~25,000 characters returned for one question. Three ceilings, all in `packages/api-contracts/src/knowledge.ts` and all covered by tests:

- `KNOWLEDGE_HITS_DEFAULT = 6`
- `KNOWLEDGE_HITS_MAX = 20` — zod rejects a bigger `limit` before the call leaves, and the route re-applies it for direct HTTP callers
- `KNOWLEDGE_EXCERPT_CHARS = 1500` per passage, with `truncated: true` when there is more and `documentId` saying where to go get it

**Rejected:** exposing `documentIds` (an external agent has no way to know which ids it wants before it has searched) and returning whole chunks (the excerpt plus the provenance says the same thing for a fraction of the window).

## Testing?

Automated, all run locally, output below. No Docker, no Playwright, no dev server — this is an API route plus a contract.

**The negative test that matters — knowledge search must never cross brands.** On the API-key path `authenticate` returns the **service-role client**, so RLS protects nothing: `p_brand` is the only isolation, and the brand id comes from `loadBrandForUser`, never from a caller parameter. This repo has already shipped a read that crossed every brand of a user with a green suite, so the test is built to actually fail: the fake Supabase imitates the real SQL (it filters by `p_brand`) and is seeded with two brands' chunks. The test searches for the **exact content** of the other brand's document and demands nothing comes back; a second test asserts every RPC leaves with the brand resolved from the slug even when the caller passes `brand_id=brand-2`.

Written first, watched fail:

<details><summary>Red — the route did not exist yet</summary>

```
 ❯ src/routes/api/v1/brands/[slug]/knowledge/search/server.test.ts (0 test)

 FAIL  src/routes/api/v1/brands/[slug]/knowledge/search/server.test.ts
Error: Failed to load url ./+server (resolved id: ./+server) ... Does the file exist?

 Test Files  1 failed (1)
      Tests  no tests
```
</details>

<details><summary>Green — 8 route tests</summary>

```
 ✓ src/routes/api/v1/brands/[slug]/knowledge/search/server.test.ts (8 tests) 6ms

 Test Files  1 passed (1)
      Tests  8 passed (8)
```

Covering: no cross-brand leak on exact foreign content; the brand always comes from the slug; provenance on every hit; a long passage is cut, not dumped; an empty question is refused with `query_required`; the ceiling is applied even when the caller asks for 500; an invented collection is dropped instead of reaching the database; and a guard test that `KNOWLEDGE_COLLECTIONS` in the contract still equals `COLLECTIONS` in `knowledge.ts` — the closed list crosses a package boundary, so a test keeps the two copies from diverging in silence.
</details>

<details><summary>Contracts, CLI, typechecks</summary>

```
$ npx vitest run packages/api-contracts
 ✓ packages/api-contracts/src/knowledge.test.ts (9 tests) 4ms
 Test Files  14 passed (14)
      Tests  170 passed (170)

$ cd cli && bun test
 57 pass
 0 fail
 611 expect() calls

$ cd cli && bun run typecheck
$ tsc --noEmit          (exit 0)

$ node scripts/typecheck-runtime.mjs
typecheck-runtime: ok (ignored 313 non-fatal type error(s))
```

`node_modules/@anomalia/api-contracts` was verified to resolve **inside this worktree** before any of it ran, so the contract tests are not passing against the main checkout's older copy:

```
$ node -e "console.log(require('fs').realpathSync('node_modules/@anomalia/api-contracts'))"
/Users/andreabuttarelli/Documents/GitHub/anomalia-wt/agent-knowledge/packages/api-contracts
```
</details>

**Not tested:** the route against a live Postgres. Retrieval quality itself is unchanged — `searchKnowledge` is untouched — so the risk this PR adds is the wrapper, which the route tests cover. The eval suite was not run: nothing here touches the chat path, prompts, tools or the model.

## Evidence

Backend change, no UI. The evidence that counts is the `tools/list` capture through `handleMcpFetch`, before and after, compared field by field:

<details><summary><code>tools/list</code> before → after</summary>

```
$ diff <(names before) <(names after)
91a92
> search_knowledge

before=115 after=116

removed: []
added: ['search_knowledge']
changed existing (field by field): []
```
</details>

<details><summary>The tool as an external model sees it</summary>

```
search_knowledge — "Search brand knowledge"

Ask the brand's own documents a question and get back the passages that answer it, each
with the document and heading it came from. Hybrid retrieval over what is already indexed:
keywords first, and a single embedding of the question only when keywords come up short —
no credits are spent and nothing is written. Each passage is cut at 1500 characters
(`truncated` says when there is more); `limit` is 6 by default and 20 at most. Narrow with
`collection` when you know the shelf. An empty `hits` means the indexed corpus has no
answer — which is not the same as the brand not knowing it, because a document still
queued has nothing to find.
```

That last sentence is a promise this PR cannot keep on its own: an agent that finds nothing still cannot tell "the brand does not know this" from "the document was never processed". The follow-up PR adds the reading that answers it.
</details>

## Anything Else?

- The closed collection list now exists twice — `KNOWLEDGE_COLLECTIONS` in the contract and `COLLECTIONS` in `knowledge.ts` — because a package may not import `$lib`. A test holds them equal rather than letting them drift.
- `search_knowledge` has no CLI command yet; it is MCP-only, which is where the external agent lives. Adding `anomalia knowledge <slug> --query …` is a one-liner when someone wants it.
- No migration. Nothing was applied anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
