### PR TITLE
Tell an agent whether the knowledge is usable

### DIFF
--- a/changelog/2026-09-04-stato-della-conoscenza.md
+++ b/changelog/2026-09-04-stato-della-conoscenza.md
@@ -1,0 +1,74 @@
+# `get_knowledge_status` — caricato non è digerito
+
+## Il problema, in una frase
+
+`search_knowledge` (PR precedente) può tornare vuoto per due motivi opposti:
+
+- il corpus è indicizzato e **il brand non sa quella cosa** → si risolve caricando un documento;
+- il documento che la contiene **non è mai stato processato** → si risolve sbloccando la pipeline.
+
+Un agente che non sa distinguerli fa la mossa sbagliata metà delle volte, e con sicurezza.
+
+## La pipeline, e dove si rompe
+
+```
+brand_documents ──processDocument──▶ brand_doc_chunks ──writeChunkEmbeddings──▶ .embedding
+   status: pending                        chunks.total                        chunks.embedded
+        → processing
+        → ready | failed
+```
+
+Tre stadi, tre modi di fermarsi, e nessuno di essi era visibile da fuori. `get_studio` elencava i
+documenti senza dire se erano stati letti.
+
+## Cosa risponde ora `GET /api/v1/brands/:slug/knowledge`
+
+- `documents` — il conteggio stadio per stadio, più `indexed`: **l'unico numero che la ricerca
+  vede**. Un documento `ready` con zero chunk (una nota anteriore alla pipeline: `status` nasce
+  con default `'ready'` dalla migrazione 0111) esiste nell'elenco e non è cercabile.
+- `chunks.total` / `chunks.embedded` — se il secondo è sotto il primo la ricerca gira solo su FTS,
+  e una parafrasi manca il bersaglio. Prima non lo sapeva nessuno.
+- `failures` — id, titolo, **il motivo** e i tentativi. Venti al massimo: sessanta guasti
+  riempiono la finestra di chi ha chiesto lo stato.
+- `collections` — quali scaffali hanno qualcosa di indicizzato, così `search_knowledge` sa cosa
+  ha senso restringere.
+- `sources` — Drive, Notion, GitHub, Gmail: stato, ultimo sync, ultimo errore, documenti portati.
+
+## Le decisioni
+
+**Le fonti le unisce la rotta, non `knowledge.ts`.** `knowledge-sources.ts` importa già
+`knowledge.ts` (`countBrandDocuments`, `docLimitForPlan`, `kickKnowledgeWork`): chiamare
+`loadKnowledgeSources` da dentro `knowledge.ts` avrebbe chiuso un anello. `knowledgeStatus`
+descrive il corpus, la rotta — che è l'adattatore — ci mette accanto le fonti.
+
+**`countEmbeddedChunks` conta con `head: true`.** Contare gli embedding senza tirarsi dietro
+768 float per riga: `count: 'exact', head: true` più `.not('embedding','is',null)`.
+
+**Niente `gateAiAction`.** Sono conteggi.
+
+## `get_studio` rinforzato
+
+Il contratto diceva `documents: z.array(JsonObject)`, `kit: JsonObject.nullable()`,
+`products`, `history`, `competitors` uguali: cinque array di oggetti generici, in un registry che
+esiste apposta per non far indovinare. Ora i campi sono quelli che `getStudio` seleziona davvero,
+dichiarati con `looseObject` — così il dump continua a portare quello che la tabella aggiungerà
+domani senza rompere chi legge un campo non ancora nominato.
+
+**Cosa cambia davvero, non solo nella dichiarazione:** ogni documento porta `status` e
+`chunkCount`. Elencare un documento senza dire se è stato digerito è precisamente ciò che fa
+credere a un agente di avere una conoscenza che la ricerca non vede.
+
+**Cosa si rompe, detto invece che forzato:** `output` non viene parsato a runtime da nessuna
+parte — `callEndpoint` restituisce il corpo così com'è e `registerTool` riceve solo `inputSchema` —
+quindi irrigidire i campi non può rompere un chiamante. La **descrizione** invece sì, è visibile
+in `tools/list`, ed è cambiata di proposito: dice che i documenti portano lo stato, e manda a
+`search_knowledge` chi ha una domanda invece di far leggere il corpus intero. Il test che fissa le
+descrizioni della migrazione (`cli/mcp/read-tools.test.ts`) è diventato rosso ed è stato
+aggiornato con il motivo scritto accanto — ha fatto esattamente il suo lavoro.
+
+## L'isolamento fra brand
+
+Come per la ricerca: sul percorso a chiave API il client è quello di servizio, la RLS non filtra
+niente. Il finto Supabase del test contiene **due brand** — il vicino ha 40 documenti falliti e 99
+chunk — e il test pretende `total: 6`, `failed: 1`, `chunks.total: 15` e che il titolo del vicino
+non compaia da nessuna parte nella risposta serializzata.

--- a/cli/lib/contracts/index.ts
+++ b/cli/lib/contracts/index.ts
@@ -55,7 +55,7 @@ import {
 import { GET_BRAND_SETTINGS, SET_BRAND_SETTINGS } from './brand-settings';
 import { DIAGNOSE_RADAR, GET_MARKET_FIELD, LIST_IDEAS } from './market';
 import { GET_MEDIA_MODELS, SET_MEDIA_MODEL } from './media-models';
-import { SEARCH_KNOWLEDGE } from './knowledge';
+import { GET_KNOWLEDGE_STATUS, SEARCH_KNOWLEDGE } from './knowledge';
 import {
   ADD_RADAR_SOURCE,
   GET_RADAR,
@@ -157,6 +157,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   GET_GSC,
   GET_GTM,
   GET_KEYWORDS,
+  GET_KNOWLEDGE_STATUS,
   GET_MARKET_FIELD,
   GET_MEDIA_MODELS,
   GET_PLAN,
@@ -300,7 +301,10 @@ export {
 } from './radar';
 export type { RadarPlatform, RadarSourceKindName } from './radar';
 export {
+  GET_KNOWLEDGE_STATUS,
   KNOWLEDGE_COLLECTIONS,
+  KNOWLEDGE_DOC_STATUSES,
+  KNOWLEDGE_FAILURES_MAX,
   KNOWLEDGE_EXCERPT_CHARS,
   KNOWLEDGE_HITS_DEFAULT,
   KNOWLEDGE_HITS_MAX,

--- a/cli/lib/contracts/knowledge.ts
+++ b/cli/lib/contracts/knowledge.ts
@@ -23,6 +23,11 @@ export const KNOWLEDGE_COLLECTIONS = [
 
 export type KnowledgeCollection = (typeof KNOWLEDGE_COLLECTIONS)[number];
 
+/** Lo stesso elenco chiuso di `DOC_STATUSES` in `$lib/server/knowledge` — un test tiene i due allineati. */
+export const KNOWLEDGE_DOC_STATUSES = ['pending', 'processing', 'ready', 'failed'] as const;
+
+export const KNOWLEDGE_FAILURES_MAX = 20;
+
 export const SEARCH_KNOWLEDGE = {
   tool: 'search_knowledge',
   title: 'Search brand knowledge',
@@ -30,7 +35,7 @@ export const SEARCH_KNOWLEDGE = {
     "Ask the brand's own documents a question and get back the passages that answer it, each with the document and heading it came from. " +
     'Hybrid retrieval over what is already indexed: keywords first, and a single embedding of the question only when keywords come up short — no credits are spent and nothing is written. ' +
     `Each passage is cut at ${KNOWLEDGE_EXCERPT_CHARS} characters (\`truncated\` says when there is more); \`limit\` is ${KNOWLEDGE_HITS_DEFAULT} by default and ${KNOWLEDGE_HITS_MAX} at most. ` +
-    'Narrow with `collection` when you know the shelf. An empty `hits` means the indexed corpus has no answer — which is not the same as the brand not knowing it, because a document still queued has nothing to find.',
+    'Narrow with `collection` when you know the shelf. An empty `hits` means the indexed corpus has no answer — which is not the same as the brand not knowing it, so read `get_knowledge_status` before concluding anything: a document still queued has nothing to find.',
   method: 'GET',
   pathUnderBrand: '/knowledge/search',
   input: z
@@ -65,5 +70,51 @@ export const SEARCH_KNOWLEDGE = {
     )
   }),
   failures: [{ error: 'query_required', status: 400 }],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const GET_KNOWLEDGE_STATUS = {
+  tool: 'get_knowledge_status',
+  title: 'Knowledge status',
+  description:
+    'Whether the brand\'s knowledge is USABLE, not just uploaded. Read it whenever `search_knowledge` comes back empty: an indexed corpus with no answer means the brand does not know the thing, a queued or failed one means nobody has read it yet — opposite situations needing opposite actions. ' +
+    '`documents` counts the pipeline stage by stage (`pending` → `processing` → `ready` | `failed`) and `indexed` is the only number retrieval can see: a `ready` document with zero chunks is not searchable. ' +
+    '`chunks.embedded` below `chunks.total` means retrieval is running on keywords alone, so paraphrases miss. ' +
+    `\`failures\` names each broken document and WHY it broke (${KNOWLEDGE_FAILURES_MAX} at most), \`collections\` says which shelves \`search_knowledge\` can usefully narrow to, and \`sources\` says which connected apps feed the corpus and when each last synced. No credits, no writes.`,
+  method: 'GET',
+  pathUnderBrand: '/knowledge',
+  input: z.object({}).strict(),
+  output: z.object({
+    documents: z.object({
+      total: z.number(),
+      indexed: z.number(),
+      pending: z.number(),
+      processing: z.number(),
+      ready: z.number(),
+      failed: z.number()
+    }),
+    chunks: z.object({ total: z.number(), embedded: z.number() }),
+    collections: z.record(z.enum(KNOWLEDGE_COLLECTIONS), z.number()),
+    failures: z.array(
+      z.object({
+        id: z.string(),
+        title: z.string(),
+        error: z.string(),
+        attempts: z.number()
+      })
+    ),
+    sources: z.array(
+      z.object({
+        provider: z.string(),
+        displayName: z.string().nullable(),
+        status: z.string(),
+        lastSyncAt: z.string().nullable(),
+        lastError: z.string().nullable(),
+        docsIngested: z.number()
+      })
+    ),
+    searchable: z.boolean()
+  }),
+  failures: [],
   destructive: false
 } satisfies BrandEndpoint;

--- a/cli/lib/contracts/reads.ts
+++ b/cli/lib/contracts/reads.ts
@@ -58,18 +58,92 @@ export const GET_WEEKLY_PLAN = {
   destructive: false
 } satisfies BrandEndpoint;
 
+/**
+ * I nomi delle colonne che `getStudio` seleziona davvero. `looseObject` perché il dump porta
+ * ancora quello che la tabella aggiunge domani: dichiarare i campi veri toglie l'indovinello
+ * senza rompere chi legge un campo non ancora nominato qui.
+ */
+const StudioKit = z.looseObject({
+  category: z.string().nullable(),
+  about: z.string().nullable(),
+  brand_style: z.string().nullable(),
+  target_audience: z.string().nullable(),
+  brand_colors: z.unknown(),
+  theme_color: z.string().nullable(),
+  favicon_url: z.string().nullable(),
+  fonts: z.unknown(),
+  logos: z.unknown(),
+  ai_character: z.string().nullable(),
+  ai_context: z.string().nullable(),
+  ai_context_updated_at: z.string().nullable(),
+  visual_style: z.unknown(),
+  visual_style_locked: z.boolean().nullable(),
+  content_pillars: z.unknown(),
+  site_type: z.string().nullable(),
+  images: z.unknown()
+});
+
+const StudioProduct = z.looseObject({
+  id: z.string(),
+  title: z.string().nullable(),
+  pricing: z.unknown(),
+  images: z.unknown(),
+  featured: z.boolean().nullable()
+});
+
+/**
+ * `status` e `chunkCount` sono la differenza fra CARICATO e DIGERITO: un documento `ready` con
+ * zero chunk esiste nell'elenco e `search_knowledge` non lo vede. `get_knowledge_status` dà lo
+ * stesso conto per l'intero brand, con il motivo di ogni guasto.
+ */
+const StudioDocument = z.looseObject({
+  id: z.string(),
+  kind: z.string(),
+  title: z.string().nullable(),
+  content_text: z.string().nullable(),
+  file_url: z.string().nullable(),
+  file_name: z.string().nullable(),
+  mime_type: z.string().nullable(),
+  created_at: z.string(),
+  status: z.string(),
+  chunkCount: z.number()
+});
+
+const StudioHistoryPost = z.looseObject({
+  id: z.string(),
+  platform: z.string().nullable(),
+  content: z.string().nullable(),
+  thumbnail_url: z.string().nullable(),
+  platform_post_url: z.string().nullable(),
+  metrics: z.unknown(),
+  published_at: z.string().nullable()
+});
+
+const StudioCompetitor = z.looseObject({
+  id: z.string(),
+  name: z.string(),
+  website: z.string().nullable(),
+  kind: z.string().nullable(),
+  rationale: z.string().nullable(),
+  source: z.string().nullable(),
+  created_at: z.string()
+});
+
 export const GET_STUDIO = {
   tool: 'get_studio',
   title: 'Studio',
-  description: 'Full studio dump: kit, people, documents, competitors, products, history summary.',
+  description:
+    'Full studio dump: kit, people, documents, competitors, products, history summary. ' +
+    'Each document carries `status` and `chunkCount`: a document that is not `ready` with at least one chunk exists here but is invisible to `search_knowledge`. ' +
+    'This returns the FULL text of every document — to answer a question, ask `search_knowledge` instead of reading the corpus.',
   method: 'GET',
   pathUnderBrand: '/studio',
   input: NoInput,
   output: z.object({
-    kit: JsonObject.nullable(),
-    products: z.array(JsonObject),
-    documents: z.array(JsonObject),
-    history: z.array(JsonObject),
+    kit: StudioKit.nullable(),
+    products: z.array(StudioProduct),
+    documents: z.array(StudioDocument),
+    history: z.array(StudioHistoryPost),
     people: z.array(
       z.object({
         id: z.string(),
@@ -81,7 +155,7 @@ export const GET_STUDIO = {
         imageCount: z.number()
       })
     ),
-    competitors: z.array(JsonObject),
+    competitors: z.array(StudioCompetitor),
     targetPlatforms: z.array(z.string()),
     platformInstructions: z.record(z.string(), z.string()),
     language: z.string(),

--- a/cli/mcp/read-tools.test.ts
+++ b/cli/mcp/read-tools.test.ts
@@ -22,7 +22,12 @@ const MIGRATED_READS = [
   {
     name: 'get_studio',
     title: 'Studio',
-    description: 'Full studio dump: kit, people, documents, competitors, products, history summary.',
+    // Cambiata di proposito: l'elenco dei documenti ora dice se sono stati digeriti, e manda a
+    // `search_knowledge` chi ha una domanda invece di far leggere il corpus intero.
+    description:
+      'Full studio dump: kit, people, documents, competitors, products, history summary. ' +
+      'Each document carries `status` and `chunkCount`: a document that is not `ready` with at least one chunk exists here but is invisible to `search_knowledge`. ' +
+      'This returns the FULL text of every document — to answer a question, ask `search_knowledge` instead of reading the corpus.',
     properties: { slug: SLUG_PROPERTY },
     required: ['slug'],
   },

--- a/cli/plugins/anomalia/skills/anomalia/references/tools.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/tools.md
@@ -233,6 +233,7 @@ one with the most clicks in the last seven days.
 | MCP | CLI |
 |-----|-----|
 | `search_knowledge` | (MCP only) |
+| `get_knowledge_status` | (MCP only) |
 
 `search_knowledge` asks the brand's OWN documents a question and returns the passages that answer
 it — not a list of files. Every hit carries where it came from (`documentId`, `title`,
@@ -245,8 +246,20 @@ default and 20 at most, so ask a narrow question several times rather than a wid
 `collection` narrows to a shelf: `brand`, `product`, `commercial`, `legal`, `operations`,
 `research`.
 
-Empty `hits` is not the same as "the brand does not know this": a document that was uploaded but
-never processed has nothing to find. `get_studio` lists what exists.
+Empty `hits` is not the same as "the brand does not know this": read `get_knowledge_status`
+before concluding anything.
+
+`get_knowledge_status` says whether the knowledge is USABLE, not just uploaded. `documents`
+counts the pipeline stage by stage — `pending` → `processing` → `ready` | `failed` — and
+`indexed` is the only number retrieval can see: a `ready` document with zero chunks is not
+searchable. `chunks.embedded` below `chunks.total` means retrieval is running on keywords alone,
+so a paraphrase misses. `failures` names each broken document and WHY it broke, `collections`
+says which shelves are worth narrowing to, and `sources` says which connected apps feed the
+corpus and when each last synced.
+
+So: `search_knowledge` empty + `searchable: true` → the brand does not know it, go add a
+document. Empty + `pending`/`failed` above zero → it may already know it and nobody has read the
+file yet. Two opposite situations, two opposite actions.
 
 ## Brand settings
 

--- a/cli/skills/anomalia/references/tools.md
+++ b/cli/skills/anomalia/references/tools.md
@@ -233,6 +233,7 @@ one with the most clicks in the last seven days.
 | MCP | CLI |
 |-----|-----|
 | `search_knowledge` | (MCP only) |
+| `get_knowledge_status` | (MCP only) |
 
 `search_knowledge` asks the brand's OWN documents a question and returns the passages that answer
 it — not a list of files. Every hit carries where it came from (`documentId`, `title`,
@@ -245,8 +246,20 @@ default and 20 at most, so ask a narrow question several times rather than a wid
 `collection` narrows to a shelf: `brand`, `product`, `commercial`, `legal`, `operations`,
 `research`.
 
-Empty `hits` is not the same as "the brand does not know this": a document that was uploaded but
-never processed has nothing to find. `get_studio` lists what exists.
+Empty `hits` is not the same as "the brand does not know this": read `get_knowledge_status`
+before concluding anything.
+
+`get_knowledge_status` says whether the knowledge is USABLE, not just uploaded. `documents`
+counts the pipeline stage by stage — `pending` → `processing` → `ready` | `failed` — and
+`indexed` is the only number retrieval can see: a `ready` document with zero chunks is not
+searchable. `chunks.embedded` below `chunks.total` means retrieval is running on keywords alone,
+so a paraphrase misses. `failures` names each broken document and WHY it broke, `collections`
+says which shelves are worth narrowing to, and `sources` says which connected apps feed the
+corpus and when each last synced.
+
+So: `search_knowledge` empty + `searchable: true` → the brand does not know it, go add a
+document. Empty + `pending`/`failed` above zero → it may already know it and nobody has read the
+file yet. Two opposite situations, two opposite actions.
 
 ## Brand settings
 

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -55,7 +55,7 @@ import {
 import { GET_BRAND_SETTINGS, SET_BRAND_SETTINGS } from './brand-settings';
 import { DIAGNOSE_RADAR, GET_MARKET_FIELD, LIST_IDEAS } from './market';
 import { GET_MEDIA_MODELS, SET_MEDIA_MODEL } from './media-models';
-import { SEARCH_KNOWLEDGE } from './knowledge';
+import { GET_KNOWLEDGE_STATUS, SEARCH_KNOWLEDGE } from './knowledge';
 import {
   ADD_RADAR_SOURCE,
   GET_RADAR,
@@ -157,6 +157,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   GET_GSC,
   GET_GTM,
   GET_KEYWORDS,
+  GET_KNOWLEDGE_STATUS,
   GET_MARKET_FIELD,
   GET_MEDIA_MODELS,
   GET_PLAN,
@@ -300,7 +301,10 @@ export {
 } from './radar';
 export type { RadarPlatform, RadarSourceKindName } from './radar';
 export {
+  GET_KNOWLEDGE_STATUS,
   KNOWLEDGE_COLLECTIONS,
+  KNOWLEDGE_DOC_STATUSES,
+  KNOWLEDGE_FAILURES_MAX,
   KNOWLEDGE_EXCERPT_CHARS,
   KNOWLEDGE_HITS_DEFAULT,
   KNOWLEDGE_HITS_MAX,

--- a/packages/api-contracts/src/knowledge.ts
+++ b/packages/api-contracts/src/knowledge.ts
@@ -23,6 +23,11 @@ export const KNOWLEDGE_COLLECTIONS = [
 
 export type KnowledgeCollection = (typeof KNOWLEDGE_COLLECTIONS)[number];
 
+/** Lo stesso elenco chiuso di `DOC_STATUSES` in `$lib/server/knowledge` — un test tiene i due allineati. */
+export const KNOWLEDGE_DOC_STATUSES = ['pending', 'processing', 'ready', 'failed'] as const;
+
+export const KNOWLEDGE_FAILURES_MAX = 20;
+
 export const SEARCH_KNOWLEDGE = {
   tool: 'search_knowledge',
   title: 'Search brand knowledge',
@@ -30,7 +35,7 @@ export const SEARCH_KNOWLEDGE = {
     "Ask the brand's own documents a question and get back the passages that answer it, each with the document and heading it came from. " +
     'Hybrid retrieval over what is already indexed: keywords first, and a single embedding of the question only when keywords come up short — no credits are spent and nothing is written. ' +
     `Each passage is cut at ${KNOWLEDGE_EXCERPT_CHARS} characters (\`truncated\` says when there is more); \`limit\` is ${KNOWLEDGE_HITS_DEFAULT} by default and ${KNOWLEDGE_HITS_MAX} at most. ` +
-    'Narrow with `collection` when you know the shelf. An empty `hits` means the indexed corpus has no answer — which is not the same as the brand not knowing it, because a document still queued has nothing to find.',
+    'Narrow with `collection` when you know the shelf. An empty `hits` means the indexed corpus has no answer — which is not the same as the brand not knowing it, so read `get_knowledge_status` before concluding anything: a document still queued has nothing to find.',
   method: 'GET',
   pathUnderBrand: '/knowledge/search',
   input: z
@@ -65,5 +70,51 @@ export const SEARCH_KNOWLEDGE = {
     )
   }),
   failures: [{ error: 'query_required', status: 400 }],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const GET_KNOWLEDGE_STATUS = {
+  tool: 'get_knowledge_status',
+  title: 'Knowledge status',
+  description:
+    'Whether the brand\'s knowledge is USABLE, not just uploaded. Read it whenever `search_knowledge` comes back empty: an indexed corpus with no answer means the brand does not know the thing, a queued or failed one means nobody has read it yet — opposite situations needing opposite actions. ' +
+    '`documents` counts the pipeline stage by stage (`pending` → `processing` → `ready` | `failed`) and `indexed` is the only number retrieval can see: a `ready` document with zero chunks is not searchable. ' +
+    '`chunks.embedded` below `chunks.total` means retrieval is running on keywords alone, so paraphrases miss. ' +
+    `\`failures\` names each broken document and WHY it broke (${KNOWLEDGE_FAILURES_MAX} at most), \`collections\` says which shelves \`search_knowledge\` can usefully narrow to, and \`sources\` says which connected apps feed the corpus and when each last synced. No credits, no writes.`,
+  method: 'GET',
+  pathUnderBrand: '/knowledge',
+  input: z.object({}).strict(),
+  output: z.object({
+    documents: z.object({
+      total: z.number(),
+      indexed: z.number(),
+      pending: z.number(),
+      processing: z.number(),
+      ready: z.number(),
+      failed: z.number()
+    }),
+    chunks: z.object({ total: z.number(), embedded: z.number() }),
+    collections: z.record(z.enum(KNOWLEDGE_COLLECTIONS), z.number()),
+    failures: z.array(
+      z.object({
+        id: z.string(),
+        title: z.string(),
+        error: z.string(),
+        attempts: z.number()
+      })
+    ),
+    sources: z.array(
+      z.object({
+        provider: z.string(),
+        displayName: z.string().nullable(),
+        status: z.string(),
+        lastSyncAt: z.string().nullable(),
+        lastError: z.string().nullable(),
+        docsIngested: z.number()
+      })
+    ),
+    searchable: z.boolean()
+  }),
+  failures: [],
   destructive: false
 } satisfies BrandEndpoint;

--- a/packages/api-contracts/src/reads.ts
+++ b/packages/api-contracts/src/reads.ts
@@ -58,18 +58,92 @@ export const GET_WEEKLY_PLAN = {
   destructive: false
 } satisfies BrandEndpoint;
 
+/**
+ * I nomi delle colonne che `getStudio` seleziona davvero. `looseObject` perché il dump porta
+ * ancora quello che la tabella aggiunge domani: dichiarare i campi veri toglie l'indovinello
+ * senza rompere chi legge un campo non ancora nominato qui.
+ */
+const StudioKit = z.looseObject({
+  category: z.string().nullable(),
+  about: z.string().nullable(),
+  brand_style: z.string().nullable(),
+  target_audience: z.string().nullable(),
+  brand_colors: z.unknown(),
+  theme_color: z.string().nullable(),
+  favicon_url: z.string().nullable(),
+  fonts: z.unknown(),
+  logos: z.unknown(),
+  ai_character: z.string().nullable(),
+  ai_context: z.string().nullable(),
+  ai_context_updated_at: z.string().nullable(),
+  visual_style: z.unknown(),
+  visual_style_locked: z.boolean().nullable(),
+  content_pillars: z.unknown(),
+  site_type: z.string().nullable(),
+  images: z.unknown()
+});
+
+const StudioProduct = z.looseObject({
+  id: z.string(),
+  title: z.string().nullable(),
+  pricing: z.unknown(),
+  images: z.unknown(),
+  featured: z.boolean().nullable()
+});
+
+/**
+ * `status` e `chunkCount` sono la differenza fra CARICATO e DIGERITO: un documento `ready` con
+ * zero chunk esiste nell'elenco e `search_knowledge` non lo vede. `get_knowledge_status` dà lo
+ * stesso conto per l'intero brand, con il motivo di ogni guasto.
+ */
+const StudioDocument = z.looseObject({
+  id: z.string(),
+  kind: z.string(),
+  title: z.string().nullable(),
+  content_text: z.string().nullable(),
+  file_url: z.string().nullable(),
+  file_name: z.string().nullable(),
+  mime_type: z.string().nullable(),
+  created_at: z.string(),
+  status: z.string(),
+  chunkCount: z.number()
+});
+
+const StudioHistoryPost = z.looseObject({
+  id: z.string(),
+  platform: z.string().nullable(),
+  content: z.string().nullable(),
+  thumbnail_url: z.string().nullable(),
+  platform_post_url: z.string().nullable(),
+  metrics: z.unknown(),
+  published_at: z.string().nullable()
+});
+
+const StudioCompetitor = z.looseObject({
+  id: z.string(),
+  name: z.string(),
+  website: z.string().nullable(),
+  kind: z.string().nullable(),
+  rationale: z.string().nullable(),
+  source: z.string().nullable(),
+  created_at: z.string()
+});
+
 export const GET_STUDIO = {
   tool: 'get_studio',
   title: 'Studio',
-  description: 'Full studio dump: kit, people, documents, competitors, products, history summary.',
+  description:
+    'Full studio dump: kit, people, documents, competitors, products, history summary. ' +
+    'Each document carries `status` and `chunkCount`: a document that is not `ready` with at least one chunk exists here but is invisible to `search_knowledge`. ' +
+    'This returns the FULL text of every document — to answer a question, ask `search_knowledge` instead of reading the corpus.',
   method: 'GET',
   pathUnderBrand: '/studio',
   input: NoInput,
   output: z.object({
-    kit: JsonObject.nullable(),
-    products: z.array(JsonObject),
-    documents: z.array(JsonObject),
-    history: z.array(JsonObject),
+    kit: StudioKit.nullable(),
+    products: z.array(StudioProduct),
+    documents: z.array(StudioDocument),
+    history: z.array(StudioHistoryPost),
     people: z.array(
       z.object({
         id: z.string(),
@@ -81,7 +155,7 @@ export const GET_STUDIO = {
         imageCount: z.number()
       })
     ),
-    competitors: z.array(JsonObject),
+    competitors: z.array(StudioCompetitor),
     targetPlatforms: z.array(z.string()),
     platformInstructions: z.record(z.string(), z.string()),
     language: z.string(),

--- a/src/lib/content/changelog/2026-09-04-knowledge-status.ts
+++ b/src/lib/content/changelog/2026-09-04-knowledge-status.ts
@@ -1,0 +1,11 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-04',
+  title: 'Your agent can tell "not known" from "not read yet"',
+  items: [
+    'Your agent can now check whether your knowledge is usable, not just uploaded: how many documents are indexed, how many are still queued, and which ones failed and why.',
+    'Connected sources — Drive, Notion, GitHub, Gmail — report when they last synced and what went wrong.',
+    'The studio listing now marks each document as searchable or not, so nothing looks available when it is not.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/cli-queries.ts
+++ b/src/lib/server/cli-queries.ts
@@ -379,7 +379,7 @@ export async function getStudio(supabase: SupabaseClient, brandId: string) {
       .eq('brand_id', brandId).maybeSingle(),
     supabase.from('products').select('id, title, pricing, images, featured')
       .eq('brand_id', brandId),
-    supabase.from('brand_documents').select('id, kind, title, content_text, file_url, file_name, mime_type, created_at')
+    supabase.from('brand_documents').select('id, kind, title, content_text, file_url, file_name, mime_type, created_at, status, chunk_count')
       .eq('brand_id', brandId),
     supabase.from('social_post_history').select('id, platform, content, thumbnail_url, platform_post_url, metrics, published_at')
       .eq('brand_id', brandId).limit(60),
@@ -409,7 +409,12 @@ export async function getStudio(supabase: SupabaseClient, brandId: string) {
   return {
     kit,
     products: productsRes.data ?? [],
-    documents: docsRes.data ?? [],
+    // `chunk_count` esce come `chunkCount`: elencare un documento senza dire se è stato digerito
+    // è ciò che fa credere a un agente di avere una conoscenza che la ricerca non vede.
+    documents: (docsRes.data ?? []).map(({ chunk_count, ...doc }) => ({
+      ...doc,
+      chunkCount: (chunk_count as number) ?? 0
+    })),
     history: historyRes.data ?? [],
     people: (peopleRes.data ?? []).map(p => ({
       id: p.id,

--- a/src/lib/server/knowledge.ts
+++ b/src/lib/server/knowledge.ts
@@ -484,6 +484,93 @@ async function htmlFromUrl(url: string): Promise<{ markdown: string; title?: str
   return { markdown: await htmlToMarkdown(html), title: titleMatch?.[1]?.trim() };
 }
 
+/** Gli stati che un documento attraversa. Chiusi: `pending` → `processing` → `ready` | `failed`. */
+export const DOC_STATUSES = ['pending', 'processing', 'ready', 'failed'] as const;
+export type DocStatus = (typeof DOC_STATUSES)[number];
+
+/** Un guasto per volta si legge; sessanta riempiono la finestra di chi ha chiesto lo stato. */
+export const KNOWLEDGE_FAILURES_MAX = 20;
+
+/**
+ * Le fonti collegate NON stanno qui: `knowledge-sources` importa già questo modulo, e chiuderlo
+ * ad anello metterebbe il confine nel posto sbagliato. Le unisce la rotta, che è l'adattatore.
+ */
+export type KnowledgeStatus = {
+  documents: Record<DocStatus | 'total' | 'indexed', number>;
+  chunks: { total: number; embedded: number };
+  collections: Record<string, number>;
+  failures: { id: string; title: string; error: string; attempts: number }[];
+  searchable: boolean;
+};
+
+/**
+ * CARICATO NON È DIGERITO, e sono due situazioni opposte: chi cerca e non trova niente deve poter
+ * distinguere «il brand non sa questa cosa» da «il documento che la contiene non è mai stato
+ * processato» — la prima si risolve caricando, la seconda sbloccando la pipeline.
+ *
+ *   brand_documents ──processDocument──▶ brand_doc_chunks ──writeChunkEmbeddings──▶ .embedding
+ *      (status)                             (chunks.total)                       (chunks.embedded)
+ *
+ * `indexed` è l'unico numero che conta per `searchKnowledge`: un documento `ready` con zero chunk
+ * — una nota anteriore alla pipeline — esiste e non è cercabile.
+ */
+export async function knowledgeStatus(
+  supabase: SupabaseClient,
+  brandId: string
+): Promise<KnowledgeStatus> {
+  const [{ data: docs }, chunkTotal, chunkEmbedded] = await Promise.all([
+    supabase
+      .from('brand_documents')
+      .select('id, title, status, error, chunk_count, collection, attempts')
+      .eq('brand_id', brandId)
+      .neq('kind', 'image'),
+    countBrandChunks(supabase, brandId),
+    countEmbeddedChunks(supabase, brandId)
+  ]);
+
+  const rows = docs ?? [];
+  const documents = { total: rows.length, indexed: 0, pending: 0, processing: 0, ready: 0, failed: 0 };
+  const collections: Record<string, number> = {};
+  const failures: KnowledgeStatus['failures'] = [];
+
+  for (const row of rows) {
+    const status = row.status as DocStatus;
+    if (DOC_STATUSES.includes(status)) documents[status] += 1;
+
+    if (status === 'ready' && ((row.chunk_count as number) ?? 0) > 0) {
+      documents.indexed += 1;
+      const shelf = (row.collection as string | null) ?? '';
+      if (shelf) collections[shelf] = (collections[shelf] ?? 0) + 1;
+    }
+
+    if (status === 'failed' && failures.length < KNOWLEDGE_FAILURES_MAX) {
+      failures.push({
+        id: row.id as string,
+        title: (row.title as string | null) ?? 'Untitled',
+        error: (row.error as string | null) ?? 'unknown',
+        attempts: (row.attempts as number) ?? 0
+      });
+    }
+  }
+
+  return {
+    documents,
+    chunks: { total: chunkTotal, embedded: chunkEmbedded },
+    collections,
+    failures,
+    searchable: chunkTotal > 0
+  };
+}
+
+async function countEmbeddedChunks(supabase: SupabaseClient, brandId: string): Promise<number> {
+  const { count } = await supabase
+    .from('brand_doc_chunks')
+    .select('id', { count: 'exact', head: true })
+    .eq('brand_id', brandId)
+    .not('embedding', 'is', null);
+  return count ?? 0;
+}
+
 export async function countBrandDocuments(
   supabase: SupabaseClient,
   brandId: string

--- a/src/routes/api/v1/brands/[slug]/knowledge/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/knowledge/+server.ts
@@ -1,0 +1,36 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { authenticate, loadBrandForUser } from '$lib/server/cli-auth';
+import { knowledgeStatus } from '$lib/server/knowledge';
+import { loadKnowledgeSources } from '$lib/server/knowledge-sources';
+
+// Lo stato della pipeline della conoscenza, per chi cerca e non trova niente: `search_knowledge`
+// vuoto su un corpus indicizzato significa «il brand non sa questa cosa», su un corpus in coda
+// significa «nessuno l'ha ancora letto». Due situazioni opposte, due azioni opposte.
+//
+// Nessun modello, nessun credito, nessuna scrittura: sono conteggi.
+
+export const GET: RequestHandler = async ({ request, params }) => {
+  const { supabase, error, apiKey } = await authenticate(request);
+  if (error) return error;
+
+  const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
+  if (brandError) return brandError;
+
+  const [status, sources] = await Promise.all([
+    knowledgeStatus(supabase, brand.id),
+    loadKnowledgeSources(supabase, brand.id)
+  ]);
+
+  return json({
+    ...status,
+    sources: sources.map((source) => ({
+      provider: source.provider,
+      displayName: source.display_name ?? null,
+      status: source.status,
+      lastSyncAt: source.last_sync_at ?? null,
+      lastError: source.last_error ?? null,
+      docsIngested: source.docs_ingested ?? 0
+    }))
+  });
+};

--- a/src/routes/api/v1/brands/[slug]/knowledge/server.test.ts
+++ b/src/routes/api/v1/brands/[slug]/knowledge/server.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('$lib/server/cli-auth', () => ({
+  authenticate: vi.fn(),
+  loadBrandForUser: vi.fn()
+}));
+
+import { GET } from './+server';
+import { authenticate, loadBrandForUser } from '$lib/server/cli-auth';
+import { DOC_STATUSES, KNOWLEDGE_FAILURES_MAX } from '$lib/server/knowledge';
+import { KNOWLEDGE_DOC_STATUSES } from '@anomalia/api-contracts';
+
+type Row = Record<string, unknown>;
+
+/**
+ * Ogni tabella della pipeline è in memoria e i filtri sono quelli veri: `eq`, `neq`, `in`, e il
+ * conteggio `head`. Il corpus contiene DUE brand, così un conteggio che dimentica `brand_id`
+ * non passa il test invece di gonfiarsi in silenzio.
+ */
+function fakeSupabase(tables: Record<string, Row[]>) {
+  return {
+    from(table: string) {
+      let rows = [...(tables[table] ?? [])];
+      let counting = false;
+
+      const q = {
+        select: (_cols: string, opts?: { count?: string; head?: boolean }) => {
+          counting = opts?.head === true;
+          return q;
+        },
+        eq(column: string, value: unknown) {
+          rows = rows.filter((r) => r[column] === value);
+          return q;
+        },
+        neq(column: string, value: unknown) {
+          rows = rows.filter((r) => r[column] !== value);
+          return q;
+        },
+        not(column: string, _op: string, _value: unknown) {
+          rows = rows.filter((r) => r[column] !== null && r[column] !== undefined);
+          return q;
+        },
+        in(column: string, values: unknown[]) {
+          rows = rows.filter((r) => values.includes(r[column]));
+          return q;
+        },
+        order: () => q,
+        limit(n: number) {
+          rows = rows.slice(0, n);
+          return q;
+        },
+        then: (resolve: (v: { data: Row[] | null; count: number; error: null }) => unknown) =>
+          resolve({ data: counting ? null : rows, count: rows.length, error: null })
+      };
+      return q;
+    }
+  };
+}
+
+const OWN_DOCS: Row[] = [
+  { id: 'd1', brand_id: 'brand-1', kind: 'document', title: 'Listino', status: 'ready', error: null, chunk_count: 12, collection: 'commercial', attempts: 1 },
+  { id: 'd2', brand_id: 'brand-1', kind: 'note', title: 'Tono di voce', status: 'ready', error: null, chunk_count: 3, collection: 'brand', attempts: 1 },
+  { id: 'd3', brand_id: 'brand-1', kind: 'document', title: 'Manuale', status: 'pending', error: null, chunk_count: 0, collection: null, attempts: 0 },
+  { id: 'd4', brand_id: 'brand-1', kind: 'document', title: 'Contratto', status: 'processing', error: null, chunk_count: 0, collection: 'legal', attempts: 1 },
+  { id: 'd5', brand_id: 'brand-1', kind: 'document', title: 'Bilancio.pdf', status: 'failed', error: 'PDF is password protected', chunk_count: 0, collection: null, attempts: 3 },
+  { id: 'd6', brand_id: 'brand-1', kind: 'document', title: 'Vecchia nota', status: 'ready', error: null, chunk_count: 0, collection: null, attempts: 0 },
+  { id: 'img', brand_id: 'brand-1', kind: 'image', title: 'logo.png', status: 'ready', error: null, chunk_count: 0, collection: null, attempts: 0 }
+];
+
+const FOREIGN_DOCS: Row[] = Array.from({ length: 40 }, (_, i) => ({
+  id: `x${i}`,
+  brand_id: 'brand-2',
+  kind: 'document',
+  title: 'Segreto industriale del vicino',
+  status: 'failed',
+  error: 'il concorrente ha rotto qualcosa',
+  chunk_count: 0,
+  collection: 'research',
+  attempts: 3
+}));
+
+const TABLES: Record<string, Row[]> = {
+  brand_documents: [...OWN_DOCS, ...FOREIGN_DOCS],
+  brand_doc_chunks: [
+    ...Array.from({ length: 15 }, (_, i) => ({ id: `c${i}`, brand_id: 'brand-1', embedding: i < 10 ? '[0.1]' : null })),
+    ...Array.from({ length: 99 }, (_, i) => ({ id: `f${i}`, brand_id: 'brand-2', embedding: '[0.2]' }))
+  ],
+  brand_knowledge_sources: [
+    {
+      id: 's1',
+      brand_id: 'brand-1',
+      provider: 'notion',
+      display_name: 'Wiki di prodotto',
+      status: 'active',
+      last_sync_at: '2026-09-03T10:00:00Z',
+      last_error: null,
+      docs_ingested: 18
+    },
+    {
+      id: 's2',
+      brand_id: 'brand-1',
+      provider: 'google-drive',
+      display_name: 'Drive marketing',
+      status: 'error',
+      last_sync_at: '2026-08-30T09:00:00Z',
+      last_error: 'folder no longer shared',
+      docs_ingested: 4
+    },
+    {
+      id: 's3',
+      brand_id: 'brand-2',
+      provider: 'github',
+      display_name: 'Repo del vicino',
+      status: 'active',
+      last_sync_at: '2026-09-04T09:00:00Z',
+      last_error: null,
+      docs_ingested: 77
+    }
+  ]
+};
+
+function signedIn(tables: Record<string, Row[]> = TABLES) {
+  vi.mocked(authenticate).mockResolvedValue({
+    supabase: fakeSupabase(tables),
+    user: { id: 'user-1' },
+    apiKey: undefined,
+    error: null
+  } as never);
+  vi.mocked(loadBrandForUser).mockResolvedValue({
+    brand: { id: 'brand-1', slug: 'demo', name: 'Demo Brand' },
+    error: null
+  } as never);
+}
+
+function call(slug = 'demo') {
+  const url = new URL(`https://anomalia.test/api/v1/brands/${slug}/knowledge`);
+  return (GET as (event: unknown) => Promise<Response>)({
+    request: new Request(url),
+    params: { slug },
+    url
+  }).then(async (res) => ({ res, body: await res.json() }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('GET /knowledge', () => {
+  it('non conta i documenti di un altro brand, né ne nomina i guasti', async () => {
+    signedIn();
+
+    const { res, body } = await call();
+
+    expect(res.status).toBe(200);
+    expect(body.documents.total).toBe(6);
+    expect(body.documents.failed).toBe(1);
+    expect(JSON.stringify(body)).not.toContain('Segreto industriale del vicino');
+    expect(JSON.stringify(body)).not.toContain('Repo del vicino');
+    expect(body.chunks.total).toBe(15);
+  });
+
+  it('distingue caricato da digerito, che sono due situazioni opposte', async () => {
+    signedIn();
+
+    const { body } = await call();
+
+    expect(body.documents).toMatchObject({
+      total: 6,
+      ready: 3,
+      pending: 1,
+      processing: 1,
+      failed: 1,
+      indexed: 2
+    });
+    expect(body.chunks).toEqual({ total: 15, embedded: 10 });
+    expect(body.searchable).toBe(true);
+  });
+
+  it('dice perché un documento è fallito, non solo che è fallito', async () => {
+    signedIn();
+
+    const { body } = await call();
+
+    expect(body.failures).toEqual([
+      { id: 'd5', title: 'Bilancio.pdf', error: 'PDF is password protected', attempts: 3 }
+    ]);
+  });
+
+  it('elenca le collezioni con qualcosa dentro, così `search_knowledge` sa cosa restringere', async () => {
+    signedIn();
+
+    const { body } = await call();
+
+    expect(body.collections).toEqual({ commercial: 1, brand: 1 });
+  });
+
+  it('dice quali fonti sono collegate e quando hanno sincronizzato', async () => {
+    signedIn();
+
+    const { body } = await call();
+
+    expect(body.sources).toEqual([
+      {
+        provider: 'notion',
+        displayName: 'Wiki di prodotto',
+        status: 'active',
+        lastSyncAt: '2026-09-03T10:00:00Z',
+        lastError: null,
+        docsIngested: 18
+      },
+      {
+        provider: 'google-drive',
+        displayName: 'Drive marketing',
+        status: 'error',
+        lastSyncAt: '2026-08-30T09:00:00Z',
+        lastError: 'folder no longer shared',
+        docsIngested: 4
+      }
+    ]);
+  });
+
+  it('un brand senza niente non è "rotto": è vuoto, e lo dice', async () => {
+    signedIn({ brand_documents: [], brand_doc_chunks: [], brand_knowledge_sources: [] });
+
+    const { body } = await call();
+
+    expect(body.documents.total).toBe(0);
+    expect(body.searchable).toBe(false);
+    expect(body.failures).toEqual([]);
+    expect(body.sources).toEqual([]);
+  });
+
+  it('non rovescia mille guasti nella finestra di chi chiede', async () => {
+    const many = Array.from({ length: 60 }, (_, i) => ({
+      id: `b${i}`,
+      brand_id: 'brand-1',
+      kind: 'document',
+      title: `rotto-${i}`,
+      status: 'failed',
+      error: 'boom',
+      chunk_count: 0,
+      collection: null,
+      attempts: 3
+    }));
+    signedIn({ ...TABLES, brand_documents: [...many, ...FOREIGN_DOCS] });
+
+    const { body } = await call();
+
+    expect(body.documents.failed).toBe(60);
+    expect(body.failures.length).toBe(KNOWLEDGE_FAILURES_MAX);
+  });
+
+  it('gli stati dichiarati nel contratto sono quelli che la pipeline attraversa', () => {
+    expect([...KNOWLEDGE_DOC_STATUSES]).toEqual([...DOC_STATUSES]);
+  });
+});


### PR DESCRIPTION
## What?

An external agent can now tell whether a brand's knowledge is **usable**, not just uploaded.

New MCP tool `get_knowledge_status` over `GET /api/v1/brands/:slug/knowledge`: how many documents exist, how many are indexed, how many are queued, how many failed **and why**, how much of the corpus is embedded, which shelves have content, and which connected sources last synced when.

`get_studio` is also hardened: its five `z.array(JsonObject)` fields are replaced with the columns it actually selects, and every document now carries `status` and `chunkCount`.

`tools/list` goes from 112 to 113. Nothing removed. Two descriptions changed on purpose — details under Evidence.

## Why?

`search_knowledge` (#293) comes back empty for two opposite reasons:

- the indexed corpus does not hold the answer → **the brand does not know it**, go add a document;
- the document that holds it was never processed → **the brand may already know it**, go unblock the pipeline.

Opposite situations, opposite actions. An agent that cannot tell them apart takes the wrong one half the time, with full confidence — which is the worst failure mode for a system whose entire pitch is that the customer's model can be trusted with the brand.

The pipeline has three stages and three ways of stalling, and none of them were visible from outside:

```
brand_documents ──processDocument──▶ brand_doc_chunks ──writeChunkEmbeddings──▶ .embedding
   status: pending                        chunks.total                        chunks.embedded
        → processing
        → ready | failed
```

`get_studio` listed the documents and never said whether anyone had read them.

## How?

**`knowledgeStatus` in `knowledge.ts`, next to the model it describes.** One read of `brand_documents` plus two `head: true` counts — counting embedded chunks without dragging 768 floats per row across the wire.

**`indexed` is the number that matters.** `ready` is not enough: `brand_documents.status` was born with default `'ready'` in migration 0111, so a note that predates the pipeline is `ready` with zero chunks — it exists in the listing and retrieval cannot see it. `indexed` counts `ready` **and** `chunk_count > 0`.

**`chunks.embedded` vs `chunks.total`** is the signal nobody had: when embeddings are missing, retrieval silently degrades to FTS-only and paraphrases stop matching.

**The connected sources are joined by the route, not by `knowledge.ts`.** `knowledge-sources.ts` already imports `knowledge.ts` (`countBrandDocuments`, `docLimitForPlan`, `kickKnowledgeWork`), so calling `loadKnowledgeSources` from inside would close a cycle. `knowledgeStatus` describes the corpus; the route — the adapter — puts the sources beside it. The existing `loadKnowledgeSources` is reused as-is.

**`failures` is capped at 20.** Sixty broken documents fill the window of whoever asked for a status.

**No `gateAiAction`.** These are counts.

### `get_studio`, and what changing it actually breaks

The contract declared `kit`, `products`, `documents`, `history` and `competitors` as anonymous JSON — five arrays of nothing, in a registry that exists precisely so nobody has to guess. They are now the columns `getStudio` selects, declared with `z.looseObject` so the dump keeps carrying whatever the table adds later without breaking a caller reading a field not yet named here.

**Does hardening `output` break anything? No, and this was checked rather than assumed:** `output` is never parsed at runtime anywhere — `callEndpoint` returns the body as-is, and `registerTool` receives only `inputSchema`. Tightening it is declaration, not enforcement.

**What does change on the wire:**

1. Every document now carries `status` and `chunkCount`. Additive. Listing a document without saying whether it was digested is exactly what makes an agent believe in knowledge the search cannot see.
2. `get_studio`'s **description**, which *is* visible in `tools/list`. Changed deliberately: it says documents carry their pipeline state, and it points whoever has a question at `search_knowledge` instead of letting them pull the whole corpus.

That second one made `cli/mcp/read-tools.test.ts` go red — the test that pins the migration-era descriptions. It did its job. The pin was updated with the reason written beside it rather than the change being smuggled past it.

## Testing?

No Docker, no Playwright, no dev server. Everything below was run locally.

**The negative test on brand isolation.** On the API-key path `authenticate` returns the service-role client, so RLS filters nothing: `brand_id` in the query is the whole defence, and a count that forgets it inflates in silence rather than failing. The fake Supabase implements the real filters (`eq`, `neq`, `not`, and `head` counting) and is seeded with **two brands** — the neighbour has 40 failed documents, 99 chunks and a connected GitHub source. The test demands `total: 6`, `failed: 1`, `chunks.total: 15`, and that neither the neighbour's document title nor its source name appears anywhere in the serialised response.

Written first, watched fail:

<details><summary>Red</summary>

```
 ❯ src/routes/api/v1/brands/[slug]/knowledge/server.test.ts (0 test)

 FAIL  src/routes/api/v1/brands/[slug]/knowledge/server.test.ts
Error: Failed to load url ./+server (resolved id: ./+server) ... Does the file exist?

 Test Files  1 failed (1)
      Tests  no tests
```
</details>

<details><summary>Red again — the deliberate <code>get_studio</code> change, caught by the guard</summary>

```
$ cd cli && bun test
error: get_studio

Expected: "Full studio dump: kit, people, documents, competitors, products, history summary."
Received: "Full studio dump: kit, people, documents, competitors, products, history summary. Each
document carries `status` and `chunkCount`: a document that is not `ready` with at least one chunk
exists here but is invisible to `search_knowledge`. This returns the FULL text of every document —
to answer a question, ask `search_knowledge` instead of reading the corpus."

 56 pass
 1 fail
```
</details>

<details><summary>Green — everything the CI runs</summary>

```
$ npx vitest run "src/routes/api/v1/brands/[slug]/knowledge"
 ✓ .../knowledge/server.test.ts        (8 tests)
 ✓ .../knowledge/search/server.test.ts (8 tests)

$ npx vitest run packages/api-contracts
 Test Files  14 passed (14)
      Tests  181 passed (181)

$ cd cli && bun test
 57 pass / 0 fail / 632 expect() calls

$ cd cli && bun run typecheck
$ tsc --noEmit           (exit 0)

$ node scripts/typecheck-runtime.mjs
typecheck-runtime: ok (ignored 313 non-fatal type error(s))
```

Everything downstream of the two files I touched (`knowledge.ts`, `cli-queries.ts`):

```
$ npx vitest run src/lib/server/knowledge.test.ts src/lib/server/knowledge-sources.test.ts \
                 src/lib/server/strategy-agent-reads.test.ts \
                 "src/routes/api/v1/brands/[slug]/registry.test.ts"
 Test Files  4 passed (4)
      Tests  40 passed (40)

$ npx vitest run "src/routes/api/v1/brands/[slug]/studio" src/lib/content/changelog src/lib/server/cli-queries
 Test Files  7 passed (7)
      Tests  45 passed (45)
```

`node_modules/@anomalia/api-contracts` resolves **inside this worktree**, so the contract tests are not passing against the main checkout's older copy:

```
/Users/andreabuttarelli/Documents/GitHub/anomalia-wt/agent-knowledge/packages/api-contracts
```
</details>

The eight status tests cover: no cross-brand counting or naming; loaded vs digested; the reason a document failed, not only that it did; which shelves have something indexed; which sources synced and when; an empty brand reported as empty rather than broken; sixty failures capped at twenty; and a guard that `KNOWLEDGE_DOC_STATUSES` in the contract still equals `DOC_STATUSES` in `knowledge.ts`.

**Not tested:** the route against live Postgres. The eval suite was not run — nothing here touches the chat path, prompts, tools or the model.

## Evidence

Backend only. The evidence is the `tools/list` capture through `handleMcpFetch`, taken from a throwaway worktree at current `origin/dev` and compared field by field against this branch:

<details><summary><code>tools/list</code> — dev vs this branch</summary>

```
dev=112  after PR2=113
removed: []
added: ['get_knowledge_status']
changed existing (field by field): ['get_studio.description', 'search_knowledge.description']
```

Both changed descriptions are intentional and are the two ends of the same sentence:

- `search_knowledge` now says *"read `get_knowledge_status` before concluding anything"* — the promise #293 could not keep on its own.
- `get_studio` now says documents carry their pipeline state, and sends a question to `search_knowledge` instead of the whole corpus.

No input schema, no annotation, no title, and no other tool changed.
</details>

<details><summary>What the tool answers</summary>

```jsonc
{
  "documents": { "total": 6, "indexed": 2, "pending": 1, "processing": 1, "ready": 3, "failed": 1 },
  "chunks":    { "total": 15, "embedded": 10 },
  "collections": { "commercial": 1, "brand": 1 },
  "failures": [
    { "id": "d5", "title": "Bilancio.pdf", "error": "PDF is password protected", "attempts": 3 }
  ],
  "sources": [
    { "provider": "notion", "displayName": "Wiki di prodotto", "status": "active",
      "lastSyncAt": "2026-09-03T10:00:00Z", "lastError": null, "docsIngested": 18 },
    { "provider": "google-drive", "displayName": "Drive marketing", "status": "error",
      "lastSyncAt": "2026-08-30T09:00:00Z", "lastError": "folder no longer shared", "docsIngested": 4 }
  ],
  "searchable": true
}
```

Read it against the seeded corpus: six documents, but only **two** the search can see. Three are `ready` — one of them a pre-pipeline note with zero chunks. One is stuck at `pending`, one at `processing`, one failed on a password-protected PDF. A third of the chunks have no embedding, so paraphrases are already missing. None of that was visible from outside before this PR.
</details>

## Anything Else?

- `get_studio` still returns the **full** `content_text` of every document. That is a window-filler now that `search_knowledge` exists, but changing it is a behaviour change for existing callers, so it is flagged rather than forced. The description now steers away from it; removing or truncating the field is a separate decision.
- Two closed lists now cross the package boundary (`KNOWLEDGE_COLLECTIONS`/`COLLECTIONS`, `KNOWLEDGE_DOC_STATUSES`/`DOC_STATUSES`), because a package may not import `$lib`. A test holds each pair equal.
- `get_knowledge_status` is MCP-only, no CLI command yet.
- No migration. Nothing applied anywhere.
- Based on #293, which is already merged into `dev`; this branch is rebased on top of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
