### PR TITLE
Declare the four deletes in the registry

### DIFF
--- a/changelog/2026-09-04-deletes-in-the-registry.md
+++ b/changelog/2026-09-04-deletes-in-the-registry.md
@@ -1,0 +1,30 @@
+# Le quattro cancellazioni passano dal registry, e prendono l'UUID pieno
+
+`delete_person`, `delete_document` e `delete_competitor` erano tre tool MCP scritti a mano in
+`cli/mcp/tools/studio.ts`: esistevano solo lì. Il CLI le fa per conto suo, la rotta REST le
+espone da sempre, e Web MCP — il quarto consumatore in arrivo — non le avrebbe mai viste. Ora
+sono tre entry di `BRAND_ENDPOINTS`, come le altre ottanta: una dichiarazione, tutti i
+consumatori.
+
+La trappola stava nel generatore. Per un endpoint con `:id` sostituiva l'id dichiarato dal
+contratto con una stringa risolta per prefisso — comodo per leggere e per correggere, perché la
+lista dice quale riga è e il prefisso basta a indicarla. Su una cancellazione no: un prefisso
+ambiguo colpisce la riga sbagliata e non c'è modo di annullare. Migrandole così, tre tool che
+oggi chiedono un UUID avrebbero cominciato ad accettare `3f1c`, e la loro descrizione — *"Delete
+a studio person by UUID"* — sarebbe diventata falsa.
+
+Si è chiuso dalla parte stretta: **la DELETE non risolve mai un prefisso**. La regola sta in un
+posto solo, `acceptsIdPrefix` in `packages/api-contracts/src/index.ts`, accanto al modello che
+governa — così il generatore MCP e chiunque arrivi dopo la leggono da lì invece di riscriverla.
+`delete_product`, che il prefisso lo accettava, ora vuole l'UUID pieno come le altre tre: è
+l'unico cambiamento di comportamento visibile, e va nel changelog pubblico.
+
+`BRAND_RESOURCES` guadagna `document`, e con esso il resolver per prefisso dei documenti in
+`cli/mcp/util.ts`: oggi nessuna rotta lo usa (l'unico endpoint sui documenti è una DELETE), ma
+la mappa dei resolver è totale sulle risorse e la riga costa meno del `Partial` più la guardia
+che servirebbero a evitarla.
+
+Equivalenza provata, non dichiarata: `tools/list` catturato attraverso `handleMcpFetch` prima e
+dopo. 112 tool prima, 112 dopo, nessuno aggiunto o rimosso. I tre migrati hanno nome, titolo,
+descrizione, proprietà e obbligatori identici; l'unico delta è `additionalProperties: false`,
+che arriva perché gli input del registry sono `.strict()`.

--- a/cli/lib/contracts/index.ts
+++ b/cli/lib/contracts/index.ts
@@ -74,6 +74,9 @@ import {
 import {
   ADD_COMPETITOR,
   CREATE_PRODUCT,
+  DELETE_COMPETITOR,
+  DELETE_DOCUMENT,
+  DELETE_PERSON,
   DELETE_PRODUCT,
   GET_BIO,
   RESEARCH_COMPETITORS,
@@ -93,7 +96,8 @@ export const BRAND_RESOURCES = {
   article: 'Article',
   product: 'Product',
   person: 'Person',
-  competitor: 'Competitor'
+  competitor: 'Competitor',
+  document: 'Document'
 } as const;
 
 export type BrandResource = keyof typeof BRAND_RESOURCES;
@@ -136,6 +140,9 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   CREATE_POST,
   CREATE_PRODUCT,
   CREATE_SHARE,
+  DELETE_COMPETITOR,
+  DELETE_DOCUMENT,
+  DELETE_PERSON,
   DELETE_PRODUCT,
   DIAGNOSE_BRAND,
   DIAGNOSE_RADAR,
@@ -214,6 +221,13 @@ export function pathFor(endpoint: BrandEndpoint, slug: string, id?: string): str
   if (endpoint.resource === undefined) return `${base}${endpoint.pathUnderBrand}`;
   if (!id) throw new Error(`${endpoint.tool} needs a ${endpoint.resource} id`);
   return `${base}${endpoint.pathUnderBrand.replace(RESOURCE_SEGMENT, encodeURIComponent(id))}`;
+}
+
+// Un id accorciato è una comodità di lettura: la lista dice quale riga, il prefisso basta a
+// indicarla. Su una cancellazione non basta — il prefisso ambiguo colpisce la riga sbagliata e
+// non si torna indietro — quindi la DELETE prende l'id che il contratto dichiara, per intero.
+export function acceptsIdPrefix(endpoint: BrandEndpoint): endpoint is ResourceEndpoint {
+  return endpoint.resource !== undefined && endpoint.method !== 'DELETE';
 }
 
 export function statusForFailure(endpoint: BrandEndpoint, error: string): number {
@@ -312,6 +326,9 @@ export { GET_BACKLINKS, GET_GSC, GET_RANKS } from './web-metrics';
 export {
   ADD_COMPETITOR,
   CREATE_PRODUCT,
+  DELETE_COMPETITOR,
+  DELETE_DOCUMENT,
+  DELETE_PERSON,
   DELETE_PRODUCT,
   GET_BIO,
   RESEARCH_COMPETITORS,

--- a/cli/lib/contracts/studio.ts
+++ b/cli/lib/contracts/studio.ts
@@ -3,6 +3,10 @@ import type { BrandEndpoint } from './index';
 
 const id = z.string().min(1).describe('Row id, verbatim from get_studio or list_products');
 
+// Una cancellazione non accetta prefissi: un prefisso ambiguo colpisce la riga sbagliata e non
+// c'è nessun modo di annullarla. Serve l'UUID pieno, come get_studio e list_products lo danno.
+const OnlyRowUuid = z.object({ id: z.uuid() }).strict();
+
 const PRODUCT_FIELDS = {
   title: z.string().min(1).describe('What the offer is called'),
   description: z.string().describe('What it is, in the brand’s own words'),
@@ -90,9 +94,48 @@ export const DELETE_PRODUCT = {
   method: 'DELETE',
   pathUnderBrand: '/products/:id',
   resource: 'product',
-  input: z.object({ id }).strict(),
+  input: OnlyRowUuid,
   output: Ok,
   failures: [NOT_FOUND, { error: 'delete_failed', status: 500 }],
+  destructive: true
+} satisfies BrandEndpoint;
+
+export const DELETE_PERSON = {
+  tool: 'delete_person',
+  title: 'Delete person',
+  description: 'Delete a studio person by UUID.',
+  method: 'DELETE',
+  pathUnderBrand: '/studio/people/:id',
+  resource: 'person',
+  input: OnlyRowUuid,
+  output: Ok,
+  failures: [{ error: 'Person not found', status: 404 }],
+  destructive: true
+} satisfies BrandEndpoint;
+
+export const DELETE_DOCUMENT = {
+  tool: 'delete_document',
+  title: 'Delete studio document',
+  description: 'Delete a knowledge document by UUID.',
+  method: 'DELETE',
+  pathUnderBrand: '/studio/documents/:id',
+  resource: 'document',
+  input: OnlyRowUuid,
+  output: Ok,
+  failures: [{ error: 'Document not found', status: 404 }],
+  destructive: true
+} satisfies BrandEndpoint;
+
+export const DELETE_COMPETITOR = {
+  tool: 'delete_competitor',
+  title: 'Delete competitor',
+  description: 'Delete a competitor by UUID.',
+  method: 'DELETE',
+  pathUnderBrand: '/studio/competitors/:id',
+  resource: 'competitor',
+  input: OnlyRowUuid,
+  output: Ok,
+  failures: [NOT_FOUND],
   destructive: true
 } satisfies BrandEndpoint;
 

--- a/cli/mcp/deletes.test.ts
+++ b/cli/mcp/deletes.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'bun:test';
+import { handleMcpFetch } from './http-app.ts';
+
+async function rpc(method: string, params: unknown, id = 1) {
+  const res = await handleMcpFetch(
+    new Request('http://localhost/mcp', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json, text/event-stream' },
+      body: JSON.stringify({ jsonrpc: '2.0', id, method, params }),
+    }),
+  );
+  return (await res.json()) as { result?: Record<string, unknown> };
+}
+
+type Tool = {
+  name: string;
+  inputSchema?: { properties?: Record<string, { format?: string }>; required?: string[] };
+  annotations?: Record<string, unknown>;
+};
+
+async function tools(): Promise<Tool[]> {
+  await rpc('initialize', {
+    protocolVersion: '2024-11-05',
+    capabilities: {},
+    clientInfo: { name: 'test', version: '0.0.1' },
+  });
+  const listed = await rpc('tools/list', {}, 2);
+  return (listed.result?.tools ?? []) as Tool[];
+}
+
+const DELETES = ['delete_product', 'delete_person', 'delete_document', 'delete_competitor'];
+
+describe('le cancellazioni esposte dal registry', () => {
+  test('chiedono l’UUID pieno della riga, non un prefisso da risolvere', async () => {
+    const all = await tools();
+
+    for (const name of DELETES) {
+      const tool = all.find((t) => t.name === name);
+      expect(tool, name).toBeDefined();
+      expect(tool?.inputSchema?.properties?.id?.format, name).toBe('uuid');
+      expect(tool?.inputSchema?.required?.slice().sort(), name).toEqual(['id', 'slug']);
+      expect(tool?.annotations?.destructiveHint, name).toBe(true);
+    }
+  });
+});

--- a/cli/mcp/tools/brand-content.ts
+++ b/cli/mcp/tools/brand-content.ts
@@ -1,7 +1,12 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { api, callEndpoint } from '../../lib/api.ts';
-import { BRAND_ENDPOINTS, BRAND_RESOURCES, type BrandResource } from '../../lib/contracts/index.ts';
+import {
+  acceptsIdPrefix,
+  BRAND_ENDPOINTS,
+  BRAND_RESOURCES,
+  type BrandResource,
+} from '../../lib/contracts/index.ts';
 import { resolvePostId, resolveResourceId, withAuth } from '../util.ts';
 
 const slug = z.string().min(1).describe('Brand URL slug');
@@ -11,16 +16,15 @@ const resourceId = (resource: BrandResource) =>
 
 function registerDeclaredEndpoints(server: McpServer) {
   for (const endpoint of BRAND_ENDPOINTS) {
-    const resource = endpoint.resource;
+    const byPrefix = acceptsIdPrefix(endpoint);
     server.registerTool(
       endpoint.tool,
       {
         title: endpoint.title,
         description: endpoint.description,
-        inputSchema:
-          resource === undefined
-            ? endpoint.input.extend({ slug })
-            : endpoint.input.extend({ slug, id: resourceId(resource) }),
+        inputSchema: byPrefix
+          ? endpoint.input.extend({ slug, id: resourceId(endpoint.resource) })
+          : endpoint.input.extend({ slug }),
         annotations: {
           readOnlyHint: endpoint.method === 'GET',
           destructiveHint: endpoint.destructive,
@@ -34,7 +38,9 @@ function registerDeclaredEndpoints(server: McpServer) {
           }
 
           const { id, ...payload } = input as { id: string } & Record<string, unknown>;
-          const resolved = await resolveResourceId(endpoint.resource, token, brandSlug as string, id);
+          const resolved = byPrefix
+            ? await resolveResourceId(endpoint.resource, token, brandSlug as string, id)
+            : id;
           const body = await callEndpoint<Record<string, unknown>>(
             endpoint,
             token,

--- a/cli/mcp/tools/studio.ts
+++ b/cli/mcp/tools/studio.ts
@@ -44,20 +44,6 @@ export function registerStudioTools(server: McpServer) {
   );
 
   server.registerTool(
-    'delete_document',
-    {
-      title: 'Delete studio document',
-      description: 'Delete a knowledge document by UUID.',
-      inputSchema: z.object({
-        slug,
-        id: z.string().uuid(),
-      }),
-      annotations: { readOnlyHint: false, destructiveHint: true },
-    },
-    async ({ slug, id }) => withAuth((token) => api.deleteDocument(token, slug, id)),
-  );
-
-  server.registerTool(
     'add_person',
     {
       title: 'Add person',
@@ -108,34 +94,6 @@ export function registerStudioTools(server: McpServer) {
           kind: 'ai',
         }),
       ),
-  );
-
-  server.registerTool(
-    'delete_person',
-    {
-      title: 'Delete person',
-      description: 'Delete a studio person by UUID.',
-      inputSchema: z.object({
-        slug,
-        id: z.string().uuid(),
-      }),
-      annotations: { readOnlyHint: false, destructiveHint: true },
-    },
-    async ({ slug, id }) => withAuth((token) => api.deletePerson(token, slug, id)),
-  );
-
-    server.registerTool(
-    'delete_competitor',
-    {
-      title: 'Delete competitor',
-      description: 'Delete a competitor by UUID.',
-      inputSchema: z.object({
-        slug,
-        id: z.string().uuid(),
-      }),
-      annotations: { readOnlyHint: false, destructiveHint: true },
-    },
-    async ({ slug, id }) => withAuth((token) => api.deleteCompetitor(token, slug, id)),
   );
 
     }

--- a/cli/mcp/util.ts
+++ b/cli/mcp/util.ts
@@ -105,6 +105,7 @@ const RESOLVE_ID: Record<BrandResource, IdResolver> = {
   product: byPrefix('product', async (token, slug) => (await api.listProducts(token, slug)).products),
   person: byPrefix('person', async (token, slug) => (await api.getStudio(token, slug)).people),
   competitor: byPrefix('competitor', async (token, slug) => (await api.getStudio(token, slug)).competitors),
+  document: byPrefix('document', async (token, slug) => (await api.getStudio(token, slug)).documents),
 };
 
 export function resolveResourceId(

--- a/cli/plugins/anomalia/skills/anomalia/references/tools.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/tools.md
@@ -1,6 +1,8 @@
 # Anomalia MCP tools ↔ CLI
 
-All tools take a brand `slug` when brand-scoped. Ids accept short unambiguous prefixes.
+All tools take a brand `slug` when brand-scoped. Ids accept short unambiguous prefixes, except
+on a delete: `delete_product`, `delete_person`, `delete_document` and `delete_competitor` take
+the full UUID, because an ambiguous prefix would remove the wrong row and nothing brings it back.
 
 ## Auth
 
@@ -215,10 +217,10 @@ A brand keeps one draft in review, so saving replaces the one that is there (`re
 `create_product` adds ONE offer. The e-commerce resync behind `sync_products` replaces the whole
 catalog and would erase a hand-made row.
 
-`update_product`, `update_person` and `update_competitor` take the row `id` verbatim from
-`get_studio` or `list_products` — no short prefixes here. They change only the fields you send:
-every other column keeps the value it had. An id from another brand answers `not_found`, exactly
-like one that does not exist anywhere.
+`update_product`, `update_person` and `update_competitor` change only the fields you send: every
+other column keeps the value it had. An id from another brand answers `not_found`, exactly like
+one that does not exist anywhere. The four deletes want the UUID in full, verbatim from
+`get_studio` or `list_products`.
 
 `update_person` cannot attest consent, turn a real person into an AI persona, or touch photos. A
 real person's face stays withheld from every generator until the operator states the consent in

--- a/cli/skills/anomalia/references/tools.md
+++ b/cli/skills/anomalia/references/tools.md
@@ -1,6 +1,8 @@
 # Anomalia MCP tools ↔ CLI
 
-All tools take a brand `slug` when brand-scoped. Ids accept short unambiguous prefixes.
+All tools take a brand `slug` when brand-scoped. Ids accept short unambiguous prefixes, except
+on a delete: `delete_product`, `delete_person`, `delete_document` and `delete_competitor` take
+the full UUID, because an ambiguous prefix would remove the wrong row and nothing brings it back.
 
 ## Auth
 
@@ -215,10 +217,10 @@ A brand keeps one draft in review, so saving replaces the one that is there (`re
 `create_product` adds ONE offer. The e-commerce resync behind `sync_products` replaces the whole
 catalog and would erase a hand-made row.
 
-`update_product`, `update_person` and `update_competitor` take the row `id` verbatim from
-`get_studio` or `list_products` — no short prefixes here. They change only the fields you send:
-every other column keeps the value it had. An id from another brand answers `not_found`, exactly
-like one that does not exist anywhere.
+`update_product`, `update_person` and `update_competitor` change only the fields you send: every
+other column keeps the value it had. An id from another brand answers `not_found`, exactly like
+one that does not exist anywhere. The four deletes want the UUID in full, verbatim from
+`get_studio` or `list_products`.
 
 `update_person` cannot attest consent, turn a real person into an AI persona, or touch photos. A
 real person's face stays withheld from every generator until the operator states the consent in

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -74,6 +74,9 @@ import {
 import {
   ADD_COMPETITOR,
   CREATE_PRODUCT,
+  DELETE_COMPETITOR,
+  DELETE_DOCUMENT,
+  DELETE_PERSON,
   DELETE_PRODUCT,
   GET_BIO,
   RESEARCH_COMPETITORS,
@@ -93,7 +96,8 @@ export const BRAND_RESOURCES = {
   article: 'Article',
   product: 'Product',
   person: 'Person',
-  competitor: 'Competitor'
+  competitor: 'Competitor',
+  document: 'Document'
 } as const;
 
 export type BrandResource = keyof typeof BRAND_RESOURCES;
@@ -136,6 +140,9 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   CREATE_POST,
   CREATE_PRODUCT,
   CREATE_SHARE,
+  DELETE_COMPETITOR,
+  DELETE_DOCUMENT,
+  DELETE_PERSON,
   DELETE_PRODUCT,
   DIAGNOSE_BRAND,
   DIAGNOSE_RADAR,
@@ -214,6 +221,13 @@ export function pathFor(endpoint: BrandEndpoint, slug: string, id?: string): str
   if (endpoint.resource === undefined) return `${base}${endpoint.pathUnderBrand}`;
   if (!id) throw new Error(`${endpoint.tool} needs a ${endpoint.resource} id`);
   return `${base}${endpoint.pathUnderBrand.replace(RESOURCE_SEGMENT, encodeURIComponent(id))}`;
+}
+
+// Un id accorciato è una comodità di lettura: la lista dice quale riga, il prefisso basta a
+// indicarla. Su una cancellazione non basta — il prefisso ambiguo colpisce la riga sbagliata e
+// non si torna indietro — quindi la DELETE prende l'id che il contratto dichiara, per intero.
+export function acceptsIdPrefix(endpoint: BrandEndpoint): endpoint is ResourceEndpoint {
+  return endpoint.resource !== undefined && endpoint.method !== 'DELETE';
 }
 
 export function statusForFailure(endpoint: BrandEndpoint, error: string): number {
@@ -312,6 +326,9 @@ export { GET_BACKLINKS, GET_GSC, GET_RANKS } from './web-metrics';
 export {
   ADD_COMPETITOR,
   CREATE_PRODUCT,
+  DELETE_COMPETITOR,
+  DELETE_DOCUMENT,
+  DELETE_PERSON,
   DELETE_PRODUCT,
   GET_BIO,
   RESEARCH_COMPETITORS,

--- a/packages/api-contracts/src/studio.test.ts
+++ b/packages/api-contracts/src/studio.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from 'vitest';
 import { pathFor, statusForFailure } from './index';
 import {
   CREATE_PRODUCT,
+  DELETE_COMPETITOR,
+  DELETE_DOCUMENT,
+  DELETE_PERSON,
   DELETE_PRODUCT,
   GET_BIO,
   SET_BIO,
@@ -9,6 +12,9 @@ import {
   UPDATE_PERSON,
   UPDATE_PRODUCT
 } from './studio';
+
+const DELETES = [DELETE_PRODUCT, DELETE_PERSON, DELETE_DOCUMENT, DELETE_COMPETITOR];
+const A_UUID = '9f8b1a2c-3d4e-4f60-8a1b-2c3d4e5f6071';
 
 const STUDIO_WRITES = [
   CREATE_PRODUCT,
@@ -68,7 +74,28 @@ describe('i contratti dello studio', () => {
     }
   });
 
+  it('una cancellazione prende un UUID pieno, mai un prefisso', () => {
+    for (const endpoint of DELETES) {
+      expect(endpoint.input.safeParse({ id: A_UUID }).success, endpoint.tool).toBe(true);
+      expect(endpoint.input.safeParse({ id: A_UUID.slice(0, 8) }).success, endpoint.tool).toBe(false);
+    }
+  });
+
+  it('ogni cancellazione dichiara il 404 della riga che non c’è', () => {
+    for (const endpoint of DELETES) {
+      expect(endpoint.destructive, endpoint.tool).toBe(true);
+      expect(endpoint.failures.some((f) => f.status === 404), endpoint.tool).toBe(true);
+    }
+  });
+
   it('ogni contratto indirizza il percorso REST che esiste già', () => {
+    expect(pathFor(DELETE_PERSON, 'demo', A_UUID)).toBe(`/api/v1/brands/demo/studio/people/${A_UUID}`);
+    expect(pathFor(DELETE_DOCUMENT, 'demo', A_UUID)).toBe(
+      `/api/v1/brands/demo/studio/documents/${A_UUID}`
+    );
+    expect(pathFor(DELETE_COMPETITOR, 'demo', A_UUID)).toBe(
+      `/api/v1/brands/demo/studio/competitors/${A_UUID}`
+    );
     expect(pathFor(CREATE_PRODUCT, 'demo')).toBe('/api/v1/brands/demo/studio/products');
     expect(pathFor(UPDATE_PRODUCT, 'demo', 'p1')).toBe('/api/v1/brands/demo/products/p1');
     expect(pathFor(DELETE_PRODUCT, 'demo', 'p1')).toBe('/api/v1/brands/demo/products/p1');

--- a/packages/api-contracts/src/studio.ts
+++ b/packages/api-contracts/src/studio.ts
@@ -3,6 +3,10 @@ import type { BrandEndpoint } from './index';
 
 const id = z.string().min(1).describe('Row id, verbatim from get_studio or list_products');
 
+// Una cancellazione non accetta prefissi: un prefisso ambiguo colpisce la riga sbagliata e non
+// c'è nessun modo di annullarla. Serve l'UUID pieno, come get_studio e list_products lo danno.
+const OnlyRowUuid = z.object({ id: z.uuid() }).strict();
+
 const PRODUCT_FIELDS = {
   title: z.string().min(1).describe('What the offer is called'),
   description: z.string().describe('What it is, in the brand’s own words'),
@@ -90,9 +94,48 @@ export const DELETE_PRODUCT = {
   method: 'DELETE',
   pathUnderBrand: '/products/:id',
   resource: 'product',
-  input: z.object({ id }).strict(),
+  input: OnlyRowUuid,
   output: Ok,
   failures: [NOT_FOUND, { error: 'delete_failed', status: 500 }],
+  destructive: true
+} satisfies BrandEndpoint;
+
+export const DELETE_PERSON = {
+  tool: 'delete_person',
+  title: 'Delete person',
+  description: 'Delete a studio person by UUID.',
+  method: 'DELETE',
+  pathUnderBrand: '/studio/people/:id',
+  resource: 'person',
+  input: OnlyRowUuid,
+  output: Ok,
+  failures: [{ error: 'Person not found', status: 404 }],
+  destructive: true
+} satisfies BrandEndpoint;
+
+export const DELETE_DOCUMENT = {
+  tool: 'delete_document',
+  title: 'Delete studio document',
+  description: 'Delete a knowledge document by UUID.',
+  method: 'DELETE',
+  pathUnderBrand: '/studio/documents/:id',
+  resource: 'document',
+  input: OnlyRowUuid,
+  output: Ok,
+  failures: [{ error: 'Document not found', status: 404 }],
+  destructive: true
+} satisfies BrandEndpoint;
+
+export const DELETE_COMPETITOR = {
+  tool: 'delete_competitor',
+  title: 'Delete competitor',
+  description: 'Delete a competitor by UUID.',
+  method: 'DELETE',
+  pathUnderBrand: '/studio/competitors/:id',
+  resource: 'competitor',
+  input: OnlyRowUuid,
+  output: Ok,
+  failures: [NOT_FOUND],
   destructive: true
 } satisfies BrandEndpoint;
 

--- a/src/lib/content/changelog/2026-09-04-deletes-take-the-full-id.ts
+++ b/src/lib/content/changelog/2026-09-04-deletes-take-the-full-id.ts
@@ -1,0 +1,10 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-04',
+  title: 'Deleting now asks for the whole id',
+  items: [
+    'Removing a product, a person, a note or a competitor from a connected AI client now takes the full id, not a shortened one. A short id that matched two rows could delete the wrong one, and nothing brings it back.',
+    'Everything else still takes the short form: reading a post, correcting a product, rescheduling — those are as forgiving as before.'
+  ]
+} satisfies ChangelogEntry;


### PR DESCRIPTION
## What?

`delete_person`, `delete_document` and `delete_competitor` were three hand-written MCP tools in
`cli/mcp/tools/studio.ts`. They are now three entries of `BRAND_ENDPOINTS`, like the other eighty.
Along with them the registry learns one rule: **a `DELETE` never resolves an id by prefix**, so
`delete_product` — which already came from the registry and did accept a prefix — now wants the
full UUID as well.

Hand-written MCP tools drop from 32 to 29. `tools/list` still answers with 112 tools.

## Why?

A hand-written tool is a capability that exists on one road and not on the others. The registry
turns one declaration into the CLI client method and the MCP tool, and a fourth consumer — Web
MCP — is on the way: everything left by hand is something that will not reach it.

The prefix rule is the other half. The generator replaced a resource id with a string resolved
by prefix, which is a real convenience when reading a post or correcting a product: the list says
which row it is and four characters point at it. On a delete it is not a convenience, it is a
loaded gun — an ambiguous prefix removes the wrong row and the user cannot undo it. Migrating
the three tools as they were would also have made their own descriptions false: *"Delete a studio
person by UUID"* while accepting `3f1c`.

## How?

- `packages/api-contracts/src/studio.ts` — `DELETE_PERSON`, `DELETE_DOCUMENT`, `DELETE_COMPETITOR`
  as plain contracts, plus `OnlyRowUuid` (`z.object({ id: z.uuid() }).strict()`) shared with
  `DELETE_PRODUCT`. Output and failures read off the routes, not guessed: `{ ok: true }`, and the
  404 each route actually returns (`Person not found`, `Document not found`, `not_found`).
- `packages/api-contracts/src/index.ts` — `acceptsIdPrefix(endpoint)`, a type predicate that says
  the exception once, next to the model that governs it, instead of leaving it in the generator
  where the next consumer would have to rediscover it. `BRAND_RESOURCES` gains `document`.
- `cli/mcp/tools/brand-content.ts` — the generator asks `acceptsIdPrefix` for both the schema and
  the resolution. A delete keeps the contract's own `id`.
- `cli/mcp/util.ts` — a `document` resolver, one line, so the resolver map stays total over
  `BrandResource`. Rejected alternative: a `Partial<Record<…>>` plus a guard — more code and a new
  runtime failure path to avoid one unused line.

Rejected: giving the deletes their own id description. Today's hand-written tools have none, so
leaving it out keeps the three schemas byte-identical apart from the declared delta.

## Testing?

Red before green, both times:

- `packages/api-contracts/src/studio.test.ts` — a delete takes a full UUID and refuses a prefix;
  every delete declares its 404 and is `destructive`. Red first: `DELETE_PERSON` did not exist and
  `DELETE_PRODUCT` accepted `9f8b1a2c`.
- `cli/mcp/deletes.test.ts` (new) — through `handleMcpFetch`, the four delete tools expose
  `format: "uuid"`, require `[id, slug]`, and carry `destructiveHint`. Red first with
  `Tool delete_document is already registered` and `delete_product` undefined at `format`.

Green: `npx vitest run packages/api-contracts` (183 tests), `npx vitest run src/routes/api/v1/brands/[slug]/registry.test.ts`
(the contract↔route test from #290, still green — the three new paths exist and export `DELETE`),
`cd cli && bun test` (58 tests), `cd cli && bun run typecheck`, `node scripts/typecheck-runtime.mjs`.

Not tested: a real delete against a real brand. The routes are untouched by this PR — only who
declares the tool changed — and the id now reaching them is a stricter subset of what they
accepted before.

## Evidence

`tools/list` captured through `handleMcpFetch` on `origin/dev` and on this branch, compared field
by field over all 112 tools.

<details>
<summary>112 tools before, 112 after — none added, none removed</summary>

```
before 112 after 112
removed: []
added: []
```

</details>

<details>
<summary>The three migrated tools: only <code>additionalProperties: false</code> moves</summary>

`delete_person`, before → after (`delete_document` and `delete_competitor` are identical in shape):

```
- "properties":{"slug":{…},"id":{"type":"string","format":"uuid","pattern":"^(…)$"}},"required":["slug","id"]
+ "properties":{"id":{"type":"string","format":"uuid","pattern":"^(…)$"},"slug":{…}},"required":["id","slug"],"additionalProperties":false
```

Same name, same title, same description (`Delete a studio person by UUID.`), same property set,
same required set, same annotations. The only delta is `additionalProperties: false`, which every
registry input carries because they are `.strict()`.

</details>

<details>
<summary>The one real behavior change: <code>delete_product</code></summary>

```
- "id":{"type":"string","minLength":1,"description":"Product id or unambiguous prefix"}
+ "id":{"type":"string","format":"uuid","pattern":"^([0-9a-fA-F]{8}-…)$"}
```

This is the change the public changelog announces: a shortened product id is no longer accepted
when deleting.

</details>

No UI surface changes, so no screenshots.

## Anything Else?

- The `document` resolver in `cli/mcp/util.ts` is unused today: the only document endpoint is a
  delete. It becomes live the moment a non-delete document endpoint is declared.
- `cli/skills/anomalia/references/tools.md` also loses a line that was already false before this
  PR — it claimed `update_product` / `update_person` / `update_competitor` take the id verbatim
  with "no short prefixes here", while the generator has been resolving prefixes for them all
  along. It now states the real rule: prefixes everywhere, full UUID on a delete.
- Still hand-written after this PR: 29 tools. The next groups are the input reshapes (renamed
  fields), and two design calls for @andreabuttarelli — splitting `/posts/:id/media` and `/web`,
  which dispatch on a constant `action`, and whether the non-brand endpoints deserve a registry
  of their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
