### PR TITLE
Serve the writing skills to a model outside the harness

### DIFF
--- a/changelog/2026-09-04-skill-di-scrittura-fuori-dal-bridge.md
+++ b/changelog/2026-09-04-skill-di-scrittura-fuori-dal-bridge.md
@@ -1,0 +1,89 @@
+# `get_writing_skills` — il mestiere esce dal bridge prima che il bridge sparisca
+
+## La regressione che stava per succedere in silenzio
+
+`src/lib/agent-docs/skills/` contiene `humanizer`, `stop-slop`, `social` (con `platform-limits`,
+`carousel-frameworks`, `listening`, e altri sei riferimenti) e `seo-audit`: 145 KB su 17 file.
+**Sono il motivo per cui i testi non suonano da chatbot.**
+
+Raggiungevano un modello per una strada sola:
+
+```
+agent-docs/skills/*.md → brand-skills.ts (?raw) → skillsForAgent() → adapters.ts:421 → harness
+                                                                     ↑
+                                                          UNICO chiamante, dentro il bridge
+                                                          che stiamo cancellando
+```
+
+Cancellato quel file, il mestiere smette di arrivare a qualsiasi modello. Nessuna eccezione,
+nessun test rosso, nessun errore nei log: la qualità della copy scende e basta. È la stessa forma
+della regressione dei motion video.
+
+Un test lo agganciava — `brand-skills.test.ts:116` fa
+`expect(src).toMatch(/skillsForAgent\(opts\.agentId\)/)` — ma è appeso al **bridge**: chi cancella
+il bridge cancella anche quell'asserzione, legittimamente, e la strada resta chiusa lo stesso.
+
+## Cosa è stato verificato prima di decidere
+
+**Le skill del brand non esistono in `brand-skills.ts`.** Il nome inganna: `brandSkills` è un
+array `const` di quattro markdown importati con `?raw`, uguali per ogni brand. La selezione che fa
+`skillsForAgent` è **per agente del team** (`content`, `ugc`, `web`, `analyst`, `auto`, `motion`),
+non per brand. Impacchettarle una volta per tutte è corretto.
+
+**Le skill del brand esistono altrove, e nessuno le serviva.** La migrazione 0178 le ha messe in
+`brand_memory` con `category = 'skill'`: markdown la cui prima riga è il trigger, scritte
+dall'operatore o distillate da `runDream` quando trova tre lezioni sulla stessa procedura. La
+rotta `/studio/memory?category=skill` esiste ma **non è nel registry**, quindi via MCP non c'è
+nessun tool: un agente esterno non poteva leggere le procedure del brand in nessun modo.
+Sono nella stessa risposta, distinte da `source`.
+
+## La strada scelta, e le due scartate
+
+**Un tool del registry** (`get_writing_skills`), non file spediti col pacchetto skill, non risorse
+MCP.
+
+- **Scartato: copiarle in `cli/skills/anomalia/`.** Il pacchetto skill oggi è 47 KB di
+  *istruzioni operative* (quale tool chiamare); le skill di scrittura sono 145 KB di *mestiere*:
+  triplicherebbero un pacchetto che ogni utente Claude Code carica — e ChatGPT e Cursor, che sono
+  metà del pivot e si collegano **solo** via MCP, non lo vedrebbero mai. Servirebbe anche un
+  secondo mirror da tenere allineato.
+- **Scartato: risorse MCP.** È la primitiva giusta sulla carta, ma il supporto alle risorse è
+  disomogeneo fra i client, e uscirebbe dal registry a `registerTool` scritti a mano.
+- **Scelto: un tool.** Ogni client MCP supporta i tool. Una sorgente sola — i file restano
+  l'unica copia — e la stessa risposta per Claude, ChatGPT e Cursor.
+
+## Come sta dentro una finestra
+
+145 KB in una risposta sono inutilizzabili. La stessa divulgazione progressiva che il formato
+skill usa già:
+
+- il **corpo** di ogni `SKILL.md` del mazzo arriva inline (mazzo predefinito ~33 KB, `content`
+  ~48 KB — che è esattamente quello che l'agente interno portava a ogni turno);
+- i **riferimenti** sono elencati per percorso e non spediti; se ne chiede uno con
+  `reference: "social/references/platform-limits.md"` e torna quello solo, senza il mazzo.
+
+Nessun taglio dei corpi: troncare il mestiere è precisamente la regressione da evitare.
+
+## Perché il modello lo chiamerà
+
+Un tool che nessuno chiama non serve a niente. Tre posti lo dicono:
+
+- la **descrizione** del tool comincia con `READ THIS BEFORE WRITING ANY COPY` (un test verifica
+  che continui a dirlo);
+- `cli/skills/anomalia/SKILL.md` lo mette fra le **regole operative**, non fra i workflow;
+- il workflow "Before you write anything" ora ha due letture: `get_writing_skills` (**come**
+  scrivere) e `get_creation_kit` (**cosa** dire).
+
+## Il test che rimpiazza quello appeso al bridge
+
+`ogni skill di prodotto raggiunge un modello per una strada che non passa dal bridge`: gira i sei
+mazzi e pretende che l'unione copra **tutte** le skill in `brandSkills`. Cancellare
+`adapters.ts` non lo tocca — la conoscenza continua ad arrivare. Cancellare una skill, o rompere
+la rotta, lo fa diventare rosso.
+
+## Cosa non è stato toccato
+
+`skillsForAgent` **non è stata spostata** e il suo unico chiamante nel bridge è intatto. È stata
+solo estratta `brandSkillsForAgent` — le sole skill di prodotto, senza toccare il disco — in un
+commit separato senza cambi di comportamento, come vuole la regola: prima si riordina, poi si
+aggiunge.

--- a/cli/lib/contracts/index.ts
+++ b/cli/lib/contracts/index.ts
@@ -65,6 +65,7 @@ import {
 import { GEO_ACTION, REFRESH_KEYWORDS, SEO_ACTION } from './search';
 import { LIST_SOCIAL_ACCOUNTS, SOCIAL_CONNECT_LINK } from './social';
 import { GET_BACKLINKS, GET_GSC, GET_RANKS } from './web-metrics';
+import { GET_WRITING_SKILLS } from './writing-skills';
 import {
   CREATE_SHARE,
   LIST_SHARES,
@@ -168,6 +169,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   GET_STUDIO,
   GET_VOICE,
   GET_WEEKLY_PLAN,
+  GET_WRITING_SKILLS,
   IMPORT_MEDIA_URL,
   LIST_ARTICLES,
   LIST_AUDIT_CITATIONS,
@@ -313,6 +315,12 @@ export {
 export type { KnowledgeCollection } from './knowledge';
 export { GEO_ACTION, REFRESH_KEYWORDS, SEO_ACTION } from './search';
 export { GET_BACKLINKS, GET_GSC, GET_RANKS } from './web-metrics';
+export {
+  GET_WRITING_SKILLS,
+  WRITING_DECK_AGENTS,
+  WRITING_SKILL_SOURCES
+} from './writing-skills';
+export type { WritingDeckAgent } from './writing-skills';
 export {
   ADD_COMPETITOR,
   CREATE_PRODUCT,

--- a/cli/lib/contracts/writing-skills.ts
+++ b/cli/lib/contracts/writing-skills.ts
@@ -1,0 +1,49 @@
+import { z } from 'zod';
+import type { BrandEndpoint } from './index';
+
+/** Lo stesso elenco chiuso di `TEAM_AGENT_IDS` in `$lib/agent-owners` — un test tiene i due allineati. */
+export const WRITING_DECK_AGENTS = ['content', 'analyst', 'web', 'ugc', 'motion', 'auto'] as const;
+
+export type WritingDeckAgent = (typeof WRITING_DECK_AGENTS)[number];
+
+export const WRITING_SKILL_SOURCES = ['product', 'brand'] as const;
+
+const WritingSkill = z.object({
+  name: z.string(),
+  source: z.enum(WRITING_SKILL_SOURCES),
+  description: z.string(),
+  body: z.string(),
+  references: z.array(z.string())
+});
+
+export const GET_WRITING_SKILLS = {
+  tool: 'get_writing_skills',
+  title: 'Writing skills',
+  description:
+    'READ THIS BEFORE WRITING ANY COPY FOR THE BRAND — a caption, a carousel, a script, an article, a bio. ' +
+    'It returns the actual craft text Anomalia writes with: `humanizer` and `stop-slop` always (why the output must not read as a chatbot), plus `social` or `seo-audit` depending on `agent`. ' +
+    'It also returns this brand\'s OWN procedures, the ones its team wrote or the system distilled — `source` says which is which, and a brand procedure overrules a product skill when they disagree. ' +
+    'Bodies come inline; each skill lists its `references` by path without sending them, and you fetch one by passing `reference: "<skill>/<path>"`, which then returns that file alone. ' +
+    'No credits, no writes. Reading it costs a few thousand tokens and is the difference between copy a person would publish and copy that reads as generated.',
+  method: 'GET',
+  pathUnderBrand: '/writing-skills',
+  input: z
+    .object({
+      agent: z
+        .enum(WRITING_DECK_AGENTS)
+        .optional()
+        .describe('Whose deck: content and ugc add `social`, web adds `seo-audit`. Omit for the writing deck alone'),
+      reference: z
+        .string()
+        .min(1)
+        .optional()
+        .describe('Fetch one reference file instead of the deck, e.g. "social/references/platform-limits.md"')
+    })
+    .strict(),
+  output: z.object({
+    skills: z.array(WritingSkill),
+    reference: z.object({ path: z.string(), content: z.string() }).nullable()
+  }),
+  failures: [{ error: 'reference_not_found', status: 404 }],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/cli/plugins/anomalia/skills/anomalia/SKILL.md
+++ b/cli/plugins/anomalia/skills/anomalia/SKILL.md
@@ -44,11 +44,22 @@ Setup details: [references/mcp.md](references/mcp.md).
 1. Start with `list_brands` (or `anomalia brands`) to learn **slugs**.
 2. Pass `slug` on every brand-scoped call.
 3. Post/article ids accept **short unambiguous prefixes** from list output — never guess if ambiguous.
+4. **Before writing ANY copy** — caption, carousel, script, article, bio — call
+   `get_writing_skills`. It returns the craft text Anomalia writes with, plus this brand's own
+   procedures. Skipping it is how output starts reading as generated.
 5. Confirm before reject / delete / discard unless the user clearly asked.
 
 ## Quick workflows
 
-**Before you write anything** → `get_creation_kit` with the goal, the platforms and the format.
+**Before you write anything** → two reads, and they answer different questions.
+
+`get_writing_skills` is **how to write**: `humanizer` and `stop-slop` always, `social` or
+`seo-audit` depending on `agent`, plus the brand's own procedures (`source: "brand"`, and those
+overrule a product skill when they disagree). Bodies come inline; references are listed by path
+and fetched one at a time with `reference: "<skill>/<path>"`. A few thousand tokens, no credits —
+and the difference between copy a person would publish and copy that reads as generated.
+
+`get_creation_kit` is **what to say** — with the goal, the platforms and the format.
 It returns the smallest brief for that one job: platform limits, brand facts and approved voice,
 the matching rubric, ONE template with its hook family, the operator's own rewrites, what has
 worked on this brand, and which calendar minutes are taken. It is a selection, not the library —

--- a/cli/plugins/anomalia/skills/anomalia/references/tools.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/tools.md
@@ -197,6 +197,26 @@ seed: `platforms`, `pillar`, `format`, `media`, `slide_count`, `day`, `time`, `s
 A brand keeps one draft in review, so saving replaces the one that is there (`replaced` says so).
 `produce_week` is the separate, paid step that turns the rows into posts.
 
+## Writing
+
+| MCP | CLI |
+|-----|-----|
+| `get_writing_skills` | (MCP only) |
+
+**Call this before writing any copy.** It returns the craft text itself, not a pointer to it:
+`humanizer` and `stop-slop` always — why the output must not read as a chatbot — plus `social`
+(captions, carousels, hooks, platform limits) or `seo-audit` depending on `agent`. Omit `agent`
+for the writing deck alone; `content` and `ugc` add `social`, `web` adds `seo-audit`.
+
+It also returns this brand's OWN procedures — what its team wrote down or the system distilled
+from repeated lessons. `source` tells them apart, and **a brand procedure overrules a product
+skill when the two disagree**: the product skill is how everyone writes, the brand procedure is
+how this one does.
+
+Bodies arrive inline. Each skill lists its `references` by path without sending them; fetch one
+with `reference: "social/references/platform-limits.md"`, which returns that file alone and no
+deck. No credits, no writes.
+
 ## Studio
 
 | MCP | CLI |

--- a/cli/skills/anomalia/SKILL.md
+++ b/cli/skills/anomalia/SKILL.md
@@ -44,11 +44,22 @@ Setup details: [references/mcp.md](references/mcp.md).
 1. Start with `list_brands` (or `anomalia brands`) to learn **slugs**.
 2. Pass `slug` on every brand-scoped call.
 3. Post/article ids accept **short unambiguous prefixes** from list output — never guess if ambiguous.
+4. **Before writing ANY copy** — caption, carousel, script, article, bio — call
+   `get_writing_skills`. It returns the craft text Anomalia writes with, plus this brand's own
+   procedures. Skipping it is how output starts reading as generated.
 5. Confirm before reject / delete / discard unless the user clearly asked.
 
 ## Quick workflows
 
-**Before you write anything** → `get_creation_kit` with the goal, the platforms and the format.
+**Before you write anything** → two reads, and they answer different questions.
+
+`get_writing_skills` is **how to write**: `humanizer` and `stop-slop` always, `social` or
+`seo-audit` depending on `agent`, plus the brand's own procedures (`source: "brand"`, and those
+overrule a product skill when they disagree). Bodies come inline; references are listed by path
+and fetched one at a time with `reference: "<skill>/<path>"`. A few thousand tokens, no credits —
+and the difference between copy a person would publish and copy that reads as generated.
+
+`get_creation_kit` is **what to say** — with the goal, the platforms and the format.
 It returns the smallest brief for that one job: platform limits, brand facts and approved voice,
 the matching rubric, ONE template with its hook family, the operator's own rewrites, what has
 worked on this brand, and which calendar minutes are taken. It is a selection, not the library —

--- a/cli/skills/anomalia/references/tools.md
+++ b/cli/skills/anomalia/references/tools.md
@@ -197,6 +197,26 @@ seed: `platforms`, `pillar`, `format`, `media`, `slide_count`, `day`, `time`, `s
 A brand keeps one draft in review, so saving replaces the one that is there (`replaced` says so).
 `produce_week` is the separate, paid step that turns the rows into posts.
 
+## Writing
+
+| MCP | CLI |
+|-----|-----|
+| `get_writing_skills` | (MCP only) |
+
+**Call this before writing any copy.** It returns the craft text itself, not a pointer to it:
+`humanizer` and `stop-slop` always — why the output must not read as a chatbot — plus `social`
+(captions, carousels, hooks, platform limits) or `seo-audit` depending on `agent`. Omit `agent`
+for the writing deck alone; `content` and `ugc` add `social`, `web` adds `seo-audit`.
+
+It also returns this brand's OWN procedures — what its team wrote down or the system distilled
+from repeated lessons. `source` tells them apart, and **a brand procedure overrules a product
+skill when the two disagree**: the product skill is how everyone writes, the brand procedure is
+how this one does.
+
+Bodies arrive inline. Each skill lists its `references` by path without sending them; fetch one
+with `reference: "social/references/platform-limits.md"`, which returns that file alone and no
+deck. No credits, no writes.
+
 ## Studio
 
 | MCP | CLI |

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -65,6 +65,7 @@ import {
 import { GEO_ACTION, REFRESH_KEYWORDS, SEO_ACTION } from './search';
 import { LIST_SOCIAL_ACCOUNTS, SOCIAL_CONNECT_LINK } from './social';
 import { GET_BACKLINKS, GET_GSC, GET_RANKS } from './web-metrics';
+import { GET_WRITING_SKILLS } from './writing-skills';
 import {
   CREATE_SHARE,
   LIST_SHARES,
@@ -168,6 +169,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   GET_STUDIO,
   GET_VOICE,
   GET_WEEKLY_PLAN,
+  GET_WRITING_SKILLS,
   IMPORT_MEDIA_URL,
   LIST_ARTICLES,
   LIST_AUDIT_CITATIONS,
@@ -313,6 +315,12 @@ export {
 export type { KnowledgeCollection } from './knowledge';
 export { GEO_ACTION, REFRESH_KEYWORDS, SEO_ACTION } from './search';
 export { GET_BACKLINKS, GET_GSC, GET_RANKS } from './web-metrics';
+export {
+  GET_WRITING_SKILLS,
+  WRITING_DECK_AGENTS,
+  WRITING_SKILL_SOURCES
+} from './writing-skills';
+export type { WritingDeckAgent } from './writing-skills';
 export {
   ADD_COMPETITOR,
   CREATE_PRODUCT,

--- a/packages/api-contracts/src/writing-skills.test.ts
+++ b/packages/api-contracts/src/writing-skills.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { GET_WRITING_SKILLS, WRITING_DECK_AGENTS } from './writing-skills';
+import { BRAND_ENDPOINTS } from './index';
+
+describe('il contratto delle skill di scrittura', () => {
+  it('è registrato, o il tool MCP non nasce', () => {
+    expect(BRAND_ENDPOINTS).toContain(GET_WRITING_SKILLS);
+  });
+
+  it('è una lettura: leggere il mestiere non lo cambia', () => {
+    expect(GET_WRITING_SKILLS.method).toBe('GET');
+    expect(GET_WRITING_SKILLS.destructive).toBe(false);
+    expect(GET_WRITING_SKILLS.openWorld).toBeUndefined();
+  });
+
+  it('si può chiamare senza argomenti: il mazzo di scrittura è il default', () => {
+    expect(GET_WRITING_SKILLS.input.safeParse({}).success).toBe(true);
+  });
+
+  it('accetta solo gli agenti che hanno un mazzo', () => {
+    for (const agent of WRITING_DECK_AGENTS) {
+      expect(GET_WRITING_SKILLS.input.safeParse({ agent }).success, agent).toBe(true);
+    }
+    expect(GET_WRITING_SKILLS.input.safeParse({ agent: 'inventato' }).success).toBe(false);
+  });
+
+  it('rifiuta un parametro che non dichiara invece di scartarlo in silenzio', () => {
+    expect(GET_WRITING_SKILLS.input.safeParse({ skill: 'humanizer' }).success).toBe(false);
+  });
+
+  it('dichiara il 404 del riferimento che non esiste', () => {
+    expect(GET_WRITING_SKILLS.failures).toContainEqual({ error: 'reference_not_found', status: 404 });
+  });
+
+  /**
+   * La descrizione è l'unica istruzione che un modello esterno riceve. Se non dice QUANDO
+   * chiamarlo, non lo chiama, e la copy torna a suonare da chatbot senza che niente fallisca.
+   */
+  it('dice quando va chiamato, o non verrà chiamato', () => {
+    expect(GET_WRITING_SKILLS.description).toContain('BEFORE WRITING');
+    expect(GET_WRITING_SKILLS.description).toMatch(/no credits/i);
+  });
+
+  it('distingue una skill di prodotto da una procedura del brand', () => {
+    const parsed = GET_WRITING_SKILLS.output.safeParse({
+      skills: [
+        { name: 'humanizer', source: 'product', description: 'x', body: 'y', references: [] },
+        { name: 'lancio', source: 'brand', description: 'x', body: 'y', references: [] }
+      ],
+      reference: null
+    });
+
+    expect(parsed.success).toBe(true);
+    expect(
+      GET_WRITING_SKILLS.output.safeParse({
+        skills: [{ name: 'x', source: 'inventata', description: '', body: '', references: [] }],
+        reference: null
+      }).success
+    ).toBe(false);
+  });
+});

--- a/packages/api-contracts/src/writing-skills.ts
+++ b/packages/api-contracts/src/writing-skills.ts
@@ -1,0 +1,49 @@
+import { z } from 'zod';
+import type { BrandEndpoint } from './index';
+
+/** Lo stesso elenco chiuso di `TEAM_AGENT_IDS` in `$lib/agent-owners` — un test tiene i due allineati. */
+export const WRITING_DECK_AGENTS = ['content', 'analyst', 'web', 'ugc', 'motion', 'auto'] as const;
+
+export type WritingDeckAgent = (typeof WRITING_DECK_AGENTS)[number];
+
+export const WRITING_SKILL_SOURCES = ['product', 'brand'] as const;
+
+const WritingSkill = z.object({
+  name: z.string(),
+  source: z.enum(WRITING_SKILL_SOURCES),
+  description: z.string(),
+  body: z.string(),
+  references: z.array(z.string())
+});
+
+export const GET_WRITING_SKILLS = {
+  tool: 'get_writing_skills',
+  title: 'Writing skills',
+  description:
+    'READ THIS BEFORE WRITING ANY COPY FOR THE BRAND — a caption, a carousel, a script, an article, a bio. ' +
+    'It returns the actual craft text Anomalia writes with: `humanizer` and `stop-slop` always (why the output must not read as a chatbot), plus `social` or `seo-audit` depending on `agent`. ' +
+    'It also returns this brand\'s OWN procedures, the ones its team wrote or the system distilled — `source` says which is which, and a brand procedure overrules a product skill when they disagree. ' +
+    'Bodies come inline; each skill lists its `references` by path without sending them, and you fetch one by passing `reference: "<skill>/<path>"`, which then returns that file alone. ' +
+    'No credits, no writes. Reading it costs a few thousand tokens and is the difference between copy a person would publish and copy that reads as generated.',
+  method: 'GET',
+  pathUnderBrand: '/writing-skills',
+  input: z
+    .object({
+      agent: z
+        .enum(WRITING_DECK_AGENTS)
+        .optional()
+        .describe('Whose deck: content and ugc add `social`, web adds `seo-audit`. Omit for the writing deck alone'),
+      reference: z
+        .string()
+        .min(1)
+        .optional()
+        .describe('Fetch one reference file instead of the deck, e.g. "social/references/platform-limits.md"')
+    })
+    .strict(),
+  output: z.object({
+    skills: z.array(WritingSkill),
+    reference: z.object({ path: z.string(), content: z.string() }).nullable()
+  }),
+  failures: [{ error: 'reference_not_found', status: 404 }],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/src/lib/content/changelog/2026-09-04-writing-skills-for-your-agent.ts
+++ b/src/lib/content/changelog/2026-09-04-writing-skills-for-your-agent.ts
@@ -1,0 +1,10 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-04',
+  title: 'Your agent writes with Anomalia’s craft, not its own',
+  items: [
+    'Claude, ChatGPT and Cursor can now read the writing skills Anomalia writes with — the ones that keep captions, carousels, scripts and articles from reading as generated.',
+    'Your brand’s own procedures travel with them, and they win when they disagree with the general rule.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/brand-skills.ts
+++ b/src/lib/server/brand-skills.ts
@@ -80,9 +80,23 @@ const SKILLS_BY_AGENT: Record<TeamAgentId, string[]> = {
 	motion: [...WRITING_SKILLS, 'social', 'remotion-best-practices']
 };
 
+function skillNamesForAgent(agentId?: string | null): string[] {
+	return SKILLS_BY_AGENT[agentId as TeamAgentId] ?? WRITING_SKILLS;
+}
+
+/**
+ * Solo le skill di prodotto del mazzo, senza toccare il disco. Le usa chi serve il TESTO a un
+ * modello che sta fuori da qui: non ha l'harness, e le skill del repo (`.agents/skills`) sono
+ * scritte per gli agenti di codice, non per chi scrive per un brand.
+ */
+export function brandSkillsForAgent(agentId?: string | null): HarnessRepoSkill[] {
+	const names = skillNamesForAgent(agentId);
+	return brandSkills.filter((skill) => names.includes(skill.name));
+}
+
 export async function skillsForAgent(agentId?: string | null): Promise<HarnessRepoSkill[]> {
-	const names = SKILLS_BY_AGENT[agentId as TeamAgentId] ?? WRITING_SKILLS;
-	const brand = brandSkills.filter((skill) => names.includes(skill.name));
+	const names = skillNamesForAgent(agentId);
+	const brand = brandSkillsForAgent(agentId);
 	const repo = await loadHarnessSkills(names.filter((name) => !brandSkills.some((skill) => skill.name === name)));
 	return [...brand, ...repo];
 }

--- a/src/routes/api/v1/brands/[slug]/writing-skills/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/writing-skills/+server.ts
@@ -1,0 +1,87 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { authenticate, loadBrandForUser } from '$lib/server/cli-auth';
+import { brandSkills, brandSkillsForAgent } from '$lib/server/brand-skills';
+import { loadMemoryEntries } from '$lib/server/brand-memory';
+import type { HarnessRepoSkill } from '$lib/server/harness-skills';
+
+// LE SKILL DI SCRITTURA, SERVITE A UN MODELLO CHE STA FUORI. Fino a qui raggiungevano un modello
+// solo attraverso `skillsForAgent`, il cui unico chiamante vive nel bridge in smantellamento:
+// tolto quello, il testo che impedisce alla copy di suonare da chatbot smetteva di arrivare a
+// chiunque, senza che niente fallisse. Un agente esterno non ha l'harness — ha da leggere.
+//
+// Due sorgenti, un elenco solo, distinte da `source`:
+//   product → i markdown del prodotto, uguali per ogni brand
+//   brand   → le procedure di QUESTO brand (`brand_memory`, categoria `skill`)
+
+type Served = {
+  name: string;
+  source: 'product' | 'brand';
+  description: string;
+  body: string;
+  references: string[];
+};
+
+const REFERENCE_SEPARATOR = '/';
+
+function serveProduct(skill: HarnessRepoSkill): Served {
+  return {
+    name: skill.name,
+    source: 'product',
+    description: skill.description,
+    body: skill.content,
+    references: (skill.files ?? []).map((file) => file.path)
+  };
+}
+
+/** Il valore di una skill del brand è markdown la cui PRIMA RIGA è il trigger; il resto sono i passi. */
+function serveBrand(entry: { key: string; value: string }): Served {
+  const [trigger, ...rest] = entry.value.split('\n');
+  return {
+    name: entry.key,
+    source: 'brand',
+    description: trigger.trim(),
+    body: rest.join('\n').trim(),
+    references: []
+  };
+}
+
+/**
+ * Il riferimento si risolve confrontando con i file che la skill dichiara, mai costruendo un
+ * percorso: una traversata non ha niente da attraversare se nessuno apre un file per nome.
+ */
+function findReference(path: string): { path: string; content: string } | null {
+  const cut = path.indexOf(REFERENCE_SEPARATOR);
+  if (cut < 1) return null;
+
+  const skill = brandSkills.find((candidate) => candidate.name === path.slice(0, cut));
+  const wanted = path.slice(cut + 1);
+  const file = skill?.files?.find((candidate) => candidate.path === wanted);
+
+  return file ? { path, content: file.content } : null;
+}
+
+export const GET: RequestHandler = async ({ request, params, url }) => {
+  const { supabase, error, apiKey } = await authenticate(request);
+  if (error) return error;
+
+  const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
+  if (brandError) return brandError;
+
+  const asked = url.searchParams.get('reference');
+  if (asked) {
+    const reference = findReference(asked);
+    if (!reference) return json({ error: 'reference_not_found' }, { status: 404 });
+    return json({ skills: [], reference });
+  }
+
+  const entries = await loadMemoryEntries(supabase, brand.id, { category: 'skill' });
+
+  return json({
+    skills: [
+      ...brandSkillsForAgent(url.searchParams.get('agent')).map(serveProduct),
+      ...entries.map(serveBrand)
+    ],
+    reference: null
+  });
+};

--- a/src/routes/api/v1/brands/[slug]/writing-skills/server.test.ts
+++ b/src/routes/api/v1/brands/[slug]/writing-skills/server.test.ts
@@ -8,6 +8,8 @@ vi.mock('$lib/server/cli-auth', () => ({
 import { GET } from './+server';
 import { authenticate, loadBrandForUser } from '$lib/server/cli-auth';
 import { brandSkills } from '$lib/server/brand-skills';
+import { TEAM_AGENT_IDS } from '$lib/agent-owners';
+import { WRITING_DECK_AGENTS } from '@anomalia/api-contracts';
 
 type Row = Record<string, unknown>;
 
@@ -101,9 +103,11 @@ describe('GET /writing-skills', () => {
     signedIn();
 
     const reachable = new Set<string>();
-    for (const agent of ['content', 'ugc', 'web', 'analyst', 'auto', 'motion']) {
+    for (const agent of WRITING_DECK_AGENTS) {
       const { body } = await call({ agent });
-      for (const skill of body.skills) reachable.add(skill.name);
+      for (const skill of body.skills) {
+        if (skill.source === 'product') reachable.add(skill.name);
+      }
     }
 
     expect([...reachable].sort()).toEqual(brandSkills.map((s) => s.name).sort());
@@ -208,6 +212,10 @@ describe('GET /writing-skills', () => {
     const { body } = await call();
 
     expect(JSON.stringify(body)).not.toContain('Milano');
+  });
+
+  it('gli agenti dichiarati nel contratto sono quelli che il team ha davvero', () => {
+    expect([...WRITING_DECK_AGENTS].sort()).toEqual([...TEAM_AGENT_IDS].sort());
   });
 
   it('un brand senza procedure proprie riceve comunque quelle di prodotto', async () => {

--- a/src/routes/api/v1/brands/[slug]/writing-skills/server.test.ts
+++ b/src/routes/api/v1/brands/[slug]/writing-skills/server.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('$lib/server/cli-auth', () => ({
+  authenticate: vi.fn(),
+  loadBrandForUser: vi.fn()
+}));
+
+import { GET } from './+server';
+import { authenticate, loadBrandForUser } from '$lib/server/cli-auth';
+import { brandSkills } from '$lib/server/brand-skills';
+
+type Row = Record<string, unknown>;
+
+function fakeSupabase(memory: Row[]) {
+  return {
+    from(table: string) {
+      let rows = table === 'brand_memory' ? [...memory] : [];
+      const q = {
+        select: () => q,
+        eq(column: string, value: unknown) {
+          rows = rows.filter((r) => r[column] === value);
+          return q;
+        },
+        neq(column: string, value: unknown) {
+          rows = rows.filter((r) => r[column] !== value);
+          return q;
+        },
+        order: () => q,
+        then: (resolve: (v: { data: Row[]; error: null }) => unknown) => resolve({ data: rows, error: null })
+      };
+      return q;
+    }
+  };
+}
+
+const OWN_SKILL: Row = {
+  id: 'm1',
+  brand_id: 'brand-1',
+  layer: 'project',
+  category: 'skill',
+  key: 'lancio-prodotto',
+  value: 'Quando esce un prodotto nuovo.\n\n1. Cita il problema prima del nome.\n2. Un prezzo, mai due.',
+  agent: null
+};
+
+const FOREIGN_SKILL: Row = {
+  id: 'm2',
+  brand_id: 'brand-2',
+  layer: 'project',
+  category: 'skill',
+  key: 'procedura-del-vicino',
+  value: 'Quando il concorrente lancia.\n\nSconta del 40 percento.',
+  agent: null
+};
+
+const A_FACT: Row = {
+  id: 'm3',
+  brand_id: 'brand-1',
+  layer: 'project',
+  category: 'fact',
+  key: 'sede',
+  value: 'Milano',
+  agent: null
+};
+
+function signedIn(memory: Row[] = [OWN_SKILL, FOREIGN_SKILL, A_FACT]) {
+  vi.mocked(authenticate).mockResolvedValue({
+    supabase: fakeSupabase(memory),
+    user: { id: 'user-1' },
+    apiKey: undefined,
+    error: null
+  } as never);
+  vi.mocked(loadBrandForUser).mockResolvedValue({
+    brand: { id: 'brand-1', slug: 'demo', name: 'Demo Brand' },
+    error: null
+  } as never);
+}
+
+function call(query: Record<string, string> = {}, slug = 'demo') {
+  const url = new URL(`https://anomalia.test/api/v1/brands/${slug}/writing-skills`);
+  for (const [k, v] of Object.entries(query)) url.searchParams.set(k, v);
+  return (GET as (event: unknown) => Promise<Response>)({
+    request: new Request(url),
+    params: { slug },
+    url
+  }).then(async (res) => ({ res, body: await res.json() }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('GET /writing-skills', () => {
+  /**
+   * IL TEST CHE ESISTE PER LA REGRESSIONE SILENZIOSA. Le skill di scrittura raggiungevano un
+   * modello solo attraverso `skillsForAgent`, che aveva un unico chiamante dentro il bridge in
+   * smantellamento: cancellato quello, il testo smetteva di arrivare a chiunque e nessun test
+   * diventava rosso. Questo diventa rosso.
+   */
+  it('ogni skill di prodotto raggiunge un modello per una strada che non passa dal bridge', async () => {
+    signedIn();
+
+    const reachable = new Set<string>();
+    for (const agent of ['content', 'ugc', 'web', 'analyst', 'auto', 'motion']) {
+      const { body } = await call({ agent });
+      for (const skill of body.skills) reachable.add(skill.name);
+    }
+
+    expect([...reachable].sort()).toEqual(brandSkills.map((s) => s.name).sort());
+  });
+
+  it('serve il testo, non un riferimento a un file che il modello non può aprire', async () => {
+    signedIn();
+
+    const { res, body } = await call();
+
+    expect(res.status).toBe(200);
+    const humanizer = body.skills.find((s: { name: string }) => s.name === 'humanizer');
+    expect(humanizer.source).toBe('product');
+    expect(humanizer.description.length).toBeGreaterThan(0);
+    expect(humanizer.body.length).toBeGreaterThan(1000);
+  });
+
+  it('il mazzo predefinito è quello di scrittura: nessun agente scrive come un bot', async () => {
+    signedIn();
+
+    const { body } = await call();
+
+    expect(body.skills.filter((s: { source: string }) => s.source === 'product').map((s: { name: string }) => s.name).sort())
+      .toEqual(['humanizer', 'stop-slop']);
+  });
+
+  it('ogni agente porta il suo mazzo, e chi scrive social porta `social`', async () => {
+    signedIn();
+
+    const content = await call({ agent: 'content' });
+    const web = await call({ agent: 'web' });
+
+    const names = (r: { body: { skills: { name: string; source: string }[] } }) =>
+      r.body.skills.filter((s) => s.source === 'product').map((s) => s.name).sort();
+
+    expect(names(content)).toEqual(['humanizer', 'social', 'stop-slop']);
+    expect(names(web)).toEqual(['humanizer', 'seo-audit', 'stop-slop']);
+  });
+
+  it('elenca i riferimenti senza spedirli: 145 KB non stanno in una risposta', async () => {
+    signedIn();
+
+    const { body } = await call({ agent: 'content' });
+
+    const social = body.skills.find((s: { name: string }) => s.name === 'social');
+    expect(social.references).toContain('references/platform-limits.md');
+    expect(social.references).toContain('references/carousel-frameworks.md');
+    expect(JSON.stringify(body)).not.toContain('CAROUSEL_FRAMEWORK_MARKER_THAT_DOES_NOT_EXIST');
+    expect(body.reference).toBeNull();
+  });
+
+  it('consegna un riferimento quando lo si chiede per nome, e allora solo quello', async () => {
+    signedIn();
+
+    const { body } = await call({ reference: 'social/references/platform-limits.md' });
+
+    expect(body.skills).toEqual([]);
+    expect(body.reference.path).toBe('social/references/platform-limits.md');
+    expect(body.reference.content.length).toBeGreaterThan(100);
+  });
+
+  it('un riferimento inventato è un 404, non un corpo vuoto che sembra un file vuoto', async () => {
+    signedIn();
+
+    const { res, body } = await call({ reference: 'social/references/inventato.md' });
+
+    expect(res.status).toBe(404);
+    expect(body.error).toBe('reference_not_found');
+  });
+
+  it('non lascia uscire un file fuori dalle skill nemmeno risalendo le cartelle', async () => {
+    signedIn();
+
+    for (const path of ['../../../../etc/passwd', 'social/../../../package.json', '/etc/passwd']) {
+      const { res } = await call({ reference: path });
+      expect(res.status, path).toBe(404);
+    }
+  });
+
+  it('le procedure del brand viaggiano col brand, e quelle di un altro non compaiono', async () => {
+    signedIn();
+
+    const { body } = await call();
+
+    const own = body.skills.filter((s: { source: string }) => s.source === 'brand');
+    expect(own).toEqual([
+      {
+        name: 'lancio-prodotto',
+        source: 'brand',
+        description: 'Quando esce un prodotto nuovo.',
+        body: '1. Cita il problema prima del nome.\n2. Un prezzo, mai due.',
+        references: []
+      }
+    ]);
+    expect(JSON.stringify(body)).not.toContain('procedura-del-vicino');
+    expect(JSON.stringify(body)).not.toContain('Sconta del 40 percento');
+  });
+
+  it('una nota che non è una procedura non finisce fra le skill', async () => {
+    signedIn();
+
+    const { body } = await call();
+
+    expect(JSON.stringify(body)).not.toContain('Milano');
+  });
+
+  it('un brand senza procedure proprie riceve comunque quelle di prodotto', async () => {
+    signedIn([]);
+
+    const { body } = await call();
+
+    expect(body.skills.every((s: { source: string }) => s.source === 'product')).toBe(true);
+    expect(body.skills.length).toBe(2);
+  });
+});


### PR DESCRIPTION
## What?

The writing skills — `humanizer`, `stop-slop`, `social`, `seo-audit`: 145 KB across 17 files in `src/lib/agent-docs/skills/` — are now served to any external model through one MCP tool, `get_writing_skills`, over `GET /api/v1/brands/:slug/writing-skills`.

The brand's **own** procedures travel in the same response, discriminated by `source`.

`tools/list` goes from 112 to 113. Nothing removed, **no existing tool changed a single field**.

## Why?

Those files are why the copy does not read as a chatbot. They reached a model down exactly one road:

```
agent-docs/skills/*.md → brand-skills.ts (?raw) → skillsForAgent() → adapters.ts:421 → harness
                                                                     ↑
                                                          the ONLY caller, inside the bridge
                                                          being dismantled
```

Delete that file and the craft stops reaching **any** model. No exception, no red test, no log line — the copy just gets worse. That is the same shape as the motion-video regression.

One test did hold it — `brand-skills.test.ts:116` asserts the source of `adapters.ts` still contains `skillsForAgent(opts.agentId)` — but it is pinned to the **bridge**. Whoever deletes the bridge deletes that assertion too, legitimately, and the road closes anyway.

## How?

### What was verified before choosing

**There are no brand-specific skills in `brand-skills.ts`.** The name misleads: `brandSkills` is a `const` array of four markdown files imported with `?raw`, identical for every brand. The selection `skillsForAgent` performs is **per team agent** (`content`, `ugc`, `web`, `analyst`, `auto`, `motion`), not per brand. Packaging them once for everyone is correct.

**Brand skills do exist — somewhere else, and nobody was serving them.** Migration 0178 put them in `brand_memory` under `category = 'skill'`: markdown whose first line is the trigger, written by the operator or distilled by `runDream` from three-plus lessons describing the same procedure. The route `/studio/memory?category=skill` exists but is **not in the registry**, so there is no MCP tool for it: an external agent could not read this brand's procedures at all. They are now in the same response, with `source: "brand"`.

### The road chosen, and the two rejected

- **Rejected — copying them into `cli/skills/anomalia/`.** That package is 47 KB of *operating instructions* (which tool to call); the writing skills are 145 KB of *craft*. It would triple a package every Claude Code user loads, need a second mirror kept in sync, and **ChatGPT and Cursor — half the pivot, connecting over MCP only — would still get nothing.**
- **Rejected — MCP resources.** The right primitive on paper, but resource support is uneven across clients, and it means hand-written `registerTool` code outside the registry.
- **Chosen — a registry tool.** Every MCP client supports tools. One source of truth (the files stay the only copy), one answer for Claude, ChatGPT and Cursor alike.

### Fitting 145 KB into a window

The same progressive disclosure the skill format already uses:

- the **body** of each `SKILL.md` in the deck arrives inline (default deck ~33 KB, `agent=content` ~48 KB — exactly what the internal agent carried every turn);
- **references** are listed by path and not sent. Fetch one with `reference: "social/references/platform-limits.md"` and it returns that file alone, no deck.

No body is truncated. Truncating the craft *is* the regression this PR exists to prevent — the ceiling here is on what is *not* sent, not on what is.

Path traversal has nothing to traverse: the reference is matched against the `files` each skill already declares in memory, so no path is ever built and no file is ever opened by name. Three traversal attempts are tested and all return 404.

### What was NOT touched

`skillsForAgent` was **not moved** and its single caller in `src/lib/agent/bridge/adapters.ts` is untouched — that file belongs to another agent's perimeter. Only `brandSkillsForAgent` was extracted from it (the product skills of a deck, without touching the disk), in a **separate commit with no behaviour change**, before anything was added.

### Why the model will actually call it

A tool nobody calls is worth nothing. Three places say so:

- the tool description opens with `READ THIS BEFORE WRITING ANY COPY` — and a contract test asserts it keeps saying it;
- `cli/skills/anomalia/SKILL.md` puts it in the **operating rules**, not the workflows;
- the "Before you write anything" workflow now has two reads: `get_writing_skills` (**how** to write) and `get_creation_kit` (**what** to say).

## Testing?

No Docker, no Playwright, no dev server.

**The test that replaces the one pinned to the bridge**, written first and watched fail:

> `ogni skill di prodotto raggiunge un modello per una strada che non passa dal bridge`

It walks all six decks and demands their union covers **every** skill in `brandSkills`. Deleting `adapters.ts` does not touch it — the craft keeps reaching a model. Deleting a skill, or breaking the route, turns it red.

**The negative test on brand isolation:** the fake `brand_memory` holds this brand's procedure, a neighbouring brand's procedure, and a plain fact. The response must contain the first and neither of the other two — asserted against the serialised body, not just the parsed field.

<details><summary>Red — the route did not exist</summary>

```
 FAIL  src/routes/api/v1/brands/[slug]/writing-skills/server.test.ts
Error: Failed to load url ./+server (resolved id: ./+server) ... Does the file exist?

 Test Files  1 failed (1)
      Tests  no tests
```
</details>

<details><summary>Green — 12 route tests + 8 contract tests</summary>

```
$ npx vitest run "src/routes/api/v1/brands/[slug]/writing-skills" packages/api-contracts src/lib/server/brand-skills.test.ts
 Test Files  18 passed (18)
      Tests  215 passed (215)

$ cd cli && bun test
 57 pass / 0 fail / 633 expect() calls

$ cd cli && bun run typecheck
$ tsc --noEmit          (exit 0)

$ node scripts/typecheck-runtime.mjs
typecheck-runtime: ok (ignored 313 non-fatal type error(s))

$ npx vitest run src/lib/content/changelog "src/routes/api/v1/brands/[slug]/registry.test.ts" src/lib/server/brand-skills.test.ts
 Test Files  3 passed (3)
      Tests  19 passed (19)
```

The 14 pre-existing `brand-skills` tests pass unchanged after the extraction — that is the evidence the first commit changed no behaviour.

`node_modules/@anomalia/api-contracts` resolves inside this worktree:

```
/Users/andreabuttarelli/Documents/GitHub/anomalia-wt/agent-knowledge/packages/api-contracts
```
</details>

Route tests cover: every product skill reachable off-bridge; real text served, not a file pointer; the default deck is the writing deck; each agent's deck (`content` gets `social`, `web` gets `seo-audit`); references listed but not sent; one reference fetched by name returns that file and no deck; an invented reference is a 404 and not an empty body; three traversal attempts refused; brand procedures scoped to the brand; a non-procedure memory entry excluded; a brand with no procedures still gets the product deck; and a guard that `WRITING_DECK_AGENTS` in the contract still equals `TEAM_AGENT_IDS`.

**Not tested:** the route against live Postgres, and whether an external model's output measurably improves after reading the deck. The second one is an eval question, not a unit-test one — see below.

## Evidence

Backend only. `tools/list` through `handleMcpFetch`, from a throwaway worktree at current `origin/dev` versus this branch, compared field by field:

<details><summary><code>tools/list</code> — dev vs this branch</summary>

```
dev=112  after PR3=113
removed: []
added: ['get_writing_skills']
changed existing (field by field): none
```
</details>

<details><summary>The tool as an external model sees it</summary>

```json
{
  "agent": {
    "description": "Whose deck: content and ugc add `social`, web adds `seo-audit`. Omit for the writing deck alone",
    "type": "string",
    "enum": ["content", "analyst", "web", "ugc", "motion", "auto"]
  },
  "reference": {
    "description": "Fetch one reference file instead of the deck, e.g. \"social/references/platform-limits.md\"",
    "type": "string", "minLength": 1
  }
}
```

Description:

> READ THIS BEFORE WRITING ANY COPY FOR THE BRAND — a caption, a carousel, a script, an article, a bio. It returns the actual craft text Anomalia writes with: `humanizer` and `stop-slop` always (why the output must not read as a chatbot), plus `social` or `seo-audit` depending on `agent`. It also returns this brand's OWN procedures, the ones its team wrote or the system distilled — `source` says which is which, and a brand procedure overrules a product skill when they disagree. Bodies come inline; each skill lists its `references` by path without sending them, and you fetch one by passing `reference: "<skill>/<path>"`, which then returns that file alone. No credits, no writes. Reading it costs a few thousand tokens and is the difference between copy a person would publish and copy that reads as generated.
</details>

<details><summary>The two decks, and what each costs</summary>

```
default (analyst / auto / no agent)   humanizer 30 KB + stop-slop 2.6 KB    ≈ 33 KB
agent=content / ugc                   + social 15 KB                        ≈ 48 KB
agent=web                             + seo-audit 16.6 KB                   ≈ 49 KB
agent=motion                          + social                              ≈ 48 KB

references, listed but never sent unless asked                              ≈ 96 KB
```

The ~48 KB figure is not a new cost: it is what the internal agent carried inlined on every single turn. Here it is paid once, deliberately, by a model that asked.
</details>

## Anything Else?

- **`motion` loses `remotion-best-practices`.** That is a repo skill from `.agents/skills`, default-off, written for code agents — not product craft, and not something an external agent rendering nothing needs. `skillsForAgent` still serves it to the harness exactly as before.
- **Brand skills bypass `read_memory`'s usage counters.** Internally, only the trigger line went into the prompt and bodies were pulled with `read_memory`, which bumps `times_used` and feeds decay in `runDream`. This route reads them directly, so an external agent's use does not reinforce them. Worth fixing when brand memory gets a proper registry surface — it has none today.
- **The rest of `brand_memory` is still invisible over MCP.** Only `category = 'skill'` is served here. Voice, constraints, facts and preferences have a route but no registry entry, so no tool.
- **This is the PR to argue about.** The design decision worth disagreeing with is serving the text through a tool rather than shipping it as skill files in the plugin. If Claude Code plugin users are the population that matters and ChatGPT/Cursor are not, the other road is cheaper. I chose the tool because the pivot names all three clients and only the tool reaches all three.
- No migration. Nothing applied anywhere.
- Independent of #293 and #296 — different files, no shared contract module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
