### PR TITLE
Let an agent change how the brand looks — and refuse it arbitrary scripts

### DIFF
--- a/changelog/2026-09-04-agent-brand-look.md
+++ b/changelog/2026-09-04-agent-brand-look.md
@@ -1,0 +1,93 @@
+# Il look del brand passa dal registry, e gli script arbitrari no
+
+Andrea ha chiesto che l'AI possa «modificare l'estetica del blog, aggiungere scripts js nell'head
+del sito web, modificare logo, colori, templates». Il censimento ha dato tre risposte diverse, e
+una di queste e' un rifiuto.
+
+## Il censimento
+
+**Esiste e non era esposto** — `brand_kit.logos`, `brand_kit.favicon_url`,
+`brand_kit.graphic_style` (i due font con cui le grafiche sono davvero composte),
+`brand_kit.visual_style`. Tutti scrivibili solo dal form dello Studio o dai tool della chat
+in-app; nessun tool MCP, nessun comando CLI. Ora `get_appearance` / `set_appearance`.
+
+**Esiste ed era gia' esposto** — i "template" del blog. Il layout (`navbar`/`sidebar`) e il font
+(`sans`/`serif`/`rounded`/`mono`) sono due enum chiusi, e `set_blog_settings` li copre gia' dalla
+PR #291. Non c'era niente da aggiungere: la parola "template" in questo prodotto vuol dire sette
+cose diverse (agent_templates, brand_design_templates, i template Remotion, i template di copy,
+il layout del blog, il preset di font, i template email) e solo due sono stato del brand.
+
+I colori erano **parzialmente** esposti: `set_colors` scrive `brand_kit.brand_colors`, e
+`blog_config.accent` passa da `set_blog_settings`. Restano fuori `theme_color` e `fonts`, che sono
+scritti solo dall'analisi del sito — esporli significherebbe far scrivere a un agente il risultato
+di una misura, non una scelta.
+
+Il censimento ha anche trovato un difetto: lo schema di `set_colors` accettava `#aabbccdd`, la
+rotta lo rifiutava con 400. L'agente credeva di aver salvato un colore. Il test confronta ora le
+due forme e non le lascia divergere.
+
+**Non esiste affatto** — un posto dove salvare script personalizzati. Nessuna colonna, nessuna
+chiave in `blog_config`, nessun codice. Non e' stata inventata.
+
+## Perche' gli script arbitrari non si espongono
+
+Il blog di un brand esce da due porte:
+
+```
+   host del brand              anomalia.so
+   (blog.cliente.com)          /blog/<slug>
+          │                          │
+     src/routes/_site        src/routes/blog/[site]
+          │                          │
+          └──────► BlogShell ◄───────┘
+                                     ▲
+                     stessa origine di /app e della
+                     sessione Supabase di chi e' loggato
+```
+
+La seconda porta e' la nostra origine. Uno `<script>` di un brand caricato li' gira con i permessi
+di anomalia.so: puo' leggere lo storage della sessione e chiamare `/api/v1` con i cookie di
+chiunque stia guardando quel blog mentre e' loggato. Non c'e' CSP da nessuna parte nel repository
+(verificato: zero occorrenze di `Content-Security-Policy` in `svelte.config.js`, `hooks.server.ts`,
+`vercel.json`, `app.html`), quindi niente lo fermerebbe.
+
+Quindi: **elenco chiuso**, quattro fornitori con un id, nessun campo per JavaScript libero. E
+l'elenco chiuso arriva fino al JSON Schema che l'agente legge — `provider` e' un enum, quindi
+`custom` non e' nemmeno esprimibile.
+
+Vale anche per i fornitori dell'elenco: un container GA4 o GTM e' JavaScript arbitrario a
+un'indirezione di distanza, perche' chi lo amministra puo' riempirlo quando vuole. Per questo i
+tracker si caricano **solo sull'albero `_site`** — quello servito quando l'host non e' il nostro —
+e solo dopo il consenso cookie che il blog gia' aveva.
+
+Quel confine e' tenuto da un test, non da una convenzione: `siteAnalytics` sta fuori da
+`brandProfile` (che alimenta entrambi gli alberi) e
+`src/lib/server/blog-analytics-boundary.test.ts` verifica che la chiami un file solo,
+`_site/+layout.server.ts`. Dimenticarsene significa non caricare niente; il contrario non e'
+raggiungibile.
+
+L'id passa per `blogAnalyticsIdOk` in tre punti — lo zod del contratto, la regola di campo accanto
+al modello, il renderer — e un test prova che nessuno dei quattro alfabeti ammette `<`, `>`, una
+virgoletta, uno spazio o un punto e virgola. E' l'unica ragione per cui interpolarlo dentro lo
+snippet del fornitore e' sicuro.
+
+## Cosa e' stato lasciato fuori, e perche'
+
+- **Un campo `<script>` libero.** Sopra il perche'. Se un giorno servisse davvero, la strada non e'
+  un tool: e' spostare `/blog/<slug>` su un'origine separata e aggiungere una CSP. Finche' quello
+  non c'e', esporlo via MCP sarebbe consegnare una porta sull'account.
+- **L'icona del blog e l'avatar di un autore.** Restano esclusi come nella #291: sono caricamenti
+  di file. `set_appearance` copre logo e favicon perche' passano gia' da `storeBrandLogoFromUrl`,
+  che scarica dietro `safeFetchBytes` e tiene i byte — non salva una URL di qualcun altro.
+- **`brand_design_templates`.** La tabella esiste dalla migration 0108 e **nessun codice la legge
+  o la scrive**. Esporre un tool su una tabella morta non fa funzionare niente.
+- **`theme_color` e `fonts` di `brand_kit`.** Sono misure prese dal sito del brand, non scelte.
+
+## Note
+
+`blog_config` guadagna una chiave (`analytics`) — nessuna migration: la colonna e' jsonb dal 0064.
+
+Il logo si scarica anche quando il campo si chiama `logo_url`, ed e' deliberato: salvare
+l'indirizzo di chi chiama metterebbe in ogni grafica del brand un'immagine che un altro puo'
+cambiare dopo averla fatta approvare. La risposta riporta l'indirizzo nostro, e la descrizione del
+tool dice di rileggerlo.

--- a/cli/lib/contracts/appearance.ts
+++ b/cli/lib/contracts/appearance.ts
@@ -1,0 +1,85 @@
+import { z } from 'zod';
+import type { BrandEndpoint } from './index';
+
+/**
+ * Il look del brand vive in `brand_kit`, e fino a qui nessun agente esterno poteva toccarlo: il
+ * logo si caricava solo da un form, i font che le grafiche usano davvero (`graphic_style`) solo
+ * dalla chat in-app. Un endpoint solo, una tabella sola.
+ *
+ * Il logo NON e' una stringa che salviamo: e' una URL che scarichiamo dietro la guardia SSRF e di
+ * cui teniamo i byte nel nostro bucket. Salvare la stringa significherebbe mettere in ogni grafica
+ * del brand un'immagine che qualcun altro puo' cambiare dopo, o togliere.
+ */
+
+const GraphicStyle = z.object({
+  display_font: z.string().nullable(),
+  body_font: z.string().nullable(),
+  instructions: z.string().nullable()
+});
+
+const Appearance = z.object({
+  logo_url: z.string().nullable(),
+  favicon_url: z.string().nullable(),
+  colors: z.array(z.string()),
+  graphic_style: GraphicStyle.nullable(),
+  visual_style: z.string().nullable(),
+  visual_style_locked: z.boolean()
+});
+
+export const GET_APPEARANCE = {
+  tool: 'get_appearance',
+  title: 'How the brand looks',
+  description:
+    'The brand’s look as every render sees it: logo, favicon, colour palette, the two Google Fonts ' +
+    'graphics are composed with, and the visual brief every image follows. Read it before ' +
+    'set_appearance — a font this answer does not carry is a font Google Fonts will not serve, and ' +
+    'the graphics would silently come out in Inter instead.',
+  method: 'GET',
+  pathUnderBrand: '/studio/appearance',
+  input: z.object({}).strict(),
+  output: z.object({ brand: z.string(), appearance: Appearance }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const SET_APPEARANCE = {
+  tool: 'set_appearance',
+  title: 'Change how the brand looks',
+  description:
+    'Change the brand’s logo, favicon, graphic fonts or visual brief. Only the fields you send ' +
+    'change. `logo_url` and `favicon_url` are DOWNLOADED and kept in our storage, not linked: the ' +
+    'answer carries the address we stored, which is the one every graphic will use — a private, ' +
+    'redirecting or oversized address is refused rather than half-saved. `remove_logo` clears it. ' +
+    '`display_font` and `body_font` must be families Google Fonts actually serves and are checked ' +
+    'before saving, because a name it will not serve renders as Inter with nothing said. Setting ' +
+    '`visual_style` LOCKS it: the nightly rebuild stops rewriting the brand’s visual brief until ' +
+    'someone regenerates it from the browser. Calls no model and spends no credits.',
+  method: 'PUT',
+  pathUnderBrand: '/studio/appearance',
+  input: z
+    .object({
+      logo_url: z.string().url().optional().describe('Public http(s) image address; downloaded and re-hosted, max 4MB'),
+      favicon_url: z.string().url().optional().describe('Same rules as logo_url'),
+      remove_logo: z.boolean().optional().describe('Clear the logo. Cannot be combined with logo_url'),
+      display_font: z.string().min(1).max(60).optional().describe('Google Fonts family for headings, e.g. "Playfair Display"'),
+      body_font: z.string().min(1).max(60).optional().describe('Google Fonts family for body text'),
+      graphic_instructions: z.string().max(1200).optional().describe('Art direction the composer follows'),
+      visual_style: z
+        .string()
+        .min(20)
+        .max(2000)
+        .optional()
+        .describe('The visual brief every image render follows. Setting it locks it against the nightly rebuild')
+    })
+    .strict(),
+  output: z.object({ ok: z.literal(true), appearance: Appearance }),
+  failures: [
+    { error: 'no_fields', status: 400 },
+    { error: 'logo_conflict', status: 400 },
+    { error: 'font_not_available', status: 400 },
+    { error: 'image_rejected', status: 400 },
+    { error: 'font_pair_incomplete', status: 400 },
+    { error: 'update_failed', status: 500 }
+  ],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/cli/lib/contracts/blog-settings.ts
+++ b/cli/lib/contracts/blog-settings.ts
@@ -14,6 +14,43 @@ export type BlogTermKind = (typeof BLOG_TERM_KINDS)[number];
 
 const term = z.enum(BLOG_TERM_KINDS).describe('Which list the entry belongs to');
 
+/**
+ * Gli unici script di terze parti che il blog di un brand puo' caricare. E' un elenco CHIUSO, e la
+ * chiusura e' il punto: un campo `<script>` libero sarebbe esecuzione di codice arbitrario sulle
+ * pagine del cliente, e su `/blog/<slug>` — che sta sulla nostra origine, insieme alla sessione di
+ * chi e' loggato in `/app` — sarebbe una presa di controllo dell'account.
+ *
+ * Ogni id finisce dentro lo snippet del fornitore, quindi il pattern non e' una validazione di
+ * comodo: e' cio' che impedisce a una virgoletta o a un `<` di uscire dal contesto previsto.
+ */
+export const BLOG_ANALYTICS_ID_PATTERNS = {
+  ga4: /^G-[A-Z0-9]{4,20}$/,
+  meta_pixel: /^[0-9]{6,20}$/,
+  plausible: /^[a-z0-9][a-z0-9.-]{1,78}[a-z0-9]$/,
+  hotjar: /^[0-9]{5,12}$/
+} as const;
+
+export const BLOG_ANALYTICS_PROVIDERS = Object.keys(
+  BLOG_ANALYTICS_ID_PATTERNS
+) as unknown as readonly BlogAnalyticsProvider[];
+
+export type BlogAnalyticsProvider = keyof typeof BLOG_ANALYTICS_ID_PATTERNS;
+
+export function blogAnalyticsIdOk(provider: string, id: string): boolean {
+  const pattern = BLOG_ANALYTICS_ID_PATTERNS[provider as BlogAnalyticsProvider];
+  return pattern !== undefined && pattern.test(id);
+}
+
+const AnalyticsEntry = z
+  .object({
+    provider: z.enum(Object.keys(BLOG_ANALYTICS_ID_PATTERNS) as [BlogAnalyticsProvider, ...BlogAnalyticsProvider[]]),
+    id: z.string().min(1).describe('Measurement id: G-XXXXXXX (ga4), numeric (meta_pixel, hotjar), domain (plausible)')
+  })
+  .strict()
+  .refine((e) => blogAnalyticsIdOk(e.provider, e.id), {
+    message: 'id does not match the shape that provider issues'
+  });
+
 const NavbarLink = z.object({ label: z.string(), url: z.string() });
 
 const BlogConfig = z.object({
@@ -31,7 +68,8 @@ const BlogConfig = z.object({
   default_locale: z.string().nullable(),
   locales: z.array(z.string()),
   navbar_links: z.array(NavbarLink),
-  icon_url: z.string().nullable()
+  icon_url: z.string().nullable(),
+  analytics: z.array(z.object({ provider: z.string(), id: z.string() }))
 });
 
 export const GET_BLOG_SETTINGS = {
@@ -87,9 +125,14 @@ export const SET_BLOG_SETTINGS = {
     'Change how the blog looks and how it writes. Only the fields you send change; every other ' +
     'one keeps its value. `articles_per_week` is CLAMPED to the plan’s ceiling rather than ' +
     'refused, and the answer says what was actually saved — read it back instead of assuming ' +
-    'your number was taken. `locales` and `navbar_links` replace their whole list. Turning ' +
-    '`enabled` off takes the public blog down; it deletes no article. The blog icon and an ' +
-    'author’s avatar are images and cannot be set here. Calls no model and spends no credits.',
+    'your number was taken. `locales`, `navbar_links` and `analytics` replace their whole list. ' +
+    'Turning `enabled` off takes the public blog down; it deletes no article. The blog icon and an ' +
+    'author’s avatar are images and cannot be set here. `analytics` takes a CLOSED list of ' +
+    'providers with their measurement id — there is no field for arbitrary JavaScript, and asking ' +
+    'for one is refused: a script tag here would run on every visitor’s page. Those trackers load ' +
+    'ONLY on a verified custom domain and ONLY after the visitor accepts cookies; on the default ' +
+    '/blog/<slug> address they are stored and never emitted, because that address is Anomalia’s ' +
+    'own origin. Calls no model and spends no credits.',
   method: 'PUT',
   pathUnderBrand: '/settings/blog',
   input: z
@@ -122,7 +165,15 @@ export const SET_BLOG_SETTINGS = {
         .array(z.string())
         .optional()
         .describe('Extra languages articles are translated into. Replaces the whole list'),
-      navbar_links: z.array(NavbarLink).optional().describe('Up to 6 custom nav links. Replaces the whole list')
+      navbar_links: z.array(NavbarLink).optional().describe('Up to 6 custom nav links. Replaces the whole list'),
+      analytics: z
+        .array(AnalyticsEntry)
+        .max(4)
+        .optional()
+        .describe(
+          'Third-party analytics, one entry per provider. Replaces the whole list; [] removes them all, ' +
+            'which is how a tracker is taken off a live site without us'
+        )
     })
     .strict(),
   output: z.object({ ok: z.literal(true), config: BlogConfig }),

--- a/cli/lib/contracts/index.ts
+++ b/cli/lib/contracts/index.ts
@@ -1,5 +1,6 @@
 import type { z } from 'zod';
 import { ADS_REMIX } from './ads';
+import { GET_APPEARANCE, SET_APPEARANCE } from './appearance';
 import { GET_AUTOMATIONS, SET_AUTOMATION } from './automations';
 import { BILLING_PORTAL_LINK, CHECKOUT_LINK } from './billing';
 import { GET_ARTICLE, UPDATE_ARTICLE } from './articles';
@@ -151,6 +152,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   GEO_ACTION,
   GET_ADS,
   GET_ANALYTICS,
+  GET_APPEARANCE,
   GET_ARTICLE,
   GET_AUDIT_FINDINGS,
   GET_AUTOMATIONS,
@@ -201,6 +203,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   SAVE_WEEK_SEEDS,
   SEARCH_KNOWLEDGE,
   SEO_ACTION,
+  SET_APPEARANCE,
   SET_AUTOMATION,
   SET_BIO,
   SET_BLOG_SETTINGS,
@@ -369,14 +372,18 @@ export type { AutomationJob } from './automations';
 export { LIST_SOCIAL_ACCOUNTS, SOCIAL_CONNECT_LINK } from './social';
 export {
   ADD_BLOG_TERM,
+  BLOG_ANALYTICS_ID_PATTERNS,
+  BLOG_ANALYTICS_PROVIDERS,
   BLOG_FONTS,
   BLOG_LAYOUTS,
   BLOG_TERM_KINDS,
+  blogAnalyticsIdOk,
   GET_BLOG_SETTINGS,
   REMOVE_BLOG_TERM,
   SET_BLOG_SETTINGS
 } from './blog-settings';
-export type { BlogTermKind } from './blog-settings';
+export type { BlogAnalyticsProvider, BlogTermKind } from './blog-settings';
+export { GET_APPEARANCE, SET_APPEARANCE } from './appearance';
 export { BILLING_PORTAL_LINK, CHECKOUT_LINK };
 export type { BillingPortalLinkResult, CheckoutLinkInput, CheckoutLinkResult } from './billing';
 export type { CheckContentInput, CheckContentResult } from './content';

--- a/cli/mcp/studio-writes.test.ts
+++ b/cli/mcp/studio-writes.test.ts
@@ -90,3 +90,38 @@ describe('le scritture dello studio esposte dal registry', () => {
     expect(names).toEqual([...new Set(names)]);
   });
 });
+
+/**
+ * Il tool e la rotta accettavano forme diverse: `#aabbccdd` passava lo schema del tool e prendeva
+ * un 400 dalla rotta. L'agente ha creduto di aver salvato un colore, la richiesta e' morta dopo,
+ * e niente glielo ha detto in tempo per correggere.
+ *
+ * L'invariante non e' "gli stessi caratteri": il tool accetta apposta un `#` mancante e lo aggiunge
+ * prima di partire. E' che TUTTO cio' che il tool accetta, una volta normalizzato, la rotta lo
+ * salvi. Niente puo' passare di qui per morire di la'.
+ */
+describe('set_colors non accetta niente che la rotta rifiuti', () => {
+  const ROUTE_HEX = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
+  const normalize = (c: string) => (c.startsWith('#') ? c : `#${c}`);
+
+  test('quello che il tool lascia passare, la rotta lo salva', async () => {
+    const schema = find(await tools(), 'set_colors').inputSchema as {
+      properties: { colors: { items: { pattern?: string } } };
+    };
+    const pattern = schema.properties.colors.items.pattern;
+    expect(pattern).toBeDefined();
+    const toolHex = new RegExp(pattern as string);
+
+    // Il caso che ha rotto: otto cifre. Il tool le prendeva, la rotta no.
+    for (const rejected of ['#aabbccdd', 'aabbccdd', '#abcd', '#12345', '#gggggg']) {
+      expect(ROUTE_HEX.test(normalize(rejected)), `la rotta accetta ${rejected}?`).toBe(false);
+      expect(toolHex.test(rejected), `il tool accetta ${rejected}, la rotta lo rifiuta`).toBe(false);
+    }
+
+    // E quello che il brand scrive davvero continua a passare, `#` o no.
+    for (const accepted of ['#fff', '#7c5cff', '#FFFFFF', 'fff', '7c5cff']) {
+      expect(toolHex.test(accepted), `il tool rifiuta ${accepted}`).toBe(true);
+      expect(ROUTE_HEX.test(normalize(accepted)), `la rotta rifiuta ${accepted}`).toBe(true);
+    }
+  });
+});

--- a/cli/mcp/tools/studio.ts
+++ b/cli/mcp/tools/studio.ts
@@ -10,10 +10,13 @@ export function registerStudioTools(server: McpServer) {
     'set_colors',
     {
       title: 'Set brand colors',
-      description: 'Set brand colors as hex values, e.g. ["#7c5cff","#ffffff"].',
+      description:
+        'Set brand colors as hex values, e.g. ["#7c5cff","#ffffff"]. Three or six digits, up to 8 colours; the list replaces the whole palette.',
       inputSchema: z.object({
         slug,
-        colors: z.array(z.string().regex(/^#?[0-9a-fA-F]{3,8}$/)).min(1),
+        // Stessa forma che la rotta salva: un `#aabbccdd` che passa di qui e prende un 400 di la'
+        // lascia l'agente convinto di aver salvato un colore. studio-writes.test.ts le confronta.
+        colors: z.array(z.string().regex(/^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/)).min(1).max(8),
       }),
       annotations: { readOnlyHint: false, destructiveHint: false },
     },

--- a/cli/plugins/anomalia/skills/anomalia/SKILL.md
+++ b/cli/plugins/anomalia/skills/anomalia/SKILL.md
@@ -122,7 +122,16 @@ layouts and locales, the plan's ceilings, and the categories, tags and authors; 
 changes it, and `add_blog_term` / `remove_blog_term` maintain the three lists. `articles_per_week`
 is clamped to the plan, so read back what was saved. Before removing a term, say what it leaves
 behind: a category leaves its articles unfiled, a tag comes off every article, an author leaves no
-byline.
+byline. `analytics` takes a closed list of providers (`ga4`, `meta_pixel`, `plausible`, `hotjar`)
+with their id — there is no field for arbitrary JavaScript, and those trackers load only on a
+verified custom domain, only after the visitor accepts cookies.
+
+**Change how the brand looks** → `get_appearance` reads the logo, favicon, palette, the two Google
+Fonts graphics are composed with and the visual brief; `set_appearance` changes them. A logo is
+given as a URL and is DOWNLOADED and re-hosted, so read back the address it answers with. Fonts go
+in pairs and are checked against Google Fonts before saving — a family it will not serve is refused
+rather than rendered as Inter. Setting `visual_style` locks it against the nightly rebuild.
+Colours stay with `set_colors`.
 
 **Choose which model draws and which films** → `get_media_models` lists the six jobs (image
 generation, image refinement, video from text, animating a still, video refinement, motion

--- a/cli/plugins/anomalia/skills/anomalia/references/tools.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/tools.md
@@ -398,7 +398,38 @@ you do it: a **category** leaves its articles filed under nothing, a **tag** com
 article that carried it, an **author** leaves their articles with no byline. The answer counts
 `articles_affected`.
 
+`analytics` is a **closed** list of providers with their measurement id — `ga4` (`G-XXXXXXX`),
+`meta_pixel` (numeric), `plausible` (a domain), `hotjar` (numeric). There is no field for arbitrary
+JavaScript and there will not be one: a script tag here runs on every visitor's page, and on the
+default `/blog/<slug>` address that page is served from Anomalia's own origin, alongside the
+session of anyone signed into `/app`. Those trackers therefore load **only on a verified custom
+domain** and **only after the visitor accepts cookies**; on `/blog/<slug>` they are stored and
+never emitted. Sending `analytics: []` takes them all off a live site without us.
+
 The blog icon and an author's avatar are images and cannot be set through these tools.
+
+## Brand appearance
+
+| MCP | CLI |
+|-----|-----|
+| `get_appearance` | (MCP only) |
+| `set_appearance` | (MCP only) |
+
+The look every render follows: logo, favicon, colour palette, the two Google Fonts graphics are
+composed with, and the visual brief.
+
+**Read `get_appearance` first** — a font it does not carry is a font Google Fonts will not serve,
+and the graphics would silently come out in Inter.
+
+`logo_url` and `favicon_url` are **downloaded and re-hosted**, not linked: the answer carries the
+address we stored, which is the one every graphic will use. A private, redirecting or oversized
+address is refused (`image_rejected`) rather than half-saved, and `remove_logo` clears the logo —
+the two cannot be combined (`logo_conflict`). `display_font` and `body_font` go together
+(`font_pair_incomplete`) and are checked against Google Fonts before saving (`font_not_available`,
+which names the missing family). Setting `visual_style` **locks** it: the nightly rebuild stops
+rewriting the brand's visual brief until someone regenerates it from the browser.
+
+Colours stay with `set_colors` (three or six hex digits, up to 8 — the list replaces the palette).
 
 ## Media models
 

--- a/cli/skills/anomalia/SKILL.md
+++ b/cli/skills/anomalia/SKILL.md
@@ -122,7 +122,16 @@ layouts and locales, the plan's ceilings, and the categories, tags and authors; 
 changes it, and `add_blog_term` / `remove_blog_term` maintain the three lists. `articles_per_week`
 is clamped to the plan, so read back what was saved. Before removing a term, say what it leaves
 behind: a category leaves its articles unfiled, a tag comes off every article, an author leaves no
-byline.
+byline. `analytics` takes a closed list of providers (`ga4`, `meta_pixel`, `plausible`, `hotjar`)
+with their id — there is no field for arbitrary JavaScript, and those trackers load only on a
+verified custom domain, only after the visitor accepts cookies.
+
+**Change how the brand looks** → `get_appearance` reads the logo, favicon, palette, the two Google
+Fonts graphics are composed with and the visual brief; `set_appearance` changes them. A logo is
+given as a URL and is DOWNLOADED and re-hosted, so read back the address it answers with. Fonts go
+in pairs and are checked against Google Fonts before saving — a family it will not serve is refused
+rather than rendered as Inter. Setting `visual_style` locks it against the nightly rebuild.
+Colours stay with `set_colors`.
 
 **Choose which model draws and which films** → `get_media_models` lists the six jobs (image
 generation, image refinement, video from text, animating a still, video refinement, motion

--- a/cli/skills/anomalia/references/tools.md
+++ b/cli/skills/anomalia/references/tools.md
@@ -398,7 +398,38 @@ you do it: a **category** leaves its articles filed under nothing, a **tag** com
 article that carried it, an **author** leaves their articles with no byline. The answer counts
 `articles_affected`.
 
+`analytics` is a **closed** list of providers with their measurement id — `ga4` (`G-XXXXXXX`),
+`meta_pixel` (numeric), `plausible` (a domain), `hotjar` (numeric). There is no field for arbitrary
+JavaScript and there will not be one: a script tag here runs on every visitor's page, and on the
+default `/blog/<slug>` address that page is served from Anomalia's own origin, alongside the
+session of anyone signed into `/app`. Those trackers therefore load **only on a verified custom
+domain** and **only after the visitor accepts cookies**; on `/blog/<slug>` they are stored and
+never emitted. Sending `analytics: []` takes them all off a live site without us.
+
 The blog icon and an author's avatar are images and cannot be set through these tools.
+
+## Brand appearance
+
+| MCP | CLI |
+|-----|-----|
+| `get_appearance` | (MCP only) |
+| `set_appearance` | (MCP only) |
+
+The look every render follows: logo, favicon, colour palette, the two Google Fonts graphics are
+composed with, and the visual brief.
+
+**Read `get_appearance` first** — a font it does not carry is a font Google Fonts will not serve,
+and the graphics would silently come out in Inter.
+
+`logo_url` and `favicon_url` are **downloaded and re-hosted**, not linked: the answer carries the
+address we stored, which is the one every graphic will use. A private, redirecting or oversized
+address is refused (`image_rejected`) rather than half-saved, and `remove_logo` clears the logo —
+the two cannot be combined (`logo_conflict`). `display_font` and `body_font` go together
+(`font_pair_incomplete`) and are checked against Google Fonts before saving (`font_not_available`,
+which names the missing family). Setting `visual_style` **locks** it: the nightly rebuild stops
+rewriting the brand's visual brief until someone regenerates it from the browser.
+
+Colours stay with `set_colors` (three or six hex digits, up to 8 — the list replaces the palette).
 
 ## Media models
 

--- a/docs/api/16-settings-blog.md
+++ b/docs/api/16-settings-blog.md
@@ -88,3 +88,33 @@ Il conto degli articoli toccati si fa **prima** della cancellazione — dopo, la
 permetteva non esiste più — e torna come `articles_affected`.
 
 `destructive: true`: è l'unico dei quattro.
+
+## `analytics` — un elenco chiuso, mai codice
+
+`set_blog_settings` accetta `analytics`: una lista di `{ provider, id }` con `provider` fra `ga4`,
+`meta_pixel`, `plausible`, `hotjar`. **Non esiste un campo per JavaScript arbitrario**, e non e' una
+dimenticanza:
+
+- il blog di un brand esce da due porte — il suo dominio (albero `src/routes/_site`) e
+  `/blog/<slug>`, che sta sulla **nostra origine**, la stessa di `/app` e della sessione di chi e'
+  loggato;
+- uno `<script>` li' dentro girerebbe con i permessi di anomalia.so. Vale anche per un container
+  GA4 o GTM, che chi lo amministra puo' riempire di JavaScript quando vuole.
+
+Da cui le due regole, tenute dal codice e non dalla convenzione:
+
+| dove | cosa succede |
+|---|---|
+| dominio verificato del brand (`_site`) | i tracker si caricano, dopo il consenso cookie |
+| `/blog/<slug>` (nostra origine) | salvati, **mai emessi** |
+
+`siteAnalytics` (`$lib/server/blog-site`) e' l'unica porta, ed e' chiamata solo da
+`src/routes/_site/+layout.server.ts`. `blog-analytics-boundary.test.ts` fallisce se qualcuno la
+chiama da un altro albero: dimenticarsene significa non caricare niente, mai il contrario.
+
+L'id e' verificato contro la forma che quel fornitore emette (`blogAnalyticsIdOk`), in tre punti —
+lo zod del contratto, la regola di campo accanto al modello (`BLOG_CONFIG_FIELDS`) e il renderer.
+Nessuno dei quattro alfabeti contiene una virgoletta, un `<` o uno spazio: e' l'unica ragione per
+cui interpolare l'id dentro lo snippet e' sicuro.
+
+`analytics: []` toglie tutto — e' cosi' che si stacca un tracker rotto da un sito live senza di noi.

--- a/docs/api/17-studio-appearance.md
+++ b/docs/api/17-studio-appearance.md
@@ -1,0 +1,58 @@
+# 17 — Studio: il look del brand
+
+`GET`/`PUT` `/api/v1/brands/:slug/studio/appearance` — logo, favicon, palette, i due font con cui
+le grafiche sono composte, e il brief visivo che ogni render segue. Tutto vive in `brand_kit`.
+
+Tool MCP: `get_appearance`, `set_appearance`. Nessun modello, nessun credito.
+
+## `GET`
+
+```json
+{
+  "brand": "demo",
+  "appearance": {
+    "logo_url": "https://…/media/<user>/studio/logo-<uuid>.png",
+    "favicon_url": null,
+    "colors": ["#7c5cff", "#ffffff"],
+    "graphic_style": { "display_font": "Playfair Display", "body_font": "Inter", "instructions": "" },
+    "visual_style": "Fotografia naturale, luce morbida…",
+    "visual_style_locked": true
+  }
+}
+```
+
+`logo_url` e' una URL sola, non l'array grezzo: una voce `type: 'og-image'` e' il logo che abbiamo
+indovinato dal sito, non quello che il brand ha scelto, e non conta.
+
+## `PUT`
+
+Cambia solo i campi inviati.
+
+| campo | nota |
+|---|---|
+| `logo_url` | **scaricata e ri-ospitata**, non collegata. Max 4MB, dietro `safeFetchBytes` |
+| `favicon_url` | stesse regole |
+| `remove_logo` | azzera il logo. Non combinabile con `logo_url` |
+| `display_font` + `body_font` | vanno insieme; verificati contro Google Fonts prima di salvare |
+| `graphic_instructions` | art direction, 1200 caratteri |
+| `visual_style` | 20–2000 caratteri. **Lo BLOCCA** (`visual_style_locked = true`) |
+
+### Perche' il logo si scarica invece di salvarne l'indirizzo
+
+Salvare la stringa significherebbe mettere in ogni grafica del brand un'immagine che qualcun altro
+puo' cambiare — o togliere — dopo che e' stata approvata. La risposta riporta l'indirizzo **nostro**,
+che e' quello che i render useranno.
+
+### Errori
+
+| errore | status | quando |
+|---|---|---|
+| `no_fields` | 400 | richiesta senza campi |
+| `logo_conflict` | 400 | `logo_url` e `remove_logo` insieme |
+| `font_pair_incomplete` | 400 | un font solo dei due |
+| `font_not_available` | 400 | Google Fonts non serve quella famiglia (`missing` la nomina) |
+| `image_rejected` | 400 | la guardia SSRF, la dimensione o il tipo hanno rifiutato l'immagine |
+| `update_failed` | 500 | scrittura fallita |
+
+I colori restano su `set_colors` (`PUT /studio/colors`): tre o sei cifre esadecimali, max 8, la
+lista sostituisce la palette.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -23,7 +23,8 @@ integrazioni esterne via API key — request, response, query params, body, erro
 | [13 — Impostazioni: come lavora il brand](13-settings-brand.md) | `/settings/brand` — fuso, piattaforme, hashtag, esempi di voce |
 | [14 — Impostazioni: lavori ricorrenti](14-settings-automations.md) | `/settings/automations` — i nove lavori del roster e il loro interruttore |
 | [15 — Impostazioni: fonti del Radar](15-settings-radar.md) | `/settings/radar` — piattaforme e fonti che il Radar guarda |
-| [16 — Impostazioni: il blog](16-settings-blog.md) | `/settings/blog` — aspetto, cadenza, lingue, categorie, tag, autori |
+| [16 — Impostazioni: il blog](16-settings-blog.md) | `/settings/blog` — aspetto, cadenza, lingue, categorie, tag, autori, analytics |
+| [17 — Studio: il look del brand](17-studio-appearance.md) | `/studio/appearance` — logo, favicon, font delle grafiche, brief visivo |
 
 ## Regole di manutenzione
 

--- a/packages/api-contracts/src/appearance.test.ts
+++ b/packages/api-contracts/src/appearance.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { GET_APPEARANCE, SET_APPEARANCE } from './appearance';
+import { BRAND_ENDPOINTS, statusForFailure } from './index';
+
+describe('il look del brand come contratto', () => {
+  it('sta nel registry, o nessun agente lo vede', () => {
+    expect(BRAND_ENDPOINTS).toContain(GET_APPEARANCE);
+    expect(BRAND_ENDPOINTS).toContain(SET_APPEARANCE);
+  });
+
+  /**
+   * Il campo si chiama `logo_url` ma non e' una URL che salviamo: la scarichiamo. Se la salvassimo,
+   * ogni grafica del brand mostrerebbe un'immagine che un altro puo' cambiare o togliere dopo.
+   */
+  it('dice che il logo viene scaricato, non collegato', () => {
+    expect(SET_APPEARANCE.description).toMatch(/DOWNLOADED and kept in our storage, not linked/);
+  });
+
+  it('rifiuta un indirizzo che non e’ un indirizzo', () => {
+    expect(SET_APPEARANCE.input.safeParse({ logo_url: 'not a url' }).success).toBe(false);
+    expect(SET_APPEARANCE.input.safeParse({ logo_url: 'https://cdn.example.com/logo.png' }).success).toBe(true);
+  });
+
+  it('non ha un campo per caricare byte: quello resta il form', () => {
+    const fields = Object.keys(SET_APPEARANCE.input.shape);
+    for (const forbidden of ['file', 'logo', 'image', 'bytes', 'base64']) {
+      expect(fields, forbidden).not.toContain(forbidden);
+    }
+  });
+
+  it('mettere e togliere il logo nella stessa richiesta e’ un rifiuto dichiarato', () => {
+    expect(statusForFailure(SET_APPEARANCE, 'logo_conflict')).toBe(400);
+  });
+
+  it('un font che Google Fonts non serve e’ un rifiuto, non un Inter silenzioso', () => {
+    expect(statusForFailure(SET_APPEARANCE, 'font_not_available')).toBe(400);
+    expect(SET_APPEARANCE.description).toMatch(/renders as Inter with nothing said/);
+  });
+
+  it('una richiesta vuota e’ un rifiuto dichiarato', () => {
+    expect(statusForFailure(SET_APPEARANCE, 'no_fields')).toBe(400);
+  });
+
+  it('dice che scrivere il brief visivo lo blocca', () => {
+    expect(SET_APPEARANCE.description).toMatch(/LOCKS it/);
+    expect(Object.keys(GET_APPEARANCE.output.shape)).toContain('appearance');
+  });
+
+  it('leggere non e’ scrivere, e nessuno dei due e’ distruttivo', () => {
+    expect(GET_APPEARANCE.method).toBe('GET');
+    expect(SET_APPEARANCE.method).toBe('PUT');
+    expect(GET_APPEARANCE.destructive).toBe(false);
+    expect(SET_APPEARANCE.destructive).toBe(false);
+  });
+});

--- a/packages/api-contracts/src/appearance.ts
+++ b/packages/api-contracts/src/appearance.ts
@@ -1,0 +1,85 @@
+import { z } from 'zod';
+import type { BrandEndpoint } from './index';
+
+/**
+ * Il look del brand vive in `brand_kit`, e fino a qui nessun agente esterno poteva toccarlo: il
+ * logo si caricava solo da un form, i font che le grafiche usano davvero (`graphic_style`) solo
+ * dalla chat in-app. Un endpoint solo, una tabella sola.
+ *
+ * Il logo NON e' una stringa che salviamo: e' una URL che scarichiamo dietro la guardia SSRF e di
+ * cui teniamo i byte nel nostro bucket. Salvare la stringa significherebbe mettere in ogni grafica
+ * del brand un'immagine che qualcun altro puo' cambiare dopo, o togliere.
+ */
+
+const GraphicStyle = z.object({
+  display_font: z.string().nullable(),
+  body_font: z.string().nullable(),
+  instructions: z.string().nullable()
+});
+
+const Appearance = z.object({
+  logo_url: z.string().nullable(),
+  favicon_url: z.string().nullable(),
+  colors: z.array(z.string()),
+  graphic_style: GraphicStyle.nullable(),
+  visual_style: z.string().nullable(),
+  visual_style_locked: z.boolean()
+});
+
+export const GET_APPEARANCE = {
+  tool: 'get_appearance',
+  title: 'How the brand looks',
+  description:
+    'The brand’s look as every render sees it: logo, favicon, colour palette, the two Google Fonts ' +
+    'graphics are composed with, and the visual brief every image follows. Read it before ' +
+    'set_appearance — a font this answer does not carry is a font Google Fonts will not serve, and ' +
+    'the graphics would silently come out in Inter instead.',
+  method: 'GET',
+  pathUnderBrand: '/studio/appearance',
+  input: z.object({}).strict(),
+  output: z.object({ brand: z.string(), appearance: Appearance }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const SET_APPEARANCE = {
+  tool: 'set_appearance',
+  title: 'Change how the brand looks',
+  description:
+    'Change the brand’s logo, favicon, graphic fonts or visual brief. Only the fields you send ' +
+    'change. `logo_url` and `favicon_url` are DOWNLOADED and kept in our storage, not linked: the ' +
+    'answer carries the address we stored, which is the one every graphic will use — a private, ' +
+    'redirecting or oversized address is refused rather than half-saved. `remove_logo` clears it. ' +
+    '`display_font` and `body_font` must be families Google Fonts actually serves and are checked ' +
+    'before saving, because a name it will not serve renders as Inter with nothing said. Setting ' +
+    '`visual_style` LOCKS it: the nightly rebuild stops rewriting the brand’s visual brief until ' +
+    'someone regenerates it from the browser. Calls no model and spends no credits.',
+  method: 'PUT',
+  pathUnderBrand: '/studio/appearance',
+  input: z
+    .object({
+      logo_url: z.string().url().optional().describe('Public http(s) image address; downloaded and re-hosted, max 4MB'),
+      favicon_url: z.string().url().optional().describe('Same rules as logo_url'),
+      remove_logo: z.boolean().optional().describe('Clear the logo. Cannot be combined with logo_url'),
+      display_font: z.string().min(1).max(60).optional().describe('Google Fonts family for headings, e.g. "Playfair Display"'),
+      body_font: z.string().min(1).max(60).optional().describe('Google Fonts family for body text'),
+      graphic_instructions: z.string().max(1200).optional().describe('Art direction the composer follows'),
+      visual_style: z
+        .string()
+        .min(20)
+        .max(2000)
+        .optional()
+        .describe('The visual brief every image render follows. Setting it locks it against the nightly rebuild')
+    })
+    .strict(),
+  output: z.object({ ok: z.literal(true), appearance: Appearance }),
+  failures: [
+    { error: 'no_fields', status: 400 },
+    { error: 'logo_conflict', status: 400 },
+    { error: 'font_not_available', status: 400 },
+    { error: 'image_rejected', status: 400 },
+    { error: 'font_pair_incomplete', status: 400 },
+    { error: 'update_failed', status: 500 }
+  ],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/packages/api-contracts/src/blog-settings.test.ts
+++ b/packages/api-contracts/src/blog-settings.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import {
   ADD_BLOG_TERM,
+  BLOG_ANALYTICS_PROVIDERS,
   BLOG_FONTS,
   BLOG_TERM_KINDS,
   GET_BLOG_SETTINGS,
   REMOVE_BLOG_TERM,
-  SET_BLOG_SETTINGS
+  SET_BLOG_SETTINGS,
+  blogAnalyticsIdOk
 } from './blog-settings';
 import { BRAND_ENDPOINTS, statusForFailure } from './index';
 
@@ -82,6 +84,48 @@ describe('le impostazioni del blog come contratto', () => {
     expect(ADD_BLOG_TERM.description).toMatch(/avatar is an image and cannot be/);
   });
 
+  /**
+   * Il campo che Andrea ha chiesto — "script js nell'head" — esiste SOLO come elenco chiuso di
+   * fornitori con un id. Un campo `<script>` libero sarebbe esecuzione di codice arbitrario sulle
+   * pagine del cliente, e su `/blog/<slug>` anche sulla nostra origine.
+   */
+  it('non esiste nessun campo che accetti markup o codice', () => {
+    const fields = Object.keys(SET_BLOG_SETTINGS.input.shape);
+    for (const forbidden of ['head_scripts', 'head_html', 'custom_script', 'scripts', 'html']) {
+      expect(fields, forbidden).not.toContain(forbidden);
+    }
+    expect(SET_BLOG_SETTINGS.input.safeParse({ analytics: [{ provider: 'ga4', id: 'G-ABC123' }] }).success).toBe(true);
+    expect(
+      SET_BLOG_SETTINGS.input.safeParse({ analytics: [{ provider: 'custom', id: '<script>x</script>' }] }).success
+    ).toBe(false);
+  });
+
+  it('un id di misurazione non può contenere niente che chiuda un tag o una stringa', () => {
+    // L'id finisce dentro uno snippet del fornitore: se accettasse una virgoletta o un `<`,
+    // l'elenco chiuso non servirebbe a niente.
+    expect(blogAnalyticsIdOk('ga4', 'G-ABC1234567')).toBe(true);
+    expect(blogAnalyticsIdOk('ga4', "G-X';alert(1);//")).toBe(false);
+    expect(blogAnalyticsIdOk('ga4', 'G-X</script><script>alert(1)</script>')).toBe(false);
+    expect(blogAnalyticsIdOk('meta_pixel', '1234567890')).toBe(true);
+    expect(blogAnalyticsIdOk('meta_pixel', 'abc')).toBe(false);
+    expect(blogAnalyticsIdOk('plausible', 'example.com')).toBe(true);
+    expect(blogAnalyticsIdOk('plausible', 'example.com"/><img onerror=x>')).toBe(false);
+    expect(blogAnalyticsIdOk('hotjar', '3512345')).toBe(true);
+    expect(blogAnalyticsIdOk('hotjar', '35_12345')).toBe(false);
+  });
+
+  it('lo schema rifiuta un id sbagliato per il fornitore, non lo salva e basta', () => {
+    expect(SET_BLOG_SETTINGS.input.safeParse({ analytics: [{ provider: 'ga4', id: '1234' }] }).success).toBe(false);
+    expect(SET_BLOG_SETTINGS.input.safeParse({ analytics: [{ provider: 'hotjar', id: 'G-ABC123' }] }).success).toBe(
+      false
+    );
+  });
+
+  it('la descrizione dice dove gli script girano davvero, perché non è dove sembra', () => {
+    expect(SET_BLOG_SETTINGS.description).toMatch(/verified custom domain/);
+    expect(BLOG_ANALYTICS_PROVIDERS).toContain('ga4');
+  });
+
   it('la lettura porta i limiti del piano, non solo la configurazione', () => {
     const parsed = GET_BLOG_SETTINGS.output.safeParse({
       brand: 'demo',
@@ -101,7 +145,8 @@ describe('le impostazioni del blog come contratto', () => {
         default_locale: 'it',
         locales: [],
         navbar_links: [],
-        icon_url: null
+        icon_url: null,
+        analytics: [{ provider: 'ga4', id: 'G-ABC1234567' }]
       },
       limits: { articles_per_week_max: 8, translation_languages: 0, custom_domain: true },
       choices: { fonts: [...BLOG_FONTS], layouts: ['navbar', 'sidebar'], locales: ['it', 'en'] },

--- a/packages/api-contracts/src/blog-settings.ts
+++ b/packages/api-contracts/src/blog-settings.ts
@@ -14,6 +14,43 @@ export type BlogTermKind = (typeof BLOG_TERM_KINDS)[number];
 
 const term = z.enum(BLOG_TERM_KINDS).describe('Which list the entry belongs to');
 
+/**
+ * Gli unici script di terze parti che il blog di un brand puo' caricare. E' un elenco CHIUSO, e la
+ * chiusura e' il punto: un campo `<script>` libero sarebbe esecuzione di codice arbitrario sulle
+ * pagine del cliente, e su `/blog/<slug>` — che sta sulla nostra origine, insieme alla sessione di
+ * chi e' loggato in `/app` — sarebbe una presa di controllo dell'account.
+ *
+ * Ogni id finisce dentro lo snippet del fornitore, quindi il pattern non e' una validazione di
+ * comodo: e' cio' che impedisce a una virgoletta o a un `<` di uscire dal contesto previsto.
+ */
+export const BLOG_ANALYTICS_ID_PATTERNS = {
+  ga4: /^G-[A-Z0-9]{4,20}$/,
+  meta_pixel: /^[0-9]{6,20}$/,
+  plausible: /^[a-z0-9][a-z0-9.-]{1,78}[a-z0-9]$/,
+  hotjar: /^[0-9]{5,12}$/
+} as const;
+
+export const BLOG_ANALYTICS_PROVIDERS = Object.keys(
+  BLOG_ANALYTICS_ID_PATTERNS
+) as unknown as readonly BlogAnalyticsProvider[];
+
+export type BlogAnalyticsProvider = keyof typeof BLOG_ANALYTICS_ID_PATTERNS;
+
+export function blogAnalyticsIdOk(provider: string, id: string): boolean {
+  const pattern = BLOG_ANALYTICS_ID_PATTERNS[provider as BlogAnalyticsProvider];
+  return pattern !== undefined && pattern.test(id);
+}
+
+const AnalyticsEntry = z
+  .object({
+    provider: z.enum(Object.keys(BLOG_ANALYTICS_ID_PATTERNS) as [BlogAnalyticsProvider, ...BlogAnalyticsProvider[]]),
+    id: z.string().min(1).describe('Measurement id: G-XXXXXXX (ga4), numeric (meta_pixel, hotjar), domain (plausible)')
+  })
+  .strict()
+  .refine((e) => blogAnalyticsIdOk(e.provider, e.id), {
+    message: 'id does not match the shape that provider issues'
+  });
+
 const NavbarLink = z.object({ label: z.string(), url: z.string() });
 
 const BlogConfig = z.object({
@@ -31,7 +68,8 @@ const BlogConfig = z.object({
   default_locale: z.string().nullable(),
   locales: z.array(z.string()),
   navbar_links: z.array(NavbarLink),
-  icon_url: z.string().nullable()
+  icon_url: z.string().nullable(),
+  analytics: z.array(z.object({ provider: z.string(), id: z.string() }))
 });
 
 export const GET_BLOG_SETTINGS = {
@@ -87,9 +125,14 @@ export const SET_BLOG_SETTINGS = {
     'Change how the blog looks and how it writes. Only the fields you send change; every other ' +
     'one keeps its value. `articles_per_week` is CLAMPED to the plan’s ceiling rather than ' +
     'refused, and the answer says what was actually saved — read it back instead of assuming ' +
-    'your number was taken. `locales` and `navbar_links` replace their whole list. Turning ' +
-    '`enabled` off takes the public blog down; it deletes no article. The blog icon and an ' +
-    'author’s avatar are images and cannot be set here. Calls no model and spends no credits.',
+    'your number was taken. `locales`, `navbar_links` and `analytics` replace their whole list. ' +
+    'Turning `enabled` off takes the public blog down; it deletes no article. The blog icon and an ' +
+    'author’s avatar are images and cannot be set here. `analytics` takes a CLOSED list of ' +
+    'providers with their measurement id — there is no field for arbitrary JavaScript, and asking ' +
+    'for one is refused: a script tag here would run on every visitor’s page. Those trackers load ' +
+    'ONLY on a verified custom domain and ONLY after the visitor accepts cookies; on the default ' +
+    '/blog/<slug> address they are stored and never emitted, because that address is Anomalia’s ' +
+    'own origin. Calls no model and spends no credits.',
   method: 'PUT',
   pathUnderBrand: '/settings/blog',
   input: z
@@ -122,7 +165,15 @@ export const SET_BLOG_SETTINGS = {
         .array(z.string())
         .optional()
         .describe('Extra languages articles are translated into. Replaces the whole list'),
-      navbar_links: z.array(NavbarLink).optional().describe('Up to 6 custom nav links. Replaces the whole list')
+      navbar_links: z.array(NavbarLink).optional().describe('Up to 6 custom nav links. Replaces the whole list'),
+      analytics: z
+        .array(AnalyticsEntry)
+        .max(4)
+        .optional()
+        .describe(
+          'Third-party analytics, one entry per provider. Replaces the whole list; [] removes them all, ' +
+            'which is how a tracker is taken off a live site without us'
+        )
     })
     .strict(),
   output: z.object({ ok: z.literal(true), config: BlogConfig }),

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -1,5 +1,6 @@
 import type { z } from 'zod';
 import { ADS_REMIX } from './ads';
+import { GET_APPEARANCE, SET_APPEARANCE } from './appearance';
 import { GET_AUTOMATIONS, SET_AUTOMATION } from './automations';
 import { BILLING_PORTAL_LINK, CHECKOUT_LINK } from './billing';
 import { GET_ARTICLE, UPDATE_ARTICLE } from './articles';
@@ -151,6 +152,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   GEO_ACTION,
   GET_ADS,
   GET_ANALYTICS,
+  GET_APPEARANCE,
   GET_ARTICLE,
   GET_AUDIT_FINDINGS,
   GET_AUTOMATIONS,
@@ -201,6 +203,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   SAVE_WEEK_SEEDS,
   SEARCH_KNOWLEDGE,
   SEO_ACTION,
+  SET_APPEARANCE,
   SET_AUTOMATION,
   SET_BIO,
   SET_BLOG_SETTINGS,
@@ -369,14 +372,18 @@ export type { AutomationJob } from './automations';
 export { LIST_SOCIAL_ACCOUNTS, SOCIAL_CONNECT_LINK } from './social';
 export {
   ADD_BLOG_TERM,
+  BLOG_ANALYTICS_ID_PATTERNS,
+  BLOG_ANALYTICS_PROVIDERS,
   BLOG_FONTS,
   BLOG_LAYOUTS,
   BLOG_TERM_KINDS,
+  blogAnalyticsIdOk,
   GET_BLOG_SETTINGS,
   REMOVE_BLOG_TERM,
   SET_BLOG_SETTINGS
 } from './blog-settings';
-export type { BlogTermKind } from './blog-settings';
+export type { BlogAnalyticsProvider, BlogTermKind } from './blog-settings';
+export { GET_APPEARANCE, SET_APPEARANCE } from './appearance';
 export { BILLING_PORTAL_LINK, CHECKOUT_LINK };
 export type { BillingPortalLinkResult, CheckoutLinkInput, CheckoutLinkResult } from './billing';
 export type { CheckContentInput, CheckContentResult } from './content';

--- a/src/lib/blog-analytics.test.ts
+++ b/src/lib/blog-analytics.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import {
+  BLOG_ANALYTICS_ID_PATTERNS as CONTRACT_PATTERNS,
+  BLOG_ANALYTICS_PROVIDERS as CONTRACT_PROVIDERS
+} from '@anomalia/api-contracts';
+import {
+  BLOG_ANALYTICS_ID_PATTERNS,
+  BLOG_ANALYTICS_PROVIDERS,
+  renderableBlogAnalytics
+} from './blog-analytics';
+
+/**
+ * Le regex sono ricopiate dal contratto per non trascinare zod nel bundle del blog pubblico. La
+ * copia va bene solo finche' qualcosa fallisce quando diverge: se il contratto accettasse una forma
+ * che il renderer non riconosce, un id salvato non caricherebbe niente e nessuno lo saprebbe; se il
+ * renderer ne accettasse una che il contratto non convalida, la chiusura dell'elenco non varrebbe
+ * piu' niente.
+ */
+describe('la tabella dei fornitori non puo’ divergere dal contratto', () => {
+  it('conosce esattamente gli stessi fornitori', () => {
+    expect([...BLOG_ANALYTICS_PROVIDERS].sort()).toEqual([...CONTRACT_PROVIDERS].sort());
+  });
+
+  it('con esattamente le stesse forme di id', () => {
+    for (const provider of CONTRACT_PROVIDERS) {
+      expect(BLOG_ANALYTICS_ID_PATTERNS[provider]?.source, provider).toBe(CONTRACT_PATTERNS[provider].source);
+    }
+  });
+});
+
+describe('cosa arriva davvero a diventare uno script', () => {
+  it('scarta un fornitore che non conosciamo', () => {
+    expect(renderableBlogAnalytics([{ provider: 'custom', id: 'x' }])).toEqual([]);
+  });
+
+  it('scarta un id che non ha la forma del suo fornitore', () => {
+    expect(renderableBlogAnalytics([{ provider: 'ga4', id: 'G-A"></script><script>alert(1)' }])).toEqual([]);
+    expect(renderableBlogAnalytics([{ provider: 'hotjar', id: "1;alert(1);//" }])).toEqual([]);
+    expect(renderableBlogAnalytics([{ provider: 'plausible', id: 'x.test"/><img onerror=1>' }])).toEqual([]);
+  });
+
+  /**
+   * Un id valido non deve poter contenere niente che chiuda la stringa o il tag in cui finisce:
+   * e' l'unica ragione per cui interpolarlo dentro lo snippet e' sicuro.
+   */
+  it('nessun id accettabile contiene un carattere che esce dal contesto', () => {
+    const dangerous = ['<', '>', '"', "'", '`', '\\', ' ', '\n', ';', '/'];
+    for (const provider of BLOG_ANALYTICS_PROVIDERS) {
+      const pattern = BLOG_ANALYTICS_ID_PATTERNS[provider];
+      for (const ch of dangerous) {
+        const probe = `${'a'.repeat(8)}${ch}${'1'.repeat(8)}`;
+        expect(pattern.test(probe), `${provider} accetta "${ch}"`).toBe(false);
+      }
+    }
+  });
+
+  it('tiene un fornitore solo per tipo', () => {
+    const kept = renderableBlogAnalytics([
+      { provider: 'ga4', id: 'G-AAAAAAA' },
+      { provider: 'ga4', id: 'G-BBBBBBB' }
+    ]);
+    expect(kept).toEqual([{ provider: 'ga4', id: 'G-AAAAAAA' }]);
+  });
+
+  it('lascia passare le quattro forme vere', () => {
+    const all = [
+      { provider: 'ga4', id: 'G-ABC1234567' },
+      { provider: 'meta_pixel', id: '1234567890123' },
+      { provider: 'plausible', id: 'example.com' },
+      { provider: 'hotjar', id: '3512345' }
+    ];
+    expect(renderableBlogAnalytics(all)).toEqual(all);
+  });
+});

--- a/src/lib/blog-analytics.ts
+++ b/src/lib/blog-analytics.ts
@@ -1,0 +1,87 @@
+/**
+ * I tracker che un brand puo' far girare sul PROPRIO blog.
+ *
+ * Tre cose, in ordine di importanza:
+ *
+ * 1. **L'elenco e' chiuso.** Non esiste un campo "script": un `<script>` libero su una pagina
+ *    pubblica e' esecuzione di codice arbitraria sui visitatori del cliente, e su `/blog/<slug>` —
+ *    che sta sulla nostra origine — anche sulla sessione di chi e' loggato in `/app`.
+ * 2. **Girano solo sul dominio del brand.** Chi li monta e' `_site/+layout.server.ts`, l'albero
+ *    servito quando l'host NON e' il nostro. `/blog/<slug>` non li passa: dimenticarsene significa
+ *    non caricarli, mai il contrario.
+ * 3. **Girano solo dopo il consenso**, come il pixel che il blog gia' aveva.
+ *
+ * Le forme degli id sono ricopiate dal contratto (`@anomalia/api-contracts`) invece di essere
+ * importate: importarle trascinerebbe zod nel bundle del blog pubblico per quattro regex.
+ * `blog-analytics.test.ts` fallisce se le due tabelle divergono.
+ */
+
+export const BLOG_ANALYTICS_ID_PATTERNS: Record<string, RegExp> = {
+  ga4: /^G-[A-Z0-9]{4,20}$/,
+  meta_pixel: /^[0-9]{6,20}$/,
+  plausible: /^[a-z0-9][a-z0-9.-]{1,78}[a-z0-9]$/,
+  hotjar: /^[0-9]{5,12}$/
+};
+
+export type BlogAnalyticsEntry = { provider: string; id: string };
+
+function inline(code: string) {
+  const s = document.createElement('script');
+  s.textContent = code;
+  document.head.appendChild(s);
+}
+
+function external(src: string, attrs: Record<string, string> = {}) {
+  const s = document.createElement('script');
+  s.async = true;
+  s.src = src;
+  for (const [k, v] of Object.entries(attrs)) s.setAttribute(k, v);
+  document.head.appendChild(s);
+}
+
+/**
+ * Uno snippet per fornitore. L'id ci entra gia' verificato contro il pattern qui sopra, che e'
+ * l'unica ragione per cui interpolarlo e' sicuro: nessuno dei quattro alfabeti contiene una
+ * virgoletta, un `<` o uno spazio.
+ */
+const LOADERS: Record<string, (id: string) => void> = {
+  ga4: (id) => {
+    external(`https://www.googletagmanager.com/gtag/js?id=${id}`);
+    inline(
+      `window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments)}gtag('js',new Date());gtag('config','${id}');`
+    );
+  },
+  meta_pixel: (id) =>
+    inline(
+      `!(function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)})(window,document,'script','https://connect.facebook.net/en_US/fbevents.js');fbq('init','${id}');fbq('track','PageView');`
+    ),
+  plausible: (id) => external('https://plausible.io/js/script.js', { 'data-domain': id, defer: '' }),
+  hotjar: (id) =>
+    inline(
+      `(function(h,o,t,j,a,r){h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};h._hjSettings={hjid:${id},hjsv:6};a=o.getElementsByTagName('head')[0];r=o.createElement('script');r.async=1;r.src=t+h._hjSettings.hjid+j;a.appendChild(r)})(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');`
+    )
+};
+
+export const BLOG_ANALYTICS_PROVIDERS = Object.keys(LOADERS);
+
+/** Quali voci sono davvero rendibili. Una riga che non lo e' non e' un errore: e' da ignorare. */
+export function renderableBlogAnalytics(entries: readonly BlogAnalyticsEntry[]): BlogAnalyticsEntry[] {
+  const seen = new Set<string>();
+  return entries.filter((e) => {
+    const pattern = BLOG_ANALYTICS_ID_PATTERNS[e.provider];
+    if (!pattern || !LOADERS[e.provider] || !pattern.test(e.id) || seen.has(e.provider)) return false;
+    seen.add(e.provider);
+    return true;
+  });
+}
+
+let loaded = false;
+
+/** Idempotente: un secondo consenso nella stessa pagina non raddoppia i PageView. */
+export function loadBlogAnalytics(entries: readonly BlogAnalyticsEntry[]) {
+  if (loaded || typeof document === 'undefined') return;
+  const renderable = renderableBlogAnalytics(entries);
+  if (!renderable.length) return;
+  loaded = true;
+  for (const e of renderable) LOADERS[e.provider](e.id);
+}

--- a/src/lib/components/blog/BlogCookieBanner.svelte
+++ b/src/lib/components/blog/BlogCookieBanner.svelte
@@ -3,8 +3,8 @@
   import { _ } from 'svelte-i18n';
   import { blogBannerOpen, initBlogConsent, setBlogConsent } from './blog-consent.svelte';
 
-  let { base = '' } = $props();
-  onMount(initBlogConsent);
+  let { base = '', analytics = [] } = $props();
+  onMount(() => initBlogConsent(analytics));
 </script>
 
 {#if blogBannerOpen()}

--- a/src/lib/components/blog/BlogShell.svelte
+++ b/src/lib/components/blog/BlogShell.svelte
@@ -5,7 +5,7 @@
   import BlogSearch from './BlogSearch.svelte';
   import { openBlogCookieSettings } from './blog-consent.svelte';
 
-  let { brand, base = '', categories = [], children } = $props();
+  let { brand, base = '', categories = [], analytics = [], children } = $props();
 
   let theme = $state<'light' | 'dark'>('light');
   $effect(() => {
@@ -177,7 +177,7 @@
     </div>
   </footer>
 
-  <BlogCookieBanner {base} />
+  <BlogCookieBanner {base} {analytics} />
 </div>
 
 <style>

--- a/src/lib/components/blog/blog-consent.svelte.ts
+++ b/src/lib/components/blog/blog-consent.svelte.ts
@@ -1,8 +1,13 @@
 // Cookie consent for the PUBLIC brand blog — independent from Anomalia's app consent (different
-// visitor, different domain). It gates ONLY the Meta Pixel, which is the sole tracker that runs on
-// blog pages. Strictly-functional storage (theme choice) needs no consent and is unaffected.
+// visitor, different domain). It gates Anomalia's Meta Pixel and the brand's own analytics, which
+// are the only trackers that run on blog pages. Strictly-functional storage (theme choice) needs no
+// consent and is unaffected.
+//
+// The brand's trackers arrive as an argument rather than being read here: only the custom-domain
+// route tree passes them (see siteAnalytics in blog-site.ts), so a page that forgets loads nothing.
 import { browser } from '$app/environment';
 import { loadMetaPixel } from '$lib/analytics';
+import { loadBlogAnalytics, type BlogAnalyticsEntry } from '$lib/blog-analytics';
 
 type Choice = 'granted' | 'denied' | null;
 const KEY = 'anomalia_blog_consent_v1';
@@ -10,17 +15,24 @@ const KEY = 'anomalia_blog_consent_v1';
 let _choice = $state<Choice>(null);
 let _open = $state(false);
 let _init = false;
+let _analytics: readonly BlogAnalyticsEntry[] = [];
+
+function loadTrackers() {
+  loadMetaPixel();
+  loadBlogAnalytics(_analytics);
+}
 
 /** Read the stored choice once (call from the banner's onMount). Re-fires the pixel for returning
  *  visitors who already accepted; shows the banner on first visit. No SSR flash: _open stays false
  *  until this runs client-side. */
-export function initBlogConsent() {
+export function initBlogConsent(analytics: readonly BlogAnalyticsEntry[] = []) {
+  _analytics = analytics;
   if (_init || !browser) return;
   _init = true;
   const v = localStorage.getItem(KEY);
   _choice = v === 'granted' || v === 'denied' ? v : null;
   if (_choice === null) _open = true;
-  else if (_choice === 'granted') loadMetaPixel();
+  else if (_choice === 'granted') loadTrackers();
 }
 
 export function blogBannerOpen() { return _open; }
@@ -30,5 +42,5 @@ export function setBlogConsent(value: 'granted' | 'denied') {
   _choice = value;
   if (browser) localStorage.setItem(KEY, value);
   _open = false;
-  if (value === 'granted') loadMetaPixel();
+  if (value === 'granted') loadTrackers();
 }

--- a/src/lib/content/changelog/2026-09-04-agent-brand-look.ts
+++ b/src/lib/content/changelog/2026-09-04-agent-brand-look.ts
@@ -1,0 +1,13 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-04',
+  title: 'Your AI can change how your brand looks',
+  items: [
+    'Claude, Cursor and any connected AI client can now set your logo and favicon, choose the two Google Fonts your graphics are composed with, and write the visual brief every image follows — without opening Anomalia.',
+    'A logo is given as a link and copied into your own storage, so the image in your graphics cannot change or disappear later because someone else moved it.',
+    'A font Google Fonts does not serve is now refused, and says which one — instead of quietly rendering everything in Inter.',
+    'Your blog can now carry your own analytics: Google Analytics 4, Meta Pixel, Plausible or Hotjar, added by measurement id. They run on your own domain, only after a visitor accepts cookies, and sending an empty list takes them off a live site immediately.',
+    'There is deliberately no field for pasting arbitrary JavaScript: on the shared anomalia.so blog address that would run alongside your Anomalia session. Connect your own domain and the analytics above cover it safely.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/blog-analytics-boundary.test.ts
+++ b/src/lib/server/blog-analytics-boundary.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Il confine, tenuto da un test invece che da una convenzione.
+ *
+ * Il blog di un brand esce da due alberi di rotte: `src/routes/_site` (il dominio del brand) e
+ * `src/routes/blog/[site]` (`/blog/<slug>`, che sta sulla NOSTRA origine, insieme a `/app` e alla
+ * sessione di chi e' loggato). I tracker di terze parti possono girare solo sul primo: un container
+ * GA4 o GTM sul secondo eseguirebbe JavaScript arbitrario con i permessi di anomalia.so, e chi lo
+ * amministra non siamo noi.
+ *
+ * `siteAnalytics` e' l'unica porta per quei tracker, e questo test dice da dove si passa. Se
+ * qualcuno lo chiamasse dall'albero sbagliato — o da un terzo albero — qui si rompe, e si rompe
+ * prima che il codice arrivi su una pagina pubblica.
+ */
+
+const ROUTES = new URL('../../routes', import.meta.url).pathname;
+const ALLOWED = ['_site/+layout.server.ts'];
+
+function walk(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    const full = join(dir, entry);
+    return statSync(full).isDirectory() ? walk(full) : [full];
+  });
+}
+
+describe('i tracker di un brand non toccano la nostra origine', () => {
+  const callers = walk(ROUTES)
+    .filter((f) => f.endsWith('.ts') || f.endsWith('.svelte'))
+    .filter((f) => /\bsiteAnalytics\b/.test(readFileSync(f, 'utf8')))
+    .map((f) => f.slice(ROUTES.length + 1))
+    .sort();
+
+  it('li chiede soltanto l’albero servito sul dominio del brand', () => {
+    expect(callers).toEqual(ALLOWED);
+  });
+
+  it('l’albero su /blog/<slug> non li nomina nemmeno', () => {
+    expect(callers.filter((f) => f.startsWith('blog/'))).toEqual([]);
+  });
+
+  /**
+   * `brandProfile` alimenta ENTRAMBI gli alberi. Se i tracker finissero li' dentro, arriverebbero
+   * su `/blog/<slug>` senza che nessuno lo abbia deciso.
+   */
+  it('e il profilo condiviso dai due alberi non li porta con se’', () => {
+    const blogSite = readFileSync(join(ROUTES, '../lib/server/blog-site.ts'), 'utf8');
+    const profile = blogSite.slice(
+      blogSite.indexOf('async function brandProfile'),
+      blogSite.indexOf('export async function siteAnalytics')
+    );
+    expect(profile).not.toMatch(/analytics/);
+  });
+});

--- a/src/lib/server/blog-settings.test.ts
+++ b/src/lib/server/blog-settings.test.ts
@@ -125,3 +125,41 @@ describe('blogConfigPatch — una regola per campo, due chiamanti', () => {
     expect(links).toEqual([{ label: 'Home', url: 'https://x.test' }]);
   });
 });
+
+describe('analytics del blog — un elenco chiuso, mai codice', () => {
+  it('tiene una coppia fornitore/id che quel fornitore emette davvero', () => {
+    expect(blogConfigPatch({ analytics: [{ provider: 'ga4', id: 'G-ABC1234567' }] })).toEqual({
+      analytics: [{ provider: 'ga4', id: 'G-ABC1234567' }]
+    });
+  });
+
+  /**
+   * Ultima linea prima che l'id finisca dentro uno snippet. Lo zod del contratto lo rifiuta gia',
+   * ma questa regola sta accanto al modello: se domani un altro chiamante scrive `blog_config`
+   * senza passare dal contratto, non porta uno script dentro una pagina pubblica.
+   */
+  it('scarta un id che non ha la forma del suo fornitore', () => {
+    expect(blogConfigPatch({ analytics: [{ provider: 'ga4', id: "G-X';alert(1);//" }] })).toEqual({ analytics: [] });
+    expect(blogConfigPatch({ analytics: [{ provider: 'hotjar', id: 'G-ABC123' }] })).toEqual({ analytics: [] });
+  });
+
+  it('scarta un fornitore che non conosciamo, invece di renderlo', () => {
+    expect(blogConfigPatch({ analytics: [{ provider: 'custom', id: '<script>x</script>' }] })).toEqual({
+      analytics: []
+    });
+  });
+
+  it('tiene un fornitore solo per tipo: due id dello stesso contano una volta', () => {
+    const patch = blogConfigPatch({
+      analytics: [
+        { provider: 'ga4', id: 'G-AAAAAAA' },
+        { provider: 'ga4', id: 'G-BBBBBBB' }
+      ]
+    });
+    expect(patch.analytics).toEqual([{ provider: 'ga4', id: 'G-AAAAAAA' }]);
+  });
+
+  it('una lista vuota toglie tutto: e’ cosi’ che si stacca un tracker rotto senza di noi', () => {
+    expect(blogConfigPatch({ analytics: [] })).toEqual({ analytics: [] });
+  });
+});

--- a/src/lib/server/blog-settings.ts
+++ b/src/lib/server/blog-settings.ts
@@ -15,6 +15,7 @@ import { storeSecrets, loadSecrets } from '$lib/server/integration-secrets';
 import { blogArticlesPerWeek, blogArticlesPerWeekMax } from '$lib/server/plans';
 import { isBlogLocale, resolveBlogLocales, type BlogLocaleConfig } from '$lib/server/blog-locales';
 import { readUploadImage } from '$lib/server/raster-image';
+import { BLOG_ANALYTICS_PROVIDERS, blogAnalyticsIdOk } from '@anomalia/api-contracts';
 
 type Ev = RequestEvent;
 
@@ -62,6 +63,7 @@ export type BlogConfigView = {
   humanizerEnabled: boolean;
   backlinkNetwork: boolean;
   locales: BlogLocaleConfig;
+  analytics: { provider: string; id: string }[];
 };
 
 export function parseBlogConfig(
@@ -87,8 +89,21 @@ export function parseBlogConfig(
     showBlogLink: cfg.showBlogLink !== false,
     humanizerEnabled: cfg.humanizerEnabled !== false,
     backlinkNetwork: cfg.backlinkNetwork !== false,
-    locales: resolveBlogLocales(cfg, plan)
+    locales: resolveBlogLocales(cfg, plan),
+    analytics: blogAnalytics(cfg)
   };
+}
+
+/**
+ * I tracker che il brand ha scelto, gia' ridotti a quelli che sanno essere resi. La lettura non si
+ * fida di cio' che sta nel jsonb: una riga scritta prima che il fornitore esistesse, o da una mano
+ * che non e' passata dal contratto, non deve diventare uno script.
+ */
+export function blogAnalytics(cfg: Record<string, unknown>): { provider: string; id: string }[] {
+  const raw = Array.isArray(cfg.analytics) ? cfg.analytics : [];
+  return raw
+    .map((e) => ({ provider: String((e as { provider?: unknown })?.provider ?? ''), id: String((e as { id?: unknown })?.id ?? '') }))
+    .filter((e) => blogAnalyticsIdOk(e.provider, e.id));
 }
 
 /** Shared load payload for blog settings pages (appearance / domain / integrations). */
@@ -327,6 +342,23 @@ const BLOG_CONFIG_FIELDS: Record<string, (v: unknown, plan?: string | null) => u
       .map((l) => ({ label: str((l as { label?: unknown })?.label, 60), url: str((l as { url?: unknown })?.url, 300) }))
       .filter((l) => l.label && l.url)
       .slice(0, 6);
+  },
+  // Ultima linea prima che un id finisca dentro lo snippet di un fornitore. Il contratto lo rifiuta
+  // gia', ma la regola sta qui, accanto al modello: un chiamante futuro che scrivesse `blog_config`
+  // senza passare dal contratto non porta comunque uno script dentro una pagina pubblica.
+  analytics: (v) => {
+    const raw = Array.isArray(v) ? v : [];
+    const seen = new Set<string>();
+    const kept: { provider: string; id: string }[] = [];
+    for (const e of raw) {
+      const provider = str((e as { provider?: unknown })?.provider, 20);
+      const id = str((e as { id?: unknown })?.id, 80);
+      if (!blogAnalyticsIdOk(provider, id) || seen.has(provider)) continue;
+      seen.add(provider);
+      kept.push({ provider, id });
+      if (kept.length === BLOG_ANALYTICS_PROVIDERS.length) break;
+    }
+    return kept;
   }
 };
 

--- a/src/lib/server/blog-site.ts
+++ b/src/lib/server/blog-site.ts
@@ -141,6 +141,24 @@ async function brandProfile(brandId: string): Promise<BlogBrand | null> {
   };
 }
 
+/**
+ * I tracker di terze parti del brand — e il motivo per cui NON stanno dentro `brandProfile`.
+ *
+ * Il blog esce da due porte: il dominio del brand (albero `_site`) e `/blog/<slug>`, che sta sulla
+ * NOSTRA origine, la stessa di `/app` e della sessione di chi e' loggato. Uno script di terze parti
+ * caricato li' — un container GA4 o GTM, che chi lo amministra puo' riempire di JavaScript quando
+ * vuole — girerebbe con i permessi di anomalia.so.
+ *
+ * Quindi non arrivano col profilo: si chiedono, e li chiede solo l'albero servito sul dominio del
+ * brand. Dimenticarsene significa non caricarli; il contrario non e' possibile.
+ */
+export async function siteAnalytics(brandId: string): Promise<{ provider: string; id: string }[]> {
+  const admin = createAdminClient();
+  const { data } = await admin.from('brands').select('blog_config').eq('id', brandId).maybeSingle();
+  const { blogAnalytics } = await import('$lib/server/blog-settings');
+  return blogAnalytics((data?.blog_config ?? {}) as Record<string, unknown>);
+}
+
 // Resolve which brand a hostname serves (custom domain). Any brand_sites row means it was connected.
 export async function resolveSiteBrand(host: string): Promise<BlogBrand | null> {
   const admin = createAdminClient();

--- a/src/routes/_site/+layout.server.ts
+++ b/src/routes/_site/+layout.server.ts
@@ -1,6 +1,6 @@
 import { error } from '@sveltejs/kit';
 import type { LayoutServerLoad } from './$types';
-import { resolveSiteBrand, listCategories } from '$lib/server/blog-site';
+import { resolveSiteBrand, listCategories, siteAnalytics } from '$lib/server/blog-site';
 
 export const load: LayoutServerLoad = async ({ url, setHeaders }) => {
   const host = url.hostname.toLowerCase();
@@ -8,6 +8,8 @@ export const load: LayoutServerLoad = async ({ url, setHeaders }) => {
   if (!brand) throw error(404, 'This site is not configured yet.');
   setHeaders({ 'cache-control': 'public, max-age=0, s-maxage=60, stale-while-revalidate=300' });
   const origin = `https://${host}`;
-  const categories = await listCategories(brand.brandId);
-  return { brand, host, origin, base: '', siteUrl: origin, categories };
+  // I tracker del brand si chiedono SOLO qui: questo è l'albero servito sul suo dominio. Su
+  // /blog/<slug> — la nostra origine — non arrivano, e blog-analytics-boundary.test.ts lo tiene.
+  const [categories, analytics] = await Promise.all([listCategories(brand.brandId), siteAnalytics(brand.brandId)]);
+  return { brand, host, origin, base: '', siteUrl: origin, categories, analytics };
 };

--- a/src/routes/_site/+layout.svelte
+++ b/src/routes/_site/+layout.svelte
@@ -3,4 +3,6 @@
   let { data, children } = $props();
 </script>
 
-<BlogShell brand={data.brand} categories={data.categories}>{@render children()}</BlogShell>
+<BlogShell brand={data.brand} categories={data.categories} analytics={data.analytics}
+  >{@render children()}</BlogShell
+>

--- a/src/routes/api/v1/brands/[slug]/settings/blog/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/settings/blog/+server.ts
@@ -32,7 +32,8 @@ const FIELD_KEYS: Record<string, string> = {
   articles_per_week: 'articlesPerWeek',
   default_locale: 'defaultLocale',
   locales: 'locales',
-  navbar_links: 'navbarLinks'
+  navbar_links: 'navbarLinks',
+  analytics: 'analytics'
 };
 
 type Cfg = Record<string, unknown>;
@@ -56,7 +57,8 @@ function view(cfg: Cfg, plan: string | null) {
     default_locale: typeof cfg.defaultLocale === 'string' ? parsed.locales.defaultLocale : null,
     locales: parsed.locales.extraLocales,
     navbar_links: parsed.navbarLinks,
-    icon_url: parsed.iconUrl
+    icon_url: parsed.iconUrl,
+    analytics: parsed.analytics
   };
 }
 

--- a/src/routes/api/v1/brands/[slug]/studio/appearance/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/studio/appearance/+server.ts
@@ -1,0 +1,135 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { authenticate, loadBrandForUser, checkApiKeyWriteAccess } from '$lib/server/cli-auth';
+import { SET_APPEARANCE, statusForFailure } from '@anomalia/api-contracts';
+import { storeBrandLogoFromUrl } from '$lib/server/studio-actions';
+import { fontIsAvailable } from '$lib/server/design-typography';
+
+// Il look del brand vive tutto in `brand_kit`. Qui si legge e si scrive quella riga sola: il logo
+// passando per la guardia SSRF che il form gia' usa, i font passando per la stessa verifica Google
+// Fonts del form. Nessun modello, nessun credito.
+
+type Kit = Record<string, unknown>;
+
+const KIT_COLUMNS = 'logos, favicon_url, brand_colors, graphic_style, visual_style, visual_style_locked';
+
+/** Un'og-image e' il logo che abbiamo indovinato dal sito, non quello che il brand ha scelto. */
+function chosenLogo(logos: unknown): string | null {
+  if (!Array.isArray(logos)) return null;
+  const hit = logos.find((l) => l?.url && l?.type !== 'og-image');
+  return hit?.url ?? null;
+}
+
+function view(kit: Kit) {
+  const style = (kit.graphic_style ?? null) as Record<string, unknown> | null;
+  return {
+    logo_url: chosenLogo(kit.logos),
+    favicon_url: (kit.favicon_url as string) ?? null,
+    colors: Array.isArray(kit.brand_colors) ? (kit.brand_colors as string[]) : [],
+    graphic_style: style
+      ? {
+          display_font: (style.display_font as string) ?? null,
+          body_font: (style.body_font as string) ?? null,
+          instructions: (style.instructions as string) ?? null
+        }
+      : null,
+    visual_style: (kit.visual_style as string) ?? null,
+    visual_style_locked: kit.visual_style_locked === true
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function readKit(supabase: any, brandId: string): Promise<Kit> {
+  const { data } = await supabase.from('brand_kit').select(KIT_COLUMNS).eq('brand_id', brandId).maybeSingle();
+  return (data ?? {}) as Kit;
+}
+
+const fail = (error: string, extra?: Record<string, unknown>) =>
+  json({ error, ...extra }, { status: statusForFailure(SET_APPEARANCE, error) });
+
+export const GET: RequestHandler = async ({ request, params }) => {
+  const { supabase, error, apiKey } = await authenticate(request);
+  if (error) return error;
+
+  const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
+  if (brandError) return brandError;
+
+  return json({ brand: brand.slug, appearance: view(await readKit(supabase, brand.id)) });
+};
+
+export const PUT: RequestHandler = async ({ request, params }) => {
+  const { supabase, error, apiKey } = await authenticate(request);
+  if (error) return error;
+
+  const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
+  if (brandError) return brandError;
+  const writeDenied = checkApiKeyWriteAccess(apiKey);
+  if (writeDenied) return writeDenied;
+
+  const parsed = SET_APPEARANCE.input.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return json({ error: 'invalid_input', details: parsed.error.issues }, { status: 400 });
+  }
+
+  const input = parsed.data;
+  if (Object.keys(input).length === 0) return fail('no_fields');
+
+  // Mettere e togliere nella stessa richiesta non ha un ordine giusto: indovinarlo lascerebbe
+  // l'agente convinto di aver fatto l'altra cosa.
+  if (input.remove_logo && input.logo_url) return fail('logo_conflict');
+
+  // I font si verificano PRIMA di toccare qualunque cosa: un nome che Google Fonts non serve esce
+  // in Inter senza dire niente, ed e' la confusione che questa verifica esiste per chiudere.
+  const wantsFonts = input.display_font !== undefined || input.body_font !== undefined;
+  if (wantsFonts && (input.display_font === undefined || input.body_font === undefined)) {
+    return fail('font_pair_incomplete');
+  }
+  if (wantsFonts) {
+    const pair = [input.display_font as string, input.body_font as string];
+    const checked = await Promise.all(pair.map(fontIsAvailable));
+    const missing = pair.filter((_, i) => !checked[i]);
+    if (missing.length) return fail('font_not_available', { missing });
+  }
+
+  const patch: Kit = {};
+
+  for (const [field, kind] of [
+    ['logo_url', 'logo'],
+    ['favicon_url', 'favicon']
+  ] as const) {
+    const src = input[field];
+    if (src === undefined) continue;
+    const { data } = await supabase.auth.getUser();
+    const stored = await storeBrandLogoFromUrl(supabase, { userId: data.user?.id ?? '', imageUrl: src });
+    if ('error' in stored) return fail('image_rejected', { detail: stored.error, url: src });
+    if (kind === 'logo') patch.logos = [{ url: stored.url, type: 'uploaded' }];
+    else patch.favicon_url = stored.url;
+  }
+
+  if (input.remove_logo) patch.logos = [];
+
+  if (wantsFonts || input.graphic_instructions !== undefined) {
+    const current = ((await readKit(supabase, brand.id)).graphic_style ?? {}) as Record<string, unknown>;
+    patch.graphic_style = {
+      display_font: input.display_font ?? current.display_font ?? null,
+      body_font: input.body_font ?? current.body_font ?? null,
+      instructions: input.graphic_instructions ?? current.instructions ?? ''
+    };
+  }
+
+  // Scrivere il brief lo BLOCCA: senza il lock la ricostruzione notturna lo riscrive, e chi
+  // l'aveva scritto lo ritroverebbe cambiato senza che nessuno glielo abbia detto.
+  if (input.visual_style !== undefined) {
+    patch.visual_style = input.visual_style;
+    patch.visual_style_locked = true;
+  }
+
+  patch.updated_at = new Date().toISOString();
+
+  const { error: updateError } = await supabase
+    .from('brand_kit')
+    .upsert({ brand_id: brand.id, ...patch }, { onConflict: 'brand_id' });
+  if (updateError) return fail('update_failed', { detail: updateError.message });
+
+  return json({ ok: true, appearance: view(await readKit(supabase, brand.id)) });
+};

--- a/src/routes/api/v1/brands/[slug]/studio/appearance/server.test.ts
+++ b/src/routes/api/v1/brands/[slug]/studio/appearance/server.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('$lib/server/cli-auth', () => ({
+  authenticate: vi.fn(),
+  loadBrandForUser: vi.fn(),
+  checkApiKeyWriteAccess: vi.fn(() => null)
+}));
+
+const state = vi.hoisted(() => ({
+  kit: {} as Record<string, unknown>,
+  written: [] as Record<string, unknown>[],
+  fetched: [] as string[],
+  fetchResult: { url: 'https://cdn.anomalia.test/stored/logo.png' } as { url: string } | { error: string },
+  availableFonts: new Set(['Inter', 'Playfair Display']),
+  updateFails: null as string | null
+}));
+
+vi.mock('$lib/server/studio-actions', () => ({
+  storeBrandLogoFromUrl: async (_c: unknown, opts: { imageUrl: string }) => {
+    state.fetched.push(opts.imageUrl);
+    return state.fetchResult;
+  }
+}));
+
+vi.mock('$lib/server/design-typography', () => ({
+  fontIsAvailable: async (name: string) => state.availableFonts.has(name)
+}));
+
+const client = {
+  from: () => {
+    const q: Record<string, unknown> = {};
+    Object.assign(q, {
+      select: () => q,
+      eq: () => q,
+      maybeSingle: async () => ({ data: state.kit }),
+      update: (row: Record<string, unknown>) => {
+        state.written.push(row);
+        return {
+          eq: async () => ({ error: state.updateFails ? { message: state.updateFails } : null })
+        };
+      },
+      upsert: async (row: Record<string, unknown>) => {
+        state.written.push(row);
+        return { error: state.updateFails ? { message: state.updateFails } : null };
+      }
+    });
+    return q;
+  },
+  auth: { getUser: async () => ({ data: { user: { id: 'user-1' } } }) }
+};
+
+import { GET, PUT } from './+server';
+import { authenticate, loadBrandForUser, checkApiKeyWriteAccess } from '$lib/server/cli-auth';
+
+const BRAND = { id: 'brand-1', slug: 'demo', plan: 'pro' };
+const base = 'https://example.test/api/v1/brands/demo/studio/appearance';
+
+const call = (h: unknown, method: string, body?: unknown) =>
+  (h as (e: unknown) => Promise<Response>)({
+    request: new Request(base, {
+      method,
+      ...(body === undefined ? {} : { body: JSON.stringify(body) })
+    }),
+    params: { slug: 'demo' }
+  });
+
+beforeEach(() => {
+  state.kit = {
+    logos: [{ url: 'https://cdn.anomalia.test/old.png', type: 'uploaded' }],
+    favicon_url: null,
+    brand_colors: ['#111111'],
+    graphic_style: { display_font: 'Inter', body_font: 'Inter', instructions: '' },
+    visual_style: null,
+    visual_style_locked: false
+  };
+  state.written = [];
+  state.fetched = [];
+  state.fetchResult = { url: 'https://cdn.anomalia.test/stored/logo.png' };
+  state.availableFonts = new Set(['Inter', 'Playfair Display']);
+  state.updateFails = null;
+  vi.mocked(authenticate).mockResolvedValue({ supabase: client, apiKey: undefined } as never);
+  vi.mocked(loadBrandForUser).mockResolvedValue({ brand: BRAND } as never);
+  vi.mocked(checkApiKeyWriteAccess).mockReturnValue(undefined as never);
+});
+
+describe('GET /studio/appearance', () => {
+  it('riporta il logo come una URL sola, non come l’array grezzo del database', async () => {
+    const body = await (await call(GET, 'GET')).json();
+    expect(body.appearance.logo_url).toBe('https://cdn.anomalia.test/old.png');
+    expect(body.appearance).not.toHaveProperty('logos');
+  });
+
+  it('un logo che e’ solo un’og-image non conta come logo', async () => {
+    state.kit.logos = [{ url: 'https://x.test/og.png', type: 'og-image' }];
+    const body = await (await call(GET, 'GET')).json();
+    expect(body.appearance.logo_url).toBeNull();
+  });
+});
+
+describe('PUT /studio/appearance', () => {
+  it('una richiesta senza campi e’ 400 dichiarato, non un salvataggio a vuoto', async () => {
+    const res = await call(PUT, 'PUT', {});
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('no_fields');
+    expect(state.written).toHaveLength(0);
+  });
+
+  /**
+   * Il campo si chiama `logo_url`, ma quello che finisce nel database e' l'indirizzo NOSTRO. Se
+   * salvassimo quello di chi chiama, ogni grafica del brand mostrerebbe un'immagine che un altro
+   * puo' cambiare o togliere dopo averla fatta approvare.
+   */
+  it('salva l’indirizzo che abbiamo scaricato, non quello che ci hanno dato', async () => {
+    const res = await call(PUT, 'PUT', { logo_url: 'https://cdn.example.com/theirs.png' });
+    expect(res.status).toBe(200);
+    expect(state.fetched).toEqual(['https://cdn.example.com/theirs.png']);
+    const logos = state.written[0].logos as { url: string }[];
+    expect(logos[0].url).toBe('https://cdn.anomalia.test/stored/logo.png');
+  });
+
+  it('un indirizzo che la guardia rifiuta non lascia niente scritto', async () => {
+    state.fetchResult = { error: 'That image URL is not fetchable (blocked or not http/https).' };
+    const res = await call(PUT, 'PUT', { logo_url: 'http://169.254.169.254/latest/meta-data/' });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('image_rejected');
+    expect(state.written).toHaveLength(0);
+  });
+
+  it('mettere e togliere il logo insieme e’ un rifiuto, non un ordine indovinato', async () => {
+    const res = await call(PUT, 'PUT', { logo_url: 'https://cdn.example.com/x.png', remove_logo: true });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('logo_conflict');
+    expect(state.fetched).toHaveLength(0);
+  });
+
+  it('un font che Google Fonts non serve e’ rifiutato prima di scrivere, e dice quale', async () => {
+    const res = await call(PUT, 'PUT', { display_font: 'Comic Papyrus', body_font: 'Inter' });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('font_not_available');
+    expect(body.missing).toEqual(['Comic Papyrus']);
+    expect(state.written).toHaveLength(0);
+  });
+
+  it('un font solo non e’ una coppia: rifiuta invece di accoppiarlo con quello vecchio', async () => {
+    const res = await call(PUT, 'PUT', { display_font: 'Playfair Display' });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('font_pair_incomplete');
+    expect(state.written).toHaveLength(0);
+  });
+
+  it('scrivere il brief visivo lo blocca, o la ricostruzione notturna lo riscrive', async () => {
+    const res = await call(PUT, 'PUT', { visual_style: 'Fotografia naturale, luce morbida, niente testo.' });
+    expect(res.status).toBe(200);
+    expect(state.written[0].visual_style_locked).toBe(true);
+  });
+
+  it('una chiave di sola lettura non scrive', async () => {
+    vi.mocked(checkApiKeyWriteAccess).mockReturnValue(
+      new Response(JSON.stringify({ error: 'API key is read-only' }), { status: 403 }) as never
+    );
+    const res = await call(PUT, 'PUT', { visual_style: 'x'.repeat(30) });
+    expect(res.status).toBe(403);
+    expect(state.written).toHaveLength(0);
+    expect(state.fetched).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## What?

Two things an agent could not do before, and one refusal.

**It can change how the brand looks.** `get_appearance` / `set_appearance` (`GET`/`PUT`
`/studio/appearance`) expose the row of `brand_kit` nothing outside the browser could touch: the
**logo**, the **favicon**, the two **Google Fonts** the graphics are actually composed with
(`graphic_style`), and the **visual brief** every image render follows. A logo is given as a URL
and is **downloaded and re-hosted** through the SSRF guard the Studio form already uses.

**Its blog can carry the brand's own analytics.** `set_blog_settings` gains `analytics`: a
**closed** list of four providers (`ga4`, `meta_pixel`, `plausible`, `hotjar`) with a measurement
id. Stored in `blog_config`. **No migration.**

**There is deliberately no field for arbitrary JavaScript**, and the reasoning is in *Why?*.

Also fixes a divergence the census turned up: `set_colors` accepted `#aabbccdd`, which the route
answered with a 400.

`tools/list` goes **112 → 114**. Object-by-object: `new: [get_appearance, set_appearance]`,
`gone: []`, `changed: [set_blog_settings, set_colors]` — both intended.

## Why?

Andrea asked for it: *«fai in modo che l'ai possa anche modificare l'estetica del blog, aggiungere
scripts js nell'head del sito web, modificare logo, colori, templates, ecc.»*

The census answered in three categories. Two are additions. One is a refusal.

### The refusal, first — because it is the load-bearing finding

A brand's blog is served from **two** places:

```
   the brand's host                anomalia.so
   (blog.customer.com)             /blog/<slug>
          │                              │
     src/routes/_site           src/routes/blog/[site]
          │                              │
          └──────────► BlogShell ◄───────┘
                                         ▲
                       same origin as /app and the
                       Supabase session of anyone signed in
```

The second address is **our origin**. A `<script>` a brand supplies, rendered there, runs with
anomalia.so's permissions: it can read the session storage and call `/api/v1` with the cookies of
any logged-in user who happens to open that blog. And there is **no CSP anywhere in this
repository** — verified: zero matches for `Content-Security-Policy` in `svelte.config.js`,
`hooks.server.ts`, `vercel.json` or `app.html`. Nothing would stop it.

So the answer to "a free `<script>` field" is **no**, and the alternative is the closed list. The
closure reaches the JSON Schema the agent reads — `provider` is an `enum`, so `custom` is not even
expressible.

**The same reasoning applies to the providers on the list.** A GA4 or GTM container is arbitrary
JavaScript one indirection away: whoever administers it can fill it whenever they like. So the
trackers load **only on the `_site` tree** — the one served when the host is not ours — and only
after the cookie consent the blog already had.

That boundary is held by a test, not a convention. `siteAnalytics` sits **outside** `brandProfile`
(which feeds both trees), and `src/lib/server/blog-analytics-boundary.test.ts` asserts exactly one
file calls it. **Forgetting means loading nothing; the opposite is not reachable.**

### The two additions

`brand_kit.logos`, `favicon_url`, `graphic_style` and `visual_style` were writable only from the
Studio form or the in-app chat tools — no MCP tool, no CLI command. The blog's "templates" needed
nothing: layout (`navbar`/`sidebar`) and font preset are closed enums `set_blog_settings` already
covered since #291.

## How?

### The logo is downloaded, not linked

`logo_url` is a URL in, and **our** address out. Saving the caller's string would put an image
somebody else can change — or delete — into every graphic of the brand, after it was approved.
`storeBrandLogoFromUrl` already does the guarded fetch (`safeFetchBytes`: DNS-resolve-then-check,
private ranges, per-hop redirect gating, 4MB) and keeps the bytes. Reusing it meant no new upload
machinery and no second SSRF surface. The answer carries the stored address and the description
says to read it back.

The blog icon and an author's avatar stay out, exactly as #291 left them: those are file uploads
with no URL path.

### The id is checked in three places, and the alphabet is the reason

`blogAnalyticsIdOk` runs in the contract's zod, in the field rule next to the model
(`BLOG_CONFIG_FIELDS`), and in the renderer. A test proves none of the four alphabets admits `<`,
`>`, a quote, a space, a backslash or a semicolon — which is the only reason interpolating the id
into a vendor snippet is safe. The renderer builds elements with `createElement`, never
`innerHTML`.

The pattern table is duplicated between `packages/api-contracts` and `src/lib/blog-analytics.ts`
rather than imported: importing would drag zod into the public blog bundle for four regexes.
`src/lib/blog-analytics.test.ts` fails if the two tables diverge — the same technique
`cli/lib/contracts.test.ts` already uses for the contract copy.

### Refuse rather than guess

- `logo_url` + `remove_logo` together → `logo_conflict`. There is no right order; guessing would
  leave the caller believing the other thing happened.
- one font of the two → `font_pair_incomplete`, rather than pairing it with the stale one.
- a family Google Fonts will not serve → `font_not_available`, **naming it**. The existing form
  already refuses; rendering it as Inter with nothing said is the confusion the check exists to end.
- `visual_style` **locks** (`visual_style_locked`). Without the lock the nightly rebuild rewrites
  it and whoever wrote it finds it changed. The description says so.

### `set_colors`, and what the invariant actually is

The tool's schema was `^#?[0-9a-fA-F]{3,8}$`, the route's `^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$`.
The first draft of the test asserted "the same characters" and **failed** — the tool deliberately
accepts a missing `#` and adds it before sending. The real invariant is: *everything the tool
accepts, once normalised, the route saves.* That is what the test states now.

## Testing?

Red before green, with real output. `node_modules/@anomalia/api-contracts` resolves to **this
worktree's** `packages/api-contracts` (checked with `realpathSync`), so the contract tests and the
`tools/list` capture ran against this branch.

| command | result |
|---|---|
| `npx vitest run packages/api-contracts` | 204 tests, pass |
| `cd cli && bun test` | 58 tests, 0 fail |
| `cd cli && bun run typecheck` | clean |
| `node scripts/typecheck-runtime.mjs` | ok |
| affected app tests (blog settings, appearance route, analytics, boundary, no-app-imports, changelog) | 372 tests, pass |

**Not tested:** no browser, Docker, dev server or Playwright — forbidden for this task. The full
`npm run test:unit` was not run; CI runs it.

**Note on the environment:** `cd cli && bun run typecheck` fails on `dev` too, in a clean checkout,
with `TS2688: Cannot find type definition file for 'bun'` — `cli/node_modules` is simply not
installed. `bun install` in `cli/` fixes it; nothing in this PR caused or changed it.

**Risk:** `patchBlogConfig` reads `blog_config`, merges and writes the whole jsonb back —
pre-existing, so a concurrent write to a different key can still lose a race. `set_appearance`
upserts `brand_kit` on the user's own client, after `loadBrandForUser` has authorised.

## Evidence

<details>
<summary>tools/list through handleMcpFetch, origin/dev vs this branch</summary>

```
count:   112 → 114
new:     ['get_appearance', 'set_appearance']
gone:    []
changed: ['set_blog_settings', 'set_colors']   ← inputSchema + description, both intended

get_appearance: {'readOnlyHint': True,  'destructiveHint': False}
set_appearance: {'readOnlyHint': False, 'destructiveHint': False}
```

The closed list as the agent actually sees it — `custom` is not expressible:

```json
"analytics": {
  "type": "array", "maxItems": 4,
  "items": { "type": "object", "additionalProperties": false,
    "required": ["provider", "id"],
    "properties": {
      "provider": { "type": "string", "enum": ["ga4","meta_pixel","plausible","hotjar"] },
      "id": { "type": "string", "minLength": 1 } } }
}
```

</details>

<details>
<summary>Red, then green: every guard removed, 11 of 35 fail</summary>

Removed the empty-request check, the logo conflict guard, the font-pair guard, the Google Fonts
check, the `visual_style` lock, the stored-address substitution, the renderer's id check and the
field rule's filter:

```
× PUT /studio/appearance > una richiesta senza campi e' 400 dichiarato, non un salvataggio a vuoto
× PUT /studio/appearance > salva l'indirizzo che abbiamo scaricato, non quello che ci hanno dato
× PUT /studio/appearance > mettere e togliere il logo insieme e' un rifiuto, non un ordine indovinato
× PUT /studio/appearance > un font che Google Fonts non serve e' rifiutato prima di scrivere, e dice quale
× PUT /studio/appearance > un font solo non e' una coppia: rifiuta invece di accoppiarlo con quello vecchio
× PUT /studio/appearance > scrivere il brief visivo lo blocca, o la ricostruzione notturna lo riscrive
× cosa arriva davvero a diventare uno script > scarta un id che non ha la forma del suo fornitore
× cosa arriva davvero a diventare uno script > tiene un fornitore solo per tipo
× analytics del blog > scarta un id che non ha la forma del suo fornitore
× analytics del blog > scarta un fornitore che non conosciamo, invece di renderlo
× analytics del blog > tiene un fornitore solo per tipo: due id dello stesso contano una volta
   Tests  11 failed | 24 passed (35)
```

Restored: **35/35**.

</details>

<details>
<summary>The negative tests, which are the ones that matter here</summary>

```
set_blog_settings { analytics: [{provider:'custom', id:'<script>x</script>'}] }  → schema refuses
set_blog_settings { analytics: [{provider:'ga4',    id:'1234'}] }                → schema refuses
set_blog_settings { analytics: [{provider:'hotjar', id:'G-ABC123'}] }            → schema refuses
blogAnalyticsIdOk('ga4', "G-X';alert(1);//")                                     → false
blogAnalyticsIdOk('ga4', 'G-X</script><script>alert(1)</script>')                → false
blogAnalyticsIdOk('plausible', 'example.com"/><img onerror=x>')                  → false

no accepted id, for any of the four providers, contains any of:
  <   >   "   '   `   \   space   newline   ;   /

PUT /studio/appearance { }                                        → 400 no_fields, nothing written
PUT { logo_url:'http://169.254.169.254/latest/meta-data/' }       → 400 image_rejected, nothing written
PUT { logo_url:'…', remove_logo:true }                            → 400 logo_conflict, nothing fetched
PUT { display_font:'Comic Papyrus', body_font:'Inter' }           → 400 font_not_available, missing:['Comic Papyrus']
PUT { display_font:'Playfair Display' }                           → 400 font_pair_incomplete
PUT { visual_style:'…' } with a READ-ONLY key                     → 403, nothing written, nothing fetched
```

The boundary test, which is the security one:

```
✓ i tracker di un brand non toccano la nostra origine
  ✓ li chiede soltanto l'albero servito sul dominio del brand   → ['_site/+layout.server.ts']
  ✓ l'albero su /blog/<slug> non li nomina nemmeno              → []
  ✓ e il profilo condiviso dai due alberi non li porta con se'
```

</details>

<details>
<summary>set_colors: the defect reproduced, then fixed</summary>

```
error: il tool accetta #aabbccdd
Expected: false   Received: true
 6 pass, 1 fail
```

After matching the route's shape: **7 pass, 0 fail**.

</details>

No UI change: no page added, no component's appearance touched. `BlogShell` and `BlogCookieBanner`
gain one prop each, defaulting to `[]`.

## Anything Else?

**What was left out, and why it is not an omission:**

- **A free `<script>` field.** Reasoning above. If it is ever genuinely needed, the route is not a
  tool — it is moving `/blog/<slug>` to a separate origin and adding a CSP. Until that exists,
  exposing it over MCP would be handing out a door onto the account.
- **`brand_design_templates`.** The table has existed since migration 0108 and **no code reads or
  writes it**. A tool over a dead table makes nothing work.
- **`brand_kit.theme_color` and `brand_kit.fonts`.** Both written only by website analysis — they
  are measurements, not choices.
- **Blog icon and author avatar.** File uploads, unchanged from #291.

**"Template" means seven different things in this product** — `agent_templates`,
`brand_design_templates`, the Remotion design templates, the copy templates in
`post-templates.md`, the blog layout, the blog font preset, the email templates. Only the last two
are per-brand state, and both were already exposed. Worth knowing before anyone builds on the word.

**Still open, unchanged:** `blog_config.backlinkNetwork` (flagged in #291) and the repository-wide
absence of a CSP, which this PR works around rather than fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
