### PR TITLE
Declare seven reshaped-input tools in the registry

### DIFF
--- a/changelog/2026-09-04-input-reshapes-in-the-registry.md
+++ b/changelog/2026-09-04-input-reshapes-in-the-registry.md
@@ -1,7 +1,7 @@
-# Sei tool scritti a mano passano dal registry, senza cambiare forma
+# Sette tool scritti a mano passano dal registry, senza cambiare forma
 
-`save_brief`, `replan_week`, `plan_week`, `add_note`, `set_colors` e `ads_action` erano sei tool
-MCP scritti a mano. Il motivo per cui erano rimasti fuori non era la rotta: era che la forma del
+`save_brief`, `replan_week`, `plan_week`, `add_note`, `set_colors`, `ads_action` e `add_person`
+erano sette tool MCP scritti a mano. Il motivo per cui erano rimasti fuori non era la rotta: era che la forma del
 tool non era la forma del corpo che la rotta legge.
 
 - la settimana: il tool la chiama `week`, la rotta `week_index`
@@ -10,6 +10,12 @@ tool non era la forma del corpo che la rotta legge.
   il client
 - gli annunci: il tool raccoglie i campi propri dell'azione in `extra`, il client li spianava in
   cima al corpo prima di spedirlo
+
+`add_person` è il caso che non chiedeva niente: la rotta, se non le dici altro, la persona la
+mette reale. Il `kind: 'real'` che il client spediva era una costante ridondante, e togliendola
+il contratto ha esattamente la forma del tool. `generate_person`, che invece deve dire
+`kind: 'ai'`, resta a mano — quella è la costante nel corpo che si sistema spezzando la rotta,
+non aggirandola.
 
 Ogni volta la traduzione viveva in `cli/mcp/tools/`, cioè in un consumatore solo: il CLI la
 rifaceva a modo suo, e Web MCP non l'avrebbe vista affatto.
@@ -26,6 +32,10 @@ cambia dei tool che gli agenti già usano: è una decisione da prendere apposta,
 collaterale di una migrazione.
 
 Equivalenza provata, non dichiarata: `tools/list` catturato attraverso `handleMcpFetch` prima e
-dopo. 113 tool prima, 113 dopo, nessuno aggiunto o rimosso. I sei migrati hanno nome, titolo,
+dopo. 113 tool prima, 113 dopo, nessuno aggiunto o rimosso. I sette migrati hanno nome, titolo,
 descrizione, proprietà, obbligatori e annotazioni identici; l'unico delta è
 `additionalProperties: false`, che arriva perché gli input del registry sono `.strict()`.
+
+Il messaggio del consenso è l'unica cosa che il contratto ripete: `CONSENT_NOT_ATTESTED` vive
+dietro `$lib` e da un package non si importa. È rispecchiato, come `PLAN_CADENCES` prima di lui,
+e il test della rotta importa le due copie e fallisce se divergono.

--- a/changelog/2026-09-04-input-reshapes-in-the-registry.md
+++ b/changelog/2026-09-04-input-reshapes-in-the-registry.md
@@ -1,0 +1,31 @@
+# Sei tool scritti a mano passano dal registry, senza cambiare forma
+
+`save_brief`, `replan_week`, `plan_week`, `add_note`, `set_colors` e `ads_action` erano sei tool
+MCP scritti a mano. Il motivo per cui erano rimasti fuori non era la rotta: era che la forma del
+tool non era la forma del corpo che la rotta legge.
+
+- la settimana: il tool la chiama `week`, la rotta `week_index`
+- la nota: il tool la chiama `text`, la rotta `content_text`
+- i colori: il tool accetta `7c5cff`, la rotta pretendeva `#7c5cff` — il cancelletto lo metteva
+  il client
+- gli annunci: il tool raccoglie i campi propri dell'azione in `extra`, il client li spianava in
+  cima al corpo prima di spedirlo
+
+Ogni volta la traduzione viveva in `cli/mcp/tools/`, cioè in un consumatore solo: il CLI la
+rifaceva a modo suo, e Web MCP non l'avrebbe vista affatto.
+
+**Ha ceduto la rotta, non il tool.** `week_index` resta il nome documentato e continua a
+funzionare; accanto, la rotta accetta `week`. Lo stesso per `content_text`/`text`. I colori li
+normalizza la rotta invece del client — `7c5cff` e `#7c5cff` sono lo stesso colore, e ora lo sono
+per chiunque chiami l'API, non solo per chi passa dall'MCP. `/ads` appiattisce `extra` una volta
+sola in cima all'handler, dove prima ogni chiamante decideva da sé.
+
+L'alternativa era rinominare i campi del tool (`week` → `week_index`, `text` → `content_text`),
+che allineerebbe i nomi ovunque ed è più pulita a lungo termine. È stata scartata qui perché
+cambia dei tool che gli agenti già usano: è una decisione da prendere apposta, non l'effetto
+collaterale di una migrazione.
+
+Equivalenza provata, non dichiarata: `tools/list` catturato attraverso `handleMcpFetch` prima e
+dopo. 113 tool prima, 113 dopo, nessuno aggiunto o rimosso. I sei migrati hanno nome, titolo,
+descrizione, proprietà, obbligatori e annotazioni identici; l'unico delta è
+`additionalProperties: false`, che arriva perché gli input del registry sono `.strict()`.

--- a/cli/lib/contracts/ads.ts
+++ b/cli/lib/contracts/ads.ts
@@ -34,3 +34,44 @@ export const ADS_REMIX = {
   ],
   destructive: false
 } satisfies BrandEndpoint;
+
+export const ADS_ACTION = {
+  tool: 'ads_action',
+  title: 'Ads action',
+  description:
+    'Run an ads action. Common actions: sync, propose, create, reject, pause, resume, toggle, ' +
+    'duplicate, delete. Pass campaignId; for a single creative add adId (and next active|paused ' +
+    'for toggle). duplicate creates a paused copy as a new proposal; approve it to launch. Pass ' +
+    'extra fields as needed.',
+  method: 'POST',
+  pathUnderBrand: '/ads',
+  input: z
+    .object({
+      action: z.string().min(1),
+      campaignId: z.string().optional(),
+      extra: z
+        .record(z.string(), z.unknown())
+        .optional()
+        .describe('Additional action payload fields')
+    })
+    .strict(),
+  output: z.looseObject({
+    ok: z.boolean().optional(),
+    error: z.string().optional(),
+    created: z.number().optional(),
+    candidates: z.number().optional(),
+    zernioAdId: z.string().optional(),
+    accounts: z.number().optional(),
+    metrics: z.number().optional(),
+    id: z.string().optional(),
+    next: z.enum(['active', 'paused']).optional(),
+    copiedCampaignId: z.string().optional()
+  }),
+  failures: [
+    { error: 'missing_campaignId', status: 400 },
+    { error: 'unknown_action', status: 400 },
+    { error: 'ads_not_on_plan', status: 403 },
+    { error: 'Not found', status: 404 }
+  ],
+  destructive: true
+} satisfies BrandEndpoint;

--- a/cli/lib/contracts/index.ts
+++ b/cli/lib/contracts/index.ts
@@ -1,5 +1,5 @@
 import type { z } from 'zod';
-import { ADS_REMIX } from './ads';
+import { ADS_ACTION, ADS_REMIX } from './ads';
 import { GET_APPEARANCE, SET_APPEARANCE } from './appearance';
 import { GET_AUTOMATIONS, SET_AUTOMATION } from './automations';
 import { BILLING_PORTAL_LINK, CHECKOUT_LINK } from './billing';
@@ -17,8 +17,11 @@ import {
   DISCARD_PLAN,
   PLAN_CADENCES,
   PLAN_CYCLE_WEEKS,
+  PLAN_WEEK,
   PROPOSE_PLAN,
+  REPLAN_WEEK,
   REVISE_PLAN,
+  SAVE_BRIEF,
   SAVE_PLAN,
   SAVE_WEEK_SEEDS,
 } from './plans';
@@ -75,6 +78,7 @@ import {
 } from './shares';
 import {
   ADD_COMPETITOR,
+  ADD_NOTE,
   CREATE_PRODUCT,
   DELETE_COMPETITOR,
   DELETE_DOCUMENT,
@@ -83,6 +87,7 @@ import {
   GET_BIO,
   RESEARCH_COMPETITORS,
   SET_BIO,
+  SET_COLORS,
   SYNC_HISTORY,
   UPDATE_BRAND_KIT,
   UPDATE_COMPETITOR,
@@ -133,7 +138,9 @@ export type BrandEndpoint = ResourcelessEndpoint | ResourceEndpoint;
 export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   ADD_BLOG_TERM,
   ADD_COMPETITOR,
+  ADD_NOTE,
   ADD_RADAR_SOURCE,
+  ADS_ACTION,
   ADS_REMIX,
   APPROVE_PLAN,
   BILLING_PORTAL_LINK,
@@ -190,15 +197,18 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   LIST_SOCIAL_ACCOUNTS,
   LIST_WEB_AUDITS,
   LIST_WEB_FIXES,
+  PLAN_WEEK,
   PROPOSE_PLAN,
   REFRESH_KEYWORDS,
   REMOVE_BLOG_TERM,
   REMOVE_RADAR_SOURCE,
   RENDER_POST,
+  REPLAN_WEEK,
   RESCHEDULE_POST,
   RESEARCH_COMPETITORS,
   REVISE_PLAN,
   REVOKE_SHARE,
+  SAVE_BRIEF,
   SAVE_PLAN,
   SAVE_WEEK_SEEDS,
   SEARCH_KNOWLEDGE,
@@ -208,6 +218,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   SET_BIO,
   SET_BLOG_SETTINGS,
   SET_BRAND_SETTINGS,
+  SET_COLORS,
   SET_MEDIA_MODEL,
   SET_RADAR_PLATFORM,
   SOCIAL_CONNECT_LINK,
@@ -241,6 +252,7 @@ export function statusForFailure(endpoint: BrandEndpoint, error: string): number
 }
 
 export {
+  ADS_ACTION,
   ADS_REMIX,
   CHECK_CONTENT,
   CREATE_POST,
@@ -340,6 +352,7 @@ export {
 export type { WritingDeckAgent } from './writing-skills';
 export {
   ADD_COMPETITOR,
+  ADD_NOTE,
   CREATE_PRODUCT,
   DELETE_COMPETITOR,
   DELETE_DOCUMENT,
@@ -348,6 +361,7 @@ export {
   GET_BIO,
   RESEARCH_COMPETITORS,
   SET_BIO,
+  SET_COLORS,
   SYNC_HISTORY,
   UPDATE_BRAND_KIT,
   UPDATE_COMPETITOR,
@@ -401,8 +415,11 @@ export {
   DISCARD_PLAN,
   PLAN_CADENCES,
   PLAN_CYCLE_WEEKS,
+  PLAN_WEEK,
   PROPOSE_PLAN,
+  REPLAN_WEEK,
   REVISE_PLAN,
+  SAVE_BRIEF,
   SAVE_PLAN,
   SAVE_WEEK_SEEDS
 };

--- a/cli/lib/contracts/index.ts
+++ b/cli/lib/contracts/index.ts
@@ -79,6 +79,7 @@ import {
 import {
   ADD_COMPETITOR,
   ADD_NOTE,
+  ADD_PERSON,
   CREATE_PRODUCT,
   DELETE_COMPETITOR,
   DELETE_DOCUMENT,
@@ -139,6 +140,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   ADD_BLOG_TERM,
   ADD_COMPETITOR,
   ADD_NOTE,
+  ADD_PERSON,
   ADD_RADAR_SOURCE,
   ADS_ACTION,
   ADS_REMIX,
@@ -353,6 +355,8 @@ export type { WritingDeckAgent } from './writing-skills';
 export {
   ADD_COMPETITOR,
   ADD_NOTE,
+  ADD_PERSON,
+  CONSENT_NOT_ATTESTED,
   CREATE_PRODUCT,
   DELETE_COMPETITOR,
   DELETE_DOCUMENT,

--- a/cli/lib/contracts/plans.ts
+++ b/cli/lib/contracts/plans.ts
@@ -221,3 +221,57 @@ export const DISCARD_PLAN = {
   failures: [],
   destructive: true
 } satisfies BrandEndpoint;
+
+// La settimana si chiama `week` da quando esiste il tool. La rotta la scrive `week_index` nella
+// sua documentazione pubblica e continua ad accettarlo: qui vive il nome che l'agente usa.
+const week = z.number().int().min(0);
+
+const NO_ACTIVE_PLAN = { error: 'No active editorial plan', status: 404 };
+const WEEK_REQUIRED = { error: 'week_index is required', status: 400 };
+
+export const SAVE_BRIEF = {
+  tool: 'save_brief',
+  title: 'Save week brief',
+  description: 'Save the brief for an editorial week (0-based index). Optional featured products.',
+  method: 'POST',
+  pathUnderBrand: '/editorial-plan/save-brief',
+  input: z
+    .object({
+      week,
+      brief: z.string(),
+      products: z.array(z.string()).optional().describe('Exact product names to feature')
+    })
+    .strict(),
+  output: Ok,
+  failures: [WEEK_REQUIRED, NO_ACTIVE_PLAN, { error: 'Invalid week_index', status: 400 }],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const REPLAN_WEEK = {
+  tool: 'replan_week',
+  title: 'Replan week',
+  description: 'Regenerate an editorial week from a brief.',
+  method: 'POST',
+  pathUnderBrand: '/editorial-plan/replan-week',
+  input: z.object({ week, brief: z.string().min(1) }).strict(),
+  output: z.object({ ok: z.literal(true), week: z.number() }),
+  failures: [
+    WEEK_REQUIRED,
+    { error: 'brief is required', status: 400 },
+    { error: 'no active editorial plan', status: 404 },
+    { error: 'invalid week_index', status: 400 }
+  ],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const PLAN_WEEK = {
+  tool: 'plan_week',
+  title: 'Generate weekly seeds',
+  description: 'Generate content seeds for a week (0-based index).',
+  method: 'POST',
+  pathUnderBrand: '/weekly-plan/plan',
+  input: z.object({ week }).strict(),
+  output: z.object({ ok: z.literal(true), draft: z.unknown() }),
+  failures: [WEEK_REQUIRED, NO_ACTIVE_PLAN],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/cli/lib/contracts/studio.ts
+++ b/cli/lib/contracts/studio.ts
@@ -344,3 +344,41 @@ export const SYNC_HISTORY = {
   destructive: false,
   openWorld: true
 } satisfies BrandEndpoint;
+
+export const ADD_NOTE = {
+  tool: 'add_note',
+  title: 'Add knowledge note',
+  description: 'Add a knowledge document / note to the studio.',
+  method: 'POST',
+  pathUnderBrand: '/studio/documents',
+  input: z.object({ text: z.string().min(1), title: z.string().optional() }).strict(),
+  output: z.object({
+    ok: z.literal(true),
+    document: z.looseObject({ id: z.string(), kind: z.string(), title: z.string() })
+  }),
+  failures: [{ error: 'content_text is required', status: 400 }],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const SET_COLORS = {
+  tool: 'set_colors',
+  title: 'Set brand colors',
+  description:
+    'Set brand colors as hex values, e.g. ["#7c5cff","#ffffff"]. Three or six digits, up to 8 ' +
+    'colours; the list replaces the whole palette.',
+  method: 'PUT',
+  pathUnderBrand: '/studio/colors',
+  // Stessa forma che la rotta salva: un `#aabbccdd` che passa di qui e prende un 400 di là
+  // lascia l'agente convinto di aver salvato un colore. studio-writes.test.ts le confronta.
+  input: z
+    .object({
+      colors: z
+        .array(z.string().regex(/^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/))
+        .min(1)
+        .max(8)
+    })
+    .strict(),
+  output: z.object({ ok: z.literal(true), colors: z.array(z.string()) }),
+  failures: [{ error: 'colors must be an array of max 8 hex strings', status: 400 }],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/cli/lib/contracts/studio.ts
+++ b/cli/lib/contracts/studio.ts
@@ -382,3 +382,45 @@ export const SET_COLORS = {
   failures: [{ error: 'colors must be an array of max 8 hex strings', status: 400 }],
   destructive: false
 } satisfies BrandEndpoint;
+
+// Rispecchia CONSENT_NOT_ATTESTED, che vive dietro $lib e da un package non si importa. Il test
+// della rotta importa entrambe e fallisce se divergono.
+export const CONSENT_NOT_ATTESTED =
+  'Confirm you have this person\u2019s consent before adding them.';
+
+export const ADD_PERSON = {
+  tool: 'add_person',
+  title: 'Add person',
+  description:
+    'Add a real person to the brand studio. Their face stays withheld from every generator ' +
+    'until consent is attested, so `consent` must be true and only the user can state it.',
+  method: 'POST',
+  pathUnderBrand: '/studio/people',
+  input: z
+    .object({
+      name: z.string().min(1),
+      role: z.string().optional(),
+      description: z.string().optional(),
+      consent: z
+        .boolean()
+        .describe(
+          'true ONLY when the USER has stated, in their own words, that they have this ' +
+            "person's consent to use their likeness. Never infer it."
+        )
+    })
+    .strict(),
+  output: z.object({
+    ok: z.literal(true),
+    person: z.looseObject({
+      id: z.string(),
+      name: z.string(),
+      role: z.string().nullable(),
+      kind: z.string()
+    })
+  }),
+  failures: [
+    { error: 'name is required', status: 400 },
+    { error: CONSENT_NOT_ATTESTED, status: 400 }
+  ],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/cli/mcp/tools/plan.ts
+++ b/cli/mcp/tools/plan.ts
@@ -6,53 +6,7 @@ import { withAuth } from '../util.ts';
 const slug = z.string().min(1).describe('Brand URL slug');
 
 export function registerPlanTools(server: McpServer) {
-          server.registerTool(
-    'save_brief',
-    {
-      title: 'Save week brief',
-      description: 'Save the brief for an editorial week (0-based index). Optional featured products.',
-      inputSchema: z.object({
-        slug,
-        week: z.number().int().min(0),
-        brief: z.string(),
-        products: z.array(z.string()).optional().describe('Exact product names to feature'),
-      }),
-      annotations: { readOnlyHint: false, destructiveHint: false },
-    },
-    async ({ slug, week, brief, products }) =>
-      withAuth((token) => api.saveBrief(token, slug, week, brief, products)),
-  );
-
-  server.registerTool(
-    'replan_week',
-    {
-      title: 'Replan week',
-      description: 'Regenerate an editorial week from a brief.',
-      inputSchema: z.object({
-        slug,
-        week: z.number().int().min(0),
-        brief: z.string().min(1),
-      }),
-      annotations: { readOnlyHint: false, destructiveHint: false },
-    },
-    async ({ slug, week, brief }) => withAuth((token) => api.replanWeek(token, slug, week, brief)),
-  );
-
-  server.registerTool(
-    'plan_week',
-    {
-      title: 'Generate weekly seeds',
-      description: 'Generate content seeds for a week (0-based index).',
-      inputSchema: z.object({
-        slug,
-        week: z.number().int().min(0),
-      }),
-      annotations: { readOnlyHint: false, destructiveHint: false },
-    },
-    async ({ slug, week }) => withAuth((token) => api.planWeek(token, slug, week)),
-  );
-
-  server.registerTool(
+    server.registerTool(
     'produce_week',
     {
       title: 'Produce weekly seeds',

--- a/cli/mcp/tools/studio.ts
+++ b/cli/mcp/tools/studio.ts
@@ -7,31 +7,6 @@ const slug = z.string().min(1).describe('Brand URL slug');
 
 export function registerStudioTools(server: McpServer) {
     server.registerTool(
-    'add_person',
-    {
-      title: 'Add person',
-      description:
-        "Add a real person to the brand studio. Their face stays withheld from every generator until consent is attested, so `consent` must be true and only the user can state it.",
-      inputSchema: z.object({
-        slug,
-        name: z.string().min(1),
-        role: z.string().optional(),
-        description: z.string().optional(),
-        consent: z
-          .boolean()
-          .describe(
-            "true ONLY when the USER has stated, in their own words, that they have this person's consent to use their likeness. Never infer it.",
-          ),
-      }),
-      annotations: { readOnlyHint: false, destructiveHint: false },
-    },
-    async ({ slug, name, role, description, consent }) =>
-      withAuth((token) =>
-        api.addPerson(token, slug, { name, role, description, kind: 'real', consent }),
-      ),
-  );
-
-  server.registerTool(
     'generate_person',
     {
       title: 'Generate AI person',

--- a/cli/mcp/tools/studio.ts
+++ b/cli/mcp/tools/studio.ts
@@ -7,46 +7,6 @@ const slug = z.string().min(1).describe('Brand URL slug');
 
 export function registerStudioTools(server: McpServer) {
     server.registerTool(
-    'set_colors',
-    {
-      title: 'Set brand colors',
-      description:
-        'Set brand colors as hex values, e.g. ["#7c5cff","#ffffff"]. Three or six digits, up to 8 colours; the list replaces the whole palette.',
-      inputSchema: z.object({
-        slug,
-        // Stessa forma che la rotta salva: un `#aabbccdd` che passa di qui e prende un 400 di la'
-        // lascia l'agente convinto di aver salvato un colore. studio-writes.test.ts le confronta.
-        colors: z.array(z.string().regex(/^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/)).min(1).max(8),
-      }),
-      annotations: { readOnlyHint: false, destructiveHint: false },
-    },
-    async ({ slug, colors }) =>
-      withAuth((token) =>
-        api.updateColors(
-          token,
-          slug,
-          colors.map((c) => (c.startsWith('#') ? c : `#${c}`)),
-        ),
-      ),
-  );
-
-  server.registerTool(
-    'add_note',
-    {
-      title: 'Add knowledge note',
-      description: 'Add a knowledge document / note to the studio.',
-      inputSchema: z.object({
-        slug,
-        text: z.string().min(1),
-        title: z.string().optional(),
-      }),
-      annotations: { readOnlyHint: false, destructiveHint: false },
-    },
-    async ({ slug, text, title }) =>
-      withAuth((token) => api.addDocument(token, slug, { title, content_text: text, kind: 'note' })),
-  );
-
-  server.registerTool(
     'add_person',
     {
       title: 'Add person',

--- a/cli/mcp/tools/web.ts
+++ b/cli/mcp/tools/web.ts
@@ -105,24 +105,4 @@ export function registerWebTools(server: McpServer) {
       }),
   );
 
-  server.registerTool(
-    'ads_action',
-    {
-      title: 'Ads action',
-      description:
-        'Run an ads action. Common actions: sync, propose, create, reject, pause, resume, toggle, duplicate, delete. Pass campaignId; for a single creative add adId (and next active|paused for toggle). duplicate creates a paused copy as a new proposal; approve it to launch. Pass extra fields as needed.',
-      inputSchema: z.object({
-        slug,
-        action: z.string().min(1),
-        campaignId: z.string().optional(),
-        extra: z.record(z.string(), z.unknown()).optional().describe('Additional action payload fields'),
-      }),
-      annotations: { readOnlyHint: false, destructiveHint: true },
-    },
-    async ({ slug, action, campaignId, extra }) =>
-      withAuth((token) =>
-        api.adsAction(token, slug, { action, campaignId, ...(extra ?? {}) }),
-      ),
-  );
-
 }

--- a/docs/api/04-studio.md
+++ b/docs/api/04-studio.md
@@ -103,7 +103,7 @@ Imposta i colori del brand (max 8 hex), salvati in `brand_kit.brand_colors`.
 
 | Campo | Tipo | Obbligatorio | Descrizione |
 |---|---|---|---|
-| `colors` | string[] | sì | Array di 1–8 colori hex (`#rgb` o `#rrggbb`) |
+| `colors` | string[] | sì | Array di 1–8 colori hex (`#rgb` o `#rrggbb`); il `#` iniziale può mancare |
 
 **Response** `200`:
 
@@ -446,7 +446,7 @@ Aggiunge un documento/conoscenza (`brand_documents`) e ricostruisce il contesto 
 | Campo | Tipo | Obbligatorio | Descrizione |
 |---|---|---|---|
 | `title` | string | no | Titolo (default `"Note"`) |
-| `content_text` | string | condizionale | Obbligatorio a meno che `kind` sia `document` |
+| `content_text` | string | condizionale | Obbligatorio a meno che `kind` sia `document`. Accettato anche come `text` |
 | `kind` | string | no | Default `note`; `document` permette testo vuoto |
 
 **Response** `200`:

--- a/docs/api/05-editorial-plan.md
+++ b/docs/api/05-editorial-plan.md
@@ -320,7 +320,7 @@ Salva sul piano attivo il brief utente (e opzionalmente i prodotti in evidenza) 
 
 | Campo | Tipo | Obbligatorio | Descrizione |
 |---|---|---|---|
-| `week_index` | number | Sì | Indice della settimana (0–3) |
+| `week_index` | number | Sì | Indice della settimana (0–3). Accettato anche come `week` |
 | `brief` | string | No | Brief per la settimana; `null` lo azzera |
 | `products` | string[] | No | Titoli esatti dei prodotti in evidenza |
 
@@ -358,7 +358,7 @@ Rigenera via AI una singola settimana del piano attivo attorno a un nuovo brief,
 
 | Campo | Tipo | Obbligatorio | Descrizione |
 |---|---|---|---|
-| `week_index` | number | Sì | Indice della settimana (0–3) |
+| `week_index` | number | Sì | Indice della settimana (0–3). Accettato anche come `week` |
 | `brief` | string | Sì | Nuovo brief autorevole |
 
 **Response** `200`:

--- a/docs/api/06-weekly-plan.md
+++ b/docs/api/06-weekly-plan.md
@@ -83,7 +83,7 @@ Genera la strategia settimanale (tema + seed per post) per la settimana `week_in
 
 | Campo | Tipo | Obbligatorio | Descrizione |
 |---|---|---|---|
-| `week_index` | number (0-based) | Sì | Indice della settimana del piano editoriale attivo |
+| `week_index` | number (0-based) | Sì | Indice della settimana del piano editoriale attivo. Accettato anche come `week` |
 
 **Response** `200`:
 

--- a/docs/api/08-ads-voice-gtm-misc.md
+++ b/docs/api/08-ads-voice-gtm-misc.md
@@ -109,6 +109,7 @@ Esegue un'azione sulle campagne ads, selezionata dal campo `action` del body.
 |---|---|---|---|
 | `action` | string | Sì | `propose` \| `approve` \| `reject` \| `duplicate` \| `delete` \| `pause` \| `resume` \| `toggle` \| `sync` \| `create` |
 | `campaignId` | string | per `approve`/`reject`/`duplicate`/`delete`/`pause`/`resume`/`toggle` | ID campagna (`ad_campaigns.id`) |
+| `extra` | object | No | Gli altri campi dell'azione, se preferisci raggrupparli invece di metterli in cima al corpo |
 | `budgetAmount` | number | No | `approve`: budget giornaliero proposto; `create`: budget |
 | `goal` | string | No | `approve`: `engagement` \| `traffic` \| `awareness` \| `video_views`; `create`: default `traffic` |
 | `adId` | string | No | Solo `toggle`: se presente agisce sulla singola creativa |

--- a/packages/api-contracts/src/ads.test.ts
+++ b/packages/api-contracts/src/ads.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { pathFor } from './index';
+import { ADS_ACTION } from './ads';
+
+describe('il contratto delle azioni sugli annunci', () => {
+  it('porta i campi propri dell’azione dentro extra, senza inventarne di nuovi', () => {
+    expect(ADS_ACTION.input.safeParse({ action: 'sync' }).success).toBe(true);
+    expect(
+      ADS_ACTION.input.safeParse({ action: 'toggle', campaignId: 'c1', extra: { next: 'paused' } })
+        .success
+    ).toBe(true);
+    expect(ADS_ACTION.input.safeParse({ action: 'toggle', next: 'paused' }).success).toBe(false);
+    expect(ADS_ACTION.input.safeParse({ action: '' }).success).toBe(false);
+  });
+
+  it('si dichiara distruttivo: spegne e cancella campagne vere', () => {
+    expect(ADS_ACTION.destructive).toBe(true);
+    expect(pathFor(ADS_ACTION, 'demo')).toBe('/api/v1/brands/demo/ads');
+  });
+});

--- a/packages/api-contracts/src/ads.ts
+++ b/packages/api-contracts/src/ads.ts
@@ -34,3 +34,44 @@ export const ADS_REMIX = {
   ],
   destructive: false
 } satisfies BrandEndpoint;
+
+export const ADS_ACTION = {
+  tool: 'ads_action',
+  title: 'Ads action',
+  description:
+    'Run an ads action. Common actions: sync, propose, create, reject, pause, resume, toggle, ' +
+    'duplicate, delete. Pass campaignId; for a single creative add adId (and next active|paused ' +
+    'for toggle). duplicate creates a paused copy as a new proposal; approve it to launch. Pass ' +
+    'extra fields as needed.',
+  method: 'POST',
+  pathUnderBrand: '/ads',
+  input: z
+    .object({
+      action: z.string().min(1),
+      campaignId: z.string().optional(),
+      extra: z
+        .record(z.string(), z.unknown())
+        .optional()
+        .describe('Additional action payload fields')
+    })
+    .strict(),
+  output: z.looseObject({
+    ok: z.boolean().optional(),
+    error: z.string().optional(),
+    created: z.number().optional(),
+    candidates: z.number().optional(),
+    zernioAdId: z.string().optional(),
+    accounts: z.number().optional(),
+    metrics: z.number().optional(),
+    id: z.string().optional(),
+    next: z.enum(['active', 'paused']).optional(),
+    copiedCampaignId: z.string().optional()
+  }),
+  failures: [
+    { error: 'missing_campaignId', status: 400 },
+    { error: 'unknown_action', status: 400 },
+    { error: 'ads_not_on_plan', status: 403 },
+    { error: 'Not found', status: 404 }
+  ],
+  destructive: true
+} satisfies BrandEndpoint;

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -1,5 +1,5 @@
 import type { z } from 'zod';
-import { ADS_REMIX } from './ads';
+import { ADS_ACTION, ADS_REMIX } from './ads';
 import { GET_APPEARANCE, SET_APPEARANCE } from './appearance';
 import { GET_AUTOMATIONS, SET_AUTOMATION } from './automations';
 import { BILLING_PORTAL_LINK, CHECKOUT_LINK } from './billing';
@@ -17,8 +17,11 @@ import {
   DISCARD_PLAN,
   PLAN_CADENCES,
   PLAN_CYCLE_WEEKS,
+  PLAN_WEEK,
   PROPOSE_PLAN,
+  REPLAN_WEEK,
   REVISE_PLAN,
+  SAVE_BRIEF,
   SAVE_PLAN,
   SAVE_WEEK_SEEDS,
 } from './plans';
@@ -75,6 +78,7 @@ import {
 } from './shares';
 import {
   ADD_COMPETITOR,
+  ADD_NOTE,
   CREATE_PRODUCT,
   DELETE_COMPETITOR,
   DELETE_DOCUMENT,
@@ -83,6 +87,7 @@ import {
   GET_BIO,
   RESEARCH_COMPETITORS,
   SET_BIO,
+  SET_COLORS,
   SYNC_HISTORY,
   UPDATE_BRAND_KIT,
   UPDATE_COMPETITOR,
@@ -133,7 +138,9 @@ export type BrandEndpoint = ResourcelessEndpoint | ResourceEndpoint;
 export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   ADD_BLOG_TERM,
   ADD_COMPETITOR,
+  ADD_NOTE,
   ADD_RADAR_SOURCE,
+  ADS_ACTION,
   ADS_REMIX,
   APPROVE_PLAN,
   BILLING_PORTAL_LINK,
@@ -190,15 +197,18 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   LIST_SOCIAL_ACCOUNTS,
   LIST_WEB_AUDITS,
   LIST_WEB_FIXES,
+  PLAN_WEEK,
   PROPOSE_PLAN,
   REFRESH_KEYWORDS,
   REMOVE_BLOG_TERM,
   REMOVE_RADAR_SOURCE,
   RENDER_POST,
+  REPLAN_WEEK,
   RESCHEDULE_POST,
   RESEARCH_COMPETITORS,
   REVISE_PLAN,
   REVOKE_SHARE,
+  SAVE_BRIEF,
   SAVE_PLAN,
   SAVE_WEEK_SEEDS,
   SEARCH_KNOWLEDGE,
@@ -208,6 +218,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   SET_BIO,
   SET_BLOG_SETTINGS,
   SET_BRAND_SETTINGS,
+  SET_COLORS,
   SET_MEDIA_MODEL,
   SET_RADAR_PLATFORM,
   SOCIAL_CONNECT_LINK,
@@ -241,6 +252,7 @@ export function statusForFailure(endpoint: BrandEndpoint, error: string): number
 }
 
 export {
+  ADS_ACTION,
   ADS_REMIX,
   CHECK_CONTENT,
   CREATE_POST,
@@ -340,6 +352,7 @@ export {
 export type { WritingDeckAgent } from './writing-skills';
 export {
   ADD_COMPETITOR,
+  ADD_NOTE,
   CREATE_PRODUCT,
   DELETE_COMPETITOR,
   DELETE_DOCUMENT,
@@ -348,6 +361,7 @@ export {
   GET_BIO,
   RESEARCH_COMPETITORS,
   SET_BIO,
+  SET_COLORS,
   SYNC_HISTORY,
   UPDATE_BRAND_KIT,
   UPDATE_COMPETITOR,
@@ -401,8 +415,11 @@ export {
   DISCARD_PLAN,
   PLAN_CADENCES,
   PLAN_CYCLE_WEEKS,
+  PLAN_WEEK,
   PROPOSE_PLAN,
+  REPLAN_WEEK,
   REVISE_PLAN,
+  SAVE_BRIEF,
   SAVE_PLAN,
   SAVE_WEEK_SEEDS
 };

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -79,6 +79,7 @@ import {
 import {
   ADD_COMPETITOR,
   ADD_NOTE,
+  ADD_PERSON,
   CREATE_PRODUCT,
   DELETE_COMPETITOR,
   DELETE_DOCUMENT,
@@ -139,6 +140,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   ADD_BLOG_TERM,
   ADD_COMPETITOR,
   ADD_NOTE,
+  ADD_PERSON,
   ADD_RADAR_SOURCE,
   ADS_ACTION,
   ADS_REMIX,
@@ -353,6 +355,8 @@ export type { WritingDeckAgent } from './writing-skills';
 export {
   ADD_COMPETITOR,
   ADD_NOTE,
+  ADD_PERSON,
+  CONSENT_NOT_ATTESTED,
   CREATE_PRODUCT,
   DELETE_COMPETITOR,
   DELETE_DOCUMENT,

--- a/packages/api-contracts/src/plans.test.ts
+++ b/packages/api-contracts/src/plans.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { PLAN_CYCLE_WEEKS, SAVE_PLAN, SAVE_WEEK_SEEDS } from './plans';
+import { pathFor } from './index';
+import { PLAN_CYCLE_WEEKS, PLAN_WEEK, REPLAN_WEEK, SAVE_BRIEF, SAVE_PLAN, SAVE_WEEK_SEEDS } from './plans';
 
 const validPlan = () => ({
   strategy: 'Portare fuori il lavoro vero di chi monta le tastiere.',
@@ -107,5 +108,25 @@ describe('il contratto dei seed scritti fuori da Anomalia', () => {
     });
 
     expect(parsed.success).toBe(true);
+  });
+});
+
+describe('le tre azioni sulla settimana', () => {
+  it('chiamano la settimana col nome che il tool ha sempre esposto', () => {
+    for (const endpoint of [SAVE_BRIEF, REPLAN_WEEK, PLAN_WEEK]) {
+      expect(Object.keys(endpoint.input.shape), endpoint.tool).toContain('week');
+      expect(endpoint.input.safeParse({ week: -1, brief: 'x' }).success, endpoint.tool).toBe(false);
+    }
+  });
+
+  it('indirizzano le rotte che esistono già', () => {
+    expect(pathFor(SAVE_BRIEF, 'demo')).toBe('/api/v1/brands/demo/editorial-plan/save-brief');
+    expect(pathFor(REPLAN_WEEK, 'demo')).toBe('/api/v1/brands/demo/editorial-plan/replan-week');
+    expect(pathFor(PLAN_WEEK, 'demo')).toBe('/api/v1/brands/demo/weekly-plan/plan');
+  });
+
+  it('un brief vuoto vale per salvarlo, non per rigenerare la settimana', () => {
+    expect(SAVE_BRIEF.input.safeParse({ week: 0, brief: '' }).success).toBe(true);
+    expect(REPLAN_WEEK.input.safeParse({ week: 0, brief: '' }).success).toBe(false);
   });
 });

--- a/packages/api-contracts/src/plans.ts
+++ b/packages/api-contracts/src/plans.ts
@@ -221,3 +221,57 @@ export const DISCARD_PLAN = {
   failures: [],
   destructive: true
 } satisfies BrandEndpoint;
+
+// La settimana si chiama `week` da quando esiste il tool. La rotta la scrive `week_index` nella
+// sua documentazione pubblica e continua ad accettarlo: qui vive il nome che l'agente usa.
+const week = z.number().int().min(0);
+
+const NO_ACTIVE_PLAN = { error: 'No active editorial plan', status: 404 };
+const WEEK_REQUIRED = { error: 'week_index is required', status: 400 };
+
+export const SAVE_BRIEF = {
+  tool: 'save_brief',
+  title: 'Save week brief',
+  description: 'Save the brief for an editorial week (0-based index). Optional featured products.',
+  method: 'POST',
+  pathUnderBrand: '/editorial-plan/save-brief',
+  input: z
+    .object({
+      week,
+      brief: z.string(),
+      products: z.array(z.string()).optional().describe('Exact product names to feature')
+    })
+    .strict(),
+  output: Ok,
+  failures: [WEEK_REQUIRED, NO_ACTIVE_PLAN, { error: 'Invalid week_index', status: 400 }],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const REPLAN_WEEK = {
+  tool: 'replan_week',
+  title: 'Replan week',
+  description: 'Regenerate an editorial week from a brief.',
+  method: 'POST',
+  pathUnderBrand: '/editorial-plan/replan-week',
+  input: z.object({ week, brief: z.string().min(1) }).strict(),
+  output: z.object({ ok: z.literal(true), week: z.number() }),
+  failures: [
+    WEEK_REQUIRED,
+    { error: 'brief is required', status: 400 },
+    { error: 'no active editorial plan', status: 404 },
+    { error: 'invalid week_index', status: 400 }
+  ],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const PLAN_WEEK = {
+  tool: 'plan_week',
+  title: 'Generate weekly seeds',
+  description: 'Generate content seeds for a week (0-based index).',
+  method: 'POST',
+  pathUnderBrand: '/weekly-plan/plan',
+  input: z.object({ week }).strict(),
+  output: z.object({ ok: z.literal(true), draft: z.unknown() }),
+  failures: [WEEK_REQUIRED, NO_ACTIVE_PLAN],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/packages/api-contracts/src/studio.test.ts
+++ b/packages/api-contracts/src/studio.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { pathFor, statusForFailure } from './index';
 import {
   ADD_NOTE,
+  ADD_PERSON,
   CREATE_PRODUCT,
   DELETE_COMPETITOR,
   DELETE_DOCUMENT,
@@ -132,5 +133,22 @@ describe('le scritture dello studio arrivate dai tool scritti a mano', () => {
   it('indirizzano le rotte che esistono già', () => {
     expect(pathFor(ADD_NOTE, 'demo')).toBe('/api/v1/brands/demo/studio/documents');
     expect(pathFor(SET_COLORS, 'demo')).toBe('/api/v1/brands/demo/studio/colors');
+  });
+});
+
+describe('l’aggiunta di una persona reale', () => {
+  it('non fa dichiarare il consenso al posto dell’utente: senza, non parte', () => {
+    expect(ADD_PERSON.input.safeParse({ name: 'Giulia', consent: true }).success).toBe(true);
+    expect(ADD_PERSON.input.safeParse({ name: 'Giulia' }).success).toBe(false);
+  });
+
+  it('non lascia dire che la persona è un’AI: quella è un’altra azione', () => {
+    expect(ADD_PERSON.input.safeParse({ name: 'Giulia', consent: true, kind: 'ai' }).success).toBe(
+      false
+    );
+  });
+
+  it('indirizza la rotta che esiste già', () => {
+    expect(pathFor(ADD_PERSON, 'demo')).toBe('/api/v1/brands/demo/studio/people');
   });
 });

--- a/packages/api-contracts/src/studio.test.ts
+++ b/packages/api-contracts/src/studio.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { pathFor, statusForFailure } from './index';
 import {
+  ADD_NOTE,
   CREATE_PRODUCT,
   DELETE_COMPETITOR,
   DELETE_DOCUMENT,
@@ -8,6 +9,7 @@ import {
   DELETE_PRODUCT,
   GET_BIO,
   SET_BIO,
+  SET_COLORS,
   UPDATE_COMPETITOR,
   UPDATE_PERSON,
   UPDATE_PRODUCT
@@ -111,5 +113,24 @@ describe('i contratti dello studio', () => {
     expect(GET_BIO.input.safeParse({}).success).toBe(true);
     expect(SET_BIO.input.safeParse({ bio_url: '' }).success).toBe(true);
     expect(SET_BIO.input.safeParse({}).success).toBe(false);
+  });
+});
+
+describe('le scritture dello studio arrivate dai tool scritti a mano', () => {
+  it('una nota si aggiunge col testo, come il tool l’ha sempre chiesto', () => {
+    expect(ADD_NOTE.input.safeParse({ text: 'Il banco è di faggio.' }).success).toBe(true);
+    expect(ADD_NOTE.input.safeParse({ text: '' }).success).toBe(false);
+    expect(ADD_NOTE.input.safeParse({ content_text: 'x' }).success).toBe(false);
+  });
+
+  it('i colori si passano con o senza cancelletto', () => {
+    expect(SET_COLORS.input.safeParse({ colors: ['#7c5cff'] }).success).toBe(true);
+    expect(SET_COLORS.input.safeParse({ colors: ['7c5cff'] }).success).toBe(true);
+    expect(SET_COLORS.input.safeParse({ colors: [] }).success).toBe(false);
+  });
+
+  it('indirizzano le rotte che esistono già', () => {
+    expect(pathFor(ADD_NOTE, 'demo')).toBe('/api/v1/brands/demo/studio/documents');
+    expect(pathFor(SET_COLORS, 'demo')).toBe('/api/v1/brands/demo/studio/colors');
   });
 });

--- a/packages/api-contracts/src/studio.ts
+++ b/packages/api-contracts/src/studio.ts
@@ -344,3 +344,41 @@ export const SYNC_HISTORY = {
   destructive: false,
   openWorld: true
 } satisfies BrandEndpoint;
+
+export const ADD_NOTE = {
+  tool: 'add_note',
+  title: 'Add knowledge note',
+  description: 'Add a knowledge document / note to the studio.',
+  method: 'POST',
+  pathUnderBrand: '/studio/documents',
+  input: z.object({ text: z.string().min(1), title: z.string().optional() }).strict(),
+  output: z.object({
+    ok: z.literal(true),
+    document: z.looseObject({ id: z.string(), kind: z.string(), title: z.string() })
+  }),
+  failures: [{ error: 'content_text is required', status: 400 }],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const SET_COLORS = {
+  tool: 'set_colors',
+  title: 'Set brand colors',
+  description:
+    'Set brand colors as hex values, e.g. ["#7c5cff","#ffffff"]. Three or six digits, up to 8 ' +
+    'colours; the list replaces the whole palette.',
+  method: 'PUT',
+  pathUnderBrand: '/studio/colors',
+  // Stessa forma che la rotta salva: un `#aabbccdd` che passa di qui e prende un 400 di là
+  // lascia l'agente convinto di aver salvato un colore. studio-writes.test.ts le confronta.
+  input: z
+    .object({
+      colors: z
+        .array(z.string().regex(/^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/))
+        .min(1)
+        .max(8)
+    })
+    .strict(),
+  output: z.object({ ok: z.literal(true), colors: z.array(z.string()) }),
+  failures: [{ error: 'colors must be an array of max 8 hex strings', status: 400 }],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/packages/api-contracts/src/studio.ts
+++ b/packages/api-contracts/src/studio.ts
@@ -382,3 +382,45 @@ export const SET_COLORS = {
   failures: [{ error: 'colors must be an array of max 8 hex strings', status: 400 }],
   destructive: false
 } satisfies BrandEndpoint;
+
+// Rispecchia CONSENT_NOT_ATTESTED, che vive dietro $lib e da un package non si importa. Il test
+// della rotta importa entrambe e fallisce se divergono.
+export const CONSENT_NOT_ATTESTED =
+  'Confirm you have this person\u2019s consent before adding them.';
+
+export const ADD_PERSON = {
+  tool: 'add_person',
+  title: 'Add person',
+  description:
+    'Add a real person to the brand studio. Their face stays withheld from every generator ' +
+    'until consent is attested, so `consent` must be true and only the user can state it.',
+  method: 'POST',
+  pathUnderBrand: '/studio/people',
+  input: z
+    .object({
+      name: z.string().min(1),
+      role: z.string().optional(),
+      description: z.string().optional(),
+      consent: z
+        .boolean()
+        .describe(
+          'true ONLY when the USER has stated, in their own words, that they have this ' +
+            "person's consent to use their likeness. Never infer it."
+        )
+    })
+    .strict(),
+  output: z.object({
+    ok: z.literal(true),
+    person: z.looseObject({
+      id: z.string(),
+      name: z.string(),
+      role: z.string().nullable(),
+      kind: z.string()
+    })
+  }),
+  failures: [
+    { error: 'name is required', status: 400 },
+    { error: CONSENT_NOT_ATTESTED, status: 400 }
+  ],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/src/routes/api/v1/brands/[slug]/ads/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/ads/+server.ts
@@ -57,7 +57,10 @@ export const POST: RequestHandler = async ({ request, params }) => {
   if (!adsFeatureEnabled()) return json({ error: 'Not found' }, { status: 404 });
   if (!adsAvailable(brand.plan)) return json({ error: 'ads_not_on_plan' }, { status: 403 });
 
-  const body = (await request.json().catch(() => ({}))) as Record<string, unknown>;
+  // Il registry dichiara i campi propri di ogni azione dentro `extra`; il CLI li manda in cima.
+  // Sono lo stesso corpo, appiattito qui una volta sola.
+  const sent = (await request.json().catch(() => ({}))) as Record<string, unknown>;
+  const body = { ...sent, ...((sent.extra as Record<string, unknown>) ?? {}) };
   const action = String(body.action ?? '');
 
   // activated_at/status feed the credits window: approving spends credits (12% management fee).

--- a/src/routes/api/v1/brands/[slug]/ads/server.extra.test.ts
+++ b/src/routes/api/v1/brands/[slug]/ads/server.extra.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const setCampaignStatus = vi.fn(async () => ({ ok: true }));
+
+vi.mock('$lib/server/cli-auth', () => ({
+  authenticate: vi.fn(),
+  loadBrandForUser: vi.fn(),
+  checkApiKeyWriteAccess: vi.fn(() => null)
+}));
+vi.mock('$lib/server/ads', () => ({
+  adsFeatureEnabled: () => true,
+  adsAvailable: () => true,
+  setCampaignStatus: (...args: unknown[]) => setCampaignStatus(...(args as [])),
+  setCreativeStatus: vi.fn(),
+  approveCampaign: vi.fn(),
+  deleteCampaign: vi.fn(),
+  duplicateCampaign: vi.fn(),
+  getPaidSummary: vi.fn(),
+  proposeBoosts: vi.fn(),
+  proposeStandalone: vi.fn(),
+  rankBoostCandidates: vi.fn(),
+  rejectCampaign: vi.fn(),
+  pauseCampaign: vi.fn(),
+  syncAdAccounts: vi.fn(),
+  syncAdMetrics: vi.fn()
+}));
+
+import { POST } from './+server';
+import { authenticate, loadBrandForUser } from '$lib/server/cli-auth';
+
+const fakeSupabase = () => ({
+  from: () => {
+    const q = {
+      select: () => q,
+      eq: () => q,
+      maybeSingle: async () => ({ data: null, error: null })
+    };
+    return q;
+  }
+});
+
+const post = (body: Record<string, unknown>) =>
+  (POST as (e: unknown) => Promise<Response>)({
+    request: new Request('https://example.test/api/v1/brands/demo/ads', {
+      method: 'POST',
+      body: JSON.stringify(body)
+    }),
+    params: { slug: 'demo' }
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(authenticate).mockResolvedValue({ supabase: fakeSupabase(), apiKey: null, error: null } as never);
+  vi.mocked(loadBrandForUser).mockResolvedValue({ brand: { id: 'brand-1', plan: 'pro' }, error: null } as never);
+});
+
+describe('POST /api/v1/brands/:slug/ads', () => {
+  it('legge i campi propri dell’azione anche quando arrivano dentro `extra`', async () => {
+    const res = await post({ action: 'toggle', campaignId: 'c1', extra: { next: 'active' } });
+
+    expect(res.status).toBe(200);
+    expect(setCampaignStatus.mock.calls[0]?.[3]).toBe('active');
+  });
+
+  it('continua a leggerli in cima al corpo, come li manda il CLI', async () => {
+    await post({ action: 'toggle', campaignId: 'c1', next: 'active' });
+
+    expect(setCampaignStatus.mock.calls[0]?.[3]).toBe('active');
+  });
+});

--- a/src/routes/api/v1/brands/[slug]/editorial-plan/replan-week/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/editorial-plan/replan-week/+server.ts
@@ -13,7 +13,9 @@ export const POST: RequestHandler = async ({ request, params }) => {
   const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
   if (brandError) return brandError;
 
-  const { week_index, brief } = await request.json();
+  const body = await request.json();
+  const { brief } = body;
+  const week_index = body.week_index ?? body.week;
   if (week_index === undefined) return json({ error: 'week_index is required' }, { status: 400 });
   if (!brief) return json({ error: 'brief is required' }, { status: 400 });
 

--- a/src/routes/api/v1/brands/[slug]/editorial-plan/save-brief/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/editorial-plan/save-brief/+server.ts
@@ -11,7 +11,9 @@ export const POST: RequestHandler = async ({ request, params }) => {
   const writeDenied = checkApiKeyWriteAccess(apiKey);
   if (writeDenied) return writeDenied;
 
-  const { week_index, brief, products } = await request.json();
+  const body = await request.json();
+  const { brief, products } = body;
+  const week_index = body.week_index ?? body.week;
   if (week_index === undefined) return json({ error: 'week_index is required' }, { status: 400 });
 
   // Load active plan

--- a/src/routes/api/v1/brands/[slug]/studio/colors/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/studio/colors/+server.ts
@@ -11,10 +11,13 @@ export const PUT: RequestHandler = async ({ request, params }) => {
   const writeDenied = checkApiKeyWriteAccess(apiKey);
   if (writeDenied) return writeDenied;
 
-  const { colors } = await request.json();
-  if (!Array.isArray(colors) || colors.length > 8) {
+  const { colors: given } = await request.json();
+  if (!Array.isArray(given) || given.length > 8) {
     return json({ error: 'colors must be an array of max 8 hex strings' }, { status: 400 });
   }
+
+  // Il cancelletto è una convenzione di scrittura, non un dato: "7c5cff" è lo stesso colore.
+  const colors = given.map((c) => (typeof c === 'string' && !c.startsWith('#') ? `#${c}` : c));
 
   // Validate hex format
   for (const c of colors) {

--- a/src/routes/api/v1/brands/[slug]/studio/colors/server.test.ts
+++ b/src/routes/api/v1/brands/[slug]/studio/colors/server.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('$lib/server/cli-auth', () => ({
+  authenticate: vi.fn(),
+  loadBrandForUser: vi.fn(),
+  checkApiKeyWriteAccess: vi.fn(() => null)
+}));
+
+import { PUT } from './+server';
+import { authenticate, loadBrandForUser } from '$lib/server/cli-auth';
+
+let upserted: Record<string, unknown>[] = [];
+
+const fakeSupabase = () => ({
+  from: () => ({
+    upsert: async (row: Record<string, unknown>) => {
+      upserted.push(row);
+      return { error: null };
+    }
+  })
+});
+
+const put = (body: Record<string, unknown>) =>
+  (PUT as (e: unknown) => Promise<Response>)({
+    request: new Request('https://example.test/api/v1/brands/demo/studio/colors', {
+      method: 'PUT',
+      body: JSON.stringify(body)
+    }),
+    params: { slug: 'demo' }
+  });
+
+beforeEach(() => {
+  upserted = [];
+  vi.clearAllMocks();
+  vi.mocked(authenticate).mockResolvedValue({ supabase: fakeSupabase(), apiKey: null, error: null } as never);
+  vi.mocked(loadBrandForUser).mockResolvedValue({ brand: { id: 'brand-1' }, error: null } as never);
+});
+
+describe('PUT /api/v1/brands/:slug/studio/colors', () => {
+  it('prende un esadecimale anche senza cancelletto e lo salva col cancelletto', async () => {
+    const res = await put({ colors: ['7c5cff', '#ffffff'] });
+
+    expect(res.status).toBe(200);
+    expect(upserted[0].brand_colors).toEqual(['#7c5cff', '#ffffff']);
+    expect(await res.json()).toEqual({ ok: true, colors: ['#7c5cff', '#ffffff'] });
+  });
+
+  it('rifiuta quello che esadecimale non è', async () => {
+    expect((await put({ colors: ['viola'] })).status).toBe(400);
+  });
+});

--- a/src/routes/api/v1/brands/[slug]/studio/documents/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/studio/documents/+server.ts
@@ -13,7 +13,8 @@ export const POST: RequestHandler = async ({ request, params }) => {
   if (writeDenied) return writeDenied;
 
   const body = await request.json();
-  const { title, content_text, kind } = body;
+  const { title, kind } = body;
+  const content_text = body.content_text ?? body.text;
 
   if (!content_text && kind !== 'document') {
     return json({ error: 'content_text is required' }, { status: 400 });

--- a/src/routes/api/v1/brands/[slug]/studio/documents/server.test.ts
+++ b/src/routes/api/v1/brands/[slug]/studio/documents/server.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('$lib/server/cli-auth', () => ({
+  authenticate: vi.fn(),
+  loadBrandForUser: vi.fn(),
+  checkApiKeyWriteAccess: vi.fn(() => null)
+}));
+vi.mock('$lib/server/brand-context', () => ({ rebuildBrandContext: async () => {} }));
+
+import { POST } from './+server';
+import { authenticate, loadBrandForUser } from '$lib/server/cli-auth';
+
+let inserted: Record<string, unknown>[] = [];
+
+const fakeSupabase = () => ({
+  from() {
+    const q = {
+      insert(row: Record<string, unknown>) {
+        inserted.push(row);
+        return q;
+      },
+      select: () => q,
+      single: async () => ({ data: { id: 'd1', kind: 'note', title: 'Note' }, error: null })
+    };
+    return q;
+  }
+});
+
+const post = (body: Record<string, unknown>) =>
+  (POST as (e: unknown) => Promise<Response>)({
+    request: new Request('https://example.test/api/v1/brands/demo/studio/documents', {
+      method: 'POST',
+      body: JSON.stringify(body)
+    }),
+    params: { slug: 'demo' }
+  });
+
+beforeEach(() => {
+  inserted = [];
+  vi.clearAllMocks();
+  vi.mocked(authenticate).mockResolvedValue({ supabase: fakeSupabase(), apiKey: null, error: null } as never);
+  vi.mocked(loadBrandForUser).mockResolvedValue({ brand: { id: 'brand-1' }, error: null } as never);
+});
+
+describe('POST /api/v1/brands/:slug/studio/documents', () => {
+  it('accetta `text`, il nome che il tool add_note ha sempre esposto', async () => {
+    const res = await post({ text: 'Il banco è di faggio.' });
+
+    expect(res.status).toBe(200);
+    expect(inserted[0].content_text).toBe('Il banco è di faggio.');
+  });
+
+  it('continua ad accettare `content_text`, il nome documentato della rotta', async () => {
+    await post({ content_text: 'Il banco è di faggio.' });
+
+    expect(inserted[0].content_text).toBe('Il banco è di faggio.');
+  });
+
+  it('senza testo e senza kind document rifiuta', async () => {
+    const res = await post({ title: 'Vuota' });
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/routes/api/v1/brands/[slug]/studio/people/server.consent.test.ts
+++ b/src/routes/api/v1/brands/[slug]/studio/people/server.consent.test.ts
@@ -10,6 +10,8 @@ vi.mock('$lib/server/people', () => ({
 }));
 
 import { POST } from './+server';
+import { CONSENT_NOT_ATTESTED as DECLARED } from '@anomalia/api-contracts';
+import { CONSENT_NOT_ATTESTED } from '$lib/server/people-consent';
 import { authenticate, loadBrandForUser } from '$lib/server/cli-auth';
 
 function fakeSupabase() {
@@ -82,5 +84,11 @@ describe('POST /api/v1/brands/:slug/studio/people', () => {
     expect(res.status).toBe(200);
     expect(inserts[0]).toMatchObject({ consent: true, consent_source: 'ai_generated' });
     expect(inserts[0].consent_at).toBeUndefined();
+  });
+});
+
+describe('il contratto di add_person', () => {
+  it('dichiara la stessa frase che la rotta restituisce, parola per parola', () => {
+    expect(DECLARED).toBe(CONSENT_NOT_ATTESTED);
   });
 });

--- a/src/routes/api/v1/brands/[slug]/week-field.test.ts
+++ b/src/routes/api/v1/brands/[slug]/week-field.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('$lib/server/cli-auth', () => ({
+  authenticate: vi.fn(),
+  loadBrandForUser: vi.fn(),
+  checkApiKeyWriteAccess: vi.fn(() => null)
+}));
+vi.mock('$lib/server/brand-context', () => ({ genaiClient: () => ({}) }));
+vi.mock('$lib/server/editorial-plan', () => ({
+  cadenceAllowed: () => [],
+  loadActivePlan: async () => null,
+  replanWeek: async () => ({}),
+  weekStrategyBrief: () => '',
+  postsForWeek: () => [],
+  selectFeaturableProducts: () => []
+}));
+vi.mock('$lib/server/planner-inputs', () => ({
+  plannerProfile: async () => ({}),
+  planEvidence: async () => ({ benchmark: null, topPosts: [] })
+}));
+vi.mock('$lib/server/content-preview', () => ({
+  planWeekStrategy: async () => {
+    throw new Error('nessun piano');
+  },
+  carouselMaxPerBatch: () => 0,
+  loadPlannerMarketSignals: async () => ({})
+}));
+vi.mock('$lib/server/content-library', () => ({ attachBrandPages: async () => [] }));
+
+import { POST as saveBrief } from './editorial-plan/save-brief/+server';
+import { POST as replanWeek } from './editorial-plan/replan-week/+server';
+import { POST as planWeek } from './weekly-plan/plan/+server';
+import { authenticate, loadBrandForUser } from '$lib/server/cli-auth';
+
+const WEEK_REQUIRED = 'week_index is required';
+
+const chainable = () => {
+  const q: Record<string, unknown> = {};
+  for (const method of ['select', 'eq', 'insert', 'update', 'delete']) q[method] = () => q;
+  q.maybeSingle = async () => ({ data: null, error: null });
+  q.single = async () => ({ data: null, error: null });
+  return q;
+};
+
+const call = (
+  handler: unknown,
+  path: string,
+  body: Record<string, unknown>
+): Promise<Response> =>
+  (handler as (e: unknown) => Promise<Response>)({
+    request: new Request(`https://example.test${path}`, {
+      method: 'POST',
+      body: JSON.stringify(body)
+    }),
+    params: { slug: 'demo' }
+  });
+
+const ROUTES = [
+  { name: 'save-brief', handler: saveBrief, path: '/editorial-plan/save-brief', body: { brief: 'x' } },
+  { name: 'replan-week', handler: replanWeek, path: '/editorial-plan/replan-week', body: { brief: 'x' } },
+  { name: 'weekly-plan/plan', handler: planWeek, path: '/weekly-plan/plan', body: {} }
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(authenticate).mockResolvedValue({
+    supabase: { from: chainable, storage: { from: () => ({ remove: async () => ({}) }) } },
+    apiKey: null,
+    error: null
+  } as never);
+  vi.mocked(loadBrandForUser).mockResolvedValue({
+    brand: { id: 'brand-1', plan: 'pro', name: 'Demo' },
+    error: null
+  } as never);
+});
+
+describe('la settimana, sulle tre rotte che la prendono', () => {
+  it('senza settimana risponde che manca', async () => {
+    for (const route of ROUTES) {
+      const res = await call(route.handler, route.path, route.body);
+      expect(await res.json(), route.name).toEqual({ error: WEEK_REQUIRED });
+      expect(res.status, route.name).toBe(400);
+    }
+  });
+
+  it('accetta `week`, il nome che l’agente usa, oltre a `week_index`', async () => {
+    for (const route of ROUTES) {
+      for (const field of ['week', 'week_index']) {
+        const res = await call(route.handler, route.path, { ...route.body, [field]: 0 });
+        expect(await res.json(), `${route.name} ${field}`).not.toEqual({ error: WEEK_REQUIRED });
+      }
+    }
+  });
+});

--- a/src/routes/api/v1/brands/[slug]/weekly-plan/plan/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/weekly-plan/plan/+server.ts
@@ -11,7 +11,8 @@ export const POST: RequestHandler = async ({ request, params }) => {
   const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
   if (brandError) return brandError;
 
-  const { week_index } = await request.json();
+  const body = await request.json();
+  const week_index = body.week_index ?? body.week;
   if (week_index === undefined) return json({ error: 'week_index is required' }, { status: 400 });
 
   try {


### PR DESCRIPTION
## What?

`src/lib/webmcp.ts` turns `BRAND_ENDPOINTS` into **Web MCP** tools — the tools a page offers to an
AI agent running inside the visitor's own browser. The registry already generates the CLI's
commands and the MCP server's tools; this is the third consumer, from the same declaration.

The root layout registers them for the brand currently open, using the signed-in session's token.
No dependency was added, and nothing loads in a browser without the spec.

**Read this first:** the URL in the request, <https://webmcp.dev>, is **a different project** — see
*Why?*.

## Why?

Andrea asked for Web MCP and for *«mcp, cli, web mcp, e endpoint … allineati su tutte le azioni che
una AI può fare»*.

### webmcp.dev is not the specification

It documents an unrelated, dormant library: a blue widget in the corner, `new WebMCP({color,
position})`, npm `@jason.today/webmcp` — **last published March 2025**, 457 weekly downloads. It
shares only the name.

The real work is **[`webmachinelearning/webmcp`](https://github.com/webmachinelearning/webmcp)**,
the W3C Web Machine Learning **Community Group**. Anyone implementing from memory, or from
webmcp.dev, builds the wrong thing.

### Where the spec actually is

| | |
|---|---|
| body | W3C Web ML **Community Group** — not a Working Group |
| maturity | **Draft Community Group Report**, "not a W3C Standard nor on the W3C Standards Track" |
| Chrome | **origin trial from 149**, `chrome://flags/#enable-webmcp-testing`. Not shipped |
| WebKit | position: **oppose** ([#670](https://github.com/WebKit/standards-positions/issues/670)), concerns tagged privacy, security, i18n, API design |
| Mozilla | neutral ([#1412](https://github.com/mozilla/standards-positions/issues/1412)) |
| clients | no first-party agent confirmed to consume it; Google's only client is a test extension |

And it is moving: `navigator.modelContext` → `document.modelContext`, `provideContext()` →
`registerTool()`, and `consequentialHint` was added to the annotations **yesterday**. There is no
`outputSchema` yet (issue #9 open) and an open issue to rename `execute` → `run`. 114 open issues.

### So why build it now

**Because the registry makes it nearly free, and keeps it free.** Adding an endpoint already
reaches the CLI and MCP without anyone remembering; it now reaches Web MCP too. If the spec had
required a shape the registry could not feed, that would have been the finding — it does not: the
descriptor is nearly 1:1 with a `tools/list` entry.

## How?

### The descriptor, and the vocabulary trap

`name`, `title`, `description`, `inputSchema` (JSON Schema), `annotations`, `execute`. Schemas come
from **`z.toJSONSchema`**, which zod 4 already has — **no new dependency**, and a closed enum in a
contract arrives closed at the agent.

The annotations are **not** MCP's. Getting this wrong is worse than not translating at all: an
agent would run an irreversible action believing it harmless.

| registry | MCP | WebMCP |
|---|---|---|
| `method === 'GET'` | `readOnlyHint` | `readOnlyHint` |
| `destructive` | `destructiveHint` | **`consequentialHint`** |
| `openWorld` | `openWorldHint` | **`untrustedContentHint`** |

The last row is **not an exact match**, and I want that on the record: the registry means "reaches
the open internet", WebMCP asks "may return content you do not vouch for". The first set is wider.
Over-marking costs nothing; under-marking removes a warning the agent should have seen — so it maps
conservatively.

### `login`, `logout`, `whoami` are absent, deliberately

Those exist in the MCP server because a CLI must obtain a token and say whose it is. In a page the
session already belongs to whoever is looking: `/api/v1` accepts the Supabase JWT as a Bearer
(`resolveCaller`, the JWT branch), and the token comes from the root layout's data. Exposing them
would give a browser agent three tools that can do nothing useful — and `logout` would do damage.

### Two decisions that keep the cost at zero

1. **No polyfill installed.** Whoever wants to try it mounts their own (`@mcp-b/global`, 17.8k
   weekly downloads) and this module finds it. Installing one here would be a forced update at the
   next change of a spec that changes weekly.
2. **Dynamic import behind a feature detect.** The layout checks `'modelContext' in document`
   *before* importing, so without the spec neither zod nor the descriptors enter the bundle. For
   every browser today the cost is one `in` on an object.

### The mount point, and a note for whoever finishes the app shell

The natural place is the brand layout (`src/routes/app/[brand]/`), which already knows the slug.
**That tree is off-limits in this session** — another agent is rebuilding the sidebar and settings
— so registration sits in the root layout, deriving the slug from `appNavScope`, the function that
file already uses for exactly this. **It is worth moving into the brand layout** once that work
lands: it is a ten-line `$effect`.

The AbortSignal unregisters everything: changing brand aborts the previous registration, or an
agent would see two brands' tools under the same names.

## Testing?

| command | result |
|---|---|
| `npx vitest run packages/api-contracts` | 204 tests, pass (unchanged — no contract touched) |
| `cd cli && bun test` | 59 tests, 0 fail |
| `cd cli && bun run typecheck` | clean |
| `node scripts/typecheck-runtime.mjs` | ok |
| `src/lib/webmcp.test.ts` + changelog + `no-app-imports` | 141 tests, pass |

`node_modules/@anomalia/api-contracts` resolves to **this worktree's** `packages/api-contracts`
(checked with `realpathSync`).

**Not tested:** no browser, Docker, dev server or Playwright — forbidden for this task. Which means
the honest statement is: **the generation, the annotation mapping, the request shaping and the
registration call are proven; a real `document.modelContext` accepting them is not.** Nobody in
this session ran Chrome 149 with the trial token. The registration path is one `await` per tool
behind a feature detect, and the failure mode is a caught, logged warning.

**Risk:** the spec moves. `execute` may become `run`; `outputSchema` may land. Both are single-file
changes — `src/lib/webmcp.ts` is the only file that knows the shape.

## Evidence

<details>
<summary>Red, then green: the adapter broken four ways, 10 of 18 fail</summary>

Swapped WebMCP's annotations for MCP's, replaced the registry map with a hand-filtered list,
dropped the error check, dropped the abort signal:

```
× il registry alimenta anche Web MCP > genera uno strumento per ogni endpoint, senza elenchi a mano
× il registry alimenta anche Web MCP > uno strumento su una risorsa chiede anche il suo id
× il registry alimenta anche Web MCP > lo schema di ingresso arriva dal contratto, non riscritto a mano
× le annotazioni … > una lettura e' readOnly, una scrittura no
× le annotazioni … > cio' che il registry chiama distruttivo diventa consequentialHint, non destructiveHint
× le annotazioni … > cio' che esce su internet e' marcato come contenuto di cui non rispondiamo
× quello che l'esecuzione manda davvero in rete > lo slug lo mette il registratore, non chi chiama lo strumento
× quello che l'esecuzione manda davvero in rete > un errore dell'API diventa un errore, non un successo silenzioso
× quello che l'esecuzione manda davvero in rete > l'agente puo' annullare: il segnale arriva fino alla fetch
× quando il browser non ha la specifica > ma se c'e', registra tutto il registry con un segnale per toglierlo
   Tests  10 failed | 8 passed (18)
```

Restored: **18/18**.

</details>

<details>
<summary>What generation and execution actually produce</summary>

```
brandWebMcpTools('demo', token).length === BRAND_ENDPOINTS.length     (every endpoint, no hand list)
every tool requires `slug`; resource tools also require `id`
set_blog_settings.inputSchema.properties.font.enum === BLOG_FONTS     (a closed enum stays closed)

get_blog_settings.annotations  → { readOnlyHint: true,  consequentialHint: false, untrustedContentHint: false }
remove_blog_term.annotations   → { readOnlyHint: false, consequentialHint: true,  untrustedContentHint: false }
diagnose_radar.annotations     → { untrustedContentHint: true }
no tool carries `destructiveHint` or `openWorldHint`

execute({})            → GET  /api/v1/brands/demo/settings/blog, Authorization: Bearer <session>, no body
execute({title:'…'})   → PUT  /api/v1/brands/demo/settings/blog, body {"title":"…"}   (slug never from the caller)
execute({id:'post-1'}) → the id lands in the path, not the body
HTTP 403               → throws, rather than a silent success
result                 → { content: [{ type: 'text', text: '…' }] }
options.signal         → reaches fetch

login / logout / whoami → absent
```

Without the spec:

```
modelContext()                      → null
registerBrandWebMcp(…)              → 0, no throw
with a stubbed document.modelContext → registerTool called BRAND_ENDPOINTS times, each with { signal }
```

</details>

No UI change: nothing rendered, nothing styled. The root layout gains one `$effect`.

## Anything Else?

**The recommendation, kept separate from the code.** The *generator* is worth having now — it is
nearly free and stays free. The *spec* is not ready: incubation, one browser in origin trial,
WebKit opposed, no first-party client. The code takes that as given — feature-detect, no
dependency, one file that knows the shape.

**Do not announce it expecting use.** Today it is visible only to someone running the Chrome origin
trial or mounting a polyfill by hand. It is there for when it arrives, not because it has.

**Alignment is not finished, and this PR does not finish it.** 32 of the 114 MCP tools are still
hand-written and therefore invisible to Web MCP: `edit_post`, `approve_post`, `publish_post`,
`reject_post`, the four `/posts/:id/media` variants, `generate_article`, `publish_article`,
`delete_article`, the week trio, `set_colors`, `add_note`, `get_dashboard`, `get_status`,
`list_brands`, and the rest. As they migrate into the registry — work assigned elsewhere — they
appear here **for free**. That is the whole point of the shape.

Three of the 32 should not migrate: `login`, `logout` and `whoami` are not HTTP calls, and in a
browser they have no job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
