### PR TITLE
Open the brand home with what is waiting for you

### DIFF
--- a/changelog/2026-09-04-home-cose-da-fare.md
+++ b/changelog/2026-09-04-home-cose-da-fare.md
@@ -1,0 +1,61 @@
+# La home apre con quello che ti aspetta
+
+La gerarchia del mockup: **ciò che richiede attenzione sta in cima, con quante sono**; il resto
+scende. Era l'unica cosa che `/v2` aveva e `/app` no, ed è il divario più grande rimasto dopo
+averla cancellata.
+
+## Cosa c'era prima, al posto suo
+
+Un blocco chiamato `control-hero` con:
+
+- un titolo che dice quanti elementi ci sono da rivedere — quello va bene, e resta la stessa idea;
+- **tre gauge ad anello** (percentuale di setup, punteggio SEO, citabilità GEO). Sono ornamento:
+  tre cerchi animati che non ti dicono cosa fare. Il setup ha già la sua barra qui sopra, e SEO e
+  GEO hanno la loro riga in barra laterale da quando «Web» si è sdoppiata;
+- una **coda paginata dei singoli post da approvare** — cinque per pagina, avanti, indietro,
+  «mostra tutti», «mostra meno», con quattro `$state` e un `$effect` a tenere in riga il numero
+  di pagina. Diceva la stessa cosa della riga «4 contenuti da approvare», con un clic in più e
+  una paginazione da mantenere.
+
+Netto: `HomeWorkbench.svelte` passa da **1.759 a 1.356 righe**.
+
+## Cosa c'è adesso
+
+«Da fare», il conteggio di quante sono, e una riga per ciascuna: cosa, dove vive, e un pulsante
+che ci porta. Le righe possibili, in quest'ordine:
+
+| Riga | Quando compare | Dove porta |
+|---|---|---|
+| N post da accettare | `queue.pending > 0` | `/calendar?status=pending_user` |
+| N articoli da accettare | `blog.pending > 0` | `/site` |
+| N segnali da rivedere | radar **acceso** e `radarReview > 0` | `/radar` |
+| N lead in attesa | `leadsPending > 0` | `/leads` |
+| Nessun account collegato | `socialAccounts === 0` | `/settings/connected-accounts` |
+
+**L'ordine è la gerarchia, e ha una ragione.** Prima ciò che ha una scadenza vera: un post
+approvato in ritardo è un post che non esce. Poi ciò che aspetta senza scadere. Infine il setup,
+che non scade mai — ma senza un account collegato l'AI produce e non pubblica, e il brand se ne
+accorge quando è tardi.
+
+**Il radar spento non produce una riga.** Offrire «segnali da rivedere» per una funzione che non
+gira è peggio che tacere.
+
+## Lo stato vuoto dice perché è vuoto
+
+Non «niente da fare», ma *«Non c'è niente in attesa. Bozze nuove, segnali del radar e lead
+compaiono qui appena arrivano.»* Chi arriva a home vuota deve capire se il prodotto sta
+lavorando o se è rotto.
+
+## Dove sta la logica
+
+In `$lib/home-todos.ts`, puro e sotto test, come `navFor` per la barra: sceglie **quali** righe e
+**in che ordine**, e non contiene una parola di testo — restituisce chiavi i18n e conteggi, e la
+pagina traduce. È l'unico pezzo di questo blocco che si può far fallire per la ragione giusta, e
+i sei casi coprono l'ordine, il conteggio, il radar spento e la riga senza numero.
+
+## Cosa NON è cambiato
+
+Tutto il resto della pagina: pipeline contenuti, in arrivo, web, analisi. Restano dov'erano e
+come erano. Il blocco nuovo dice le stesse cose in forma di lavoro da fare, quindi c'è una
+sovrapposizione dichiarata con la sezione «Pipeline contenuti» qui sotto — si scioglie nello
+sfoltimento pagina per pagina, non qui.

--- a/src/lib/components/HomeWorkbench.svelte
+++ b/src/lib/components/HomeWorkbench.svelte
@@ -4,6 +4,7 @@
   import AnimatedNum from '$lib/components/AnimatedNum.svelte';
   import GrowthReadiness from '$lib/components/GrowthReadiness.svelte';
   import { fmtCompactNum } from '$lib/fmt-num';
+  import { homeTodos } from '$lib/home-todos';
 
   type Extras = {
     pendingCount?: number;
@@ -129,116 +130,22 @@
     }
   );
 
-  const reviewTotal = $derived(pendingPostCount + pendingBlogCount);
-  const controlOk = $derived(reviewTotal === 0);
-
-  type ReviewItem = {
-    key: string;
-    kind: 'social' | 'blog';
-    id: string;
-    href: string;
-    title: string;
-    meta: string;
-    media: string | null;
-    placeholder: string;
-  };
-
-  const REVIEW_PREVIEW = 5;
-  const REVIEW_PAGE_SIZE = 5;
-
-  const reviewItems = $derived.by((): ReviewItem[] => {
-    const social: ReviewItem[] = pendingPosts.map((post) => ({
-      key: `social-${post.id}`,
-      kind: 'social',
-      id: post.id,
-      href: `${base}/calendar?status=pending_user`,
-      title: captionPreview(post.caption, 90) || '—',
-      meta: post.platform ?? 'social',
-      media: post.media_url,
-      placeholder: (post.platform ?? '?').slice(0, 2).toUpperCase()
-    }));
-    const blogs: ReviewItem[] = pendingBlogs.map((art) => ({
-      key: `blog-${art.id}`,
-      kind: 'blog',
-      id: art.id,
-      href: `${base}/site/edit/${art.id}`,
-      title: captionPreview(art.title, 90) || '—',
-      meta: art.status,
-      media: art.cover_url,
-      placeholder: 'B'
-    }));
-    return [...social, ...blogs];
-  });
-
-  const loadedReviewCount = $derived(reviewItems.length);
-  const reviewTruncated = $derived(reviewTotal > loadedReviewCount);
-
-  let reviewExpanded = $state(false);
-  let reviewPage = $state(0);
-
-  const reviewPageCount = $derived(
-    Math.max(1, Math.ceil(loadedReviewCount / REVIEW_PAGE_SIZE))
-  );
-  const visibleReviewItems = $derived.by(() => {
-    if (!reviewExpanded) return reviewItems.slice(0, REVIEW_PREVIEW);
-    const start = reviewPage * REVIEW_PAGE_SIZE;
-    return reviewItems.slice(start, start + REVIEW_PAGE_SIZE);
-  });
-  const canExpandReview = $derived(loadedReviewCount > REVIEW_PREVIEW || reviewTruncated);
-
-  $effect(() => {
-    if (reviewPage > reviewPageCount - 1) reviewPage = Math.max(0, reviewPageCount - 1);
-  });
-
-  function expandReview() {
-    reviewExpanded = true;
-    reviewPage = 0;
-  }
-  function collapseReview() {
-    reviewExpanded = false;
-    reviewPage = 0;
-  }
-
-  function gradeToScore(grade: string | null): number | null {
-    if (!grade) return null;
-    const g = grade.trim().toUpperCase();
-    const map: Record<string, number> = {
-      'A+': 97,
-      A: 92,
-      'A-': 88,
-      'B+': 84,
-      B: 78,
-      'B-': 72,
-      'C+': 68,
-      C: 62,
-      'C-': 55,
-      D: 45,
-      F: 25
-    };
-    return map[g] ?? null;
-  }
-
-  const seoGauge = $derived(
-    overview.web.techScore != null
-      ? Math.max(0, Math.min(100, overview.web.techScore))
-      : (gradeToScore(overview.web.seoGrade) ?? 0)
-  );
-  const seoGaugeLabel = $derived(
-    overview.web.techScore != null
-      ? String(Math.round(overview.web.techScore))
-      : (overview.web.seoGrade ?? '—')
-  );
-  const geoGauge = $derived(
-    overview.web.citationsTotal > 0
-      ? Math.round((overview.web.citationsMentioned / overview.web.citationsTotal) * 100)
-      : (overview.web.shareOfVoice ?? 0)
-  );
-  const geoGaugeLabel = $derived(
-    overview.web.citationsTotal > 0
-      ? `${overview.web.citationsMentioned}/${overview.web.citationsTotal}`
-      : overview.web.shareOfVoice != null
-        ? `${overview.web.shareOfVoice}%`
-        : '—'
+  // Le cose da fare in cima: la SELEZIONE e l'ORDINE stanno in `$lib/home-todos`, puro e sotto
+  // test; qui si aggiunge solo ciò che quel modulo non può sapere — l'href col brand e la
+  // traduzione. Ha preso il posto di tre gauge (setup, SEO, GEO) e di una coda paginata dei
+  // singoli post: i primi erano ornamento, la seconda diceva la stessa cosa della riga
+  // «N da approvare» con un clic in più e una paginazione da mantenere.
+  const todos = $derived(
+    homeTodos({
+      queue: { pending: pendingPostCount },
+      blog: { pending: pendingBlogCount },
+      automations: {
+        radarEnabled: auto.radarEnabled,
+        radarReview: auto.radarReview,
+        leadsPending: auto.leadsPending
+      },
+      setup: { socialAccounts: setup.socialAccounts }
+    })
   );
 
   const socialPipeMax = $derived(
@@ -371,150 +278,36 @@
     <GrowthReadiness checks={overview.growth.checks} compact={overview.growth.ready} />
   {/if}
 
-  <!-- Command center: status + gauges -->
-  <section class="control-hero" class:ok={controlOk}>
-    <div class="control-copy">
-      <span class="ov-kicker">{$_('app.home.overview.sectionAttention')}</span>
-      <h2 class="control-title">
-        {#if controlOk}
-          {$_('app.home.overview.controlOk')}
-        {:else}
-          {$_('app.home.overview.controlNeedsReview', { values: { n: reviewTotal } })}
-        {/if}
-      </h2>
-      <p class="control-desc">
-        {#if controlOk}
-          {$_('app.home.overview.controlOkDesc')}
-        {:else}
-          {$_('app.home.overview.controlNeedsDesc')}
-        {/if}
-      </p>
-    </div>
-    <div class="gauge-row">
-      <div class="gauge">
-        <div class="gauge-ring" style={`--v:${Math.round(setupPct)}`} aria-hidden="true">
-          <span><AnimatedNum value={Math.round(setupPct)} format={(n) => String(Math.round(n))} /></span>
-        </div>
-        <span class="gauge-label">{$_('app.home.overview.setupGauge')}</span>
-      </div>
-      <a class="gauge" href={`${base}/seo`}>
-        <div class="gauge-ring" style={`--v:${Math.round(seoGauge)}`} aria-hidden="true">
-          <span>
-            {#if overview.web.techScore != null}
-              <AnimatedNum value={Math.round(overview.web.techScore)} format={(n) => String(Math.round(n))} />
-            {:else}
-              {seoGaugeLabel}
-            {/if}
-          </span>
-        </div>
-        <span class="gauge-label">{$_('app.home.overview.seoGauge')}</span>
-      </a>
-      <a class="gauge" href={`${base}/geo`}>
-        <div class="gauge-ring" style={`--v:${Math.round(geoGauge)}`} aria-hidden="true">
-          <span>
-            {#if overview.web.citationsTotal > 0}
-              <AnimatedNum value={overview.web.citationsMentioned} format={(n) => String(Math.round(n))} />/{overview.web.citationsTotal}
-            {:else if overview.web.shareOfVoice != null}
-              <AnimatedNum value={overview.web.shareOfVoice} format={(n) => String(Math.round(n))} suffix="%" />
-            {:else}
-              {geoGaugeLabel}
-            {/if}
-          </span>
-        </div>
-        <span class="gauge-label">{$_('app.home.overview.geoGauge')}</span>
-      </a>
+  <!-- IL BLOCCO DEL MOCKUP: ciò che richiede attenzione sta in cima, con quante sono. Il resto
+       della pagina scende sotto, invariato. -->
+  <section class="todo" aria-labelledby="todo-title">
+    <div class="todo-head">
+      <h2 id="todo-title">{$_('app.home.todo.title')}</h2>
+      {#if todos.length > 0}
+        <p class="todo-count">{$_('app.home.todo.count', { values: { n: todos.length } })}</p>
+      {/if}
     </div>
 
-    {#if reviewTotal > 0}
-      <div class="review-queue">
-        <div class="review-queue-head">
-          <div class="review-queue-copy">
-            <span class="review-queue-title">{$_('app.home.overview.toReview')}</span>
-            <span class="review-queue-meta">
-              {#if pendingPostCount > 0}
-                {$_('app.home.overview.postsToAccept', { values: { n: pendingPostCount } })}
-              {/if}
-              {#if pendingPostCount > 0 && pendingBlogCount > 0}
-                <span aria-hidden="true"> · </span>
-              {/if}
-              {#if pendingBlogCount > 0}
-                {$_('app.home.overview.blogsToAccept', { values: { n: pendingBlogCount } })}
-              {/if}
-            </span>
-          </div>
-        </div>
-
-        <ul class="review-list">
-          {#each visibleReviewItems as item (item.key)}
-            <li>
-              <a href={item.href}>
-                <span class="up-thumb">
-                  {#if item.media}
-                    <img src={item.media} alt="" loading="lazy" />
-                  {:else}
-                    <span class="up-ph">{item.placeholder}</span>
-                  {/if}
-                </span>
-                <span class="up-body">
-                  <span class="up-meta">
-                    <span class="ov-kind"
-                      >{item.kind === 'social'
-                        ? $_('app.home.overview.kindSocial')
-                        : $_('app.home.overview.kindBlog')}</span
-                    >
-                    {item.meta}
-                  </span>
-                  <span class="up-title">{item.title}</span>
-                </span>
-              </a>
-            </li>
-          {/each}
-        </ul>
-
-        <div class="review-queue-foot">
-          {#if !reviewExpanded && canExpandReview}
-            <button type="button" class="ov-link review-toggle" onclick={expandReview}>
-              {$_('app.home.overview.showAllReview', { values: { n: reviewTotal } })} →
-            </button>
-          {:else if reviewExpanded}
-            <div class="review-pager">
-              <button
-                type="button"
-                class="ov-ai"
-                disabled={reviewPage <= 0}
-                onclick={() => (reviewPage = Math.max(0, reviewPage - 1))}
-              >
-                {$_('app.home.overview.prev')}
-              </button>
-              <span class="review-page-label"
-                >{$_('app.home.overview.pageOf', {
-                  values: { page: reviewPage + 1, pages: reviewPageCount }
-                })}</span
-              >
-              <button
-                type="button"
-                class="ov-ai"
-                disabled={reviewPage >= reviewPageCount - 1}
-                onclick={() => (reviewPage = Math.min(reviewPageCount - 1, reviewPage + 1))}
-              >
-                {$_('app.home.overview.next')}
-              </button>
-            </div>
-            <button type="button" class="ov-link review-toggle" onclick={collapseReview}>
-              {$_('app.home.overview.showLessReview')}
-            </button>
-            {#if reviewTruncated}
-              <a class="ov-link" href={`${base}/calendar?status=pending_user`}
-                >{$_('app.home.overview.seeAll')} →</a
-              >
-            {/if}
-          {/if}
-        </div>
-      </div>
+    {#if todos.length === 0}
+      <!-- Uno stato vuoto che dice PERCHÉ è vuoto e cosa lo riempirà, invece di una riga muta. -->
+      <p class="todo-empty">{$_('app.home.todo.empty')}</p>
+    {:else}
+      <ul class="todo-list">
+        {#each todos as todo (todo.key)}
+          <li>
+            <a href={`${base}${todo.path}`}>
+              <span class="todo-body">
+                <span class="todo-what">{$_(todo.labelKey, { values: { n: todo.count } })}</span>
+                <span class="todo-where">{$_(todo.hintKey)}</span>
+              </span>
+              <span class="todo-cta">{$_('app.home.overview.review')}</span>
+            </a>
+          </li>
+        {/each}
+      </ul>
     {/if}
   </section>
 
-  <!-- Pipeline -->
   <section class="ov-section">
     <div class="ov-section-head">
       <div class="ov-section-copy">
@@ -845,6 +638,82 @@
 </div>
 
 <style>
+  /* IL BLOCCO DELLE COSE DA FARE. Niente cornici, niente riempimenti: la gerarchia la fanno
+     spaziatura, dimensione e peso — che è la regola del mockup, dove l'unico bordo è quello
+     della riga che chiede qualcosa. */
+  .todo {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-bottom: 28px;
+  }
+  .todo-head h2 {
+    margin: 0;
+    font-size: 22px;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    color: var(--ink);
+  }
+  .todo-count {
+    margin: 2px 0 0;
+    font-size: 13px;
+    color: var(--ink-soft);
+  }
+  .todo-empty {
+    margin: 0;
+    font-size: 13.5px;
+    line-height: 1.6;
+    color: var(--ink-soft);
+    max-width: 62ch;
+  }
+  .todo-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .todo-list a {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 13px 16px;
+    border: 1px solid var(--line);
+    border-radius: 14px;
+    background: var(--paper);
+    text-decoration: none;
+    transition: border-color 140ms ease;
+  }
+  .todo-list a:hover {
+    border-color: color-mix(in srgb, var(--accent) 45%, var(--line));
+  }
+  .todo-body {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+  }
+  .todo-what {
+    font-size: 14.5px;
+    font-weight: 600;
+    color: var(--ink);
+  }
+  .todo-where {
+    font-size: 12.5px;
+    color: var(--ink-soft);
+  }
+  .todo-cta {
+    flex: none;
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    padding: 5px 14px;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--ink);
+  }
+
   /* Registering the angle is what makes the rotating border possible at all: an unregistered
      custom property has no type, so CSS jumps it 0deg→360deg instead of interpolating and the
      gradient never moves. Where @property is unsupported the border simply sits still — the
@@ -1002,204 +871,6 @@
     font-weight: 650;
     color: var(--accent);
     text-decoration: none;
-  }
-
-  /* ── Control hero ─────────────────────────────────────────── */
-  .control-hero {
-    display: grid;
-    gap: 18px;
-    margin: 0 0 64px;
-    padding: 18px 18px 16px;
-    border-radius: 18px;
-    border: 1px solid var(--line);
-    min-width: 0;
-    max-width: 100%;
-    overflow-x: clip;
-    background:
-      radial-gradient(
-        120% 80% at 100% 0%,
-        color-mix(in srgb, var(--accent) 10%, transparent) 0%,
-        transparent 55%
-      ),
-      var(--paper);
-  }
-  .control-hero.ok {
-    border-color: color-mix(in srgb, var(--accent) 28%, var(--line));
-  }
-  .control-copy {
-    min-width: 0;
-  }
-  .control-title {
-    margin: 4px 0 6px;
-    font-size: 1.35rem;
-    font-weight: 700;
-    letter-spacing: -0.03em;
-    line-height: 1.2;
-    overflow-wrap: anywhere;
-  }
-  .control-desc {
-    margin: 0;
-    font-size: 13.5px;
-    color: var(--ink-soft);
-    max-width: 42ch;
-  }
-  .gauge-row {
-    display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 10px;
-  }
-  .gauge {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 8px;
-    padding: 12px 8px;
-    border-radius: 14px;
-    background: color-mix(in srgb, var(--paper-2) 70%, var(--paper));
-    border: 1px solid transparent;
-    text-decoration: none;
-    color: inherit;
-  }
-  a.gauge:hover {
-    border-color: color-mix(in srgb, var(--accent) 28%, var(--line));
-  }
-  .gauge-ring {
-    width: 72px;
-    height: 72px;
-    border-radius: 50%;
-    display: grid;
-    place-items: center;
-    background: conic-gradient(var(--accent) calc(var(--v) * 1%), color-mix(in srgb, var(--ink) 8%, transparent) 0);
-    transition: background 0.6s ease;
-  }
-  .gauge-ring span {
-    width: 54px;
-    height: 54px;
-    border-radius: 50%;
-    background: var(--paper);
-    display: grid;
-    place-items: center;
-    font-size: 15px;
-    font-weight: 700;
-    letter-spacing: -0.02em;
-    color: var(--ink);
-  }
-  .gauge-label {
-    font-size: 12px;
-    font-weight: 600;
-    color: var(--ink-soft);
-    text-align: center;
-  }
-
-  .review-queue {
-    margin-top: 4px;
-    padding-top: 14px;
-    border-top: 1px solid var(--line);
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-    min-width: 0;
-    max-width: 100%;
-  }
-  .review-queue-head {
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: 12px;
-    flex-wrap: wrap;
-    min-width: 0;
-  }
-  .review-queue-copy {
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-    min-width: 0;
-    flex: 1 1 12rem;
-  }
-  .review-queue-title {
-    font-size: 14px;
-    font-weight: 650;
-    letter-spacing: -0.02em;
-  }
-  .review-queue-meta {
-    font-size: 12.5px;
-    color: var(--ink-soft);
-    overflow-wrap: anywhere;
-  }
-  .review-list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    border: 1px solid var(--line);
-    border-radius: 14px;
-    background: color-mix(in srgb, var(--paper-2) 55%, var(--paper));
-    overflow: hidden;
-    min-width: 0;
-    max-width: 100%;
-    width: 100%;
-  }
-  .review-list li {
-    min-width: 0;
-  }
-  .review-list li + li {
-    border-top: 1px solid var(--line);
-  }
-  .review-list a {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    padding: 10px 12px;
-    text-decoration: none;
-    color: inherit;
-    min-width: 0;
-    max-width: 100%;
-    overflow: hidden;
-    box-sizing: border-box;
-  }
-  .review-list a:hover {
-    background: color-mix(in srgb, var(--accent) 6%, transparent);
-  }
-  .review-list .up-meta {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    flex-wrap: wrap;
-    min-width: 0;
-    max-width: 100%;
-  }
-  .review-queue-foot {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 10px;
-    flex-wrap: wrap;
-    min-width: 0;
-  }
-  .review-pager {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    flex-wrap: wrap;
-    min-width: 0;
-  }
-  .review-pager .ov-ai:disabled {
-    opacity: 0.4;
-    cursor: not-allowed;
-  }
-  .review-page-label {
-    font-size: 12.5px;
-    font-weight: 600;
-    color: var(--ink-soft);
-    min-width: 4.5ch;
-    text-align: center;
-  }
-  button.review-toggle {
-    appearance: none;
-    border: 0;
-    background: transparent;
-    padding: 0;
-    cursor: pointer;
-    font: inherit;
   }
 
   /* ── Pipeline ─────────────────────────────────────────────── */
@@ -1374,23 +1045,6 @@
     flex-wrap: wrap;
     min-width: 0;
     max-width: 100%;
-  }
-  .ov-ai {
-    appearance: none;
-    border: 1px solid var(--line);
-    background: var(--paper);
-    color: var(--ink);
-    font: inherit;
-    font-size: 12.5px;
-    font-weight: 600;
-    padding: 6px 10px;
-    border-radius: 999px;
-    cursor: pointer;
-    max-width: 100%;
-    white-space: nowrap;
-  }
-  .ov-ai:hover {
-    border-color: color-mix(in srgb, var(--accent) 35%, var(--line));
   }
   .ov-ai-strong {
     background: color-mix(in srgb, var(--accent) 12%, var(--paper));
@@ -1668,44 +1322,17 @@
     .mini-bar span,
     .likes-bars span,
     .setup-bar span,
-    .gauge-ring,
     .mini-ring {
       transition: none;
     }
   }
 
   @container workbench (max-width: 640px) {
-    .gauge-row {
-      grid-template-columns: repeat(3, minmax(0, 1fr));
-      gap: 6px;
-    }
-    .gauge-ring {
-      width: 58px;
-      height: 58px;
-    }
-    .gauge-ring span {
-      width: 44px;
-      height: 44px;
-      font-size: 12px;
-    }
     .pipe-grid {
       grid-template-columns: 1fr;
     }
     .perf-layout {
       grid-template-columns: 1fr;
-    }
-    .control-hero {
-      padding: 14px 12px 12px;
-    }
-    .control-title {
-      font-size: 1.2rem;
-    }
-    .review-queue-head {
-      flex-direction: column;
-      align-items: stretch;
-    }
-    .review-queue-copy {
-      flex: 1 1 auto;
     }
     .ov-panel-actions {
       width: 100%;
@@ -1715,10 +1342,6 @@
       text-align: center;
       white-space: normal;
     }
-    .review-list a {
-      padding: 10px;
-      gap: 8px;
-    }
     .up-title {
       white-space: normal;
       display: -webkit-box;
@@ -1726,34 +1349,8 @@
       -webkit-box-orient: vertical;
       text-overflow: ellipsis;
     }
-    .review-queue-foot {
-      flex-direction: column;
-      align-items: stretch;
-    }
-    .review-pager {
-      justify-content: space-between;
-      width: 100%;
-    }
   }
 
   @container workbench (max-width: 420px) {
-    .gauge-row {
-      gap: 4px;
-    }
-    .gauge {
-      padding: 10px 4px;
-    }
-    .gauge-ring {
-      width: 52px;
-      height: 52px;
-    }
-    .gauge-ring span {
-      width: 40px;
-      height: 40px;
-      font-size: 11px;
-    }
-    .gauge-label {
-      font-size: 11px;
-    }
   }
 </style>

--- a/src/lib/home-todos.test.ts
+++ b/src/lib/home-todos.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { homeTodos, type TodoSource } from './home-todos';
+
+const nothing: TodoSource = {
+  queue: { pending: 0 },
+  blog: { pending: 0 },
+  automations: { radarEnabled: true, radarReview: 0, leadsPending: 0 },
+  setup: { socialAccounts: 1 }
+};
+
+const src = (patch: Partial<TodoSource>): TodoSource => ({ ...nothing, ...patch });
+
+describe('le cose da fare in cima alla home', () => {
+  it('non inventa righe quando non c’è niente da fare', () => {
+    expect(homeTodos(nothing)).toEqual([]);
+  });
+
+  /**
+   * L'ordine è la gerarchia del mockup: prima ciò che ha una scadenza vera — un post approvato
+   * in ritardo è un post che non esce — poi ciò che aspetta senza scadere, poi il setup, che
+   * non scade mai.
+   */
+  it('mette per prime le approvazioni, che sono le uniche con una scadenza', () => {
+    const todos = homeTodos({
+      queue: { pending: 4 },
+      blog: { pending: 2 },
+      automations: { radarEnabled: true, radarReview: 7, leadsPending: 3 },
+      setup: { socialAccounts: 0 }
+    });
+
+    expect(todos.map((t) => t.key)).toEqual(['posts', 'articles', 'radar', 'leads', 'social']);
+  });
+
+  it('porta il conteggio, perché «4 da approvare» dice più di «da approvare»', () => {
+    const [posts] = homeTodos(src({ queue: { pending: 4 } }));
+
+    expect(posts.count).toBe(4);
+    expect(posts.path).toBe('/calendar?status=pending_user');
+  });
+
+  it('non offre il radar da rivedere se il radar è spento', () => {
+    const todos = homeTodos(
+      src({ automations: { radarEnabled: false, radarReview: 9, leadsPending: 0 } })
+    );
+
+    expect(todos).toEqual([]);
+  });
+
+  /**
+   * Zero account collegati è l'unica riga che non nasce da un conteggio ma da un'assenza: senza
+   * un account l'AI produce e non pubblica, e il brand se ne accorge quando è tardi.
+   */
+  it('dice che manca un account collegato, che è la riga senza numero', () => {
+    const [social] = homeTodos(src({ setup: { socialAccounts: 0 } }));
+
+    expect(social.key).toBe('social');
+    expect(social.count).toBe(0);
+    expect(social.path).toBe('/settings/connected-accounts');
+  });
+
+  it('ogni riga sa dove porta e come si chiama, senza testo scritto dentro', () => {
+    const todos = homeTodos({
+      queue: { pending: 1 },
+      blog: { pending: 1 },
+      automations: { radarEnabled: true, radarReview: 1, leadsPending: 1 },
+      setup: { socialAccounts: 0 }
+    });
+
+    for (const todo of todos) {
+      expect(todo.labelKey, todo.key).toMatch(/^app\./);
+      expect(todo.hintKey, todo.key).toMatch(/^app\./);
+      expect(todo.path.startsWith('/'), todo.key).toBe(true);
+    }
+  });
+});

--- a/src/lib/home-todos.ts
+++ b/src/lib/home-todos.ts
@@ -1,0 +1,87 @@
+/**
+ * LE COSE DA FARE, in cima alla home del brand.
+ *
+ * La regola del mockup: ciò che richiede attenzione sta sopra, con quante sono; il resto scende.
+ * Qui c'è solo la SELEZIONE e l'ORDINE — nessun testo, come per la nav: le etichette sono chiavi
+ * i18n, e la pagina le traduce. Così questo si può far fallire per la ragione giusta.
+ *
+ * Una riga esiste solo se ha qualcosa da dire: niente riquadri vuoti a riempire lo spazio.
+ */
+
+export type TodoSource = {
+  queue: { pending: number };
+  blog: { pending: number };
+  automations: { radarEnabled: boolean; radarReview: number; leadsPending: number };
+  setup: { socialAccounts: number };
+};
+
+export type TodoItem = {
+  key: string;
+  /** Frase col conteggio dentro (`{n, plural, …}`). */
+  labelKey: string;
+  count: number;
+  /** Dove vive la cosa: la riga secondaria, la stessa parola della sidebar. */
+  hintKey: string;
+  /** Sotto `/app/<slug>`. */
+  path: string;
+};
+
+export function homeTodos(overview: TodoSource): TodoItem[] {
+  const todos: TodoItem[] = [];
+
+  // Prima ciò che ha una scadenza vera: un post approvato in ritardo è un post che non esce.
+  if (overview.queue.pending > 0) {
+    todos.push({
+      key: 'posts',
+      labelKey: 'app.home.overview.postsToAccept',
+      count: overview.queue.pending,
+      hintKey: 'app.hub.publish.calendar',
+      path: '/calendar?status=pending_user'
+    });
+  }
+
+  if (overview.blog.pending > 0) {
+    todos.push({
+      key: 'articles',
+      labelKey: 'app.home.overview.blogsToAccept',
+      count: overview.blog.pending,
+      hintKey: 'app.nav2.site',
+      path: '/site'
+    });
+  }
+
+  // Poi ciò che aspetta senza scadere.
+  if (overview.automations.radarEnabled && overview.automations.radarReview > 0) {
+    todos.push({
+      key: 'radar',
+      labelKey: 'app.home.overview.radarReview',
+      count: overview.automations.radarReview,
+      hintKey: 'app.nav2.newsRadar',
+      path: '/radar'
+    });
+  }
+
+  if (overview.automations.leadsPending > 0) {
+    todos.push({
+      key: 'leads',
+      labelKey: 'app.home.overview.leadsPending',
+      count: overview.automations.leadsPending,
+      hintKey: 'app.hub.automations.leads',
+      path: '/leads'
+    });
+  }
+
+  // Infine il setup, che non scade mai — ma senza un account collegato l'AI produce e non
+  // pubblica, e il brand se ne accorge quando è tardi.
+  if (overview.setup.socialAccounts === 0) {
+    todos.push({
+      key: 'social',
+      labelKey: 'app.home.todo.noSocial',
+      count: 0,
+      hintKey: 'app.settings.connectedAccounts',
+      path: '/settings/connected-accounts'
+    });
+  }
+
+  return todos;
+}

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -4521,6 +4521,12 @@
           "gsc": "Connect Google Search Console"
         }
       },
+      "todo": {
+        "title": "To do",
+        "count": "{n, plural, one {# thing needs you} other {# things need you}}",
+        "empty": "Nothing needs you right now. New drafts, radar signals and leads land here as they arrive.",
+        "noSocial": "No account connected yet"
+      },
       "overview": {
         "title": "Overview",
         "subtitle": "What needs your attention, what's coming up, how the web is performing, and how content is doing.",

--- a/src/lib/i18n/locales/es.json
+++ b/src/lib/i18n/locales/es.json
@@ -4182,6 +4182,12 @@
           "gsc": "Conecta Google Search Console"
         }
       },
+      "todo": {
+        "title": "Por hacer",
+        "count": "{n, plural, one {# cosa necesita tu atención} other {# cosas necesitan tu atención}}",
+        "empty": "No hay nada esperando. Los borradores nuevos, las señales del radar y los leads aparecen aquí en cuanto llegan.",
+        "noSocial": "Aún no hay ninguna cuenta conectada"
+      },
       "overview": {
         "title": "Resumen",
         "subtitle": "Qué necesita tu atención, qué está programado, cómo va la web y cómo rinden los contenidos.",

--- a/src/lib/i18n/locales/fr.json
+++ b/src/lib/i18n/locales/fr.json
@@ -4182,6 +4182,12 @@
           "gsc": "Connecter Google Search Console"
         }
       },
+      "todo": {
+        "title": "À faire",
+        "count": "{n, plural, one {# chose demande votre attention} other {# choses demandent votre attention}}",
+        "empty": "Rien n’attend. Les nouveaux brouillons, les signaux du radar et les leads apparaissent ici dès leur arrivée.",
+        "noSocial": "Aucun compte connecté pour l’instant"
+      },
       "overview": {
         "title": "Aperçu",
         "subtitle": "Ce qui demande votre attention, ce qui est planifié, les perfs web et comment vont vos contenus.",

--- a/src/lib/i18n/locales/it.json
+++ b/src/lib/i18n/locales/it.json
@@ -4522,6 +4522,12 @@
           "gsc": "Collega Google Search Console"
         }
       },
+      "todo": {
+        "title": "Da fare",
+        "count": "{n, plural, one {# cosa richiede la tua attenzione} other {# cose richiedono la tua attenzione}}",
+        "empty": "Non c’è niente in attesa. Bozze nuove, segnali del radar e lead compaiono qui appena arrivano.",
+        "noSocial": "Nessun account ancora collegato"
+      },
       "overview": {
         "title": "Panoramica",
         "subtitle": "Cosa richiede la tua attenzione, cosa è in programma, come sta andando il web e come performano i contenuti.",


### PR DESCRIPTION
## What?

La home del brand (`/app/<slug>/workbench`, dove `/app/<slug>` rimanda) apre con **«Da fare»**:
quante cose ti aspettano, e una riga per ciascuna con dove porta. È la gerarchia del mockup —
ciò che richiede attenzione in cima, il resto sotto.

Al suo posto c'era il blocco `control-hero`. Se ne va con lui la coda paginata dei singoli post
e i tre gauge ad anello: **`HomeWorkbench.svelte` passa da 1.759 a 1.356 righe**, netto
`+365 / −521`.

## Why?

Era l'unica cosa che `/v2` aveva e `/app` no, e il divario più grande rimasto dopo aver
cancellato `/v2` (#288).

Cosa c'era, e perché non faceva il lavoro:

- **Tre gauge ad anello** — percentuale di setup, punteggio SEO, citabilità GEO. Sono ornamento:
  tre cerchi animati che non dicono cosa fare. E sono anche ridondanti, adesso: il setup ha già
  la sua barra dieci righe sopra, SEO e GEO hanno la loro riga in barra laterale da quando «Web»
  si è sdoppiata (#295).
- **Una coda paginata dei singoli post da approvare** — cinque per pagina, avanti/indietro,
  «mostra tutti», «mostra meno»: quattro `$state`, un `$effect` che riallinea il numero di
  pagina, due funzioni. Diceva la stessa cosa della riga «4 contenuti da approvare» con un clic
  in più e una paginazione da mantenere.

## How?

**La selezione e l'ordine stanno in `$lib/home-todos.ts`**, puro e sotto test, come `navFor` per
la barra. Non contiene una parola di testo: restituisce chiavi i18n e conteggi, e la pagina
traduce. È l'unico pezzo del blocco che si può far fallire per la ragione giusta.

| Riga | Quando compare | Dove porta |
|---|---|---|
| N post da accettare | `queue.pending > 0` | `/calendar?status=pending_user` |
| N articoli da accettare | `blog.pending > 0` | `/site` |
| N segnali da rivedere | radar **acceso** e `radarReview > 0` | `/radar` |
| N lead in attesa | `leadsPending > 0` | `/leads` |
| Nessun account collegato | `socialAccounts === 0` | `/settings/connected-accounts` |

**L'ordine è la gerarchia, e ha una ragione che sta nel test**: prima ciò che ha una scadenza
vera — un post approvato in ritardo è un post che non esce — poi ciò che aspetta senza scadere,
infine il setup, che non scade mai. Ma zero account collegati resta una riga, perché senza un
account l'AI produce e non pubblica, e il brand se ne accorge quando è tardi: è l'unica che nasce
da un'assenza invece che da un conteggio.

**Il radar spento non produce una riga.** Offrire «segnali da rivedere» per una funzione che non
gira è peggio che tacere.

**Cinque etichette su sei erano già nei cataloghi** (`postsToAccept`, `blogsToAccept`,
`radarReview`, `leadsPending`, `review`): ho aggiunto solo `app.home.todo.*` — titolo, conteggio
al plurale, stato vuoto e «nessun account» — nelle quattro lingue.

**Lo stato vuoto dice perché è vuoto**: non «niente da fare», ma *«Non c'è niente in attesa.
Bozze nuove, segnali del radar e lead compaiono qui appena arrivano.»* Chi arriva a home vuota
deve capire se il prodotto sta lavorando o se è rotto.

**Il CSS morto è stato tolto**, non lasciato lì: le regole di `control-hero`, `gauge*` e
`review-*` sparivano dal markup ma sarebbero rimaste nel foglio. Le ho rimosse solo dove **tutti**
i selettori della regola erano morti — `.up-*` e `.ov-*` sono condivise con la sezione «In arrivo»
e restano.

## Testing?

**La verifica in browser è rimandata**: niente Docker, niente dev server, niente Playwright,
nessuna verifica visiva. Questa è una PR visiva e la verifica conta più del solito — i punti in
*Anything Else?*.

| Comando | Esito |
|---|---|
| `node scripts/typecheck-runtime.mjs` | `ok (ignored 331 non-fatal type error(s))` |
| `npx vitest run $(git grep -ln "readFileSync\|readdirSync\|existsSync" -- 'src/**/*.test.ts')` | **74 file, 1.005 test, tutti verdi** |
| `npx vitest run src/lib/home-todos.test.ts src/lib/i18n/locales.test.ts` | **24 verdi** (6 nuovi) |

**Rosso prima del verde**, col modulo scritto dopo il suo test:

```
Error: Failed to load url ./home-todos (resolved id: ./home-todos) in
  …/src/lib/home-todos.test.ts. Does the file exist?
 Test Files  1 failed (1)
      Tests  no tests
```

I sei casi: nessuna riga quando non c'è niente; l'ordine completo con tutte le fonti accese; il
conteggio e la destinazione; il radar spento che non produce niente; la riga senza numero; e che
ogni riga porti chiavi i18n e un path, non testo.

**Non testato**: il rendering. Qui i componenti non si montano nei test, e la logica che avrebbe
avuto dentro sta nel modulo puro. Non ho eseguito la suite intera né l'eval (nessun tocco a chat,
prompt, tool o modello).

## Evidence

Nessuno screenshot: la verifica visiva è rimandata e non voglio farla sembrare fatta.

<details>
<summary>La cima della home, prima e dopo</summary>

```
PRIMA                                     DOPO
──────────────────────────────            ──────────────────────────────
Attenzione                                Da fare
4 elementi da rivedere                    3 cose richiedono la tua attenzione
Approva le bozze per tenere…
                                          ┌────────────────────────────────┐
   ◯ 62      ◯ 78      ◯ 4/9              │ 4 post da accettare    [Rivedi]│
  Setup      SEO        GEO               │ Calendario                     │
                                          ├────────────────────────────────┤
Da rivedere                               │ 7 da rivedere          [Rivedi]│
4 post da accettare                       │ News Radar                     │
┌──┐ instagram                            ├────────────────────────────────┤
│▓▓│ Carosello — 3 piatti dell'autunno     │ Nessun account collegato       │
└──┘                                      │ Account collegati      [Rivedi]│
┌──┐ …altre 4 righe…                      └────────────────────────────────┘
Mostra tutti (12) →   ‹ 1 di 3 ›
```
</details>

<details>
<summary>Il conto</summary>

```
 8 files changed, 365 insertions(+), 521 deletions(-)

 src/lib/components/HomeWorkbench.svelte   1759 → 1356 righe
 src/lib/home-todos.ts                     nuovo
 src/lib/home-todos.test.ts                nuovo, 6 casi
 src/lib/i18n/locales/*.json               +4 chiavi ×4 lingue
```
</details>

## Anything Else?

**Da guardare nella verifica in browser** — è una PR visiva, quindi vale doppio:

- una home con **tutte** le righe accese e una **senza nessuna** (lo stato vuoto è la metà che
  non si vede mai per caso);
- il plurale a 1 e a 0 nelle quattro lingue — il conteggio passa da `{n, plural, …}`;
- che ogni riga porti dove dice, e che il filtro `?status=pending_user` arrivi al calendario
  applicato;
- la larghezza stretta: le righe sono `flex` con il pulsante a destra, e un'etichetta lunga in
  tedesco… non c'è il tedesco, ma il francese è lungo.

**Una sovrapposizione dichiarata**: la sezione «Pipeline contenuti» qui sotto continua a mostrare
gli stessi conteggi in forma di barre. Il blocco nuovo li dice in forma di lavoro da fare. Non è
un difetto oggi — sono due letture dello stesso dato — ma è esattamente il genere di doppione che
lo sfoltimento pagina per pagina deve sciogliere, e la home è la prima pagina della lista.

**Cosa NON ho toccato**: pipeline, in arrivo, web, analisi. Restano dov'erano. Ridisegnare tutta
la pagina mentre le si cambia la cima avrebbe mescolato due diagnosi.

**Changelog**: interno (`changelog/2026-09-04-home-cose-da-fare.md`). Il pubblico lo scriverei
**qui**, e non con la barra: «la home ti dice cosa ti aspetta, con quante sono» è una notizia per
chi usa il prodotto; «la barra ha nove voci» no. Dimmi se lo aggiungo a questa PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
