### PR TITLE
Serve the built-in production skills too

### DIFF
--- a/changelog/2026-09-04-skill-di-scrittura-fuori-dal-bridge.md
+++ b/changelog/2026-09-04-skill-di-scrittura-fuori-dal-bridge.md
@@ -87,3 +87,25 @@ la rotta, lo fa diventare rosso.
 solo estratta `brandSkillsForAgent` — le sole skill di prodotto, senza toccare il disco — in un
 commit separato senza cambi di comportamento, come vuole la regola: prima si riordina, poi si
 aggiunge.
+
+## Aggiunta dopo la revisione: le skill di default in codice
+
+`DEFAULT_SKILLS` (`src/lib/server/default-skills.ts`) sono sei procedure di produzione definite in
+codice — quattro motion, due grafica — ognuna con il nome del **gate che rifiuta il render** se non
+la si segue (`assertMotionVoiceGate`, `graphic-check`). Non sono conoscenza del brand: sono tecnica
+del prodotto, aggiornata col deploy.
+
+Arrivavano a un modello per due strade, **entrambe nel perimetro in smantellamento**: il trigger
+nell'indice del prompt via `buildMemoryContext`, e il corpo via `read_memory` in
+`src/lib/agent/tools/expression-memory-tools.ts`. Stessa regressione delle skill markdown, scoperta
+solo guardando i contatori.
+
+Un agente esterno che scrive uno script motion senza `motion-voiceover-fit` si vede rifiutare
+`make_video` e non sa perché. Ora escono dallo stesso tool, con `defaultSkillEntries(agent)` —
+la stessa funzione, lo stesso scoping per agente, gli stessi id `builtin:` che non devono mai
+finire in `recordMemoryUsage`.
+
+Nella stessa passata, `serveBrand` è stato sostituito da `serveSkillEntry`, che usa **`skillTrigger`**
+invece di tagliare la prima riga a mano: è la funzione che riempie l'indice del prompt interno, salta
+le righe vuote, toglie `#` e `**` e taglia a 100 caratteri. Due modi di estrarre lo stesso trigger
+divergono al primo `## Use when …`.

--- a/cli/lib/contracts/writing-skills.ts
+++ b/cli/lib/contracts/writing-skills.ts
@@ -22,7 +22,7 @@ export const GET_WRITING_SKILLS = {
   description:
     'READ THIS BEFORE WRITING ANY COPY FOR THE BRAND — a caption, a carousel, a script, an article, a bio. ' +
     'It returns the actual craft text Anomalia writes with: `humanizer` and `stop-slop` always (why the output must not read as a chatbot), plus `social` or `seo-audit` depending on `agent`. ' +
-    'It also returns this brand\'s OWN procedures, the ones its team wrote or the system distilled — `source` says which is which, and a brand procedure overrules a product skill when they disagree. ' +
+    'It also returns the built-in production skills for that agent — the ones naming the gates that refuse a render — and this brand\'s OWN procedures, the ones its team wrote or the system distilled. `source` says product from brand, and a brand procedure overrules a product skill when they disagree. ' +
     'Bodies come inline; each skill lists its `references` by path without sending them, and you fetch one by passing `reference: "<skill>/<path>"`, which then returns that file alone. ' +
     'No credits, no writes. Reading it costs a few thousand tokens and is the difference between copy a person would publish and copy that reads as generated.',
   method: 'GET',

--- a/cli/plugins/anomalia/skills/anomalia/references/tools.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/tools.md
@@ -210,10 +210,14 @@ A brand keeps one draft in review, so saving replaces the one that is there (`re
 (captions, carousels, hooks, platform limits) or `seo-audit` depending on `agent`. Omit `agent`
 for the writing deck alone; `content` and `ugc` add `social`, `web` adds `seo-audit`.
 
-It also returns this brand's OWN procedures — what its team wrote down or the system distilled
-from repeated lessons. `source` tells them apart, and **a brand procedure overrules a product
-skill when the two disagree**: the product skill is how everyone writes, the brand procedure is
-how this one does.
+It also returns the **built-in production skills** for that agent — the ones that name the gates
+which refuse a render (`motion-voiceover-fit`, `graphic-feed-legibility`, and the rest). Write a
+motion script without them and `make_video` gets refused with no explanation.
+
+And it returns this brand's OWN procedures — what its team wrote down or the system distilled
+from repeated lessons. `source` tells product from brand, and **a brand procedure overrules a
+product skill when the two disagree**: the product skill is how everyone writes, the brand
+procedure is how this one does.
 
 Bodies arrive inline. Each skill lists its `references` by path without sending them; fetch one
 with `reference: "social/references/platform-limits.md"`, which returns that file alone and no

--- a/cli/skills/anomalia/references/tools.md
+++ b/cli/skills/anomalia/references/tools.md
@@ -210,10 +210,14 @@ A brand keeps one draft in review, so saving replaces the one that is there (`re
 (captions, carousels, hooks, platform limits) or `seo-audit` depending on `agent`. Omit `agent`
 for the writing deck alone; `content` and `ugc` add `social`, `web` adds `seo-audit`.
 
-It also returns this brand's OWN procedures — what its team wrote down or the system distilled
-from repeated lessons. `source` tells them apart, and **a brand procedure overrules a product
-skill when the two disagree**: the product skill is how everyone writes, the brand procedure is
-how this one does.
+It also returns the **built-in production skills** for that agent — the ones that name the gates
+which refuse a render (`motion-voiceover-fit`, `graphic-feed-legibility`, and the rest). Write a
+motion script without them and `make_video` gets refused with no explanation.
+
+And it returns this brand's OWN procedures — what its team wrote down or the system distilled
+from repeated lessons. `source` tells product from brand, and **a brand procedure overrules a
+product skill when the two disagree**: the product skill is how everyone writes, the brand
+procedure is how this one does.
 
 Bodies arrive inline. Each skill lists its `references` by path without sending them; fetch one
 with `reference: "social/references/platform-limits.md"`, which returns that file alone and no

--- a/packages/api-contracts/src/writing-skills.ts
+++ b/packages/api-contracts/src/writing-skills.ts
@@ -22,7 +22,7 @@ export const GET_WRITING_SKILLS = {
   description:
     'READ THIS BEFORE WRITING ANY COPY FOR THE BRAND — a caption, a carousel, a script, an article, a bio. ' +
     'It returns the actual craft text Anomalia writes with: `humanizer` and `stop-slop` always (why the output must not read as a chatbot), plus `social` or `seo-audit` depending on `agent`. ' +
-    'It also returns this brand\'s OWN procedures, the ones its team wrote or the system distilled — `source` says which is which, and a brand procedure overrules a product skill when they disagree. ' +
+    'It also returns the built-in production skills for that agent — the ones naming the gates that refuse a render — and this brand\'s OWN procedures, the ones its team wrote or the system distilled. `source` says product from brand, and a brand procedure overrules a product skill when they disagree. ' +
     'Bodies come inline; each skill lists its `references` by path without sending them, and you fetch one by passing `reference: "<skill>/<path>"`, which then returns that file alone. ' +
     'No credits, no writes. Reading it costs a few thousand tokens and is the difference between copy a person would publish and copy that reads as generated.',
   method: 'GET',

--- a/src/routes/api/v1/brands/[slug]/writing-skills/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/writing-skills/+server.ts
@@ -2,16 +2,19 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { authenticate, loadBrandForUser } from '$lib/server/cli-auth';
 import { brandSkills, brandSkillsForAgent } from '$lib/server/brand-skills';
-import { loadMemoryEntries } from '$lib/server/brand-memory';
+import { loadMemoryEntries, skillTrigger } from '$lib/server/brand-memory';
+import { defaultSkillEntries } from '$lib/server/default-skills';
 import type { HarnessRepoSkill } from '$lib/server/harness-skills';
 
-// LE SKILL DI SCRITTURA, SERVITE A UN MODELLO CHE STA FUORI. Fino a qui raggiungevano un modello
-// solo attraverso `skillsForAgent`, il cui unico chiamante vive nel bridge in smantellamento:
-// tolto quello, il testo che impedisce alla copy di suonare da chatbot smetteva di arrivare a
-// chiunque, senza che niente fallisse. Un agente esterno non ha l'harness — ha da leggere.
+// LE SKILL, SERVITE A UN MODELLO CHE STA FUORI. Fino a qui raggiungevano un modello per due
+// strade che muoiono insieme: `skillsForAgent`, il cui unico chiamante vive nel bridge in
+// smantellamento, e `read_memory` in `agent/tools/`, che sta nello stesso perimetro. Tolti quelli,
+// il testo che impedisce alla copy di suonare da chatbot — e quello che impedisce a un render di
+// essere rifiutato — smetteva di arrivare a chiunque. Un agente esterno non ha l'harness: legge.
 //
-// Due sorgenti, un elenco solo, distinte da `source`:
-//   product → i markdown del prodotto, uguali per ogni brand
+// Tre sorgenti, un elenco solo, due valori di `source`:
+//   product → i markdown del mestiere (`agent-docs/skills`) e le skill di default in codice
+//             (`DEFAULT_SKILLS`): uguali per ogni brand, si aggiornano col deploy
 //   brand   → le procedure di QUESTO brand (`brand_memory`, categoria `skill`)
 
 type Served = {
@@ -34,14 +37,20 @@ function serveProduct(skill: HarnessRepoSkill): Served {
   };
 }
 
-/** Il valore di una skill del brand è markdown la cui PRIMA RIGA è il trigger; il resto sono i passi. */
-function serveBrand(entry: { key: string; value: string }): Served {
-  const [trigger, ...rest] = entry.value.split('\n');
+/**
+ * Il valore di una skill è markdown la cui prima riga utile è il trigger e il resto sono i passi.
+ * Il trigger lo estrae `skillTrigger`, lo stesso che riempie l'indice del prompt interno: due
+ * modi di tagliare la stessa riga divergerebbero al primo titolo scritto come `## Use when …`.
+ */
+function serveSkillEntry(entry: { key: string; value: string }, source: Served['source']): Served {
+  const lines = entry.value.split('\n');
+  const trigger = lines.findIndex((line) => line.trim());
+
   return {
     name: entry.key,
-    source: 'brand',
-    description: trigger.trim(),
-    body: rest.join('\n').trim(),
+    source,
+    description: skillTrigger(entry.value),
+    body: lines.slice(trigger + 1).join('\n').trim(),
     references: []
   };
 }
@@ -75,12 +84,14 @@ export const GET: RequestHandler = async ({ request, params, url }) => {
     return json({ skills: [], reference });
   }
 
+  const agent = url.searchParams.get('agent');
   const entries = await loadMemoryEntries(supabase, brand.id, { category: 'skill' });
 
   return json({
     skills: [
-      ...brandSkillsForAgent(url.searchParams.get('agent')).map(serveProduct),
-      ...entries.map(serveBrand)
+      ...brandSkillsForAgent(agent).map(serveProduct),
+      ...defaultSkillEntries(agent).map((entry) => serveSkillEntry(entry, 'product')),
+      ...entries.map((entry) => serveSkillEntry(entry, 'brand'))
     ],
     reference: null
   });

--- a/src/routes/api/v1/brands/[slug]/writing-skills/server.test.ts
+++ b/src/routes/api/v1/brands/[slug]/writing-skills/server.test.ts
@@ -8,6 +8,7 @@ vi.mock('$lib/server/cli-auth', () => ({
 import { GET } from './+server';
 import { authenticate, loadBrandForUser } from '$lib/server/cli-auth';
 import { brandSkills } from '$lib/server/brand-skills';
+import { DEFAULT_SKILLS, defaultSkillsFor } from '$lib/server/default-skills';
 import { TEAM_AGENT_IDS } from '$lib/agent-owners';
 import { WRITING_DECK_AGENTS } from '@anomalia/api-contracts';
 
@@ -88,6 +89,13 @@ function call(query: Record<string, string> = {}, slug = 'demo') {
   }).then(async (res) => ({ res, body: await res.json() }));
 }
 
+/** Il mazzo dei markdown del mestiere, separato dalle skill di default in codice. */
+const craftDeck = (body: { skills: { name: string }[] }) =>
+  body.skills
+    .filter((skill) => brandSkills.some((craft) => craft.name === skill.name))
+    .map((skill) => skill.name)
+    .sort();
+
 beforeEach(() => {
   vi.clearAllMocks();
 });
@@ -105,12 +113,54 @@ describe('GET /writing-skills', () => {
     const reachable = new Set<string>();
     for (const agent of WRITING_DECK_AGENTS) {
       const { body } = await call({ agent });
-      for (const skill of body.skills) {
-        if (skill.source === 'product') reachable.add(skill.name);
-      }
+      for (const name of craftDeck(body)) reachable.add(name);
     }
 
     expect([...reachable].sort()).toEqual(brandSkills.map((s) => s.name).sort());
+  });
+
+  /**
+   * Le skill di default sono TECNICA DEL PRODOTTO in codice — i gate che fanno rifiutare un
+   * render. Arrivavano a un modello solo da `read_memory` in `agent/tools/`, cioè dallo stesso
+   * perimetro in smantellamento: senza questo, un agente esterno scrive uno script che il voice
+   * gate boccia e non sa perché.
+   */
+  it('anche le skill di default in codice escono dal perimetro che sta per sparire', async () => {
+    signedIn();
+
+    const reachable = new Set<string>();
+    for (const agent of WRITING_DECK_AGENTS) {
+      const { body } = await call({ agent });
+      for (const skill of body.skills) reachable.add(skill.name);
+    }
+
+    for (const skill of DEFAULT_SKILLS) {
+      expect([...reachable], skill.key).toContain(skill.key);
+    }
+  });
+
+  it('ogni agente vede solo le skill di default che lo riguardano', async () => {
+    signedIn();
+
+    const { body } = await call({ agent: 'analyst' });
+    const served = body.skills.map((s: { name: string }) => s.name);
+
+    expect(defaultSkillsFor('analyst')).toEqual([]);
+    for (const skill of DEFAULT_SKILLS) {
+      expect(served, skill.key).not.toContain(skill.key);
+    }
+  });
+
+  it('una skill di default porta il trigger come descrizione e i passi come corpo', async () => {
+    signedIn();
+
+    const { body } = await call({ agent: 'motion' });
+    const voice = body.skills.find((s: { name: string }) => s.name === 'motion-voiceover-fit');
+
+    expect(voice.source).toBe('product');
+    expect(voice.description).toBe('Use when a motion video has (or should have) a voice-over.');
+    expect(voice.body).toContain('generate_voiceover');
+    expect(voice.body).not.toContain('Use when a motion video has');
   });
 
   it('serve il testo, non un riferimento a un file che il modello non può aprire', async () => {
@@ -130,8 +180,7 @@ describe('GET /writing-skills', () => {
 
     const { body } = await call();
 
-    expect(body.skills.filter((s: { source: string }) => s.source === 'product').map((s: { name: string }) => s.name).sort())
-      .toEqual(['humanizer', 'stop-slop']);
+    expect(craftDeck(body)).toEqual(['humanizer', 'stop-slop']);
   });
 
   it('ogni agente porta il suo mazzo, e chi scrive social porta `social`', async () => {
@@ -140,11 +189,8 @@ describe('GET /writing-skills', () => {
     const content = await call({ agent: 'content' });
     const web = await call({ agent: 'web' });
 
-    const names = (r: { body: { skills: { name: string; source: string }[] } }) =>
-      r.body.skills.filter((s) => s.source === 'product').map((s) => s.name).sort();
-
-    expect(names(content)).toEqual(['humanizer', 'social', 'stop-slop']);
-    expect(names(web)).toEqual(['humanizer', 'seo-audit', 'stop-slop']);
+    expect(craftDeck(content.body)).toEqual(['humanizer', 'social', 'stop-slop']);
+    expect(craftDeck(web.body)).toEqual(['humanizer', 'seo-audit', 'stop-slop']);
   });
 
   it('elenca i riferimenti senza spedirli: 145 KB non stanno in una risposta', async () => {
@@ -224,6 +270,6 @@ describe('GET /writing-skills', () => {
     const { body } = await call();
 
     expect(body.skills.every((s: { source: string }) => s.source === 'product')).toBe(true);
-    expect(body.skills.length).toBe(2);
+    expect(craftDeck(body)).toEqual(['humanizer', 'stop-slop']);
   });
 });


### PR DESCRIPTION
## What?

`get_writing_skills` (#298) now also serves `DEFAULT_SKILLS` — the six built-in production procedures defined in `src/lib/server/default-skills.ts` — and stops reimplementing `skillTrigger`.

`tools/list` stays at 114. No tool added, removed, or changed: `changed existing: none`.

## Why?

#298 closed one road and missed its twin, found only by following the usage counters flagged in that PR's own notes.

`DEFAULT_SKILLS` are four motion and two graphic procedures, each naming the **gate that refuses a render** when it is ignored (`assertMotionVoiceGate`, `graphic-check`). They are product technique, updated by deploy, not brand knowledge. They reached a model down two roads, and **both are inside the perimeter being dismantled**:

- the trigger line, through `buildMemoryContext`;
- the body, through `read_memory` in `src/lib/agent/tools/expression-memory-tools.ts`.

That is exactly the regression #298 exists to prevent, one file over. Concretely: an external agent writes a motion script without `motion-voiceover-fit`, calls `make_video`, and the voice gate refuses the render — with no way for it to learn why, because the skill that explains the gate was only reachable through the harness.

Second, smaller: #298's route split the first line of a skill by hand. `skillTrigger` already exists in `brand-memory.ts` and is what fills the internal prompt index — it skips blank lines, strips `#` and `**`, and caps at 100 characters. Two ways of cutting the same trigger diverge on the first skill written as `## Use when …`.

## How?

`defaultSkillEntries(agent)` already returns them agent-scoped in memory-entry shape, with `builtin:` ids that must never reach `recordMemoryUsage` (it updates by uuid) or `remove_memory`. Serving them is the same call the internal tool makes — no second scoping rule, no copy of the list.

`serveBrand` becomes `serveSkillEntry(entry, source)`, shared by built-in and brand skills, using `skillTrigger` for the description and the remainder for the body.

**Agent scoping is left exactly as the internal rule has it**, including `defaultSkillsFor(null)` returning all of them. Omitting `agent` means "unknown caller, full toolset" internally, and the same is true externally — an external agent that declares no role can still call `make_video`. One rule in one place beats two that drift.

**`source` stays two values.** Built-in skills are `product`: same owner, same deploy cadence, same losing side when a brand procedure disagrees. Adding a third value to say "this one is about rendering" would encode in metadata what the name and the trigger line already say.

## Testing?

<details><summary>Red — the built-in skills were not served</summary>

```
 × anche le skill di default in codice escono dal perimetro che sta per sparire
   → expected [ 'humanizer', 'stop-slop', … ] to contain 'motion-voiceover-fit'
```

And the deck assertions from #298 went red once the built-ins were added, which is the guard working: they asserted over *all* product skills instead of over the craft deck. They now compare against `brandSkills` explicitly through a `craftDeck` helper, so a built-in skill can never be mistaken for a markdown one.

```
 × ogni skill di prodotto raggiunge un modello per una strada che non passa dal bridge
   → expected [ 'graphic-feed-legibility', …(9) ] to deeply equal [ 'humanizer', 'seo-audit', …(2) ]
 × il mazzo predefinito è quello di scrittura
 × ogni agente porta il suo mazzo
 × un brand senza procedure proprie riceve comunque quelle di prodotto
```
</details>

<details><summary>Green</summary>

```
$ npx vitest run packages/api-contracts "src/routes/api/v1/brands/[slug]/writing-skills" \
                 src/lib/server/brand-skills.test.ts src/lib/server/default-skills.test.ts \
                 src/lib/server/brand-memory.test.ts
 Test Files  20 passed (20)
      Tests  253 passed (253)

$ cd cli && bun test
 0 fail / 665 expect() calls / 58 tests across 12 files

$ cd cli && bun run typecheck
$ tsc --noEmit          (exit 0)

$ node scripts/typecheck-runtime.mjs
typecheck-runtime: ok (ignored 313 non-fatal type error(s))
```
</details>

Three new tests: every `DEFAULT_SKILLS` key is reachable across the six decks; `analyst` — for which `defaultSkillsFor` returns `[]` — sees none of them; and a built-in skill carries its trigger as `description` and the steps as `body`, with the trigger not repeated inside the body. The existing `brand-memory` and `default-skills` suites pass untouched.

## Evidence

<details><summary><code>tools/list</code> — dev vs this branch</summary>

```
dev=113  PR=114
removed: []  added: ['get_writing_skills']
changed existing: none
```

114 is the same number #298 reached: this PR changes what the tool *answers*, not the catalogue. The only description edit is `get_writing_skills`'s own, which did not exist on dev at capture time.
</details>

<details><summary>What <code>agent=motion</code> now returns that it did not</summary>

```jsonc
{
  "name": "motion-voiceover-fit",
  "source": "product",
  "description": "Use when a motion video has (or should have) a voice-over.",
  "body": "1. Write every spoken line first, then call generate_voiceover ONCE with all of them …",
  "references": []
}
```

Plus `motion-alive-scenes`, `motion-screenshot-legibility`, `motion-transition-mechanism`, and for `content` the two graphic ones. About 6 KB, only for the agents they apply to.
</details>

## Anything Else?

- The counter gap from #298 is unchanged and still open: an external read of a brand skill does not bump `times_used`, so it does not feed decay in `runDream`. Built-in skills are unaffected — their `builtin:` ids were never counted by design.
- Fix for #298, already merged. Independent of everything else in flight.
- No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
