### PR TITLE
Generate Web MCP tools from the same registry

### DIFF
--- a/changelog/2026-09-04-webmcp.md
+++ b/changelog/2026-09-04-webmcp.md
@@ -1,0 +1,94 @@
+# Web MCP: il registry alimenta un terzo consumatore
+
+Andrea ha chiesto Web MCP indicando <https://webmcp.dev>, e ha chiesto che «mcp, cli, web mcp, e
+endpoint siano allineati su tutte le azioni che una AI può fare».
+
+## Prima cosa: webmcp.dev non è la specifica
+
+Il sito indicato documenta un progetto **diverso e fermo**: una libreria JavaScript con un widget
+blu in basso a destra, `new WebMCP({color, position})`, npm `@jason.today/webmcp` — ultima
+pubblicazione **marzo 2025**, 457 download a settimana. Condivide solo il nome.
+
+La cosa vera è **`webmachinelearning/webmcp`**, W3C Web Machine Learning Community Group. Chi
+implementa a memoria partendo da webmcp.dev implementa la libreria sbagliata.
+
+## Dove è arrivata davvero la specifica
+
+| | |
+|---|---|
+| corpo | W3C Web ML **Community Group** (non un Working Group) |
+| maturità | **Draft Community Group Report** — «not a W3C Standard nor on the W3C Standards Track» |
+| Chrome | **origin trial dalla 149**, flag `chrome://flags/#enable-webmcp-testing`. Non shipped |
+| WebKit | posizione **contraria** (`oppose`), con obiezioni su privacy, sicurezza, i18n, API design |
+| Mozilla | neutrale |
+| client | nessun agente first-party confermato la consuma. L'unico client Google è un'estensione di test |
+
+E si muove: `navigator.modelContext` è diventato `document.modelContext`, `provideContext()` è
+diventato `registerTool()`, `consequentialHint` è stato aggiunto alle annotazioni **ieri**.
+`outputSchema` non esiste ancora (issue #9 aperta) e c'è una issue aperta per rinominare `execute`
+in `run`. 114 issue aperte.
+
+**Chi scrive `navigator.modelContext` sta copiando un post di sei mesi fa.**
+
+## Cosa è stato costruito, e perché costa poco
+
+Il registry genera già i comandi CLI e i tool MCP da una dichiarazione sola. `src/lib/webmcp.ts`
+è il terzo consumatore: `BRAND_ENDPOINTS` → descrittori WebMCP. Il prossimo endpoint arriva su
+tutte e tre le strade senza che nessuno se ne ricordi, ed è l'unica ragione per cui questo lavoro
+vale la pena adesso.
+
+Il descrittore è quasi 1:1 con una voce di `tools/list`: `name`, `title`, `description`,
+`inputSchema` (JSON Schema), `annotations`. Lo schema esce da `z.toJSONSchema` — che zod 4 ha già,
+quindi nessuna dipendenza nuova.
+
+### Le annotazioni NON sono quelle di MCP
+
+Tradurle male è peggio che non tradurle: un agente userebbe un'azione irreversibile credendola
+innocua.
+
+| registry | MCP | WebMCP |
+|---|---|---|
+| `method === 'GET'` | `readOnlyHint` | `readOnlyHint` |
+| `destructive` | `destructiveHint` | **`consequentialHint`** |
+| `openWorld` | `openWorldHint` | **`untrustedContentHint`** |
+
+L'ultima riga non è una corrispondenza esatta: il registry dice «esce su internet», WebMCP chiede
+«il risultato può contenere testo di cui non rispondi». Il primo insieme è più largo. Marcarne uno
+di troppo non costa niente; marcarne uno di meno toglie all'agente un avviso.
+
+### `login`, `logout`, `whoami` non ci sono
+
+Quei tre esistono nel server MCP perché una CLI deve procurarsi un token e dire di chi è. In una
+pagina la sessione è già quella di chi sta guardando: `/api/v1` accetta il JWT Supabase come
+Bearer (`resolveCaller`, ramo JWT), e il token arriva dal root layout. Esporli darebbe a un agente
+nel browser tre strumenti inutili, e `logout` farebbe un danno.
+
+## Le due scelte che tengono il costo a zero
+
+1. **Nessuna dipendenza.** Non è stato installato nessun polyfill. Chi vuole provarla monta il suo
+   (`@mcp-b/global`, 17.8k download a settimana) e il modulo lo trova. Installarlo qui sarebbe un
+   aggiornamento obbligato al prossimo cambio di una specifica che cambia ogni settimana.
+2. **Import dinamico dietro il rilevamento.** Il root layout controlla `'modelContext' in document`
+   prima di importare: senza la specifica accesa, né zod né i descrittori entrano nel bundle. Per
+   il 100% dei browser di oggi il costo è un `in` su un oggetto.
+
+## Il punto di montaggio, e perché è lì
+
+Il posto naturale sarebbe il layout del brand (`src/routes/app/[brand]/`), che conosce già lo slug.
+Quell'albero è off-limits in questa sessione (un altro agente ci sta rifacendo sidebar e settings),
+quindi la registrazione sta nel root layout, ricavando lo slug da `appNavScope` — la funzione che
+quel file usa già per la stessa cosa. **Vale la pena spostarla nel layout del brand** quando quel
+lavoro è finito: è un `$effect` di dieci righe.
+
+Il segnale toglie tutto: cambiando brand si abortisce il precedente, o un agente vedrebbe gli
+strumenti di due brand con lo stesso nome.
+
+## La raccomandazione, che resta separata dal codice
+
+Il generatore vale la pena **adesso**, perché è quasi gratis e resta gratis. La **specifica** non
+è pronta: incubazione, un solo browser in origin trial, WebKit contrario, nessun client
+first-party. Il codice ne prende atto — feature-detect, nessuna dipendenza, un file solo che
+conosce la forma — così che il giorno in cui `execute` diventa `run` cambi una riga.
+
+Non accendere niente in produzione aspettandosi che qualcuno lo usi: oggi lo vede solo chi ha
+l'origin trial acceso o un polyfill montato a mano. È lì per quando arriva, non perché sia arrivato.

--- a/src/lib/content/changelog/2026-09-04-webmcp.ts
+++ b/src/lib/content/changelog/2026-09-04-webmcp.ts
@@ -1,0 +1,11 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-04',
+  title: 'An AI agent running in your browser can now drive Anomalia',
+  items: [
+    'Anomalia now offers its tools to AI agents that run inside your browser, through the emerging WebMCP standard — the same actions our MCP server and CLI expose, on the brand you have open.',
+    'No API key and no setup: the agent works as you, with the session you are already signed in with, and only on the brand you are looking at.',
+    'Support is browser-side and still early — today it needs Chrome with the WebMCP trial enabled, or a compatible extension. Where it is unavailable, nothing changes and nothing is loaded.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/webmcp.test.ts
+++ b/src/lib/webmcp.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { BLOG_FONTS, BRAND_ENDPOINTS } from '@anomalia/api-contracts';
+import { brandWebMcpTools, modelContext, registerBrandWebMcp } from './webmcp';
+
+const TOKEN = 'eyJ-fake-session-token';
+const tools = () => brandWebMcpTools('demo', TOKEN);
+const byName = (name: string) => {
+  const tool = tools().find((t) => t.name === name);
+  if (!tool) throw new Error(`${name} non generato`);
+  return tool;
+};
+
+describe('il registry alimenta anche Web MCP', () => {
+  it('genera uno strumento per ogni endpoint, senza elenchi a mano', () => {
+    expect(tools()).toHaveLength(BRAND_ENDPOINTS.length);
+    expect(tools().map((t) => t.name).sort()).toEqual([...BRAND_ENDPOINTS].map((e) => e.tool).sort());
+  });
+
+  /**
+   * La ragione per cui questo lavoro vale la pena: il prossimo endpoint arriva su CLI, MCP e Web
+   * MCP senza che nessuno se ne ricordi. Se qualcuno introducesse un elenco a mano, questo test
+   * resterebbe verde e il valore sparirebbe — quindi il test guarda l'inverso: nessuno strumento
+   * che il registry non conosca.
+   */
+  it('e nessuno strumento che il registry non conosca', () => {
+    const known = new Set(BRAND_ENDPOINTS.map((e) => e.tool));
+    for (const tool of tools()) expect(known.has(tool.name), tool.name).toBe(true);
+  });
+
+  it('ogni strumento chiede lo slug del brand', () => {
+    for (const tool of tools()) {
+      const schema = tool.inputSchema as { properties: Record<string, unknown>; required: string[] };
+      expect(schema.properties.slug, tool.name).toBeDefined();
+      expect(schema.required, tool.name).toContain('slug');
+    }
+  });
+
+  it('uno strumento su una risorsa chiede anche il suo id', () => {
+    const resourceEndpoint = BRAND_ENDPOINTS.find((e) => e.resource !== undefined);
+    if (!resourceEndpoint) throw new Error('il registry non ha piu’ endpoint su risorsa');
+    const schema = byName(resourceEndpoint.tool).inputSchema as {
+      properties: Record<string, unknown>;
+      required: string[];
+    };
+    expect(schema.properties.id).toBeDefined();
+    expect(schema.required).toContain('id');
+  });
+
+  it('lo schema di ingresso arriva dal contratto, non riscritto a mano', () => {
+    // Un enum chiuso del contratto deve arrivare CHIUSO fino all'agente: se lo schema fosse
+    // riscritto a mano, `font` diventerebbe una stringa libera e il primo valore inventato
+    // arriverebbe fino alla rotta.
+    const schema = byName('set_blog_settings').inputSchema as {
+      properties: { font?: { enum?: string[] } };
+    };
+    expect(schema.properties.font?.enum).toEqual([...BLOG_FONTS]);
+  });
+});
+
+/**
+ * Le annotazioni di WebMCP non sono quelle di MCP: `destructiveHint` non esiste, e il suo posto lo
+ * prende `consequentialHint`. Tradurle male e' peggio che non tradurle: un agente nel browser
+ * userebbe un'azione irreversibile credendola innocua.
+ */
+describe('le annotazioni dicono la verita’ nel vocabolario giusto', () => {
+  it('una lettura e’ readOnly, una scrittura no', () => {
+    expect(byName('get_blog_settings').annotations.readOnlyHint).toBe(true);
+    expect(byName('set_blog_settings').annotations.readOnlyHint).toBe(false);
+  });
+
+  it('cio’ che il registry chiama distruttivo diventa consequentialHint, non destructiveHint', () => {
+    const destructive = BRAND_ENDPOINTS.find((e) => e.destructive);
+    if (!destructive) throw new Error('il registry non ha piu’ endpoint distruttivi');
+    const tool = byName(destructive.tool);
+    expect(tool.annotations.consequentialHint).toBe(true);
+    expect(tool.annotations).not.toHaveProperty('destructiveHint');
+    expect(tool.annotations).not.toHaveProperty('openWorldHint');
+  });
+
+  it('cio’ che esce su internet e’ marcato come contenuto di cui non rispondiamo', () => {
+    const openWorld = BRAND_ENDPOINTS.find((e) => e.openWorld === true);
+    if (!openWorld) throw new Error('il registry non ha piu’ endpoint openWorld');
+    expect(byName(openWorld.tool).annotations.untrustedContentHint).toBe(true);
+    expect(byName('get_blog_settings').annotations.untrustedContentHint).toBe(false);
+  });
+});
+
+/**
+ * `login`, `logout` e `whoami` esistono nel server MCP perche' una CLI deve procurarsi un token e
+ * dire di chi e'. In una pagina la sessione e' gia' quella di chi sta guardando: esporli darebbe a
+ * un agente nel browser tre strumenti che non possono fare niente di utile — e uno di essi,
+ * `logout`, farebbe un danno.
+ */
+describe('l’autenticazione nel browser non e’ quella di una CLI', () => {
+  it('non offre login, logout o whoami', () => {
+    const names = tools().map((t) => t.name);
+    for (const absent of ['login', 'logout', 'whoami']) expect(names, absent).not.toContain(absent);
+  });
+});
+
+describe('quello che l’esecuzione manda davvero in rete', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue({ ok: true, status: 200, json: async () => ({ ok: true }) });
+    vi.stubGlobal('fetch', fetchMock);
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('porta la sessione di chi guarda, non una chiave API', async () => {
+    await byName('get_blog_settings').execute({});
+    const [path, init] = fetchMock.mock.calls[0];
+    expect(path).toBe('/api/v1/brands/demo/settings/blog');
+    expect(init.headers.Authorization).toBe(`Bearer ${TOKEN}`);
+    expect(init.method).toBe('GET');
+    expect(init.body).toBeUndefined();
+  });
+
+  it('lo slug lo mette il registratore, non chi chiama lo strumento', async () => {
+    await byName('set_blog_settings').execute({ title: 'Il blog' });
+    const [path, init] = fetchMock.mock.calls[0];
+    expect(path).toBe('/api/v1/brands/demo/settings/blog');
+    expect(JSON.parse(init.body)).toEqual({ title: 'Il blog' });
+  });
+
+  it('un id di risorsa entra nel percorso, non nel corpo', async () => {
+    await byName('get_post').execute({ id: 'post-1' });
+    const [path, init] = fetchMock.mock.calls[0];
+    expect(path).toContain('post-1');
+    expect(init.body).toBeUndefined();
+  });
+
+  it('un errore dell’API diventa un errore, non un successo silenzioso', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 403, json: async () => ({ error: 'API key is read-only' }) });
+    await expect(byName('set_blog_settings').execute({ title: 'x' })).rejects.toThrow(/403/);
+  });
+
+  it('il risultato viaggia nella busta che i client si aspettano', async () => {
+    const out = (await byName('get_blog_settings').execute({})) as { content: { type: string; text: string }[] };
+    expect(out.content[0].type).toBe('text');
+    expect(JSON.parse(out.content[0].text)).toEqual({ ok: true });
+  });
+
+  it('l’agente puo’ annullare: il segnale arriva fino alla fetch', async () => {
+    const controller = new AbortController();
+    await byName('get_blog_settings').execute({}, { signal: controller.signal });
+    expect(fetchMock.mock.calls[0][1].signal).toBe(controller.signal);
+  });
+});
+
+describe('quando il browser non ha la specifica', () => {
+  it('non c’e’ nessun contesto da trovare', () => {
+    expect(modelContext()).toBeNull();
+  });
+
+  it('registrare non fa niente e non esplode', async () => {
+    await expect(registerBrandWebMcp('demo', TOKEN, new AbortController().signal)).resolves.toBe(0);
+  });
+
+  it('ma se c’e’, registra tutto il registry con un segnale per toglierlo', async () => {
+    const registerTool = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal('document', { modelContext: { registerTool } });
+    const controller = new AbortController();
+
+    const count = await registerBrandWebMcp('demo', TOKEN, controller.signal);
+
+    expect(count).toBe(BRAND_ENDPOINTS.length);
+    expect(registerTool).toHaveBeenCalledTimes(BRAND_ENDPOINTS.length);
+    expect(registerTool.mock.calls[0][1]).toEqual({ signal: controller.signal });
+    vi.unstubAllGlobals();
+  });
+});

--- a/src/lib/webmcp.ts
+++ b/src/lib/webmcp.ts
@@ -1,0 +1,152 @@
+/**
+ * Web MCP — il terzo consumatore del registry.
+ *
+ * `BRAND_ENDPOINTS` genera gia' i comandi della CLI e i tool del server MCP. Qui genera anche gli
+ * strumenti che una pagina espone a un agente che gira NEL browser dell'utente: chi apre Anomalia
+ * con un agente nel browser puo' farla lavorare senza passare dal nostro server MCP, e senza una
+ * chiave API, perche' la sessione e' gia' quella della persona che sta guardando.
+ *
+ * Aggiungere un endpoint al registry lo fa comparire su tutte e tre le strade. Nessuno deve
+ * ricordarsene.
+ *
+ * ## Lo stato della specifica, perche' conta
+ *
+ * WebMCP e' una **Draft Community Group Report** del W3C Web Machine Learning CG — incubazione,
+ * non standards track. Chrome la offre in origin trial dalla 149 dietro
+ * `chrome://flags/#enable-webmcp-testing`; WebKit ha registrato una posizione **contraria**,
+ * Mozilla neutrale. La forma si e' mossa di recente: `navigator.modelContext` e' diventato
+ * `document.modelContext`, e `provideContext()` e' diventato `registerTool()`.
+ *
+ * Da cui due scelte:
+ *
+ * 1. **Niente dipendenza.** Nessun polyfill installato: chi vuole provarla monta il suo
+ *    (`@mcp-b/global`) e questo modulo lo trova. Una dipendenza per una specifica che si muove e'
+ *    un aggiornamento obbligato al prossimo cambio.
+ * 2. **Costo zero quando non c'e'.** Il rilevamento sta nel chiamante, che importa questo modulo
+ *    solo se `document.modelContext` esiste — quindi zod e i descrittori non entrano nel bundle di
+ *    nessun browser che non abbia la specifica accesa.
+ *
+ * Quando la specifica cambia, cambia questo file: e' l'unico che la conosce.
+ */
+
+import { BRAND_ENDPOINTS, RESOURCE_SEGMENT, pathFor, type BrandEndpoint } from '@anomalia/api-contracts';
+import { z } from 'zod';
+
+/** La forma che la specifica chiama `ModelContextTool`. */
+export type WebMcpTool = {
+  name: string;
+  title: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  annotations: { readOnlyHint: boolean; consequentialHint: boolean; untrustedContentHint: boolean };
+  execute: (input: Record<string, unknown>, options?: { signal?: AbortSignal }) => Promise<unknown>;
+};
+
+type ModelContext = {
+  registerTool: (tool: WebMcpTool, options?: { signal?: AbortSignal }) => Promise<void>;
+};
+
+export function modelContext(): ModelContext | null {
+  const doc = globalThis.document as unknown as { modelContext?: ModelContext } | undefined;
+  return doc?.modelContext ?? null;
+}
+
+const SLUG_PROPERTY = { type: 'string', minLength: 1, description: 'Brand URL slug' };
+
+/**
+ * Le annotazioni di WebMCP NON sono quelle di MCP: non esiste `destructiveHint`, e `openWorldHint`
+ * e' diventato `untrustedContentHint`, che chiede una cosa leggermente diversa — se il risultato
+ * puo' contenere testo di cui non rispondiamo. Il registry dice "esce su internet", che e' un
+ * insieme piu' largo. Marcarne uno di troppo non costa niente; marcarne uno di meno toglie
+ * all'agente un avviso che avrebbe dovuto vedere.
+ */
+function annotationsFor(endpoint: BrandEndpoint) {
+  return {
+    readOnlyHint: endpoint.method === 'GET',
+    consequentialHint: endpoint.destructive,
+    untrustedContentHint: endpoint.openWorld === true
+  };
+}
+
+function inputSchemaFor(endpoint: BrandEndpoint): Record<string, unknown> {
+  const base = z.toJSONSchema(endpoint.input, { io: 'input' }) as {
+    properties?: Record<string, unknown>;
+    required?: string[];
+  };
+  const properties = { slug: SLUG_PROPERTY, ...(base.properties ?? {}) };
+  const required = ['slug', ...(base.required ?? [])];
+  if (endpoint.resource !== undefined) {
+    Object.assign(properties, {
+      id: { type: 'string', minLength: 1, description: `${endpoint.resource} id` }
+    });
+    required.splice(1, 0, 'id');
+  }
+  return { ...base, type: 'object', properties, required };
+}
+
+/**
+ * Il risultato nella busta che MCP usa per convenzione. La specifica non ha ancora un
+ * `outputSchema` (issue aperta), quindi la forma e' quella che i client si aspettano oggi.
+ */
+const envelope = (value: unknown) => ({ content: [{ type: 'text', text: JSON.stringify(value) }] });
+
+async function callApi(
+  endpoint: BrandEndpoint,
+  token: string,
+  input: Record<string, unknown>,
+  signal?: AbortSignal
+): Promise<unknown> {
+  const { slug, id, ...body } = input as { slug: string; id?: string } & Record<string, unknown>;
+  const path =
+    endpoint.resource === undefined
+      ? pathFor(endpoint, slug)
+      : pathFor(endpoint, slug, String(id ?? ''));
+
+  const res = await fetch(path, {
+    method: endpoint.method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      ...(endpoint.method === 'GET' ? {} : { 'Content-Type': 'application/json' })
+    },
+    ...(endpoint.method === 'GET' ? {} : { body: JSON.stringify(body) }),
+    signal
+  });
+
+  const payload = await res.json().catch(() => null);
+  if (!res.ok) throw new Error(`${endpoint.tool} failed (${res.status}): ${JSON.stringify(payload)}`);
+  return payload;
+}
+
+/**
+ * Gli strumenti di UN brand, per la sessione di chi sta guardando. Puro: nessun accesso al DOM,
+ * cosi' che la generazione si possa provare senza un browser.
+ *
+ * `login`, `logout` e `whoami` — che il server MCP espone — qui non ci sono, e non e' una
+ * dimenticanza: quei tre esistono perche' una CLI deve procurarsi un token e dire di chi e'. In una
+ * pagina la sessione e' gia' quella dell'utente, e il token arriva come argomento.
+ */
+export function brandWebMcpTools(slug: string, token: string): WebMcpTool[] {
+  return BRAND_ENDPOINTS.map((endpoint) => ({
+    name: endpoint.tool,
+    title: endpoint.title,
+    description: endpoint.description,
+    inputSchema: inputSchemaFor(endpoint),
+    annotations: annotationsFor(endpoint),
+    execute: async (input: Record<string, unknown>, options?: { signal?: AbortSignal }) =>
+      envelope(await callApi(endpoint, token, { slug, ...input }, options?.signal))
+  }));
+}
+
+/**
+ * Registra gli strumenti del brand aperto. Il segnale li toglie tutti insieme: cambiando brand si
+ * abortisce il precedente, o un agente vedrebbe gli strumenti di due brand con lo stesso nome.
+ */
+export async function registerBrandWebMcp(slug: string, token: string, signal: AbortSignal): Promise<number> {
+  const context = modelContext();
+  if (!context) return 0;
+  const tools = brandWebMcpTools(slug, token);
+  await Promise.all(tools.map((tool) => context.registerTool(tool, { signal })));
+  return tools.length;
+}
+
+export { RESOURCE_SEGMENT };

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -123,6 +123,31 @@
     return () => window.removeEventListener('storage', onStorage);
   });
 
+  // Web MCP: espone al browser gli stessi strumenti che il server MCP espone a un client esterno,
+  // generati dal registry. Un agente che gira nella pagina lavora sul brand aperto con la sessione
+  // di chi sta guardando — nessuna chiave API, nessun nostro server nel mezzo.
+  //
+  // Il rilevamento sta QUI e non nel modulo: senza `document.modelContext` — cioè in ogni browser
+  // che non abbia l'origin trial acceso o un polyfill montato — l'import non parte, e né zod né i
+  // descrittori entrano nel bundle. Costo zero finché la specifica non c'è.
+  //
+  // Il segnale toglie tutto: cambiando brand si abortisce il precedente, o un agente vedrebbe gli
+  // strumenti di due brand con lo stesso nome.
+  $effect(() => {
+    const scope = appNavScope($page.url.pathname);
+    const token = (data?.session as { access_token?: string } | undefined)?.access_token;
+    if (!scope?.startsWith('brand:') || !token) return;
+    if (typeof document === 'undefined' || !('modelContext' in document)) return;
+
+    const brand = scope.slice('brand:'.length);
+
+    const abort = new AbortController();
+    import('$lib/webmcp')
+      .then(({ registerBrandWebMcp }) => registerBrandWebMcp(brand, token, abort.signal))
+      .catch((error) => console.warn('web mcp registration failed', error));
+    return () => abort.abort();
+  });
+
   // Mark the app shell so marketing CSS (e.g. landing.css `section { padding: 110px }`)
   // does not leak onto /app routes after SPA navigation. Also mark while the optimistic
   // app-entry overlay is up (URL still points at marketing during the load).


### PR DESCRIPTION
## What?

`src/lib/webmcp.ts` turns `BRAND_ENDPOINTS` into **Web MCP** tools — the tools a page offers to an
AI agent running inside the visitor's own browser. The registry already generates the CLI's
commands and the MCP server's tools; this is the third consumer, from the same declaration.

The root layout registers them for the brand currently open, using the signed-in session's token.
No dependency was added, and nothing loads in a browser without the spec.

**Read this first:** the URL in the request, <https://webmcp.dev>, is **a different project** — see
*Why?*.

## Why?

Andrea asked for Web MCP and for *«mcp, cli, web mcp, e endpoint … allineati su tutte le azioni che
una AI può fare»*.

### webmcp.dev is not the specification

It documents an unrelated, dormant library: a blue widget in the corner, `new WebMCP({color,
position})`, npm `@jason.today/webmcp` — **last published March 2025**, 457 weekly downloads. It
shares only the name.

The real work is **[`webmachinelearning/webmcp`](https://github.com/webmachinelearning/webmcp)**,
the W3C Web Machine Learning **Community Group**. Anyone implementing from memory, or from
webmcp.dev, builds the wrong thing.

### Where the spec actually is

| | |
|---|---|
| body | W3C Web ML **Community Group** — not a Working Group |
| maturity | **Draft Community Group Report**, "not a W3C Standard nor on the W3C Standards Track" |
| Chrome | **origin trial from 149**, `chrome://flags/#enable-webmcp-testing`. Not shipped |
| WebKit | position: **oppose** ([#670](https://github.com/WebKit/standards-positions/issues/670)), concerns tagged privacy, security, i18n, API design |
| Mozilla | neutral ([#1412](https://github.com/mozilla/standards-positions/issues/1412)) |
| clients | no first-party agent confirmed to consume it; Google's only client is a test extension |

And it is moving: `navigator.modelContext` → `document.modelContext`, `provideContext()` →
`registerTool()`, and `consequentialHint` was added to the annotations **yesterday**. There is no
`outputSchema` yet (issue #9 open) and an open issue to rename `execute` → `run`. 114 open issues.

### So why build it now

**Because the registry makes it nearly free, and keeps it free.** Adding an endpoint already
reaches the CLI and MCP without anyone remembering; it now reaches Web MCP too. If the spec had
required a shape the registry could not feed, that would have been the finding — it does not: the
descriptor is nearly 1:1 with a `tools/list` entry.

## How?

### The descriptor, and the vocabulary trap

`name`, `title`, `description`, `inputSchema` (JSON Schema), `annotations`, `execute`. Schemas come
from **`z.toJSONSchema`**, which zod 4 already has — **no new dependency**, and a closed enum in a
contract arrives closed at the agent.

The annotations are **not** MCP's. Getting this wrong is worse than not translating at all: an
agent would run an irreversible action believing it harmless.

| registry | MCP | WebMCP |
|---|---|---|
| `method === 'GET'` | `readOnlyHint` | `readOnlyHint` |
| `destructive` | `destructiveHint` | **`consequentialHint`** |
| `openWorld` | `openWorldHint` | **`untrustedContentHint`** |

The last row is **not an exact match**, and I want that on the record: the registry means "reaches
the open internet", WebMCP asks "may return content you do not vouch for". The first set is wider.
Over-marking costs nothing; under-marking removes a warning the agent should have seen — so it maps
conservatively.

### `login`, `logout`, `whoami` are absent, deliberately

Those exist in the MCP server because a CLI must obtain a token and say whose it is. In a page the
session already belongs to whoever is looking: `/api/v1` accepts the Supabase JWT as a Bearer
(`resolveCaller`, the JWT branch), and the token comes from the root layout's data. Exposing them
would give a browser agent three tools that can do nothing useful — and `logout` would do damage.

### Two decisions that keep the cost at zero

1. **No polyfill installed.** Whoever wants to try it mounts their own (`@mcp-b/global`, 17.8k
   weekly downloads) and this module finds it. Installing one here would be a forced update at the
   next change of a spec that changes weekly.
2. **Dynamic import behind a feature detect.** The layout checks `'modelContext' in document`
   *before* importing, so without the spec neither zod nor the descriptors enter the bundle. For
   every browser today the cost is one `in` on an object.

### The mount point, and a note for whoever finishes the app shell

The natural place is the brand layout (`src/routes/app/[brand]/`), which already knows the slug.
**That tree is off-limits in this session** — another agent is rebuilding the sidebar and settings
— so registration sits in the root layout, deriving the slug from `appNavScope`, the function that
file already uses for exactly this. **It is worth moving into the brand layout** once that work
lands: it is a ten-line `$effect`.

The AbortSignal unregisters everything: changing brand aborts the previous registration, or an
agent would see two brands' tools under the same names.

## Testing?

| command | result |
|---|---|
| `npx vitest run packages/api-contracts` | 204 tests, pass (unchanged — no contract touched) |
| `cd cli && bun test` | 59 tests, 0 fail |
| `cd cli && bun run typecheck` | clean |
| `node scripts/typecheck-runtime.mjs` | ok |
| `src/lib/webmcp.test.ts` + changelog + `no-app-imports` | 141 tests, pass |

`node_modules/@anomalia/api-contracts` resolves to **this worktree's** `packages/api-contracts`
(checked with `realpathSync`).

**Not tested:** no browser, Docker, dev server or Playwright — forbidden for this task. Which means
the honest statement is: **the generation, the annotation mapping, the request shaping and the
registration call are proven; a real `document.modelContext` accepting them is not.** Nobody in
this session ran Chrome 149 with the trial token. The registration path is one `await` per tool
behind a feature detect, and the failure mode is a caught, logged warning.

**Risk:** the spec moves. `execute` may become `run`; `outputSchema` may land. Both are single-file
changes — `src/lib/webmcp.ts` is the only file that knows the shape.

## Evidence

<details>
<summary>Red, then green: the adapter broken four ways, 10 of 18 fail</summary>

Swapped WebMCP's annotations for MCP's, replaced the registry map with a hand-filtered list,
dropped the error check, dropped the abort signal:

```
× il registry alimenta anche Web MCP > genera uno strumento per ogni endpoint, senza elenchi a mano
× il registry alimenta anche Web MCP > uno strumento su una risorsa chiede anche il suo id
× il registry alimenta anche Web MCP > lo schema di ingresso arriva dal contratto, non riscritto a mano
× le annotazioni … > una lettura e' readOnly, una scrittura no
× le annotazioni … > cio' che il registry chiama distruttivo diventa consequentialHint, non destructiveHint
× le annotazioni … > cio' che esce su internet e' marcato come contenuto di cui non rispondiamo
× quello che l'esecuzione manda davvero in rete > lo slug lo mette il registratore, non chi chiama lo strumento
× quello che l'esecuzione manda davvero in rete > un errore dell'API diventa un errore, non un successo silenzioso
× quello che l'esecuzione manda davvero in rete > l'agente puo' annullare: il segnale arriva fino alla fetch
× quando il browser non ha la specifica > ma se c'e', registra tutto il registry con un segnale per toglierlo
   Tests  10 failed | 8 passed (18)
```

Restored: **18/18**.

</details>

<details>
<summary>What generation and execution actually produce</summary>

```
brandWebMcpTools('demo', token).length === BRAND_ENDPOINTS.length     (every endpoint, no hand list)
every tool requires `slug`; resource tools also require `id`
set_blog_settings.inputSchema.properties.font.enum === BLOG_FONTS     (a closed enum stays closed)

get_blog_settings.annotations  → { readOnlyHint: true,  consequentialHint: false, untrustedContentHint: false }
remove_blog_term.annotations   → { readOnlyHint: false, consequentialHint: true,  untrustedContentHint: false }
diagnose_radar.annotations     → { untrustedContentHint: true }
no tool carries `destructiveHint` or `openWorldHint`

execute({})            → GET  /api/v1/brands/demo/settings/blog, Authorization: Bearer <session>, no body
execute({title:'…'})   → PUT  /api/v1/brands/demo/settings/blog, body {"title":"…"}   (slug never from the caller)
execute({id:'post-1'}) → the id lands in the path, not the body
HTTP 403               → throws, rather than a silent success
result                 → { content: [{ type: 'text', text: '…' }] }
options.signal         → reaches fetch

login / logout / whoami → absent
```

Without the spec:

```
modelContext()                      → null
registerBrandWebMcp(…)              → 0, no throw
with a stubbed document.modelContext → registerTool called BRAND_ENDPOINTS times, each with { signal }
```

</details>

No UI change: nothing rendered, nothing styled. The root layout gains one `$effect`.

## Anything Else?

**The recommendation, kept separate from the code.** The *generator* is worth having now — it is
nearly free and stays free. The *spec* is not ready: incubation, one browser in origin trial,
WebKit opposed, no first-party client. The code takes that as given — feature-detect, no
dependency, one file that knows the shape.

**Do not announce it expecting use.** Today it is visible only to someone running the Chrome origin
trial or mounting a polyfill by hand. It is there for when it arrives, not because it has.

**Alignment is not finished, and this PR does not finish it.** 32 of the 114 MCP tools are still
hand-written and therefore invisible to Web MCP: `edit_post`, `approve_post`, `publish_post`,
`reject_post`, the four `/posts/:id/media` variants, `generate_article`, `publish_article`,
`delete_article`, the week trio, `set_colors`, `add_note`, `get_dashboard`, `get_status`,
`list_brands`, and the rest. As they migrate into the registry — work assigned elsewhere — they
appear here **for free**. That is the whole point of the shape.

Three of the 32 should not migrate: `login`, `logout` and `whoami` are not HTTP calls, and in a
browser they have no job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
