### PR TITLE
Stop shipping the corpus with the studio dump

### DIFF
--- a/changelog/2026-09-04-studio-senza-corpus.md
+++ b/changelog/2026-09-04-studio-senza-corpus.md
@@ -1,0 +1,51 @@
+# `get_studio` smette di spedire il corpus
+
+## Il campo non aveva un lettore
+
+`getStudio` selezionava `content_text` per ogni documento del brand e lo spediva. Chi lo leggeva,
+tracciato uno per uno:
+
+| consumatore | cosa legge davvero |
+|---|---|
+| `cli/commands/studio.ts:181` | icona, titolo, id — **non stampa nessun testo** |
+| `strategy-agent-reads.ts:134` | `studio.documents.length` |
+| pagina Knowledge | `studio-deferred.ts:38`, una query **sua** |
+| MCP `get_studio` | l'intero corpus, senza averlo chiesto |
+
+`cli/lib/api.ts:179` lo dichiarava nel tipo e nessuno lo rendeva. L'unico effetto reale era
+riempire la finestra di un agente esterno con il corpus che dovrebbe **cercare**: il tetto per
+documento è 200.000 caratteri e `DOC_LIMIT_PRO` è 300, ma bastano 30 documenti da 20 KB per
+~150.000 token in una risposta sola. Un agente che riceve tutto non chiama più `search_knowledge`.
+
+## Cosa cambia
+
+`documents: 'index' | 'full'`, difetto `index`.
+
+- **`index`** — niente `content_text`. Al suo posto `textBytes`, che dice che il testo c'è e
+  quanto pesa, accanto a `status` e `chunkCount` che dicono se è cercabile.
+- **`full`** — la risposta di prima, byte per byte.
+
+## Perché un parametro e non la rimozione
+
+Nessun chiamante **dentro il repo** legge quel campo, e questo l'ho verificato. Ma i terzi che
+usano una chiave API contro `/api/v1/brands/:slug/studio` **non sono visibili da qui**: toglierlo
+in silenzio sarebbe scommettere su una cosa che non so. Un parametro con un difetto sicuro non
+scommette — chi lo leggeva aggiunge una parola e ha indietro esattamente quello che aveva.
+
+Solo `full` apre il rubinetto: qualsiasi altro valore — inventato, vuoto, assente — è `index`.
+Il registry rifiuta comunque un parametro non dichiarato (`.strict()`), quindi un client vecchio
+che non manda niente riceve il nuovo difetto, che è il punto.
+
+## Cosa è stato scartato
+
+**Il troncamento con un rimando a `search_knowledge`.** Cinquecento caratteri di un contratto non
+sono né la risposta né il sapere che bisogna cercare: si paga il costo del campo per sempre e non
+si risolve niente.
+
+## Effetto collaterale gradito
+
+`readBrandStudioForAgent` chiama `getStudio` senza opzioni e usa solo `documents.length`: adesso
+quella lettura interna smette di tirarsi dietro il corpus che non guardava.
+
+La CLI, che ora ha `status` e `chunkCount` sul filo, dice quali documenti non sono cercabili
+invece di elencarli tutti uguali.

--- a/cli/commands/studio.ts
+++ b/cli/commands/studio.ts
@@ -181,7 +181,10 @@ async function showStudio(token: string, slug: string) {
   section(`Knowledge (${data.documents.length})`);
   for (const doc of data.documents) {
     const icon = doc.kind === 'image' ? '🖼' : doc.kind === 'document' ? '📄' : '📝';
-    console.log(`  ${icon} ${doc.title}  ${c.dim(doc.id.slice(0, 8))}`);
+    // Cercabile = processato E spezzato. Un `ready` con zero chunk esiste e la ricerca non lo vede.
+    const searchable = doc.status === 'ready' && doc.chunkCount > 0;
+    const state = searchable ? '' : c.dim(`  (${doc.status}, not searchable)`);
+    console.log(`  ${icon} ${doc.title}  ${c.dim(doc.id.slice(0, 8))}${state}`);
   }
   console.log();
 

--- a/cli/lib/api.ts
+++ b/cli/lib/api.ts
@@ -176,7 +176,7 @@ export type AnalyticsData = {
 export type StudioData = {
   kit: Record<string, unknown> | null;
   products: { id: string; title: string; pricing: string | null; images: unknown; featured: boolean | null }[];
-  documents: { id: string; kind: string; title: string; content_text: string | null }[];
+  documents: { id: string; kind: string; title: string; status: string; chunkCount: number; textBytes: number }[];
   history: { id: string; platform: string; content: string | null; metrics: Record<string, number> }[];
   people: { id: string; name: string; role: string | null; kind: string; description: string | null; consent: boolean; imageCount: number }[];
   competitors: { id: string; name: string; website: string | null; kind: string; rationale: string | null; source: string }[];

--- a/cli/lib/contracts/index.ts
+++ b/cli/lib/contracts/index.ts
@@ -284,6 +284,8 @@ export {
   LIST_ARTICLES,
   LIST_PRODUCTS
 };
+export { STUDIO_DOCUMENT_MODES } from './reads';
+export type { StudioDocumentMode } from './reads';
 export {
   GET_BRAND_SETTINGS,
   SET_BRAND_SETTINGS,

--- a/cli/lib/contracts/reads.ts
+++ b/cli/lib/contracts/reads.ts
@@ -5,6 +5,10 @@ const NoInput = z.object({}).strict();
 
 const JsonObject = z.record(z.string(), z.unknown());
 
+export const STUDIO_DOCUMENT_MODES = ['index', 'full'] as const;
+
+export type StudioDocumentMode = (typeof STUDIO_DOCUMENT_MODES)[number];
+
 export const GET_PLAN = {
   tool: 'get_plan',
   title: 'Editorial plan',
@@ -100,13 +104,15 @@ const StudioDocument = z.looseObject({
   id: z.string(),
   kind: z.string(),
   title: z.string().nullable(),
-  content_text: z.string().nullable(),
   file_url: z.string().nullable(),
   file_name: z.string().nullable(),
   mime_type: z.string().nullable(),
   created_at: z.string(),
   status: z.string(),
-  chunkCount: z.number()
+  chunkCount: z.number(),
+  textBytes: z.number(),
+  /** Presente solo con `documents: "full"`. */
+  content_text: z.string().nullable().optional()
 });
 
 const StudioHistoryPost = z.looseObject({
@@ -134,11 +140,19 @@ export const GET_STUDIO = {
   title: 'Studio',
   description:
     'Full studio dump: kit, people, documents, competitors, products, history summary. ' +
-    'Each document carries `status` and `chunkCount`: a document that is not `ready` with at least one chunk exists here but is invisible to `search_knowledge`. ' +
-    'This returns the FULL text of every document — to answer a question, ask `search_knowledge` instead of reading the corpus.',
+    'Each document carries `status` and `chunkCount` (a document that is not `ready` with at least one chunk exists here but is invisible to `search_knowledge`) and `textBytes`, which says how much text it holds. ' +
+    'The text itself is NOT included: to answer a question, ask `search_knowledge` — it returns the passages that answer it with the document each came from, instead of the whole corpus. ' +
+    '`documents: "full"` restores the complete text of every document; it exists for callers that were reading it before and is almost never what you want.',
   method: 'GET',
   pathUnderBrand: '/studio',
-  input: NoInput,
+  input: z
+    .object({
+      documents: z
+        .enum(STUDIO_DOCUMENT_MODES)
+        .optional()
+        .describe('`index` (default) lists documents without their text; `full` includes content_text')
+    })
+    .strict(),
   output: z.object({
     kit: StudioKit.nullable(),
     products: z.array(StudioProduct),

--- a/cli/mcp/read-tools.test.ts
+++ b/cli/mcp/read-tools.test.ts
@@ -22,13 +22,21 @@ const MIGRATED_READS = [
   {
     name: 'get_studio',
     title: 'Studio',
-    // Cambiata di proposito: l'elenco dei documenti ora dice se sono stati digeriti, e manda a
-    // `search_knowledge` chi ha una domanda invece di far leggere il corpus intero.
+    // Cambiata di proposito, due volte: l'elenco dei documenti dice se sono stati digeriti, e il
+    // testo non viaggia più per difetto — `documents: "full"` lo restituisce a chi lo leggeva.
     description:
       'Full studio dump: kit, people, documents, competitors, products, history summary. ' +
-      'Each document carries `status` and `chunkCount`: a document that is not `ready` with at least one chunk exists here but is invisible to `search_knowledge`. ' +
-      'This returns the FULL text of every document — to answer a question, ask `search_knowledge` instead of reading the corpus.',
-    properties: { slug: SLUG_PROPERTY },
+      'Each document carries `status` and `chunkCount` (a document that is not `ready` with at least one chunk exists here but is invisible to `search_knowledge`) and `textBytes`, which says how much text it holds. ' +
+      'The text itself is NOT included: to answer a question, ask `search_knowledge` — it returns the passages that answer it with the document each came from, instead of the whole corpus. ' +
+      '`documents: "full"` restores the complete text of every document; it exists for callers that were reading it before and is almost never what you want.',
+    properties: {
+      slug: SLUG_PROPERTY,
+      documents: {
+        type: 'string',
+        enum: ['index', 'full'],
+        description: '`index` (default) lists documents without their text; `full` includes content_text',
+      },
+    },
     required: ['slug'],
   },
   {

--- a/cli/plugins/anomalia/skills/anomalia/references/tools.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/tools.md
@@ -238,6 +238,12 @@ deck. No credits, no writes.
 | `get_bio` / `set_bio` | (MCP only) |
 | `sync_history` | `anomalia studio <slug> sync-history` |
 
+`get_studio` lists documents **without their text**. Each carries `status`, `chunkCount` and
+`textBytes`: the text exists, its size is stated, and it does not travel. To answer a question,
+call `search_knowledge` — it returns the passages that answer it with the document each came
+from. `documents: "full"` restores `content_text` on every document; it is there for callers
+that read it before and is almost never what you want.
+
 `create_product` adds ONE offer. The e-commerce resync behind `sync_products` replaces the whole
 catalog and would erase a hand-made row.
 

--- a/cli/skills/anomalia/references/tools.md
+++ b/cli/skills/anomalia/references/tools.md
@@ -238,6 +238,12 @@ deck. No credits, no writes.
 | `get_bio` / `set_bio` | (MCP only) |
 | `sync_history` | `anomalia studio <slug> sync-history` |
 
+`get_studio` lists documents **without their text**. Each carries `status`, `chunkCount` and
+`textBytes`: the text exists, its size is stated, and it does not travel. To answer a question,
+call `search_knowledge` — it returns the passages that answer it with the document each came
+from. `documents: "full"` restores `content_text` on every document; it is there for callers
+that read it before and is almost never what you want.
+
 `create_product` adds ONE offer. The e-commerce resync behind `sync_products` replaces the whole
 catalog and would erase a hand-made row.
 

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -284,6 +284,8 @@ export {
   LIST_ARTICLES,
   LIST_PRODUCTS
 };
+export { STUDIO_DOCUMENT_MODES } from './reads';
+export type { StudioDocumentMode } from './reads';
 export {
   GET_BRAND_SETTINGS,
   SET_BRAND_SETTINGS,

--- a/packages/api-contracts/src/reads.test.ts
+++ b/packages/api-contracts/src/reads.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { GET_STUDIO, STUDIO_DOCUMENT_MODES } from './reads';
+
+describe('il contratto dello studio', () => {
+  it('dichiara i due modi, e nessun altro', () => {
+    expect([...STUDIO_DOCUMENT_MODES]).toEqual(['index', 'full']);
+    for (const documents of STUDIO_DOCUMENT_MODES) {
+      expect(GET_STUDIO.input.safeParse({ documents }).success, documents).toBe(true);
+    }
+    expect(GET_STUDIO.input.safeParse({ documents: 'tutto' }).success).toBe(false);
+  });
+
+  it('si chiama ancora senza argomenti: il difetto è `index`', () => {
+    expect(GET_STUDIO.input.safeParse({}).success).toBe(true);
+  });
+
+  /** `content_text` non è più garantito, `textBytes` sì: è quello che dice che il testo esiste. */
+  it('il testo è opzionale, il suo peso no', () => {
+    const withoutText = GET_STUDIO.output.shape.documents.element.safeParse({
+      id: 'd1',
+      kind: 'document',
+      title: 'Contratto',
+      file_url: null,
+      file_name: 'c.pdf',
+      mime_type: 'application/pdf',
+      created_at: '2026-08-01T00:00:00Z',
+      status: 'ready',
+      chunkCount: 9,
+      textBytes: 2600
+    });
+    expect(withoutText.success).toBe(true);
+
+    const withoutBytes = GET_STUDIO.output.shape.documents.element.safeParse({
+      id: 'd1',
+      kind: 'document',
+      title: 'Contratto',
+      file_url: null,
+      file_name: null,
+      mime_type: null,
+      created_at: '2026-08-01T00:00:00Z',
+      status: 'ready',
+      chunkCount: 9
+    });
+    expect(withoutBytes.success).toBe(false);
+  });
+
+  it('manda a `search_knowledge` invece che al corpus intero', () => {
+    expect(GET_STUDIO.description).toContain('search_knowledge');
+    expect(GET_STUDIO.description).toContain('NOT included');
+  });
+});

--- a/packages/api-contracts/src/reads.ts
+++ b/packages/api-contracts/src/reads.ts
@@ -5,6 +5,10 @@ const NoInput = z.object({}).strict();
 
 const JsonObject = z.record(z.string(), z.unknown());
 
+export const STUDIO_DOCUMENT_MODES = ['index', 'full'] as const;
+
+export type StudioDocumentMode = (typeof STUDIO_DOCUMENT_MODES)[number];
+
 export const GET_PLAN = {
   tool: 'get_plan',
   title: 'Editorial plan',
@@ -100,13 +104,15 @@ const StudioDocument = z.looseObject({
   id: z.string(),
   kind: z.string(),
   title: z.string().nullable(),
-  content_text: z.string().nullable(),
   file_url: z.string().nullable(),
   file_name: z.string().nullable(),
   mime_type: z.string().nullable(),
   created_at: z.string(),
   status: z.string(),
-  chunkCount: z.number()
+  chunkCount: z.number(),
+  textBytes: z.number(),
+  /** Presente solo con `documents: "full"`. */
+  content_text: z.string().nullable().optional()
 });
 
 const StudioHistoryPost = z.looseObject({
@@ -134,11 +140,19 @@ export const GET_STUDIO = {
   title: 'Studio',
   description:
     'Full studio dump: kit, people, documents, competitors, products, history summary. ' +
-    'Each document carries `status` and `chunkCount`: a document that is not `ready` with at least one chunk exists here but is invisible to `search_knowledge`. ' +
-    'This returns the FULL text of every document — to answer a question, ask `search_knowledge` instead of reading the corpus.',
+    'Each document carries `status` and `chunkCount` (a document that is not `ready` with at least one chunk exists here but is invisible to `search_knowledge`) and `textBytes`, which says how much text it holds. ' +
+    'The text itself is NOT included: to answer a question, ask `search_knowledge` — it returns the passages that answer it with the document each came from, instead of the whole corpus. ' +
+    '`documents: "full"` restores the complete text of every document; it exists for callers that were reading it before and is almost never what you want.',
   method: 'GET',
   pathUnderBrand: '/studio',
-  input: NoInput,
+  input: z
+    .object({
+      documents: z
+        .enum(STUDIO_DOCUMENT_MODES)
+        .optional()
+        .describe('`index` (default) lists documents without their text; `full` includes content_text')
+    })
+    .strict(),
   output: z.object({
     kit: StudioKit.nullable(),
     products: z.array(StudioProduct),

--- a/src/lib/content/changelog/2026-09-04-studio-lists-documents.ts
+++ b/src/lib/content/changelog/2026-09-04-studio-lists-documents.ts
@@ -1,0 +1,10 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-04',
+  title: 'The studio lists your documents instead of reciting them',
+  items: [
+    'Reading your studio no longer returns the full text of every document — it lists them with their size and whether they are searchable, so your agent asks a question instead of swallowing the corpus.',
+    '`anomalia studio` now marks the documents that are not searchable yet.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/cli-queries.ts
+++ b/src/lib/server/cli-queries.ts
@@ -373,7 +373,20 @@ export async function getAnalytics(supabase: SupabaseClient, brandId: string, br
 
 // ── Studio ──────────────────────────────────────────────────────────────
 
-export async function getStudio(supabase: SupabaseClient, brandId: string) {
+/**
+ * `index` non spedisce `content_text`, `full` sì. Il difetto è `index` perché il campo non aveva
+ * un lettore — la CLI stampa icona/titolo/id, `readBrandStudioForAgent` usa `.length`, la pagina
+ * Knowledge ha la sua query — e il suo unico effetto era rovesciare il corpus nella finestra di un
+ * agente esterno, che a quel punto smette di usare `search_knowledge`. `textBytes` dice che il
+ * testo c'è e quanto pesa, e resta in entrambi i modi.
+ */
+export type StudioDocuments = 'index' | 'full';
+
+export async function getStudio(
+  supabase: SupabaseClient,
+  brandId: string,
+  opts?: { documents?: StudioDocuments }
+) {
   const [kitRes, productsRes, docsRes, historyRes, competitorsRes, brandRes, peopleRes] = await Promise.all([
     supabase.from('brand_kit').select('category, about, brand_style, target_audience, brand_colors, theme_color, favicon_url, fonts, logos, ai_character, ai_context, ai_context_updated_at, visual_style, visual_style_locked, content_pillars, site_type, images')
       .eq('brand_id', brandId).maybeSingle(),
@@ -411,9 +424,11 @@ export async function getStudio(supabase: SupabaseClient, brandId: string) {
     products: productsRes.data ?? [],
     // `chunk_count` esce come `chunkCount`: elencare un documento senza dire se è stato digerito
     // è ciò che fa credere a un agente di avere una conoscenza che la ricerca non vede.
-    documents: (docsRes.data ?? []).map(({ chunk_count, ...doc }) => ({
+    documents: (docsRes.data ?? []).map(({ chunk_count, content_text, ...doc }) => ({
       ...doc,
-      chunkCount: (chunk_count as number) ?? 0
+      chunkCount: (chunk_count as number) ?? 0,
+      textBytes: ((content_text as string | null) ?? '').length,
+      ...(opts?.documents === 'full' ? { content_text: (content_text as string | null) ?? null } : {})
     })),
     history: historyRes.data ?? [],
     people: (peopleRes.data ?? []).map(p => ({

--- a/src/routes/api/v1/brands/[slug]/studio/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/studio/+server.ts
@@ -3,13 +3,16 @@ import type { RequestHandler } from './$types';
 import { authenticate, loadBrandForUser } from '$lib/server/cli-auth';
 import { getStudio } from '$lib/server/cli-queries';
 
-export const GET: RequestHandler = async ({ request, params }) => {
+export const GET: RequestHandler = async ({ request, params, url }) => {
   const { supabase, error, apiKey } = await authenticate(request);
   if (error) return error;
 
   const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
   if (brandError) return brandError;
 
-  const studio = await getStudio(supabase, brand.id);
+  // Solo `full` apre il rubinetto: qualsiasi altra cosa — inventata, vuota, assente — è `index`.
+  const documents = url.searchParams.get('documents') === 'full' ? 'full' : 'index';
+
+  const studio = await getStudio(supabase, brand.id, { documents });
   return json(studio);
 };

--- a/src/routes/api/v1/brands/[slug]/studio/server.documents.test.ts
+++ b/src/routes/api/v1/brands/[slug]/studio/server.documents.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('$lib/server/cli-auth', () => ({
+  authenticate: vi.fn(),
+  loadBrandForUser: vi.fn()
+}));
+
+import { GET } from './+server';
+import { authenticate, loadBrandForUser } from '$lib/server/cli-auth';
+
+type Row = Record<string, unknown>;
+
+function fakeSupabase(tables: Record<string, Row[]>) {
+  return {
+    from(table: string) {
+      let rows = [...(tables[table] ?? [])];
+      const q = {
+        select: () => q,
+        eq(column: string, value: unknown) {
+          rows = rows.filter((r) => r[column] === value);
+          return q;
+        },
+        limit: () => q,
+        maybeSingle: async () => ({ data: rows[0] ?? null, error: null }),
+        then: (resolve: (v: { data: Row[]; error: null }) => unknown) => resolve({ data: rows, error: null })
+      };
+      return q;
+    }
+  };
+}
+
+const CONTRACT = 'Clausola 4.2: la garanzia decade se il macinacaffè viene aperto. '.repeat(40);
+
+const TABLES: Record<string, Row[]> = {
+  brand_documents: [
+    {
+      id: 'd1',
+      brand_id: 'brand-1',
+      kind: 'document',
+      title: 'Contratto di fornitura',
+      content_text: CONTRACT,
+      file_url: null,
+      file_name: 'contratto.pdf',
+      mime_type: 'application/pdf',
+      created_at: '2026-08-01T00:00:00Z',
+      status: 'ready',
+      chunk_count: 9
+    },
+    {
+      id: 'd2',
+      brand_id: 'brand-1',
+      kind: 'note',
+      title: 'Nota vuota',
+      content_text: null,
+      file_url: null,
+      file_name: null,
+      mime_type: null,
+      created_at: '2026-08-02T00:00:00Z',
+      status: 'pending',
+      chunk_count: 0
+    }
+  ]
+};
+
+function signedIn() {
+  vi.mocked(authenticate).mockResolvedValue({
+    supabase: fakeSupabase(TABLES),
+    user: { id: 'user-1' },
+    apiKey: undefined,
+    error: null
+  } as never);
+  vi.mocked(loadBrandForUser).mockResolvedValue({
+    brand: { id: 'brand-1', slug: 'demo', name: 'Demo Brand' },
+    error: null
+  } as never);
+}
+
+function call(query: Record<string, string> = {}, slug = 'demo') {
+  const url = new URL(`https://anomalia.test/api/v1/brands/${slug}/studio`);
+  for (const [k, v] of Object.entries(query)) url.searchParams.set(k, v);
+  return (GET as (event: unknown) => Promise<Response>)({
+    request: new Request(url),
+    params: { slug },
+    url
+  }).then(async (res) => ({ res, body: await res.json() }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('GET /studio — documents', () => {
+  /**
+   * Il campo non aveva nessun lettore: la CLI stampa icona, titolo e id, `strategy-agent-reads`
+   * usa `.length`, la pagina Knowledge ha la sua query. L'unico effetto era rovesciare il corpus
+   * nella finestra di un agente esterno, che a quel punto non cerca più.
+   */
+  it('per difetto non spedisce il testo dei documenti', async () => {
+    signedIn();
+
+    const { res, body } = await call();
+
+    expect(res.status).toBe(200);
+    expect(body.documents).toHaveLength(2);
+    expect(body.documents[0]).not.toHaveProperty('content_text');
+    expect(JSON.stringify(body)).not.toContain('Clausola 4.2');
+  });
+
+  it('dice che il testo c’è e quanto pesa, senza spedirlo', async () => {
+    signedIn();
+
+    const { body } = await call();
+
+    expect(body.documents[0]).toMatchObject({
+      id: 'd1',
+      title: 'Contratto di fornitura',
+      status: 'ready',
+      chunkCount: 9,
+      textBytes: CONTRACT.length
+    });
+    expect(body.documents[1].textBytes).toBe(0);
+  });
+
+  it('restituisce il testo, byte per byte, a chi lo chiede', async () => {
+    signedIn();
+
+    const { body } = await call({ documents: 'full' });
+
+    expect(body.documents[0].content_text).toBe(CONTRACT);
+    expect(body.documents[1].content_text).toBeNull();
+    expect(body.documents[0].textBytes).toBe(CONTRACT.length);
+  });
+
+  it('un valore inventato non apre il rubinetto: vale il difetto', async () => {
+    signedIn();
+
+    const { body } = await call({ documents: 'tutto' });
+
+    expect(body.documents[0]).not.toHaveProperty('content_text');
+  });
+
+  it('il resto dello studio non cambia', async () => {
+    signedIn();
+
+    const { body } = await call();
+
+    for (const key of ['kit', 'products', 'history', 'people', 'competitors', 'targetPlatforms', 'studioPct']) {
+      expect(body, key).toHaveProperty(key);
+    }
+  });
+});


### PR DESCRIPTION
## What?

`get_studio` stops returning the full text of every brand document. `documents` is a new parameter: `index` (the default) lists documents with `status`, `chunkCount` and a new `textBytes`; `full` returns the old payload byte for byte.

`tools/list` stays at 116. No tool added or removed. `get_studio.description` and `get_studio.inputSchema` change — and nothing else.

## Why?

The field had no reader. I traced every one:

| consumer | what it actually reads |
|---|---|
| `cli/commands/studio.ts:181` | icon, title, id — **prints no text** |
| `strategy-agent-reads.ts:134` | `studio.documents.length` |
| Knowledge page | `studio-deferred.ts:38`, its **own** query |
| MCP `get_studio` | the whole corpus, unasked |

`cli/lib/api.ts:179` declared it in the type and nothing rendered it.

Its only real effect was filling an external agent's window with the corpus it should be *searching*. The per-document cap is 200,000 characters and `DOC_LIMIT_PRO` is 300; a modest brand at 30 documents × 20 KB is already ~150k tokens in one response. An agent handed everything stops calling `search_knowledge` — the field was competing with the right tool.

## How?

`getStudio(supabase, brandId, { documents })`. `index` drops `content_text` and adds `textBytes`, so the agent knows the text exists and how big it is, next to the `status`/`chunkCount` that say whether it is searchable at all.

**Why a parameter and not a removal.** Nothing inside this repo reads the field — verified above. But third parties hitting `/api/v1/brands/:slug/studio` with an API key **are not visible from here**. Removing it silently would bet on something I cannot see; a safe default does not bet. Anyone who was reading it adds one word and gets exactly what they had.

Only `"full"` opens the tap — anything else, invented or absent, is `index`. The registry already rejects undeclared parameters (`.strict()`), so an old client sending nothing gets the new default, which is the point.

**Rejected: truncation with a pointer.** 500 characters of a contract are neither the answer nor the knowledge that one should search. It pays the field's cost forever and solves nothing.

**Welcome side effect:** `readBrandStudioForAgent` calls `getStudio` with no options and only uses `documents.length` — that internal read now stops dragging along a corpus it never looked at. And the CLI, which now has `status` and `chunkCount` on the wire, marks the documents that are not searchable instead of listing them all alike.

## Testing?

<details><summary>Red — five failures, written first</summary>

```
 × per difetto non spedisce il testo dei documenti
   → expected { id: 'd1', … } to not have property "content_text"
 × dice che il testo c'è e quanto pesa, senza spedirlo
   → expected { id: 'd1', … } to match object { id: 'd1', …(4) }
 × restituisce il testo, byte per byte, a chi lo chiede
   → expected undefined to be 2600
 × un valore inventato non apre il rubinetto: vale il difetto
   → expected { id: 'd1', … } to not have property "content_text"
```
</details>

<details><summary>Red again — the pinned description, caught by its guard</summary>

```
$ cd cli && bun test
Received: "Full studio dump: … The text itself is NOT included: to answer a question, ask
`search_knowledge` … `documents: \"full\"` restores the complete text of every document …"
 58 pass / 1 fail
```

Updated with the reason beside it, and the pin now also asserts the new `documents` property in `inputSchema` — so a future change to the parameter cannot slip past either.
</details>

<details><summary>Green</summary>

```
$ npx vitest run packages/api-contracts "src/routes/api/v1/brands/[slug]/studio"
 Test Files  23 passed (23)
      Tests  242 passed (242)

$ npx vitest run "…/studio" strategy-agent-reads cli-queries packages/api-contracts   (pre-rebase)
 Test Files  25 passed (25)
      Tests  252 passed (252)

$ cd cli && bun test
 0 fail / 695 expect() calls / 59 tests across 12 files

$ cd cli && bun run typecheck        →  tsc --noEmit, exit 0
$ node scripts/typecheck-runtime.mjs →  typecheck-runtime: ok
```
</details>

Five route tests: the default sends no text and the contract's own words never appear in the body; `textBytes` reports the real length and `0` for an empty note; `full` returns the text byte-for-byte plus `textBytes`; an invented value falls back to the default rather than opening the tap; and the rest of the studio payload is untouched. Four contract tests cover the enum, the no-argument call, `content_text` being optional while `textBytes` is required, and the description pointing at `search_knowledge`.

**Not tested:** a live third-party API-key caller. That is exactly the population the parameter exists to protect, and it cannot be tested from here — which is the argument for the parameter, not against it.

## Evidence

<details><summary><code>tools/list</code> — dev vs this branch</summary>

```
dev=116  PR=116
removed: []  added: []
changed existing: ['get_studio.inputSchema', 'get_studio.description']
```

Exactly the intended surface: one tool gains one optional parameter and says what it now does.
</details>

<details><summary>What a document looks like, before and after</summary>

```jsonc
// before — and for documents: "full"
{ "id": "d1", "kind": "document", "title": "Contratto di fornitura",
  "content_text": "Clausola 4.2: la garanzia decade se … (2600 chars, up to 200_000)",
  "file_name": "contratto.pdf", "status": "ready", "chunkCount": 9 }

// after, by default
{ "id": "d1", "kind": "document", "title": "Contratto di fornitura",
  "file_name": "contratto.pdf", "status": "ready", "chunkCount": 9, "textBytes": 2600 }
```
</details>

## Anything Else?

- `textBytes` is a character count, not UTF-8 bytes. It is an order-of-magnitude signal for deciding whether to search, not an accounting figure; naming it `textLength` would be more literal and less legible. Say the word and I will rename it.
- The `documents` route (`/studio/documents`) and the Knowledge page are untouched: they have their own queries and their own audience.
- No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
