### PR TITLE
Make the CLI release fail before it half-lands

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -1,5 +1,9 @@
-# Builds the standalone CLI binaries + npm package from cli/, attaches GitHub
-# Release assets, updates the Homebrew formula and publishes to npm.
+# Builds the standalone CLI binaries + npm package from cli/, publishes to npm,
+# attaches GitHub Release assets and updates the Homebrew tap.
+#
+# Every credential the release needs is checked BEFORE the first irreversible step,
+# so a missing token fails the run while nothing has been published yet. A release
+# that half-lands — binaries on GitHub, nothing on npm — is the failure to avoid.
 name: CLI Release
 
 on:
@@ -13,8 +17,6 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      RELEASE_TAG: ${{ startsWith(github.ref, 'refs/tags/cli-v') }}
     steps:
       - uses: actions/checkout@v4
 
@@ -25,6 +27,22 @@ jobs:
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Verify release credentials
+        if: startsWith(github.ref, 'refs/tags/cli-v')
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          TAP_TOKEN: ${{ secrets.TAP_TOKEN }}
+        run: |
+          if [ -z "$NODE_AUTH_TOKEN" ]; then
+            echo "::error::NPM_TOKEN is not set. Add it in Settings → Secrets → Actions."
+            exit 1
+          fi
+          npm whoami || { echo "::error::NPM_TOKEN does not authenticate against registry.npmjs.org."; exit 1; }
+          if [ -z "$TAP_TOKEN" ]; then
+            echo "::error::TAP_TOKEN is not set. It is needed to push the formula to anomaliaso/homebrew-tap."
+            exit 1
+          fi
 
       - name: Install, check, test
         working-directory: cli
@@ -40,6 +58,7 @@ jobs:
           TAG="${GITHUB_REF_NAME#cli-v}"
           node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json','utf8')); p.version=process.argv[1]; fs.writeFileSync('package.json', JSON.stringify(p,null,2)+'\n');" "$TAG"
           sed -i.bak "s/\.version('[^']*')/.version('${TAG}')/" cli.ts && rm cli.ts.bak
+          sed -i.bak "s/version: '[^']*'/version: '${TAG}'/" mcp/server.ts && rm mcp/server.ts.bak
 
       - name: Build binaries + npm package
         working-directory: cli
@@ -58,6 +77,13 @@ jobs:
           chmod +x scripts/update-homebrew-formula.sh
           scripts/update-homebrew-formula.sh "${GITHUB_REF_NAME#cli-v}"
 
+      - name: Publish to npm
+        if: startsWith(github.ref, 'refs/tags/cli-v')
+        working-directory: cli/dist-npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Publish binaries to GitHub Release
         if: startsWith(github.ref, 'refs/tags/cli-v')
         uses: softprops/action-gh-release@v2
@@ -67,25 +93,8 @@ jobs:
             cli/dist/SHA256SUMS.txt
           generate_release_notes: true
 
-      - name: Commit Homebrew formula bump to main
-        if: startsWith(github.ref, 'refs/tags/cli-v')
-        run: |
-          cp cli/Formula/anomalia.rb /tmp/anomalia.rb
-          git fetch origin main
-          git checkout -B cli-formula-bump origin/main
-          cp /tmp/anomalia.rb cli/Formula/anomalia.rb
-          if git diff --quiet cli/Formula/anomalia.rb; then
-            echo "Formula unchanged"
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add cli/Formula/anomalia.rb
-          git commit -m "chore: bump Homebrew formula to ${GITHUB_REF_NAME}"
-          git push origin cli-formula-bump:main
-
       - name: Push formula to Homebrew tap
-        if: startsWith(github.ref, 'refs/tags/cli-v') && env.TAP_TOKEN != ''
+        if: startsWith(github.ref, 'refs/tags/cli-v')
         env:
           TAP_TOKEN: ${{ secrets.TAP_TOKEN }}
         run: |
@@ -103,15 +112,8 @@ jobs:
           git commit -m "anomalia ${GITHUB_REF_NAME#cli-v}"
           git push
 
-      - name: Publish to npm
-        if: startsWith(github.ref, 'refs/tags/cli-v')
-        working-directory: cli/dist-npm
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
       - name: Upload build artifacts (manual runs)
-        if: github.ref != 'refs/tags/cli-v'
+        if: ${{ !startsWith(github.ref, 'refs/tags/cli-v') }}
         uses: actions/upload-artifact@v4
         with:
           name: anomalia-dist

--- a/changelog/2026-09-04-cli-release-preflight.md
+++ b/changelog/2026-09-04-cli-release-preflight.md
@@ -1,0 +1,57 @@
+# Il rilascio della CLI non può più atterrare a metà
+
+Il workflow `cli-release.yml` esisteva completo da mesi e non è mai partito: zero tag
+`cli-v*`, `anomalia-cli` inesistente su npm. Prima di proporne il primo lancio abbiamo
+fatto il pre-volo, e quattro cose lo avrebbero rotto.
+
+**Il rilascio fantasma.** Nel repository non esiste nessun secret: né `NPM_TOKEN`, né
+`TAP_TOKEN`. Il workflow pubblicava la GitHub Release *prima* di `npm publish`, e in mezzo
+c'era uno step che spinge un commit direttamente su `main` — che è protetto da una required
+review, e il `GITHUB_TOKEN` del bot non è admin. Esito: Release creata con 380 MB di binari,
+push su `main` rifiutato, job rosso, npm mai raggiunto. Esattamente la versione fantasma che
+l'antenato di questo workflow (nel vecchio repo `andreabuttarelli/anomalia-cli`) evitava con
+una guardia che saltava in silenzio `npm publish` — guardia rimossa di proposito, perché un
+rilascio che tace è peggio di uno che grida.
+
+La motivazione resta valida, ma gridare *dopo* aver pubblicato non serve a niente. Ora un
+solo step, `Verify release credentials`, gira prima di qualunque cosa irreversibile: verifica
+che `NPM_TOKEN` esista **e** autentichi davvero (`npm whoami`, non solo non-vuoto) e che
+`TAP_TOKEN` ci sia. Il rilascio fallisce mentre non è stato pubblicato ancora nulla. Lo step
+che spingeva su `main` è stato tolto: non poteva funzionare, e il tap riceve comunque la
+formula compilata. La stessa incoerenza stava nel tap, che si auto-saltava con
+`env.TAP_TOKEN != ''`; ora è il preflight a deciderlo, in un posto solo.
+
+**I tag si chiamano `cli-v0.1.0`, non `v0.1.0`.** Il monorepo prefissa i tag del CLI, ma sia
+`install.sh --version X` sia i quattro URL della formula Homebrew puntavano a
+`releases/download/v${X}/`. Un tag che non esisterà mai: `brew install anomalia` avrebbe dato
+404 al primo utente, e lo script che riscrive la formula rimetteva `v#{version}` a ogni
+release, annullando ogni correzione a mano.
+
+**L'installer non verificava niente.** `SHA256SUMS.txt` viene pubblicato con la release e non
+lo leggeva nessuno: l'unico controllo era «il file scaricato pesa più di 1000 byte». Per uno
+script che chiediamo a degli sconosciuti di eseguire con `curl | bash` e `sudo`, non basta.
+Ora scarica i checksum, confronta, e si rifiuta di installare se mancano, se non c'è la riga
+della piattaforma, o se il digest non torna.
+
+**Il `read` si mangiava lo script.** Sotto `curl | bash` lo script *è* stdin: `read -p` non
+legge la risposta dell'utente, consuma le righe successive dell'installer, che quindi non
+vengono mai eseguite. Verificato: in una shell non interattiva il prompt cadeva a vuoto e il
+ramo «installa la skill nel progetto» partiva lo stesso, scrivendo `.claude/skills/`,
+`.cursorrules` e `llms.txt` nella directory in cui l'utente si trovava per caso. Ora il prompt
+apre `/dev/tty` esplicitamente, e senza terminale il blocco si salta con un suggerimento.
+
+Un dettaglio in coda: `mktemp` crea a 0600 e `chmod +x` lasciava il binario installato a 0711,
+root-owned e non leggibile. Ora è 755.
+
+**`build.ts` mentiva.** Un target che falliva faceva `continue`: `build:all` usciva 0 con due
+binari su quattro. Ora esce 1.
+
+**La versione.** Il tag sincronizzava `package.json` e `cli.ts` ma non `mcp/server.ts`, che
+avrebbe continuato ad annunciarsi `0.1.0` per sempre agli host MCP. Aggiunto alla sync.
+
+`scripts/release-contract.test.ts` tiene insieme le tre copie del prefisso del tag, l'ordine
+degli step e la sincronizzazione delle versioni: contro i file di prima falliva 7 test su 10.
+
+Restano fuori dal codice e servono a mano: i due secret non esistono, il repository
+`anomaliaso/homebrew-tap` non esiste, e il nome corto `anomalia` su npm è occupato da un
+progetto `create-next-app` di terzi pubblicato nel 2024 — `anomalia-cli` è libero.

--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -14,3 +14,7 @@ api/_oauth.bundle.js
 api/_bundle.cjs
 api/_bundle.cjs.map
 api/*.cjs
+mcp/api/_bundle.js
+mcp/api/mcp.js
+mcp/api/oauth-protected-resource.js
+mcp/api/*.cjs

--- a/cli/Formula/anomalia.rb
+++ b/cli/Formula/anomalia.rb
@@ -7,7 +7,7 @@
 #   brew tap anomaliaso/tap https://github.com/anomaliaso/homebrew-tap
 #   brew install anomalia
 #
-# SHA256 placeholders below are filled by .github/workflows/release.yml on each v* tag.
+# SHA256 placeholders below are filled by .github/workflows/cli-release.yml on each cli-v* tag.
 
 class Anomalia < Formula
   desc "Command-line client for Anomalia — social media AI autopilot"
@@ -17,27 +17,28 @@ class Anomalia < Formula
 
   livecheck do
     url "https://github.com/anomaliaso/anomalia/releases/latest"
+    regex(%r{/tag/cli-v?(\d+(?:\.\d+)+)"}i)
     strategy :github_latest
   end
 
   on_macos do
     on_arm do
-      url "https://github.com/anomaliaso/anomalia/releases/download/v#{version}/anomalia-macos-arm64.tar.gz"
+      url "https://github.com/anomaliaso/anomalia/releases/download/cli-v#{version}/anomalia-macos-arm64.tar.gz"
       sha256 "REPLACE_SHA256_MACOS_ARM64"
     end
     on_intel do
-      url "https://github.com/anomaliaso/anomalia/releases/download/v#{version}/anomalia-macos-x64.tar.gz"
+      url "https://github.com/anomaliaso/anomalia/releases/download/cli-v#{version}/anomalia-macos-x64.tar.gz"
       sha256 "REPLACE_SHA256_MACOS_X64"
     end
   end
 
   on_linux do
     on_arm do
-      url "https://github.com/anomaliaso/anomalia/releases/download/v#{version}/anomalia-linux-arm64.tar.gz"
+      url "https://github.com/anomaliaso/anomalia/releases/download/cli-v#{version}/anomalia-linux-arm64.tar.gz"
       sha256 "REPLACE_SHA256_LINUX_ARM64"
     end
     on_intel do
-      url "https://github.com/anomaliaso/anomalia/releases/download/v#{version}/anomalia-linux-x64.tar.gz"
+      url "https://github.com/anomaliaso/anomalia/releases/download/cli-v#{version}/anomalia-linux-x64.tar.gz"
       sha256 "REPLACE_SHA256_LINUX_X64"
     end
   end

--- a/cli/scripts/build.ts
+++ b/cli/scripts/build.ts
@@ -80,7 +80,7 @@ for (const target of selectedTargets) {
 
   if (proc.exitCode !== 0) {
     console.error(`  ✗ Failed to build ${outName}`);
-    continue;
+    process.exit(1);
   }
 
   console.log(`  ✓ ${outName} (${(Bun.file(outPath).size / 1024 / 1024).toFixed(1)} MB)`);
@@ -114,7 +114,7 @@ for (const target of selectedTargets) {
   });
   if (tar.exitCode !== 0) {
     console.error(`  ✗ Failed to archive ${outName}`);
-    continue;
+    process.exit(1);
   }
   console.log(`  ✓ ${outName}.tar.gz`);
 }

--- a/cli/scripts/install.sh
+++ b/cli/scripts/install.sh
@@ -22,6 +22,8 @@ BINARY_NAME="anomalia"
 DEFAULT_DIR="/usr/local/bin"
 FALLBACK_DIR="$HOME/.local/bin"
 VERSION="latest"
+TAG_PREFIX="cli-v"          # release tags: cli-v0.1.0
+CHECKSUMS_FILE="SHA256SUMS.txt"
 
 # ── Colors ─────────────────────────────────────────────────────────────
 
@@ -137,52 +139,92 @@ else
   SUDO=""
 fi
 
-# Determine download URL
+# Determine download URL. Release tags are prefixed cli-v (the repo is a monorepo).
 if [[ "$VERSION" == "latest" ]]; then
-  DOWNLOAD_URL="https://github.com/${REPO}/releases/latest/download/anomalia-${PLATFORM}"
+  RELEASE_BASE="https://github.com/${REPO}/releases/latest/download"
 else
-  DOWNLOAD_URL="https://github.com/${REPO}/releases/download/v${VERSION}/anomalia-${PLATFORM}"
+  RELEASE_BASE="https://github.com/${REPO}/releases/download/${TAG_PREFIX}${VERSION#v}"
+fi
+DOWNLOAD_URL="${RELEASE_BASE}/anomalia-${PLATFORM}"
+CHECKSUMS_URL="${RELEASE_BASE}/${CHECKSUMS_FILE}"
+
+# ── Download helpers ───────────────────────────────────────────────────
+
+if command -v curl &> /dev/null; then
+  fetch() { curl -fsSL -o "$1" "$2"; }
+elif command -v wget &> /dev/null; then
+  fetch() { wget -qO "$1" "$2"; }
+else
+  fatal "Neither curl nor wget found. Please install one."
+fi
+
+if command -v sha256sum &> /dev/null; then
+  sha256() { sha256sum "$1" | awk '{print $1}'; }
+elif command -v shasum &> /dev/null; then
+  sha256() { shasum -a 256 "$1" | awk '{print $1}'; }
+else
+  fatal "Neither sha256sum nor shasum found: cannot verify the download."
 fi
 
 info "Downloading Anomalia CLI..."
 info "URL: ${DOWNLOAD_URL}"
 
-# Download
 TEMP_FILE="$(mktemp)"
-if command -v curl &> /dev/null; then
-  curl -sSL -o "$TEMP_FILE" "$DOWNLOAD_URL" || fatal "Download failed"
-elif command -v wget &> /dev/null; then
-  wget -qO "$TEMP_FILE" "$DOWNLOAD_URL" || fatal "Download failed"
-else
-  fatal "Neither curl nor wget found. Please install one."
-fi
+CHECKSUMS_FL="$(mktemp)"
+trap 'rm -f "$TEMP_FILE" "$CHECKSUMS_FL"' EXIT
 
-# Verify download
-FILE_SIZE="$(wc -c < "$TEMP_FILE" | tr -d ' ')"
-if [[ "$FILE_SIZE" -lt 1000 ]]; then
-  error "Downloaded file is too small ($FILE_SIZE bytes). Release may not exist for $PLATFORM."
-  cat "$TEMP_FILE"
-  rm -f "$TEMP_FILE"
-  fatal "Download verification failed"
-fi
+fetch "$TEMP_FILE" "$DOWNLOAD_URL" \
+  || fatal "Download failed. No release asset anomalia-${PLATFORM} at ${RELEASE_BASE}"
 
-# Make executable
-chmod +x "$TEMP_FILE"
+# Verify the binary against the checksums published with the release. Refusing to
+# install an unverified executable is the whole point of shipping SHA256SUMS.txt.
+fetch "$CHECKSUMS_FL" "$CHECKSUMS_URL" \
+  || fatal "Could not download ${CHECKSUMS_FILE} from ${RELEASE_BASE}: refusing to install unverified."
+
+EXPECTED="$(awk -v f="anomalia-${PLATFORM}" '$2 == f || $2 == "*" f {print $1}' "$CHECKSUMS_FL" | head -1)"
+[[ -n "$EXPECTED" ]] || fatal "${CHECKSUMS_FILE} has no entry for anomalia-${PLATFORM}: refusing to install unverified."
+
+ACTUAL="$(sha256 "$TEMP_FILE")"
+if [[ "$ACTUAL" != "$EXPECTED" ]]; then
+  error "Checksum mismatch for anomalia-${PLATFORM}"
+  error "  expected: $EXPECTED"
+  error "  actual:   $ACTUAL"
+  fatal "Refusing to install a binary that does not match the published checksum."
+fi
+success "Checksum verified (${ACTUAL:0:16}…)"
+
+chmod 755 "$TEMP_FILE"
 
 # Install
 info "Installing to ${INSTALL_DIR}/${BINARY_NAME}..."
 $SUDO mv "$TEMP_FILE" "${INSTALL_DIR}/${BINARY_NAME}" || fatal "Installation failed"
+trap 'rm -f "$CHECKSUMS_FL"' EXIT
 
 success "Anomalia CLI installed to ${INSTALL_DIR}/${BINARY_NAME}"
 
-# Install AI skill (ask user)
+# Install AI skill (ask user).
+#
+# Under `curl … | bash` the script itself is on stdin, so a bare `read` consumes the
+# next lines of the installer instead of the user's answer. Prompt on /dev/tty, and
+# skip the whole block when there is no terminal — a non-interactive run must not
+# silently drop files (.cursorrules, llms.txt) into whatever the current directory is.
 echo ""
-read -p "  Installare la skill per AI coding assistants? [Y/n]: " install_skill
-if [[ "$install_skill" != "n" && "$install_skill" != "N" ]]; then
+install_skill=""
+skill_choice=""
+TTY_OK=false
+if { exec 3< /dev/tty; } 2>/dev/null; then
+  TTY_OK=true
+  read -r -u 3 -p "  Installare la skill per AI coding assistants? [Y/n]: " install_skill || true
+else
+  info "Shell non interattiva: skill non installata."
+  info "Per installarla: curl -sSL https://raw.githubusercontent.com/${REPO}/main/cli/scripts/install-skill.sh | bash"
+fi
+
+if [[ "$TTY_OK" == true && "$install_skill" != "n" && "$install_skill" != "N" ]]; then
   echo ""
   echo "  1) Progetto corrente (.claude/skills/, .cursorrules, etc.)"
   echo "  2) Globale (~/.claude/skills/)"
-  read -p "  Scelta [1/2]: " skill_choice
+  read -r -u 3 -p "  Scelta [1/2]: " skill_choice || true
   echo ""
 
   SKILL_URL="https://raw.githubusercontent.com/anomaliaso/anomalia/main/cli/skills/anomalia-cli.md"
@@ -191,24 +233,24 @@ if [[ "$install_skill" != "n" && "$install_skill" != "N" ]]; then
     # Global install
     CLAUDE_SKILLS_DIR="$HOME/.claude/skills"
     mkdir -p "$CLAUDE_SKILLS_DIR"
-    curl -sSL "$SKILL_URL" -o "$CLAUDE_SKILLS_DIR/anomalia-cli.md" 2>/dev/null && \
+    fetch "$CLAUDE_SKILLS_DIR/anomalia-cli.md" "$SKILL_URL" 2>/dev/null && \
       success "Skill installata globalmente → $CLAUDE_SKILLS_DIR/anomalia-cli.md" || \
       warn "Could not install skill (non-critical)"
   else
     # Project install
     mkdir -p ".claude/skills"
-    curl -sSL "$SKILL_URL" -o ".claude/skills/anomalia-cli.md" 2>/dev/null && \
+    fetch ".claude/skills/anomalia-cli.md" "$SKILL_URL" 2>/dev/null && \
       success "Skill installata nel progetto → .claude/skills/anomalia-cli.md" || \
       warn "Could not install skill (non-critical)"
 
     # Also install for Cursor if .cursor exists
     if [[ -d ".cursor" ]] || command -v cursor &> /dev/null; then
-      curl -sSL "$SKILL_URL" -o ".cursorrules" 2>/dev/null && \
+      fetch ".cursorrules" "$SKILL_URL" 2>/dev/null && \
         success "Cursor rules installato → .cursorrules" || true
     fi
 
     # Also install llms.txt
-    curl -sSL "https://raw.githubusercontent.com/anomaliaso/anomalia/main/cli/llms.txt" -o "llms.txt" 2>/dev/null && \
+    fetch "llms.txt" "https://raw.githubusercontent.com/anomaliaso/anomalia/main/cli/llms.txt" 2>/dev/null && \
       success "llms.txt installato" || true
   fi
 fi

--- a/cli/scripts/release-contract.test.ts
+++ b/cli/scripts/release-contract.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { fileURLToPath } from 'url';
+
+const CLI = fileURLToPath(new URL('../', import.meta.url));
+const REPO = join(CLI, '..');
+
+const read = (rel: string) => readFileSync(join(REPO, rel), 'utf8');
+
+const workflow = read('.github/workflows/cli-release.yml');
+const installer = read('cli/scripts/install.sh');
+const formula = read('cli/Formula/anomalia.rb');
+const formulaUpdater = read('cli/scripts/update-homebrew-formula.sh');
+
+const TAG_PREFIX = 'cli-v';
+
+describe('release tag prefix', () => {
+  test('the workflow only fires on cli-v* tags', () => {
+    expect(workflow).toContain(`tags: ['${TAG_PREFIX}*']`);
+  });
+
+  test('the installer downloads from a cli-v tag', () => {
+    expect(installer).toContain(`TAG_PREFIX="${TAG_PREFIX}"`);
+  });
+
+  test('every formula url points at a cli-v tag', () => {
+    const urls = formula.match(/releases\/download\/[^/]+\//g) ?? [];
+    expect(urls.length).toBe(4);
+    for (const url of urls) {
+      expect(url).toBe(`releases/download/${TAG_PREFIX}#{version}/`);
+    }
+  });
+
+  test('the formula updater rewrites urls back to a cli-v tag', () => {
+    expect(formulaUpdater).toContain(`\\g<1>${TAG_PREFIX}#{{version}}\\2`);
+  });
+});
+
+describe('published binaries are verifiable', () => {
+  test('the workflow publishes SHA256SUMS.txt with the binaries', () => {
+    expect(workflow).toContain('sha256sum anomalia-* > SHA256SUMS.txt');
+    expect(workflow).toContain('cli/dist/SHA256SUMS.txt');
+  });
+
+  test('the installer refuses a binary it cannot verify', () => {
+    expect(installer).toContain('CHECKSUMS_FILE="SHA256SUMS.txt"');
+    expect(installer).toMatch(/Refusing to install a binary that does not match/);
+  });
+});
+
+describe('nothing irreversible runs before the credentials are checked', () => {
+  const stepNames = [...workflow.matchAll(/^ {6}- name: (.+)$/gm)].map((m) => m[1]);
+  const at = (name: string) => stepNames.indexOf(name);
+
+  test('the credential check precedes every publish step', () => {
+    const check = at('Verify release credentials');
+    expect(check).toBeGreaterThanOrEqual(0);
+    for (const step of [
+      'Publish to npm',
+      'Publish binaries to GitHub Release',
+      'Push formula to Homebrew tap',
+    ]) {
+      expect(at(step)).toBeGreaterThan(check);
+    }
+  });
+
+  test('npm publishes before the GitHub Release, so a bad token cannot strand a release', () => {
+    expect(at('Publish to npm')).toBeLessThan(at('Publish binaries to GitHub Release'));
+  });
+});
+
+describe('the version the tag carries reaches everything that reports one', () => {
+  const declared = [
+    ['cli/package.json', /"version": "(\d+\.\d+\.\d+)"/],
+    ['cli/cli.ts', /\.version\('(\d+\.\d+\.\d+)'\)/],
+    ['cli/mcp/server.ts', /version: '(\d+\.\d+\.\d+)'/],
+  ] as const;
+
+  test('every declared version agrees', () => {
+    const versions = declared.map(([file, re]) => read(file).match(re)?.[1]);
+    expect(versions.every(Boolean)).toBe(true);
+    expect(new Set(versions).size).toBe(1);
+  });
+
+  test('the workflow rewrites each of them from the tag', () => {
+    expect(workflow).toContain("p.version=process.argv[1]");
+    expect(workflow).toContain("sed -i.bak \"s/\\.version('[^']*')/.version('${TAG}')/\" cli.ts");
+    expect(workflow).toContain("sed -i.bak \"s/version: '[^']*'/version: '${TAG}'/\" mcp/server.ts");
+  });
+});

--- a/cli/scripts/update-homebrew-formula.sh
+++ b/cli/scripts/update-homebrew-formula.sh
@@ -70,10 +70,10 @@ for artifact, digest in platform_digests:
         rf"\g<1>{digest}\2",
         text,
     )
-    # Keep version interpolation in URLs: .../download/v#{version}/artifact
+    # Keep version interpolation in URLs: .../download/cli-v#{version}/artifact
     text = re.sub(
-        rf'(releases/download/)v[^/]+(/{re.escape(artifact)}")',
-        rf"\g<1>v#{{version}}\2",
+        rf'(releases/download/)(?:cli-)?v[^/]+(/{re.escape(artifact)}")',
+        rf"\g<1>cli-v#{{version}}\2",
         text,
     )
 

--- a/src/lib/content/changelog/2026-09-04-cli-installer-hardening.ts
+++ b/src/lib/content/changelog/2026-09-04-cli-installer-hardening.ts
@@ -1,0 +1,12 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-04',
+  title: 'A safer CLI installer',
+  items: [
+    'The install script now verifies the checksum of every binary it downloads, and refuses to install one that does not match.',
+    'Installing with `curl … | bash` no longer drops skill files into whatever folder you happened to be in.',
+    '`--version` installs the release you asked for instead of failing on a version that never existed.',
+    'Homebrew now points at the right release, so `brew install anomalia` finds the binary.',
+  ],
+} satisfies ChangelogEntry;


### PR DESCRIPTION
## What?

The CLI release pipeline has never run. There are zero `cli-v*` tags, `anomalia-cli` is a 404 on npm, and the repository has **no Actions secrets at all**. This PR is the pre-flight: it fixes the defects that would have broken the first launch, and leaves a test that keeps them fixed. It does **not** tag, publish, or run anything.

Six concrete defects, all verified by running the code rather than reading it:

1. **The release could half-land.** `Publish binaries to GitHub Release` ran *before* `npm publish`, with a step in between that pushes a bot commit straight to `main` — which is protected by a required review, and the bot's `GITHUB_TOKEN` is not an admin. The run would have created the Release with 380 MB of binaries, been rejected pushing to `main`, gone red, and never reached npm.
2. **Homebrew and `install.sh --version` pointed at a tag that will never exist.** Tags are `cli-v0.1.0`; both built `releases/download/v0.1.0/…`.
3. **`install.sh` verified nothing.** `SHA256SUMS.txt` ships with every release and nobody read it — the only check was "the download weighs more than 1000 bytes".
4. **`read -p` ate the installer.** Under `curl | bash` the script *is* stdin, so the prompt consumed the installer's own next lines. Non-interactively the skill branch ran anyway and wrote `.claude/skills/`, `.cursorrules` and `llms.txt` into whatever directory the user was standing in.
5. **`build.ts` lied.** A failed target did `continue`, so `build:all` exited 0 with two binaries out of four.
6. **`mcp/server.ts` was outside the version sync** and would have announced `0.1.0` to MCP hosts forever.

Plus a papercut: `cli/.gitignore` still ignores the old `api/` paths, while `build-vercel.mjs` now writes a 3.7 MB bundle into `mcp/api/`, untracked and one `git add -A` away from being committed.

## Why?

Andrea wants the CLI on npm, the installer, and the Claude plugin. Publishing to a public registry is irreversible: a taken name and a published version do not really come back. The point of this PR is that the first `cli-v0.1.0` either works or fails while nothing has been published — never in between.

The `install.sh` items are not cosmetic. That script is what we ask strangers to pipe into `bash` and run with `sudo`. An installer that fetches an executable over the network and does not check it against the checksum we publish alongside it is a supply-chain hole we opened ourselves.

## How?

**One gate before anything irreversible.** A single `Verify release credentials` step runs before the first publish: `NPM_TOKEN` must exist *and actually authenticate* (`npm whoami`, not merely non-empty), `TAP_TOKEN` must exist.

This restores the intent recorded when this workflow was ported from `andreabuttarelli/anomalia-cli`. The ancestor skipped `npm publish` silently when the token was empty; that guard was dropped deliberately, because *a release that quietly does not publish is worse than one that fails loudly*. That reasoning holds — but failing loudly **after** publishing helps nobody. Checking up front keeps the loud failure and removes the split. The same inconsistency lived in the tap step, which silently skipped itself via `env.TAP_TOKEN != ''`; the decision now lives in one place.

**Rejected alternative:** re-adding a skip guard on npm. It reintroduces exactly the silent-non-publish the note argues against.

`npm publish` now precedes the GitHub Release — it is the step most likely to fail on auth and the cheapest to detect — and the step pushing to `main` is **removed**: it could not have succeeded against branch protection, and the tap receives the compiled formula regardless. If the in-repo formula copy should be bumped, that is a PR a human opens.

**`install.sh`.** The tag prefix is a named constant. Checksums are downloaded and compared, and the install is refused three ways: file missing, no line for this platform, digest mismatch. The prompt opens `/dev/tty` explicitly; with no terminal the whole block is skipped with a hint instead of writing files into the CWD. `chmod 755` replaces `chmod +x`, which left the installed binary root-owned at 0711.

Note the tty probe is `if { exec 3< /dev/tty; } 2>/dev/null` — my first attempt used `[[ -r /dev/tty ]]`, which returns true in contexts where the open then fails, and the CWD pollution came right back. Caught by testing it, not by reading it.

**One test for the defect class.** `cli/scripts/release-contract.test.ts` holds together the three copies of the tag prefix (installer, formula, formula updater), the step ordering, and the version sync. The prefix living in three files is what let it drift.

## Testing?

**Unit** — `cd cli && bun test`: **69 pass, 0 fail** (58 before; the 10 new plus one from a parallel branch). `bun run typecheck` clean. `node scripts/typecheck-runtime.mjs` clean. All re-run after rebasing onto `origin/dev` at #303.

**The new test was watched fail first.** Against the pre-fix files from `origin/dev`: **7 of 10 failed**. After: 10 pass.

**All four build paths** — `bun run typecheck`, `bun run build`, `bun run build:npm`, `node scripts/build-vercel.mjs`, plus `build:all` (4 binaries, 64–95 MB each, tarballs, checksums). All exit 0.

**The npm package was installed and run, not assumed.** `npm pack` → 5 files, 477 kB, nothing stray. Installed from the tarball into an isolated prefix with an isolated `HOME`:
- `anomalia --version` → `0.1.0`; `--help` renders the full command list
- `anomalia brands` unauthenticated → `Sessione scaduta o non trovata. Esegui: anomalia login`
- `anomalia-mcp` completes an MCP `initialize` handshake, and **stdout is pure JSON-RPC** (the banner is on stderr, as it must be)

**`install.sh` was exercised against a fake release**, via a `curl` shim on `PATH` so the real script ran unmodified:

| Case | Result |
|---|---|
| Valid checksum | installs, mode 755, binary runs |
| Tampered binary | refuses, prints expected vs actual |
| `SHA256SUMS.txt` missing | refuses |
| No entry for this platform | refuses |
| Non-interactive | skips the skill block, **CWD stays empty** |
| `--version 9.9.9` | requests `cli-v9.9.9` |

**The Homebrew updater was run twice** — once on the template with `REPLACE_` tokens, once on the already-filled formula at a new version. Idempotent, no tokens left, `ruby -c` Syntax OK.

**The Claude plugin was installed end to end** in an isolated `CLAUDE_CONFIG_DIR`: `claude plugin marketplace add anomaliaso/anomalia` then `claude plugin install anomalia@anomalia`, both exit 0, cache carries `plugin.json` + `skills/anomalia/SKILL.md` + `.mcp.json`. `claude plugin validate` passes on both manifests. **No change was needed here.**

**Not tested, and why:** the workflow itself never ran — no tag was created, no `workflow_dispatch` fired, nothing was published. That was the explicit constraint, and it is also the point: the whole PR exists so the first real run is the first real run. Its YAML parses and its step order is asserted by the test, but "the credential gate fires on a missing `NPM_TOKEN`" can only be proven by Andrea's first tag. Risk is bounded: if the gate misfires the release fails having published nothing, which is the same outcome as not tagging.

## Evidence

<details><summary>The new test, red before and green after</summary>

```
=== RED against pre-fix (origin/dev) files ===
 3 pass
 7 fail

  ✗ npm publishes before the GitHub Release, so a bad token cannot strand a release
      Expected: < 5
      Received: 8

=== GREEN with fixes ===
 10 pass
 0 fail
```
</details>

<details><summary>install.sh — checksum verified, then refused on tamper</summary>

```
ℹ URL: https://github.com/anomaliaso/anomalia/releases/download/cli-v9.9.9/anomalia-macos-arm64
✓ Checksum verified (9f44ccb187f4611b…)
ℹ Installing to …/bin/anomalia...
✓ Anomalia CLI installed to …/bin/anomalia

--- installed ---
-rwxr-xr-x  anomalia
9.9.9

=== TAMPERED binary (checksum unchanged) ===
✗ Checksum mismatch for anomalia-macos-arm64
✗   expected: 9f44ccb187f4611b0c7b6e9383cac0c207261b1467b8eca4e8e25b222995bafd
✗   actual:   084ce074c3eceacdf369554a5ecd1cdb35b8bb84d7a606823660f5b3b5d0c582
✗ Refusing to install a binary that does not match the published checksum.
installed? -> (nothing)
```
</details>

<details><summary>install.sh — non-interactive run leaves the CWD alone</summary>

```
ℹ Shell non interattiva: skill non installata.
ℹ Per installarla: curl -sSL …/cli/scripts/install-skill.sh | bash

--- CWD pollution (must be empty) ---
total 0
drwxr-xr-x  .
drwxr-xr-x  ..
```
Before the fix the same run created `.claude/skills/` in the CWD.
</details>

<details><summary>npm package: packed, installed from tarball, executed</summary>

```
📦  anomalia-cli@0.1.0
 34.5kB LICENSE   8.7kB README.md   844.7kB cli.js   935.6kB mcp-stdio.js   772B package.json
package size: 477.3 kB   total files: 5

$ anomalia --version
0.1.0
$ anomalia brands
Sessione scaduta o non trovata. Esegui: anomalia login
$ echo '{"jsonrpc":"2.0",…"initialize"…}' | anomalia-mcp 2>/dev/null
{"result":{"protocolVersion":"2024-11-05","capabilities":{"tools":{"listChanged":true}},
 "serverInfo":{"name":"anomalia","version":"0.1.0",…
```
</details>

<details><summary>Homebrew formula updater, run twice</summary>

```
=== run 1 (template with REPLACE_ tokens) ===
Updated Formula/anomalia.rb → v0.1.0
  url ".../releases/download/cli-v#{version}/anomalia-macos-arm64.tar.gz"
  sha256 "c9e930e666b42bfc14cc1eef04da02be48ac920463309985f565bb194637e2d7"

=== run 2 (already-filled formula, new version) ===
Updated Formula/anomalia.rb → v0.2.0
  url ".../releases/download/cli-v#{version}/anomalia-macos-arm64.tar.gz"

REPLACE_ tokens left: 0
ruby -c: Syntax OK
```
</details>

<details><summary>Claude plugin installs from the public repo, unchanged</summary>

```
$ claude plugin marketplace add anomaliaso/anomalia
✔ Successfully added marketplace: anomalia
$ claude plugin install anomalia@anomalia
✔ Successfully installed plugin: anomalia@anomalia (scope: user)

cache/anomalia/anomalia/1.0.0/
├── .claude-plugin/plugin.json
├── .codex-plugin/plugin.json
├── .mcp.json
└── skills/anomalia/SKILL.md
```
</details>

No UI change, so no screenshots.

## Anything Else?

**This PR cannot make the release work. Four things only Andrea can do:**

1. **`NPM_TOKEN`** — create an npm automation token, add it at Settings → Secrets → Actions. The repository currently has zero secrets.
2. **`TAP_TOKEN`** — a PAT with `contents: write` on the tap.
3. **Create `anomaliaso/homebrew-tap`** — it does not exist; the org has two repos. The workflow clones it unconditionally.
4. **Decide the npm name.** `anomalia-cli` is free. The short `anomalia` is taken by an unrelated `create-next-app` scaffold published 2024-05-26 by `anomalia <bellissimacuore@gmail.com>` (repo `bellissimacuore/anomalia`). If that account is Andrea's, the name can be reused; **I could not verify it and did not assume**.

If Homebrew is not wanted for v0.1.0, drop the tap step and its half of the credential gate rather than leaving a token unset — the gate now refuses to run without it, by design.

**Known debt:** adding the marketplace clones the whole 78 MB monorepo into `~/.claude/plugins/marketplaces/`. One-time, acceptable; a dedicated plugin repo would fix it if it ever bites. And the CLI's help text and installer prompts are in Italian while the README is English — a product call, not a defect, but the first npm user will notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
