### PR TITLE
Redirect to the workbench after the auth guards, not before

### DIFF
--- a/changelog/2026-09-04-rimando-dopo-autenticazione.md
+++ b/changelog/2026-09-04-rimando-dopo-autenticazione.md
@@ -1,0 +1,38 @@
+# Il rimando al workbench stava sopra l'autenticazione
+
+La #269 ha spostato in cima al layout del brand il rimando verso `/workbench`, per togliere una
+corsa con la scrittura del cookie dell'ultimo brand. Troppo in cima: **sopra il controllo di
+sessione**.
+
+Conseguenza, presa dalla CI:
+
+```
+unauthenticated /app/[brand] redirects to /login
+  Expected: 303
+  Received: 302
+```
+
+Un utente non autenticato che apriva `/app/qualunque` veniva mandato al workbench invece che al
+login. Non è una falla — il workbench il controllo lo rifà — ma è il flusso di ingresso rotto, e
+`dev` è rimasta rossa finché non lo si è visto.
+
+## Dove sta adesso, e perché lì
+
+Fra il `404` del brand inesistente e la scrittura del cookie. È l'unico punto che soddisfa
+entrambe le proprietà:
+
+- **dopo** sessione, accesso e brand: chi non deve entrare riceve la risposta che l'app promette
+  ovunque, cioè `303` verso `/login` o `/waitlist`;
+- **prima** del `cookies.set`: SvelteKit rifiuta di scrivere un cookie dopo che la risposta è
+  stata generata, ed è la ragione per cui la #269 lo aveva alzato.
+
+## Il test che mancava, e perché passava lo stesso
+
+I quattro test esistenti eseguivano il `load` con `locals: {}` — senza Supabase, senza sessione.
+Passavano **perché il rimando usciva prima di toccarli**: non provavano l'ordine, provavano solo
+la destinazione. Spostare il rimando li ha fatti esplodere, che è il modo in cui si scopre che un
+test verde stava sorvegliando meno di quanto sembrasse.
+
+Ora il layout riceve una sessione finta e i test coprono anche il caso senza. Rimettendo il
+rimando in cima, `expected 302 to be 303` — lo stesso errore che ha dato la CI, un secondo invece
+di dieci minuti.

--- a/src/routes/app/[brand]/+layout.server.ts
+++ b/src/routes/app/[brand]/+layout.server.ts
@@ -49,15 +49,6 @@ function gtmPhasesHaveContent(phases: unknown): boolean {
 }
 
 export const load: LayoutServerLoad = async ({ url, params, cookies, locals: { supabase, safeGetSession } }) => {
-  // La home del brand era la chat: tolta quella, il guscio non ha più niente da mostrare lì e il
-  // workbench È la home. Il rimando sta QUI e non in un +page.server.ts perché quello correva in
-  // parallelo a questo load: chiudeva la risposta prima che la riga sotto scrivesse il cookie
-  // dell'ultimo brand, e SvelteKit rifiutava con «cookies.set after the response has been
-  // generated». Qui il rimando parte prima di ogni attesa, quindi non c'è corsa da perdere.
-  if (decodeURIComponent(url.pathname).replace(/\/$/, '') === `/app/${params.brand}`) {
-    redirect(302, `/app/${encodeURIComponent(params.brand)}/workbench`);
-  }
-
   // Le pagine fanno `await parent()`: questa sezione bloccante È tutto il ritardo fra una pagina
   // e l'altra, oltre alle query della pagina stessa.
   const cookieSessionP = supabase.auth.getSession();
@@ -84,6 +75,16 @@ export const load: LayoutServerLoad = async ({ url, params, cookies, locals: { s
   const brandRows = shell.peers;
 
   if (!brand) throw error(404, 'Brand not found');
+
+  // La home del brand era la chat: tolta quella, il workbench È la home. Il rimando sta DOPO i
+  // controlli — sessione, accesso, brand esistente — perché sopra di essi rispondeva 302 al
+  // workbench a chi non era autenticato, invece del 303 verso /login che tutto il resto dell'app
+  // promette. E sta PRIMA della riga che scrive il cookie dell'ultimo brand, perché un
+  // +page.server.ts che rimandava correva in parallelo a questo load e chiudeva la risposta prima
+  // di quella scrittura: SvelteKit rifiuta un cookies.set dopo che la risposta è stata generata.
+  if (decodeURIComponent(url.pathname).replace(/\/$/, '') === `/app/${params.brand}`) {
+    redirect(302, `/app/${encodeURIComponent(params.brand)}/workbench`);
+  }
 
   if (cookies.get(LAST_BRAND_COOKIE) !== brand.slug) {
     cookies.set(LAST_BRAND_COOKIE, brand.slug, {

--- a/src/routes/app/[brand]/home-redirect.test.ts
+++ b/src/routes/app/[brand]/home-redirect.test.ts
@@ -24,15 +24,34 @@ const redirect = vi.fn((status: number, location: string) => {
 
 vi.mock('@sveltejs/kit', async (orig) => ({ ...(await orig<object>()), redirect, error: vi.fn() }));
 
-async function loadLayout(pathname: string, brand: string) {
+// Il layout, sotto il rimando, interroga sessione, accesso e tenant. Finché il rimando stava in
+// cima nessuna di queste veniva raggiunta e il test passava con `locals: {}` — cioè non provava
+// l'ordine, che è precisamente la cosa che si è rotta.
+vi.mock('$lib/server/access', () => ({ canEnter: async () => true }));
+vi.mock('$lib/server/tenant', () => ({
+	resolveTenant: async (_c: unknown, _u: string, slug: string) => ({
+		brand: { id: 'b1', slug, brand_kit: null },
+		peers: []
+	})
+}));
+
+async function loadLayout(pathname: string, brand: string, session: unknown = { user: { id: 'u1' } }) {
 	const mod = await import('./+layout.server');
 	const cookies = { get: vi.fn(() => undefined), set: vi.fn() };
+	// Il layout lancia anche `loadDeferred`, che nessuno di questi test guarda ma la cui promessa
+	// rifiutata farebbe uscire vitest con errore. Una catena che risponde a qualunque metodo, e che
+	// è attendibile in fondo, la lascia finire in silenzio.
+	const chain: Record<string, unknown> = new Proxy(
+		{ then: (res: (v: unknown) => unknown) => Promise.resolve({ data: [], count: 0, error: null }).then(res) },
+		{ get: (t, k) => (k in t ? (t as Record<string | symbol, unknown>)[k] : () => chain) }
+	);
+	const supabase = { auth: { getSession: async () => ({ data: { session } }) }, from: () => chain };
 	try {
 		await (mod.load as (e: unknown) => Promise<unknown>)({
 			url: new URL(`https://app.test${pathname}`),
 			params: { brand },
 			cookies,
-			locals: {},
+			locals: { supabase, safeGetSession: async () => ({ session, user: session ? { id: 'u1' } : null }) },
 			depends: vi.fn()
 		});
 		return { redirected: null as null | { status: number; location: string }, cookies };
@@ -57,6 +76,12 @@ describe('la home del brand rimanda al workbench del brand', () => {
 	it('non scrive nessun cookie prima di rimandare: la risposta si chiude subito', async () => {
 		const { cookies } = await loadLayout('/app/demo', 'demo');
 		expect(cookies.set).not.toHaveBeenCalled();
+	});
+
+	it('chi non è autenticato va al login, non al workbench', async () => {
+		const { redirected } = await loadLayout('/app/demo', 'demo', null);
+		expect(redirected?.status).toBe(303);
+		expect(redirected?.location).toBe('/login');
 	});
 
 	it('una rotta figlia non viene rimandata', async () => {


### PR DESCRIPTION
## What?

Moves the brand-home redirect from the top of `+layout.server.ts` to a point after the session, access and brand checks — and still before the last-brand cookie write.

## Why?

**`dev` is red because of this, and has been for several merges.**

PR #269 lifted the redirect to the top of the load to escape a race with `cookies.set`. It landed above the session check, so an unauthenticated visit to `/app/<brand>` answered `302` to the workbench instead of the `303` to `/login` that the rest of the app promises:

```
[chromium] › tests/e2e/app-redirects.spec.ts:14
  unauthenticated /app/[brand] redirects to /login
  Expected: 303
  Received: 302
```

It isn't a leak — the workbench layout is the same file and checks again — but it breaks the entry flow, and it kept CI red on every branch that merged after it.

## How?

The redirect now sits between `if (!brand) throw error(404)` and the cookie write. That is the only position satisfying both constraints:

- **after** every guard, so anyone who should not be here gets the answer the app gives everywhere else;
- **before** `cookies.set`, which SvelteKit refuses once the response has been generated — the constraint that pushed #269 upward in the first place.

The cost is one `resolveTenant` query on a request that ends in a redirect. That is the right trade against sending unauthenticated users somewhere they cannot be.

## Testing?

**The four existing tests were green while the bug was live.** They ran the load with `locals: {}` — no Supabase, no session — and passed *because the redirect returned before touching any of it*. They pinned the destination and never the order.

Moving the redirect down made them throw, which is how it became visible that they were guarding less than they appeared to. They now receive a session, and a fifth covers the anonymous case.

Red, with the redirect put back on top:

```
× chi non è autenticato va al login, non al workbench
  → expected 302 to be 303
```

That is the CI failure, reproduced by a unit test in one second instead of a ten-minute Playwright run.

Green:

```
npx vitest run "src/routes/app/[brand]/home-redirect.test.ts"
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

One detail worth knowing: the fake Supabase is a chainable `Proxy`. The layout fires `loadDeferred` without awaiting it, and a shallow stub made that background call reject — vitest then exited non-zero with every test green, which is its own small trap.

**Not verified in a browser.** The E2E test that caught this is the browser check, and it runs in CI.

## Evidence

The failing CI run is on `dev` itself, on every merge since #269 landed. It is the same assertion quoted above.

## Anything Else?

The general shape, and it is the second time today: **a redirect is not free to move.** Its position decides which guards have run when it fires. #269 moved it up to escape one constraint and crossed another that nothing in the unit tests could see — the only thing watching was an E2E test, and by then it was merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY