### PR TITLE
Open the brand memory to an external agent

### DIFF
--- a/changelog/2026-09-04-memoria-del-brand-per-agenti-esterni.md
+++ b/changelog/2026-09-04-memoria-del-brand-per-agenti-esterni.md
@@ -1,0 +1,85 @@
+# La memoria del brand esce da MCP, e il decadimento smette di punire chi non segnala
+
+## Cosa mancava
+
+`brand_memory` tiene quello che il brand sa: la voce, i vincoli, i fatti confermati, le preferenze
+dichiarate, le osservazioni del lavoro passato. La rotta `/studio/memory` esiste dal principio ma
+**non è mai stata nel registry**, quindi via MCP non c'era nessun tool: un agente esterno
+ricostruiva a ogni conversazione cose che il prodotto già sapeva, e chiedeva all'operatore risposte
+che l'operatore aveva già dato.
+
+La categoria `skill` era l'unica servita, dalla PR delle skill di scrittura. Il resto no.
+
+## Tre tool, non cinque
+
+- **`get_memory`** — la memoria del brand, con `category` e `limit` (50 di difetto, 200 al massimo).
+- **`save_memory`** — deposita quello che un agente ha imparato.
+- **`record_memory_used`** — dice quali voci hanno davvero plasmato il risultato.
+
+`promoteMemoryToProject`, `updateMemoryEntry` e `deleteMemory` restano dentro finché qualcosa non
+li chiede davvero.
+
+## Una rotta nuova, non `/studio/memory` irrigidita
+
+`/studio/memory` è la superficie dell'**operatore**: `BrandMemoryPanel.svelte` ci scrive la
+categoria che la persona sceglie, `voice` e `constraint` comprese, ed è giusto così. La superficie
+dell'**agente** ha regole diverse, e regole diverse sulla stessa rotta sarebbero un `if`
+sull'identità di chi chiama — la condizione sparsa che poi diverge. Due rotte, due pubblici, due
+regole, ciascuna scritta in un posto solo; la logica condivisa (`loadMemoryEntries`, `writeMemory`,
+`detectConflict`, `recordMemoryUsage`) è già estratta e non viene duplicata.
+
+## Il `GET` resta puro, e non è un cavillo
+
+Dentro, leggere e usare collassano: il turno inietta ciò che carica, quindi `read_memory` chiama
+`recordMemoryUsage`. Fuori no — un agente elenca quaranta voci e ne usa due. Contarle tutte alla
+lettura darebbe un dato **peggiore** di quello interno, e sarebbe un `GET` con effetto collaterale,
+la stessa forma di `ensureReferralCode` che qui consideriamo un difetto.
+
+Quindi la segnalazione è una scrittura esplicita, e il dato che produce è più fine: non «l'ho
+caricata» ma «l'ho usata». Gli id si filtrano per brand **prima** di contarli — un id estraneo
+terrebbe viva la memoria del vicino, e la risposta non lascia nemmeno capire che quell'id esista.
+
+## La difesa che non dipende dall'adozione
+
+Il rischio della segnalazione esplicita è asimmetrico e silenzioso: se nessuno chiama
+`record_memory_used`, le voci decadono come inutilizzate, scendono sotto il pavimento di iniezione
+e smettono di raggiungere i prompt. Quando te ne accorgi, il danno è già nei dati.
+
+Una riga nella descrizione non basta. Quindi in `runDreamInner`:
+
+```
+const usageIsReported = (entries ?? []).some((entry) => !!entry.last_used_at);
+```
+
+**Se in questo brand nessuna riga è MAI stata segnalata, il decadimento sull'inutilizzo non parte.**
+Un'assenza totale di dati non è un dato: l'ipotesi giusta non è «non le usa nessuno» ma «nessuno
+sta segnalando». Appena una voce qualsiasi porta un segnale, il segnale è vivo e il decadimento
+riprende per tutte.
+
+Zero query in più — le righe sono già caricate. Nessuna migrazione. Il criterio è per brand e non
+per riga di proposito: una riga mai usata mentre le altre lo sono **è** prova di inutilizzo (ha
+perso la selezione sul budget di 800 token), e va trattata come oggi.
+
+L'archiviazione non cambia: aveva già lo scudo `times_used > 0`, e una scadenza esplicita
+(`expires_at`) vale comunque — l'ha decisa chi ha scritto la riga.
+
+## La tabella delle scritture, e la riga che manca
+
+| categoria | scrivibile da un agente | perché |
+|---|---|---|
+| `insight`, `preference` | sì | quello che impara lavorando, raggio d'azione corto |
+| `skill` | sì, col tetto di 20 già applicato in `brand-memory.ts:411` | le procedure sono il senso del magazzino |
+| `fact` | sì, ma `source: 'chat'` e confidenza 0.7 | un fatto sbagliato si propaga in ogni prompt |
+| `voice`, `constraint` | **no** | governano tutto ciò che sta a valle: un modello che riscrive la voce è un cambio di marca in una chiamata |
+
+## L'ultimo arrivato non vince
+
+Un valore che contraddice quello che c'è risponde **409 con entrambi i valori e non scrive niente**:
+l'agente se la discute con l'operatore, non vince per essere arrivato ultimo. Lo stesso valore
+ripetuto resta un rinforzo, non un conflitto — `detectConflict` lo distingueva già.
+
+## L'isolamento fra brand
+
+Tre filtri, tutti con un test che li guarda cadere: la memoria di un altro brand non esce nemmeno
+con la stessa chiave; la chiacchiera di sessione resta nel suo thread; le note di mestiere di un
+altro agente non sono conoscenza del brand ma rumore, e `scopeToAgent(query, null)` le esclude.

--- a/cli/lib/contracts/index.ts
+++ b/cli/lib/contracts/index.ts
@@ -59,6 +59,7 @@ import {
 import { GET_BRAND_SETTINGS, SET_BRAND_SETTINGS } from './brand-settings';
 import { DIAGNOSE_RADAR, GET_MARKET_FIELD, LIST_IDEAS } from './market';
 import { GET_MEDIA_MODELS, SET_MEDIA_MODEL } from './media-models';
+import { GET_MEMORY, RECORD_MEMORY_USED, SAVE_MEMORY } from './memory';
 import { GET_KNOWLEDGE_STATUS, SEARCH_KNOWLEDGE } from './knowledge';
 import {
   ADD_RADAR_SOURCE,
@@ -179,6 +180,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   GET_KNOWLEDGE_STATUS,
   GET_MARKET_FIELD,
   GET_MEDIA_MODELS,
+  GET_MEMORY,
   GET_PLAN,
   GET_POST,
   GET_RADAR,
@@ -201,6 +203,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   LIST_WEB_FIXES,
   PLAN_WEEK,
   PROPOSE_PLAN,
+  RECORD_MEMORY_USED,
   REFRESH_KEYWORDS,
   REMOVE_BLOG_TERM,
   REMOVE_RADAR_SOURCE,
@@ -211,6 +214,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   REVISE_PLAN,
   REVOKE_SHARE,
   SAVE_BRIEF,
+  SAVE_MEMORY,
   SAVE_PLAN,
   SAVE_WEEK_SEEDS,
   SEARCH_KNOWLEDGE,
@@ -346,6 +350,17 @@ export {
   SEARCH_KNOWLEDGE
 } from './knowledge';
 export type { KnowledgeCollection } from './knowledge';
+export {
+  AGENT_MEMORY_CATEGORIES,
+  GET_MEMORY,
+  MEMORY_CATEGORIES,
+  MEMORY_ENTRIES_DEFAULT,
+  MEMORY_ENTRIES_MAX,
+  MEMORY_USED_MAX,
+  RECORD_MEMORY_USED,
+  SAVE_MEMORY
+} from './memory';
+export type { AgentMemoryCategory } from './memory';
 export { GEO_ACTION, REFRESH_KEYWORDS, SEO_ACTION } from './search';
 export { GET_BACKLINKS, GET_GSC, GET_RANKS } from './web-metrics';
 export {

--- a/cli/lib/contracts/memory.ts
+++ b/cli/lib/contracts/memory.ts
@@ -1,0 +1,130 @@
+import { z } from 'zod';
+import type { BrandEndpoint } from './index';
+
+export const MEMORY_ENTRIES_DEFAULT = 50;
+export const MEMORY_ENTRIES_MAX = 200;
+
+/** Quante voci si possono segnalare come usate in una volta. Un turno ne usa una manciata. */
+export const MEMORY_USED_MAX = 50;
+
+/** Lo stesso elenco chiuso di `MemoryCategory` in `$lib/server/brand-memory` — un test li allinea. */
+export const MEMORY_CATEGORIES = [
+  'voice',
+  'constraint',
+  'fact',
+  'preference',
+  'insight',
+  'skill'
+] as const;
+
+/**
+ * QUELLO CHE UN AGENTE PUÒ SCRIVERE, e la riga che manca è la regola: `voice` e `constraint`
+ * governano tutto ciò che sta a valle — un modello che riscrive la voce è un cambio di marca in
+ * una chiamata. Restano all'operatore, dalla sua pagina.
+ */
+export const AGENT_MEMORY_CATEGORIES = ['fact', 'preference', 'insight', 'skill'] as const;
+
+export type AgentMemoryCategory = (typeof AGENT_MEMORY_CATEGORIES)[number];
+
+const MemoryEntry = z.object({
+  id: z.string(),
+  key: z.string(),
+  value: z.string(),
+  category: z.enum(MEMORY_CATEGORIES),
+  source: z.string(),
+  confidence: z.number(),
+  timesUsed: z.number(),
+  lastUsedAt: z.string().nullable(),
+  pinned: z.boolean(),
+  createdAt: z.string()
+});
+
+export const GET_MEMORY = {
+  tool: 'get_memory',
+  title: 'Brand memory',
+  description:
+    "What this brand already knows, so you do not rebuild it every conversation: its voice, the constraints it works under, the facts it has confirmed, the preferences it has stated, and what previous work learned. " +
+    'Read it before asking the operator something the brand has already answered. ' +
+    `\`category\` narrows (${MEMORY_CATEGORIES.join(', ')}); \`limit\` is ${MEMORY_ENTRIES_DEFAULT} by default and ${MEMORY_ENTRIES_MAX} at most. ` +
+    'Chat-session notes and other agents\' working notes are never returned — only what belongs to the brand. ' +
+    'Reading changes nothing and counts nothing: when an entry actually shaped what you produced, say so with `record_memory_used`, or the entry decays as if it had never helped.',
+  method: 'GET',
+  pathUnderBrand: '/memory',
+  input: z
+    .object({
+      category: z.enum(MEMORY_CATEGORIES).optional().describe('Restrict to one kind of knowledge'),
+      limit: z.coerce
+        .number()
+        .int()
+        .min(1)
+        .max(MEMORY_ENTRIES_MAX)
+        .optional()
+        .describe(`How many entries, ${MEMORY_ENTRIES_DEFAULT} by default, ${MEMORY_ENTRIES_MAX} at most`)
+    })
+    .strict(),
+  output: z.object({
+    entries: z.array(MemoryEntry),
+    count: z.number()
+  }),
+  failures: [{ error: 'unknown_category', status: 400 }],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const SAVE_MEMORY = {
+  tool: 'save_memory',
+  title: 'Save to brand memory',
+  description:
+    'Record something you learned about this brand so the next conversation starts from it. ' +
+    `Writable categories: ${AGENT_MEMORY_CATEGORIES.join(', ')}. \`voice\` and \`constraint\` are NOT writable here — they govern everything downstream and only the operator sets them. ` +
+    'A `key` that already holds a DIFFERENT value answers 409 with both values and writes nothing: you take it to the operator, you do not win by arriving last. Sending the same value again reinforces it. ' +
+    'Entries land as brand knowledge, never scoped to a chat, and arrive with the confidence of something a model inferred rather than something a person stated.',
+  method: 'POST',
+  pathUnderBrand: '/memory',
+  input: z
+    .object({
+      key: z.string().min(1).describe('Stable slug, e.g. "shipping_threshold" — reusing it reinforces'),
+      value: z.string().min(1).describe('The knowledge itself. For a skill: first line = when to use it, then the steps'),
+      category: z.enum(AGENT_MEMORY_CATEGORIES)
+    })
+    .strict(),
+  output: z.object({
+    ok: z.boolean(),
+    id: z.string(),
+    reinforced: z.boolean()
+  }),
+  failures: [
+    { error: 'category_not_writable', status: 403 },
+    { error: 'memory_conflict', status: 409 },
+    { error: 'skill_limit_reached', status: 409 }
+  ],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const RECORD_MEMORY_USED = {
+  tool: 'record_memory_used',
+  title: 'Report memory you used',
+  description:
+    'Say which memory entries actually shaped what you just produced. Call it after acting, with the ids from `get_memory` — a handful, not everything you read. ' +
+    'This is what keeps a working entry alive: entries that are never reported decay out of the prompts they were helping. ' +
+    `Ids that do not belong to this brand are ignored. At most ${MEMORY_USED_MAX} per call.`,
+  method: 'POST',
+  pathUnderBrand: '/memory/used',
+  input: z
+    .object({
+      ids: z
+        .array(z.string().min(1))
+        .min(1)
+        .max(MEMORY_USED_MAX)
+        .describe('Ids of the entries you actually used')
+    })
+    .strict(),
+  output: z.object({
+    ok: z.boolean(),
+    counted: z.number()
+  }),
+  failures: [
+    { error: 'ids_required', status: 400 },
+    { error: 'too_many_ids', status: 400 }
+  ],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/cli/plugins/anomalia/skills/anomalia/SKILL.md
+++ b/cli/plugins/anomalia/skills/anomalia/SKILL.md
@@ -47,7 +47,10 @@ Setup details: [references/mcp.md](references/mcp.md).
 4. **Before writing ANY copy** — caption, carousel, script, article, bio — call
    `get_writing_skills`. It returns the craft text Anomalia writes with, plus this brand's own
    procedures. Skipping it is how output starts reading as generated.
-5. Confirm before reject / delete / discard unless the user clearly asked.
+5. **Read `get_memory` before asking the operator** something the brand may already know — and
+   call `record_memory_used` with the ids that actually shaped your output. An entry nobody
+   reports decays out of the prompts it was helping.
+6. Confirm before reject / delete / discard unless the user clearly asked.
 
 ## Quick workflows
 

--- a/cli/plugins/anomalia/skills/anomalia/references/tools.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/tools.md
@@ -199,6 +199,34 @@ seed: `platforms`, `pillar`, `format`, `media`, `slide_count`, `day`, `time`, `s
 A brand keeps one draft in review, so saving replaces the one that is there (`replaced` says so).
 `produce_week` is the separate, paid step that turns the rows into posts.
 
+## Memory
+
+| MCP | CLI |
+|-----|-----|
+| `get_memory` | (MCP only) |
+| `save_memory` | (MCP only) |
+| `record_memory_used` | (MCP only) |
+
+`get_memory` is what the brand already knows, so you stop asking the operator things it has
+already answered: its voice, the constraints it works under, the facts it confirmed, the
+preferences it stated, what previous work learned. `category` narrows to one kind; `limit` is 50
+by default, 200 at most. Chat-session notes and other agents' working notes never come out — only
+what belongs to the brand.
+
+**Reading is not using.** The read changes nothing and counts nothing. When an entry actually
+shaped what you produced, say so with `record_memory_used` and the ids you used — a handful, not
+everything you read. That counter is what keeps a working entry alive: entries nobody reports
+decay out of the prompts they were helping.
+
+`save_memory` records what you learned, so the next conversation starts from it. Writable:
+`fact`, `preference`, `insight`, `skill`. **`voice` and `constraint` are not** — they govern
+everything downstream, and only the operator sets them from the app.
+
+A `key` that already holds a DIFFERENT value answers **409 with both values and writes nothing**:
+you take the disagreement to the operator, you do not win it by arriving last. Sending the same
+value again reinforces it instead. Entries arrive with the confidence of something a model
+inferred, not something a person stated, and are never scoped to a chat.
+
 ## Writing
 
 | MCP | CLI |

--- a/cli/skills/anomalia/SKILL.md
+++ b/cli/skills/anomalia/SKILL.md
@@ -47,7 +47,10 @@ Setup details: [references/mcp.md](references/mcp.md).
 4. **Before writing ANY copy** — caption, carousel, script, article, bio — call
    `get_writing_skills`. It returns the craft text Anomalia writes with, plus this brand's own
    procedures. Skipping it is how output starts reading as generated.
-5. Confirm before reject / delete / discard unless the user clearly asked.
+5. **Read `get_memory` before asking the operator** something the brand may already know — and
+   call `record_memory_used` with the ids that actually shaped your output. An entry nobody
+   reports decays out of the prompts it was helping.
+6. Confirm before reject / delete / discard unless the user clearly asked.
 
 ## Quick workflows
 

--- a/cli/skills/anomalia/references/tools.md
+++ b/cli/skills/anomalia/references/tools.md
@@ -199,6 +199,34 @@ seed: `platforms`, `pillar`, `format`, `media`, `slide_count`, `day`, `time`, `s
 A brand keeps one draft in review, so saving replaces the one that is there (`replaced` says so).
 `produce_week` is the separate, paid step that turns the rows into posts.
 
+## Memory
+
+| MCP | CLI |
+|-----|-----|
+| `get_memory` | (MCP only) |
+| `save_memory` | (MCP only) |
+| `record_memory_used` | (MCP only) |
+
+`get_memory` is what the brand already knows, so you stop asking the operator things it has
+already answered: its voice, the constraints it works under, the facts it confirmed, the
+preferences it stated, what previous work learned. `category` narrows to one kind; `limit` is 50
+by default, 200 at most. Chat-session notes and other agents' working notes never come out — only
+what belongs to the brand.
+
+**Reading is not using.** The read changes nothing and counts nothing. When an entry actually
+shaped what you produced, say so with `record_memory_used` and the ids you used — a handful, not
+everything you read. That counter is what keeps a working entry alive: entries nobody reports
+decay out of the prompts they were helping.
+
+`save_memory` records what you learned, so the next conversation starts from it. Writable:
+`fact`, `preference`, `insight`, `skill`. **`voice` and `constraint` are not** — they govern
+everything downstream, and only the operator sets them from the app.
+
+A `key` that already holds a DIFFERENT value answers **409 with both values and writes nothing**:
+you take the disagreement to the operator, you do not win it by arriving last. Sending the same
+value again reinforces it instead. Entries arrive with the confidence of something a model
+inferred, not something a person stated, and are never scoped to a chat.
+
 ## Writing
 
 | MCP | CLI |

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -59,6 +59,7 @@ import {
 import { GET_BRAND_SETTINGS, SET_BRAND_SETTINGS } from './brand-settings';
 import { DIAGNOSE_RADAR, GET_MARKET_FIELD, LIST_IDEAS } from './market';
 import { GET_MEDIA_MODELS, SET_MEDIA_MODEL } from './media-models';
+import { GET_MEMORY, RECORD_MEMORY_USED, SAVE_MEMORY } from './memory';
 import { GET_KNOWLEDGE_STATUS, SEARCH_KNOWLEDGE } from './knowledge';
 import {
   ADD_RADAR_SOURCE,
@@ -179,6 +180,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   GET_KNOWLEDGE_STATUS,
   GET_MARKET_FIELD,
   GET_MEDIA_MODELS,
+  GET_MEMORY,
   GET_PLAN,
   GET_POST,
   GET_RADAR,
@@ -201,6 +203,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   LIST_WEB_FIXES,
   PLAN_WEEK,
   PROPOSE_PLAN,
+  RECORD_MEMORY_USED,
   REFRESH_KEYWORDS,
   REMOVE_BLOG_TERM,
   REMOVE_RADAR_SOURCE,
@@ -211,6 +214,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   REVISE_PLAN,
   REVOKE_SHARE,
   SAVE_BRIEF,
+  SAVE_MEMORY,
   SAVE_PLAN,
   SAVE_WEEK_SEEDS,
   SEARCH_KNOWLEDGE,
@@ -346,6 +350,17 @@ export {
   SEARCH_KNOWLEDGE
 } from './knowledge';
 export type { KnowledgeCollection } from './knowledge';
+export {
+  AGENT_MEMORY_CATEGORIES,
+  GET_MEMORY,
+  MEMORY_CATEGORIES,
+  MEMORY_ENTRIES_DEFAULT,
+  MEMORY_ENTRIES_MAX,
+  MEMORY_USED_MAX,
+  RECORD_MEMORY_USED,
+  SAVE_MEMORY
+} from './memory';
+export type { AgentMemoryCategory } from './memory';
 export { GEO_ACTION, REFRESH_KEYWORDS, SEO_ACTION } from './search';
 export { GET_BACKLINKS, GET_GSC, GET_RANKS } from './web-metrics';
 export {

--- a/packages/api-contracts/src/memory.test.ts
+++ b/packages/api-contracts/src/memory.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AGENT_MEMORY_CATEGORIES,
+  GET_MEMORY,
+  MEMORY_CATEGORIES,
+  MEMORY_ENTRIES_MAX,
+  MEMORY_USED_MAX,
+  RECORD_MEMORY_USED,
+  SAVE_MEMORY
+} from './memory';
+import { BRAND_ENDPOINTS } from './index';
+
+const MEMORY = [GET_MEMORY, SAVE_MEMORY, RECORD_MEMORY_USED];
+
+describe('il contratto della memoria del brand', () => {
+  it('sono registrati, o i tool MCP non nascono', () => {
+    for (const endpoint of MEMORY) {
+      expect(BRAND_ENDPOINTS, endpoint.tool).toContain(endpoint);
+    }
+  });
+
+  it('nessuno di essi è distruttivo: niente qui cancella', () => {
+    for (const endpoint of MEMORY) {
+      expect(endpoint.destructive, endpoint.tool).toBe(false);
+    }
+  });
+
+  it('rifiutano un parametro che non dichiarano', () => {
+    for (const endpoint of MEMORY) {
+      expect(endpoint.input.safeParse({ campo_inventato: 'x' }).success, endpoint.tool).toBe(false);
+    }
+  });
+
+  /** LA RIGA CHE MANCA È LA REGOLA: voice e constraint non si scrivono da fuori. */
+  it('`voice` e `constraint` sono leggibili e NON scrivibili', () => {
+    for (const category of ['voice', 'constraint'] as const) {
+      expect(MEMORY_CATEGORIES).toContain(category);
+      expect(AGENT_MEMORY_CATEGORIES as readonly string[], category).not.toContain(category);
+      expect(SAVE_MEMORY.input.safeParse({ key: 'k', value: 'v', category }).success, category).toBe(false);
+      expect(GET_MEMORY.input.safeParse({ category }).success, category).toBe(true);
+    }
+  });
+
+  it('scrivibili sono e solo sono quelle che un agente impara lavorando', () => {
+    expect([...AGENT_MEMORY_CATEGORIES]).toEqual(['fact', 'preference', 'insight', 'skill']);
+    for (const category of AGENT_MEMORY_CATEGORIES) {
+      expect(SAVE_MEMORY.input.safeParse({ key: 'k', value: 'v', category }).success, category).toBe(true);
+    }
+  });
+
+  it('la lettura dichiara il tetto che la rotta applica', () => {
+    expect(GET_MEMORY.input.safeParse({ limit: MEMORY_ENTRIES_MAX }).success).toBe(true);
+    expect(GET_MEMORY.input.safeParse({ limit: MEMORY_ENTRIES_MAX + 1 }).success).toBe(false);
+    expect(GET_MEMORY.input.safeParse({ limit: 0 }).success).toBe(false);
+  });
+
+  it('la segnalazione d’uso vuole almeno un id e non più del tetto', () => {
+    expect(RECORD_MEMORY_USED.input.safeParse({ ids: [] }).success).toBe(false);
+    expect(RECORD_MEMORY_USED.input.safeParse({ ids: ['a'] }).success).toBe(true);
+    expect(
+      RECORD_MEMORY_USED.input.safeParse({ ids: Array.from({ length: MEMORY_USED_MAX + 1 }, () => 'a') }).success
+    ).toBe(false);
+  });
+
+  it('dichiara il conflitto invece di far scoprire una sovrascrittura', () => {
+    expect(SAVE_MEMORY.failures).toContainEqual({ error: 'memory_conflict', status: 409 });
+    expect(SAVE_MEMORY.failures).toContainEqual({ error: 'category_not_writable', status: 403 });
+    expect(SAVE_MEMORY.failures).toContainEqual({ error: 'skill_limit_reached', status: 409 });
+  });
+
+  /**
+   * Il decadimento presume che qualcuno segnali. Se la descrizione non lo dice, nessuno lo fa e
+   * le voci che funzionavano escono dai prompt in silenzio.
+   */
+  it('la lettura dice che leggere non conta, e dove si conta', () => {
+    expect(GET_MEMORY.description).toContain('record_memory_used');
+    expect(GET_MEMORY.description).toContain('decays');
+  });
+
+  it('la scrittura dice che l’ultimo arrivato non vince', () => {
+    expect(SAVE_MEMORY.description).toContain('409');
+    expect(SAVE_MEMORY.description).toContain('NOT writable');
+  });
+});

--- a/packages/api-contracts/src/memory.ts
+++ b/packages/api-contracts/src/memory.ts
@@ -1,0 +1,130 @@
+import { z } from 'zod';
+import type { BrandEndpoint } from './index';
+
+export const MEMORY_ENTRIES_DEFAULT = 50;
+export const MEMORY_ENTRIES_MAX = 200;
+
+/** Quante voci si possono segnalare come usate in una volta. Un turno ne usa una manciata. */
+export const MEMORY_USED_MAX = 50;
+
+/** Lo stesso elenco chiuso di `MemoryCategory` in `$lib/server/brand-memory` — un test li allinea. */
+export const MEMORY_CATEGORIES = [
+  'voice',
+  'constraint',
+  'fact',
+  'preference',
+  'insight',
+  'skill'
+] as const;
+
+/**
+ * QUELLO CHE UN AGENTE PUÒ SCRIVERE, e la riga che manca è la regola: `voice` e `constraint`
+ * governano tutto ciò che sta a valle — un modello che riscrive la voce è un cambio di marca in
+ * una chiamata. Restano all'operatore, dalla sua pagina.
+ */
+export const AGENT_MEMORY_CATEGORIES = ['fact', 'preference', 'insight', 'skill'] as const;
+
+export type AgentMemoryCategory = (typeof AGENT_MEMORY_CATEGORIES)[number];
+
+const MemoryEntry = z.object({
+  id: z.string(),
+  key: z.string(),
+  value: z.string(),
+  category: z.enum(MEMORY_CATEGORIES),
+  source: z.string(),
+  confidence: z.number(),
+  timesUsed: z.number(),
+  lastUsedAt: z.string().nullable(),
+  pinned: z.boolean(),
+  createdAt: z.string()
+});
+
+export const GET_MEMORY = {
+  tool: 'get_memory',
+  title: 'Brand memory',
+  description:
+    "What this brand already knows, so you do not rebuild it every conversation: its voice, the constraints it works under, the facts it has confirmed, the preferences it has stated, and what previous work learned. " +
+    'Read it before asking the operator something the brand has already answered. ' +
+    `\`category\` narrows (${MEMORY_CATEGORIES.join(', ')}); \`limit\` is ${MEMORY_ENTRIES_DEFAULT} by default and ${MEMORY_ENTRIES_MAX} at most. ` +
+    'Chat-session notes and other agents\' working notes are never returned — only what belongs to the brand. ' +
+    'Reading changes nothing and counts nothing: when an entry actually shaped what you produced, say so with `record_memory_used`, or the entry decays as if it had never helped.',
+  method: 'GET',
+  pathUnderBrand: '/memory',
+  input: z
+    .object({
+      category: z.enum(MEMORY_CATEGORIES).optional().describe('Restrict to one kind of knowledge'),
+      limit: z.coerce
+        .number()
+        .int()
+        .min(1)
+        .max(MEMORY_ENTRIES_MAX)
+        .optional()
+        .describe(`How many entries, ${MEMORY_ENTRIES_DEFAULT} by default, ${MEMORY_ENTRIES_MAX} at most`)
+    })
+    .strict(),
+  output: z.object({
+    entries: z.array(MemoryEntry),
+    count: z.number()
+  }),
+  failures: [{ error: 'unknown_category', status: 400 }],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const SAVE_MEMORY = {
+  tool: 'save_memory',
+  title: 'Save to brand memory',
+  description:
+    'Record something you learned about this brand so the next conversation starts from it. ' +
+    `Writable categories: ${AGENT_MEMORY_CATEGORIES.join(', ')}. \`voice\` and \`constraint\` are NOT writable here — they govern everything downstream and only the operator sets them. ` +
+    'A `key` that already holds a DIFFERENT value answers 409 with both values and writes nothing: you take it to the operator, you do not win by arriving last. Sending the same value again reinforces it. ' +
+    'Entries land as brand knowledge, never scoped to a chat, and arrive with the confidence of something a model inferred rather than something a person stated.',
+  method: 'POST',
+  pathUnderBrand: '/memory',
+  input: z
+    .object({
+      key: z.string().min(1).describe('Stable slug, e.g. "shipping_threshold" — reusing it reinforces'),
+      value: z.string().min(1).describe('The knowledge itself. For a skill: first line = when to use it, then the steps'),
+      category: z.enum(AGENT_MEMORY_CATEGORIES)
+    })
+    .strict(),
+  output: z.object({
+    ok: z.boolean(),
+    id: z.string(),
+    reinforced: z.boolean()
+  }),
+  failures: [
+    { error: 'category_not_writable', status: 403 },
+    { error: 'memory_conflict', status: 409 },
+    { error: 'skill_limit_reached', status: 409 }
+  ],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const RECORD_MEMORY_USED = {
+  tool: 'record_memory_used',
+  title: 'Report memory you used',
+  description:
+    'Say which memory entries actually shaped what you just produced. Call it after acting, with the ids from `get_memory` — a handful, not everything you read. ' +
+    'This is what keeps a working entry alive: entries that are never reported decay out of the prompts they were helping. ' +
+    `Ids that do not belong to this brand are ignored. At most ${MEMORY_USED_MAX} per call.`,
+  method: 'POST',
+  pathUnderBrand: '/memory/used',
+  input: z
+    .object({
+      ids: z
+        .array(z.string().min(1))
+        .min(1)
+        .max(MEMORY_USED_MAX)
+        .describe('Ids of the entries you actually used')
+    })
+    .strict(),
+  output: z.object({
+    ok: z.boolean(),
+    counted: z.number()
+  }),
+  failures: [
+    { error: 'ids_required', status: 400 },
+    { error: 'too_many_ids', status: 400 }
+  ],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/src/lib/content/changelog/2026-09-04-brand-memory-for-your-agent.ts
+++ b/src/lib/content/changelog/2026-09-04-brand-memory-for-your-agent.ts
@@ -1,0 +1,10 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-04',
+  title: 'Your agent stops asking what your brand already told it',
+  items: [
+    'Claude, ChatGPT and Cursor can now read your brand memory — the voice, the constraints, the facts you confirmed, what earlier work learned — instead of rebuilding it every conversation.',
+    'They can add what they learn, too. Your voice and your constraints stay yours: an agent cannot rewrite them, and a value that contradicts something you already recorded comes back for you to settle instead of silently replacing it.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/brand-memory.test.ts
+++ b/src/lib/server/brand-memory.test.ts
@@ -354,6 +354,51 @@ describe('runDream', () => {
     expect(rows.map((x) => x.key)).toEqual(['k1']);
   });
 
+  /**
+   * UN'ASSENZA TOTALE DI DATI NON È UN DATO. Il decadimento sull'inutilizzo presume che qualcuno
+   * stia segnalando l'uso. Con la superficie esterna, chi legge la memoria è un modello che sta
+   * fuori e segnala con una scrittura esplicita: se non lo fa, l'ipotesi giusta non è «non le usa
+   * nessuno» ma «nessuno sta segnalando», e far scendere la confidence sotto il pavimento di
+   * iniezione toglierebbe dai prompt righe che stavano funzionando. Un'adozione mancata non deve
+   * poter cancellare il patrimonio del cliente.
+   */
+  it('non decade niente in un brand dove nessuna riga è mai stata segnalata', async () => {
+    const rows = [
+      staleRow(1, { times_used: 0, last_used_at: null }),
+      staleRow(2, { times_used: 0, last_used_at: null })
+    ];
+    const { supabase, writes } = dreamSupabase({ brand_memory: rows });
+
+    const r = await runDream(supabase as never, 'brand-1');
+
+    expect(r.decayed).toBe(0);
+    expect(writes.updates).toBe(0);
+    expect(rows.map((x) => x.confidence)).toEqual([0.8, 0.8]);
+  });
+
+  it('appena una riga è segnalata, il segnale è vivo e le altre tornano a decadere', async () => {
+    const rows = [
+      staleRow(1, { times_used: 0, last_used_at: null }),
+      staleRow(2, { times_used: 3, last_used_at: OLD })
+    ];
+    const { supabase } = dreamSupabase({ brand_memory: rows });
+
+    const r = await runDream(supabase as never, 'brand-1');
+
+    expect(r.decayed).toBe(2);
+    for (const row of rows) expect(row.confidence as number).toBeCloseTo(0.7);
+  });
+
+  it('una scadenza esplicita vale anche senza nessuna segnalazione: l’ha decisa chi ha scritto', async () => {
+    const rows = [staleRow(1, { times_used: 0, last_used_at: null, expires_at: OLD })];
+    const { supabase } = dreamSupabase({ brand_memory: rows });
+
+    const r = await runDream(supabase as never, 'brand-1');
+
+    expect(r.archivedKeys).toEqual(['k1']);
+    expect(rows).toHaveLength(0);
+  });
+
   it('promuove il fatto che la chat ha confermato quattro volte (oggi non succede mai)', async () => {
     // Il caso reale: quattro turni della STESSA chat riportano lo stesso fatto. Con il prompt che
     // diceva "salta ciò che è già in memoria" il modello non lo riestraeva, times_reinforced

--- a/src/lib/server/brand-memory.ts
+++ b/src/lib/server/brand-memory.ts
@@ -8,7 +8,16 @@ type AnyRec = Record<string, any>;
 
 // ── Types ──────────────────────────────────────────────────────────────────────
 
-export type MemoryCategory = 'voice' | 'constraint' | 'fact' | 'preference' | 'insight' | 'skill';
+/** L'elenco chiuso, uguale al CHECK di `brand_memory.category` (0178). Un test lo tiene allineato al contratto. */
+export const MEMORY_CATEGORY_VALUES = [
+  'voice',
+  'constraint',
+  'fact',
+  'preference',
+  'insight',
+  'skill'
+] as const;
+export type MemoryCategory = (typeof MEMORY_CATEGORY_VALUES)[number];
 export type MemorySource = 'chat' | 'research' | 'onboarding' | 'user' | 'analysis';
 export type MemoryLayer = 'session' | 'project' | 'global';
 
@@ -858,6 +867,15 @@ async function runDreamInner(
     .eq('brand_id', brandId)
     .order('updated_at', { ascending: true });
 
+  // UN'ASSENZA TOTALE DI DATI NON È UN DATO. Il decadimento sull'inutilizzo presume che qualcuno
+  // stia segnalando l'uso — dentro lo fa il turno che inietta, fuori lo fa un modello con una
+  // scrittura esplicita. Se in questo brand nessuna riga è MAI stata segnalata, l'ipotesi giusta
+  // non è «non le usa nessuno» ma «nessuno sta segnalando», e far scendere la confidence sotto il
+  // pavimento di iniezione toglierebbe dai prompt righe che stavano funzionando: un guasto
+  // silenzioso e distruttivo, visibile solo quando il danno è già nei dati.
+  // Una scadenza esplicita resta valida comunque — l'ha decisa chi ha scritto la riga.
+  const usageIsReported = (entries ?? []).some((entry) => !!(entry as MemoryEntry).last_used_at);
+
   if (entries?.length) {
     for (const entry of entries as MemoryEntry[]) {
       if (writes >= DREAM_MAX_WRITES_PER_BRAND) {
@@ -872,7 +890,7 @@ async function runDreamInner(
           : new Date(entry.created_at);
       const daysSince = (now.getTime() - lastTouch.getTime()) / 86400000;
 
-      if (!entry.pinned && daysSince > 30 && entry.confidence > 0.3) {
+      if (!entry.pinned && usageIsReported && daysSince > 30 && entry.confidence > 0.3) {
         const decay = Math.max(0.3, entry.confidence - 0.1);
         if (!dryRun) {
           await supabase

--- a/src/routes/api/v1/brands/[slug]/memory/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/memory/+server.ts
@@ -1,0 +1,120 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { authenticate, loadBrandForUser, checkApiKeyWriteAccess } from '$lib/server/cli-auth';
+import {
+  loadMemoryEntries,
+  writeMemory,
+  detectConflict,
+  type MemoryCategory
+} from '$lib/server/brand-memory';
+import {
+  AGENT_MEMORY_CATEGORIES,
+  MEMORY_CATEGORIES,
+  MEMORY_ENTRIES_DEFAULT,
+  MEMORY_ENTRIES_MAX,
+  type AgentMemoryCategory
+} from '@anomalia/api-contracts';
+
+// LA MEMORIA DEL BRAND PER UN AGENTE CHE STA FUORI. `/studio/memory` resta la superficie
+// dell'OPERATORE, che dalla sua pagina può scrivere anche voice e constraint; questa è quella
+// dell'agente, e ha regole diverse — che è il motivo per cui è una rotta diversa invece di un
+// ramo dentro l'altra.
+//
+// GET  → puro. Leggere non è usare: il contatore lo muove `/memory/used`, dopo aver agito.
+// POST → scrive solo ciò che un agente ha imparato lavorando, e non vince mai un conflitto.
+
+/** Confidenza di un fatto dedotto da un modello: sotto quella di una riga scritta a mano (1.0). */
+const INFERRED_CONFIDENCE = 0.7;
+
+const isWritable = (value: string): value is AgentMemoryCategory =>
+  (AGENT_MEMORY_CATEGORIES as readonly string[]).includes(value);
+
+export const GET: RequestHandler = async ({ request, params, url }) => {
+  const { supabase, error, apiKey } = await authenticate(request);
+  if (error) return error;
+
+  const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
+  if (brandError) return brandError;
+
+  const asked = url.searchParams.get('category');
+  if (asked && !(MEMORY_CATEGORIES as readonly string[]).includes(asked)) {
+    return json({ error: 'unknown_category' }, { status: 400 });
+  }
+
+  const requested = Number(url.searchParams.get('limit'));
+  const limit = Number.isFinite(requested) && requested > 0
+    ? Math.min(MEMORY_ENTRIES_MAX, Math.round(requested))
+    : MEMORY_ENTRIES_DEFAULT;
+
+  // `agent: null` è il filtro, non l'assenza di uno: la memoria del brand, mai le note di mestiere
+  // di un collega. Il layer di sessione lo esclude già `loadMemoryEntries`.
+  const entries = await loadMemoryEntries(supabase, brand.id, {
+    ...(asked ? { category: asked as MemoryCategory } : {}),
+    agent: null
+  });
+
+  const page = entries.slice(0, limit);
+
+  return json({
+    count: page.length,
+    entries: page.map((entry) => ({
+      id: entry.id,
+      key: entry.key,
+      value: entry.value,
+      category: entry.category,
+      source: entry.source,
+      confidence: entry.confidence,
+      timesUsed: entry.times_used ?? 0,
+      lastUsedAt: entry.last_used_at ?? null,
+      pinned: entry.pinned ?? false,
+      createdAt: entry.created_at
+    }))
+  });
+};
+
+export const POST: RequestHandler = async ({ request, params }) => {
+  const { supabase, error, apiKey } = await authenticate(request);
+  if (error) return error;
+
+  const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
+  if (brandError) return brandError;
+
+  const writeDenied = checkApiKeyWriteAccess(apiKey);
+  if (writeDenied) return writeDenied;
+
+  const body = (await request.json()) as { key?: string; value?: string; category?: string };
+  const key = body.key?.trim();
+  const value = body.value?.trim();
+
+  if (!key || !value || !body.category) {
+    return json({ error: 'key, value and category are required' }, { status: 400 });
+  }
+  if (!isWritable(body.category)) {
+    return json({ error: 'category_not_writable' }, { status: 403 });
+  }
+
+  // L'ULTIMO ARRIVATO NON VINCE. Un valore che contraddice quello che c'è torna con entrambi e non
+  // scrive: se la memoria fosse dell'ultimo scrittore, un modello potrebbe ribaltare in silenzio
+  // una cosa che qualcuno aveva messo a mano. Lo stesso valore, invece, è un rinforzo.
+  const conflict = await detectConflict(supabase, brand.id, key, value);
+  if (conflict) {
+    return json({ error: 'memory_conflict', conflict }, { status: 409 });
+  }
+
+  try {
+    const written = await writeMemory(supabase, brand.id, {
+      key,
+      value,
+      category: body.category,
+      source: 'chat',
+      confidence: INFERRED_CONFIDENCE
+    });
+    return json({ ok: true, ...written });
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    if (message.startsWith('skill_limit_reached')) {
+      return json({ error: 'skill_limit_reached', detail: message }, { status: 409 });
+    }
+    throw e;
+  }
+};

--- a/src/routes/api/v1/brands/[slug]/memory/server.test.ts
+++ b/src/routes/api/v1/brands/[slug]/memory/server.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('$lib/server/cli-auth', () => ({
+  authenticate: vi.fn(),
+  loadBrandForUser: vi.fn(),
+  checkApiKeyWriteAccess: vi.fn(() => null)
+}));
+
+import { GET, POST } from './+server';
+import { authenticate, loadBrandForUser } from '$lib/server/cli-auth';
+import { AGENT_MEMORY_CATEGORIES, MEMORY_CATEGORIES, MEMORY_ENTRIES_MAX } from '@anomalia/api-contracts';
+import { MEMORY_CATEGORY_VALUES } from '$lib/server/brand-memory';
+
+type Row = Record<string, unknown>;
+
+/** Il filtro `.is('agent', null)` di `scopeToAgent` e `.neq('layer','session')` sono quelli veri. */
+function fakeSupabase(tables: Record<string, Row[]>) {
+  return {
+    from(table: string) {
+      const all = (tables[table] ??= []);
+      let rows = [...all];
+      const q = {
+        select: () => q,
+        eq(column: string, value: unknown) {
+          rows = rows.filter((r) => r[column] === value);
+          return q;
+        },
+        neq(column: string, value: unknown) {
+          rows = rows.filter((r) => r[column] !== value);
+          return q;
+        },
+        is(column: string, value: unknown) {
+          rows = rows.filter((r) => (r[column] ?? null) === value);
+          return q;
+        },
+        or: () => q,
+        order: () => q,
+        limit(n: number) {
+          rows = rows.slice(0, n);
+          return q;
+        },
+        maybeSingle: async () => ({ data: rows[0] ?? null, error: null }),
+        insert(row: Row) {
+          all.push({ id: `new-${all.length}`, ...row });
+          return {
+            select: () => ({
+              single: async () => ({ data: all[all.length - 1], error: null }),
+              maybeSingle: async () => ({ data: all[all.length - 1], error: null })
+            })
+          };
+        },
+        update: () => ({ eq: async () => ({ data: null, error: null }) }),
+        then: (resolve: (v: { data: Row[]; error: null }) => unknown) => resolve({ data: rows, error: null })
+      };
+      return q;
+    },
+    rpc: async () => ({ data: null, error: null })
+  };
+}
+
+const entry = (over: Row = {}): Row => ({
+  id: 'm1',
+  brand_id: 'brand-1',
+  layer: 'project',
+  category: 'fact',
+  key: 'spedizione',
+  value: 'Gratuita sopra i 50 euro',
+  source: 'user',
+  confidence: 1,
+  times_reinforced: 0,
+  times_used: 2,
+  last_used_at: null,
+  last_reinforced_at: null,
+  expires_at: null,
+  created_at: '2026-08-01T00:00:00Z',
+  updated_at: '2026-08-01T00:00:00Z',
+  pinned: false,
+  agent: null,
+  ...over
+});
+
+let tables: Record<string, Row[]>;
+
+function signedIn(rows: Row[] = []) {
+  tables = { brand_memory: rows };
+  vi.mocked(authenticate).mockResolvedValue({
+    supabase: fakeSupabase(tables),
+    user: { id: 'user-1' },
+    apiKey: undefined,
+    error: null
+  } as never);
+  vi.mocked(loadBrandForUser).mockResolvedValue({
+    brand: { id: 'brand-1', slug: 'demo', name: 'Demo Brand' },
+    error: null
+  } as never);
+}
+
+function get(query: Record<string, string> = {}, slug = 'demo') {
+  const url = new URL(`https://anomalia.test/api/v1/brands/${slug}/memory`);
+  for (const [k, v] of Object.entries(query)) url.searchParams.set(k, v);
+  return (GET as (e: unknown) => Promise<Response>)({
+    request: new Request(url),
+    params: { slug },
+    url
+  }).then(async (res) => ({ res, body: await res.json() }));
+}
+
+function post(payload: Record<string, unknown>, slug = 'demo') {
+  const url = new URL(`https://anomalia.test/api/v1/brands/${slug}/memory`);
+  return (POST as (e: unknown) => Promise<Response>)({
+    request: new Request(url, { method: 'POST', body: JSON.stringify(payload) }),
+    params: { slug },
+    url
+  }).then(async (res) => ({ res, body: await res.json() }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('GET /memory', () => {
+  it('non restituisce la memoria di un altro brand, nemmeno con la stessa chiave', async () => {
+    signedIn([
+      entry(),
+      entry({ id: 'm2', brand_id: 'brand-2', key: 'spedizione', value: 'Il vicino spedisce a 9 euro' })
+    ]);
+
+    const { res, body } = await get();
+
+    expect(res.status).toBe(200);
+    expect(body.entries).toHaveLength(1);
+    expect(JSON.stringify(body)).not.toContain('Il vicino spedisce');
+  });
+
+  it('non fa uscire la chiacchiera di una chat: la memoria di sessione resta nel suo thread', async () => {
+    signedIn([entry(), entry({ id: 'm2', layer: 'session', key: 'estemporanea', value: 'forse domani' })]);
+
+    const { body } = await get();
+
+    expect(body.entries.map((e: { key: string }) => e.key)).toEqual(['spedizione']);
+  });
+
+  it('non fa uscire le note di mestiere di un agente: solo la memoria del brand', async () => {
+    signedIn([entry(), entry({ id: 'm2', agent: 'motion', key: 'nota-di-motion' })]);
+
+    const { body } = await get();
+
+    expect(body.entries.map((e: { key: string }) => e.key)).toEqual(['spedizione']);
+  });
+
+  /** IL `GET` RESTA PURO: leggere non è usare, e questo non è un `ensureReferralCode`. */
+  it('leggere non conta come usare: nessuna scrittura parte da una lettura', async () => {
+    signedIn([entry()]);
+
+    await get();
+
+    expect(tables.brand_memory[0].times_used).toBe(2);
+    expect(tables.brand_memory[0].last_used_at).toBeNull();
+  });
+
+  it('restringe a una categoria, e rifiuta una inventata', async () => {
+    signedIn([entry(), entry({ id: 'm2', category: 'insight', key: 'osservazione' })]);
+
+    const only = await get({ category: 'insight' });
+    expect(only.body.entries.map((e: { key: string }) => e.key)).toEqual(['osservazione']);
+
+    const bad = await get({ category: 'inventata' });
+    expect(bad.res.status).toBe(400);
+    expect(bad.body.error).toBe('unknown_category');
+  });
+
+  it('applica il tetto invece di rovesciare mille righe', async () => {
+    signedIn(Array.from({ length: MEMORY_ENTRIES_MAX + 40 }, (_, i) => entry({ id: `m${i}`, key: `k${i}` })));
+
+    const { body } = await get({ limit: '999' });
+
+    expect(body.entries).toHaveLength(MEMORY_ENTRIES_MAX);
+  });
+});
+
+describe('POST /memory', () => {
+  it('rifiuta voice e constraint: riscrivere la voce è un cambio di marca in una chiamata', async () => {
+    signedIn();
+
+    for (const category of ['voice', 'constraint']) {
+      const { res, body } = await post({ key: 'tono', value: 'sempre in maiuscolo', category });
+      expect(res.status, category).toBe(403);
+      expect(body.error, category).toBe('category_not_writable');
+    }
+
+    expect(tables.brand_memory).toHaveLength(0);
+  });
+
+  it('accetta quello che un agente impara lavorando', async () => {
+    signedIn();
+
+    for (const category of AGENT_MEMORY_CATEGORIES) {
+      const { res } = await post({ key: `k-${category}`, value: `v-${category}`, category });
+      expect(res.status, category).toBe(200);
+    }
+
+    expect(tables.brand_memory).toHaveLength(AGENT_MEMORY_CATEGORIES.length);
+  });
+
+  it('un fatto scritto da un agente non arriva con la certezza di uno scritto a mano', async () => {
+    signedIn();
+
+    await post({ key: 'sede', value: 'Milano', category: 'fact' });
+
+    const written = tables.brand_memory[0];
+    expect(written.source).toBe('chat');
+    expect(written.confidence as number).toBeLessThan(1);
+  });
+
+  /** L'ULTIMO ARRIVATO NON VINCE. Il conflitto torna con entrambi i valori e non scrive niente. */
+  it('un valore che contraddice quello che c’è risponde 409 con tutti e due, e non sovrascrive', async () => {
+    signedIn([entry({ key: 'spedizione', value: 'Gratuita sopra i 50 euro' })]);
+
+    const { res, body } = await post({
+      key: 'spedizione',
+      value: 'Costa sempre 7 euro',
+      category: 'fact'
+    });
+
+    expect(res.status).toBe(409);
+    expect(body.error).toBe('memory_conflict');
+    expect(body.conflict.existing.value).toBe('Gratuita sopra i 50 euro');
+    expect(body.conflict.incoming.value).toBe('Costa sempre 7 euro');
+    expect(tables.brand_memory[0].value).toBe('Gratuita sopra i 50 euro');
+  });
+
+  it('ripetere lo stesso valore non è un conflitto: è un rinforzo', async () => {
+    signedIn([entry({ key: 'spedizione', value: 'Gratuita sopra i 50 euro' })]);
+
+    const { res } = await post({
+      key: 'spedizione',
+      value: 'Gratuita sopra i 50 euro',
+      category: 'fact'
+    });
+
+    expect(res.status).toBe(200);
+  });
+
+  it('non scrive mai nel layer di sessione: fuori non esiste un thread', async () => {
+    signedIn();
+
+    await post({ key: 'k', value: 'v', category: 'insight', layer: 'session', thread_id: 't1' });
+
+    expect(tables.brand_memory[0].layer).toBe('project');
+  });
+
+  it('le categorie dichiarate nel contratto sono quelle che il database accetta', () => {
+    expect([...MEMORY_CATEGORIES].sort()).toEqual([...MEMORY_CATEGORY_VALUES].sort());
+  });
+
+  it('chiede chiave, valore e categoria invece di indovinarli', async () => {
+    signedIn();
+
+    for (const payload of [{ value: 'v', category: 'fact' }, { key: 'k', category: 'fact' }, { key: 'k', value: 'v' }]) {
+      const { res } = await post(payload);
+      expect(res.status).toBe(400);
+    }
+  });
+});

--- a/src/routes/api/v1/brands/[slug]/memory/used/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/memory/used/+server.ts
@@ -1,0 +1,40 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { authenticate, loadBrandForUser, checkApiKeyWriteAccess } from '$lib/server/cli-auth';
+import { recordMemoryUsage } from '$lib/server/brand-memory';
+import { MEMORY_USED_MAX } from '@anomalia/api-contracts';
+
+// USARE NON È LEGGERE, ED È PER QUESTO CHE È UNA SCRITTURA. Dentro le due cose collassano — il
+// turno inietta ciò che carica — ma un agente esterno elenca quaranta voci e ne usa due: contarle
+// tutte alla lettura sarebbe un dato peggiore, e un GET con effetto collaterale.
+//
+// Gli id si filtrano PRIMA di contarli: un id di un altro brand terrebbe viva la memoria del
+// vicino, e la risposta non deve nemmeno lasciar capire che quell'id esiste.
+
+export const POST: RequestHandler = async ({ request, params }) => {
+  const { supabase, error, apiKey } = await authenticate(request);
+  if (error) return error;
+
+  const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
+  if (brandError) return brandError;
+
+  const writeDenied = checkApiKeyWriteAccess(apiKey);
+  if (writeDenied) return writeDenied;
+
+  const body = (await request.json()) as { ids?: unknown };
+  const ids = Array.isArray(body.ids) ? body.ids.filter((id): id is string => typeof id === 'string' && !!id) : [];
+
+  if (!ids.length) return json({ error: 'ids_required' }, { status: 400 });
+  if (ids.length > MEMORY_USED_MAX) return json({ error: 'too_many_ids' }, { status: 400 });
+
+  const { data: owned } = await supabase
+    .from('brand_memory')
+    .select('id')
+    .eq('brand_id', brand.id)
+    .in('id', ids);
+
+  const mine = (owned ?? []).map((row) => row.id as string);
+  if (mine.length) await recordMemoryUsage(supabase, mine);
+
+  return json({ ok: true, counted: mine.length });
+};

--- a/src/routes/api/v1/brands/[slug]/memory/used/server.test.ts
+++ b/src/routes/api/v1/brands/[slug]/memory/used/server.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('$lib/server/cli-auth', () => ({
+  authenticate: vi.fn(),
+  loadBrandForUser: vi.fn(),
+  checkApiKeyWriteAccess: vi.fn(() => null)
+}));
+
+import { POST } from './+server';
+import { authenticate, loadBrandForUser } from '$lib/server/cli-auth';
+import { MEMORY_USED_MAX } from '@anomalia/api-contracts';
+
+type Row = Record<string, unknown>;
+
+let bumped: string[][];
+let owned: Row[];
+
+function fakeSupabase() {
+  return {
+    from() {
+      let rows = [...owned];
+      const q = {
+        select: () => q,
+        eq(column: string, value: unknown) {
+          rows = rows.filter((r) => r[column] === value);
+          return q;
+        },
+        in(column: string, values: unknown[]) {
+          rows = rows.filter((r) => values.includes(r[column]));
+          return q;
+        },
+        then: (resolve: (v: { data: Row[]; error: null }) => unknown) => resolve({ data: rows, error: null })
+      };
+      return q;
+    },
+    rpc: async (_fn: string, args: { entry_ids: string[] }) => {
+      bumped.push(args.entry_ids);
+      return { data: null, error: null };
+    }
+  };
+}
+
+function signedIn(rows: Row[] = [{ id: 'm1', brand_id: 'brand-1' }, { id: 'm2', brand_id: 'brand-1' }]) {
+  bumped = [];
+  owned = rows;
+  vi.mocked(authenticate).mockResolvedValue({
+    supabase: fakeSupabase(),
+    user: { id: 'user-1' },
+    apiKey: undefined,
+    error: null
+  } as never);
+  vi.mocked(loadBrandForUser).mockResolvedValue({
+    brand: { id: 'brand-1', slug: 'demo', name: 'Demo Brand' },
+    error: null
+  } as never);
+}
+
+function post(payload: Record<string, unknown>, slug = 'demo') {
+  const url = new URL(`https://anomalia.test/api/v1/brands/${slug}/memory/used`);
+  return (POST as (e: unknown) => Promise<Response>)({
+    request: new Request(url, { method: 'POST', body: JSON.stringify(payload) }),
+    params: { slug },
+    url
+  }).then(async (res) => ({ res, body: await res.json() }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('POST /memory/used', () => {
+  it('segnala l’uso delle voci indicate', async () => {
+    signedIn();
+
+    const { res, body } = await post({ ids: ['m1', 'm2'] });
+
+    expect(res.status).toBe(200);
+    expect(body.counted).toBe(2);
+    expect(bumped).toEqual([['m1', 'm2']]);
+  });
+
+  /**
+   * Il contatore alimenta il decadimento in `runDream`: un id di un altro brand che passasse di
+   * qui terrebbe viva la memoria del vicino, o peggio la userebbe come sonda per scoprire che
+   * esiste. Le righe si filtrano PRIMA di contarle.
+   */
+  it('non conta l’uso di una voce di un altro brand, e non ammette di averla vista', async () => {
+    signedIn([{ id: 'm1', brand_id: 'brand-1' }]);
+
+    const { res, body } = await post({ ids: ['m1', 'm-del-vicino'] });
+
+    expect(res.status).toBe(200);
+    expect(body.counted).toBe(1);
+    expect(bumped).toEqual([['m1']]);
+    expect(JSON.stringify(body)).not.toContain('m-del-vicino');
+  });
+
+  it('un elenco di soli id estranei non scrive niente', async () => {
+    signedIn([]);
+
+    const { body } = await post({ ids: ['x1', 'x2'] });
+
+    expect(body.counted).toBe(0);
+    expect(bumped).toEqual([]);
+  });
+
+  it('rifiuta un elenco vuoto invece di fingere di aver contato', async () => {
+    signedIn();
+
+    const { res, body } = await post({ ids: [] });
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('ids_required');
+  });
+
+  it('applica il tetto invece di accettare un elenco qualunque', async () => {
+    signedIn();
+
+    const { res, body } = await post({ ids: Array.from({ length: MEMORY_USED_MAX + 1 }, (_, i) => `m${i}`) });
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('too_many_ids');
+  });
+});


### PR DESCRIPTION
## What?

`brand_memory` becomes readable and writable over MCP. Three tools — `get_memory`, `save_memory`, `record_memory_used` — over `GET/POST /api/v1/brands/:slug/memory` and `POST /api/v1/brands/:slug/memory/used`.

Plus one guard in `runDream`: **decay does not run in a brand where no entry has ever been reported as used.**

`tools/list` goes from 116 to 119. Nothing removed, **no existing tool changed a single field**.

## Why?

`brand_memory` holds what the brand knows — its voice, the constraints it works under, the facts it confirmed, the preferences it stated, what earlier work learned. `/studio/memory` has existed from the start but was **never in the registry**, so MCP had no tool for it. An external agent rebuilt all of that every conversation and asked the operator things the operator had already answered. Only `category = 'skill'` was served, by the writing-skills PR.

And an agent that can only read never grows the customer's asset: the memory would keep being written by the product alone.

## How?

### A new route, not `/studio/memory` hardened

`/studio/memory` is the **operator's** surface: `BrandMemoryPanel.svelte` posts whatever category the person picks, `voice` and `constraint` included, and that is correct. The **agent's** surface has different rules, and different rules on one route would be an `if` on who is calling — the scattered condition that diverges later. Two routes, two audiences, two rule sets, each written in one place. The shared logic (`loadMemoryEntries`, `writeMemory`, `detectConflict`, `recordMemoryUsage`) is already extracted and is not duplicated.

### The GET stays pure

Inside, reading and using collapse: the turn injects what it loads, so `read_memory` calls `recordMemoryUsage`. Outside they do not — an agent lists forty entries and uses two. Counting on read would be **worse data than the internal path** and a `GET` with a side effect, the `ensureReferralCode` shape we treat as a defect.

So reporting is an explicit write, and the data it produces is finer: not "I loaded it" but "I used it". Ids are filtered by brand **before** being counted — a foreign id would keep the neighbour's memory alive, and the response does not even reveal that the id exists.

### The defence that does not depend on adoption

The risk of explicit reporting is asymmetric and silent: if nobody calls `record_memory_used`, entries decay as unused, fall below the injection floor and stop reaching prompts. By the time you see it, the damage is in the data. A line in the description is not enough.

So, in `runDreamInner`:

```ts
const usageIsReported = (entries ?? []).some((entry) => !!entry.last_used_at);
```

**If no row in this brand has EVER been reported, the non-use decay does not run.** A total absence of data is not data: the right assumption is "nobody is reporting", not "nobody uses these". As soon as any one entry carries a signal, the signal is live and decay resumes for all of them.

Zero extra queries — the rows are already loaded. No migration. The criterion is **per brand, not per row**, deliberately: a row never used while others are being used *is* evidence of non-use (it lost the 800-token budget selection) and is treated as it is today. On brands with chat traffic `last_used_at` is already populated, so the guard is inert and decay behaves exactly as now.

Archiving is untouched: it already had the `times_used > 0` shield, and an explicit `expires_at` still archives regardless — whoever wrote it decided.

### The write surface

| category | writable by an agent | why |
|---|---|---|
| `insight`, `preference` | yes | what it learns working; short blast radius |
| `skill` | yes, `MAX_SKILLS_PER_BRAND` (20) already enforced at `brand-memory.ts:411` | procedures are the point of the store |
| `fact` | yes, but `source: 'chat'` and confidence `0.7` | a wrong fact propagates into every prompt |
| `voice`, `constraint` | **no** | they govern everything downstream: a model rewriting the voice is a rebrand in one call |

**The last writer does not win.** A value contradicting what exists answers **409 with both values and writes nothing** — the agent takes it to the operator rather than winning by arriving last. The same value repeated stays a reinforcement; `detectConflict` already told them apart.

**Two read tools, not five.** `promoteMemoryToProject`, `updateMemoryEntry` and `deleteMemory` stay internal until something actually asks.

## Testing?

**The negative tests on isolation — three filters, each watched fail.** Another brand's memory does not come out even under the same key; session chatter stays in its thread; another agent's working notes are noise, not brand knowledge, and `scopeToAgent(query, null)` excludes them. On the usage report, a foreign id is filtered before counting and never appears in the response — otherwise the counter would be a probe for discovering that an entry exists.

<details><summary>Red — routes did not exist</summary>

```
 FAIL  src/routes/api/v1/brands/[slug]/memory/server.test.ts
 FAIL  src/routes/api/v1/brands/[slug]/memory/used/server.test.ts
Error: Failed to load url ./+server (resolved id: ./+server) ... Does the file exist?
```
</details>

<details><summary>Red — the decay guard, before it existed</summary>

```
 × runDream > non decade niente in un brand dove nessuna riga è mai stata segnalata
   → expected 2 to be +0
```

The two companion tests hold the other side: as soon as one entry carries a signal, decay resumes for all; and an explicit `expires_at` archives even with no signal anywhere.
</details>

<details><summary>Green</summary>

```
$ npx vitest run "src/routes/api/v1/brands/[slug]/memory" packages/api-contracts src/lib/server/brand-memory.test.ts
 Test Files  23 passed (23)
      Tests  265 passed (265)

$ npx vitest run brand-memory default-skills registry.test.ts changelog studio
 Test Files  11 passed (11)
      Tests  81 passed (81)

$ cd cli && bun test
 0 fail / 736 expect() calls / 59 tests across 12 files

$ cd cli && bun run typecheck    →  tsc --noEmit, exit 0
```
</details>

Eighteen route tests plus three decay tests plus ten contract tests. They cover: the three isolation filters; the read writing nothing; category filtering and an invented category refused; the 200-entry ceiling; `voice`/`constraint` refused with 403 and nothing written; all four writable categories accepted; an agent-written fact arriving with `source: 'chat'` and confidence below 1; the 409 carrying both values with the stored one unchanged; the same value treated as reinforcement; session layer never written; and guards that `MEMORY_CATEGORIES` in the contract still equals `MEMORY_CATEGORY_VALUES` in `brand-memory.ts` — extracted from the bare union type so the closed list has one home.

**Not tested:** the routes against live Postgres, and whether agents actually call `record_memory_used`. The second is the adoption risk, and it is precisely why the decay guard exists rather than a line of documentation.

## Evidence

<details><summary><code>tools/list</code> — dev vs this branch</summary>

```
dev=116  PR=119
removed: []
added: ['get_memory', 'record_memory_used', 'save_memory']
changed existing: none
```
</details>

<details><summary>The 409, which is the piece worth reading</summary>

```jsonc
// POST /memory  { "key": "spedizione", "value": "Costa sempre 7 euro", "category": "fact" }
// 409
{
  "error": "memory_conflict",
  "conflict": {
    "key": "spedizione",
    "existing": { "value": "Gratuita sopra i 50 euro", "source": "user", "confidence": 1 },
    "incoming": { "value": "Costa sempre 7 euro", "source": "incoming" }
  }
}
```

The stored value is unchanged. The agent has both and takes the disagreement to the operator.
</details>

## Anything Else?

- **Where else does the last writer win silently?** You asked me to flag them. One so far, and it is in this PR's own neighbourhood: `writeMemory` reinforces on an existing key without consulting `detectConflict` — every internal caller can overwrite a hand-written entry, and `detectConflict`'s own comment says document ingest is its only caller. This route calls it explicitly; the internal paths do not. Worth a follow-up, and I did not widen this PR to cover them.
- `save_memory` cannot set `pinned` or `importance` — `writeMemory` only applies them on INSERT precisely so a manual change in the UI is never overwritten. Leaving them to the operator is consistent with that.
- The decay guard makes a brand with zero usage signal never decay at all. That is the deliberate trade: memory may go stale-but-confident there, and a failed adoption cannot erase the customer's asset. Explicit expiry still applies.
- No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
