### PR TITLE
Generate media into the library, without a post

### DIFF
--- a/changelog/2026-09-04-generate-media-without-a-post.md
+++ b/changelog/2026-09-04-generate-media-without-a-post.md
@@ -1,0 +1,109 @@
+# L'agente esterno genera verso la libreria, non verso un post
+
+Nel registry c'erano 114 tool e nessuno sapeva **generare** un media. `render_post` è
+`POST /posts/:id/render`, `regenerate_post_media` e `make_video` pure: tutti vogliono un post che
+esista già. `import_media_url` importa un file fatto altrove, `list_media` elenca e basta. Quindi
+per ottenere un'immagine un agente esterno doveva **prima creare un post in calendario**.
+
+Tre conseguenze, tutte sbagliate: si sporcava il calendario per esplorare (tre direzioni visive =
+tre post finti da cancellare), l'asset nasceva attaccato a un post invece che nella libreria dove
+sarebbe stato riutilizzabile, e il generatore di media era di fatto irraggiungibile — cioè proprio
+la cosa che un modello di chat non sa fare da solo. `docs/external-agent-plan.md` dichiarava
+"Image generation, video generation, rendering … remain explicit paid Anomalia capabilities":
+capacità dichiarate, senza una porta.
+
+## Il vincolo del post era cablaggio, non un vincolo vero
+
+Il censimento lo ha chiarito: `renderPostImage` prende una stringa e nient'altro; `enqueueVideoRender`
+accetta `post_id` nullo **da sempre**, e `applyToPost` si apre con `if (!row.post_id) return true;`.
+Una rotta in produzione (`content/create-single`) chiamava già `submitAndTrackVideoRender` con
+`postId: null`. La strada era aperta e nessuno ci era passato.
+
+Quindi qui non si è costruito un motore: si è aperta una porta su quelli che c'erano.
+
+```
+genera → l'asset entra in brand_media → create_post lo attacca con media_ids
+```
+
+L'ultimo passo esisteva già e funzionava. Mancava il primo.
+
+## Due tempi, due forme
+
+Immagine e video non si aspettano allo stesso modo, quindi non hanno la stessa forma:
+
+```
+immagine  →  sincrona, ~10s   →  { status: 'ready',     media: [...] }
+video     →  minuti           →  { status: 'rendering', job_id }  → check_media_job
+```
+
+Aspettare un video non era un'opzione da valutare: il poll di kie arriva a 600s contro un muro di
+funzione a 300s, quindi chi aspetta muore **sempre** a metà. Si riusa la coda `video_renders` e il
+cron che già la drena — nessuna coda nuova, nessuna tabella nuova.
+
+L'unico cambiamento al motore è un ramo nel reconciler: quando `post_id` è nullo il clip va in
+libreria via `saveRenderedVideoToLibrary`, con `sourceRef` uguale all'id del lavoro. È così che
+`check_media_job` ritrova l'asset **senza una colonna in più** — `brand_media.source_ref` esisteva,
+e `source = 'generate'` era già nel CHECK di `0220_widen_source_checks.sql`. Zero migration.
+
+### Effetto collaterale che valeva da solo
+
+`saveRenderedVideoToLibrary` è l'**unica** funzione del repo che deposita un video generato in
+`brand_media`, e i suoi due soli chiamanti erano `src/lib/server/chat/job-executor.ts` e
+`src/lib/agent/tools/create-content-tools.ts` — entrambi in smantellamento. Sarebbe diventata
+codice morto nel giro di una settimana: la porta murata dall'interno mentre la costruivamo. Ora ha
+un chiamante che sopravvive, e la correzione nasce dal progetto invece di essere una toppa messa
+dopo.
+
+## L'allocazione mensile si conta comunque
+
+`addUsage({ videos: 1 })` viveva **dentro** il ramo del post, e lasciarlo lì apriva un arbitraggio:
+genero in libreria, attacco dopo, e il video non conta mai. Non è un difetto teorico — è la
+scorciatoia che un cliente attento trova da solo, e la troverebbe prima di noi. Spostata in
+`chargeMonthlyVideo`, che gira ovunque il clip atterri. Resta addebitata **all'atterraggio** e non
+all'invio, così dieci render rifiutati non si mangiano il margine di un mese.
+
+È una decisione di prezzo, non tecnica, e va detta: da oggi anche i video generati in libreria
+consumano l'allocazione mensile.
+
+## Crediti e tetto
+
+Il percorso è quello delle 13 rotte a pagamento che già esistono — `gateAiAction` (403 chiave di
+sola lettura, 402 crediti finiti) e poi `withBrandContext`, sotto cui ogni `logAiCall` accredita
+il costo al brand giusto. Nessun flag `paid` aggiunto a `BrandEndpoint`: un campo su 14 endpoint
+con un consumatore vero è l'astrazione difensiva che questo repo vieta.
+
+La descrizione del tool **apre con il conto** invece di nasconderlo in fondo. È il rovescio esatto
+di `import_media_url`, che dichiara di non spendere: se lì lo diciamo, qui lo diciamo.
+
+Il tetto sulle alternative è `MAX_MEDIA_ALTERNATIVES = 4`, definito **una volta** in
+`api-contracts` e usato dallo schema zod. Un solo ceiling, non due che divergono: il server non ha
+una seconda soglia da tenere allineata, perché è lo schema a rifiutare al confine. Un video per
+chiamata e basta — su ~210 crediti un parametro di lotto è un modo per perdere soldi con un errore
+di battitura.
+
+## Un contratto che mentiva
+
+Cinque endpoint (`render_post`, `seo_action`, `geo_action`, `refresh_keywords`,
+`research_competitors`) chiamavano `gateAiAction` senza dichiarare `credits_exhausted`. Un agente
+esterno legge quell'elenco per decidere cosa fare di un errore, e `statusForFailure` degradava quel
+402 a **500** — che si legge come "guasto nostro" invece di "crediti finiti". Un contratto che
+mente è peggio di un contratto assente.
+
+Corretti in un commit a parte, con un guardiano in `registry.test.ts`, che già inverte `pathFor`
+per trovare la rotta su disco: se il file chiama `gateAiAction` e l'endpoint non è una GET, il
+contratto deve dichiarare `credits_exhausted`. Le GET sono escluse perché il gate sta sempre
+nell'handler che scrive — una GET che condivide il file legge soltanto (verificato su `seo`, `geo`,
+`keywords`, `backlinks`).
+
+## Cosa resta fuori, e perché
+
+- **Motion video / Remotion**: vuole sorgente TSX e una riga `motion_videos`, rende in modo
+  sincrono per 8 minuti e addebita secondi di sandbox anche quando fallisce. Forma sbagliata per un
+  agente esterno.
+- **UGC batch**: SSE, affettato su `chat_jobs`, fino a 20 clip. Capacità vera, contratto di lavoro
+  molto più grande di questo.
+- **`transformVideo`** (refine / motion-control): raggiungibile in teoria — prende un URL di clip,
+  non un post — ma il suo unico chiamante sta per essere cancellato, quindi esporlo è una decisione
+  separata sul se tenerlo.
+- **`design_graphic`**: gratis (satori, nessun modello), senza post, e utile. Vive dentro il loop
+  dell'agente media-generator invece che come primitiva chiamabile. Vale un giro suo.

--- a/cli/lib/contracts/index.ts
+++ b/cli/lib/contracts/index.ts
@@ -26,7 +26,9 @@ import {
   SAVE_WEEK_SEEDS,
 } from './plans';
 import {
+  CHECK_MEDIA_JOB,
   CREATE_POST,
+  GENERATE_MEDIA,
   GET_CALENDAR,
   GET_POST,
   IMPORT_MEDIA_URL,
@@ -148,6 +150,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   BILLING_PORTAL_LINK,
   CHECKOUT_LINK,
   CHECK_CONTENT,
+  CHECK_MEDIA_JOB,
   CREATE_POST,
   CREATE_PRODUCT,
   CREATE_SHARE,
@@ -158,6 +161,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   DIAGNOSE_BRAND,
   DIAGNOSE_RADAR,
   DISCARD_PLAN,
+  GENERATE_MEDIA,
   GEO_ACTION,
   GET_ADS,
   GET_ANALYTICS,
@@ -257,7 +261,9 @@ export {
   ADS_ACTION,
   ADS_REMIX,
   CHECK_CONTENT,
+  CHECK_MEDIA_JOB,
   CREATE_POST,
+  GENERATE_MEDIA,
   GET_ARTICLE,
   GET_AUDIT_FINDINGS,
   GET_CALENDAR,
@@ -416,6 +422,7 @@ export type {
 export { KIT_FORMATS } from './creation-kit';
 export type { GetCreationKitInput, GetCreationKitResult } from './creation-kit';
 export type { CreatePostInput, CreatePostResult } from './posts';
+export { MAX_MEDIA_ALTERNATIVES } from './posts';
 export {
   APPROVE_PLAN,
   DISCARD_PLAN,

--- a/cli/lib/contracts/posts.ts
+++ b/cli/lib/contracts/posts.ts
@@ -281,3 +281,92 @@ export const IMPORT_MEDIA_URL = {
   ],
   destructive: false
 } satisfies BrandEndpoint;
+
+/**
+ * Un tetto solo per le alternative, non due che divergono: lo schema rifiuta oltre questo numero,
+ * quindi il server non ha una seconda soglia da tenere allineata. È lo stesso ceiling che la
+ * pagina Media generator applica alle sue varianti — ogni alternativa è un render pagato.
+ */
+export const MAX_MEDIA_ALTERNATIVES = 4;
+
+const GeneratedMediaSchema = z.object({
+  id: z.string(),
+  kind: z.string(),
+  mime: z.string().nullable(),
+  width: z.number().nullable(),
+  height: z.number().nullable(),
+  signed_url: z.string().nullable()
+});
+
+export const GENERATE_MEDIA = {
+  tool: 'generate_media',
+  title: 'Generate media into the library',
+  description:
+    'Generate a new image or video into the brand media library, then pass the id it returns as ' +
+    'media_ids on create_post. THIS SPENDS CREDITS: every image is a paid render and every video ' +
+    'is a paid clip, so ask for what you need and no more. It creates nothing in the calendar — ' +
+    'generate alternatives, look at them with list_media, and attach only the one you keep. ' +
+    'Images come back ready, up to ' + MAX_MEDIA_ALTERNATIVES + ' per call. A video takes minutes: ' +
+    'it comes back as a job_id with status rendering, and check_media_job says when it landed — ' +
+    'do not call this again for the same clip while one is still rendering.',
+  method: 'POST',
+  pathUnderBrand: '/media/generate',
+  input: z
+    .object({
+      prompt: z.string().min(1).describe('What the image or video should show'),
+      kind: z.enum(['image', 'video']).optional().describe('Defaults to image'),
+      count: z.coerce
+        .number()
+        .int()
+        .min(1)
+        .max(MAX_MEDIA_ALTERNATIVES)
+        .optional()
+        .describe(
+          'How many alternatives to draw, images only, 1-' + MAX_MEDIA_ALTERNATIVES +
+            '. Each one bills a render. Defaults to 1.'
+        ),
+      aspect_ratio: z.enum(['1:1', '4:5', '9:16', '16:9']).optional(),
+      title: z.string().optional().describe('The name the asset carries in the library')
+    })
+    .strict(),
+  output: z.object({
+    ok: z.literal(true),
+    status: z.enum(['ready', 'rendering']),
+    media: z.array(GeneratedMediaSchema),
+    job_id: z.string().nullable()
+  }),
+  failures: [
+    { error: 'credits_exhausted', status: 402 },
+    { error: 'video_budget_exhausted', status: 400 },
+    { error: 'render_failed', status: 502 },
+    { error: 'store_failed', status: 502 }
+  ],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const CHECK_MEDIA_JOB = {
+  tool: 'check_media_job',
+  title: 'Check a media generation job',
+  description:
+    'Where the videos generate_media started have got to, newest first. status is rendering while ' +
+    'the clip is being made, done once it is in the library — and then media_id is the id ' +
+    'create_post accepts as media_ids. failed says why. Calls no model and spends no credits.',
+  method: 'GET',
+  pathUnderBrand: '/media/generate',
+  input: z
+    .object({ job_id: z.string().optional().describe('One job; omit for the brand\'s recent ones') })
+    .strict(),
+  output: z.object({
+    jobs: z.array(
+      z.object({
+        id: z.string(),
+        status: z.string(),
+        media_id: z.string().nullable(),
+        error: z.string().nullable(),
+        submitted_at: z.string().nullable()
+      })
+    )
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/cli/lib/contracts/posts.ts
+++ b/cli/lib/contracts/posts.ts
@@ -171,7 +171,7 @@ export const RENDER_POST = {
     z.object({ ok: z.literal(true), url: z.string().nullable(), error: z.string().nullable() }),
     z.object({ error: z.string(), url: z.string() })
   ]),
-  failures: [],
+  failures: [{ error: 'credits_exhausted', status: 402 }],
   destructive: false
 } satisfies BrandEndpoint;
 

--- a/cli/lib/contracts/search.ts
+++ b/cli/lib/contracts/search.ts
@@ -25,7 +25,7 @@ export const SEO_ACTION = {
     articleId: z.string().optional(),
     techScore: z.number().nullable().optional()
   }),
-  failures: [],
+  failures: [{ error: 'credits_exhausted', status: 402 }],
   destructive: false
 } satisfies BrandEndpoint;
 
@@ -42,7 +42,7 @@ export const GEO_ACTION = {
     shareOfVoice: z.number().optional(),
     generated: z.number().optional()
   }),
-  failures: [],
+  failures: [{ error: 'credits_exhausted', status: 402 }],
   destructive: false
 } satisfies BrandEndpoint;
 
@@ -54,6 +54,6 @@ export const REFRESH_KEYWORDS = {
   pathUnderBrand: '/keywords',
   input: z.object({}).strict(),
   output: z.object({ ok: z.literal(true), keywords: z.number() }),
-  failures: [],
+  failures: [{ error: 'credits_exhausted', status: 402 }],
   destructive: false
 } satisfies BrandEndpoint;

--- a/cli/lib/contracts/studio.ts
+++ b/cli/lib/contracts/studio.ts
@@ -323,7 +323,7 @@ export const RESEARCH_COMPETITORS = {
   pathUnderBrand: '/studio/competitors/research',
   input: z.object({}).strict(),
   output: z.object({ ok: z.literal(true), found: z.number(), added: z.number() }),
-  failures: [],
+  failures: [{ error: 'credits_exhausted', status: 402 }],
   destructive: false,
   openWorld: true
 } satisfies BrandEndpoint;

--- a/cli/plugins/anomalia/skills/anomalia/references/tools.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/tools.md
@@ -32,6 +32,8 @@ the full UUID, because an ambiguous prefix would remove the wrong row and nothin
 | `list_media` | (MCP only) |
 | `check_content` | (MCP only) |
 | `import_media_url` | (MCP only) |
+| `generate_media` | (MCP only) |
+| `check_media_job` | (MCP only) |
 | `approve_posts` | `anomalia approve <slug> --all` |
 | `get_post` | `anomalia post <slug> <id>` |
 | `edit_post` | `anomalia post <slug> <id> edit …` |
@@ -107,6 +109,27 @@ that resolves to one, and a redirect that walks into one or drops back to http �
 before a byte is stored, so a rejected import leaves nothing behind. The result carries the id,
 the resolved `source_url` kept as the asset's origin, and a `signed_url` you can open to check
 that the right file arrived.
+
+`generate_media` makes a NEW image or video and puts it straight into the brand library — no
+post, nothing in the calendar. Required: `slug`, `prompt`; optional `kind` (`image` default, or
+`video`), `count`, `aspect_ratio`, `title`. **This spends credits**, unlike `import_media_url`:
+every image is a paid render and every video a paid clip. `count` draws up to 4 alternatives in
+one call and bills each one, so generate a few, look at them with `list_media`, and pass only the
+id you keep to `create_post` as `media_ids` — the calendar stays clean either way.
+
+An image comes back finished: `status` is `ready` and `media` carries the rows, each with a
+`signed_url` you can open. A video cannot: it takes minutes, longer than any single call may
+last, so it comes back with `status` `rendering` and a `job_id`, and `check_media_job` says where
+it got to. Do not call `generate_media` again for the same clip while one is still rendering —
+that bills a second one. Refusals: `credits_exhausted` (402) means the brand's pool is empty and
+nothing was drawn; `video_budget_exhausted` (400) means the monthly video allowance is used up,
+counting the clips still rendering; `render_failed` (502) is the model returning nothing, and
+nothing is stored; `store_failed` (502) means it was drawn but could not be filed.
+
+`check_media_job` reads those jobs back, newest first. Required: `slug`; optional `job_id` for
+one of them. Each row carries `status` (`rendering`, `done`, `failed` or `expired`), `error` when
+it failed, and `media_id` once the clip is in the library — that id is what `create_post` takes
+as `media_ids`. It calls no model and spends no credits, so poll it rather than guessing.
 
 `create_post` stores copy **you** wrote: Anomalia calls no model and spends no credits. It does
 not publish and does not schedule — `scheduled_for` is the proposed calendar time and stays a

--- a/cli/skills/anomalia/references/tools.md
+++ b/cli/skills/anomalia/references/tools.md
@@ -32,6 +32,8 @@ the full UUID, because an ambiguous prefix would remove the wrong row and nothin
 | `list_media` | (MCP only) |
 | `check_content` | (MCP only) |
 | `import_media_url` | (MCP only) |
+| `generate_media` | (MCP only) |
+| `check_media_job` | (MCP only) |
 | `approve_posts` | `anomalia approve <slug> --all` |
 | `get_post` | `anomalia post <slug> <id>` |
 | `edit_post` | `anomalia post <slug> <id> edit …` |
@@ -107,6 +109,27 @@ that resolves to one, and a redirect that walks into one or drops back to http �
 before a byte is stored, so a rejected import leaves nothing behind. The result carries the id,
 the resolved `source_url` kept as the asset's origin, and a `signed_url` you can open to check
 that the right file arrived.
+
+`generate_media` makes a NEW image or video and puts it straight into the brand library — no
+post, nothing in the calendar. Required: `slug`, `prompt`; optional `kind` (`image` default, or
+`video`), `count`, `aspect_ratio`, `title`. **This spends credits**, unlike `import_media_url`:
+every image is a paid render and every video a paid clip. `count` draws up to 4 alternatives in
+one call and bills each one, so generate a few, look at them with `list_media`, and pass only the
+id you keep to `create_post` as `media_ids` — the calendar stays clean either way.
+
+An image comes back finished: `status` is `ready` and `media` carries the rows, each with a
+`signed_url` you can open. A video cannot: it takes minutes, longer than any single call may
+last, so it comes back with `status` `rendering` and a `job_id`, and `check_media_job` says where
+it got to. Do not call `generate_media` again for the same clip while one is still rendering —
+that bills a second one. Refusals: `credits_exhausted` (402) means the brand's pool is empty and
+nothing was drawn; `video_budget_exhausted` (400) means the monthly video allowance is used up,
+counting the clips still rendering; `render_failed` (502) is the model returning nothing, and
+nothing is stored; `store_failed` (502) means it was drawn but could not be filed.
+
+`check_media_job` reads those jobs back, newest first. Required: `slug`; optional `job_id` for
+one of them. Each row carries `status` (`rendering`, `done`, `failed` or `expired`), `error` when
+it failed, and `media_id` once the clip is in the library — that id is what `create_post` takes
+as `media_ids`. It calls no model and spends no credits, so poll it rather than guessing.
 
 `create_post` stores copy **you** wrote: Anomalia calls no model and spends no credits. It does
 not publish and does not schedule — `scheduled_for` is the proposed calendar time and stays a

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -26,7 +26,9 @@ import {
   SAVE_WEEK_SEEDS,
 } from './plans';
 import {
+  CHECK_MEDIA_JOB,
   CREATE_POST,
+  GENERATE_MEDIA,
   GET_CALENDAR,
   GET_POST,
   IMPORT_MEDIA_URL,
@@ -148,6 +150,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   BILLING_PORTAL_LINK,
   CHECKOUT_LINK,
   CHECK_CONTENT,
+  CHECK_MEDIA_JOB,
   CREATE_POST,
   CREATE_PRODUCT,
   CREATE_SHARE,
@@ -158,6 +161,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   DIAGNOSE_BRAND,
   DIAGNOSE_RADAR,
   DISCARD_PLAN,
+  GENERATE_MEDIA,
   GEO_ACTION,
   GET_ADS,
   GET_ANALYTICS,
@@ -257,7 +261,9 @@ export {
   ADS_ACTION,
   ADS_REMIX,
   CHECK_CONTENT,
+  CHECK_MEDIA_JOB,
   CREATE_POST,
+  GENERATE_MEDIA,
   GET_ARTICLE,
   GET_AUDIT_FINDINGS,
   GET_CALENDAR,
@@ -416,6 +422,7 @@ export type {
 export { KIT_FORMATS } from './creation-kit';
 export type { GetCreationKitInput, GetCreationKitResult } from './creation-kit';
 export type { CreatePostInput, CreatePostResult } from './posts';
+export { MAX_MEDIA_ALTERNATIVES } from './posts';
 export {
   APPROVE_PLAN,
   DISCARD_PLAN,

--- a/packages/api-contracts/src/posts.ts
+++ b/packages/api-contracts/src/posts.ts
@@ -281,3 +281,92 @@ export const IMPORT_MEDIA_URL = {
   ],
   destructive: false
 } satisfies BrandEndpoint;
+
+/**
+ * Un tetto solo per le alternative, non due che divergono: lo schema rifiuta oltre questo numero,
+ * quindi il server non ha una seconda soglia da tenere allineata. È lo stesso ceiling che la
+ * pagina Media generator applica alle sue varianti — ogni alternativa è un render pagato.
+ */
+export const MAX_MEDIA_ALTERNATIVES = 4;
+
+const GeneratedMediaSchema = z.object({
+  id: z.string(),
+  kind: z.string(),
+  mime: z.string().nullable(),
+  width: z.number().nullable(),
+  height: z.number().nullable(),
+  signed_url: z.string().nullable()
+});
+
+export const GENERATE_MEDIA = {
+  tool: 'generate_media',
+  title: 'Generate media into the library',
+  description:
+    'Generate a new image or video into the brand media library, then pass the id it returns as ' +
+    'media_ids on create_post. THIS SPENDS CREDITS: every image is a paid render and every video ' +
+    'is a paid clip, so ask for what you need and no more. It creates nothing in the calendar — ' +
+    'generate alternatives, look at them with list_media, and attach only the one you keep. ' +
+    'Images come back ready, up to ' + MAX_MEDIA_ALTERNATIVES + ' per call. A video takes minutes: ' +
+    'it comes back as a job_id with status rendering, and check_media_job says when it landed — ' +
+    'do not call this again for the same clip while one is still rendering.',
+  method: 'POST',
+  pathUnderBrand: '/media/generate',
+  input: z
+    .object({
+      prompt: z.string().min(1).describe('What the image or video should show'),
+      kind: z.enum(['image', 'video']).optional().describe('Defaults to image'),
+      count: z.coerce
+        .number()
+        .int()
+        .min(1)
+        .max(MAX_MEDIA_ALTERNATIVES)
+        .optional()
+        .describe(
+          'How many alternatives to draw, images only, 1-' + MAX_MEDIA_ALTERNATIVES +
+            '. Each one bills a render. Defaults to 1.'
+        ),
+      aspect_ratio: z.enum(['1:1', '4:5', '9:16', '16:9']).optional(),
+      title: z.string().optional().describe('The name the asset carries in the library')
+    })
+    .strict(),
+  output: z.object({
+    ok: z.literal(true),
+    status: z.enum(['ready', 'rendering']),
+    media: z.array(GeneratedMediaSchema),
+    job_id: z.string().nullable()
+  }),
+  failures: [
+    { error: 'credits_exhausted', status: 402 },
+    { error: 'video_budget_exhausted', status: 400 },
+    { error: 'render_failed', status: 502 },
+    { error: 'store_failed', status: 502 }
+  ],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const CHECK_MEDIA_JOB = {
+  tool: 'check_media_job',
+  title: 'Check a media generation job',
+  description:
+    'Where the videos generate_media started have got to, newest first. status is rendering while ' +
+    'the clip is being made, done once it is in the library — and then media_id is the id ' +
+    'create_post accepts as media_ids. failed says why. Calls no model and spends no credits.',
+  method: 'GET',
+  pathUnderBrand: '/media/generate',
+  input: z
+    .object({ job_id: z.string().optional().describe('One job; omit for the brand\'s recent ones') })
+    .strict(),
+  output: z.object({
+    jobs: z.array(
+      z.object({
+        id: z.string(),
+        status: z.string(),
+        media_id: z.string().nullable(),
+        error: z.string().nullable(),
+        submitted_at: z.string().nullable()
+      })
+    )
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/packages/api-contracts/src/posts.ts
+++ b/packages/api-contracts/src/posts.ts
@@ -171,7 +171,7 @@ export const RENDER_POST = {
     z.object({ ok: z.literal(true), url: z.string().nullable(), error: z.string().nullable() }),
     z.object({ error: z.string(), url: z.string() })
   ]),
-  failures: [],
+  failures: [{ error: 'credits_exhausted', status: 402 }],
   destructive: false
 } satisfies BrandEndpoint;
 

--- a/packages/api-contracts/src/search.ts
+++ b/packages/api-contracts/src/search.ts
@@ -25,7 +25,7 @@ export const SEO_ACTION = {
     articleId: z.string().optional(),
     techScore: z.number().nullable().optional()
   }),
-  failures: [],
+  failures: [{ error: 'credits_exhausted', status: 402 }],
   destructive: false
 } satisfies BrandEndpoint;
 
@@ -42,7 +42,7 @@ export const GEO_ACTION = {
     shareOfVoice: z.number().optional(),
     generated: z.number().optional()
   }),
-  failures: [],
+  failures: [{ error: 'credits_exhausted', status: 402 }],
   destructive: false
 } satisfies BrandEndpoint;
 
@@ -54,6 +54,6 @@ export const REFRESH_KEYWORDS = {
   pathUnderBrand: '/keywords',
   input: z.object({}).strict(),
   output: z.object({ ok: z.literal(true), keywords: z.number() }),
-  failures: [],
+  failures: [{ error: 'credits_exhausted', status: 402 }],
   destructive: false
 } satisfies BrandEndpoint;

--- a/packages/api-contracts/src/studio.ts
+++ b/packages/api-contracts/src/studio.ts
@@ -323,7 +323,7 @@ export const RESEARCH_COMPETITORS = {
   pathUnderBrand: '/studio/competitors/research',
   input: z.object({}).strict(),
   output: z.object({ ok: z.literal(true), found: z.number(), added: z.number() }),
-  failures: [],
+  failures: [{ error: 'credits_exhausted', status: 402 }],
   destructive: false,
   openWorld: true
 } satisfies BrandEndpoint;

--- a/src/lib/content/changelog/2026-09-04-generate-media-without-a-post.ts
+++ b/src/lib/content/changelog/2026-09-04-generate-media-without-a-post.ts
@@ -1,0 +1,11 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-04',
+  title: 'Your agent can make images and videos without touching the calendar',
+  items: [
+    'Claude, ChatGPT and Cursor can now ask Anomalia for a new image or video straight into your media library — no draft post to create, and none to delete afterwards.',
+    'Try up to four visual directions in one go, look at them, and publish only the one you keep.',
+    'Videos take minutes, so they come back as a job your agent can check on instead of a call that hangs.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/brand-media.ts
+++ b/src/lib/server/brand-media.ts
@@ -789,7 +789,15 @@ export const publishLibraryImageAsPostMedia = (
  */
 export async function saveRenderedVideoToLibrary(
   supabase: SupabaseClient,
-  opts: { brandId: string; userId: string; url: string; title: string; durationSeconds?: number }
+  opts: {
+    brandId: string;
+    userId: string;
+    url: string;
+    title: string;
+    durationSeconds?: number;
+    /** Da dove viene il clip — l'id del lavoro, per chi dovra' ritrovare l'asset che ne e' uscito. */
+    sourceRef?: string;
+  }
 ): Promise<{ mediaId: string } | { error: string }> {
   const res = await fetch(opts.url);
   if (!res.ok) return { error: `could not read the rendered clip (${res.status})` };
@@ -811,7 +819,8 @@ export async function saveRenderedVideoToLibrary(
     durationSeconds: opts.durationSeconds,
     fileName: storagePath.split('/').pop() ?? 'generated.mp4',
     title: opts.title,
-    source: 'generate'
+    source: 'generate',
+    sourceRef: opts.sourceRef ?? null
   });
   if (error || !row) {
     swallow('rendered clip not registered in the library', error ?? 'insert returned no row');

--- a/src/lib/server/media-generate.ts
+++ b/src/lib/server/media-generate.ts
@@ -1,0 +1,267 @@
+/**
+ * Generare verso la LIBRERIA del brand, non verso un post.
+ *
+ *   genera → l'asset entra in brand_media → create_post lo attacca con media_ids
+ *
+ * L'ultimo passo esisteva già; mancava il primo, e senza di lui un agente esterno doveva creare
+ * un post finto in calendario per ottenere un'immagine — poi cancellarlo. Tre direzioni visive
+ * erano tre post da buttare, e l'asset nasceva attaccato a un post invece che riutilizzabile.
+ *
+ * Il vincolo del post era cablaggio, non un vincolo vero: `renderPostImage` prende una stringa, e
+ * la coda `video_renders` accetta `post_id` nullo da sempre. Qui si usa quello che c'era.
+ *
+ * Immagine e video hanno due tempi diversi e quindi due forme diverse:
+ *
+ *   immagine  →  sincrona, ~10s   →  { status: 'ready',     media: [...] }
+ *   video     →  minuti           →  { status: 'rendering', jobId }  → check_media_job
+ *
+ * Aspettare un video non è un'opzione: il poll di kie arriva a 600s contro un muro di funzione a
+ * 300s, quindi chi aspetta muore sempre a metà. È il reconciler del cron a finirlo.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { insertBrandMedia, storeBrandMediaBytes, probeImageDimensions } from '$lib/server/brand-media';
+import { signKnowledgePaths } from '$lib/server/media-archive';
+import { markImage, DIGITAL_SOURCE_TYPE } from '$lib/server/content-credentials';
+import type { AspectRatio } from '$lib/server/content-preview';
+
+export type GeneratedMedia = {
+  id: string;
+  kind: string;
+  mime: string | null;
+  width: number | null;
+  height: number | null;
+  signed_url: string | null;
+};
+
+export type GenerateMediaOpts = {
+  brandId: string;
+  userId: string;
+  prompt: string;
+  kind?: 'image' | 'video';
+  count?: number;
+  aspectRatio?: AspectRatio;
+  title?: string;
+};
+
+export type GenerateMediaResult =
+  | { ok: true; status: 'ready'; media: GeneratedMedia[]; jobId: null }
+  | { ok: true; status: 'rendering'; media: []; jobId: string }
+  | { ok: false; error: 'render_failed' | 'store_failed' | 'video_budget_exhausted' };
+
+const IMAGE_MIME = 'image/png';
+
+function dataUrlBytes(dataUrl: string): { bytes: Buffer; mime: string } | null {
+  const [head, base64] = dataUrl.split(',');
+  if (!base64) return null;
+
+  return { bytes: Buffer.from(base64, 'base64'), mime: head?.match(/data:([^;]+)/)?.[1] ?? IMAGE_MIME };
+}
+
+/**
+ * Un'immagine generata finisce nel bucket privato della libreria, non fra i media pubblici dei
+ * post: è materiale del brand, riutilizzabile, e nessuno deve poterla leggere senza una firma.
+ */
+async function depositImage(
+  supabase: SupabaseClient,
+  opts: GenerateMediaOpts,
+  dataUrl: string
+): Promise<GeneratedMedia | null> {
+  const decoded = dataUrlBytes(dataUrl);
+  if (!decoded) return null;
+
+  // Marcata sintetica prima di toccare lo storage: un'immagine di modello che gira senza la sua
+  // provenienza è un problema che non si ripara a valle.
+  const bytes = await markImage(decoded.bytes, decoded.mime, DIGITAL_SOURCE_TYPE.synthetic);
+  const ext = decoded.mime.includes('jpeg') ? 'jpg' : decoded.mime.includes('webp') ? 'webp' : 'png';
+  const fileName = `generated-${crypto.randomUUID()}.${ext}`;
+  const storagePath = `${opts.userId}/${opts.brandId}/media/${fileName}`;
+
+  const stored = await storeBrandMediaBytes(supabase, storagePath, bytes, decoded.mime);
+  if (stored.error) return null;
+
+  const { width, height } = await probeImageDimensions(bytes);
+  const { row } = await insertBrandMedia(supabase, {
+    brandId: opts.brandId,
+    userId: opts.userId,
+    storagePath,
+    fileName,
+    mime: decoded.mime,
+    bytes: bytes.length,
+    width,
+    height,
+    source: 'generate',
+    title: opts.title?.trim() || opts.prompt.slice(0, 80)
+  });
+  if (!row) return null;
+
+  const signed = await signKnowledgePaths(supabase, [storagePath]).catch(() => new Map<string, string>());
+
+  return {
+    id: row.id,
+    kind: row.kind,
+    mime: decoded.mime,
+    width,
+    height,
+    signed_url: signed.get(storagePath) ?? null
+  };
+}
+
+async function generateImages(
+  supabase: SupabaseClient,
+  opts: GenerateMediaOpts
+): Promise<GenerateMediaResult> {
+  const [{ renderPostImage }, { imageModelFor, imageRefineModelFor }] = await Promise.all([
+    import('$lib/server/content-preview'),
+    import('$lib/image-models')
+  ]);
+
+  const { data: brand } = await supabase
+    .from('brands')
+    .select('content_prefs')
+    .eq('id', opts.brandId)
+    .maybeSingle();
+  const prefs = (brand?.content_prefs ?? {}) as Record<string, unknown>;
+
+  const media: GeneratedMedia[] = [];
+  for (let i = 0; i < (opts.count ?? 1); i++) {
+    // Il primo argomento è morto da quando renderPostImage costruisce il proprio client: lo
+    // dichiara `void ai` e ogni altro chiamante gli passa null allo stesso modo.
+    const dataUrl = await renderPostImage(null as never, opts.prompt, {
+      model: imageModelFor(prefs),
+      refineModel: imageRefineModelFor(prefs),
+      aspectRatio: opts.aspectRatio
+    }).catch(() => undefined);
+    if (!dataUrl) break;
+
+    const deposited = await depositImage(supabase, opts, dataUrl);
+    if (!deposited) return { ok: false, error: 'store_failed' };
+
+    media.push(deposited);
+  }
+
+  // Nessuna alternativa prodotta è un fallimento, non un successo vuoto: chi legge `ok` deve poter
+  // credere che qualcosa esista.
+  if (!media.length) return { ok: false, error: 'render_failed' };
+
+  return { ok: true, status: 'ready', media, jobId: null };
+}
+
+/**
+ * 4:5 è un formato da fotografia e nessun modello video lo accetta: passarlo rimappato su un altro
+ * sarebbe consegnare una clip con un taglio che nessuno ha chiesto. Qui cade, e vale il default.
+ */
+const VIDEO_ASPECTS = ['1:1', '9:16', '16:9'] as const;
+
+function videoAspect(ratio?: AspectRatio) {
+  return VIDEO_ASPECTS.find((a) => a === ratio);
+}
+
+async function startVideo(opts: GenerateMediaOpts): Promise<GenerateMediaResult> {
+  const [{ createAdminClient }, { countOutstandingVideoRenders, submitAndTrackVideoRender }] =
+    await Promise.all([
+      import('$lib/server/supabase-admin'),
+      import('$lib/server/video-render-queue')
+    ]);
+  const admin = createAdminClient();
+
+  const { data: brand } = await admin
+    .from('brands')
+    .select('plan, timezone, content_prefs')
+    .eq('id', opts.brandId)
+    .maybeSingle();
+  const prefs = (brand?.content_prefs ?? {}) as Record<string, string | number | null>;
+
+  const { remaining } = await import('$lib/server/usage');
+  const budget = await remaining(admin, opts.brandId, brand?.plan, brand?.timezone ?? 'Europe/Rome');
+
+  // I render in volo contano sull'allowance: il numero mensile si addebita quando il clip atterra,
+  // e guardare solo `usage` lascerebbe spendere lo stesso budget più volte di fila.
+  const inFlight = await countOutstandingVideoRenders(admin, opts.brandId);
+  if (budget.videos - inFlight <= 0) return { ok: false, error: 'video_budget_exhausted' };
+
+  const submitted = await submitAndTrackVideoRender({
+    admin,
+    brandId: opts.brandId,
+    userId: opts.userId,
+    postId: null,
+    threadId: null,
+    // `imagePrompt` è la SCENA — cosa si vede. `render.prompt` sarebbe il brief di regia (camera,
+    // movimento, energia) e resta vuoto apposta: ripeterci dentro la stessa stringa la
+    // duplicherebbe nel prompt finale, dove scena e regia vengono concatenate.
+    imagePrompt: opts.prompt,
+    render: {
+      aspectRatio: videoAspect(opts.aspectRatio),
+      duration: prefs.videoDuration as number | undefined,
+      instructions: prefs.videoInstructions as string | null | undefined,
+      resolution: prefs.videoResolution as string | null | undefined,
+      model: prefs.videoModel as string | null | undefined
+    }
+  });
+  if (!submitted) return { ok: false, error: 'render_failed' };
+
+  const { data: job } = await admin
+    .from('video_renders')
+    .select('id')
+    .eq('task_id', submitted.taskId)
+    .maybeSingle();
+  if (!job) return { ok: false, error: 'store_failed' };
+
+  return { ok: true, status: 'rendering', media: [], jobId: job.id as string };
+}
+
+export async function generateBrandMedia(
+  supabase: SupabaseClient,
+  opts: GenerateMediaOpts
+): Promise<GenerateMediaResult> {
+  const { withBrandContext } = await import('$lib/server/ai-log');
+
+  return withBrandContext(opts.brandId, () =>
+    opts.kind === 'video' ? startVideo(opts) : generateImages(supabase, opts)
+  );
+}
+
+export type MediaJob = {
+  id: string;
+  status: string;
+  media_id: string | null;
+  error: string | null;
+  submitted_at: string | null;
+};
+
+const JOBS_PAGE = 20;
+
+/**
+ * I lavori di questo brand, e SOLO di questo brand: l'id arriva da `loadBrandForUser`, mai dal
+ * chiamante, quindi un job_id indovinato di un altro brand non trova niente.
+ */
+export async function listMediaJobs(
+  supabase: SupabaseClient,
+  brandId: string,
+  jobId?: string
+): Promise<MediaJob[]> {
+  let query = supabase
+    .from('video_renders')
+    .select('id, status, error, submitted_at')
+    .eq('brand_id', brandId)
+    .is('post_id', null)
+    .order('submitted_at', { ascending: false })
+    .limit(JOBS_PAGE);
+  if (jobId) query = query.eq('id', jobId);
+
+  const { data } = await query;
+  const rows = (data ?? []) as Array<Omit<MediaJob, 'media_id'>>;
+  if (!rows.length) return [];
+
+  // L'asset depositato porta l'id del job in `source_ref`: è così che un lavoro finito diventa un
+  // media_id che create_post accetta, senza una colonna in più su video_renders.
+  const { data: assets } = await supabase
+    .from('brand_media')
+    .select('id, source_ref')
+    .eq('brand_id', brandId)
+    .in('source_ref', rows.map((r) => r.id));
+  const byJob = new Map(
+    ((assets ?? []) as Array<{ id: string; source_ref: string }>).map((a) => [a.source_ref, a.id])
+  );
+
+  return rows.map((r) => ({ ...r, media_id: byJob.get(r.id) ?? null }));
+}

--- a/src/lib/server/video-render-queue.test.ts
+++ b/src/lib/server/video-render-queue.test.ts
@@ -18,6 +18,17 @@ vi.mock('$lib/server/ai-log', () => ({
 	withBrandContext: <T>(_brandId: string, fn: () => T) => fn()
 }));
 
+const saveRenderedVideoToLibrary = vi.fn();
+const addUsage = vi.fn();
+
+vi.mock('$lib/server/brand-media', () => ({
+	saveRenderedVideoToLibrary: (...args: unknown[]) => saveRenderedVideoToLibrary(...args)
+}));
+vi.mock('$lib/server/usage', () => ({
+	addUsage: (...args: unknown[]) => addUsage(...args),
+	monthKey: () => '2026-09'
+}));
+
 /** In-memory tables where a conditional UPDATE really re-checks the row it matched. */
 function makeDb(seed: Record<string, Row[]>) {
 	const tables: Record<string, Row[]> = {};
@@ -102,6 +113,10 @@ async function reconcile(client: unknown) {
 
 beforeEach(() => {
 	finishVideoRender.mockReset();
+	saveRenderedVideoToLibrary.mockReset();
+	saveRenderedVideoToLibrary.mockResolvedValue({ mediaId: 'media-1' });
+	addUsage.mockReset();
+	addUsage.mockResolvedValue(undefined);
 });
 
 describe('reconcileVideoRenders', () => {
@@ -312,6 +327,65 @@ describe('reconcileVideoRenders', () => {
 
 		expect(tables.video_renders[0].status).toBe('rendering');
 		expect(tables.video_renders[0].error).toBe('storage unreachable');
+	});
+
+	// Un clip generato VERSO LA LIBRERIA non ha un post a cui attaccarsi: senza questo ramo
+	// finirebbe `done` con la sua url e nessun id che create_post sappia accettare — pagato e
+	// irraggiungibile. `source_ref` porta l'id del lavoro, ed è così che check_media_job lo ritrova.
+	it('deposita in libreria un clip che non appartiene a nessun post', async () => {
+		finishVideoRender.mockResolvedValue({
+			status: 'done',
+			url: 'https://cdn/clip.mp4',
+			durationSeconds: 12,
+			resolution: '720p'
+		});
+		const { tables, client } = makeDb({ video_renders: [renderRow({ post_id: null })] });
+
+		expect(await reconcile(client)).toMatchObject({ done: 1 });
+
+		expect(saveRenderedVideoToLibrary).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				brandId: 'brand-1',
+				userId: 'user-1',
+				url: 'https://cdn/clip.mp4',
+				sourceRef: 'render-1'
+			})
+		);
+		expect(tables.video_renders[0].status).toBe('done');
+	});
+
+	// L'allocazione mensile si contava solo dentro il ramo del post, e questo apriva un arbitraggio:
+	// genero in libreria, attacco dopo, e il video non conta mai. Un video è un video.
+	it('conta il video sull allocazione mensile anche senza un post', async () => {
+		finishVideoRender.mockResolvedValue({
+			status: 'done',
+			url: 'https://cdn/clip.mp4',
+			durationSeconds: 12,
+			resolution: '720p'
+		});
+		const { client } = makeDb({ video_renders: [renderRow({ post_id: null })] });
+
+		await reconcile(client);
+
+		expect(addUsage).toHaveBeenCalledWith(expect.anything(), 'brand-1', '2026-09', { videos: 1 });
+	});
+
+	it('non deposita in libreria un clip che un post ha gia preso', async () => {
+		finishVideoRender.mockResolvedValue({
+			status: 'done',
+			url: 'https://cdn/clip.mp4',
+			durationSeconds: 12,
+			resolution: '720p'
+		});
+		const { client } = makeDb({
+			video_renders: [renderRow()],
+			posts: [{ id: 'post-1' }]
+		});
+
+		await reconcile(client);
+
+		expect(saveRenderedVideoToLibrary).not.toHaveBeenCalled();
 	});
 });
 

--- a/src/lib/server/video-render-queue.ts
+++ b/src/lib/server/video-render-queue.ts
@@ -213,13 +213,65 @@ async function settle(
  * marked done whose post never got the url is a clip that exists, is paid for, and is reachable by
  * nothing — and no query in this module looks at `done` rows again.
  */
+/**
+ * Il clip che nessun post reclama va nella LIBRERIA del brand, o resta un file pagato che nessun
+ * tool sa raggiungere: `create_post` accetta `media_ids`, e questo è l'id che glielo procura.
+ * `source_ref` porta l'id del lavoro, così `check_media_job` ritrova l'asset senza una colonna in
+ * più su `video_renders`.
+ */
+async function applyToLibrary(
+	admin: SupabaseClient,
+	row: VideoRenderRow,
+	url: string
+): Promise<boolean> {
+	const { saveRenderedVideoToLibrary } = await import('$lib/server/brand-media');
+	const saved = await saveRenderedVideoToLibrary(admin, {
+		brandId: row.brand_id,
+		userId: row.user_id,
+		url,
+		title: row.prompt?.trim().slice(0, 80) || 'Generated clip',
+		durationSeconds: row.duration_seconds ?? undefined,
+		sourceRef: row.id
+	});
+	if ('error' in saved) {
+		console.error(`[video-render] clip ${url} not registered in the library:`, saved.error);
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * L'allocazione mensile la consuma un clip che ATTERRA, ovunque atterri — su un post o in
+ * libreria. Contarla solo nel ramo del post apriva un arbitraggio: genero in libreria, attacco
+ * dopo, e il video non conta mai. Un video è un video.
+ *
+ * Addebitare all'invio invece — come facevano i chiamanti, perché era lì che un clip esisteva —
+ * lascerebbe che dieci render rifiutati si mangino il margine di un mese.
+ */
+async function chargeMonthlyVideo(admin: SupabaseClient, row: VideoRenderRow): Promise<void> {
+	try {
+		const { addUsage, monthKey } = await import('$lib/server/usage');
+		const { data: brand } = await admin
+			.from('brands')
+			.select('timezone')
+			.eq('id', row.brand_id)
+			.maybeSingle();
+		await addUsage(admin, row.brand_id, monthKey((brand?.timezone as string) ?? 'Europe/Rome'), {
+			videos: 1
+		});
+	} catch (e) {
+		console.error('[video-render] usage accounting failed:', e);
+	}
+}
+
 async function applyToPost(
 	admin: SupabaseClient,
 	row: VideoRenderRow,
 	url: string,
 	thumbnailUrl?: string
 ): Promise<boolean> {
-	if (!row.post_id) return true;
+	if (!row.post_id) return applyToLibrary(admin, row, url);
 	// `.select('id')` so a zero-row match is visible: an UPDATE that hits nothing reports no error,
 	// so without this an orphaned render — post insert rolled back, post since deleted — would be
 	// billed, settled `done`, and reported to the user as attached to a post that does not exist.
@@ -247,23 +299,6 @@ async function applyToPost(
 		// Nothing to attach to and nothing to retry — the clip is stored, but its post is gone.
 		console.error(`[video-render] post ${row.post_id} no longer exists; clip ${url} is orphaned`);
 		return false;
-	}
-
-	// Only a clip that actually landed consumes the brand's monthly video budget. Charging at
-	// submit time — as the callers used to, because that was when a clip existed — would let ten
-	// rejected renders eat a month's headroom.
-	try {
-		const { addUsage, monthKey } = await import('$lib/server/usage');
-		const { data: brand } = await admin
-			.from('brands')
-			.select('timezone')
-			.eq('id', row.brand_id)
-			.maybeSingle();
-		await addUsage(admin, row.brand_id, monthKey((brand?.timezone as string) ?? 'Europe/Rome'), {
-			videos: 1
-		});
-	} catch (e) {
-		console.error('[video-render] usage accounting failed:', e);
 	}
 
 	return true;
@@ -448,6 +483,7 @@ export async function reconcileVideoRenders(
 					.then(undefined, () => {});
 				continue;
 			}
+			await chargeMonthlyVideo(admin, raw);
 			await settle(admin, raw, { status: 'done', media_url: outcome.url });
 			await notifyThread(admin, raw, "the clip is ready and attached to the post", origin);
 			done += 1;

--- a/src/routes/api/v1/brands/[slug]/media/generate/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/media/generate/+server.ts
@@ -1,0 +1,59 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { authenticate, loadBrandForUser, gateAiAction } from '$lib/server/cli-auth';
+import { generateBrandMedia, listMediaJobs } from '$lib/server/media-generate';
+import { CHECK_MEDIA_JOB, GENERATE_MEDIA, statusForFailure } from '@anomalia/api-contracts';
+
+// Quattro immagini di fila stanno sotto il minuto, ma non sotto il default.
+export const config = { maxDuration: 300 };
+
+export const GET: RequestHandler = async ({ request, params, url }) => {
+  const { supabase, error, apiKey } = await authenticate(request);
+  if (error) return error;
+
+  const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
+  if (brandError) return brandError;
+
+  const parsed = CHECK_MEDIA_JOB.input.safeParse(Object.fromEntries(url.searchParams));
+  if (!parsed.success) {
+    return json({ error: 'invalid_input', details: parsed.error.issues }, { status: 400 });
+  }
+
+  return json({ jobs: await listMediaJobs(supabase, brand.id, parsed.data.job_id) });
+};
+
+export const POST: RequestHandler = async ({ request, params }) => {
+  const { supabase, user, error, apiKey } = await authenticate(request);
+  if (error) return error;
+
+  const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
+  if (brandError) return brandError;
+
+  // Prima il gate, poi il corpo: una chiave di sola lettura e un brand senza crediti si fermano
+  // qui, prima che qualcosa costi.
+  const gate = await gateAiAction(brand, apiKey);
+  if (gate) return gate;
+
+  const parsed = GENERATE_MEDIA.input.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return json({ error: 'invalid_input', details: parsed.error.issues }, { status: 400 });
+  }
+
+  const result = await generateBrandMedia(supabase, {
+    // Il brand è quello risolto dallo slug, mai un id che arriva dal corpo: è il confine fra
+    // inquilini, e passa da qui una volta sola.
+    brandId: brand.id,
+    userId: user.id,
+    prompt: parsed.data.prompt,
+    kind: parsed.data.kind,
+    count: parsed.data.count,
+    aspectRatio: parsed.data.aspect_ratio,
+    title: parsed.data.title
+  });
+
+  if (!result.ok) {
+    return json({ error: result.error }, { status: statusForFailure(GENERATE_MEDIA, result.error) });
+  }
+
+  return json({ ok: true, status: result.status, media: result.media, job_id: result.jobId });
+};

--- a/src/routes/api/v1/brands/[slug]/media/generate/server.generate.test.ts
+++ b/src/routes/api/v1/brands/[slug]/media/generate/server.generate.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * QUESTA È LA PRIMA ROTTA A PAGAMENTO CHE PRODUCE UN ASSET SENZA UN POST, quindi i test che
+ * contano sono i rifiuti: un render che parte quando non doveva è denaro speso, non un bug da
+ * correggere dopo. Il percorso felice ha un test solo; i quattro rifiuti ne hanno uno ciascuno.
+ */
+
+const generateBrandMedia = vi.fn();
+
+vi.mock('$lib/server/cli-auth', () => ({
+  authenticate: vi.fn(),
+  loadBrandForUser: vi.fn(),
+  gateAiAction: vi.fn()
+}));
+vi.mock('$lib/server/media-generate', () => ({
+  generateBrandMedia: (...args: unknown[]) => generateBrandMedia(...args),
+  listMediaJobs: vi.fn()
+}));
+
+import { POST } from './+server';
+import { authenticate, loadBrandForUser, gateAiAction } from '$lib/server/cli-auth';
+
+const GENERATED = {
+  id: 'media-1',
+  kind: 'image',
+  mime: 'image/png',
+  width: 1080,
+  height: 1350,
+  signed_url: 'https://signed.test/a.png'
+};
+
+function call(body: unknown, slug = 'demo') {
+  const url = new URL(`https://anomalia.test/api/v1/brands/${slug}/media/generate`);
+
+  return (POST as (event: unknown) => Promise<Response>)({
+    request: new Request(url, { method: 'POST', body: JSON.stringify(body) }),
+    params: { slug },
+    url
+  }).then(async (res) => ({ res, body: await res.json() }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(authenticate).mockResolvedValue({
+    supabase: {},
+    user: { id: 'user-1' },
+    apiKey: undefined,
+    error: null
+  } as never);
+  vi.mocked(loadBrandForUser).mockResolvedValue({
+    brand: { id: 'brand-1', slug: 'demo' },
+    error: null
+  } as never);
+  vi.mocked(gateAiAction).mockResolvedValue(undefined as never);
+  generateBrandMedia.mockResolvedValue({ ok: true, status: 'ready', media: [GENERATED], jobId: null });
+});
+
+describe('POST /api/v1/brands/:slug/media/generate', () => {
+  it('deposita in libreria e restituisce l id che create_post accetta in media_ids', async () => {
+    const { res, body } = await call({ prompt: 'un banco di lavoro in noce' });
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ ok: true, status: 'ready', media: [GENERATED], job_id: null });
+  });
+
+  it('un brand senza crediti non genera: il gate risponde e il modello non parte', async () => {
+    vi.mocked(gateAiAction).mockResolvedValue(
+      new Response(JSON.stringify({ error: 'credits_exhausted' }), { status: 402 }) as never
+    );
+
+    const { res, body } = await call({ prompt: 'qualunque cosa' });
+
+    expect(res.status).toBe(402);
+    expect(body.error).toBe('credits_exhausted');
+    expect(generateBrandMedia).not.toHaveBeenCalled();
+  });
+
+  it('una chiave di sola lettura non genera', async () => {
+    // gateAiAction rifiuta la chiave read-only prima ancora di guardare i crediti.
+    vi.mocked(gateAiAction).mockResolvedValue(
+      new Response(JSON.stringify({ error: 'API key is read-only' }), { status: 403 }) as never
+    );
+
+    const { res, body } = await call({ prompt: 'qualunque cosa' });
+
+    expect(res.status).toBe(403);
+    expect(body.error).toBe('API key is read-only');
+    expect(generateBrandMedia).not.toHaveBeenCalled();
+  });
+
+  it('il tetto sulle alternative è applicato: oltre il massimo si rifiuta senza spendere', async () => {
+    const { res, body } = await call({ prompt: 'tre direzioni visive', count: 5 });
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('invalid_input');
+    expect(generateBrandMedia).not.toHaveBeenCalled();
+  });
+
+  it('l asset appartiene al brand che ha chiamato, non a quello nominato nel corpo', async () => {
+    // `brand_id` nel corpo non è un campo del contratto: lo schema strict lo rifiuta invece di
+    // lasciarlo arrivare fino alla insert, dove sarebbe un asset depositato nel brand sbagliato.
+    const { res } = await call({ prompt: 'x', brand_id: 'brand-di-qualcun-altro' });
+
+    expect(res.status).toBe(400);
+    expect(generateBrandMedia).not.toHaveBeenCalled();
+  });
+
+  it('genera per il brand risolto dallo slug, mai per un id che arriva da fuori', async () => {
+    await call({ prompt: 'un banco di lavoro in noce' });
+
+    expect(generateBrandMedia).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ brandId: 'brand-1', userId: 'user-1' })
+    );
+  });
+
+  it('un brand che il chiamante non può vedere si ferma prima di generare', async () => {
+    vi.mocked(loadBrandForUser).mockResolvedValue({
+      error: new Response(JSON.stringify({ error: 'Brand not found' }), { status: 404 })
+    } as never);
+
+    const { res } = await call({ prompt: 'x' }, 'brand-altrui');
+
+    expect(res.status).toBe(404);
+    expect(gateAiAction).not.toHaveBeenCalled();
+    expect(generateBrandMedia).not.toHaveBeenCalled();
+  });
+
+  it('un video torna come lavoro, non come attesa', async () => {
+    generateBrandMedia.mockResolvedValue({
+      ok: true,
+      status: 'rendering',
+      media: [],
+      jobId: 'job-1'
+    });
+
+    const { res, body } = await call({ prompt: 'un carrello lento sul prodotto', kind: 'video' });
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ ok: true, status: 'rendering', media: [], job_id: 'job-1' });
+  });
+
+  it('un fallimento del render non finge un successo', async () => {
+    generateBrandMedia.mockResolvedValue({ ok: false, error: 'render_failed' });
+
+    const { res, body } = await call({ prompt: 'x' });
+
+    expect(res.status).toBe(502);
+    expect(body).toEqual({ error: 'render_failed' });
+  });
+});

--- a/src/routes/api/v1/brands/[slug]/registry.test.ts
+++ b/src/routes/api/v1/brands/[slug]/registry.test.ts
@@ -60,4 +60,24 @@ describe('BRAND_ENDPOINTS', () => {
 
     expect(wrongVerb).toEqual([]);
   });
+
+  // Un contratto che tace su `credits_exhausted` mentre la rotta lo restituisce mente a chi legge
+  // le varianti d'errore per decidere cosa fare — e `statusForFailure` degrada quel 402 a 500, che
+  // si legge come "guasto nostro" invece che "crediti finiti". Peggio di un contratto assente.
+  it('chi chiama gateAiAction dichiara credits_exhausted', () => {
+    const silent = BRAND_ENDPOINTS
+      .filter((e) => {
+        // Il gate vive sempre nell'handler che scrive: una GET condivide il file con la POST che
+        // spende, ma legge e basta. Il metodo distingue i due senza analizzare il sorgente.
+        if (e.method === 'GET') return false;
+
+        const file = join(REPO_ROOT, routeFile(e));
+        if (!existsSync(file) || !readFileSync(file, 'utf8').includes('gateAiAction')) return false;
+
+        return !e.failures.some((f) => f.error === 'credits_exhausted');
+      })
+      .map((e) => `${e.tool} -> spende crediti ma non dichiara credits_exhausted`);
+
+    expect(silent).toEqual([]);
+  });
 });


### PR DESCRIPTION
## What?

An external agent can now ask Anomalia for a **new image or video without creating a post**. Two
tools, `generate_media` and `check_media_job`, put the asset straight into the brand media library,
where `create_post` already knows how to pick it up with `media_ids`.

```
genera → l'asset entra in brand_media → create_post lo attacca con media_ids
```

The last step already existed and worked. Only the first was missing.

Also here, because it was found on the way and is small: five contracts declared no failures while
their route returns `402 credits_exhausted`. Fixed in its own commit, with a guard so the next one
can't happen.

## Why?

Of the 114 tools in the registry, none could **generate**. `render_post` is
`POST /posts/:id/render`; `regenerate_post_media` and `make_video` are the same shape;
`import_media_url` copies a file made elsewhere; `list_media` only lists. So to get one image an
external agent had to **create a calendar post first**.

Three consequences, all wrong:

1. **The calendar got dirty just to explore** — trying three visual directions meant three fake
   posts to delete afterwards.
2. **The asset was born attached to a post** instead of living in the library, where it would be
   reusable.
3. **The media generator and motion video were effectively unreachable** — and they are the moat:
   the thing a chat model cannot do on its own.

It also contradicted `docs/external-agent-plan.md`, which states *"Image generation, video
generation, rendering, audits, and other model-backed operations remain explicit paid Anomalia
capabilities"*. Capabilities declared, with no door.

## How?

**The post was wiring, not a real constraint.** The census settled it: `renderPostImage` takes a
string and nothing else; `enqueueVideoRender` has accepted a null `post_id` since it was written,
and `applyToPost` opens with `if (!row.post_id) return true;`. A production route
(`content/create-single`) already calls `submitAndTrackVideoRender` with `postId: null`. The road
was open and nobody had walked it. So this PR builds no engine — it opens a door onto the ones
that were there.

**Two waits, two shapes.** An image and a video are not waited on the same way:

```
immagine  →  sincrona, ~10s   →  { status: 'ready',     media: [...] }
video     →  minuti           →  { status: 'rendering', job_id }  → check_media_job
```

Waiting on a video was never an option to weigh: kie's poll runs to 600s against a 300s function
wall, so whoever waits dies halfway, every time. The existing `video_renders` queue and its `*/1`
cron are reused — **no new queue, no new table**.

**The only engine change is one branch in the reconciler.** When `post_id` is null the clip goes to
the library via `saveRenderedVideoToLibrary`, with `sourceRef` set to the job id. That is how
`check_media_job` finds the asset again **without a new column**: `brand_media.source_ref` already
existed, and `source = 'generate'` was already in the CHECK constraint from
`0220_widen_source_checks.sql`. **Zero migrations.**

### A side effect that was worth it on its own

`saveRenderedVideoToLibrary` is the **only** function in the repo that files a generated video into
`brand_media`, and its only two callers were `src/lib/server/chat/job-executor.ts` and
`src/lib/agent/tools/create-content-tools.ts` — both being dismantled right now. It was about to
become dead code: the door bricked up from the inside while we were building it. It now has a
caller that survives, and the fix comes out of the design instead of being a patch applied later.

### The monthly allowance is counted either way

`addUsage({ videos: 1 })` lived **inside** the post branch. Leaving it there opened an arbitrage:
generate into the library, attach afterwards, and the video never counts. Not a theoretical defect
— it is the shortcut an attentive customer finds on their own, and they would find it before we
did. Moved into `chargeMonthlyVideo`, which runs wherever the clip lands. Still charged **on
landing** rather than on submit, so rejected renders still eat no headroom.

**This is a pricing decision, not a technical one, and it should be said out loud: from now on
videos generated into the library also consume the monthly allowance.**

### Credits and the ceiling

The path is the one the thirteen existing paid routes use — `gateAiAction` (403 read-only key, 402
no credits) then `withBrandContext`, under which every `logAiCall` accrues to the right brand. **No
`paid` flag was added to `BrandEndpoint`**: a field across 14 endpoints with one real consumer is
exactly the defensive abstraction this repo forbids.

The tool description **opens with the bill** instead of burying it — the exact inverse of
`import_media_url`, which declares that it spends nothing. If we say it there, we say it here.

The ceiling is `MAX_MEDIA_ALTERNATIVES = 4`, defined **once** in `api-contracts` and consumed by
the zod schema. One ceiling, not two that drift: the server has no second threshold to keep
aligned, because the schema refuses at the boundary. One video per call — at ~210 credits, a batch
parameter is a way to lose money to a typo.

### The contract that lied

`render_post`, `seo_action`, `geo_action`, `refresh_keywords` and `research_competitors` all call
`gateAiAction` without declaring `credits_exhausted`. An external agent reads that list to decide
what to do with an error, and `statusForFailure` degraded that 402 to **500** — which reads as "our
fault" instead of "your credits ran out".

The guard lives in `registry.test.ts`, which already inverts `pathFor` to find each route on disk:
if the file calls `gateAiAction` and the endpoint is not a GET, the contract must declare
`credits_exhausted`. GETs are excluded because the gate always sits in the writing handler —
verified on `seo`, `geo`, `keywords` and `backlinks`, where the GET only reads.

## Testing?

Negative tests were written **first** and watched fail. The four that matter, all green:

| What is refused | Test |
|---|---|
| A brand with no credits | `un brand senza crediti non genera: il gate risponde e il modello non parte` |
| A read-only key | `una chiave di sola lettura non genera` |
| The asset belongs to the calling brand | `l asset appartiene al brand che ha chiamato, non a quello nominato nel corpo` + `un brand che il chiamante non può vedere si ferma prima di generare` |
| The ceiling on alternatives | `il tetto sulle alternative è applicato: oltre il massimo si rifiuta senza spendere` |

**No paid model was ever called**: `renderPostImage` and the queue are mocked throughout. No
Docker, no dev server, no Playwright, and no real media generated.

<details>
<summary>Full run of the new tests</summary>

```
✓ .../media/generate/server.generate.test.ts > deposita in libreria e restituisce l id che create_post accetta in media_ids
✓ .../media/generate/server.generate.test.ts > un brand senza crediti non genera: il gate risponde e il modello non parte
✓ .../media/generate/server.generate.test.ts > una chiave di sola lettura non genera
✓ .../media/generate/server.generate.test.ts > il tetto sulle alternative è applicato: oltre il massimo si rifiuta senza spendere
✓ .../media/generate/server.generate.test.ts > l asset appartiene al brand che ha chiamato, non a quello nominato nel corpo
✓ .../media/generate/server.generate.test.ts > genera per il brand risolto dallo slug, mai per un id che arriva da fuori
✓ .../media/generate/server.generate.test.ts > un brand che il chiamante non può vedere si ferma prima di generare
✓ .../media/generate/server.generate.test.ts > un video torna come lavoro, non come attesa
✓ .../media/generate/server.generate.test.ts > un fallimento del render non finge un successo

✓ video-render-queue.test.ts > deposita in libreria un clip che non appartiene a nessun post
✓ video-render-queue.test.ts > conta il video sull allocazione mensile anche senza un post
✓ video-render-queue.test.ts > non deposita in libreria un clip che un post ha gia preso
```

The three reconciler tests were red before the change and are green after; the other 14 in that
file were already green and stayed green — the post path is unchanged.

</details>

<details>
<summary>The guard on the lying contracts, red before the fix</summary>

```
FAIL src/routes/api/v1/brands/[slug]/registry.test.ts > chi chiama gateAiAction dichiara credits_exhausted
+ Array [
+   "geo_action -> spende crediti ma non dichiara credits_exhausted",
+   "refresh_keywords -> spende crediti ma non dichiara credits_exhausted",
+   "render_post -> spende crediti ma non dichiara credits_exhausted",
+   "research_competitors -> spende crediti ma non dichiara credits_exhausted",
+   "seo_action -> spende crediti ma non dichiara credits_exhausted",
+ ]
```

</details>

### Required checks, all green

```
npx vitest run packages/api-contracts     →  19 files, 219 tests passed
cd cli && bun test                        →  59 pass, 0 fail
cd cli && bun run typecheck                →  exit 0
node scripts/typecheck-runtime.mjs        →  exit 0, ok (315 non-fatal ignored, same as base)
```

`node_modules` in the worktree was rebuilt entry by entry with `@anomalia/*` symlinked to the
worktree's own `packages/`, so the contract tests run against **this** branch and not the main
checkout:

```
$ node -e "console.log(require('fs').realpathSync('node_modules/@anomalia/api-contracts'))"
/Users/.../anomalia-wt/generate-to-library/packages/api-contracts
```

### Not tested, and the risk

The **real** render and the **real** clip were never executed — that costs money and the brief
forbade it. What is unverified is therefore the live behaviour of `renderPostImage` against a real
provider and the end-to-end landing of a clip through the cron. The mitigation is that neither is
new code: both are the paths the product already runs in production, reached here through the same
functions with the same arguments. What **is** new — the gate, the ceiling, the tenancy boundary,
the library branch of the reconciler and the usage move — is exactly what the tests above cover.

No browser verification: this PR adds no UI.

## Evidence

### `tools/list` through `handleMcpFetch`, before and after

Captured on the same base, before any change and after:

```
$ node -e "...diff before/after..."
before 114 after 116
ADDED  : check_media_job, generate_media
REMOVED: (none)
CHANGED: (none)
```

Not one existing tool changed shape. After rebasing onto the current `dev` the branch reports 118 —
114 + my 2 + `get_appearance` / `set_appearance`, which came from `dev`:

```
pre-rebase base: 114 -> branch after rebase: 118
mine       : check_media_job, generate_media
from dev   : get_appearance, set_appearance
removed    : (none)
```

<details>
<summary>The two new tools, field by field, as an external agent sees them</summary>

```
=== generate_media ===
title: Generate media into the library
annotations: {"readOnlyHint":false,"destructiveHint":false}
description: Generate a new image or video into the brand media library, then pass the id it
returns as media_ids on create_post. THIS SPENDS CREDITS: every image is a paid render and every
video is a paid clip, so ask for what you need and no more. It creates nothing in the calendar —
generate alternatives, look at them with list_media, and attach only the one you keep. Images come
back ready, up to 4 per call. A video takes minutes: it comes back as a job_id with status
rendering, and check_media_job says when it landed — do not call this again for the same clip
while one is still rendering.

properties: prompt (required), kind (image|video), count (integer 1..4),
            aspect_ratio (1:1|4:5|9:16|16:9), title, slug (required)
additionalProperties: false

=== check_media_job ===
title: Check a media generation job
annotations: {"readOnlyHint":true,"destructiveHint":false}
description: Where the videos generate_media started have got to, newest first. status is
rendering while the clip is being made, done once it is in the library — and then media_id is the
id create_post accepts as media_ids. failed says why. Calls no model and spends no credits.

properties: job_id, slug (required)
additionalProperties: false
```

The ceiling reads `1-4` in the description because the text interpolates
`MAX_MEDIA_ALTERNATIVES` — change the constant and the prose follows.

</details>

## Anything Else?

**Four urgent findings from the census, already relayed to the agent dismantling the chat.** One is
fixed by this PR as a side effect; the others are not mine to fix:

1. `transformVideo` (`video.ts:999`) — sole caller `src/lib/agent/tools/create-content-tools.ts:96`.
   Dies with the dismantling.
2. `saveRenderedVideoToLibrary` — **fixed here**, it now has a surviving caller.
3. `sourceToSatoriTree` (`design-render.ts:280`) — only external caller is
   `src/lib/server/chat/graphic-source-edit.ts:93`; it survives as a private function.
4. `media-generator/agent.ts:28` imports `geminiFast` from `$lib/server/chat/model`. Not a dying
   caller — a **dependency of a surviving capability**, and the kind of break that shows up at the
   first image rather than at compile time.

**Already dead, unrelated to any of this**, noted for whoever wants the deletion:
`renderGraphic` (`design-render.ts:171`, zero callers), `wrapGraphicAsComposition` (test-only),
`loadMotionTurnKit`'s export, and the stale `renderVideo` imports in
`content/create-single/+server.ts:6` and `content/generate/+server.ts:24`.

**What stays unreachable, and why:**

- **Motion video / Remotion** — wants TSX source and a `motion_videos` row, renders synchronously
  for 8 minutes, and bills sandbox seconds even when it fails. Wrong shape for an external agent.
- **UGC batch** — SSE, sliced over `chat_jobs`, up to 20 clips. A real capability, but a much
  larger job contract than this.
- **`transformVideo`** (refine / motion-control) — reachable in principle, since it takes a clip
  URL rather than a post, but its only caller is being deleted, so exposing it is a separate
  decision about whether to keep it at all.
- **`design_graphic`** — free (satori, no model), needs no post, and genuinely useful. It lives
  inside the media-generator agent loop instead of being a callable primitive. Worth its own pass.

**Two stale things spotted in passing, not touched:** `ugc-batch.ts:772-775` claims the cover runs
on "Nano Banana PRO" while `UGC_COVER_MODEL` is `gemini-3.1-flash-lite-image` (Lite) — those are
different bills, so one of the two is wrong. And `design-render.ts:265-272` has duplicated lines
that look like a bad merge which happens to still parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
