### PR TITLE
Restore the page where a customer picks a plan

### DIFF
--- a/changelog/2026-09-04-restore-activate.md
+++ b/changelog/2026-09-04-restore-activate.md
@@ -1,0 +1,85 @@
+# La pagina per pagare torna a esistere
+
+`/app/[brand]/activate` e `/app/[brand]/upgrade` non erano state cancellate: non
+sono **mai state importate**. Il commit fondativo di questo repository è la build
+aperta già esportata, e `scripts/export-oss.mjs` elenca entrambe le cartelle fra
+le esclusioni commerciali. Da allora ventisei file non-test ci puntano — nove
+`throw redirect(303, …)` lato server, nove navigazioni client, i prompt degli
+agenti — e ognuno di quei percorsi finiva in un 404.
+
+I due peggiori erano `billingPortal` e `upgrade` in `settings-actions.ts`, sui
+rami `no_customer` / `no_subscription`: esattamente chi non ha mai pagato.
+L'altro era il bottone «Choose a plan» di `/app/billing`, l'unica offerta per
+un'organizzazione senza abbonamento.
+
+## Cosa è tornato, e cosa no
+
+L'originale sta in `andreabuttarelli/021-app`. Non è un copia-incolla: il
+repository è cambiato molto in otto giorni, e metà di quel file era già morto
+prima di uscire di scena.
+
+**Il ramo di setup non è tornato.** Nell'originale `load` restituiva
+`setup: false` scritto a mano, quindi il blocco `{#if setup}` della pagina non si
+apriva mai e nessuna form puntava a `syncAccounts`, `confirmPosts`,
+`autoSchedule`, `skipSetup`, `setTimezone`. Con loro se ne vanno
+`config.maxDuration = 1800`, la chiamata sincrona a `renderVideo`,
+`publishApprovedPost`, `addUsage`, `ensureBrandProfile` / `syncBrandAccounts`. La
+domanda «quella firma è ancora quella?» non si pone: quel codice non veniva
+eseguito. Restano `load` e l'azione `checkout`.
+
+**`meta-capi.ts` non è tornato.** È attribuzione pubblicitaria, non pagamento, e
+la sua unica chiamata sulla strada dei soldi (`metaCapiPurchase`, attesa prima
+del redirect post-checkout, più due letture Stripe per ricavare l'importo) è
+proprio quella che non voglio lì: un `fetch` verso Meta senza timeout che ritarda
+l'atterraggio di chi ha appena pagato. Il pixel del browser è ancora acceso
+(`loadMetaPixel` nel layout radice) e la pagina continua a mandare
+`CompleteRegistration` con lo stesso `eventID` di prima, quindi la metà server si
+riaggiunge dopo senza toccare nient'altro. Purchase non era comunque mai stato
+tracciato dal browser: questa PR non toglie un segnale che c'era.
+
+**`upgrade/+server.ts` è stato riscritto, non riportato.** L'originale apriva una
+sessione del portale Stripe **su GET**, con un price id esplicito. Questo
+repository ha deciso il contrario due settimane fa — `workbench-paths.ts` lo
+scrive: «un click in sidebar è navigazione, non consenso a pagare» — e ha spostato
+i cambi di piano dentro il portale ospitato, dove i prezzi li configura Stripe.
+La rotta ora instrada e basta: `/activate?plan=…` per un'organizzazione senza
+abbonamento, `/app/billing` per una che già paga. Nessuna chiamata a Stripe.
+
+## I price id tornano, e solo per il primo abbonamento
+
+`createBillingPortalSession` prometteva che «l'app non nomina mai un price id».
+Per i cambi di piano resta vero; per il **primo** abbonamento non può esserlo, il
+portale cambia una sottoscrizione e non ne esiste ancora una. Quindi `PRICES`,
+`priceFor`, `geoCouponFor`, `ensureBrandCustomer` e `createCheckoutSession`
+tornano in `stripe.ts` — e il commento sopra al portale ora dice la verità.
+
+`currencyForCountry` **non** è tornata: l'originale la duplicava «per tenere il
+modulo server autosufficiente», e la stessa funzione sta già in `$lib/plans`, che
+è pure quella che la pagina usa per mostrare i prezzi. Due copie della stessa
+soglia eurozona divergono al primo cambio.
+
+## Il test
+
+`src/lib/billing/paywall-routes.test.ts` legge i sorgenti, raccoglie ogni
+destinazione `/app/…/activate` e `/app/…/upgrade`, e pretende che la rotta esista
+su disco. Su `origin/dev` falliva elencando i diciannove file che puntavano a
+`activate` e i due che puntavano a `upgrade`. Una terza asserzione impedisce che
+passi a vuoto: se la scansione si rompe e non trova più nessun riferimento, è
+quella a fallire.
+
+## Quello che resta aperto
+
+- **La riconciliazione della fatturazione non c'è.** `billing-reconcile.ts` e il
+  suo tick giornaliero sono un'altra esclusione mai importata. L'attivazione
+  funziona lo stesso — la fa il trigger della migration 0007 su
+  `stripe.subscriptions`, che è qui — ma nessuno verifica più il trigger, ed è
+  proprio il buco che quel job era stato scritto per chiudere: un brand `starter`
+  attivo con l'abbonamento cancellato da due mesi, scoperto a mano.
+- **`igniteBrandTeam` non ha chiamanti.** Il suo commento nomina questo file
+  («da chiamare da activate/+page.server.ts dopo la conferma del pagamento — UNA
+  riga»). Aggiungerla è una riga, ma è un comportamento nuovo su un percorso che
+  oggi nessuno percorre: merita di essere guardata da sola, non dentro la PR che
+  ripara un 404.
+- **I dodici price id non sono verificabili da qui.** L'account Stripe collegato a
+  questa sessione (`leads.anomalia`) non è quello che li possiede. Vanno
+  riconfermati sull'account giusto prima del merge.

--- a/src/lib/billing/paywall-routes.test.ts
+++ b/src/lib/billing/paywall-routes.test.ts
@@ -1,0 +1,83 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * DOVE SI PAGA DEVE ESISTERE. Ogni redirect, ogni href e ogni prompt che manda l'utente a
+ * pagare nomina una rotta: se quella rotta non sta su disco, il cliente che vuole abbonarsi
+ * vede un 404 — e un 404 sul percorso dei soldi non lo intercetta nessun test di unità,
+ * perché il codice che ci punta compila benissimo.
+ *
+ *   throw redirect(303, `/app/${slug}/activate`)  ->  src/routes/app/[brand]/activate/
+ *   goto(`/app/${slug}/upgrade?plan=pro`)         ->  src/routes/app/[brand]/upgrade/
+ *
+ * Le rotte sono escluse dall'export open (scripts/export-oss.mjs): questo test gira sul
+ * repository commerciale, che è quello da cui si costruisce la produzione.
+ */
+
+const REPO_ROOT = fileURLToPath(new URL('../../../', import.meta.url));
+const SCANNED = ['src', 'cli'];
+const SKIPPED_DIRS = new Set(['node_modules', '.svelte-kit', 'build', 'dist']);
+
+const PAYWALL_DESTINATION = /\/app\/[^\s'"`]*?\/(activate|upgrade)\b/g;
+const ROUTE_DIR = (name: string) => join('src', 'routes', 'app', '[brand]', name);
+
+function sources(): string[] {
+	const found: string[] = [];
+
+	for (const top of SCANNED) {
+		const root = join(REPO_ROOT, top);
+		if (!existsSync(root)) continue;
+
+		for (const entry of readdirSync(root, { recursive: true, withFileTypes: true })) {
+			if (!entry.isFile()) continue;
+			if (entry.parentPath.split(/[\\/]/).some((p) => SKIPPED_DIRS.has(p))) continue;
+			if (!/\.(ts|svelte)$/.test(entry.name) || entry.name.endsWith('.test.ts')) continue;
+
+			found.push(join(entry.parentPath, entry.name));
+		}
+	}
+
+	return found;
+}
+
+function referencesByRoute(): Map<string, string[]> {
+	const byRoute = new Map<string, string[]>([
+		['activate', []],
+		['upgrade', []]
+	]);
+
+	for (const file of sources()) {
+		const text = readFileSync(file, 'utf8');
+
+		for (const [, route] of text.matchAll(PAYWALL_DESTINATION)) {
+			byRoute.get(route)?.push(file.slice(REPO_ROOT.length));
+		}
+	}
+
+	return byRoute;
+}
+
+function routeExists(name: string): boolean {
+	const dir = join(REPO_ROOT, ROUTE_DIR(name));
+	if (!existsSync(dir)) return false;
+
+	return ['+page.server.ts', '+page.svelte', '+server.ts'].some((f) => existsSync(join(dir, f)));
+}
+
+describe('il percorso di pagamento non porta a un 404', () => {
+	const byRoute = referencesByRoute();
+
+	// Se la scansione si rompe la mappa si svuota e il test passerebbe a vuoto: questo lo impedisce.
+	it('il codice manda davvero gli utenti su activate e upgrade', () => {
+		expect(byRoute.get('activate')!.length).toBeGreaterThan(0);
+		expect(byRoute.get('upgrade')!.length).toBeGreaterThan(0);
+	});
+
+	it.each([...byRoute.keys()])('/app/[brand]/%s esiste su disco', (route) => {
+		const referrers = byRoute.get(route)!;
+
+		expect(routeExists(route), `${ROUTE_DIR(route)} manca, ma ci puntano: ${referrers.join(', ')}`).toBe(true);
+	});
+});

--- a/src/lib/content/changelog/2026-09-04-restore-activate.ts
+++ b/src/lib/content/changelog/2026-09-04-restore-activate.ts
@@ -1,0 +1,10 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-04',
+  title: 'The page where you pick a plan works again',
+  items: [
+    'Choosing a plan, upgrading, or connecting a social account on a free brand used to end on a “page not found”. Those links now open the plan picker.',
+    'Prices follow where you are: euros in the eurozone, dollars elsewhere, with the regional discount applied at checkout.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/stripe.ts
+++ b/src/lib/server/stripe.ts
@@ -1,5 +1,7 @@
 import { env } from '$env/dynamic/private';
+import type { SupabaseClient } from '@supabase/supabase-js';
 import Stripe from 'stripe';
+import type { Currency } from '$lib/plans';
 
 let client: Stripe | null = null;
 
@@ -12,8 +14,118 @@ function stripe(): Stripe {
 }
 
 /**
- * Every plan change happens inside Stripe's hosted portal, on the prices configured there — the
- * app never names a price id, so there is nothing here to drift from the Stripe dashboard.
+ * The FIRST subscription is the one thing the hosted portal cannot sell: it changes a
+ * subscription, and there is none yet. Checkout has to be handed a price, so these ids live here
+ * — and nowhere else. Every later plan change stays in the portal, on the prices configured
+ * there. Not secret (they travel in the checkout URL); the eurozone pays in EUR, everyone else on
+ * the parallel USD ladder.
+ */
+export const PRICES = {
+  go: {
+    eur: { month: 'price_1U1Li6RxN8PTIw40wpOkPdVy', year: 'price_1U1Li7RxN8PTIw40r1ESOfKs' },
+    usd: { month: 'price_1U1Li7RxN8PTIw40cSQTHgoa', year: 'price_1U1Li7RxN8PTIw40DS8GpdHG' }
+  },
+  starter: {
+    eur: { month: 'price_1Tfx7NRxN8PTIw40e2md3XM3', year: 'price_1Tfx7ORxN8PTIw40zbThuICT' },
+    usd: { month: 'price_1TwIisRxN8PTIw40DO1gzGRn', year: 'price_1TwIkiRxN8PTIw4069cfBSqj' }
+  },
+  pro: {
+    eur: { month: 'price_1TsqcSRxN8PTIw40NwIFR94X', year: 'price_1TsqcSRxN8PTIw40uJn3KM8f' },
+    usd: { month: 'price_1TwIkiRxN8PTIw40pHJIw9YA', year: 'price_1TwIkjRxN8PTIw40mkrp09Hn' }
+  }
+} as const;
+
+export function priceFor(plan: string, cycle: string, currency: Currency): string | undefined {
+  const tier = PRICES[plan as keyof typeof PRICES];
+  return tier ? tier[currency][cycle === 'year' ? 'year' : 'month'] : undefined;
+}
+
+/**
+ * Purchasing-power discounts, auto-applied at checkout from the visitor's country
+ * (`x-vercel-ip-country`). Good-faith, not fraud-proof: a VPN defeats it. First match wins, and
+ * the coupons live in the same Stripe account as the prices above.
+ */
+const GEO_COUPONS: Array<{ coupon: string; countries: ReadonlySet<string> }> = [
+  {
+    coupon: 'latam40',
+    countries: new Set([
+      'MX',
+      'GT', 'BZ', 'SV', 'HN', 'NI', 'CR', 'PA',
+      'CO', 'VE', 'EC', 'PE', 'BO', 'CL', 'AR', 'UY', 'PY', 'BR', 'GY', 'SR',
+      'DO', 'CU'
+    ])
+  },
+  {
+    // Singapore and Brunei stay out: high income, no purchasing-power case.
+    coupon: 'sea50',
+    countries: new Set(['ID', 'TH', 'VN', 'PH', 'MY', 'MM', 'KH', 'LA', 'TL'])
+  }
+];
+
+export function geoCouponFor(country: string | null | undefined): string | undefined {
+  if (!country) return undefined;
+  return GEO_COUPONS.find((g) => g.countries.has(country))?.coupon;
+}
+
+/**
+ * A brand's Stripe customer, created on first need. The id on the row is what migration 0007's
+ * trigger joins on to mirror the subscription back into `brands.plan` / `brands.status`, so it
+ * has to be written before checkout, not after it.
+ */
+export async function ensureBrandCustomer(
+  supabase: SupabaseClient,
+  brand: { id: string; name: string; stripe_customer_id: string | null }
+): Promise<string> {
+  if (brand.stripe_customer_id) return brand.stripe_customer_id;
+
+  const customer = await stripe().customers.create({
+    name: brand.name,
+    metadata: { brand_id: brand.id }
+  });
+  await supabase.from('brands').update({ stripe_customer_id: customer.id }).eq('id', brand.id);
+
+  return customer.id;
+}
+
+/**
+ * Stripe-hosted checkout for the first subscription. `subscription_data.metadata.plan` is not
+ * decoration: the 0007 trigger reads it to set `brands.plan` when the subscription lands.
+ *
+ * Regime forfettario — no VAT is charged, so `automatic_tax` stays OFF; the VAT id and legal name
+ * are still collected for the invoice.
+ */
+export async function createCheckoutSession(opts: {
+  customerId: string;
+  brandId: string;
+  plan: string;
+  priceId: string;
+  successUrl: string;
+  cancelUrl: string;
+  couponId?: string;
+}): Promise<string> {
+  const session = await stripe().checkout.sessions.create({
+    mode: 'subscription',
+    customer: opts.customerId,
+    line_items: [{ price: opts.priceId, quantity: 1 }],
+    // Stripe forbids pairing `discounts` with `allow_promotion_codes`: an auto-applied geo coupon
+    // replaces the promo-code field rather than sitting next to it.
+    ...(opts.couponId ? { discounts: [{ coupon: opts.couponId }] } : { allow_promotion_codes: true }),
+    success_url: opts.successUrl,
+    cancel_url: opts.cancelUrl,
+    tax_id_collection: { enabled: true },
+    customer_update: { name: 'auto', address: 'auto' },
+    billing_address_collection: 'required',
+    subscription_data: { metadata: { brand_id: opts.brandId, plan: opts.plan } },
+    metadata: { brand_id: opts.brandId }
+  });
+  if (!session.url) throw new Error('Stripe: no checkout URL');
+
+  return session.url;
+}
+
+/**
+ * Every plan CHANGE happens inside Stripe's hosted portal, on the prices configured there — the
+ * app names a price only to open the first subscription (see PRICES above).
  */
 export async function createBillingPortalSession(opts: {
   customerId: string;

--- a/src/routes/app/[brand]/activate/+page.server.ts
+++ b/src/routes/app/[brand]/activate/+page.server.ts
@@ -1,0 +1,64 @@
+import { fail, redirect } from '@sveltejs/kit';
+import type { Actions, PageServerLoad } from './$types';
+import { currencyForCountry } from '$lib/plans';
+import { isPlanGoEnabled } from '$lib/server/feature-flags';
+import { createCheckoutSession, ensureBrandCustomer, geoCouponFor, priceFor } from '$lib/server/stripe';
+
+/**
+ * IL PAYWALL: l'unico posto da cui parte il primo abbonamento. Ogni altra superficie che parla di
+ * pagare — i redirect delle impostazioni, le CTA "collega i social", i prompt degli agenti —
+ * atterra qui, e chi non ha ancora un abbonamento non ha nessun altro modo di aprirne uno: il
+ * portale Stripe cambia un abbonamento, non ne crea il primo.
+ *
+ * Dopo il checkout Stripe rimanda su `?status=processing`, la pagina ricarica ogni pochi secondi e
+ * il brand diventa attivo per il trigger della 0007 sulla sottoscrizione: da lì questo load
+ * rimanda a /success. Nessun webhook nostro nel mezzo.
+ */
+export const load: PageServerLoad = async ({ parent, locals: { supabase } }) => {
+  const { brand } = await parent();
+
+  if (brand.status === 'active') {
+    throw redirect(303, brand.launched_at ? `/app/${brand.slug}` : `/app/${brand.slug}/success`);
+  }
+
+  // Quanti post aspettano già di essere pubblicati: è l'incentivo concreto del paywall.
+  const { count } = await supabase
+    .from('posts')
+    .select('id', { count: 'exact', head: true })
+    .eq('brand_id', brand.id);
+
+  return { readyPosts: count ?? 0 };
+};
+
+export const actions: Actions = {
+  checkout: async ({ request, params, url, locals: { supabase } }) => {
+    const data = await request.formData();
+    const plan = String(data.get('plan') ?? 'pro');
+    // Go si vende solo mentre FEATURE_PLAN_GO è acceso: un checkout costruito a mano non lo aggira.
+    if (plan === 'go' && !isPlanGoEnabled()) return fail(400, { error: 'Unknown plan' });
+
+    const cycle = String(data.get('cycle') ?? 'month') === 'year' ? 'year' : 'month';
+    const country = request.headers.get('x-vercel-ip-country');
+    const priceId = priceFor(plan, cycle, currencyForCountry(country));
+    if (!priceId) return fail(400, { error: 'Unknown plan' });
+
+    const { data: brand } = await supabase
+      .from('brands')
+      .select('id, name, slug, stripe_customer_id')
+      .eq('slug', params.brand)
+      .maybeSingle();
+    if (!brand) throw redirect(303, '/app');
+
+    const checkoutUrl = await createCheckoutSession({
+      customerId: await ensureBrandCustomer(supabase, brand),
+      brandId: brand.id,
+      plan,
+      priceId,
+      couponId: geoCouponFor(country),
+      successUrl: `${url.origin}/app/${brand.slug}/activate?status=processing`,
+      cancelUrl: `${url.origin}/app/${brand.slug}/activate`
+    });
+
+    throw redirect(303, checkoutUrl);
+  }
+};

--- a/src/routes/app/[brand]/activate/+page.svelte
+++ b/src/routes/app/[brand]/activate/+page.svelte
@@ -1,0 +1,175 @@
+<script lang="ts">
+  import { page } from '$app/stores';
+  import { onMount, untrack } from 'svelte';
+  import { _ } from 'svelte-i18n';
+  import { X } from '@lucide/svelte';
+  import { showsLocalCurrency, currencyForCountry, visiblePlans } from '$lib/plans';
+  import { track, metaPixelTrack } from '$lib/analytics';
+  import DeleteBrandDialog from '$lib/components/DeleteBrandDialog.svelte';
+  import PlanCards from '$lib/components/PlanCards.svelte';
+
+  let { data, form } = $props();
+  const brand = $derived(data.brand);
+  const readyPosts = $derived(data.readyPosts ?? 0);
+  const localCurrency = $derived(showsLocalCurrency(data.country));
+  const currency = $derived(currencyForCountry(data.country));
+  const plans = $derived(visiblePlans(!!data.planGo));
+
+  // Dopo il checkout il brand diventa attivo e il load rimanda a /success: qui restano due stati
+  // soli, il paywall e l'attesa che l'attivazione arrivi.
+  const processing = $derived($page.url.searchParams.get('status') === 'processing');
+  // Ciclo e piano evidenziato arrivano dal listino pubblico (?plan&cycle). Valore iniziale
+  // soltanto (untrack): il componente si ricrea a ogni navigazione.
+  let cycle = $state<'month' | 'year'>(
+    untrack(() => ($page.url.searchParams.get('cycle') === 'month' ? 'month' : 'year'))
+  );
+  const chosenPlan = untrack(() => $page.url.searchParams.get('plan'));
+
+  onMount(() => {
+    // Arrivare al paywall vuol dire prospect registrato e onboardato: l'acquisto vero capita
+    // troppo di rado perché Meta ci ottimizzi sopra una campagna, questa conversione a monte no.
+    if (!processing) {
+      metaPixelTrack('CompleteRegistration', undefined, `reg_${brand.id}`);
+      return;
+    }
+    // Il brand diventa attivo per il trigger sulla sottoscrizione, non per una risposta che
+    // stiamo aspettando: l'unico modo di accorgersene è richiedere la pagina finché il load
+    // rimanda a /success.
+    const poll = setInterval(() => location.reload(), 4000);
+    return () => clearInterval(poll);
+  });
+
+  // Non lo vuole affatto, un piano? Il brand si cancella dal paywall stesso.
+  let deleteOpen = $state(false);
+</script>
+
+<!-- Sfondo: la dashboard a metà caricamento, puramente visivo. -->
+<div class="dash-skel" aria-hidden="true">
+  <div class="sk-row"><div class="sk-stat"></div><div class="sk-stat"></div><div class="sk-stat"></div><div class="sk-stat"></div></div>
+  <div class="sk-block"></div>
+  <div class="sk-grid"><div class="sk-card"></div><div class="sk-card"></div><div class="sk-card"></div></div>
+</div>
+
+{#if processing}
+  <!-- Il pagamento è tornato: si sta attivando, e non si chiude. -->
+  <div class="overlay strong">
+    <div class="dialog sm">
+      <div class="spinner"></div>
+      <h2>{$_('app.activate.processing.title')}</h2>
+      <p>{$_('app.activate.processing.body', { values: { brand: brand.name } })}</p>
+      <a class="back" href={`/app/${brand.slug}/activate`}>{$_('app.activate.processing.retry')}</a>
+    </div>
+  </div>
+{:else}
+  <!-- Paywall a tutta larghezza: niente scorciatoie, solo una via d'uscita silenziosa. -->
+  <div class="overlay strong">
+    <div class="dialog wide">
+      <a class="exit" href={`/app/${brand.slug}`} aria-label={$_('app.activate.paywall.back')}><X size={20} /></a>
+      <div class="activate-head">
+        {#if readyPosts > 0}
+          <div class="ready-pill"><span class="rdot"></span>{$_('app.activate.paywall.readyPill', { values: { count: readyPosts, brand: brand.name } })}</div>
+        {/if}
+        <p>
+          {#if readyPosts > 0}{$_('app.activate.paywall.queued', { values: { count: readyPosts } })} {/if}
+          {@html $_('app.activate.paywall.pitch')}
+        </p>
+        <div class="price-toggles">
+          <div class="bill-toggle" role="group" aria-label={$_('pricing.toggle.cycleAria')}>
+            <button type="button" class:on={cycle === 'month'} onclick={() => (cycle = 'month')}>{$_('pricing.toggle.monthly')}</button>
+            <button type="button" class:on={cycle === 'year'} onclick={() => (cycle = 'year')}>{$_('pricing.toggle.annual')} <span class="save">{$_('pricing.toggle.save')}</span></button>
+          </div>
+        </div>
+      </div>
+
+      {#if localCurrency}
+        <p class="local-cur-note">{$_('pricing.localCurrency')}</p>
+      {/if}
+
+      <PlanCards {cycle} {currency} {plans} selectedPlan={chosenPlan}>
+        {#snippet cta(p)}
+          <form method="POST" action="?/checkout">
+            <input type="hidden" name="plan" value={p.key} />
+            <input type="hidden" name="cycle" value={cycle} />
+            <button
+              class="pcta {p.popular ? 'is-primary' : 'is-ghost'}"
+              type="submit"
+              onclick={() => track('checkout_started', { plan: p.key, cycle })}
+            >
+              {$_('app.activate.paywall.trialCta')}
+            </button>
+          </form>
+        {/snippet}
+      </PlanCards>
+
+      <div class="perbrand-note">
+        {$_('app.activate.paywall.footerNote')} {#if form?.error}<span style="color:#c0392b;">{form.error}</span>{/if}
+      </div>
+      <div class="del-row">
+        <button class="del-link" type="button" onclick={() => (deleteOpen = true)}>{$_('app.settings.del.cta')}</button>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<DeleteBrandDialog bind:open={deleteOpen} brand={{ name: brand.name, slug: brand.slug }} action={`/app/${brand.slug}/settings/danger?/deleteBrand`} />
+
+<style>
+  /* finta dashboard in caricamento dietro il dialogo */
+  .dash-skel { padding: 4px 4px 24px; }
+  .sk-row { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; }
+  .sk-stat { height: 92px; border-radius: 16px; }
+  .sk-block { height: 220px; border-radius: 18px; margin-top: 16px; }
+  .sk-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; margin-top: 16px; }
+  .sk-card { height: 150px; border-radius: 16px; }
+  .sk-stat, .sk-block, .sk-card {
+    background: linear-gradient(100deg, #f1f1f3 30%, #f8f8fa 50%, #f1f1f3 70%);
+    background-size: 200% 100%; animation: shimmer 1.4s linear infinite;
+  }
+  @keyframes shimmer { from { background-position: 200% 0; } to { background-position: -200% 0; } }
+
+  /* overlay bloccante — nessun modo di chiuderlo */
+  .overlay { position: fixed; inset: 0; z-index: 60; display: flex; align-items: center; justify-content: center; padding: 0; animation: fade 0.25s ease; }
+  .overlay.strong { background: rgba(18, 26, 22, 0.42); backdrop-filter: blur(6px); }
+  .dialog { background: var(--paper, #fff); border-radius: 0; box-shadow: none; }
+  .dialog.sm { max-width: 100%; width: 100%; height: 100%; padding: 38px 34px; text-align: center; display: flex; flex-direction: column; align-items: center; justify-content: center; }
+  .dialog.wide { position: relative; width: 100%; height: 100%; max-height: 100vh; overflow-y: auto; padding: 36px clamp(20px, 4vw, 44px) 32px; }
+  @keyframes fade { from { opacity: 0; } to { opacity: 1; } }
+
+  .exit { position: absolute; top: 18px; right: clamp(20px, 4vw, 44px); z-index: 1; color: var(--ink-faint, #86868b);
+    display: inline-flex; align-items: center; justify-content: center; text-decoration: none; transition: color 0.15s ease; }
+  .exit:hover { color: var(--ink, #1d1d1f); }
+
+  .dialog.sm h2 { font-size: 1.5rem; font-weight: var(--heading-weight); margin-top: 14px; letter-spacing: var(--heading-tracking); }
+  .dialog.sm p { color: var(--ink-soft); margin-top: 10px; line-height: 1.5; }
+
+  .activate-head { text-align: center; max-width: 46ch; margin: 2px auto 26px; }
+  .ready-pill { display: inline-flex; align-items: center; gap: 8px; padding: 7px 14px; border-radius: 980px; margin-bottom: 16px;
+    background: rgba(var(--accent-rgb), 0.08); color: var(--accent); font-size: 13px; font-weight: 600; }
+  .rdot { width: 8px; height: 8px; border-radius: 50%; background: var(--accent); box-shadow: 0 0 0 0 rgba(var(--accent-rgb), 0.5); animation: pulse 1.8s infinite; }
+  @keyframes pulse { 0% { box-shadow: 0 0 0 0 rgba(var(--accent-rgb), 0.45); } 70% { box-shadow: 0 0 0 7px rgba(var(--accent-rgb), 0); } 100% { box-shadow: 0 0 0 0 rgba(var(--accent-rgb), 0); } }
+  .activate-head p { color: var(--ink-soft); margin: 10px 0 18px; }
+  .price-toggles {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+  }
+  .bill-toggle { margin: 0; }
+  .local-cur-note { margin: 0 auto 18px; max-width: 460px; font-size: 13px; line-height: 1.5; opacity: 0.6; text-align: center; }
+  .perbrand-note { text-align: center; margin-top: 22px; color: var(--ink-soft); font-size: 13.5px; line-height: 1.6; }
+  .del-row { text-align: center; margin-top: 14px; }
+  .del-link { background: none; border: none; font: inherit; font-size: 12px; cursor: pointer;
+    color: var(--ink-faint, #86868b); text-decoration: underline; padding: 2px; }
+  .del-link:hover { color: #c0392b; }
+  .back { color: var(--ink-soft); text-decoration: none; }
+  .spinner { width: 30px; height: 30px; margin: 0 auto; border-radius: 50%;
+    border: 3px solid rgba(var(--accent-rgb), 0.25); border-top-color: var(--accent); animation: spin 0.8s linear infinite; }
+  @keyframes spin { to { transform: rotate(360deg); } }
+  form { margin: 0; }
+
+  @container workbench (max-width: 720px) {
+    .sk-row { grid-template-columns: repeat(2, 1fr); }
+    .sk-grid { grid-template-columns: 1fr; }
+  }
+</style>

--- a/src/routes/app/[brand]/upgrade/+server.ts
+++ b/src/routes/app/[brand]/upgrade/+server.ts
@@ -1,0 +1,32 @@
+import { redirect } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { canEnter } from '$lib/server/access';
+import { orgBillingForBrand } from '$lib/server/org-billing';
+import { plansAbove } from '$lib/server/plans';
+
+/**
+ * GET /app/{brand}/upgrade?plan=pro — un LINK, e un click su un link è navigazione, non consenso a
+ * pagare: qui dentro non si apre nessuna sessione Stripe. Instrada e basta, verso la superficie
+ * che la decisione può prenderla davvero.
+ *
+ *   org senza abbonamento  →  /activate?plan=…   (il checkout: l'abbonamento non esiste ancora)
+ *   org che già paga       →  /app/billing       (il portale Stripe, con la scala dei piani)
+ *
+ * Un `?plan` che non sta sopra il piano attuale viene lasciato cadere invece di rifiutato: chi ha
+ * cliccato voleva comunque salire, e il paywall gli mostra tutta la scala.
+ */
+export const GET: RequestHandler = async ({ params, url, locals: { supabase, safeGetSession } }) => {
+  const { session } = await safeGetSession();
+  if (!session) throw redirect(303, '/login');
+  if (!(await canEnter(supabase))) throw redirect(303, '/waitlist');
+
+  const billing = await orgBillingForBrand(supabase, { slug: params.brand });
+  if (!billing) throw redirect(303, '/app');
+
+  if (billing.subscriptionId) throw redirect(303, '/app/billing');
+
+  const plan = (url.searchParams.get('plan') ?? '').toLowerCase();
+  const offered = plansAbove(billing.plan).some((p) => p.key === plan);
+
+  throw redirect(303, `/app/${params.brand}/activate${offered ? `?plan=${encodeURIComponent(plan)}` : ''}`);
+};


### PR DESCRIPTION
## What?

`/app/[brand]/activate` and `/app/[brand]/upgrade` do not exist in this repository, and production is built from here. Twenty-six non-test files send customers to them — nine server-side `throw redirect(303, …)`, nine client navigations, and the agent prompts — so today the path a customer walks to pay ends on a 404.

This restores both routes, adds back to `src/lib/server/stripe.ts` the four functions the first subscription needs, and leaves behind a test that fails whenever a paywall destination stops resolving.

The two worst referrers were `billingPortal` and `upgrade` in `src/lib/server/settings-actions.ts`, on the `no_customer` / `no_subscription` branches — exactly whoever has never paid. The third was the "Choose a plan" button on `/app/billing`, the only offer shown to an organization without a subscription.

## Why?

They were never deleted: they were **never imported**. The founding commit of this repo is `Import Anomalia, the open self-hostable build`, and `scripts/export-oss.mjs` lists `src/routes/app/[brand]/upgrade/` and `.../activate/` among the commercial exclusions, so the import brought in the already-exported build. `src/lib/server/stripe.ts` arrived as a stub (`export {}`) for the same reason and was rebuilt since — but only its portal half.

The result is that nothing in this repository can open a *first* subscription. The Stripe billing portal changes a subscription; it cannot create one.

## How?

The originals live in `andreabuttarelli/021-app` (last pushed 27 August). This is not a copy-paste — the repo moved a long way in eight days, and half of that file was already dead before it left.

**The setup branch is not restored.** In the original, `load` returned a hard-coded `setup: false`, so the page's `{#if setup}` block never opened and no form reached `syncAccounts`, `confirmPosts`, `autoSchedule`, `skipSetup` or `setTimezone`. Removing them takes with it `config.maxDuration = 1800`, the blocking `renderVideo` call, `publishApprovedPost`, `addUsage`, and `ensureBrandProfile` / `syncBrandAccounts`. The question "are those signatures still current?" does not arise: that code never ran. What remains is `load` and the `checkout` action — 63 lines instead of 358.

**`meta-capi.ts` is not restored.** It is ad attribution, not payment, and its one call on the money path (`metaCapiPurchase`, *awaited* before the post-checkout redirect, plus two extra Stripe reads to find the amount) is the one I least want there: an untimed `fetch` to Meta delaying the landing of someone who has just paid. The browser pixel is still wired (`loadMetaPixel` in the root layout) and the page still fires `CompleteRegistration` under the same `eventID`, so the server half is a pure addition later. `Purchase` was never tracked from the browser either, so nothing regresses.

**`upgrade/+server.ts` is rewritten, not restored.** The original opened a Stripe portal session **on GET**, naming an explicit price id. This repository decided the opposite two weeks ago — `src/lib/workbench-paths.ts` says it out loud: *"un click in sidebar è navigazione, non consenso a pagare"* — and moved plan changes into the hosted portal where Stripe owns the prices. The route now only routes, and calls Stripe not at all:

| state | destination |
|---|---|
| org with no subscription | `/activate?plan=…` (checkout — there is no subscription to change) |
| org that already pays | `/app/billing` (the portal, with the plan ladder) |

**Price ids come back, for the first subscription only.** The doc comment on `createBillingPortalSession` promised "the app never names a price id". That stays true for plan *changes*; it cannot be true for the first one. So `PRICES`, `priceFor`, `geoCouponFor`, `ensureBrandCustomer` and `createCheckoutSession` return to `stripe.ts`, and that comment now says what is actually the case.

`currencyForCountry` did **not** come back. The original duplicated it "so the server module stays self-contained", but the same eurozone threshold already lives in `$lib/plans` — and that is the copy the page itself reads to display prices. Two copies diverge at the first change.

## Testing?

`src/lib/billing/paywall-routes.test.ts` walks `src/` and `cli/`, collects every `/app/…/activate` and `/app/…/upgrade` destination in non-test sources, and asserts the route exists on disk. A third assertion stops it passing vacuously: if the scan breaks and finds no referrers at all, that is the test that fails.

<details>
<summary>Red on <code>origin/dev</code>, before the files were brought back</summary>

```
FAIL src/lib/billing/paywall-routes.test.ts > il percorso di pagamento non porta a un 404 > /app/[brand]/activate esiste su disco
AssertionError: src/routes/app/[brand]/activate manca, ma ci puntano:
  src/lib/components/DashboardSidebar.svelte, src/lib/components/SettingsSidebar.svelte (x2),
  src/lib/server/settings-actions.ts (x2), src/lib/components/studio/StudioPage.svelte,
  src/routes/app/billing/+page.svelte, src/routes/app/[brand]/backlinks/+page.svelte (x2),
  src/routes/app/[brand]/proposal/+page.server.ts, src/routes/app/[brand]/success/+page.server.ts,
  src/routes/app/[brand]/settings/blog-domain/+page.server.ts,
  src/routes/app/[brand]/settings/blog-integrations/+page.server.ts,
  src/routes/app/[brand]/settings/facebook/+page.server.ts,
  src/routes/app/[brand]/settings/linkedin/+page.server.ts,
  src/routes/app/[brand]/site/new/+page.server.ts,
  src/routes/app/[brand]/settings/connect/[platform]/+server.ts,
  src/routes/api/v1/brands/[slug]/social/connect/+server.ts, cli/commands/upgrade.ts

FAIL ... > /app/[brand]/upgrade esiste su disco
AssertionError: src/routes/app/[brand]/upgrade manca, ma ci puntano:
  src/lib/components/UpgradeLink.svelte, src/lib/components/motion-video/MotionVideoSettings.svelte

Test Files  1 failed (1)
     Tests  2 failed | 1 passed (3)
```
Green after the restore: `3 passed (3)`.
</details>

Also run:

- `node scripts/typecheck-runtime.mjs` → **ok** (the CI gate; 646 new lines were the reason to care).
- Every test that reads sources by path — `npx vitest run $(git grep -ln "readFileSync" -- 'src/**/*.test.ts')` → **73 files, 923 tests, all pass**. This is the class that reddened `dev` three times today, and this PR adds routes.
- The registry ↔ route test from #290 → green.
- `src/lib/server/stripe.test.ts`, `src/lib/billing/`, `src/lib/workbench-paths.test.ts`, and the 16 test files mentioning activate/checkout → **218 tests, all pass**.
- The Svelte compiler on the new page → compiles, **0 warnings** (no dead CSS left from the branch that was cut).

**Not tested, and why:** no browser run — Andrea's machine went into swap three times today and I was asked not to start a dev server. No Stripe call that creates anything: no checkout session, no customer, no payment. The one Stripe read I attempted (verifying a price id) hit the wrong account and is reported below as an open risk. The risk that carries: the paywall renders and posts, but nobody has watched a real checkout come back through `?status=processing` on this codebase.

## Evidence (screenshots/videos)

No UI screenshots: the change was verified without starting the app, as requested. Backend evidence instead.

<details>
<summary>The OSS export still excludes both routes, and this PR adds no new export failure</summary>

```
$ node scripts/export-oss.mjs --out <scratch>/oss-out --force
$ ls <scratch>/oss-out/src/routes/app/\[brand\]/activate
ls: ... No such file or directory                     # (a) excluded, as intended
$ cat <scratch>/oss-out/src/lib/server/stripe.ts
throw new Error('not available in the open build')    # STUB_MODULES, price ids never ship
export {}
```

The export aborts on guards — but it aborts *identically* on the parent commit:

```
$ diff <(grep -v '^$' oss.log) <(grep -v '^$' oss-base.log) && echo IDENTICAL
IDENTICAL: my change adds no new export guard failure
```

Both runs fail on the same pre-existing 16 items: one dangling import (`src/lib/server/oauth-discovery.test.ts -> ../../../cli/lib/config`) and fifteen files mentioning `anomalia.so`. **(b) is answered: the export is no more broken than it was.**
</details>

<details>
<summary>The twelve hardcoded price ids are the ones the database already knows</summary>

The Stripe MCP account available in this session (`leads.anomalia`) is not the account that owns these prices, so a live check was impossible. But the price→plan map the `0007` trigger relies on lives in the migrations, and it can be checked offline:

```
$ comm -23 <(grep -ohE "price_1[A-Za-z0-9]+" src/lib/server/stripe.ts | sort -u) \
           <(grep -ohE "price_1[A-Za-z0-9]+" supabase/migrations/00{75,96}*.sql \
                                             supabase/migrations/01{31,32,41}*.sql | sort -u)
# (empty)
counts: code=12 db=29
```

Every id the code names is in the trigger's map. Not proof they are still active in Stripe — see the risk below.
</details>

<details>
<summary>How the money actually gets in, end to end</summary>

```
  /activate  ──POST ?/checkout──►  ensureBrandCustomer      writes brands.stripe_customer_id
                                   createCheckoutSession    subscription_data.metadata.plan
       │                                    │
       │                                    ▼
       │                          Stripe hosted checkout  (customer pays here, not in our code)
       │                                    │
       ▼                                    ▼
  /activate?status=processing        stripe.subscriptions row
       │  reload every 4s                   │
       │                          trg_sync_brand_from_sub (migration 0007)
       │                          joins on stripe_customer_id, writes
       │                          brands.{stripe_subscription_id, plan, status, activated_at}
       ▼                                    │
  load() sees status='active'  ◄────────────┘
       └──► /success  (sets launched_at)
```

No webhook of ours anywhere in that chain — which is why the reconciler noted below matters.
</details>

## Anything Else?

Three things I found while reading the money path and deliberately did **not** put in this PR:

1. **Billing reconciliation is missing entirely.** `src/lib/server/billing-reconcile.ts` and `src/routes/api/v1/billing/reconcile/tick/` are another never-imported exclusion. Activation itself still works — the `0007` trigger does it — but nothing verifies the trigger any more, and that is precisely the hole the job was written to close: a `starter` brand left active with a subscription cancelled two months earlier, found by hand. Its own header says so. Worth its own PR, and it costs a full Stripe read per run, so it needs a decision rather than a merge.

2. **`igniteBrandTeam` has no caller.** Its comment names the file this PR creates: *"da chiamare da activate/+page.server.ts dopo la conferma del pagamento — UNA riga"*. One line would do it. I left it out because it is new behaviour on a path nobody currently walks, and it deserves to be reviewed on its own rather than inside the PR that repairs a 404.

3. **The export has no route counterpart to `STUB_MODULES`.** A module that is excluded gets stubbed, so its importers still resolve; an excluded *route* leaves every reference to it dangling. Twenty references to `/activate` and `/upgrade` survive in the exported build and 404 there exactly as they do here today. This affects all four route-shaped exclusions, not just these two. A cheap fix in the same spirit as `STUB_MODULES` would be a generated `+page.server.ts` per excluded route that redirects somewhere honest (`/app/{brand}/settings/billing`) instead of 404ing — but it is an export defect, it needs its own round, and it should not ride along here.

**The one risk I could not close:** the twelve price ids are live ids in an account this session cannot reach. They match the migrations, and they were serving production eight days ago, but someone should confirm them on the billing Stripe account before this merges. A stale id fails at the worst possible moment — the click on "Start".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
