### PR TITLE
Draw with Lite when there is no reference either

### DIFF
--- a/changelog/2026-09-04-default-image-model-lite.md
+++ b/changelog/2026-09-04-default-image-model-lite.md
@@ -1,0 +1,38 @@
+# Il default di un'immagine senza riferimenti passa a Nano Banana 2 Lite
+
+Andrea ha chiesto **una** immagine dall'agente esterno. In `ai_calls` ne sono comparse **due**, a
+46 secondi l'una dall'altra, `nano-banana-2` su kie, **$0,06 ciascuna**.
+
+Il modello è il primo dei due difetti, ed è una riga. In `buildImageRequest`:
+
+```ts
+(needsFidelity ? NANO_BANANA_2_LITE : env.IMAGE_MODEL_NO_REF || BLOG_IMAGE_MODEL)
+```
+
+Il ramo **con** riferimenti era già passato a Lite nel 2026-08 — «Lite al posto di Pro su OGNI
+superficie» — ma quello **senza** era rimasto su `BLOG_IMAGE_MODEL`, cioè il modello pieno. Ed è
+il ramo dove cade la maggioranza delle immagini: un prompt e basta, nessuna foto da riprodurre.
+
+La convinzione sbagliata era scritta in un test: si chiamava *«drops to the half-price tier with
+no reproduction refs»* e asseriva `BLOG_IMAGE_MODEL`, che è il modello **più caro**, non il più
+economico. Il nome diceva il contrario di quello che il codice faceva, e nessuno lo ha riletto —
+la ragione per cui questo cambio arriva da una fattura invece che da una revisione.
+
+## Cosa NON è cambiato
+
+- **Il blog.** `blog-month.ts` e `content-preview/articles.ts` passano `model: BLOG_IMAGE_MODEL`
+  esplicito, perché la batch API vuole quel modello e lì lo sconto del 50% della batch vale più
+  della differenza di listino. Il default non li tocca, e un test lo tiene fermo.
+- **Il modello di refine.** Modificare un'immagine è un mestiere diverso dal disegnarne una, e la
+  scelta del brand su `imageRefineModel` resta sua.
+- **Il ramo con riferimenti**, che era già Lite.
+
+## Una cosa da sapere prima di fidarsi
+
+`env.IMAGE_MODEL_NO_REF` **vince ancora** su questo default: è l'unico ramo che lo consulta, ed è
+la via per riportare un ambiente sul modello pieno senza deploy. In `.env.example` è commentata,
+quindi in teoria non è impostata da nessuna parte — ma se qualcuno l'ha messa nell'ambiente di
+produzione, questo cambio non si vede. **Va verificato lì, non qui.**
+
+Nessuna scrittura sui brand: tutti e 15 gli attivi hanno `content_prefs->>'imageModel'` nullo e
+cadono su questo default, quindi la costante è l'unico posto da toccare.

--- a/src/lib/content/changelog/2026-09-04-cheaper-image-default.ts
+++ b/src/lib/content/changelog/2026-09-04-cheaper-image-default.ts
@@ -1,0 +1,10 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-04',
+  title: 'Images cost less by default',
+  items: [
+    'Images generated from a prompt alone now use the lighter, cheaper model — the same one already used when you give a reference photo.',
+    'Blog article images are unchanged, and if you have pinned your own image model in Settings, your choice still wins.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/content-preview.test.ts
+++ b/src/lib/server/content-preview.test.ts
@@ -518,9 +518,19 @@ describe('buildImageRequest (image model tier)', () => {
     expect(buildImageRequest('p', { baseImage: img }).model).toBe(LITE);
   });
 
-  it('drops to the half-price tier with no reproduction refs — mood and logo do not count', () => {
-    expect(buildImageRequest('p', {}).model).toBe(BLOG_IMAGE_MODEL);
-    expect(buildImageRequest('p', { moodImages: [img], logoImage: img }).model).toBe(BLOG_IMAGE_MODEL);
+  // Il nome vecchio di questo test diceva "half-price tier" e asseriva BLOG_IMAGE_MODEL, che e' il
+  // modello PIENO: la convinzione era rovesciata, e intanto la maggioranza delle immagini — un
+  // prompt e nessun riferimento — pagava $0,06 a chiamata. Ora Lite vale anche qui.
+  it('senza riferimenti da riprodurre disegna con Lite — mood e logo non contano', () => {
+    expect(buildImageRequest('p', {}).model).toBe(LITE);
+    expect(buildImageRequest('p', { moodImages: [img], logoImage: img }).model).toBe(LITE);
+  });
+
+  it('il blog resta sul modello pieno, perche' + "'" + ' lo chiede esplicitamente', () => {
+    // La batch API del blog vuole quel modello e lo passa a mano: cambiare il default non lo
+    // tocca, ed e' esattamente cio' che questo cambio NON doveva spostare.
+    expect(BLOG_IMAGE_MODEL).not.toBe(LITE);
+    expect(buildImageRequest('p', { model: BLOG_IMAGE_MODEL }).model).toBe(BLOG_IMAGE_MODEL);
   });
 
   it('a base image is an EDIT, and the brand can edit with another model', () => {

--- a/src/lib/server/content-preview/images.ts
+++ b/src/lib/server/content-preview/images.ts
@@ -157,9 +157,11 @@ export type RenderImageOpts = {
  */
 export function buildImageRequest(imagePrompt: string, opts: RenderImageOpts = {}) {
   const aspectRatio = opts.aspectRatio ?? '1:1';
-  // Il default di render è Nano Banana 2 Lite, anche con riferimenti da riprodurre: decisione di
-  // prodotto presa nel 2026-08, Lite al posto di Pro su OGNI superficie. Un opts.model esplicito
-  // vince comunque — è la strada per riportare un call site su Pro senza deploy.
+  // Il default di render è Nano Banana 2 Lite OVUNQUE: decisione di prodotto del 2026-08, Lite al
+  // posto di Pro su ogni superficie. Il ramo senza riferimenti era rimasto indietro sul modello
+  // pieno, ed è dove cade la maggioranza delle immagini — un prompt e basta: misurate a $0,06 a
+  // chiamata. Un opts.model esplicito vince comunque, ed è la strada per riportare un call site
+  // sul modello pieno senza deploy; il blog lo fa già, passando BLOG_IMAGE_MODEL.
   const needsFidelity = !!(
     opts.personImages?.length ||
     opts.referenceImages?.length ||
@@ -173,7 +175,7 @@ export function buildImageRequest(imagePrompt: string, opts: RenderImageOpts = {
   const imageModel =
     (opts.baseImage ? opts.refineModel : undefined) ??
     opts.model ??
-    (needsFidelity ? NANO_BANANA_2_LITE : env.IMAGE_MODEL_NO_REF || BLOG_IMAGE_MODEL);
+    (needsFidelity ? NANO_BANANA_2_LITE : env.IMAGE_MODEL_NO_REF || NANO_BANANA_2_LITE);
   // Con foto di persona, il testo sul genere non deve mai scavalcare le foto.
   const cleanPrompt = opts.personImages?.length ? scrubPersonAppearance(imagePrompt) : imagePrompt;
   const styleSuffix = opts.visualStyle ? `\n\nBRAND VISUAL STYLE to match: ${opts.visualStyle}` : '';


### PR DESCRIPTION
## What?

One line. In `buildImageRequest`, the default image model when there are **no reference images**
moves from `BLOG_IMAGE_MODEL` (the full Nano Banana 2) to `NANO_BANANA_2_LITE`.

## Why?

Andrea asked the external agent for **one** image. `ai_calls` shows **two** calls, 46 seconds
apart, `nano-banana-2` on kie, **$0.06 each**.

The model is the first of the two defects, and it is a one-line fix. The branch **with**
reproduction refs already moved to Lite in 2026-08 — *"Lite instead of Pro on every surface"* —
but the branch **without** one stayed on the full model. That is where most images land: a prompt
and nothing else, no photo to reproduce.

The wrong belief was sitting in a test. It was named *"drops to the half-price tier with no
reproduction refs"* and asserted `BLOG_IMAGE_MODEL` — the **more** expensive model, not the
cheaper one. The name said the opposite of what the code did, which is why this arrived from a
bill rather than from a review. That test is corrected here, and renamed to say what it checks.

## How?

```diff
-    (needsFidelity ? NANO_BANANA_2_LITE : env.IMAGE_MODEL_NO_REF || BLOG_IMAGE_MODEL);
+    (needsFidelity ? NANO_BANANA_2_LITE : env.IMAGE_MODEL_NO_REF || NANO_BANANA_2_LITE);
```

The `needsFidelity` ternary is kept rather than collapsed, because the two branches still differ:
the no-reference one consults `env.IMAGE_MODEL_NO_REF`, the other does not.

### What this deliberately does NOT change

- **Blog images.** `blog-month.ts` and `content-preview/articles.ts` pass `model:
  BLOG_IMAGE_MODEL` explicitly — the batch API wants that model, and there the 50% batch discount
  beats the list-price difference. The default never reaches them, and a new test holds that.
- **The refine model.** Editing an image and inventing one are two jobs; the brand's
  `imageRefineModel` choice is untouched.
- **The branch with references**, which was already Lite.

## Testing?

```
npx vitest run src/lib/server/content-preview.test.ts   →  105 passed
npx vitest run src/lib/content/changelog                →  green
```

Written test-first: the new assertion failed with `expected 'gemini-3.1-flash-image' to be
'gemini-3.1-flash-lite-image'` — naming the exact model Andrea was billed for — and passes after
the change. No paid model was called; `buildImageRequest` is pure and builds the request without
sending it.

Not tested: that the cheaper model is *good enough* for reference-free prompts. That is a taste
judgement, not something a unit test settles, and it is the same model already serving every
image that has a reference.

## Evidence

<details>
<summary>The failing test, before the change</summary>

```
× il modello di default per un immagine > senza riferimenti disegna con Lite, non col modello pieno
  → expected 'gemini-3.1-flash-image' to be 'gemini-3.1-flash-lite-image'
```

</details>

No UI change, so no screenshots.

## Anything Else?

**One thing to check outside this PR:** `env.IMAGE_MODEL_NO_REF` still wins over this default —
it is the only branch that consults it, and it is the way to put an environment back on the full
model without a deploy. It is commented out in `.env.example`, so in principle it is set nowhere,
but **if it is set in the production environment this change will not be visible.** That needs
checking there, not here.

**No database writes needed:** all 15 active brands have a null `content_prefs->>'imageModel'` and
fall through to this constant, so the constant is the only place to touch.

**Two defects from the same report are not fixed here**, and are being handled separately: one
image request produced *two* paid calls 46s apart (`renderPostImage` retries up to
`MAX_IMAGE_ATTEMPTS = 3`, and kie polls to `KIE_TIMEOUT_MS = 120_000`, so the worst case is six
minutes and three charges for an image the contract prices as one), and the tool does not declare
that wait. A proposal on whether image generation stays synchronous or becomes a job like video is
going to Andrea separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY