### PR TITLE
Report renders billed, not images returned

### DIFF
--- a/changelog/2026-09-04-refine-what-you-already-made.md
+++ b/changelog/2026-09-04-refine-what-you-already-made.md
@@ -80,3 +80,36 @@ sua descrizione ora dice di preferire i due tool espliciti.
 `SKILL.md` portava un agente a concludere che l'editing non esiste — è successo davvero. Ora la
 riga c'è, e nomina l'errore: usare `generate_image` per modificare qualcosa paga un render nuovo e
 restituisce un soggetto diverso.
+
+## Il conto dichiarato raccontava le immagini, non i render
+
+Tre righe in `ai_calls` per la sessione di Andrea, tutte `ok = true`, tutte con costo, per
+un'immagine sola. La prima ipotesi — kie renderizza e fattura, noi non scarichiamo il risultato,
+`flatCostUsd` scritto lo stesso — **è stata smentita dai dati**: `ok` è `!!dataUrl`, e `ok: true`
+significa che il dataUrl c'era. Resta un difetto reale in quel ramo, ma non è questo.
+
+Quello che i dati dicono è peggio: **render riusciti, pagati, e scartati a valle**. In
+`renderWithQC` ce ne sono due sorgenti, entrambe attive:
+
+- `HIGH_STAKES_CANDIDATES = 2` — due render **in parallelo**, il critico ne sceglie uno, l'altro si
+  butta. Entrambi pagati. È il motivo per cui in `ai_calls` compaiono chiamate a mezzo secondo di
+  distanza: sono paralleli, non ritentativi.
+- `MAX_QC_RETRIES = 2` — un render riuscito che il critico boccia viene **ridisegnato a prezzo
+  pieno**, fino a due volte.
+
+Nel caso peggiore sono **quattro render fatturati** per un'immagine che `IMAGE_CREDITS` prezza
+come uno. `QcVerdict.attempts` li conta già — «quanti render sono stati prodotti in totale
+(candidati paralleli + ritentativi)» — ma quel numero non è mai arrivato a chi chiama, e `ai_calls`
+non dice da nessuna parte che un render è stato scartato. Il conto sale in silenzio.
+
+Qui la risposta porta `renders`: **quanti render sono stati pagati**, non quante immagini sono
+tornate. I due numeri divergono ogni volta che qualcosa a valle butta via un successo, ed è
+esattamente quando serve saperlo.
+
+E porta `model`: **quale modello ha disegnato davvero**, dopo la scelta del brand e il default di
+piattaforma. `env.IMAGE_MODEL_NO_REF` può ancora scavalcare tutto, quindi il fatto va reso
+visibile invece che sperato — si vede dalla prima chiamata, non da un'indagine.
+
+Il percorso di questi tool chiama `renderPostImage` direttamente, senza QC: un render chiesto, un
+render pagato. I due candidati e i ritentativi vivono sul percorso dei post e del blog, e restano
+da sistemare lì.

--- a/cli/lib/contracts/posts.ts
+++ b/cli/lib/contracts/posts.ts
@@ -349,7 +349,8 @@ export const GENERATE_MEDIA = {
     model: z
       .string()
       .nullable()
-      .describe('The model that made it; null when the platform default chose')
+      .describe('The model that ACTUALLY made it, after brand and platform defaults'),
+    renders: z.number().describe('How many renders were BILLED; 0 for a video, which bills when the clip lands')
   }),
   failures: [
     { error: 'credits_exhausted', status: 402 },
@@ -560,7 +561,11 @@ function modelField(slot: string) {
 const ImageResult = z.object({
   ok: z.literal(true),
   media: z.array(GeneratedMediaSchema),
-  model: z.string().nullable().describe('The model that drew it; null when the platform default chose')
+  model: z.string().nullable().describe('The model that ACTUALLY drew it, after brand and platform defaults — read it rather than assuming your request won'
+    + "'" + 't'),
+  renders: z
+    .number()
+    .describe('How many renders were BILLED. Can exceed the images returned: a render that fails downstream is still paid for.')
 });
 
 const MODEL_FAILURE = { error: 'model_not_for_slot', status: 400 } as const;

--- a/cli/plugins/anomalia/skills/anomalia/references/tools.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/tools.md
@@ -133,8 +133,11 @@ nothing is stored; `store_failed` (502) means it was drawn but could not be file
 optional `count` (1-4 alternatives, **each one billed**), `aspect_ratio`, `model`, `title`. It
 bills a render per image — roughly 8 credits each — and creates nothing in the calendar, so ask
 for two or three, look at them with `list_media`, and pass only the id you keep to `create_post`.
-The response carries `model`: the model that actually drew it, so an agent that chose nothing
-still knows what it got.
+The response carries two facts worth reading. `model` is the model that **actually** drew it,
+after the brand's choice and the platform default — read it rather than assuming your request won,
+because an environment override can still outrank it. `renders` is how many renders were **billed**,
+which can exceed the images you got back: a render that succeeds and is then discarded downstream
+is paid for all the same, so trust `renders` over your own count when reconciling spend.
 
 `refine_image` changes an image that is already in the library and files the result as a **new**
 asset — the original is never overwritten, so a refinement cannot destroy what it started from.

--- a/cli/skills/anomalia/references/tools.md
+++ b/cli/skills/anomalia/references/tools.md
@@ -133,8 +133,11 @@ nothing is stored; `store_failed` (502) means it was drawn but could not be file
 optional `count` (1-4 alternatives, **each one billed**), `aspect_ratio`, `model`, `title`. It
 bills a render per image — roughly 8 credits each — and creates nothing in the calendar, so ask
 for two or three, look at them with `list_media`, and pass only the id you keep to `create_post`.
-The response carries `model`: the model that actually drew it, so an agent that chose nothing
-still knows what it got.
+The response carries two facts worth reading. `model` is the model that **actually** drew it,
+after the brand's choice and the platform default — read it rather than assuming your request won,
+because an environment override can still outrank it. `renders` is how many renders were **billed**,
+which can exceed the images you got back: a render that succeeds and is then discarded downstream
+is paid for all the same, so trust `renders` over your own count when reconciling spend.
 
 `refine_image` changes an image that is already in the library and files the result as a **new**
 asset — the original is never overwritten, so a refinement cannot destroy what it started from.

--- a/packages/api-contracts/src/posts.ts
+++ b/packages/api-contracts/src/posts.ts
@@ -349,7 +349,8 @@ export const GENERATE_MEDIA = {
     model: z
       .string()
       .nullable()
-      .describe('The model that made it; null when the platform default chose')
+      .describe('The model that ACTUALLY made it, after brand and platform defaults'),
+    renders: z.number().describe('How many renders were BILLED; 0 for a video, which bills when the clip lands')
   }),
   failures: [
     { error: 'credits_exhausted', status: 402 },
@@ -560,7 +561,11 @@ function modelField(slot: string) {
 const ImageResult = z.object({
   ok: z.literal(true),
   media: z.array(GeneratedMediaSchema),
-  model: z.string().nullable().describe('The model that drew it; null when the platform default chose')
+  model: z.string().nullable().describe('The model that ACTUALLY drew it, after brand and platform defaults — read it rather than assuming your request won'
+    + "'" + 't'),
+  renders: z
+    .number()
+    .describe('How many renders were BILLED. Can exceed the images returned: a render that fails downstream is still paid for.')
 });
 
 const MODEL_FAILURE = { error: 'model_not_for_slot', status: 400 } as const;

--- a/src/lib/server/media-generate.refine.test.ts
+++ b/src/lib/server/media-generate.refine.test.ts
@@ -154,6 +154,37 @@ describe('rifinire un asset della libreria', () => {
     expect(renderPostImage).not.toHaveBeenCalled();
   });
 
+  // Il conto dichiarato deve raccontare i RENDER, non le immagini consegnate. Un render riuscito
+  // che qualcosa a valle scarta e' pagato lo stesso, e la sessione che ha aperto questa indagine
+  // aveva tre righe `ok: true` con costo per un'immagine sola: `ai_calls` non dice mai che un
+  // render e' stato buttato, quindi se non lo dice la risposta non lo dice nessuno.
+  it('dice quanti render sono stati PAGATI, non quante immagini consegna', async () => {
+    const out = await generateBrandImages(supabaseWith({}), {
+      brandId: 'brand-1',
+      userId: 'user-1',
+      prompt: 'tre direzioni',
+      count: 3
+    });
+
+    expect(out.ok && out.renders).toBe(3);
+    expect(out.ok && out.media.length).toBe(3);
+  });
+
+  it('un render pagato che non torna con un immagine resta nel conto', async () => {
+    renderPostImage.mockResolvedValueOnce(PNG_DATA_URL).mockResolvedValueOnce(undefined);
+
+    const out = await generateBrandImages(supabaseWith({}), {
+      brandId: 'brand-1',
+      userId: 'user-1',
+      prompt: 'due direzioni',
+      count: 2
+    });
+
+    // Una immagine consegnata, due render partiti: dichiarare "1" nasconderebbe il secondo conto.
+    expect(out.ok && out.media.length).toBe(1);
+    expect(out.ok && out.renders).toBe(2);
+  });
+
   it('l originale non viene sovrascritto: esce un asset NUOVO', async () => {
     await refineBrandImage(supabaseWith({}), {
       brandId: 'brand-1',

--- a/src/lib/server/media-generate.ts
+++ b/src/lib/server/media-generate.ts
@@ -46,8 +46,15 @@ export type GenerateMediaOpts = {
 };
 
 export type GenerateMediaResult =
-  | { ok: true; status: 'ready'; media: GeneratedMedia[]; jobId: null; model: string | null }
-  | { ok: true; status: 'rendering'; media: []; jobId: string; model: string | null }
+  | {
+      ok: true;
+      status: 'ready';
+      media: GeneratedMedia[];
+      jobId: null;
+      model: string | null;
+      renders: number;
+    }
+  | { ok: true; status: 'rendering'; media: []; jobId: string; model: string | null; renders: 0 }
   | { ok: false; error: 'render_failed' | 'store_failed' | 'video_budget_exhausted' }
   | { ok: false; error: 'model_not_for_slot'; allowed: string[] };
 
@@ -162,7 +169,7 @@ export type ImageJob = {
 };
 
 export type ImageJobResult =
-  | { ok: true; media: GeneratedMedia[]; model: string | null }
+  | { ok: true; media: GeneratedMedia[]; model: string | null; renders: number }
   | { ok: false; error: 'render_failed' | 'store_failed' | 'source_not_found' }
   | { ok: false; error: 'model_not_for_slot'; allowed: string[] };
 
@@ -222,7 +229,12 @@ async function runImageJob(
   const chosen = buildImageRequest(job.prompt, opts).model ?? null;
 
   const media: GeneratedMedia[] = [];
+  // Quanti render sono stati PAGATI, non quanti ne sono stati chiesti. Un render riuscito che
+  // qualcosa a valle scarta si paga lo stesso, e finche' il conto dichiarato racconta le immagini
+  // invece dei render, mente — in silenzio, perche' `ai_calls` si riempie di `ok: true`.
+  let renders = 0;
   for (let i = 0; i < (job.count ?? 1); i++) {
+    renders += 1;
     const dataUrl = await renderPostImage(null as never, job.prompt, opts).catch(() => undefined);
     if (!dataUrl) break;
 
@@ -236,7 +248,7 @@ async function runImageJob(
   // credere che qualcosa esista.
   if (!media.length) return { ok: false, error: 'render_failed' };
 
-  return { ok: true, media, model: chosen };
+  return { ok: true, media, model: chosen, renders };
 }
 
 export async function generateBrandImages(
@@ -328,7 +340,8 @@ async function startVideo(opts: GenerateMediaOpts): Promise<GenerateMediaResult>
     status: 'rendering',
     media: [],
     jobId: job.id as string,
-    model: submitted.model ?? null
+    model: submitted.model ?? null,
+    renders: 0
   };
 }
 
@@ -349,7 +362,7 @@ export async function generateBrandMedia(
   const out = await generateBrandImages(supabase, opts);
   if (!out.ok) return out;
 
-  return { ok: true, status: 'ready', media: out.media, jobId: null, model: out.model };
+  return { ok: true, status: 'ready', media: out.media, jobId: null, model: out.model, renders: out.renders };
 }
 
 export type MediaJob = {

--- a/src/routes/api/v1/brands/[slug]/media/generate/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/media/generate/+server.ts
@@ -64,6 +64,7 @@ export const POST: RequestHandler = async ({ request, params }) => {
     status: result.status,
     media: result.media,
     job_id: result.jobId,
-    model: result.model
+    model: result.model,
+    renders: result.renders
   });
 };

--- a/src/routes/api/v1/brands/[slug]/media/generate/server.generate.test.ts
+++ b/src/routes/api/v1/brands/[slug]/media/generate/server.generate.test.ts
@@ -58,7 +58,8 @@ beforeEach(() => {
     status: 'ready',
     media: [GENERATED],
     jobId: null,
-    model: 'nano-banana-2-lite'
+    model: 'nano-banana-2-lite',
+    renders: 1
   });
 });
 
@@ -72,7 +73,8 @@ describe('POST /api/v1/brands/:slug/media/generate', () => {
       status: 'ready',
       media: [GENERATED],
       job_id: null,
-      model: 'nano-banana-2-lite'
+      model: 'nano-banana-2-lite',
+      renders: 1
     });
   });
 
@@ -145,7 +147,8 @@ describe('POST /api/v1/brands/:slug/media/generate', () => {
       status: 'rendering',
       media: [],
       jobId: 'job-1',
-      model: 'grok-imagine/text-to-video'
+      model: 'grok-imagine/text-to-video',
+      renders: 0
     });
 
     const { res, body } = await call({ prompt: 'un carrello lento sul prodotto', kind: 'video' });
@@ -156,7 +159,8 @@ describe('POST /api/v1/brands/:slug/media/generate', () => {
       status: 'rendering',
       media: [],
       job_id: 'job-1',
-      model: 'grok-imagine/text-to-video'
+      model: 'grok-imagine/text-to-video',
+      renders: 0
     });
   });
 

--- a/src/routes/api/v1/brands/[slug]/media/images/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/media/images/+server.ts
@@ -40,5 +40,5 @@ export const POST: RequestHandler = async ({ request, params }) => {
     );
   }
 
-  return json({ ok: true, media: result.media, model: result.model });
+  return json({ ok: true, media: result.media, model: result.model, renders: result.renders });
 };

--- a/src/routes/api/v1/brands/[slug]/media/images/refine/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/media/images/refine/+server.ts
@@ -40,5 +40,5 @@ export const POST: RequestHandler = async ({ request, params }) => {
     );
   }
 
-  return json({ ok: true, media: result.media, model: result.model });
+  return json({ ok: true, media: result.media, model: result.model, renders: result.renders });
 };

--- a/src/routes/api/v1/brands/[slug]/media/images/server.images.test.ts
+++ b/src/routes/api/v1/brands/[slug]/media/images/server.images.test.ts
@@ -61,8 +61,8 @@ beforeEach(() => {
     error: null
   } as never);
   vi.mocked(gateAiAction).mockResolvedValue(undefined as never);
-  generateBrandImages.mockResolvedValue({ ok: true, media: [DRAWN], model: 'nano-banana-2-lite' });
-  refineBrandImage.mockResolvedValue({ ok: true, media: [DRAWN], model: 'nano-banana-2-pro' });
+  generateBrandImages.mockResolvedValue({ ok: true, media: [DRAWN], model: 'nano-banana-2-lite', renders: 1 });
+  refineBrandImage.mockResolvedValue({ ok: true, media: [DRAWN], model: 'nano-banana-2-pro', renders: 1 });
 });
 
 describe('POST /media/images — generate_image', () => {
@@ -70,7 +70,7 @@ describe('POST /media/images — generate_image', () => {
     const { res, body } = await generate({ prompt: 'un banco di lavoro in noce' });
 
     expect(res.status).toBe(200);
-    expect(body).toEqual({ ok: true, media: [DRAWN], model: 'nano-banana-2-lite' });
+    expect(body).toEqual({ ok: true, media: [DRAWN], model: 'nano-banana-2-lite', renders: 1 });
   });
 
   it('un brand senza crediti non disegna', async () => {
@@ -152,7 +152,7 @@ describe('POST /media/images/refine — refine_image', () => {
     const { res, body } = await refine({ base_media_id: 'media-0', instruction: 'sfondo più caldo' });
 
     expect(res.status).toBe(200);
-    expect(body).toEqual({ ok: true, media: [DRAWN], model: 'nano-banana-2-pro' });
+    expect(body).toEqual({ ok: true, media: [DRAWN], model: 'nano-banana-2-pro', renders: 1 });
     expect(refineBrandImage).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ baseMediaId: 'media-0', prompt: 'sfondo più caldo' })


### PR DESCRIPTION
## What?

The image generators now return **`renders`** — how many renders were actually **billed** — next to
the images they hand back. The two numbers diverge exactly when someone needs to know.

## Why?

I was wrong about the double charge, and being wrong pointed at something worse.

My first reading was that kie renders and bills, we fail to download the result, and `flatCostUsd`
gets written anyway. **The production rows refute it:**

```
15:38:05  nano-banana-2  kie  0.060000  ok=true  error=null
15:38:51  nano-banana-2  kie  0.060000  ok=true  error=null
15:42:45  nano-banana-2  kie  0.060000  ok=true  error=null
```

`ok` is `!!dataUrl`, so `ok: true` means the image was there. Three successful, paid renders. That
download-failure branch is still a real defect, but it is not this one.

What the rows actually show is **successful renders, paid for, thrown away downstream** — and
nothing anywhere records that it happened. `ai_calls` fills with `ok: true`, the bill climbs, and no
row says a render was discarded.

`renderWithQC` has two sources of it, both on by default:

| Constant | Value | What it costs |
|---|---|---|
| `HIGH_STAKES_CANDIDATES` | 2 | Two renders **in parallel**, the critic keeps one, the other is discarded. Both billed. |
| `MAX_QC_RETRIES` | 2 | A render that succeeded but fails the critic is **redrawn at full price**, up to twice. |

Worst case: **four billed renders** for something `IMAGE_CREDITS` prices as one
(`credits(0.069 + 0.008)`). The parallel pair also explains the other pattern in the data — three
calls inside half a second are candidates, not retries.

`QcVerdict.attempts` already counts this, and is even documented as *"quanti render sono stati
prodotti in totale (candidati paralleli + ritentativi)"*. **It just never reaches the caller.**

## How?

`runImageJob` counts the renders it starts and returns the number; the contract declares it; the
routes pass it through. `generate_media` reports it too — `0` for a video, which bills when the clip
lands rather than when it is asked for.

The description says what it is for: *"How many renders were BILLED. Can exceed the images returned:
a render that fails downstream is still paid for."*

`model` gained the same honesty in wording — *"the model that ACTUALLY drew it, after brand and
platform defaults — read it rather than assuming your request won"*. `env.IMAGE_MODEL_NO_REF` can
still outrank both the brand's choice and the new Lite default from #321, so that fact should be
visible from the first call instead of from an investigation.

**Scope:** these tools call `renderPostImage` directly — one render asked, one render paid. The
candidates and QC retries live on the post and blog paths and are **not touched here**; they need
their own change, and it is a bigger one than a field.

## Testing?

Two new tests, both about the number being true rather than convenient:

- `dice quanti render sono stati PAGATI, non quante immagini consegna` — `count: 3` returns
  `renders: 3`.
- `un render pagato che non torna con un immagine resta nel conto` — the second render comes back
  empty; one image is delivered and **`renders` is still 2**. Declaring `1` would hide the second
  charge, which is the whole defect in miniature.

```
npx vitest run packages/api-contracts src/routes/api/v1/brands/[slug] \
    src/lib/server/media-generate.*.test.ts src/lib/content/changelog  →  all passed
cd cli && bun test           →  69 pass, 0 fail
cd cli && bun run typecheck  →  exit 0
```

No paid model called; `renderPostImage` is mocked throughout. No dev server, no Docker, no
Playwright.

**Not tested, and worth saying:** that `renders` matches what the provider actually charged. It
counts calls we made, which is the number we control; reconciling it against `ai_calls.cost_usd` is
a separate job.

## Evidence

`tools/list` through `handleMcpFetch`, re-captured on this rebased base:

```
base (dev, post-#323): 123 -> branch: 123
ADDED  : (none)
REMOVED: (none)
CHANGED: refine_image
```

The single `CHANGED` is **stale baseline drift, not this PR**: my capture predates a description fix
that shipped in #323, and `git show origin/dev:packages/api-contracts/src/posts.ts` confirms the new
wording is already on `dev`. `renders` is an **output** field, and MCP tools carry only
`inputSchema`, so this PR moves nothing an agent sees in the listing — it changes what comes back
from a call.

No UI change.

## Anything Else?

**What still has no explanation, and I am not going to guess a third time.** Two billed successes 46
seconds apart cannot come from `generate_media`'s code path: it calls `renderPostImage` directly, and
the kie loop returns on the first truthy result. So either those rows came from a QC-bearing surface,
or the request was made twice. If it was made twice, the likely cause is a client-side timeout and
retry against an endpoint with **no idempotency** — a render takes ~40s, and 46s is uncomfortably
close to a default MCP client timeout. That is checkable against the request log and worth doing,
because an idempotency key would be the fix and this PR is not it.

**The QC discard is the bigger fish.** Two parallel candidates and up to two full-price redraws sit
on every post and blog image, priced as one render, with only a `console.warn` to show for it. The
honest options are to reuse the discarded candidate, to stop paying for the second one, or to surface
`qc.attempts` the way `renders` is surfaced here. That is a product decision about image quality
versus spend, not a refactor.

**Image generation as a job** — agreed and next. Until a successful render can be silently discarded,
"documenting the wait" means documenting a wait whose ceiling nobody knows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY