### PR TITLE
Resume a timed-out kie task instead of opening another

### DIFF
--- a/changelog/2026-09-04-kie-timeout-non-riapre.md
+++ b/changelog/2026-09-04-kie-timeout-non-riapre.md
@@ -1,0 +1,68 @@
+# Un task kie scaduto si riprende, non si riapre
+
+Andrea ha guardato il cruscotto di kie e ha chiesto se avessimo allungato i timeout, perché *«ci
+sta facendo consumare un sacco di chiamate inutili»*. Il numero sul loro cruscotto non tornava col
+nostro.
+
+## Il difetto
+
+`pollKieTask` restituiva `undefined` per **due cose diverse**:
+
+- kie ha **rifiutato** il lavoro (`state === 'fail'`) — non ci è costato niente, ritentare è giusto;
+- il nostro tempo è **scaduto** mentre kie stava ancora renderizzando — il task resta suo, lo
+  finisce e lo fattura.
+
+Il chiamante non poteva distinguerli, quindi trattava entrambi come «non è tornato niente» e
+ritentava. Il ritentativo apriva un **task nuovo** mentre il primo continuava a girare. kie li
+fattura tutti e due.
+
+Con `IMAGE_TIMEOUT_MS = 300_000` e due tentativi, il caso peggiore è **dieci minuti e due task
+pagati** per un'immagine sola. (`MAX_IMAGE_ATTEMPTS = 3` è il percorso Google, non questo: su kie i
+tentativi sono due.)
+
+## Perché era invisibile
+
+Il costo si scrive da `creditsConsumed`, che esiste **solo sul ramo `success`**. Un task
+abbandonato non produceva nessuna riga in `ai_calls`: addebitato da kie, inesistente da noi. È
+esattamente la differenza che Andrea stava guardando fra i due cruscotti.
+
+Ed è anche la spiegazione migliore dei due render a 46 secondi: non serve ipotizzare un ritentativo
+del client, il ritentativo ce l'avevamo dentro.
+
+## La correzione
+
+`pollKieTask` ora restituisce un esito esplicito — `done`, `failed`, `timeout` — e la scadenza
+**porta con sé il `taskId`**. Non è un dettaglio di tipo: far collassare due stati diversi in un
+`undefined` *era* la causa, perché rendeva impossibile al chiamante ritentare solo il caso giusto.
+
+Il ciclo di `renderPostImage` ora passa quel `taskId` al secondo tentativo e **riprende lo stesso
+lavoro**, senza ricaricare i riferimenti e senza aprire niente. Il ritentativo vero — quello che
+riparte da zero — resta dove ha senso: sul rifiuto, che non abbiamo pagato.
+
+Una scadenza lascia una riga in `ai_calls` con l'esito e il `taskId`, e **senza costo inventato**:
+kie ci addebita, ma quanto non si sa finché il task non finisce. Un buco dichiarato è leggibile; un
+numero plausibile e sbagliato no.
+
+## Sull'annullamento
+
+**kie non espone un annullamento** nell'API che usiamo: le sole due chiamate sono
+`POST /jobs/createTask` e `GET /jobs/recordInfo`. Non ne ho inventata una. Se esistesse, il posto
+dove chiamarla sarebbe il ramo `timeout` di `pollKieTask`.
+
+## Il video non serviva sistemarlo
+
+Verificato invece che riscritto due volte: il percorso video **non riapre niente**. `runKieVideoJob`
+crea un task e lo interroga una volta sola, senza ciclo; e il percorso asincrono — quello che conta
+— fa già la cosa giusta, perché `finishVideoRender` reinterroga il **medesimo** `task_id` salvato su
+`video_renders` e restituisce `pending`, così il reconciler lo ripesca al giro dopo. Era già il
+modello da copiare.
+
+Gli altri cinque punti che chiamavano `pollKieTask` sono stati adeguati al nuovo esito: nessuno di
+loro riapre un task, e ora ognuno dice esplicitamente cosa fa di una scadenza invece di confonderla
+con un fallimento.
+
+## Cosa NON è cambiato
+
+I due candidati paralleli di `renderWithQC` (`HIGH_STAKES_CANDIDATES = 2`) e i suoi ritentativi
+(`MAX_QC_RETRIES = 2`) restano come sono. Sono una scelta fra qualità e spesa e la decisione è di
+Andrea. Questo qui non era una scelta: era pagare due volte lo stesso lavoro.

--- a/src/lib/content/changelog/2026-09-04-fewer-wasted-renders.ts
+++ b/src/lib/content/changelog/2026-09-04-fewer-wasted-renders.ts
@@ -1,0 +1,10 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-04',
+  title: 'Slow renders no longer cost twice',
+  items: [
+    'When an image takes longer than expected, Anomalia now waits on the render already in progress instead of starting a second one — the same picture was being paid for twice.',
+    'A render that runs over now leaves a record, so the credits it used are visible instead of missing.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/content-preview/images.ts
+++ b/src/lib/server/content-preview/images.ts
@@ -261,13 +261,27 @@ export async function renderPostImage(
   if (route('image').endpoint === 'kie') {
     // Due tentativi, non tre: su kie il fallimento arriva già diagnosticato in pochi secondi, e
     // non serve l'insistenza che serve con la risposta vuota di Gemini.
+    //
+    // Il ritentativo vale su un RIFIUTO, che non ci è costato niente. Su una SCADENZA no: kie sta
+    // ancora renderizzando quel task e lo fatturerà comunque, quindi aprirne un secondo è chiedere
+    // lo stesso lavoro due volte — proprio quando il fornitore è in affanno — e pagarlo due volte.
+    // Si riprende lo stesso taskId.
+    let resumeTaskId: string | undefined;
     for (let attempt = 1; attempt <= 2; attempt++) {
       // L'URL di kie vive 24 ore: non deve sopravvivere alla funzione, men che meno finire in una
       // riga del database.
-      const viaKie = await generateImageOnKie(req, { context: `image:${imageModel}` });
-      if (viaKie) return viaKie;
+      const viaKie = await generateImageOnKie(req, {
+        context: `image:${imageModel}`,
+        resumeTaskId
+      });
+      if (viaKie.dataUrl) return viaKie.dataUrl;
+      resumeTaskId = viaKie.timedOutTaskId;
     }
-    throw new Error(`No image returned from kie (${imageModel}) after 2 attempts`);
+    throw new Error(
+      resumeTaskId
+        ? `kie task ${resumeTaskId} (${imageModel}) still unfinished — it is rendering and will be billed`
+        : `No image returned from kie (${imageModel}) after 2 attempts`
+    );
   }
   // Pixel Google: il client si costruisce QUI, non nei chiamanti (testo/QC non devono toccare Google).
   // Un modello che vive solo su kie non è un modello per Google: `googleImageModel` lo riporta a

--- a/src/lib/server/kie-jobs.test.ts
+++ b/src/lib/server/kie-jobs.test.ts
@@ -178,7 +178,7 @@ describe('generateImageOnKie', () => {
     expect(submit.input.resolution).toMatch(/^[124]K$/);
 
     // L'URL di kie vive 24h: quello che esce di qui è già un data URL scaricato.
-    expect(out?.startsWith('data:image/png;base64,')).toBe(true);
+    expect(out.dataUrl?.startsWith('data:image/png;base64,')).toBe(true);
     expect(out).not.toContain('tempfile.kie');
   });
 
@@ -248,7 +248,10 @@ describe('generateImageOnKie', () => {
     const out = await generateImageOnKie(
       geminiRequest([{ text: 'x' }, { inlineData: { mimeType: 'image/png', data: PNG_B64 } }])
     );
-    expect(out).toBeUndefined();
+    // Niente immagine e nessun task da riprendere: qui non si e' aperto nulla, quindi non c'e'
+    // niente che kie stia ancora renderizzando.
+    expect(out.dataUrl).toBeUndefined();
+    expect(out.timedOutTaskId).toBeUndefined();
     expect(logged.at(-1)).toMatchObject({ ok: false, provider: 'kie' });
   });
 });

--- a/src/lib/server/kie-jobs.timeout.test.ts
+++ b/src/lib/server/kie-jobs.timeout.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/**
+ * UN TASK SCADUTO NON È UN TASK FALLITO, e trattarli allo stesso modo costa due volte.
+ *
+ * `pollKieTask` restituiva `undefined` per entrambi: kie ha rifiutato il lavoro, oppure kie lo sta
+ * ancora facendo e noi abbiamo smesso di guardare. Il chiamante non poteva distinguerli, quindi
+ * ritentava — aprendo un task NUOVO mentre il primo continuava a renderizzare. kie fattura tutti e
+ * due. E il costo si scrive solo dal ramo `success`, quindi il task abbandonato non lascia nessuna
+ * riga: invisibile da noi, addebitato da loro. È la differenza che si vede fra il loro cruscotto e
+ * i nostri numeri.
+ *
+ * Il test guarda UNA cosa: quante volte si è chiamato createTask. Se dopo una scadenza ne compare
+ * un secondo, stiamo pagando due volte lo stesso lavoro.
+ */
+
+const CREATE = 'https://api.kie.ai/api/v1/jobs/createTask';
+const INFO = 'https://api.kie.ai/api/v1/jobs/recordInfo';
+
+let created: number;
+let infoCalls: string[];
+let states: string[];
+
+function jsonResponse(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' }
+  });
+}
+
+beforeEach(() => {
+  created = 0;
+  infoCalls = [];
+  states = [];
+  vi.stubEnv('KIE_API_KEY', 'test-key');
+
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+
+      if (url.startsWith(CREATE)) {
+        created += 1;
+        return jsonResponse({ data: { taskId: `task-${created}` } });
+      }
+
+      if (url.startsWith(INFO)) {
+        const taskId = new URL(url).searchParams.get('taskId') ?? '';
+        infoCalls.push(taskId);
+        const state = states.shift() ?? 'waiting';
+        if (state === 'success') {
+          return jsonResponse({
+            data: {
+              state: 'success',
+              resultJson: JSON.stringify({ resultUrls: ['https://cdn.test/img.png'] }),
+              creditsConsumed: 12
+            }
+          });
+        }
+        return jsonResponse({ data: { state } });
+      }
+
+      // Il download del risultato.
+      return new Response(new Uint8Array([1, 2, 3]), {
+        status: 200,
+        headers: { 'content-type': 'image/png' }
+      });
+    })
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+describe('pollKieTask distingue scaduto da fallito', () => {
+  it('uno SCADUTO si riconosce, e porta con sé il taskId da riprendere', async () => {
+    const { pollKieTask } = await import('./kie-jobs');
+    states = ['waiting'];
+
+    // Un solo giro: la finestra è più corta dell'intervallo, quindi scade subito.
+    const out = await pollKieTask('task-1', 1, undefined, 'test', 1);
+
+    expect(out).toEqual({ status: 'timeout', taskId: 'task-1' });
+  });
+
+  it('un RIFIUTATO si riconosce, e dice perché', async () => {
+    const { pollKieTask } = await import('./kie-jobs');
+    states = ['fail'];
+
+    const out = await pollKieTask('task-1', 10_000, undefined, 'test', 1);
+
+    expect(out).toMatchObject({ status: 'failed', taskId: 'task-1' });
+  });
+
+  it('un RIUSCITO porta url, taskId e i crediti che kie ha addebitato', async () => {
+    const { pollKieTask } = await import('./kie-jobs');
+    states = ['success'];
+
+    const out = await pollKieTask('task-1', 10_000, undefined, 'test', 1);
+
+    expect(out).toMatchObject({
+      status: 'done',
+      taskId: 'task-1',
+      url: 'https://cdn.test/img.png',
+      credits: 12
+    });
+  });
+});
+
+describe('generateImageOnKie riprende invece di riaprire', () => {
+  const req = {
+    model: 'gemini-3.1-flash-lite-image',
+    contents: [{ role: 'user', parts: [{ text: 'un banco di lavoro in noce' }] }],
+    config: { responseModalities: ['TEXT', 'IMAGE'] }
+  };
+
+  it('riprende il task scaduto invece di aprirne un altro', async () => {
+    const { generateImageOnKie } = await import('./kie-jobs');
+    states = ['success'];
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const out = await generateImageOnKie(req as any, { resumeTaskId: 'task-scaduto' });
+
+    // Il fatto che conta: nessun task nuovo. Il lavoro che kie sta già facendo è quello che si aspetta.
+    expect(created).toBe(0);
+    expect(infoCalls).toEqual(['task-scaduto']);
+    expect(out.dataUrl).toBeTruthy();
+  });
+
+  it('senza un task da riprendere ne apre uno, come sempre', async () => {
+    const { generateImageOnKie } = await import('./kie-jobs');
+    states = ['success'];
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await generateImageOnKie(req as any, {});
+
+    expect(created).toBe(1);
+  });
+
+  it('una scadenza lascia una riga: paghiamo senza sapere quanto, e si deve vedere', async () => {
+    const logged: Array<Record<string, unknown>> = [];
+    vi.doMock('$lib/server/ai-log', () => ({
+      logAiCall: (e: Record<string, unknown>) => logged.push(e),
+      withBrandContext: <T,>(_b: string, fn: () => T) => fn(),
+      getBrandContext: () => undefined
+    }));
+    vi.resetModules();
+
+    const { generateImageOnKie } = await import('./kie-jobs');
+    states = ['waiting'];
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await generateImageOnKie({ model: 'm', contents: [{ role: 'user', parts: [{ text: 'x' }] }] } as any, {
+      timeoutMs: 1
+    });
+
+    const row = logged.at(-1)!;
+    expect(row.provider).toBe('kie');
+    expect(row.ok).toBe(false);
+    // Il costo NON si inventa: kie lo addebita, noi non sappiamo quanto finche' il task non finisce.
+    expect(row.flatCostUsd).toBeUndefined();
+    expect(String(row.error)).toContain('task-1');
+    expect(String(row.error)).toContain('scaduto');
+
+    vi.doUnmock('$lib/server/ai-log');
+    vi.resetModules();
+  });
+
+  it('una scadenza restituisce il taskId da riprendere, non un fallimento muto', async () => {
+    const { generateImageOnKie } = await import('./kie-jobs');
+    states = ['waiting'];
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const out = await generateImageOnKie(req as any, { timeoutMs: 1 });
+
+    expect(out.dataUrl).toBeUndefined();
+    expect(out.timedOutTaskId).toBe('task-1');
+  });
+});

--- a/src/lib/server/kie-jobs.ts
+++ b/src/lib/server/kie-jobs.ts
@@ -113,6 +113,18 @@ export async function createKieTask(
 }
 
 /**
+ * L'esito di un poll. SCADUTO e FALLITO sono due cose diverse e qui non collassano piu' in un
+ * `undefined`: kie che RIFIUTA un lavoro non ci costa niente e si puo' ritentare, kie che sta
+ * ANCORA lavorando mentre noi smettiamo di guardare ci costa comunque — e ritentare li' apre un
+ * secondo task che kie fattura di nuovo, per lo stesso lavoro. Il `taskId` viaggia con la scadenza
+ * apposta: e' cio' che serve per riprendere quello invece di aprirne un altro.
+ */
+export type KiePollOutcome =
+  | { status: 'done'; url: string; taskId: string; credits?: number }
+  | { status: 'failed'; taskId: string; error: string }
+  | { status: 'timeout'; taskId: string };
+
+/**
  * Poll fino alla fine. L'URL finale sta in `data.resultJson` (una *stringa* JSON) a `resultUrls[0]`;
  * `creditsConsumed` sullo stesso payload è l'addebito ESATTO di kie — si fattura quello, mai una stima.
  *
@@ -125,16 +137,16 @@ export async function pollKieTask(
   signal?: AbortSignal,
   label = 'kie',
   intervalMs = 5000
-): Promise<KieJobResult | undefined> {
+): Promise<KiePollOutcome> {
   const deadline = Date.now() + timeoutMs;
   let first = true;
   while (Date.now() < deadline) {
-    if (signal?.aborted) return undefined;
+    if (signal?.aborted) return { status: 'timeout', taskId };
     // Si CHIEDE prima e si aspetta dopo: un job già pronto (o già rifiutato) torna subito invece di
     // costare un intervallo intero di attesa a vuoto.
     if (!first) await kieSleep(intervalMs, signal);
     first = false;
-    if (signal?.aborted) return undefined;
+    if (signal?.aborted) return { status: 'timeout', taskId };
     const infoRes = await fetch(`${KIE_JOBS_BASE}/jobs/recordInfo?taskId=${encodeURIComponent(taskId)}`, {
       headers: kieJobHeaders(),
       signal
@@ -148,7 +160,7 @@ export async function pollKieTask(
       const why =
         info?.data?.failMsg ?? info?.data?.failCode ?? info?.data?.errorMessage ?? '(nessun motivo)';
       console.error(`[${label}] kie task ${taskId} ${state}: ${String(why).slice(0, 400)}`);
-      return undefined;
+      return { status: 'failed', taskId, error: String(why).slice(0, 400) };
     }
     if (state === 'success' || state === 'completed') {
       const raw = info?.data?.resultJson;
@@ -156,18 +168,21 @@ export async function pollKieTask(
       try {
         parsed = typeof raw === 'string' ? JSON.parse(raw) : raw;
       } catch {
-        return undefined;
+        return { status: 'failed', taskId, error: 'resultJson non leggibile' };
       }
       const url = parsed?.resultUrls?.[0];
-      if (!url) return undefined;
+      if (!url) return { status: 'failed', taskId, error: 'nessun resultUrl' };
       const rawCredits = info?.data?.creditsConsumed ?? info?.data?.credits_consumed;
       const credits = Number.isFinite(Number(rawCredits)) ? Number(rawCredits) : undefined;
-      return { url, taskId, credits };
+      return { status: 'done', url, taskId, credits };
     }
     // qualsiasi altro stato (waiting/queuing/generating) → si continua a chiedere
   }
+  // ABBANDONATO, non annullato: kie continua a renderizzare e a fatturare. L'API che usiamo
+  // (`createTask` + `recordInfo`) non espone un annullamento, quindi l'unica cosa onesta e'
+  // riprendere questo taskId invece di aprirne un altro.
   console.error(`[${label}] kie task ${taskId} non finito dopo ${Math.round(timeoutMs / 1000)}s`);
-  return undefined; // scaduto
+  return { status: 'timeout', taskId };
 }
 
 /**
@@ -358,10 +373,23 @@ export type GeminiImageRequest = {
  * prodotto o persona), quindi ~2–4s in più sui ~30s del render; il caso peggiore che
  * `buildImageRequest` può produrre è 6, cioè ~12s. Si caricano in parallelo apposta.
  */
+export type KieImageOutcome = {
+  dataUrl?: string;
+  /** Presente = kie sta ANCORA lavorando su questo task. Si riprende, non se ne apre un altro. */
+  timedOutTaskId?: string;
+};
+
 export async function generateImageOnKie(
   req: GeminiImageRequest,
-  opts: { label?: string; context?: string; signal?: AbortSignal } = {}
-): Promise<string | undefined> {
+  opts: {
+    label?: string;
+    context?: string;
+    signal?: AbortSignal;
+    /** Il task di un tentativo scaduto: si riprende quello, e non si carica niente due volte. */
+    resumeTaskId?: string;
+    timeoutMs?: number;
+  } = {}
+): Promise<KieImageOutcome> {
   const label = opts.label ?? 'renderPostImage';
   const parts = req.contents?.[0]?.parts ?? [];
   const prompt = parts
@@ -383,8 +411,33 @@ export async function generateImageOnKie(
       error,
       context: opts.context
     });
-    return undefined;
+    return {};
   };
+
+  /**
+   * Un task scaduto e' l'unico esito che si paga senza sapere quanto: `creditsConsumed` arriva solo
+   * dal ramo `success`, quindi senza questa riga l'addebito esiste su kie e da noi non esiste
+   * affatto. Non si inventa un numero — si scrive l'esito e il taskId, e la differenza col
+   * cruscotto di kie diventa leggibile invece che misteriosa.
+   */
+  const abandoned = (taskId: string): KieImageOutcome => {
+    logAiCall({
+      label,
+      provider: 'kie',
+      model,
+      ms: Date.now() - t0,
+      ok: false,
+      error: `task ${taskId} scaduto: kie lo sta ancora renderizzando e lo fattura, costo ignoto`,
+      context: opts.context
+    });
+    return { timedOutTaskId: taskId };
+  };
+
+  // Un tentativo che riprende un task gia' aperto non ricarica i riferimenti e non ne crea un
+  // altro: il lavoro e' gia' in corso e pagato, qui si torna solo a guardarlo.
+  if (opts.resumeTaskId) {
+    return finishKieImage(opts.resumeTaskId, label, model, t0, opts, abandoned);
+  }
 
   // I riferimenti in parallelo: sono giri di rete indipendenti, in serie sarebbero 6× la latenza.
   const refUrls = (await Promise.all(refs.map((r) => uploadKieRef(r, opts.signal)))).filter(
@@ -405,8 +458,41 @@ export async function generateImageOnKie(
   const taskId = await createKieTask(model, input, opts.signal, 'kie-image');
   if (!taskId) return fail('createTask rifiutata');
 
-  const job = await pollKieTask(taskId, IMAGE_TIMEOUT_MS, opts.signal, 'kie-image', POLL_INTERVAL_MS);
-  if (!job) return fail('job fallito o scaduto');
+  return finishKieImage(taskId, label, model, t0, opts, abandoned);
+}
+
+/** Da qui in giu' il task esiste gia': si guarda come va e si paga cio' che kie ha addebitato. */
+async function finishKieImage(
+  taskId: string,
+  label: string,
+  model: string,
+  t0: number,
+  opts: { context?: string; signal?: AbortSignal; timeoutMs?: number },
+  abandoned: (taskId: string) => KieImageOutcome
+): Promise<KieImageOutcome> {
+  const job = await pollKieTask(
+    taskId,
+    opts.timeoutMs ?? IMAGE_TIMEOUT_MS,
+    opts.signal,
+    'kie-image',
+    POLL_INTERVAL_MS
+  );
+
+  if (job.status === 'timeout') return abandoned(taskId);
+
+  if (job.status === 'failed') {
+    // Rifiutato = non addebitato. Qui `cost_usd` a null e' la verita', non un buco.
+    logAiCall({
+      label,
+      provider: 'kie',
+      model,
+      ms: Date.now() - t0,
+      ok: false,
+      error: job.error,
+      context: opts.context
+    });
+    return {};
+  }
 
   const dataUrl = await fetchAsDataUrl(job.url, opts.signal);
   logAiCall({
@@ -420,7 +506,7 @@ export async function generateImageOnKie(
     flatCostUsd: kieFlatCostUsd(job.credits),
     context: opts.context
   });
-  return dataUrl;
+  return { dataUrl };
 }
 
 // ── Voce ────────────────────────────────────────────────────────────────────────────────────
@@ -483,7 +569,7 @@ export async function generateSpeechOnKie(opts: {
   if (!taskId) return undefined;
 
   const job = await pollKieTask(taskId, TTS_TIMEOUT_MS, opts.signal, 'kie-tts', POLL_INTERVAL_MS);
-  if (!job) return undefined;
+  if (job.status !== 'done') return undefined;
 
   const res = await fetch(job.url, {
     signal: opts.signal ?? AbortSignal.timeout(60_000)

--- a/src/lib/server/video.ts
+++ b/src/lib/server/video.ts
@@ -712,7 +712,11 @@ async function runVideoJob(
     'video'
   );
   if (!taskId) return undefined;
-  return pollKieTask(taskId, POLL_TIMEOUT_MS, opts.abortSignal, 'video', POLL_INTERVAL_MS);
+  const job = await pollKieTask(taskId, POLL_TIMEOUT_MS, opts.abortSignal, 'video', POLL_INTERVAL_MS);
+
+  // Una scadenza non riapre niente: il task resta di kie, e chi passa dalla coda lo ripesca dal
+  // `task_id` che ha gia' scritto. Aprire un secondo task qui pagherebbe due volte lo stesso clip.
+  return job.status === 'done' ? job : undefined;
 }
 
 // Gli URL di kie non sono permanenti. La RLS dello Storage pretende che il primo segmento del path
@@ -1041,7 +1045,9 @@ export async function transformVideo(opts: {
               'video.transform'
             );
             return taskId
-              ? pollKieTask(taskId, POLL_TIMEOUT_MS, opts.abortSignal, 'video.transform', POLL_INTERVAL_MS)
+              ? pollKieTask(taskId, POLL_TIMEOUT_MS, opts.abortSignal, 'video.transform', POLL_INTERVAL_MS).then(
+                  (r) => (r.status === 'done' ? r : undefined)
+                )
               : undefined;
           })();
   } catch (e) {
@@ -1257,7 +1263,10 @@ export async function upscaleVideo(
   const t0 = Date.now();
   try {
     const newTaskId = await createKieTask(MODEL_UPSCALE, { task_id: taskId, resolution }, undefined, 'video');
-    const job = newTaskId ? await pollKieTask(newTaskId, UPSCALE_TIMEOUT_MS, undefined, 'video', POLL_INTERVAL_MS) : undefined;
+    const polled = newTaskId
+      ? await pollKieTask(newTaskId, UPSCALE_TIMEOUT_MS, undefined, 'video', POLL_INTERVAL_MS)
+      : undefined;
+    const job = polled?.status === 'done' ? polled : undefined;
     logAiCall({
       label: 'video.upscale',
       provider: 'kie',


### PR DESCRIPTION
## What?

`pollKieTask` now reports **why** it stopped — `done`, `failed`, or `timeout` — and a timeout
carries its `taskId`. The image retry loop uses that to **resume the render already in progress**
instead of opening a second one.

## Why?

Andrea looked at the kie dashboard and asked whether we had lengthened the timeouts, because *"ci
sta facendo consumare un sacco di chiamate inutili"*. Their number and ours did not agree.

`pollKieTask` returned `undefined` for **two different things**:

- kie **refused** the work (`state === 'fail'`) — cost us nothing, retrying is correct;
- our clock **ran out** while kie was still rendering — the task is still theirs, they finish it,
  and they bill it.

The caller could not tell them apart, so it treated both as "nothing came back" and retried. The
retry opened a **new task** while the first kept rendering. kie charges for both.

With `IMAGE_TIMEOUT_MS = 300_000` and two attempts, the worst case is **ten minutes and two paid
tasks** for a single image. (`MAX_IMAGE_ATTEMPTS = 3` is the Google path, not this one — on kie the
loop runs twice.)

**It was invisible.** Cost is written from `creditsConsumed`, which exists **only on the `success`
branch**. An abandoned task produced no row in `ai_calls` at all: billed by kie, absent from us.
That is precisely the discrepancy between the two dashboards.

It also explains the two renders 46 seconds apart better than my earlier client-retry theory — no
need to posit a client retry when the retry was ours.

## How?

Collapsing two states into one `undefined` **was** the cause, not a typing detail: it made retrying
only the right case impossible. So the outcome became explicit:

```ts
export type KiePollOutcome =
  | { status: 'done'; url: string; taskId: string; credits?: number }
  | { status: 'failed'; taskId: string; error: string }
  | { status: 'timeout'; taskId: string };
```

`generateImageOnKie` takes a `resumeTaskId` and, when given one, goes straight to polling — no
reference re-upload, no `createTask`. `renderPostImage` passes the timed-out id into its second
attempt. The genuine retry, the one that starts over, stays where it belongs: on a refusal.

**A timeout leaves a row** in `ai_calls` with the outcome and the `taskId` and **no invented cost**.
kie charges us; how much is unknown until the task finishes. A declared hole is readable, a
plausible wrong number is not — the same reasoning as the `renders` field in #324.

### Cancellation

**kie exposes no cancellation** in the API we use — `POST /jobs/createTask` and
`GET /jobs/recordInfo` are the only two calls anywhere in the code. I did not invent one. If it
exists, the place to call it is the `timeout` branch of `pollKieTask`.

### Video needed no change — verified, not written twice

- `runKieVideoJob` creates a task and polls it **once**, with no retry loop. Nothing reopens.
- The async path already does the right thing: `finishVideoRender` re-polls the **same** `task_id`
  stored on `video_renders` and returns `pending`, so the reconciler picks it up next tick. That was
  already the model to copy.

The other five `pollKieTask` sites are updated to the new outcome, so each one now says explicitly
what it does with a timeout rather than confusing it with a failure.

## Testing?

Written test-first. The one that matters counts `createTask` calls, because that is the money:

```
× generateImageOnKie riprende invece di riaprire > riprende il task scaduto invece di aprirne un altro
  → expected 1 to be +0
```

That `1` is the second task. After the change it is `0`, and the poll goes to the resumed id.

Seven tests: timeout / failed / done are each distinguishable; a resume opens nothing and polls the
given id; no resume still opens one; a timeout returns the id to resume; and a timeout writes an
`ai_calls` row with `ok: false`, the taskId, and **`flatCostUsd` undefined** — the cost is not
guessed.

Two pre-existing tests in `kie-jobs.test.ts` asserted the old `string | undefined` shape and were
updated; their intent is unchanged, and one gained an assertion that a failed reference upload
leaves **no** task to resume, since nothing was opened.

```
vitest: kie-jobs, kie-jobs.timeout, content-preview, video, video-render-queue,
        voiceover-cut, api-contracts, api/v1/brands/[slug], changelog  →  952 passed
cd cli && bun test          →  69 pass, 0 fail
cd cli && bun run typecheck →  exit 0
node scripts/typecheck-runtime.mjs → exit 0
```

`fetch` is stubbed throughout — **no paid model, no real kie call**. No dev server, no Docker, no
Playwright.

**Not tested:** that kie really keeps rendering and billing an abandoned task. That is a statement
about their side, taken from Andrea's dashboard reading; what is pinned here is that we no longer
open a second one either way.

## Evidence

`tools/list` through `handleMcpFetch`: **123 tools, unchanged** — this PR touches no contract and no
tool surface.

<details>
<summary>The failing assertion, before the fix</summary>

```
× pollKieTask distingue scaduto da fallito > uno SCADUTO si riconosce, e porta con sé il taskId
  → expected undefined to deeply equal { status: 'timeout', taskId: 'task-1' }
× generateImageOnKie riprende invece di riaprire > riprende il task scaduto invece di aprirne un altro
  → expected 1 to be +0
  Tests  5 failed | 1 passed (6)
```

</details>

No UI change.

## Anything Else?

**Deliberately not touched:** `renderWithQC`'s two parallel candidates (`HIGH_STAKES_CANDIDATES = 2`)
and its retries (`MAX_QC_RETRIES = 2`). Those are a quality-versus-spend tradeoff and the call is
Andrea's. This one was not a tradeoff — it was paying twice for the same work, with no upside.

**Worth knowing for whoever picks up the QC decision:** the two defects compound. A QC retry that
times out now resumes instead of reopening, so the ceiling on a single image dropped even before any
QC change lands.

**Still open from earlier:** image generation as a job rather than a synchronous call. This fix
lowers the urgency — the wait no longer doubles the bill — but a 300s poll inside an MCP call is
still longer than clients tolerate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY