### PR TITLE
Decide the query gate on authority, not on a session

### DIFF
--- a/changelog/2026-09-04-query-over-mcp.md
+++ b/changelog/2026-09-04-query-over-mcp.md
@@ -1,0 +1,114 @@
+# `query` arriva su CLI e MCP, e il cancello smette di guardare la cosa sbagliata
+
+`query` — la lettura diretta del database con i permessi dell'utente — esisteva già in
+`src/lib/server/chat/query-tool.ts` ed era montata solo nel registro della chat. Su MCP non
+c'era, e sul percorso REST si sarebbe rifiutata da sola. Qui diventa un endpoint, e il rifiuto
+torna a coincidere con la ragione per cui esiste.
+
+## Il difetto: la sonda misurava una cosa diversa da quella che decideva
+
+Il cancello chiedeva `supabase.auth.getSession()` e leggeva solo con una sessione in mano. Sembra
+la stessa domanda di «questo client ha i permessi dell'utente?» e non lo è.
+
+`cli-auth.ts` costruisce il client del percorso JWT con la chiave anon e l'header `Authorization`
+dell'utente, ma con i cookie a vuoto (`getAll: () => []`). Costruito quel client e chiamato
+`getSession()`, la risposta è `null` — misurata, non dedotta:
+
+```
+getSession() on the RLS-scoped JWT client => null
+=> query-tool would REFUSE (no_user_session)
+```
+
+Quindi il cancello chiudeva la porta esattamente al client giusto. In produzione:
+`db_query:refused:no_session` 46 volte fra il 24 agosto e il 4 settembre, contro 5 chiamate
+riuscite alla lista delle tabelle. E nell'altro verso era altrettanto sbagliato: una service role
+che una sessione ce l'avesse avuta sarebbe passata, perché la sessione non dice niente su quale
+chiave sta parlando.
+
+Ora la domanda la risponde chi costruisce il client, che è l'unico a saperlo
+(`src/lib/server/rls-client.ts`). Il marchio si mette in due punti soli — `hooks.server.ts` per il
+browser, `cli-auth.ts` per il percorso JWT — e in nessun altro. Chi non è marchiato non legge: il
+default è il rifiuto, quindi un percorso nuovo che si dimentica di dichiararsi resta chiuso invece
+di aprirsi da solo. Sono gli unici due `createServerClient` del repo, verificato: nessun altro
+posto costruisce un client con un'identità utente, `setSession` non compare da nessuna parte.
+
+## Perché la chiave API resta rifiutata, anche in futuro
+
+`SUPABASE_JWT_SECRET` non esiste: non in `.env`, non in `.env.local`, non nel codice, e non fra le
+93 variabili su Vercel. Ci sono solo la chiave anon e la service role. Quindi coniare un JWT a vita
+breve per il proprietario di una chiave non si può, e passare le claim sulla connessione nemmeno —
+PostgREST verifica la firma.
+
+**Ma la ragione vera non è il segreto mancante, ed è questa che va ricordata il giorno in cui un
+segreto di firma ci sarà:** una chiave API porta `permissions.brand_ids`, spesso più stretto dei
+brand a cui il suo proprietario appartiene. Un JWT vede *tutti* i brand dell'utente, e la RLS non
+vede la restrizione della chiave. Coniare una sessione per una chiave allargherebbe in silenzio una
+chiave deliberatamente ristretta — trasformando un limite scelto dal cliente in niente. Non è un
+ripiego in attesa del segreto: è la decisione.
+
+Sulla superficie che conta il punto è comunque teorico: **MCP non accetta chiavi statiche**
+(`cli/mcp/verify-token.ts`, «never accepts a static API key»; `cli/mcp/server.ts`, «No static API
+tokens»), e la CLI conserva una sessione Supabase vera che rinfresca da sola. Ogni richiesta MCP
+porta già il JWT dell'utente, quindi il percorso corretto era già lì: mancava solo che il cancello
+lo riconoscesse.
+
+## `.rpc()` resta fuori, e la lista delle tabelle si genera
+
+Nessun cambiamento sul primo: decine di funzioni `SECURITY DEFINER` sono eseguibili da
+`authenticated`, una manda email. `query` parla solo `.from().select()`.
+
+La lista delle tabelle era battuta a mano ed era **già invecchiata di 16 nomi** — `thread_events`,
+`agent_kit_runs`, `agent_kit_effects`, `agent_kit_approval_requests`, `post_verdicts`,
+`video_reviews`, `org_usage`, `shared_views`, `chat_model_catalog`, `lead_suppressions`,
+`agent_computers`, `sandbox_holders` fra gli altri. In chat un nome mancante costava un giro; su
+MCP la lista è un `enum`, e un nome mancante **rifiuta una tabella valida prima che la richiesta
+parta** — un guasto peggiore di quello che risolve.
+
+Ora si genera (`scripts/query-tables-from-migrations.mjs`), e **dalle migrazioni, non dal catalogo
+di produzione**. La regola è una: *una tabella esiste se una migrazione la crea*. Generare dal
+catalogo sembra più diretto e sbaglia due volte:
+
+- rimetterebbe dentro `asset_projects`, `asset_project_files` e `mcp_logs`, che in produzione
+  esistono ma da un'installazione da zero no — erano già stati tolti a mano proprio per questo, e
+  l'agente ci sbatteva;
+- rimetterebbe dentro `thread_events_backup_20260901`. Un backup sta in `public` ma non è un dato
+  da leggere, e la regola lo esclude **senza un'eccezione scritta per lui**: nessuna migrazione lo
+  crea. Vale per il prossimo backup allo stesso modo.
+
+Lo script segue anche `drop table` e `alter table … rename to` (tre rinomine reali: `nango` →
+`app`, `onboarding_competitor_jobs` → `onboarding_step_jobs`), e accetta solo `public`: un
+`create table stripe.subscriptions` non entra. Risultato: 149 tabelle, che sono esattamente le 153
+di produzione meno le quattro che nessuna migrazione crea. Un test rigenera e confronta, quindi
+fallisce da solo il giorno in cui una migrazione aggiunge una tabella — che è il giorno in cui
+serve.
+
+## I due limiti chiesti erano già veri, e la PR lo dimostra invece di costruirlo
+
+Interrogato il catalogo di produzione: 153 tabelle in `public`, **0 senza RLS**, **0 viste e 0
+viste materializzate** (quindi la trappola della vista che esegue coi permessi del proprietario
+qui non esiste), 29 tabelle con RLS e zero policy (deny-all), `authenticated` con
+`bypassrls=false` e `statement_timeout=8s` — che conferma gli 8s dichiarati nella testata e mai
+imposti dal codice — e `service_role` con `bypassrls=true`, che è la riga che spiega perché il
+client non marchiato non deve leggere.
+
+Le uniche 4 policy permissive con predicato `true` sono `blog_authors`, `blog_categories`,
+`blog_tags`, `brand_article_tags`: tassonomia del blog pubblico. Nessuna tabella di dati di brand
+è aperta ad `anon`. «Solo `public`» lo impone PostgREST, che espone solo gli schemi configurati:
+`.from('auth.users')` non è una richiesta che esiste.
+
+Non è stata scritta nessuna policy nuova, e nessuna tabella è stata sbloccata per far passare il
+tool.
+
+## Superficie
+
+`QUERY_DATABASE` nel registro dei contratti (`packages/api-contracts/src/query.ts`), quindi REST,
+CLI e MCP restano allineati; la rotta monta lo **stesso** tool della chat invece di riscriverne uno
+— tetti, traduzione degli errori, confine del brand e rifiuto della service role sono un pezzo di
+codice solo. POST per la forma dell'input (`where` è un array di oggetti), non per l'effetto: la
+lettura non spende niente ed è `destructive: false`.
+
+## Da sapere
+
+Sei tabelle senza lettore applicativo trovate dallo sweep del codice morto ricadono in parte fra le
+16 aggiunte qui (`shared_views`, `org_usage`, `post_verdicts`, `video_reviews`): nominate e basta,
+il loro destino non si decide in questa PR.

--- a/cli/lib/contracts/index.ts
+++ b/cli/lib/contracts/index.ts
@@ -13,6 +13,7 @@ import {
   UPDATE_ARTICLE
 } from './articles';
 import { CHECK_CONTENT } from './content';
+import { QUERY_DATABASE } from './query';
 import { GET_CREATION_KIT } from './creation-kit';
 import {
   GET_AUDIT_FINDINGS,
@@ -231,8 +232,9 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   PLAN_WEEK,
   PROPOSE_PLAN,
   PUBLISH_ARTICLE,
-  REFINE_IMAGE,
+  QUERY_DATABASE,
   RECORD_MEMORY_USED,
+  REFINE_IMAGE,
   REFRESH_KEYWORDS,
   REGENERATE_POST_MEDIA,
   REGENERATE_SLIDE,
@@ -319,6 +321,8 @@ export {
   RESCHEDULE_POST,
   UPDATE_ARTICLE,
 };
+export { QUERY_DATABASE, QUERY_OPS, QUERY_TABLE_NAMES, QUERY_DEFAULT_ROWS, QUERY_MAX_ROWS } from './query';
+export { QUERY_TABLES } from './query-tables';
 export {
   DELETE_ARTICLE,
   GENERATE_ARTICLE,

--- a/cli/lib/contracts/query-tables.ts
+++ b/cli/lib/contracts/query-tables.ts
@@ -1,0 +1,33 @@
+/**
+ * GENERATO — non si modifica a mano: `node scripts/query-tables-from-migrations.mjs --write`.
+ *
+ * Ogni tabella di `public` che una migrazione crea, cioè ogni tabella che esiste anche da
+ * un'installazione da zero. La regola e il perché stanno nello script; `query-tool.test.ts`
+ * rigenera e confronta, quindi una migrazione che aggiunge una tabella fa fallire il test finché
+ * questo file non viene rigenerato — e l'agente non resta cieco su una tabella nuova.
+ */
+export const QUERY_TABLES =
+  'ad_campaigns ad_metrics admins ads_remix_briefs agent_computers agent_kit_approval_requests agent_kit_effects ' +
+  'agent_kit_runs agent_notifications agent_runs agent_sessions agent_templates ai_calls api_keys app_flags ' +
+  'article_views benchmark_runs blog_authors blog_categories blog_integrations blog_month_jobs blog_tags ' +
+  'brand_app_connections brand_article_tags brand_article_versions brand_articles brand_backlink_opportunities ' +
+  'brand_backlink_orders brand_backlink_placements brand_community_profiles brand_crawl_runs brand_demo_accounts ' +
+  'brand_design_templates brand_doc_chunks brand_documents brand_field_posts brand_geo_artifacts brand_geo_audits ' +
+  'brand_geo_opportunities brand_geo_prompts brand_gsc_connections brand_gsc_metrics brand_internal_links ' +
+  'brand_invites brand_job_optouts brand_kit brand_knowledge_edges brand_knowledge_sources brand_market_references ' +
+  'brand_media brand_members brand_memory brand_news_items brand_news_sources brand_pages brand_rank_snapshots ' +
+  'brand_seo_keyword_strategy brand_seo_plans brand_site_pages brand_sites brand_social_handles brand_strategy ' +
+  'brand_tracked_keywords brand_triggers brand_usage brand_visual_insights brand_webhooks brands chat_artifacts ' +
+  'chat_goal_events chat_goals chat_jobs chat_messages chat_model_catalog chat_thread_reads chat_threads ' +
+  'competitors content_plans content_quality_samples credit_grants custom_agent_schedules custom_agent_thread_runs ' +
+  'custom_agents disruptive_ideas editorial_plans expert_requests graphic_designs gtm_plans incidents ' +
+  'lead_outcomes lead_suppressions lifecycle_emails loop_cursors loop_ticks market_account_baselines ' +
+  'market_account_fetch_attempts market_harvest_errors market_harvest_runs market_post_observations market_posts ' +
+  'market_teardowns market_video_analyses media_generator_items media_generator_prompts motion_craft_scores ' +
+  'motion_reference_specs motion_video_prompts motion_video_references motion_videos onboarding_drafts ' +
+  'onboarding_errors onboarding_jobs onboarding_step_jobs org_members org_usage organizations people ' +
+  'post_links post_revisions post_verdicts post_visual_meta posts products profiles publish_logs push_subscriptions ' +
+  'radar_feed_cache radar_jobs radar_searches referral_codes referrals rubrics sandbox_holders scheduler_runs ' +
+  'scrapecreators_cache shared_views social_accounts social_post_history social_thumb_cache talent_views ' +
+  'talents thread_events tool_usage video_renders video_requests video_reviews waitlist webhook_deliveries ' +
+  'zernio_ad_accounts';

--- a/cli/lib/contracts/query.ts
+++ b/cli/lib/contracts/query.ts
@@ -1,0 +1,80 @@
+import { z } from 'zod';
+import type { BrandEndpoint } from './index';
+import { QUERY_TABLES } from './query-tables';
+
+export const QUERY_TABLE_NAMES = QUERY_TABLES.split(' ') as [string, ...string[]];
+
+export const QUERY_OPS = ['eq', 'neq', 'gt', 'gte', 'lt', 'lte', 'like', 'ilike', 'is', 'in', 'cs', 'cd'] as const;
+
+export const QUERY_DEFAULT_ROWS = 20;
+export const QUERY_MAX_ROWS = 100;
+
+const Filter = z.object({
+  column: z.string().describe('A bare column name'),
+  op: z.enum(QUERY_OPS),
+  value: z.union([z.string(), z.number(), z.boolean(), z.null(), z.array(z.union([z.string(), z.number()]))])
+});
+
+/**
+ * `table` è un `enum` QUI e non nella chat, e la differenza è di prezzo, non di gusto: la
+ * descrizione di un tool di chat si paga a ogni passo di ogni turno, mentre su MCP `tools/list` si
+ * prende una volta per sessione. 149 nomi costano ~810 token una volta sola, e in cambio l'agente
+ * non indovina `post_metrics` o `platforms` — tre PGRST205 in produzione, un giro sprecato l'uno.
+ */
+export const QUERY_DATABASE = {
+  tool: 'query',
+  title: 'Query the database',
+  description:
+    'Read ANY table in the database directly, AS YOU — the request runs with the anon key plus your ' +
+    'own session, so Postgres RLS returns exactly the rows you would see in the app, and nothing more. ' +
+    'READ ONLY: there is no SQL here. You name a table, columns and filters, and it issues one ' +
+    'PostgREST read, so a write has nowhere to go — no INSERT, no CTE, no function call, nothing to ' +
+    'attempt. Omit `table` to list every table you can name. Ask for a table with no `columns` to get ' +
+    'real rows with every column: the keys of a row ARE the schema. One table per call — no joins, no ' +
+    'embeds; read two tables and match the ids yourself. Reach for it when the answer needs a table ' +
+    'nothing else exposes, a count, or a join you do by hand. Costs nothing.',
+  method: 'POST',
+  pathUnderBrand: '/query',
+  input: z
+    .object({
+      table: z
+        .enum(QUERY_TABLE_NAMES)
+        .optional()
+        .describe('Table to read. Omit to list every table instead.'),
+      columns: z
+        .array(z.string())
+        .optional()
+        .describe('Bare column names. Omit for all columns — which is also how you discover them.'),
+      where: z
+        .array(Filter)
+        .optional()
+        .describe('Filters, ANDed together. `in` takes an array; `is` takes null/true/false.'),
+      order: z
+        .object({ column: z.string(), ascending: z.boolean().optional() })
+        .optional()
+        .describe('Sort. Descending when `ascending` is omitted.'),
+      limit: z.number().int().positive().optional().describe(`Rows to return. ${QUERY_MAX_ROWS} at most.`)
+    })
+    .strict(),
+  /**
+   * Le righe sono di forma libera — è il punto del tool — e il rifiuto è un risultato, non un
+   * 500: `query` risponde 200 con `error` dentro perché un agente deve poter leggere il motivo e
+   * cambiare mossa, non ricevere un corpo vuoto con uno status.
+   */
+  output: z.object({
+    table: z.string().optional(),
+    rows: z.array(z.record(z.string(), z.unknown())).optional(),
+    returned: z.number().optional(),
+    total: z.number().optional(),
+    limits: z.string().optional(),
+    tables: z.array(z.string()).optional(),
+    count: z.number().optional(),
+    note: z.string().optional(),
+    error: z.string().optional(),
+    message: z.string().optional(),
+    fix: z.string().optional(),
+    columns_available: z.array(z.string()).optional()
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -13,6 +13,7 @@ import {
   UPDATE_ARTICLE
 } from './articles';
 import { CHECK_CONTENT } from './content';
+import { QUERY_DATABASE } from './query';
 import { GET_CREATION_KIT } from './creation-kit';
 import {
   GET_AUDIT_FINDINGS,
@@ -231,8 +232,9 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   PLAN_WEEK,
   PROPOSE_PLAN,
   PUBLISH_ARTICLE,
-  REFINE_IMAGE,
+  QUERY_DATABASE,
   RECORD_MEMORY_USED,
+  REFINE_IMAGE,
   REFRESH_KEYWORDS,
   REGENERATE_POST_MEDIA,
   REGENERATE_SLIDE,
@@ -319,6 +321,8 @@ export {
   RESCHEDULE_POST,
   UPDATE_ARTICLE,
 };
+export { QUERY_DATABASE, QUERY_OPS, QUERY_TABLE_NAMES, QUERY_DEFAULT_ROWS, QUERY_MAX_ROWS } from './query';
+export { QUERY_TABLES } from './query-tables';
 export {
   DELETE_ARTICLE,
   GENERATE_ARTICLE,

--- a/packages/api-contracts/src/query-tables.ts
+++ b/packages/api-contracts/src/query-tables.ts
@@ -1,0 +1,33 @@
+/**
+ * GENERATO — non si modifica a mano: `node scripts/query-tables-from-migrations.mjs --write`.
+ *
+ * Ogni tabella di `public` che una migrazione crea, cioè ogni tabella che esiste anche da
+ * un'installazione da zero. La regola e il perché stanno nello script; `query-tool.test.ts`
+ * rigenera e confronta, quindi una migrazione che aggiunge una tabella fa fallire il test finché
+ * questo file non viene rigenerato — e l'agente non resta cieco su una tabella nuova.
+ */
+export const QUERY_TABLES =
+  'ad_campaigns ad_metrics admins ads_remix_briefs agent_computers agent_kit_approval_requests agent_kit_effects ' +
+  'agent_kit_runs agent_notifications agent_runs agent_sessions agent_templates ai_calls api_keys app_flags ' +
+  'article_views benchmark_runs blog_authors blog_categories blog_integrations blog_month_jobs blog_tags ' +
+  'brand_app_connections brand_article_tags brand_article_versions brand_articles brand_backlink_opportunities ' +
+  'brand_backlink_orders brand_backlink_placements brand_community_profiles brand_crawl_runs brand_demo_accounts ' +
+  'brand_design_templates brand_doc_chunks brand_documents brand_field_posts brand_geo_artifacts brand_geo_audits ' +
+  'brand_geo_opportunities brand_geo_prompts brand_gsc_connections brand_gsc_metrics brand_internal_links ' +
+  'brand_invites brand_job_optouts brand_kit brand_knowledge_edges brand_knowledge_sources brand_market_references ' +
+  'brand_media brand_members brand_memory brand_news_items brand_news_sources brand_pages brand_rank_snapshots ' +
+  'brand_seo_keyword_strategy brand_seo_plans brand_site_pages brand_sites brand_social_handles brand_strategy ' +
+  'brand_tracked_keywords brand_triggers brand_usage brand_visual_insights brand_webhooks brands chat_artifacts ' +
+  'chat_goal_events chat_goals chat_jobs chat_messages chat_model_catalog chat_thread_reads chat_threads ' +
+  'competitors content_plans content_quality_samples credit_grants custom_agent_schedules custom_agent_thread_runs ' +
+  'custom_agents disruptive_ideas editorial_plans expert_requests graphic_designs gtm_plans incidents ' +
+  'lead_outcomes lead_suppressions lifecycle_emails loop_cursors loop_ticks market_account_baselines ' +
+  'market_account_fetch_attempts market_harvest_errors market_harvest_runs market_post_observations market_posts ' +
+  'market_teardowns market_video_analyses media_generator_items media_generator_prompts motion_craft_scores ' +
+  'motion_reference_specs motion_video_prompts motion_video_references motion_videos onboarding_drafts ' +
+  'onboarding_errors onboarding_jobs onboarding_step_jobs org_members org_usage organizations people ' +
+  'post_links post_revisions post_verdicts post_visual_meta posts products profiles publish_logs push_subscriptions ' +
+  'radar_feed_cache radar_jobs radar_searches referral_codes referrals rubrics sandbox_holders scheduler_runs ' +
+  'scrapecreators_cache shared_views social_accounts social_post_history social_thumb_cache talent_views ' +
+  'talents thread_events tool_usage video_renders video_requests video_reviews waitlist webhook_deliveries ' +
+  'zernio_ad_accounts';

--- a/packages/api-contracts/src/query.ts
+++ b/packages/api-contracts/src/query.ts
@@ -1,0 +1,80 @@
+import { z } from 'zod';
+import type { BrandEndpoint } from './index';
+import { QUERY_TABLES } from './query-tables';
+
+export const QUERY_TABLE_NAMES = QUERY_TABLES.split(' ') as [string, ...string[]];
+
+export const QUERY_OPS = ['eq', 'neq', 'gt', 'gte', 'lt', 'lte', 'like', 'ilike', 'is', 'in', 'cs', 'cd'] as const;
+
+export const QUERY_DEFAULT_ROWS = 20;
+export const QUERY_MAX_ROWS = 100;
+
+const Filter = z.object({
+  column: z.string().describe('A bare column name'),
+  op: z.enum(QUERY_OPS),
+  value: z.union([z.string(), z.number(), z.boolean(), z.null(), z.array(z.union([z.string(), z.number()]))])
+});
+
+/**
+ * `table` è un `enum` QUI e non nella chat, e la differenza è di prezzo, non di gusto: la
+ * descrizione di un tool di chat si paga a ogni passo di ogni turno, mentre su MCP `tools/list` si
+ * prende una volta per sessione. 149 nomi costano ~810 token una volta sola, e in cambio l'agente
+ * non indovina `post_metrics` o `platforms` — tre PGRST205 in produzione, un giro sprecato l'uno.
+ */
+export const QUERY_DATABASE = {
+  tool: 'query',
+  title: 'Query the database',
+  description:
+    'Read ANY table in the database directly, AS YOU — the request runs with the anon key plus your ' +
+    'own session, so Postgres RLS returns exactly the rows you would see in the app, and nothing more. ' +
+    'READ ONLY: there is no SQL here. You name a table, columns and filters, and it issues one ' +
+    'PostgREST read, so a write has nowhere to go — no INSERT, no CTE, no function call, nothing to ' +
+    'attempt. Omit `table` to list every table you can name. Ask for a table with no `columns` to get ' +
+    'real rows with every column: the keys of a row ARE the schema. One table per call — no joins, no ' +
+    'embeds; read two tables and match the ids yourself. Reach for it when the answer needs a table ' +
+    'nothing else exposes, a count, or a join you do by hand. Costs nothing.',
+  method: 'POST',
+  pathUnderBrand: '/query',
+  input: z
+    .object({
+      table: z
+        .enum(QUERY_TABLE_NAMES)
+        .optional()
+        .describe('Table to read. Omit to list every table instead.'),
+      columns: z
+        .array(z.string())
+        .optional()
+        .describe('Bare column names. Omit for all columns — which is also how you discover them.'),
+      where: z
+        .array(Filter)
+        .optional()
+        .describe('Filters, ANDed together. `in` takes an array; `is` takes null/true/false.'),
+      order: z
+        .object({ column: z.string(), ascending: z.boolean().optional() })
+        .optional()
+        .describe('Sort. Descending when `ascending` is omitted.'),
+      limit: z.number().int().positive().optional().describe(`Rows to return. ${QUERY_MAX_ROWS} at most.`)
+    })
+    .strict(),
+  /**
+   * Le righe sono di forma libera — è il punto del tool — e il rifiuto è un risultato, non un
+   * 500: `query` risponde 200 con `error` dentro perché un agente deve poter leggere il motivo e
+   * cambiare mossa, non ricevere un corpo vuoto con uno status.
+   */
+  output: z.object({
+    table: z.string().optional(),
+    rows: z.array(z.record(z.string(), z.unknown())).optional(),
+    returned: z.number().optional(),
+    total: z.number().optional(),
+    limits: z.string().optional(),
+    tables: z.array(z.string()).optional(),
+    count: z.number().optional(),
+    note: z.string().optional(),
+    error: z.string().optional(),
+    message: z.string().optional(),
+    fix: z.string().optional(),
+    columns_available: z.array(z.string()).optional()
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/scripts/query-tables-from-migrations.mjs
+++ b/scripts/query-tables-from-migrations.mjs
@@ -1,0 +1,109 @@
+/**
+ * LE TABELLE CHE `query` PUÒ NOMINARE, DERIVATE DALLE MIGRAZIONI E NON DAL DATABASE.
+ *
+ * La regola è una sola: una tabella esiste se una migrazione la crea. Non «esiste se sta in
+ * produzione», che è la trappola in cui cade il primo tentativo di generare dal catalogo —
+ * produzione contiene anche ciò che nessuna migrazione crea, e da un'installazione da zero quei
+ * nomi non esistono affatto: `asset_projects`, `asset_project_files` e `mcp_logs` erano già stati
+ * tolti a mano proprio per questo, e generando dal catalogo tornerebbero dentro.
+ *
+ * La stessa regola, senza un'eccezione in più, tiene fuori i backup: `thread_events_backup_20260901`
+ * è nato da una mano, non da una migrazione, e un backup in `public` non è un dato da leggere.
+ *
+ * Vale solo `public`: un `create table stripe.subscriptions` non entra, ed è il limite «solo
+ * public» applicato dove si genera invece che raccomandato nella descrizione del tool.
+ *
+ *   node scripts/query-tables-from-migrations.mjs          # stampa l'elenco
+ *   node scripts/query-tables-from-migrations.mjs --write   # riscrive query-tables.ts
+ */
+import { readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const MIGRATIONS = join(ROOT, 'supabase', 'migrations');
+const GENERATED = join(ROOT, 'packages', 'api-contracts', 'src', 'query-tables.ts');
+
+const NAME = String.raw`"?[a-z_][a-z0-9_]*"?(?:\s*\.\s*"?[a-z_][a-z0-9_]*"?)?`;
+const STATEMENT = new RegExp(
+  [
+    String.raw`create\s+table\s+(?:if\s+not\s+exists\s+)?(?<created>${NAME})`,
+    String.raw`drop\s+table\s+(?:if\s+exists\s+)?(?<dropped>${NAME})`,
+    String.raw`alter\s+table\s+(?:if\s+exists\s+)?(?<from>${NAME})\s+rename\s+to\s+(?<to>${NAME})`
+  ].join('|'),
+  'gis'
+);
+
+/**
+ * `public.posts` e `posts` sono la stessa tabella; `stripe.subscriptions` non è di `public` e non
+ * entra. È qui che «solo lo schema public» smette di essere una raccomandazione.
+ */
+function publicTable(raw) {
+  if (!raw) return null;
+  const parts = raw.replace(/"/g, '').split('.').map((s) => s.trim().toLowerCase());
+  if (parts.length === 2) return parts[0] === 'public' ? parts[1] : null;
+  return parts[0];
+}
+
+export function tablesFromMigrations(dir = MIGRATIONS) {
+  const files = readdirSync(dir).filter((f) => f.endsWith('.sql')).sort();
+  const tables = new Set();
+
+  for (const file of files) {
+    const sql = readFileSync(join(dir, file), 'utf8');
+    for (const match of sql.matchAll(STATEMENT)) {
+      const created = publicTable(match.groups.created);
+      if (created) {
+        tables.add(created);
+        continue;
+      }
+
+      const dropped = publicTable(match.groups.dropped);
+      if (dropped) {
+        tables.delete(dropped);
+        continue;
+      }
+
+      const renamedFrom = publicTable(match.groups.from);
+      const renamedTo = publicTable(match.groups.to);
+      if (renamedFrom && renamedTo && tables.delete(renamedFrom)) tables.add(renamedTo);
+    }
+  }
+
+  return [...tables].sort();
+}
+
+function render(tables) {
+  const lines = [];
+  let row = [];
+  for (const t of tables) {
+    row.push(t);
+    if (row.join(' ').length > 96) {
+      lines.push(`  '${row.join(' ')} ' +`);
+      row = [];
+    }
+  }
+  if (row.length) lines.push(`  '${row.join(' ')}';`);
+  else lines[lines.length - 1] = lines[lines.length - 1].replace(/ \+$/, ';').replace(/ '$/, "'");
+
+  return `/**
+ * GENERATO — non si modifica a mano: \`node scripts/query-tables-from-migrations.mjs --write\`.
+ *
+ * Ogni tabella di \`public\` che una migrazione crea, cioè ogni tabella che esiste anche da
+ * un'installazione da zero. La regola e il perché stanno nello script; \`query-tool.test.ts\`
+ * rigenera e confronta, quindi una migrazione che aggiunge una tabella fa fallire il test finché
+ * questo file non viene rigenerato — e l'agente non resta cieco su una tabella nuova.
+ */
+export const QUERY_TABLES =
+${lines.join('\n')}
+`;
+}
+
+const tables = tablesFromMigrations();
+
+if (process.argv.includes('--write')) {
+  writeFileSync(GENERATED, render(tables));
+  console.log(`query-tables.ts: ${tables.length} tabelle`);
+} else if (import.meta.url === `file://${process.argv[1]}`) {
+  console.log(tables.join('\n'));
+}

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -2,6 +2,7 @@ import {sequence} from '@sveltejs/kit/hooks';
 import { json, redirect, text } from '@sveltejs/kit';
 import * as Sentry from '@sentry/sveltekit';
 import { createServerClient, type CookieOptions } from '@supabase/ssr';
+import { markRlsScoped } from '$lib/server/rls-client';
 import { env as publicEnv } from '$env/dynamic/public';
 import type { Handle } from '@sveltejs/kit';
 import { pickLocale } from '$lib/i18n/locale';
@@ -80,7 +81,9 @@ export const handle: Handle = sequence(csrf, Sentry.sentryHandle(), async ({ eve
   await catalogModelIds().catch(() => []);
 
   // Per-request Supabase client bound to the request cookies (SSR auth).
-  event.locals.supabase = createServerClient(publicEnv.PUBLIC_SUPABASE_URL, publicEnv.PUBLIC_SUPABASE_ANON_KEY, {
+  // Marchiato come RLS-scoped: chiave anon, quindi Postgres valuta le policy dell'utente. È la
+  // dichiarazione su cui `query` decide di leggere — vedi $lib/server/rls-client.
+  event.locals.supabase = markRlsScoped(createServerClient(publicEnv.PUBLIC_SUPABASE_URL, publicEnv.PUBLIC_SUPABASE_ANON_KEY, {
     cookies: {
       getAll: () => validSessionCookies(event.cookies.getAll()),
       setAll: (cookiesToSet: CookieToSet[]) => {
@@ -98,7 +101,7 @@ export const handle: Handle = sequence(csrf, Sentry.sentryHandle(), async ({ eve
         });
       }
     }
-  });
+  }));
 
   // getSession() is local (cookie → JWT). getUser() hits GoTrue — cache it across SPA
   // navigations on this isolate so every in-brand click is not a 300–800ms auth RTT.

--- a/src/lib/content/changelog/2026-09-04-query-your-data.ts
+++ b/src/lib/content/changelog/2026-09-04-query-your-data.ts
@@ -1,0 +1,12 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-04',
+  title: 'Ask your agent anything about your data, not just what we built a button for',
+  items: [
+    'Claude, ChatGPT and Cursor can now read your Anomalia data directly — "how many posts went out per platform in the last 90 days, and which one got the best engagement" is one question now, instead of three separate reads and mental arithmetic.',
+    'It reads as you: the same permissions you have when you open the app, decided by the database itself, so an agent can never see a brand you cannot see.',
+    'It can only read. There is no way for it to change or delete anything, by construction rather than by rule.',
+    'The agent now gets the list of tables it can ask for, so it stops guessing names and wasting a turn on a table that does not exist.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/chat/query-tool.test.ts
+++ b/src/lib/server/chat/query-tool.test.ts
@@ -10,6 +10,7 @@ import {
   QUERY_MAX_ROWS,
   QUERY_TABLE_LIST
 } from './query-tool';
+import { markRlsScoped } from '$lib/server/rls-client';
 
 vi.mock('$lib/server/ai-log', () => ({ logAiCall: vi.fn() }));
 import { logAiCall } from '$lib/server/ai-log';
@@ -19,6 +20,7 @@ import { logAiCall } from '$lib/server/ai-log';
  * dimostrare che certe chiamate non partono mai) e restituisce quel che gli si dice.
  */
 function fakeClient(opts: {
+  authority?: 'user' | 'service';
   session?: { access_token: string } | null;
   rows?: Array<Record<string, unknown>>;
   count?: number;
@@ -42,14 +44,14 @@ function fakeClient(opts: {
       Promise.resolve({ data: opts.error ? null : (opts.rows ?? []), error: opts.error ?? null, count: opts.count ?? null });
     return b;
   };
-  return {
-    calls,
-    client: {
-      auth: { getSession: async () => ({ data: { session: opts.session === undefined ? { access_token: 'jwt' } : opts.session } }) },
-      from: (table: string) => ({ select: (cols: string) => builder(table, cols) })
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } as any
-  };
+  const client = {
+    auth: { getSession: async () => ({ data: { session: opts.session === undefined ? { access_token: 'jwt' } : opts.session } }) },
+    from: (table: string) => ({ select: (cols: string) => builder(table, cols) })
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+  // Il default è il client dell'utente, che è il caso di ogni test tranne quelli sul cancello:
+  // `authority: 'service'` lo lascia senza marchio, che è ciò che rende la service role respinta.
+  return { calls, client: opts.authority === 'service' ? client : markRlsScoped(client) };
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -108,8 +110,8 @@ describe('sola lettura: le scritture non sono rifiutate, sono inesprimibili', ()
 });
 
 describe('il cancello: senza sessione utente non si legge', () => {
-  it('un client service-role (nessuna sessione) viene respinto, e non tocca il database', async () => {
-    const { client, calls } = fakeClient({ session: null, rows: [{ id: 'segreto-di-un-altro-brand' }] });
+  it('un client service-role viene respinto, e non tocca il database', async () => {
+    const { client, calls } = fakeClient({ authority: 'service', rows: [{ id: 'segreto-di-un-altro-brand' }] });
     const out = await run(client, { table: 'posts' });
     expect(out.error).toBe('no_user_session');
     expect(out).not.toHaveProperty('rows');
@@ -119,6 +121,88 @@ describe('il cancello: senza sessione utente non si legge', () => {
   it('il rifiuto spiega che la service role scavalcherebbe la RLS', () => {
     expect(NO_SESSION_ERROR.message).toMatch(/RLS/);
     expect(NO_SESSION_ERROR.message).toMatch(/service-role/);
+  });
+
+  it('il rifiuto nomina anche la chiave API, che è più stretta dei brand dell utente', () => {
+    expect(NO_SESSION_ERROR.message).toMatch(/brand_ids/);
+  });
+});
+
+/**
+ * IL PERCORSO API (CLI e MCP) PORTA IL CLIENT GIUSTO E VENIVA RIFIUTATO LO STESSO.
+ *
+ * `cli-auth.ts` costruisce il client del percorso JWT con la chiave anon e l'header dell'utente,
+ * ma con i cookie a vuoto: `auth.getSession()` risponde `null` — misurato — pur essendo un client
+ * a cui Postgres applica le policy dell'utente. Il cancello guardava la sessione, e chiudeva la
+ * porta proprio al client corretto mentre la service role restava fuori per la ragione giusta.
+ */
+describe('il cancello guarda i permessi, non la sessione', () => {
+  it('un client RLS-scoped SENZA sessione legge: è il percorso JWT di CLI e MCP', async () => {
+    const { client, calls } = fakeClient({ session: null, rows: [{ id: 'p1' }] });
+
+    const out = await run(client, { table: 'posts' });
+
+    expect(out.error).toBeUndefined();
+    expect(out.rows).toEqual([{ id: 'p1' }]);
+    expect(calls).toHaveLength(1);
+  });
+
+  /**
+   * La seconda metà, che è quella che conta: dal percorso API non deve comparire NIENTE che dal
+   * browser non si vedeva. Quali righe tornano lo decide Postgres, quindi qui si verifica l'unica
+   * cosa che potrebbe farle divergere — che la richiesta parta identica: stessa tabella, stesse
+   * colonne, stessi filtri, stesso tetto. Marchiare un client non allarga la lettura.
+   */
+  it('stessa domanda dai due percorsi, stessa richiesta al database — non una riga in più', async () => {
+    const browser = fakeClient({ session: { access_token: 'jwt' }, rows: [{ id: 'p1' }] });
+    const api = fakeClient({ session: null, rows: [{ id: 'p1' }] });
+
+    const fromBrowser = await run(browser.client, { table: 'posts', columns: ['id'], limit: 5 });
+    const fromApi = await run(api.client, { table: 'posts', columns: ['id'], limit: 5 });
+
+    expect(fromApi.rows).toEqual(fromBrowser.rows);
+    expect(api.calls).toEqual(browser.calls);
+  });
+
+  it('la service role resta respinta anche con una sessione: decide il marchio, non il token', async () => {
+    const { client, calls } = fakeClient({ authority: 'service', session: { access_token: 'jwt' }, rows: [{ id: 'ogni-brand' }] });
+
+    const out = await run(client, { table: 'posts' });
+
+    expect(out.error).toBe('no_user_session');
+    expect(calls).toHaveLength(0);
+  });
+
+  it('il marchio non si mette sul client service-role, in nessun punto del sorgente', () => {
+    const admin = readFileSync(new URL('../supabase-admin.ts', import.meta.url), 'utf8');
+    expect(admin).not.toContain('markRlsScoped');
+  });
+});
+
+/**
+ * IL GUARDIANO DELLA LISTA. Fallisce da solo il giorno in cui una migrazione aggiunge una tabella,
+ * che è precisamente il giorno in cui serve: su MCP la lista è un `enum`, e un nome mancante non
+ * confonde l'agente — gli impedisce di chiedere una tabella che esiste.
+ */
+describe('le tabelle si generano dalle migrazioni, non si battono a mano', () => {
+  it('query-tables.ts è allineato alle migrazioni', async () => {
+    const { tablesFromMigrations } = await import('../../../../scripts/query-tables-from-migrations.mjs');
+
+    expect(QUERY_TABLE_LIST).toEqual(tablesFromMigrations());
+  });
+
+  it('niente backup e niente tabelle che nessuna migrazione crea', () => {
+    // I primi tre esistono in produzione ma non da un'installazione da zero; il quarto è un backup
+    // fatto a mano. Nessuno dei quattro va nominato all'agente, e la regola li esclude tutti senza
+    // un elenco di eccezioni: una tabella esiste se una migrazione la crea.
+    for (const ghost of ['asset_projects', 'asset_project_files', 'mcp_logs', 'thread_events_backup_20260901']) {
+      expect(QUERY_TABLE_LIST).not.toContain(ghost);
+    }
+  });
+
+  it('nessuna tabella fuori da public: uno schema diverso non entra', () => {
+    expect(QUERY_TABLE_LIST).not.toContain('stripe');
+    expect(QUERY_TABLE_LIST.every((t) => !t.includes('.'))).toBe(true);
   });
 });
 
@@ -256,12 +340,12 @@ describe('il registro', () => {
   });
 
   it("registra anche i rifiuti — è l'errore che ha reso invisibile sandbox_exec", async () => {
-    for (const [input, session] of [
-      [{ table: 'posts' }, null],
-      [{ table: 'posts; insert into x' }, undefined]
+    for (const [input, authority] of [
+      [{ table: 'posts' }, 'service'],
+      [{ table: 'posts; insert into x' }, 'user']
     ] as const) {
       vi.mocked(logAiCall).mockClear();
-      const { client } = fakeClient({ session });
+      const { client } = fakeClient({ authority });
       await run(client, input as Record<string, unknown>);
       const entry = vi.mocked(logAiCall).mock.calls[0][0];
       expect(entry.ok).toBe(false);
@@ -331,11 +415,11 @@ function scriptedClient(
   };
   return {
     calls,
-    client: {
+    client: markRlsScoped({
       auth: { getSession: async () => ({ data: { session: { access_token: 'jwt' } } }) },
       from: (table: string) => ({ select: (cols: string) => builder(table, cols) })
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } as any
+    } as any)
   };
 }
 

--- a/src/lib/server/chat/query-tool.ts
+++ b/src/lib/server/chat/query-tool.ts
@@ -17,15 +17,23 @@
  *    sparisse. Qui si DICHIARA, e si aggiunge solo il pezzo che il database non copre: una
  *    connessione HTTP appesa senza nessuna query che gira (`AbortSignal.timeout`).
  *
- * LA CECITÀ, DICHIARATA: `query` funziona solo dove esiste una sessione utente, cioè sui turni
- * interattivi. Nella coda e sulla superficie CLI il client è la service role, che scavalcherebbe la
- * RLS e leggerebbe OGNI brand: lì si RIFIUTA e il rifiuto spiega perché. Un tool che «a volte legge
+ * IL CONFINE, DICHIARATO: `query` funziona dove il client porta i permessi dell'utente, e si RIFIUTA
+ * dove porta la service role — nella coda e sul percorso a chiave API. Un tool che «a volte legge
  * tutto» sarebbe peggio di un tool che a volte non c'è.
+ *
+ * Il confine non si indovina guardando il client: lo dichiara chi lo costruisce (`isRlsScoped`,
+ * `$lib/server/rls-client`). Prima si guardava `auth.getSession()`, che sembra la stessa domanda e
+ * non lo è: sul percorso API il client nasce con i cookie a vuoto, quindi è senza sessione pur
+ * essendo perfettamente scoped, e il cancello chiudeva la porta ai JWT di CLI e MCP — 46 rifiuti in
+ * produzione in dodici giorni — mentre avrebbe fatto passare una service role che una sessione ce
+ * l'avesse avuta.
  */
 import { tool } from 'ai';
 import { POST_STATUS_VOCABULARY } from '$lib/server/chat/post-status';
+import { QUERY_TABLES } from '@anomalia/api-contracts';
 import { z } from 'zod';
 import type { SupabaseClient } from '@supabase/supabase-js';
+import { isRlsScoped } from '$lib/server/rls-client';
 import { logAiCall } from '$lib/server/ai-log';
 
 /** Righe di default per chiamata quando il modello non chiede un `limit`. */
@@ -70,55 +78,24 @@ const OPS = ['eq', 'neq', 'gt', 'gte', 'lt', 'lte', 'like', 'ilike', 'is', 'in',
 type Op = (typeof OPS)[number];
 
 /**
- * Le tabelle di `public`, lette da `pg_tables`. Qui e NON nella descrizione del tool per costo: nella
- * descrizione si pagherebbero a ogni step di ogni turno di ogni agente, per una lista che serve una
- * volta a conversazione. Qui si pagano solo quando il modello chiama `query` senza `table`.
+ * Le tabelle di `public` che `query` può nominare. GENERATA dalle migrazioni, mai battuta a mano:
+ * la lista scritta a mano era già invecchiata di 16 nomi — `thread_events`, `agent_kit_runs`,
+ * `post_verdicts`, `video_reviews` fra gli altri — e una lista che invecchia non confonde soltanto,
+ * su MCP RIFIUTA una tabella valida prima che la richiesta parta.
  *
- * ponytail: lista statica, può invecchiare di una tabella. Non è cieca — PostgREST risponde PGRST205
- * con «Perhaps you meant…» su un nome quasi giusto e `query` passa il suggerimento al modello. Il
- * giorno in cui invecchia sul serio si genera da `pg_tables` in un passo di build.
- *
- * Nomi tolti perché nessuna migration li crea: `asset_projects`, `asset_project_files` (retaggio
- * dell'editor Remotion, frontend rimosso in 5e725399) e `mcp_logs`. In produzione esistono ancora,
- * con 1, 3 e 0 righe; da un'installazione da zero non esistono affatto, e l'agente ci sbatteva.
+ * Dalle migrazioni e non dal catalogo di produzione, perché la domanda giusta è «questa tabella
+ * esiste anche da un'installazione da zero?»: in produzione sopravvivono nomi che nessuna
+ * migrazione crea, e generarli dentro rimetterebbe l'agente a sbattere dove era già sbattuto.
+ * La stessa regola tiene fuori i backup, senza doverli elencare.
  */
-const TABLES =
-  'ad_campaigns ad_metrics admins ads_remix_briefs agent_notifications agent_runs agent_sessions ' +
-  'agent_templates ai_calls api_keys app_flags article_views ' +
-  'benchmark_runs blog_authors blog_categories blog_integrations blog_month_jobs blog_tags ' +
-  'brand_app_connections brand_article_tags brand_article_versions brand_articles ' +
-  'brand_backlink_opportunities brand_backlink_orders brand_backlink_placements ' +
-  'brand_community_profiles brand_crawl_runs brand_demo_accounts brand_design_templates ' +
-  'brand_doc_chunks brand_documents brand_field_posts brand_geo_artifacts brand_geo_audits ' +
-  'brand_geo_opportunities brand_geo_prompts brand_gsc_connections brand_gsc_metrics ' +
-  'brand_internal_links brand_invites brand_job_optouts brand_kit brand_knowledge_edges ' +
-  'brand_knowledge_sources brand_market_references brand_media brand_members brand_memory ' +
-  'brand_news_items brand_news_sources brand_pages brand_rank_snapshots ' +
-  'brand_seo_keyword_strategy brand_seo_plans brand_site_pages brand_sites brand_social_handles ' +
-  'brand_strategy brand_tracked_keywords brand_triggers brand_usage brand_visual_insights ' +
-  'brand_webhooks brands chat_artifacts chat_goal_events chat_goals chat_jobs chat_messages ' +
-  'chat_thread_reads chat_threads competitors content_plans content_quality_samples credit_grants ' +
-  'custom_agent_schedules custom_agent_thread_runs custom_agents disruptive_ideas editorial_plans ' +
-  'expert_requests graphic_designs gtm_plans incidents lead_outcomes lifecycle_emails ' +
-  'loop_cursors loop_ticks market_account_baselines market_account_fetch_attempts ' +
-  'market_harvest_errors market_harvest_runs market_post_observations market_posts ' +
-  'market_teardowns market_video_analyses media_generator_items ' +
-  'media_generator_prompts motion_craft_scores motion_reference_specs motion_video_prompts ' +
-  'motion_video_references motion_videos onboarding_drafts onboarding_errors onboarding_jobs ' +
-  'onboarding_step_jobs org_members organizations people post_links post_revisions ' +
-  'post_visual_meta posts products profiles publish_logs push_subscriptions radar_feed_cache ' +
-  'radar_jobs radar_searches referral_codes referrals rubrics scheduler_runs scrapecreators_cache ' +
-  'social_accounts social_post_history social_thumb_cache talent_views talents tool_usage ' +
-  'video_renders video_requests waitlist webhook_deliveries zernio_ad_accounts';
+export const QUERY_TABLE_LIST = QUERY_TABLES.split(' ');
 
-export const QUERY_TABLE_LIST = TABLES.split(' ');
-
-/** Il rifiuto quando manca la sessione utente. Esportato perché il test lo verifica per contenuto. */
+/** Il rifiuto quando il client non porta i permessi dell'utente. Il test lo verifica per contenuto. */
 export const NO_SESSION_ERROR = {
   error: 'no_user_session',
   message:
-    '`query` reads the database AS THIS USER: anon key + their JWT, so Postgres RLS grants the agent exactly the user permissions and nothing more. This turn has no user session — it is a background/queue turn or a CLI API-key request, and both hold a service-role client that would bypass RLS and read EVERY brand in the database. Refusing to read with it.',
-  fix: 'Use the purpose-built read tools (read_posts, read_brand_kit, read_plan, …) — they scope to this brand by construction. `query` works on the interactive chat surface.'
+    '`query` reads the database AS THIS USER: anon key + their JWT, so Postgres RLS grants the agent exactly the user permissions and nothing more. This client is not user-scoped — it is a background/queue turn or a CLI API-key request, and both hold a service-role client (`bypassrls=true`) that would read EVERY brand in the database. Refusing to read with it. An API key is not promoted to a user session on purpose: a key carries `permissions.brand_ids`, often narrower than the brands its owner belongs to, and RLS cannot see that restriction — minting a session for it would silently widen a deliberately narrow key.',
+  fix: 'Use the purpose-built read tools (read_posts, read_brand_kit, read_plan, …) — they scope to this brand by construction. `query` works wherever the caller signs in as themselves: the app, `anomalia login`, and MCP.'
 } as const;
 
 /**
@@ -263,14 +240,11 @@ export function createQueryTool({ supabase, brandId, userId, threadId }: QueryTo
           return out;
         };
 
-          // Nessuna sessione utente, nessuna lettura. `getSession()` è locale (cookie → JWT), nessun
-          // giro di rete; `createAdminClient()` nasce con persistSession:false, quindi la service role
-          // non ha mai una sessione e la coda cade qui per costruzione, non per convenzione.
-        const session = await supabase.auth
-          .getSession()
-          .then((r) => r.data?.session ?? null)
-          .catch(() => null);
-        if (!session?.access_token) return finish({ ...NO_SESSION_ERROR }, 'db_query:refused:no_session');
+          // Client non marchiato, nessuna lettura. Il marchio lo mette chi COSTRUISCE il client con
+          // la chiave anon (`hooks.server.ts` per il browser, `cli-auth.ts` per il percorso JWT),
+          // che è l'unico a sapere quale dei due ha in mano; la service role non lo riceve mai. Il
+          // default è il rifiuto, quindi un percorso nuovo resta chiuso finché non si dichiara.
+        if (!isRlsScoped(supabase)) return finish({ ...NO_SESSION_ERROR }, 'db_query:refused:no_session');
 
         if (!input.table) {
           return finish(

--- a/src/lib/server/cli-auth.test.ts
+++ b/src/lib/server/cli-auth.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { SupabaseClient } from '@supabase/supabase-js';
-import { loadBrandForUser, type ApiKeyInfo, type CliBrand } from './cli-auth';
+import { readFileSync } from 'node:fs';
+import { authenticate, loadBrandForUser, type ApiKeyInfo, type CliBrand } from './cli-auth';
+import { isRlsScoped } from '$lib/server/rls-client';
 import { createTestSupabase } from '$lib/testkit/supabase';
 import { BOOKING_URL } from '$lib/links';
 
@@ -184,6 +186,38 @@ describe('una chiave di sola lettura', () => {
 
       expect(res.error?.status, method).toBe(403);
       expect(await res.error!.json(), method).toEqual({ error: 'API key is read-only' });
+    }
+  });
+});
+
+/**
+ * QUALE DEI DUE CLIENT ESCE DA `authenticate`. È la domanda su cui `query` decide di leggere, e
+ * sbagliarla non dà un errore: dà le righe di ogni brand di ogni cliente.
+ */
+describe('il marchio RLS esce solo dal percorso JWT', () => {
+  const bearer = (token: string) =>
+    new Request('https://anomalia.so/api/v1/brands/acme', { headers: { Authorization: `Bearer ${token}` } });
+
+  it('il JWT utente torna un client marchiato: chiave anon, policy dell utente', async () => {
+    const { supabase, error } = await authenticate(bearer('a.user.jwt'));
+
+    expect(error).toBeUndefined();
+    expect(isRlsScoped(supabase)).toBe(true);
+  });
+
+  /**
+   * Il percorso a chiave API costruisce la service role (`bypassrls=true`): non si marchia, e non
+   * si promuove a sessione utente nemmeno il giorno in cui avremo un segreto di firma — una chiave
+   * porta `permissions.brand_ids`, spesso più stretto dei brand del suo proprietario, e la RLS non
+   * vede quella restrizione. Coniare un JWT allargherebbe in silenzio una chiave ristretta.
+   */
+  it('il client service-role della chiave API non viene mai marchiato', () => {
+    const src = readFileSync(new URL('./cli-auth.ts', import.meta.url), 'utf8');
+    const marks = src.match(/markRlsScoped\(/g) ?? [];
+
+    expect(marks).toHaveLength(1);
+    for (const line of src.split('\n')) {
+      if (line.includes('adminKey')) expect(line).not.toContain('markRlsScoped');
     }
   });
 });

--- a/src/lib/server/cli-auth.ts
+++ b/src/lib/server/cli-auth.ts
@@ -4,6 +4,7 @@ import { env as publicEnv } from '$env/dynamic/public';
 import { env } from '$env/dynamic/private';
 import { json } from '@sveltejs/kit';
 import type { SupabaseClient } from '@supabase/supabase-js';
+import { markRlsScoped } from '$lib/server/rls-client';
 import { userCanEnter } from '$lib/server/access';
 import { BOOKING_URL } from '$lib/links';
 
@@ -86,7 +87,10 @@ async function resolveCaller(request: Request): Promise<Caller> {
     return { error: json({ error: 'Invalid or expired token' }, { status: 401 }) };
   }
 
-  return { supabase, user };
+  // Chiave anon + il JWT dell'utente: Postgres valuta le sue policy, esattamente come nel browser.
+  // Il marchio si DICHIARA perché il client, guardato da fuori, è indistinguibile dalla service
+  // role — e la sessione qui non c'è: i cookie sono a vuoto per costruzione, non per errore.
+  return { supabase: markRlsScoped(supabase), user };
 }
 
 async function authenticateApiKey(token: string) {

--- a/src/lib/server/rls-client.ts
+++ b/src/lib/server/rls-client.ts
@@ -1,0 +1,33 @@
+/**
+ * QUALE CLIENT PORTA I PERMESSI DELL'UTENTE, E QUALE LI SCAVALCA.
+ *
+ * Due client parlano allo stesso database e non hanno niente in comune: quello costruito con la
+ * chiave anon (più i cookie del browser o il JWT che arriva sull'header) fa valutare le policy a
+ * Postgres, e quello service-role le scavalca — `service_role` ha `bypassrls=true`, verificato su
+ * `pg_roles`. Un lettore che accetta il secondo legge OGNI brand di OGNI cliente.
+ *
+ * Distinguerli guardando il client non si può: sono lo stesso oggetto con dentro una chiave
+ * diversa. Chiedergli `auth.getSession()` sembra la stessa domanda e NON lo è — sul percorso API
+ * il client è costruito con i cookie a vuoto, quindi non ha sessione pur essendo perfettamente
+ * scoped: quella sonda rifiutava i JWT della CLI e di MCP, che erano esattamente i client giusti.
+ *
+ * Allora la risposta non si deduce: la dichiara chi costruisce il client, che è l'unico a saperla.
+ * Il marchio si mette dove nasce un client a chiave anon — `hooks.server.ts` per il browser,
+ * `cli-auth.ts` per il percorso JWT — e in nessun altro posto. Chi non è marchiato non è scoped:
+ * il default è il rifiuto, quindi un percorso nuovo che si dimentica di marchiare resta chiuso
+ * invece di aprirsi da solo.
+ */
+const rlsScoped = new WeakSet<object>();
+
+/**
+ * Il tipo resta quello che entra: `createServerClient` restituisce un client con i suoi generici,
+ * e stringerlo a `SupabaseClient` qui in mezzo romperebbe l'assegnazione a `locals.supabase`.
+ */
+export function markRlsScoped<T extends object>(client: T): T {
+  rlsScoped.add(client);
+  return client;
+}
+
+export function isRlsScoped(client: unknown): boolean {
+  return typeof client === 'object' && client !== null && rlsScoped.has(client);
+}

--- a/src/routes/api/v1/brands/[slug]/query/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/query/+server.ts
@@ -1,0 +1,36 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { authenticate, loadBrandForUser } from '$lib/server/cli-auth';
+import { QUERY_DATABASE } from '@anomalia/api-contracts';
+import { createQueryTool } from '$lib/server/chat/query-tool';
+
+/**
+ * `query` sopra REST, e quindi sopra CLI e MCP. Non riscrive niente: monta lo STESSO tool della
+ * chat, quindi tetti, traduzione degli errori, confine del brand e — soprattutto — il rifiuto del
+ * client service-role sono un solo pezzo di codice, non due che divergono al primo cambiamento.
+ *
+ * `authenticate` restituisce il client dell'utente sul percorso JWT (marchiato RLS-scoped) e la
+ * service role sul percorso a chiave API: nel secondo caso `query` si rifiuta da solo, ed è la
+ * ragione per cui qui non c'è nessun controllo in più da ricordarsi.
+ *
+ * POST per la forma dell'input, non per l'effetto: `where` è un array di oggetti, e passarlo come
+ * JSON dentro una querystring sarebbe una serializzazione in più da sbagliare. La lettura non
+ * spende niente e resta `destructive: false` nel registro.
+ */
+export const POST: RequestHandler = async ({ request, params }) => {
+  const { supabase, error, user, apiKey } = await authenticate(request);
+  if (error) return error;
+
+  const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
+  if (brandError) return brandError;
+
+  const parsed = QUERY_DATABASE.input.safeParse(await request.json().catch(() => ({})));
+  if (!parsed.success) {
+    return json({ error: 'invalid_input', details: parsed.error.issues }, { status: 400 });
+  }
+
+  const { query } = createQueryTool({ supabase, brandId: brand.id, userId: user.id });
+  const read = query.execute as (input: unknown, options: unknown) => Promise<unknown>;
+
+  return json(await read(parsed.data, {}));
+};


### PR DESCRIPTION
## What?

`query` — direct database reads with the caller's own permissions — already existed in
`src/lib/server/chat/query-tool.ts`, mounted only in the chat tool registry. This PR makes it
reachable from the CLI and MCP, and fixes the gate that was refusing the very clients it was
built to serve.

Three things change:

1. **The gate stops asking the wrong question.** It checked `auth.getSession()`; it now checks
   whether the client was built with the anon key, declared by the code that builds it.
2. **The table list is generated from the migrations** instead of typed by hand.
3. **`QUERY_DATABASE` joins the contract registry**, so REST, CLI and MCP stay aligned.

## Why?

Andrea asked for an MCP tool that runs RLS-enabled reads against the database, so an external
agent is not limited to the questions someone already built an endpoint for. *"How many posts
went out per platform in the last 90 days, and which one got the best engagement"* is three
reads and mental arithmetic today, or nothing.

The brief I started from said the blocker was the API-key path in `cli-auth.ts` handing out a
service-role client, and asked me to bring back a way to give that path the user's permissions.
**That premise turned out to be wrong, and the measurement is what showed it.**

MCP never accepts static API keys:

- `cli/mcp/verify-token.ts` — *"never accepts a static API key"*
- `cli/mcp/server.ts` — *"Auth: browser OAuth … **No static API tokens.**"*
- no `ANOMALIA_API_KEY`-style override anywhere in `cli/`; `cli/lib/auth.ts` stores a real
  Supabase session and refreshes it silently

So every MCP request already carries a user JWT, and `resolveCaller` already answers it with an
anon-key client that Postgres applies the user's policies to. The right client was there. What
was missing was a gate that could recognise it.

## How?

### The defect: the probe and the decision were different questions

`cli-auth.ts` builds the JWT-path client with the anon key plus the user's `Authorization`
header, but with cookies stubbed to `[]`. I built that exact client and asked it:

```
getSession() on the RLS-scoped JWT client => null
=> query-tool would REFUSE (no_user_session)
```

So the gate shut the door on the correct client. In production, `db_query:refused:no_session`
fired **46 times between Aug 24 and Sep 4**, against 5 successful table listings. And it was
wrong in the other direction too: a service-role client that happened to carry a session would
have passed, because a session says nothing about which key is talking.

`src/lib/server/rls-client.ts` replaces the probe with a declaration from whoever constructs the
client — the only code that knows. Marked in the two places that build an anon-key client
(`hooks.server.ts`, `cli-auth.ts`), never on the service role. **Unmarked does not read**, so a
new path stays closed instead of opening itself.

Those two are the only `createServerClient` sites in the repo, and `setSession` appears nowhere,
so no currently-working path loses its client.

### Why API keys stay refused — and would stay refused even with a signing secret

`SUPABASE_JWT_SECRET` does not exist: not in `.env`, not in `.env.local`, not in code, and not
among the 93 Vercel environment variables. Only the anon key and the service role. So minting a
short-lived user JWT is impossible, and passing claims on the connection is worse — PostgREST
verifies the signature.

**But the missing secret is not the reason, and this is the part worth remembering the day we
have one.** An API key carries `permissions.brand_ids`, often narrower than the brands its owner
belongs to. A JWT sees *every* brand the user belongs to, and RLS cannot see the key's
restriction. Minting a session for a key would silently widen a deliberately narrow key, turning
a limit the customer chose into nothing. That is a decision, not a stopgap, and it is written
into the internal changelog and into the refusal message itself.

### Rejected: the plpgsql design I was originally sent to build

The first brief asked for `SET LOCAL transaction_read_only`, a dedicated role, and a `.rpc()`
entry point. Building it would have been a worse duplicate of what exists:

- read-only would have been *enforced* rather than **inexpressible** — `query` speaks PostgREST
  (`.from().select()`), so there is no string that becomes SQL and a write has nowhere to go;
- `.rpc()` is excluded on purpose, because dozens of `SECURITY DEFINER` functions are executable
  by `authenticated`, one of which sends email. Mounting it would have let back in through the
  window exactly what the file keeps out of the door.

### The table list is generated, and from the migrations

The hand-typed list had **already aged by 16 names**: `thread_events`, `agent_kit_runs`,
`agent_kit_effects`, `agent_kit_approval_requests`, `post_verdicts`, `video_reviews`,
`org_usage`, `shared_views`, `chat_model_catalog`, `lead_suppressions`, `agent_computers`,
`sandbox_holders`, and four more. In chat a missing name cost a turn; as an `enum` on MCP it
**rejects a valid table before the request leaves** — worse than the problem it solves.

`scripts/query-tables-from-migrations.mjs` derives it from `supabase/migrations`, not from the
production catalogue. One rule: *a table exists if a migration creates it*. Generating from the
catalogue looks more direct and is wrong twice:

- it would restore `asset_projects`, `asset_project_files` and `mcp_logs`, which exist in
  production but not in a from-scratch install — they had been hand-removed for exactly this
  reason, and the agent kept tripping on them;
- it would restore `thread_events_backup_20260901`. A backup sits in `public` but is not data to
  read, and the rule excludes it **without an exception written for it**. The next backup is
  handled the same way.

The script also follows `drop table` and `alter table … rename to` (three real renames), and
accepts `public` only — `create table stripe.subscriptions` does not enter, which is Andrea's
"public schema only" limit applied where the list is produced rather than recommended in prose.
Result: **149 tables — exactly production's 153 minus the four no migration creates.**

### Surface

`QUERY_DATABASE` in `packages/api-contracts/src/query.ts`; the route mounts the **same** tool the
chat uses rather than reimplementing it, so caps, error translation, the brand boundary and the
service-role refusal are one piece of code. `POST` for the shape of the input (`where` is an array
of objects), not for its effect: the read spends nothing and is `destructive: false`.

The enum costs ~810 tokens once per MCP session in `tools/list`, versus a chat tool description
that is paid on every step of every turn — which is why the list is an enum here and stays out of
the chat description.

## Testing?

**The red came first and was watched fail.** Four failures before the fix, including one that
showed the old gate would have *accepted* a service-role client carrying a session:

```
× il cancello guarda i permessi... > un client RLS-scoped SENZA sessione legge
× ... > stessa domanda dai due percorsi, stessa richiesta al database
× ... > la service role resta respinta: non è marchiata
× il cancello: senza sessione utente non si legge > il rifiuto nomina anche la chiave API
```

The second half of the isolation test is the one that matters — *not one row more*. Which rows
come back is Postgres's decision, so the test pins the only thing that could make the two paths
diverge: that the request leaves identical. Same table, same columns, same filters, same cap.

At the auth layer, `cli-auth.test.ts` asserts the JWT path returns a marked client and the
service-role client is never marked. Both were confirmed to fail with the fix reverted:

```
× il marchio RLS esce solo dal percorso JWT > il JWT utente torna un client marchiato
× ... > il client service-role della chiave API non viene mai marchiato
```

The drift guardian was also confirmed falsifiable — adding a phantom name to the generated file
fails it, removing it passes.

**Full suite: 7224 passed, 0 failed** (645 files), after rebasing onto `dev`. CLI mirror
byte-compare green.

One caveat worth stating: a fresh worktree has no `.env`, and `src/hooks.server.test.ts` fails
with `Invalid URL` without it — environmental, not a defect. It passes on clean `dev` and passes
here once `.env` is present.

**Not tested:** no browser run and no dev server — this is a server-side read path with no UI,
and `npm run eval:durability` was not run because nothing here touches the chat turn, prompts,
tools or the model.

## Evidence

Andrea's second limit — *"public schema only, RLS tables only"* — **was already true**. It needed
no code, and the catalogue proves it rather than asserting it.

<details>
<summary>Production catalogue (read-only queries, project <code>kszazivzwievqixcnanp</code>)</summary>

| Check | Result |
|---|---|
| Tables in `public` | 153 |
| **Without RLS** | **0** |
| Views / materialized views | **0 / 0** |
| RLS tables with zero policies (deny-all) | 29 |
| Permissive `true` SELECT policies | 4 |
| `authenticated` | `bypassrls=false`, `statement_timeout=8s` |
| `anon` | `bypassrls=false`, `statement_timeout=3s` |
| `service_role` | **`bypassrls=true`** |

```sql
select
  (select count(*) from pg_class c join pg_namespace n on n.oid=c.relnamespace
     where n.nspname='public' and c.relkind='r') as public_tables,
  (select count(*) from pg_class c join pg_namespace n on n.oid=c.relnamespace
     where n.nspname='public' and c.relkind='r' and not c.relrowsecurity) as tables_without_rls,
  (select count(*) from pg_class c join pg_namespace n on n.oid=c.relnamespace
     where n.nspname='public' and c.relkind in ('v','m')) as public_views;
-- → 153 | 0 | 0
```

The four permissive `true` policies are `blog_authors`, `blog_categories`, `blog_tags`,
`brand_article_tags` — public blog taxonomy. **No brand-data table is open to `anon`.**

Two consequences worth naming:

- **Zero views** means the trap I was warned about — a view running with its owner's privileges
  rather than the caller's — does not exist in this database. Nothing to exclude, nothing to audit
  one by one.
- **`service_role bypassrls=true`** is the catalogue line that explains why an unmarked client
  must not read. It is not a stylistic preference.

"Public schema only" is enforced by PostgREST, which exposes only its configured schemas:
`.from('auth.users')` is not a request that exists.

**No policy was written and no table was unlocked to let this tool through.**

</details>

<details>
<summary>The blindness, measured in production</summary>

```sql
select created_at::date as day,
       count(*) filter (where context = 'db_query:refused:no_session') as refused,
       count(*) filter (where context <> 'db_query:refused:no_session') as ran
from ai_calls where label = 'db_query' group by 1 order by 1;
```

| day | refused | ran |
|---|---|---|
| 2026-08-24 | 5 | 0 |
| 2026-08-28 | 3 | 0 |
| 2026-08-29 | 7 | 0 |
| 2026-09-01 | 5 | 0 |
| 2026-09-03 | 11 | 12 |
| 2026-09-04 | 9 | 0 |

46 refusals total. Every one of them a turn where the agent asked for data it was entitled to and
was told no.

</details>

<details>
<summary>Generated list vs production, both directions</summary>

```
in generated, NOT in prod  → (empty)
in prod, NOT in generated  → asset_project_files, asset_projects, mcp_logs,
                              thread_events_backup_20260901
```

Exactly the four tables no migration creates. Nothing else diverges.

</details>

## Anything Else?

- **Six tables have no application reader**, per the dead-code sweep; four of them
  (`shared_views`, `org_usage`, `post_verdicts`, `video_reviews`) are among the 16 this PR adds to
  the list. Named, not decided — their fate is not this PR's call.
- **The queue still runs on the service role**, so `query` stays refused on background turns. That
  is correct today, but it means the chat surface only gets `query` on the interactive path. Worth
  a separate look at whether queue turns should carry the requesting user's client.
- **The generated list needs regenerating** when a migration adds a table:
  `node scripts/query-tables-from-migrations.mjs --write`. The test fails until you do, which is
  the intended nag rather than an oversight.
- `QUERY_TABLES` lives in the contracts package rather than `$lib` because the package cannot
  import the app (`packages/no-app-imports.test.ts` holds that boundary), and the enum needs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
