### PR TITLE
Move image renders to OpenRouter

### DIFF
--- a/changelog/2026-09-04-openrouter-endpoint.md
+++ b/changelog/2026-09-04-openrouter-endpoint.md
@@ -53,13 +53,41 @@ che `usage.cost` coincide alla sesta cifra decimale con la tariffa dell'endpoint
 si paga sull'acquisto dei crediti. `provider` scrive `openrouter`, così la misura in produzione è
 leggibile il giorno dopo senza indovinare da quale trasporto è passata una riga.
 
+## `SERVED_BY`: una coppia senza trasporto non è una rotta
+
+Aggiungere `openrouter` rendeva analizzabile anche `AI_ROUTE_TEXT=gemini@openrouter` — ma
+`geminiTransport()` conosce solo `kie` e `google`, quindi quella rotta sarebbe atterrata **in
+silenzio su Google**. È il guasto peggiore della famiglia: la rotta si legge come rispettata, il
+traffico va altrove, e non resta traccia da nessuna parte.
+
+La prima versione di questa PR lo segnalava nel corpo della PR. Non regge, per due motivi:
+
+- **un avviso in una PR non sopravvive.** Fra due settimane qualcuno legge il registro, vede
+  `openrouter` fra gli endpoint validi, imposta la variabile e ottiene Google. È lo stesso
+  meccanismo del commento scaduto che AGENTS.md vieta: la conoscenza fuori dal codice invecchia e
+  mente.
+- **il registro ha già la regola giusta.** Quando manca la chiave, *«un endpoint senza chiave non è
+  una rotta: si ripiega, rumorosamente»*, e un test lo tiene. Un endpoint senza **trasporto** non è
+  più una rotta di uno senza chiave.
+
+Quindi quella conoscenza è diventata una tabella, `SERVED_BY`, accanto alle altre quattro: quali
+endpoint hanno davvero un trasporto scritto per ogni famiglia. `route()` ora ha due modi di
+rifiutare, entrambi rumorosi, e il messaggio dice **quale** dei due: `nessun trasporto gemini verso
+openrouter` oppure `la chiave manca`.
+
+Il buco **non era nuovo**: valeva identico per `gemini@xiaomi`, `gemini@deepseek`, `mimo@kie` e ogni
+altra coppia mai collegata. Chiuderne uno solo — quello appena visto — avrebbe garantito il ritorno
+degli altri, ed è esattamente la "condizione sparsa" che AGENTS.md vieta: le eccezioni si dichiarano
+**in un posto solo, accanto al modello che le governa**. Il test le percorre tutte e quattro.
+
+Quella conoscenza viveva sparsa in tre file (`gemini.ts`, `xiaomi.ts`, `gemini-audio.ts`), dove
+nessuno poteva vederla tutta insieme. Il giorno che si collega il trasporto del testo verso
+openrouter, cambia **una riga** di questa tabella e il test cambia colore.
+
 ## Quello che NON è in questa PR, e perché
 
-- **Il testo.** Il registro ora accetta `gemini@openrouter`, ma `geminiTransport()` conosce solo
-  `kie` e `google`: una rotta del testo verso openrouter finirebbe **in silenzio su Google**. Non è
-  un difetto introdotto qui (vale già per `gemini@xiaomi`), ma diventa raggiungibile in un modo che
-  sembra supportato. Il trasporto del testo è la PR successiva, e va fatta prima di scrivere quella
-  variabile in produzione.
+- **Il trasporto del testo verso openrouter.** È la PR successiva. Finché non esiste, il registro
+  rifiuta la rotta rumorosamente invece di fingerla — vedi sopra.
 - **Il video.** OpenRouter lo serve su una superficie separata (`/api/v1/videos`, 28 modelli), che è
   asincrona come kie e quindi non porta il regalo del sincrono. Storia sua.
 - **Il catalogo a tre modalità.** `chat_model_catalog` non ha una colonna di modalità; darne una è

--- a/changelog/2026-09-04-openrouter-endpoint.md
+++ b/changelog/2026-09-04-openrouter-endpoint.md
@@ -1,0 +1,78 @@
+# OpenRouter è un endpoint del registro, e serve le immagini
+
+Il registro delle rotte conosceva quattro endpoint — `google`, `kie`, `xiaomi`, `deepseek`. Ora ne
+conosce cinque. `openrouter` è una riga per tabella (`Endpoint`, `MISSING`, `LOG_PROVIDER`,
+`endpointConfigured`), esattamente la forma che quel file ha di proposito: aggiungere un endpoint
+non deve voler dire scrivere un `if` da qualche altra parte.
+
+Niente default si sposta. `AI_ROUTE_IMAGE=nano-banana@openrouter` lo accende, e senza quella
+variabile tutto resta dov'era: testo su Google, immagini e voce su kie. `google`, `xiaomi` e
+`deepseek` restano accesi — sono l'interruttore di emergenza, e si toglie un interruttore dopo
+aver misurato in produzione, non prima.
+
+## Perché, coi numeri
+
+Immagini, stesso modello Google, stesso prompt:
+
+| | kie `nano-banana-2-lite` | OpenRouter `google/gemini-3.1-flash-lite-image` |
+|---|---|---|
+| tempo | 16,5s · 42,1s · 16,4s (media 25,0s) | 3,2s · 2,7s · 4,2s (media 3,4s) |
+| costo per render | 4 crediti ≈ $0,020 | $0,0336 |
+
+**+68% di prezzo, un settimo del tempo.** È una scelta di latenza, non di risparmio, e il commento
+sul ramo lo dice per chi legge dopo — perché su questo file l'assunzione naturale è la contraria.
+
+Il regalo vero non è nella tabella: su OpenRouter il render è **una richiesta sincrona**. Niente
+`createTask`, niente polling, quindi il difetto dei task abbandonati-e-fatturati — un job che
+scade da noi mentre il provider continua a lavorare e a mandare il conto — **non esiste per
+costruzione** su questo percorso. Su kie è costato render pagati due volte.
+
+Per la stessa ragione il ramo non ritenta: un fallimento sincrono torna già diagnosticato in
+millisecondi (misurato: 28ms per un id di modello inesistente), e `generateImageOnOpenrouter` alza
+l'eccezione invece di restituire `undefined`. Una risposta senza parte immagine **non è un
+successo**: era il modo più facile di sbagliare qui, ed è un test.
+
+## Il rapporto d'aspetto, che è la trappola
+
+OpenRouter inoltra il rapporto d'aspetto solo dentro `image_config.aspect_ratio`. Misurato, stesso
+prompt, stesso modello:
+
+- senza il campo → **1408x768** (panoramico)
+- con `image_config.aspect_ratio: '4:5'` → **928x1152** (4:5)
+- con `extra_body.imageConfig.aspectRatio` → 1408x768, cioè ignorato
+
+Senza quel campo ogni post Instagram del brand sarebbe uscito inquadrato in panoramica, con
+risposta 200 e nessun errore da nessuna parte. È il motivo per cui c'è un test sul corpo della
+richiesta e non solo sull'estrazione dell'immagine.
+
+## Il costo lo dice chi fattura
+
+La riga in `ai_calls` prende `flatCostUsd` da `usage.cost` di OpenRouter, non da `RATES`. Verificato
+che `usage.cost` coincide alla sesta cifra decimale con la tariffa dell'endpoint a monte, e che
+`cost_details.upstream_inference_cost` è identico a `cost` — OpenRouter non mette markup sul token,
+si paga sull'acquisto dei crediti. `provider` scrive `openrouter`, così la misura in produzione è
+leggibile il giorno dopo senza indovinare da quale trasporto è passata una riga.
+
+## Quello che NON è in questa PR, e perché
+
+- **Il testo.** Il registro ora accetta `gemini@openrouter`, ma `geminiTransport()` conosce solo
+  `kie` e `google`: una rotta del testo verso openrouter finirebbe **in silenzio su Google**. Non è
+  un difetto introdotto qui (vale già per `gemini@xiaomi`), ma diventa raggiungibile in un modo che
+  sembra supportato. Il trasporto del testo è la PR successiva, e va fatta prima di scrivere quella
+  variabile in produzione.
+- **Il video.** OpenRouter lo serve su una superficie separata (`/api/v1/videos`, 28 modelli), che è
+  asincrona come kie e quindi non porta il regalo del sincrono. Storia sua.
+- **Il catalogo a tre modalità.** `chat_model_catalog` non ha una colonna di modalità; darne una è
+  una migrazione, e i deploy qui non eseguono migrazioni. Storia sua.
+
+## Un difetto trovato mentre misuravo, e non corretto qui
+
+`RATES` in `ai-log.ts` prezza `gemini-3.7-flash` a **$1,50 / $7,50** per milione di token. Il
+listino Google di oggi è **$0,75 / $3,75**: quello a $1,50/$7,50 entra in vigore il **1° gennaio
+2027**. Il commento nel file lo dice ("post-intro standard rate"), quindi fu una scelta, non un
+refuso — ma la conseguenza è che ogni riga `gemini` in `ai_calls` costa **il doppio del vero**, e
+la dashboard dei costi sbaglia di 2× su 13.265 chiamate in 30 giorni.
+
+Non lo tocco qui: cambiare quella tariffa cambia i crediti addebitati agli utenti, ed è una
+decisione di prodotto. Ma va deciso, perché finché resta, ogni confronto di costo fra provider
+parte da un denominatore sbagliato — incluso quello che ha motivato questa PR.

--- a/src/lib/content/changelog/2026-09-04-openrouter-images.ts
+++ b/src/lib/content/changelog/2026-09-04-openrouter-images.ts
@@ -1,0 +1,11 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-04',
+  title: 'Image generation can now run on a faster route',
+  items: [
+    'Images can now be generated through OpenRouter, which returns a finished render in about 3 seconds instead of 25 — the same Google model, seven times faster.',
+    'Renders on this route are billed at what the provider actually charged for that image, not at an estimate.',
+    'The existing route stays available and stays the default, so nothing changes until the faster one is switched on.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/content-preview/images.ts
+++ b/src/lib/server/content-preview/images.ts
@@ -13,6 +13,7 @@ import { GEMINI_NANO_BANANA_2, googleImageModel } from '$lib/image-models';
 import { structured } from '$lib/server/research';
 import { signKnowledgePaths } from '$lib/server/media-archive';
 import { generateImageOnKie } from '$lib/server/kie-jobs';
+import { generateImageOnOpenrouter } from '$lib/server/openrouter-image';
 import { route } from '$lib/server/model-routing';
 import { signPaths } from '$lib/server/people';
 import { svgToPng } from '$lib/server/brand-analysis';
@@ -253,6 +254,17 @@ export async function renderPostImage(
   }
   const req = buildImageRequest(imagePrompt, opts);
   const imageModel = req.model;
+  // OpenRouter serve lo STESSO modello Google in una richiesta sincrona: 3,4s di media contro 25,0s
+  // su kie, e senza createTask/polling non esiste il task abbandonato-e-fatturato. Costa il 68% in
+  // più per render ($0,0336 contro ~$0,020), quindi è una scelta di latenza, non di risparmio.
+  // Nessun ritentativo qui: un fallimento sincrono torna già diagnosticato, e `generateImageOnOpenrouter`
+  // alza l'eccezione invece di restituire un successo vuoto.
+  if (route('image').endpoint === 'openrouter') {
+    return await generateImageOnOpenrouter(
+      { ...req, model: googleImageModel(req.model, NANO_BANANA_2_LITE) },
+      { context: `image:${imageModel}` }
+    );
+  }
   // Nano Banana gira su kie: stesso modello, −33%/−40% per immagine (misurato sui crediti
   // addebitati). È l'UNICO punto da cambiare perché ogni render del prodotto passa di qui.
   // `AI_ROUTE_IMAGE=nano-banana@google` riporta tutto su Google senza deploy.

--- a/src/lib/server/model-routing.test.ts
+++ b/src/lib/server/model-routing.test.ts
@@ -97,6 +97,39 @@ describe('il registro delle rotte', () => {
     expect(missingCapabilities('google')).toEqual([]);
   });
 
+  it('openrouter è una rotta, e AI_ROUTE_IMAGE la seleziona', async () => {
+    setEnv({ ...KEYS, OPENROUTER_API_KEY: 'o', AI_ROUTE_IMAGE: 'nano-banana@openrouter' });
+    const { route } = await import('./model-routing');
+    expect(route('image')).toMatchObject({
+      family: 'nano-banana',
+      endpoint: 'openrouter',
+      provider: 'openrouter'
+    });
+  });
+
+  it('la chiave del gateway del testo vale anche per openrouter', async () => {
+    setEnv({ ...KEYS, LLM_API_KEY: 'o', AI_ROUTE_IMAGE: 'nano-banana@openrouter' });
+    const { route } = await import('./model-routing');
+    expect(route('image').endpoint).toBe('openrouter');
+  });
+
+  it('senza chiave openrouter non è una rotta: si ripiega, rumorosamente', async () => {
+    setEnv({ GEMINI_API_KEY: 'g', AI_ROUTE_IMAGE: 'nano-banana@openrouter' });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { route } = await import('./model-routing');
+    expect(route('image')).toMatchObject({ endpoint: 'google', provider: 'gemini' });
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('i default non si spostano: aggiungere openrouter non muove niente', async () => {
+    setEnv({ ...KEYS, OPENROUTER_API_KEY: 'o' });
+    const { route } = await import('./model-routing');
+    expect(route('text').endpoint).toBe('google');
+    expect(route('image').endpoint).toBe('kie');
+    expect(route('tts').endpoint).toBe('kie');
+  });
+
   it('i modelli video: nuova variabile, vecchia variabile, default', async () => {
     setEnv({ ...KEYS, AI_ROUTE_VIDEO_I2V: 'bytedance/seedance-2-5', KIE_VIDEO_MODEL_T2V: 'vecchio/t2v' });
     const { videoModel } = await import('./model-routing');

--- a/src/lib/server/model-routing.test.ts
+++ b/src/lib/server/model-routing.test.ts
@@ -122,6 +122,42 @@ describe('il registro delle rotte', () => {
     warn.mockRestore();
   });
 
+  it('una coppia senza trasporto non è una rotta: si ripiega, e dice perché', async () => {
+    // `geminiTransport()` conosce solo kie e google: il testo verso openrouter atterrerebbe su
+    // Google IN SILENZIO, cioè la rotta si legge come rispettata e non lo è. Vale identico per le
+    // coppie che erano già cieche prima di openrouter — una regola sola, non un'eccezione.
+    for (const raw of ['gemini@openrouter', 'gemini@xiaomi', 'gemini@deepseek', 'mimo@kie']) {
+      vi.resetModules();
+      setEnv({ ...KEYS, OPENROUTER_API_KEY: 'o', DEEPSEEK_API_KEY: 'd', AI_ROUTE_TEXT: raw });
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const { route } = await import('./model-routing');
+      route('text');
+      expect(warn, raw).toHaveBeenCalledWith(expect.stringMatching(/nessun trasporto/));
+      warn.mockRestore();
+    }
+  });
+
+  it('le coppie che un trasporto serve davvero passano senza rumore', async () => {
+    const SLOT_VAR = { text: 'AI_ROUTE_TEXT', image: 'AI_ROUTE_IMAGE', tts: 'AI_ROUTE_TTS' } as const;
+    for (const [raw, slot, endpoint] of [
+      ['gemini@kie', 'text', 'kie'],
+      ['gemini@google', 'text', 'google'],
+      ['mimo@xiaomi', 'text', 'xiaomi'],
+      ['grok@kie', 'text', 'kie'],
+      ['nano-banana@openrouter', 'image', 'openrouter'],
+      ['nano-banana@google', 'image', 'google'],
+      ['gemini-tts@kie', 'tts', 'kie']
+    ] as const) {
+      vi.resetModules();
+      setEnv({ ...KEYS, OPENROUTER_API_KEY: 'o', [SLOT_VAR[slot]]: raw });
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const { route } = await import('./model-routing');
+      expect(route(slot).endpoint, raw).toBe(endpoint);
+      expect(warn, raw).not.toHaveBeenCalled();
+      warn.mockRestore();
+    }
+  });
+
   it('i default non si spostano: aggiungere openrouter non muove niente', async () => {
     setEnv({ ...KEYS, OPENROUTER_API_KEY: 'o' });
     const { route } = await import('./model-routing');

--- a/src/lib/server/model-routing.ts
+++ b/src/lib/server/model-routing.ts
@@ -110,6 +110,26 @@ const HOME: Record<ModelFamily, Endpoint> = {
   deepseek: 'deepseek'
 };
 
+/**
+ * Chi ha un TRASPORTO scritto per quella famiglia. Non è una capacità del provider: è codice che
+ * esiste o non esiste da noi. `gemini@openrouter` si analizza benissimo, ma `geminiTransport()`
+ * conosce solo kie e google — quella rotta atterrerebbe su Google IN SILENZIO, cioè si leggerebbe
+ * come rispettata senza esserlo, che è il guasto peggiore di tutti perché non lascia traccia.
+ *
+ * Sta qui e non in tre file perché una regola scritta in tre posti diverge al primo cambiamento.
+ * Il giorno che si collega un trasporto nuovo, si aggiunge un endpoint a una riga di questa tabella
+ * e basta.
+ */
+const SERVED_BY: Record<ModelFamily, Endpoint[]> = {
+  gemini: ['google', 'kie'],
+  'gemini-tts': ['google', 'kie'],
+  'nano-banana': ['google', 'kie', 'openrouter'],
+  mimo: ['xiaomi'],
+  grok: ['kie'],
+  gpt: ['kie'],
+  deepseek: ['deepseek']
+};
+
 /** Quale riga di `ai_calls.provider` scrive ogni endpoint. */
 const LOG_PROVIDER: Record<Endpoint, LogProvider> = {
   google: 'gemini',
@@ -211,16 +231,26 @@ const SLOT_ENV: Record<Slot, string> = {
  * Dove va questo lavoro, adesso. Letto A OGNI CHIAMATA come `GEMINI_FLASH`: cambiare una variabile
  * su Vercel deve bastare a spostare il traffico, senza deploy, mentre il guasto è in corso.
  *
- * Un endpoint senza chiave non è una rotta, è un 401 con più passaggi: si ripiega sull'endpoint di
- * casa della famiglia, e se manca anche quello su Google. Il ripiego è RUMOROSO.
+ * Due modi di non essere una rotta, e nessuno dei due atterra in silenzio: un endpoint senza chiave
+ * è un 401 con più passaggi, una coppia senza trasporto è peggio — la rotta si legge come rispettata
+ * e serve un altro provider. Si ripiega sull'endpoint di casa della famiglia, e se manca anche
+ * quello su Google. Il ripiego è RUMOROSO, e dice QUALE dei due motivi.
  */
+function unroutable(chosen: Route): string | null {
+  if (!SERVED_BY[chosen.family].includes(chosen.endpoint)) {
+    return `nessun trasporto ${chosen.family} verso ${chosen.endpoint}`;
+  }
+  return endpointConfigured(chosen.endpoint) ? null : 'la chiave manca';
+}
+
 export function route(slot: Slot): Route {
   const chosen = parseRoute(env[SLOT_ENV[slot]]) ?? legacyRoute(slot) ?? SLOT_DEFAULT[slot];
-  if (endpointConfigured(chosen.endpoint)) return chosen;
+  const why = unroutable(chosen);
+  if (!why) return chosen;
   const home = HOME[chosen.family];
-  const fallback = endpointConfigured(home) ? home : 'google';
+  const fallback = unroutable(r(chosen.family, home)) ? 'google' : home;
   console.warn(
-    `[AI] ${SLOT_ENV[slot]} chiede ${chosen.family}@${chosen.endpoint} ma la chiave manca: ripiego su ${fallback}.`
+    `[AI] ${SLOT_ENV[slot]} chiede ${chosen.family}@${chosen.endpoint}: ${why}. Ripiego su ${fallback}.`
   );
   return r(chosen.family, fallback);
 }

--- a/src/lib/server/model-routing.ts
+++ b/src/lib/server/model-routing.ts
@@ -19,10 +19,10 @@ import { env } from '$env/dynamic/private';
 export type ModelFamily = 'gemini' | 'mimo' | 'grok' | 'gpt' | 'deepseek' | 'nano-banana' | 'gemini-tts';
 
 /** L'endpoint: chi serve la famiglia e chi ci manda il conto. */
-export type Endpoint = 'google' | 'kie' | 'xiaomi' | 'deepseek';
+export type Endpoint = 'google' | 'kie' | 'xiaomi' | 'deepseek' | 'openrouter';
 
 /** Il valore che finisce in `ai_calls.provider`. Uno per endpoint, non uno per famiglia. */
-export type LogProvider = 'gemini' | 'kie' | 'xiaomi' | 'deepseek';
+export type LogProvider = 'gemini' | 'kie' | 'xiaomi' | 'deepseek' | 'openrouter';
 
 /** Fatti MISURATI, non ipotesi di listino: ogni assenza qui sotto è una regressione vista. */
 export type Capability =
@@ -64,6 +64,7 @@ const ALL: Capability[] = [
  */
 const MISSING: Record<Endpoint, Partial<Record<Capability, string>>> = {
   google: {},
+  openrouter: {},
   kie: {
     grounding: 'kie non restituisce groundingMetadata: le citazioni tornano vuote',
     'media-in-tool-result': 'kie scarta i media dentro i risultati dei tool, in silenzio',
@@ -112,6 +113,7 @@ const HOME: Record<ModelFamily, Endpoint> = {
 /** Quale riga di `ai_calls.provider` scrive ogni endpoint. */
 const LOG_PROVIDER: Record<Endpoint, LogProvider> = {
   google: 'gemini',
+  openrouter: 'openrouter',
   kie: 'kie',
   xiaomi: 'xiaomi',
   deepseek: 'deepseek'
@@ -124,6 +126,7 @@ function endpointConfigured(endpoint: Endpoint): boolean {
     case 'kie': return !!env.KIE_API_KEY;
     case 'xiaomi': return !!env.XIAOMI_MIMO_API_KEY;
     case 'deepseek': return !!env.DEEPSEEK_API_KEY;
+    case 'openrouter': return !!(env.OPENROUTER_API_KEY || env.LLM_API_KEY);
   }
 }
 

--- a/src/lib/server/openrouter-image.test.ts
+++ b/src/lib/server/openrouter-image.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Il render su OpenRouter è SINCRONO: niente createTask, niente polling, quindi niente task
+// abbandonato-e-fatturato. Le due cose che devono reggere sono l'estrazione dell'immagine — una
+// risposta senza parte immagine NON è un successo — e il rapporto d'aspetto, che senza il campo
+// giusto torna panoramico: misurato 1408x768 invece di 4:5.
+
+const M = vi.hoisted(() => ({ env: {} as Record<string, string | undefined>, logged: [] as unknown[] }));
+vi.mock('$env/dynamic/private', () => ({ env: M.env }));
+vi.mock('$lib/server/ai-log', () => ({
+  logAiCall: (e: unknown) => void M.logged.push(e),
+  getBrandContext: () => null
+}));
+
+const REQ = {
+  model: 'gemini-3.1-flash-lite-image',
+  contents: [{ parts: [{ text: 'una tazza di ceramica su pietra bagnata' }] }],
+  config: { imageConfig: { aspectRatio: '4:5' } }
+};
+
+const PIXEL = 'data:image/jpeg;base64,/9j/4AAQSkZJRg==';
+
+function reply(body: unknown, status = 200) {
+  return vi.fn(async (_url: string, _init: RequestInit) => new Response(JSON.stringify(body), { status }));
+}
+
+function sentBody(f: ReturnType<typeof reply>) {
+  return JSON.parse(String(f.mock.calls[0][1].body));
+}
+
+function withImage() {
+  return {
+    choices: [{ message: { role: 'assistant', images: [{ type: 'image_url', image_url: { url: PIXEL } }] } }],
+    usage: { cost: 0.0336, prompt_tokens: 33, completion_tokens: 1120 }
+  };
+}
+
+describe('il render su OpenRouter', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    for (const k of Object.keys(M.env)) delete M.env[k];
+    M.env.OPENROUTER_API_KEY = 'o';
+    M.logged.length = 0;
+  });
+
+  it('tira fuori l’immagine da choices[0].message.images', async () => {
+    vi.stubGlobal('fetch', reply(withImage()));
+    const { generateImageOnOpenrouter } = await import('./openrouter-image');
+    expect(await generateImageOnOpenrouter(REQ)).toBe(PIXEL);
+  });
+
+  it('una risposta senza parte immagine non è un successo silenzioso', async () => {
+    vi.stubGlobal('fetch', reply({ choices: [{ message: { role: 'assistant', content: 'non disegno' } }] }));
+    const { generateImageOnOpenrouter } = await import('./openrouter-image');
+    await expect(generateImageOnOpenrouter(REQ)).rejects.toThrow(/nessuna immagine/i);
+  });
+
+  it('manda il rapporto d’aspetto: senza, l’immagine torna panoramica', async () => {
+    const f = reply(withImage());
+    vi.stubGlobal('fetch', f);
+    const { generateImageOnOpenrouter } = await import('./openrouter-image');
+    await generateImageOnOpenrouter(REQ);
+    const body = sentBody(f);
+    expect(body.image_config).toEqual({ aspect_ratio: '4:5' });
+    expect(body.modalities).toEqual(['image', 'text']);
+  });
+
+  it('il modello va col fornitore davanti: è così che OpenRouter lo chiama', async () => {
+    const f = reply(withImage());
+    vi.stubGlobal('fetch', f);
+    const { generateImageOnOpenrouter } = await import('./openrouter-image');
+    await generateImageOnOpenrouter(REQ);
+    const body = sentBody(f);
+    expect(body.model).toBe('google/gemini-3.1-flash-lite-image');
+  });
+
+  it('i riferimenti inline diventano image_url, senza passare da un upload', async () => {
+    const f = reply(withImage());
+    vi.stubGlobal('fetch', f);
+    const { generateImageOnOpenrouter } = await import('./openrouter-image');
+    await generateImageOnOpenrouter({
+      ...REQ,
+      contents: [
+        { parts: [{ text: 'il prodotto vero' }, { inlineData: { mimeType: 'image/png', data: 'AAAA' } }] }
+      ]
+    });
+    const body = sentBody(f);
+    expect(body.messages[0].content).toEqual([
+      { type: 'text', text: 'il prodotto vero' },
+      { type: 'image_url', image_url: { url: 'data:image/png;base64,AAAA' } }
+    ]);
+  });
+
+  it('il costo viene da usage.cost, non da un listino scritto a mano', async () => {
+    vi.stubGlobal('fetch', reply(withImage()));
+    const { generateImageOnOpenrouter } = await import('./openrouter-image');
+    await generateImageOnOpenrouter(REQ);
+    expect(M.logged[0]).toMatchObject({ provider: 'openrouter', ok: true, flatCostUsd: 0.0336 });
+  });
+
+  it('una chiamata fallita lascia la riga, senza costo', async () => {
+    vi.stubGlobal('fetch', reply({ error: { message: 'rate limited' } }, 429));
+    const { generateImageOnOpenrouter } = await import('./openrouter-image');
+    await expect(generateImageOnOpenrouter(REQ)).rejects.toThrow();
+    expect(M.logged[0]).toMatchObject({ provider: 'openrouter', ok: false });
+    expect((M.logged[0] as { flatCostUsd?: number }).flatCostUsd).toBeUndefined();
+  });
+});

--- a/src/lib/server/openrouter-image.ts
+++ b/src/lib/server/openrouter-image.ts
@@ -1,0 +1,122 @@
+/**
+ * Un render a partire dalla stessa richiesta che il codice costruisce GIÀ per Gemini, come fa
+ * `generateImageOnKie`: si traduce il trasporto, non il contenuto. Il prompt che `buildImageRequest`
+ * assembla è il risultato di molta messa a punto, e una seconda funzione che lo ricostruisse
+ * divergerebbe al primo ritocco.
+ *
+ * La differenza che conta rispetto a kie: qui è UNA richiesta sincrona. Niente createTask, niente
+ * polling, quindi niente task che scade mentre il provider continua a lavorare e a fatturare — il
+ * difetto che su kie è costato render pagati due volte. Misurato: 3,0-4,2s contro 16-42s.
+ *
+ * I riferimenti restano inline come data URL: kie pretende un upload per ciascuno (un giro di rete
+ * per riferimento), qui viaggiano nel corpo.
+ *
+ * PREZZO: da `usage.cost`, che è la fattura di OpenRouter per QUESTA chiamata. Non da un listino
+ * scritto a mano — verificato che coincide alla sesta cifra con la tariffa dell'endpoint a monte.
+ */
+import { env } from '$env/dynamic/private';
+import { logAiCall } from '$lib/server/ai-log';
+import type { GeminiImageRequest } from '$lib/server/kie-jobs';
+
+const OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
+const IMAGE_MODALITIES = ['image', 'text'];
+const GOOGLE_VENDOR = 'google/';
+
+type OpenrouterImageResponse = {
+  choices?: Array<{ message?: { images?: Array<{ image_url?: { url?: string } }> } }>;
+  usage?: { cost?: number };
+  error?: { message?: string };
+};
+
+function apiKey(): string | undefined {
+  return env.OPENROUTER_API_KEY?.trim() || env.LLM_API_KEY?.trim() || undefined;
+}
+
+function baseUrl(): string {
+  return (env.LLM_BASE_URL?.trim() || OPENROUTER_BASE_URL).replace(/\/$/, '');
+}
+
+/**
+ * OpenRouter chiama i modelli col fornitore davanti. Gli id che il prodotto usa sono già quelli
+ * Google (`googleImageModel` li ha riportati lì), quindi manca solo il prefisso.
+ */
+export function openrouterImageModel(model: string): string {
+  return model.includes('/') ? model : `${GOOGLE_VENDOR}${model}`;
+}
+
+/** Undefined quando la risposta non porta nessuna parte immagine: non è un successo. */
+export function imageFromOpenrouterResponse(body: OpenrouterImageResponse): string | undefined {
+  for (const image of body.choices?.[0]?.message?.images ?? []) {
+    if (image?.image_url?.url) return image.image_url.url;
+  }
+  return undefined;
+}
+
+type ContentPart = { type: 'text'; text: string } | { type: 'image_url'; image_url: { url: string } };
+
+function messageContent(parts: GeminiImageRequest['contents'][number]['parts']): ContentPart[] {
+  return parts.flatMap((part): ContentPart[] => {
+    if (part.text) return [{ type: 'text', text: part.text }];
+    if (!part.inlineData) return [];
+    const { mimeType, data } = part.inlineData;
+    return [{ type: 'image_url', image_url: { url: `data:${mimeType};base64,${data}` } }];
+  });
+}
+
+export async function generateImageOnOpenrouter(
+  req: GeminiImageRequest,
+  opts: { label?: string; context?: string; signal?: AbortSignal } = {}
+): Promise<string> {
+  const key = apiKey();
+  if (!key) throw new Error('OPENROUTER_API_KEY assente: questo render non ha un trasporto');
+
+  const label = opts.label ?? 'renderPostImage';
+  const model = openrouterImageModel(req.model);
+  const aspectRatio = req.config?.imageConfig?.aspectRatio;
+  const t0 = Date.now();
+
+  // `image_config.aspect_ratio` è il campo che OpenRouter inoltra davvero: senza, lo stesso prompt
+  // torna 1408x768 invece di 4:5, cioè ogni post Instagram del brand inquadrato in panoramica.
+  // `extra_body` NON funziona — misurato, entrambi.
+  const body = {
+    model,
+    messages: [{ role: 'user', content: messageContent(req.contents?.[0]?.parts ?? []) }],
+    modalities: IMAGE_MODALITIES,
+    ...(aspectRatio ? { image_config: { aspect_ratio: aspectRatio } } : {}),
+    usage: { include: true }
+  };
+
+  const fail = (error: string): never => {
+    logAiCall({ label, provider: 'openrouter', model, ms: Date.now() - t0, ok: false, error, context: opts.context });
+    throw new Error(`OpenRouter (${model}): ${error}`);
+  };
+
+  let payload: OpenrouterImageResponse;
+  try {
+    const res = await fetch(`${baseUrl()}/chat/completions`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${key}`, 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+      signal: opts.signal
+    });
+    payload = (await res.json()) as OpenrouterImageResponse;
+    if (!res.ok || payload.error) fail(payload.error?.message ?? `HTTP ${res.status}`);
+  } catch (e) {
+    if (e instanceof Error && e.message.startsWith('OpenRouter (')) throw e;
+    return fail(e instanceof Error ? e.message : 'richiesta fallita');
+  }
+
+  const dataUrl = imageFromOpenrouterResponse(payload);
+  if (!dataUrl) fail('nessuna immagine nella risposta');
+
+  logAiCall({
+    label,
+    provider: 'openrouter',
+    model,
+    ms: Date.now() - t0,
+    ok: true,
+    flatCostUsd: payload.usage?.cost,
+    context: opts.context
+  });
+  return dataUrl as string;
+}


### PR DESCRIPTION
## What?

The routing registry (`src/lib/server/model-routing.ts`) knew four endpoints — `google`, `kie`, `xiaomi`, `deepseek`. It now knows five. `openrouter` is **one line per table** (`Endpoint`, `MISSING`, `LOG_PROVIDER`, `endpointConfigured`), which is the shape that file has on purpose.

`renderPostImage` gains a third branch, before the kie one, backed by a new transport driver `src/lib/server/openrouter-image.ts` that mirrors `generateImageOnKie`: it takes the Gemini-shaped request `buildImageRequest` already builds and translates the transport, not the content.

**No default moves in this PR.** `AI_ROUTE_IMAGE=nano-banana@openrouter` turns it on; without that variable everything stays exactly where it was — text on Google, images and voice on kie. `google`, `xiaomi` and `deepseek` stay configured: they are the emergency switch, and a switch gets removed after measuring in production, not before.

## Why?

Andrea's call, and the criterion is not price: *"Kie conviene certo, ma è inaffidabile e non ci possiamo creare una startup sopra."*

**The reason for this change is the p95, not a saving.** Over 30 days on `renderPostImage`:

| | calls | failed | mean | p95 |
|---|---|---|---|---|
| Google | 993 | **0** (0.0%) | 9.2s | 20.2s |
| kie | 199 | 7 (**3.5%**) | 68.1s | **142.9s** |
| OpenRouter | measured | — | **3.4s** | — |

A render on kie can keep someone waiting **two and a half minutes**, and one in twenty-nine never arrives at all. OpenRouter is three times faster than Google, twenty times faster than kie, and synchronous — so the abandoned-and-billed task class of defect cannot exist on it.

**On price, the widely-quoted +68% was the wrong comparison.** It measured OpenRouter against *kie*, but 83% of renders run on *Google*. Re-measured against the real mix:

| model | Google (prod) | kie (prod) | OpenRouter (measured) |
|---|---|---|---|
| Nano Banana 2 — **71% of all renders** | $0.06891 | $0.05797 | **$0.06721** |
| Nano Banana 2 Lite | — | $0.02000 | $0.03361 |
| Nano Banana Pro | $0.11939 | $0.09000 | $0.13525 |

On the model carrying 71% of renders, OpenRouter costs **2.5% less than Google**. Across the whole mix the move is **+$13.17/month (+17%)**, not +68%. Nobody reading this in six months should find a saving claimed here — there isn't one worth mentioning; there is a p95 of 142.9s that went away.

## How?

**The registry stays the only place that decides.** Adding the endpoint is four one-line additions. `renderPostImage` reads `route('image').endpoint` exactly as it already did for kie — no `if` on the endpoint anywhere else.

**No retry on this branch, deliberately.** A synchronous failure comes back already diagnosed in milliseconds (measured: 28ms for a non-existent model id), so the insistence kie needs is not needed here. `generateImageOnOpenrouter` raises instead of returning `undefined` — a response with no image part is **not** a success. That was the easiest way to get this wrong, so it is a test.

**Model id mapping reuses what exists.** `googleImageModel()` already maps our ids to Google's; OpenRouter serves the same models under `google/<google id>`. A kie-only model (Seedream, Qwen, GPT Image) falls back to the home model with the existing loud warning rather than 400-ing every render.

**Cost comes from `usage.cost`**, the invoice for that call, written to `ai_calls.flatCostUsd`. Not from `RATES`. Verified that `usage.cost` matches the upstream endpoint's rate to the sixth decimal and that `cost_details.upstream_inference_cost` is identical to `cost` — OpenRouter puts no markup on the token, it is paid on credit purchase (~5%).

**Rejected:** a second gateway client. `llm.ts` owns the AI SDK text client, but it cannot send `modalities` and `image_config`, so this is a direct `fetch` in a driver module — the same layering as `kie-jobs.ts`, and the reason it isn't inline in `images.ts`.

## Testing?

`model-routing.test.ts` (+4 tests) and a new `openrouter-image.test.ts` (7 tests). **Written first and watched fail** — 9 red before the implementation existed:

- `openrouter` is a valid route and `AI_ROUTE_IMAGE=nano-banana@openrouter` selects it
- `LLM_API_KEY` counts as the key too (it is the same gateway the text catalogue already uses)
- without a key it is not a route: it falls back, **noisily**, like every other endpoint
- adding the endpoint moves **no** default (text/image/tts assertions)
- the image is extracted from `choices[0].message.images`
- a response with no image part is **not** a silent success
- the request carries `image_config.aspect_ratio` and `modalities`
- inline references become `image_url` without an upload round-trip
- cost comes from `usage.cost`; a failed call still leaves the `ai_calls` row, without a cost

109 tests green across the touched area (routing, transport, gemini, ai-log, image-models, changelog).

**Not tested:** no dev server and no browser, per the task's own constraint — so this is not the CLAUDE.md browser gate, and I am not claiming it. The strongest evidence available is below: the real module against the real API.

## Evidence

<details>
<summary>The aspect-ratio trap — the reason this PR has a test on the request body</summary>

OpenRouter forwards the aspect ratio **only** inside `image_config.aspect_ratio`. Same prompt, same model, measured:

```
no parameter               : 1408x768  ratio=1.833   3.56s  $0.033604
image_config.aspect_ratio  : 928x1152  ratio=0.806   3.08s  $0.033604   <-- 4:5
extra_body.imageConfig     : 1408x768  ratio=1.833   3.15s  $0.033604   <-- ignored
```

Without that field every Instagram post would have come back framed in landscape, with a 200 and no error anywhere.
</details>

<details>
<summary>Live end-to-end through the real module (not a hand-written replica)</summary>

Ran the actual `generateImageOnOpenrouter` against the real API, then deleted the probe:

```
LIVE: 928x1152 ratio=0.806 3192ms 148KB
LIVE ai_calls row: {"label":"renderPostImage","provider":"openrouter",
  "model":"google/gemini-3.1-flash-lite-image","ms":3192,"ok":true,
  "flatCostUsd":0.03360475,"context":"live-probe"}

LIVE error path: {"label":"renderPostImage","provider":"openrouter",
  "model":"google/gemini-non-esiste-image","ms":28,"ok":false,
  "error":"google/gemini-non-esiste-image is not a valid model ID"}
```

4:5 honoured, real cost logged, failure loud and free.
</details>

<details>
<summary>Cost provenance: usage.cost is the upstream rate, exactly</summary>

```
google/gemini-3.7-flash: 20 in + 2856 out -> usage.cost $0.010725
  20*0.75e-6 + 2856*3.75e-6 = 0.010725                     exact
deepseek via DigitalOcean: 21 in + 130 out -> $0.0000232659
  21*0.068e-6 + 130*0.168e-6 = 0.0000232659                exact
cost_details.upstream_inference_cost == cost in both       no token markup
```
</details>

## Anything Else?

**A defect found while measuring, deliberately not fixed here.** `RATES` in `ai-log.ts` prices `gemini-3.7-flash` at **$1.50 / $7.50** per million tokens. Google's list price *today* is **$0.75 / $3.75**; the $1.50/$7.50 tier starts **1 January 2027** (ai.google.dev/gemini-api/docs/pricing). The comment says "post-intro standard rate", so it was a choice — but the consequence is that **every `gemini` row in `ai_calls` costs double the truth**, across 13,265 calls in 30 days. The $218.65 we are reasoning about is really ~$109.

Not touched here because changing that rate changes the credits charged to users — a product decision, not a fix. It needs deciding, because until then every cross-provider cost comparison starts from a wrong denominator, including the one that motivated this PR.

**A family/endpoint pair with no transport is now refused, not faked.** The first version of this PR only *warned* that `gemini@openrouter` would land silently on Google. That was wrong: a warning outside the code does not survive, and it is the expired-comment mechanism the repo forbids. The registry already refuses an endpoint without a key, noisily — an endpoint without a *transport* is no more a route than one without a key.

So the knowledge is now a fifth table, `SERVED_BY`, and `route()` has two ways to refuse, both noisy, with the message saying which: `nessun trasporto gemini verso openrouter` or `la chiave manca`. The hole was **not new** — identical for `gemini@xiaomi`, `gemini@deepseek`, `mimo@kie` and every pair never wired; closing only the one just seen would have guaranteed the others return. The test walks all four. That knowledge previously lived spread across `gemini.ts`, `xiaomi.ts` and `gemini-audio.ts`, where nobody could see it whole; wiring a new transport is now one row.

Measured for the next PR, so the decision has numbers: on Gemini, OpenRouter charges **exactly** Google's list price ($0.75/$3.75, verified twice on real `usage.cost`), so moving text is **cost-neutral**, not +68%. On DeepSeek, OpenRouter is 3-8x cheaper than our `RATES` — but it routes to third-party resellers (DigitalOcean, StreamLake, Baidu), and I measured 36-41s latency and one upstream 429. There the risk is availability, not price, and it needs a pinned `provider.order`.

**Video is in scope but is its own story.** OpenRouter serves video on a separate surface (`GET/POST /api/v1/videos`, 28 models, confirmed). It is asynchronous like kie, so it does **not** bring the synchronous gift this PR brings — and it must not repeat #325's abandoned-task bug. Note for whoever takes it: video pricing **is** published, in `pricing_skus` (not `pricing`, which is null) — e.g. `x-ai/grok-imagine-video-1.5` at 8¢/s at 480p, 14¢/s at 720p, 25¢/s at 1080p. No need to burn a render to learn the order of magnitude.

**Known debt:** `MISSING.openrouter` is `{}`. That is the file's designed default ("a new endpoint starts capable of everything and is discovered incapable one failure at a time"), and I checked the two that would have degraded silently: grounding returns real citations (5 `url_citation` annotations off `vertexaisearch.cloud.google.com`) and `/embeddings` works. `video-fps`, `media-in-tool-result` and `prompt-cache` are **unmeasured** on this endpoint — not asserted capable, just not yet disproven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY


