### PR TITLE
Stop treating an unpriced call as a free one

### DIFF
--- a/changelog/2026-09-04-cost-unknown-is-not-free.md
+++ b/changelog/2026-09-04-cost-unknown-is-not-free.md
@@ -1,0 +1,83 @@
+# «Costo ignoto» non vuol più dire «gratis»
+
+`ai_calls.cost_usd` a `null` significava DUE cose incompatibili: *«esente, non addebitare»* e
+*«non siamo riusciti a prezzarla»*. `credits.ts` somma solo le righe non nulle, quindi il secondo
+significato non era prudente — era **gratis, in silenzio**.
+
+Non è un ragionamento: è misurato in produzione prima di scrivere una riga di codice.
+
+| | 30 giorni | ultimi 7 |
+|---|---|---|
+| chiamate RIUSCITE, con brand, prezzate a zero | **62** | 33 |
+| token fatturati a nessuno | **6.099.353** | 3.722.174 |
+
+Il 53% del totale di 30 giorni è caduto negli ultimi 7. Non è un residuo storico: è un buco che si
+allargava.
+
+Il caso che da solo giustifica il lavoro: `llm/deepseek/deepseek-v4-flash-vision-exp`, 1,72M token
+a costo zero — ed è **in `chat_model_catalog`**, cioè un modello che l'utente può scegliere dal
+menu e che nessuna tariffa scritta a mano copriva. È esattamente l'argomento della testata di
+`llm-usage-cost.ts`: *«un listino a mano non regge un catalogo che sceglie l'utente»*.
+
+## I due significati diventano due valori
+
+- `0` → esente per costruzione. Le righe `internal` sono eventi dell'agente (`read_file`, `grep`,
+  `glob`, `ls`, `db_query`), non chiamate a un modello: nessuno ce le fattura. Zero è un **fatto**.
+- `null` → non siamo riusciti a prezzarla, e basta.
+
+Da cui l'invariante che rende il buco **interrogabile** invece che invisibile:
+
+    ok = true and cost_usd is null  ==>  guasto di prezzatura, sempre
+
+Prima quella query restituiva un miscuglio di eventi interni e guasti veri, quindi non la si poteva
+usare per niente.
+
+## Perché non un sentinella, e perché non una colonna
+
+Un `-1` avrebbe rotto **in silenzio** `sum_brand_ai_cost_usd` e `sum_org_ai_cost_usd`, che fanno
+`coalesce(sum(cost_usd), 0)`: i totali dei crediti sarebbero scesi senza che niente fallisse. Una
+colonna nuova avrebbe voluto dire una migrazione **più** ogni lettore che impara un secondo campo,
+in un repo dove i deploy non eseguono migrazioni.
+
+Zero non sposta una somma. Nessun totale di crediti cambia, sugli stessi dati.
+
+## I fallimenti restano `null`, di proposito
+
+Il primo disegno portava a `0` anche le chiamate fallite. Sbagliato per due motivi: `ok = false`
+le disambigua **già** senza aiuto, e portarle a zero le avrebbe rese visibili al tetto orario della
+chat — che oggi scarta le righe nulle — cioè avrebbe fatto **pagare all'utente i turni andati
+storti**. Meno righe toccate e nessun cambio di comportamento accidentale.
+
+## Ogni lettore di `cost_usd`, verificato riga per riga
+
+È un percorso che tocca quanto paghiamo noi e i crediti che pagano i clienti, quindi non è stato
+dato per buono nessun elenco:
+
+- `sum_brand_ai_cost_usd`, `sum_org_ai_cost_usd` — sommano. Zero è neutro.
+- `chat/rate-limits.ts` — **somma** (`creditsFromRows` è un reduce, non un conteggio di righe) e in
+  più `resumeAtForWindow` scarta esplicitamente `credits > 0`. Doppiamente al sicuro.
+- `motion-video/unfinished.ts` — somma.
+- `api/v1/health/costs/tick` — somma con `c > 0`. Tiene anche un conteggio di righe, ma finisce
+  solo nel **testo** dell'avviso, mai nella soglia che lo fa scattare.
+- l'indice parziale di `0164` (`where cost_usd is not null`) — cresce di poche righe.
+
+E le righe `internal` non portano **mai** un'etichetta di chat: le loro cinque etichette sono
+`db_query, glob, grep, ls, read_file`, verificato in produzione. Il filtro `label in ('chat',
+'chatCompact')` del limitatore non le può vedere in nessun caso.
+
+## Le 65 chat che oggi non costano niente
+
+Query collaterale, da tenere d'occhio: 65 turni di chat **riusciti** con `cost_usd` nullo (28
+openrouter, 21 llm, 16 kie). Oggi non costano né crediti né tetto orario. Con questo cambio non
+diventano gratis di meno — diventano **trovabili**, che è il primo passo per prezzarle.
+
+## Il seguito
+
+Questo è il pavimento sotto lo svuotamento di `RATES`: quando i trasporti riportano il costo
+(`usage.cost` su OpenRouter, `credits_consumed` su kie), una tariffa scritta a mano si toglie e
+quello che resta senza prezzo si **vede**, invece di sparire in un `null` che sembrava innocuo.
+
+Nota per chi applica: il backfill delle 722 righe `internal` storiche è una scrittura su
+produzione e **non** è in questo commit. Il codice qui riguarda le righe NUOVE; le vecchie restano
+nulle finché qualcuno non esegue l'update, e fino ad allora la query dell'invariante va letta con
+`created_at` maggiore della data di deploy.

--- a/src/lib/content/changelog/2026-09-04-usage-accuracy.ts
+++ b/src/lib/content/changelog/2026-09-04-usage-accuracy.ts
@@ -1,0 +1,11 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-04',
+  title: 'Usage reporting tells apart "free" from "not measured"',
+  items: [
+    'Some AI work was being recorded without a price, and anything without a price counted as free — so a share of real usage never showed up in your credits or your usage page.',
+    'Unpriced work is now distinguishable from genuinely free activity, which means we can find it and fix it instead of it passing unnoticed.',
+    'Credit totals are unchanged on the same activity, and failed requests still cost you nothing.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/ai-log.test.ts
+++ b/src/lib/server/ai-log.test.ts
@@ -9,6 +9,38 @@ const GO = 'go';
 // price list ($2/M in, $12/M thinking, $120/M image out → 1120 tok = $0.134/image ≤2K).
 describe('computeCostUsd', () => {
   /**
+   * `null` voleva dire DUE cose incompatibili: "esente, non addebitare" e "non siamo riusciti a
+   * prezzarla". `credits.ts` somma solo le righe non nulle, quindi il secondo significato non era
+   * prudente — era GRATIS, in silenzio. Misurato in produzione: 62 righe riuscite e 6.099.353
+   * token fatturati a nessuno in 30 giorni, il 53% negli ultimi 7.
+   *
+   * Dopo: `0` è l'esenzione (un fatto), `null` è solo il buco (un guasto interrogabile).
+   */
+  it('una chiamata riuscita senza prezzo non vale quanto una esente', () => {
+    const esente = computeCostUsd({ label: 'read_file', provider: 'internal', ms: 1, ok: true });
+    const ignoto = computeCostUsd({
+      label: 'chat', provider: 'llm', model: 'un/modello-che-nessuno-ha-prezzato',
+      ms: 1200, ok: true, inputTokens: 40_000, outputTokens: 8_000
+    });
+    expect(esente).toBe(0);
+    expect(ignoto).toBeNull();
+  });
+
+  it('l’esenzione non tocca i crediti: zero non sposta una somma', () => {
+    expect(computeCostUsd({ label: 'grep', provider: 'internal', ms: 1, ok: true })).toBe(0);
+    // Anche con dei token addosso: `internal` è un evento dell'agente, non una chiamata a un modello.
+    expect(
+      computeCostUsd({ label: 'db_query', provider: 'internal', ms: 1, ok: true, inputTokens: 900, outputTokens: 100 })
+    ).toBe(0);
+  });
+
+  it('una fallita resta null: `ok` la disambigua già, e forzarla a zero la farebbe contare', () => {
+    // Portare i fallimenti a 0 li renderebbe visibili al tetto orario della chat, che oggi
+    // scarta le righe nulle. `ok=false` dice già "non fatturata" senza aiuto.
+    expect(computeCostUsd({ label: 'chat', provider: 'kie', ms: 5, ok: false, flatCostUsd: 0.02 })).toBeNull();
+  });
+
+  /**
    * I turni openrouter arrivavano con `cost_usd` NULL — 25 chiamate in tre giorni, zero
    * addebitate — perche` nessuna tariffa portava il loro id. Spostarci il traffico principale
    * senza questo avrebbe smesso di misurare l'agente piu` caro del prodotto.

--- a/src/lib/server/ai-log.ts
+++ b/src/lib/server/ai-log.ts
@@ -257,9 +257,32 @@ function planForVisualShare(explicit?: string | null): string | null | undefined
   return undefined;
 }
 
-// null = not computable (no usage, unknown model). A MISSING model on a gemini call means Flash;
-// `plan` is accepted for the call sites that still thread one, and no longer changes the price.
+/**
+ * Esente per costruzione: l'evento c'è stato ma non è una chiamata a un modello, e nessuno ce lo
+ * fattura. Vale `0`, che è un FATTO — non `null`, che ormai vuol dire una cosa sola.
+ */
+const COST_EXEMPT_PROVIDERS: ReadonlySet<AiCallLog['provider']> = new Set(['internal']);
+
+/**
+ * `null` significava DUE cose incompatibili: «esente, non addebitare» e «non siamo riusciti a
+ * prezzarla». `credits.ts` somma solo le righe non nulle, quindi il secondo significato non era
+ * prudente: era GRATIS, in silenzio. Misurato in produzione — 62 chiamate RIUSCITE e 6.099.353
+ * token fatturati a nessuno in 30 giorni, il 53% nei soli ultimi 7. Non un residuo storico: un
+ * buco che si allargava.
+ *
+ * Adesso i due significati sono due valori:
+ *   · `0`    → esente, per costruzione. Non sposta nessuna somma.
+ *   · `null` → NON siamo riusciti a prezzarla, e `ok` dice se il lavoro è avvenuto davvero.
+ *
+ * Da cui l'invariante che rende il buco interrogabile invece che invisibile:
+ * **`ok = true` e `cost_usd is null` è un guasto di prezzatura**, sempre, e si trova con una query.
+ *
+ * I FALLIMENTI restano `null` di proposito: `ok = false` li disambigua già senza aiuto, e portarli
+ * a `0` li renderebbe visibili al tetto orario della chat — che oggi scarta le righe nulle — cioè
+ * farebbe pagare all'utente i turni che gli sono andati storti.
+ */
 export function computeCostUsd(entry: AiCallLog, plan?: string | null): number | null {
+  if (COST_EXEMPT_PROVIDERS.has(entry.provider)) return 0;
   // Flat-fee providers: la richiesta fallita non ce la fatturano, quindi non la fatturiamo.
   // LA SANDBOX È L'ECCEZIONE: la microVM è stata accesa e ha consumato tempo macchina comunque.
   // Esentarla su `ok = false` rendeva gratis il percorso più caro (32,1% dei secondi misurati non


### PR DESCRIPTION
## What?

`ai_calls.cost_usd = null` meant **two incompatible things**: "exempt, do not charge" and "we failed to price this". `credits.ts` sums only non-null rows, so the second meaning was not prudent — it was **free, in silence**.

This splits them into two values: `0` is exemption (a fact), `null` is only the hole. One guard at the single write point, `computeCostUsd`.

## Why?

Measured in production **before** writing any code, not estimated:

| | 30 days | last 7 days |
|---|---|---|
| successful, brand-attributed calls priced at zero | **62** | 33 |
| tokens billed to nobody | **6,099,353** | 3,722,174 |

**53% of the 30-day total landed in the last 7 days.** This is not historical residue — it is a hole that was widening.

The single case that justifies the work: `llm/deepseek/deepseek-v4-flash-vision-exp`, **1.72M tokens at zero cost** — and it sits in `chat_model_catalog`, meaning it is a model a **user can pick from the menu** that no hand-written rate covered. That is precisely the argument already written at the top of `llm-usage-cost.ts`: *"un listino a mano non regge un catalogo che sceglie l'utente"*.

The payoff is an invariant that makes the hole queryable instead of invisible:

```
ok = true and cost_usd is null   ==>   a pricing defect, always
```

Before, that query returned a mixture of internal events and real defects, so it was useless for anything.

## How?

`internal` rows are agent events (`read_file`, `grep`, `glob`, `ls`, `db_query`), not calls to a model — nobody invoices us for them, so they are worth `0`.

**Rejected — a `-1` sentinel:** it would have broken `sum_brand_ai_cost_usd` and `sum_org_ai_cost_usd` **silently**, since both do `coalesce(sum(cost_usd), 0)`. Credit totals would have dropped with nothing failing.

**Rejected — a new column:** a migration *plus* every reader learning a second field, in a repo whose deploys do not run migrations. Zero does not move a sum, so no credit total changes on the same data.

**Failures stay `null`, deliberately.** My first design took them to `0` too. That was wrong twice over: `ok = false` already disambiguates them without help, and forcing them to zero would make them visible to the chat hourly cap — which today discards null rows — i.e. it would **charge the user for turns that went wrong**. Fewer rows touched, and no accidental behaviour change.

## Testing?

Three tests in `ai-log.test.ts`, written first and watched fail (`expected null to be +0`):

- a successful call with no price is not worth the same as an exempt one (`0` vs `null`)
- exemption does not touch credits, including when the row carries tokens
- a failed call stays `null`, so it cannot start counting against the hourly cap

**4286 tests pass**, zero failures, across `src/lib/server` + `src/lib/content`. This is a money path, so I swept the suite rather than the touched files.

<details>
<summary>Every reader of <code>cost_usd</code>, checked rather than taken on trust</summary>

| reader | shape | zeros safe? |
|---|---|---|
| `sum_brand_ai_cost_usd`, `sum_org_ai_cost_usd` | `coalesce(sum(cost_usd),0)` | yes, 0 is neutral |
| `chat/rate-limits.ts` | **sums** (`creditsFromRows` is a reduce, not a row count) and `resumeAtForWindow` drops `credits > 0` | yes, doubly |
| `motion-video/unfinished.ts` | reduce sum | yes |
| `api/v1/health/costs/tick` | sums with `c > 0`; its row count reaches only the alert **text**, never the threshold | yes |
| partial index in `0164` (`where cost_usd is not null`) | grows by a few rows | yes |

And `internal` rows never carry a chat label — their five labels in production are `db_query, glob, grep, ls, read_file` — so the limiter's `label in ('chat','chatCompact')` filter cannot see them under any circumstance.
</details>

<details>
<summary>Side finding: 65 chat turns that cost nothing today</summary>

65 **successful** chat turns with a null cost (28 openrouter, 21 llm, 16 kie). Today they cost neither credits nor hourly cap. This change does not make them less free — it makes them **findable**, which is the first step to pricing them.
</details>

## Evidence (screenshots/videos)

Backend change, no UI. Production measurements are the tables above, taken read-only against `ai_calls` before any code was written.

## Anything Else?

**The backfill of the 722 historical `internal` rows has been applied**, separately from this commit and with Andrea's explicit mandate. It is verified, not assumed — "before" captured on three brands, "after" re-read on the same three:

| brand | sum before | sum after | rows counted | `internal` nulls left |
|---|---|---|---|---|
| `22bf9fdc…` | 307.575846 | **307.575846** | +225 | 0 |
| `a552809c…` | 38.650462 | **38.650462** | +4 | 0 |
| `c3683228…` | 34.688201 | **34.688201** | +31 | 0 |

Sums identical to the sixth decimal. Counted rows grow by exactly the 225, 4 and 31 recorded beforehand — the zeros entered the counted set and moved nothing. 722 converted, zero left globally. Not a cent of anyone's credits changed.

One note for whoever re-runs this check: `sum_brand_ai_cost_usd` cannot be used as the control from outside the app. Its body guards on `auth.role() = 'service_role' or p_brand_id in (auth_brand_ids())`, so a plain SQL session gets `0.000000` for every brand — including one with $307 of real spend. The raw sum it wraps is the right control anyway, since what is being verified is that adding zeros does not move a total.

Useful reassurance found while measuring: **666 rows already sat at `cost_usd = 0`** before any of this, so zeros were never new to this table or to its readers.

**This is the floor under emptying `RATES`**, which is the next step in the agreed order. Once transports report their own cost (`usage.cost` on OpenRouter, `credits_consumed` on kie), a hand-written rate can be removed and whatever is left unpriced becomes **visible** instead of disappearing into a null that looked harmless.

Worth stating together, because they are the same defect from opposite ends: we **over-bill Gemini by 2×** (`RATES` carries the January 2027 tier, $1.50/$7.50, while today's Google list is $0.75/$3.75) and we **under-bill to zero** on models with no rate. Both are one hand-written table deciding what a call costs. Fixing only one leaves the mechanism standing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY

