### PR TITLE
Send the web plugin where the gateway can see it

### DIFF
--- a/changelog/2026-09-04-grounding-citations-lost.md
+++ b/changelog/2026-09-04-grounding-citations-lost.md
@@ -1,0 +1,63 @@
+# L'audit GEO misurava la memoria del modello, non il web
+
+`groundedGemini` esiste per una domanda sola: *«il brand è citato nelle risposte di Gemini?»*. È il
+motore **nominato** — l'audit GEO lo usa apposta invece del più economico, perché lì conta CHI ha
+risposto.
+
+Tornava **zero citazioni**, e il modello rispondeva senza cercare. `ok: true`, testo plausibile,
+nessun errore da nessuna parte.
+
+## Dov'era
+
+`llmText({ webSearch: true })` passava il plugin all'AI SDK così:
+
+```ts
+providerOptions: { openai: { ...reasoningOptions(), ...{ plugins: [{ id: 'web', engine: 'native' }] } } }
+```
+
+`plugins` è un'estensione **di OpenRouter**, non un parametro OpenAI. L'SDK non la riconosce e la
+**scarta in silenzio** — e per giunta `@ai-sdk/openai` v4 parla l'endpoint **Responses**. Misurato
+intercettando la richiesta in uscita, le chiavi del corpo erano:
+
+    model, input, usage
+
+`plugins: null`. Nessuna ricerca fatta, `annotations` assenti nella risposta, `citations: []`.
+
+Poi il codice leggeva le citazioni da `result.sources`, che l'SDK popola dal grounding dei provider
+che conosce: con la ricerca mai avvenuta, quel campo era vuoto per il motivo sbagliato. Due strati
+che si coprivano a vicenda, e nessuno dei due rumoroso.
+
+## La prova, prima e dopo
+
+Stessa funzione, stessa domanda, chiamata vera:
+
+| | citazioni | costo scritto |
+|---|---|---|
+| prima | **0** | nessuno (solo token) |
+| dopo | **4** | **$0,031081** |
+
+Il costo è la seconda metà del difetto: le query di ricerca non venivano fatte, quindi non venivano
+nemmeno fatturate — la riga sembrava una normale chiamata di testo.
+
+## La correzione
+
+La chiamata con ricerca web si manda **a mano**, come già fa il render immagini su OpenRouter:
+`POST /chat/completions` con `plugins` nel corpo, dove il gateway può vederlo. Le citazioni si
+leggono da `annotations` — che è dove OpenRouter mette il grounding di Google: **stesse fonti,
+altro nome**. Il costo da `usage.cost`.
+
+Il percorso SENZA ricerca resta sull'AI SDK, intatto: lì l'SDK fa il suo mestiere e non c'è niente
+da aggirare. Con esso è sparita l'estrazione da `result.sources`, che su quel ramo non poteva
+restituire niente.
+
+## Perché non si è provato a farlo dire all'SDK
+
+Un campo che il provider non conosce viene scartato, e non c'è modo di accorgersene dal lato
+chiamante: è esattamente la trappola che ha prodotto questo difetto. Mandare la richiesta dove il
+suo formato è noto costa venticinque righe e non ha strati che possano ingoiare un campo.
+
+## Nota per chi legge i numeri di prima
+
+Ogni audit GEO eseguito finché questo era rotto ha misurato la conoscenza pregressa del modello, non
+il web: i suoi risultati non sono confrontabili con quelli successivi. Non è una regressione
+introdotta da un cambio di trasporto — era già così, e si vede solo guardando le citazioni.

--- a/src/lib/content/changelog/2026-09-04-geo-citations.ts
+++ b/src/lib/content/changelog/2026-09-04-geo-citations.ts
@@ -1,0 +1,11 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-04',
+  title: 'AI visibility checks read the live web again',
+  items: [
+    'The AI visibility audit asks whether your brand gets cited in AI answers. It had stopped actually searching the web, so it was answering from the model\'s own memory and returning no sources.',
+    'Those checks now search the live web and come back with their citations, as they were meant to.',
+    'Results from before this fix are not comparable with results after it — an audit run now may look different for that reason alone.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/llm-grounded.test.ts
+++ b/src/lib/server/llm-grounded.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Il grounding di `groundedGemini` è il motore NOMINATO: l'audit GEO misura "il brand è citato
+// nelle risposte di Gemini". Se torna senza citazioni, quell'audit misura la memoria del modello
+// invece del web, e nessuno se ne accorge — è una risposta plausibile invece di un errore.
+//
+// Misurato in produzione prima di questo test: il plugin `web` veniva passato all'SDK dentro
+// `providerOptions.openai`, l'SDK parla l'endpoint Responses (corpo `model, input, usage`) e
+// scartava la chiave. Zero ricerche, zero citazioni, `ok: true`.
+
+const M = vi.hoisted(() => ({ env: {} as Record<string, string | undefined>, logged: [] as unknown[] }));
+vi.mock('$env/dynamic/private', () => ({ env: M.env }));
+vi.mock('$lib/server/ai-log', () => ({
+  logAiCall: (e: unknown) => void M.logged.push(e),
+  getBrandContext: () => null,
+  requireBrandContext: () => null,
+  extractSdkUsage: () => ({}),
+  noteLlmCost: () => {},
+  takeLlmCost: () => null
+}));
+
+const ANNOTATED = {
+  choices: [{
+    message: {
+      role: 'assistant',
+      content: 'La finale si è giocata il 19 luglio 2026.',
+      annotations: [
+        { type: 'url_citation', url_citation: { url: 'https://example.org/finale', title: 'La finale' } },
+        { type: 'url_citation', url_citation: { url: 'https://example.org/altro', title: 'Altro' } },
+        { type: 'url_citation', url_citation: { url: 'https://example.org/finale', title: 'La finale' } }
+      ]
+    }
+  }],
+  usage: { prompt_tokens: 20, completion_tokens: 100, cost: 0.03 }
+};
+
+function reply(body: unknown, status = 200) {
+  return vi.fn(async (_u: string, _i: RequestInit) => new Response(JSON.stringify(body), { status }));
+}
+const sentBody = (f: ReturnType<typeof reply>) => JSON.parse(String(f.mock.calls[0][1].body));
+
+describe('grounding sul centralino', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    for (const k of Object.keys(M.env)) delete M.env[k];
+    Object.assign(M.env, {
+      LLM_API_KEY: 'k',
+      LLM_BASE_URL: 'https://openrouter.ai/api/v1',
+      LLM_DEFAULT_MODEL: 'google/gemini-3.7-flash'
+    });
+    M.logged.length = 0;
+  });
+
+  it('una risposta con annotations produce citazioni, non un array vuoto', async () => {
+    vi.stubGlobal('fetch', reply(ANNOTATED));
+    const { llmText } = await import('./llm');
+    const res = await llmText({ prompt: 'chi ha vinto?', webSearch: true });
+    expect(res.text).toContain('19 luglio');
+    expect(res.citations).toEqual([
+      { uri: 'https://example.org/finale', title: 'La finale' },
+      { uri: 'https://example.org/altro', title: 'Altro' }
+    ]);
+  });
+
+  it('il plugin web arriva DAVVERO nel corpo: era lì che si perdeva', async () => {
+    const f = reply(ANNOTATED);
+    vi.stubGlobal('fetch', f);
+    const { llmText } = await import('./llm');
+    await llmText({ prompt: 'x', webSearch: true });
+    const body = sentBody(f);
+    expect(body.plugins).toEqual([{ id: 'web', engine: 'native' }]);
+    // Corpo Chat Completions, non Responses: `messages`, non `input`.
+    expect(body.messages).toBeTruthy();
+    expect(body.input).toBeUndefined();
+  });
+
+  it('il costo viene da usage.cost del gateway', async () => {
+    vi.stubGlobal('fetch', reply(ANNOTATED));
+    const { llmText } = await import('./llm');
+    await llmText({ prompt: 'x', webSearch: true });
+    expect(M.logged[0]).toMatchObject({ provider: 'llm', ok: true, flatCostUsd: 0.03 });
+  });
+
+  it('una risposta senza annotations non inventa citazioni, e lo dice nei log', async () => {
+    vi.stubGlobal('fetch', reply({ choices: [{ message: { content: 'niente fonti' } }], usage: {} }));
+    const { llmText } = await import('./llm');
+    const res = await llmText({ prompt: 'x', webSearch: true });
+    expect(res.citations).toEqual([]);
+    expect(res.text).toBe('niente fonti');
+  });
+});

--- a/src/lib/server/llm.ts
+++ b/src/lib/server/llm.ts
@@ -266,6 +266,53 @@ export async function llmStructured<T>(opts: {
 	}
 }
 
+const WEB_PLUGIN = [{ id: 'web', engine: 'native' }];
+
+/**
+ * La chiamata con ricerca web, mandata A MANO invece che dall'AI SDK.
+ *
+ * `plugins` è un'estensione di OpenRouter, non un parametro OpenAI: passandola in
+ * `providerOptions.openai` l'SDK la SCARTAVA senza dire niente, e per giunta parla l'endpoint
+ * Responses (corpo `model, input, usage`). Risultato misurato in produzione: nessuna ricerca fatta,
+ * `annotations` assenti, zero citazioni — e `ok: true`. L'audit GEO, che esiste per rispondere
+ * «il brand è citato nelle risposte di Gemini?», stava misurando la MEMORIA del modello.
+ *
+ * Le citazioni si leggono da `annotations`, che è dove OpenRouter mette il grounding di Google:
+ * stesse fonti, altro nome. Il costo dal `usage.cost` del gateway, come ovunque.
+ */
+async function groundedCall(
+	modelId: string,
+	opts: { prompt: string; system?: string }
+): Promise<{ text: string; citations: Array<{ uri: string; title: string }> } & { cost?: number }> {
+	const messages = [
+		...(opts.system ? [{ role: 'system', content: opts.system }] : []),
+		{ role: 'user', content: opts.prompt }
+	];
+	const res = await fetch(`${llmBaseUrl()}/chat/completions`, {
+		method: 'POST',
+		headers: { authorization: `Bearer ${llmApiKey() ?? ''}`, 'content-type': 'application/json' },
+		body: JSON.stringify({ model: modelId, messages, plugins: WEB_PLUGIN, usage: { include: true } }),
+		signal: AbortSignal.timeout(LLM_TIMEOUT_MS)
+	});
+	const body = (await res.json()) as {
+		choices?: Array<{ message?: { content?: string; annotations?: Array<{ url_citation?: { url?: string; title?: string } }> } }>;
+		usage?: { cost?: number };
+		error?: { message?: string };
+	};
+	if (!res.ok || body.error) throw new Error(body.error?.message ?? `HTTP ${res.status}`);
+
+	const message = body.choices?.[0]?.message;
+	const citations: Array<{ uri: string; title: string }> = [];
+	const seen = new Set<string>();
+	for (const a of message?.annotations ?? []) {
+		const uri = a?.url_citation?.url;
+		if (!uri || seen.has(uri)) continue;
+		seen.add(uri);
+		citations.push({ uri, title: a.url_citation?.title || uri });
+	}
+	return { text: message?.content ?? '', citations, cost: body.usage?.cost };
+}
+
 export async function llmText(opts: {
 	prompt: string;
 	system?: string;
@@ -277,27 +324,30 @@ export async function llmText(opts: {
 	label?: string;
 }): Promise<{ text: string; citations: Array<{ uri: string; title: string }> }> {
 	const modelId = opts.model ?? (opts.webSearch ? llmGeminiSearchModel() : llmDefaultModel());
-	const extra = opts.webSearch ? { plugins: [{ id: 'web', engine: 'native' }] } : undefined;
 	const t0 = Date.now();
 	const label = opts.label ?? (opts.webSearch ? 'llm.grounded' : 'llm.text');
+
+	if (opts.webSearch) {
+		try {
+			const { text, citations, cost } = await groundedCall(modelId, opts);
+			logAiCall({ label, provider: 'llm', model: modelId, prompt: opts.prompt, ms: Date.now() - t0, ok: true, flatCostUsd: cost });
+			return { text, citations };
+		} catch (e) {
+			logAiCall({
+				label, provider: 'llm', model: modelId, prompt: opts.prompt, ms: Date.now() - t0, ok: false,
+				error: e instanceof Error ? e.message : 'grounded call failed'
+			});
+			return { text: '', citations: [] };
+		}
+	}
 	try {
 		const result = await generateText({
 			model: llmLanguageModel(modelId),
 			system: opts.system,
 			abortSignal: AbortSignal.timeout(LLM_TIMEOUT_MS),
 			messages: [{ role: 'user', content: userContent(opts.prompt, opts.images, opts.file) }],
-			providerOptions: { openai: { ...reasoningOptions(), ...(extra ?? {}) } }
+			providerOptions: { openai: reasoningOptions() }
 		});
-		const citations: Array<{ uri: string; title: string }> = [];
-		const seen = new Set<string>();
-		const sources = (result as { sources?: Array<{ url?: string; title?: string }> }).sources ?? [];
-		for (const s of sources) {
-			const uri = s?.url;
-			if (uri && !seen.has(uri)) {
-				seen.add(uri);
-				citations.push({ uri, title: s.title ?? uri });
-			}
-		}
 		logAiCall({
 			label,
 			provider: 'llm',
@@ -307,7 +357,7 @@ export async function llmText(opts: {
 			ok: true,
 			...extractSdkUsage(result.usage)
 		});
-		return { text: result.text ?? '', citations };
+		return { text: result.text ?? '', citations: [] };
 	} catch (e) {
 		logAiCall({
 			label,


### PR DESCRIPTION
## What?

`groundedGemini` — the function the GEO audit uses to answer *"is the brand cited in Gemini's answers?"* — was returning **zero citations**, with the model answering from its own memory instead of searching. `ok: true`, plausible prose, no error anywhere.

The grounded call now goes out by hand and reads its citations from OpenRouter's `annotations`. The non-search path is untouched.

## Why?

This is the failure the routing registry's header describes in its opening lines: *"il guasto arrivava come una risposta plausibile invece che come un errore"*. It was live in production, and nothing surfaced it.

`llmText({ webSearch: true })` handed the plugin to the AI SDK like this:

```ts
providerOptions: { openai: { ...reasoningOptions(), ...{ plugins: [{ id: 'web', engine: 'native' }] } } }
```

`plugins` is an **OpenRouter extension, not an OpenAI parameter**, so the SDK dropped it silently — and `@ai-sdk/openai` v4 speaks the **Responses** endpoint regardless. Measured by intercepting the outgoing request:

```
CORPO chiavi:   model, input, usage
CORPO plugins:  null
RISPOSTA annotations: assenti
```

A second layer hid the first: citations were read from `result.sources`, which the SDK fills from grounding it recognises. With the search never performed, that field was empty for the wrong reason — two layers covering for each other, neither of them noisy.

## How?

The grounded call is sent directly: `POST /chat/completions` with `plugins` in the body, where the gateway can actually see it — the same shape `openrouter-image.ts` already uses for renders. Citations come from `annotations`, which is where OpenRouter puts Google's grounding: **same sources, different name**. Cost from `usage.cost`.

**Rejected — making the SDK carry it.** A field the provider doesn't recognise gets dropped with no signal to the caller, which is precisely the trap that produced this defect. Sending the request where its format is known costs ~25 lines and has no layer that can swallow a field.

The non-search path stays on the AI SDK, deliberately: there the SDK does its job and there is nothing to work around. The `result.sources` extraction went with it — on that branch it could never return anything.

## Testing?

`llm-grounded.test.ts`, four tests, written first and watched fail:

- a response with `annotations` produces citations, not an empty array (and de-duplicates repeated URLs)
- **the plugin actually reaches the body** — asserted on the outgoing request, since that is exactly where it was being lost, plus `messages` present and `input` absent to pin the Chat Completions shape
- cost comes from the gateway's `usage.cost`
- a response without annotations invents nothing

**4287 tests pass**, zero failures, across `src/lib/server` + `src/lib/content`.

## Evidence (screenshots/videos)

Backend change, no UI.

<details>
<summary>Same function, same question, live call — before and after</summary>

Before:
```
LIVE testo: The winner of the 2026 FIFA World Cup has not yet been determined because the tournament h...
LIVE citazioni: 0
LIVE riga ai_calls: {"label":"grounded","provider":"llm","model":"google/gemini-3.7-flash",
  "ms":6009,"ok":true,"inputTokens":22,"outputTokens":483,"thinkingTokens":341}
```

After:
```
LIVE testo: The latest stable **Active LTS** version of Node.js is **Node.js 24 (codename "Krypton")**
LIVE citazioni: 4
LIVE ai_calls: {"label":"llm.grounded","provider":"llm","model":"google/gemini-3.7-flash",
  "ms":8457,"ok":true,"flatCostUsd":0.031081}
```

| | citations | cost recorded |
|---|---|---|
| before | **0** | none, tokens only |
| after | **4** | **$0.031081** |

The cost is the other half of the defect: the search queries were never made, so they were never billed, and the row looked like an ordinary text call.
</details>

## Anything Else?

**Audits run while this was broken are not comparable with audits run after.** Every GEO audit measured the model's prior knowledge rather than the live web. That is not a regression introduced by moving transports — it was already the case, and it is only visible if you look at the citations. Said plainly in the public changelog too, because a customer re-running an audit will see different numbers and deserves the reason.

**How this was found:** while sizing the "move text to OpenRouter" step, I checked whether grounding would survive the move — and discovered the text path is *already* on OpenRouter (`structuredGemini` and `groundedGemini` both call `llm.ts`; the Google SDK client is passed but unused, `_ai`). So the migration step is much smaller than planned. The grounding translation the move was supposed to need turned out to be a defect already shipped.

**Not in this PR:** measuring `structured`, `tools`, `image-in` and `thinkingLevel` on the OpenRouter path so any absence lands in `MISSING` as a measured fact. `grounding` is now measured and present. That belongs with the remaining transport work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
