### PR TITLE
Clear what the video reviewer left behind

### DIFF
--- a/changelog/2026-09-04-video-review-gia-morta.md
+++ b/changelog/2026-09-04-video-review-gia-morta.md
@@ -1,0 +1,75 @@
+# I giudizi sui video erano già stati tolti: qui restano solo le tracce
+
+Mandato: togliere i giudizi sui video, misurati in 30 giorni a **$51,52** — `video.review.agent`
+(1.387 chiamate, $42,64), `video.review` (447, $8,40), `motion.craft_review` (26, $0,48).
+
+**Non c'era niente da togliere.** Il perimetro è già stato smontato il **29 agosto**, e la ragione
+è scritta nel changelog di quel giorno: il modello dietro il giudice ha smesso di accettare file
+video, quindi falliva su ogni clip. Le ultime righe in `ai_calls` sono del 30 agosto perché sono la
+coda di quella rimozione, non un cron ancora vivo.
+
+Verificato prima di scrivere una riga:
+
+- **nessuna rotta**: sotto `src/routes/api/v1/videos/` esiste solo `render/work`. Né
+  `videos/review/work`, né `brands/:slug/videos/review`.
+- **nessun cron**: in `vercel.json` non c'è nessuna voce `videos/review`.
+- **nessun emettitore**: `video.review.agent`, `video.review` e `motion.craft_review` non compaiono
+  in nessun punto del codice che chiami un modello.
+- **nessun file**: `video-review.ts` e `video-review-agent.ts` non esistono più.
+
+## La correzione che conta sul numero
+
+**I $51,52 non sono un risparmio da incassare: si sono già fermati il 29 agosto.** Contarli come
+mensili ricorrenti li conterebbe due volte, ed è esattamente l'errore che questa verifica evita.
+Il costo dei giudizi ancora vivi va misurato senza quelle tre label.
+
+## Cosa resta davvero
+
+**Due tabelle orfane**, che confermano quanto già segnalato dallo sweep del codice morto:
+`video_reviews` e `motion_craft_scores` — 620 righe scritte e nessun lettore applicativo.
+`motion_craft_scores` compare ancora in un elenco di nomi di tabella dentro
+`src/lib/server/chat/query-tool.ts`, che è un elenco e non un lettore (ed è fuori dai file che
+posso toccare).
+
+**Non si droppano qui, e sono d'accordo sul perché**: cancellare codice si annulla con un revert,
+droppare 620 righe no, e i deploy di questo repo non eseguono le migration. Il drop diventa una
+decisione separata quando quelle tabelle non vengono toccate da un mese.
+
+**Due commenti che mentivano**, corretti perché erano peggio di nessun commento:
+
+- `design-judge.ts` diceva al presente che `video-review.ts` «guarda una clip». Non esiste più.
+- `market-trends.ts` diceva che `video_url` «è ciò che alimenta il giudice Gemini». Non alimenta
+  più niente: la colonna si raccoglie ancora — raccoglierla non costa e ricostruire lo storico
+  costerebbe — ma **non ha un consumatore**, e il commento faceva credere di sì.
+
+Sono la ragione per cui questa PR esiste invece di essere solo un messaggio: il prossimo che legge
+quei file rifarebbe l'indagine che ho appena fatto.
+
+## I riferimenti pendenti che la rimozione si era lasciata dietro
+
+Cercati apposta, perché togliere una rotta lascia tracce che nessun controllo di import vede.
+Verificato anche `scripts/export-oss.mjs`, che tiene liste di percorsi scritte a mano: **non
+conteneva nulla di questo perimetro**.
+
+Trovati e sistemati:
+
+- **`textFromGraphicSource`** in `graphic-source.ts` — «visible text … used by video-review
+  on-screen copy». Nessun chiamante di produzione: solo il suo test. Rimasta orfana quando il
+  giudice è sparito, quindi esce adesso insieme al suo test.
+- **`content-quality.ts`** diceva al presente «We already have an LLM judge for media» e citava
+  `video-review-doctrine.ts`, un file che non esiste. La regola che quel commento spiegava — la
+  seconda persona, il «call out» di Fekri — resta valida: è sopravvissuta al file che la nominava,
+  e ora il commento lo dice.
+- **`design-judge.ts`** e **`market-trends.ts`**, già descritti sopra.
+
+## Uno che NON ho potuto toccare, e va segnalato
+
+`src/routes/app/[brand]/calendar/page.server.delete.test.ts:26` fa
+`vi.mock('$lib/server/video-review-store', …)` su un modulo **che non esiste più**. `vi.mock` con
+una factory non fallisce su un percorso inesistente, quindi quel test passa mentre finge di
+sostituire qualcosa che non c'è: se domani quella pagina tornasse a caricare i badge, il test non
+se ne accorgerebbe. È sotto `src/routes/app/`, fuori dai file che posso modificare.
+
+Nella stessa categoria, e nello stesso stato: `src/lib/server/chat/query-tool.ts` elenca ancora
+`motion_craft_scores` fra i nomi di tabella interrogabili — è un elenco, non un lettore, ma nomina
+una tabella orfana, ed è sotto `src/lib/server/chat/`.

--- a/src/lib/design/graphic-source.test.ts
+++ b/src/lib/design/graphic-source.test.ts
@@ -5,7 +5,6 @@ import {
 	detectGraphicSourceKind,
 	parseGraphicCanvasSize,
 	unwrapGraphicSource,
-	textFromGraphicSource,
 	defaultGraphicHtml,
 	defaultGraphicTsx,
 	formatGraphicEditorSystemSuffix
@@ -124,9 +123,3 @@ export default function Graphic() { return <div />; }`)
 	});
 });
 
-describe('on-screen text', () => {
-	it('pulls copy out of HTML source', () => {
-		const lines = textFromGraphicSource(graphicToHtml(sample));
-		expect(lines.some((l) => l.includes('Anomalia'))).toBe(true);
-	});
-});

--- a/src/lib/design/graphic-source.ts
+++ b/src/lib/design/graphic-source.ts
@@ -354,23 +354,6 @@ function escTs(s: string): string {
 	return s.replace(/\\/g, '\\\\').replace(/'/g, "\\'").replace(/\n/g, '\\n');
 }
 
-/** Visible text inside HTML/TSX source — used by video-review on-screen copy. */
-export function textFromGraphicSource(source: string): string[] {
-	const html = detectGraphicSourceKind(source) === 'tsx' ? tsxToRoughHtml(source) : source;
-	const stripped = html
-		.replace(/<style[\s\S]*?<\/style>/gi, ' ')
-		.replace(/<script[\s\S]*?<\/script>/gi, ' ')
-		.replace(/<[^>]+>/g, ' ')
-		.replace(/&nbsp;/g, ' ')
-		.replace(/&amp;/g, '&')
-		.replace(/&lt;/g, '<')
-		.replace(/&gt;/g, '>')
-		.replace(/&quot;/g, '"');
-	return stripped
-		.split(/\n+/)
-		.map((l) => l.replace(/\s+/g, ' ').trim())
-		.filter((l) => l.length > 1);
-}
 
 function tsxToRoughHtml(source: string): string {
 	return source

--- a/src/lib/server/content-quality.ts
+++ b/src/lib/server/content-quality.ts
@@ -3,7 +3,8 @@
  * output benchmark. No AI call, no I/O, no clock: same input → same number, forever.
  *
  * WHY DETERMINISTIC AND NOT AN LLM JUDGE.
- * We already have an LLM judge for media (`video-review.ts`, rubric → ship/fix/kill). It is richer
+ * We had an LLM judge for media (`video-review.ts`, rubric → ship/fix/kill), removed on 2026-08-29
+ * when its model stopped accepting video. It was richer
  * than anything here, and it is the wrong instrument for a regression benchmark on its own: swap the
  * judge model — as happened when the chat tiers moved to Gemini 3.7 Flash — and every historical
  * score silently becomes incomparable, so the trend line breaks exactly when you most need it. This
@@ -363,7 +364,8 @@ function scoreHook(caption: string): { value: number; note: string } {
     value += 0.15;
     reasons.push('numero');
   }
-  // Second person = the reader is addressed, the Fekri "call out" in video-review-doctrine.ts.
+  // Second person = the reader is addressed — the Fekri "call out", from the video-review doctrine
+  // that was removed with the judge on 2026-08-29. The rule outlived the file that named it.
   if (/\b(tu|tuo|tua|tuoi|tue|ti|vi|vostro|you|your|yours)\b/.test(norm)) {
     value += 0.15;
     reasons.push('si rivolge al lettore');

--- a/src/lib/server/design-judge.ts
+++ b/src/lib/server/design-judge.ts
@@ -2,8 +2,8 @@
  * Grade a harvested post AS DESIGN, and decide whether we are willing to publish it.
  *
  * WHY A SECOND SCORER. `content-quality.ts` scores TEXT with the rubric we grade our own captions
- * with, and `video-review.ts` watches a clip for hook, hold and CTA. Neither has ever looked at a
- * layout. "Which of these posts is beautiful" is a question about type, grid, colour and restraint,
+ * with. A second scorer used to watch a clip for hook, hold and CTA; it was removed on 2026-08-29
+ * when the model behind it stopped accepting video. Neither has ever looked at a layout. "Which of these posts is beautiful" is a question about type, grid, colour and restraint,
  * and none of it is recoverable from a caption or from a retention curve — so it gets its own
  * column, its own version and its own rubric rather than being folded into `quality_index`, where it
  * would silently change what every existing fit means.

--- a/src/lib/server/market-trends.ts
+++ b/src/lib/server/market-trends.ts
@@ -12,9 +12,11 @@
  * every discovered post is labellable on arrival. That was the thing LinkedIn and Reddit could not
  * do (see BASELINE_CAPABLE in market-harvest.ts).
  *
- * And a video carries the payload the caption never did: `video_url` here is what feeds the Gemini
- * judge in `video-review.ts`, which watches the clip and returns hook type, scroll-stop, hold,
- * reveal timing and CTA placement. Scoring a caption with regex was always the thin version of this.
+ * And a video carries the payload the caption never did. `video_url` was harvested to feed a Gemini
+ * judge that returned hook type, scroll-stop, hold, reveal timing and CTA placement; that judge was
+ * removed on 2026-08-29, so the column is stored and currently read by nobody. Kept because
+ * harvesting it costs nothing and re-harvesting history would cost a lot — but do not assume a
+ * consumer exists.
  *
  * Parsing is defensive: these payloads are third-party and change without notice. Anything
  * unparseable is dropped rather than guessed at — a post with the wrong engagement attached is worse


### PR DESCRIPTION
## What?

**The video judging was already gone.** This PR removes what its deletion left behind: one orphaned
function, three comments that described it in the present tense, and a record of two orphaned tables.

## Why?

The brief was to remove video judging, measured over 30 days at **$51.52** — `video.review.agent`
(1,387 calls, $42.64), `video.review` (447, $8.40), `motion.craft_review` (26, $0.48).

**There was nothing to remove.** The whole perimeter went on **2026-08-29**, and the reason is in
that day's changelog: the model behind the judge stopped accepting video files, so it failed on
every clip. The last `ai_calls` rows on 30 August are that removal's tail, not a live cron.

Verified before writing a line — the expectation was reversed to "confirm it is detached", and it is:

| Checked | Result |
|---|---|
| Routes under `src/routes/api/v1/videos/` | only `render/work`. No `videos/review/work`, no `brands/:slug/videos/review`. |
| `vercel.json` cron entries | no `videos/review` line. |
| Emitters of the three labels | none anywhere in code. |
| `video-review.ts`, `video-review-agent.ts`, `video-review-store.ts`, `video-review-doctrine.ts` | all missing. |
| `scripts/export-oss.mjs` hand-written paths | nothing from this perimeter. |

**Nothing still invokes it**, so removing code breaks no live caller.

### The correction that matters on the number

**The $51.52 is not a saving to bank — it stopped on 29 August.** Counting it as recurring monthly
would count it twice, and would inflate the "total spent on judging" figure that the image work is
measured against. The cost of judging that is *still live* has to be measured without those three
labels.

### On the criterion

No ingredient was hiding inside this judge, because there is no judge left to look inside. The one
thing it *did* leave that looked like an ingredient — `textFromGraphicSource`, "visible text … used
by video-review on-screen copy" — turned out to have **no production caller at all**, only its own
test. It was an ingredient for a consumer that no longer exists, so it goes.

## How?

- **`textFromGraphicSource`** removed from `graphic-source.ts` with its test.
- **Three comments corrected**, because each promised something that is not there:
  - `market-trends.ts` said `video_url` "is what feeds the Gemini judge". It feeds nobody. The column
    is still harvested — harvesting costs nothing and rebuilding history would cost a lot — but the
    comment now says plainly that no consumer exists.
  - `content-quality.ts` said "We already have an LLM judge for media", and cited
    `video-review-doctrine.ts`, a file that does not exist. The *rule* it explained — second person,
    Fekri's "call out" — is still valid and outlived the file that named it; the comment now says so.
  - `design-judge.ts` described the reviewer in the present tense.

### The tables are not dropped

`video_reviews` (620 rows) and `motion_craft_scores` (11) are orphaned, which matches today's
dead-code sweep. **Deleting code is a revert away; deleting rows is not, and deploys here do not run
migrations.** They are declared orphaned in the internal changelog, and the drop becomes a separate
decision once nothing has touched them for a month.

## Testing?

```
vitest: design, content-quality, design-judge, market-trends, changelog  →  187 passed
cd cli && bun test        →  69 pass, 0 fail
node scripts/typecheck-runtime.mjs → exit 0
```

Removing `textFromGraphicSource` left an empty `describe('on-screen text')`, which vitest reports as
a failure — caught and removed rather than left as a hollow suite.

No paid model called, no dev server, no Docker.

**Not tested:** nothing here has behaviour to test. It is a deletion of dead code and a correction of
prose; the checks above exist to prove nothing else depended on it.

### Added after review: the lie with the widest audience

`CLAUDE.md` still advertised two routes that do not exist:

```
# Video review: POST /api/v1/brands/:slug/videos/review  { url | post_id, standard: organic|ads }
# Auto-score worker: GET/POST /api/v1/videos/review/work (cron */5)
```

`src/routes/api/v1/brands/[slug]/videos/` is absent and `src/routes/api/v1/videos/` holds only
`render`. Same defect class as the comments above, but **every agent in this repo loads `CLAUDE.md`
at session start**, so it was the line most likely to be acted on. Caught by the session updating
the skill, not by me — my sweep looked for *code* referencing the reviewer, not prose promising it.

While the file was open I checked **every** endpoint it advertises. All the others exist, so the rot
was confined to these two rather than being a property of the list:

```
OK   /api/v1/agent-templates          OK   /api/v1/brands/:slug/market/field
OK   /api/v1/brands/:slug/backlinks   OK   /api/v1/brands/:slug/radar/diagnose
OK   /api/v1/brands/:slug/connections OK   /api/v1/composio/webhook
OK   /api/v1/brands/:slug/doctor      OK   /api/v1/webhooks/work
OK   /api/v1/brands/:slug/goals       OK   /api/v1/brands/:slug/ideas
```

**Note:** this edits the repo's checked-in `CLAUDE.md` — two line deletions, both factual
corrections of routes that were deleted on 2026-08-29. No rule or instruction changed.

## Anything Else?

**One dangling reference I could not fix, and it is the kind that hides.**
`src/routes/app/[brand]/calendar/page.server.delete.test.ts:26` does
`vi.mock('$lib/server/video-review-store', …)` on a module **that no longer exists**. `vi.mock` with
a factory does not fail on a missing path, so that test passes while pretending to substitute
something absent — if that page ever loaded score badges again, the test would not notice. It is
under `src/routes/app/`, outside the files I may modify.

Same category, same state: `src/lib/server/chat/query-tool.ts` still lists `motion_craft_scores`
among queryable table names. It is a list, not a reader, but it names an orphaned table — and it is
under `src/lib/server/chat/`.

**Untouched on purpose:** `analyticsReviewAgent`, `produce-reviewer`, `reviewCaptions`,
`reviewSeeds`, `reviewUgcScripts`. They are not video, they are cheap, and Andrea did not name them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
