### PR TITLE
Make three guards able to fail, and stop describing removed mechanisms

### DIFF
--- a/changelog/2026-09-05-guardie-e-commenti-che-mentivano.md
+++ b/changelog/2026-09-05-guardie-e-commenti-che-mentivano.md
@@ -1,0 +1,87 @@
+# Guardie che non potevano fallire, e commenti che descrivevano meccanismi smontati
+
+Il grafo degli import trova il codice che nessuno chiama. Non trova il codice che
+mente: un commento al presente su una cosa finita, un test che sostituisce un
+modulo cancellato, un guardiano che davanti a una directory rinominata tace
+invece di rompersi. Questa passata cerca solo quella seconda metà.
+
+## Le tre guardie
+
+Ognuna verificata rompendo la cosa sorvegliata e guardando il test restare verde.
+È la sola prova che conta: un test che non è mai fallito non dimostra niente.
+
+**`blog-analytics-boundary`** teneva un confine di sicurezza — i tracker di terze
+parti possono girare sul dominio del brand, mai sulla nostra origine, dove vive
+la sessione di chi è loggato. Ritagliava il corpo di `brandProfile` con due
+`indexOf`. Un marcatore rinominato torna `-1`, `slice(-1, n)` esce vuota, e la
+stringa vuota non contiene mai "analytics". Provato: con `const analytics = 1`
+dentro `brandProfile` il test falliva; rinominando la funzione in
+`loadBrandProfile` e lasciando la violazione, tornava verde. Adesso i due
+marcatori si asseriscono prima del ritaglio.
+
+**`no-vite-globals`** protegge il worker: `import.meta.env` non esiste fuori da
+Vite e uccide il turno prima di cominciare (due job persi in dieci ore, il 26/8).
+Il suo commento promette di guardare «la CLASSE, non quella riga» — ma la
+directory mancante veniva ingoiata da un `catch { continue }`. Provato: con
+`import.meta.env.MODE` in `swallow.ts` falliva; spostando `src/lib/server` e
+lasciando la violazione, passava leggendo zero file. Adesso i file si contano
+prima (>100) e una directory che non c'è è un errore, non un silenzio.
+
+**`calendar/page.server.delete`** faceva `vi.mock('$lib/server/video-review-store')`
+su un modulo cancellato il 29/8 (`5df714e7`). `vi.mock` con una factory non
+verifica che il percorso esista: quel mock sostituiva niente. La prova che era
+inerte è che toglierlo non cambia l'esito dei due test.
+
+Due guardie del repo — `packages/no-app-imports` e `cron-outliers.guard` — hanno
+già il loro denominatore esplicito («il test non passa vuoto per errore»), e
+`home-redirect` ha un controllo negativo che dimostra che lo scanner sa anche
+dire di no. Il modello c'era: mancava in questi due.
+
+## I commenti
+
+Tutti trovati confrontando i nomi di file e di simbolo citati fra backtick con
+quello che esiste davvero su disco. Nessuno cambia una riga di comportamento.
+
+Il giudizio video è stato tolto il **29/8/2026** e ha lasciato dietro di sé sei
+punti che ne parlano al presente: `qc.ts` che «scrive i punteggi» in
+`motion-video/agent.ts`, il tetto di 4 render al giorno giustificato da «due giri
+di QC» in `output-tools.ts`, `craft-review.ts` e la QC nell'intestazione del
+ricettario delle transizioni, `detectWowMechanisms` elencato in `storyboard.ts`
+fra i controlli che girano (quel file ne importa due, non tre),
+`market-video-analysis.ts` in `wall-digest.ts`, `video-review.ts` in
+`hook-tactics.ts`. La regola sotto ognuno è ancora buona: è stata riscritta senza
+il riferimento morto, non cancellata.
+
+Due file citati non sono mai esistiti: `onboarding-generate.ts` in
+`content-preview/creation.ts` (la CALLER RULE annunciava due persist site, ce n'è
+uno) e `meta-capi.ts` in `analytics.ts`. Il secondo è il caso peggiore della
+serie: `metaPixelTrack` dice di passare lo stesso `eventID` del «matching
+server-side `metaCapiEvent`», e in questo repo non esiste né quel simbolo né una
+Conversions API lato server. Un'istruzione che indica un pezzo inesistente.
+
+Il resto è deriva di nomi: `plugins/team.ts` (il kit ha perso i plugin in
+`98b18453`), `live.test.ts`, `video-review-agent.ts`, `REMOTION_CRAFT_BLOCK` — il
+ricettario non sta più nel prompt ma nel file `how/MAKE-MOTION-VIDEO.md` —,
+`guardrailsInstruction` per `GUARDRAILS_INSTRUCTION`, `runSubagent` per
+`runSubagentRun`, gli emulatori dati per «accanto» a `agent-kit/interfaces.ts`
+mentre vivono in `agent-adapters`, e le due card che `HomeChatMockup` dichiarava
+di ricalcare da componenti che non ci sono più.
+
+## Quello che NON è stato toccato
+
+`detectWowMechanisms` non ha più chiamanti di produzione da quando il giudice è
+sparito, ed è tenuto in vita solo dai suoi test. Con lui, tre skill in
+`default-skills.ts` dichiarano al modello un `gate` che non esiste — «QC reads
+the TSX and fails a 4+ beat composition», `qc_review`, «stagger step checked by
+`detectWowMechanisms`» — e `default-skills.test.ts` verifica la coppia
+skill↔gate chiamando l'euristica **direttamente**, non il percorso di produzione:
+per questo il test non si è mai accorto di niente. Quel testo è prompt: correggerlo
+cambia cosa leggono gli agenti, e rimettere il cancello è una decisione di
+prodotto. Elencato, non toccato.
+
+Le migration (`0195`, `0187`) nominano `qc.ts` e `market-video-analysis.ts`: sono
+storia applicata, non si riscrivono.
+
+`content-quality.ts`, `design-judge.ts` e `market-trends.ts` hanno le stesse
+bugie e sono già corrette sul branch `chore/video-review-residue`, non ancora
+unito: lasciate a lui per non aprire un conflitto.

--- a/packages/agent-kit/src/interfaces.ts
+++ b/packages/agent-kit/src/interfaces.ts
@@ -1,7 +1,7 @@
 /**
  * Ciò che si può sostituire senza toccare il resto: il runtime non sa quale provider parla,
- * l'executor non sa dove gira la shell. Ogni implementazione ha un `*-emulator.ts` accanto, e i
- * test girano su quello.
+ * l'executor non sa dove gira la shell. Gli emulatori su cui girano i test stanno in
+ * `packages/agent-adapters/src/*-emulator.ts`, non accanto a questo file.
  *
  * ponytail: solo le interfacce che hanno un'implementazione oggi — una senza è peso, non
  * architettura.

--- a/src/lib/agent/no-vite-globals.test.ts
+++ b/src/lib/agent/no-vite-globals.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -32,19 +32,17 @@ function tsFiles(dir: string): string[] {
 }
 
 describe('niente globali di Vite nel codice che il worker impacchetta', () => {
+	const watched = WATCHED.flatMap((base) => tsFiles(join(ROOT, base)));
+
+	it('ha trovato i file da controllare (il test non passa vuoto per errore)', () => {
+		expect(watched.length).toBeGreaterThan(100);
+	});
+
 	it('nessun `import.meta.env` sotto lib/agent e lib/server', () => {
-		const guilty: string[] = [];
-		for (const base of WATCHED) {
-			const dir = join(ROOT, base);
-			try {
-				if (!statSync(dir).isDirectory()) continue;
-			} catch {
-				continue;
-			}
-			for (const file of tsFiles(dir)) {
-				if (/import\.meta\.env/.test(readFileSync(file, 'utf8'))) guilty.push(file.slice(ROOT.length));
-			}
-		}
+		const guilty = watched
+			.filter((file) => /import\.meta\.env/.test(readFileSync(file, 'utf8')))
+			.map((file) => file.slice(ROOT.length));
+
 		expect(guilty, 'usa process.env: il worker gira fuori da Vite').toEqual([]);
 	});
 });

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -57,8 +57,8 @@ export function isProdHost(hostname: string | null | undefined): boolean {
   return !!h && !NON_PROD_HOST.test(h);
 }
 
-/** Guard 1 — l'ambiente. Un solo posto a cui chiedere "qui si traccia?": lo usano anche il root
- * +layout.server.ts e meta-capi.ts, così client e server rispondono uguale. */
+/** Guard 1 — l'ambiente. Un solo posto a cui chiedere "qui si traccia?": lo usa anche il root
+ * +layout.server.ts, così client e server rispondono uguale. */
 export function trackingAllowed(hostname: string | null | undefined): boolean {
   return !dev && isProdHost(hostname);
 }
@@ -144,9 +144,9 @@ export function loadMetaPixel() {
 }
 
 /**
- * Fire a Meta Pixel conversion event (e.g. CompleteRegistration) from the browser. Works even when
- * the server Conversions API token is down, so it's the resilient half of the signal. Pass the same
- * `eventID` as the matching server-side metaCapiEvent so Meta dedups the two into one conversion.
+ * Fire a Meta Pixel conversion event (e.g. CompleteRegistration) from the browser. There is no
+ * server-side Conversions API half in this repo, so `eventID` buys nothing today — it is there for
+ * the day one exists and the two need deduping into one conversion.
  * No-ops on the server or before the pixel has loaded.
  */
 export function metaPixelTrack(event: string, params?: Record<string, unknown>, eventID?: string) {

--- a/src/lib/components/HomeChatMockup.svelte
+++ b/src/lib/components/HomeChatMockup.svelte
@@ -29,9 +29,9 @@
   // tool-call vere e uno slug di brand. Qui serve solo il disegno — e una pagina marketing non
   // deve dipendere da file che la chat sta ancora cambiando. Volti e colori invece sono quelli
   // veri (BUILTIN_AGENT_AVATARS), perché quelli sì sono client-safe e non devono mentire. Le due
-  // card di connessione ricalcano la forma vera: ChatConnectCard.svelte (logo + nome + pillola
-  // ghost + motivo rientrato) e la riga `.open-tab-card` di ChatColumn.svelte (riga quieta
-  // centrata, motivo sopra e azione in accent sotto).
+  // card di connessione ricalcavano ChatConnectCard.svelte (logo + nome + pillola ghost + motivo
+  // rientrato) e la riga `.open-tab-card` di ChatColumn.svelte: nessuno dei due esiste più, quindi
+  // questo disegno non ricalca più niente — è un mockup e basta.
   import { _ } from 'svelte-i18n';
   import { siGoogledrive } from 'simple-icons';
   import AgentAvatar from '$lib/components/AgentAvatar.svelte';

--- a/src/lib/motion-video/transitions-cookbook.ts
+++ b/src/lib/motion-video/transitions-cookbook.ts
@@ -4,21 +4,22 @@
  * La lezione che ha generato questo file: le regole di craft scritte in prosa non cambiano il
  * comportamento del modello; quelle con il CODICE dentro sì (vedi `craft.ts`, che cita
  * `<TransitionSeries.Sequence durationInFrames={3*fps}>` ed è l'unica sezione che ha spostato
- * l'output). E una regola di prompt senza un controllo in QC viene saltata. Quindi il "wow" che
- * il proprietario chiede — scale dell'intera pagina, match-cut in cui una scena collassa in un
- * punto che diventa il puntino della "i" del titolo dopo — vive qui in tre forme che si tengono
- * a vicenda:
+ * l'output). Quindi il "wow" che il proprietario chiede — scale dell'intera pagina, match-cut in
+ * cui una scena collassa in un punto che diventa il puntino della "i" del titolo dopo — vive qui
+ * in due forme che si tengono a vicenda:
  *
  *  1. Snippet COMPLETI e COMPILANTI (il test li passa in `compileMotionSource`): l'agente copia
  *     e adatta, non re-inventa.
  *  2. La regola con un numero in `MOTION_CRAFT_SPECS` (craft.ts) che li nomina.
- *  3. `detectWowMechanisms` — l'euristica sul sorgente che `craft-review.ts` usa per rifiutare
- *     una composizione a 4+ beat senza nessun meccanismo wow.
  *
- * Ogni snippet porta un commento marcatore `// wow: NOME` sul meccanismo: la QC lo usa come
- * indizio (mai da solo — conta solo insieme alla forma di codice che gli sta dietro).
+ * Ogni snippet porta un commento marcatore `// wow: NOME` sul meccanismo.
  *
- * Puro, client-safe (niente $lib/server): lo leggono il prompt dell'agente e il giudice di craft.
+ * `detectWowMechanisms` era la terza forma: l'euristica che il giudice di craft leggeva per
+ * rifiutare una composizione a 4+ beat senza nessun meccanismo. Il giudice è stato tolto il
+ * 29/8/2026 e l'euristica è rimasta senza chiamanti di produzione — la esercitano solo i test.
+ * Niente rifiuta più una composizione su questa base.
+ *
+ * Puro, client-safe (niente $lib/server): lo legge il prompt dell'agente.
  */
 import {
 	MOTION_EXPO_IN_OUT,

--- a/src/lib/server/agent-base.ts
+++ b/src/lib/server/agent-base.ts
@@ -81,7 +81,7 @@ const REVIEW_ROLES: SubagentRole[] = ['verify'];
 
 /**
  * Il tetto ai rifiuti di `finish` per review mancante — e senza di lui la guardia butta il lavoro
- * invece di proteggerlo. `onRun` conta solo le run partite DAVVERO, e `runSubagent` esce prima
+ * invece di proteggerlo. `onRun` conta solo le run partite DAVVERO, e `runSubagentRun` esce prima
  * quando il tempo è finito: l'agente veniva rifiutato, delegava a vuoto, richiamava `finish`, e
  * bruciava gli step senza consegnare (due video vuoti in produzione). Dopo due rifiuti si passa, e
  * il risultato di `finish` lo dichiara.

--- a/src/lib/server/blog-analytics-boundary.test.ts
+++ b/src/lib/server/blog-analytics-boundary.test.ts
@@ -47,10 +47,12 @@ describe('i tracker di un brand non toccano la nostra origine', () => {
    */
   it('e il profilo condiviso dai due alberi non li porta con se’', () => {
     const blogSite = readFileSync(join(ROUTES, '../lib/server/blog-site.ts'), 'utf8');
-    const profile = blogSite.slice(
-      blogSite.indexOf('async function brandProfile'),
-      blogSite.indexOf('export async function siteAnalytics')
-    );
-    expect(profile).not.toMatch(/analytics/);
+    const start = blogSite.indexOf('async function brandProfile');
+    const end = blogSite.indexOf('export async function siteAnalytics');
+
+    expect(start, 'brandProfile non si chiama più così: il confine non guarda niente').toBeGreaterThan(-1);
+    expect(end, 'siteAnalytics non si chiama più così: il confine non guarda niente').toBeGreaterThan(start);
+
+    expect(blogSite.slice(start, end)).not.toMatch(/analytics/);
   });
 });

--- a/src/lib/server/brand-guardrails.ts
+++ b/src/lib/server/brand-guardrails.ts
@@ -20,7 +20,7 @@
  * nothing about whether a line will land.
  *
  * NO MIGRATION. The block lives inside `brand_kit.ai_context`, which every planner, blog, ad and
- * video prompt already reads. `guardrailsInstruction` makes the synthesiser produce it;
+ * video prompt already reads. `GUARDRAILS_INSTRUCTION` makes the synthesiser produce it;
  * `extractGuardrails` lifts it back out for the prompts that need it emphasised rather than buried
  * in 500 words of prose.
  *

--- a/src/lib/server/chat/agents.ts
+++ b/src/lib/server/chat/agents.ts
@@ -490,10 +490,9 @@ export const HANDOFFS: Record<AgentId, AgentId[]> = {
 /**
  * Il paragrafo «squadra + confini» per `agentId`.
  *
- * `canMessage: false` per le superfici che NON montano `message_agent` — i consulti one-shot, non
- * più il kit, che da `plugins/team.ts` ce l'ha: la consapevolezza della squadra resta, la promessa
- * di scrivergli no. Un agente che nomina un tool che non ha è il difetto che questo repo ha già
- * spedito una volta.
+ * `canMessage: false` per le superfici che NON montano `message_agent` — i consulti one-shot: la
+ * consapevolezza della squadra resta, la promessa di scrivergli no. Un agente che nomina un tool
+ * che non ha è il difetto che questo repo ha già spedito una volta.
  */
 export function teamBlock(agentId: AgentId, opts: { canMessage?: boolean } = {}): string {
   const roster = AGENT_IDS.filter((id) => id !== agentId)

--- a/src/lib/server/chat/prompt-cuts.test.ts
+++ b/src/lib/server/chat/prompt-cuts.test.ts
@@ -246,8 +246,7 @@ describe('il prompt non ricresce da solo', () => {
 
 /**
  * La regola che ha fermato amazon.in (27/8/2026): un messaggio inglese non deve poter diventare
- * una risposta italiana. Vale per OGNI mestiere — non solo per i turni del kit, dove
- * `live.test.ts` la copia già con il messaggio reale di quella sessione.
+ * una risposta italiana. Vale per OGNI mestiere.
  */
 describe('REPLY LANGUAGE nel prompt classico', () => {
   it('il blocco assoluta è in ogni prompt, e nessuna direttiva contraddice il messaggio dell\'utente', async () => {

--- a/src/lib/server/chat/typed-output.test.ts
+++ b/src/lib/server/chat/typed-output.test.ts
@@ -31,7 +31,7 @@ import { z } from 'zod';
  * Quindi `Output` aggiungerebbe una cosa sola: uno slot leggibile a macchina al posto di una regex
  * sulla prosa (production-claim.ts ammette che «la lista non finisce mai»). E quella cosa, in questo
  * repo, ha già la sua forma compatibile con lo streaming e col ciclo: un tool `finish` con schema
- * zod, come `submit_review` in video-review-agent.ts o `finish` in image-agent.ts — l'input di una
+ * zod, come `finish` in image-agent.ts — l'input di una
  * chiamata a strumento È validato dallo schema, È un passo, e il suo risultato è terreno solido che
  * le guardie leggono già.
  *

--- a/src/lib/server/content-preview/creation.ts
+++ b/src/lib/server/content-preview/creation.ts
@@ -589,9 +589,9 @@ export async function generateStandaloneImage(opts: {
 //   3. the short URL written back onto post.link_url AND swapped into the caption (the writer
 //      wove the raw URL in verbatim) — the short link is what actually ships, so it's the only
 //      version a reader can click and therefore the only one we can count.
-// CALLER RULE (the persist sites are in scheduler.ts / onboarding-generate.ts, out of scope
-// here): call this ONLY for posts whose persisted row will have source = 'plan' — the scheduler
-// autopilot persist and the onboarding persist. NEVER for Radar (source = 'radar'): Radar links
+// CALLER RULE (the only persist site is scheduler.ts, out of scope here): call this ONLY for
+// posts whose persisted row will have source = 'plan' — the scheduler
+// autopilot persist. NEVER for Radar (source = 'radar'): Radar links
 // point at news source_urls (not the brand's own pages) and Radar already appends its own utm_
 // tags. Also skip any link_url that already contains a utm_ parameter — a Reddit link_post
 // (media:'link') with a real external target, or a user-edited URL, must never be rewritten

--- a/src/lib/server/default-skills.ts
+++ b/src/lib/server/default-skills.ts
@@ -20,11 +20,12 @@
  * check statico non esiste). Il test di questo file verifica la coppia skill↔gate su un caso
  * sbagliato: se il gate smette di bocciare, il test lo dice.
  *
- * IL CODICE NON STA QUI. Dal 22/8/2026 il ricettario intero è nel prompt dei due agenti che
- * scrivono TSX (`REMOTION_CRAFT_BLOCK` in chat/agents.ts): una skill che ne incollasse di nuovo
- * gli snippet sarebbe la seconda copia che diverge — il difetto che questo sistema esiste per
- * evitare. Le skill restano quello che il ricettario non è: la PROCEDURA e il nome del gate che
- * la rende vincolante. Il codice si cita per nome, e il nome sta nel prompt.
+ * IL CODICE NON STA QUI. Il ricettario intero arriva agli agenti che scrivono TSX come file
+ * (`how/MAKE-MOTION-VIDEO.md`, composto in agent-files.ts da `MOTION_CRAFT_SPECS` +
+ * `MOTION_TRANSITIONS_COOKBOOK_PROMPT`): una skill che ne incollasse di nuovo gli snippet sarebbe
+ * la seconda copia che diverge — il difetto che questo sistema esiste per evitare. Le skill
+ * restano quello che il ricettario non è: la PROCEDURA e il nome del gate che la rende
+ * vincolante. Il codice si cita per nome, e il nome sta nel file.
  */
 import {
 	MAX_LINE_CHARS,

--- a/src/lib/server/hook-tactics.ts
+++ b/src/lib/server/hook-tactics.ts
@@ -1,8 +1,9 @@
 /**
  * THE HOOK TACTIC TAXONOMY — eighteen named ways to open, and the coverage map they unlock.
  *
- * WHY EIGHTEEN AND NOT SEVEN. `video-review.ts` labelled hooks with seven loose strings and
- * `visual-meta.ts` with five shape buckets (question / stat / howto / myth / claim). Both are
+ * WHY EIGHTEEN AND NOT SEVEN. The video reviewer (gone on 29/8/2026) labelled hooks with seven
+ * loose strings and `visual-meta.ts` labels them with five shape buckets (question / stat / howto /
+ * myth / claim). Both are
  * usable as labels and useless as a map: with seven buckets a brand looks "covered" after a month,
  * so the planner keeps rewriting the same three openings and calls it variety.
  *

--- a/src/lib/server/motion-video/agent.ts
+++ b/src/lib/server/motion-video/agent.ts
@@ -509,9 +509,10 @@ Need photo assets? Call read_media first. If a library image fits, use_library_i
 	// The wall needs nothing from the session but the brand's name — it is a public reference site,
 	// not brand data — so it is available on every turn, for every brand.
 	//
-	// What it looked at is recorded against the videos this turn touched. That link is the only way
-	// to answer the question the whole feature rests on — do referenced clips actually score better
-	// than unreferenced ones — and `qc.ts` writes the scores on the other side of it.
+	// What it looked at is recorded against the videos this turn touched. The other half of that
+	// question — do referenced clips actually score better than unreferenced ones — was the video
+	// judge, gone on 29/8/2026: nothing writes a score any more, so the link records what was
+	// studied and nobody reads it back.
 	const studiedReferences = new Set<string>();
 	/**
 	 * Gli studi con i loro frame e il loro contratto, per `prepareStep` (sonda 2026-08-21, vedi

--- a/src/lib/server/motion-video/output-tools.ts
+++ b/src/lib/server/motion-video/output-tools.ts
@@ -60,11 +60,10 @@ export const MAX_VIDEO_RENDERS_PER_TURN = 2;
 /**
  * Render finiti per VIDEO per GIORNO — il tetto vero, contato dal registro e non da una closure.
  *
- * "Per turno" era una bugia strutturale: ogni slice di continuazione e ogni turno di patch della QC
- * (`qc.ts` apre turni interi) azzerava il contatore, quindi una sessione normale rendeva 3+ MP4
- * dello stesso video. E il tetto non può essere 2/giorno, perché la QC ha BISOGNO di un re-render
- * dopo una patch (confronta anteprima e sorgente). Quattro copre bozza + due giri di QC + una
- * correzione chiesta dall'utente; oltre, è un loop.
+ * "Per turno" era una bugia strutturale: ogni slice di continuazione azzerava il contatore, quindi
+ * una sessione normale rendeva 3+ MP4 dello stesso video. E il tetto non può essere 2/giorno,
+ * perché un re-render dopo una patch è normale — si confronta l'anteprima col sorgente. Quattro
+ * copre bozza + due giri di correzione + una chiesta dall'utente; oltre, è un loop.
  */
 export const MAX_VIDEO_RENDERS_PER_DAY = 4;
 

--- a/src/lib/server/motion-video/storyboard.ts
+++ b/src/lib/server/motion-video/storyboard.ts
@@ -22,8 +22,8 @@
  *
  * Il movimento. Un fotogramma fermo non mostra una coda morta, un'interpolazione lineare, una
  * transizione che legge come un taglio secco, il ritmo. Quelle le vede l'aritmetica sul sorgente
- * — `findLinearMotion`, `findStaticTails`, `detectWowMechanisms` — che gira sullo stesso TSX e
- * quindi può girare nello stesso momento. Le due metà viaggiano insieme nella stessa risposta:
+ * — `findLinearMotion` e `findStaticTails`, gli unici due che questo file importa — che gira sullo
+ * stesso TSX e quindi può girare nello stesso momento. Le due metà viaggiano insieme nella stessa risposta:
  * le immagini per la composizione, i numeri per il movimento. Chi scrive che lo storyboard copre
  * anche il movimento si sta raccontando una storia.
  *

--- a/src/lib/server/redact.ts
+++ b/src/lib/server/redact.ts
@@ -130,7 +130,7 @@ const ENV_SECRETS: string[] = Object.entries(env)
 /**
  * L1b — i valori coniati a runtime, PER BRAND e non per closure: la VM è del brand
  * (`anomalia-<brandId>-<mode>`), e orchestratore e delegati la condividono. È la sostituzione
- * minima del registro di turno: nessuna firma da cambiare in `withSandboxTools` / `runSubagent`.
+ * minima del registro di turno: nessuna firma da cambiare in `withSandboxTools` / `runSubagentRun`.
  *
  * ponytail: Map di processo, non uno store. Il tetto è dichiarato — un'altra istanza di Function
  * non la vede — ed è esattamente il motivo per cui L2..L5 e `hasLiveCredential` esistono comunque.

--- a/src/lib/server/wall-digest.ts
+++ b/src/lib/server/wall-digest.ts
@@ -4,8 +4,9 @@
  *
  * PERCHÉ NESSUNA CHIAMATA VISION QUI. Ogni item del wall è GIÀ stato guardato da un modello,
  * una volta, quando è entrato: il design judge ha guardato il poster (design_note, design_tags,
- * punteggi per asse — design-judge.ts) e il reviewer video ha guardato il clip (hook_type,
- * hook_at_s, reveal, cta, dead_seconds, summary — market-video-analysis.ts). Il distillatore
+ * punteggi per asse — design-judge.ts) e il reviewer video aveva guardato il clip (hook_type,
+ * hook_at_s, reveal, cta, dead_seconds, summary), fino a quando è stato tolto il 29/8/2026 —
+ * quei campi si leggono ancora dalle righe già scritte, ma nessuno ne scrive di nuove. Il distillatore
  * rilegge QUEL testo e lo sintetizza: due chiamate Gemini solo-testo a settimana in totale,
  * zero pixel. È lo stesso pattern di motion-references.ts (studia una volta con vision → cache
  * di uno spec testuale → la generazione legge lo spec gratis), applicato un livello più su.

--- a/src/routes/app/[brand]/calendar/page.server.delete.test.ts
+++ b/src/routes/app/[brand]/calendar/page.server.delete.test.ts
@@ -23,7 +23,6 @@ vi.mock('$lib/server/email', () => ({
 }));
 vi.mock('$lib/server/video-requests', () => ({ founderVideoBudget: vi.fn(), listVideoRequests: vi.fn() }));
 vi.mock('$lib/server/supabase-admin', () => ({ createAdminClient: vi.fn() }));
-vi.mock('$lib/server/video-review-store', () => ({ loadVideoScoreBadges: vi.fn(), mediaUrlHash: vi.fn() }));
 vi.mock('$lib/server/page-cache', () => ({ cachedBrandPage: vi.fn() }));
 
 import { actions } from './+page.server';


### PR DESCRIPTION
## What?

Three tests that declared they were guarding something and could not fail, plus fourteen comments that named a file or a symbol that does not exist. No behaviour changes: the diff is test assertions and prose. `npm run check` returns the identical error set before and after (338 errors / 202 warnings, already red on `dev`), modulo three line numbers pushed down one by a longer comment.

This is the half of "delete the unused code" that no import graph can see. The two passes that ran earlier today removed ~54.000 and ~3.492 lines of code nobody calls. They could not see the code that *lies*.

## Why?

AGENTS.md states the cost directly: *«An expired comment is worse than no comment: we paid for one that described a decision already reversed and led to a wrong diagnosis.»* The same holds one level up — a test that cannot fail is worse than no test, because it occupies the slot where a real guard would go and reports green while the thing it names is broken.

The video judge was removed on **2026-08-29** (`5df714e7`). Six days later, six separate places still described it in the present tense, and a security boundary test could be switched off by renaming a function.

## How?

**The verification method, applied to every test claim: break the thing the test guards and watch it stay green.** A test that has never failed proves nothing, so each finding below carries the experiment that produced it, run against the real suite, with `git diff` restored to clean afterwards.

For comments the method was mechanical: extract every file name and every backticked identifier that appears inside a comment, and check it against what is actually on disk. That is what surfaced all fourteen — including two files that never existed in the history at all.

Where a comment explained a rule that is still true, the rule was **rewritten without the dead reference, not deleted**. `MAX_VIDEO_RENDERS_PER_DAY = 4` still needs its reason; the reason just is not "two rounds of QC" any more.

### The three guards

**1. `blog-analytics-boundary.test.ts` — a security boundary defeated by a rename.**

The rule: third-party trackers (GA4, GTM) may run on the brand's own domain, never on `anomalia.so`, where the logged-in session lives. The test sliced `brandProfile`'s body out of `blog-site.ts` with two `indexOf` calls. A renamed marker returns `-1`, `slice(-1, n)` yields the empty string, and the empty string never matches `/analytics/`.

**2. `no-vite-globals.test.ts` — a swallowed directory.**

The worker runs on plain Node, where `import.meta.env` is a TypeError that kills the turn before it starts (two chat jobs lost in ten hours on 26/8). The test's own header promises it watches *«la CLASSE, non quella riga»* — but a missing watched directory was swallowed by `catch { continue }`.

**3. `calendar/page.server.delete.test.ts` — `vi.mock` on a module deleted on 29/8.**

`vi.mock` with a factory does not check that the path resolves, so the line substituted nothing. Removing it does not change either test's outcome — which is the proof it was inert.

### The comments

| What it said | Where | False since |
|---|---|---|
| `qc.ts` writes the reference scores | `motion-video/agent.ts` | 29/8 (`5df714e7`) |
| 4 renders/day = "draft + two rounds of QC" | `motion-video/output-tools.ts` | 29/8 |
| `craft-review.ts` refuses a 4+ beat composition; "the QC uses the marker" | `motion-video/transitions-cookbook.ts` | 29/8 |
| `detectWowMechanisms` among the checks storyboard runs (it imports two, not three) | `motion-video/storyboard.ts` | 29/8 |
| the video reviewer looked at the clip — `market-video-analysis.ts` | `wall-digest.ts` | 29/8 |
| `video-review.ts` labelled hooks with seven strings | `hook-tactics.ts` | 29/8 |
| the persist sites are in `scheduler.ts` / `onboarding-generate.ts` | `content-preview/creation.ts` | never existed |
| `trackingAllowed` is shared with `meta-capi.ts` | `analytics.ts` | never existed |
| pass the same `eventID` as the server-side `metaCapiEvent` | `analytics.ts` | never existed |
| the kit has `message_agent` from `plugins/team.ts` | `chat/agents.ts` | `98b18453` |
| `live.test.ts` copies the reply-language rule | `chat/prompt-cuts.test.ts` | kit removal |
| `submit_review` in `video-review-agent.ts` | `chat/typed-output.test.ts` | 29/8 |
| the cookbook is in the prompt as `REMOTION_CRAFT_BLOCK` | `default-skills.ts` | moved to `how/MAKE-MOTION-VIDEO.md` |
| every implementation has a `*-emulator.ts` **alongside** | `agent-kit/interfaces.ts` | they live in `agent-adapters` |

Plus two name drifts: `guardrailsInstruction` → `GUARDRAILS_INSTRUCTION`, `runSubagent` → `runSubagentRun`; and `HomeChatMockup` claiming to trace `ChatConnectCard.svelte` / `ChatColumn.svelte`, neither of which exists.

`analytics.ts` is the worst of the set: `metaPixelTrack` instructs a caller to pair an `eventID` with a server-side Conversions API that this repo has never had — and the function has **no callers at all**.

**Rejected alternatives.** Re-wiring the wow gate instead of correcting the prose: that is a product decision and a redesign, not a cleanup. Deleting `detectWowMechanisms` outright: `craftFloor` earlier today looked like part of a removed judge and was actually feeding a prompt, so anything that *might* be an ingredient in disguise gets listed, not deleted.

## Testing?

Every claim above was produced by an experiment, not by reading.

<details>
<summary>Guard 1 — rename defeats the security boundary (before the fix)</summary>

```
$ npx vitest run src/lib/server/blog-analytics-boundary.test.ts
  Tests  3 passed (3)                       # baseline

# inject a real violation inside brandProfile
$ sed -i '' '115i\  const analytics = 1;' src/lib/server/blog-site.ts
$ npx vitest run src/lib/server/blog-analytics-boundary.test.ts
  × e il profilo condiviso dai due alberi non li porta con se'
  Tests  1 failed | 2 passed (3)            # the guard works...

# keep the violation, only rename the marker
$ sed -i '' 's/async function brandProfile(/async function loadBrandProfile(/' src/lib/server/blog-site.ts
$ npx vitest run src/lib/server/blog-analytics-boundary.test.ts
  Tests  3 passed (3)                       # ...and a rename switches it off
```

After the fix, the same rename fails loudly on the marker assertion. `git diff` restored clean.
</details>

<details>
<summary>Guard 2 — a moved directory silences the worker guard (before the fix)</summary>

```
# inject a real violation under a watched tree
$ printf '\nconst mode = import.meta.env.MODE;\n' >> src/lib/server/swallow.ts
$ npx vitest run src/lib/agent/no-vite-globals.test.ts
  × nessun `import.meta.env` sotto lib/agent e lib/server
  Tests  1 failed (1)                       # the guard works...

# keep the violation, move the watched tree
$ mv src/lib/server src/lib/srv-moved
$ npx vitest run src/lib/agent/no-vite-globals.test.ts
  Tests  1 passed (1)                       # ...zero files read, green
```

After the fix the same move produces `ENOENT: scandir 'src/lib/server'` — a loud failure. `git diff` restored clean.
</details>

<details>
<summary>Guard 3 — the mock substituted nothing</summary>

```
$ npx vitest run 'src/routes/app/[brand]/calendar/page.server.delete.test.ts'
  Tests  2 passed (2)     # with vi.mock('$lib/server/video-review-store')
  Tests  2 passed (2)     # without it
```
</details>

<details>
<summary>npm run check — the error sets, not the count</summary>

`dev` is already red, so the number says nothing and the difference says everything.

```
before: COMPLETED 10362 FILES 338 ERRORS 202 WARNINGS 166 FILES_WITH_PROBLEMS
after:  COMPLETED 10362 FILES 338 ERRORS 202 WARNINGS 166 FILES_WITH_PROBLEMS

$ diff <(sorted errors before) <(sorted errors after)
205,207c205,207
< ERROR "src/lib/server/motion-video/agent.ts" 1198:16 ...
---
> ERROR "src/lib/server/motion-video/agent.ts" 1199:16 ...
```

The only delta is three pre-existing errors in `agent.ts` shifted down one line by a comment that gained a line.
</details>

<details>
<summary>Unit tests on every touched file</summary>

```
$ npx vitest run default-skills transitions-cookbook gates-on-real-source \
    prompt-cuts typed-output blog-analytics-boundary no-vite-globals analytics
  Test Files  8 passed (8)
  Tests     123 passed (123)
```
</details>

**Not tested:** no browser verification — this PR changes no rendered surface and no runtime path. **Risk:** confined to whether a corrected sentence is *true*, not to whether code runs.

## Evidence (screenshots/videos)

No UI change: the diff is test assertions and comment prose. The evidence that matters here is the failing/passing transitions above, which is what the change is actually about.

## Anything Else?

**Listed, deliberately not touched — the biggest finding in the sweep.**

`detectWowMechanisms` lost its production caller on 29/8 when the craft judge went. Nothing refuses a composition on that basis any more. But three skills in `default-skills.ts` still declare a `gate` to the model on every read of the skill file, and `agent-files.ts` renders it as `GATE: ...`:

- `motion-alive-scenes` — *"stagger step checked by `detectWowMechanisms`"*, body: *"A stagger with step 0 ... fails QC"*
- `motion-screenshot-legibility` — gate `qc_review`, body: *"QC watches the rendered frames — legibility is a scored dimension and fails the review"*
- `motion-transition-mechanism` — *"ENFORCED IN CODE: QC reads the TSX and fails a 4+ beat composition without these code shapes"*

None of the three runs. This is the defect `chat/agents.ts` names in its own header — *«un agente che nomina un tool che non ha è il difetto che questo repo ha già spedito una volta»* — pointed at the agents themselves.

And `default-skills.test.ts` opens with *«una skill vale solo se il gate che dichiara boccia davvero il caso sbagliato ... se il controllo smette di rifiutare, il test lo dice»*. It calls `detectWowMechanisms` **directly** rather than the production path, so it proves the function still works and says nothing about whether anything calls it. That is why six days passed with nobody noticing.

Left alone because the fix is a fork in the road and both branches are yours: **re-wire the gate** (a product change — compositions that ship today would start being refused) or **drop the claim** (prompt text, so it wants an eval run). Either way it is not a cleanup.

**Also listed, unverified enough to delete:** `metaPixelTrack` in `analytics.ts` has no callers; `persistFailedPartial`, `holdBroken`, `AiRuntime` and the tool name `set_brand_logo` each appear exactly once in the repo, inside the comment that names them.

**Out of my perimeter, reported as asked:** none found in `model-routing.ts`, `ai-log.ts`, `credits.ts`, `content-preview/images.ts`, `kie-jobs.ts` or `packages/api-contracts/`.

**Left to `chore/video-review-residue`:** `content-quality.ts`, `design-judge.ts` and `market-trends.ts` carry the same class of lie and are already fixed on that unmerged branch. Not touched here, to avoid a conflict.

**Migrations `0195` and `0187`** name `qc.ts` and `market-video-analysis.ts`. Applied history is not rewritten.

**The pattern worth keeping.** Two guards in this repo already carry an explicit denominator — *«il test non passa vuoto per errore»* — and `home-redirect.test.ts` ships a negative control proving its scanner can also return non-empty. The model existed; it was just missing from these two. Anything that scans the filesystem and asserts emptiness should assert the scan found something first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
