### PR TITLE
Leave two transports: openrouter serves, kie falls back

### DIFF
--- a/changelog/2026-09-05-two-endpoints-left.md
+++ b/changelog/2026-09-05-two-endpoints-left.md
@@ -1,0 +1,84 @@
+# Restano due trasporti: openrouter serve, kie ripiega
+
+`Endpoint` era `google | kie | xiaomi | deepseek | openrouter`. Adesso è **`kie | openrouter`**.
+
+La ragione non è il prezzo, ed è la stessa per tutti e tre:
+
+| | chiamate | fallite | p95 |
+|---|---|---|---|
+| kie (immagini) | 199 | 3,5% | **142,9s** |
+| **deepseek** | 5.122 | **41,3%** | — |
+| OpenRouter | — | — | **3,4s** |
+
+Su un fornitore che sbaglia due chiamate su cinque non ci si costruisce un prodotto. kie resta —
+non come pari, come **ripiego** — perché il TTS lo fa e OpenRouter no, e perché un secondo
+trasporto vale più di zero.
+
+## Cosa cambia, tabella per tabella
+
+Il registro è fatto per questo: togliere un endpoint è **una riga per tabella**.
+
+- `Endpoint`, `LogProvider` → `kie | openrouter`
+- `ModelFamily` → via `mimo` e `deepseek`, che avevano casa solo lì
+- `HOME` → tutto su kie: è la tabella del RIPIEGO, e il ripiego ora è uno solo
+- `SERVED_BY` → `gemini` e `nano-banana` su entrambi, `gemini-tts` **solo kie**, `grok`/`gpt` solo kie
+- `SLOT_DEFAULT` → testo e immagini su openrouter, voce su kie
+- `endpointConfigured` → due casi
+
+E l'ultima spiaggia di `route()`, che era `'google'`, diventa `'kie'`. Era l'unico punto in cui
+Google sopravviveva senza essere nominato.
+
+## Il TTS non si sposta, ed è MISURATO
+
+Su OpenRouter `lyria-3` è **musica**, non sintesi vocale. Restano `openai/gpt-audio` e
+`gpt-audio-mini`, e non servono:
+
+    modalities:['text','audio'] senza stream  ->  400 "Audio output requires stream: true"
+    con stream:true e format wav              ->  400 "does not support 'wav' when stream=true"
+
+E il nostro tagliatore pretende L16 **24 kHz mono 16 bit**, che è il formato che kie già
+restituisce e che `gemini-audio.ts` verifica prima di tagliare. Quindi la voce resta su kie, e
+l'assenza è **dichiarata** in `MISSING` come capacità `tts` — non scoperta in produzione.
+
+Il codice, per inciso, lo diceva già: il ramo non-kie di `generateVoiceOver` lanciava
+`'TTS is kie-only. Google speech is not on the gateway.'`. La riga `gemini-tts → google` in `HOME`
+era già morta, e nessuno l'aveva notata.
+
+## Gli embedding NON sono una dipendenza da Google
+
+`EMBEDDING_MODEL=google/gemini-embedding-001` **sembra** Google e non lo è: passa da `llmClient()`,
+cioè da OpenRouter, e ci passa da sempre. Verificato: `dimensions: 768` è onorato (senza il campo
+tornano 3072), e `llmEmbed` scarta già ogni vettore di lunghezza sbagliata invece di scriverlo.
+
+Sta scritto qui perché è esattamente il nome che qualcuno "sistemerà" per sbaglio.
+
+## Una regola che viveva in due posti
+
+`supportsClipInToolResult` chiedeva `geminiTransport() === 'kie'` per sapere se un clip sopravvive
+dentro il risultato di un tool. È una **capacità dell'endpoint**, e la risposta vive nel registro:
+`graphic-review.ts` la chiedeva già con `can(route('text').endpoint, 'media-in-tool-result')`. Le
+due sarebbero divergute al primo endpoint nuovo — adesso è una sola.
+
+## Il criterio, e la deroga dichiarata
+
+La regola era: una riga esce quando `ai_calls` dice che non ci arriva più niente. Per `deepseek` è
+soddisfatta alla lettera — **zero chiamate nelle ultime 24 ore**. Per `gemini` e `xiaomi` no: nelle
+ultime 24 ore restano `renderPostImage` (85) e `critiqueImage` (8).
+
+Quel traffico però viene da codice che **non esiste più su `dev`**: #333 ha spostato le immagini su
+OpenRouter e #329 ha cancellato il critico. La produzione gira codice di due giorni fa, quindi
+`ai_calls` misura il passato, non il presente. Qui il criterio è il **grafo dei chiamanti**, non il
+registro delle chiamate — ed è una deroga, quindi è scritta invece che applicata di nascosto.
+
+## Quello che NON esce in questa PR
+
+Il registro non instrada più lì, ma i moduli client restano finché non si dimostra che nessuno li
+chiama: `gemini.ts`, `xiaomi.ts` (importato da 15 file), `deepseek.ts`, `deepseek-search.ts`,
+`gemini-audio.ts`. Sono una storia diversa e una revisione diversa.
+
+Per la stessa ragione **le chiavi restano in `.env.example`**: `deepseek-search.ts` legge ancora
+`DEEPSEEK_API_KEY` e `xiaomi.ts` legge ancora `XIAOMI_MIMO_API_KEY`. Toglierle adesso farebbe
+mentire il file nell'altro verso — escono col codice che le legge.
+
+Restano anche da fare: le righe di `RATES` dei modelli di quegli endpoint, e il ramo Google dentro
+`renderPostImage`, che il registro non può più raggiungere.

--- a/src/lib/content/changelog/2026-09-05-fewer-providers.ts
+++ b/src/lib/content/changelog/2026-09-05-fewer-providers.ts
@@ -1,0 +1,11 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-05',
+  title: 'AI work now runs on one provider, with one backup',
+  items: [
+    'Text and images now run on a single provider chosen for reliability rather than price — one of the ones we dropped was failing more than four requests in ten.',
+    'Voice-over stays on the provider that has always produced it, because the new one does not do speech synthesis.',
+    'Nothing changes in what you ask for or what you get back; slow and failed generations should simply become rarer.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/gemini-transport.test.ts
+++ b/src/lib/server/gemini-transport.test.ts
@@ -27,20 +27,27 @@ describe('lo scambio di trasporto', () => {
   });
   afterEach(() => vi.unstubAllGlobals());
 
-  it('senza GEMINI_TRANSPORT resta su Google', async () => {
-    setEnv({ GEMINI_API_KEY: 'google-test-key', KIE_API_KEY: 'kie-test-key' });
+  it('col default su openrouter il client NON e` quello di kie', async () => {
+    setEnv({ OPENROUTER_API_KEY: 'o', KIE_API_KEY: 'kie-test-key' });
     const { geminiTransport, makeGenaiClient, isKieTransport, flashModelFor, geminiFlash } = await import('./gemini');
+    // `geminiTransport()` risponde a una domanda sola: serve il passthrough di kie? Col testo su
+    // openrouter no, e il client Google che torna e` ormai il parametro `ai` che i chiamanti
+    // ignorano (`_ai` in structuredGemini/groundedGemini).
     expect(geminiTransport()).toBe('google');
     const ai = makeGenaiClient();
     expect(isKieTransport(ai)).toBe(false);
     expect(flashModelFor(ai)).toBe(geminiFlash());
   });
 
-  it('senza KIE_API_KEY non si sposta niente, anche se l’env dice kie', async () => {
-    setEnv({ GEMINI_API_KEY: 'google-test-key', GEMINI_TRANSPORT: 'kie' });
-    const { geminiTransport, makeGenaiClient, isKieTransport } = await import('./gemini');
-    expect(geminiTransport()).toBe('google');
-    expect(isKieTransport(makeGenaiClient())).toBe(false);
+  it('senza KIE_API_KEY la rotta resta kie e lo dice: Google non e` piu` una rete', async () => {
+    // Prima si ripiegava su Google. Google non e` piu` un endpoint, quindi l'unico ripiego e` kie
+    // e una chiave mancante diventa un errore di chiave, non una deviazione silenziosa altrove.
+    setEnv({ GEMINI_TRANSPORT: 'kie' });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { geminiTransport } = await import('./gemini');
+    expect(geminiTransport()).toBe('kie');
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
   });
 
   it('su kie il client parla con api.kie.ai in Bearer, e manda l’id modello con i trattini', async () => {
@@ -90,7 +97,7 @@ describe('le superfici sul centralino (non lo SDK Google)', () => {
   });
 
   it('1. i media dentro i risultati dei tool: su kie il clip è rifiutato, non degradato', async () => {
-    setEnv({ GEMINI_API_KEY: 'g' });
+    setEnv({ OPENROUTER_API_KEY: 'o' });
     const google = await import('./motion-video/reference-tools');
     expect(google.supportsClipInToolResult('gemini-3.7-flash')).toBe(true);
     // Nota: l'id che vuole kie passerebbe la vecchia regex — è esattamente il caso da fermare.

--- a/src/lib/server/model-routing.test.ts
+++ b/src/lib/server/model-routing.test.ts
@@ -12,7 +12,7 @@ function setEnv(vars: Record<string, string | undefined>) {
   Object.assign(M.env, vars);
 }
 
-const KEYS = { GEMINI_API_KEY: 'g', KIE_API_KEY: 'k', XIAOMI_MIMO_API_KEY: 'x' };
+const KEYS = { KIE_API_KEY: 'k', OPENROUTER_API_KEY: 'o' };
 
 describe('il registro delle rotte', () => {
   beforeEach(() => {
@@ -20,10 +20,9 @@ describe('il registro delle rotte', () => {
     setEnv(KEYS);
   });
 
-  it('i default: testo su Google, immagini su openrouter, voce su kie', async () => {
-    setEnv({ ...KEYS, OPENROUTER_API_KEY: 'o' });
+  it('i default: testo e immagini su openrouter, voce su kie', async () => {
     const { route } = await import('./model-routing');
-    expect(route('text')).toMatchObject({ family: 'gemini', endpoint: 'google', provider: 'gemini' });
+    expect(route('text')).toMatchObject({ family: 'gemini', endpoint: 'openrouter', provider: 'openrouter' });
     expect(route('image')).toMatchObject({ endpoint: 'openrouter', provider: 'openrouter' });
     expect(route('tts')).toMatchObject({ endpoint: 'kie', provider: 'kie' });
   });
@@ -36,18 +35,15 @@ describe('il registro delle rotte', () => {
   });
 
   it('senza @ prende l’endpoint di casa della famiglia', async () => {
-    setEnv({ ...KEYS, AI_ROUTE_TEXT: 'mimo' });
+    setEnv({ ...KEYS, AI_ROUTE_TEXT: 'grok' });
     const { route } = await import('./model-routing');
-    expect(route('text')).toMatchObject({ family: 'mimo', endpoint: 'xiaomi', provider: 'xiaomi' });
+    expect(route('text')).toMatchObject({ family: 'grok', endpoint: 'kie', provider: 'kie' });
   });
 
-  it('le cinque vecchie variabili continuano a comandare', async () => {
+  it('le vecchie variabili che nominano un endpoint VIVO continuano a comandare', async () => {
     for (const [env, expected] of [
-      [{ GTM_PROVIDER: 'xiaomi' }, { slot: 'text', family: 'mimo', endpoint: 'xiaomi' }],
       [{ GTM_PROVIDER: 'kie' }, { slot: 'text', family: 'grok', endpoint: 'kie' }],
-      [{ GEMINI_TRANSPORT: 'kie' }, { slot: 'text', family: 'gemini', endpoint: 'kie' }],
-      [{ IMAGE_PROVIDER: 'gemini' }, { slot: 'image', family: 'nano-banana', endpoint: 'google' }],
-      [{ TTS_PROVIDER: 'gemini' }, { slot: 'tts', family: 'gemini-tts', endpoint: 'google' }]
+      [{ GEMINI_TRANSPORT: 'kie' }, { slot: 'text', family: 'gemini', endpoint: 'kie' }]
     ] as const) {
       vi.resetModules();
       setEnv({ ...KEYS, ...env });
@@ -58,16 +54,16 @@ describe('il registro delle rotte', () => {
   });
 
   it('la nuova variabile batte la vecchia', async () => {
-    setEnv({ ...KEYS, GTM_PROVIDER: 'xiaomi', AI_ROUTE_TEXT: 'gemini' });
+    setEnv({ ...KEYS, GTM_PROVIDER: 'kie', AI_ROUTE_TEXT: 'gemini@openrouter' });
     const { route } = await import('./model-routing');
-    expect(route('text')).toMatchObject({ family: 'gemini', endpoint: 'google' });
+    expect(route('text')).toMatchObject({ family: 'gemini', endpoint: 'openrouter' });
   });
 
   it('un endpoint senza chiave non è una rotta: si ripiega, rumorosamente', async () => {
-    setEnv({ GEMINI_API_KEY: 'g', AI_ROUTE_IMAGE: 'nano-banana@kie' });
+    setEnv({ KIE_API_KEY: 'k', AI_ROUTE_IMAGE: 'nano-banana@openrouter' });
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const { route } = await import('./model-routing');
-    expect(route('image')).toMatchObject({ endpoint: 'google', provider: 'gemini' });
+    expect(route('image')).toMatchObject({ endpoint: 'kie', provider: 'kie' });
     expect(warn).toHaveBeenCalled();
     warn.mockRestore();
   });
@@ -76,14 +72,14 @@ describe('il registro delle rotte', () => {
     setEnv({ ...KEYS, AI_ROUTE_TEXT: 'llama@ollama' });
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     const { route } = await import('./model-routing');
-    expect(route('text')).toMatchObject({ family: 'gemini', endpoint: 'google' });
+    expect(route('text')).toMatchObject({ family: 'gemini', endpoint: 'openrouter' });
   });
 
   it('una capacità mancante si ferma qui, con dentro la variabile da cambiare', async () => {
     setEnv({ ...KEYS, AI_ROUTE_TEXT: 'gemini@kie' });
     const { requireCapabilities, can } = await import('./model-routing');
     expect(can('kie', 'grounding')).toBe(false);
-    expect(can('google', 'grounding')).toBe(true);
+    expect(can('openrouter', 'grounding')).toBe(true);
     // Le citazioni vuote non fanno rumore da nessuna parte: meglio l'eccezione.
     expect(() => requireCapabilities('text', ['grounding'])).toThrow(/AI_ROUTE_TEXT.*grounding/s);
     // Quello che kie sa fare passa senza storie.
@@ -95,11 +91,11 @@ describe('il registro delle rotte', () => {
     expect(missingCapabilities('kie')).toEqual(
       expect.arrayContaining(['grounding', 'media-in-tool-result', 'video-fps', 'prompt-cache', 'embeddings', 'music'])
     );
-    expect(missingCapabilities('google')).toEqual([]);
+    expect(missingCapabilities('openrouter')).toEqual(['tts']);
   });
 
   it('openrouter è una rotta, e AI_ROUTE_IMAGE la seleziona', async () => {
-    setEnv({ ...KEYS, OPENROUTER_API_KEY: 'o', AI_ROUTE_IMAGE: 'nano-banana@openrouter' });
+    setEnv({ ...KEYS, AI_ROUTE_IMAGE: 'nano-banana@openrouter' });
     const { route } = await import('./model-routing');
     expect(route('image')).toMatchObject({
       family: 'nano-banana',
@@ -114,11 +110,11 @@ describe('il registro delle rotte', () => {
     expect(route('image').endpoint).toBe('openrouter');
   });
 
-  it('senza chiave openrouter non è una rotta: si ripiega, rumorosamente', async () => {
-    setEnv({ GEMINI_API_KEY: 'g', AI_ROUTE_IMAGE: 'nano-banana@openrouter' });
+  it('senza chiave openrouter non è una rotta: si ripiega su kie, rumorosamente', async () => {
+    setEnv({ KIE_API_KEY: 'k', AI_ROUTE_IMAGE: 'nano-banana@openrouter' });
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const { route } = await import('./model-routing');
-    expect(route('image')).toMatchObject({ endpoint: 'google', provider: 'gemini' });
+    expect(route('image')).toMatchObject({ endpoint: 'kie', provider: 'kie' });
     expect(warn).toHaveBeenCalled();
     warn.mockRestore();
   });
@@ -127,9 +123,9 @@ describe('il registro delle rotte', () => {
     // `geminiTransport()` conosce solo kie e google: il testo verso openrouter atterrerebbe su
     // Google IN SILENZIO, cioè la rotta si legge come rispettata e non lo è. Vale identico per le
     // coppie che erano già cieche prima di openrouter — una regola sola, non un'eccezione.
-    for (const raw of ['gemini@openrouter', 'gemini@xiaomi', 'gemini@deepseek', 'mimo@kie']) {
+    for (const raw of ['gemini-tts@openrouter', 'grok@openrouter', 'gpt@openrouter']) {
       vi.resetModules();
-      setEnv({ ...KEYS, OPENROUTER_API_KEY: 'o', DEEPSEEK_API_KEY: 'd', AI_ROUTE_TEXT: raw });
+      setEnv({ ...KEYS, AI_ROUTE_TEXT: raw });
       const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const { route } = await import('./model-routing');
       route('text');
@@ -142,15 +138,14 @@ describe('il registro delle rotte', () => {
     const SLOT_VAR = { text: 'AI_ROUTE_TEXT', image: 'AI_ROUTE_IMAGE', tts: 'AI_ROUTE_TTS' } as const;
     for (const [raw, slot, endpoint] of [
       ['gemini@kie', 'text', 'kie'],
-      ['gemini@google', 'text', 'google'],
-      ['mimo@xiaomi', 'text', 'xiaomi'],
+      ['gemini@openrouter', 'text', 'openrouter'],
       ['grok@kie', 'text', 'kie'],
       ['nano-banana@openrouter', 'image', 'openrouter'],
-      ['nano-banana@google', 'image', 'google'],
+      ['nano-banana@kie', 'image', 'kie'],
       ['gemini-tts@kie', 'tts', 'kie']
     ] as const) {
       vi.resetModules();
-      setEnv({ ...KEYS, OPENROUTER_API_KEY: 'o', [SLOT_VAR[slot]]: raw });
+      setEnv({ ...KEYS, [SLOT_VAR[slot]]: raw });
       const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const { route } = await import('./model-routing');
       expect(route(slot).endpoint, raw).toBe(endpoint);
@@ -162,38 +157,30 @@ describe('il registro delle rotte', () => {
   it('le immagini vanno su openrouter per default, senza nessuna variabile', async () => {
     // Non e` il prezzo: kie ha il 3,5% di fallimenti e un p95 di 142,9s contro i 3,4s di
     // OpenRouter. Il default e` la disponibilita`, non il risparmio.
-    setEnv({ ...KEYS, OPENROUTER_API_KEY: 'o' });
     const { route } = await import('./model-routing');
     expect(route('image')).toMatchObject({ family: 'nano-banana', endpoint: 'openrouter' });
   });
 
-  it('il testo e la voce NON si spostano con le immagini', async () => {
-    setEnv({ ...KEYS, OPENROUTER_API_KEY: 'o' });
+  it('la voce NON si sposta col resto: OpenRouter non fa TTS', async () => {
     const { route } = await import('./model-routing');
-    expect(route('text').endpoint).toBe('google');
     expect(route('tts').endpoint).toBe('kie');
   });
 
   it('senza chiave openrouter le immagini ripiegano su kie, che resta il ripiego', async () => {
-    setEnv({ ...KEYS });
+    setEnv({ KIE_API_KEY: 'k' });
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const { route } = await import('./model-routing');
     expect(route('image').endpoint).toBe('kie');
     warn.mockRestore();
   });
 
-  it('IMAGE_PROVIDER=gemini VINCE ancora: e` scritta in produzione e tiene le immagini su Google', async () => {
-    // Il difetto piu` facile di questo cambio: girare il default e credere che basti. La vecchia
-    // variabile batte SLOT_DEFAULT, quindi finche` resta impostata su Vercel il deploy non sposta
-    // un solo render. Si scavalca con AI_ROUTE_IMAGE, che batte entrambe.
-    setEnv({ ...KEYS, OPENROUTER_API_KEY: 'o', IMAGE_PROVIDER: 'gemini' });
+  it('IMAGE_PROVIDER=gemini è ritirata: ignorata rumorosamente, non più vincente', async () => {
+    setEnv({ ...KEYS, IMAGE_PROVIDER: 'gemini' });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const { route } = await import('./model-routing');
-    expect(route('image').endpoint).toBe('google');
-
-    vi.resetModules();
-    setEnv({ ...KEYS, OPENROUTER_API_KEY: 'o', IMAGE_PROVIDER: 'gemini', AI_ROUTE_IMAGE: 'nano-banana@openrouter' });
-    const { route: route2 } = await import('./model-routing');
-    expect(route2('image').endpoint).toBe('openrouter');
+    expect(route('image').endpoint).toBe('openrouter');
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/IMAGE_PROVIDER=gemini.*rimosso/));
+    warn.mockRestore();
   });
 
   it('i modelli video: nuova variabile, vecchia variabile, default', async () => {
@@ -224,5 +211,74 @@ describe('i due assi non si collassano', () => {
     const { AI_PROVIDER } = await import('./xiaomi');
     expect(geminiTransport()).toBe('kie');
     expect(AI_PROVIDER).toBe('gemini');
+  });
+});
+
+// Restano due trasporti: openrouter serve, kie ripiega. Le tre uscite — google, xiaomi, deepseek —
+// non sono piu` rotte, e la cosa che deve reggere e` che chi le nomina se ne accorga: un valore
+// morto accettato in silenzio manda il traffico altrove e la rotta si legge come rispettata.
+describe('restano solo openrouter e kie', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    setEnv({ OPENROUTER_API_KEY: 'o', KIE_API_KEY: 'k' });
+  });
+
+  it('un valore che nomina un endpoint rimosso viene rifiutato RUMOROSAMENTE', async () => {
+    for (const raw of ['gemini@google', 'mimo@xiaomi', 'deepseek@deepseek', 'nano-banana@google']) {
+      vi.resetModules();
+      setEnv({ OPENROUTER_API_KEY: 'o', KIE_API_KEY: 'k', AI_ROUTE_TEXT: raw });
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const { route } = await import('./model-routing');
+      const chosen = route('text');
+      expect(warn, raw).toHaveBeenCalled();
+      expect(['kie', 'openrouter'], raw).toContain(chosen.endpoint);
+      warn.mockRestore();
+    }
+  });
+
+  it('le vecchie variabili che nominano un endpoint morto non atterrano altrove in silenzio', async () => {
+    for (const legacy of [
+      { GTM_PROVIDER: 'xiaomi' },
+      { GEMINI_TRANSPORT: 'google' },
+      { IMAGE_PROVIDER: 'gemini' },
+      { TTS_PROVIDER: 'gemini' }
+    ]) {
+      vi.resetModules();
+      setEnv({ OPENROUTER_API_KEY: 'o', KIE_API_KEY: 'k', ...legacy });
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const { route } = await import('./model-routing');
+      for (const slot of ['text', 'image', 'tts'] as const) {
+        expect(['kie', 'openrouter'], JSON.stringify(legacy)).toContain(route(slot).endpoint);
+      }
+      expect(warn, JSON.stringify(legacy)).toHaveBeenCalled();
+      warn.mockRestore();
+    }
+  });
+
+  it('openrouter e` il default dove puo` servire, kie dove no', async () => {
+    const { route } = await import('./model-routing');
+    expect(route('text').endpoint).toBe('openrouter');
+    expect(route('image').endpoint).toBe('openrouter');
+    // Il TTS resta su kie: MISURATO, non assunto. `lyria-3` su OpenRouter e` MUSICA, e
+    // `openai/gpt-audio` pretende stream:true per l'audio ma rifiuta il WAV in streaming —
+    // mentre il nostro tagliatore vuole L16 24 kHz mono 16 bit.
+    expect(route('tts').endpoint).toBe('kie');
+  });
+
+  it('il ripiego di ogni slot e` kie, mai altro', async () => {
+    setEnv({ KIE_API_KEY: 'k' });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { route } = await import('./model-routing');
+    for (const slot of ['text', 'image', 'tts'] as const) {
+      expect(route(slot).endpoint, slot).toBe('kie');
+    }
+    warn.mockRestore();
+  });
+
+  it('openrouter non sa fare il TTS, ed e` scritto nel registro', async () => {
+    const { missingCapabilities, can } = await import('./model-routing');
+    expect(can('openrouter', 'tts')).toBe(false);
+    expect(can('kie', 'tts')).toBe(true);
+    expect(missingCapabilities('openrouter')).toContain('tts');
   });
 });

--- a/src/lib/server/model-routing.ts
+++ b/src/lib/server/model-routing.ts
@@ -4,25 +4,36 @@
  * poteva togliergli in silenzio il grounding, gli embedding o i fps di un video, e il guasto
  * arrivava come una risposta plausibile invece che come un errore.
  *
+ * Restano DUE trasporti: **openrouter serve, kie ripiega.** Google, Xiaomi e DeepSeek sono usciti —
+ * non per prezzo, ma perché su questo non ci si fonda: kie fallisce il 3,5% dei render con un p95
+ * di 142,9s contro i 3,4s di OpenRouter, e DeepSeek falliva il 41,3% di 5.122 chiamate. kie resta
+ * perché il TTS lo fa e OpenRouter no, e perché un secondo trasporto vale più di zero.
+ *
  * Due assi, che non si collassano mai in uno:
- *   · famiglia — QUALE modello scrive. È la garanzia di qualità: `PIN_GEMINI` in 28 call site vuol
- *     dire "questo lavoro lo fa Gemini", e non deve mai diventare un interruttore di trasporto.
- *   · endpoint — CHI lo serve e chi ci fattura. Gemini lo servono sia Google sia kie.
+ *   · famiglia — QUALE modello scrive. È la garanzia di qualità: `PIN_GEMINI` vuol dire "questo
+ *     lavoro lo fa Gemini", e non deve mai diventare un interruttore di trasporto.
+ *   · endpoint — CHI lo serve e chi ci fattura. Gemini lo servono sia openrouter sia kie.
  * `AI_ROUTE_TEXT=gemini@kie` = famiglia Gemini, servita da kie. Senza `@`, l'endpoint di casa.
  *
- * PREZZI: nessuno qui, di proposito — stanno in `RATES` dentro `ai-log.ts` e ci arrivano per
- * `ai_calls.model`. Il registro dice solo sotto quale `provider` va scritta la riga.
+ * Le tabelle sono allineate apposta: aggiungere o togliere un endpoint è UNA RIGA per tabella, e
+ * `SERVED_BY` dice quali coppie hanno davvero un trasporto scritto. Una coppia che non ce l'ha non
+ * è una rotta: si rifiuta rumorosamente invece di atterrare altrove facendo credere di essere stata
+ * rispettata. Vale anche per le vecchie variabili che nominano un endpoint rimosso (`RETIRED_LEGACY`).
+ *
+ * PREZZI: nessuno qui, di proposito. Il costo lo dice chi ce lo fattura — `usage.cost` su
+ * openrouter, `credits_consumed` su kie. Il registro dice solo sotto quale `provider` va scritta
+ * la riga di `ai_calls`.
  */
 import { env } from '$env/dynamic/private';
 
 /** La famiglia di modelli: cosa scrive/disegna, indipendentemente da chi la serve. */
-export type ModelFamily = 'gemini' | 'mimo' | 'grok' | 'gpt' | 'deepseek' | 'nano-banana' | 'gemini-tts';
+export type ModelFamily = 'gemini' | 'grok' | 'gpt' | 'nano-banana' | 'gemini-tts';
 
 /** L'endpoint: chi serve la famiglia e chi ci manda il conto. */
-export type Endpoint = 'google' | 'kie' | 'xiaomi' | 'deepseek' | 'openrouter';
+export type Endpoint = 'kie' | 'openrouter';
 
 /** Il valore che finisce in `ai_calls.provider`. Uno per endpoint, non uno per famiglia. */
-export type LogProvider = 'gemini' | 'kie' | 'xiaomi' | 'deepseek' | 'openrouter';
+export type LogProvider = 'kie' | 'openrouter';
 
 /** Fatti MISURATI, non ipotesi di listino: ogni assenza qui sotto è una regressione vista. */
 export type Capability =
@@ -51,11 +62,13 @@ export type Capability =
   /** `embedContent`. */
   | 'embeddings'
   /** Generazione musicale (Lyria). */
-  | 'music';
+  | 'music'
+  /** Sintesi vocale: testo → parlato, con una voce scelta. NON è "un modello audio". */
+  | 'tts';
 
 const ALL: Capability[] = [
   'structured', 'tools', 'image-in', 'video-in', 'audio-in', 'grounding', 'thinking-level',
-  'media-in-tool-result', 'video-fps', 'prompt-cache', 'fast-first-token', 'embeddings', 'music'
+  'media-in-tool-result', 'video-fps', 'prompt-cache', 'fast-first-token', 'embeddings', 'music', 'tts'
 ];
 
 /**
@@ -63,8 +76,9 @@ const ALL: Capability[] = [
  * parte capace di tutto e si scopre incapace un guasto alla volta.
  */
 const MISSING: Record<Endpoint, Partial<Record<Capability, string>>> = {
-  google: {},
-  openrouter: {},
+  openrouter: {
+    tts: 'OpenRouter non fa sintesi vocale: lyria-3 è MUSICA, e gpt-audio pretende stream:true per l\'audio ma rifiuta il WAV in streaming — mentre il tagliatore vuole L16 24 kHz mono 16 bit'
+  },
   kie: {
     grounding: 'kie non restituisce groundingMetadata: le citazioni tornano vuote',
     'media-in-tool-result': 'kie scarta i media dentro i risultati dei tool, in silenzio',
@@ -73,29 +87,6 @@ const MISSING: Record<Endpoint, Partial<Record<Capability, string>>> = {
     'fast-first-token': 'kie impiega ~80s al primo token in streaming',
     embeddings: 'kie non serve embedContent',
     music: 'kie non serve Lyria'
-  },
-  xiaomi: {
-    // `mimo-v2.5-pro` rifiuta le immagini: solo il tier base le accetta, per questo
-    // `structuredXiaomi` cambia modello da solo quando ne arrivano.
-    'video-in': 'MiMo non accetta video in ingresso',
-    'audio-in': 'MiMo non accetta audio in ingresso',
-    grounding: 'MiMo ha una sua web search, non il grounding Google con citazioni',
-    'thinking-level': 'MiMo non espone un livello di ragionamento',
-    'media-in-tool-result': 'MiMo non accetta media nei risultati dei tool',
-    'video-fps': 'MiMo non legge video',
-    embeddings: 'MiMo non serve embedding',
-    music: 'MiMo non genera musica'
-  },
-  deepseek: {
-    'image-in': 'la API DeepSeek rifiuta l\'input immagine',
-    'video-in': 'DeepSeek non legge video',
-    'audio-in': 'DeepSeek non legge audio',
-    grounding: 'DeepSeek fa web search a modello, non grounding Google con citazioni',
-    'media-in-tool-result': 'DeepSeek non accetta media nei risultati dei tool',
-    'video-fps': 'DeepSeek non legge video',
-    'thinking-level': 'DeepSeek prende un blocco thinking iniettato, non un livello',
-    embeddings: 'DeepSeek non è configurato per gli embedding qui',
-    music: 'DeepSeek non genera musica'
   }
 };
 
@@ -109,13 +100,11 @@ const MISSING: Record<Endpoint, Partial<Record<Capability, string>>> = {
  * mandava il ripiego su Google saltando kie del tutto, che è l'opposto di «kie resta il ripiego».
  */
 const HOME: Record<ModelFamily, Endpoint> = {
-  gemini: 'google',
-  'gemini-tts': 'google',
+  gemini: 'kie',
+  'gemini-tts': 'kie',
   'nano-banana': 'kie',
-  mimo: 'xiaomi',
   grok: 'kie',
-  gpt: 'kie',
-  deepseek: 'deepseek'
+  gpt: 'kie'
 };
 
 /**
@@ -129,31 +118,23 @@ const HOME: Record<ModelFamily, Endpoint> = {
  * e basta.
  */
 const SERVED_BY: Record<ModelFamily, Endpoint[]> = {
-  gemini: ['google', 'kie'],
-  'gemini-tts': ['google', 'kie'],
-  'nano-banana': ['google', 'kie', 'openrouter'],
-  mimo: ['xiaomi'],
+  gemini: ['kie', 'openrouter'],
+  'gemini-tts': ['kie'],
+  'nano-banana': ['kie', 'openrouter'],
   grok: ['kie'],
-  gpt: ['kie'],
-  deepseek: ['deepseek']
+  gpt: ['kie']
 };
 
 /** Quale riga di `ai_calls.provider` scrive ogni endpoint. */
 const LOG_PROVIDER: Record<Endpoint, LogProvider> = {
-  google: 'gemini',
   openrouter: 'openrouter',
-  kie: 'kie',
-  xiaomi: 'xiaomi',
-  deepseek: 'deepseek'
+  kie: 'kie'
 };
 
 /** La chiave che ogni endpoint pretende. Senza, l'instradamento non ci prova nemmeno. */
 function endpointConfigured(endpoint: Endpoint): boolean {
   switch (endpoint) {
-    case 'google': return !!(env.GEMINI_API_KEY || env.GOOGLE_API_KEY);
     case 'kie': return !!env.KIE_API_KEY;
-    case 'xiaomi': return !!env.XIAOMI_MIMO_API_KEY;
-    case 'deepseek': return !!env.DEEPSEEK_API_KEY;
     case 'openrouter': return !!(env.OPENROUTER_API_KEY || env.LLM_API_KEY);
   }
 }
@@ -170,15 +151,12 @@ export type Route = { family: ModelFamily; endpoint: Endpoint; provider: LogProv
 export type Slot = 'text' | 'image' | 'tts';
 
 const SLOT_DEFAULT: Record<Slot, Route> = {
-  // Il lavoro di sfondo resta su Gemini servito da Google, come oggi.
-  text: r('gemini', 'google'),
-  // Le immagini su OpenRouter, e la ragione NON è il costo: kie fallisce il 3,5% dei render e ha
-  // un p95 di 142,9s (media 68,1s) contro i 3,4s di OpenRouter, che è anche sincrono. Sul modello
-  // che porta il 71% dei render OpenRouter costa il 2,5% MENO di Google; sul totale sono +$13/mese.
-  // Chi legge dopo cercherà un risparmio: non c'è, c'è la disponibilità. kie resta il ripiego.
+  // Il testo su OpenRouter: `structuredGemini` e `groundedGemini` ci passavano gia` da `llm.ts`,
+  // e il carico su Google si era fermato da solo il 30 agosto. Qui il default dice la verita`.
+  text: r('gemini', 'openrouter'),
+  // Non il prezzo: kie fallisce il 3,5% dei render con un p95 di 142,9s contro i 3,4s di OpenRouter.
   image: r('nano-banana', 'openrouter'),
-  // La voce su kie COSTA DI PIÙ (~3× a parità di battuta): lo scopo è togliere una dipendenza
-  // dalla API di Google, non risparmiare. Chi legge dopo darà per scontato il contrario.
+  // La voce resta su kie perche' OpenRouter NON fa sintesi vocale — misurato, sta in MISSING.
   tts: r('gemini-tts', 'kie')
 };
 
@@ -216,18 +194,37 @@ export function parseRoute(raw: string | undefined | null): Route | null {
 function legacyRoute(slot: Slot): Route | null {
   switch (slot) {
     case 'text': {
-      // GTM_PROVIDER sceglieva la FAMIGLIA (gemini|xiaomi|kie) e GEMINI_TRANSPORT l'ENDPOINT della
-      // sola famiglia Gemini: erano già i due assi, scritti come se fossero scollegati.
-      const gtm = env.GTM_PROVIDER?.trim().toLowerCase();
-      if (gtm === 'xiaomi') return r('mimo', 'xiaomi');
-      if (gtm === 'kie') return r('grok', 'kie');
+      // GTM_PROVIDER=kie e GEMINI_TRANSPORT=kie restano onorate: kie e` ancora un endpoint.
+      if (env.GTM_PROVIDER?.trim().toLowerCase() === 'kie') return r('grok', 'kie');
       if (env.GEMINI_TRANSPORT?.trim().toLowerCase() === 'kie') return r('gemini', 'kie');
       return null;
     }
     case 'image':
-      return env.IMAGE_PROVIDER?.trim().toLowerCase() === 'gemini' ? r('nano-banana', 'google') : null;
     case 'tts':
-      return env.TTS_PROVIDER?.trim().toLowerCase() === 'gemini' ? r('gemini-tts', 'google') : null;
+      return null;
+  }
+}
+
+/**
+ * I valori delle vecchie variabili che nominavano un endpoint ORA RIMOSSO. Accettarne uno in
+ * silenzio manderebbe il traffico altrove lasciando credere che la rotta sia stata rispettata: e`
+ * lo stesso guasto di una coppia senza trasporto, e si tratta allo stesso modo — si avvisa e si
+ * ignora, e decide il default.
+ */
+const RETIRED_LEGACY: Array<[name: string, value: string]> = [
+  ['GTM_PROVIDER', 'xiaomi'],
+  ['GEMINI_TRANSPORT', 'google'],
+  ['IMAGE_PROVIDER', 'gemini'],
+  ['TTS_PROVIDER', 'gemini'],
+  ['AI_PROVIDER', 'xiaomi']
+];
+
+function warnRetiredLegacy(): void {
+  for (const [name, dead] of RETIRED_LEGACY) {
+    if (env[name]?.trim().toLowerCase() !== dead) continue;
+    console.warn(
+      `[AI] ${name}=${dead} nomina un endpoint rimosso: ignorata. Restano kie e openrouter, e si scelgono con AI_ROUTE_*.`
+    );
   }
 }
 
@@ -254,11 +251,12 @@ function unroutable(chosen: Route): string | null {
 }
 
 export function route(slot: Slot): Route {
+  warnRetiredLegacy();
   const chosen = parseRoute(env[SLOT_ENV[slot]]) ?? legacyRoute(slot) ?? SLOT_DEFAULT[slot];
   const why = unroutable(chosen);
   if (!why) return chosen;
   const home = HOME[chosen.family];
-  const fallback = unroutable(r(chosen.family, home)) ? 'google' : home;
+  const fallback = unroutable(r(chosen.family, home)) ? 'kie' : home;
   console.warn(
     `[AI] ${SLOT_ENV[slot]} chiede ${chosen.family}@${chosen.endpoint}: ${why}. Ripiego su ${fallback}.`
   );

--- a/src/lib/server/motion-video/reference-tools.test.ts
+++ b/src/lib/server/motion-video/reference-tools.test.ts
@@ -1,4 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+// Il clip dentro il risultato di un tool e` una CAPACITA` DELL'ENDPOINT, non del modello: la
+// domanda passa dal registro. Senza una chiave la rotta ripiega su kie, che i media nei risultati
+// dei tool li scarta in silenzio — quindi qui si dichiara la rotta viva, altrimenti si misura il
+// ripiego invece della regola.
+vi.mock('$env/dynamic/private', () => ({ env: { OPENROUTER_API_KEY: 'o', KIE_API_KEY: 'k' } }));
+
 import { MOTION_REFERENCE_PROMPT, supportsClipInToolResult } from './reference-tools';
 
 describe('supportsClipInToolResult', () => {

--- a/src/lib/server/motion-video/reference-tools.ts
+++ b/src/lib/server/motion-video/reference-tools.ts
@@ -53,7 +53,7 @@ import {
 	type ReferenceMedia
 } from '$lib/server/motion-references';
 import { isPostsDesignEnabled } from '$lib/server/posts-design';
-import { geminiTransport } from '$lib/server/gemini';
+import { can, route } from '$lib/server/model-routing';
 import { cookbookNameForMechanism } from '$lib/motion-video/transitions-cookbook';
 
 /** Stills attached per watch. Four is what the craft judge uses to read a scene sequence. */
@@ -81,7 +81,10 @@ export type MotionWatchMode = (typeof MOTION_WATCH_MODES)[number];
  * GEMINI_TRANSPORT=kie renderebbe la degradazione invisibile due volte.
  */
 export function supportsClipInToolResult(modelId: string | null | undefined): boolean {
-	if (geminiTransport() === 'kie') return false;
+	// La domanda e` una capacita` dell'endpoint, e la risposta vive nel registro: chiederla a
+	// `geminiTransport()` era la stessa regola scritta in un secondo posto, e le due sarebbero
+	// divergute al primo endpoint nuovo. `graphic-review.ts` la chiedeva gia` cosi`.
+	if (!can(route('text').endpoint, 'media-in-tool-result')) return false;
 	return /^gemini-3[.-]/.test((modelId ?? '').trim());
 }
 

--- a/src/lib/server/onboarding-steps.ts
+++ b/src/lib/server/onboarding-steps.ts
@@ -737,8 +737,7 @@ async function processResearch(
         if (visualPlaybook) baseContext = [baseContext, visualPlaybook].filter(Boolean).join('\n\n');
         profile.ai_context = baseContext;
 
-        const { XIAOMI_ULTRASPEED_MODEL, AI_PROVIDER } = await import('$lib/server/xiaomi');
-        const fastModel = AI_PROVIDER === 'xiaomi' ? XIAOMI_ULTRASPEED_MODEL : undefined;
+        const fastModel = undefined;
 
         const report = await synthesizeStrategyReport(
           ai,
@@ -802,8 +801,7 @@ async function processResearch(
       if (planInputs.visualStyle) profile.visual_style = planInputs.visualStyle;
       const strategyBrief = strategyBriefFromReport(report);
       const benchmark = researchData?.benchmark ?? null;
-      const { XIAOMI_ULTRASPEED_MODEL: ULTRASPEED, AI_PROVIDER: PROVIDER } = await import('$lib/server/xiaomi');
-      const planModel = PROVIDER === 'xiaomi' ? ULTRASPEED : undefined;
+      const planModel = undefined;
 
       await pushProgress('editorialPlan', 'Drafting your editorial plan…');
       const topPosts = planInputs.topPosts;

--- a/src/lib/server/xiaomi.ts
+++ b/src/lib/server/xiaomi.ts
@@ -44,11 +44,7 @@ function toXiaomiContent(prompt: string, images?: ImagePart[]) {
 // "xiaomi che sta per prendere una sfilza di 401".
 const TEXT_ROUTE = route('text');
 export const AI_PROVIDER =
-  TEXT_ROUTE.provider === 'xiaomi'
-    ? 'xiaomi'
-    : TEXT_ROUTE.provider === 'kie' && TEXT_ROUTE.family !== 'gemini'
-      ? 'kie'
-      : 'gemini';
+  TEXT_ROUTE.provider === 'kie' && TEXT_ROUTE.family !== 'gemini' ? 'kie' : 'gemini';
 /**
  * Chi serve il testo DAVVERO, per la riga di boot. Non è la famiglia richiesta: da quando ogni
  * testo passa dal centralino, `AI_PROVIDER === 'gemini'` vuol dire "gateway", e la riga di prima
@@ -56,7 +52,6 @@ export const AI_PROVIDER =
  * diagnosi dalla parte sbagliata prima ancora di cominciare.
  */
 export function textRouteLabel(): string {
-  if (AI_PROVIDER === 'xiaomi') return `xiaomi (${XIAOMI_MODEL})`;
   if (AI_PROVIDER === 'kie') return `kie (${env.KIE_MODEL || 'grok-4-5'})`;
   if (!llmConfigured()) return 'not configured (LLM_API_KEY missing)';
   const host = llmBaseUrl().replace(/^https?:\/\//, '').split('/')[0];


### PR DESCRIPTION
## What?

`Endpoint` was `google | kie | xiaomi | deepseek | openrouter`. It is now **`kie | openrouter`**.

Registry only. The client modules stay until nothing calls them — that is a separate PR.

## Why?

Andrea's call, third time and explicit: *"Togli google, deepseek e xiaomi, per tutto: testo, immagini, video, embedding. Usa solo e soltanto openrouter (e kie di riserva)."*

The reason is not price, and it is the same for all three:

| | calls | failed | p95 |
|---|---|---|---|
| kie (images) | 199 | 3.5% | **142.9s** |
| **deepseek** | 5,122 | **41.3%** | — |
| OpenRouter | — | — | **3.4s** |

You do not build a product on a provider that gets two calls in five wrong. kie stays as the **fallback**, not a peer, because it does TTS and OpenRouter does not.

## How?

One line per table, which is exactly what the registry is for: `Endpoint`, `LogProvider`, `ModelFamily` (`mimo` and `deepseek` had a home only there), `HOME` (now all kie — it is the *fallback* table and there is one fallback left), `SERVED_BY`, `SLOT_DEFAULT`, `endpointConfigured`.

And `route()`'s last resort, which was `'google'`, becomes `'kie'` — the one place Google survived without being named.

**Retired legacy switches refuse loudly.** `GTM_PROVIDER=xiaomi`, `GEMINI_TRANSPORT=google`, `IMAGE_PROVIDER=gemini`, `TTS_PROVIDER=gemini`, `AI_PROVIDER=xiaomi` name endpoints that no longer exist. A `RETIRED_LEGACY` table warns and ignores them, rather than letting them land somewhere else while reading as honoured — the same defect `SERVED_BY` closed, which it would have been absurd to reopen through the back door. `GTM_PROVIDER=kie` and `GEMINI_TRANSPORT=kie` still work, because kie is still an endpoint.

**A rule that lived in two places, now one.** `supportsClipInToolResult` asked `geminiTransport() === 'kie'` whether a clip survives inside a tool result. That is an endpoint *capability*, and `graphic-review.ts` already asked it correctly via `can(route('text').endpoint, 'media-in-tool-result')`. The two would have diverged at the first new endpoint.

## Testing?

Red first. Five new tests in `model-routing.test.ts`, plus stale ones rewritten to the new intent:

- **a value naming a removed endpoint is refused loudly**, never silently rerouted
- old switches naming a dead endpoint do not land elsewhere in silence
- OpenRouter is the default where it can serve, kie where it cannot
- every slot's fallback is kie, never anything else
- OpenRouter cannot do TTS, and that is in the registry

<details>
<summary>Suite delta against the same base: zero</summary>

The local suite shows 30 failures — **identical on `b1ab0a89` without this change**, same 16 files. Verified by running the unmodified base in a scratch worktree, then diffing the failing-file sets:

```
=== files failing only with my change (empty = zero delta) ===
(empty)
```

Cause: worktrees symlink the main checkout's `node_modules`, whose `@anomalia/*` entries are symlinks into that checkout's `packages/` — and it sits at `5e8ff6dd`, 15 merges behind, so `QUERY_TABLES` from `@anomalia/api-contracts` resolves `undefined`. This is the hybrid trap `LESSONS.md` documents. CI installs fresh and is unaffected.

Four failures **were** mine and are fixed: two transport tests asserting Google is the default text transport, and two capability tests whose env predated the new default.
</details>

## Evidence

<details>
<summary>TTS does not move, and it is measured</summary>

On OpenRouter `lyria-3` is **music**, not speech synthesis. That leaves `openai/gpt-audio` and `gpt-audio-mini`:

```
modalities:['text','audio'] without stream  ->  400 "Audio output requires stream: true"
with stream:true and format wav             ->  400 "does not support 'wav' when stream=true"
```

Our cutter needs L16 **24 kHz mono 16-bit**, which kie already returns and `gemini-audio.ts` verifies before cutting. So voice stays on kie, and the absence is **declared** in `MISSING` as a `tts` capability rather than discovered in production.

The code already said so: the non-kie branch of `generateVoiceOver` threw `'TTS is kie-only. Google speech is not on the gateway.'` The `gemini-tts → google` row in `HOME` was already dead and nobody had noticed.
</details>

<details>
<summary>Embeddings were never a Google dependency, despite the name</summary>

`EMBEDDING_MODEL=google/gemini-embedding-001` **looks** like Google and is not: it goes through `llmClient()`, which is OpenRouter, and always has. Measured: `dimensions: 768` is honoured (omit it and you get 3072), and `llmEmbed` already drops any wrong-length vector instead of writing it.

Written down because that is precisely the name someone will "fix" by mistake.
</details>

## Anything Else?

**A declared departure from our own criterion.** The rule was: a row leaves when `ai_calls` says nothing reaches it. `deepseek` satisfies it literally — **zero calls in 24 hours**. `gemini` and `xiaomi` do not: `renderPostImage` (85) and `critiqueImage` (8) in the last 24h.

But that traffic comes from code that **no longer exists on `dev`** — #333 moved images to OpenRouter, #329 deleted the critic. Production runs two-day-old code, so `ai_calls` measures the past, not the present. Here the criterion is the **caller graph**, not the call log. That is a departure, so it is written down rather than applied quietly.

**Risk this carries:** removing Google removes the Google *fallback*. Previously a missing kie key fell back to Google; now a missing key is a missing-key error rather than a silent detour. That is the intent, and it is why the refusals are loud.

**Not in this PR, listed rather than half-done:**

- the client modules — `gemini.ts`, `xiaomi.ts` (imported by 15 files), `deepseek.ts`, `deepseek-search.ts`, `gemini-audio.ts` — stay until nothing calls them
- **their keys stay in `.env.example`** for the same reason: `deepseek-search.ts` still reads `DEEPSEEK_API_KEY` and `xiaomi.ts` still reads `XIAOMI_MIMO_API_KEY`. Removing them now would make that file lie the other way round
- the `RATES` rows for those endpoints' models
- the Google branch inside `renderPostImage`, which the registry can no longer reach
- `geminiTransport()` still returns `'google'` for an openrouter route — harmless today because the client it builds is the vestigial `ai` parameter that `structuredGemini`/`groundedGemini` ignore (`_ai`), but it goes with the client modules

**Keys still live on Vercel** and become secrets for nothing once the follow-up lands: `GEMINI_API_KEY`, `DEEPSEEK_API_KEY`, `XIAOMI_MIMO_API_KEY`, `XIAOMI_MODEL`.

**Coordination:** `aa927ab87bc092545` is adding the video slot to this same file. Agreed order — this merges first, they rebase. Their `route()` fallback question is answered here: the last resort is now `'kie'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
