### PR TITLE
Give the video a slot, and OpenRouter a transport to serve it

### DIFF
--- a/changelog/2026-09-05-video-openrouter-slot.md
+++ b/changelog/2026-09-05-video-openrouter-slot.md
@@ -1,0 +1,118 @@
+# Il video ha uno slot, e OpenRouter ha un trasporto per servirlo
+
+Il registro aveva quattro slot e il video non era uno di quelli. `videoModel(job)` non passava da
+`route()`: un video era l'id di un modello di kie, scelto da `AI_ROUTE_VIDEO_I2V`, e non esisteva
+il posto dove dire **chi lo serve**. Aggiungere `openrouter` agli endpoint due PR fa è quindi
+arrivato al testo e alle immagini e si è fermato prima del video — non per una scelta, per la
+mancanza dello slot.
+
+Adesso il video è uno slot come gli altri, una riga per tabella, e `AI_ROUTE_VIDEO` lo indirizza.
+
+## Le famiglie sono per (fornitore, modalità), e non è pedanteria
+
+`grok-imagine` non è `grok`. Sembra la stessa cosa e non lo è, perché `SERVED_BY` è indicizzato
+**per famiglia**: collegare il trasporto video di Grok su una famiglia condivisa col testo
+renderebbe valida anche `AI_ROUTE_TEXT=grok@openrouter`, che nessun trasporto serve. Quella rotta
+atterrerebbe altrove **in silenzio** — cioè si leggerebbe come rispettata senza esserlo, che è
+esattamente il guasto per cui `SERVED_BY` è stato scritto il giorno prima.
+
+Il file aveva già la convenzione giusta e la seguiva senza dirla: `gemini` e `gemini-tts` sono due
+famiglie, `nano-banana` è la modalità immagine di Google. Le tre nuove — `grok-imagine`, `seedance`,
+`kling` — la rendono esplicita nel tipo.
+
+## Nessun default si sposta
+
+`HOME` e `SLOT_DEFAULT` tengono il video su kie. Questa PR costruisce la strada, non ci manda il
+traffico: lo spostamento è una decisione che arriva dopo, coi numeri qui sotto, e un test la tiene
+ferma (*«il video resta su kie: questa rotta costruisce la strada, non ci manda il traffico»*).
+
+## Il trasporto è asincrono, quindi è la forma della #325 e non una seconda
+
+OpenRouter serve il video su una superficie **separata** dal catalogo chat: `POST /videos`,
+`GET /videos/{jobId}`, `GET /videos/models`. Cercare quei 28 modelli in `GET /api/v1/models` dà
+zero risultati e fa concludere che non esistano — è già successo.
+
+Essendo asincrono porta con sé lo stesso rischio che su kie è costato clip pagate due volte, quindi
+porta la stessa soluzione già in produzione, non una nuova:
+
+- l'esito è esplicito — `done` / `failed` / `timeout`, mai un `undefined` che li confonde;
+- una **scadenza porta il suo `jobId`**, e il tentativo dopo **riprende quello**. Il ritentativo
+  vero resta legittimo solo sui **rifiuti**, mai sulle scadenze;
+- una scadenza lascia una riga in `ai_calls` con l'id e **senza costo inventato**.
+
+`renderOpenrouterVideo` con `resumeJobId` non invia niente e va dritto al poll. Il test conta gli
+invii, perché è quello il soldo: se ne passassero due, staremmo pagando due volte la stessa clip.
+
+### Il trasporto si legge dalla RIGA, mai dalla variabile di adesso
+
+L'id che finisce su `video_renders.task_id` porta scritto chi lo può interrogare
+(`openrouter:<jobId>`). Senza il marchio, una riga consegnata prima di un deploy che cambia
+`AI_ROUTE_VIDEO` verrebbe cercata su kie dal riconciliatore, non trovata mai, e la clip **già
+pagata** resterebbe lì senza che nessuno se ne accorga. Per la stessa ragione l'upscale di kie
+rifiuta un id marchiato invece di spenderci un giro di rete.
+
+## Due trappole misurate, non dedotte
+
+**La clip non si scarica senza la chiave.** `unsigned_urls` punta a
+`/videos/{id}/content`, che senza `Authorization` risponde **401**; `persistMp4` faceva una `fetch`
+nuda. Il render sarebbe riuscito, sarebbe stato **fatturato**, e la clip sarebbe finita come «clip
+rendered but could not be stored». Misurato: 401 senza header, 200 e 6,5 MB con.
+
+**Una durata fuori scala non viene rifiutata: viene silenziosamente riportata dentro.** Un invio
+con `duration_seconds: 999` — nome di campo sbagliato, il vero è `duration` — è stato **accettato**
+(202) e ha prodotto 8 secondi, addebitati $0,64. Non c'è nessuna validazione che salvi da un campo
+scritto male: la clampatura resta nostra, in `videoModelCaps`.
+
+## I prezzi, misurati da entrambe le parti
+
+Il lato OpenRouter si legge da `pricing_skus` **senza spendere** — `pricing` è nullo su tutti e 28,
+e guardare lì fa concludere il falso. Il lato kie è quello che abbiamo davvero pagato in 30 giorni.
+
+Su Grok Imagine 1.5 il confronto è chiuso, con soldi veri da entrambe le parti:
+
+| Grok Imagine 1.5, 480p | kie (misurato, 30 render) | OpenRouter (`pricing_skus`, confermato) |
+|---|---|---|
+| al secondo | $0,0132 | $0,080 |
+| clip da 10s | **$0,132** | **$0,80** |
+
+**OpenRouter costa 6× kie su questo modello.** Il numero di OpenRouter non è una stima: un invio
+partito per sbaglio durante la ricerca ha reso 8 secondi a 480p e ha addebitato **$0,64**, cioè
+esattamente gli $0,08/s del listino. Il costo è stato reale ed è dichiarato qui.
+
+Su Seedance 2.5 il confronto **non si chiude senza spendere**, e va detto invece di riempirlo:
+
+- kie, misurato: **$114,11 per 63 render riusciti, $1,811 l'uno**, tipicamente 15s 480p (più 9
+  falliti, che non paghiamo). Da solo supera l'intero budget immagini del mese.
+- OpenRouter prezza Seedance **a token video** (`video_tokens: 0.0000107`), non al secondo. Quanti
+  token siano 15 secondi a 480p dipende da una tokenizzazione che il catalogo non pubblica: le due
+  formule plausibili danno **$0,82** e **$3,29** per una clip da 8s, cioè una più economica di kie e
+  l'altra quasi il doppio.
+
+Quindi: **prima di spostare Seedance serve UN render misurato**, non un'altra lettura di listino.
+Visto il 6× su Grok, l'ipotesi da battere è che OpenRouter costi di più anche qui.
+
+Messo accanto agli altri due assi — testo **neutro** (#335), immagini **+17%** (#333), video
+**+500%** — «tutto su OpenRouter» non ha lo stesso prezzo dappertutto, e il video è l'unico dove il
+conto è di un altro ordine di grandezza. È la ragione per cui il default resta su kie: dev'essere
+una decisione esplicita con quel numero davanti, non un effetto collaterale dell'uniformità.
+
+## Quello che NON è in questa PR, e perché
+
+- **`generate_audio`.** Il payload kie lo manda per le clip parlate; sulla superficie video di
+  OpenRouter non è documentato. Non l'ho inventato: un campo sconosciuto su un job a pagamento è un
+  esperimento che si paga. Va verificato prima di spostare qualunque clip con copione.
+- **I `reference_*` di Seedance.** Non esistono su OpenRouter. Un render con riferimenti resta su
+  kie, **rumorosamente**, invece di girare senza i riferimenti con un 200 e nessun errore.
+- **`refine` e `motion`.** Partono da un video che esiste gia' e vivono su `runTransformJob` (Aleph
+  ha perfino un endpoint kie tutto suo). La superficie `/videos` di OpenRouter esprime un
+  `frame_images`, non un video in ingresso: e' un altro mestiere, non lo stesso su un altro
+  trasporto. Restano su kie **senza consultare `AI_ROUTE_VIDEO`**, il che e' onesto solo finche' e'
+  scritto — quindi e' scritto qui.
+- **L'upscale.** Prende il `task_id` di kie e di nessun altro; su OpenRouter sarebbe un altro
+  modello (`black-forest-labs/flux-video-upscale`, prezzato a megapixel-secondo) e un altro
+  mestiere.
+- **I webhook di completamento.** OpenRouter accetta un `callback_url` e ci risparmierebbe il
+  polling. È la strada giusta il giorno che il traffico ci va davvero; costruirla adesso, per una
+  rotta che non porta traffico, sarebbe codice scritto per un'ipotesi.
+- **Il changelog pubblico.** Nessun default si muove: per chi usa il prodotto oggi non cambia
+  niente, e annunciare che «i video girano su OpenRouter» sarebbe falso.

--- a/src/lib/server/model-routing.test.ts
+++ b/src/lib/server/model-routing.test.ts
@@ -183,6 +183,70 @@ describe('il registro delle rotte', () => {
     warn.mockRestore();
   });
 
+  it('il video è uno slot, e si indirizza per famiglia e endpoint come gli altri', async () => {
+    setEnv({ ...KEYS, OPENROUTER_API_KEY: 'o', AI_ROUTE_VIDEO: 'seedance@openrouter' });
+    const { route } = await import('./model-routing');
+    expect(route('video')).toMatchObject({
+      family: 'seedance',
+      endpoint: 'openrouter',
+      provider: 'openrouter'
+    });
+  });
+
+  it('una coppia video senza trasporto non è una rotta: si ripiega, e dice perché', async () => {
+    // Famiglie che esistono e endpoint che esistono, ma nessun trasporto fra i due: e` il caso che
+    // NON deve atterrare zitto su kie mentre la variabile dice openrouter.
+    //
+    // Le coppie vanno riscelte quando `SERVED_BY` cambia, e non e` pedanteria: `gemini@openrouter`
+    // stava qui finche` il testo non aveva un trasporto, e adesso ce l'ha. Una coppia che diventa
+    // servita rende il test rosso — rumoroso, quindi innocuo; una che diventa NON PARSABILE lo
+    // farebbe restare verde misurando il ripiego al default invece dell'invariante. Sono due modi
+    // opposti di sbagliare, e solo uno si vede.
+    for (const raw of ['grok@openrouter', 'gpt@openrouter', 'gemini-tts@openrouter']) {
+      vi.resetModules();
+      setEnv({ ...KEYS, OPENROUTER_API_KEY: 'o', AI_ROUTE_VIDEO: raw });
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const { route } = await import('./model-routing');
+      expect(route('video').endpoint, raw).not.toBe('openrouter');
+      expect(warn, raw).toHaveBeenCalledWith(expect.stringMatching(/nessun trasporto/));
+      warn.mockRestore();
+    }
+  });
+
+  it('senza chiave openrouter il video non ci va: si ripiega su kie, rumorosamente', async () => {
+    setEnv({ KIE_API_KEY: 'k', GEMINI_API_KEY: 'g', AI_ROUTE_VIDEO: 'seedance@openrouter' });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { route } = await import('./model-routing');
+    expect(route('video')).toMatchObject({ endpoint: 'kie', provider: 'kie' });
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/la chiave manca/));
+    warn.mockRestore();
+  });
+
+  it('le coppie video che un trasporto serve davvero passano senza rumore', async () => {
+    for (const [raw, endpoint] of [
+      ['grok-imagine@kie', 'kie'],
+      ['seedance@kie', 'kie'],
+      ['kling@kie', 'kie'],
+      ['grok-imagine@openrouter', 'openrouter'],
+      ['seedance@openrouter', 'openrouter'],
+      ['kling@openrouter', 'openrouter']
+    ] as const) {
+      vi.resetModules();
+      setEnv({ ...KEYS, OPENROUTER_API_KEY: 'o', AI_ROUTE_VIDEO: raw });
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const { route } = await import('./model-routing');
+      expect(route('video').endpoint, raw).toBe(endpoint);
+      expect(warn, raw).not.toHaveBeenCalled();
+      warn.mockRestore();
+    }
+  });
+
+  it('il video resta su kie: questa rotta costruisce la strada, non ci manda il traffico', async () => {
+    setEnv({ ...KEYS, OPENROUTER_API_KEY: 'o' });
+    const { route } = await import('./model-routing');
+    expect(route('video')).toMatchObject({ endpoint: 'kie', provider: 'kie' });
+  });
+
   it('i modelli video: nuova variabile, vecchia variabile, default', async () => {
     setEnv({ ...KEYS, AI_ROUTE_VIDEO_I2V: 'bytedance/seedance-2-5', KIE_VIDEO_MODEL_T2V: 'vecchio/t2v' });
     const { videoModel } = await import('./model-routing');

--- a/src/lib/server/model-routing.ts
+++ b/src/lib/server/model-routing.ts
@@ -26,8 +26,23 @@
  */
 import { env } from '$env/dynamic/private';
 
-/** La famiglia di modelli: cosa scrive/disegna, indipendentemente da chi la serve. */
-export type ModelFamily = 'gemini' | 'grok' | 'gpt' | 'nano-banana' | 'gemini-tts';
+/**
+ * La famiglia di modelli: cosa scrive/disegna/gira, indipendentemente da chi la serve.
+ *
+ * Una famiglia per (fornitore, modalità), mai una sola per fornitore: `gemini` e `gemini-tts` sono
+ * già due, e `grok` (testo) e `grok-imagine` (video) restano due per la stessa ragione. Collassarle
+ * renderebbe `SERVED_BY` una bugia — collegare il trasporto video di Grok aprirebbe in silenzio la
+ * rotta del suo testo verso un endpoint che quel testo non serve.
+ */
+export type ModelFamily =
+  | 'gemini'
+  | 'grok'
+  | 'gpt'
+  | 'nano-banana'
+  | 'gemini-tts'
+  | 'grok-imagine'
+  | 'seedance'
+  | 'kling';
 
 /** L'endpoint: chi serve la famiglia e chi ci manda il conto. */
 export type Endpoint = 'kie' | 'openrouter';
@@ -104,7 +119,10 @@ const HOME: Record<ModelFamily, Endpoint> = {
   'gemini-tts': 'kie',
   'nano-banana': 'kie',
   grok: 'kie',
-  gpt: 'kie'
+  gpt: 'kie',
+  'grok-imagine': 'kie',
+  seedance: 'kie',
+  kling: 'kie'
 };
 
 /**
@@ -122,7 +140,10 @@ const SERVED_BY: Record<ModelFamily, Endpoint[]> = {
   'gemini-tts': ['kie'],
   'nano-banana': ['kie', 'openrouter'],
   grok: ['kie'],
-  gpt: ['kie']
+  gpt: ['kie'],
+  'grok-imagine': ['kie', 'openrouter'],
+  seedance: ['kie', 'openrouter'],
+  kling: ['kie', 'openrouter']
 };
 
 /** Quale riga di `ai_calls.provider` scrive ogni endpoint. */
@@ -148,7 +169,7 @@ export type Route = { family: ModelFamily; endpoint: Endpoint; provider: LogProv
  * La chat NON è uno slot, di proposito: misurata inutilizzabile su kie (~80s al primo token), e
  * `chat/model.ts` non deve avere un interruttore da sbagliare.
  */
-export type Slot = 'text' | 'image' | 'tts';
+export type Slot = 'text' | 'image' | 'tts' | 'video';
 
 const SLOT_DEFAULT: Record<Slot, Route> = {
   // Il testo su OpenRouter: `structuredGemini` e `groundedGemini` ci passavano gia` da `llm.ts`,
@@ -157,7 +178,12 @@ const SLOT_DEFAULT: Record<Slot, Route> = {
   // Non il prezzo: kie fallisce il 3,5% dei render con un p95 di 142,9s contro i 3,4s di OpenRouter.
   image: r('nano-banana', 'openrouter'),
   // La voce resta su kie perche' OpenRouter NON fa sintesi vocale — misurato, sta in MISSING.
-  tts: r('gemini-tts', 'kie')
+  tts: r('gemini-tts', 'kie'),
+  // Il video resta dov'è, e OpenRouter costa 6× kie su Grok Imagine (misurato): spostarlo e` una
+  // decisione esplicita, non un effetto dell'uniformita'. La famiglia qui e` la LINEA DI DEFAULT,
+  // non il modello del render — quello lo scelgono le preferenze del brand (`videoModelForRole`) e
+  // `videoModel(job)`. Del video slot il trasporto legge l'ENDPOINT.
+  video: r('grok-imagine', 'kie')
 };
 
 function r(family: ModelFamily, endpoint: Endpoint): Route {
@@ -202,6 +228,10 @@ function legacyRoute(slot: Slot): Route | null {
     case 'image':
     case 'tts':
       return null;
+    // Il video non ha mai avuto una variabile di TRASPORTO: `KIE_VIDEO_MODEL_*` sceglieva l'id del
+    // modello, e continua a farlo in `videoModel(job)`.
+    case 'video':
+      return null;
   }
 }
 
@@ -231,7 +261,8 @@ function warnRetiredLegacy(): void {
 const SLOT_ENV: Record<Slot, string> = {
   text: 'AI_ROUTE_TEXT',
   image: 'AI_ROUTE_IMAGE',
-  tts: 'AI_ROUTE_TTS'
+  tts: 'AI_ROUTE_TTS',
+  video: 'AI_ROUTE_VIDEO'
 };
 
 /**
@@ -291,9 +322,8 @@ export function requireCapabilities(slot: Slot, caps: Capability[]): Route {
   return chosen;
 }
 
-// Il video non ha due assi: Seedance e Grok Imagine sono ENTRAMBI modelli di kie, quindi la scelta
-// è solo l'id del modello. Le variabili hanno la stessa forma degli altri slot solo per
-// vocabolario, non perché il meccanismo sia lo stesso.
+// L'id del modello per ciascun mestiere video. È l'asse della FAMIGLIA sceso al modello singolo:
+// `AI_ROUTE_VIDEO` dice chi serve il render, queste variabili dicono quale modello gira.
 
 export type VideoJob = 'i2v' | 't2v' | 'upscale';
 

--- a/src/lib/server/openrouter-video.live.test.ts
+++ b/src/lib/server/openrouter-video.live.test.ts
@@ -1,0 +1,52 @@
+/**
+ * I test che parlano con OpenRouter DAVVERO, e che non spendono niente: il catalogo è una GET, e
+ * un invio con un id inesistente è rifiutato alla validazione, prima di qualunque render.
+ *
+ *   OPENROUTER_LIVE=1 npx vitest run src/lib/server/openrouter-video.live.test.ts
+ *
+ * Perché esistono: la mappa `openrouterId` è scritta a mano, una riga per modello, e un trattino
+ * al posto di un punto è un 400 al 100% in produzione che nessun test su payload finti può vedere.
+ * Il catalogo video vive su una superficie SEPARATA — cercarli in `GET /models` dà zero risultati
+ * e fa concludere che non esistano.
+ *
+ * NESSUN VIDEO VIENE GENERATO QUI. Un job vero costa fra $0,40 e $4 e non serve a sapere se parte.
+ */
+import { describe, expect, it } from 'vitest';
+import { VIDEO_MODEL_CHOICES, videoModelSpec } from '$lib/video-models';
+
+const LIVE = process.env.OPENROUTER_LIVE === '1' && !!process.env.OPENROUTER_API_KEY;
+const BASE = 'https://openrouter.ai/api/v1';
+const auth = () => ({ authorization: `Bearer ${process.env.OPENROUTER_API_KEY}` });
+
+describe.skipIf(!LIVE)('OpenRouter video, dal vivo', () => {
+  it('ogni openrouterId che mappiamo esiste davvero nel catalogo video', async () => {
+    const res = await fetch(`${BASE}/videos/models`, { headers: auth() });
+    expect(res.ok).toBe(true);
+    const catalogue = new Set(((await res.json())?.data ?? []).map((m: { id: string }) => m.id));
+
+    for (const choice of VIDEO_MODEL_CHOICES) {
+      const id = videoModelSpec(choice.id)?.openrouterId;
+      if (!id) continue;
+      expect(catalogue.has(id), `${choice.id} → ${id}`).toBe(true);
+    }
+  }, 30_000);
+
+  it('il prezzo si legge senza spendere: sta in pricing_skus, non in pricing', async () => {
+    const res = await fetch(`${BASE}/videos/models`, { headers: auth() });
+    const models = ((await res.json())?.data ?? []) as { id: string; pricing: unknown; pricing_skus: unknown }[];
+
+    const seedance = models.find((m) => m.id === 'bytedance/seedance-2.5');
+    expect(seedance?.pricing, 'pricing è nullo su tutti e 28: guardare lì fa concludere il falso').toBeFalsy();
+    expect(seedance?.pricing_skus).toBeTruthy();
+  }, 30_000);
+
+  it('un invio con un id inesistente è rifiutato alla validazione, e non costa niente', async () => {
+    const res = await fetch(`${BASE}/videos`, {
+      method: 'POST',
+      headers: { ...auth(), 'content-type': 'application/json' },
+      body: JSON.stringify({ model: 'bytedance/seedance-2-5', prompt: 'x' })
+    });
+    expect(res.status).toBe(400);
+    expect(String((await res.json())?.error?.message)).toMatch(/does not exist/i);
+  }, 30_000);
+});

--- a/src/lib/server/openrouter-video.test.ts
+++ b/src/lib/server/openrouter-video.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * IL VIDEO SU OPENROUTER È ASINCRONO, quindi porta con sé lo stesso rischio che su kie è costato
+ * render pagati due volte: la nostra scadenza non ferma il fornitore, che finisce e fattura. La
+ * forma è quella già in produzione (#325): l'esito è esplicito, una scadenza porta il `jobId`, e il
+ * tentativo successivo RIPRENDE quello. Il test che conta conta gli invii.
+ */
+
+const SUBMIT = 'https://openrouter.ai/api/v1/videos';
+
+const M = vi.hoisted(() => ({
+  env: {} as Record<string, string | undefined>,
+  logged: [] as Record<string, unknown>[]
+}));
+vi.mock('$env/dynamic/private', () => ({ env: M.env }));
+vi.mock('$lib/server/ai-log', () => ({
+  logAiCall: (e: Record<string, unknown>) => void M.logged.push(e),
+  getBrandContext: () => null
+}));
+
+let submits: number;
+let polls: string[];
+let states: unknown[];
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+}
+
+function stubFetch() {
+  const f = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (init?.method === 'POST' && url === SUBMIT) {
+      submits += 1;
+      return json({ id: `job-${submits}`, status: 'pending' }, 202);
+    }
+    polls.push(url.slice(SUBMIT.length + 1));
+    const next = states.shift() ?? { status: 'pending' };
+    return json(next);
+  });
+  vi.stubGlobal('fetch', f);
+  return f;
+}
+
+const RENDER = {
+  model: 'bytedance/seedance-2-5',
+  prompt: 'una tazza che fuma sul bancone',
+  durationSeconds: 8,
+  resolution: '480p',
+  aspectRatio: '9:16'
+};
+
+const DONE = {
+  status: 'completed',
+  unsigned_urls: ['https://openrouter.ai/api/v1/videos/job-1/content?index=0'],
+  usage: { cost: 0.64 }
+};
+
+describe('il trasporto video su OpenRouter', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    for (const k of Object.keys(M.env)) delete M.env[k];
+    M.env.OPENROUTER_API_KEY = 'o';
+    M.logged.length = 0;
+    submits = 0;
+    polls = [];
+    states = [];
+  });
+
+  it('un invio e un poll: la clip torna con il costo che OpenRouter fattura', async () => {
+    states = [DONE];
+    stubFetch();
+    const { renderOpenrouterVideo } = await import('./openrouter-video');
+    const out = await renderOpenrouterVideo(RENDER, { intervalMs: 1 });
+    expect(out).toMatchObject({ status: 'done', jobId: 'job-1', costUsd: 0.64 });
+    expect(out.status === 'done' && out.url).toMatch(/\/content\?index=0$/);
+    expect(submits).toBe(1);
+  });
+
+  it('un polling scaduto riprende lo stesso jobId invece di aprirne un altro', async () => {
+    states = [{ status: 'pending' }];
+    stubFetch();
+    const { renderOpenrouterVideo } = await import('./openrouter-video');
+
+    const first = await renderOpenrouterVideo(RENDER, { timeoutMs: 0, intervalMs: 1 });
+    expect(first).toMatchObject({ status: 'timeout', jobId: 'job-1' });
+    expect(submits).toBe(1);
+
+    // Il secondo tentativo NON è un invio: è lo stesso lavoro, già in corso e già fatturato.
+    states = [DONE];
+    const second = await renderOpenrouterVideo(RENDER, { resumeJobId: first.jobId, intervalMs: 1 });
+    expect(second).toMatchObject({ status: 'done', jobId: 'job-1' });
+    expect(submits, 'un secondo invio è una clip pagata due volte').toBe(1);
+    expect(polls).toEqual(['job-1', 'job-1']);
+  });
+
+  it('scaduto e fallito non collassano, e solo il fallito è ritentabile', async () => {
+    states = [{ status: 'failed', error: 'moderazione' }];
+    stubFetch();
+    const { renderOpenrouterVideo } = await import('./openrouter-video');
+    expect(await renderOpenrouterVideo(RENDER, { intervalMs: 1 })).toMatchObject({
+      status: 'failed',
+      jobId: 'job-1',
+      error: 'moderazione'
+    });
+  });
+
+  it('una scadenza lascia una riga con l’id e senza costo inventato', async () => {
+    states = [{ status: 'pending' }];
+    stubFetch();
+    const { renderOpenrouterVideo } = await import('./openrouter-video');
+    await renderOpenrouterVideo(RENDER, { timeoutMs: 0, intervalMs: 1 });
+
+    const row = M.logged.at(-1)!;
+    expect(row).toMatchObject({ provider: 'openrouter', ok: false });
+    expect(String(row.context)).toContain('job-1');
+    expect(row.flatCostUsd, 'ignoto non è zero').toBeUndefined();
+  });
+
+  it('LOG_PROVIDER scrive openrouter: dopo il deploy si vede da una query dove è andato il video', async () => {
+    states = [DONE];
+    stubFetch();
+    const { renderOpenrouterVideo } = await import('./openrouter-video');
+    await renderOpenrouterVideo(RENDER, { intervalMs: 1 });
+    expect(M.logged.at(-1)).toMatchObject({
+      provider: 'openrouter',
+      model: 'bytedance/seedance-2.5',
+      ok: true,
+      flatCostUsd: 0.64
+    });
+  });
+
+  it('un successo senza costo riportato non costa zero: costa ignoto', async () => {
+    states = [{ status: 'completed', unsigned_urls: ['https://openrouter.ai/x'] }];
+    stubFetch();
+    const { renderOpenrouterVideo } = await import('./openrouter-video');
+    await renderOpenrouterVideo(RENDER, { intervalMs: 1 });
+    expect(M.logged.at(-1)!.flatCostUsd).toBeUndefined();
+  });
+
+  it('gli id di kie diventano quelli di OpenRouter, e un modello che non c’è non è servito', async () => {
+    const { openrouterVideoModel } = await import('./openrouter-video');
+    expect(openrouterVideoModel('bytedance/seedance-2-5')).toBe('bytedance/seedance-2.5');
+    expect(openrouterVideoModel('grok-imagine-video-1-5-preview')).toBe('x-ai/grok-imagine-video-1.5');
+    expect(openrouterVideoModel('kling-3.0/video')).toBe('kwaivgi/kling-v3.0-pro');
+    expect(openrouterVideoModel('runway/aleph')).toBeUndefined();
+  });
+
+  it('la cover viaggia come frame_images, e il ratio sparisce quando c’è', async () => {
+    states = [DONE];
+    const f = stubFetch();
+    const { renderOpenrouterVideo } = await import('./openrouter-video');
+    await renderOpenrouterVideo({ ...RENDER, imageUrl: 'https://cdn.test/cover.png' }, { intervalMs: 1 });
+
+    const body = JSON.parse(String(f.mock.calls[0][1]!.body));
+    expect(body).toMatchObject({
+      model: 'bytedance/seedance-2.5',
+      duration: 8,
+      resolution: '480p',
+      frame_images: [
+        { type: 'image_url', image_url: { url: 'https://cdn.test/cover.png' }, frame_type: 'first_frame' }
+      ]
+    });
+    expect(body.aspect_ratio).toBeUndefined();
+  });
+
+  it('senza chiave non parte niente: non è un trasporto', async () => {
+    delete M.env.OPENROUTER_API_KEY;
+    stubFetch();
+    const { renderOpenrouterVideo } = await import('./openrouter-video');
+    expect(await renderOpenrouterVideo(RENDER, { intervalMs: 1 })).toMatchObject({ status: 'failed' });
+    expect(submits).toBe(0);
+  });
+
+  it('la clip si scarica solo con la chiave: un download nudo prende 401', async () => {
+    const { openrouterVideoHeaders } = await import('./openrouter-video');
+    expect(openrouterVideoHeaders()).toMatchObject({ authorization: 'Bearer o' });
+  });
+});

--- a/src/lib/server/openrouter-video.ts
+++ b/src/lib/server/openrouter-video.ts
@@ -1,0 +1,230 @@
+/**
+ * Il video su OpenRouter, che è una superficie SUA — `/videos`, non `/chat/completions`. Cercare i
+ * 28 modelli video in `GET /models` dà zero risultati e fa concludere che non esistano.
+ *
+ * A differenza delle immagini qui NON c'è il regalo del sincrono: si invia, si riceve un `jobId`, e
+ * si interroga finché non finisce. Cioè lo stesso rischio che su kie è costato clip pagate due
+ * volte, e quindi la stessa forma della soluzione già in produzione (#325):
+ *
+ *   · l'esito è esplicito — `done` / `failed` / `timeout`, mai un `undefined` che li confonde;
+ *   · una SCADENZA porta con sé il `jobId`, perché il lavoro è ancora del fornitore e lo fattura
+ *     lui: il tentativo dopo riprende quello, e ritentare da capo resta legittimo solo sui rifiuti;
+ *   · una scadenza lascia una riga in `ai_calls` con l'id e SENZA costo inventato — ignoto non è
+ *     zero, e non è nemmeno `null` per distrazione: `ok = false` dice che non l'abbiamo pagata noi.
+ *
+ * PREZZO: da `usage.cost`, la fattura di OpenRouter per QUESTO job. Mai da un listino a mano — la
+ * stima a priori sta in `pricing_skus` sul catalogo, e il conto vero lo dice chi lo manda.
+ */
+import { env } from '$env/dynamic/private';
+import { logAiCall } from '$lib/server/ai-log';
+import { clampVideoPrompt, videoModelSpec } from '$lib/video-models';
+
+const OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
+const POLL_INTERVAL_MS = 5000;
+const POLL_TIMEOUT_MS = 10 * 60 * 1000;
+
+export type OpenrouterVideoOutcome =
+  | { status: 'done'; url: string; jobId: string; costUsd?: number }
+  | { status: 'failed'; jobId?: string; error: string }
+  | { status: 'timeout'; jobId: string };
+
+export type OpenrouterVideoRender = {
+  model: string;
+  prompt: string;
+  durationSeconds: number;
+  resolution: string;
+  aspectRatio: string;
+  imageUrl?: string;
+  lastFrameUrl?: string;
+};
+
+function apiKey(): string | undefined {
+  return env.OPENROUTER_API_KEY?.trim() || env.LLM_API_KEY?.trim() || undefined;
+}
+
+function baseUrl(): string {
+  return (env.LLM_VIDEO_BASE_URL?.trim() || OPENROUTER_BASE_URL).replace(/\/$/, '');
+}
+
+/** Gli header valgono anche per SCARICARE la clip: `unsigned_urls` senza chiave torna 401. */
+export function openrouterVideoHeaders(): Record<string, string> {
+  return { authorization: `Bearer ${apiKey() ?? ''}` };
+}
+
+/** Undefined quando il catalogo video di OpenRouter non ha quel modello: non è servibile di qui. */
+export function openrouterVideoModel(model: string): string | undefined {
+  return videoModelSpec(model)?.openrouterId;
+}
+
+const JOB_TAG = 'openrouter:';
+
+/**
+ * L'id che finisce su `video_renders.task_id` porta scritto CHI lo può interrogare.
+ *
+ * Una riga in coda sopravvive al deploy che cambia `AI_ROUTE_VIDEO`: senza il marchio, il
+ * riconciliatore chiederebbe a kie un job di OpenRouter, non lo troverebbe mai, e la clip pagata
+ * resterebbe lì. Il trasporto si legge dalla RIGA, mai dalla variabile d'ambiente di adesso.
+ */
+export function tagOpenrouterJob(jobId: string): string {
+  return `${JOB_TAG}${jobId}`;
+}
+
+export function untagOpenrouterJob(taskId: string): string | undefined {
+  return taskId.startsWith(JOB_TAG) ? taskId.slice(JOB_TAG.length) : undefined;
+}
+
+type Frame = { type: 'image_url'; image_url: { url: string }; frame_type: 'first_frame' | 'last_frame' };
+
+export function buildOpenrouterVideoInput(
+  model: string,
+  render: OpenrouterVideoRender
+): Record<string, unknown> {
+  const frames: Frame[] = [];
+  if (render.imageUrl) {
+    frames.push({ type: 'image_url', image_url: { url: render.imageUrl }, frame_type: 'first_frame' });
+  }
+  if (render.imageUrl && render.lastFrameUrl) {
+    frames.push({ type: 'image_url', image_url: { url: render.lastFrameUrl }, frame_type: 'last_frame' });
+  }
+  return {
+    model,
+    prompt: clampVideoPrompt(render.prompt, render.model),
+    duration: render.durationSeconds,
+    resolution: render.resolution,
+    ...(frames.length ? { frame_images: frames } : { aspect_ratio: render.aspectRatio })
+  };
+}
+
+/**
+ * Consegna il lavoro e si ferma. Il percorso asincrono si ferma QUI: l'attesa non compra niente, e
+ * il `jobId` e' un appiglio durevole che qualunque processo puo' riprendere.
+ *
+ * Non scrive nessuna riga in `ai_calls`: il costo lo dira' il job finito, e un invio che non
+ * diventa mai una clip non si fattura — lo stesso contratto del percorso kie.
+ */
+export async function submitOpenrouterVideo(
+  render: OpenrouterVideoRender,
+  signal?: AbortSignal
+): Promise<{ jobId?: string; error?: string }> {
+  if (!apiKey()) return { error: 'OPENROUTER_API_KEY assente: questo render non ha un trasporto' };
+  const model = openrouterVideoModel(render.model);
+  if (!model) return { error: `${render.model} non è nel catalogo video di OpenRouter` };
+  return submit(model, render, signal);
+}
+
+async function submit(
+  model: string,
+  render: OpenrouterVideoRender,
+  signal?: AbortSignal
+): Promise<{ jobId?: string; error?: string }> {
+  const res = await fetch(`${baseUrl()}/videos`, {
+    method: 'POST',
+    headers: { ...openrouterVideoHeaders(), 'content-type': 'application/json' },
+    body: JSON.stringify(buildOpenrouterVideoInput(model, render)),
+    signal
+  });
+  const body = await res.json().catch(() => ({}));
+  const jobId = body?.id;
+  if (!res.ok || !jobId) {
+    return { error: String(body?.error?.message ?? body?.error ?? `HTTP ${res.status}`).slice(0, 400) };
+  }
+  return { jobId: String(jobId) };
+}
+
+const TERMINAL_FAILURES = ['failed', 'cancelled', 'canceled', 'expired'];
+
+/**
+ * Una interrogazione sola, senza attese: è ciò che serve al riconciliatore, che è un tick di cron e
+ * non un processo seduto su un timer. `pending` non è un esito, è "richiedi più tardi".
+ */
+export async function checkOpenrouterVideo(
+  jobId: string,
+  signal?: AbortSignal
+): Promise<OpenrouterVideoOutcome | { status: 'pending' }> {
+  const res = await fetch(`${baseUrl()}/videos/${encodeURIComponent(jobId)}`, {
+    headers: openrouterVideoHeaders(),
+    signal
+  });
+  // Un 5xx non è un render fallito: il job resta del fornitore, si richiede al giro dopo.
+  if (!res.ok) return { status: 'pending' };
+
+  const body = await res.json().catch(() => null);
+  const state = String(body?.status ?? '');
+  if (TERMINAL_FAILURES.includes(state)) {
+    const why = body?.error?.message ?? body?.error ?? state;
+    return { status: 'failed', jobId, error: String(why).slice(0, 400) };
+  }
+  if (state !== 'completed') return { status: 'pending' };
+
+  const url = body?.unsigned_urls?.[0];
+  if (!url) return { status: 'failed', jobId, error: 'completato senza nessuna clip' };
+  const cost = Number(body?.usage?.cost);
+  return { status: 'done', url: String(url), jobId, costUsd: Number.isFinite(cost) ? cost : undefined };
+}
+
+/**
+ * Invia (o RIPRENDE) e attende. `resumeJobId` è l'intera ragione per cui questa funzione non
+ * assomiglia a un ciclo qualunque: senza, un secondo tentativo dopo una scadenza aprirebbe un
+ * secondo job mentre il primo continua a renderizzare, e li paghiamo entrambi.
+ */
+export async function renderOpenrouterVideo(
+  render: OpenrouterVideoRender,
+  opts: {
+    resumeJobId?: string;
+    timeoutMs?: number;
+    intervalMs?: number;
+    signal?: AbortSignal;
+    label?: string;
+    context?: string;
+  } = {}
+): Promise<OpenrouterVideoOutcome> {
+  const label = opts.label ?? 'video.render';
+  const t0 = Date.now();
+
+  const model = openrouterVideoModel(render.model);
+  const done = (outcome: OpenrouterVideoOutcome): OpenrouterVideoOutcome => {
+    logAiCall({
+      label,
+      provider: 'openrouter',
+      model: model ?? render.model,
+      prompt: render.prompt,
+      ms: Date.now() - t0,
+      ok: outcome.status === 'done',
+      error: outcome.status === 'done' ? undefined : outcome.status === 'failed' ? outcome.error : 'timeout',
+      ...(outcome.status === 'done' && outcome.costUsd != null ? { flatCostUsd: outcome.costUsd } : {}),
+      context: [opts.context, `${render.durationSeconds}s ${render.resolution}`, outcome.jobId && `job ${outcome.jobId}`]
+        .filter(Boolean)
+        .join(' · ')
+    });
+    return outcome;
+  };
+
+  if (!apiKey()) return done({ status: 'failed', error: 'OPENROUTER_API_KEY assente: questo render non ha un trasporto' });
+  if (!model) return done({ status: 'failed', error: `${render.model} non è nel catalogo video di OpenRouter` });
+
+  let jobId = opts.resumeJobId;
+  if (!jobId) {
+    const created = await submit(model, render, opts.signal);
+    if (!created.jobId) return done({ status: 'failed', error: created.error ?? 'invio rifiutato' });
+    jobId = created.jobId;
+  }
+
+  const intervalMs = opts.intervalMs ?? POLL_INTERVAL_MS;
+  const deadline = Date.now() + (opts.timeoutMs ?? POLL_TIMEOUT_MS);
+  let first = true;
+  while (!opts.signal?.aborted) {
+    if (!first) {
+      if (Date.now() >= deadline) break;
+      await new Promise((r) => setTimeout(r, intervalMs));
+    }
+    first = false;
+    const outcome = await checkOpenrouterVideo(jobId, opts.signal);
+    if (outcome.status !== 'pending') return done(outcome);
+    if (Date.now() >= deadline) break;
+  }
+
+  // ABBANDONATO, non annullato: OpenRouter non espone un annullamento sulla superficie video, e il
+  // job resta suo. L'unica cosa onesta è riprendere questo id, mai aprirne un altro.
+  console.error(`[${label}] job openrouter ${jobId} non finito dopo ${Math.round((opts.timeoutMs ?? POLL_TIMEOUT_MS) / 1000)}s`);
+  return done({ status: 'timeout', jobId });
+}

--- a/src/lib/server/video.openrouter.test.ts
+++ b/src/lib/server/video.openrouter.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * IL CABLAGGIO, non il trasporto: che `AI_ROUTE_VIDEO` arrivi davvero fin dentro il render, e che
+ * un job consegnato a OpenRouter resti recuperabile DA CHI L'HA PRESO.
+ *
+ * La proprietà che costa se si rompe è l'ultima. Una riga in coda sopravvive al deploy che cambia
+ * la variabile: se il riconciliatore decidesse il fornitore da `AI_ROUTE_VIDEO` invece che dalla
+ * riga, dopo uno spostamento chiederebbe a kie un job di OpenRouter, non lo troverebbe mai, e la
+ * clip già pagata resterebbe lì senza che nessuno se ne accorga.
+ */
+
+const M = vi.hoisted(() => ({
+  env: {} as Record<string, string | undefined>,
+  logged: [] as Record<string, unknown>[]
+}));
+vi.mock('$env/dynamic/private', () => ({ env: M.env }));
+vi.mock('$lib/server/ai-log', () => ({
+  logAiCall: (e: Record<string, unknown>) => void M.logged.push(e),
+  getBrandContext: () => null,
+  withBrandContext: <T>(_b: string, fn: () => T) => fn()
+}));
+
+let hits: string[];
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+}
+
+function stubFetch(replies: Record<string, unknown> = {}) {
+  const f = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    hits.push(`${init?.method ?? 'GET'} ${url}`);
+    if (url.includes('openrouter.ai/api/v1/videos') && init?.method === 'POST') {
+      return json({ id: 'or-job-1', status: 'pending' }, 202);
+    }
+    if (url.includes('openrouter.ai/api/v1/videos/')) {
+      return json(replies.poll ?? { status: 'pending' });
+    }
+    if (url.includes('api.kie.ai')) return json({ data: { taskId: 'kie-1', state: 'waiting' } });
+    return new Response(new Uint8Array([1, 2, 3]), { status: 200 });
+  });
+  vi.stubGlobal('fetch', f);
+  return f;
+}
+
+const RENDER = {
+  model: 'bytedance/seedance-2-5',
+  prompt: 'p',
+  durationSeconds: 8,
+  resolution: '480p',
+  coverUrl: undefined,
+  persistOpts: { captions: false, tighten: false },
+  submittedAt: Date.now()
+};
+
+const supabase = {
+  storage: {
+    from: () => ({
+      upload: async () => ({ error: null }),
+      getPublicUrl: () => ({ data: { publicUrl: 'https://cdn.test/stored.mp4' } })
+    })
+  }
+} as never;
+
+describe('il cablaggio del video verso OpenRouter', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    for (const k of Object.keys(M.env)) delete M.env[k];
+    Object.assign(M.env, { KIE_API_KEY: 'k', OPENROUTER_API_KEY: 'o' });
+    M.logged.length = 0;
+    hits = [];
+  });
+
+  it('AI_ROUTE_VIDEO manda l’invio a OpenRouter, e l’id resta marchiato', async () => {
+    M.env.AI_ROUTE_VIDEO = 'seedance@openrouter';
+    stubFetch();
+    const { submitVideoRender } = await import('./video');
+    const out = await submitVideoRender('una tazza che fuma', { model: 'bytedance/seedance-2-5' });
+
+    expect(out?.taskId).toBe('openrouter:or-job-1');
+    expect(hits.some((h) => h.includes('api.kie.ai')), 'nessun task su kie').toBe(false);
+  });
+
+  it('il riconciliatore segue la RIGA, non la variabile di adesso', async () => {
+    // La variabile è tornata su kie dopo il deploy; il job però è di OpenRouter e resta suo.
+    M.env.AI_ROUTE_VIDEO = 'grok-imagine@kie';
+    stubFetch({
+      poll: {
+        status: 'completed',
+        unsigned_urls: ['https://openrouter.ai/api/v1/videos/or-job-1/content?index=0'],
+        usage: { cost: 0.64 }
+      }
+    });
+    const { finishVideoRender } = await import('./video');
+    const outcome = await finishVideoRender(supabase, 'user-1', {
+      ...RENDER,
+      taskId: 'openrouter:or-job-1'
+    });
+
+    expect(outcome.status).toBe('done');
+    expect(hits.some((h) => h.includes('api.kie.ai')), 'non ha chiesto a kie').toBe(false);
+    expect(hits.filter((h) => h.startsWith('POST')), 'nessun secondo invio').toEqual([]);
+    expect(M.logged.at(-1)).toMatchObject({
+      provider: 'openrouter',
+      model: 'bytedance/seedance-2.5',
+      ok: true,
+      flatCostUsd: 0.64
+    });
+  });
+
+  it('la clip si scarica con la chiave: senza, OpenRouter risponde 401', async () => {
+    M.env.AI_ROUTE_VIDEO = 'grok-imagine@kie';
+    const f = stubFetch({
+      poll: {
+        status: 'completed',
+        unsigned_urls: ['https://openrouter.ai/api/v1/videos/or-job-1/content?index=0'],
+        usage: { cost: 0.64 }
+      }
+    });
+    const { finishVideoRender } = await import('./video');
+    await finishVideoRender(supabase, 'user-1', { ...RENDER, taskId: 'openrouter:or-job-1' });
+
+    const download = f.mock.calls.find(([u]) => String(u).includes('/content?index=0'));
+    expect((download?.[1] as RequestInit)?.headers).toMatchObject({ authorization: 'Bearer o' });
+  });
+
+  it('un modello che OpenRouter non ha resta su kie, e lo dice', async () => {
+    M.env.AI_ROUTE_VIDEO = 'seedance@openrouter';
+    stubFetch();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { submitVideoRender } = await import('./video');
+    await submitVideoRender('p', { model: 'runway/aleph' });
+
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/non è nel suo catalogo video/));
+    expect(hits.some((h) => h.includes('api.kie.ai')), 'è andato su kie').toBe(true);
+    warn.mockRestore();
+  });
+
+  it('i riferimenti non passano da OpenRouter: quel render resta su kie, rumorosamente', async () => {
+    M.env.AI_ROUTE_VIDEO = 'seedance@openrouter';
+    stubFetch();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { submitVideoRender } = await import('./video');
+    await submitVideoRender('p', {
+      model: 'bytedance/seedance-2-5',
+      referenceImageUrls: ['https://cdn.test/ref.png']
+    });
+
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/riferimenti non passano/));
+    expect(hits.some((h) => h.includes('api.kie.ai'))).toBe(true);
+    warn.mockRestore();
+  });
+
+  it('l’upscale di kie non accetta un id di OpenRouter', async () => {
+    stubFetch();
+    const { upscaleVideo } = await import('./video');
+    expect(await upscaleVideo(supabase, 'user-1', 'openrouter:or-job-1', '720p')).toBeUndefined();
+    expect(hits, 'nemmeno un giro di rete').toEqual([]);
+  });
+});

--- a/src/lib/server/video.ts
+++ b/src/lib/server/video.ts
@@ -18,6 +18,7 @@ import {
   VIDEO_MODEL_CHOICES as SHARED_VIDEO_MODEL_CHOICES,
   isKnownVideoModelId,
   isSeedance25Model,
+  clampVideoPrompt,
   videoModelCaps,
   videoModelForRole,
   videoModelSpec,
@@ -25,6 +26,16 @@ import {
   type VideoRole
 } from '$lib/video-models';
 import { nearestAspectRatio } from '$lib/aspect-ratio';
+import { route } from '$lib/server/model-routing';
+import {
+  checkOpenrouterVideo,
+  openrouterVideoHeaders,
+  openrouterVideoModel,
+  renderOpenrouterVideo,
+  submitOpenrouterVideo,
+  tagOpenrouterJob,
+  untagOpenrouterJob
+} from '$lib/server/openrouter-video';
 
 // Generazione video vera, via kie. È il percorso a PAGAMENTO: la preview gratuita di onboarding
 // non passa mai di qui, quindi un utente free non incorre nel costo video.
@@ -63,12 +74,7 @@ export function clampVideoResolution(value: unknown): string {
 // What an approved clip gets upscaled to. kie's upscale accepts 720p | 1080p.
 export const UPSCALE_RESOLUTION = env.KIE_VIDEO_UPSCALE_RESOLUTION || '720p';
 
-/** Truncate a video prompt to the model's provider ceiling. Keeps the head, where the scene and
- *  the clean-frame rule live, and drops only the tail that already exceeded the model. */
-export function clampVideoPrompt(prompt: string, model: string): string {
-  const limit = videoModelCaps(model).maxPromptChars;
-  return prompt.length > limit ? prompt.slice(0, limit).trim() : prompt;
-}
+export { clampVideoPrompt } from '$lib/video-models';
 
 export type { VideoModelFamily, VideoModelCaps } from '$lib/video-models';
 export { videoModelCaps } from '$lib/video-models';
@@ -678,7 +684,32 @@ export function buildJobInput(
   };
 }
 
+/**
+ * CHI serve questo render. L'unico posto che lo decide, e l'unico che può dire di no a OpenRouter.
+ *
+ * Il registro sceglie l'endpoint; qui si aggiungono i due motivi per cui quella scelta non si può
+ * onorare per QUESTO render. Entrambi sono rumorosi di proposito: un ripiego silenzioso su kie
+ * mentre la variabile dice openrouter è esattamente il guasto che `SERVED_BY` esiste per impedire,
+ * e non lascerebbe traccia da nessuna parte.
+ */
+function videoEndpoint(model: string, opts: { hasRefs?: boolean } = {}): 'kie' | 'openrouter' {
+  if (route('video').endpoint !== 'openrouter') return 'kie';
+
+  if (!openrouterVideoModel(model)) {
+    console.warn(`[video] AI_ROUTE_VIDEO chiede openrouter ma ${model} non è nel suo catalogo video: ripiego su kie.`);
+    return 'kie';
+  }
+  // I `reference_*` di Seedance non esistono sulla superficie video di OpenRouter: mandarli lì
+  // significherebbe girare la clip SENZA i riferimenti, con un 200 e nessun errore.
+  if (opts.hasRefs) {
+    console.warn('[video] i riferimenti non passano da openrouter: questo render resta su kie.');
+    return 'kie';
+  }
+  return 'openrouter';
+}
+
 async function runVideoJob(
+  endpoint: 'kie' | 'openrouter',
   model: string,
   prompt: string,
   durationSeconds: number,
@@ -693,7 +724,15 @@ async function runVideoJob(
     referenceImageUrls?: string[];
     abortSignal?: AbortSignal;
   } = {}
-): Promise<VideoJobResult | undefined> {
+): Promise<(VideoJobResult & { costUsd?: number }) | undefined> {
+  if (endpoint === 'openrouter') {
+    const out = await renderOpenrouterVideo(
+      { model, prompt, durationSeconds, resolution, aspectRatio, imageUrl: opts.imageUrl, lastFrameUrl: opts.lastFrameUrl },
+      { signal: opts.abortSignal, context: 'inline' }
+    );
+    // Come su kie: una scadenza non riapre niente. Il job resta del fornitore col suo id.
+    return out.status === 'done' ? { url: out.url, taskId: tagOpenrouterJob(out.jobId), costUsd: out.costUsd } : undefined;
+  }
   const taskId = await createKieTask(
     model,
     buildJobInput(model, {
@@ -725,9 +764,9 @@ async function persistMp4(
   supabase: SupabaseClient,
   userId: string,
   srcUrl: string,
-  opts: { captions?: boolean; fontName?: string; tighten?: boolean } = {}
+  opts: { captions?: boolean; fontName?: string; tighten?: boolean; headers?: Record<string, string> } = {}
 ): Promise<string | undefined> {
-  const dl = await fetch(srcUrl);
+  const dl = await fetch(srcUrl, opts.headers ? { headers: opts.headers } : undefined);
   if (!dl.ok) return undefined;
   let bytes: Buffer = Buffer.from(await dl.arrayBuffer());
   // Il vuoto in testa e in coda si taglia PRIMA dei sottotitoli, o il timing non corrisponde al
@@ -900,8 +939,11 @@ async function runPreparedRender(
   const { model, prompt, durationSeconds, aspectRatio, resolution, cover, script, lastFrame } = p;
   const { referenceVideoUrls, referenceAudioUrls, referenceImageUrls } = p;
   const t0 = Date.now();
+  const endpoint = videoEndpoint(model, {
+    hasRefs: referenceVideoUrls.length > 0 || referenceAudioUrls.length > 0 || referenceImageUrls.length > 0
+  });
   try {
-    const job = await runVideoJob(model, prompt, durationSeconds, aspectRatio, resolution, {
+    const job = await runVideoJob(endpoint, model, prompt, durationSeconds, aspectRatio, resolution, {
       imageUrl: cover,
       hasScript: !!script,
       lastFrameUrl: lastFrame,
@@ -913,22 +955,29 @@ async function runPreparedRender(
     // L'addebito ESATTO di kie: un job fallito o scaduto kie non lo fattura, quindi non lo
     // fatturiamo al brand. Il brandId arriva dallo scope, quindi il costo cade in ai_calls e da lì
     // nella quota.
-    logAiCall({
-      label: 'video.render',
-      provider: 'kie',
-      model,
-      prompt,
-      ms: Date.now() - t0,
-      ok: !!job,
-      error: job ? undefined : 'no video returned',
-      ...(job?.credits != null
-        ? { providerCredits: job.credits, flatCostUsd: Math.round(job.credits * KIE_CREDIT_USD * 1e6) / 1e6 }
-        : {}),
-      context: `${durationSeconds}s ${resolution}`
-    });
+    // Su openrouter la riga in `ai_calls` l'ha gia' scritta il trasporto, che e' l'unico a
+    // conoscere il `jobId` e il costo fatturato — anche quando il job e' SCADUTO e qui non arriva.
+    if (endpoint === 'kie') {
+      logAiCall({
+        label: 'video.render',
+        provider: 'kie',
+        model,
+        prompt,
+        ms: Date.now() - t0,
+        ok: !!job,
+        error: job ? undefined : 'no video returned',
+        ...(job?.credits != null
+          ? { providerCredits: job.credits, flatCostUsd: Math.round(job.credits * KIE_CREDIT_USD * 1e6) / 1e6 }
+          : {}),
+        context: `${durationSeconds}s ${resolution}`
+      });
+    }
     if (!job) return undefined;
 
-    const url = await persistMp4(supabase, userId, job.url, p.persistOpts);
+    const url = await persistMp4(supabase, userId, job.url, {
+      ...p.persistOpts,
+      ...(endpoint === 'openrouter' ? { headers: openrouterVideoHeaders() } : {})
+    });
     if (!url) return undefined;
     // taskId e risoluzione tornano indietro perché sono ciò che rende possibile l'upscale
     // all'approvazione senza rigenerare la clip. `thumbnailUrl` è la COVER: senza restituirla il
@@ -1108,8 +1157,42 @@ export async function submitVideoRender(
   // so the caller ships the cover. Without this a blip unwinds into the caller's outer catch and
   // takes the whole post with it — including the cover image already generated and paid for.
   // CreditsExhaustedError is re-thrown: that is a message for the user, not a render failure.
+  const endpoint = videoEndpoint(p.model, {
+    hasRefs:
+      p.referenceVideoUrls.length > 0 || p.referenceAudioUrls.length > 0 || p.referenceImageUrls.length > 0
+  });
+
   let taskId: string | undefined;
   try {
+    if (endpoint === 'openrouter') {
+      // Si INVIA e basta: il poll lo fara' il riconciliatore, sullo stesso id, quante volte serve.
+      const out = await submitOpenrouterVideo(
+        {
+          model: p.model,
+          prompt: p.prompt,
+          durationSeconds: p.durationSeconds,
+          resolution: p.resolution,
+          aspectRatio: p.aspectRatio,
+          imageUrl: p.cover,
+          lastFrameUrl: p.lastFrame
+        },
+        opts.abortSignal
+      );
+      if (!out.jobId) {
+        console.error(`[video] submit openrouter rifiutato: ${out.error}`);
+        return undefined;
+      }
+      return {
+        taskId: tagOpenrouterJob(out.jobId),
+        model: p.model,
+        prompt: p.prompt,
+        durationSeconds: p.durationSeconds,
+        resolution: p.resolution,
+        coverUrl: p.cover,
+        persistOpts: p.persistOpts,
+        submittedAt: Date.now()
+      };
+    }
     taskId = await createKieTask(
       p.model,
       buildJobInput(p.model, {
@@ -1162,6 +1245,11 @@ export async function finishVideoRender(
   userId: string,
   submitted: SubmittedVideoRender
 ): Promise<VideoRenderOutcome> {
+  // CHI interrogare lo dice la RIGA, non `AI_ROUTE_VIDEO` di adesso: una clip consegnata prima di
+  // un deploy che sposta la variabile deve restare recuperabile da chi l'ha presa in carico.
+  const openrouterJobId = untagOpenrouterJob(submitted.taskId);
+  if (openrouterJobId) return finishOpenrouterRender(supabase, userId, submitted, openrouterJobId);
+
   if (!env.KIE_API_KEY) throw new Error('KIE_API_KEY not configured');
 
   const res = await fetch(
@@ -1222,6 +1310,51 @@ export async function finishVideoRender(
   };
 }
 
+/**
+ * L'altra meta' di `finishVideoRender`, per i job che vivono su OpenRouter.
+ *
+ * Una interrogazione sola, mai un ciclo: `pending` vuol dire "richiedi al giro dopo", e nessun
+ * secondo invio parte da qui — il job e' gia' del fornitore, e riaprirlo lo pagherebbe due volte.
+ */
+async function finishOpenrouterRender(
+  supabase: SupabaseClient,
+  userId: string,
+  submitted: SubmittedVideoRender,
+  jobId: string
+): Promise<VideoRenderOutcome> {
+  const outcome = await checkOpenrouterVideo(jobId);
+  if (outcome.status === 'pending') return { status: 'pending' };
+  if (outcome.status === 'failed') return { status: 'failed', error: outcome.error };
+  if (outcome.status === 'timeout') return { status: 'pending' };
+
+  // Si RIOSPITA prima e si fattura dopo: il download puo' fallire, e chi ci richiama e' un cron.
+  const url = await persistMp4(supabase, userId, outcome.url, {
+    ...submitted.persistOpts,
+    headers: openrouterVideoHeaders()
+  });
+  if (!url) return { status: 'failed', error: 'clip rendered but could not be stored' };
+
+  logAiCall({
+    label: 'video.render',
+    provider: 'openrouter',
+    model: openrouterVideoModel(submitted.model) ?? submitted.model,
+    prompt: submitted.prompt,
+    ms: Math.max(0, Date.now() - submitted.submittedAt),
+    ok: true,
+    // Ignoto non e' zero: se OpenRouter non riporta il costo, la riga lo dice invece di inventarlo.
+    ...(outcome.costUsd != null ? { flatCostUsd: outcome.costUsd } : {}),
+    context: `${submitted.durationSeconds}s ${submitted.resolution} (async) · job ${jobId}`
+  });
+
+  return {
+    status: 'done',
+    url,
+    durationSeconds: submitted.durationSeconds,
+    resolution: submitted.resolution,
+    thumbnailUrl: submitted.coverUrl
+  };
+}
+
 // Re-render an ALREADY GENERATED clip at a higher resolution, without paying to generate it again.
 // kie's upscale takes the original job's task_id (never a URL), which is exactly why renderVideo
 // hands the id back and the post row keeps it.
@@ -1242,6 +1375,10 @@ export async function upscaleVideo(
   resolution: string = UPSCALE_RESOLUTION
 ): Promise<{ url: string; resolution: string } | undefined> {
   if (!env.KIE_API_KEY || !taskId) return undefined;
+
+  // L'upscale di kie prende un task_id DI KIE. Un id di OpenRouter qui otterrebbe un 404 dopo un
+  // giro di rete, e nel caso peggiore l'id di qualcun altro.
+  if (untagOpenrouterJob(taskId)) return undefined;
 
   // Upscale is a Grok-Imagine endpoint that takes a Grok task_id. Seedance (and unknown) drafts
   // have no matching upscale path — skip rather than burn a round-trip that will fail.

--- a/src/lib/video-models.ts
+++ b/src/lib/video-models.ts
@@ -120,6 +120,16 @@ export type VideoModelSpec = VideoModelCaps & {
    */
   kieId?: Partial<Record<VideoRole, string>>;
   /**
+   * Lo stesso modello nel catalogo video di OpenRouter, che lo chiama in un altro modo: i punti al
+   * posto dei trattini, il fornitore davanti. Uno solo per riga — `frame_images` decide il verso, e
+   * i due id kie di Grok collassano in uno.
+   *
+   * Assente vuol dire che su OpenRouter quel modello NON C'È, e il trasporto non lo può servire. È
+   * il motivo per cui questa è una riga della tabella e non una regex: un id ricostruito a naso
+   * prende un 400 dopo un giro di rete, o peggio ne colpisce un altro.
+   */
+  openrouterId?: string;
+  /**
    * Come si chiama, nel payload kie, il campo che porta il video sorgente. Solo per `refine` e
    * `motion` — gli altri due ruoli non hanno un video in ingresso.
    */
@@ -146,6 +156,7 @@ const SPECS: VideoModelSpec[] = [
   {
     id: SEEDANCE_25_MODEL,
     label: 'Seedance 2.5',
+    openrouterId: 'bytedance/seedance-2.5',
     match: /^bytedance\/seedance-2-5\b/,
     roles: ['text', 'image'],
     endpoint: 'jobs',
@@ -161,6 +172,7 @@ const SPECS: VideoModelSpec[] = [
   {
     id: 'bytedance/seedance-2',
     label: 'Seedance 2',
+    openrouterId: 'bytedance/seedance-2.0',
     match: /^bytedance\/seedance-2\b/,
     roles: ['text', 'image'],
     endpoint: 'jobs',
@@ -176,6 +188,7 @@ const SPECS: VideoModelSpec[] = [
   {
     id: 'bytedance/seedance-2-fast',
     label: 'Seedance 2 Fast',
+    openrouterId: 'bytedance/seedance-2.0-fast',
     match: /^bytedance\/seedance-2-fast\b/,
     roles: ['text', 'image'],
     endpoint: 'jobs',
@@ -191,6 +204,7 @@ const SPECS: VideoModelSpec[] = [
   {
     id: 'bytedance/seedance-2-mini',
     label: 'Seedance 2 Mini',
+    openrouterId: 'bytedance/seedance-2.0-mini',
     match: /^bytedance\/seedance-2-mini\b/,
     roles: ['text', 'image'],
     endpoint: 'jobs',
@@ -206,6 +220,7 @@ const SPECS: VideoModelSpec[] = [
   {
     id: GROK_IMAGINE_VIDEO_MODEL,
     label: 'Grok Imagine',
+    openrouterId: 'x-ai/grok-imagine-video-1.5',
     match: /^grok-imagine-video-1-5/,
     roles: ['text', 'image'],
     endpoint: 'jobs',
@@ -222,6 +237,7 @@ const SPECS: VideoModelSpec[] = [
   {
     id: 'grok-imagine/image-to-video',
     label: 'Grok Imagine v1',
+    openrouterId: 'x-ai/grok-imagine-video',
     match: /^grok-imagine\//,
     roles: ['text', 'image'],
     endpoint: 'jobs',
@@ -241,6 +257,7 @@ const SPECS: VideoModelSpec[] = [
     // `kling-3.0/motion-control` e' un altro modello, che vuole ANCHE il video guida.
     id: KLING_3_VIDEO_MODEL,
     label: 'Kling 3.0',
+    openrouterId: 'kwaivgi/kling-v3.0-pro',
     match: /^kling-3\.0\//,
     roles: ['text', 'image', 'motion'],
     endpoint: 'jobs',
@@ -319,6 +336,15 @@ export type VideoModelChoiceId = (typeof VIDEO_MODEL_CHOICES)[number]['id'];
 export function isKnownVideoModelId(value: unknown): value is VideoModelChoiceId {
   const v = String(value ?? '').trim();
   return VIDEO_MODEL_CHOICES.some((c) => c.id === v);
+}
+
+/**
+ * Taglia un brief al tetto del modello che lo eseguirà. Tiene la testa, dove stanno la scena e la
+ * regola del frame pulito, e butta solo la coda che il modello avrebbe rifiutato comunque.
+ */
+export function clampVideoPrompt(prompt: string, model: string): string {
+  const limit = videoModelCaps(model).maxPromptChars;
+  return prompt.length > limit ? prompt.slice(0, limit).trim() : prompt;
 }
 
 /** Lo spec di un modello, da qualunque forma quell'id arrivi. */


### PR DESCRIPTION
## What?

Il registro delle rotte aveva quattro slot e il video non era uno di quelli. `videoModel(job)` non
passava da `route()`: un video era l'**id di un modello di kie**, e non esisteva il posto dove dire
*chi lo serve*. Aggiungere `openrouter` agli endpoint (#327) è quindi arrivato al testo e alle
immagini e si è fermato prima del video — non per una scelta, per la mancanza dello slot.

Questa PR fa due cose, in due commit separati:

1. **Il video diventa uno slot vero**, una riga per tabella (`ModelFamily`, `HOME`, `SERVED_BY`,
   `SLOT_DEFAULT`, `SLOT_ENV`, `legacyRoute`), indirizzabile con `AI_ROUTE_VIDEO=<famiglia>@<endpoint>`.
2. **OpenRouter ha un trasporto scritto** per servirlo: `POST /videos`, `GET /videos/{jobId}`.

**Nessun default si sposta.** `HOME` e `SLOT_DEFAULT` tengono il video su kie, e un test lo tiene
fermo. Questa PR costruisce la strada; mandarci il traffico è una decisione successiva, e i numeri
per prenderla sono qui sotto.

## Why?

`SERVED_BY` è stato aggiunto ieri perché una rotta senza trasporto **atterrava in silenzio**
altrove: si leggeva come rispettata senza esserlo, e non lasciava traccia da nessuna parte. Aprire
lo stesso buco sull'asse video sarebbe stato il difetto peggiore consegnabile, quindi **`SERVED_BY`
copre lo slot video dal primo commit**: `seedance@google` non è una rotta, e si ripiega
rumorosamente dicendo *quale* dei due motivi.

## How?

### Le famiglie sono per (fornitore, modalità), e non è pedanteria

`grok-imagine` **non** è `grok`. `SERVED_BY` è indicizzato per famiglia: fonderle renderebbe valida
anche `AI_ROUTE_TEXT=grok@openrouter`, che nessun trasporto serve, e quella rotta atterrerebbe
altrove in silenzio. Il file aveva già la convenzione (`gemini` vs `gemini-tts`, `nano-banana`);
le tre nuove famiglie — `grok-imagine`, `seedance`, `kling` — la rendono esplicita nel tipo.

### Il trasporto è asincrono, quindi è la forma della #325 e non una seconda

Non ho inventato una seconda soluzione per un problema già risolto:

- l'esito è esplicito — `done` / `failed` / `timeout`, mai un `undefined` che li confonde;
- una **scadenza porta il suo `jobId`**, e il tentativo dopo **riprende quello**. Il ritentativo
  vero resta legittimo **solo sui rifiuti**, mai sulle scadenze;
- una scadenza lascia una riga in `ai_calls` con l'id e **senza costo inventato**.

### Il trasporto si legge dalla RIGA, mai dalla variabile di adesso

L'id salvato su `video_renders.task_id` porta scritto chi lo può interrogare (`openrouter:<jobId>`).
Senza il marchio, una riga consegnata prima di un deploy che cambia `AI_ROUTE_VIDEO` verrebbe
cercata su kie dal riconciliatore, non trovata mai, e **una clip già pagata resterebbe lì**. Per la
stessa ragione l'upscale di kie rifiuta un id marchiato invece di spenderci un giro di rete.

### Un punto solo decide, e dice sempre di no ad alta voce

`videoEndpoint()` è l'unico posto che sceglie il fornitore, e l'unico che può rifiutare OpenRouter:
per un modello fuori catalogo, o per un render con `reference_*` (che su OpenRouter non esistono, e
girerebbero **senza i riferimenti** con un 200 e nessun errore). Entrambi i rifiuti sono rumorosi.

## Testing?

Rosso osservato prima, sempre. **Il test che vale più di tutti** — una coppia video senza trasporto
— scritto per primo:

```
FAIL model-routing.test.ts > il video è uno slot, e si indirizza per famiglia e endpoint come gli altri
FAIL model-routing.test.ts > una coppia video senza trasporto non è una rotta: si ripiega, e dice perché
FAIL model-routing.test.ts > senza chiave openrouter il video non ci va: si ripiega su kie, rumorosamente
FAIL model-routing.test.ts > le coppie video che un trasporto serve davvero passano senza rumore
FAIL model-routing.test.ts > il video resta su kie: questa rotta costruisce la strada, non ci manda il traffico
     Tests  5 failed | 18 passed (23)

TypeError: Cannot read properties of undefined (reading 'family')
 ❯ unroutable src/lib/server/model-routing.ts:240:25
```

I 6 test di cablaggio sono stati scritti dopo il codice, quindi **ho verificato che siano portanti**
rimuovendo una guardia alla volta:

<details><summary>ogni guardia rimossa fa cadere il suo test</summary>

```
# tolto il dispatch dalla riga, la guardia dell'upscale, il rifiuto dei riferimenti
FAIL il riconciliatore segue la RIGA, non la variabile di adesso
FAIL la clip si scarica con la chiave: senza, OpenRouter risponde 401
FAIL i riferimenti non passano da OpenRouter: quel render resta su kie, rumorosamente
FAIL l'upscale di kie non accetta un id di OpenRouter
     Tests  4 failed | 2 passed (6)

# tolto l'arrivo del registro dentro il render
FAIL AI_ROUTE_VIDEO manda l'invio a OpenRouter, e l'id resta marchiato
FAIL un modello che OpenRouter non ha resta su kie, e lo dice
FAIL i riferimenti non passano da OpenRouter: quel render resta su kie, rumorosamente
     Tests  3 failed | 3 passed (6)
```
</details>

Il test del **ritentativo** conta gli invii, perché è quello il soldo: `expect(submits, 'un secondo
invio è una clip pagata due volte').toBe(1)`. Se passasse creando due job non misurerebbe niente.

```
vitest: model-routing, openrouter-video, video.openrouter, video, video-render-queue,
        openrouter-image, kie-jobs, kie-jobs.timeout, video-models, media-model-slots
        → 179 passed
svelte-check → 0 errori nei file toccati (i 344 del repo sono preesistenti)
```

Entrambi i commit sono verdi **in isolamento** (`model-routing.test.ts` 26/26 su HEAD~1).

**Verifica contro l'API vera, a costo zero**, in `openrouter-video.live.test.ts`
(`OPENROUTER_LIVE=1`, skippato di default esattamente come `video.kie-live.test.ts`): i 7
`openrouterId` esistono davvero nel catalogo, il prezzo sta in `pricing_skus` e non in `pricing`, e
un invio con l'id kie (`bytedance/seedance-2-5`, coi trattini) è **rifiutato alla validazione** —
cioè la traduzione degli id è portante. 3 passed.

**Nessun video è stato generato apposta.** Ha però generato una clip un mio invio di ricerca
partito per sbaglio: vedi Evidence, costo dichiarato.

## Evidence (screenshots/videos)

Cambiamento backend: nessuna UI. Le prove sono numeri, e vengono da entrambi i lati.

### Il prezzo, misurato da entrambe le parti

Il lato OpenRouter si legge da `pricing_skus` **senza spendere** (`pricing` è nullo su tutti e 28:
guardare lì fa concludere il falso). Il lato kie è quello che abbiamo pagato in 30 giorni.

<details><summary>produzione, <code>ai_calls</code>, ultimi 30 giorni</summary>

```sql
select model, ok, count(*) calls, sum(cost_usd) usd, avg(cost_usd) filter (where ok) per_ok,
       mode() within group (order by context) typical
from ai_calls where label in ('video.render','video.upscale')
  and created_at > now() - interval '30 days' group by model, ok;
```

| model | ok | calls | usd | per_ok | typical |
|---|---|---|---|---|---|
| `bytedance/seedance-2-5` | true | 63 | **114,11** | **1,811** | 15s 480p |
| `grok-imagine-video-1-5-preview` | true | 30 | 3,96 | **0,132** | 10s 480p |
| `grok-imagine/text-to-video` | true | 5 | 0,60 | 0,120 | 10s 480p |
| `bytedance/seedance-2-5` | false | 9 | — | — | 15s 480p |
| `grok-imagine-video-1-5-preview` | false | 11 | — | — | 15s 480p |
</details>

**Su Grok Imagine 1.5 il confronto è chiuso, con soldi veri da entrambe le parti:**

| Grok Imagine 1.5, 480p | kie (misurato, 30 render) | OpenRouter (`pricing_skus`) |
|---|---|---|
| al secondo | $0,0132 | $0,080 |
| clip da 10s | **$0,132** | **$0,80** |

### ⚠️ OpenRouter costa 6× kie sul solo modello dove entrambi i lati sono misurati

Il numero di OpenRouter **non è una stima**: un invio partito per sbaglio durante la ricerca ha reso
8 secondi a 480p e ha addebitato **$0,64** — esattamente gli $0,08/s del listino, alla cifra.

```
{"id":"7wFdNKj3DFEOVPU9qC0g","status":"completed",
 "unsigned_urls":["https://openrouter.ai/api/v1/videos/7wFdNKj3DFEOVPU9qC0g/content?index=0"],
 "usage":{"cost":0.64,"is_byok":false}}
```

**Costo reale di questa ricerca: $0,64.** Dichiarato invece che nascosto. OpenRouter non espone
nessun annullamento su questa superficie (`DELETE` → 404), che è anche il motivo per cui il
trasporto riprende un job scaduto invece di aprirne un altro.

### «Tutto su OpenRouter» non ha lo stesso prezzo sui tre assi

Messo accanto agli altri due spostamenti (numeri di #333 e #335, incrociati con chi le ha fatte):

| asse | spostamento | prezzo |
|---|---|---|
| testo | `gemini@google` → `gemini@openrouter` (#335) | **neutro** ($0,75/$3,75 identici) |
| immagini | già spostato (#333) | **+17%** sul mix reale, comprato in latenza |
| **video** | **non spostato, questa PR** | **+500%** su Grok, ignoto su Seedance |

Il video è l'unico asse dove il conto è di **un altro ordine di grandezza**. È la ragione per cui
questa PR costruisce la strada e non ci manda il traffico: lo spostamento dev'essere una decisione
esplicita con quel numero davanti, non un effetto collaterale dell'uniformità.

### Seedance 2.5: il confronto NON si chiude senza spendere, e lo dico invece di riempirlo

- kie, misurato: **$114,11 per 63 render riusciti, $1,811 l'uno**. Da solo supera l'intero budget
  immagini del mese.
- OpenRouter prezza Seedance **a token video** (`video_tokens: 0.0000107`), non al secondo. Quanti
  token siano 15s a 480p dipende da una tokenizzazione che il catalogo non pubblica: le due formule
  plausibili danno **$0,82** e **$3,29** per una clip da 8s — una più economica di kie, l'altra
  quasi il doppio.

**Serve UN render misurato prima di spostare Seedance**, non un'altra lettura di listino. Visto il
6× su Grok, l'ipotesi da battere è che OpenRouter costi di più anche qui. Non l'ho fatto perché il
brief dice di non generare video veri: è la prima cosa da fare se si vuole girare il default.

### Due trappole misurate, non dedotte

<details><summary>la clip non si scarica senza la chiave (401)</summary>

```
-- no auth:   401 67 application/json
-- with auth: 200 6575007 video/mp4
```

`persistMp4` faceva una `fetch` nuda: il render sarebbe riuscito, sarebbe stato **fatturato**, e la
clip sarebbe finita come «clip rendered but could not be stored». Adesso `persistMp4` accetta gli
header e un test lo tiene.
</details>

<details><summary>una durata fuori scala non viene rifiutata: viene silenziosamente riportata dentro</summary>

`{"model":"x-ai/grok-imagine-video-1.5","duration_seconds":999}` → **202 Accepted**, 8 secondi
prodotti, $0,64 addebitati. Il nome giusto del campo è `duration`, e non c'è nessuna validazione che
salvi da un campo scritto male: la clampatura resta nostra, in `videoModelCaps`.
</details>

## Anything Else?

- **I webhook di completamento esistono.** OpenRouter accetta un `callback_url` e ci risparmierebbe
  il polling. Li segnalo e non ci costruisco sopra adesso: è la strada giusta il giorno che il
  traffico ci va davvero, e scriverla per una rotta che non porta traffico sarebbe codice per
  un'ipotesi.
- **`generate_audio` non è portato.** Il payload kie lo manda per le clip parlate; sulla superficie
  video di OpenRouter non è documentato, e non l'ho inventato — un campo sconosciuto su un job a
  pagamento è un esperimento che si paga. **Va verificato prima di spostare qualunque clip con
  copione.**
- **`RATES`, `credits.ts`, `content-preview/images.ts` non sono toccati**, come da perimetro. Il
  costo non passa mai da un listino a mano: viene da `usage.cost`, e se non arriva la riga dice
  costo ignoto (`ok:false`, `flatCostUsd` undefined) invece di zero — l'invariante di #328.
- **Nessun changelog pubblico**, di proposito: nessun default si muove, e annunciare che «i video
  girano su OpenRouter» sarebbe falso. Solo quello interno.
- **Rebasata su #335** (merged), e su #337/#338 arrivate nel frattempo. La collisione vera era
  `model-routing.ts`: risolta a mano tenendo il mondo nuovo (`Endpoint = 'kie' | 'openrouter'`,
  ripiego finale `'kie'`, `RETIRED_LEGACY`) e innestando solo le righe video. `HOME` per le tre
  famiglie video era gia` `'kie'`, quindi sull'ultima spiaggia non serviva cambiare niente.

  **La trappola si e` presentata davvero, e al rovescio.** Il test della coppia-senza-trasporto
  citava `gemini@openrouter`, che dopo #335 **e` diventata servita** (il trasporto testo e`
  atterrato). Riscelte: `grok@openrouter`, `gpt@openrouter`, `gemini-tts@openrouter`.

  Riverificato dopo il rebase che il test **misuri ancora l'invariante e non niente**, nei due versi
  che si possono sbagliare:

  ```
  # A) le coppie sono NON SERVITE, non nomi morti: dando loro un trasporto il test se ne accorge
  FAIL una coppia senza trasporto non è una rotta        ← il test di #327
  FAIL una coppia video senza trasporto non è una rotta  ← il mio
       Tests  2 failed | 29 passed (31)

  # B) e la guardia e` portante: azzerando il controllo SERVED_BY in unroutable()
  FAIL una coppia senza trasporto non è una rotta
  FAIL una coppia video senza trasporto non è una rotta
       Tests  2 failed | 29 passed (31)
  ```

  (A) e` quello che conta: se quelle coppie fossero **non parsabili** invece che **non servite**,
  collegare il trasporto non cambierebbe nulla e il test resterebbe verde misurando il ripiego al
  default. Le due cose restano distinte.

- **#338 passa dal dispatcher.** `generate_video` con `base_media_id` chiama
  `submitAndTrackVideoRender` → `submitVideoRender`, dove sta `videoEndpoint()`: il percorso nuovo
  e` governato dallo slot senza aver dovuto toccare `media-generate.ts`. I suoi 7 test passano.

- **Nessun default si e` mosso**, verificato oltre che dal test anche dal diff:
  ```
  -  tts: r('gemini-tts', 'kie')
  +  tts: r('gemini-tts', 'kie'),
  +  video: r('grok-imagine', 'kie')
  ```

- **`refine` e `motion` restano su kie senza consultare `AI_ROUTE_VIDEO`.** Partono da un video che
  esiste gia` (`runTransformJob`, e Aleph ha un endpoint kie tutto suo); la superficie `/videos` di
  OpenRouter esprime `frame_images`, non un video in ingresso. E` un altro mestiere, non lo stesso
  su un altro trasporto — onesto solo finche` e` scritto, quindi e` scritto.

- **Upscale su OpenRouter** sarebbe un altro modello (`black-forest-labs/flux-video-upscale`,
  prezzato a megapixel-secondo) e un altro mestiere: fuori perimetro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
