### PR TITLE
Keep the agent skill honest about the tools that exist

### DIFF
--- a/changelog/2026-09-05-la-skill-non-invecchia-in-silenzio.md
+++ b/changelog/2026-09-05-la-skill-non-invecchia-in-silenzio.md
@@ -1,0 +1,105 @@
+# La skill non invecchia più in silenzio
+
+`cli/skills/anomalia/` è quello che un agente esterno legge per decidere cosa Anomalia sa fare.
+In due giorni ha fatto fallire due sessioni vere, e in nessuna delle due il difetto era nel
+codice:
+
+1. Un'immagine già in libreria, la richiesta «rendila rossa». L'agente ha risposto che Anomalia
+   non sa modificare un asset esistente e ha ridisegnato il soggetto da zero — un render pagato
+   per una foto diversa. `refine_image` esisteva da `21c530d7` (#323, 4 settembre) e la skill lo
+   nominava già: il modello non l'ha trovato perché nessuna riga metteva il nome del tool accanto
+   al problema con le parole dell'utente.
+2. «Anima questa immagine in un video di 5 secondi». L'agente ha risposto che l'animazione è
+   esposta solo per la copertina di un post e ha rinunciato.
+
+Il secondo caso era vero, il primo no. In entrambi ha deciso la skill, non il prodotto.
+
+## Cosa diceva di sbagliato
+
+- **`query` non era nominato da nessuna parte.** È l'unico tool che legge una tabella qualsiasi
+  del database con i permessi dell'utente, sola lettura, gratis. Un agente che non sa di averlo
+  fa tre chiamate dove ne basta una.
+- **`ads_remix` non era nominato da nessuna parte**, e spende crediti. Un tool che costa e che
+  nessuno documenta è la combinazione peggiore: non viene usato quando serve, e quando viene
+  trovato per caso nessuno sa cosa paga.
+- **La skill prometteva un giudizio a pagamento su immagini e video** («judging an image or a
+  video is a separate, explicitly paid action»). Quell'azione non esiste più: il giudizio sui
+  video è stato tolto il 29 agosto, il controllo qualità sulle immagini con #329 (`0233a657`
+  «Drop quality control from images», `911c919e` «Remove the image agent too», 4 settembre).
+  Era una bugia detta al modello, che è la forma peggiore: il modello ci costruisce sopra il
+  comportamento.
+- **Non diceva che un render è un colpo singolo.** Dopo #329 non c'è più nessun critico interno,
+  nessun retry automatico: quello che torna è quello che è stato pagato. Il rimedio a un
+  risultato storto è `refine_image`, e chi guarda il risultato è l'agente esterno. È un cambio di
+  modello mentale, non un tool in più, e senza dirlo la skill lasciava credere in una rete di
+  protezione rimossa.
+- **Non diceva che il flusso è lineare**: genera il media, passa il suo id a `create_post`. Il
+  catalogo, letto dall'alto, lasciava credere che un'immagine o un video passassero per forza da
+  un post — che è esattamente la conclusione del secondo fallimento.
+
+## La guardia
+
+Aggiornare la skill la ripara oggi. È già invecchiata due volte in due giorni e nessuno se n'è
+accorto finché un umano non ci ha sbattuto contro: mancava il filo che confronta quello che la
+skill dichiara con i tool che esistono davvero.
+
+`cli/skills/tools-coverage.test.ts` lo tiene, e fallisce in due direzioni:
+
+- un tool esiste e `references/tools.md` non lo nomina → nessun agente lo troverà mai;
+- `tools.md` nomina un tool che non esiste → un agente ci proverà e fallirà.
+
+L'insieme dei tool che esistono è l'unione di due sorgenti: i `tool:` dichiarati in
+`packages/api-contracts/src/*.ts`, e una **lista esplicita degli undici registrati a mano** in
+`cli/mcp/tools/`, ognuno con accanto il motivo per cui non passa dal registry (`list_brands`
+perché `GET /api/v1/brands` non sta sotto un brand e il registry è scoped sul brand;
+`produce_week` perché legge il piano per trovare la bozza dei seed prima di produrla; e così
+via). Il motivo è un valore, non un commento: sta in un `Record` su cui il test asserisce, quindi
+non può marcire senza far fallire qualcosa. Un dodicesimo `registerTool` aggiunto senza motivo fa
+rosso — aggiungerne uno resta una decisione che si vede in diff.
+
+L'estrattore della skill legge la **prima cella** delle righe di tabella di `tools.md`, che è dove
+un agente cerca il nome di un tool. Preciso: sui file di oggi non produce un solo falso positivo
+né un solo falso negativo.
+
+### La trappola che il test evita
+
+Un test che scandisce dei file e asserisce il vuoto passa anche quando non trova niente: se
+l'estrattore si rompe, i due insiemi diventano vuoti, la differenza è vuota, e il test diventa
+verde proprio nel momento in cui ha smesso di misurare. Per questo asserisce **prima** di aver
+trovato un numero plausibile di nomi in ognuna delle tre sorgenti (100 dal registry, 8 a mano,
+100 nella skill). Cambiando `tool:` in `toolz:` nell'estrattore, il conteggio scende a 0 e il test
+fallisce invece di tacere.
+
+### Rosso osservato, quattro volte
+
+Un test che non hai visto fallire non sai cosa misura. Prima di renderlo verde:
+
+1. **Nome finto nella skill** — riga `| \`teleport_brand\` | (MCP only) |` aggiunta a `tools.md`:
+   rosso su «un tool che la skill nomina e non esiste».
+2. **Nome vero tolto dalla skill** — riga di `refine_image` cancellata: rosso su «un tool che
+   esiste e la skill non nomina».
+3. **Estrattore rotto** — `tool:` → `toolz:`: rosso sul pavimento (`0 >= 100` falso), non verde.
+4. **Tool a mano senza motivo** — `registerTool('nuke_brand', …)` aggiunto a `plan.ts`: rosso su
+   «ogni tool registrato a mano porta il suo motivo».
+
+Il primo rosso, però, non è stato costruito: alla prima esecuzione il test ha trovato da solo
+`query` e `ads_remix` mancanti. La deriva che doveva catturare c'era già.
+
+## Cosa è rimasto fuori, e perché
+
+- **`generate_video` / `refine_video`** — `generate_video` lo sta scrivendo un'altra sessione sul
+  branch `feat/agent-video-tools`, skill compresa: le sue righe arrivano con la sua PR, non
+  duplicate qui. `refine_video` non è nel suo PR (`transformVideo` è sincrono end-to-end e la coda
+  `video_renders` è modellata su generate: renderla job-shaped è una PR sua), quindi la skill non
+  lo promette. Quando atterrerà, la guardia pretenderà la riga nello stesso commit.
+- **`slug` opzionale sui generatori** — proposta, non decisa: tre domande di design ancora aperte,
+  fra cui se il caso multi-org rifiuti invece di risolvere in silenzio. Le due frasi che oggi
+  dicono «passa `slug` su ogni chiamata brand-scoped» restano come sono. Una riga in meno oggi
+  costa meno di una bugia da correggere domani.
+
+## Quello che la guardia ancora non copre
+
+Il test verifica che un tool sia **nominato**, non che la sua descrizione sia **vera**. Il
+fallimento numero uno di questa storia — un agente che legge il catalogo, non riconosce la cosa
+che cerca e conclude che non si può fare — non sarebbe stato preso da una riga mancante, perché
+la riga c'era. Contro quello serve la valutazione degli agenti, non un confronto di stringhe.

--- a/cli/plugins/anomalia/skills/anomalia/SKILL.md
+++ b/cli/plugins/anomalia/skills/anomalia/SKILL.md
@@ -51,8 +51,22 @@ Setup details: [references/mcp.md](references/mcp.md).
    call `record_memory_used` with the ids that actually shaped your output. An entry nobody
    reports decays out of the prompts it was helping.
 6. Confirm before reject / delete / discard unless the user clearly asked.
+7. **A render is one shot.** Nothing looks at an image after the model draws it — no internal
+   critic, no automatic retry, no second attempt you did not ask for. **You** are the quality
+   control: open the `signed_url`, judge it, and when it is wrong call `refine_image` on that
+   asset. Prompting again buys a different picture at a second render's price.
 
 ## Quick workflows
+
+**The flow is linear**: generate the media → pass the id it returns to `create_post`. No post is
+needed to make an image or a clip, and nothing you generate reaches the calendar on its own.
+
+**When no tool answers the question** → `query`. It reads any table in the database **as you** —
+the request carries your own session, so Postgres returns exactly the rows the app would show you
+and nothing more. Read only, one table per call, no credits. Omit `table` to list what you can
+name; ask for a table with no `columns` and the keys of a row are the schema. Reach for it for a
+count, a join you do by hand, or a fact none of the tools below returns — instead of three calls
+that approximate it.
 
 **Before you write anything** → two reads, and they answer different questions.
 

--- a/cli/plugins/anomalia/skills/anomalia/references/tools.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/tools.md
@@ -14,6 +14,28 @@ nothing brings it back.
 | `whoami` | (session file / brands imply identity) |
 | `list_brands` | `anomalia brands` |
 
+## Database
+
+| MCP | CLI |
+|-----|-----|
+| `query` | (MCP only) |
+
+`query` reads ANY table in the database directly, **as you**: the request runs with your own
+session, so Postgres RLS returns exactly the rows you would see in the app and nothing more. It
+is READ ONLY by construction — you name a table, columns and filters, it issues one PostgREST
+read, and a write has nowhere to go. No SQL string, no joins, no function calls. It calls no
+model and costs nothing.
+
+Optional `table` (omit it and you get the list of every table you can name), `columns` (omit them
+and you get real rows with every column — the keys of a row ARE the schema), `where` (filters
+ANDed together, each `column` / `op` / `value`, where `op` is one of `eq`, `neq`, `gt`, `gte`,
+`lt`, `lte`, `like`, `ilike`, `is`, `in`, `cs`, `cd`), `order` and `limit` (20 by default, 100 at
+most). One table per call: read two and match the ids yourself.
+
+Reach for it when the answer needs a count, a join you do by hand, or a table nothing else
+exposes — that is one call instead of three that approximate it. A refusal comes back as `200`
+with `error`, `message` and often `fix` inside, so you can read why and change move.
+
 ## Brand & posts
 
 | MCP | CLI |
@@ -139,6 +161,11 @@ because an environment override can still outrank it. `renders` is how many rend
 which can exceed the images you got back: a render that succeeds and is then discarded downstream
 is paid for all the same, so trust `renders` over your own count when reconciling spend.
 
+**One prompt, one render, no safety net.** Nothing inspects the image after the model draws it:
+there is no quality control, no critic that rejects a bad frame, no retry you did not ask for.
+What comes back is what was billed, however crooked. Judging it is YOUR job — open the
+`signed_url`, look, and if it is wrong send it to `refine_image` rather than prompting again.
+
 `refine_image` changes an image that is already in the library and files the result as a **new**
 asset — the original is never overwritten, so a refinement cannot destroy what it started from.
 Required: `slug`, `media_id` (from `list_media`, and it must belong to this brand — anything else
@@ -184,7 +211,8 @@ It answers with `ok`, `errors`, `warnings`, `scores` and `versions`:
   length, readability, hashtags, emoji. Fix the low value with the highest weight first.
 - **versions** pins the ruleset and the scorer: two verdicts compare only when they match.
 
-It never looks at pixels — judging an image or a video is a separate, explicitly paid action.
+It reads the copy and nothing else. **No tool here judges an image or a video** — Anomalia stopped
+scoring them, and there is no paid action that will. Looking at the render is on you.
 
 ## Client links
 
@@ -563,6 +591,7 @@ writes it.
 | `get_article` / `update_article` | (MCP only) |
 | `publish_article` / `unpublish_article` / `delete_article` | `anomalia web <slug> publish\|…` |
 | `get_ads` / `ads_action` | `anomalia ads <slug> [--propose\|--create\|--approve\|--pause\|--resume\|--duplicate\|--delete\|--reject] [--ad <adId>]` |
+| `ads_remix` | (MCP only) |
 | `get_market_field` | (MCP only) |
 | `diagnose_radar` | (MCP only) |
 | `list_ideas` | (MCP only) |
@@ -600,6 +629,15 @@ given and received plus the open give/receive opportunities, and `unlocked` tell
 the network is usable — it needs Starter or above **and** the brand's opt-in, so `planAllowed`
 and `enabled` say which of the two is missing. All three are reads: no model, no credits, no
 writes.
+
+`ads_remix` is the opposite: it **spends credits**. It harvests the competitor and trending ads
+already collected for the brand, looks at them with vision, and returns ranked remix briefs in the
+brand's voice — `rank`, `strategy`, `keep`, `change`, `hook`, `headline`, `body`, `cta`,
+`productName`, `visualPrompt`. It takes `slug` and nothing else, and it **replaces** the briefs
+that were there, so run it when you mean to redo them. Refusals: `no_competitor_ads` (400, nothing
+harvested yet — there is nothing to remix), `no_remix_briefs` (400, the pass produced none),
+`ads_not_on_plan` (403) and `credits_exhausted` (402). Launching an ad is still `ads_action`; this
+only writes the briefs.
 
 `list_web_audits` is the index of every audit, newest first — `id`, `at`, `tech_score`,
 `share_of_voice`, `citability_score`, `binding_constraint`, and how many citations and findings

--- a/cli/skills/anomalia/SKILL.md
+++ b/cli/skills/anomalia/SKILL.md
@@ -51,8 +51,22 @@ Setup details: [references/mcp.md](references/mcp.md).
    call `record_memory_used` with the ids that actually shaped your output. An entry nobody
    reports decays out of the prompts it was helping.
 6. Confirm before reject / delete / discard unless the user clearly asked.
+7. **A render is one shot.** Nothing looks at an image after the model draws it — no internal
+   critic, no automatic retry, no second attempt you did not ask for. **You** are the quality
+   control: open the `signed_url`, judge it, and when it is wrong call `refine_image` on that
+   asset. Prompting again buys a different picture at a second render's price.
 
 ## Quick workflows
+
+**The flow is linear**: generate the media → pass the id it returns to `create_post`. No post is
+needed to make an image or a clip, and nothing you generate reaches the calendar on its own.
+
+**When no tool answers the question** → `query`. It reads any table in the database **as you** —
+the request carries your own session, so Postgres returns exactly the rows the app would show you
+and nothing more. Read only, one table per call, no credits. Omit `table` to list what you can
+name; ask for a table with no `columns` and the keys of a row are the schema. Reach for it for a
+count, a join you do by hand, or a fact none of the tools below returns — instead of three calls
+that approximate it.
 
 **Before you write anything** → two reads, and they answer different questions.
 

--- a/cli/skills/anomalia/references/tools.md
+++ b/cli/skills/anomalia/references/tools.md
@@ -14,6 +14,28 @@ nothing brings it back.
 | `whoami` | (session file / brands imply identity) |
 | `list_brands` | `anomalia brands` |
 
+## Database
+
+| MCP | CLI |
+|-----|-----|
+| `query` | (MCP only) |
+
+`query` reads ANY table in the database directly, **as you**: the request runs with your own
+session, so Postgres RLS returns exactly the rows you would see in the app and nothing more. It
+is READ ONLY by construction — you name a table, columns and filters, it issues one PostgREST
+read, and a write has nowhere to go. No SQL string, no joins, no function calls. It calls no
+model and costs nothing.
+
+Optional `table` (omit it and you get the list of every table you can name), `columns` (omit them
+and you get real rows with every column — the keys of a row ARE the schema), `where` (filters
+ANDed together, each `column` / `op` / `value`, where `op` is one of `eq`, `neq`, `gt`, `gte`,
+`lt`, `lte`, `like`, `ilike`, `is`, `in`, `cs`, `cd`), `order` and `limit` (20 by default, 100 at
+most). One table per call: read two and match the ids yourself.
+
+Reach for it when the answer needs a count, a join you do by hand, or a table nothing else
+exposes — that is one call instead of three that approximate it. A refusal comes back as `200`
+with `error`, `message` and often `fix` inside, so you can read why and change move.
+
 ## Brand & posts
 
 | MCP | CLI |
@@ -139,6 +161,11 @@ because an environment override can still outrank it. `renders` is how many rend
 which can exceed the images you got back: a render that succeeds and is then discarded downstream
 is paid for all the same, so trust `renders` over your own count when reconciling spend.
 
+**One prompt, one render, no safety net.** Nothing inspects the image after the model draws it:
+there is no quality control, no critic that rejects a bad frame, no retry you did not ask for.
+What comes back is what was billed, however crooked. Judging it is YOUR job — open the
+`signed_url`, look, and if it is wrong send it to `refine_image` rather than prompting again.
+
 `refine_image` changes an image that is already in the library and files the result as a **new**
 asset — the original is never overwritten, so a refinement cannot destroy what it started from.
 Required: `slug`, `media_id` (from `list_media`, and it must belong to this brand — anything else
@@ -184,7 +211,8 @@ It answers with `ok`, `errors`, `warnings`, `scores` and `versions`:
   length, readability, hashtags, emoji. Fix the low value with the highest weight first.
 - **versions** pins the ruleset and the scorer: two verdicts compare only when they match.
 
-It never looks at pixels — judging an image or a video is a separate, explicitly paid action.
+It reads the copy and nothing else. **No tool here judges an image or a video** — Anomalia stopped
+scoring them, and there is no paid action that will. Looking at the render is on you.
 
 ## Client links
 
@@ -563,6 +591,7 @@ writes it.
 | `get_article` / `update_article` | (MCP only) |
 | `publish_article` / `unpublish_article` / `delete_article` | `anomalia web <slug> publish\|…` |
 | `get_ads` / `ads_action` | `anomalia ads <slug> [--propose\|--create\|--approve\|--pause\|--resume\|--duplicate\|--delete\|--reject] [--ad <adId>]` |
+| `ads_remix` | (MCP only) |
 | `get_market_field` | (MCP only) |
 | `diagnose_radar` | (MCP only) |
 | `list_ideas` | (MCP only) |
@@ -600,6 +629,15 @@ given and received plus the open give/receive opportunities, and `unlocked` tell
 the network is usable — it needs Starter or above **and** the brand's opt-in, so `planAllowed`
 and `enabled` say which of the two is missing. All three are reads: no model, no credits, no
 writes.
+
+`ads_remix` is the opposite: it **spends credits**. It harvests the competitor and trending ads
+already collected for the brand, looks at them with vision, and returns ranked remix briefs in the
+brand's voice — `rank`, `strategy`, `keep`, `change`, `hook`, `headline`, `body`, `cta`,
+`productName`, `visualPrompt`. It takes `slug` and nothing else, and it **replaces** the briefs
+that were there, so run it when you mean to redo them. Refusals: `no_competitor_ads` (400, nothing
+harvested yet — there is nothing to remix), `no_remix_briefs` (400, the pass produced none),
+`ads_not_on_plan` (403) and `credits_exhausted` (402). Launching an ad is still `ads_action`; this
+only writes the briefs.
 
 `list_web_audits` is the index of every audit, newest first — `id`, `at`, `tech_score`,
 `share_of_voice`, `citability_score`, `binding_constraint`, and how many citations and findings

--- a/cli/skills/tools-coverage.test.ts
+++ b/cli/skills/tools-coverage.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from 'bun:test';
+import { readdirSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { fileURLToPath } from 'url';
+
+const CLI = fileURLToPath(new URL('../', import.meta.url));
+const REPO = join(CLI, '..');
+const CONTRACTS = join(REPO, 'packages', 'api-contracts', 'src');
+const MCP_TOOLS = join(CLI, 'mcp', 'tools');
+const REFERENCE = join(CLI, 'skills', 'anomalia', 'references', 'tools.md');
+
+const HAND_REGISTERED_BECAUSE: Record<string, string> = {
+  login: 'la sessione OAuth vive nel client, non dietro una rotta di brand',
+  logout: 'cancella il file di sessione locale, nessuna chiamata HTTP',
+  whoami: 'legge la sessione locale o il Bearer della richiesta',
+  list_brands: 'GET /api/v1/brands non sta sotto un brand, e il registry e scoped sul brand',
+  get_status: 'compone due letture dell API in una risposta sola',
+  approve_post: 'risolve un prefisso di id, poi chiama la rotta del singolo post',
+  approve_posts: 'approva tutta la coda pending con una chiamata dedicata',
+  publish_post: 'risolve un prefisso di id, poi pubblica il singolo post',
+  reject_post: 'risolve un prefisso di id, poi cancella il post',
+  generate_person: 'add_person con kind ai gia impostato',
+  produce_week: 'legge il piano per trovare la bozza dei seed, poi la produce'
+};
+
+const MIN_REGISTRY_TOOLS = 100;
+const MIN_HAND_REGISTERED = 8;
+const MIN_NAMED_BY_THE_SKILL = 100;
+
+function names(pattern: RegExp, text: string): string[] {
+  return [...text.matchAll(pattern)].map((match) => match[1]);
+}
+
+function sourceOf(dir: string): string {
+  return readdirSync(dir)
+    .filter((file) => file.endsWith('.ts') && !file.endsWith('.test.ts'))
+    .map((file) => readFileSync(join(dir, file), 'utf8'))
+    .join('\n');
+}
+
+function registryTools(): Set<string> {
+  return new Set(names(/tool:\s*'([a-z][a-z0-9_]*)'/g, sourceOf(CONTRACTS)));
+}
+
+function handRegisteredTools(): Set<string> {
+  return new Set(names(/registerTool\(\s*'([a-z][a-z0-9_]*)'/g, sourceOf(MCP_TOOLS)));
+}
+
+function firstTableCell(line: string): string {
+  return line.startsWith('|') ? (line.split('|')[1] ?? '') : '';
+}
+
+function toolsNamedBySkill(): Set<string> {
+  const cells = readFileSync(REFERENCE, 'utf8').split('\n').map(firstTableCell).join('\n');
+  return new Set(names(/`([a-z][a-z0-9_]*)`/g, cells));
+}
+
+function exposedTools(): Set<string> {
+  return new Set([...registryTools(), ...Object.keys(HAND_REGISTERED_BECAUSE)]);
+}
+
+function sorted(set: Set<string>): string[] {
+  return [...set].sort();
+}
+
+describe('la skill sta al passo con i tool che esistono', () => {
+  test('gli estrattori trovano ancora qualcosa', () => {
+    expect(registryTools().size).toBeGreaterThanOrEqual(MIN_REGISTRY_TOOLS);
+    expect(handRegisteredTools().size).toBeGreaterThanOrEqual(MIN_HAND_REGISTERED);
+    expect(toolsNamedBySkill().size).toBeGreaterThanOrEqual(MIN_NAMED_BY_THE_SKILL);
+  });
+
+  test('ogni tool registrato a mano porta il suo motivo', () => {
+    expect(sorted(handRegisteredTools())).toEqual(Object.keys(HAND_REGISTERED_BECAUSE).sort());
+  });
+
+  test('un tool che esiste e la skill non nomina non lo trova nessuno', () => {
+    const named = toolsNamedBySkill();
+    expect(sorted(exposedTools()).filter((tool) => !named.has(tool))).toEqual([]);
+  });
+
+  test('un tool che la skill nomina e non esiste lo chiama qualcuno', () => {
+    const exposed = exposedTools();
+    expect(sorted(toolsNamedBySkill()).filter((tool) => !exposed.has(tool))).toEqual([]);
+  });
+});

--- a/src/lib/content/changelog/2026-09-05-agent-skill-catalogue.ts
+++ b/src/lib/content/changelog/2026-09-05-agent-skill-catalogue.ts
@@ -1,0 +1,12 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-05',
+  title: 'Agents can find every tool Anomalia has',
+  items: [
+    'Ask an agent to change an image you already have and it edits that image, instead of drawing a new one from scratch.',
+    'Agents can now query your data directly — one call for a count or a table nothing else exposes.',
+    'Ad remixes are documented, credit cost included, so an agent knows what it spends before it spends it.',
+    'An image render is one shot with no automatic retry, and the agent instructions now say so instead of promising a quality check that no longer runs.'
+  ]
+} satisfies ChangelogEntry;


### PR DESCRIPTION
## What?

The Anomalia agent skill (`cli/skills/anomalia/`) is what an external agent reads to decide what
Anomalia can do. This PR does two things: it brings the catalogue back in line with the tools that
actually exist, and it adds the test that makes it fail loudly the next time it drifts.

The skill update: `query` and `ads_remix` are now named and described, the promise of a paid
image/video verdict is gone because that action no longer exists, the "a render is one shot, you
are the quality control, `refine_image` is the remedy" model is stated explicitly, and the linear
flow (generate the media → pass its id to `create_post`) is stated in one line where the catalogue
starts.

The guard: `cli/skills/tools-coverage.test.ts` compares the tool names the skill declares against
the tools that exist, and fails in both directions.

## Why?

The skill aged twice in two days and nobody noticed until a human hit it in a real session.

1. An image already in the library, "make it red". The agent redrew the subject from scratch — a
   render paid for a different picture.
2. "Animate this image into a 5s video". The agent answered that animation is only exposed for a
   post cover, and gave up.

Two failures, both decided by the skill rather than by the product. Updating it fixes today. The
test is what stops it happening again in silence.

**One correction to the framing, from `git log -S`:** the first failure was NOT a missing
`refine_image`. That tool and its skill paragraph landed in the same commit, `21c530d7` (#323,
4 Sept) — the skill said it. What the skill did not say is that #329 removed the safety net
underneath it, so a model reading the catalogue had no reason to treat looking at the render as its
own job. That is what this PR adds. Worth knowing, because "the skill was missing a row" would have
been fixed by the guard alone, and it would not have been enough.

### What was wrong, and since when

| Claim in the skill | Truth | Since |
|---|---|---|
| `query` never named | tool shipped, reads any table with the caller's own RLS, free | `1a9fd14b`, 4 Sept |
| `ads_remix` never named | tool shipped, **spends credits** | `1bb5c6f8`, 4 Sept |
| "judging an image or a video is a separate, explicitly paid action" | no such action — the video reviewer was killed by `5df714e7` (#66) on **29 Aug** | sentence written `982c4581`, **3 Sept — five days after the thing it promises was deleted** |
| nothing said about a render being one shot | #329 removed image quality control (`0233a657`) and the image agent (`911c919e`) | 4 Sept |

The third row is the one that matters most: the sentence was born false. That is the worst class of
defect here, because the reader is a model and it builds behaviour on top of the lie.

## How?

**The guard's sources.** The set of tools that exist is the union of two:

- every `tool:` declared in `packages/api-contracts/src/*.ts` (test files excluded) — 113 today;
- an **explicit list of the eleven registered by hand** in `cli/mcp/tools/`, each with the reason it
  does not go through the registry (`list_brands` because `GET /api/v1/brands` has no brand to sit
  under and the registry is brand-scoped; `produce_week` because it reads the plan to find the seed
  draft before producing it; `get_status` because it composes two reads; and so on).

The reason is a **value the test asserts on**, not a comment: `handRegisteredTools()` is extracted
from the source and compared against the keys of the map. A twelfth `registerTool` added without a
reason turns the suite red, so adding one stays a decision visible in the diff — and a reason cannot
rot without something failing.

**The skill's side.** Tool names are extracted from the **first cell of markdown table rows** in
`references/tools.md` — that is where an agent looks for a tool name. On today's files it produces
zero false positives and zero false negatives; a naive "every backticked lowercase word" extractor
produced 442 candidates, most of them field names.

**Rejected: booting the MCP server and calling `tools/list`.** A peer agent suggested it, and it is
a stronger source in principle — it catches registry and hand-registered tools with no list to
maintain. Rejected because the explicit list is the point, not a workaround: it is what makes each
hand-written tool a written-down decision instead of an accident, and it costs no server boot in the
test. I verified the peer's specific worry was unfounded — `get_dashboard`, `edit_post`,
`regenerate_post_media`, `regenerate_slide`, `reorder_slides` and `make_video` all ARE in the
registry; the eleven in the map are exactly what `cli/mcp/tools/*.ts` registers directly.

**The trap this test avoids.** A test that scans files and asserts emptiness passes when it finds
nothing at all — which is precisely the moment it stopped measuring. So it asserts a plausible count
first, from each of the three sources (100 registry, 8 hand-registered, 100 named by the skill),
before comparing anything.

## Testing?

`bun test` in `cli/`: **73 pass, 0 fail** (69 before this PR + 4 new). Under vitest, which is what CI
runs (`cli/**/*.{test,spec}.{js,ts}` with `bun:test` aliased): the new file, the existing mirror test
and the changelog test all pass. `bash cli/scripts/sync-plugin-skill.sh` was run, so the plugin
mirror is intact.

Not tested: nothing in the browser, because this PR changes no runtime behaviour — two markdown
files, one test, two changelog entries. `npx tsc --noEmit` in `cli/` reports `TS2688 Cannot find type
definition file for 'bun'`, identical on `dev` at the merge base — pre-existing, not from this PR.

**Risk:** the extractor is a convention, not a parser. If someone adds a table to `tools.md` whose
first column is backticked snake_case but is not a tool name, the guard goes red on a false positive.
The failure message names the offending string, so the fix is a minute.

### Red observed, four ways

A test you have not watched fail is a test you cannot describe. Before making it green:

<details>
<summary>1. The skill names a tool that does not exist — added <code>| `teleport_brand` | (MCP only) |</code> to tools.md</summary>

```
82 |   test('un tool che la skill nomina e non esiste lo chiama qualcuno', () => {
84 |     expect(sorted(toolsNamedBySkill()).filter((tool) => !exposed.has(tool))).toEqual([]);
error: expect(received).toEqual(expected)
- []
+ [
+   "teleport_brand",
+ ]
(fail) la skill sta al passo con i tool che esistono > un tool che la skill nomina e non esiste lo chiama qualcuno
```
</details>

<details>
<summary>2. A real tool the skill stops naming — deleted the <code>refine_image</code> row</summary>

```
77 |   test('un tool che esiste e la skill non nomina non lo trova nessuno', () => {
79 |     expect(sorted(exposedTools()).filter((tool) => !named.has(tool))).toEqual([]);
error: expect(received).toEqual(expected)
- []
+ [
+   "ads_remix",
+   "query",
+   "refine_image",
+ ]
(fail) la skill sta al passo con i tool che esistono > un tool che esiste e la skill non nomina non lo trova nessuno
```
</details>

<details>
<summary>3. The extractor breaks — <code>tool:</code> changed to <code>toolz:</code>. It must FAIL, not go green</summary>

```
67 |   test('gli estrattori trovano ancora qualcosa', () => {
68 |     expect(registryTools().size).toBeGreaterThanOrEqual(MIN_REGISTRY_TOOLS);
error: expect(received).toBeGreaterThanOrEqual(expected)
Expected: >= 100
Received: 0
(fail) la skill sta al passo con i tool che esistono > gli estrattori trovano ancora qualcosa
```

The "invented tool" test goes red at the same time, because every documented name suddenly looks
invented. It screams; it does not go quiet.
</details>

<details>
<summary>4. A hand-registered tool with no reason — added <code>registerTool('nuke_brand', …)</code> to plan.ts</summary>

```
73 |   test('ogni tool registrato a mano porta il suo motivo', () => {
74 |     expect(sorted(handRegisteredTools())).toEqual(Object.keys(HAND_REGISTERED_BECAUSE).sort());
error: expect(received).toEqual(expected)
@@ -8,3 +8,3 @@
    "logout",
+   "nuke_brand",
    "produce_week",
(fail) la skill sta al passo con i tool che esistono > ogni tool registrato a mano porta il suo motivo
```
</details>

The first red was not staged. On its very first run, against the skill as it stood on `dev`, the test
found `query` and `ads_remix` missing by itself:

```
error: expect(received).toEqual(expected)
- []
+ [
+   "ads_remix",
+   "query",
+ ]
 3 pass
 1 fail
```

The drift it was built to catch was already there.

## Evidence (screenshots/videos)

No UI. The skill is read by models, not rendered, so the evidence is the red above and the green
below.

<details>
<summary><code>bun test</code> in <code>cli/</code> — after</summary>

```
 73 pass
 0 fail
 830 expect() calls
Ran 73 tests across 14 files.
```
</details>

<details>
<summary>Under vitest, the runner CI uses</summary>

```
 ✓ cli/plugins/anomalia/plugin-skill.test.ts (2 tests) 4ms
 ✓ cli/skills/tools-coverage.test.ts (4 tests) 12ms
 ✓ src/lib/content/changelog/index.test.ts (3 tests) 7ms

 Test Files  3 passed (3)
      Tests  9 passed (9)
```
</details>

## Anything Else?

**Left out on purpose, coordinated with the agents writing them.**

- `generate_video` — being written on `feat/agent-video-tools`, skill copy included. Its rows ship
  with its PR, not duplicated here. Both diffs are additive in different regions of the same two
  files; whoever merges second resolves a trivial conflict.
- `refine_video` — confirmed **not** in that PR: `transformVideo` is synchronous end to end
  (`createKieTask` + a 600s poll + `persistMp4` + billing in one function), and the `video_renders`
  queue is generate-shaped, so making transform job-shaped is its own PR. Shipping it synchronously
  would hang an MCP client for ten minutes. Nothing written, so nothing promised.
- `generate_carousel` — queued behind `refine_video`, no contract yet.
- **Optional `slug` on the generators** — proposed, not decided. Three design questions are still
  open with you, including whether the multi-org case refuses instead of resolving silently, and the
  answer changes what the skill would have to say (a brand-free asset gets no row, so `id` comes back
  null and it cannot reach `create_post` or `list_media` — a behavioural difference, not a shorter
  argument list). "Pass `slug` on every brand-scoped call" is left exactly as it is.

**What this guard does not cover, and it is the part that bit us.** The test asserts a tool is
*named*. It asserts nothing about whether its description is *true* or *findable*. Failure #1 in this
story — an agent reading the catalogue, not recognising the thing it wanted, and concluding it could
not be done — would not have been caught by a missing-row check, because the row was there. Against
that, the agent evaluation is the instrument, not a string comparison.

**One lie left standing, outside this PR's scope:** the root `CLAUDE.md` still advertises
`# Video review: POST /api/v1/brands/:slug/videos/review` and `# Auto-score worker: GET/POST
/api/v1/videos/review/work (cron */5)`. Both routes were deleted on 29 Aug. Same defect class as the
sentence this PR removed, same reader. Not touched here to keep the diff honest and avoid a conflict
with the sessions currently in that file — worth its own one-line PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
