### PR TITLE
Stop advertising two routes that do not exist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,10 +30,8 @@ anomalia web <slug>                                # Blog articles (drafts too)
 # Field watch: GET/POST /api/v1/brands/:slug/market/field (what moves in the brand's field, taken apart)
 # Radar self-test: GET /api/v1/brands/:slug/radar/diagnose (fetches every source live, says why one finds nothing)
 # Brand doctor: GET /api/v1/brands/:slug/doctor (per cycle, the first gate the brand fails and how to unlock it)
-# Video review: POST /api/v1/brands/:slug/videos/review  { url | post_id, standard: organic|ads }
 # Agent Library: GET /api/v1/agent-templates (public catalogue behind /agents + Automations › Custom Agents)
 # Chat goals: GET /api/v1/brands/:slug/goals (history + summary of goal mode — met_first_pass, laps, stopped_by)
-# Auto-score worker: GET/POST /api/v1/videos/review/work (cron */5)
 anomalia studio <slug> add-note --text "..."       # Add knowledge
 ```
 

--- a/changelog/2026-09-04-video-review-gia-morta.md
+++ b/changelog/2026-09-04-video-review-gia-morta.md
@@ -73,3 +73,22 @@ se ne accorgerebbe. È sotto `src/routes/app/`, fuori dai file che posso modific
 Nella stessa categoria, e nello stesso stato: `src/lib/server/chat/query-tool.ts` elenca ancora
 `motion_craft_scores` fra i nomi di tabella interrogabili — è un elenco, non un lettore, ma nomina
 una tabella orfana, ed è sotto `src/lib/server/chat/`.
+
+
+## E la bugia con più lettori di tutte: `CLAUDE.md`
+
+Segnalata da chi stava aggiornando la skill, e me l'ero persa. La lista di endpoint in `CLAUDE.md`
+annunciava ancora due rotte che non esistono:
+
+```
+# Video review: POST /api/v1/brands/:slug/videos/review  { url | post_id, standard: organic|ads }
+# Auto-score worker: GET/POST /api/v1/videos/review/work (cron */5)
+```
+
+`src/routes/api/v1/brands/[slug]/videos/` non esiste, e sotto `src/routes/api/v1/videos/` c'è solo
+`render`. È lo stesso difetto dei commenti — un testo che promette una capacità sparita — ma con il
+pubblico più ampio: **ogni agente di questo repo carica `CLAUDE.md` all'avvio della sessione**,
+quindi era la riga con più probabilità di essere creduta.
+
+Tolte. E già che il file era aperto, **verificate tutte le altre rotte che annuncia**: esistono
+tutte. La marcescenza era confinata a queste due, non è un problema del file.


### PR DESCRIPTION
## What?

Two line deletions in the repo's `CLAUDE.md`. It still advertised the video review endpoint and its
auto-score worker cron; neither exists.

```
- # Video review: POST /api/v1/brands/:slug/videos/review  { url | post_id, standard: organic|ads }
- # Auto-score worker: GET/POST /api/v1/videos/review/work (cron */5)
```

## Why?

`src/routes/api/v1/brands/[slug]/videos/` is absent, and `src/routes/api/v1/videos/` holds only
`render`. The video reviewer was deleted on **2026-08-29**, when the model behind it stopped
accepting video files.

This is the same defect class as the stale comments cleaned up in #332 — text promising a capability
that is gone — but with the widest audience of any of them: **every agent in this repo loads
`CLAUDE.md` at session start**, so it was the line most likely to be believed and acted on. An agent
told "this endpoint exists" will try to call it.

It was caught by the session updating the Anomalia skill, not by me. #332 was meant to be the commit
that closed this cleanup, and my sweep looked for **code** referencing the reviewer rather than prose
advertising it — the wrong shape of search for the wrong shape of residue. It arrives as a follow-up
because #332 merged while this was being written.

## How?

Two deletions, nothing else. While the file was open I checked **every** endpoint it advertises, so
this is not just the two I was handed:

```
OK   /api/v1/agent-templates            OK   /api/v1/brands/:slug/market/field
OK   /api/v1/brands/:slug/backlinks     OK   /api/v1/brands/:slug/radar/diagnose
OK   /api/v1/brands/:slug/connections   OK   /api/v1/composio/webhook
OK   /api/v1/brands/:slug/doctor        OK   /api/v1/webhooks/work
OK   /api/v1/brands/:slug/goals         OK   /api/v1/brands/:slug/ideas
```

All the others resolve to a real `+server.ts`. **The rot was confined to these two**, not a property
of the list — worth knowing, because the opposite finding would have justified a guard test and this
one does not.

## Testing?

Nothing executable changes: this is documentation, and the check that matters is the route-existence
sweep above, run by hand and reproduced in full so a reviewer can re-run it rather than trust it.

The equivalent guarantee for *code* already exists and is stronger:
`src/routes/api/v1/brands/[slug]/registry.test.ts` asserts every `BRAND_ENDPOINTS` entry has a
`+server.ts` on disk. These two lines were never contracts — they were prose in a list, which is
exactly why nothing caught them.

## Evidence

```
$ ls src/routes/api/v1/brands/[slug]/videos
ls: No such file or directory

$ ls src/routes/api/v1/videos/
render
```

## Anything Else?

**This edits the checked-in `CLAUDE.md`.** Both changes are factual corrections of routes deleted on
2026-08-29 — **no rule, instruction or convention is touched.** Flagging it explicitly because that
file carries the repo's working agreements and a diff to it deserves to be read as more than a typo
fix.

**Not proposed:** a guard test asserting every path mentioned in `CLAUDE.md` resolves to a route. The
sweep found one dead pair out of eleven, both from a single deletion six days ago, so the evidence
does not support the machinery — and a test over prose in a hand-maintained list would fail on the
next legitimate mention of a path that isn't an endpoint. If this recurs, that changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY