### PR TITLE
Send video renders to OpenRouter by default

### DIFF
--- a/changelog/2026-09-05-video-default-openrouter.md
+++ b/changelog/2026-09-05-video-default-openrouter.md
@@ -1,0 +1,65 @@
+# I video vanno su OpenRouter, e kie resta la riserva
+
+La strada l'ha costruita la PR dello slot video; questa ci manda il traffico. Una riga:
+`SLOT_DEFAULT.video` da `grok-imagine@kie` a `grok-imagine@openrouter`.
+
+## Il prezzo qui va nel verso opposto agli altri slot, e va detto
+
+Sul testo lo spostamento era **a costo neutro**, sulle immagini **+17%** comprato in latenza. Sul
+video si paga **il 500% in più**: $0,80 contro $0,132 per una clip da 10s a 480p su Grok Imagine,
+misurato da entrambe le parti — kie dai render veri in produzione, OpenRouter da un addebito reale.
+
+La ragione non è il prezzo. È che su kie il video **non arriva**:
+
+| kie, `video.render`, 30 giorni | chiamate | falliti | medio | p95 |
+|---|---|---|---|---|
+| `bytedance/seedance-2-5` | 72 | **12,5%** | 248s | **382s** |
+| `grok-imagine-video-1-5-preview` | 41 | **26,8%** | 49s | 91s |
+
+Un video su quattro su Grok non arriva affatto, e su Seedance il p95 supera i **sei minuti**. È lo
+stesso criterio con cui si sono spostate le immagini — lì il p95 di kie era 142,9s — solo che qui la
+disponibilità si paga invece di essere gratis.
+
+## ⚠️ La bolletta è ignota, e non è un modo di dire
+
+Il +500% è misurato su **Grok Imagine**. Su **Seedance no** — e Seedance è **$114,11 dei $118 di
+spesa video degli ultimi 30 giorni, il 97%**.
+
+OpenRouter prezza Seedance **a token video** (`video_tokens: 0.0000107`), non al secondo, e la
+tokenizzazione non è pubblicata. Le due formule plausibili danno **$0,82** o **$3,29** per 8
+secondi: **a cavallo dei $1,81 che paghiamo oggi a kie**.
+
+Quindi dopo questo cambio la spesa video può **dimezzarsi o raddoppiare**, e non lo sappiamo.
+Andrea ha deciso col numero di Grok davanti e ha detto che il costo non è il criterio — ma «non è il
+criterio» non vuol dire «è +500%»: la dimensione è ignota e si scoprirà dalla prima fattura.
+**Un render misurato la chiude**, uno-tre dollari.
+
+## Le due tabelle non devono coincidere
+
+`SLOT_DEFAULT` dice dove va il traffico **quando funziona**; `HOME` dove va **quando OpenRouter non
+è utilizzabile**. `HOME` per le tre famiglie video resta `kie`, che è il ruolo esplicito che Andrea
+gli assegna: *«kie solo di riserva»*. Farle coincidere manderebbe il ripiego su OpenRouter — cioè da
+nessuna parte — proprio quando OpenRouter è la cosa che non va.
+
+### Un buco nella rete, trovato provandola
+
+Il test che teneva fermo il vecchio default è stato **ribaltato, non cancellato**: adesso tiene
+fermo il nuovo. Provandolo è venuto fuori che non sorveglia quello che sembrerebbe:
+
+cambiando `HOME['grok-imagine']` in `openrouter` — cioè introducendo esattamente il difetto qui
+sopra — **passano tutti e 32 i test**, perché l'ultima spiaggia di `route()` è `'kie'` scritta a mano
+e recupera comunque. `HOME` giusto qui è quindi **ridondante e non sorvegliato**: chi lo cambia non
+trova rete.
+
+Non l'ho corretto — togliere l'ultima spiaggia o renderla derivata è un cambiamento al registro che
+vale per tutti gli slot, non per il video. Sta scritto nel test, così la prossima persona lo trova
+invece di riscoprirlo.
+
+## Cosa NON cambia
+
+- **La voce** resta su kie: OpenRouter non fa sintesi vocale, e sta in `MISSING`.
+- **`refine` e `motion`** restano su kie senza consultare `AI_ROUTE_VIDEO`: partono da un video che
+  esiste già, e `/videos` esprime `frame_images`, non un video in ingresso.
+- **I render con `reference_*`** ripiegano su kie rumorosamente, perché OpenRouter non ha quei campi
+  e girerebbero senza i riferimenti.
+- **L'interruttore.** `AI_ROUTE_VIDEO=grok-imagine@kie` riporta tutto su kie senza deploy.

--- a/src/lib/content/changelog/2026-09-05-videos-arrive.ts
+++ b/src/lib/content/changelog/2026-09-05-videos-arrive.ts
@@ -1,0 +1,10 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-05',
+  title: 'Videos arrive',
+  items: [
+    'Video generation moved to a faster, more reliable provider: clips that used to fail one time in four now come back.',
+    'A clip whose render is still running is picked up where it left off instead of being started again.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/model-routing.test.ts
+++ b/src/lib/server/model-routing.test.ts
@@ -20,10 +20,11 @@ describe('il registro delle rotte', () => {
     setEnv(KEYS);
   });
 
-  it('i default: testo, immagini e voce su openrouter', async () => {
+  it('i default: ogni slot su openrouter', async () => {
     const { route } = await import('./model-routing');
     expect(route('text')).toMatchObject({ family: 'gemini', endpoint: 'openrouter', provider: 'openrouter' });
     expect(route('image')).toMatchObject({ endpoint: 'openrouter', provider: 'openrouter' });
+    expect(route('video')).toMatchObject({ endpoint: 'openrouter', provider: 'openrouter' });
     expect(route('tts')).toMatchObject({ family: 'gemini-tts', endpoint: 'openrouter', provider: 'openrouter' });
   });
 
@@ -251,10 +252,31 @@ describe('il registro delle rotte', () => {
     }
   });
 
-  it('il video resta su kie: questa rotta costruisce la strada, non ci manda il traffico', async () => {
-    setEnv({ ...KEYS, OPENROUTER_API_KEY: 'o' });
+  it('il video va su openrouter per default, e kie resta SOLO la riserva', async () => {
+    // Non e` il prezzo, che qui va nell'altro verso: OpenRouter sul video costa DI PIU` — 6x
+    // misurati su Grok Imagine. E` la disponibilita`: su kie il video fallisce il 12,5% delle volte
+    // su Seedance e il 26,8% su Grok, con medie di 248s e 49s. Chi legge dopo dara` per scontato il
+    // contrario, come per la voce.
+    setEnv({ ...KEYS });
+    const { route } = await import('./model-routing');
+    expect(route('video')).toMatchObject({ endpoint: 'openrouter', provider: 'openrouter' });
+  });
+
+  it('senza chiave openrouter il video cade su kie da solo, e lo dice', async () => {
+    // Il default e` openrouter e il ripiego e` kie: sono due ruoli, e questo test guarda il
+    // COMPORTAMENTO dei due messi insieme.
+    //
+    // Quello che NON puo` guardare, e che vale la pena sapere: se `HOME` per le famiglie video
+    // diventasse `openrouter` — cioe` se le due tabelle coincidessero — questo test resterebbe
+    // VERDE, perche' l'ultima spiaggia di `route()` e` `'kie'` scritta a mano e recupera comunque.
+    // Verificato: cambiando `HOME['grok-imagine']` in `openrouter` passano tutti e 32.
+    // `HOME` giusto qui e` quindi ridondante, non sorvegliato — chi lo cambia non trova rete.
+    setEnv({ KIE_API_KEY: 'k' });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const { route } = await import('./model-routing');
     expect(route('video')).toMatchObject({ endpoint: 'kie', provider: 'kie' });
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/la chiave manca/));
+    warn.mockRestore();
   });
 
   it('i modelli video: nuova variabile, vecchia variabile, default', async () => {
@@ -333,6 +355,7 @@ describe('restano solo openrouter e kie', () => {
     const { route } = await import('./model-routing');
     expect(route('text').endpoint).toBe('openrouter');
     expect(route('image').endpoint).toBe('openrouter');
+    expect(route('video').endpoint).toBe('openrouter');
     expect(route('tts').endpoint).toBe('openrouter');
   });
 
@@ -340,7 +363,7 @@ describe('restano solo openrouter e kie', () => {
     setEnv({ KIE_API_KEY: 'k' });
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const { route } = await import('./model-routing');
-    for (const slot of ['text', 'image', 'tts'] as const) {
+    for (const slot of ['text', 'image', 'tts', 'video'] as const) {
       expect(route(slot).endpoint, slot).toBe('kie');
     }
     warn.mockRestore();

--- a/src/lib/server/model-routing.ts
+++ b/src/lib/server/model-routing.ts
@@ -190,7 +190,16 @@ const SLOT_DEFAULT: Record<Slot, Route> = {
   // decisione esplicita, non un effetto dell'uniformita'. La famiglia qui e` la LINEA DI DEFAULT,
   // non il modello del render — quello lo scelgono le preferenze del brand (`videoModelForRole`) e
   // `videoModel(job)`. Del video slot il trasporto legge l'ENDPOINT.
-  video: r('grok-imagine', 'kie')
+  // Il video su OpenRouter COSTA DI PIU`, ed e` l'unico slot dove il verso e` questo: 6x misurati
+  // su Grok Imagine ($0,80 contro $0,132 per 10s a 480p). Si paga per la disponibilita`, perche' su
+  // kie il video non arriva — 12,5% di fallimenti su Seedance, 26,8% su Grok, con medie di 248s e
+  // 49s. Chi legge dopo dara` per scontato che ci si sia spostati per risparmiare: non e` cosi`.
+  //
+  // La famiglia qui e` la LINEA DI DEFAULT, non il modello del render: quello lo scelgono le
+  // preferenze del brand (`videoModelForRole`) e `videoModel(job)`. Il trasporto legge l'ENDPOINT.
+  // `HOME` resta kie ed e` la RISERVA — le due tabelle non devono coincidere, o il ripiego finisce
+  // sulla cosa che non funziona.
+  video: r('grok-imagine', 'openrouter')
 };
 
 function r(family: ModelFamily, endpoint: Endpoint): Route {


### PR DESCRIPTION
## ⛔ NON MERGIARE finche' `main` e' indietro rispetto a `dev`

Trovato verificando una diagnosi di un altro agente sul deploy skew, e riguarda direttamente questa
PR.

Produzione gira `main`@cce7f4e8 (2 settembre). **`main` non conosce OpenRouter sul video**: zero
occorrenze in `model-routing.ts`, nessun `openrouter-video.ts`, e il suo `finishVideoRender`
interroga kie **incondizionatamente** con `submitted.taskId`.

Il cron `*/1` gira su **produzione** e riconcilia le righe del database **condiviso**. Quindi, con
questa PR su `dev` e `main` indietro, un render avviato dal localhost di Andrea salva
`task_id = openrouter:<jobId>` e il reconciler di produzione lo chiede a kie:

```
GET api.kie.ai/api/v1/jobs/recordInfo?taskId=openrouter%3AtestNotReal
HTTP 200  {"code":422,"msg":"recordInfo is null","data":null}
```

**HTTP 200**, quindi `res.ok` e` vero, `info.data` e` null, `state` e` `undefined`, e il vecchio
codice cade su `return { status: 'pending' }`. I `pending` **non incrementano `attempts`** (e` scritto
nel commento: contarli trasformerebbe il tetto in una scadenza). La riga sopravvive fino a
`VIDEO_RENDER_MAX_AGE_MS` e poi viene chiusa cosi`:

> `expired` — *"kie never resolved this task"*

Cioe`: **clip pagata su OpenRouter, mai depositata, e all'utente viene detto che e` colpa di kie** —
un job che kie non ha mai visto. E` lo stesso sintomo che un altro agente stava investigando, con
un'altra causa, e questa PR lo renderebbe **il percorso normale** invece che teorico (con la sola
#336 il default era kie: serviva impostare `AI_ROUTE_VIDEO` a mano).

**Il codice di questa PR non va cambiato** — il difetto e` il disallineamento, non il trasporto, e
il marchio `openrouter:` sta facendo esattamente il suo mestiere: e` il lettore vecchio che non sa
leggerlo. **Va cambiato l'ordine**: `dev` deve arrivare su `main` prima o insieme a questo merge.

Fino ad allora questa PR resta aperta. Se serve mergiarla subito, l'interruttore
`AI_ROUTE_VIDEO=grok-imagine@kie` in produzione la neutralizza senza deploy.

**Niente da bonificare: il rischio e' solo prospettico.** In tutto il database:

```sql
select count(*) tutte,
       count(*) filter (where task_id like 'openrouter:%') marchiate,
       count(*) filter (where status in ('rendering','finishing')) aperte
from video_renders;
--  tutte 4 | marchiate 0 | aperte 0
```

Zero righe marchiate `openrouter:`, zero ancora aperte — coerente col fatto che #336 e' entrata col
default su kie. Non c'e' nessun arretrato da recuperare: il blocco qui sopra e' puramente
preventivo.

## What?

Una riga: `SLOT_DEFAULT.video` da `grok-imagine@kie` a `grok-imagine@openrouter`. La strada l'ha
costruita #336; questa ci manda il traffico.

**`HOME` resta `kie`** per le tre famiglie video, ed è il ruolo esplicito che Andrea gli assegna:
*«kie solo di riserva»*.

Il test che teneva fermo il vecchio default è **ribaltato, non cancellato**.

## Why?

Andrea, col numero davanti: *«Passa pure i video di default a openrouter, con kie solo di riserva.
Me ne sbatto che costi di meno.»*

**La ragione non è il prezzo, e su questo slot il prezzo va nel verso opposto agli altri:**
OpenRouter costa **6× kie** su Grok Imagine ($0,80 contro $0,132 per 10s a 480p). È che su kie il
video **non arriva**:

| kie, `video.render`, 30 giorni | chiamate | falliti | medio | p95 |
|---|---|---|---|---|
| `bytedance/seedance-2-5` | 72 | **12,5%** | 248s | **382s** |
| `grok-imagine-video-1-5-preview` | 41 | **26,8%** | 49s | 91s |

Un video su quattro su Grok non arriva affatto; su Seedance il p95 supera i **sei minuti**. Stesso
criterio delle immagini (p95 kie 142,9s), solo che qui la disponibilità si paga.

## How?

Una riga in `SLOT_DEFAULT`, più il commento che dice il verso del prezzo — perché su questo file
l'assunzione naturale è la contraria, esattamente come per la voce.

**Le due tabelle non devono coincidere.** `SLOT_DEFAULT` dice dove va il traffico quando funziona,
`HOME` dove va quando OpenRouter non è utilizzabile. Farle coincidere manderebbe il ripiego su
OpenRouter — cioè da nessuna parte — proprio quando OpenRouter è la cosa che non va.

## Testing?

Rosso prima. I test ribaltati, osservati fallire contro il vecchio default:

```
FAIL i default: testo, immagini e video su openrouter, voce su kie
FAIL il video va su openrouter per default, e kie resta SOLO la riserva
FAIL senza chiave openrouter il video cade su kie da solo, e lo dice
FAIL openrouter e` il default dove puo` servire, kie dove no
     Tests  4 failed | 28 passed (32)
```

Dopo: **204 test verdi** su 13 file (registro, trasporto, cablaggio, coda, media-generate, kie,
changelog). `svelte-check`: 0 errori nei file toccati.

Il ripiego è coperto dal loop già esistente `il ripiego di ogni slot e` kie, mai altro`, a cui ho
aggiunto `video`.

### ⚠️ Un buco nella rete, trovato provandola

Ho provato a rompere l'invariante che questa PR introduce — far coincidere le due tabelle — e **il
test non se ne accorge**:

```
# HOME['grok-imagine'] = 'openrouter', cioè il difetto vero, dentro
Tests  32 passed (32)
```

Perché l'ultima spiaggia di `route()` è `'kie'` scritta a mano e recupera comunque. **`HOME` giusto
qui è ridondante e non sorvegliato: chi lo cambia non trova rete.**

Non l'ho corretto: togliere l'ultima spiaggia o renderla derivata da `HOME` è un cambiamento al
registro che vale per **tutti** gli slot, non per il video, e non è questa la PR. L'ho scritto nel
test, così la prossima persona lo trova invece di riscoprirlo.

## Evidence (screenshots/videos)

Backend: nessuna UI. I numeri vengono da `ai_calls` in produzione.

<details><summary>fallimenti e latenza per modello, 30 giorni</summary>

```sql
select model, count(*) calls, count(*) filter (where not ok) failed,
       round(100.0*count(*) filter (where not ok)/count(*),1) fail_pct,
       round(avg(ms) filter (where ok)/1000.0) avg_s,
       round((percentile_cont(0.95) within group (order by ms) filter (where ok))/1000.0) p95_s
from ai_calls where label='video.render' and created_at > now() - interval '30 days'
group by model order by calls desc;
```

| model | calls | failed | fail% | avg | p95 |
|---|---|---|---|---|---|
| `bytedance/seedance-2-5` | 72 | 9 | 12,5% | 248s | 382s |
| `grok-imagine-video-1-5-preview` | 41 | 11 | 26,8% | 49s | 91s |
| `grok-imagine/text-to-video` | 6 | 0 | 0,0% | 44s | 50s |
</details>

### ⚠️ Girando il default, il 97% della spesa video va su un prezzo che non conosciamo

Questo è il punto che la PR deve dire chiaro invece di lasciar credere «+500%».

Il 6× è misurato su **Grok Imagine**. Su **Seedance no** — e Seedance è **$114,11 dei $118 di spesa
video, il 97%**. OpenRouter lo prezza **a token video** (`video_tokens: 0.0000107`), non al secondo,
e la tokenizzazione non è pubblicata: le due formule plausibili danno **$0,82** o **$3,29** per 8
secondi, cioè **a cavallo dei $1,81 di kie**.

**La bolletta può dimezzarsi o raddoppiare, e non lo sappiamo.** Si scoprirà dalla prima fattura.

**Un render misurato la chiude**, uno-tre dollari. Non l'ho fatto perché spendere non era mio da
decidere: se lo si vuole, il numero prende il posto della forbice.

## Anything Else?

- **L'interruttore.** `AI_ROUTE_VIDEO=grok-imagine@kie` riporta tutto su kie **senza deploy**, mentre
  il guasto è in corso.
- **Cosa non si sposta**: la voce (OpenRouter non fa TTS), `refine`/`motion` (partono da un video in
  ingresso, che `/videos` non esprime), e i render con `reference_*` (ripiegano su kie rumorosamente
  invece di girare senza i riferimenti).
- **`generate_audio` resta il rischio aperto** e adesso è sul percorso di default: il payload kie lo
  manda per le clip parlate, sulla superficie video di OpenRouter non è documentato e non l'ho
  inventato. **È la prima cosa da guardare sulle clip con copione dopo il deploy.**
- **PR separata da #336 perché quella è già mergiata**, e va bene così: la strada e il traffico sono
  due decisioni, e questa è revertibile da sola con una riga.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
