### PR TITLE
Record how to read a red CI with no red test

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -94,6 +94,32 @@ Se la pila si abbandona, le PR che ci stavano sopra non si chiudono da sole: van
 
 ## Test: distinguere il tuo difetto dal rumore
 
+### CI rossa con zero test falliti è una promessa non attesa, non un test tuo
+`Test Files 649 passed | Tests 7259 passed | Errors 1 error`, e il job esce comunque 1. Non
+cercare il test rosso: non esiste. Vitest conta come fallimento anche una `Unhandled Rejection`
+sollevata FUORI da un test — qui `supabase.rpc is not a function` da `credits.ts`, arrivata da un
+`loadDeferred` di `+layout.server.ts` che risolve dopo la fine del file che l'aveva avviata
+(`home-redirect.test.ts`), su uno stub senza `.rpc`. Il file, eseguito da solo, passa: la promessa
+fa in tempo a essere raccolta. Segnale: la riga `This error originated in "<file>"` seguita da
+`It doesn't mean the error was thrown inside the file itself`.
+
+**La mossa: cerca lo stesso messaggio su una run che NON contiene il tuo diff.** E qui sta la
+trappola, pagata per intero: `gh run list --branch dev` restituisce anche la run del merge del tuo
+stesso PR, che il tuo diff ce l'ha dentro. Preso quello per prova d'innocenza, hai scritto
+«riprodotto senza le mie modifiche» avendo misurato esattamente le tue. La prova buona si prende
+da un PR altrui e si verifica, non si assume:
+
+```
+gh run list --commit "$(gh pr view <altro-pr> --json headRefOid -q .headRefOid)" \
+  --workflow ci.yml --limit 1 --json databaseId -q '.[0].databaseId'
+gh run view <id> --log-failed | grep -c '<messaggio>'
+git merge-base --is-ancestor <tuo-primo-commit> <quella-sha>   # deve dire NO
+```
+
+L'ultima riga è quella che chiude la questione: se il tuo commit non è antenato di quella sha, il
+difetto è latente e non è tuo. E non fidarti del solo «dev è verde»: la run di dev può essere
+caduta prima, sugli e2e, senza mai arrivare alla suite unitaria.
+
 ### La suite completa fallisce da sola: confronta run-per-run con dev puro
 Sotto carico (worker paralleli) i test di timing e race cadono da soli: `redact` ≤ 200ms che ne impiega 404, JPEG ≤ 2MB, drain "executes exactly once". Lo stesso sottoinsieme, rilanciato isolato, passa. Prima di imputarsi un fallimento della suite completa: (1) rilancia il sottoinsieme isolato, (2) lancia la suite completa su **dev puro** nello stesso setup. Se dev fallisce uguale, il rumore non è tuo. Vero anche il rovescio: "tutta verde" sul tuo branch non dice niente se dev non lo è.
 


### PR DESCRIPTION
## What?

Adds one entry to `LESSONS.md`: how to read a CI job that is red while every test passed, and how
to prove such a failure is not yours without proving the opposite by accident.

This is the lesson #339 paid for. It was written on that branch and pushed a few minutes after the
PR had already merged, so it never landed — this is that commit, corrected and on its own.

## Why?

#339's CI came back red like this:

```
 Test Files  649 passed | 3 skipped (652)
      Tests  7259 passed | 11 skipped (7270)
     Errors  1 error
```

There is no failing test to find. Vitest fails the job on an unhandled rejection raised **outside**
any test — a `loadDeferred` in `+layout.server.ts` settling after `home-redirect.test.ts` has
finished, against a stub with no `.rpc`. Run that file alone and it is green. Half an hour went
into looking for a red test that does not exist, and the log says so in a line easy to skim past:
`This error originated in "<file>" … It doesn't mean the error was thrown inside the file itself`.

The second half is the part worth writing down, because I got it wrong in public. I claimed the
failure was pre-existing and cited a run listed under `gh run list --branch dev` carrying the same
message. That run was **the merge commit of my own pull request** — my diff was inside it. I had
measured exactly what I claimed to have excluded, and said so in a comment on #339.

The conclusion happened to survive. The evidence did not, and a lesson that only records the
correct-sounding method would let the next person make the same mistake with the same confidence.

## How?

The entry states the signal, then the move, then the trap by name, with the commands that settle it:

```
gh run list --commit "$(gh pr view <other-pr> --json headRefOid -q .headRefOid)" \
  --workflow ci.yml --limit 1 --json databaseId -q '.[0].databaseId'
gh run view <id> --log-failed | grep -c '<message>'
git merge-base --is-ancestor <your-first-commit> <that-sha>   # must say NO
```

The third line is what actually closes the question — everything before it is circumstantial. It
went in because without it the first two commands are exactly what produced the wrong answer.

Placed at the top of the existing "Test: distinguere il tuo difetto dal rumore" section, next to
the run-per-run comparison it complements: that one is about flaky timing, this one about a job
that fails with nothing red in it.

## Testing?

Documentation only, no code. `LESSONS.md` has no test and nothing imports it.

The claims in it were verified before writing:

- **Same error, no diff of mine.** PR #329 (`fix/no-qc-on-images`), run `33915136945`, created
  `2026-09-04T20:13:18Z` — nine hours before my first commit existed — carries the identical
  `supabase.rpc is not a function`, twice. `git merge-base --is-ancestor 0e4b1b86 911c919e` answers
  NO, so none of my work is in it. That is the evidence I should have produced the first time.
- **The file passes alone.** `npx vitest run 'src/routes/app/[brand]/home-redirect.test.ts'` → 7/7.
- **Reproducible, not a flake.** The failed job on #339 was re-run and failed identically.

## Evidence (screenshots/videos)

No UI.

<details>
<summary>The failure, from the #339 job log</summary>

```
⎯⎯⎯⎯ Unhandled Rejection ⎯⎯⎯⎯⎯
TypeError: supabase.rpc is not a function
 ❯ fetchStripePeriodStart src/lib/server/credits.ts:111:6
 ❯ brandCreditsUsage src/lib/server/credits.ts:293:29
 ❯ Module.getCreditsUsage src/lib/server/credits.ts:250:20
 ❯ Module.remaining src/lib/server/usage.ts:147:44
 ❯ loadDeferred src/routes/app/[brand]/+layout.server.ts:159:9

This error originated in "src/routes/app/[brand]/home-redirect.test.ts" test file.
It doesn't mean the error was thrown inside the file itself, but while it was running.
```
</details>

<details>
<summary>The check that settles ownership</summary>

```
$ gh run view 33915136945 --json createdAt,headBranch,headSha
2026-09-04T20:13:18Z
fix/no-qc-on-images
911c919e452496e826712aacb8406c24f3843cfe

$ gh run view 33915136945 --log-failed | grep -c 'supabase.rpc is not a function'
2

$ git show -s --format='%ci' 0e4b1b86
2026-09-05 07:36:43 +0200

$ git merge-base --is-ancestor 0e4b1b86 911c919e && echo YES || echo NO
NO
```
</details>

## Anything Else?

**The underlying defect is real and not fixed here.** `loadDeferred` floats a promise nothing
awaits, so any test stubbing Supabase without `.rpc` can turn a fully passing suite into a red job
depending on scheduling. It has already hit at least two branches. Fixing it means deciding whether
`loadDeferred` should swallow its own rejections or whether the test should stub `.rpc` — a
decision with a blast radius beyond a docs PR, so it is left alone and named here.

**Correction posted where the wrong claim was made:** the comment on #339 asserting the error
reproduced without my changes cited the merge of #339 itself. I will not edit the merged PR's
history, but this entry records the mistake and the check that prevents it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
