### PR TITLE
Record that a gateway catalogue hides its separate surfaces

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -921,3 +921,34 @@ indipendenti: due dicevano «la patch non applica», il terzo «il pacchetto non
 sintomi di **una causa sola** — l'albero di `node_modules` rotto — e nessuno dei tre parlava delle
 patch. Dopo un `npm install` pulito applicano tutte e tre. Più errori insieme invitano a
 concludere; guarda invece se hanno un antenato comune.
+
+## Il catalogo di un gateway non elenca le sue superfici separate
+
+Tre volte in un giorno abbiamo concluso «OpenRouter non lo fa» interrogando `GET /api/v1/models`,
+e tre volte era falso. I **video** non compaiono lì: stanno su `POST /api/v1/videos` con catalogo
+proprio su `GET /api/v1/videos/models`, 28 modelli. Il **text-to-speech** non compare lì:
+`google/gemini-3.1-flash-tts-preview` vive su `POST /api/v1/audio/speech` e risponde
+`audio/pcm; rate=24000; channels=1`, esattamente il formato che il nostro tagliatore pretende.
+
+Il costo delle tre volte: una famiglia di tool video rimandata come impossibile, un `MISSING` che
+dichiarava `tts` assente su openrouter mentre funzionava, e un'ora spesa a cercare un ripiego per
+un limite che non c'era.
+
+**Segnale**: un catalogo interrogato per modalità risponde «zero» per una capacità che il
+fornitore documenta o pubblicizza. Un `GET` su un endpoint che vuole `POST` risponde 404, che si
+legge identico a «non esiste».
+
+**Mossa**: chiama il modello sull'endpoint che credi sbagliato e **leggi l'errore per intero** —
+un gateway ben fatto ti dice dove sta la superficie giusta:
+
+> `google/gemini-3.1-flash-tts-preview is a text-to-speech model and cannot be used with the
+> chat/completions endpoint. Use the /api/v1/audio/speech endpoint instead.`
+
+Vale anche per il messaggio che rifiuta un parametro: `does not support 'wav' when stream=true.
+Supported values are: 'pcm16'` conteneva già la risposta, e chi si è fermato alla parola
+«rifiutato» ha concluso che la voce non si potesse spostare.
+
+**La regola dietro**: «l'ho cercato e non c'è» non è una misura finché non sai **dove** hai
+cercato. Un'assenza va dichiarata con l'endpoint interrogato accanto, o è un'opinione travestita
+da fatto — e finisce in `MISSING`, dove la testata promette «fatti misurati, non ipotesi di
+listino».


### PR DESCRIPTION
## What?

Adds one lesson to `LESSONS.md`: OpenRouter's `GET /api/v1/models` does not list its separate
surfaces, and three times in one day we read that absence as "the provider cannot do this".

## Why?

It cost real work. Video generation was deferred as impossible until someone found
`POST /api/v1/videos` with its own catalogue of 28 models. Voice was written into `MISSING` as an
absent capability on openrouter — while `google/gemini-3.1-flash-tts-preview` on
`POST /api/v1/audio/speech` returns `audio/pcm; rate=24000; channels=1`, which is exactly the
format `gemini-audio.ts` requires, with no conversion.

The same shape twice more: a `GET` on a `POST`-only endpoint answers 404, indistinguishable from
"does not exist"; and an error that names the supported value (`Supported values are: 'pcm16'`)
was read as a plain refusal.

## How?

One section, in the file's existing shape: the signal that lets you recognise it, and the move
that resolves it — call the model on the endpoint you believe is wrong and read the whole error,
because the gateway names the right surface.

## Testing?

Documentation only. Every claim in it was verified with live calls against the real API before
being written: the 404s, the 400 naming `pcm16`, the chat/completions error naming
`/api/v1/audio/speech`, and the 200 returning 151,680 bytes of 24kHz mono PCM.

## Evidence (screenshots/videos)

Not applicable — no UI change.

## Anything Else?

The rule this generalises: an absence is not a measurement until the endpoint you queried is
stated next to it. That matters most for `MISSING` in `model-routing.ts`, whose header promises
"fatti misurati, non ipotesi di listino" — a wrong entry there is a capability silently declared
dead.