### PR TITLE
Stop answering done when the clip never reached the library

### DIFF
--- a/changelog/2026-09-05-done-without-media.md
+++ b/changelog/2026-09-05-done-without-media.md
@@ -1,0 +1,56 @@
+# `done` senza `media_id` non è più una risposta che si può dare
+
+`check_media_job` ha risposto ad Andrea `status: 'done', media_id: null`, e il suo agente esterno
+si è fermato lì — giustamente: il contratto dello stesso tool dice l'opposto, «done once it is in
+the library — and then media_id is the id create_post accepts». Un `done` senza id non è un lavoro
+riuscito e non è un lavoro fallito: è una frase che non dice niente su cosa fare dopo.
+
+## Perché è successo, che non è dove sembrava
+
+Il deposito in libreria **c'è ed è protetto**, in `video-render-queue.ts`: `applyToPost` instrada
+a `applyToLibrary` quando `post_id` è nullo, e il chiamante non segna `done` finché quella non
+riesce. Leggendo `dev` il difetto è impossibile.
+
+Il codice che ha scritto `done` non è quello. È uno **split brain fra deploy**:
+
+| | codice | ruolo |
+|---|---|---|
+| `localhost:5173` di Andrea | `dev` | l'unico che accoda un render con `post_id` nullo |
+| produzione (`anomalia.so`) | `main`@`cce7f4e8`, 2 settembre | il cron `*/1` che riconcilia |
+
+Il database è **lo stesso**. E `main` non ha ancora `9fa00158`: il suo `applyToPost` è
+`if (!row.post_id) return true;`. Un render senza post viene quindi dichiarato atterrato senza che
+niente lo depositi, l'allocazione mensile viene addebitata, e la riga si chiude `done`.
+
+La riga `d616dcda-8a2f-4017-b9e6-74542f77a8cd` lo dice per intero: `status done`, `post_id` nullo,
+`attempts 0`, `error` nullo, `media_url` valorizzato — e **zero** righe `brand_media` con quel
+`source_ref`. L'mp4 risponde `200` con 2.098.026 byte. Il clip esiste, è pagato, e nessun tool del
+prodotto sa raggiungerlo.
+
+## Cosa cambia qui, e cosa no
+
+Qui non si tocca la scrittura: quel lato lo chiude il merge di `dev` su `main`, e il messaggio di
+errore del reconciler lo sta già riscrivendo un'altra PR. Qui si chiude il **lato lettura**, che è
+la superficie su cui l'agente esterno si è arreso, e che ripete la contraddizione **chiunque**
+abbia scritto `done`: un deploy indietro, una `UPDATE` a mano, una regressione futura.
+
+`listMediaJobs` filtra già `post_id is null`, quindi per le righe che restituisce l'invariante è
+esatta: **`done` vuol dire che l'asset c'è**. Se non c'è, il lavoro non viene più riportato `done`.
+
+Non viene riportato nemmeno `failed`, ed è la parte che conta: il clip è stato renderizzato e
+**pagato**, `media_url` lo prova. Un agente che legge `failed` rigenera, ed è la reazione giusta
+al messaggio sbagliato — pagherebbe una seconda copia di un file che esiste già. Serviva una
+terza parola vera, e `not_in_library` è quella: il `error` dice cos'è successo e dice di non
+rigenerare.
+
+## Il test
+
+L'invariante di scrittura — nessun `done` con `post_id` nullo senza una `brand_media` che lo
+reclami — **passa già** su `dev`, perché `9fa00158` l'ha chiusa, e sta nei test di
+`video-render-queue`. Ripeterla qui non avrebbe misurato niente.
+
+Il rosso è dall'altra parte del confine, e riproduce esattamente la sessione: dato un lavoro
+`done` che nessun asset reclama, `listMediaJobs` rispondeva `done` con `media_id: null` e `error`
+nullo. I tre controlli intorno — il caso felice, un lavoro in corso, un lavoro fallito davvero —
+passavano già prima e continuano a passare: sono lì perché la guardia non può diventare una rete
+che cattura anche loro.

--- a/cli/lib/contracts/posts.ts
+++ b/cli/lib/contracts/posts.ts
@@ -371,7 +371,9 @@ export const CHECK_MEDIA_JOB = {
   description:
     'Where the videos generate_media started have got to, newest first. status is rendering while ' +
     'the clip is being made, done once it is in the library — and then media_id is the id ' +
-    'create_post accepts as media_ids. failed says why. Calls no model and spends no credits.',
+    'create_post accepts as media_ids. failed says why. not_in_library means the clip was ' +
+    'rendered and paid for but never filed, so there is no media_id and a second render buys ' +
+    'a second copy. Calls no model and spends no credits.',
   method: 'GET',
   pathUnderBrand: '/media/generate',
   input: z

--- a/packages/api-contracts/src/posts.ts
+++ b/packages/api-contracts/src/posts.ts
@@ -371,7 +371,9 @@ export const CHECK_MEDIA_JOB = {
   description:
     'Where the videos generate_media started have got to, newest first. status is rendering while ' +
     'the clip is being made, done once it is in the library — and then media_id is the id ' +
-    'create_post accepts as media_ids. failed says why. Calls no model and spends no credits.',
+    'create_post accepts as media_ids. failed says why. not_in_library means the clip was ' +
+    'rendered and paid for but never filed, so there is no media_id and a second render buys ' +
+    'a second copy. Calls no model and spends no credits.',
   method: 'GET',
   pathUnderBrand: '/media/generate',
   input: z

--- a/src/lib/content/changelog/2026-09-05-done-without-media.ts
+++ b/src/lib/content/changelog/2026-09-05-done-without-media.ts
@@ -1,0 +1,9 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-05',
+  title: 'A finished video job now tells you if the clip never arrived',
+  items: [
+    'Checking a video job no longer answers "done" when the clip is not in your media library — it says the clip was made but never filed, so an assistant knows not to pay for a second render of a video that already exists.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/media-generate.jobs.test.ts
+++ b/src/lib/server/media-generate.jobs.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { listMediaJobs, CLIP_NOT_IN_LIBRARY } from './media-generate';
+
+/**
+ * LA SESSIONE DI ANDREA. generate_media({ kind: 'video' }) torna un job_id, e check_media_job
+ * risponde `status: 'done', media_id: null`. Il contratto di check_media_job dice l'opposto:
+ * «done once it is in the library — and then media_id is the id create_post accepts». Un agente
+ * esterno che riceve done senza media_id non ha niente su cui agire, e si e' fermato li'.
+ *
+ * La riga d616dcda esiste davvero: done, post_id nullo, attempts 0, media_url valorizzato, e
+ * nessuna riga brand_media che la reclami. L'mp4 risponde 200, 2.098.026 byte: il clip e' stato
+ * pagato. A scriverla e' stato il cron di produzione, ferma a `main`, che per un render senza
+ * post non aveva ancora il ramo del deposito.
+ *
+ * Il lettore non deve ripetere la contraddizione, chiunque abbia scritto `done`.
+ */
+
+const BRAND = 'brand-1';
+const JOB = 'd616dcda-8a2f-4017-b9e6-74542f77a8cd';
+
+type Row = Record<string, unknown>;
+
+const db = (renders: Row[], assets: Row[]) =>
+  ({
+    from: (table: string) => {
+      const data = table === 'video_renders' ? renders : assets;
+      const builder: Record<string, unknown> = {
+        then: (resolve: (v: unknown) => unknown) => resolve({ data, error: null })
+      };
+      for (const step of ['select', 'eq', 'is', 'order', 'limit', 'in']) {
+        builder[step] = () => builder;
+      }
+      return builder;
+    }
+  }) as never;
+
+const settledJob = (over: Row = {}): Row => ({
+  id: JOB,
+  status: 'done',
+  error: null,
+  submitted_at: '2026-09-05T05:40:59.761+00:00',
+  ...over
+});
+
+const claimedBy = (jobId: string) => ({ id: 'media-1', source_ref: jobId });
+
+describe('check_media_job', () => {
+  it('un lavoro done con il suo asset e done, e porta il media_id', async () => {
+    const jobs = await listMediaJobs(db([settledJob()], [claimedBy(JOB)]), BRAND);
+
+    expect(jobs[0]).toMatchObject({ status: 'done', media_id: 'media-1' });
+  });
+
+  it('non dice done a un lavoro che nessun asset reclama', async () => {
+    const jobs = await listMediaJobs(db([settledJob()], []), BRAND);
+
+    expect(jobs[0].media_id).toBeNull();
+    expect(jobs[0].status).not.toBe('done');
+  });
+
+  it('non lo dice nemmeno failed: il clip esiste ed e gia pagato', async () => {
+    const jobs = await listMediaJobs(db([settledJob()], []), BRAND);
+
+    expect(jobs[0].status).toBe(CLIP_NOT_IN_LIBRARY);
+    expect(jobs[0].status).not.toBe('failed');
+  });
+
+  it('dice perche, invece di lasciare un agente senza niente su cui agire', async () => {
+    const jobs = await listMediaJobs(db([settledJob()], []), BRAND);
+
+    expect(jobs[0].error).toBeTruthy();
+  });
+
+  it('lascia in pace un lavoro ancora in corso, che un asset non puo avere', async () => {
+    const jobs = await listMediaJobs(db([settledJob({ status: 'rendering' })], []), BRAND);
+
+    expect(jobs[0]).toMatchObject({ status: 'rendering', media_id: null, error: null });
+  });
+
+  it('non tocca l errore di un lavoro fallito davvero', async () => {
+    const jobs = await listMediaJobs(
+      db([settledJob({ status: 'failed', error: 'kie refused the job' })], []),
+      BRAND
+    );
+
+    expect(jobs[0]).toMatchObject({ status: 'failed', error: 'kie refused the job' });
+  });
+});

--- a/src/lib/server/media-generate.ts
+++ b/src/lib/server/media-generate.ts
@@ -424,6 +424,11 @@ export type MediaJob = {
 
 const JOBS_PAGE = 20;
 
+export const CLIP_NOT_IN_LIBRARY = 'not_in_library';
+const NOTHING_CLAIMED_IT =
+  'the clip rendered and is stored, but it never reached the library, so there is no media_id to ' +
+  'use — generating it again would pay for a second copy';
+
 /**
  * I lavori di questo brand, e SOLO di questo brand: l'id arriva da `loadBrandForUser`, mai dal
  * chiamante, quindi un job_id indovinato di un altro brand non trova niente.

--- a/src/lib/server/media-generate.ts
+++ b/src/lib/server/media-generate.ts
@@ -462,5 +462,10 @@ export async function listMediaJobs(
     ((assets ?? []) as Array<{ id: string; source_ref: string }>).map((a) => [a.source_ref, a.id])
   );
 
-  return rows.map((r) => ({ ...r, media_id: byJob.get(r.id) ?? null }));
+  return rows.map((r) => {
+    const mediaId = byJob.get(r.id) ?? null;
+    if (r.status !== 'done' || mediaId) return { ...r, media_id: mediaId };
+
+    return { ...r, media_id: null, status: CLIP_NOT_IN_LIBRARY, error: NOTHING_CLAIMED_IT };
+  });
 }


### PR DESCRIPTION
## What?

`check_media_job` could answer `status: "done", media_id: null` — a job reported finished with
nothing to hand over. That contradicts the tool's own contract ("done once it is in the library —
and then `media_id` is the id `create_post` accepts"), and an external agent that receives it has
no move to make.

`listMediaJobs` now refuses to repeat the contradiction. A job whose row says `done` but that no
asset claims comes back as `not_in_library`, with an `error` saying the clip was rendered and paid
for but never filed — and that re-rendering buys a second copy.

Nothing on the generation path is touched. The writer's half of this defect is closed on `dev` by
9fa00158 and is being improved in parallel by #TBD (`fix/render-done-says-why`).

## Why?

Andrea's session, over MCP against his local server:

```
generate_media({ slug: "anomalia-3", kind: "video" })
  → { ok: true, status: "rendering", job_id: "d616dcda-…", model: "grok-imagine/text-to-video" }
check_media_job → status: "rendering", media_id: null
check_media_job → status: "done",      media_id: null      ← here
list_media      → images only, no video
```

The agent stopped there, correctly: `done` with no id is neither a success it can use nor a
failure it can report.

**The root cause is a deploy skew, and it is worth stating on its own** because it outlives this
PR. Production (`anomalia.so`) is built from `main`@`cce7f4e8` (2 September). `main` does not carry
9fa00158, so its `applyToPost` is still `if (!row.post_id) return true;`. Andrea's localhost runs
`dev`, which is the only code that enqueues a render with `post_id = null`. The `*/1` reconcile
cron runs on **production**, against the **same** database. New writer, old reconciler: a post-less
render is declared landed, the monthly video allowance is charged, and nothing is ever deposited.

So the fix for the write side is a merge, not a diff — and until `main` catches up, every clip
generated into the library will be billed and orphaned the same way. #338 (`generate_video`) makes
that shape easy to produce, and #341 widens it further.

This PR is the other half: the reader must not hand an agent a self-contradictory answer no matter
who wrote `done` — a deployment running older code, a hand-written `UPDATE`, a future regression.

## How?

**The guard lives at the single read all surfaces route through.** The HTTP endpoint and the MCP
tool both go through `listMediaJobs`, so one branch there covers every caller.

**The check is exact, not a heuristic.** The query above it already filters `post_id is null`, so
for the rows this function returns `done` really does mean "the asset is in the library". An absent
asset cannot be a false positive. Ordering is safe too: the reconciler inserts into `brand_media`
*before* settling `done`, so a row read as `done` always has its insert already committed.

**Rejected: reporting it as `failed`.** The clip rendered and was paid for — `media_url` is set and
the mp4 is reachable. An agent reading `failed` would sensibly regenerate and pay for a second copy
of a file that already exists. Swapping one lie for a more expensive lie is not a fix. `done` and
`failed` are both false here, so the honest answer needed a third word.

**Rejected: annotating `error` and leaving the status at `done`.** It gives the agent information
but keeps the contract violation Andrea named.

**Rejected: repairing the row on read.** A read function that writes is the wrong layer, and
recovery of already-orphaned clips is generation-path work — flagged to that owner rather than
smuggled in here.

The new status word is documented in `CHECK_MEDIA_JOB` in the same commit (both contract mirrors).
A status an agent has never seen is only marginally better than the contradiction it replaces.

## Testing?

`src/lib/server/media-generate.jobs.test.ts`, six tests, committed red before the fix
(`e8fce5d9`) and green after (`89cc330f`).

Three of them reproduce the incident: a `done` job no asset claims must not be reported `done`,
must not be reported `failed`, and must say why. The other three are controls that were green
before and stay green — the happy path, a job still rendering, a job that really failed — so the
guard cannot grow into a net that catches them too.

The fake client is faithful to the real row: I ran the two queries `listMediaJobs` issues against
the actual database before writing it, and the shapes match (evidence below).

**Deliberately not duplicated here:** the write-side invariant ("no `done` render with a null
`post_id` without a `brand_media` row claiming it"). It passes on `dev` already — 9fa00158 closed
it — and it is covered in `video-render-queue`'s own tests. Restating it in this file would measure
nothing.

**Not verified in a browser.** This path has no UI: it is reachable only over HTTP and MCP, and
exercising it as a user would needs a bearer token for a brand on the shared database. Local Docker
is not running, and the local `.env` points at the hosted project, so there is no local stack to
seed against without writing to real data. What I did instead is read the real row and the real
`brand_media` join with the service key, read-only — the state the guard now handles is the state
that is actually in the table.

Also green: `npx vitest run src/lib/server/media-generate src/routes/api/v1/brands/[slug]/media
src/lib/content/changelog packages/api-contracts` (309 tests), `cli/lib/contracts.test.ts`,
`node scripts/typecheck-runtime.mjs`.

## Evidence (screenshots/videos)

<details>
<summary>The row that produced the report — <code>done</code>, and nothing claiming it</summary>

```
$ curl "$SUPABASE/rest/v1/video_renders?id=eq.d616dcda-8a2f-4017-b9e6-74542f77a8cd"
{
  "id": "d616dcda-8a2f-4017-b9e6-74542f77a8cd",
  "post_id": null,
  "status": "done",
  "attempts": 0,
  "error": null,
  "media_url": "https://…/media/99209f57…/generated/f6cbff34….mp4",
  "submitted_at": "2026-09-05T05:40:59.761+00:00",
  "completed_at": "2026-09-05T05:41:48.294+00:00"
}

$ curl "$SUPABASE/rest/v1/brand_media?source_ref=eq.d616dcda-…"
[]
$ curl "$SUPABASE/rest/v1/brand_media?brand_id=eq.65b20b74-…&kind=eq.video"
[]
```

`attempts 0` and `error null` are what rule out the download/expiry hypotheses: the row settled on
one clean pass, with no retry and no failure.
</details>

<details>
<summary>The clip exists and was paid for — which is why <code>failed</code> would be wrong</summary>

```
$ curl -I "https://…/f6cbff34-2e5a-4e03-a766-fc67791bd8e1.mp4"
HTTP/2 200
content-type: video/mp4
content-length: 2098026
```

2 MB of rendered video, billed, and reachable by nothing in the product.
</details>

<details>
<summary>Red before the fix</summary>

```
FAIL  media-generate.jobs.test.ts > non dice done a un lavoro che nessun asset reclama
AssertionError: expected 'done' not to be 'done'

FAIL  media-generate.jobs.test.ts > non lo dice nemmeno failed: il clip esiste ed e gia pagato
AssertionError: expected 'done' to be 'not_in_library'

FAIL  media-generate.jobs.test.ts > dice perche, invece di lasciare un agente senza niente su cui agire
AssertionError: expected null to be truthy

Tests  3 failed | 3 passed (6)
```
</details>

<details>
<summary>Green after</summary>

```
✓ src/lib/server/media-generate.jobs.test.ts (6 tests)
Tests  6 passed (6)
```
</details>

## Anything Else?

**The precondition this PR does not satisfy: `dev` → `main`.** Merging this stops the reader from
lying, but it does not stop clips being orphaned — that needs 9fa00158 in production. #341 is
blocked on the same merge for a different reason (production's reconciler cannot read an
`openrouter:` task id and closes the row `expired — "kie never resolved this task"`, blaming a
provider that never saw the job).

**One clip is already orphaned.** `d616dcda-…` still holds a valid `media_url`. It can be recovered
rather than written off — a later reconcile pass could file it into `brand_media`, since the
`source_ref` link needs no migration. That is generation-path work and belongs to the owner of
`video-render-queue.ts`; it is flagged there, not started here, so neither side assumes the other
is covering recovery.

**Left alone deliberately:** `'kie never resolved this task'` in the reconciler's expiry branch is
hand-written for a world with one provider and now misleads. It is in the file another PR is
actively changing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
