### PR TITLE
Serve the voice-over slot from OpenRouter

### DIFF
--- a/changelog/2026-09-05-tts-openrouter.md
+++ b/changelog/2026-09-05-tts-openrouter.md
@@ -1,0 +1,112 @@
+# La voce passa a OpenRouter, e kie diventa il ripiego
+
+Lo slot `tts` era l'ultimo su kie, e il registro spiegava perché con una riga in
+`MISSING`: «OpenRouter non fa sintesi vocale». Era falsa. Le prove che l'hanno
+sostituita stanno qui sotto, insieme ai due modi in cui è stata cercata e non
+trovata — perché la riga sbagliata è costata due sessioni, e chi rilegge
+`MISSING` fra due mesi deve trovare scritto anche come ci si sbaglia.
+
+## Le due conclusioni sbagliate
+
+**Uno: «gpt-audio rifiuta il WAV».** Chi ha provato per primo ha usato
+`chat/completions` con `openai/gpt-audio`, `audio.format: "wav"` e `stream: true`,
+e ha preso un 400. Il 400 diceva: *«does not support 'wav' when stream=true.
+Supported values are: 'pcm16'»*. La risposta era dentro l'errore, alla riga dopo
+quella letta. Con `pcm16` lo streaming funziona — sei chunk, 79.200 byte di PCM.
+
+**Due: «l'endpoint /audio/speech non è utilizzabile».** Corretto il primo errore,
+`/audio/speech` è stato sondato con `openai/tts-1`, `tts-1-hd`, `gpt-4o-mini-tts`,
+`gemini-2.5-flash-preview-tts`, `eleven-v3` — tutti 400 «modello inesistente», e
+la conclusione è stata che l'endpoint fosse morto. L'endpoint era giusto: erano
+gli id a essere inventati. Il modello vero è `google/gemini-3.1-flash-tts-preview`,
+e **non compare** nel catalogo `/models` filtrato per modalità audio — la seconda
+superficie di OpenRouter in un giorno che da quel catalogo non si vede.
+
+Il modo che funziona per trovarne altre: chiamare un modello TTS su
+`chat/completions` restituisce un errore che **nomina l'endpoint corretto**.
+
+## Cosa è stato misurato prima di scrivere il codice
+
+Contro l'API vera, non dal listino:
+
+- **`POST /audio/speech`** con `google/gemini-3.1-flash-tts-preview` → 200, e
+  `content-type: audio/pcm;rate=24000;channels=1`. `response_format` accetta
+  `mp3|pcm` sull'endpoint, ma questo modello risponde `pcm` e basta (400 esplicito
+  sull'altro).
+- **La frequenza è davvero 24 kHz**, e non perché lo dice l'intestazione. Stesso
+  copione, stessa voce, su kie (il cui WAV dichiara 24000/1/16 nel suo header): il
+  parlato copre **3,20 s** su kie e **3,20 s** su OpenRouter letto a 24000. Su uno
+  script di tre righe le pause cadono a 2,20/3,82 s su kie e 2,16/3,80 s su
+  OpenRouter. A 16 o 48 kHz quegli istanti sarebbero scalati di 1,5× o 2×.
+  Il WAV prodotto, ridato a un modello con audio in ingresso, torna trascritto
+  parola per parola e giudicato «natural in pitch and pace».
+- **Le voci sono le stesse.** `Kore`, `Puck`, `Charon`, `Aoede`, `Fenrir` — le
+  cinque che il prodotto offre — accettate tutte. Un nome fuori elenco (`alloy`) è
+  400: l'endpoint valida invece di ripiegare in silenzio su una voce di default,
+  che era il rischio vero. Per il cliente non cambia niente: stessa famiglia
+  Gemini, stessi preset.
+- **Il costo è lo stesso.** Stesso copione di tre righe: kie 1,19 crediti =
+  **$0,00595**, OpenRouter **$0,005772**. La testata del registro diceva che il
+  TTS su kie costa ~3× Google e che lo scopo era togliere una dipendenza, non
+  risparmiare; il confronto giusto oggi è kie contro OpenRouter, e non c'è
+  differenza. Il motivo per spostarsi non è il prezzo: è che kie torna a essere il
+  ripiego che è ovunque, e la voce smette di essere l'unico slot senza rete.
+- **La direzione di lettura non viene letta ad alta voce.** Il take con la
+  direzione in testa dura **meno** di quello senza (3,36 s contro 3,76 s): è
+  interpretata come stile, esattamente come `sample_context` su kie. Quindi
+  `buildVoiceOverPrompt` passa così com'è.
+
+## Cosa è cambiato
+
+`SLOT_DEFAULT.tts` è `gemini-tts@openrouter`; `HOME['gemini-tts']` resta `kie`.
+Sono due ruoli diversi e non si collassano: il default dice dove va il traffico
+quando funziona, `HOME` dove va quando il default non è servibile. Senza
+`OPENROUTER_API_KEY` la rotta ripiega su kie **rumorosamente**, come ogni altro
+slot.
+
+`MISSING.openrouter` è vuoto. `SERVED_BY['gemini-tts']` ha due endpoint.
+
+Il trasporto è `llmSpeech` in `llm.ts`, una richiesta sola: non streaming, non
+`gpt-audio`. `gpt-audio` funziona davvero (`pcm16` + `stream: true`, provato) ma è
+OpenAI, cambierebbe la voce, e andrebbe ricomposto a pezzi. Resta annotato come
+alternativa, non come scelta.
+
+Il PCM grezzo non ha intestazione, quindi `llmSpeech` **riporta a chi chiama** la
+frequenza e i canali che ha letto dal `content-type` invece di darli per scontati:
+un 48 kHz stereo non fallisce, dura il doppio e parla a metà velocità. Il controllo
+del formato, che prima esisteva solo dentro il ramo kie, adesso è una funzione
+sola (`assertCuttable`) usata da entrambi i rami — la regola è una, e sta in un
+posto. L'incapsulamento riusa `wavFromPcm`, che c'era già.
+
+**UNA generazione per tutte le righe** resta la proprietà del file, e ora ha un
+test che la sorveglia: sei righe, esattamente un POST, e tutte e sei nel corpo.
+
+## Quello che si perde, e non si nasconde
+
+Su kie la riga di `ai_calls` porta `creditsConsumed` e quindi un costo.
+`/audio/speech` non porta nessuna fattura: nessuna intestazione, nessun corpo JSON.
+`GET /generation?id=` esiste ma è già stato misurato e scartato — sta scritto in
+`llm-usage-cost.ts`: il record compare **nove secondi dopo** la risposta, e tenere
+viva una funzione serverless per aspettarlo perde anche la riga di log.
+
+Quindi la riga del voice-over resta **senza costo**. Un buco visibile invece di un
+numero plausibile e sbagliato, che è la regola già scritta in questo file. Il
+prezzo per audio token esiste ($0,00002) ma i token per secondo misurati sono
+ballati fra 25 e 49 su tre chiamate: dedurne un costo sarebbe inventarlo.
+
+## I test
+
+Il primo non è «arriva dell'audio»: quello passerebbe con un formato inutilizzabile,
+che è precisamente l'errore che ha prodotto la conclusione sbagliata. È **la forma
+che il tagliatore accetta** — il WAV caricato viene riletto da `pcmFromWav` e deve
+dire 24000/1/16, con i campioni identici a quelli generati. Il secondo rifiuta un
+48 kHz e uno stereo. Poi: una generazione sola, e il ripiego rumoroso su kie senza
+chiave.
+
+In `model-routing.test.ts` due test usavano `gemini-tts@openrouter` come esempio di
+*coppia senza trasporto*, e sono diventati rossi — l'esito buono. Le coppie sono
+state **cambiate**, non le asserzioni: restano `grok@openrouter` e `gpt@openrouter`,
+e che sorveglino ancora qualcosa è stato verificato dando loro un trasporto e
+guardandoli diventare rossi. Una coppia che diventa *non parsabile* invece che
+*servita* lascerebbe il test verde a misurare il ripiego al default: è già successo,
+e non si vede.

--- a/src/lib/content/changelog/2026-09-05-tts-openrouter.ts
+++ b/src/lib/content/changelog/2026-09-05-tts-openrouter.ts
@@ -1,0 +1,9 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-05',
+  title: 'Voice-over now comes from the faster provider',
+  items: [
+    'Motion video voice-overs are generated through our primary provider instead of the backup one. Same voices, same sound, same price — and when the primary is unavailable the backup still takes over on its own.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/gemini-audio.ts
+++ b/src/lib/server/gemini-audio.ts
@@ -38,8 +38,27 @@ import {
 	planCuts,
 	sliceToWav,
 	type DroppedCut,
-	type Gap
+	type Gap,
+	type PcmFormat
 } from '$lib/server/voiceover-cut';
+
+/**
+ * Il formato che il tagliatore sa usare, in UN posto solo perché la regola è una sola. Il taglio a
+ * valle assume L16 24 kHz mono e lo assume in SILENZIO: un 48 kHz stereo non fallisce, produce
+ * pezzi lunghi la metà e una voce al doppio della velocità.
+ */
+function assertCuttable(model: string, format: PcmFormat): void {
+	if (
+		format.sampleRate === TTS_PCM.sampleRate &&
+		format.channels === TTS_PCM.channels &&
+		format.bitsPerSample === TTS_PCM.bitsPerSample
+	) {
+		return;
+	}
+	throw new Error(
+		`${model} returned ${format.sampleRate} Hz ${format.channels}-channel ${format.bitsPerSample}-bit audio; the cutter needs ${TTS_PCM.sampleRate} Hz mono ${TTS_PCM.bitsPerSample}-bit.`
+	);
+}
 
 /** Il modello TTS. Sovrascrivibile senza deploy — vedi l'intestazione. */
 export function ttsModel(): string {
@@ -209,18 +228,8 @@ export async function generateVoiceOver(opts: {
 			});
 			if (!spoken) throw new Error('kie returned no audio.');
 			credits = spoken.credits;
-			// Il taglio a valle assume L16 24 kHz mono e lo assume in SILENZIO: un WAV a 48 kHz
-			// stereo non fallisce, produce pezzi lunghi la metà e una voce al doppio della velocità.
 			const decoded = pcmFromWav(spoken.wav);
-			if (
-				decoded.sampleRate !== TTS_PCM.sampleRate ||
-				decoded.channels !== TTS_PCM.channels ||
-				decoded.bitsPerSample !== TTS_PCM.bitsPerSample
-			) {
-				throw new Error(
-					`${model} returned ${decoded.sampleRate} Hz ${decoded.channels}-channel ${decoded.bitsPerSample}-bit audio; the cutter needs ${TTS_PCM.sampleRate} Hz mono ${TTS_PCM.bitsPerSample}-bit.`
-				);
-			}
+			assertCuttable(model, decoded);
 			samples = decoded.samples;
 			// Il WAV di kie è già valido e il suo URL vive 24h: si carica subito.
 			fullUrl = await uploadAudio(opts.supabase, opts.brandId, spoken.wav, 'full');

--- a/src/lib/server/gemini-audio.ts
+++ b/src/lib/server/gemini-audio.ts
@@ -12,6 +12,11 @@
  *
  * Gli id dei modelli si leggono dall'ambiente: la suite audio di Gemini si muove più in fretta
  * della nostra release, e un id cablato costa un deploy mentre una variabile costa un minuto.
+ *
+ * La famiglia è Gemini da entrambi i trasporti, ed è il motivo per cui lo slot si sposta senza che
+ * il brand cambi voce: openrouter e kie servono gli stessi preset. Il costo lo scrive solo kie
+ * (`creditsConsumed`); su openrouter `/audio/speech` non porta nessuna fattura e la riga resta
+ * senza costo — un buco visibile, che qui è la regola.
  */
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { spawnSync } from 'node:child_process';
@@ -26,6 +31,8 @@ import {
 	LYRIA_CLIP_SECONDS,
 	LYRIA_COST_USD,
 	llmChatCompletions,
+	llmSpeech,
+	llmTtsModel,
 	lyriaModel,
 	musicBytesFromChatCompletion,
 	type MusicTier
@@ -36,11 +43,16 @@ import {
 	findGaps,
 	pcmFromWav,
 	planCuts,
+	samplesFromPcm,
 	sliceToWav,
+	wavFromPcm,
 	type DroppedCut,
 	type Gap,
 	type PcmFormat
 } from '$lib/server/voiceover-cut';
+
+/** Due minuti coprono un copione lungo con margine, su entrambi i trasporti. */
+const TTS_TIMEOUT_MS = 120_000;
 
 /**
  * Il formato che il tagliatore sa usare, in UN posto solo perché la regola è una sola. Il taglio a
@@ -58,11 +70,6 @@ function assertCuttable(model: string, format: PcmFormat): void {
 	throw new Error(
 		`${model} returned ${format.sampleRate} Hz ${format.channels}-channel ${format.bitsPerSample}-bit audio; the cutter needs ${TTS_PCM.sampleRate} Hz mono ${TTS_PCM.bitsPerSample}-bit.`
 	);
-}
-
-/** Il modello TTS. Sovrascrivibile senza deploy — vedi l'intestazione. */
-export function ttsModel(): string {
-	return env.GEMINI_TTS_MODEL?.trim() || 'gemini-2.5-flash-preview-tts';
 }
 
 /**
@@ -199,12 +206,9 @@ export async function generateVoiceOver(opts: {
 	const lines = opts.lines.map((l) => String(l ?? '').trim()).filter(Boolean);
 	if (!lines.length) throw new Error('No lines to read.');
 	const voice = opts.voice && isVoiceOverVoice(opts.voice) ? opts.voice : DEFAULT_VOICE;
-	/**
-	 * La voce passa da kie: il centralino non fa TTS. Un endpoint diverso si ferma qui, senza
-	 * cadere sullo SDK Google.
-	 */
-	const useKie = route('tts').endpoint === 'kie';
-	const model = useKie ? kieTtsModel() : ttsModel();
+	const endpoint = route('tts').endpoint;
+	const useKie = endpoint === 'kie';
+	const model = useKie ? kieTtsModel() : llmTtsModel();
 	let credits: number | undefined;
 	const t0 = Date.now();
 
@@ -234,12 +238,26 @@ export async function generateVoiceOver(opts: {
 			// Il WAV di kie è già valido e il suo URL vive 24h: si carica subito.
 			fullUrl = await uploadAudio(opts.supabase, opts.brandId, spoken.wav, 'full');
 		} else {
-			throw new Error('TTS is kie-only. Google speech is not on the gateway.');
+			// UNA chiamata per tutte le righe anche qui: il copione intero è l'`input`. La direzione
+			// di lettura ci sta dentro senza essere letta ad alta voce — misurato, il take con la
+			// direzione non dura più di quello senza.
+			const spoken = await llmSpeech({
+				model,
+				input: buildVoiceOverPrompt(lines, opts.style),
+				voice: voiceName(voice),
+				timeoutMs: TTS_TIMEOUT_MS,
+				abortSignal: opts.abortSignal
+			});
+			// I 16 bit per campione non stanno nel `content-type`: sono la definizione di L16, e
+			// `wavFromPcm` è ciò che li scrive nell'intestazione che il PCM grezzo non ha.
+			assertCuttable(model, { ...spoken, bitsPerSample: TTS_PCM.bitsPerSample });
+			samples = samplesFromPcm(spoken.pcm);
+			fullUrl = await uploadAudio(opts.supabase, opts.brandId, wavFromPcm(spoken.pcm), 'full');
 		}
 	} catch (e) {
 		logAiCall({
 			label: 'voiceover',
-			provider: useKie ? 'kie' : 'gemini',
+			provider: endpoint,
 			model,
 			ms: Date.now() - t0,
 			ok: false,
@@ -257,7 +275,7 @@ export async function generateVoiceOver(opts: {
 
 	logAiCall({
 		label: 'voiceover',
-		provider: useKie ? 'kie' : 'gemini',
+		provider: endpoint,
 		model,
 		ms: Date.now() - t0,
 		ok: true,

--- a/src/lib/server/llm.ts
+++ b/src/lib/server/llm.ts
@@ -487,3 +487,63 @@ export async function llmChatCompletions(opts: {
 	}
 	return res.json();
 }
+
+export const GEMINI_TTS = 'google/gemini-3.1-flash-tts-preview';
+
+export function llmTtsModel(): string {
+	return env.OPENROUTER_TTS_MODEL?.trim() || GEMINI_TTS;
+}
+
+/**
+ * Una voce, in una richiesta sola. `POST /audio/speech` risponde con PCM GREZZO: nessuna
+ * intestazione dentro i byte, quindi la frequenza e i canali li dice soltanto il `content-type`
+ * (`audio/pcm;rate=24000;channels=1`) e vanno riportati a chi chiama, che è l'unico a sapere quale
+ * formato sa usare. Darli per scontati è il guasto che non fallisce: un 48 kHz stereo letto come
+ * 24 kHz mono non lancia, dura il doppio e parla a metà velocità.
+ *
+ * Non è streaming, di proposito: la chat completions serve `openai/gpt-audio` e pretende
+ * `stream: true` con `format: "pcm16"`, cioè cambia fornitore, cambia la voce e va ricomposta a
+ * pezzi. Qui la famiglia resta Gemini, com'era su kie.
+ *
+ * `mp3` esiste come `response_format` sull'endpoint ma non per questo modello (400 esplicito), e
+ * il costo NON torna: nessuna intestazione lo porta, e `GET /generation?id=` è già stato misurato
+ * e scartato in `llm-usage-cost.ts` — il record compare nove secondi dopo.
+ */
+export async function llmSpeech(opts: {
+	model: string;
+	input: string;
+	voice: string;
+	timeoutMs: number;
+	abortSignal?: AbortSignal;
+}): Promise<{ pcm: Uint8Array; sampleRate: number; channels: number }> {
+	const key = llmApiKey();
+	if (!key) throw new Error('LLM_API_KEY is not configured');
+	const res = await fetch(`${llmBaseUrl()}/audio/speech`, {
+		method: 'POST',
+		headers: {
+			authorization: `Bearer ${key}`,
+			'content-type': 'application/json'
+		},
+		body: JSON.stringify({
+			model: opts.model,
+			input: opts.input,
+			voice: opts.voice,
+			response_format: 'pcm'
+		}),
+		signal: AbortSignal.any([
+			...(opts.abortSignal ? [opts.abortSignal] : []),
+			AbortSignal.timeout(opts.timeoutMs)
+		])
+	});
+	if (!res.ok) {
+		const detail = (await res.text().catch(() => '')).slice(0, 300);
+		throw new Error(`${opts.model} answered ${res.status}. ${detail}`);
+	}
+	const contentType = res.headers.get('content-type') ?? '';
+	const sampleRate = Number(/rate=(\d+)/.exec(contentType)?.[1]);
+	const channels = Number(/channels=(\d+)/.exec(contentType)?.[1]);
+	if (!Number.isFinite(sampleRate) || !Number.isFinite(channels)) {
+		throw new Error(`${opts.model} answered "${contentType}", which does not say what PCM this is.`);
+	}
+	return { pcm: new Uint8Array(await res.arrayBuffer()), sampleRate, channels };
+}

--- a/src/lib/server/model-routing.test.ts
+++ b/src/lib/server/model-routing.test.ts
@@ -20,11 +20,11 @@ describe('il registro delle rotte', () => {
     setEnv(KEYS);
   });
 
-  it('i default: testo e immagini su openrouter, voce su kie', async () => {
+  it('i default: testo, immagini e voce su openrouter', async () => {
     const { route } = await import('./model-routing');
     expect(route('text')).toMatchObject({ family: 'gemini', endpoint: 'openrouter', provider: 'openrouter' });
     expect(route('image')).toMatchObject({ endpoint: 'openrouter', provider: 'openrouter' });
-    expect(route('tts')).toMatchObject({ endpoint: 'kie', provider: 'kie' });
+    expect(route('tts')).toMatchObject({ family: 'gemini-tts', endpoint: 'openrouter', provider: 'openrouter' });
   });
 
   it('dice i due assi separatamente: famiglia @ endpoint', async () => {
@@ -91,7 +91,9 @@ describe('il registro delle rotte', () => {
     expect(missingCapabilities('kie')).toEqual(
       expect.arrayContaining(['grounding', 'media-in-tool-result', 'video-fps', 'prompt-cache', 'embeddings', 'music'])
     );
-    expect(missingCapabilities('openrouter')).toEqual(['tts']);
+    // Nessuna: l'ultima assenza era il TTS, ed era falsa. `/audio/speech` con
+    // `google/gemini-3.1-flash-tts-preview` torna `audio/pcm;rate=24000;channels=1`.
+    expect(missingCapabilities('openrouter')).toEqual([]);
   });
 
   it('openrouter è una rotta, e AI_ROUTE_IMAGE la seleziona', async () => {
@@ -123,7 +125,7 @@ describe('il registro delle rotte', () => {
     // `geminiTransport()` conosce solo kie e google: il testo verso openrouter atterrerebbe su
     // Google IN SILENZIO, cioè la rotta si legge come rispettata e non lo è. Vale identico per le
     // coppie che erano già cieche prima di openrouter — una regola sola, non un'eccezione.
-    for (const raw of ['gemini-tts@openrouter', 'grok@openrouter', 'gpt@openrouter']) {
+    for (const raw of ['grok@openrouter', 'gpt@openrouter']) {
       vi.resetModules();
       setEnv({ ...KEYS, AI_ROUTE_TEXT: raw });
       const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -142,7 +144,8 @@ describe('il registro delle rotte', () => {
       ['grok@kie', 'text', 'kie'],
       ['nano-banana@openrouter', 'image', 'openrouter'],
       ['nano-banana@kie', 'image', 'kie'],
-      ['gemini-tts@kie', 'tts', 'kie']
+      ['gemini-tts@kie', 'tts', 'kie'],
+      ['gemini-tts@openrouter', 'tts', 'openrouter']
     ] as const) {
       vi.resetModules();
       setEnv({ ...KEYS, [SLOT_VAR[slot]]: raw });
@@ -161,9 +164,16 @@ describe('il registro delle rotte', () => {
     expect(route('image')).toMatchObject({ family: 'nano-banana', endpoint: 'openrouter' });
   });
 
-  it('la voce NON si sposta col resto: OpenRouter non fa TTS', async () => {
+  it('la voce si sposta col resto, e kie resta il ripiego', async () => {
     const { route } = await import('./model-routing');
-    expect(route('tts').endpoint).toBe('kie');
+    expect(route('tts').endpoint).toBe('openrouter');
+    vi.resetModules();
+    setEnv({ KIE_API_KEY: 'k' });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { route: routeWithoutKey } = await import('./model-routing');
+    expect(routeWithoutKey('tts').endpoint).toBe('kie');
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/AI_ROUTE_TTS.*Ripiego su kie/));
+    warn.mockRestore();
   });
 
   it('senza chiave openrouter le immagini ripiegano su kie, che resta il ripiego', async () => {
@@ -202,7 +212,7 @@ describe('il registro delle rotte', () => {
     // servita rende il test rosso — rumoroso, quindi innocuo; una che diventa NON PARSABILE lo
     // farebbe restare verde misurando il ripiego al default invece dell'invariante. Sono due modi
     // opposti di sbagliare, e solo uno si vede.
-    for (const raw of ['grok@openrouter', 'gpt@openrouter', 'gemini-tts@openrouter']) {
+    for (const raw of ['grok@openrouter', 'gpt@openrouter']) {
       vi.resetModules();
       setEnv({ ...KEYS, OPENROUTER_API_KEY: 'o', AI_ROUTE_VIDEO: raw });
       const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -323,10 +333,7 @@ describe('restano solo openrouter e kie', () => {
     const { route } = await import('./model-routing');
     expect(route('text').endpoint).toBe('openrouter');
     expect(route('image').endpoint).toBe('openrouter');
-    // Il TTS resta su kie: MISURATO, non assunto. `lyria-3` su OpenRouter e` MUSICA, e
-    // `openai/gpt-audio` pretende stream:true per l'audio ma rifiuta il WAV in streaming —
-    // mentre il nostro tagliatore vuole L16 24 kHz mono 16 bit.
-    expect(route('tts').endpoint).toBe('kie');
+    expect(route('tts').endpoint).toBe('openrouter');
   });
 
   it('il ripiego di ogni slot e` kie, mai altro', async () => {
@@ -339,10 +346,13 @@ describe('restano solo openrouter e kie', () => {
     warn.mockRestore();
   });
 
-  it('openrouter non sa fare il TTS, ed e` scritto nel registro', async () => {
+  it('openrouter sa fare il TTS, e ora il registro lo dice', async () => {
+    // Era scritto il contrario, e la prova che lo smentisce e` una chiamata sola:
+    // `POST /audio/speech` con `google/gemini-3.1-flash-tts-preview` risponde 200 e
+    // `content-type: audio/pcm;rate=24000;channels=1` — la forma esatta che il tagliatore vuole.
     const { missingCapabilities, can } = await import('./model-routing');
-    expect(can('openrouter', 'tts')).toBe(false);
+    expect(can('openrouter', 'tts')).toBe(true);
     expect(can('kie', 'tts')).toBe(true);
-    expect(missingCapabilities('openrouter')).toContain('tts');
+    expect(missingCapabilities('openrouter')).not.toContain('tts');
   });
 });

--- a/src/lib/server/model-routing.ts
+++ b/src/lib/server/model-routing.ts
@@ -7,7 +7,8 @@
  * Restano DUE trasporti: **openrouter serve, kie ripiega.** Google, Xiaomi e DeepSeek sono usciti —
  * non per prezzo, ma perché su questo non ci si fonda: kie fallisce il 3,5% dei render con un p95
  * di 142,9s contro i 3,4s di OpenRouter, e DeepSeek falliva il 41,3% di 5.122 chiamate. kie resta
- * perché il TTS lo fa e OpenRouter no, e perché un secondo trasporto vale più di zero.
+ * come RIPIEGO — un secondo trasporto vale più di zero — non perché sappia fare qualcosa che
+ * OpenRouter non sa: l'ultima cosa in quell'elenco era il TTS, e non era vera.
  *
  * Due assi, che non si collassano mai in uno:
  *   · famiglia — QUALE modello scrive. È la garanzia di qualità: `PIN_GEMINI` vuol dire "questo
@@ -91,9 +92,12 @@ const ALL: Capability[] = [
  * parte capace di tutto e si scopre incapace un guasto alla volta.
  */
 const MISSING: Record<Endpoint, Partial<Record<Capability, string>>> = {
-  openrouter: {
-    tts: 'OpenRouter non fa sintesi vocale: lyria-3 è MUSICA, e gpt-audio pretende stream:true per l\'audio ma rifiuta il WAV in streaming — mentre il tagliatore vuole L16 24 kHz mono 16 bit'
-  },
+  // Vuoto, e ci è voluto sbagliare due volte per arrivarci: qui c'era scritto che OpenRouter non
+  // fa sintesi vocale. Era falso. `POST /audio/speech` con `google/gemini-3.1-flash-tts-preview`
+  // risponde 200 e `content-type: audio/pcm;rate=24000;channels=1` — la forma esatta che il
+  // tagliatore vuole. Cercarla su `chat/completions` (dove risponde solo `gpt-audio`, e solo in
+  // streaming) e cercarla su `/audio/speech` con id inventati sono due modi di non trovarla.
+  openrouter: {},
   kie: {
     grounding: 'kie non restituisce groundingMetadata: le citazioni tornano vuote',
     'media-in-tool-result': 'kie scarta i media dentro i risultati dei tool, in silenzio',
@@ -116,6 +120,7 @@ const MISSING: Record<Endpoint, Partial<Record<Capability, string>>> = {
  */
 const HOME: Record<ModelFamily, Endpoint> = {
   gemini: 'kie',
+  // Come `nano-banana` e `grok-imagine`: openrouter è il DEFAULT dello slot, kie è dove si ripiega.
   'gemini-tts': 'kie',
   'nano-banana': 'kie',
   grok: 'kie',
@@ -137,7 +142,7 @@ const HOME: Record<ModelFamily, Endpoint> = {
  */
 const SERVED_BY: Record<ModelFamily, Endpoint[]> = {
   gemini: ['kie', 'openrouter'],
-  'gemini-tts': ['kie'],
+  'gemini-tts': ['kie', 'openrouter'],
   'nano-banana': ['kie', 'openrouter'],
   grok: ['kie'],
   gpt: ['kie'],
@@ -177,8 +182,10 @@ const SLOT_DEFAULT: Record<Slot, Route> = {
   text: r('gemini', 'openrouter'),
   // Non il prezzo: kie fallisce il 3,5% dei render con un p95 di 142,9s contro i 3,4s di OpenRouter.
   image: r('nano-banana', 'openrouter'),
-  // La voce resta su kie perche' OpenRouter NON fa sintesi vocale — misurato, sta in MISSING.
-  tts: r('gemini-tts', 'kie'),
+  // Stessa famiglia Gemini servita da openrouter: le voci sono le stesse (Kore, Puck, Charon,
+  // Aoede, Fenrir tutte accettate), quindi per il cliente non cambia nulla. Il costo nemmeno —
+  // stesso copione, kie 1,19 crediti = $0,00595 contro $0,005772. Cambia il ripiego, che ora c'e'.
+  tts: r('gemini-tts', 'openrouter'),
   // Il video resta dov'è, e OpenRouter costa 6× kie su Grok Imagine (misurato): spostarlo e` una
   // decisione esplicita, non un effetto dell'uniformita'. La famiglia qui e` la LINEA DI DEFAULT,
   // non il modello del render — quello lo scelgono le preferenze del brand (`videoModelForRole`) e

--- a/src/lib/server/voiceover-cut.test.ts
+++ b/src/lib/server/voiceover-cut.test.ts
@@ -1,8 +1,15 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Il modulo che genera tocca rete, chiave e registro: qui si sostituiscono i tre, così anche la
 // parte non pura di `gemini-audio` si prova senza uscire dal processo.
-vi.mock('$env/dynamic/private', () => ({ env: { GEMINI_API_KEY: 'test-key', LLM_API_KEY: 'test-key', KIE_API_KEY: 'test-key' } }));
+const M = vi.hoisted(() => ({ env: {} as Record<string, string | undefined> }));
+vi.mock('$env/dynamic/private', () => ({ env: M.env }));
+const KEYS = { GEMINI_API_KEY: 'test-key', LLM_API_KEY: 'test-key', KIE_API_KEY: 'test-key' };
+function setEnv(vars: Record<string, string | undefined>) {
+	for (const k of Object.keys(M.env)) delete M.env[k];
+	Object.assign(M.env, vars);
+}
+setEnv(KEYS);
 const logged = vi.hoisted(() => [] as Array<Record<string, unknown>>);
 vi.mock('$lib/server/ai-log', () => ({
 	logAiCall: (row: Record<string, unknown>) => {
@@ -345,11 +352,16 @@ function wavOf(samples: Int16Array, format = { sampleRate: TTS_SAMPLE_RATE, chan
 	);
 }
 
+const uploaded: Buffer[] = [];
+
 function fakeSupabase(uploadError?: string): SupabaseClient {
 	return {
 		storage: {
 			from: () => ({
-				upload: async () => ({ error: uploadError ? { message: uploadError } : null }),
+				upload: async (_path: string, body: Buffer) => {
+					uploaded.push(body);
+					return { error: uploadError ? { message: uploadError } : null };
+				},
 				getPublicUrl: (p: string) => ({ data: { publicUrl: BASE + p } })
 			})
 		}
@@ -499,7 +511,10 @@ describe('generateMusicBed', () => {
 	});
 });
 
-describe('generateVoiceOver', () => {
+describe('generateVoiceOver sul ripiego kie', () => {
+	beforeEach(() => setEnv({ ...KEYS, AI_ROUTE_TTS: 'gemini-tts@kie' }));
+	afterEach(() => setEnv(KEYS));
+
 	it('un caricamento fallito lascia una riga nel registro, non il silenzio', async () => {
 		kieJobs.generateSpeechOnKie.mockResolvedValue({
 			wav: wavFromPcm(new Uint8Array(TTS_SAMPLE_RATE * 2)),
@@ -514,5 +529,98 @@ describe('generateVoiceOver', () => {
 			})
 		).rejects.toThrow(/Audio upload failed/);
 		expect(logged.at(-1)).toMatchObject({ label: 'voiceover', ok: false });
+	});
+});
+
+/**
+ * LA VOCE SU OPENROUTER.
+ *
+ * `POST /audio/speech` torna PCM GREZZO, senza intestazione: la frequenza la dichiara solo
+ * `content-type: audio/pcm;rate=24000;channels=1`. Il primo test non è "arrivano dei byte" — con
+ * quello passerebbe anche un 48 kHz stereo, che non fallisce, produce pezzi lunghi la metà e una
+ * voce al doppio della velocità. Si prova la FORMA che il tagliatore accetta.
+ */
+function speech(pcm: ArrayBuffer, rate = TTS_SAMPLE_RATE, channels = 1) {
+	return new Response(pcm, { headers: { 'content-type': `audio/pcm;rate=${rate};channels=${channels}` } });
+}
+
+function spokenPcm(samples: Int16Array): ArrayBuffer {
+	const bytes = new Uint8Array(samples.length * 2);
+	for (let i = 0; i < samples.length; i++) {
+		bytes[i * 2] = samples[i] & 0xff;
+		bytes[i * 2 + 1] = (samples[i] >> 8) & 0xff;
+	}
+	return bytes.buffer;
+}
+
+describe('generateVoiceOver su openrouter', () => {
+	const take = concat(tone(1000), hush(400), tone(1000));
+
+	beforeEach(() => {
+		setEnv({ ...KEYS, OPENROUTER_API_KEY: 'o' });
+		uploaded.length = 0;
+	});
+	afterEach(() => setEnv(KEYS));
+
+	it('carica un WAV che il tagliatore riaccetta: 24 kHz mono 16 bit', async () => {
+		const res = await withFetch(
+			(async () => speech(spokenPcm(take))) as typeof fetch,
+			() => generateVoiceOver({ supabase: fakeSupabase(), brandId: 'b', lines: ['una riga', 'due'] })
+		);
+		const read = pcmFromWav(uploaded[0]);
+		expect({ sampleRate: read.sampleRate, channels: read.channels, bitsPerSample: read.bitsPerSample }).toEqual({
+			sampleRate: TTS_SAMPLE_RATE,
+			channels: 1,
+			bitsPerSample: 16
+		});
+		expect(Array.from(read.samples)).toEqual(Array.from(take));
+		expect(res.fullDurationSeconds).toBeCloseTo(take.length / TTS_SAMPLE_RATE, 6);
+		expect(logged.at(-1)).toMatchObject({ label: 'voiceover', ok: true, provider: 'openrouter' });
+	});
+
+	it('un PCM che non è 24 kHz mono si rifiuta, non si taglia a metà velocità', async () => {
+		for (const [rate, channels] of [
+			[48_000, 1],
+			[TTS_SAMPLE_RATE, 2]
+		] as const) {
+			await expect(
+				withFetch(
+					(async () => speech(spokenPcm(take), rate, channels)) as typeof fetch,
+					() => generateVoiceOver({ supabase: fakeSupabase(), brandId: 'b', lines: ['una riga'] })
+				),
+				`${rate} Hz ${channels}ch`
+			).rejects.toThrow(/the cutter needs/i);
+			expect(uploaded).toHaveLength(0);
+			expect(logged.at(-1)).toMatchObject({ label: 'voiceover', ok: false });
+		}
+	});
+
+	it('una generazione sola per tutte le righe, non una per riga', async () => {
+		const lines = ['uno', 'due', 'tre', 'quattro', 'cinque', 'sei'];
+		const calls: string[] = [];
+		await withFetch(
+			(async (_url: string, init: RequestInit) => {
+				calls.push(String(init.body));
+				return speech(spokenPcm(take));
+			}) as unknown as typeof fetch,
+			() => generateVoiceOver({ supabase: fakeSupabase(), brandId: 'b', lines })
+		);
+		expect(calls).toHaveLength(1);
+		for (const line of lines) expect(calls[0]).toContain(line);
+	});
+
+	it('senza chiave openrouter la voce ripiega su kie, e lo dice', async () => {
+		setEnv({ KIE_API_KEY: 'test-key' });
+		kieJobs.generateSpeechOnKie.mockResolvedValue({
+			wav: wavFromPcm(new Uint8Array(spokenPcm(take))),
+			credits: 1,
+			model: 'gemini-3.5-pro-preview-tts'
+		});
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		const res = await generateVoiceOver({ supabase: fakeSupabase(), brandId: 'b', lines: ['una riga'] });
+		expect(res.fullDurationSeconds).toBeCloseTo(take.length / TTS_SAMPLE_RATE, 6);
+		expect(logged.at(-1)).toMatchObject({ label: 'voiceover', ok: true, provider: 'kie' });
+		expect(warn).toHaveBeenCalledWith(expect.stringMatching(/AI_ROUTE_TTS.*Ripiego su kie/));
+		warn.mockRestore();
 	});
 });


### PR DESCRIPTION
## What?

The voice-over slot moves from kie to OpenRouter. `SLOT_DEFAULT.tts` becomes
`gemini-tts@openrouter`, `SERVED_BY['gemini-tts']` gains a second endpoint, and
`MISSING.openrouter` — which declared that OpenRouter cannot do speech synthesis —
is now empty, because that line was false.

The transport is one new function, `llmSpeech` in `llm.ts`: a single
`POST /audio/speech` to `google/gemini-3.1-flash-tts-preview`. It answers 200 with
`content-type: audio/pcm;rate=24000;channels=1` — the exact format the cutter
already wants, so nothing is converted and nothing is reassembled from a stream.

`HOME['gemini-tts']` deliberately stays `kie`: the slot default says where traffic
goes when things work, `HOME` says where it goes when the default is not servable.
Without `OPENROUTER_API_KEY` the route falls back to kie, noisily, like every other
slot.

## Why?

The voice was the last slot still pinned to kie, and the registry explained why with
a measured-looking sentence that was wrong. Two sessions concluded it could not be
done, in two different ways, and both are worth writing down because whoever rereads
`MISSING` in two months will otherwise repeat one of them.

**Mistake one — «gpt-audio refuses WAV».** The first probe used `chat/completions`
with `openai/gpt-audio`, `audio.format: "wav"`, `stream: true`, and got a 400. The
400 said: *"does not support 'wav' when stream=true. Supported values are:
'pcm16'."* The answer was inside the error, one line below the one that was read.
With `pcm16` the stream works — 6 chunks, 79,200 bytes of PCM.

**Mistake two — «/audio/speech is unusable».** After correcting the first, the right
endpoint was probed with invented model ids (`openai/tts-1`, `tts-1-hd`,
`gpt-4o-mini-tts`, `gemini-2.5-flash-preview-tts`, `eleven-v3`), all 400 "no such
model", and the conclusion was that the endpoint was dead. The endpoint was correct;
the ids were not. The real model does **not** appear in the `/models` catalogue
filtered by audio modality — the second OpenRouter surface in one day that is
invisible from that catalogue, after video.

The way that actually finds these: calling a TTS model on `chat/completions` returns
an error that **names the correct endpoint**.

Beyond fixing the false claim, the point is that kie goes back to being the fallback
it is everywhere else, and the voice stops being the one slot with no safety net.

## How?

**The rate was verified, not assumed.** Raw streaming PCM has no header, which is why
the earlier attempt was stuck; the non-streaming endpoint declares the format in
`content-type`. But a declaration is still not a measurement, so it was cross-checked
against kie, whose WAV header we already trust in production:

| same line, voice Kore | kie (header says 24000/1/16) | OpenRouter PCM read at 24000 |
|---|---|---|
| speech span | 0.26 → 3.46 = **3.20s** | 0.24 → 3.44 = **3.20s** |
| 3-line script, pause onsets | 2.20s, 3.82s | 2.16s, 3.80s |

At 16 or 48 kHz those instants would be scaled by 1.5× or 2×. As a last check, the
WAV this branch produces was handed to an audio-in model: it came back transcribed
word for word and judged "natural in pitch and pace".

**The voices are the same ones.** `Kore`, `Puck`, `Charon`, `Aoede`, `Fenrir` — the
five the product offers — all accepted. An off-list name (`alloy`) is a 400, so the
endpoint validates instead of silently substituting a default voice, which was the
real risk. Same Gemini family, same presets: nothing changes about how a brand sounds.

**Cost is a wash.** Same three-line script: kie 1.19 credits = **$0.00595**,
OpenRouter **$0.005772**. The registry header said TTS on kie costs ~3× Google and
that the goal was removing a dependency rather than saving money; against OpenRouter
there is simply no difference. The reason to move is the fallback, not the price.

**The reading direction is not spoken.** The take with the direction in front is
*shorter* than the one without (3.36s vs 3.76s): it is read as style, exactly like
kie's `sample_context`. So `buildVoiceOverPrompt` is passed through unchanged.

**Chosen against:** `openai/gpt-audio` on `chat/completions`. It genuinely works
(`pcm16` + `stream: true`, probed), but it is OpenAI, it would change the voice, and
the audio arrives base64 in `delta.audio.data` to be concatenated. It stays a note,
not a choice.

**Two commits, split on purpose.** The first only moves the cutter's format check out
of the kie branch into `assertCuttable` — same condition, same message, no behaviour
change, so the rule lives in one place before a second caller needs it. The second
changes behaviour. `wavFromPcm` was already there and is reused; nothing was
rewritten.

`llmSpeech` **reports** the rate and channels it read from `content-type` back to its
caller instead of assuming them. A 48 kHz stereo take does not fail: it lasts twice as
long and speaks at half speed. The rule about what is acceptable belongs to the
cutter, not the transport.

## Testing?

**Unit** — the first test is deliberately not "some audio arrived": that would pass
with an unusable format, which is precisely the error that produced the wrong
conclusion. It is *the shape the cutter accepts* — the uploaded WAV is read back
through `pcmFromWav` and must say 24000/1/16 with samples identical to what was
generated. Then: a 48 kHz and a stereo response are refused; six lines produce
exactly one POST with all six in the body; and with no OpenRouter key the route falls
back to kie with the warning.

In `model-routing.test.ts` two tests used `gemini-tts@openrouter` as their example of
a *pair with no transport* and went red — the good outcome. The **pairs** were
changed, not the assertions: `grok@openrouter` and `gpt@openrouter` remain, and that
they still guard something was verified by giving them a transport and watching both
go red. A pair that becomes *unparsable* instead of *served* would leave the test
green measuring the fallback-to-default rather than the invariant; that has happened
before and it does not show.

**Live, through the real code path** — a throwaway spec (not committed) drove the real
`generateVoiceOver` against the real API with a fake storage, then fed the result to
the real `cutVoiceOver`. Not a curl: the product's own path end to end.

**Suite** — 7,283 tests pass. One unrelated file (`home-redirect.test.ts`) emits an
async teardown error under the full run and passes in isolation on this branch and on
`dev` alike; it touches credits/usage, which this PR does not.

**Not tested** — the browser. This is a server path with no UI surface; the motion
video that consumes it renders from the same URL as before.

## Evidence

<details><summary>The endpoint and the format, live</summary>

```
$ curl -D - -X POST https://openrouter.ai/api/v1/audio/speech \
    -d '{"model":"google/gemini-3.1-flash-tts-preview","input":"...","voice":"Kore"}'

HTTP/2 200
content-type: audio/pcm;rate=24000;channels=1
x-generation-id: gen-tts-1788588199-NlIAtsrOyBnoFZjttIPX
439680 bytes                      # = 9.16s at 24 kHz mono 16-bit
```

`response_format` accepts `mp3|pcm` on the endpoint, but this model answers only
`pcm`: `{"error":{"message":"Gemini TTS only supports response_format=\"pcm\". Got \"mp3\"."}}`
</details>

<details><summary>The rate, cross-checked against kie instead of against arithmetic</summary>

Same line, same voice. kie's WAV header declares 24000/1/16 and production already
depends on it.

```
kie          samples 176640  7.36s total   speech 0.26 → 3.46   (3.20s)
openrouter   samples  90262  3.76s total   speech 0.24 → 3.44   (3.20s)

3-line script, pause onsets:
kie          0.30 | 2.20 | 3.82 | 6.10 | 7.88
openrouter   0.28 | 2.16 | 3.80 | 6.32 | 8.56 | 11.04
```

The first two onsets agree to within 40 ms. kie also pads 3.90s of trailing silence
onto a 3.20s line; OpenRouter does not.
</details>

<details><summary>The voices we ship, all five</summary>

```
Kore     200   107520 bytes
Puck     200   117120 bytes
Charon   200   128640 bytes
Aoede    200   119040 bytes
Fenrir   200   126720 bytes
Zephyr   200   126720 bytes
alloy    400   {"error":{"message":"Provider returned 400","code":400}}
```

`alloy` (an OpenAI voice) is refused, so an unknown name cannot silently become a
different voice.
</details>

<details><summary>Cost, same script on both</summary>

```
kie          creditsConsumed 1.19  × $0.005 = $0.00595   8.44s   6802 ms
openrouter   usage                          = $0.005772  11.40s  5206 ms
```
</details>

<details><summary>The live end-to-end run, through generateVoiceOver and cutVoiceOver</summary>

```
LIVE full 11.44 s; gaps 4
LIVE log row {"label":"voiceover","provider":"openrouter",
              "model":"google/gemini-3.1-flash-tts-preview","ms":8112,"ok":true,
              "context":"voiceover:lines3:gaps4"}
uploaded WAV read back: [24000, 1, 16]
cut into 3 labelled pieces, dropped: []
```

And the produced WAV handed to an audio-in model:

> Most teams ship the feature and never look at it again. We watch it for a week,
> then cut what nobody used. That is the whole method.
>
> The speech sounds natural in pitch and pace.

Verbatim, and the reading direction was not spoken.
</details>

## Anything Else?

**The one deliberate regression: per-call cost.** On kie the `ai_calls` row carries
`creditsConsumed` and therefore a price. `/audio/speech` carries no invoice — no
header, no JSON body. `GET /generation?id=` exists, and has already been measured and
rejected in `llm-usage-cost.ts`: the record appears **nine seconds** after the
response, and holding a serverless function open to wait for it loses the log row
too. So the voice-over row keeps `cost_usd` null. The price per audio token is
published ($0.00002), but the tokens-per-second measured across three calls swung
between 25 and 49, so deriving a cost would be inventing one — and a visible hole
beating a plausible wrong number is this file's own rule. If billing continuity
matters more than that, the fix is a flat listing constant like `LYRIA_COST_USD`, and
it should be a decision rather than a side effect.

**`gpt-audio` as a second option.** Documented in `llmSpeech`'s header. If Google's
TTS is ever withdrawn from OpenRouter it is the route that already works, at the cost
of a different voice.

**Coordination.** #341 (`feat/video-default-openrouter`) touches the same file, one
line, `SLOT_DEFAULT.video`. No overlap with these tables; whichever lands second
rebases without friction. Its comment comparing itself to "the voice, which stays on
kie" stops being true once this merges — flagged to that author, who is fixing it on
whichever side lands last.

**`AI_ROUTE_TTS=gemini-tts@kie` reverses this instantly**, without a deploy, if the
voice ever sounds wrong in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
