### PR TITLE
Record that OpenRouter hides its separate surfaces

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -266,6 +266,21 @@ Il frontmatter di una skill non si riscrive: `parseSkillFrontmatter` esiste già
 ### Config senza consumatori non si scrive
 Una colonna `skills` su `custom_agents` era la mossa ovvia per "skill per custom agent". Ma i custom agent girano sul motore classico, fuori dal percorso kit: nessuno l'avrebbe mai letta. Il criterio: questa separazione dà un beneficio reale **adesso**? Se la risposta è "quando i custom agent saliranno sul kit", la mossa è un commento in LESSONS, non una migrazione.
 
+### Il catalogo di OpenRouter NON elenca le superfici separate: `/models` vuoto non vuol dire «non esiste»
+Cercando i modelli video in `GET /api/v1/models` si ottiene **zero**, e la conclusione naturale —
+«OpenRouter non fa video» — è falsa: vivono su `GET /api/v1/videos/models`, e sono 28. Stessa cosa
+il giorno stesso col TTS: `google/gemini-3.1-flash-tts-preview` non compare filtrando `/models` per
+modalità audio, ma funziona. Due volte in un giorno, due agenti diversi, la stessa conclusione
+sbagliata. Segnale: stai per scrivere «il provider X non supporta Y» basandoti su un catalogo
+vuoto. Mossa: **chiama l'endpoint e leggi l'errore** — un id inesistente risponde `Model ... does
+not exist`, mentre un id vero su una superficie sbagliata nomina la superficie giusta. Un rifiuto
+alla validazione costa zero e batte qualunque lettura di catalogo.
+
+**E il prezzo ha lo stesso vizio**: sui 28 modelli video `pricing` è **nullo per tutti**, e il
+listino vero sta in `pricing_skus`. Guardare il campo che ci si aspetta, trovarlo vuoto e concludere
+«non è prezzato» porta a inventare una tariffa a mano — che è esattamente ciò che `RATES` sta
+venendo smantellato per evitare.
+
 ### Il fallback è parte del contratto
 `skillsForAgent(unknown)` restituisce le skill di scrittura, non `[]`: un agente non noto non deve girare a mani vuote per una stringa sbagliata. Ogni selezione per-chiave decide esplicitamente cosa succede fuori mappa.
 


### PR DESCRIPTION
## What?

Una lezione in `LESSONS.md`: il catalogo di OpenRouter non elenca le sue superfici separate, e un
`/models` vuoto non vuol dire che una capacità non esista. Un file, nessun codice.

## Why?

**È successo due volte in un giorno, a due agenti diversi, con la stessa conclusione sbagliata.**

- Cercando i modelli video in `GET /api/v1/models` si ottiene **zero**. La conclusione naturale —
  «OpenRouter non fa video» — è falsa: vivono su `GET /api/v1/videos/models`, e sono **28**.
- Lo stesso giorno, `google/gemini-3.1-flash-tts-preview` non compare filtrando `/models` per
  modalità audio. Funziona (PR #345).

Due volte è il criterio che `LESSONS.md` chiede: *«una lezione pagata entra qui»*. La terza volta
costa a qualcun altro, e questa è una conclusione che si scrive in una PR e ci resta.

## How?

Il segnale e la mossa, come le altre voci del file:

- **Segnale**: stai per scrivere «il provider X non supporta Y» basandoti su un catalogo vuoto.
- **Mossa**: chiama l'endpoint e **leggi l'errore**. Un id inesistente risponde `Model ... does not
  exist`; un id vero su una superficie sbagliata nomina la superficie giusta. Un rifiuto alla
  validazione costa **zero**.

Con una seconda metà sullo stesso vizio, perché è la stessa trappola in un campo diverso: sui 28
modelli video `pricing` è **nullo per tutti**, e il listino vero sta in `pricing_skus`. Guardare il
campo che ci si aspetta, trovarlo vuoto e concludere «non è prezzato» è il modo in cui si inventa
una tariffa a mano — cioè esattamente quello che lo smantellamento di `RATES` esiste per evitare.

## Testing?

Nessun codice, nessun test. `LESSONS.md` non è importato da niente.

## Evidence (screenshots/videos)

<details><summary>il catalogo chat non conosce i modelli video</summary>

```
GET /api/v1/models            → nessun modello video
GET /api/v1/videos/models     → 28 modelli (kling-v3.0-pro, seedance-2.5, veo-3.1, sora-2-pro, …)
```
</details>

<details><summary>l'errore nomina la superficie giusta, e costa zero</summary>

```
POST /api/v1/videos  {"model":"nope/not-a-model","prompt":"x"}
→ 400  {"error":{"message":"Model nope/not-a-model does not exist","code":400}}

POST /api/v1/videos  {"model":"bytedance/seedance-2-5", ...}   ← l'id kie, coi trattini
→ 400  Model ... does not exist
```
</details>

<details><summary>il prezzo non è dove ci si aspetta</summary>

```
pricing       → null su tutti e 28
pricing_skus  → {"video_tokens":"0.0000107"}                     (seedance-2.5)
                {"cents_per_video_output_second_480p":"8", …}    (grok-imagine-video-1.5)
```
</details>

## Anything Else?

- La regola dice che una lezione entra **nel commit che l'ha pagata**. Quel commit
  (#336, il trasporto video) è già mergiato, e la seconda metà l'ha pagata #345, di un altro
  agente: una PR sua è la cosa più vicina possibile, e non blocca nessuno.
- Tenuta fuori dalla #341 di proposito: quella è ferma in attesa che `dev` arrivi su `main`, e
  seppellire lì una lezione che serve adesso sarebbe il modo di non farla leggere a nessuno.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
