### PR TITLE
Say why a clip failed, and how long it will really be

### DIFF
--- a/changelog/2026-09-05-il-video-dice-perche.md
+++ b/changelog/2026-09-05-il-video-dice-perche.md
@@ -65,3 +65,22 @@ costruito, invio partito.
 Vale però sapere che quel percorso **dipende dal fatto che il fornitore possa scaricare il nostro
 signed URL**. Se lo Storage diventasse privato si romperebbe lì — e con la correzione al punto 1,
 adesso lo direbbe.
+
+
+## Il motivo si ripassa, ma senza il token
+
+Il messaggio del fornitore cita gli argomenti che gli abbiamo mandato, URL firmati compresi. L'URL
+in sé non è un segreto — è lo stesso che il chiamante ci ha dato, e sapere **quale** riferimento è
+stato rifiutato è metà della diagnosi. **La query string sì**: la firma vive lì, e un log del
+cliente che la cattura è un token vivo in un posto in cui nessuno l'ha messo apposta.
+
+`safeProviderReason` taglia la query string di ogni URL e mette un tetto di 400 caratteri. La parte
+utile del messaggio sta comunque prima del `?`, quindi il taglio non toglie niente a chi legge:
+
+```
+Invalid reference URL: https://…/sign/media/a.png?token=eyJhbGciOi.SECRET is unreachable
+→ Invalid reference URL: https://…/sign/media/a.png is unreachable
+```
+
+Se un giorno un fornitore mettesse qualcosa di indispensabile dopo il `?`, il messaggio diventerebbe
+incomprensibile e questa scelta andrebbe ribaltata — ma si parte dal tagliare.

--- a/changelog/2026-09-05-il-video-dice-perche.md
+++ b/changelog/2026-09-05-il-video-dice-perche.md
@@ -1,0 +1,67 @@
+# Il video dice perché ha fallito, e quanto dura davvero
+
+Prova capo a capo da un client MCP vero, stack locale, render veri. Immagini e video funzionano e il
+`job_id` arriva a un `media_id`. Sono usciti due difetti, ed è lo stesso difetto due volte: **il tool
+sapeva una cosa e non la diceva.**
+
+## 1. `render_failed` nudo
+
+L'agente esterno riceveva:
+
+```
+API 502: {"error":"render_failed"}
+```
+
+Il motivo — `Invalid reference URL: Localhost URLs are not allowed` — **esisteva già**, in
+`submitVideoRender`: veniva `console.error`'ato e poi buttato con un `return undefined`. Chi chiamava
+il tool non sapeva se riprovare, cambiare parametro o rinunciare. È probabilmente il motivo per cui
+l'agente si è arreso: riprovare uguale è l'unica mossa che un errore muto suggerisce.
+
+È lo stesso principio già applicato in `query-tool.ts` per gli errori PostgREST — *«un errore nudo
+dice a un modello che ha sbagliato e non come si fa a non sbagliare, quindi riprova uguale»*.
+
+Il motivo ora risale fino alla risposta, in un campo `reason` accanto a `error`. Quando il fornitore
+non dice niente, **la chiave non c'è**: assente è meglio di una stringa di comodo che nessuno ha
+pronunciato.
+
+### Perché un canale a parte e non un valore di ritorno
+
+`submitVideoRender` ha due chiamanti e uno vive in `src/lib/agent/tools/create-content-tools.ts`, che
+è fuori dai file toccabili. Cambiargli la firma per far passare una stringa costava più di quanto
+valesse: `onSubmitError?: (reason: string) => void` è additivo e i chiamanti esistenti non cambiano
+di una riga.
+
+## 2. La durata raddoppiata in silenzio
+
+Chiesti **5 secondi**, salvati **10**. I video si pagano al secondo, quindi era il doppio del conto
+senza che niente lo dicesse.
+
+`clampVideoDuration` alza il pavimento a `MIN_DURATION = 10` **ignorando** `caps.minDuration` che
+Grok Imagine dichiara a 1:
+
+```ts
+const floor = Math.min(Math.max(caps.minDuration, MIN_DURATION), caps.maxDuration);
+```
+
+**`MIN_DURATION` non è stata toccata.** È un pavimento di prodotto e vale per il percorso dei post,
+dove una clip social da 2 secondi non ha senso: spostarlo avrebbe cambiato l'autopilot, che nessuno
+ha chiesto di cambiare. Il difetto era sulla mia superficie, ed è lì che si chiude — **la durata si
+contratta prima di inviare**: se il modello scelto non può filmare i secondi chiesti, si **rifiuta**
+con `duration_out_of_range` dicendo il numero più vicino che accetta. Mai riportata di nascosto.
+
+E la risposta porta `duration_seconds`, i secondi davvero mandati — stessa forma di `renders` e del
+modello effettivo: la risposta dice cosa è successo, non cosa era stato chiesto.
+
+Un test che passava è stato **corretto**: chiedeva 5 secondi e li vedeva accettati. Codificava il
+difetto.
+
+## Cosa NON era un difetto
+
+L'animazione da `base_media_id` è fallita solo perché la copertina viaggia **come URL** e in locale è
+`http://localhost:8000/...`, che OpenRouter non può raggiungere. In produzione è un URL Supabase
+pubblico. Tutta la catena aveva funzionato: id risolto, modello immagine→video scelto, `first_frame`
+costruito, invio partito.
+
+Vale però sapere che quel percorso **dipende dal fatto che il fornitore possa scaricare il nostro
+signed URL**. Se lo Storage diventasse privato si romperebbe lì — e con la correzione al punto 1,
+adesso lo direbbe.

--- a/cli/lib/contracts/posts.ts
+++ b/cli/lib/contracts/posts.ts
@@ -646,7 +646,11 @@ const VideoJobResult = z.object({
   ok: z.literal(true),
   status: z.literal('rendering'),
   job_id: z.string(),
-  model: z.string().nullable().describe('The model that is filming it; null when the platform default chose')
+  model: z.string().nullable().describe('The model that is filming it; null when the platform default chose'),
+  duration_seconds: z
+    .number()
+    .nullable()
+    .describe('The seconds ACTUALLY submitted. A clip is billed per second, so read this rather than assuming your request was taken.')
 });
 
 export const GENERATE_VIDEO = {
@@ -674,7 +678,17 @@ export const GENERATE_VIDEO = {
         .describe(
           'A library IMAGE to animate, from list_media — an id or an unambiguous prefix. Omit to film from the prompt alone.'
         ),
-      duration: z.coerce.number().int().min(1).max(30).optional().describe('Seconds, e.g. 5'),
+      duration: z.coerce
+        .number()
+        .int()
+        .min(1)
+        .max(30)
+        .optional()
+        .describe(
+          'Seconds. Each model accepts its own window and most will not go below 10 — a duration ' +
+            'outside it is refused as duration_out_of_range naming the nearest it accepts, rather ' +
+            'than quietly rounded up, because a clip is billed per second.'
+        ),
       aspect_ratio: z.enum(['1:1', '9:16', '16:9']).optional(),
       model: modelField('videoModel, or videoImageModel when base_media_id is set'),
       title: z.string().optional().describe('The name the clip carries in the library')
@@ -687,6 +701,7 @@ export const GENERATE_VIDEO = {
     { error: 'video_budget_exhausted', status: 400 },
     { error: 'source_not_found', status: 404 },
     { error: 'source_not_an_image', status: 400 },
+    { error: 'duration_out_of_range', status: 400 },
     { error: 'render_failed', status: 502 },
     { error: 'store_failed', status: 502 }
   ],

--- a/cli/plugins/anomalia/skills/anomalia/references/tools.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/tools.md
@@ -186,7 +186,12 @@ Animating and filming are two different jobs with two different model lists (`vi
 `videoModel`): a model valid for one is refused for the other with `model_not_for_slot` and the
 accepted list. Refusals: `source_not_found` (404) means the id is not this brand's or does not
 resolve to one asset; `source_not_an_image` (400) means it exists but is a video;
-`video_budget_exhausted` (400) counts the clips still rendering, not just the ones that landed.
+`video_budget_exhausted` (400) counts the clips still rendering, not just the ones that landed;
+`duration_out_of_range` (400) means the model cannot film the seconds you asked for and the message
+names the nearest it accepts. A refusal from the provider comes back as `render_failed` **with a
+`reason`** saying what it objected to — read it before retrying, because retrying the same request
+buys the same refusal. The success response carries `duration_seconds`, the seconds actually
+submitted: a clip is billed per second, so read it rather than assuming your number was taken.
 
 **Choosing the model.** Every generator takes an optional `model` that applies to **that call
 only** and changes no brand setting — that is the difference from `set_media_model`, which is "from

--- a/cli/skills/anomalia/references/tools.md
+++ b/cli/skills/anomalia/references/tools.md
@@ -186,7 +186,12 @@ Animating and filming are two different jobs with two different model lists (`vi
 `videoModel`): a model valid for one is refused for the other with `model_not_for_slot` and the
 accepted list. Refusals: `source_not_found` (404) means the id is not this brand's or does not
 resolve to one asset; `source_not_an_image` (400) means it exists but is a video;
-`video_budget_exhausted` (400) counts the clips still rendering, not just the ones that landed.
+`video_budget_exhausted` (400) counts the clips still rendering, not just the ones that landed;
+`duration_out_of_range` (400) means the model cannot film the seconds you asked for and the message
+names the nearest it accepts. A refusal from the provider comes back as `render_failed` **with a
+`reason`** saying what it objected to — read it before retrying, because retrying the same request
+buys the same refusal. The success response carries `duration_seconds`, the seconds actually
+submitted: a clip is billed per second, so read it rather than assuming your number was taken.
 
 **Choosing the model.** Every generator takes an optional `model` that applies to **that call
 only** and changes no brand setting — that is the difference from `set_media_model`, which is "from

--- a/packages/api-contracts/src/posts.ts
+++ b/packages/api-contracts/src/posts.ts
@@ -646,7 +646,11 @@ const VideoJobResult = z.object({
   ok: z.literal(true),
   status: z.literal('rendering'),
   job_id: z.string(),
-  model: z.string().nullable().describe('The model that is filming it; null when the platform default chose')
+  model: z.string().nullable().describe('The model that is filming it; null when the platform default chose'),
+  duration_seconds: z
+    .number()
+    .nullable()
+    .describe('The seconds ACTUALLY submitted. A clip is billed per second, so read this rather than assuming your request was taken.')
 });
 
 export const GENERATE_VIDEO = {
@@ -674,7 +678,17 @@ export const GENERATE_VIDEO = {
         .describe(
           'A library IMAGE to animate, from list_media — an id or an unambiguous prefix. Omit to film from the prompt alone.'
         ),
-      duration: z.coerce.number().int().min(1).max(30).optional().describe('Seconds, e.g. 5'),
+      duration: z.coerce
+        .number()
+        .int()
+        .min(1)
+        .max(30)
+        .optional()
+        .describe(
+          'Seconds. Each model accepts its own window and most will not go below 10 — a duration ' +
+            'outside it is refused as duration_out_of_range naming the nearest it accepts, rather ' +
+            'than quietly rounded up, because a clip is billed per second.'
+        ),
       aspect_ratio: z.enum(['1:1', '9:16', '16:9']).optional(),
       model: modelField('videoModel, or videoImageModel when base_media_id is set'),
       title: z.string().optional().describe('The name the clip carries in the library')
@@ -687,6 +701,7 @@ export const GENERATE_VIDEO = {
     { error: 'video_budget_exhausted', status: 400 },
     { error: 'source_not_found', status: 404 },
     { error: 'source_not_an_image', status: 400 },
+    { error: 'duration_out_of_range', status: 400 },
     { error: 'render_failed', status: 502 },
     { error: 'store_failed', status: 502 }
   ],

--- a/src/lib/content/changelog/2026-09-05-video-errors-say-why.ts
+++ b/src/lib/content/changelog/2026-09-05-video-errors-say-why.ts
@@ -1,0 +1,10 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-05',
+  title: 'Video failures now say what went wrong',
+  items: [
+    'When a clip cannot be made, your agent is told why instead of just that it failed — so it can fix the request rather than retry the same one.',
+    'Asking for a duration a model cannot film is now refused with the nearest it accepts, instead of being quietly rounded up and billed for.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/media-generate.ts
+++ b/src/lib/server/media-generate.ts
@@ -58,7 +58,16 @@ export type GenerateMediaResult =
       model: string | null;
       renders: number;
     }
-  | { ok: true; status: 'rendering'; media: []; jobId: string; model: string | null; renders: 0 }
+  | {
+      ok: true;
+      status: 'rendering';
+      media: [];
+      jobId: string;
+      model: string | null;
+      renders: 0;
+      /** I secondi DAVVERO mandati: il modello ha una sua finestra e non e' quella chiesta. */
+      durationSeconds: number | null;
+    }
   | {
       ok: false;
       error:
@@ -67,7 +76,10 @@ export type GenerateMediaResult =
         | 'video_budget_exhausted'
         | 'source_not_found'
         | 'source_not_an_image';
+      /** Cosa ha detto il fornitore. Assente quando non ha detto niente: non si inventa. */
+      reason?: string;
     }
+  | { ok: false; error: 'duration_out_of_range'; reason: string }
   | { ok: false; error: 'model_not_for_slot'; allowed: string[] };
 
 const IMAGE_MIME = 'image/png';
@@ -334,6 +346,28 @@ async function startVideo(opts: GenerateMediaOpts): Promise<GenerateMediaResult>
     coverUrl = urls[0];
   }
 
+  // La durata si CONTRATTA prima di inviare. `clampVideoDuration` alzerebbe in silenzio 5 a 10 —
+  // e i video si pagano al secondo, quindi un riporto muto raddoppia il conto senza dirlo. Il
+  // pavimento di prodotto (MIN_DURATION) resta dov'e' per il percorso dei post: qui si rifiuta
+  // dichiarando la finestra, invece di consegnare qualcosa che nessuno ha chiesto.
+  const { resolveVideoModel, clampVideoDuration } = await import('$lib/server/video');
+  const effectiveModel = resolveVideoModel({
+    model: opts.model ?? null,
+    prefs,
+    hasCover: !!opts.baseMediaId
+  });
+  const wanted = opts.durationSeconds;
+  if (wanted != null) {
+    const achievable = clampVideoDuration(wanted, effectiveModel);
+    if (achievable !== wanted) {
+      return {
+        ok: false,
+        error: 'duration_out_of_range',
+        reason: `${effectiveModel} cannot film ${wanted}s — the nearest it accepts is ${achievable}s. Ask for that instead; a clip is billed per second.`
+      };
+    }
+  }
+
   const { remaining } = await import('$lib/server/usage');
   const budget = await remaining(admin, opts.brandId, brand?.plan, brand?.timezone ?? 'Europe/Rome');
 
@@ -342,8 +376,12 @@ async function startVideo(opts: GenerateMediaOpts): Promise<GenerateMediaResult>
   const inFlight = await countOutstandingVideoRenders(admin, opts.brandId);
   if (budget.videos - inFlight <= 0) return { ok: false, error: 'video_budget_exhausted' };
 
+  let submitReason: string | undefined;
   const submitted = await submitAndTrackVideoRender({
     admin,
+    onSubmitError: (why: string) => {
+      submitReason = why;
+    },
     brandId: opts.brandId,
     userId: opts.userId,
     postId: null,
@@ -365,7 +403,7 @@ async function startVideo(opts: GenerateMediaOpts): Promise<GenerateMediaResult>
         ((opts.baseMediaId ? prefs.videoImageModel : prefs.videoModel) as string | null | undefined)
     }
   });
-  if (!submitted) return { ok: false, error: 'render_failed' };
+  if (!submitted) return { ok: false, error: 'render_failed', ...(submitReason ? { reason: submitReason } : {}) };
 
   const { data: job } = await admin
     .from('video_renders')
@@ -380,7 +418,8 @@ async function startVideo(opts: GenerateMediaOpts): Promise<GenerateMediaResult>
     media: [],
     jobId: job.id as string,
     model: submitted.model ?? null,
-    renders: 0
+    renders: 0,
+    durationSeconds: submitted.durationSeconds ?? wanted ?? null
   };
 }
 

--- a/src/lib/server/media-generate.ts
+++ b/src/lib/server/media-generate.ts
@@ -21,6 +21,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { insertBrandMedia, storeBrandMediaBytes, probeImageDimensions } from '$lib/server/brand-media';
 import { mediaUrl } from '$lib/media-url';
+import { safeProviderReason } from '$lib/server/provider-reason';
 import { markImage, DIGITAL_SOURCE_TYPE } from '$lib/server/content-credentials';
 import type { AspectRatio } from '$lib/server/content-preview';
 
@@ -380,7 +381,7 @@ async function startVideo(opts: GenerateMediaOpts): Promise<GenerateMediaResult>
   const submitted = await submitAndTrackVideoRender({
     admin,
     onSubmitError: (why: string) => {
-      submitReason = why;
+      submitReason = safeProviderReason(why);
     },
     brandId: opts.brandId,
     userId: opts.userId,

--- a/src/lib/server/media-generate.video-errors.test.ts
+++ b/src/lib/server/media-generate.video-errors.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * DUE BUGIE DELLO STESSO TIPO, trovate provando i tool da un client MCP vero.
+ *
+ * 1. `render_failed` nudo. Il motivo — «Localhost URLs are not allowed» — esisteva solo nel log del
+ *    server. Chi chiama il tool non sapeva se riprovare, cambiare parametro o rinunciare, ed e'
+ *    probabilmente il motivo per cui l'agente si e' arreso. Un errore che dice CHE e' fallito e
+ *    nasconde PERCHE' e' la forma peggiore.
+ *
+ * 2. La durata raddoppiata in silenzio. Chiesti 5 secondi, salvati 10, pagati 10 — i video si
+ *    fatturano al secondo. `clampVideoDuration` alza il pavimento a MIN_DURATION ignorando il
+ *    minimo che il modello dichiara. Non si riporta di nascosto: o si rifiuta dicendo la finestra,
+ *    o si dichiara cosa e' stato mandato.
+ */
+
+const submitAndTrackVideoRender = vi.fn();
+const countOutstandingVideoRenders = vi.fn();
+
+vi.mock('$lib/server/supabase-admin', () => ({ createAdminClient: () => admin }));
+vi.mock('$lib/server/video-render-queue', () => ({
+  submitAndTrackVideoRender: (...a: unknown[]) => submitAndTrackVideoRender(...a),
+  countOutstandingVideoRenders: (...a: unknown[]) => countOutstandingVideoRenders(...a)
+}));
+vi.mock('$lib/server/brand-media', () => ({ resolveBrandImageIds: async () => ['https://x/y.png'] }));
+vi.mock('$lib/server/usage', () => ({ remaining: async () => ({ videos: 5 }) }));
+vi.mock('$lib/server/ai-log', () => ({ withBrandContext: <T>(_b: string, fn: () => T) => fn() }));
+
+const admin = {
+  from: (table: string) => ({
+    select: () => ({
+      eq: () =>
+        table === 'brand_media'
+          ? { limit: async () => ({ data: [], error: null }) }
+          : {
+              maybeSingle: async () => ({
+                data:
+                  table === 'brands'
+                    ? { plan: 'pro', timezone: 'Europe/Rome', content_prefs: {} }
+                    : { id: 'job-1' },
+                error: null
+              })
+            }
+    })
+  })
+} as never;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  countOutstandingVideoRenders.mockResolvedValue(0);
+  submitAndTrackVideoRender.mockResolvedValue({ taskId: 't', model: 'grok-imagine-video-1-5-preview' });
+});
+
+const run = async (over: Record<string, unknown> = {}) => {
+  const { generateBrandVideo } = await import('./media-generate');
+  return generateBrandVideo({
+    brandId: 'brand-1',
+    userId: 'user-1',
+    prompt: 'un carrello lento',
+    ...over
+  } as never);
+};
+
+describe('il fornitore rifiuta: il motivo deve arrivare a chi ha chiamato', () => {
+  it('porta su la causa invece di un render_failed nudo', async () => {
+    // Il fornitore rifiuta l'invio e spiega perche'.
+    submitAndTrackVideoRender.mockImplementation(async (opts: { onSubmitError?: (r: string) => void }) => {
+      opts.onSubmitError?.('Invalid reference URL: Localhost URLs are not allowed');
+      return null;
+    });
+
+    const out = await run();
+
+    expect(out.ok).toBe(false);
+    expect('error' in out && out.error).toBe('render_failed');
+    // La riga che decide se l'agente sa cosa fare.
+    expect('reason' in out && out.reason).toContain('Localhost URLs are not allowed');
+  });
+
+  it('senza motivo dal fornitore non inventa niente', async () => {
+    submitAndTrackVideoRender.mockResolvedValue(null);
+
+    const out = await run();
+
+    expect('error' in out && out.error).toBe('render_failed');
+    // La chiave non c'e' proprio: meglio assente che una stringa di comodo che nessuno ha detto.
+    expect('reason' in out).toBe(false);
+  });
+});
+
+describe('la durata non si riporta di nascosto', () => {
+  it('sotto il minimo del modello si rifiuta, dicendo la finestra', async () => {
+    // Grok Imagine dichiara minDuration 1, ma il pavimento di prodotto e' 10: 5 non e' ottenibile.
+    const out = await run({ durationSeconds: 5, model: 'grok-imagine-video-1-5-preview' });
+
+    expect(out.ok).toBe(false);
+    expect('error' in out && out.error).toBe('duration_out_of_range');
+    // Senza i numeri il rifiuto e' un vicolo cieco: l'agente non sa cosa richiedere.
+    expect('reason' in out && String(out.reason)).toMatch(/10/);
+    expect(submitAndTrackVideoRender).not.toHaveBeenCalled();
+  });
+
+  it('una durata ottenibile passa e viene dichiarata nella risposta', async () => {
+    const out = await run({ durationSeconds: 12, model: 'grok-imagine-video-1-5-preview' });
+
+    expect(out.ok).toBe(true);
+    expect(out.ok && out.durationSeconds).toBe(12);
+    expect(submitAndTrackVideoRender.mock.calls[0][0].render.duration).toBe(12);
+  });
+
+  it('senza durata chiesta non si rifiuta niente', async () => {
+    const out = await run();
+
+    expect(out.ok).toBe(true);
+    expect(submitAndTrackVideoRender).toHaveBeenCalled();
+  });
+});

--- a/src/lib/server/media-generate.video.test.ts
+++ b/src/lib/server/media-generate.video.test.ts
@@ -69,13 +69,15 @@ const run = async (over: Record<string, unknown> = {}) => {
 
 describe('animare un immagine della libreria', () => {
   it('la foto di partenza arriva al fornitore come copertina', async () => {
-    const out = await run({ baseMediaId: FULL_ID, durationSeconds: 5 });
+    // 12s e non 5: il modello non scende sotto i 10, e chiedere 5 ora viene RIFIUTATO invece di
+    // essere riportato in silenzio a 10 — vedi media-generate.video-errors.test.ts.
+    const out = await run({ baseMediaId: FULL_ID, durationSeconds: 12 });
 
     expect(out.ok).toBe(true);
     const sent = submitAndTrackVideoRender.mock.calls[0][0];
     // La riga che distingue «anima questa foto» da «filmami un gatto».
     expect(sent.render.imageUrl).toBe(COVER);
-    expect(sent.render.duration).toBe(5);
+    expect(sent.render.duration).toBe(12);
     expect(sent.postId).toBeNull();
   });
 

--- a/src/lib/server/provider-reason.test.ts
+++ b/src/lib/server/provider-reason.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { safeProviderReason } from './provider-reason';
+
+describe('il motivo del fornitore prima di ripassarlo', () => {
+  it('taglia la query string, dove vive il token di firma', () => {
+    const out = safeProviderReason(
+      'Invalid reference URL: https://x.supabase.co/storage/v1/object/sign/media/a.png?token=eyJhbGciOi.SECRET is unreachable'
+    );
+
+    expect(out).toContain('https://x.supabase.co/storage/v1/object/sign/media/a.png');
+    // Il pezzo che non deve finire nel log di un cliente.
+    expect(out).not.toContain('token=');
+    expect(out).not.toContain('SECRET');
+  });
+
+  it('tiene l URL: sapere QUALE riferimento e stato rifiutato e meta della diagnosi', () => {
+    const out = safeProviderReason('Localhost URLs are not allowed: http://localhost:8000/a.png');
+
+    expect(out).toBe('Localhost URLs are not allowed: http://localhost:8000/a.png');
+  });
+
+  it('taglia piu di un URL nello stesso messaggio', () => {
+    const out = safeProviderReason('bad https://a/x?sig=1 and https://b/y?sig=2');
+
+    expect(out).toBe('bad https://a/x and https://b/y');
+  });
+
+  it('mette un tetto alla lunghezza', () => {
+    const out = safeProviderReason('x'.repeat(900))!;
+
+    expect(out.length).toBeLessThanOrEqual(401);
+    expect(out.endsWith('…')).toBe(true);
+  });
+
+  it('un motivo vuoto resta assente, non diventa una stringa vuota', () => {
+    expect(safeProviderReason('')).toBeUndefined();
+    expect(safeProviderReason(null)).toBeUndefined();
+    expect(safeProviderReason('   ')).toBeUndefined();
+  });
+});

--- a/src/lib/server/provider-reason.ts
+++ b/src/lib/server/provider-reason.ts
@@ -1,0 +1,27 @@
+/**
+ * Il motivo di un rifiuto del fornitore, reso sicuro da ripassare a chi ha chiamato.
+ *
+ * Il messaggio serve — senza, l'agente riprova identico — ma arriva da fuori e cita gli argomenti
+ * che gli abbiamo mandato, URL firmati compresi. Il token di firma vive nella query string: un log
+ * del cliente che lo cattura e' un token vivo in un posto in cui nessuno l'ha messo apposta, e la
+ * parte utile del messaggio sta comunque PRIMA del `?`.
+ *
+ * Quindi: si taglia la query string e si mette un tetto alla lunghezza. Non si nasconde l'URL —
+ * e' lo stesso che il chiamante ci ha dato, e sapere QUALE riferimento e' stato rifiutato e' meta'
+ * della diagnosi.
+ */
+const MAX_REASON_CHARS = 400;
+
+/** Un URL con la sua query: e' li' che sta la firma. */
+const URL_WITH_QUERY = /(https?:\/\/[^\s'"]+?)\?[^\s'"]*/gi;
+
+export function safeProviderReason(raw: unknown): string | undefined {
+  const text = String(raw ?? '').trim();
+  if (!text) return undefined;
+
+  const stripped = text.replace(URL_WITH_QUERY, '$1');
+
+  return stripped.length > MAX_REASON_CHARS
+    ? `${stripped.slice(0, MAX_REASON_CHARS)}…`
+    : stripped;
+}

--- a/src/lib/server/video-render-queue.ts
+++ b/src/lib/server/video-render-queue.ts
@@ -116,9 +116,14 @@ export async function submitAndTrackVideoRender(opts: {
 	threadId?: string | null;
 	imagePrompt: string;
 	render: RenderVideoOpts;
+	/** Il motivo di un rifiuto del fornitore, se ne arriva uno: passa dritto a chi ha chiamato. */
+	onSubmitError?: (reason: string) => void;
 }): Promise<SubmittedVideoRender | null> {
 	const { submitVideoRender } = await import('$lib/server/video');
-	const submitted = await submitVideoRender(opts.imagePrompt, opts.render).catch((e) => {
+	const submitted = await submitVideoRender(opts.imagePrompt, {
+		...opts.render,
+		onSubmitError: opts.onSubmitError
+	}).catch((e) => {
 		// CreditsExhaustedError must reach the caller — it is a message for the user, not a failure
 		// to swallow into a silent photo fallback.
 		if (e instanceof Error && e.name === 'CreditsExhaustedError') throw e;

--- a/src/lib/server/video.ts
+++ b/src/lib/server/video.ts
@@ -1179,7 +1179,10 @@ export async function submitVideoRender(
         opts.abortSignal
       );
       if (!out.jobId) {
+        // Il motivo esisteva gia' qui e moriva nel log: chi ha chiamato il tool riceveva
+        // `render_failed` nudo e non poteva sapere se riprovare o cambiare parametro.
         console.error(`[video] submit openrouter rifiutato: ${out.error}`);
+        if (out.error) opts.onSubmitError?.(String(out.error));
         return undefined;
       }
       return {
@@ -1211,10 +1214,15 @@ export async function submitVideoRender(
     );
   } catch (e) {
     if (e instanceof Error && e.name === 'CreditsExhaustedError') throw e;
-    console.error('[video] submit failed:', e instanceof Error ? e.message : e);
+    const why = e instanceof Error ? e.message : String(e);
+    console.error('[video] submit failed:', why);
+    opts.onSubmitError?.(why);
     return undefined;
   }
-  if (!taskId) return undefined;
+  if (!taskId) {
+    opts.onSubmitError?.('the provider accepted no task for this request');
+    return undefined;
+  }
 
   return {
     taskId,

--- a/src/routes/api/v1/brands/[slug]/media/videos/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/media/videos/+server.ts
@@ -32,12 +32,24 @@ export const POST: RequestHandler = async ({ request, params }) => {
   });
 
   if (!result.ok) {
+    // Il MOTIVO del fornitore risale fino a qui: un `render_failed` nudo dice che e' fallito e
+    // nasconde l'unica cosa che serviva per decidere se riprovare.
     return json(
-      { error: result.error, ...('allowed' in result ? { allowed: result.allowed } : {}) },
+      {
+        error: result.error,
+        ...('allowed' in result ? { allowed: result.allowed } : {}),
+        ...('reason' in result && result.reason ? { reason: result.reason } : {})
+      },
       { status: statusForFailure(GENERATE_VIDEO, result.error) }
     );
   }
 
   // Un clip non torna mai pronto: la coda lo finisce e check_media_job dice quando e' atterrato.
-  return json({ ok: true, status: 'rendering', job_id: result.jobId, model: result.model });
+  return json({
+    ok: true,
+    status: 'rendering',
+    job_id: result.jobId,
+    model: result.model,
+    duration_seconds: result.durationSeconds
+  });
 };


### PR DESCRIPTION
## What?

Two fixes on `generate_video`, both the same defect: **the tool knew something and did not say it.**

1. A rejected submit returned `{"error":"render_failed"}`. It now carries a **`reason`**.
2. Asking for 5 seconds stored **10**. A duration the model cannot film is now **refused** naming the
   nearest it accepts, and the response reports `duration_seconds` — what was actually sent.

## Why?

End-to-end from a real MCP client on the local stack, with real renders.

### 1. `render_failed` swallowed the cause

The agent received:

```
API 502: {"error":"render_failed"}
```

The useful message — `Invalid reference URL: frame_images[0].image_url.url: Localhost URLs are not
allowed` — **already existed** in `submitVideoRender`: `console.error`'d, then thrown away by
`return undefined`. The caller could not tell whether to retry, change a parameter, or give up.

That is likely why the agent gave up: **retrying unchanged is the only move a mute error suggests.**
Same principle already applied to PostgREST errors in `query-tool.ts` — *"a bare error tells a model
it was wrong and not how to be right, so it retries identically."*

When the provider says nothing, the `reason` key is **absent** rather than filled with a convenient
string nobody uttered.

### 2. The duration doubled in silence

Asked **5s**, `video_renders.duration_seconds` said **10**. Clips bill per second, so that is double
the bill with nothing saying so.

```ts
const floor = Math.min(Math.max(caps.minDuration, MIN_DURATION), caps.maxDuration);
```

`clampVideoDuration` floors at `MIN_DURATION = 10`, ignoring the `caps.minDuration = 1` that Grok
Imagine declares.

## How?

**`MIN_DURATION` is untouched.** It is a product floor for the **post** path, where a 2-second social
clip is not a thing, and moving it would change autopilot behaviour nobody asked about. The defect
was on my surface and closes there: the duration is **negotiated before submitting**. A model that
cannot film the seconds requested refuses with `duration_out_of_range` naming the nearest it accepts
— never quietly rounded up.

The response carries `duration_seconds`, the same shape as `renders` and the effective `model`: **the
response says what happened, not what was asked.**

**The reason rides an optional callback, not a changed return type.** `submitVideoRender` has two
callers and one lives in `src/lib/agent/tools/create-content-tools.ts`, outside the files I may
touch. `onSubmitError?: (reason: string) => void` is additive and existing callers do not change by a
line. Wired at all three failure paths: the OpenRouter rejection, the catch, and a submit that
yielded no task.

## Testing?

Red first, both defects:

```
× porta su la causa invece di un render_failed nudo
  → expected [] to include 'Localhost URLs are not allowed'
× sotto il minimo del modello si rifiuta, dicendo la finestra
  → expected true to be false
```

Five new tests: the cause reaches the caller; no invented reason when the provider is silent; a
sub-minimum duration is refused **with the number in the message** and never reaches the provider; an
achievable duration passes and is declared; no duration asked refuses nothing.

**A passing test encoded the defect** — it asked for 5s and saw it accepted. Corrected, with a
comment saying why, so it does not get "fixed" back.

```
vitest: api-contracts, media-generate, api/v1/brands/[slug], video-render-queue, video → 793 passed
cd cli && bun test          →  73 pass, 0 fail
cd cli && bun run typecheck →  exit 0
node scripts/typecheck-runtime.mjs → exit 0
```

No paid model called; the queue and provider are mocked.

**Not tested:** that the provider's message is always safe to surface. It is passed through as
received. I checked the shapes we produce — a rejection names the offending field and value, so a
signed URL *can* appear in it. That is the same URL the caller supplied, never a key or an internal
credential, but it is a judgement worth a reviewer's eye rather than my assertion.

## Evidence

`tools/list`: **125 tools**, `generate_video` unchanged in name and shape, with the duration
description now telling the truth:

```
Seconds. Each model accepts its own window and most will not go below 10 — a duration outside it
is refused as duration_out_of_range naming the nearest it accepts, rather than quietly rounded up,
because a clip is billed per second.
```

## Anything Else?

**What was NOT a defect, and I did not chase it.** `base_media_id` animation failed only because the
cover travels **as a URL** and locally that is `http://localhost:8000/...`, which OpenRouter cannot
reach. In production it is a public Supabase URL. The whole chain worked: id resolved, image→video
model chosen, `first_frame` built, submit sent.

Worth knowing though: **that path depends on the provider being able to download our signed URL.** If
Storage ever goes private it breaks exactly there — and with fix 1, it will now say so instead of
returning a bare `render_failed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY