### PR TITLE
Say why a clip did not land, and name the provider that had it

### DIFF
--- a/changelog/2026-09-05-render-done-says-why.md
+++ b/changelog/2026-09-05-render-done-says-why.md
@@ -1,0 +1,59 @@
+# Un render che non atterra dice perché, e nomina il fornitore vero
+
+Dall'MCP contro un server locale è tornato un lavoro video con
+`status: "done"` e `media_id: null`, e niente in libreria. Una contraddizione
+su cui non c'è niente da fare: la clip è stata prodotta, pagata, e non è
+raggiungibile da nessun tool.
+
+La #344 ha chiuso la metà del lettore — `check_media_job` non ripete più la
+contraddizione e risponde `not_in_library`. Questa è la metà dello scrittore.
+
+## Cosa non andava
+
+`applyToPost` rispondeva con un booleano, quindi ogni motivo per cui una clip
+non atterrava collassava su una stringa che il chiamante aveva già scritto:
+`clip stored but the post could not be updated`. Su un render di libreria quella
+frase nomina un post che il lavoro non ha mai avuto, e `error` è la colonna che
+`check_media_job` mostra verbatim a un agente esterno — che quindi leggeva «il
+tuo clip è bloccato su un problema di post» quando la causa vera era un 403 sul
+download dell'mp4, un file vuoto, o un insert rifiutato.
+
+Il motivo esisteva già: `saveRenderedVideoToLibrary` torna `{ error }` su ogni
+percorso di fallimento, e veniva loggato e buttato via al ritorno.
+
+Il secondo difetto stava a due schermate di distanza, nello stesso file. Il ramo
+sull'età scriveva a mano `kie never resolved this task`. Da #336 un `task_id`
+può essere marchiato `openrouter:`, e per quelle righe la frase è falsa: manda
+chi legge `error` — un agente esterno adesso, un umano che guarda `ai_calls` fra
+un mese — a cercare in una dashboard che quel lavoro non l'ha mai visto. Il ramo
+`exhausted` subito sopra era già onesto (`gave up after N attempts (…)`), e la
+distanza fra i due diceva già qual era quello sbagliato.
+
+## Come è chiuso
+
+`landClip` (era `applyToPost`, e da due commit non applica più a un post) torna
+`string | null`: null vuol dire atterrato, una stringa è il motivo, e finisce
+sulla riga. Le semantiche di retry non cambiano — un motivo presente rimette la
+riga in coda, dove `MAX_ATTEMPTS` la ferma.
+
+Per il fornitore: `videoTaskProvider` in `video.ts` dà un nome al ramo che
+`finishVideoRender` prende già, e la coda chiede al suo vicino invece di
+imparare il marchio `openrouter:` per conto suo — lo stesso motivo per cui il
+trasporto si legge dalla RIGA e mai da `AI_ROUTE_VIDEO` di adesso: una riga in
+coda sopravvive al deploy che sposta la variabile.
+
+## I test
+
+L'invariante è scritta come proprietà su tutte le righe che il riconciliatore
+chiude, non come percorso felice: nessun render `done` con post nullo esiste
+senza una riga `brand_media` che lo reclama per `source_ref` sotto lo stesso
+brand — la stessa coppia con cui `listMediaJobs` risolve l'asset. Passa oggi,
+e fallisce contro la riga che ha prodotto l'incidente (`if (!row.post_id)
+return true;`): è questo che la rende una guardia e non una ripetizione.
+
+I due negativi: il deposito in libreria che fallisce registra il motivo vero e
+non un post inesistente; e un lavoro `openrouter:` che scade non nomina kie.
+Entrambi visti rossi prima del fix — il secondo contro la stringa fissa.
+
+Il riconciliatore resta l'unico posto che scrive `done` su `video_renders`, e
+lo fa solo dopo che `landClip` è tornato null.

--- a/src/lib/content/changelog/2026-09-05-render-done-says-why.ts
+++ b/src/lib/content/changelog/2026-09-05-render-done-says-why.ts
@@ -1,0 +1,10 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-05',
+  title: 'When a clip does not arrive, you get the real reason',
+  items: [
+    'A video that fails to reach your library now records what actually went wrong, instead of a message about a post the clip never belonged to.',
+    'A render that runs out of time names the provider that really had the job, so you look in the right place.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/video-render-queue.test.ts
+++ b/src/lib/server/video-render-queue.test.ts
@@ -10,9 +10,11 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 type Row = Record<string, any>;
 
 const finishVideoRender = vi.fn();
+const videoTaskProvider = vi.fn((_taskId: string): string => 'kie');
 
 vi.mock('$lib/server/video', () => ({
-	finishVideoRender: (...args: unknown[]) => finishVideoRender(...args)
+	finishVideoRender: (...args: unknown[]) => finishVideoRender(...args),
+	videoTaskProvider: (taskId: string) => videoTaskProvider(taskId)
 }));
 vi.mock('$lib/server/ai-log', () => ({
 	withBrandContext: <T>(_brandId: string, fn: () => T) => fn()
@@ -113,6 +115,8 @@ async function reconcile(client: unknown) {
 
 beforeEach(() => {
 	finishVideoRender.mockReset();
+	videoTaskProvider.mockReset();
+	videoTaskProvider.mockReturnValue('kie');
 	saveRenderedVideoToLibrary.mockReset();
 	saveRenderedVideoToLibrary.mockResolvedValue({ mediaId: 'media-1' });
 	addUsage.mockReset();
@@ -230,6 +234,28 @@ describe('reconcileVideoRenders', () => {
 		expect(finishVideoRender).not.toHaveBeenCalled();
 		expect(tables.video_renders[0].status).toBe('expired');
 		expect(tables.posts[0].video_render_status).toBe('failed');
+	});
+
+	// `error` is what check_media_job hands verbatim to whoever asks why the clip never came. A
+	// fixed 'kie' on an openrouter job sends them to read a dashboard that never had the task.
+	it('blames the provider that actually held the task, not a fixed one', async () => {
+		const { VIDEO_RENDER_MAX_AGE_MS } = await import('./video-render-queue');
+		videoTaskProvider.mockReturnValue('openrouter');
+		const { tables, client } = makeDb({
+			video_renders: [
+				renderRow({
+					task_id: 'openrouter:job-9',
+					submitted_at: new Date(Date.now() - VIDEO_RENDER_MAX_AGE_MS - 60_000).toISOString()
+				})
+			],
+			posts: [{ id: 'post-1' }]
+		});
+
+		expect(await reconcile(client)).toMatchObject({ expired: 1 });
+
+		expect(videoTaskProvider).toHaveBeenCalledWith('openrouter:job-9');
+		expect(String(tables.video_renders[0].error)).toContain('openrouter');
+		expect(String(tables.video_renders[0].error)).not.toContain('kie');
 	});
 
 	it('recovers a claim whose holder died mid-finish', async () => {

--- a/src/lib/server/video-render-queue.test.ts
+++ b/src/lib/server/video-render-queue.test.ts
@@ -387,6 +387,70 @@ describe('reconcileVideoRenders', () => {
 
 		expect(saveRenderedVideoToLibrary).not.toHaveBeenCalled();
 	});
+
+	// L'invariante che `check_media_job` promette: `done` vuol dire «il media è in libreria». Un
+	// lavoro chiuso done che nessun asset reclama arriva a un agente esterno come
+	// { status: 'done', media_id: null } — una contraddizione su cui non c'è niente da fare, e il
+	// clip è già pagato. Detta come proprietà su tutte le righe, non come percorso felice.
+	it('nessun lavoro chiuso done resta senza un asset che lo reclama', async () => {
+		finishVideoRender.mockResolvedValue({
+			status: 'done',
+			url: 'https://cdn/clip.mp4',
+			durationSeconds: 12,
+			resolution: '720p'
+		});
+		const { tables, client } = makeDb({
+			video_renders: [
+				renderRow({ id: 'render-lib', post_id: null }),
+				renderRow({ id: 'render-lib-ko', post_id: null }),
+				renderRow({ id: 'render-post', post_id: 'post-1' })
+			],
+			posts: [{ id: 'post-1' }],
+			brand_media: []
+		});
+		saveRenderedVideoToLibrary.mockImplementation(async (_admin: unknown, opts: Row) => {
+			if (opts.sourceRef === 'render-lib-ko') return { error: 'could not read the rendered clip (403)' };
+			tables.brand_media.push({
+				id: `media-${opts.sourceRef}`,
+				brand_id: opts.brandId,
+				source_ref: opts.sourceRef
+			});
+			return { mediaId: `media-${opts.sourceRef}` };
+		});
+
+		await reconcile(client);
+
+		// La stessa coppia con cui listMediaJobs risolve l'asset: brand_id filtrato, source_ref in.
+		const claimed = new Set(tables.brand_media.map((m) => `${m.brand_id}:${m.source_ref}`));
+		const stranded = tables.video_renders
+			.filter((r) => r.status === 'done' && r.post_id === null)
+			.filter((r) => !claimed.has(`${r.brand_id}:${r.id}`))
+			.map((r) => r.id);
+
+		expect(stranded).toEqual([]);
+	});
+
+	// Il motivo vero arriva già da saveRenderedVideoToLibrary e veniva buttato via al ritorno: la
+	// riga ereditava «il post non si è potuto aggiornare» su un lavoro che un post non ce l'ha, ed
+	// è la colonna `error` che check_media_job mostra verbatim a un agente esterno.
+	it('registra perche il deposito in libreria e fallito, non un post che non esiste', async () => {
+		finishVideoRender.mockResolvedValue({
+			status: 'done',
+			url: 'https://cdn/clip.mp4',
+			durationSeconds: 12,
+			resolution: '720p'
+		});
+		saveRenderedVideoToLibrary.mockResolvedValue({ error: 'could not read the rendered clip (403)' });
+		const { tables, client } = makeDb({ video_renders: [renderRow({ post_id: null })] });
+
+		expect(await reconcile(client)).toMatchObject({ done: 0 });
+
+		expect(tables.video_renders[0].status).toBe('rendering');
+		expect(tables.video_renders[0].attempts).toBe(1);
+		expect(tables.video_renders[0].error).toBe('could not read the rendered clip (403)');
+		// Un clip che non è atterrato non consuma l'allocazione mensile del brand.
+		expect(addUsage).not.toHaveBeenCalled();
+	});
 });
 
 describe('enqueueVideoRender', () => {

--- a/src/lib/server/video-render-queue.ts
+++ b/src/lib/server/video-render-queue.ts
@@ -13,6 +13,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import {
 	finishVideoRender,
+	videoTaskProvider,
 	type RenderVideoOpts,
 	type SubmittedVideoRender,
 	type VideoPersistOpts
@@ -254,12 +255,7 @@ async function chargeMonthlyVideo(admin: SupabaseClient, row: VideoRenderRow): P
 	}
 }
 
-/**
- * Null vuol dire che il clip è atterrato; una stringa è il motivo per cui non lo è, e finisce sulla
- * colonna `error` della riga — quella che `check_media_job` mostra verbatim a un agente esterno. Un
- * boolean la sostituiva con una frase su un post che un lavoro di libreria non ha mai avuto.
- */
-async function applyToPost(
+async function landClip(
 	admin: SupabaseClient,
 	row: VideoRenderRow,
 	url: string,
@@ -394,7 +390,7 @@ export async function reconcileVideoRenders(
 		if (age > VIDEO_RENDER_MAX_AGE_MS || exhausted) {
 			const why = exhausted
 				? `gave up after ${raw.attempts} attempts (${raw.error ?? 'repeated failures'})`
-				: 'kie never resolved this task';
+				: `${videoTaskProvider(raw.task_id)} never resolved this task`;
 			await settle(admin, raw, { status: 'expired', error: why });
 			if (raw.post_id) {
 				await admin
@@ -459,7 +455,7 @@ export async function reconcileVideoRenders(
 			// Post first, settle second. Settling `done` before the post has the url strands a paid
 			// clip nowhere: nothing re-reads a done row. If the post write fails the row goes back
 			// to the queue, where the attempt cap eventually stops it.
-			const notLanded = await applyToPost(admin, raw, outcome.url, outcome.thumbnailUrl);
+			const notLanded = await landClip(admin, raw, outcome.url, outcome.thumbnailUrl);
 			if (notLanded) {
 				console.error(`[video-render] clip did not land id=${raw.id}:`, notLanded);
 				await admin

--- a/src/lib/server/video-render-queue.ts
+++ b/src/lib/server/video-render-queue.ts
@@ -207,13 +207,6 @@ async function settle(
 }
 
 /**
- * Attach the finished clip to its post, replacing the cover that stood in for it.
- *
- * Returns whether it worked, and the caller only settles the render `done` once it has: a render
- * marked done whose post never got the url is a clip that exists, is paid for, and is reachable by
- * nothing — and no query in this module looks at `done` rows again.
- */
-/**
  * Il clip che nessun post reclama va nella LIBRERIA del brand, o resta un file pagato che nessun
  * tool sa raggiungere: `create_post` accetta `media_ids`, e questo è l'id che glielo procura.
  * `source_ref` porta l'id del lavoro, così `check_media_job` ritrova l'asset senza una colonna in
@@ -223,7 +216,7 @@ async function applyToLibrary(
 	admin: SupabaseClient,
 	row: VideoRenderRow,
 	url: string
-): Promise<boolean> {
+): Promise<string | null> {
 	const { saveRenderedVideoToLibrary } = await import('$lib/server/brand-media');
 	const saved = await saveRenderedVideoToLibrary(admin, {
 		brandId: row.brand_id,
@@ -233,12 +226,8 @@ async function applyToLibrary(
 		durationSeconds: row.duration_seconds ?? undefined,
 		sourceRef: row.id
 	});
-	if ('error' in saved) {
-		console.error(`[video-render] clip ${url} not registered in the library:`, saved.error);
-		return false;
-	}
 
-	return true;
+	return 'error' in saved ? saved.error : null;
 }
 
 /**
@@ -265,12 +254,17 @@ async function chargeMonthlyVideo(admin: SupabaseClient, row: VideoRenderRow): P
 	}
 }
 
+/**
+ * Null vuol dire che il clip è atterrato; una stringa è il motivo per cui non lo è, e finisce sulla
+ * colonna `error` della riga — quella che `check_media_job` mostra verbatim a un agente esterno. Un
+ * boolean la sostituiva con una frase su un post che un lavoro di libreria non ha mai avuto.
+ */
 async function applyToPost(
 	admin: SupabaseClient,
 	row: VideoRenderRow,
 	url: string,
 	thumbnailUrl?: string
-): Promise<boolean> {
+): Promise<string | null> {
 	if (!row.post_id) return applyToLibrary(admin, row, url);
 	// `.select('id')` so a zero-row match is visible: an UPDATE that hits nothing reports no error,
 	// so without this an orphaned render — post insert rolled back, post since deleted — would be
@@ -292,16 +286,13 @@ async function applyToPost(
 		.eq('id', row.post_id)
 		.select('id');
 	if (error) {
-		console.error(`[video-render] could not attach clip to post ${row.post_id}:`, error.message);
-		return false;
+		return `the clip is stored but post ${row.post_id} could not be updated: ${error.message}`;
 	}
 	if (!touched?.length) {
-		// Nothing to attach to and nothing to retry — the clip is stored, but its post is gone.
-		console.error(`[video-render] post ${row.post_id} no longer exists; clip ${url} is orphaned`);
-		return false;
+		return `the clip is stored but post ${row.post_id} no longer exists`;
 	}
 
-	return true;
+	return null;
 }
 
 /**
@@ -468,8 +459,9 @@ export async function reconcileVideoRenders(
 			// Post first, settle second. Settling `done` before the post has the url strands a paid
 			// clip nowhere: nothing re-reads a done row. If the post write fails the row goes back
 			// to the queue, where the attempt cap eventually stops it.
-			const attached = await applyToPost(admin, raw, outcome.url, outcome.thumbnailUrl);
-			if (!attached) {
+			const notLanded = await applyToPost(admin, raw, outcome.url, outcome.thumbnailUrl);
+			if (notLanded) {
+				console.error(`[video-render] clip did not land id=${raw.id}:`, notLanded);
 				await admin
 					.from('video_renders')
 					.update({
@@ -477,7 +469,7 @@ export async function reconcileVideoRenders(
 						claimed_at: null,
 						attempts: raw.attempts + 1,
 						media_url: outcome.url,
-						error: 'clip stored but the post could not be updated'
+						error: notLanded.slice(0, 2000)
 					})
 					.eq('id', raw.id)
 					.then(undefined, () => {});
@@ -485,7 +477,14 @@ export async function reconcileVideoRenders(
 			}
 			await chargeMonthlyVideo(admin, raw);
 			await settle(admin, raw, { status: 'done', media_url: outcome.url });
-			await notifyThread(admin, raw, "the clip is ready and attached to the post", origin);
+			await notifyThread(
+				admin,
+				raw,
+				raw.post_id
+					? 'the clip is ready and attached to the post'
+					: 'the clip is ready and filed in the media library',
+				origin
+			);
 			done += 1;
 		} catch (e) {
 			// Unknown failure: give the row back rather than burying it. The age check above is what

--- a/src/lib/server/video.openrouter.test.ts
+++ b/src/lib/server/video.openrouter.test.ts
@@ -109,6 +109,14 @@ describe('il cablaggio del video verso OpenRouter', () => {
     });
   });
 
+  it('chi ha tenuto il lavoro si legge dall’id, non dalla variabile di adesso', async () => {
+    M.env.AI_ROUTE_VIDEO = 'grok-imagine@kie';
+    const { videoTaskProvider } = await import('./video');
+
+    expect(videoTaskProvider('openrouter:or-job-1')).toBe('openrouter');
+    expect(videoTaskProvider('kie-task-1')).toBe('kie');
+  });
+
   it('la clip si scarica con la chiave: senza, OpenRouter risponde 401', async () => {
     M.env.AI_ROUTE_VIDEO = 'grok-imagine@kie';
     const f = stubFetch({

--- a/src/lib/server/video.ts
+++ b/src/lib/server/video.ts
@@ -1234,6 +1234,10 @@ export type VideoRenderOutcome =
   | { status: 'done'; url: string; durationSeconds: number; resolution: string; thumbnailUrl?: string }
   | { status: 'failed'; error: string };
 
+export function videoTaskProvider(taskId: string): 'openrouter' | 'kie' {
+  return untagOpenrouterJob(taskId) ? 'openrouter' : 'kie';
+}
+
 /**
  * Check a submitted render once, and finish it if kie is done.
  *


### PR DESCRIPTION
## What?

A clip render that does not reach the library now records **why**, and a render
that runs out of time names **the provider that actually held the job**.

Three things change in `video-render-queue.ts`:

1. `landClip` (was `applyToPost`, and it has not applied only to a post since
   library renders exist) returns `string | null` instead of a boolean: `null`
   means the clip landed, a string is the reason it did not, and that string is
   what the row records.
2. The give-up-on-age branch stops writing a hardcoded `kie never resolved this
   task` and asks the row who had the job.
3. The landing notice stops claiming a post on a render that never had one.

This is the writer half of #344. That PR taught `check_media_job` to stop
repeating the contradiction it was handed (`status: "done"` with
`media_id: null`) and answer `not_in_library`. This one stops the contradiction
being written, and makes the row say what went wrong.

## Why?

`error` is not a log line. It is the column `check_media_job` hands **verbatim**
to an external agent asking why its clip never came, and it is still sitting in
the row a month later when a human goes looking. Two paths were putting text in
there that pointed at the wrong thing:

- **The wrong subject.** Every failure to land collapsed into one sentence the
  caller had already written: `clip stored but the post could not be updated`.
  On a library render that names a post the job never had — while the real cause
  (a 403 fetching the mp4, an empty file, a rejected insert) came back from
  `saveRenderedVideoToLibrary`, was logged, and was dropped at the call site.
- **The wrong supplier.** Since #336 a `task_id` can be marked `openrouter:`.
  The age branch said `kie` regardless, which sends whoever reads it to search a
  dashboard that never saw the task. The `exhausted` branch immediately above was
  already honest — `gave up after N attempts (…)` — and the gap between the two
  is what made the wrong one obvious.

A message that misdirects is worse than no message: it costs the reader the time
they spend looking in the wrong place.

## How?

**The reason already existed.** `saveRenderedVideoToLibrary` returns `{ error }`
on every failure path. Plumbing it through cost nothing but a return type: `null`
landed, a string is why not. Retry semantics are untouched — a reason present
still returns the row to the queue, where `MAX_ATTEMPTS` stops it — so no new
state and no new branch.

**The provider is on the row, not in the environment.** `videoTaskProvider` in
`video.ts` gives a name to the branch `finishVideoRender` already takes on
`untagOpenrouterJob`. The queue asks its neighbour rather than learning the
`openrouter:` marker itself, so the prefix stays defined in exactly one place —
and reading it from the row is what keeps a queued render recoverable across a
deploy that moves `AI_ROUTE_VIDEO`.

**Rejected:** inlining `raw.task_id.startsWith('openrouter:')` in the queue. One
line shorter, and it puts the transport marker in a second file where it can
drift silently from the first.

## Testing?

Unit — `src/lib/server/video-render-queue.test.ts`,
`src/lib/server/video.openrouter.test.ts`. Three tests, each watched red against
the thing it guards before the fix:

- **The invariant, as a property over every row the reconciler settles** — no
  `done` render with a null post exists without a `brand_media` row claiming it
  by `source_ref` under the same brand (the exact pair `listMediaJobs` uses to
  resolve the asset). It passes on `dev`, and fails against the line that
  produced the incident (`if (!row.post_id) return true;`), which is what makes
  it a guard rather than a restatement.
- **The library deposit that fails records the real reason**, not a post that
  job never had. Red against the fixed string.
- **An `openrouter:` job that expires does not name kie.** Red against the fixed
  `'kie never resolved this task'`.

Bearing verified by breaking each guarded line and watching the right tests fail
(3 fail / 16 pass, then 1 / 18, then 1 / 19), not by reading them.

Run: `npx vitest run src/lib/server/video.test.ts src/lib/server/video.openrouter.test.ts src/lib/server/video-render-queue.test.ts src/lib/server/media-generate.video.test.ts src/lib/server/openrouter-video.test.ts src/lib/server/video-fetch.test.ts src/lib/server/motion-references.video.test.ts src/lib/content/changelog/index.test.ts`
→ 8 files, 126 tests, green. `tsc --noEmit` clean on the touched files.

**Not tested:** the happy path end-to-end against a real provider — it costs a
paid render per run, and the two failure paths this PR changes are precisely the
ones a successful render never takes. There is no UI surface here: this is an
hourly cron writing a text column, and the reading surface (#344) already shipped
its own tests.

## Evidence

<details>
<summary>The reconciler run against the local self-hosted stack (never hosted) — the row says who really had the job</summary>

Two rows seeded into the local Postgres, both three hours old so the age branch
takes them, differing only in `task_id`. The real `reconcileVideoRenders` ran
against the real database through `@supabase/supabase-js`, no fakes:

```
AFTER [
  {
    "id": "d7d0f3ad-23c5-4dfd-bd36-0baca9c6035c",
    "task_id": "openrouter:job-verify",
    "status": "expired",
    "error": "openrouter never resolved this task"
  },
  {
    "id": "e993b4d2-9094-4a99-8957-e0d15e80f4ad",
    "task_id": "kie-task-verify",
    "status": "expired",
    "error": "kie never resolved this task"
  }
]
```

Before this PR both rows read `kie never resolved this task`.

</details>

<details>
<summary>The invariant as SQL against the same local database</summary>

The property stated in the unit test, re-asked of the real rows: every `done`
render with a null post, checked against `brand_media` claims by
`(brand_id, source_ref)`.

```
DONE ROWS 1 STRANDED []
```

The scratch rows were deleted after the run; the harness that produced this is
not part of the diff.

</details>

## Anything Else?

- This branch was picked up unfinished from a stopped agent: two commits existed
  and were kept (the test that pins the contract, and the reason plumbing), the
  uncommitted `applyToPost` → `landClip` rename was committed on its own as a
  pure rename, and the Italian docblock it carried was dropped because the
  return type says the same thing. Nothing was thrown away.
- Rebased on `origin/dev` before working. `dev` had not touched
  `video-render-queue.ts` since the merge base, so the defect was still live and
  is not something #336/#341 had already closed.
- `applyToLibrary` keeps its name; it really does only talk to the library.
- The reconciler remains the only writer of `status = 'done'` on
  `video_renders`, and it only gets there after `landClip` returns `null` —
  that is what makes the invariant checkable in one place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
