### PR TITLE
Take the video duration floor from the model

### DIFF
--- a/changelog/2026-09-05-durata-dal-modello.md
+++ b/changelog/2026-09-05-durata-dal-modello.md
@@ -1,0 +1,54 @@
+# La durata di un video viene dal modello, non da una costante nostra
+
+Andrea ha chiesto **5 secondi** e ne ha pagati **10**. I video si fatturano al secondo, quindi era
+il doppio del conto, e niente lo diceva.
+
+```ts
+const floor = Math.min(Math.max(caps.minDuration, MIN_DURATION), caps.maxDuration);
+```
+
+`MIN_DURATION = 10` vinceva sul minimo che il modello **dichiara**. E il minimo vero non è
+un'incognita: il catalogo video di OpenRouter pubblica `supported_durations` modello per modello.
+
+```
+alibaba/wan-3.0         [2,3,4,…,30]     ← parte da 2
+bytedance/seedance-2.5  [4,5,6,…,30]
+minimax/hailuo-3-max    [5,…,15]
+```
+
+Decisione di Andrea: **«leviamolo, lasciamo all'ai esterna decidere la durata, usando il range di
+valori ripreso dall'api di openrouter direttamente»**.
+
+## Pavimento e default sono due cose diverse
+
+È la distinzione che rende il cambio sicuro, ed è quella che mancava:
+
+- **un DEFAULT si può scavalcare.** Chi non chiede una durata riceve `DEFAULT_VIDEO_DURATION`, che
+  **non è stato toccato** — ed è **13**, non 10. Verificato invece che assunto: `MIN_DURATION` non è
+  mai stato un default, solo un pavimento.
+- **un PAVIMENTO no.** E questo si spacciava per legge, facendo pagare il doppio di quanto chiesto.
+
+Chi chiede una durata la ottiene, se il modello la sa fare. `clampVideoDuration` ora prende minimo e
+tetto **entrambi** da `videoModelCaps(model)`.
+
+## Cosa NON è cambiato
+
+- **I gradini di Settings** (`videoDurationOptions`) restano 10/13/15/20/22/30. Sono una scelta di
+  interfaccia, non un pavimento: chi passa dalla API può chiedere 5, chi sceglie da una tendina
+  sceglie fra i gradini. Un test lo dice, perché la prima versione di questo cambio aveva provato a
+  spostarli anche lì — allargamento non richiesto.
+- **Il default**, appunto.
+
+## Due test che asserivano il difetto
+
+- `raises anything under the product floor — a clip too short to hold a cta is not a saving`
+  asseriva il pavimento. Era una decisione difendibile e Andrea l'ha rovesciata; il test ora dice
+  che si scende al minimo **del modello**, con il motivo scritto sopra così non viene «corretto»
+  all'indietro.
+- Il rifiuto `duration_out_of_range` della #347 usava **5 secondi su Grok** come esempio di durata
+  irraggiungibile. Con il pavimento tolto, 5 su Grok si ottiene eccome. Il rifiuto resta giusto —
+  cambia quando scatta: sui numeri che il modello davvero non fa, non su una preferenza nostra.
+  L'esempio è ora 1 secondo su Seedance 2.5, che parte da 4.
+
+È la quinta specie di test difettoso di queste due giornate, e la stessa della QC: **un test che
+difende attivamente il comportamento sbagliato quando qualcuno prova a correggerlo.**

--- a/src/lib/content/changelog/2026-09-05-video-length-you-asked-for.ts
+++ b/src/lib/content/changelog/2026-09-05-video-length-you-asked-for.ts
@@ -1,0 +1,10 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-05',
+  title: 'Videos are the length you asked for',
+  items: [
+    'Short clips are no longer rounded up to ten seconds: ask for five and you get five, on any model that supports it — and clips are billed per second.',
+    'If a model cannot do the length you asked for, you are told the nearest it accepts instead of being charged for a longer one.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/media-generate.video-errors.test.ts
+++ b/src/lib/server/media-generate.video-errors.test.ts
@@ -90,14 +90,26 @@ describe('il fornitore rifiuta: il motivo deve arrivare a chi ha chiamato', () =
 
 describe('la durata non si riporta di nascosto', () => {
   it('sotto il minimo del modello si rifiuta, dicendo la finestra', async () => {
-    // Grok Imagine dichiara minDuration 1, ma il pavimento di prodotto e' 10: 5 non e' ottenibile.
-    const out = await run({ durationSeconds: 5, model: 'grok-imagine-video-1-5-preview' });
+    // Seedance 2.5 parte da 4 secondi: uno non e' ottenibile su QUEL modello.
+    //
+    // L'esempio era 5 secondi su Grok, che il pavimento di prodotto a 10 rendeva irraggiungibile.
+    // Quel pavimento e' stato tolto — il minimo ora viene dal modello, e Grok dichiara 1, quindi 5
+    // si ottiene eccome. Il rifiuto resta giusto, cambia solo quando scatta: sui numeri che il
+    // modello davvero non fa, non su una preferenza nostra.
+    const out = await run({ durationSeconds: 1, model: 'bytedance/seedance-2-5' });
 
     expect(out.ok).toBe(false);
     expect('error' in out && out.error).toBe('duration_out_of_range');
     // Senza i numeri il rifiuto e' un vicolo cieco: l'agente non sa cosa richiedere.
-    expect('reason' in out && String(out.reason)).toMatch(/10/);
+    expect('reason' in out && String(out.reason)).toMatch(/4/);
     expect(submitAndTrackVideoRender).not.toHaveBeenCalled();
+  });
+
+  it('cinque secondi ora si ottengono: e il conto che Andrea aveva pagato doppio', async () => {
+    const out = await run({ durationSeconds: 5, model: 'grok-imagine-video-1-5-preview' });
+
+    expect(out.ok).toBe(true);
+    expect(submitAndTrackVideoRender.mock.calls[0][0].render.duration).toBe(5);
   });
 
   it('una durata ottenibile passa e viene dichiarata nella risposta', async () => {

--- a/src/lib/server/video.duration.test.ts
+++ b/src/lib/server/video.duration.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { clampVideoDuration, DEFAULT_VIDEO_DURATION, videoDurationOptions } from './video';
+
+/**
+ * IL MINIMO VIENE DAL MODELLO, NON DA UNA COSTANTE NOSTRA.
+ *
+ * Andrea ha chiesto 5 secondi e ne ha pagati 10: `MIN_DURATION = 10` alzava il pavimento ignorando
+ * il minimo che il modello dichiara. I video si fatturano al secondo, quindi era il doppio, e in
+ * silenzio.
+ *
+ * La distinzione che resta valida: un DEFAULT si puo' scavalcare, un PAVIMENTO no. Chi non chiede
+ * niente riceve `DEFAULT_VIDEO_DURATION`; chi chiede una durata la ottiene, se il modello la sa
+ * fare. Il catalogo di OpenRouter pubblica `supported_durations` e per `wan-3.0` parte da 2.
+ */
+describe('la durata chiesta', () => {
+  it('5 secondi restano 5 su un modello che li sa fare', () => {
+    // grok-imagine dichiara minDuration 1: cinque secondi sono nella sua finestra.
+    expect(clampVideoDuration(5, 'grok-imagine/text-to-video')).toBe(5);
+  });
+
+  it('2 secondi restano 2 dove il modello arriva a 2', () => {
+    expect(clampVideoDuration(2, 'grok-imagine/text-to-video')).toBe(2);
+  });
+
+  it('sotto il minimo DEL MODELLO si sale al minimo del modello, non al nostro', () => {
+    // seedance-2.5 parte da 4: chiedere 1 da' 4, non 10.
+    expect(clampVideoDuration(1, 'bytedance/seedance-2-5')).toBe(4);
+  });
+
+  it('sopra il tetto del modello si scende al tetto', () => {
+    expect(clampVideoDuration(999, 'grok-imagine/text-to-video')).toBe(15);
+  });
+
+  it('chi non chiede niente riceve il default, che non e stato toccato', () => {
+    expect(clampVideoDuration(undefined, 'bytedance/seedance-2-5')).toBe(DEFAULT_VIDEO_DURATION);
+    expect(clampVideoDuration('non un numero', 'bytedance/seedance-2-5')).toBe(DEFAULT_VIDEO_DURATION);
+  });
+
+  it('i gradini di Settings restano quelli, che e un altra cosa', () => {
+    // La tendina offre 10/13/15/…: e' una scelta di interfaccia, non un pavimento. Chi passa dalla
+    // API puo' chiedere 5; chi sceglie da un menu sceglie fra i gradini.
+    expect(videoDurationOptions('grok-imagine/text-to-video')).toContain(10);
+  });
+});

--- a/src/lib/server/video.test.ts
+++ b/src/lib/server/video.test.ts
@@ -264,10 +264,15 @@ describe('videoModelCaps', () => {
 });
 
 describe('clampVideoDuration (model-aware)', () => {
-  it('raises anything under the product floor — a clip too short to hold a cta is not a saving', () => {
-    expect(clampVideoDuration(3, 'grok-imagine-video-1-5-preview')).toBe(MIN_DURATION);
-    expect(clampVideoDuration(6, 'bytedance/seedance-2-5')).toBe(MIN_DURATION);
-    expect(clampVideoDuration(1, 'bytedance/seedance-2')).toBe(MIN_DURATION);
+  // Questo test asseriva il PAVIMENTO DI PRODOTTO a 10 secondi — «una clip troppo corta per reggere
+  // una cta non e' un risparmio». Era una decisione difendibile e Andrea l'ha rovesciata: ha chiesto
+  // 5 secondi e ne ha pagati 10, e i video si fatturano al secondo. Il minimo ora viene dal modello,
+  // che e' un fatto pubblicato, non da una costante nostra.
+  it('scende al minimo DEL MODELLO, che e un fatto e non una nostra preferenza', () => {
+    expect(clampVideoDuration(3, 'grok-imagine-video-1-5-preview')).toBe(3);
+    expect(clampVideoDuration(6, 'bytedance/seedance-2-5')).toBe(6);
+    // Seedance 2 parte da 4: uno non e' ottenibile e diventa quattro, non dieci.
+    expect(clampVideoDuration(1, 'bytedance/seedance-2')).toBe(4);
   });
 
   it('caps at the CHOSEN model ceiling — not a global constant', () => {

--- a/src/lib/server/video.ts
+++ b/src/lib/server/video.ts
@@ -150,7 +150,7 @@ export function ugcDurationCap(
 /** I gradini offerti in Settings, filtrati su ciò che `model` sa davvero produrre. */
 export function videoDurationOptions(model?: string | null): number[] {
   const caps = videoModelCaps(model?.trim() || envModelI2V());
-  const floor = Math.min(Math.max(caps.minDuration, MIN_DURATION), caps.maxDuration);
+  const floor = caps.minDuration;
   const candidates = [10, 13, 15, 20, 22, 30];
   const opts = candidates.filter((s) => s >= floor && s <= caps.maxDuration);
   // Il tetto del modello resta sempre scegliibile, anche se non è uno dei gradini.
@@ -159,12 +159,21 @@ export function videoDurationOptions(model?: string | null): number[] {
 }
 
 /**
- * Nella finestra del modello SCELTO, poi nel pavimento di prodotto. Il tetto è sempre
- * `videoModelCaps(model).maxDuration` — mai una env var, mai una costante globale.
+ * Nella finestra del modello SCELTO, e basta. Il minimo e il tetto vengono ENTRAMBI da
+ * `videoModelCaps(model)` — mai una env var, mai una costante globale.
+ *
+ * C'era un pavimento di prodotto a 10 secondi che vinceva sul minimo dichiarato dal modello, e ha
+ * fatto pagare 10 secondi a chi ne aveva chiesti 5: i video si fatturano al secondo, quindi era il
+ * doppio, in silenzio. Il catalogo pubblica `supported_durations` per modello e per `wan-3.0`
+ * parte da 2.
+ *
+ * Un DEFAULT si puo' scavalcare, un PAVIMENTO no — ed e' la differenza che questo cambio ripristina.
+ * Chi non chiede niente riceve `DEFAULT_VIDEO_DURATION`, che non e' stato toccato; chi chiede una
+ * durata la ottiene, se il modello la sa fare.
  */
 export function clampVideoDuration(seconds: unknown, model?: string | null): number {
   const caps = videoModelCaps(model?.trim() || envModelI2V());
-  const floor = Math.min(Math.max(caps.minDuration, MIN_DURATION), caps.maxDuration);
+  const floor = caps.minDuration;
   const fallback = Math.min(Math.max(DEFAULT_VIDEO_DURATION, floor), caps.maxDuration);
   const n = Math.round(Number(seconds));
   if (!Number.isFinite(n)) return fallback;


### PR DESCRIPTION
## What?

`clampVideoDuration` now takes **both ends** of the window from `videoModelCaps(model)`. The
hand-written `MIN_DURATION = 10` no longer overrides what the model declares.

## Why?

Andrea asked for **5 seconds** and paid for **10**. Clips bill per second, so that was double, and
nothing said so.

```ts
const floor = Math.min(Math.max(caps.minDuration, MIN_DURATION), caps.maxDuration);
```

And the real minimum is not unknown — OpenRouter's video catalogue publishes it per model:

```
alibaba/wan-3.0         [2,3,4,…,30]     ← starts at 2
bytedance/seedance-2.5  [4,5,6,…,30]
minimax/hailuo-3-max    [5,…,15]
```

Andrea's call: *"leviamolo, lasciamo all'ai esterna decidere la durata, usando il range di valori
ripreso dall'api di openrouter direttamente."*

## How?

### A default and a floor are different things

This is the distinction that was missing, and it is what makes the change safe:

- **A default can be overridden.** Whoever asks for nothing gets `DEFAULT_VIDEO_DURATION`, untouched.
- **A floor cannot.** This one passed itself off as law and billed double what was requested.

**Verified rather than assumed, and it corrects the brief I was given:** `DEFAULT_VIDEO_DURATION` is
**13**, not 10. `MIN_DURATION` was never a default — only a floor — so removing it changes nothing
for callers that pass no duration.

### What deliberately did NOT change

**Settings steps** (`videoDurationOptions`) stay 10/13/15/20/22/30. A dropdown is an interface
choice, not a floor: an API caller can ask for 5, a menu user picks from steps. A test now says so,
because my first pass at this change moved those too — an unrequested widening I caught and undid.

## Testing?

Red first, and the message is Andrea's bill:

```
× 5 secondi restano 5 su un modello che li sa fare   → expected 10 to be 5
× 2 secondi restano 2 dove il modello arriva a 2     → expected 10 to be 2
× sotto il minimo DEL MODELLO si sale al minimo del modello, non al nostro → expected 10 to be 4
```

Six tests: 5s and 2s survive on a model that supports them; below a model's own minimum rises to
**that** minimum (Seedance 2.5 → 4, not 10); above the ceiling caps at the ceiling; no duration asked
still returns the default; Settings steps unchanged.

### Two tests asserted the defect

- `raises anything under the product floor — a clip too short to hold a cta is not a saving` pinned
  the floor outright. It was a defensible product decision and Andrea reversed it; the test now says
  the minimum comes from the model, **with the reason written above it** so it does not get
  "corrected" back.
- #347's `duration_out_of_range` refusal used **5s on Grok** as its unreachable example. With the
  floor gone, 5s on Grok is very much reachable. The refusal is still right — what changed is *when*
  it fires: on numbers the model genuinely cannot do, not on a preference of ours. The example is now
  1s on Seedance 2.5, which starts at 4.

That is the fifth species of defective test in two days, and the same as the QC one: **a test that
actively defends the wrong behaviour when someone tries to fix it.**

```
vitest src/lib/server + video-models  →  4,353 passed, 1 failed → fixed → all green
```

The single failure in the wide run was #347's example above — caught by running wide rather than
only the files I touched.

No paid model called.

**Not tested:** that a 2-second clip is *good*. That was the product argument behind the floor, and
Andrea has taken that call knowingly.

## Evidence

Fetched live from `GET /api/v1/videos/models` (a metadata GET — no render, no spend), 28 models, all
publishing `supported_durations`.

## Anything Else?

**This is the duration only, deliberately.** Sourcing all of `caps` from the catalogue —
`supported_resolutions`, `supported_aspect_ratios`, `supported_frame_images`, `generate_audio`,
`pricing_skus` — is the next PR. It touches every video path, and bundling it here would make one
change that fixes a bill *and* re-sources the facts under every other video tool. That gets approved
sight-unseen rather than reviewed, and this one touches what a customer pays.

**One thing to carry into that PR:** `runway/aleph-2` publishes `supported_durations: null` because
it takes footage, not frames. When caps come from the catalogue, **a null field must mean "does not
apply", not "no value is valid"** — the same shape as the `null` that meant two things in `cost_usd`,
which has already cost us once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY