### PR TITLE
Write captions for every network, without creating a post

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -33,6 +33,14 @@ LOGICA con i test (il caricamento si mocka) e nel browser verifica quello che il
 ### Il worktree nuovo ha bisogno di `npm ci` — e ancora dopo ogni rebase su dev
 Un worktree parte senza `node_modules`, e `vite.config.ts` muore subito (`Cannot find package '@sentry/sveltekit'`). Ma il caso insidioso è l'altro: dopo aver ribasato su dev che ha accolto PR nuove, il `node_modules` installato col vecchio lockfile produce guasti **deterministici e fuori posto** — v. `extractUserText is not a function` in un test di immagini: il codice era giusto, le dipendenze vecchie. Segnale: un errore `X is not a function` su codice mai toccato, in un worktree ribasato. Mossa: `npm ci` nel worktree, sempre, dopo il rebase.
 
+**E il worktree nuovo non ha nemmeno `.env`: `hooks.server.test.ts` fallisce da solo.** Con
+`node_modules` a posto resta un rosso che sembra tuo: `TypeError: Invalid URL` all'import, un file
+solo, in un test che la tua modifica non sfiora. Non è una regressione — è una variabile
+d'ambiente che manca, e il checkout principale ce l'ha. Segnale: quel test è l'UNICO rosso su
+~7.300 passati, e passa nel checkout principale. Mossa: rilancialo nel checkout principale prima
+di indagare; se lì è verde, è l'ambiente, non il tuo diff. Ha già fatto perdere tempo a due
+agenti lo stesso giorno.
+
 **E prima di credere a un rosso locale, guarda la CI.** Lo stesso `extractUserText`/
 `extractUserImages` è tornato il 4/9 su `dev`: quei simboli non erano codice nostro ma una patch
 `patch-package`, tolta perché non applicava più alla versione installata. In locale i test

--- a/changelog/2026-09-05-generate-captions.md
+++ b/changelog/2026-09-05-generate-captions.md
@@ -1,0 +1,73 @@
+# generate_captions — testo e basta, con la sequenza che non si può pubblicare
+
+Mancava un tool che scrivesse **solo didascalie**. Chi voleva del testo passava da
+`create_post`, che però deposita un post: per avere tre varianti da guardare ne creava tre da
+cancellare. E la scorciatoia opposta — scrivere una didascalia sola e riusarla ovunque — è
+esattamente ciò che `ensureShortNetworkCuts` fa oggi in fase di pubblicazione: tronca. Un testo
+pensato per LinkedIn, amputato a 280 caratteri, non è una didascalia per X.
+
+`generate_captions` (POST `/captions/generate`) scrive per ogni piattaforma la sua, dentro il
+limite di quella piattaforma. Una chiamata sola al modello, con lo schema che nomina **solo** le
+piattaforme chieste: chiedere X da sola costa una didascalia, non nove con otto buttate. È il
+requisito che il test tiene (`caption-writer.test.ts`), e lo tiene guardando lo schema passato al
+modello, non le didascalie tornate.
+
+## La sequenza esiste, ma non si pubblica da qui — ed è dichiarato
+
+Prima di generare thread ho verificato se si potessero pubblicare. **No.** Il publisher è Zernio
+(`src/lib/server/publishing/zernio.ts`): il payload porta `content: string`, uno, e
+`platformSpecificData` è un insieme chiuso — `subreddit`, `url`, `title`, la dichiarazione AI.
+Nessun `in_reply_to`, nessun parent id, in tutto lo stack: `PublishInput`
+(`publishing/port.ts`) non ha un campo dove appendere le parti 2..N, `posts` non ha una colonna
+di ordinamento, e `platform_captions` è `Record<string, string>` — un array lì dentro cade nel
+fallback silenzioso di `captionFor`. Composio non è una seconda strada: il proxy lo usano solo
+gli ingestori di conoscenza.
+
+Quindi `format: 'thread'` torna le parti con `publishable: false`, e la descrizione del tool dice
+perché: pubblicare manda **un** post per piattaforma, la sequenza è da incollare a mano. La
+scelta è deliberata e reversibile in un diff piccolo — generare thread taciuti sarebbe stato
+peggio che non generarli, perché l'agente crede di avere una cosa che non arriverà mai in linea.
+
+## Il taglio, che è la parte che si rompe in silenzio
+
+`splitForPlatform(testo, limite)` sta in `platform-limits.ts`, pura: niente modello, niente
+database, niente rete. Riserva **prima di impacchettare** il marcatore più largo che la sequenza
+può produrre (`" 12/12"`), così ogni parte ha lo stesso budget e l'ultima non sfora quando la
+numerazione viene appesa — il difetto classico di questa funzione, e il test lo prova con un
+testo che sfora di un carattere solo.
+
+I punti di taglio non sono nuovi: riusano `truncateForPlatform`, che guadagna il livello che gli
+mancava. L'ordine ora è frase, riga, **proposizione**, e solo come ultima risorsa lo spazio fra
+due parole; il pavimento al 50% del budget resta, così una frase che finisce troppo presto non
+produce una parte mezza vuota. Ogni candidato è ancorato a uno spazio, per cui un URL, una
+menzione o un hashtag non si spezzano mai: la prova non elenca i casi, verifica che ogni parte
+cominci e finisca su un confine di parola nel testo originale.
+
+Aggiungere la proposizione cambia il comportamento anche di chi già usava
+`truncateForPlatform` (il taglio automatico per X/Threads in pubblicazione, e il manual posting):
+le parti diventano leggermente più corte e più sensate. È un miglioramento nella stessa
+direzione, non un effetto collaterale.
+
+## Il costo lo dice chi ce lo fattura
+
+`gateAiAction` prima del corpo, come gli altri: una chiave di sola lettura e un brand senza
+crediti si fermano prima che qualcosa costi, e il test che conta lo verifica guardando che il
+modello **non** sia partito. La chiamata sta dentro `withBrandContext`, così la riga in
+`ai_calls` è attribuita al brand e il prezzo è quello che OpenRouter ci fattura.
+
+La risposta **non** porta un campo con il costo, ed è una scelta: nessuna rotta lo fa, e l'unico
+modo per metterlo lì sarebbe stato ricalcolarlo — cioè una tariffa scritta a mano accanto a
+`ai_calls`, una seconda verità che diverge al primo cambio di listino. La descrizione dice
+«Costs credits», come `ads_remix`.
+
+## Scartato
+
+- **Una chiamata per piattaforma.** Nove volte il contesto del brand in prompt per lo stesso
+  lavoro, e il modello che non vede le altre otto didascalie mentre scrive la nona — quindi si
+  ripete. Una chiamata sola con lo schema ristretto costa meno e differenzia meglio.
+- **Un secondo motore di taglio** accanto a `truncateForPlatform`. Due algoritmi che decidono
+  dove finisce una frase divergono al primo ritocco.
+- **`slug` opzionale.** Il lavoro brand-free non è atterrato: `BRAND_ENDPOINTS` inietta `slug`
+  per costruzione (`cli/mcp/tools/brand-content.ts`), `pathFor` lo mette nel percorso, e
+  `registry.test.ts` lo dà per scontato. Senza brand non c'è nemmeno la voce del brand, che è
+  metà del valore del tool.

--- a/changelog/2026-09-05-generate-captions.md
+++ b/changelog/2026-09-05-generate-captions.md
@@ -55,10 +55,16 @@ crediti si fermano prima che qualcosa costi, e il test che conta lo verifica gua
 modello **non** sia partito. La chiamata sta dentro `withBrandContext`, così la riga in
 `ai_calls` è attribuita al brand e il prezzo è quello che OpenRouter ci fattura.
 
-La risposta **non** porta un campo con il costo, ed è una scelta: nessuna rotta lo fa, e l'unico
-modo per metterlo lì sarebbe stato ricalcolarlo — cioè una tariffa scritta a mano accanto a
-`ai_calls`, una seconda verità che diverge al primo cambio di listino. La descrizione dice
-«Costs credits», come `ads_remix`.
+E la risposta **lo dice**, in `cost_usd`. Non è un ricalcolo: `takeLlmCost`, oltre a consegnare la
+fattura alla riga che la scrive, ora la lascia leggibile nello scope (`billedUsdInScope`), così la
+rotta restituisce **lo stesso numero** finito in `ai_calls` invece di riscriversi un listino
+accanto. È la terza strada che avevo mancato al primo giro: non una tariffa nostra e non una
+seconda fonte di verità, ma la fattura di OpenRouter — quella che `llm-usage-cost.ts` chiede con
+`usage: { include: true }` e che copre il modello che ha risposto davvero.
+
+`null` significa **sconosciuto, non gratis**, e un test lo tiene: la #328 ha stabilito che una riga
+riuscita senza prezzo è un difetto di prezzatura, e uno `0` di comodo lo nasconderebbe. La
+descrizione dice comunque «Costs credits», come `ads_remix`.
 
 ## Scartato
 

--- a/cli/lib/contracts/captions.ts
+++ b/cli/lib/contracts/captions.ts
@@ -50,7 +50,17 @@ export const GENERATE_CAPTIONS = {
         )
     })
     .strict(),
-  output: z.object({ ok: z.literal(true), captions: z.array(Caption) }),
+  output: z.object({
+    ok: z.literal(true),
+    captions: z.array(Caption),
+    cost_usd: z
+      .number()
+      .nullable()
+      .describe(
+        'What the gateway billed for this call, the same figure written to the usage ledger. ' +
+          'null means no invoice came back: unknown, not free'
+      )
+  }),
   failures: [
     { error: 'invalid_input', status: 400 },
     { error: 'credits_exhausted', status: 402 },

--- a/cli/lib/contracts/captions.ts
+++ b/cli/lib/contracts/captions.ts
@@ -1,0 +1,60 @@
+import { z } from 'zod';
+import { TARGET_PLATFORMS } from './brand-settings';
+import type { BrandEndpoint } from './index';
+
+const platform = z.enum(TARGET_PLATFORMS);
+
+export const CAPTION_FORMATS = ['single', 'thread'] as const;
+
+const Caption = z.object({
+  platform,
+  parts: z
+    .array(z.string())
+    .describe('One entry for a single post; several, numbered "1/3", for a sequence'),
+  limit: z.number().describe("The platform's character limit, which every part respects"),
+  publishable: z
+    .boolean()
+    .describe(
+      'false when this is a multi-post sequence: create_post publishes one post per platform, ' +
+        'so a sequence has to be posted by hand'
+    )
+});
+
+export const GENERATE_CAPTIONS = {
+  tool: 'generate_captions',
+  title: 'Generate captions',
+  description:
+    'Write captions — text only, no media, and NO post is created: pass a caption to create_post ' +
+    'when you want to publish it. By default every platform gets its own caption, written for ' +
+    'that platform and inside its character limit, instead of one text cut nine ways. Pass ' +
+    'platforms to get only those, each written to its own limit with no extra shortening. ' +
+    'format "thread" lets X and Threads come back as a numbered sequence of posts rather than ' +
+    'one — good to paste by hand, but create_post publishes a single post per platform, so a ' +
+    'sequence is not publishable from here. Uses the brand voice. Costs credits.',
+  method: 'POST',
+  pathUnderBrand: '/captions/generate',
+  input: z
+    .object({
+      topic: z.string().min(1).describe('What the caption is about'),
+      platforms: z
+        .array(platform)
+        .min(1)
+        .optional()
+        .describe('Only these platforms. Omitted, every platform gets one'),
+      format: z
+        .enum(CAPTION_FORMATS)
+        .optional()
+        .describe(
+          '"single" (default) keeps every caption inside one post. "thread" lets X and Threads ' +
+            'run past their limit as a numbered sequence'
+        )
+    })
+    .strict(),
+  output: z.object({ ok: z.literal(true), captions: z.array(Caption) }),
+  failures: [
+    { error: 'invalid_input', status: 400 },
+    { error: 'credits_exhausted', status: 402 },
+    { error: 'no_captions', status: 502 }
+  ],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/cli/lib/contracts/index.ts
+++ b/cli/lib/contracts/index.ts
@@ -3,6 +3,7 @@ import { ADS_ACTION, ADS_REMIX } from './ads';
 import { GET_APPEARANCE, SET_APPEARANCE } from './appearance';
 import { GET_AUTOMATIONS, SET_AUTOMATION } from './automations';
 import { BILLING_PORTAL_LINK, CHECKOUT_LINK } from './billing';
+import { GENERATE_CAPTIONS } from './captions';
 import {
   DELETE_ARTICLE,
   GENERATE_ARTICLE,
@@ -184,6 +185,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   DISCARD_PLAN,
   EDIT_POST,
   GENERATE_ARTICLE,
+  GENERATE_CAPTIONS,
   GENERATE_CAROUSEL,
   GENERATE_IMAGE,
   GENERATE_VIDEO,
@@ -302,6 +304,7 @@ export {
   CHECK_CONTENT,
   CHECK_MEDIA_JOB,
   CREATE_POST,
+  GENERATE_CAPTIONS,
   GENERATE_CAROUSEL,
   GENERATE_IMAGE,
   GENERATE_VIDEO,

--- a/cli/plugins/anomalia/skills/anomalia/references/tools.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/tools.md
@@ -54,6 +54,7 @@ with `error`, `message` and often `fix` inside, so you can read why and change m
 | `create_post` | (MCP only) |
 | `list_media` | (MCP only) |
 | `check_content` | (MCP only) |
+| `generate_captions` | (MCP only) |
 | `import_media_url` | (MCP only) |
 | `generate_media` | (MCP only) |
 | `generate_image` | (MCP only) |
@@ -152,6 +153,25 @@ that bills a second one. Refusals: `credits_exhausted` (402) means the brand's p
 nothing was drawn; `video_budget_exhausted` (400) means the monthly video allowance is used up,
 counting the clips still rendering; `render_failed` (502) is the model returning nothing, and
 nothing is stored; `store_failed` (502) means it was drawn but could not be filed.
+
+`generate_captions` writes captions and nothing else — text, no image, no video, and **no post**:
+it creates nothing in the calendar, so the caption you keep still has to go to `create_post` as
+`caption` (or inside `platform_captions`) to exist anywhere. Required: `slug`, `topic`; optional
+`platforms` and `format`. **This spends credits** — one model turn per call.
+
+Called with `topic` alone it writes for every platform at once, each caption composed for the
+platform it is going to and already inside that platform's character limit, rather than one text
+trimmed nine different ways. Name `platforms` and you get only those, written to their own limits
+with no further shortening — asking for X alone costs one caption, not nine with eight thrown
+away. Every entry comes back with `parts`, the platform's `limit`, and `publishable`.
+
+`format` defaults to `single`: one post per platform, guaranteed to fit. `format: "thread"` lets
+X and Threads run as long as the idea needs and returns `parts` as a numbered sequence — each
+part whole words only, never a URL or a mention cut in two, with the `1/4` counted inside the
+limit. Such a sequence comes back with `publishable: false`, and it means it: publishing sends
+one post per platform, so a sequence is for pasting by hand, not for `create_post`. Refusals:
+`credits_exhausted` (402) means the pool is empty and nothing was written; `no_captions` (502) is
+the model returning nothing.
 
 `generate_image` draws a NEW image into the library from a prompt. Required: `slug`, `prompt`;
 optional `count` (1-4 alternatives, **each one billed**), `aspect_ratio`, `model`, `title`. It

--- a/cli/plugins/anomalia/skills/anomalia/references/tools.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/tools.md
@@ -165,6 +165,11 @@ trimmed nine different ways. Name `platforms` and you get only those, written to
 with no further shortening — asking for X alone costs one caption, not nine with eight thrown
 away. Every entry comes back with `parts`, the platform's `limit`, and `publishable`.
 
+The response carries `cost_usd`: what the gateway billed for that call, the same figure written
+to the usage ledger, not a price list rewritten here. `null` means no invoice came back — that is
+**unknown, not free** — so reconcile against the ledger rather than reading a missing number as
+zero.
+
 `format` defaults to `single`: one post per platform, guaranteed to fit. `format: "thread"` lets
 X and Threads run as long as the idea needs and returns `parts` as a numbered sequence — each
 part whole words only, never a URL or a mention cut in two, with the `1/4` counted inside the

--- a/cli/skills/anomalia/references/tools.md
+++ b/cli/skills/anomalia/references/tools.md
@@ -54,6 +54,7 @@ with `error`, `message` and often `fix` inside, so you can read why and change m
 | `create_post` | (MCP only) |
 | `list_media` | (MCP only) |
 | `check_content` | (MCP only) |
+| `generate_captions` | (MCP only) |
 | `import_media_url` | (MCP only) |
 | `generate_media` | (MCP only) |
 | `generate_image` | (MCP only) |
@@ -152,6 +153,25 @@ that bills a second one. Refusals: `credits_exhausted` (402) means the brand's p
 nothing was drawn; `video_budget_exhausted` (400) means the monthly video allowance is used up,
 counting the clips still rendering; `render_failed` (502) is the model returning nothing, and
 nothing is stored; `store_failed` (502) means it was drawn but could not be filed.
+
+`generate_captions` writes captions and nothing else — text, no image, no video, and **no post**:
+it creates nothing in the calendar, so the caption you keep still has to go to `create_post` as
+`caption` (or inside `platform_captions`) to exist anywhere. Required: `slug`, `topic`; optional
+`platforms` and `format`. **This spends credits** — one model turn per call.
+
+Called with `topic` alone it writes for every platform at once, each caption composed for the
+platform it is going to and already inside that platform's character limit, rather than one text
+trimmed nine different ways. Name `platforms` and you get only those, written to their own limits
+with no further shortening — asking for X alone costs one caption, not nine with eight thrown
+away. Every entry comes back with `parts`, the platform's `limit`, and `publishable`.
+
+`format` defaults to `single`: one post per platform, guaranteed to fit. `format: "thread"` lets
+X and Threads run as long as the idea needs and returns `parts` as a numbered sequence — each
+part whole words only, never a URL or a mention cut in two, with the `1/4` counted inside the
+limit. Such a sequence comes back with `publishable: false`, and it means it: publishing sends
+one post per platform, so a sequence is for pasting by hand, not for `create_post`. Refusals:
+`credits_exhausted` (402) means the pool is empty and nothing was written; `no_captions` (502) is
+the model returning nothing.
 
 `generate_image` draws a NEW image into the library from a prompt. Required: `slug`, `prompt`;
 optional `count` (1-4 alternatives, **each one billed**), `aspect_ratio`, `model`, `title`. It

--- a/cli/skills/anomalia/references/tools.md
+++ b/cli/skills/anomalia/references/tools.md
@@ -165,6 +165,11 @@ trimmed nine different ways. Name `platforms` and you get only those, written to
 with no further shortening — asking for X alone costs one caption, not nine with eight thrown
 away. Every entry comes back with `parts`, the platform's `limit`, and `publishable`.
 
+The response carries `cost_usd`: what the gateway billed for that call, the same figure written
+to the usage ledger, not a price list rewritten here. `null` means no invoice came back — that is
+**unknown, not free** — so reconcile against the ledger rather than reading a missing number as
+zero.
+
 `format` defaults to `single`: one post per platform, guaranteed to fit. `format: "thread"` lets
 X and Threads run as long as the idea needs and returns `parts` as a numbered sequence — each
 part whole words only, never a URL or a mention cut in two, with the `1/4` counted inside the

--- a/packages/api-contracts/src/captions.test.ts
+++ b/packages/api-contracts/src/captions.test.ts
@@ -26,6 +26,14 @@ describe('il contratto delle didascalie', () => {
     expect(pathFor(GENERATE_CAPTIONS, 'demo')).toBe('/api/v1/brands/demo/captions/generate');
   });
 
+  it('dice quanto e` costato, e sa dire che non lo sa', () => {
+    const ok = { ok: true, captions: [], cost_usd: 0.004 };
+    expect(GENERATE_CAPTIONS.output.safeParse(ok).success).toBe(true);
+    expect(GENERATE_CAPTIONS.output.safeParse({ ...ok, cost_usd: null }).success).toBe(true);
+    // Un costo assente non e` un costo zero: il campo c'e` sempre.
+    expect(GENERATE_CAPTIONS.output.safeParse({ ok: true, captions: [] }).success).toBe(false);
+  });
+
   it('dice che non pubblica: chi legge tools/list deve trovare create_post da qui', () => {
     expect(GENERATE_CAPTIONS.description).toContain('create_post');
     expect(GENERATE_CAPTIONS.description).toMatch(/no post is created/i);

--- a/packages/api-contracts/src/captions.test.ts
+++ b/packages/api-contracts/src/captions.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { pathFor } from './index';
+import { GENERATE_CAPTIONS } from './captions';
+
+describe('il contratto delle didascalie', () => {
+  it('chiede solo un topic: senza piattaforme le scrive per tutte', () => {
+    expect(GENERATE_CAPTIONS.input.safeParse({ topic: 'un lancio' }).success).toBe(true);
+    expect(GENERATE_CAPTIONS.input.safeParse({}).success).toBe(false);
+    expect(GENERATE_CAPTIONS.input.safeParse({ topic: '' }).success).toBe(false);
+  });
+
+  it('accetta una piattaforma sola e rifiuta un nome che non esiste', () => {
+    expect(GENERATE_CAPTIONS.input.safeParse({ topic: 't', platforms: ['x'] }).success).toBe(true);
+    expect(GENERATE_CAPTIONS.input.safeParse({ topic: 't', platforms: ['myspace'] }).success).toBe(false);
+    expect(GENERATE_CAPTIONS.input.safeParse({ topic: 't', platforms: [] }).success).toBe(false);
+  });
+
+  it('conosce due formati soli, e la sequenza va chiesta', () => {
+    expect(GENERATE_CAPTIONS.input.safeParse({ topic: 't', format: 'thread' }).success).toBe(true);
+    expect(GENERATE_CAPTIONS.input.safeParse({ topic: 't', format: 'sequence' }).success).toBe(false);
+  });
+
+  it('non crea niente, e dichiara il 402 perché spende crediti', () => {
+    expect(GENERATE_CAPTIONS.destructive).toBe(false);
+    expect(GENERATE_CAPTIONS.failures).toContainEqual({ error: 'credits_exhausted', status: 402 });
+    expect(pathFor(GENERATE_CAPTIONS, 'demo')).toBe('/api/v1/brands/demo/captions/generate');
+  });
+
+  it('dice che non pubblica: chi legge tools/list deve trovare create_post da qui', () => {
+    expect(GENERATE_CAPTIONS.description).toContain('create_post');
+    expect(GENERATE_CAPTIONS.description).toMatch(/no post is created/i);
+  });
+});

--- a/packages/api-contracts/src/captions.ts
+++ b/packages/api-contracts/src/captions.ts
@@ -50,7 +50,17 @@ export const GENERATE_CAPTIONS = {
         )
     })
     .strict(),
-  output: z.object({ ok: z.literal(true), captions: z.array(Caption) }),
+  output: z.object({
+    ok: z.literal(true),
+    captions: z.array(Caption),
+    cost_usd: z
+      .number()
+      .nullable()
+      .describe(
+        'What the gateway billed for this call, the same figure written to the usage ledger. ' +
+          'null means no invoice came back: unknown, not free'
+      )
+  }),
   failures: [
     { error: 'invalid_input', status: 400 },
     { error: 'credits_exhausted', status: 402 },

--- a/packages/api-contracts/src/captions.ts
+++ b/packages/api-contracts/src/captions.ts
@@ -1,0 +1,60 @@
+import { z } from 'zod';
+import { TARGET_PLATFORMS } from './brand-settings';
+import type { BrandEndpoint } from './index';
+
+const platform = z.enum(TARGET_PLATFORMS);
+
+export const CAPTION_FORMATS = ['single', 'thread'] as const;
+
+const Caption = z.object({
+  platform,
+  parts: z
+    .array(z.string())
+    .describe('One entry for a single post; several, numbered "1/3", for a sequence'),
+  limit: z.number().describe("The platform's character limit, which every part respects"),
+  publishable: z
+    .boolean()
+    .describe(
+      'false when this is a multi-post sequence: create_post publishes one post per platform, ' +
+        'so a sequence has to be posted by hand'
+    )
+});
+
+export const GENERATE_CAPTIONS = {
+  tool: 'generate_captions',
+  title: 'Generate captions',
+  description:
+    'Write captions — text only, no media, and NO post is created: pass a caption to create_post ' +
+    'when you want to publish it. By default every platform gets its own caption, written for ' +
+    'that platform and inside its character limit, instead of one text cut nine ways. Pass ' +
+    'platforms to get only those, each written to its own limit with no extra shortening. ' +
+    'format "thread" lets X and Threads come back as a numbered sequence of posts rather than ' +
+    'one — good to paste by hand, but create_post publishes a single post per platform, so a ' +
+    'sequence is not publishable from here. Uses the brand voice. Costs credits.',
+  method: 'POST',
+  pathUnderBrand: '/captions/generate',
+  input: z
+    .object({
+      topic: z.string().min(1).describe('What the caption is about'),
+      platforms: z
+        .array(platform)
+        .min(1)
+        .optional()
+        .describe('Only these platforms. Omitted, every platform gets one'),
+      format: z
+        .enum(CAPTION_FORMATS)
+        .optional()
+        .describe(
+          '"single" (default) keeps every caption inside one post. "thread" lets X and Threads ' +
+            'run past their limit as a numbered sequence'
+        )
+    })
+    .strict(),
+  output: z.object({ ok: z.literal(true), captions: z.array(Caption) }),
+  failures: [
+    { error: 'invalid_input', status: 400 },
+    { error: 'credits_exhausted', status: 402 },
+    { error: 'no_captions', status: 502 }
+  ],
+  destructive: false
+} satisfies BrandEndpoint;

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -3,6 +3,7 @@ import { ADS_ACTION, ADS_REMIX } from './ads';
 import { GET_APPEARANCE, SET_APPEARANCE } from './appearance';
 import { GET_AUTOMATIONS, SET_AUTOMATION } from './automations';
 import { BILLING_PORTAL_LINK, CHECKOUT_LINK } from './billing';
+import { GENERATE_CAPTIONS } from './captions';
 import {
   DELETE_ARTICLE,
   GENERATE_ARTICLE,
@@ -184,6 +185,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   DISCARD_PLAN,
   EDIT_POST,
   GENERATE_ARTICLE,
+  GENERATE_CAPTIONS,
   GENERATE_CAROUSEL,
   GENERATE_IMAGE,
   GENERATE_VIDEO,
@@ -302,6 +304,7 @@ export {
   CHECK_CONTENT,
   CHECK_MEDIA_JOB,
   CREATE_POST,
+  GENERATE_CAPTIONS,
   GENERATE_CAROUSEL,
   GENERATE_IMAGE,
   GENERATE_VIDEO,

--- a/src/lib/content/changelog/2026-09-05-generate-captions.ts
+++ b/src/lib/content/changelog/2026-09-05-generate-captions.ts
@@ -1,0 +1,12 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-05',
+  title: 'Captions written for each network, not one text cut nine ways',
+  items: [
+    'Ask for captions on a topic and every platform gets its own, composed for that network and already inside its character limit.',
+    'Ask for one platform and you get one platform, written to its own limit with nothing shortened on top.',
+    'X and Threads can come back as a numbered sequence, split on whole sentences and never through a link or a mention.',
+    'It writes text only and creates no post: keep the caption you want and publish it as usual.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/content/changelog/2026-09-05-generate-captions.ts
+++ b/src/lib/content/changelog/2026-09-05-generate-captions.ts
@@ -7,6 +7,7 @@ export default {
     'Ask for captions on a topic and every platform gets its own, composed for that network and already inside its character limit.',
     'Ask for one platform and you get one platform, written to its own limit with nothing shortened on top.',
     'X and Threads can come back as a numbered sequence, split on whole sentences and never through a link or a mention.',
-    'It writes text only and creates no post: keep the caption you want and publish it as usual.'
+    'It writes text only and creates no post: keep the caption you want and publish it as usual.',
+    'Every call reports what it cost, taken from the bill we are charged rather than an estimate.'
   ]
 } satisfies ChangelogEntry;

--- a/src/lib/platform-limits.test.ts
+++ b/src/lib/platform-limits.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { captionFor, captionViolations, ensureShortNetworkCuts, truncateForPlatform, youtubeTitleFrom } from './platform-limits';
+import {
+  captionFor,
+  captionViolations,
+  ensureShortNetworkCuts,
+  splitForPlatform,
+  truncateForPlatform,
+  youtubeTitleFrom
+} from './platform-limits';
 
 const LONG = 'a'.repeat(1200); // fine on Instagram, way over X (280) and Threads (500)
 
@@ -45,6 +52,86 @@ describe('ensureShortNetworkCuts', () => {
     const out = truncateForPlatform(prose, 80);
     expect(out.length).toBeLessThanOrEqual(80);
     expect(out.endsWith(' ')).toBe(false);
+  });
+});
+
+describe('splitForPlatform', () => {
+  const X = 280;
+  const marker = / \d+\/\d+$/;
+  const unnumbered = (parts: string[]) => parts.map((p) => p.replace(marker, ''));
+  const words = (count: number) => Array.from({ length: count }, (_, i) => `word${i}`).join(' ');
+
+  const startsAndEndsOnAWordBoundary = (parts: string[], original: string) =>
+    unnumbered(parts).every((part) => {
+      const at = original.indexOf(part);
+      if (at < 0) return false;
+      const before = original[at - 1];
+      const after = original[at + part.length];
+      return (!before || /\s/.test(before)) && (!after || /\s/.test(after));
+    });
+
+  it('leaves a caption that already fits as a single unnumbered part', () => {
+    expect(splitForPlatform('short and sweet', X)).toEqual(['short and sweet']);
+    expect(splitForPlatform('a'.repeat(X), X)).toEqual(['a'.repeat(X)]);
+  });
+
+  it('counts the numbering inside the limit when the text overflows by one character', () => {
+    const text = `${'word '.repeat(56)}x`;
+    expect(text.length).toBe(X + 1);
+
+    const parts = splitForPlatform(text, X);
+
+    expect(parts).toHaveLength(2);
+    for (const part of parts) {
+      expect(part.length).toBeLessThanOrEqual(X);
+    }
+    expect(parts[0].endsWith(' 1/2')).toBe(true);
+    expect(parts[1].endsWith(' 2/2')).toBe(true);
+  });
+
+  it('keeps every part of a long thread inside the limit', () => {
+    for (const limit of [280, 300, 500]) {
+      const parts = splitForPlatform(words(900), limit);
+      expect(parts.length).toBeGreaterThan(1);
+      for (const part of parts) {
+        expect(part.length).toBeLessThanOrEqual(limit);
+      }
+    }
+  });
+
+  it('never cuts inside a word, a URL, a mention or a hashtag', () => {
+    const url = 'https://example.com/a/very/long/path?with=query&and=more';
+    const text = `${words(30)} ${url} @a_long_mention_handle #a_long_hashtag_too ${words(30)}`;
+
+    const parts = splitForPlatform(text, X);
+
+    expect(startsAndEndsOnAWordBoundary(parts, text)).toBe(true);
+    expect(unnumbered(parts).filter((p) => p.includes(url))).toHaveLength(1);
+    expect(unnumbered(parts).filter((p) => p.includes('@a_long_mention_handle'))).toHaveLength(1);
+    expect(unnumbered(parts).filter((p) => p.includes('#a_long_hashtag_too'))).toHaveLength(1);
+  });
+
+  it('prefers the end of a sentence, then of a clause, over a bare word break', () => {
+    const sentence = `${words(25)}. ${words(40)}`;
+    expect(unnumbered(splitForPlatform(sentence, X))[0].endsWith('.')).toBe(true);
+
+    const clause = `${words(25)}, ${words(40)}`;
+    expect(unnumbered(splitForPlatform(clause, X))[0].endsWith(',')).toBe(true);
+  });
+
+  it('loses nothing: the parts recompose the whole original text', () => {
+    const text = `${words(40)}. ${words(40)}, ${words(40)}\n${words(40)}`;
+    const normalise = (s: string) => s.replace(/\s+/g, ' ').trim();
+
+    expect(normalise(unnumbered(splitForPlatform(text, X)).join(' '))).toBe(normalise(text));
+  });
+
+  it('hard-cuts only when a single token is longer than the budget', () => {
+    const parts = splitForPlatform('z'.repeat(X * 2), X);
+    for (const part of parts) {
+      expect(part.length).toBeLessThanOrEqual(X);
+    }
+    expect(parts.length).toBeGreaterThan(1);
   });
 });
 

--- a/src/lib/platform-limits.ts
+++ b/src/lib/platform-limits.ts
@@ -123,12 +123,15 @@ export function truncateForPlatform(text: string, limit: number): string {
   if (raw.length <= limit) return raw;
   const budget = Math.max(1, limit);
   const slice = raw.slice(0, budget);
-  // Prefer breaking on sentence, then newline, then word — but only if the break isn't too early.
+  // Prefer breaking on sentence, then newline, then clause, then word — never too early.
   const candidates = [
     slice.lastIndexOf('. '),
     slice.lastIndexOf('! '),
     slice.lastIndexOf('? '),
     slice.lastIndexOf('\n'),
+    slice.lastIndexOf(', '),
+    slice.lastIndexOf('; '),
+    slice.lastIndexOf(': '),
     slice.lastIndexOf(' ')
   ];
   const minBreak = Math.floor(budget * 0.5);
@@ -142,6 +145,37 @@ export function truncateForPlatform(text: string, limit: number): string {
   const cut = (breakAt >= 0 ? slice.slice(0, breakAt + (slice[breakAt] === ' ' ? 0 : 1)) : slice).trim();
   // If we still overflow somehow (edge: no spaces), hard slice.
   return cut.length <= budget ? cut : cut.slice(0, budget).trim();
+}
+
+const widestNumbering = (parts: number) => 2 * String(parts).length + 2;
+
+const packToBudget = (text: string, budget: number): string[] => {
+  const room = Math.max(1, budget);
+  const parts: string[] = [];
+  let rest = text;
+
+  while (rest.length > room) {
+    const head = truncateForPlatform(rest, room);
+    parts.push(head);
+    rest = rest.slice(head.length).trim();
+  }
+  if (rest) parts.push(rest);
+
+  return parts;
+};
+
+export function splitForPlatform(text: string, limit: number): string[] {
+  const raw = text.trim();
+  if (raw.length <= limit) return [raw];
+
+  let reserved = 0;
+  let parts = packToBudget(raw, limit);
+  while (widestNumbering(parts.length) > reserved) {
+    reserved = widestNumbering(parts.length);
+    parts = packToBudget(raw, limit - reserved);
+  }
+
+  return parts.map((part, i) => `${part} ${i + 1}/${parts.length}`);
 }
 
 /**

--- a/src/lib/server/ai-log.test.ts
+++ b/src/lib/server/ai-log.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { computeCostUsd, extractSdkUsage, noteLlmCost, takeLlmCost, withBrandContext } from './ai-log';
+import { billedUsdInScope, computeCostUsd, extractSdkUsage, noteLlmCost, takeLlmCost, withBrandContext } from './ai-log';
 import { GEMINI_FLASH, NANO_BANANA_PRO } from './gemini';
 
 const GO = 'go';
@@ -338,5 +338,34 @@ describe('fatture del gateway nello scope', () => {
   it('fuori da uno scope non esplode e non ricorda nulla', () => {
     noteLlmCost(5);
     expect(takeLlmCost()).toBeUndefined();
+  });
+
+  it('quello che e` stato ritirato resta leggibile: e` il numero scritto nella riga', async () => {
+    await withBrandContext('brand-1', async () => {
+      expect(billedUsdInScope()).toBeUndefined();
+
+      noteLlmCost(0.004);
+      expect(takeLlmCost()).toBeCloseTo(0.004, 10);
+
+      expect(billedUsdInScope()).toBeCloseTo(0.004, 10);
+    });
+  });
+
+  it('somma le fatture di piu` chiamate nello stesso scope', async () => {
+    await withBrandContext('brand-1', async () => {
+      noteLlmCost(0.001);
+      takeLlmCost();
+      noteLlmCost(0.002);
+      takeLlmCost();
+
+      expect(billedUsdInScope()).toBeCloseTo(0.003, 10);
+    });
+  });
+
+  it('senza fattura del gateway non inventa uno zero: resta sconosciuto', async () => {
+    await withBrandContext('brand-1', async () => {
+      takeLlmCost();
+      expect(billedUsdInScope()).toBeUndefined();
+    });
   });
 });

--- a/src/lib/server/ai-log.ts
+++ b/src/lib/server/ai-log.ts
@@ -18,6 +18,8 @@ type BrandLogContext = {
   kieCredits?: number;
   /** Costo fatturato dal gateway in questo scope, sommato: la fattura vera del turno. */
   llmCostUsd?: number;
+  /** Le fatture gia` ritirate e scritte in `ai_calls`, per chi deve DIRE quanto e` costato. */
+  billedUsd?: number;
 };
 
 const brandStorage = new AsyncLocalStorage<BrandLogContext>();
@@ -103,7 +105,17 @@ export function takeLlmCost(): number | undefined {
   const cost = ctx?.llmCostUsd;
   if (!ctx || cost == null) return undefined;
   ctx.llmCostUsd = undefined;
+  ctx.billedUsd = (ctx.billedUsd ?? 0) + cost;
   return cost;
+}
+
+/**
+ * Quanto il gateway ha fatturato in questo scope, gia` finito nelle righe di `ai_calls`. Serve a
+ * una rotta che deve dire quanto e` costata: e` lo stesso numero della riga, non un listino
+ * riscritto accanto. `undefined` significa che nessuna fattura e` arrivata — non zero.
+ */
+export function billedUsdInScope(): number | undefined {
+  return brandStorage.getStore()?.billedUsd;
 }
 
 /** $5 = 1000 crediti kie. */

--- a/src/lib/server/caption-writer.test.ts
+++ b/src/lib/server/caption-writer.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const llmStructured = vi.fn();
+
+vi.mock('$lib/server/llm', () => ({
+  llmConfigured: () => true,
+  llmStructured: (opts: unknown) => llmStructured(opts)
+}));
+
+import { writeCaptions } from './caption-writer';
+
+const ALL = ['instagram', 'tiktok', 'facebook', 'linkedin', 'x', 'threads', 'youtube', 'bluesky', 'reddit'];
+
+const answerFor = (platforms: string[], text: string) => ({
+  captions: platforms.map((platform) => ({ platform, text }))
+});
+
+type CaptionsSchema = {
+  properties: { captions: { items: { properties: { platform: { enum: string[] } } } } };
+};
+
+const platformsAskedFor = () => {
+  const [{ schema }] = llmStructured.mock.calls[0] as [{ schema: CaptionsSchema }];
+  return schema.properties.captions.items.properties.platform.enum;
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  llmStructured.mockResolvedValue(answerFor(ALL, 'a caption'));
+});
+
+describe('writeCaptions', () => {
+  it('asks the model once for every platform, and returns one caption each', async () => {
+    const out = await writeCaptions({ topic: 'a launch', platforms: ALL, format: 'single', voice: '' });
+
+    expect(llmStructured).toHaveBeenCalledTimes(1);
+    expect(out.map((c) => c.platform)).toEqual(ALL);
+  });
+
+  it('one platform is one platform: the other eight are never generated', async () => {
+    llmStructured.mockResolvedValue(answerFor(['x'], 'just for X'));
+
+    const out = await writeCaptions({ topic: 'a launch', platforms: ['x'], format: 'single', voice: '' });
+
+    expect(llmStructured).toHaveBeenCalledTimes(1);
+    expect(platformsAskedFor()).toEqual(['x']);
+    expect(out).toHaveLength(1);
+    expect(out[0].platform).toBe('x');
+  });
+
+  it('keeps a single post inside the limit and calls it publishable', async () => {
+    llmStructured.mockResolvedValue(answerFor(['x'], 'z'.repeat(400)));
+
+    const [caption] = await writeCaptions({ topic: 't', platforms: ['x'], format: 'single', voice: '' });
+
+    expect(caption.parts).toHaveLength(1);
+    expect(caption.parts[0].length).toBeLessThanOrEqual(280);
+    expect(caption.limit).toBe(280);
+    expect(caption.publishable).toBe(true);
+  });
+
+  it('splits X into a numbered sequence on format "thread", and says it is not publishable', async () => {
+    const long = Array.from({ length: 120 }, (_, i) => `word${i}`).join(' ');
+    llmStructured.mockResolvedValue(answerFor(['x'], long));
+
+    const [caption] = await writeCaptions({ topic: 't', platforms: ['x'], format: 'thread', voice: '' });
+
+    expect(caption.parts.length).toBeGreaterThan(1);
+    for (const part of caption.parts) {
+      expect(part.length).toBeLessThanOrEqual(280);
+    }
+    expect(caption.publishable).toBe(false);
+  });
+
+  it('does not split a caption that already fits, even on format "thread"', async () => {
+    llmStructured.mockResolvedValue(answerFor(['x'], 'short enough for X'));
+
+    const [caption] = await writeCaptions({ topic: 't', platforms: ['x'], format: 'thread', voice: '' });
+
+    expect(caption.parts).toEqual(['short enough for X']);
+    expect(caption.publishable).toBe(true);
+  });
+
+  it('never turns a long-form platform into a sequence', async () => {
+    llmStructured.mockResolvedValue(answerFor(['linkedin'], 'z'.repeat(5000)));
+
+    const [caption] = await writeCaptions({
+      topic: 't',
+      platforms: ['linkedin'],
+      format: 'thread',
+      voice: ''
+    });
+
+    expect(caption.parts).toHaveLength(1);
+    expect(caption.publishable).toBe(true);
+  });
+});

--- a/src/lib/server/caption-writer.ts
+++ b/src/lib/server/caption-writer.ts
@@ -1,0 +1,118 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import {
+  ALT_CAPTION_PLATFORMS,
+  PLATFORM_CHAR_LIMITS,
+  platformLabel,
+  splitForPlatform,
+  truncateForPlatform
+} from '$lib/platform-limits';
+import { llmConfigured, llmStructured } from '$lib/server/llm';
+
+export type CaptionFormat = 'single' | 'thread';
+
+export type WrittenCaption = {
+  platform: string;
+  parts: string[];
+  limit: number;
+  publishable: boolean;
+};
+
+const SYSTEM = [
+  'You write social captions in the brand voice.',
+  'Every platform gets a caption written natively for it — its own hook, its own rhythm, its own',
+  'use of hashtags and line breaks — never one text reshaped to fit the others.',
+  'Stay inside the character limit given for each platform.'
+].join(' ');
+
+const canRunLong = (platform: string) =>
+  ALT_CAPTION_PLATFORMS.some((short) => short === platform);
+
+const schemaFor = (platforms: string[]) => ({
+  type: 'object',
+  properties: {
+    captions: {
+      type: 'array',
+      minItems: platforms.length,
+      maxItems: platforms.length,
+      items: {
+        type: 'object',
+        properties: {
+          platform: { type: 'string', enum: platforms },
+          text: { type: 'string' }
+        },
+        required: ['platform', 'text']
+      }
+    }
+  },
+  required: ['captions']
+});
+
+const briefFor = (platform: string, format: CaptionFormat) => {
+  const limit = PLATFORM_CHAR_LIMITS[platform] ?? 0;
+  const room =
+    format === 'thread' && canRunLong(platform)
+      ? `write it at the length the idea needs — it will be split into a numbered sequence of posts of ${limit} characters each`
+      : `at most ${limit} characters, and it must read as finished at that length`;
+
+  return `- ${platformLabel(platform)} (${platform}): ${room}`;
+};
+
+const promptFor = (opts: { topic: string; platforms: string[]; format: CaptionFormat; voice: string }) =>
+  [
+    `Topic: ${opts.topic}`,
+    opts.voice ? `\nBrand:\n${opts.voice}` : '',
+    `\nWrite one caption for each of these platforms, and no others:`,
+    opts.platforms.map((platform) => briefFor(platform, opts.format)).join('\n')
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+const shape = (platform: string, text: string, format: CaptionFormat): WrittenCaption => {
+  const limit = PLATFORM_CHAR_LIMITS[platform] ?? 0;
+  const parts =
+    format === 'thread' && canRunLong(platform)
+      ? splitForPlatform(text, limit)
+      : [truncateForPlatform(text, limit)];
+
+  return { platform, parts, limit, publishable: parts.length === 1 };
+};
+
+export async function brandVoice(supabase: SupabaseClient, brandId: string): Promise<string> {
+  const { data } = await supabase
+    .from('brand_kit')
+    .select('about, ai_context, category, target_audience, brand_style, content_pillars')
+    .eq('brand_id', brandId)
+    .maybeSingle();
+  if (!data) return '';
+
+  return Object.entries(data)
+    .filter(([, value]) => value)
+    .map(([field, value]) => `${field}: ${Array.isArray(value) ? value.join(', ') : value}`)
+    .join('\n');
+}
+
+export async function writeCaptions(opts: {
+  topic: string;
+  platforms: string[];
+  format: CaptionFormat;
+  voice: string;
+}): Promise<WrittenCaption[]> {
+  if (!llmConfigured() || !opts.platforms.length) return [];
+
+  const written = await llmStructured<{ captions?: Array<{ platform?: string; text?: string }> }>({
+    label: 'generate_captions',
+    system: SYSTEM,
+    prompt: promptFor(opts),
+    schema: schemaFor(opts.platforms)
+  });
+
+  const byPlatform = new Map(
+    (written?.captions ?? [])
+      .filter((c) => typeof c?.text === 'string' && c.text.trim())
+      .map((c) => [String(c.platform ?? ''), String(c.text)])
+  );
+
+  return opts.platforms
+    .filter((platform) => byPlatform.has(platform))
+    .map((platform) => shape(platform, byPlatform.get(platform) as string, opts.format));
+}

--- a/src/routes/api/v1/brands/[slug]/captions/generate/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/captions/generate/+server.ts
@@ -3,7 +3,7 @@ import type { RequestHandler } from './$types';
 import { authenticate, loadBrandForUser, gateAiAction } from '$lib/server/cli-auth';
 import { brandVoice, writeCaptions } from '$lib/server/caption-writer';
 import { GENERATE_CAPTIONS, TARGET_PLATFORMS, statusForFailure } from '@anomalia/api-contracts';
-import { withBrandContext } from '$lib/server/ai-log';
+import { billedUsdInScope, withBrandContext } from '$lib/server/ai-log';
 
 export const POST: RequestHandler = async ({ request, params }) => {
   const { supabase, error, apiKey } = await authenticate(request);
@@ -21,18 +21,20 @@ export const POST: RequestHandler = async ({ request, params }) => {
   }
 
   const platforms = parsed.data.platforms ?? [...TARGET_PLATFORMS];
-  const captions = await withBrandContext(brand.id, async () =>
-    writeCaptions({
+  const { captions, costUsd } = await withBrandContext(brand.id, async () => {
+    const written = await writeCaptions({
       topic: parsed.data.topic,
       platforms,
       format: parsed.data.format ?? 'single',
       voice: await brandVoice(supabase, brand.id)
-    })
-  );
+    });
+
+    return { captions: written, costUsd: billedUsdInScope() ?? null };
+  });
 
   if (!captions.length) {
     return json({ error: 'no_captions' }, { status: statusForFailure(GENERATE_CAPTIONS, 'no_captions') });
   }
 
-  return json({ ok: true, captions });
+  return json({ ok: true, captions, cost_usd: costUsd });
 };

--- a/src/routes/api/v1/brands/[slug]/captions/generate/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/captions/generate/+server.ts
@@ -1,0 +1,38 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { authenticate, loadBrandForUser, gateAiAction } from '$lib/server/cli-auth';
+import { brandVoice, writeCaptions } from '$lib/server/caption-writer';
+import { GENERATE_CAPTIONS, TARGET_PLATFORMS, statusForFailure } from '@anomalia/api-contracts';
+import { withBrandContext } from '$lib/server/ai-log';
+
+export const POST: RequestHandler = async ({ request, params }) => {
+  const { supabase, error, apiKey } = await authenticate(request);
+  if (error) return error;
+
+  const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
+  if (brandError) return brandError;
+
+  const gate = await gateAiAction(brand, apiKey);
+  if (gate) return gate;
+
+  const parsed = GENERATE_CAPTIONS.input.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return json({ error: 'invalid_input', details: parsed.error.issues }, { status: 400 });
+  }
+
+  const platforms = parsed.data.platforms ?? [...TARGET_PLATFORMS];
+  const captions = await withBrandContext(brand.id, async () =>
+    writeCaptions({
+      topic: parsed.data.topic,
+      platforms,
+      format: parsed.data.format ?? 'single',
+      voice: await brandVoice(supabase, brand.id)
+    })
+  );
+
+  if (!captions.length) {
+    return json({ error: 'no_captions' }, { status: statusForFailure(GENERATE_CAPTIONS, 'no_captions') });
+  }
+
+  return json({ ok: true, captions });
+};

--- a/src/routes/api/v1/brands/[slug]/captions/generate/server.test.ts
+++ b/src/routes/api/v1/brands/[slug]/captions/generate/server.test.ts
@@ -2,11 +2,16 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const writeCaptions = vi.fn();
 const brandVoice = vi.fn();
+const billedUsdInScope = vi.fn();
 
 vi.mock('$lib/server/cli-auth', () => ({
   authenticate: vi.fn(),
   loadBrandForUser: vi.fn(),
   gateAiAction: vi.fn()
+}));
+vi.mock('$lib/server/ai-log', () => ({
+  withBrandContext: (_brandId: string, fn: () => unknown) => fn(),
+  billedUsdInScope: () => billedUsdInScope()
 }));
 vi.mock('$lib/server/caption-writer', () => ({
   writeCaptions: (...args: unknown[]) => writeCaptions(...args),
@@ -43,6 +48,7 @@ beforeEach(() => {
   } as never);
   vi.mocked(gateAiAction).mockResolvedValue(undefined as never);
   brandVoice.mockResolvedValue('');
+  billedUsdInScope.mockReturnValue(0.0042);
   writeCaptions.mockResolvedValue([
     { platform: 'x', parts: ['a caption'], limit: 280, publishable: true }
   ]);
@@ -96,13 +102,22 @@ describe('POST /api/v1/brands/:slug/captions/generate', () => {
     expect(body.error).toBe('no_captions');
   });
 
-  it('returns the captions it wrote', async () => {
+  it('returns the captions it wrote, and what the gateway billed for them', async () => {
     const { res, body } = await call({ topic: 'a launch', platforms: ['x'] });
 
     expect(res.status).toBe(200);
     expect(body).toEqual({
       ok: true,
-      captions: [{ platform: 'x', parts: ['a caption'], limit: 280, publishable: true }]
+      captions: [{ platform: 'x', parts: ['a caption'], limit: 280, publishable: true }],
+      cost_usd: 0.0042
     });
+  });
+
+  it('an invoice that never arrived is null, not a free call', async () => {
+    billedUsdInScope.mockReturnValue(undefined);
+
+    const { body } = await call({ topic: 'a launch', platforms: ['x'] });
+
+    expect(body.cost_usd).toBeNull();
   });
 });

--- a/src/routes/api/v1/brands/[slug]/captions/generate/server.test.ts
+++ b/src/routes/api/v1/brands/[slug]/captions/generate/server.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const writeCaptions = vi.fn();
+const brandVoice = vi.fn();
+
+vi.mock('$lib/server/cli-auth', () => ({
+  authenticate: vi.fn(),
+  loadBrandForUser: vi.fn(),
+  gateAiAction: vi.fn()
+}));
+vi.mock('$lib/server/caption-writer', () => ({
+  writeCaptions: (...args: unknown[]) => writeCaptions(...args),
+  brandVoice: (...args: unknown[]) => brandVoice(...args)
+}));
+
+import { POST } from './+server';
+import { authenticate, loadBrandForUser, gateAiAction } from '$lib/server/cli-auth';
+
+const ALL = ['instagram', 'tiktok', 'facebook', 'linkedin', 'x', 'threads', 'youtube', 'bluesky', 'reddit'];
+
+function call(body: unknown, slug = 'demo') {
+  const url = new URL(`https://anomalia.test/api/v1/brands/${slug}/captions/generate`);
+  return (POST as (event: unknown) => Promise<Response>)({
+    request: new Request(url, { method: 'POST', body: JSON.stringify(body) }),
+    params: { slug },
+    url
+  }).then(async (res) => ({ res, body: await res.json() }));
+}
+
+const platformsAskedFor = () => (writeCaptions.mock.calls[0][0] as { platforms: string[] }).platforms;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(authenticate).mockResolvedValue({
+    supabase: {},
+    user: { id: 'user-1' },
+    apiKey: undefined,
+    error: null
+  } as never);
+  vi.mocked(loadBrandForUser).mockResolvedValue({
+    brand: { id: 'brand-1', slug: 'demo' },
+    error: null
+  } as never);
+  vi.mocked(gateAiAction).mockResolvedValue(undefined as never);
+  brandVoice.mockResolvedValue('');
+  writeCaptions.mockResolvedValue([
+    { platform: 'x', parts: ['a caption'], limit: 280, publishable: true }
+  ]);
+});
+
+describe('POST /api/v1/brands/:slug/captions/generate', () => {
+  it('a brand out of credits writes nothing: the gate answers and the model never runs', async () => {
+    vi.mocked(gateAiAction).mockResolvedValue(
+      new Response(JSON.stringify({ error: 'credits_exhausted' }), { status: 402 }) as never
+    );
+
+    const { res, body } = await call({ topic: 'a launch' });
+
+    expect(res.status).toBe(402);
+    expect(body.error).toBe('credits_exhausted');
+    expect(writeCaptions).not.toHaveBeenCalled();
+  });
+
+  it('writes for every platform when none is named', async () => {
+    await call({ topic: 'a launch' });
+
+    expect(platformsAskedFor()).toEqual(ALL);
+  });
+
+  it('one platform asked is one platform written: the other eight are never requested', async () => {
+    await call({ topic: 'a launch', platforms: ['x'] });
+
+    expect(writeCaptions).toHaveBeenCalledTimes(1);
+    expect(platformsAskedFor()).toEqual(['x']);
+  });
+
+  it('defaults to a single post per platform', async () => {
+    await call({ topic: 'a launch' });
+
+    expect((writeCaptions.mock.calls[0][0] as { format: string }).format).toBe('single');
+  });
+
+  it('refuses an unknown platform instead of writing for it', async () => {
+    const { res } = await call({ topic: 'a launch', platforms: ['myspace'] });
+
+    expect(res.status).toBe(400);
+    expect(writeCaptions).not.toHaveBeenCalled();
+  });
+
+  it('says so when the model came back with nothing', async () => {
+    writeCaptions.mockResolvedValue([]);
+
+    const { res, body } = await call({ topic: 'a launch' });
+
+    expect(res.status).toBe(502);
+    expect(body.error).toBe('no_captions');
+  });
+
+  it('returns the captions it wrote', async () => {
+    const { res, body } = await call({ topic: 'a launch', platforms: ['x'] });
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({
+      ok: true,
+      captions: [{ platform: 'x', parts: ['a caption'], limit: 280, publishable: true }]
+    });
+  });
+});


### PR DESCRIPTION
## What?

Adds `generate_captions`, an MCP tool and endpoint (`POST /api/v1/brands/:slug/captions/generate`) that writes social captions and **nothing else** — no image, no video, and no post. Called with a topic alone it writes one caption per platform, each composed for that network and already inside its character limit. Named platforms get only those. `format: "thread"` returns X and Threads as a numbered sequence.

It also adds `splitForPlatform`, a pure text-splitting function in `platform-limits.ts`, and lets a route read back what the gateway billed for its own model call.

`create_post` is untouched and unrenamed; it remains the separate action that deposits a post.

## Why?

Getting captions meant calling `create_post`, which deposits a post: three variants to compare were three posts to delete. The opposite shortcut — one caption reused everywhere — is what the publish path already does badly. `ensureShortNetworkCuts` truncates a long caption to fit X, so a LinkedIn text becomes an amputated tweet with the ending silently thrown away.

## How?

**One model call, with a schema naming only the platforms asked for.** Requesting X alone costs one caption, not nine with eight discarded. Fanning out per platform was rejected: it repeats the brand context nine times and the model can't see the other captions while writing, so it repeats itself.

**The splitting is pure and reuses the existing break engine.** `splitForPlatform(text, limit)` takes text and a limit and returns an array — no model, no database, no network. It reserves the widest marker the run can produce (`" 12/12"`) **before** packing, so every part gets the same budget and the last one can't overflow once numbered; that off-by-the-marker is the classic defect of this function. Break points reuse `truncateForPlatform` rather than adding a second algorithm — two functions deciding where a sentence ends diverge at the first edit. It gains the tier it was missing, so the order is now sentence → line → **clause** → bare word, with the existing 50% fill floor kept so a sentence ending too early doesn't produce a half-empty part. Every candidate is whitespace-anchored, which is why URLs, mentions and hashtags are never cut in two.

**Cost comes from the invoice, not a rate table.** `takeLlmCost` already withdraws OpenRouter's `usage.cost` for the row that writes it; it now also leaves it readable in the scope via `billedUsdInScope`, so the response returns the *same* number that reached `ai_calls`. An absent invoice is `null`, never `0` — a successful call with no price is a pricing defect (#328) and a convenient zero would hide it.

**Reused rather than rewritten:** `TARGET_PLATFORMS`, `ALT_CAPTION_PLATFORMS`, `PLATFORM_CHAR_LIMITS`, `truncateForPlatform`, `gateAiAction`, `withBrandContext`.

## ⚠️ This ships something we cannot yet deliver

**`format: "thread"` produces sequences that this system cannot publish.** I checked before building, not after:

- Zernio is the only publisher. `PublishInput` (`src/lib/server/publishing/port.ts:63`) carries **one** `content: string`.
- `platformSpecificData` (`publishing/zernio.ts:214`) is a **closed set** — subreddit, url, title, AI-disclosure. Nothing for X or Threads.
- `in_reply_to` / `reply_to` / `parent_post` / `conversation_id`: **zero hits repo-wide**. No ordering column on `posts`.
- `platform_captions` is `Record<string,string>`; an array there hits `captionFor`'s `typeof alt === 'string'` guard and falls back to the main caption **silently**.
- Composio is not a second route: `composioProxy`'s only callers are the knowledge connectors.

This is deliberate. Andrea asked for sequences explicitly, and a thread nobody can publish from here is still worth generating — on X and Threads many people paste them by hand, and the value is in the cut being made well. So the tool declares the limit instead of hiding it: `publishable: false` in the output, stated in the field's own schema description and in the tool description that every external agent reads in `tools/list`.

**What would close it:** a publish path that can post a reply to a post. Either Zernio gaining a parent-id field, or an X/Threads publishing path through Composio, whose toolkits do expose reply endpoints. That work is real and worth doing — until then this is a declared limit, not a promise someone discovers at publish time.

Note the axis: this is about the number of **posts**. A carousel is one post with N **media** and publishes today — `generate_carousel` correctly carries no such flag.

## Testing?

`npx vitest run` → **7355 passed**, 14 skipped.

The one failure, `src/hooks.server.test.ts`, is environmental and pre-existing: a fresh worktree has no `.env`, so it throws `Invalid URL` at import. It passes in the main checkout. It has now cost two agents time on the same day, so this PR adds it to `LESSONS.md`.

Written test-first, red observed before green. For the route I wrote test-then-code without running between, so I went back and **mutated the source to prove the assertion bites**: deleting the two `gateAiAction` lines turns exactly one test red — the one asserting the model never starts.

<details>
<summary>The splitter proven on its own — no model, no database, no network</summary>

`splitForPlatform` is the part that breaks silently, and it's the only part that can be tested exhaustively. 16 tests in `src/lib/platform-limits.test.ts`:

- **numbering counted inside the limit**, proven with a text that overflows by exactly one character (281 chars at a 280 limit) — the boundary where a naive implementation appends `" 1/2"` and ships 284
- every part inside the limit across 280 / 300 / 500
- **no cut inside a word, a URL, a mention or a hashtag** — asserted structurally: every part must begin and end on a whitespace boundary of the original, which covers all four at once rather than enumerating cases
- a caption that already fits is **not** split, even on `format: "thread"`
- the parts **recompose the whole original** — nothing vanishes in the cut
- sentence and clause breaks preferred over a bare word break
- a single token longer than the budget hard-cuts (the only case where nothing better exists)

```
✓ src/lib/platform-limits.test.ts (16 tests)
✓ src/lib/server/caption-writer.test.ts (6 tests)
✓ src/routes/api/v1/brands/[slug]/captions/generate/server.test.ts (8 tests)
✓ packages/api-contracts/src/captions.test.ts (6 tests)
✓ src/lib/server/ai-log.test.ts (46 tests)
```
</details>

<details>
<summary>The money assertions</summary>

The test that matters is the refusal, because a call that starts when it shouldn't is spent money, not a bug to fix later:

- a brand out of credits gets 402 and **`writeCaptions` is never called**
- asking for one platform calls the model **once**, and the schema handed to it names **only** that platform — asserted on the request, not on the captions returned, because that is what proves the other eight were never generated
- an unknown platform is refused before the model runs
- `cost_usd` reports the billed figure; a missing invoice is `null`, not `0`

Mutation check on the gate:
```
$ # with the two gateAiAction lines removed
× a brand out of credits writes nothing: the gate answers and the model never runs
  Tests  1 failed | 6 passed (7)
$ # restored
  Tests  7 passed (7)
```
</details>

<details>
<summary>Registry and drift guards</summary>

```
✓ src/routes/api/v1/brands/[slug]/registry.test.ts   route exists, exports POST,
                                                     gateAiAction ⇒ credits_exhausted declared
✓ cli/lib/contracts.test.ts                          contract mirror in sync
✓ cli/skills/tools-coverage.test.ts                  tool documented in tools.md
✓ cli/plugins/anomalia/plugin-skill.test.ts          plugin skill mirror in sync
```
Rebased onto current `dev`; the conflict with #349 (both insert into the same two slots in `index.ts`) was resolved keeping both, alphabetically. `package-lock.json` did not move across those 26 commits, so the installed tree is still valid and the `npm ci`-after-rebase lesson doesn't apply here — checked rather than assumed.
</details>

No UI changes, so no screenshots: this is an API endpoint and an MCP tool.

## Anything Else?

- **`slug` stays required.** The brand-free work has not landed — `brand-free-media` is groundwork only (an `ai_calls.org_id` migration plus two credits exports, no endpoint). `BRAND_ENDPOINTS` injects `slug` by construction. Without a brand there is no brand voice either, which is half the tool.
- **A hand-written tariff still sits in the docs.** `tools.md` quotes "roughly 8 credits each" for `generate_image`. That is exactly the kind of number that rots; worth replacing with the same `cost_usd` treatment now that a route can read its own invoice.
- **`billedUsdInScope` is additive** — a new optional field on the scope and a new export. Existing `takeLlmCost` callers are unaffected, and `logAiCall` is the only one.
- **The single-platform path still truncates** if the model overshoots its limit, matching existing publish behaviour. Only `format: "thread"` splits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
