### PR TITLE
Deploy the remote MCP from files Vercel can see

### DIFF
--- a/changelog/2026-09-05-mcp-remote-deploy.md
+++ b/changelog/2026-09-05-mcp-remote-deploy.md
@@ -1,0 +1,87 @@
+# Il server MCP remoto si ridispiega di nuovo
+
+`mcp.anomalia.so` serviva la build del 12 agosto. Non era una regressione recente:
+il progetto Vercel `anomalia-cli` non completava un deploy da allora, e ogni build
+di produzione moriva sempre sulla stessa riga.
+
+```
+Error: The pattern "api/mcp.js" defined in `functions`
+doesn't match any Serverless Functions inside the `api` directory.
+```
+
+Tre affermazioni nel repo non potevano essere vere insieme: `cli/mcp/package.json`
+diceva che gli handler erano prebundlati sotto `api/`, `cli/.gitignore` li teneva
+fuori da git per sempre, e sotto `cli/mcp/` non c'era nessuno script che li
+generasse. Il generatore stava in `cli/scripts/build-vercel.mjs`, un livello sopra
+la Root Directory del progetto (`cli/mcp`): irraggiungibile da lì, quindi mai
+eseguito.
+
+## Il fatto che decide la forma della soluzione
+
+Vercel valida i pattern di `functions` **prima** di installare e prima di eseguire
+il build command. Verificato con `vercel build` in locale sulla stessa versione
+della CLI che gira in cloud (59.11.7): con `installCommand` e `buildCommand`
+impostati, l'errore usciva comunque e `node_modules` non veniva nemmeno creata.
+
+Quindi niente di generato a build time può soddisfare `functions`. I file nominati
+lì devono stare in git.
+
+## Cosa è stato provato e scartato
+
+**Lasciare che `@vercel/node` compili direttamente le entry TypeScript** — cioè
+`api/mcp.ts` che importa `../vercel-handler.ts`, buttando via del tutto il
+prebundle esbuild. Il build passa, le tre funzioni vengono prodotte, e a runtime
+la funzione è morta:
+
+```
+ERR_MODULE_NOT_FOUND: .../api/mcp.func/cli/mcp/vercel-handler.ts
+```
+
+`@vercel/node` traspila l'entry ma lascia intatto lo specifier `.ts`, che Node non
+risolve. È esattamente il motivo per cui il prebundle esisteva. Farlo funzionare
+vorrebbe dire riscrivere ogni import di `cli/mcp/` e `cli/lib/` da `.ts` a `.js`,
+rompendo Bun ovunque.
+
+**Committare `_bundle.js`** — 3,8 MB rigenerati a ogni cambio di dipendenza, dentro
+git. Funziona e non lo vogliamo.
+
+## Come è fatto adesso
+
+I due wrapper sotto `cli/mcp/api/` sono **sorgente**, non artefatti: tre righe
+ciascuno, stabili, committate. Sono ciò che Vercel vede quando valida `functions`.
+Solo `_bundle.js` resta generato, e lo genera il `buildCommand` in `vercel.json`,
+che è anche l'unico posto dove il deploy è descritto:
+
+```
+"buildCommand": "npm install --prefix .. && node ../scripts/build-vercel.mjs"
+```
+
+L'install sta lì dentro perché `installCommand` in `vercel.json` viene ignorato —
+provato con la marker string, non stampa mai. Le dipendenze restano dichiarate in
+un posto solo, `cli/package.json`.
+
+`build-vercel.mjs` scende da 110 righe a 25: non scrive più i wrapper (ora sono
+sorgente), non copia più `health.js` in `cli/api/` "se mai la Root Directory
+diventasse `.`", non spazza più file stale che non produce più nessuno.
+
+`cli/mcp/entries/` era già morto — nessuno lo importava — ed era la terza
+dichiarazione in concorrenza di cosa sia l'entry point. Rimosso.
+
+`outputDirectory: "public"` con dentro un `robots.txt`: serve perché con un
+`buildCommand` Vercel pretende una directory statica non vuota, e come effetto
+smette di pubblicare il sorgente. Prima `mcp.anomalia.so/vercel-handler.ts`
+rispondeva 200, file di test inclusi.
+
+## Il guardiano
+
+`cli/mcp/vercel-config.test.ts` fallisce se un pattern di `functions` nomina un
+file che git non traccia. È il difetto esatto, ed è l'unica cosa che lo avrebbe
+preso: il codice era corretto, il deploy no.
+
+## Cosa cambia lato remoto
+
+La superficie remota prende sei mesi di modifiche in un colpo solo: da 63 tool
+(agosto, incluso `chat` che non esiste più) a 125. Arrivano `query`,
+`generate_image`, `refine_image`, `generate_video`, `create_post`, `list_media`,
+`diagnose_brand` e il resto. Chi puntava a `mcp.anomalia.so` e vedeva tool vecchi
+vedrà quelli di oggi al primo deploy.

--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -6,15 +6,5 @@ dist-npm/
 !.env.example
 .DS_Store
 *.log
-api/_bundle.js
-api/mcp.js
-api/oauth-protected-resource.js
-api/_mcp.bundle.js
-api/_oauth.bundle.js
-api/_bundle.cjs
-api/_bundle.cjs.map
-api/*.cjs
 mcp/api/_bundle.js
-mcp/api/mcp.js
-mcp/api/oauth-protected-resource.js
-mcp/api/*.cjs
+package-lock.json

--- a/cli/mcp/api/mcp.js
+++ b/cli/mcp/api/mcp.js
@@ -1,0 +1,3 @@
+import { mcp as handler } from './_bundle.js';
+export default handler;
+export const config = { api: { bodyParser: false }, maxDuration: 60 };

--- a/cli/mcp/api/oauth-protected-resource.js
+++ b/cli/mcp/api/oauth-protected-resource.js
@@ -1,0 +1,3 @@
+import { oauthProtectedResource as handler } from './_bundle.js';
+export default handler;
+export const config = { api: { bodyParser: false }, maxDuration: 30 };

--- a/cli/mcp/entries/mcp.ts
+++ b/cli/mcp/entries/mcp.ts
@@ -1,2 +1,0 @@
-import { mcp } from '../vercel-handler.ts';
-export default mcp;

--- a/cli/mcp/entries/oauth-protected-resource.ts
+++ b/cli/mcp/entries/oauth-protected-resource.ts
@@ -1,2 +1,0 @@
-import { oauthProtectedResource } from '../vercel-handler.ts';
-export default oauthProtectedResource;

--- a/cli/mcp/package.json
+++ b/cli/mcp/package.json
@@ -2,7 +2,7 @@
   "name": "anomalia-mcp-http",
   "private": true,
   "type": "module",
-  "description": "Vercel Root Directory is this folder (mcp/). Handlers are prebundled under api/.",
+  "description": "Vercel Root Directory is this folder (mcp/). vercel.json#buildCommand bundles api/_bundle.js from ../.",
   "engines": {
     "node": ">=20"
   }

--- a/cli/mcp/public/robots.txt
+++ b/cli/mcp/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/cli/mcp/vercel-config.test.ts
+++ b/cli/mcp/vercel-config.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'bun:test';
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { $ } from 'bun';
+import vercelConfig from './vercel.json';
+
+const MCP_ROOT = dirname(fileURLToPath(import.meta.url));
+
+const functionPatterns = Object.keys(vercelConfig.functions);
+
+describe('vercel.json functions', () => {
+  it('names files that exist before the build runs', () => {
+    for (const pattern of functionPatterns) {
+      expect(existsSync(join(MCP_ROOT, pattern))).toBe(true);
+    }
+  });
+
+  it('names files git tracks, since Vercel validates the pattern before installing', async () => {
+    const tracked = await $`git ls-files --cached ${functionPatterns}`.cwd(MCP_ROOT).text();
+
+    for (const pattern of functionPatterns) {
+      expect(tracked).toContain(pattern);
+    }
+  });
+
+  it('keeps the generated bundle out of the patterns', () => {
+    expect(functionPatterns).not.toContain('api/_bundle.js');
+  });
+});

--- a/cli/mcp/vercel.json
+++ b/cli/mcp/vercel.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": null,
+  "buildCommand": "npm install --prefix .. && node ../scripts/build-vercel.mjs",
+  "outputDirectory": "public",
   "headers": [
     {
       "source": "/(.*)",

--- a/cli/scripts/build-vercel.mjs
+++ b/cli/scripts/build-vercel.mjs
@@ -1,25 +1,17 @@
 #!/usr/bin/env node
-/**
- * Bundle MCP HTTP handlers into self-contained ESM under mcp/api/.
- *
- * Vercel project Root Directory is `mcp`, so runtime artifacts must live there.
- * The bundle inlines ../lib so the deploy does not need the repo root on Vercel.
- */
-import { mkdirSync, unlinkSync, existsSync, writeFileSync } from 'node:fs';
+import { mkdirSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import * as esbuild from 'esbuild';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const API = join(ROOT, 'mcp/api');
-mkdirSync(API, { recursive: true });
 
-const bundleName = '_bundle.js';
-const bundlePath = join(API, bundleName);
+mkdirSync(API, { recursive: true });
 
 await esbuild.build({
   entryPoints: [join(ROOT, 'mcp/vercel-handler.ts')],
-  outfile: bundlePath,
+  outfile: join(API, '_bundle.js'),
   bundle: true,
   platform: 'node',
   target: 'node20',
@@ -30,84 +22,3 @@ await esbuild.build({
     js: `import { createRequire as __anomaCreateRequire } from 'module'; const require = __anomaCreateRequire(import.meta.url);`,
   },
 });
-
-const wrappers = [
-  { file: 'mcp.js', exportName: 'mcp', maxDuration: 60 },
-  { file: 'oauth-protected-resource.js', exportName: 'oauthProtectedResource', maxDuration: 30 },
-];
-
-const healthSrc = `/**
- * Ultra-minimal health endpoint (ESM).
- * Kept dependency-free so /health stays up even if the MCP bundle fails to build.
- */
-export default function handler(req, res) {
-  if (req.method === 'OPTIONS') {
-    res.statusCode = 204;
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
-    res.setHeader(
-      'Access-Control-Allow-Headers',
-      'Content-Type, Authorization, mcp-session-id, Last-Event-ID, mcp-protocol-version',
-    );
-    res.end();
-    return;
-  }
-
-  res.statusCode = 200;
-  res.setHeader('Content-Type', 'application/json');
-  res.setHeader('Access-Control-Allow-Origin', '*');
-  res.end(
-    JSON.stringify({
-      ok: true,
-      name: 'anomalia-mcp',
-      transport: 'streamable-http',
-      mcp: '/mcp',
-    }),
-  );
-}
-
-export const config = { maxDuration: 10 };
-`;
-
-for (const w of wrappers) {
-  writeFileSync(
-    join(API, w.file),
-    `import { ${w.exportName} as handler } from './${bundleName}';
-export default handler;
-export const config = { api: { bodyParser: false }, maxDuration: ${w.maxDuration} };
-`,
-  );
-}
-
-writeFileSync(join(API, 'health.js'), healthSrc);
-
-// Keep a copy at repo-root api/health.js for local reference / if Root Directory is ever ".".
-mkdirSync(join(ROOT, 'api'), { recursive: true });
-writeFileSync(join(ROOT, 'api', 'health.js'), healthSrc);
-
-for (const stale of [
-  '_vercel.ts',
-  '_mcp.bundle.js',
-  '_oauth.bundle.js',
-  '_bundle.cjs',
-  '_bundle.cjs.map',
-  'health.ts',
-  'health.cjs',
-  'mcp.ts',
-  'mcp.cjs',
-  'mcp.js',
-  'oauth-protected-resource.ts',
-  'oauth-protected-resource.cjs',
-  'oauth-protected-resource.js',
-  '_bundle.js',
-]) {
-  // Only scrub stale generated files from repo-root api/ (not mcp/api live outputs).
-  if (stale === 'health.js') continue;
-  const p = join(ROOT, 'api', stale);
-  if (existsSync(p)) {
-    unlinkSync(p);
-    console.log('removed', p);
-  }
-}
-
-console.log('Done. Deploy path: mcp/api/* (Vercel Root Directory = mcp)');

--- a/src/lib/content/changelog/2026-09-05-mcp-remote-updated.ts
+++ b/src/lib/content/changelog/2026-09-05-mcp-remote-updated.ts
@@ -1,0 +1,10 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-05',
+  title: 'The remote MCP server is current again',
+  items: [
+    'Connecting Claude, ChatGPT or Cursor to mcp.anomalia.so now gives you every tool the CLI has — 125 instead of the 63 the remote server had been stuck on since August.',
+    'Newly reachable from a remote MCP client: query, generate_image, refine_image, generate_video, create_post, list_media and diagnose_brand, among others.'
+  ]
+} satisfies ChangelogEntry;


### PR DESCRIPTION
## What?

The Vercel project `anomalia-cli` — the remote MCP server behind `mcp.anomalia.so` — could not
complete a build. Every production deploy since 12 August died on the same line:

```
Error: The pattern "api/mcp.js" defined in `functions`
doesn't match any Serverless Functions inside the `api` directory.
```

This makes it deploy again. The two handler wrappers under `cli/mcp/api/` become tracked source
instead of build-time artefacts, `vercel.json` declares the build command that produces the
bundle they import, and a test fails if a `functions` pattern ever again names a file git does
not track.

## Why?

`mcp.anomalia.so` has been serving the 12 August build for six months. It is not a build that
broke yesterday — it is a build that has **never** worked in this shape, while the product moved
underneath it. Anyone pointing Claude, ChatGPT or Cursor at the remote server has been getting
August's surface: 63 tools, including a `chat` tool that no longer exists, and missing everything
added since.

Three statements in the repo could not all be true:

| where | said |
|---|---|
| `cli/mcp/package.json` | *"Handlers are prebundled under `api/`"* → the files are committed |
| `cli/.gitignore` | `mcp/api/mcp.js` → they never will be |
| `cli/mcp/` | no build script → and nothing generates them there |

The generator, `cli/scripts/build-vercel.mjs`, is driven by `vercel-build` in `cli/package.json`
— one level **above** the project's Root Directory (`cli/mcp`). Unreachable from there, so it
never ran.

## How?

**The fact that decides the shape of the fix:** Vercel validates the `functions` patterns
**before** it installs and **before** it runs the build command. Verified locally with
`vercel build` on the exact CLI version the cloud runs (59.11.7): with both `installCommand` and
`buildCommand` set, the same error still fired and `node_modules` was never even created. So
nothing generated at build time can satisfy `functions` — the files it names have to be in git.

**Rejected — letting `@vercel/node` compile the TypeScript entries directly** (`api/mcp.ts`
importing `../vercel-handler.ts`, dropping the esbuild prebundle entirely). The build passes and
produces all three functions, and the function is dead at runtime:

```
ERR_MODULE_NOT_FOUND: .../api/mcp.func/cli/mcp/vercel-handler.ts
```

`@vercel/node` transpiles the entry but leaves the `.ts` specifier untouched, and Node cannot
resolve it. This is precisely why the prebundle exists. Making it work would mean rewriting every
import in `cli/mcp/` and `cli/lib/` from `.ts` to `.js`, breaking Bun everywhere. This is the
worst failure mode available here — a green build serving a broken function — so it is worth
naming.

**Rejected — committing `_bundle.js`.** 3.8 MB regenerated on every dependency change, in git.

**Taken.** The two wrappers are three lines each and never change: they are source, not
artefacts, and they are what Vercel reads when it validates. Only `_bundle.js` stays generated,
by the build command declared in `vercel.json` — which is also the one place the deploy is
described:

```json
"buildCommand": "npm install --prefix .. && node ../scripts/build-vercel.mjs"
```

The install lives inside the build command because an `installCommand` in `vercel.json` is
silently ignored — proven with a marker string that never printed. Dependencies stay declared in
exactly one place, `cli/package.json`.

`outputDirectory` becomes mandatory once a build command exists. Pointing it at a `public/`
holding a `robots.txt` also stops the deploy from publishing the MCP's own source: today
`https://mcp.anomalia.so/vercel-handler.ts` answers 200, test files included.

Along the way: `build-vercel.mjs` drops from 110 lines to 25 (it no longer writes the wrappers,
no longer copies `health.js` into `cli/api/` "in case Root Directory ever becomes `.`", no longer
scrubs stale files it stopped producing), and the dead `cli/mcp/entries/` — imported by nothing,
a third competing declaration of what the entry point is — is removed.

## Testing?

**No Vercel project setting was changed.** Root Directory stays `cli/mcp`, Build Command stays
empty (`vercel.json` supplies it), "Include files outside root directory" stays on.

`cli/mcp/vercel-config.test.ts` is the guard, and it was watched fail first for exactly the
deploy's reason — `api/mcp.js` present on disk, absent from `git ls-files` — then pass once the
file was tracked. It asserts every `functions` pattern names a file that exists **and** that git
tracks, because Vercel checks the pattern before it installs anything.

`cd cli && bun test` → 76 pass, 0 fail. `bun run typecheck` → clean.

Everything below was run against a **pristine checkout of this branch** (a fresh worktree at the
commit, nothing local carried in), built with `vercel@59.11.7`, the same version the cloud runs.

### Evidence

<details><summary>Before — the failure, reproduced locally, identical to the cloud log</summary>

```
$ vercel build --prod
Error: The pattern "api/mcp.js" defined in `functions` doesn't match any
Serverless Functions inside the `api` directory.
```

Cloud build log for `dpl_88g7LXqCgU3TsyexQd197W9SRoEB` (production, commit 39b9bbf):

```
07:07:23  Running "vercel build"
07:07:23  Vercel CLI 59.11.7
07:07:23  Error: The pattern "api/mcp.js" defined in `functions` doesn't match any Serverless Functions inside the `api` directory.
```

Note the timestamps: clone, then the error in the same second. No install, no build — the
validation is first.
</details>

<details><summary>After — pristine checkout builds green, three functions, one static file</summary>

```
$ vercel build --prod
{ "status": "ok", "message": "Build completed successfully." }

$ ls .vercel/output/functions/api/
health.func   mcp.func   oauth-protected-resource.func

$ ls .vercel/output/static
robots.txt

$ cat .vercel/output/functions/api/mcp.func/.vc-config.json
{ "handler": "cli/mcp/api/mcp.js", "runtime": "nodejs24.x", "memory": 1024, "maxDuration": 60 }
```

`memory` and `maxDuration` confirm the `functions` block in `vercel.json` is being applied, and
the static output is one file instead of the whole source tree.
</details>

<details><summary>After — the built functions actually answer (the check that matters)</summary>

Each `.func` booted from the pristine build output behind a minimal Node server, with the
project's own production environment:

```
GET  /health                                    -> 200
GET  /mcp (no bearer)                           -> 401
GET  /.well-known/oauth-protected-resource      -> 200
OPTIONS /mcp (CORS preflight)                   -> 204
POST /mcp (garbage bearer)                      -> 401
POST /mcp tools/list (valid bearer)             -> 125 tools
```

401 on `/mcp` is the correct answer for an OAuth-protected MCP, not an error. The CORS headers
and all four rewrites came through untouched — they were moved nowhere, only two keys were added
above them.
</details>

<details><summary>After — tools/list proves it is today's server, not August's</summary>

A build that passes while serving the old surface is the failure that looks like success, so this
is the real acceptance test. Same bearer token, same request, two servers:

```
live mcp.anomalia.so (12 August build):  63 tools
this branch, built:                     125 tools

query           OK
generate_image  OK
refine_image    OK
generate_video  OK
create_post     OK
list_media      OK
diagnose_brand  OK
chat            gone  (August-only, no longer in the repo)
```
</details>

### Not tested, and the risk

The production deploy itself. This is the one step that cannot be run from a branch — the proof
is that a pristine checkout of this commit builds green and its functions answer correctly under
the cloud's own CLI version. **Watch the first production build after merge**, and then
`tools/list` against `mcp.anomalia.so`: it should go from 63 tools to 125.

`generate_carousel` was expected in the new surface and is **not there** — it does not exist
anywhere in the repo. Carousels are served by `create_post` plus `regenerate_slide` /
`reorder_slides`. There is a `feat/agent-carousel` branch in flight, which is likely where the
expectation came from.

## Anything Else?

**The remote surface changes all at once.** This deploy hands the remote MCP six months of work
in a single step: 63 tools to 125. Anyone with `mcp.anomalia.so` configured gets a different
server the moment this merges. That is the point of the fix, but it is not a quiet change.

**No lockfile.** `npm install --prefix ..` resolves the `^` ranges in `cli/package.json` fresh on
every deploy, so a new minor of `@modelcontextprotocol/sdk` could change the remote MCP without a
commit. Adding an npm lockfile to a repo that uses `bun.lock` is a decision worth making
deliberately rather than in this PR; `cli/package-lock.json` is gitignored for now so a local
build cannot commit one by accident.

**The preview builds are switched off.** `commandForIgnoringBuildStep` skips every non-production
build, which is why the last thirty deploys read CANCELED. It means a change to this deploy path
is never exercised before it reaches production — this PR included. Turning previews on for this
project would make the next change to it verifiable; that is a dashboard setting, so it is not in
this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
