### PR TITLE
Let the nav test describe the bar we ship

### DIFF
--- a/tests/e2e/landing.spec.ts
+++ b/tests/e2e/landing.spec.ts
@@ -10,10 +10,10 @@ test('landing renders with hero heading and site nav', async ({ page }) => {
   await expect(page.locator('header.nav')).toBeVisible();
 });
 
-test('the desktop bar offers sign-in as its own link, not folded into the CTA', async ({ page }) => {
+test('sign-in lives in the drawer, and the CTA is the door on desktop', async ({ page }) => {
   await page.goto('/');
 
-  await expect(page.locator('header.nav .nav-right a[href="/login"]')).toHaveCount(1);
+  await expect(page.locator('header.nav .nav-right a[href="/login"]')).toHaveCount(0);
   await expect(page.locator('header.nav a.nav-cta')).toHaveCount(1);
 });
 


### PR DESCRIPTION
## What?

Renames and flips one assertion in `tests/e2e/landing.spec.ts`. Nothing else — no component,
no page, no styling.

## Why?

`24848113` ("Drop theme, language and sign-in from the desktop nav") moved sign-in into the drawer
deliberately, and wrote the cost into its own commit body: *"the door is labelled 'Get started',
so a returning customer has to infer it"*. Andrea confirmed the decision stands — the CTA stays,
the text link goes.

That commit changed guarded behaviour without touching the guard. The test has failed on **eight
consecutive runs on `dev`**, and three unrelated PRs — #351, #352, #353 — are all `BLOCKED` behind
those runs. #331 carries this fix, but it is now `CONFLICTING` and its homepage content is being
replaced anyway, so the fix is extracted here on its own.

## How?

The name changes **with** the assertion, and that is the point of the diff rather than a detail:

```diff
-test('the desktop bar offers sign-in as its own link, not folded into the CTA', ...
-  await expect(page.locator('header.nav .nav-right a[href="/login"]')).toHaveCount(1);
+test('sign-in lives in the drawer, and the CTA is the door on desktop', ...
+  await expect(page.locator('header.nav .nav-right a[href="/login"]')).toHaveCount(0);
```

A test named for a rule that was deliberately reversed is worse than no test: the next reader
cannot tell a regression from a decision. The name is where that knowledge survives — a commit
body is not read again.

## Testing?

**Verified by reading, and by CI — not locally.** `SiteNav.svelte:154` contains exactly three
things in `.nav-right`: the GitHub link, `nav-cta`, and `nav-burger`. No `a[href="/login"]`. The
assertion matches what ships.

The e2e suite needs a built app and a server; this is a two-line test change whose only real gate
is the CI run on this PR. I am not claiming a local run I did not do.

**The third test is untouched and now carries more weight**: with the desktop bar down to three
controls, `.nav-dialog a[href="/login"]` at 390px is the only guard on the only explicit door to
`/login`. A `toHaveCount(0)` passes vacuously; that one does not, and it should stay that way.

## Evidence (screenshots/videos)

Not applicable — no user-visible change. The failing CI line, identical on eight `dev` runs:

```
landing.spec.ts:13 › the desktop bar offers sign-in as its own link, not folded into the CTA
Expected: 1  Received: 0
```

## Anything Else?

No changelog: nothing a customer can notice changes. The behaviour this now describes shipped in
`24848113`, which carried its own.

If the decision is ever reversed again — sign-in back in the desktop bar — this test is where it
should be argued, not in a commit body.