### PR TITLE
Point the carousel at the module that exists

### DIFF
--- a/src/lib/server/carousel-generate.test.ts
+++ b/src/lib/server/carousel-generate.test.ts
@@ -10,7 +10,7 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 
 const aiStructured = vi.fn();
 
-vi.mock('$lib/server/xiaomi', () => ({ aiStructured: (...a: unknown[]) => aiStructured(...a) }));
+vi.mock('$lib/server/ai-text', () => ({ aiStructured: (...a: unknown[]) => aiStructured(...a) }));
 vi.mock('$lib/server/brand-context', () => ({ genaiClient: () => ({}) }));
 
 import {

--- a/src/lib/server/carousel-generate.ts
+++ b/src/lib/server/carousel-generate.ts
@@ -79,7 +79,7 @@ export async function planCarousel(
   opts: { brandId: string; brief: string; slides: number }
 ): Promise<CarouselPlan | { error: 'plan_failed' }> {
   const [{ aiStructured }, { genaiClient }] = await Promise.all([
-    import('$lib/server/xiaomi'),
+    import('$lib/server/ai-text'),
     import('$lib/server/brand-context')
   ]);
   void supabase;


### PR DESCRIPTION
## What?

Two import paths, `$lib/server/xiaomi` → `$lib/server/ai-text`, in
`carousel-generate.ts` and its test. Nothing else.

## Why?

**Production cannot build right now.** The deploy for `f75c45ad` (the #355 merge) failed after
2 minutes:

```
[vite:load-fallback] Could not load /vercel/path0/src/lib/server/xiaomi
  (imported by src/lib/server/carousel-generate.ts): ENOENT
```

#349 added `carousel-generate.ts` importing `xiaomi`; #351 renamed that module to `ai-text.ts`
because it had stopped being Xiaomi's anything — it is the text dispatcher. Both merged within the
hour, neither touched the other's lines, so **git merged them cleanly and the break is semantic**.
Only the bundler sees it.

Production is still serving the deploy from two hours earlier.

## How?

The rename, in both files. Verified that the destination carries what the caller asks for:
`ai-text.ts:79` exports `aiStructured`, and `brand-context.ts:178` still exports `genaiClient`,
which the same call passes as the (deliberately unused) `_ai` parameter.

## Testing?

**The test was the reason this reached production, and it is the part worth reading.**

`carousel-generate.test.ts` did `vi.mock('$lib/server/xiaomi', () => ({ … }))`. **`vi.mock` with a
factory does not fail on a missing path** — so the test passed, substituting nothing, for a module
that no longer existed. The suite was green while the bundle was broken. That is the fourth time
today this class has appeared, and it is already in `LESSONS.md`.

**Not built locally.** The worktree has no `node_modules` (`Cannot find module 'typescript/bin/tsc'`),
and installing it is the documented move but a slow one while production is down. I verified the
two things that can actually be wrong — the destination module exists and exports the symbol — and
I am not claiming a build I did not run. CI on this PR is the gate.

## Evidence (screenshots/videos)

```
39m  anomalia-9m37h9h2x  ● Error  Production  2m   ← the #355 merge
2h   anomalia-qrg4ucdj6  ● Ready  Production  8m   ← what customers see
```

## Anything Else?

**The MCP deploy is fine** — that half of #355 landed: `mcp.anomalia.so/health` returns 200 and
`/vercel-handler.ts` now returns 404, so it is no longer serving its own source.

**Worth doing separately:** a guard that fails when a `vi.mock` path does not resolve would have
caught this at the moment #351 renamed the module, instead of at the production build. Every
occurrence found today was found by a human noticing, not by the suite.