### PR TITLE
Unblock the production build

### DIFF
--- a/src/lib/server/carousel-generate.test.ts
+++ b/src/lib/server/carousel-generate.test.ts
@@ -10,7 +10,7 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 
 const aiStructured = vi.fn();
 
-vi.mock('$lib/server/xiaomi', () => ({ aiStructured: (...a: unknown[]) => aiStructured(...a) }));
+vi.mock('$lib/server/ai-text', () => ({ aiStructured: (...a: unknown[]) => aiStructured(...a) }));
 vi.mock('$lib/server/brand-context', () => ({ genaiClient: () => ({}) }));
 
 import {

--- a/src/lib/server/carousel-generate.ts
+++ b/src/lib/server/carousel-generate.ts
@@ -79,7 +79,7 @@ export async function planCarousel(
   opts: { brandId: string; brief: string; slides: number }
 ): Promise<CarouselPlan | { error: 'plan_failed' }> {
   const [{ aiStructured }, { genaiClient }] = await Promise.all([
-    import('$lib/server/xiaomi'),
+    import('$lib/server/ai-text'),
     import('$lib/server/brand-context')
   ]);
   void supabase;


### PR DESCRIPTION
## What?

Two commits, one fix: `carousel-generate.ts` and its test now import `$lib/server/ai-text`
instead of `$lib/server/xiaomi`.

## Why?

**Production has not deployed since 07:00.** The build for `f75c45ad` failed in two minutes:

```
[vite:load-fallback] Could not load /vercel/path0/src/lib/server/xiaomi
  (imported by src/lib/server/carousel-generate.ts): ENOENT
```

#349 added the carousel importing `xiaomi`; #351 renamed that module to `ai-text.ts` because it
had stopped being Xiaomi's anything. Both merged within the hour, neither touched the other's
lines, so **git merged them cleanly and the break is semantic** — only the bundler sees it.

Customers are on the deploy from two hours before, which means everything in #355 — the remote MCP
serving 125 tools instead of 63, the last non-OpenRouter providers gone — is on `main` but not
running.

## How?

The rename in both files, and nothing else. Verified the destination carries what the caller asks
for: `ai-text.ts:79` exports `aiStructured`, `brand-context.ts:178` still exports `genaiClient`.

## Testing?

**The test is why this reached production, and it is the part worth reading.**
`carousel-generate.test.ts` did `vi.mock('$lib/server/xiaomi', () => ({ … }))`, and **`vi.mock`
with a factory does not fail on a missing path** — so it passed while substituting nothing, for a
module that no longer existed. Green suite, broken bundle. Fourth appearance of that class today;
it is already in `LESSONS.md`.

CI on #356 is the gate. I did not run the production build locally: the worktree had no
`node_modules` and installing it while production is down costs more than it proves.

## Evidence (screenshots/videos)

```
57m  anomalia-9m37h9h2x  ● Error  Production  2m   ← the #355 merge
2h   anomalia-qrg4ucdj6  ● Ready  Production  8m   ← what customers are on
```

## Anything Else?

**Worth doing separately:** a guard that fails when a `vi.mock` path does not resolve. It would
have caught this the moment #351 renamed the module rather than at the production build. Every
instance found today was found by a person noticing, not by the suite.

Nothing else is waiting: the only open PRs are the two home-page ones, and the home page is being
rebuilt.