### PR TITLE
Count brand-free AI spend against the org that pays

### DIFF
--- a/changelog/2026-09-05-ai-calls-org-id.md
+++ b/changelog/2026-09-05-ai-calls-org-id.md
@@ -1,0 +1,22 @@
+# `ai_calls.org_id`: la spesa senza brand entra nel conto
+
+Fino a qui ogni chiamata AI misurata portava un brand, e la spesa di un'organizzazione era la
+somma di quella dei suoi brand: `sum_org_ai_cost_usd` fa `join brands on b.id = c.brand_id`.
+
+Sta per esistere un render che un brand non ce l'ha — la generazione estemporanea, senza slug.
+Quella riga logga `brand_id` nullo, la `join` la scarta, e la sua spesa vale zero per qualunque
+organizzazione. Non è un buco di misurazione: `gateCredits` decide sul totale che quella funzione
+restituisce, quindi il cancello dei crediti lascerebbe passare per sempre chi genera senza brand.
+
+La colonna è la seconda strada verso lo stesso pool. La `join` diventa `left join` e la
+condizione `coalesce(b.org_id, c.org_id) = p_org_id`: chi ha un brand risponde attraverso il
+brand, chi non ce l'ha risponde da sé.
+
+`org_id` resta nullo sulle righe che hanno un brand, di proposito. Scriverlo su entrambe darebbe
+due risposte alla stessa domanda, e prima o poi divergerebbero — la `join` sui brand è già
+l'unica risposta per loro.
+
+Solo schema, come `20260903190000_org_billing_schema.sql`: nessun codice scrive `org_id` ancora.
+Arriva col PR dei generatori brand-free, che deve andare **dopo** questa migrazione applicata a
+mano — qui i deploy non eseguono le migrazioni, e il codice che scrive una colonna inesistente
+rompe ogni logging AI, non solo il percorso nuovo.

--- a/cli/mcp/vercel-config.test.ts
+++ b/cli/mcp/vercel-config.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'bun:test';
 import { existsSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { $ } from 'bun';
+import { execFileSync } from 'node:child_process';
 import vercelConfig from './vercel.json';
 
 const MCP_ROOT = dirname(fileURLToPath(import.meta.url));
@@ -16,8 +16,14 @@ describe('vercel.json functions', () => {
     }
   });
 
-  it('names files git tracks, since Vercel validates the pattern before installing', async () => {
-    const tracked = await $`git ls-files --cached ${functionPatterns}`.cwd(MCP_ROOT).text();
+  it('names files git tracks, since Vercel validates the pattern before installing', () => {
+    // `node:child_process` e non lo shell di bun: questo file gira sotto DUE runner — `bun test`
+    // e vitest, che aliasa `bun:test` ma non puo` aliasare il runtime `bun`, e senza di questo
+    // non si carica affatto (zero test falliti, un file rosso).
+    const tracked = execFileSync('git', ['ls-files', '--cached', ...functionPatterns], {
+      cwd: MCP_ROOT,
+      encoding: 'utf8'
+    });
 
     for (const pattern of functionPatterns) {
       expect(tracked).toContain(pattern);

--- a/supabase/migrations/20260905100000_ai_calls_org_id.sql
+++ b/supabase/migrations/20260905100000_ai_calls_org_id.sql
@@ -1,0 +1,50 @@
+-- Brand-free AI spend, step A: schema only. Nothing writes org_id yet — the code that does
+-- arrives with the brand-free generators.
+--
+-- Today every metered call carries a brand, and the org's spend is the sum of its brands'.
+-- A render asked for without a brand has no brand to carry, so it logs brand_id null — and
+-- sum_org_ai_cost_usd joins THROUGH brands, which means such a row sums to zero for every org.
+-- The quota would never see it and the gate above it would pass forever.
+--
+--   with a brand   →  ai_calls.brand_id → brands.org_id → the pool
+--   without one    →  ai_calls.org_id ─────────────────→ the same pool
+--
+-- Two ways in, one pool. org_id stays null on branded rows: the brand join already answers for
+-- them, and writing both would invite the two answers to disagree.
+
+alter table public.ai_calls
+  add column if not exists org_id uuid references public.organizations (id);
+
+-- The org sum now also scans rows that have no brand to join through.
+create index if not exists ai_calls_org_created_idx
+  on public.ai_calls (org_id, created_at desc)
+  where org_id is not null;
+
+-- Same function as 20260903190000, with the join made outer so a brand-free row survives it.
+-- coalesce picks the brand's org when there is a brand, the row's own org when there is not.
+create or replace function public.sum_org_ai_cost_usd(
+  p_org_id uuid,
+  p_start timestamptz,
+  p_end timestamptz
+)
+returns numeric
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select coalesce(sum(c.cost_usd), 0)::numeric
+  from public.ai_calls c
+  left join public.brands b on b.id = c.brand_id
+  where coalesce(b.org_id, c.org_id) = p_org_id
+    and c.created_at >= p_start
+    and c.created_at < p_end
+    and c.cost_usd is not null
+    and (
+      auth.role() = 'service_role'
+      or p_org_id in (select public.auth_org_ids())
+    );
+$$;
+
+revoke execute on function public.sum_org_ai_cost_usd(uuid, timestamptz, timestamptz) from public, anon;
+grant execute on function public.sum_org_ai_cost_usd(uuid, timestamptz, timestamptz) to authenticated, service_role;


### PR DESCRIPTION
## What?

Adds `ai_calls.org_id` and reopens `sum_org_ai_cost_usd` so it can see a row that has no brand. Schema only — **nothing writes the column yet**. The code that does arrives in the follow-up PR (brand-free `generate_image`), and it is deliberately separate: this repo's deploys do not run migrations, so the schema has to land and be applied *before* the code that depends on it.

## Why?

Every metered AI call today carries a brand, and an organization's spend is the sum of its brands':

```
sum_org_ai_cost_usd:  ai_calls  ──join brands──▶  brands.org_id = p_org_id
```

A render asked for **without** a brand has no brand to carry, so it logs `brand_id null` — and that join drops it. Such a row contributes **zero** to every organization's spend. The quota would never see it, the credit gate above it would pass forever, and those generations would be free in permanence. The unit suite stays green throughout, because the fake database sums nothing.

```
with a brand   →  ai_calls.brand_id → brands.org_id → the pool
without one    →  ai_calls.org_id ─────────────────→ the same pool
```

## How?

- `alter table ai_calls add column org_id uuid references organizations(id)` — nullable, no backfill: existing rows all have a brand and reach their org through the join already.
- `sum_org_ai_cost_usd` becomes a **left** join with `coalesce(b.org_id, c.org_id) = p_org_id`. Same function name, same signature, same security-definer guard (service role, or the caller owns the org) — only the reach widens.
- A partial index `ai_calls (org_id, created_at desc) where org_id is not null`, because the org sum now scans rows the brand index cannot answer for.

**`org_id` stays null on branded rows, by rule.** The brand join already answers for them; writing both would invite the two answers to disagree, and a spend figure with two sources is a spend figure nobody trusts. That rule lives in the migration's own comment and in `logAiCall`, which is the only writer.

**Rejected: making `brand_media.brand_id` nullable** so a brand-free asset could sit in the library. All four policies in `0149` read `brand_id in (select auth_brand_ids())`, and `NULL in (…)` evaluates to `NULL`, not `true` — the row would be invisible to everyone *and* uninsertable. That is why the follow-up files no row at all.

## Testing?

Applied to the local self-hosted stack (`npm run db:migrate`) and exercised against the real plpgsql, with a real brand-free row present:

<details>
<summary>The old join could not see the row; the new one can</summary>

```
$ # one ai_calls row with brand_id null, org_id set, cost_usd 0.033646
 label           | provider   | brand_id | org_id                               | cost_usd | ok
 renderPostImage | openrouter |          | 0ea75a3a-1c8a-4b78-967b-1a2666fbae5e | 0.033646 | t

$ select ... join brands ...            -- the shape before this migration
 what_the_old_join_saw | 0.668883

$ select sum_org_ai_cost_usd(...)       -- the shape after
 what_the_gate_sees    | 0.702529       -- 0.668883 + 0.033646, the brand-free row included
```

And the consequence that matters, with a $1000 brand-free row inserted to exhaust the pool:

```
 what_the_old_join_saw | what_the_gate_sees | renders_after_the_402
 0.702528              | 1000.769818        | 0
```

Under the old shape the gate would have seen $0.70 — comfortably inside a Pro quota — and let the render through. Under the new one it answers 402 and nothing is billed.
</details>

`npx vitest run` → **7387 passed**, 14 skipped, 0 failed tests. Two test *files* fail for environmental reasons, both reproducible on unmodified `dev`: `src/hooks.server.test.ts` (a fresh worktree has no `.env`, so it throws `Invalid URL` at import — the lesson is already in `LESSONS.md`) and `cli/mcp/vercel-config.test.ts` (`import { $ } from 'bun'`, which vitest cannot resolve; the `bun:test` alias does not cover the `bun` module itself). Neither file is touched here.

## Evidence (screenshots/videos)

Backend-only migration, no UI. The SQL output above is the evidence, taken against the local Docker stack — never production.

## Anything Else?

- **This must be applied to the database before the follow-up PR ships.** Deploys here do not run migrations, so merging the code first would leave the gate passing on unmetered spend for as long as the gap lasts. `node scripts/schema-drift-check.mjs` says whether it has landed.
- The `credits.ts` split that the follow-up needs (`readOrgBillingById`, `orgCreditsUsage`) is **not** here — it ships with the code that uses it.
- Backfilling `org_id` on historical rows was considered and rejected: they all have a brand, the join already reaches their org, and a backfill would create exactly the two-sources-of-truth this PR's rule exists to prevent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY

---

**One unrelated commit rides along, because it was blocking this PR's own CI.** `cli/mcp/vercel-config.test.ts` (added by #353) imports the bun **runtime** for a single `git ls-files`. `vite.config.ts` aliases `bun:test` to vitest, but nothing can alias an executable, so under vitest the file failed to **load** — a red job with zero failing tests, which is the hardest red to read. `execFileSync` from `node:child_process` does the same work under both runners; the file still passes under `bun test`. The signal and the move are in `LESSONS.md` on the follow-up branch.