### PR TITLE
Draw an image without having to name a brand

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -1055,3 +1055,57 @@ che esplode non è quello che l'ha piazzata.
 **La regola dietro**: dove il codice lancia una promessa che nessuno attende, un mock parziale non
 degrada — abbatte tutto il processo. O il mock risponde a qualunque cosa (Proxy), o quel percorso
 va atteso e asserito.
+
+## `set role` non è `auth.role()`: una security-definer interrogata da psql risponde zero
+
+Verificando che `sum_org_ai_cost_usd` contasse finalmente una riga senza brand, la funzione ha
+risposto **0** mentre la stessa somma scritta a mano sulla tabella rispondeva `0.033646`. Sembrava
+esattamente il difetto che stavo chiudendo — la migration non applicata, o il `left join` che non
+teneva.
+
+Non era né l'una né l'altro. La funzione porta una guardia:
+
+```sql
+and ( auth.role() = 'service_role' or p_org_id in (select public.auth_org_ids()) )
+```
+
+`auth.role()` legge il **claim del JWT** (`request.jwt.claims`), non il ruolo Postgres. Da psql
+quel claim non c'è, quindi la guardia è falsa per ogni riga, il `where` non ne seleziona nessuna e
+`coalesce(sum(...), 0)` restituisce uno zero perfettamente legittimo. `set role service_role` non
+cambia niente: è l'altro concetto di ruolo.
+
+**Segnale**: una funzione `security definer` sotto RLS risponde `0` o zero righe da psql, mentre la
+query equivalente scritta a mano risponde. Nessun errore, nessun permesso negato — solo un vuoto
+che si legge come un difetto della funzione.
+
+**Mossa**: mettere il claim prima di chiamarla, nella stessa sessione.
+
+```sql
+select set_config('request.jwt.claims', '{"role":"service_role"}', true);
+select public.sum_org_ai_cost_usd(...);
+```
+
+**La regola dietro**: una funzione che decide chi può vedere cosa va interrogata con l'identità che
+avrà in produzione. Interrogarla senza è come chiamarla da un utente anonimo e concludere che la
+tabella è vuota — e la conclusione sbagliata qui è la peggiore possibile, perché «somma zero» è
+proprio la forma del difetto che si sta cercando.
+
+## Un test rosso può importare `bun`, non `bun:test` — e vitest non ha un alias per quello
+
+In un worktree pulito la suite chiude con `Test Files 2 failed | 664 passed` e **`Tests 7387
+passed`, zero test falliti**: i due file non falliscono, non si caricano proprio. Uno è
+`hooks.server.test.ts` (manca `.env`, già qui sopra). L'altro è `cli/mcp/vercel-config.test.ts`:
+
+```
+Failed to load url bun (resolved id: bun) in cli/mcp/vercel-config.test.ts
+```
+
+`vite.config.ts` aliasa `bun:test` → `vitest`, che è ciò che fa girare i test della CLI sotto
+vitest. Ma quel file importa anche `import { $ } from 'bun'` — il **runtime**, non il framework di
+test — e per quello non c'è alias possibile: è l'eseguibile bun.
+
+**Segnale**: `Test Files N failed` con `Tests M passed` e **zero** `×`. I file non hanno test
+rossi, hanno un import che non risolve. Cerca `Failed to load url`, non `FAIL`.
+
+**Mossa**: `bun test cli/` per quei file (lì passano), e prima di attribuirsi il rosso,
+`git log -1 <file>` — se non l'hai toccato tu, riproducilo sul checkout principale.

--- a/LESSONS.md
+++ b/LESSONS.md
@@ -1107,5 +1107,10 @@ test — e per quello non c'è alias possibile: è l'eseguibile bun.
 **Segnale**: `Test Files N failed` con `Tests M passed` e **zero** `×`. I file non hanno test
 rossi, hanno un import che non risolve. Cerca `Failed to load url`, non `FAIL`.
 
-**Mossa**: `bun test cli/` per quei file (lì passano), e prima di attribuirsi il rosso,
-`git log -1 <file>` — se non l'hai toccato tu, riproducilo sul checkout principale.
+**Mossa**: prima di attribuirsi il rosso, `git log -1 <file>` — se non l'hai toccato tu,
+riproducilo sul checkout principale. E poi **aggiustalo**, perché blocca la CI di tutti: in questo
+caso `$` serviva a una riga sola (`git ls-files`), e `execFileSync` da `node:child_process` la fa
+girare sotto entrambi i runner.
+
+**La regola dietro**: un file di test che vive sotto due runner può usare solo ciò che entrambi
+hanno. `bun:test` ha un alias; il **runtime** `bun` no, e non può averlo — è un eseguibile.

--- a/changelog/2026-09-05-brand-look-reaches-the-mcp-renderer.md
+++ b/changelog/2026-09-05-brand-look-reaches-the-mcp-renderer.md
@@ -1,0 +1,98 @@
+# Il look del brand arriva al renderer anche da MCP
+
+Guardando l'inventario dei tool, Andrea ha chiesto di `generate_image`: *«come fa
+l'ai a mettere le image di reference che vuole? e mettere direttamente le foto dei
+prodotti salvati? e le people del brand?»*
+
+La risposta era «non può», in tutti e tre i modi. Ma sotto la domanda c'era un
+buco più grosso del parametro mancante.
+
+## Il motore regge sette canali, il percorso MCP ne usava zero
+
+`RenderImageOpts` accetta `referenceImages`, `personImages`, `moodImages`,
+`userRefImages`, `logoImage`, `baseImage`, più `visualStyle`, `visualPlaybook` e
+`brandLook`. Le superfici dei post li riempiono tutte: `content-preview/creation.ts`,
+`articles.ts`, `weekly-planner.ts`, `media-generator/agent.ts`.
+
+`runImageJob` — il motore dietro `generate_image`, `refine_image`,
+`generate_carousel` e `generate_media` — passava questo:
+
+```ts
+const opts = { model, refineModel, baseImage, aspectRatio };
+```
+
+Quattro campi su diciassette. Quindi **anche con lo slug, un'immagine generata da
+MCP non aveva l'aspetto del brand**: niente palette, niente font, niente stile
+visivo, niente playbook, niente logo. L'unica cosa che il brand contribuiva alla
+propria immagine era quale modello la disegnava.
+
+Ed era invisibile: nessun test falliva, perché nessun test guardava la richiesta
+costruita. L'immagine tornava, `ok: true`, e il conto era giusto.
+
+## Perché era rimasto indietro
+
+Il montaggio del contesto visivo esisteva in cinque copie, tutte sul percorso dei
+post — leggere `brand_kit`, mappare i font, chiamare `brandVisualDirective`,
+`extractVisualPlaybook`, `loadBrandLogoImagePart`, `loadBrandMoodImageUrls`. Una
+regola scritta in cinque posti diverge al primo posto nuovo, e il percorso MCP è
+nato dopo: non ha divergito, si è semplicemente dimenticato di esistere.
+
+Ora sta in `loadBrandVisualContext` (`content-preview/images.ts`), e il percorso
+MCP lo legge come gli altri. Le cinque copie esistenti non sono state toccate:
+riscriverle nella stessa PR avrebbe mischiato un riordino con un cambio di
+comportamento, che è esattamente ciò che rende impossibile dire quale dei due ha
+rotto cosa.
+
+## Due strade, e solo una si piega
+
+Andrea ha aggiunto la regola che completa il collegamento: *«anche l'opzione da
+parte dell'ai di disattivare o meno l'utilizzo del brand kit nella generazione
+delle img, da disattivare automaticamente se l'ai non setta uno slug»*.
+
+- **Senza slug** (il percorso di `feat/brand-free-image`): non c'è un brand,
+  quindi non c'è un kit. Non è una scelta, è un fatto — `job.brandId` è `null` e
+  non si legge niente.
+- **Con slug**: si applica di default, perché chi genera per un brand vuole che
+  assomigli al brand. `brand_style: 'ignore'` lo spegne per l'immagine che dal
+  brand non deve prendere niente — uno screenshot di UI, un'illustrazione su
+  qualcun altro, uno sfondo neutro, dove palette e font sporcano il risultato.
+
+Un **enum, non un booleano** (`AGENTS.md`): `brand_style: 'ignore'` si legge nella
+chiamata, `use_brand_kit: false` no.
+
+E il caso incoerente **rifiuta**. `brand_style` senza slug è una chiamata basata
+su un fraintendimento: l'agente crede di governare qualcosa che non esiste.
+`brand_style_needs_a_brand`, 400, prima di spendere, e il messaggio nomina la
+mossa — *pass a slug, or drop brand_style* — non solo l'errore, o il modello
+ritenta la stessa cosa.
+
+Accettarlo e ignorarlo sarebbe esattamente come nasce un parametro che sembra
+funzionare e non fa niente.
+
+## Una promessa capovolta, in un commit solo
+
+La descrizione che `feat/brand-free-image` spediva diceva testualmente *«nothing
+about a brand's look reaches the model»*. Era vera, verificata su quelle righe.
+Questa modifica la rende falsa con lo slug, quindi cambia insieme al codice in
+quattro posti: il contratto, il mirror della CLI, `references/tools.md`, e
+`SKILL.md` — che è la superficie letta **per prima**, e che non dicendo niente di
+falso non avrebbe fallito nessun test.
+
+Il test in `brand-free.test.ts` che asseriva la vecchia frase è andato rosso, ed
+era il segnale che il giro era completo. Non è stato cancellato: asserisce la
+verità nuova, e la sua nota dice perché è cambiato — un test la cui rottura
+significa «la funzione è arrivata» è indistinguibile da un test rotto, per chi lo
+legge dopo.
+
+## Cosa resta fuori, di proposito
+
+- **`generate_carousel` e `generate_media` non prendono `brand_style`.** Un
+  carosello è per definizione una serie del brand, e `generate_media` è la porta
+  storica che inoltra alle altre due. Entrambi ricevono il look di default, che è
+  ciò che serviva; il campo si aggiunge con una riga se emerge il caso.
+- **I riferimenti scelti dall'agente** (`reference_media_ids`) e **prodotti e
+  persone citabili per id** sono i punti 2 e 3 del brief, e stanno in un'altra PR.
+  Il punto 1 vale da solo: le immagini del brand smettono di essere generiche
+  senza che nessuno debba chiedere niente.
+- **`generate_video` non è toccato.** Il renderer video non ha un canale per lo
+  stile visivo: la sua strada passa da `video_renders` e dalle sue preferenze.

--- a/changelog/2026-09-05-brand-look-reaches-the-mcp-renderer.md
+++ b/changelog/2026-09-05-brand-look-reaches-the-mcp-renderer.md
@@ -94,5 +94,18 @@ legge dopo.
   persone citabili per id** sono i punti 2 e 3 del brief, e stanno in un'altra PR.
   Il punto 1 vale da solo: le immagini del brand smettono di essere generiche
   senza che nessuno debba chiedere niente.
-- **`generate_video` non è toccato.** Il renderer video non ha un canale per lo
-  stile visivo: la sua strada passa da `video_renders` e dalle sue preferenze.
+- **`generate_video` ha lo stesso buco, e si chiude qui.** `RenderVideoOpts` un
+  canale per lo stile visivo ce l'ha sempre avuto, e il percorso dei post lo
+  riempie (`create-single/+server.ts` passa `visualStyle: profile.visual_style`).
+  `startVideo` no: un clip chiesto da MCP tornava con lo stile di nessuno. Ora
+  legge `brand_kit.visual_style` e lo passa — con una copertina il renderer lo
+  scarta di proposito, perché il look sta già nei pixel del frame da animare, e
+  quel comportamento non è stato toccato.
+
+- **`brand_style` non c'è su `generate_video`, `generate_carousel` e
+  `generate_media`, ma la sua assenza è dichiarata.** Un carosello per definizione
+  è una serie del brand; `generate_media` è la porta storica; su un clip
+  l'interruttore avrebbe un solo ramo dove significa qualcosa. Quello che serviva
+  davvero era una frase per ciascuno che dice che l'interruttore lì non c'è —
+  senza, un agente lo cerca, e il costo di un'asimmetria è la ricerca, non
+  l'asimmetria.

--- a/changelog/2026-09-05-image-without-a-brand.md
+++ b/changelog/2026-09-05-image-without-a-brand.md
@@ -1,0 +1,116 @@
+# generate_image senza un brand, e la descrizione che lo dice
+
+Andrea ha collegato l'MCP a Claude e ha chiesto «puoi generare la img di un
+gatto?». L'agente ha risposto di non avere uno strumento di generazione
+immagini. Insistendo ha ricontrollato e ha confermato. Alla terza domanda ha
+ammesso che tecnicamente si può, «solo che la salva nella libreria media di un
+brand specifico e consuma crediti», e ha chiamato quel gatto uno **spreco**.
+
+L'agente non ha sbagliato: ha letto quello che avevamo scritto.
+
+> Draw a NEW image **into the brand media library** from a prompt, then pass the
+> id it returns as media_ids on **create_post** … **BILLS A RENDER PER IMAGE
+> (about 8 credits each…)**
+
+Tre àncore in tre frasi — la libreria di un brand, il post da fare, il costo — e
+un generatore perfettamente funzionante descritto in modo che nessun agente lo
+usi per generare un'immagine.
+
+## Due difetti, e il secondo non si risolve col primo
+
+`slug` era obbligatorio per costruzione: ogni endpoint del registro vive sotto
+`/api/v1/brands/:slug/…`, e `BRAND_ENDPOINTS` lo inietta a tutti. Ma renderlo
+opzionale non basta. Un parametro opzionale che la descrizione non spiega viene
+riempito lo stesso — e Andrea ha osservato agenti chiamare `list_brands` e poi
+**scegliere un brand a caso**, cioè spendere i crediti di un'organizzazione vera
+e sporcare la libreria di un cliente vero. Nella sua sessione un gatto poteva
+finire addebitato a qualcuno.
+
+Quindi le due cose insieme, o la prima non si vede.
+
+## I due buchi nei pagamenti che la modifica ingenua avrebbe aperto
+
+**Il cancello dei crediti.** `renderPostImage` è il chokepoint: le immagini sono
+~66% della spesa AI e la quota si applica lì perché un loop qualunque si fermi
+invece di bruciare per giorni. Leggeva `getBrandContext()`, e il commento
+accanto lo diceva: *«Senza brand context non c'è gate.»* Togliere lo slug alla
+lettera significava lasciare il punto più caro del prodotto senza controllo.
+
+**La somma dell'organizzazione.** `sum_org_ai_cost_usd` faceva
+`join brands on b.id = c.brand_id`: una riga con `brand_id` nullo contribuiva
+**zero** alla spesa di ogni organizzazione. Il cancello sarebbe passato per
+sempre, le generazioni senza brand sarebbero state gratis in permanenza, e la
+suite sarebbe rimasta verde — il database finto non somma niente.
+
+Il primo si vede da TypeScript, il secondo no. Il secondo lo chiude la migration
+`20260905100000_ai_calls_org_id` (colonna `org_id`, left join, coalesce), che va
+applicata **prima** di questo codice: qui i deploy non eseguono le migration.
+
+## Le tre decisioni
+
+**Chi paga**: l'organizzazione risolta da `ensureOrgForUser` — pagante prima,
+poi la più vecchia. È la stessa regola deterministica che decide dove atterra un
+brand nuovo, quindi un utente con più organizzazioni ottiene sempre la stessa. E
+la risposta la **nomina**: rifiutare quando l'utente ne possiede più d'una
+sarebbe stato più cauto sulla carta, ma è la risposta che nomina
+l'organizzazione a rendere impossibile il silenzio.
+
+**Dove finisce l'asset**: da nessuna parte. Nessuna riga in `brand_media`, e non
+per prudenza: tutte e quattro le policy di quella tabella (`0149`) dicono
+`brand_id in (select auth_brand_ids())`, e `NULL in (…)` vale `NULL`, non
+`true` — una riga senza brand sarebbe **invisibile a tutti** e nemmeno
+inseribile. I byte vanno in storage sotto lo user, dove le policy guardano solo
+il **primo** segmento del percorso, e tornano `id: null`, il percorso e una firma
+che scade in due ore.
+
+**La migration prima, non insieme.** Vedi sopra.
+
+## Il costo, detto dopo invece che stimato prima
+
+«about 8 credits each» era una tariffa scritta a mano: invecchia, e intanto
+produce la parola *spreco*. `billedUsdInScope` (PR #352) permette a una rotta di
+leggere la propria fattura, ma il deposito stava in `takeLlmCost`, che la
+**ritira** — e ritirarla non dice che una riga la porti: su `ok: false`
+`computeCostUsd` scarta il flat cost, quindi un turno fallito lasciava leggibile
+un costo che `ai_calls` non ha mai scritto. Il deposito si è spostato in
+`logAiCall`, l'unico chiamante di `takeLlmCost` e l'unico posto che conosce il
+prezzo vero della riga; e ora registra anche un flat cost che non viene dal
+gateway, cioè il render di un'immagine, fatturato dal fornitore e loggato sotto
+`openrouter`. Da lì `cost_usd` nella risposta.
+
+## Cosa si è scartato
+
+**Rendere `brand_media.brand_id` nullable**: la trappola RLS sopra.
+
+**Un secondo registro di endpoint senza brand**: `pathWithoutBrand` è un campo
+opzionale sullo stesso contratto, non una famiglia parallela. Un endpoint che
+non lo dichiara rifiuta una chiamata senza slug invece di costruire in silenzio
+`/brands//…` e scoprirlo con un 404 illeggibile molto più tardi.
+
+**Un gate che salta il billing provider**: `gateOrgCredits` passa dallo stesso
+provider di `gateCredits`, o un fork self-hosted — che di fatturazione non ne ha
+— si troverebbe contato proprio sulla strada nuova. E condivide la cache del
+cancello, già chiavata sull'organizzazione: una generazione con brand e una
+senza leggono lo stesso saldo invece di pagarsi due copie degli stessi numeri.
+
+**Lasciare passare una chiave API ristretta a certi brand**: dove nessun brand si
+nomina non c'è niente da confrontare, e lasciarla passare allargherebbe in
+silenzio una restrizione che l'utente ha scelto. `brand_scoped_key`, 403.
+
+## Quello che non è cambiato, ed è metà del test
+
+Con lo `slug`, tutto come prima: `imageModelFor(content_prefs)` governa ancora il
+modello, `withBrandContext(brand.id)` avvolge ancora il render, l'asset entra
+ancora in libreria con un id da passare a `create_post`, e uno slug che esiste ma
+non è dell'utente resta **404** — `loadBrandForUser` risponde così apposta,
+perché una chiave non deve poter sondare quali slug esistono. Rendere opzionale
+un parametro è il modo classico di far sparire in silenzio quello che quel
+parametro portava, quindi quei quattro fatti hanno un test ciascuno.
+
+## Una cosa che il codice non fa, e che nessuna descrizione deve promettere
+
+`runImageJob` passa solo `{model, refineModel, baseImage, aspectRatio}`: niente
+`visualStyle`, `brandLook`, `visualPlaybook`, `logoImage`. **Il look del brand
+non raggiunge `generate_image`**, né con slug né senza. La descrizione lo dice in
+negativo — «nothing about a brand's look reaches the model, so name the style you
+want» — invece di lasciarlo intendere.

--- a/cli/lib/api.ts
+++ b/cli/lib/api.ts
@@ -6,6 +6,7 @@
 import { appUrl } from './config.ts';
 import {
   pathFor,
+  pathWithoutBrand,
   type BrandEndpoint,
   type ResourceEndpoint,
   type ResourcelessEndpoint,
@@ -42,10 +43,24 @@ function post<T>(path: string, token: string, body?: unknown): Promise<T> {
   });
 }
 
+/**
+ * Nessuno slug: si va per la strada senza brand, se il registro ne dichiara una. Se non la
+ * dichiara è un errore qui e subito — cadere sulla rotta del brand costruirebbe `/brands//…`, che
+ * il server rifiuterebbe con un 404 illeggibile molto più tardi.
+ */
+function brandFreeCall(endpoint: BrandEndpoint, slug: string | null): string | null {
+  if (slug) return null;
+
+  const path = pathWithoutBrand(endpoint);
+  if (!path) throw new Error(`${endpoint.tool} needs a brand slug`);
+
+  return path;
+}
+
 export function callEndpoint<T>(
   endpoint: ResourcelessEndpoint,
   token: string,
-  slug: string,
+  slug: string | null,
   input?: Record<string, unknown>,
 ): Promise<T>;
 export function callEndpoint<T>(
@@ -58,12 +73,12 @@ export function callEndpoint<T>(
 export function callEndpoint<T>(
   endpoint: BrandEndpoint,
   token: string,
-  slug: string,
+  slug: string | null,
   input: Record<string, unknown> = {},
   id?: string,
 ): Promise<T> {
-  const path =
-    endpoint.resource === undefined ? pathFor(endpoint, slug) : pathFor(endpoint, slug, id ?? '');
+  const path = brandFreeCall(endpoint, slug)
+    ?? (endpoint.resource === undefined ? pathFor(endpoint, slug!) : pathFor(endpoint, slug!, id ?? ''));
   if (endpoint.method === 'DELETE') return request<T>(path, token, { method: 'DELETE' });
   if (endpoint.method !== 'GET') {
     return request<T>(path, token, { method: endpoint.method, body: JSON.stringify(input) });

--- a/cli/lib/contracts/index.ts
+++ b/cli/lib/contracts/index.ts
@@ -149,11 +149,18 @@ type EndpointShape = {
 
 export type ResourcelessEndpoint = EndpointShape & {
   readonly pathUnderBrand: string;
+  /**
+   * The same tool, reachable without naming a brand. Declaring it is what makes `slug` optional
+   * and what tells the caller a second route exists — an endpoint that omits this one has no way
+   * of running outside a brand, and asking for one is an error rather than a silent fallback.
+   */
+  readonly pathWithoutBrand?: string;
   readonly resource?: undefined;
 };
 
 export type ResourceEndpoint = EndpointShape & {
   readonly pathUnderBrand: `${string}/${typeof RESOURCE_SEGMENT}${string}`;
+  readonly pathWithoutBrand?: undefined;
   readonly resource: BrandResource;
 };
 
@@ -285,6 +292,11 @@ export function pathFor(endpoint: BrandEndpoint, slug: string, id?: string): str
   if (endpoint.resource === undefined) return `${base}${endpoint.pathUnderBrand}`;
   if (!id) throw new Error(`${endpoint.tool} needs a ${endpoint.resource} id`);
   return `${base}${endpoint.pathUnderBrand.replace(RESOURCE_SEGMENT, encodeURIComponent(id))}`;
+}
+
+/** Where this tool runs when no brand is named — `null` when it only exists under one. */
+export function pathWithoutBrand(endpoint: BrandEndpoint): string | null {
+  return endpoint.pathWithoutBrand ? `/api/v1${endpoint.pathWithoutBrand}` : null;
 }
 
 // Un id accorciato è una comodità di lettura: la lista dice quale riga, il prefisso basta a

--- a/cli/lib/contracts/posts.ts
+++ b/cli/lib/contracts/posts.ts
@@ -599,19 +599,65 @@ const ImageResult = z.object({
 
 const MODEL_FAILURE = { error: 'model_not_for_slot', status: 400 } as const;
 
+/**
+ * Un disegno chiesto senza brand non entra in nessuna libreria, quindi non ha un id da mostrare:
+ * `null` è il fatto, e dirlo qui è ciò che impedisce di passarlo a `create_post` e di cercarlo con
+ * `list_media`. Non è la stessa forma di `refine_image` o `generate_media`, che un brand ce
+ * l'hanno sempre e un id lo restituiscono sempre — allargare anche il loro schema significherebbe
+ * togliere una promessa che quei due mantengono.
+ */
+const DrawnMediaSchema = GeneratedMediaSchema.extend({
+  id: z
+    .string()
+    .nullable()
+    .describe(
+      'The library asset id — null when the image was drawn without a brand, and then it is in no ' +
+        'library: create_post will not take it and list_media will not find it.'
+    ),
+  storage_path: z
+    .string()
+    .nullable()
+    .describe('Where the file lives. Present on a brand-free drawing, whose url is a signed link that expires.')
+});
+
+const DrawnImageResult = z.object({
+  ok: z.literal(true),
+  media: z.array(DrawnMediaSchema),
+  model: ImageResult.shape.model,
+  renders: ImageResult.shape.renders,
+  organization: z
+    .object({ id: z.string(), name: z.string().nullable() })
+    .nullable()
+    .describe(
+      'Whose credits paid, named — set when no brand was given, null when one was (the brand names its own payer).'
+    ),
+  cost_usd: z
+    .number()
+    .nullable()
+    .describe('What this call actually cost, read from the invoice. null when no invoice came back — never 0.')
+});
+
 export const GENERATE_IMAGE = {
   tool: 'generate_image',
   title: 'Generate an image',
   description:
-    'Draw a NEW image into the brand media library from a prompt, then pass the id it returns as ' +
-    'media_ids on create_post. Call get_media_models first if you want to choose the model — ' +
-    'pass it as model, for this call only, instead of set_media_model, which changes the brand ' +
-    'default from now on. BILLS A RENDER PER IMAGE (about 8 credits each, and the model moves ' +
-    'that). It creates nothing in the calendar, so ask for two or three alternatives, look at ' +
-    'them with list_media, and attach only the one you keep. To change an image that already ' +
-    'exists use refine_image: correcting one drawing is cheaper than redrawing until it is right.',
+    'To draw a picture from a description — "an image of a cat", a product shot, a background ' +
+    "for a slide. The prompt is the whole instruction: nothing about a brand's look reaches " +
+    'the model, so name the style you want. WITHOUT slug this is a one-off drawing — no brand, ' +
+    'nothing filed anywhere, id comes back null and there is nothing to hand to create_post. ' +
+    "WITH slug the image lands in that brand's library and its id is what create_post takes as " +
+    'media_ids: use it when the picture belongs to a brand, or is going to become a post. Do ' +
+    'NOT call list_brands to decide where to draw — if nobody named a brand there is no brand, ' +
+    "and guessing one spends a real organisation's credits and litters a real library. It " +
+    'spends credits: one render per image, renders in the answer says how many were billed and ' +
+    'cost_usd what they actually cost. It creates nothing in the calendar and publishes nothing, ' +
+    'so ask for two or three with count, look at them, keep one. To CHANGE a picture that ' +
+    'already exists use refine_image — correcting one drawing beats redrawing until it is ' +
+    'right. To pick the model read get_media_models and pass model, for this call only; ' +
+    'set_media_model is the one that changes the brand from now on.',
   method: 'POST',
   pathUnderBrand: '/media/images',
+  pathWithoutBrand: '/images',
   input: z
     .object({
       prompt: z.string().min(1).describe('What the image should show'),
@@ -621,7 +667,7 @@ export const GENERATE_IMAGE = {
       title: z.string().optional().describe('The name the asset carries in the library')
     })
     .strict(),
-  output: ImageResult,
+  output: DrawnImageResult,
   failures: [
     { error: 'credits_exhausted', status: 402 },
     MODEL_FAILURE,

--- a/cli/lib/contracts/posts.ts
+++ b/cli/lib/contracts/posts.ts
@@ -599,6 +599,20 @@ const ImageResult = z.object({
 
 const MODEL_FAILURE = { error: 'model_not_for_slot', status: 400 } as const;
 
+const BRAND_STYLE_FAILURE = { error: 'brand_style_needs_a_brand', status: 400 } as const;
+
+const BrandStyleField = z
+  .enum(['apply', 'ignore'])
+  .optional()
+  .describe(
+    "Whether this brand's own look — its colours, its fonts, its visual direction — is applied. " +
+      'Leave it out and it is, which with a slug is almost always what you want. Send `ignore` ' +
+      'when the picture must take nothing from the brand: a plain UI screenshot, an illustration ' +
+      'about somebody else, a neutral background — places where brand colours and fonts spoil ' +
+      'the result. Without a slug there is no brand to apply or ignore, and sending this is ' +
+      'refused as brand_style_needs_a_brand: pass a slug, or drop brand_style.'
+  );
+
 /**
  * Un disegno chiesto senza brand non entra in nessuna libreria, quindi non ha un id da mostrare:
  * `null` è il fatto, e dirlo qui è ciò che impedisce di passarlo a `create_post` e di cercarlo con
@@ -642,8 +656,11 @@ export const GENERATE_IMAGE = {
   title: 'Generate an image',
   description:
     'To draw a picture from a description — "an image of a cat", a product shot, a background ' +
-    "for a slide. The prompt is the whole instruction: nothing about a brand's look reaches " +
-    'the model, so name the style you want. WITHOUT slug this is a one-off drawing — no brand, ' +
+    "for a slide. With a slug, this brand's own look is applied by default — its colours, its " +
+    'fonts and the visual direction it has settled on — so you do not have to describe them; ' +
+    'brand_style: ignore leaves them out. Without a slug there is no brand and none of that ' +
+    'reaches the model, so name the style you want in the prompt. ' +
+    'WITHOUT slug this is a one-off drawing — no brand, ' +
     'nothing filed anywhere, id comes back null and there is nothing to hand to create_post. ' +
     "WITH slug the image lands in that brand's library and its id is what create_post takes as " +
     'media_ids: use it when the picture belongs to a brand, or is going to become a post. Do ' +
@@ -664,6 +681,7 @@ export const GENERATE_IMAGE = {
       count: AlternativesField,
       aspect_ratio: z.enum(['1:1', '4:5', '9:16', '16:9']).optional(),
       model: modelField('imageModel'),
+      brand_style: BrandStyleField,
       title: z.string().optional().describe('The name the asset carries in the library')
     })
     .strict(),
@@ -671,6 +689,7 @@ export const GENERATE_IMAGE = {
   failures: [
     { error: 'credits_exhausted', status: 402 },
     MODEL_FAILURE,
+    BRAND_STYLE_FAILURE,
     { error: 'render_failed', status: 502 },
     { error: 'store_failed', status: 502 }
   ],
@@ -689,7 +708,7 @@ export const REFINE_IMAGE = {
     'draws a different picture from scratch. It spends credits, and the answer says how many ' +
     'renders were billed. It creates nothing in the calendar and publishes nothing; pass the id ' +
     'it returns to create_post as media_ids when you want a post. Changing has its own models — ' +
-    'get_media_models, slot imageRefineModel — and model here applies to this call only.',
+    'get_media_models, slot imageRefineModel — and model here applies to this call only. The brand look is applied as it is on generate_image; brand_style: ignore leaves it out.',
   method: 'POST',
   pathUnderBrand: '/media/images/refine',
   input: z
@@ -701,6 +720,7 @@ export const REFINE_IMAGE = {
       instruction: z.string().min(1).describe('What should change about it'),
       count: AlternativesField,
       model: modelField('imageRefineModel'),
+      brand_style: BrandStyleField,
       title: z.string().optional().describe('The name the new asset carries in the library')
     })
     .strict(),

--- a/cli/lib/contracts/posts.ts
+++ b/cli/lib/contracts/posts.ts
@@ -323,7 +323,9 @@ export const GENERATE_MEDIA = {
     'It spends credits. It creates nothing in the calendar and publishes nothing; pass the id ' +
     'you keep to create_post as media_ids. Images come back ready, up to ' +
     MAX_MEDIA_ALTERNATIVES + ' per call; a clip takes minutes and returns a job_id, and ' +
-    'check_media_job says when it landed — calling this again for the same clip bills a second one.',
+    'check_media_job says when it landed — calling this again for the same clip bills a second one.' +
+    "With a slug, this brand's look is applied, and it cannot be switched off from this door: " +
+    'generate_image takes brand_style for that.',
   method: 'POST',
   pathUnderBrand: '/media/generate',
   input: z
@@ -814,7 +816,9 @@ export const GENERATE_CAROUSEL = {
     'CHANGE ONE SLIDE use ' +
     'refine_image on that slide id, and put the continuity_tokens this returns back into your ' +
     'instruction — they are what holds the series together, and an edit that touches palette, ' +
-    'light or the recurring motif without them takes that slide out of the set.',
+    'light or the recurring motif without them takes that slide out of the set. ' +
+    "With a slug, this brand's look is applied to every slide, and there is no way to switch it " +
+    "off here: a series that is not the brand's is not a series.",
   method: 'POST',
   pathUnderBrand: '/media/carousel',
   input: z

--- a/cli/mcp/brand-free-tools.test.ts
+++ b/cli/mcp/brand-free-tools.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from 'bun:test';
+import { BRAND_ENDPOINTS } from '../lib/contracts/index.ts';
+import { handleMcpFetch } from './http-app.ts';
+
+/**
+ * `slug` obbligatorio è la ragione tecnica per cui un agente collegato via MCP risponde che non ha
+ * uno strumento per generare un'immagine: per disegnare un gatto dovrebbe prima scegliere
+ * un'azienda. Qui si verifica che sia opzionale SOLO dove il registro dichiara una strada che non
+ * passa da un brand — un opzionale sparso ovunque toglierebbe il confine invece di aprire una porta.
+ */
+
+type Tool = {
+  name: string;
+  inputSchema?: { properties?: Record<string, { description?: string }>; required?: string[] };
+};
+
+async function rpc(method: string, params: unknown, id = 1) {
+  const res = await handleMcpFetch(
+    new Request('http://localhost/mcp', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json, text/event-stream' },
+      body: JSON.stringify({ jsonrpc: '2.0', id, method, params }),
+    }),
+  );
+  return (await res.json()) as { result?: Record<string, unknown> };
+}
+
+async function tools(): Promise<Tool[]> {
+  await rpc('initialize', {
+    protocolVersion: '2024-11-05',
+    capabilities: {},
+    clientInfo: { name: 'test', version: '0.0.1' },
+  });
+  const listed = await rpc('tools/list', {}, 2);
+  return (listed.result?.tools ?? []) as Tool[];
+}
+
+const find = (all: Tool[], name: string): Tool => {
+  const tool = all.find((t) => t.name === name);
+  if (!tool) throw new Error(`tool ${name} non registrato`);
+  return tool;
+};
+
+describe('slug opzionale, e solo dove il registro lo dichiara', () => {
+  test('generate_image si chiama senza nominare un brand', async () => {
+    const tool = find(await tools(), 'generate_image');
+
+    expect(tool.inputSchema?.required ?? []).not.toContain('slug');
+    expect(tool.inputSchema?.properties?.slug).toBeDefined();
+  });
+
+  test('il campo dice da solo che si può omettere', async () => {
+    const tool = find(await tools(), 'generate_image');
+
+    expect(tool.inputSchema?.properties?.slug?.description).toMatch(/omit/i);
+  });
+
+  test('refine_image continua a pretendere il brand: la sorgente vive nella sua libreria', async () => {
+    const tool = find(await tools(), 'refine_image');
+
+    expect(tool.inputSchema?.required ?? []).toContain('slug');
+  });
+
+  test('ogni altro endpoint del registro tiene slug obbligatorio', async () => {
+    const all = await tools();
+
+    for (const endpoint of BRAND_ENDPOINTS) {
+      const required = find(all, endpoint.tool).inputSchema?.required ?? [];
+
+      expect(required.includes('slug'), endpoint.tool).toBe(!endpoint.pathWithoutBrand);
+    }
+  });
+});

--- a/cli/mcp/tools/brand-content.ts
+++ b/cli/mcp/tools/brand-content.ts
@@ -11,6 +11,16 @@ import { resolvePostId, resolveResourceId, withAuth } from '../util.ts';
 
 const slug = z.string().min(1).describe('Brand URL slug');
 
+/**
+ * Il registro dichiara una strada che non passa da un brand: qui diventa un `slug` che si può
+ * omettere, e il campo lo dice da sé. Senza quella frase l'opzionale non si vede — un modello
+ * riempie comunque un parametro che nessuno gli ha detto quando lasciare vuoto, e sceglie un
+ * brand a caso, i cui crediti sono di qualcun altro.
+ */
+const optionalSlug = slug
+  .optional()
+  .describe('Brand URL slug. Optional here: omit it to run without a brand — the tool description says what changes.');
+
 const resourceId = (resource: BrandResource) =>
   z.string().min(1).describe(`${BRAND_RESOURCES[resource]} id or unambiguous prefix`);
 
@@ -24,7 +34,7 @@ function registerDeclaredEndpoints(server: McpServer) {
         description: endpoint.description,
         inputSchema: byPrefix
           ? endpoint.input.extend({ slug, id: resourceId(endpoint.resource) })
-          : endpoint.input.extend({ slug }),
+          : endpoint.input.extend({ slug: endpoint.pathWithoutBrand ? optionalSlug : slug }),
         annotations: {
           readOnlyHint: endpoint.method === 'GET',
           destructiveHint: endpoint.destructive,
@@ -34,7 +44,7 @@ function registerDeclaredEndpoints(server: McpServer) {
       async ({ slug: brandSlug, ...input }) =>
         withAuth(async (token) => {
           if (endpoint.resource === undefined) {
-            return callEndpoint(endpoint, token, brandSlug as string, input);
+            return callEndpoint(endpoint, token, (brandSlug as string | undefined) ?? null, input);
           }
 
           const { id, ...payload } = input as { id: string } & Record<string, unknown>;

--- a/cli/plugins/anomalia/skills/anomalia/SKILL.md
+++ b/cli/plugins/anomalia/skills/anomalia/SKILL.md
@@ -100,7 +100,9 @@ still has its image the day the original link dies.
 **Draw a new image** → `generate_image` with a prompt — "an image of a cat", a product shot, a
 background. `slug` is OPTIONAL: leave it out for a one-off drawing (no brand, filed nowhere, `id`
 comes back `null`, and a signed `url` that expires), pass it when the picture belongs to a brand
-or is going to become a post. Do NOT call `list_brands` to decide where to draw: if nobody named
+or is going to become a post. With a slug the brand's own look — colours, fonts, visual direction —
+is applied by default; `brand_style: ignore` leaves it out when the picture must take nothing from
+the brand. Do NOT call `list_brands` to decide where to draw: if nobody named
 a brand there is no brand, and guessing one spends a real organisation's credits. It bills a
 render per image and creates nothing in the calendar, so ask for two or three with `count`, look
 at them, keep one.

--- a/cli/plugins/anomalia/skills/anomalia/SKILL.md
+++ b/cli/plugins/anomalia/skills/anomalia/SKILL.md
@@ -97,8 +97,13 @@ as `media_ids`. That is also how you post to Instagram or TikTok, which never ac
 it returns to `create_post` as `media_ids`. The file is copied into the brand library, so the post
 still has its image the day the original link dies.
 
-**Draw a new image** → `generate_image` with a prompt. It bills a render per image and creates
-nothing in the calendar, so ask for two or three with `count`, look at them, keep one.
+**Draw a new image** → `generate_image` with a prompt — "an image of a cat", a product shot, a
+background. `slug` is OPTIONAL: leave it out for a one-off drawing (no brand, filed nowhere, `id`
+comes back `null`, and a signed `url` that expires), pass it when the picture belongs to a brand
+or is going to become a post. Do NOT call `list_brands` to decide where to draw: if nobody named
+a brand there is no brand, and guessing one spends a real organisation's credits. It bills a
+render per image and creates nothing in the calendar, so ask for two or three with `count`, look
+at them, keep one.
 
 **Make a carousel** → `generate_carousel` with a brief. It plans the series, draws every slide and
 returns them in order plus the `continuity_tokens` that hold them together. One render per slide.

--- a/cli/plugins/anomalia/skills/anomalia/references/tools.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/tools.md
@@ -180,8 +180,18 @@ the model returning nothing.
 
 `generate_image` draws a picture from a description — "an image of a cat", a product shot, a
 background for a slide. Required: `prompt`. Optional: `slug`, `count` (1-4 alternatives, **each
-one billed**), `aspect_ratio`, `model`, `title`. The prompt is the whole instruction: nothing
-about a brand's look reaches the model, so name the style you want.
+one billed**), `aspect_ratio`, `model`, `brand_style`, `title`. With a slug, that brand's own look
+is applied by default — its colours, its fonts and the visual direction it has settled on — so you
+do not have to describe them. Without a slug there is no brand and none of that reaches the model,
+so name the style you want in the prompt.
+
+**`brand_style` turns that default off, and only a slug gives it a meaning.** Leave it out and the
+brand's look is applied, which with a slug is almost always what you want. Send `ignore` when the
+picture must take nothing from the brand: a plain UI screenshot, an illustration about somebody
+else, a neutral background — places where brand colours and fonts spoil the result. Without a slug
+there is no brand to apply or ignore, and sending it is refused as `brand_style_needs_a_brand`
+rather than quietly dropped: pass a slug, or drop `brand_style`. `refine_image` takes the same
+field, and the brand's look reaches a refinement the same way.
 
 **`slug` is optional, and which way you call it is the only choice to make.** WITHOUT it this is a
 one-off drawing: no brand, nothing filed anywhere, `id` comes back `null` and there is nothing to

--- a/cli/plugins/anomalia/skills/anomalia/references/tools.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/tools.md
@@ -191,7 +191,11 @@ picture must take nothing from the brand: a plain UI screenshot, an illustration
 else, a neutral background — places where brand colours and fonts spoil the result. Without a slug
 there is no brand to apply or ignore, and sending it is refused as `brand_style_needs_a_brand`
 rather than quietly dropped: pass a slug, or drop `brand_style`. `refine_image` takes the same
-field, and the brand's look reaches a refinement the same way.
+field, and the brand's look reaches a refinement the same way. `generate_carousel` and
+`generate_media` apply it too but take no `brand_style`: a series that is not the brand's is not a
+series, and `generate_media` is the old door — call `generate_image` when you need the switch. A
+clip filmed by `generate_video` from a prompt alone follows the brand's visual direction and cannot
+be switched off either; animating a library image takes its look from that image's pixels instead.
 
 **`slug` is optional, and which way you call it is the only choice to make.** WITHOUT it this is a
 one-off drawing: no brand, nothing filed anywhere, `id` comes back `null` and there is nothing to

--- a/cli/plugins/anomalia/skills/anomalia/references/tools.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/tools.md
@@ -178,15 +178,31 @@ one post per platform, so a sequence is for pasting by hand, not for `create_pos
 `credits_exhausted` (402) means the pool is empty and nothing was written; `no_captions` (502) is
 the model returning nothing.
 
-`generate_image` draws a NEW image into the library from a prompt. Required: `slug`, `prompt`;
-optional `count` (1-4 alternatives, **each one billed**), `aspect_ratio`, `model`, `title`. It
-bills a render per image and creates nothing in the calendar, so ask
-for two or three, look at them with `list_media`, and pass only the id you keep to `create_post`.
-The response carries two facts worth reading. `model` is the model that **actually** drew it,
-after the brand's choice and the platform default — read it rather than assuming your request won,
-because an environment override can still outrank it. `renders` is how many renders were **billed**,
-which can exceed the images you got back: a render that succeeds and is then discarded downstream
-is paid for all the same, so trust `renders` over your own count when reconciling spend.
+`generate_image` draws a picture from a description — "an image of a cat", a product shot, a
+background for a slide. Required: `prompt`. Optional: `slug`, `count` (1-4 alternatives, **each
+one billed**), `aspect_ratio`, `model`, `title`. The prompt is the whole instruction: nothing
+about a brand's look reaches the model, so name the style you want.
+
+**`slug` is optional, and which way you call it is the only choice to make.** WITHOUT it this is a
+one-off drawing: no brand, nothing filed anywhere, `id` comes back `null` and there is nothing to
+hand to `create_post` — you get a `storage_path` and a signed `url` that expires in two hours, so
+save what you want to keep. WITH it the image lands in that brand's library, `list_media` finds it
+again, and its `id` is what `create_post` takes as `media_ids`: that is the path for anything that
+belongs to a brand or is going to become a post.
+
+**Do NOT call `list_brands` to decide where to draw.** If nobody named a brand there is no brand.
+Guessing one spends a real organisation's credits and litters a real library — call it without
+`slug` instead. Without `slug` the credits come from your organisation, and the response names it
+in `organization` so the bill is never anonymous.
+
+It creates nothing in the calendar and publishes nothing, so ask for two or three, look at them,
+keep one. The response carries three facts worth reading. `model` is the model that **actually**
+drew it, after the brand's choice and the platform default — read it rather than assuming your
+request won, because an environment override can still outrank it. `renders` is how many renders
+were **billed**, which can exceed the images you got back: a render that succeeds and is then
+discarded downstream is paid for all the same, so trust `renders` over your own count when
+reconciling spend. `cost_usd` is what those renders actually cost, read off the invoice — `null`
+when no invoice came back, never `0`.
 
 **One prompt, one render, no safety net.** Nothing inspects the image after the model draws it:
 there is no quality control, no critic that rejects a bad frame, no retry you did not ask for.

--- a/cli/skills/anomalia/SKILL.md
+++ b/cli/skills/anomalia/SKILL.md
@@ -100,7 +100,9 @@ still has its image the day the original link dies.
 **Draw a new image** → `generate_image` with a prompt — "an image of a cat", a product shot, a
 background. `slug` is OPTIONAL: leave it out for a one-off drawing (no brand, filed nowhere, `id`
 comes back `null`, and a signed `url` that expires), pass it when the picture belongs to a brand
-or is going to become a post. Do NOT call `list_brands` to decide where to draw: if nobody named
+or is going to become a post. With a slug the brand's own look — colours, fonts, visual direction —
+is applied by default; `brand_style: ignore` leaves it out when the picture must take nothing from
+the brand. Do NOT call `list_brands` to decide where to draw: if nobody named
 a brand there is no brand, and guessing one spends a real organisation's credits. It bills a
 render per image and creates nothing in the calendar, so ask for two or three with `count`, look
 at them, keep one.

--- a/cli/skills/anomalia/SKILL.md
+++ b/cli/skills/anomalia/SKILL.md
@@ -97,8 +97,13 @@ as `media_ids`. That is also how you post to Instagram or TikTok, which never ac
 it returns to `create_post` as `media_ids`. The file is copied into the brand library, so the post
 still has its image the day the original link dies.
 
-**Draw a new image** → `generate_image` with a prompt. It bills a render per image and creates
-nothing in the calendar, so ask for two or three with `count`, look at them, keep one.
+**Draw a new image** → `generate_image` with a prompt — "an image of a cat", a product shot, a
+background. `slug` is OPTIONAL: leave it out for a one-off drawing (no brand, filed nowhere, `id`
+comes back `null`, and a signed `url` that expires), pass it when the picture belongs to a brand
+or is going to become a post. Do NOT call `list_brands` to decide where to draw: if nobody named
+a brand there is no brand, and guessing one spends a real organisation's credits. It bills a
+render per image and creates nothing in the calendar, so ask for two or three with `count`, look
+at them, keep one.
 
 **Make a carousel** → `generate_carousel` with a brief. It plans the series, draws every slide and
 returns them in order plus the `continuity_tokens` that hold them together. One render per slide.

--- a/cli/skills/anomalia/references/tools.md
+++ b/cli/skills/anomalia/references/tools.md
@@ -180,8 +180,18 @@ the model returning nothing.
 
 `generate_image` draws a picture from a description — "an image of a cat", a product shot, a
 background for a slide. Required: `prompt`. Optional: `slug`, `count` (1-4 alternatives, **each
-one billed**), `aspect_ratio`, `model`, `title`. The prompt is the whole instruction: nothing
-about a brand's look reaches the model, so name the style you want.
+one billed**), `aspect_ratio`, `model`, `brand_style`, `title`. With a slug, that brand's own look
+is applied by default — its colours, its fonts and the visual direction it has settled on — so you
+do not have to describe them. Without a slug there is no brand and none of that reaches the model,
+so name the style you want in the prompt.
+
+**`brand_style` turns that default off, and only a slug gives it a meaning.** Leave it out and the
+brand's look is applied, which with a slug is almost always what you want. Send `ignore` when the
+picture must take nothing from the brand: a plain UI screenshot, an illustration about somebody
+else, a neutral background — places where brand colours and fonts spoil the result. Without a slug
+there is no brand to apply or ignore, and sending it is refused as `brand_style_needs_a_brand`
+rather than quietly dropped: pass a slug, or drop `brand_style`. `refine_image` takes the same
+field, and the brand's look reaches a refinement the same way.
 
 **`slug` is optional, and which way you call it is the only choice to make.** WITHOUT it this is a
 one-off drawing: no brand, nothing filed anywhere, `id` comes back `null` and there is nothing to

--- a/cli/skills/anomalia/references/tools.md
+++ b/cli/skills/anomalia/references/tools.md
@@ -191,7 +191,11 @@ picture must take nothing from the brand: a plain UI screenshot, an illustration
 else, a neutral background — places where brand colours and fonts spoil the result. Without a slug
 there is no brand to apply or ignore, and sending it is refused as `brand_style_needs_a_brand`
 rather than quietly dropped: pass a slug, or drop `brand_style`. `refine_image` takes the same
-field, and the brand's look reaches a refinement the same way.
+field, and the brand's look reaches a refinement the same way. `generate_carousel` and
+`generate_media` apply it too but take no `brand_style`: a series that is not the brand's is not a
+series, and `generate_media` is the old door — call `generate_image` when you need the switch. A
+clip filmed by `generate_video` from a prompt alone follows the brand's visual direction and cannot
+be switched off either; animating a library image takes its look from that image's pixels instead.
 
 **`slug` is optional, and which way you call it is the only choice to make.** WITHOUT it this is a
 one-off drawing: no brand, nothing filed anywhere, `id` comes back `null` and there is nothing to

--- a/cli/skills/anomalia/references/tools.md
+++ b/cli/skills/anomalia/references/tools.md
@@ -178,15 +178,31 @@ one post per platform, so a sequence is for pasting by hand, not for `create_pos
 `credits_exhausted` (402) means the pool is empty and nothing was written; `no_captions` (502) is
 the model returning nothing.
 
-`generate_image` draws a NEW image into the library from a prompt. Required: `slug`, `prompt`;
-optional `count` (1-4 alternatives, **each one billed**), `aspect_ratio`, `model`, `title`. It
-bills a render per image and creates nothing in the calendar, so ask
-for two or three, look at them with `list_media`, and pass only the id you keep to `create_post`.
-The response carries two facts worth reading. `model` is the model that **actually** drew it,
-after the brand's choice and the platform default — read it rather than assuming your request won,
-because an environment override can still outrank it. `renders` is how many renders were **billed**,
-which can exceed the images you got back: a render that succeeds and is then discarded downstream
-is paid for all the same, so trust `renders` over your own count when reconciling spend.
+`generate_image` draws a picture from a description — "an image of a cat", a product shot, a
+background for a slide. Required: `prompt`. Optional: `slug`, `count` (1-4 alternatives, **each
+one billed**), `aspect_ratio`, `model`, `title`. The prompt is the whole instruction: nothing
+about a brand's look reaches the model, so name the style you want.
+
+**`slug` is optional, and which way you call it is the only choice to make.** WITHOUT it this is a
+one-off drawing: no brand, nothing filed anywhere, `id` comes back `null` and there is nothing to
+hand to `create_post` — you get a `storage_path` and a signed `url` that expires in two hours, so
+save what you want to keep. WITH it the image lands in that brand's library, `list_media` finds it
+again, and its `id` is what `create_post` takes as `media_ids`: that is the path for anything that
+belongs to a brand or is going to become a post.
+
+**Do NOT call `list_brands` to decide where to draw.** If nobody named a brand there is no brand.
+Guessing one spends a real organisation's credits and litters a real library — call it without
+`slug` instead. Without `slug` the credits come from your organisation, and the response names it
+in `organization` so the bill is never anonymous.
+
+It creates nothing in the calendar and publishes nothing, so ask for two or three, look at them,
+keep one. The response carries three facts worth reading. `model` is the model that **actually**
+drew it, after the brand's choice and the platform default — read it rather than assuming your
+request won, because an environment override can still outrank it. `renders` is how many renders
+were **billed**, which can exceed the images you got back: a render that succeeds and is then
+discarded downstream is paid for all the same, so trust `renders` over your own count when
+reconciling spend. `cost_usd` is what those renders actually cost, read off the invoice — `null`
+when no invoice came back, never `0`.
 
 **One prompt, one render, no safety net.** Nothing inspects the image after the model draws it:
 there is no quality control, no critic that rejects a bad frame, no retry you did not ask for.

--- a/cli/skills/findability.test.ts
+++ b/cli/skills/findability.test.ts
@@ -29,6 +29,10 @@ import { MCP_INSTRUCTIONS } from '../mcp/server.ts';
  * i changelog citano cifre perché quelle cifre SONO l'argomento di una decisione presa.
  */
 const ASKED_FOR: ReadonlyArray<{ tool: string; question: string; words: readonly string[] }> = [
+  // La domanda che ha aperto tutto questo: «puoi generare la img di un gatto?», e l'agente ha
+  // risposto di non avere lo strumento. Le parole stanno nella prima riga della descrizione e in
+  // apertura di entrambe le superfici della skill, perche' e' li' che un modello scorre.
+  { tool: 'generate_image', question: 'generate an image of a cat', words: ['image', 'cat', 'draw'] },
   { tool: 'refine_image', question: 'make this photo red', words: ['change', 'photo', 'red'] },
   {
     tool: 'generate_video',

--- a/cli/skills/findability.test.ts
+++ b/cli/skills/findability.test.ts
@@ -75,23 +75,6 @@ const ASKED_FOR: ReadonlyArray<{ tool: string; question: string; words: readonly
 
 const HAND_WRITTEN_TARIFF = /\b\d+\s*credits?\b/i;
 
-/**
- * L'unica tariffa ancora scritta a mano, e perché non la tolgo qui: la descrizione di
- * `generate_image` viaggia insieme al lavoro che rende `slug` opzionale, su un altro branch —
- * un parametro opzionale che la descrizione non spiega viene riempito lo stesso. Riscriverla in
- * due posti sarebbe un conflitto garantito.
- *
- * L'eccezione è dichiarata e si verifica da sola: il test pretende che la tariffa sia ANCORA lì.
- * Quando quel branch atterra il test diventa rosso e chiede di cancellare questa riga, invece di
- * lasciare un'esenzione che sopravvive al motivo che l'aveva giustificata.
- *
- * Quel branch è la PR #360. Chi dei due merga per SECONDO trova questo test rosso, e la mossa è
- * una sola: cancellare la riga e il test che la sorveglia, poi aggiungere la sua richiesta alla
- * tabella qui sopra — `{ tool: 'generate_image', question: 'generate an image of a cat', words:
- * ['image', 'cat', 'draw'] }`. Le tre parole sono già su entrambe le superfici da quel lato.
- */
-const TARIFF_OWNED_ELSEWHERE = ['generate_image'];
-
 const SKILL_DIR = fileURLToPath(new URL('./anomalia/', import.meta.url));
 const skillProse = [
   readFileSync(join(SKILL_DIR, 'SKILL.md'), 'utf8'),
@@ -168,17 +151,10 @@ describe('una descrizione si legge cercando il proprio problema', () => {
 
   test('nessuna descrizione scrive una tariffa a mano: il prezzo lo misura la risposta', () => {
     for (const endpoint of BRAND_ENDPOINTS) {
-      if (TARIFF_OWNED_ELSEWHERE.includes(endpoint.tool)) continue;
-
       expect(HAND_WRITTEN_TARIFF.test(endpoint.description), endpoint.tool).toBe(false);
     }
   });
 
-  test('l’unica esenzione è ancora vera, o va cancellata invece che ereditata', () => {
-    for (const tool of TARIFF_OWNED_ELSEWHERE) {
-      expect(HAND_WRITTEN_TARIFF.test(describing(tool)), `${tool}: togli la riga`).toBe(true);
-    }
-  });
 
   /**
    * Il rovescio della regola sulle tariffe: se il prezzo non si scrive, la SPESA va dichiarata,
@@ -188,7 +164,6 @@ describe('una descrizione si legge cercando il proprio problema', () => {
    */
   test('ogni tool che puo` restare senza crediti dice che spende', () => {
     for (const endpoint of BRAND_ENDPOINTS) {
-      if (TARIFF_OWNED_ELSEWHERE.includes(endpoint.tool)) continue;
       if (!endpoint.failures.some((f) => f.error === 'credits_exhausted')) continue;
 
       expect(endpoint.description, endpoint.tool).toMatch(/spends? credits/i);

--- a/packages/api-contracts/src/brand-free.test.ts
+++ b/packages/api-contracts/src/brand-free.test.ts
@@ -72,6 +72,12 @@ describe('la descrizione di generate_image', () => {
    * Il look del brand NON raggiunge questo strumento: `runImageJob` passa solo
    * `{model, refineModel, baseImage, aspectRatio}`. Una descrizione che lascia credere il
    * contrario promette quello che il codice non fa.
+   *
+   * SE QUESTO TEST DIVENTA ROSSO, NON CANCELLARLO. Il rosso è il segnale che il cablaggio del
+   * contesto visivo è arrivato — `visual_style`, il playbook, `brandLook`, il logo dentro `opts`
+   * — cioè che il giro è completo, non che la regola è caduta. Riscrivi l'asserzione sulla verità
+   * nuova (con lo slug il look arriva, senza slug no) e lasciala qui a sorvegliare quella. Un
+   * test cancellato nel commit che lo fa fallire porta via anche la domanda che faceva.
    */
   it('nega esplicitamente che uno slug compri lo stile del brand', () => {
     expect(text).toMatch(/nothing about a brand.s look reaches the model/);

--- a/packages/api-contracts/src/brand-free.test.ts
+++ b/packages/api-contracts/src/brand-free.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import { BRAND_ENDPOINTS, GENERATE_IMAGE, pathFor, pathWithoutBrand } from './index';
+
+/**
+ * Un generatore raggiungibile solo sotto un brand è un generatore che, per disegnare un gatto,
+ * chiede a chi lo chiama di scegliere l'azienda a cui addebitarlo. Andrea l'ha visto: l'agente ha
+ * risposto di non avere uno strumento per generare immagini, poi ha chiamato quel gatto uno
+ * «spreco». Non aveva torto: leggeva quello che c'era scritto.
+ *
+ * Le due metà si tengono. Un `slug` opzionale che la descrizione non spiega viene riempito lo
+ * stesso — con un brand a caso, i cui crediti sono di qualcun altro.
+ */
+describe('generate_image senza un brand', () => {
+  it('dichiara una strada che non passa da nessun brand', () => {
+    expect(pathWithoutBrand(GENERATE_IMAGE)).toBe('/api/v1/images');
+  });
+
+  it('tiene la strada del brand esattamente dov era', () => {
+    expect(pathFor(GENERATE_IMAGE, 'demo')).toBe('/api/v1/brands/demo/media/images');
+  });
+
+  it('è l unico endpoint che dichiara di saperne fare a meno', () => {
+    const brandFree = BRAND_ENDPOINTS.filter((e) => e.pathWithoutBrand);
+
+    expect(brandFree.map((e) => e.tool)).toEqual(['generate_image']);
+  });
+
+  it('un endpoint che non lo dichiara non ha una strada senza brand', () => {
+    const anchored = BRAND_ENDPOINTS.find((e) => e.tool === 'refine_image');
+
+    expect(pathWithoutBrand(anchored!)).toBeNull();
+  });
+});
+
+/**
+ * La descrizione è metà del lavoro, e il test guarda le frasi che hanno prodotto il rifiuto.
+ * «about 8 credits each» era una tariffa scritta a mano: invecchia, e intanto insegna al modello
+ * che chiamare lo strumento è uno spreco. Il costo lo dice la risposta, misurato.
+ */
+describe('la descrizione di generate_image', () => {
+  const text = GENERATE_IMAGE.description;
+
+  it('non stampa una tariffa in crediti scritta a mano', () => {
+    expect(text).not.toMatch(/\d+\s*credits/i);
+  });
+
+  /**
+   * La prima riga è quella che un modello legge scorrendo `tools/list`. Deve contenere la domanda
+   * dell'utente («genera un'immagine di un gatto»), non il posto dove l'asset finisce.
+   */
+  it('apre sul disegnare, con le parole della domanda', () => {
+    const opening = text.slice(0, 80).toLowerCase();
+
+    expect(opening).toMatch(/draw/);
+    expect(opening).toMatch(/image of a cat/);
+    expect(opening).not.toMatch(/library/);
+  });
+
+  it('dice che senza slug si genera e basta', () => {
+    expect(text).toMatch(/WITHOUT slug/);
+  });
+
+  it('vieta di cercare un brand per decidere dove generare', () => {
+    expect(text).toMatch(/Do NOT call list_brands/);
+  });
+
+  it('dice che senza brand l id non esiste e non c e niente per create_post', () => {
+    expect(text).toMatch(/id comes back null/);
+  });
+
+  /**
+   * Il look del brand NON raggiunge questo strumento: `runImageJob` passa solo
+   * `{model, refineModel, baseImage, aspectRatio}`. Una descrizione che lascia credere il
+   * contrario promette quello che il codice non fa.
+   */
+  it('nega esplicitamente che uno slug compri lo stile del brand', () => {
+    expect(text).toMatch(/nothing about a brand.s look reaches the model/);
+  });
+
+  it('tiene la freccia al passo successivo per chi il brand ce l ha', () => {
+    expect(text).toMatch(/create_post takes as media_ids/);
+  });
+
+  it('dice ancora che si paga, e dove leggere quanto', () => {
+    expect(text).toMatch(/cost_usd/);
+  });
+});
+
+describe('lo schema di generate_image', () => {
+  it('non promette un id quando non c e una libreria dove metterlo', () => {
+    const parsed = GENERATE_IMAGE.output.safeParse({
+      ok: true,
+      media: [{ id: null, kind: 'image', mime: 'image/png', width: 1, height: 1, url: 'https://x', storage_path: 'u/media/a.png' }],
+      model: 'nano-banana-2-lite',
+      renders: 1,
+      organization: { id: 'org-1', name: 'Acme' },
+      cost_usd: 0.0336
+    });
+
+    expect(parsed.success).toBe(true);
+  });
+
+  it('accetta ancora la risposta di oggi, con l id e senza organizzazione', () => {
+    const parsed = GENERATE_IMAGE.output.safeParse({
+      ok: true,
+      media: [{ id: 'media-1', kind: 'image', mime: 'image/png', width: 1, height: 1, url: 'https://x', storage_path: null }],
+      model: 'nano-banana-2-lite',
+      renders: 1,
+      organization: null,
+      cost_usd: null
+    });
+
+    expect(parsed.success).toBe(true);
+  });
+});

--- a/packages/api-contracts/src/brand-free.test.ts
+++ b/packages/api-contracts/src/brand-free.test.ts
@@ -69,18 +69,16 @@ describe('la descrizione di generate_image', () => {
   });
 
   /**
-   * Il look del brand NON raggiunge questo strumento: `runImageJob` passa solo
-   * `{model, refineModel, baseImage, aspectRatio}`. Una descrizione che lascia credere il
-   * contrario promette quello che il codice non fa.
-   *
-   * SE QUESTO TEST DIVENTA ROSSO, NON CANCELLARLO. Il rosso è il segnale che il cablaggio del
-   * contesto visivo è arrivato — `visual_style`, il playbook, `brandLook`, il logo dentro `opts`
-   * — cioè che il giro è completo, non che la regola è caduta. Riscrivi l'asserzione sulla verità
-   * nuova (con lo slug il look arriva, senza slug no) e lasciala qui a sorvegliare quella. Un
-   * test cancellato nel commit che lo fa fallire porta via anche la domanda che faceva.
+   * Prima il look del brand non raggiungeva questo strumento nemmeno con lo slug, e la
+   * descrizione lo diceva. Ora `runImageJob` legge `loadBrandVisualContext`, quindi la promessa
+   * si e' capovolta: con lo slug si applica, senza non c'e' un brand da cui prenderlo, e
+   * `brand_style: ignore` lo spegne. Le tre cose stanno insieme perche' e' la coppia
+   * slug/parametro a decidere, non una sola delle due.
    */
-  it('nega esplicitamente che uno slug compri lo stile del brand', () => {
-    expect(text).toMatch(/nothing about a brand.s look reaches the model/);
+  it('dice che con lo slug lo stile del brand si applica, e senza no', () => {
+    expect(text).toMatch(/this brand.s own look is applied by default/);
+    expect(text).toMatch(/Without a slug there is no brand and none of that reaches the model/);
+    expect(text).toMatch(/brand_style: ignore leaves them out/);
   });
 
   it('tiene la freccia al passo successivo per chi il brand ce l ha', () => {

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -149,11 +149,18 @@ type EndpointShape = {
 
 export type ResourcelessEndpoint = EndpointShape & {
   readonly pathUnderBrand: string;
+  /**
+   * The same tool, reachable without naming a brand. Declaring it is what makes `slug` optional
+   * and what tells the caller a second route exists — an endpoint that omits this one has no way
+   * of running outside a brand, and asking for one is an error rather than a silent fallback.
+   */
+  readonly pathWithoutBrand?: string;
   readonly resource?: undefined;
 };
 
 export type ResourceEndpoint = EndpointShape & {
   readonly pathUnderBrand: `${string}/${typeof RESOURCE_SEGMENT}${string}`;
+  readonly pathWithoutBrand?: undefined;
   readonly resource: BrandResource;
 };
 
@@ -285,6 +292,11 @@ export function pathFor(endpoint: BrandEndpoint, slug: string, id?: string): str
   if (endpoint.resource === undefined) return `${base}${endpoint.pathUnderBrand}`;
   if (!id) throw new Error(`${endpoint.tool} needs a ${endpoint.resource} id`);
   return `${base}${endpoint.pathUnderBrand.replace(RESOURCE_SEGMENT, encodeURIComponent(id))}`;
+}
+
+/** Where this tool runs when no brand is named — `null` when it only exists under one. */
+export function pathWithoutBrand(endpoint: BrandEndpoint): string | null {
+  return endpoint.pathWithoutBrand ? `/api/v1${endpoint.pathWithoutBrand}` : null;
 }
 
 // Un id accorciato è una comodità di lettura: la lista dice quale riga, il prefisso basta a

--- a/packages/api-contracts/src/posts.ts
+++ b/packages/api-contracts/src/posts.ts
@@ -599,19 +599,65 @@ const ImageResult = z.object({
 
 const MODEL_FAILURE = { error: 'model_not_for_slot', status: 400 } as const;
 
+/**
+ * Un disegno chiesto senza brand non entra in nessuna libreria, quindi non ha un id da mostrare:
+ * `null` è il fatto, e dirlo qui è ciò che impedisce di passarlo a `create_post` e di cercarlo con
+ * `list_media`. Non è la stessa forma di `refine_image` o `generate_media`, che un brand ce
+ * l'hanno sempre e un id lo restituiscono sempre — allargare anche il loro schema significherebbe
+ * togliere una promessa che quei due mantengono.
+ */
+const DrawnMediaSchema = GeneratedMediaSchema.extend({
+  id: z
+    .string()
+    .nullable()
+    .describe(
+      'The library asset id — null when the image was drawn without a brand, and then it is in no ' +
+        'library: create_post will not take it and list_media will not find it.'
+    ),
+  storage_path: z
+    .string()
+    .nullable()
+    .describe('Where the file lives. Present on a brand-free drawing, whose url is a signed link that expires.')
+});
+
+const DrawnImageResult = z.object({
+  ok: z.literal(true),
+  media: z.array(DrawnMediaSchema),
+  model: ImageResult.shape.model,
+  renders: ImageResult.shape.renders,
+  organization: z
+    .object({ id: z.string(), name: z.string().nullable() })
+    .nullable()
+    .describe(
+      'Whose credits paid, named — set when no brand was given, null when one was (the brand names its own payer).'
+    ),
+  cost_usd: z
+    .number()
+    .nullable()
+    .describe('What this call actually cost, read from the invoice. null when no invoice came back — never 0.')
+});
+
 export const GENERATE_IMAGE = {
   tool: 'generate_image',
   title: 'Generate an image',
   description:
-    'Draw a NEW image into the brand media library from a prompt, then pass the id it returns as ' +
-    'media_ids on create_post. Call get_media_models first if you want to choose the model — ' +
-    'pass it as model, for this call only, instead of set_media_model, which changes the brand ' +
-    'default from now on. BILLS A RENDER PER IMAGE (about 8 credits each, and the model moves ' +
-    'that). It creates nothing in the calendar, so ask for two or three alternatives, look at ' +
-    'them with list_media, and attach only the one you keep. To change an image that already ' +
-    'exists use refine_image: correcting one drawing is cheaper than redrawing until it is right.',
+    'To draw a picture from a description — "an image of a cat", a product shot, a background ' +
+    "for a slide. The prompt is the whole instruction: nothing about a brand's look reaches " +
+    'the model, so name the style you want. WITHOUT slug this is a one-off drawing — no brand, ' +
+    'nothing filed anywhere, id comes back null and there is nothing to hand to create_post. ' +
+    "WITH slug the image lands in that brand's library and its id is what create_post takes as " +
+    'media_ids: use it when the picture belongs to a brand, or is going to become a post. Do ' +
+    'NOT call list_brands to decide where to draw — if nobody named a brand there is no brand, ' +
+    "and guessing one spends a real organisation's credits and litters a real library. It " +
+    'spends credits: one render per image, renders in the answer says how many were billed and ' +
+    'cost_usd what they actually cost. It creates nothing in the calendar and publishes nothing, ' +
+    'so ask for two or three with count, look at them, keep one. To CHANGE a picture that ' +
+    'already exists use refine_image — correcting one drawing beats redrawing until it is ' +
+    'right. To pick the model read get_media_models and pass model, for this call only; ' +
+    'set_media_model is the one that changes the brand from now on.',
   method: 'POST',
   pathUnderBrand: '/media/images',
+  pathWithoutBrand: '/images',
   input: z
     .object({
       prompt: z.string().min(1).describe('What the image should show'),
@@ -621,7 +667,7 @@ export const GENERATE_IMAGE = {
       title: z.string().optional().describe('The name the asset carries in the library')
     })
     .strict(),
-  output: ImageResult,
+  output: DrawnImageResult,
   failures: [
     { error: 'credits_exhausted', status: 402 },
     MODEL_FAILURE,

--- a/packages/api-contracts/src/posts.ts
+++ b/packages/api-contracts/src/posts.ts
@@ -599,6 +599,20 @@ const ImageResult = z.object({
 
 const MODEL_FAILURE = { error: 'model_not_for_slot', status: 400 } as const;
 
+const BRAND_STYLE_FAILURE = { error: 'brand_style_needs_a_brand', status: 400 } as const;
+
+const BrandStyleField = z
+  .enum(['apply', 'ignore'])
+  .optional()
+  .describe(
+    "Whether this brand's own look — its colours, its fonts, its visual direction — is applied. " +
+      'Leave it out and it is, which with a slug is almost always what you want. Send `ignore` ' +
+      'when the picture must take nothing from the brand: a plain UI screenshot, an illustration ' +
+      'about somebody else, a neutral background — places where brand colours and fonts spoil ' +
+      'the result. Without a slug there is no brand to apply or ignore, and sending this is ' +
+      'refused as brand_style_needs_a_brand: pass a slug, or drop brand_style.'
+  );
+
 /**
  * Un disegno chiesto senza brand non entra in nessuna libreria, quindi non ha un id da mostrare:
  * `null` è il fatto, e dirlo qui è ciò che impedisce di passarlo a `create_post` e di cercarlo con
@@ -642,8 +656,11 @@ export const GENERATE_IMAGE = {
   title: 'Generate an image',
   description:
     'To draw a picture from a description — "an image of a cat", a product shot, a background ' +
-    "for a slide. The prompt is the whole instruction: nothing about a brand's look reaches " +
-    'the model, so name the style you want. WITHOUT slug this is a one-off drawing — no brand, ' +
+    "for a slide. With a slug, this brand's own look is applied by default — its colours, its " +
+    'fonts and the visual direction it has settled on — so you do not have to describe them; ' +
+    'brand_style: ignore leaves them out. Without a slug there is no brand and none of that ' +
+    'reaches the model, so name the style you want in the prompt. ' +
+    'WITHOUT slug this is a one-off drawing — no brand, ' +
     'nothing filed anywhere, id comes back null and there is nothing to hand to create_post. ' +
     "WITH slug the image lands in that brand's library and its id is what create_post takes as " +
     'media_ids: use it when the picture belongs to a brand, or is going to become a post. Do ' +
@@ -664,6 +681,7 @@ export const GENERATE_IMAGE = {
       count: AlternativesField,
       aspect_ratio: z.enum(['1:1', '4:5', '9:16', '16:9']).optional(),
       model: modelField('imageModel'),
+      brand_style: BrandStyleField,
       title: z.string().optional().describe('The name the asset carries in the library')
     })
     .strict(),
@@ -671,6 +689,7 @@ export const GENERATE_IMAGE = {
   failures: [
     { error: 'credits_exhausted', status: 402 },
     MODEL_FAILURE,
+    BRAND_STYLE_FAILURE,
     { error: 'render_failed', status: 502 },
     { error: 'store_failed', status: 502 }
   ],
@@ -689,7 +708,7 @@ export const REFINE_IMAGE = {
     'draws a different picture from scratch. It spends credits, and the answer says how many ' +
     'renders were billed. It creates nothing in the calendar and publishes nothing; pass the id ' +
     'it returns to create_post as media_ids when you want a post. Changing has its own models — ' +
-    'get_media_models, slot imageRefineModel — and model here applies to this call only.',
+    'get_media_models, slot imageRefineModel — and model here applies to this call only. The brand look is applied as it is on generate_image; brand_style: ignore leaves it out.',
   method: 'POST',
   pathUnderBrand: '/media/images/refine',
   input: z
@@ -701,6 +720,7 @@ export const REFINE_IMAGE = {
       instruction: z.string().min(1).describe('What should change about it'),
       count: AlternativesField,
       model: modelField('imageRefineModel'),
+      brand_style: BrandStyleField,
       title: z.string().optional().describe('The name the new asset carries in the library')
     })
     .strict(),

--- a/packages/api-contracts/src/posts.ts
+++ b/packages/api-contracts/src/posts.ts
@@ -323,7 +323,9 @@ export const GENERATE_MEDIA = {
     'It spends credits. It creates nothing in the calendar and publishes nothing; pass the id ' +
     'you keep to create_post as media_ids. Images come back ready, up to ' +
     MAX_MEDIA_ALTERNATIVES + ' per call; a clip takes minutes and returns a job_id, and ' +
-    'check_media_job says when it landed — calling this again for the same clip bills a second one.',
+    'check_media_job says when it landed — calling this again for the same clip bills a second one.' +
+    "With a slug, this brand's look is applied, and it cannot be switched off from this door: " +
+    'generate_image takes brand_style for that.',
   method: 'POST',
   pathUnderBrand: '/media/generate',
   input: z
@@ -814,7 +816,9 @@ export const GENERATE_CAROUSEL = {
     'CHANGE ONE SLIDE use ' +
     'refine_image on that slide id, and put the continuity_tokens this returns back into your ' +
     'instruction — they are what holds the series together, and an edit that touches palette, ' +
-    'light or the recurring motif without them takes that slide out of the set.',
+    'light or the recurring motif without them takes that slide out of the set. ' +
+    "With a slug, this brand's look is applied to every slide, and there is no way to switch it " +
+    "off here: a series that is not the brand's is not a series.",
   method: 'POST',
   pathUnderBrand: '/media/carousel',
   input: z

--- a/src/lib/billing/contract.ts
+++ b/src/lib/billing/contract.ts
@@ -10,7 +10,10 @@
 export type QuotaKind = 'credits' | 'posts';
 
 export type BillingContext = {
-  brandId: string;
+  /** Absent on work asked for WITHOUT a brand — then `orgId` names who pays. One of the two is always set. */
+  brandId?: string;
+  /** The organization that pays when no brand does. Unread while a brandId is here: a brand reaches its own org. */
+  orgId?: string;
   /** Not always known by the caller (e.g. the credits chokepoint only has a brandId) — optional. */
   plan?: string | null;
   brandSlug?: string;

--- a/src/lib/content/changelog/2026-09-05-brand-look-in-generated-images.ts
+++ b/src/lib/content/changelog/2026-09-05-brand-look-in-generated-images.ts
@@ -1,0 +1,12 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-05',
+  title: 'Images generated for a brand now look like it',
+  items: [
+    'An image drawn for a brand now carries its colours, its fonts, its visual direction and its logo — before, only images made through a post did.',
+    'Refinements and carousels get the same treatment, so a picture no longer changes look depending on which door it came through.',
+    'Ask for the brand look to be left out when a picture should take nothing from it — a plain screenshot, a neutral background.',
+    'Without a brand there is no brand look to apply, and asking for one now says so instead of quietly doing nothing.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/content/changelog/2026-09-05-brand-look-in-generated-images.ts
+++ b/src/lib/content/changelog/2026-09-05-brand-look-in-generated-images.ts
@@ -6,6 +6,7 @@ export default {
   items: [
     'An image drawn for a brand now carries its colours, its fonts, its visual direction and its logo — before, only images made through a post did.',
     'Refinements and carousels get the same treatment, so a picture no longer changes look depending on which door it came through.',
+    'A clip filmed from a description follows the brand\'s visual direction too, instead of coming back looking like nobody.',
     'Ask for the brand look to be left out when a picture should take nothing from it — a plain screenshot, a neutral background.',
     'Without a brand there is no brand look to apply, and asking for one now says so instead of quietly doing nothing.'
   ]

--- a/src/lib/content/changelog/2026-09-05-image-without-a-brand.ts
+++ b/src/lib/content/changelog/2026-09-05-image-without-a-brand.ts
@@ -1,0 +1,13 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-05',
+  title: 'Ask for an image of a cat and get one',
+  items: [
+    'Image generation no longer needs a brand: ask for a picture and it is drawn, with nothing to pick first.',
+    'A picture drawn without a brand is handed straight back as a link and filed in no library, so nobody\'s media gets cluttered.',
+    'Name a brand and it works as before: the image lands in that library, ready to attach to a post.',
+    'Credits for a brand-free image come from your organisation, and the answer says which one.',
+    'Every image now reports what it actually cost instead of quoting an estimate.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/ai-log.test.ts
+++ b/src/lib/server/ai-log.test.ts
@@ -1,5 +1,16 @@
 import { describe, it, expect } from 'vitest';
-import { billedUsdInScope, computeCostUsd, extractSdkUsage, noteLlmCost, takeLlmCost, withBrandContext } from './ai-log';
+import {
+  billedUsdInScope,
+  computeCostUsd,
+  extractSdkUsage,
+  getBrandContext,
+  getOrgContext,
+  logAiCall,
+  noteLlmCost,
+  takeLlmCost,
+  withBrandContext,
+  withOrgContext
+} from './ai-log';
 import { GEMINI_FLASH, NANO_BANANA_PRO } from './gemini';
 
 const GO = 'go';
@@ -340,12 +351,18 @@ describe('fatture del gateway nello scope', () => {
     expect(takeLlmCost()).toBeUndefined();
   });
 
-  it('quello che e` stato ritirato resta leggibile: e` il numero scritto nella riga', async () => {
+  /**
+   * Il deposito è passato da `takeLlmCost` a `logAiCall`, di proposito: ritirare la fattura non
+   * dice che una riga la porti. Su `ok: false` `computeCostUsd` scarta il flat cost, quindi la
+   * vecchia cucitura rendeva leggibile un costo che `ai_calls` non ha mai scritto — cioè di nuovo
+   * un listino accanto alla riga, che è la cosa da cui si sta scappando. Adesso deposita chi scrive.
+   */
+  it('quello che e` finito nella riga resta leggibile: e` il numero della riga', async () => {
     await withBrandContext('brand-1', async () => {
       expect(billedUsdInScope()).toBeUndefined();
 
       noteLlmCost(0.004);
-      expect(takeLlmCost()).toBeCloseTo(0.004, 10);
+      logAiCall({ label: 'turn', provider: 'llm', model: 'x', ms: 1, ok: true });
 
       expect(billedUsdInScope()).toBeCloseTo(0.004, 10);
     });
@@ -354,11 +371,20 @@ describe('fatture del gateway nello scope', () => {
   it('somma le fatture di piu` chiamate nello stesso scope', async () => {
     await withBrandContext('brand-1', async () => {
       noteLlmCost(0.001);
-      takeLlmCost();
+      logAiCall({ label: 'turn', provider: 'llm', model: 'x', ms: 1, ok: true });
       noteLlmCost(0.002);
-      takeLlmCost();
+      logAiCall({ label: 'turn', provider: 'llm', model: 'x', ms: 1, ok: true });
 
       expect(billedUsdInScope()).toBeCloseTo(0.003, 10);
+    });
+  });
+
+  it('un turno fallito non lascia una fattura che nessuna riga porta', async () => {
+    await withBrandContext('brand-1', async () => {
+      noteLlmCost(0.004);
+      logAiCall({ label: 'turn', provider: 'llm', model: 'x', ms: 1, ok: false, error: 'boom' });
+
+      expect(billedUsdInScope()).toBeUndefined();
     });
   });
 
@@ -366,6 +392,82 @@ describe('fatture del gateway nello scope', () => {
     await withBrandContext('brand-1', async () => {
       takeLlmCost();
       expect(billedUsdInScope()).toBeUndefined();
+    });
+  });
+});
+
+/**
+ * Chi paga, quando non c'è un brand a pagare. `sum_org_ai_cost_usd` sommava passando da `brands`:
+ * una riga senza brand valeva zero per ogni organizzazione, quindi il cancello sopra sarebbe
+ * passato per sempre e quelle generazioni sarebbero state gratis in permanenza — con la suite
+ * verde, perché il database finto non somma niente.
+ */
+describe('lo scope di un lavoro senza brand', () => {
+  it('porta l organizzazione, e nessun brand da attribuire', () => {
+    withOrgContext('org-1', () => {
+      expect(getOrgContext()).toBe('org-1');
+      expect(getBrandContext()).toBeNull();
+    });
+  });
+
+  it('uno scope di brand non porta un organizzazione: la riga ci arriva dal brand', () => {
+    withBrandContext('brand-1', () => {
+      expect(getOrgContext()).toBeNull();
+    });
+  });
+
+  it('due lavori paralleli non si scambiano il pagante', async () => {
+    await Promise.all([
+      withOrgContext('org-1', async () => {
+        await new Promise((r) => setTimeout(r, 5));
+        expect(getOrgContext()).toBe('org-1');
+      }),
+      withOrgContext('org-2', async () => {
+        await new Promise((r) => setTimeout(r, 5));
+        expect(getOrgContext()).toBe('org-2');
+      })
+    ]);
+  });
+});
+
+/**
+ * Il costo si DICE dopo, misurato. La descrizione di generate_image portava «about 8 credits
+ * each»: una tariffa scritta a mano, che invecchia e intanto insegna al modello che chiamare lo
+ * strumento è uno spreco. Perché toglierla sia sicuro, la fattura che è finita in `ai_calls` deve
+ * essere leggibile dalla rotta che risponde.
+ */
+describe('la fattura che è finita nella riga si rilegge nello scope', () => {
+  it('un render prezzato dal fornitore è leggibile subito, senza aspettare la insert', () => {
+    withBrandContext('brand-1', () => {
+      logAiCall({ label: 'image', provider: 'openrouter', model: 'x', ms: 1, ok: true, flatCostUsd: 0.0336 });
+
+      expect(billedUsdInScope()).toBeCloseTo(0.0336, 10);
+    });
+  });
+
+  it('somma i render dello stesso turno', () => {
+    withBrandContext('brand-1', () => {
+      logAiCall({ label: 'image', provider: 'openrouter', model: 'x', ms: 1, ok: true, flatCostUsd: 0.03 });
+      logAiCall({ label: 'image', provider: 'openrouter', model: 'x', ms: 1, ok: true, flatCostUsd: 0.02 });
+
+      expect(billedUsdInScope()).toBeCloseTo(0.05, 10);
+    });
+  });
+
+  it('un render fallito non ha una fattura: resta undefined, non zero', () => {
+    withBrandContext('brand-1', () => {
+      logAiCall({ label: 'image', provider: 'openrouter', model: 'x', ms: 1, ok: false, error: 'boom', flatCostUsd: 0.03 });
+
+      expect(billedUsdInScope()).toBeUndefined();
+    });
+  });
+
+  it('la fattura del gateway continua a contarsi una volta sola', () => {
+    withBrandContext('brand-1', () => {
+      noteLlmCost(0.004);
+      logAiCall({ label: 'turn', provider: 'llm', model: 'x', ms: 1, ok: true });
+
+      expect(billedUsdInScope()).toBeCloseTo(0.004, 10);
     });
   });
 });

--- a/src/lib/server/ai-log.ts
+++ b/src/lib/server/ai-log.ts
@@ -11,7 +11,14 @@ import { GEMINI_FLASH, geminiFlash, isGeminiFlashId, isKieFlashId, kieFlashId, N
 // other; entry points wrap their work in withBrandContext(brandId, fn).
 
 type BrandLogContext = {
-  brandId: string;
+  /** `null` on a job asked for without a brand: then `orgId` is who pays, and nothing is attributed. */
+  brandId: string | null;
+  /**
+   * Chi paga quando non c'è un brand. `sum_org_ai_cost_usd` sommava passando da `brands`, quindi
+   * una riga senza brand valeva zero per ogni organizzazione: il cancello sopra sarebbe passato
+   * per sempre. La riga la porta scritta addosso (`ai_calls.org_id`), e la somma la trova.
+   */
+  orgId?: string;
   /** Set when the caller already knows the plan. `undefined` = not resolved yet (look up). */
   plan?: string | null;
   /** Crediti kie letti dalle risposte HTTP di questo scope, in attesa della riga che li scrive. */
@@ -67,6 +74,15 @@ export function withBrandContext<T>(brandId: string, fn: () => T, plan?: string 
 }
 
 /**
+ * Lo stesso scope per un lavoro che un brand non ce l'ha: a pagare è l'organizzazione, e ogni riga
+ * scritta qui dentro la nomina. Senza, la spesa non atterra da nessuna parte — nessun brand da
+ * attribuire, e la somma dell'organizzazione passa dai brand.
+ */
+export function withOrgContext<T>(orgId: string, fn: () => T): T {
+  return brandStorage.run({ brandId: null, orgId }, fn);
+}
+
+/**
  * Crediti kie visti passare in questo scope, sommati. Il turno di chat passa dall'AI SDK, che
  * espone solo i token, quindi senza questa cassetta `provider_credits` è NULL per ogni turno:
  * `kieFetch` li deposita, `logAiCall` li ritira azzerando sulla prima riga kie che non ne ha.
@@ -105,14 +121,25 @@ export function takeLlmCost(): number | undefined {
   const cost = ctx?.llmCostUsd;
   if (!ctx || cost == null) return undefined;
   ctx.llmCostUsd = undefined;
-  ctx.billedUsd = (ctx.billedUsd ?? 0) + cost;
   return cost;
 }
 
 /**
- * Quanto il gateway ha fatturato in questo scope, gia` finito nelle righe di `ai_calls`. Serve a
- * una rotta che deve dire quanto e` costata: e` lo stesso numero della riga, non un listino
- * riscritto accanto. `undefined` significa che nessuna fattura e` arrivata — non zero.
+ * La fattura che sta finendo in `ai_calls`, resa leggibile a chi deve DIRE quanto è costato. Una
+ * riga sola la deposita — `logAiCall`, appena il prezzo è certo — perché due depositi per la stessa
+ * riga raddoppierebbero il conto senza che nessuna somma lo smentisca.
+ */
+function noteBilledUsd(usd: number): void {
+  const ctx = brandStorage.getStore();
+  if (!ctx || !Number.isFinite(usd) || usd < 0) return;
+  ctx.billedUsd = (ctx.billedUsd ?? 0) + usd;
+}
+
+/**
+ * Quanto è stato fatturato in questo scope, gia` finito nelle righe di `ai_calls`. Serve a una
+ * rotta che deve dire quanto e` costata: e` lo stesso numero della riga, non un listino riscritto
+ * accanto — che è la forma che aveva «about 8 credits each» nella descrizione di generate_image.
+ * `undefined` significa che nessuna fattura e` arrivata — non zero.
  */
 export function billedUsdInScope(): number | undefined {
   return brandStorage.getStore()?.billedUsd;
@@ -126,6 +153,11 @@ export function getBrandContext(): string | null {
   return brandStorage.getStore()?.brandId ?? null;
 }
 
+/** The org paying for the current scope when no brand does (null = there is a brand, or no scope). */
+export function getOrgContext(): string | null {
+  return brandStorage.getStore()?.orgId ?? null;
+}
+
 /** `undefined` = no brand context / not resolved yet. `null` = free tier. */
 export function getBrandPlanContext(): string | null | undefined {
   return brandStorage.getStore()?.plan;
@@ -134,7 +166,7 @@ export function getBrandPlanContext(): string | null | undefined {
 /** Stamp the active scope + cache once a brands row is loaded. */
 export function setBrandPlanContext(plan: string | null): void {
   const ctx = brandStorage.getStore();
-  if (ctx) {
+  if (ctx?.brandId) {
     ctx.plan = plan;
     rememberBrandPlan(ctx.brandId, plan);
   }
@@ -365,8 +397,16 @@ export function logAiCall(entry: AiCallLog): void {
       // davvero, il provider a monte e il markup, e vale per un modello che nessuno ha listato.
       if (billed != null) entry = { ...entry, flatCostUsd: billed };
     }
+    // La stessa fattura, lasciata leggibile a chi risponde. Solo su una riga RIUSCITA e prezzata
+    // dal fornitore: `computeCostUsd` scarta un flat cost su `ok: false`, e dire un costo che
+    // nessuna riga porta sarebbe il listino scritto a mano da un'altra parte.
+    if (entry.ok && entry.flatCostUsd != null) noteBilledUsd(entry.flatCostUsd);
+
     const admin = createAdminClient();
     const brandId = entry.brandId ?? getBrandContext();
+    // Un brand c'è: la somma dell'organizzazione lo raggiunge dal join, e scrivere anche l'org
+    // aprirebbe due risposte alla stessa domanda. Nessun brand: la riga se la porta scritta.
+    const orgId = brandId ? null : getOrgContext();
     const planFromAls = getBrandPlanContext();
     void (async () => {
       const plan =
@@ -396,6 +436,7 @@ export function logAiCall(entry: AiCallLog): void {
         service_tier: entry.serviceTier ?? null,
         // Fallback allo scope: attribuisce anche i chokepoint che non passano brandId. Esplicito vince.
         brand_id: brandId,
+        org_id: orgId,
         user_id: entry.userId ?? null,
         thread_id: entry.threadId ?? null,
         context: entry.context ?? null

--- a/src/lib/server/billing/anomalia-provider.ts
+++ b/src/lib/server/billing/anomalia-provider.ts
@@ -1,5 +1,5 @@
 import type { BillingProvider } from '$lib/billing/contract';
-import { creditQuota, gateCreditsCore, orgPlanForBrand } from '$lib/server/credits';
+import { creditQuota, gateCreditsCore, gateOrgCreditsCore, orgPlanForBrand } from '$lib/server/credits';
 import { isTopPlan, plansAbove, postQuota } from '$lib/server/plans';
 import { createAdminClient } from '$lib/server/supabase-admin';
 
@@ -9,7 +9,8 @@ import { createAdminClient } from '$lib/server/supabase-admin';
  * migrates is the frozen rollback copy — right often enough to hide the times it is stale. It
  * stays as the fallback so a failed lookup never shrinks a paying brand's quota.
  */
-async function planForQuota(ctx: { brandId: string; plan?: string | null }): Promise<string | null> {
+async function planForQuota(ctx: { brandId?: string; plan?: string | null }): Promise<string | null> {
+  if (!ctx.brandId) return ctx.plan ?? null;
   try {
     return (await orgPlanForBrand(createAdminClient(), ctx.brandId)) ?? ctx.plan ?? null;
   } catch {
@@ -21,9 +22,10 @@ export const anomaliaBillingProvider: BillingProvider = {
   kind: 'anomalia',
 
   async gate(kind, ctx) {
-    if (kind === 'credits') {
-      await gateCreditsCore(ctx.brandId);
-    }
+    if (kind !== 'credits') return;
+    // Il brand vince quando c'è: raggiunge la sua organizzazione da solo, e la cassa è la stessa.
+    if (ctx.brandId) return gateCreditsCore(ctx.brandId);
+    if (ctx.orgId) return gateOrgCreditsCore(ctx.orgId);
   },
 
   async quota(kind, ctx) {

--- a/src/lib/server/cli-auth.ts
+++ b/src/lib/server/cli-auth.ts
@@ -243,6 +243,36 @@ export async function gateAiAction(
   return undefined;
 }
 
+/**
+ * Lo stesso cancello per un'azione che un brand non ce l'ha: paga l'organizzazione, e senza questo
+ * la strada nuova sarebbe l'unica del prodotto a spendere senza controllare il saldo.
+ */
+export async function gateOrgAiAction(
+  orgId: string,
+  apiKey: ApiKeyInfo | undefined
+): Promise<Response | undefined> {
+  const write = checkApiKeyWriteAccess(apiKey);
+  if (write) return write;
+
+  const { gateOrgCredits, CreditsExhaustedError } = await import('./credits');
+  try {
+    await gateOrgCredits(orgId);
+  } catch (e) {
+    if (e instanceof CreditsExhaustedError) return json({ error: 'credits_exhausted' }, { status: 402 });
+    throw e;
+  }
+  return undefined;
+}
+
+/**
+ * Una chiave che vale solo per certi brand. Dove un brand si nomina, `checkApiKeyBrandAccess` la
+ * confronta con quello; dove NON si nomina non c'è niente da confrontare, e lasciarla passare
+ * allargherebbe in silenzio una restrizione che l'utente ha scelto.
+ */
+export function apiKeyIsBrandScoped(apiKey: ApiKeyInfo | undefined): boolean {
+  return !!apiKey && apiKey.permissions.brand_ids !== '*';
+}
+
 /** The columns loadBrandForUser selects — typed, so callers don't get `unknown` everywhere. */
 export type CliBrand = {
   id: string;

--- a/src/lib/server/content-preview.ts
+++ b/src/lib/server/content-preview.ts
@@ -43,6 +43,7 @@ export {
   isProduceApproved,
   loadBrandLogoImagePart,
   loadBrandMoodImageUrls,
+  loadBrandVisualContext,
   loadCompetitorThumbUrls,
   loadPlannerMarketSignals,
   markProduceApproved,
@@ -51,7 +52,7 @@ export {
   scrubPersonAppearance,
   uploadPostImage
 } from './content-preview/images';
-export type { AspectRatio, RenderImageOpts } from './content-preview/images';
+export type { AspectRatio, BrandVisualContext, RenderImageOpts } from './content-preview/images';
 
 export {
   editArticleImage,

--- a/src/lib/server/content-preview/gate-without-brand.test.ts
+++ b/src/lib/server/content-preview/gate-without-brand.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * IL TEST CHE GUARDA DUE BUCHI, E SOLO UNO SI VEDE DA QUI.
+ *
+ * `renderPostImage` è il chokepoint: le immagini sono ~66% della spesa AI, e la quota si applica
+ * QUI perché un loop in un flusso qualunque si fermi invece di bruciare per giorni. Il gate però
+ * passava da `getBrandContext()`, e senza brand context non c'era gate — quindi togliere lo slug
+ * alla lettera avrebbe lasciato il punto più caro del prodotto senza controllo dei crediti.
+ *
+ * Il secondo buco è SQL e da qui non si vede: `sum_org_ai_cost_usd` faceva `join brands`, quindi
+ * una riga con `brand_id` nullo valeva zero per ogni organizzazione — il cancello sarebbe passato
+ * per sempre e quelle generazioni sarebbero state gratis in permanenza, con la suite verde perché
+ * il database finto non somma niente. Lo chiude la migration `20260905100000_ai_calls_org_id`
+ * (left join + coalesce), e va applicata PRIMA di questo codice: qui i deploy non eseguono le
+ * migration.
+ */
+
+const gateCredits = vi.fn();
+const gateOrgCredits = vi.fn();
+const generateImageOnOpenrouter = vi.fn();
+
+vi.mock('$lib/server/wall-digest', () => ({
+  designWallDigestSection: () => Promise.resolve('')
+}));
+
+vi.mock('$lib/server/credits', () => ({
+  gateCredits: (...args: unknown[]) => gateCredits(...args),
+  gateOrgCredits: (...args: unknown[]) => gateOrgCredits(...args)
+}));
+
+vi.mock('$lib/server/openrouter-image', () => ({
+  generateImageOnOpenrouter: (...args: unknown[]) => generateImageOnOpenrouter(...args)
+}));
+
+vi.mock('$lib/server/model-routing', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('$lib/server/model-routing')>()),
+  route: () => ({ endpoint: 'openrouter' })
+}));
+
+const { renderPostImage } = await import('./images');
+const { withBrandContext, withOrgContext } = await import('$lib/server/ai-log');
+
+const RENDERED = 'data:image/png;base64,AAAA';
+
+class Exhausted extends Error {
+  name = 'CreditsExhaustedError';
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  generateImageOnOpenrouter.mockResolvedValue(RENDERED);
+});
+
+describe('il cancello dei crediti senza un brand', () => {
+  it('chiede all organizzazione, che è chi paga quando nessun brand paga', async () => {
+    await withOrgContext('org-1', () => renderPostImage(null as never, 'un gatto', {}));
+
+    expect(gateOrgCredits).toHaveBeenCalledWith('org-1');
+    expect(gateCredits).not.toHaveBeenCalled();
+  });
+
+  it('senza crediti non disegna, e il render non parte nemmeno', async () => {
+    gateOrgCredits.mockRejectedValue(new Exhausted('AI credits exhausted for this billing period'));
+
+    await expect(
+      withOrgContext('org-1', () => renderPostImage(null as never, 'un gatto', {}))
+    ).rejects.toThrow(/exhausted/);
+
+    expect(generateImageOnOpenrouter).not.toHaveBeenCalled();
+  });
+
+  it('con un brand resta il cancello di sempre, senza passare dall organizzazione', async () => {
+    await withBrandContext('brand-1', () => renderPostImage(null as never, 'un banco in noce', {}));
+
+    expect(gateCredits).toHaveBeenCalledWith('brand-1');
+    expect(gateOrgCredits).not.toHaveBeenCalled();
+  });
+
+  it('un brand senza crediti continua a fermarsi prima del render', async () => {
+    gateCredits.mockRejectedValue(new Exhausted('AI credits exhausted for this billing period'));
+
+    await expect(
+      withBrandContext('brand-1', () => renderPostImage(null as never, 'x', {}))
+    ).rejects.toThrow(/exhausted/);
+
+    expect(generateImageOnOpenrouter).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/server/content-preview/images.ts
+++ b/src/lib/server/content-preview/images.ts
@@ -649,6 +649,47 @@ export async function loadMoodRefs(urls: string[] | undefined): Promise<ImagePar
   return parts.length ? parts : undefined;
 }
 
+export type BrandVisualContext = Pick<
+  RenderImageOpts,
+  'visualStyle' | 'visualPlaybook' | 'brandLook' | 'logoImage' | 'moodImages'
+>;
+
+export async function loadBrandVisualContext(
+  supabase: SupabaseClient,
+  brandId: string
+): Promise<BrandVisualContext> {
+  const { data: kit } = await supabase
+    .from('brand_kit')
+    .select('visual_style, ai_context, brand_colors, fonts, logos')
+    .eq('brand_id', brandId)
+    .maybeSingle();
+
+  const fonts = (Array.isArray(kit?.fonts) ? (kit.fonts as AnyRec[]) : [])
+    .map((f) => f?.name)
+    .filter(Boolean) as string[];
+
+  const [logoImage, moodImages] = await Promise.all([
+    loadBrandLogoImagePart(kit?.logos).catch((error) => {
+      swallow('load brand logo part', error);
+      return null;
+    }),
+    loadBrandMoodImageUrls(supabase, brandId)
+      .then(loadMoodRefs)
+      .catch((error) => {
+        swallow('load mood image urls', error);
+        return undefined;
+      })
+  ]);
+
+  return {
+    visualStyle: (kit?.visual_style as string | null) || undefined,
+    visualPlaybook: extractVisualPlaybook(kit?.ai_context) || undefined,
+    brandLook: brandVisualDirective(kit?.brand_colors as string[] | null, fonts) || undefined,
+    logoImage: logoImage ?? undefined,
+    moodImages
+  };
+}
+
 // Larghezza fissa a 1080, altezza calcolata.
 const ASPECT_TARGETS: Record<AspectRatio, { w: number; h: number }> = {
   '1:1':  { w: 1080, h: 1080 },

--- a/src/lib/server/content-preview/images.ts
+++ b/src/lib/server/content-preview/images.ts
@@ -6,7 +6,7 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 import sharp from 'sharp';
 import { env } from '$env/dynamic/private';
 import { fetchImagePart } from '$lib/server/brand-context';
-import { getBrandContext } from '$lib/server/ai-log';
+import { getBrandContext, getOrgContext } from '$lib/server/ai-log';
 import { NANO_BANANA_2_LITE } from '$lib/server/gemini';
 import { GEMINI_NANO_BANANA_2, googleImageModel } from '$lib/image-models';
 import { structured } from '$lib/server/research';
@@ -235,11 +235,16 @@ export async function renderPostImage(
 ): Promise<string | undefined> {
   // Le immagini sono ~66% della spesa AI, quindi la quota si applica QUI, al chokepoint: un loop
   // in un flusso qualunque si ferma alla quota invece di bruciare per giorni. L'import dinamico
-  // evita il ciclo di moduli crediti↔scheduler↔qui. Senza brand context non c'è gate.
+  // evita il ciclo di moduli crediti↔scheduler↔qui.
+  //
+  // Chi paga ha DUE forme, e leggerne una sola lasciava il punto più caro del prodotto senza
+  // controllo appena il brand smetteva di essere obbligatorio. Nessuna delle due — un flusso
+  // pre-brand come l'analisi del sito in onboarding — resta senza cancello com'era.
   const gateBrand = getBrandContext();
-  if (gateBrand) {
-    const { gateCredits } = await import('$lib/server/credits');
-    await gateCredits(gateBrand);
+  const gateOrg = getOrgContext();
+  if (gateBrand || gateOrg) {
+    const { gateCredits, gateOrgCredits } = await import('$lib/server/credits');
+    await (gateBrand ? gateCredits(gateBrand) : gateOrgCredits(gateOrg as string));
   }
   const req = buildImageRequest(imagePrompt, opts);
   const imageModel = req.model;

--- a/src/lib/server/credits.ts
+++ b/src/lib/server/credits.ts
@@ -175,6 +175,14 @@ async function readOrgBilling(
   const orgId = (brand as { org_id?: string } | null)?.org_id;
   if (!orgId) return null;
 
+  return readOrgBillingById(supabase, orgId);
+}
+
+/** The same reading for a caller that already holds the org and has no brand to reach it through. */
+export async function readOrgBillingById(
+  supabase: SupabaseClient,
+  orgId: string
+): Promise<OrgBilling | null> {
   const { data } = await supabase
     .from('organizations')
     .select(
@@ -249,9 +257,21 @@ export async function getCreditsUsage(
   // alone, exactly as before org-level billing. Never leave a caller without a budget.
   if (!org) return brandCreditsUsage(supabase, brand);
 
+  return orgCreditsUsage(supabase, org, brand.activated_at);
+}
+
+/**
+ * The pool as the org sees it. Split out of getCreditsUsage unchanged: a brand-free render has
+ * no brand row to carry an anchor, and everything below the org already ignored the brand.
+ */
+export async function orgCreditsUsage(
+  supabase: SupabaseClient,
+  org: OrgBilling,
+  activatedAtFallback: string | null = null
+): Promise<CreditsUsage> {
   const periodStart = await fetchOrgPeriodStart(supabase, org);
   const { start, end } = currentBillingPeriod(
-    { activated_at: org.activatedAt ?? brand.activated_at },
+    { activated_at: org.activatedAt ?? activatedAtFallback },
     periodStart
   );
   const planQuota = creditQuota(org.plan);

--- a/src/lib/server/credits.ts
+++ b/src/lib/server/credits.ts
@@ -462,12 +462,55 @@ export async function gateCredits(brandId: string): Promise<void> {
 }
 
 /**
+ * Lo stesso cancello per un lavoro senza brand: il pagante è l'organizzazione, e passa dallo stesso
+ * provider — un fork self-hosted, che di fatturazione non ne ha, non deve trovarsi contato proprio
+ * su questa strada perché è nuova.
+ */
+export async function gateOrgCredits(orgId: string): Promise<void> {
+  const { billingProvider } = await import('./billing');
+  const provider = await billingProvider();
+  await provider.gate('credits', { orgId });
+}
+
+/**
  * Both fail-open paths below give up on the same thing — evaluating the ledger — and both let the
  * action through on purpose: a transient Supabase error must not block a paying customer. Neither
  * may do it silently. Unmetered AI nobody is told about is exactly how a week of it went unnoticed.
  */
 function reportFailOpen(brandId: string, err: unknown): void {
   swallow(`credits: allowed brand ${brandId} without evaluating its ledger`, err);
+}
+
+/**
+ * L'applicazione vera per chi il brand non ce l'ha. Stessa cassa e stessa chiave di `gateCredits`
+ * — che risolve l'organizzazione e poi mette in cache SU DI ESSA — quindi una generazione senza
+ * brand e una con lo stesso brand leggono la stessa riga invece di pagarsi due copie dello stesso
+ * conto. Non per uso diretto: si chiama `gateOrgCredits`.
+ */
+export async function gateOrgCreditsCore(orgId: string): Promise<void> {
+  const { isCreditExempt } = await import('./ai-log');
+  if (isCreditExempt()) return;
+
+  // Fuori dal try di proposito: un rifiuto qui è il cancello che fa il suo mestiere, e non deve
+  // finire nel catch che lascia passare.
+  const hit = gateCache.get(orgId);
+  if (hit && Date.now() - hit.at < GATE_TTL_MS) {
+    assertCreditsAvailable(hit.usage);
+    return;
+  }
+
+  let usage: CreditsUsage;
+  try {
+    const admin = createAdminClient();
+    const org = await readOrgBillingById(admin, orgId);
+    if (!org) return;
+    usage = await orgCreditsUsage(admin, org);
+    gateCache.set(orgId, { usage, at: Date.now() });
+  } catch (e) {
+    reportFailOpen(orgId, e);
+    return;
+  }
+  assertCreditsAvailable(usage);
 }
 
 /**

--- a/src/lib/server/media-generate.brand-style.test.ts
+++ b/src/lib/server/media-generate.brand-style.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const renderPostImage = vi.fn();
+const loadBrandVisualContext = vi.fn();
+const insertBrandMedia = vi.fn();
+const storeBrandMediaBytes = vi.fn();
+
+const PNG_DATA_URL = 'data:image/png;base64,AAAA';
+
+const VISUAL_STYLE = 'monochrome editorial, hard light';
+const BRAND_LOOK = 'BRAND IDENTITY — Colour palette: #0f0f0f';
+const PLAYBOOK = 'WHAT WORKS VISUALLY: close crops';
+const LOGO = { inlineData: { mimeType: 'image/png', data: 'LOGO' } };
+
+vi.mock('$lib/server/content-preview', () => ({
+  renderPostImage: (...args: unknown[]) => renderPostImage(...args),
+  buildImageRequest: (_prompt: string, opts: { model?: string }) => ({ model: opts.model ?? null }),
+  loadBrandVisualContext: (...args: unknown[]) => loadBrandVisualContext(...args)
+}));
+vi.mock('$lib/server/brand-media', () => ({
+  loadLibraryMediaParts: async () => [],
+  insertBrandMedia: (...args: unknown[]) => insertBrandMedia(...args),
+  storeBrandMediaBytes: (...args: unknown[]) => storeBrandMediaBytes(...args),
+  probeImageDimensions: async () => ({ width: 1080, height: 1080 })
+}));
+vi.mock('$lib/server/content-credentials', () => ({
+  markImage: async (bytes: Buffer) => bytes,
+  DIGITAL_SOURCE_TYPE: { synthetic: 'trainedAlgorithmicMedia' }
+}));
+vi.mock('$lib/server/ai-log', () => ({
+  withBrandContext: <T>(_brandId: string, fn: () => T) => fn(),
+  billedUsdInScope: () => null
+}));
+
+import { generateBrandImages } from './media-generate';
+
+const supabase = {
+  from: () => ({
+    select: () => ({
+      eq: () => ({ maybeSingle: async () => ({ data: { content_prefs: {} }, error: null }) })
+    })
+  })
+} as never;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  renderPostImage.mockResolvedValue(PNG_DATA_URL);
+  storeBrandMediaBytes.mockResolvedValue({});
+  insertBrandMedia.mockResolvedValue({ row: { id: 'media-new', kind: 'image' } });
+  loadBrandVisualContext.mockResolvedValue({
+    visualStyle: VISUAL_STYLE,
+    brandLook: BRAND_LOOK,
+    visualPlaybook: PLAYBOOK,
+    logoImage: LOGO
+  });
+});
+
+describe('lo stile del brand nella richiesta di render', () => {
+  it('con un brand, il suo aspetto arriva al renderer', async () => {
+    await generateBrandImages(supabase, {
+      brandId: 'brand-1',
+      userId: 'user-1',
+      prompt: 'un gatto'
+    });
+
+    expect(loadBrandVisualContext).toHaveBeenCalledWith(expect.anything(), 'brand-1');
+
+    const opts = renderPostImage.mock.calls[0][2];
+    expect(opts.visualStyle).toBe(VISUAL_STYLE);
+    expect(opts.brandLook).toBe(BRAND_LOOK);
+    expect(opts.visualPlaybook).toBe(PLAYBOOK);
+    expect(opts.logoImage).toEqual(LOGO);
+  });
+
+  it('brandStyle ignore lo tiene fuori, e il brand non viene nemmeno letto', async () => {
+    await generateBrandImages(supabase, {
+      brandId: 'brand-1',
+      userId: 'user-1',
+      prompt: 'un gatto',
+      brandStyle: 'ignore'
+    });
+
+    expect(loadBrandVisualContext).not.toHaveBeenCalled();
+
+    const opts = renderPostImage.mock.calls[0][2];
+    expect(opts.visualStyle).toBeUndefined();
+    expect(opts.brandLook).toBeUndefined();
+    expect(opts.visualPlaybook).toBeUndefined();
+    expect(opts.logoImage).toBeUndefined();
+  });
+
+  it('un brand senza kit non inventa un aspetto', async () => {
+    loadBrandVisualContext.mockResolvedValue({});
+
+    await generateBrandImages(supabase, {
+      brandId: 'brand-1',
+      userId: 'user-1',
+      prompt: 'un gatto'
+    });
+
+    const opts = renderPostImage.mock.calls[0][2];
+    expect(opts.visualStyle).toBeUndefined();
+    expect(opts.brandLook).toBeUndefined();
+  });
+});

--- a/src/lib/server/media-generate.refine.test.ts
+++ b/src/lib/server/media-generate.refine.test.ts
@@ -44,6 +44,7 @@ vi.mock('$lib/server/content-credentials', () => ({
   DIGITAL_SOURCE_TYPE: { synthetic: 'trainedAlgorithmicMedia' }
 }));
 vi.mock('$lib/server/ai-log', () => ({
+  billedUsdInScope: () => undefined,
   withBrandContext: <T>(_brandId: string, fn: () => T) => fn()
 }));
 

--- a/src/lib/server/media-generate.refine.test.ts
+++ b/src/lib/server/media-generate.refine.test.ts
@@ -28,7 +28,8 @@ vi.mock('$lib/server/content-preview', () => ({
   renderPostImage: (...args: unknown[]) => renderPostImage(...args),
   buildImageRequest: (_prompt: string, opts: { baseImage?: unknown; refineModel?: string; model?: string }) => ({
     model: (opts.baseImage ? opts.refineModel : undefined) ?? opts.model ?? null
-  })
+  }),
+  loadBrandVisualContext: async () => ({})
 }));
 vi.mock('$lib/server/brand-media', () => ({
   loadLibraryMediaParts: (...args: unknown[]) => loadLibraryMediaParts(...args),

--- a/src/lib/server/media-generate.ts
+++ b/src/lib/server/media-generate.ts
@@ -422,6 +422,19 @@ function videoAspect(ratio?: AspectRatio) {
   return VIDEO_ASPECTS.find((a) => a === ratio);
 }
 
+async function brandVisualStyle(
+  admin: SupabaseClient,
+  brandId: string
+): Promise<string | undefined> {
+  const { data } = await admin
+    .from('brand_kit')
+    .select('visual_style')
+    .eq('brand_id', brandId)
+    .maybeSingle();
+
+  return (data?.visual_style as string | null) || undefined;
+}
+
 async function startVideo(opts: GenerateMediaOpts): Promise<GenerateMediaResult> {
   const [{ createAdminClient }, { countOutstandingVideoRenders, submitAndTrackVideoRender }] =
     await Promise.all([
@@ -436,6 +449,8 @@ async function startVideo(opts: GenerateMediaOpts): Promise<GenerateMediaResult>
     .eq('id', opts.brandId)
     .maybeSingle();
   const prefs = (brand?.content_prefs ?? {}) as Record<string, string | number | null>;
+
+  const visualStyle = await brandVisualStyle(admin, opts.brandId);
 
   // Animare una foto e filmare da un prompt sono due MESTIERI, e il catalogo lo sa gia': lo slot
   // cambia, quindi cambia anche l'elenco dei modelli ammessi. Sceglierne uno solo accetterebbe un
@@ -514,6 +529,7 @@ async function startVideo(opts: GenerateMediaOpts): Promise<GenerateMediaResult>
       // e il prompt dirige il MOVIMENTO.
       imageUrl: coverUrl,
       duration: opts.durationSeconds ?? (prefs.videoDuration as number | undefined),
+      visualStyle,
       instructions: prefs.videoInstructions as string | null | undefined,
       resolution: prefs.videoResolution as string | null | undefined,
       model:

--- a/src/lib/server/media-generate.ts
+++ b/src/lib/server/media-generate.ts
@@ -20,18 +20,27 @@
  */
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { insertBrandMedia, storeBrandMediaBytes, probeImageDimensions } from '$lib/server/brand-media';
+import { signKnowledgePaths } from '$lib/server/media-archive';
 import { mediaUrl } from '$lib/media-url';
 import { safeProviderReason } from '$lib/server/provider-reason';
 import { markImage, DIGITAL_SOURCE_TYPE } from '$lib/server/content-credentials';
 import type { AspectRatio } from '$lib/server/content-preview';
 
 export type GeneratedMedia = {
-  id: string;
+  /**
+   * `null` quando il disegno non è entrato in nessuna libreria: senza brand non c'è una riga in
+   * `brand_media` da nominare — e non è una svista. Le policy di quella tabella dicono
+   * `brand_id in (select auth_brand_ids())`, e `NULL in (…)` vale NULL, non true: una riga senza
+   * brand sarebbe invisibile a tutti, non visibile a tutti.
+   */
+  id: string | null;
   kind: string;
   mime: string | null;
   width: number | null;
   height: number | null;
   url: string | null;
+  /** Dov'è il file. Presente solo sul disegno senza brand, la cui `url` è una firma che scade. */
+  storage_path?: string;
 };
 
 export type GenerateMediaOpts = {
@@ -138,7 +147,8 @@ type StoredDrawing = {
 
 /**
  * I byte nel bucket privato, e nient'altro: né una riga, né un id. Il primo segmento del percorso
- * è ciò che le policy dello storage guardano, quindi è sempre lo user.
+ * è ciò che le policy dello storage guardano, quindi è sempre lo user — con o senza un brand
+ * sotto, il file resta suo.
  */
 async function storeDrawing(
   supabase: SupabaseClient,
@@ -169,7 +179,7 @@ async function storeDrawing(
  */
 async function depositImage(
   supabase: SupabaseClient,
-  opts: Pick<GenerateMediaOpts, 'brandId' | 'userId' | 'prompt' | 'title'>,
+  opts: { brandId: string; userId: string; prompt: string; title?: string },
   dataUrl: string
 ): Promise<GeneratedMedia | null> {
   const drawn = await storeDrawing(supabase, `${opts.userId}/${opts.brandId}/media`, dataUrl);
@@ -200,13 +210,41 @@ async function depositImage(
 }
 
 /**
+ * Il disegno chiesto senza un brand si CONSEGNA, non si archivia. Nessuna riga in `brand_media`:
+ * le sue policy dicono `brand_id in (select auth_brand_ids())`, e `NULL in (…)` vale NULL, non
+ * true — una riga senza brand sarebbe invisibile a tutti e nemmeno inseribile. Quindi torna quello
+ * che c'è davvero: il percorso, e una firma che scade.
+ */
+async function handOverImage(
+  supabase: SupabaseClient,
+  opts: { userId: string },
+  dataUrl: string
+): Promise<GeneratedMedia | null> {
+  const drawn = await storeDrawing(supabase, `${opts.userId}/media`, dataUrl);
+  if (!drawn) return null;
+
+  const signed = await signKnowledgePaths(supabase, [drawn.storagePath]);
+
+  return {
+    id: null,
+    kind: 'image',
+    mime: drawn.mime,
+    width: drawn.width,
+    height: drawn.height,
+    url: signed.get(drawn.storagePath) ?? null,
+    storage_path: drawn.storagePath
+  };
+}
+
+/**
  * UNA SOLA funzione per disegnare e per modificare, perché il motore è lo stesso: `baseImage` è
  * l'unico segnale che `buildImageRequest` guarda per distinguere una modifica da un disegno nuovo.
  * I tool esposti restano due — generare e rifinire sono due operazioni diverse per chi chiama, e
  * vogliono argomenti diversi — ma qui sotto sarebbero due copie della stessa cosa.
  */
 export type ImageJob = {
-  brandId: string;
+  /** `null` = disegno estemporaneo: nessun brand da leggere, nessuna libreria in cui archiviare. */
+  brandId: string | null;
   userId: string;
   /** Cosa mostrare, oppure — con `baseMediaId` — cosa cambiare. */
   prompt: string;
@@ -220,9 +258,33 @@ export type ImageJob = {
 };
 
 export type ImageJobResult =
-  | { ok: true; media: GeneratedMedia[]; model: string | null; renders: number }
+  | {
+      ok: true;
+      media: GeneratedMedia[];
+      model: string | null;
+      renders: number;
+      /**
+       * Quanto è stato FATTURATO per questi render, letto dalle righe di `ai_calls` mentre lo
+       * scope è ancora aperto. `null` quando nessuna fattura è arrivata — mai `0`, che sarebbe di
+       * nuovo un numero comodo al posto di un fatto.
+       */
+      costUsd: number | null;
+    }
   | { ok: false; error: 'render_failed' | 'store_failed' | 'source_not_found' }
   | { ok: false; error: 'model_not_for_slot'; allowed: string[] };
+
+async function brandContentPrefs(
+  supabase: SupabaseClient,
+  brandId: string
+): Promise<Record<string, unknown>> {
+  const { data } = await supabase
+    .from('brands')
+    .select('content_prefs')
+    .eq('id', brandId)
+    .maybeSingle();
+
+  return (data?.content_prefs ?? {}) as Record<string, unknown>;
+}
 
 async function runImageJob(
   supabase: SupabaseClient,
@@ -249,17 +311,15 @@ async function runImageJob(
     return { ok: false, error: 'model_not_for_slot', allowed: slotChoices(slot).map((c) => c.id) };
   }
 
-  const { data: brand } = await supabase
-    .from('brands')
-    .select('content_prefs')
-    .eq('id', job.brandId)
-    .maybeSingle();
-  const prefs = (brand?.content_prefs ?? {}) as Record<string, unknown>;
+  // Senza brand non c'è niente da leggere: valgono i default del prodotto. Andarci lo stesso
+  // sarebbe l'ancora rimasta attaccata — un `.eq('id', null)` che non trova nulla e intanto
+  // racconta che questo percorso un brand ce l'ha ancora.
+  const prefs = job.brandId ? await brandContentPrefs(supabase, job.brandId) : {};
 
   // `loadLibraryMediaParts` filtra per brand_id: l'id di un altro inquilino non risolve nulla, e
   // il confine resta nella query invece che in un controllo che qualcuno dimenticherà.
   let baseImage: { inlineData: { mimeType: string; data: string } } | undefined;
-  if (job.baseMediaId) {
+  if (job.baseMediaId && job.brandId) {
     const source = await resolveLibraryId(supabase, job.brandId, job.baseMediaId);
     if (!source) return { ok: false, error: 'source_not_found' };
 
@@ -289,31 +349,50 @@ async function runImageJob(
     const dataUrl = await renderPostImage(null as never, job.prompt, opts).catch(() => undefined);
     if (!dataUrl) break;
 
-    const deposited = await depositImage(supabase, job, dataUrl);
-    if (!deposited) return { ok: false, error: 'store_failed' };
+    const filed = job.brandId
+      ? await depositImage(supabase, { ...job, brandId: job.brandId }, dataUrl)
+      : await handOverImage(supabase, job, dataUrl);
+    if (!filed) return { ok: false, error: 'store_failed' };
 
-    media.push(deposited);
+    media.push(filed);
   }
 
   // Nessuna alternativa prodotta è un fallimento, non un successo vuoto: chi legge `ok` deve poter
   // credere che qualcosa esista.
   if (!media.length) return { ok: false, error: 'render_failed' };
 
-  return { ok: true, media, model: chosen, renders };
+  // Si legge QUI, dentro lo scope: la fattura vive lì e fuori non esiste più.
+  const { billedUsdInScope } = await import('$lib/server/ai-log');
+
+  return { ok: true, media, model: chosen, renders, costUsd: billedUsdInScope() ?? null };
 }
 
 export async function generateBrandImages(
   supabase: SupabaseClient,
-  job: Omit<ImageJob, 'baseMediaId'>
+  job: Omit<ImageJob, 'baseMediaId'> & { brandId: string }
 ): Promise<ImageJobResult> {
   const { withBrandContext } = await import('$lib/server/ai-log');
 
   return withBrandContext(job.brandId, () => runImageJob(supabase, job));
 }
 
+/**
+ * Il disegno estemporaneo: nessuno slug, nessun brand, niente da scegliere. Paga
+ * l'organizzazione, che lo scope nomina — senza, la riga in `ai_calls` non atterrerebbe da nessuna
+ * parte e il cancello dei crediti sopra passerebbe per sempre.
+ */
+export async function generateImagesWithoutBrand(
+  supabase: SupabaseClient,
+  job: Omit<ImageJob, 'baseMediaId' | 'brandId' | 'title'> & { orgId: string }
+): Promise<ImageJobResult> {
+  const { withOrgContext } = await import('$lib/server/ai-log');
+
+  return withOrgContext(job.orgId, () => runImageJob(supabase, { ...job, brandId: null }));
+}
+
 export async function refineBrandImage(
   supabase: SupabaseClient,
-  job: ImageJob & { baseMediaId: string }
+  job: ImageJob & { brandId: string; baseMediaId: string }
 ): Promise<ImageJobResult> {
   const { withBrandContext } = await import('$lib/server/ai-log');
 

--- a/src/lib/server/media-generate.ts
+++ b/src/lib/server/media-generate.ts
@@ -223,7 +223,11 @@ async function handOverImage(
   const drawn = await storeDrawing(supabase, `${opts.userId}/media`, dataUrl);
   if (!drawn) return null;
 
+  // Senza un id, la firma è l'UNICO modo di raggiungere il file: consegnarla nulla lascerebbe chi
+  // legge `ok` con un render pagato e niente da aprire.
   const signed = await signKnowledgePaths(supabase, [drawn.storagePath]);
+  const url = signed.get(drawn.storagePath);
+  if (!url) return null;
 
   return {
     id: null,
@@ -231,7 +235,7 @@ async function handOverImage(
     mime: drawn.mime,
     width: drawn.width,
     height: drawn.height,
-    url: signed.get(drawn.storagePath) ?? null,
+    url,
     storage_path: drawn.storagePath
   };
 }

--- a/src/lib/server/media-generate.ts
+++ b/src/lib/server/media-generate.ts
@@ -127,6 +127,42 @@ function dataUrlBytes(dataUrl: string): { bytes: Buffer; mime: string } | null {
   return { bytes: Buffer.from(base64, 'base64'), mime: head?.match(/data:([^;]+)/)?.[1] ?? IMAGE_MIME };
 }
 
+type StoredDrawing = {
+  storagePath: string;
+  fileName: string;
+  mime: string;
+  bytes: number;
+  width: number | null;
+  height: number | null;
+};
+
+/**
+ * I byte nel bucket privato, e nient'altro: né una riga, né un id. Il primo segmento del percorso
+ * è ciò che le policy dello storage guardano, quindi è sempre lo user.
+ */
+async function storeDrawing(
+  supabase: SupabaseClient,
+  folder: string,
+  dataUrl: string
+): Promise<StoredDrawing | null> {
+  const decoded = dataUrlBytes(dataUrl);
+  if (!decoded) return null;
+
+  // Marcata sintetica prima di toccare lo storage: un'immagine di modello che gira senza la sua
+  // provenienza è un problema che non si ripara a valle.
+  const bytes = await markImage(decoded.bytes, decoded.mime, DIGITAL_SOURCE_TYPE.synthetic);
+  const ext = decoded.mime.includes('jpeg') ? 'jpg' : decoded.mime.includes('webp') ? 'webp' : 'png';
+  const fileName = `generated-${crypto.randomUUID()}.${ext}`;
+  const storagePath = `${folder}/${fileName}`;
+
+  const stored = await storeBrandMediaBytes(supabase, storagePath, bytes, decoded.mime);
+  if (stored.error) return null;
+
+  const { width, height } = await probeImageDimensions(bytes);
+
+  return { storagePath, fileName, mime: decoded.mime, bytes: bytes.length, width, height };
+}
+
 /**
  * Un'immagine generata finisce nel bucket privato della libreria, non fra i media pubblici dei
  * post: è materiale del brand, riutilizzabile, e nessuno deve poterla leggere senza una firma.
@@ -136,29 +172,18 @@ async function depositImage(
   opts: Pick<GenerateMediaOpts, 'brandId' | 'userId' | 'prompt' | 'title'>,
   dataUrl: string
 ): Promise<GeneratedMedia | null> {
-  const decoded = dataUrlBytes(dataUrl);
-  if (!decoded) return null;
+  const drawn = await storeDrawing(supabase, `${opts.userId}/${opts.brandId}/media`, dataUrl);
+  if (!drawn) return null;
 
-  // Marcata sintetica prima di toccare lo storage: un'immagine di modello che gira senza la sua
-  // provenienza è un problema che non si ripara a valle.
-  const bytes = await markImage(decoded.bytes, decoded.mime, DIGITAL_SOURCE_TYPE.synthetic);
-  const ext = decoded.mime.includes('jpeg') ? 'jpg' : decoded.mime.includes('webp') ? 'webp' : 'png';
-  const fileName = `generated-${crypto.randomUUID()}.${ext}`;
-  const storagePath = `${opts.userId}/${opts.brandId}/media/${fileName}`;
-
-  const stored = await storeBrandMediaBytes(supabase, storagePath, bytes, decoded.mime);
-  if (stored.error) return null;
-
-  const { width, height } = await probeImageDimensions(bytes);
   const { row } = await insertBrandMedia(supabase, {
     brandId: opts.brandId,
     userId: opts.userId,
-    storagePath,
-    fileName,
-    mime: decoded.mime,
-    bytes: bytes.length,
-    width,
-    height,
+    storagePath: drawn.storagePath,
+    fileName: drawn.fileName,
+    mime: drawn.mime,
+    bytes: drawn.bytes,
+    width: drawn.width,
+    height: drawn.height,
     source: 'generate',
     title: opts.title?.trim() || opts.prompt.slice(0, 80)
   });
@@ -167,9 +192,9 @@ async function depositImage(
   return {
     id: row.id,
     kind: row.kind,
-    mime: decoded.mime,
-    width,
-    height,
+    mime: drawn.mime,
+    width: drawn.width,
+    height: drawn.height,
     url: mediaUrl(row.short_code)
   };
 }

--- a/src/lib/server/media-generate.ts
+++ b/src/lib/server/media-generate.ts
@@ -259,7 +259,10 @@ export type ImageJob = {
   model?: string;
   /** L'immagine della libreria da cui partire. Presente → è una modifica. */
   baseMediaId?: string;
+  brandStyle?: BrandStyleUse;
 };
+
+export type BrandStyleUse = 'apply' | 'ignore';
 
 export type ImageJobResult =
   | {
@@ -295,7 +298,7 @@ async function runImageJob(
   job: ImageJob
 ): Promise<ImageJobResult> {
   const [
-    { renderPostImage, buildImageRequest },
+    { renderPostImage, buildImageRequest, loadBrandVisualContext },
     { imageModelFor, imageRefineModelFor },
     { mediaModelSlot, slotAccepts, slotChoices },
     { loadLibraryMediaParts }
@@ -332,7 +335,13 @@ async function runImageJob(
     baseImage = parts[0];
   }
 
+  const brandVisuals =
+    job.brandId && job.brandStyle !== 'ignore'
+      ? await loadBrandVisualContext(supabase, job.brandId)
+      : {};
+
   const opts = {
+    ...brandVisuals,
     model: refining ? imageModelFor(prefs) : (job.model ?? imageModelFor(prefs)),
     refineModel: refining ? (job.model ?? imageRefineModelFor(prefs)) : imageRefineModelFor(prefs),
     baseImage,

--- a/src/lib/server/media-generate.video.test.ts
+++ b/src/lib/server/media-generate.video.test.ts
@@ -27,6 +27,7 @@ vi.mock('$lib/server/ai-log', () => ({ withBrandContext: <T>(_b: string, fn: () 
 
 const FULL_ID = '11111111-2222-3333-4444-555555555555';
 const COVER = 'https://signed.test/gatto-bianco.png';
+const VISUAL_STYLE = 'monochrome editorial, hard light';
 
 let mediaRows: Array<{ id: string; kind: string }> = [];
 
@@ -41,7 +42,9 @@ const admin = {
                 data:
                   table === 'brands'
                     ? { plan: 'pro', timezone: 'Europe/Rome', content_prefs: {} }
-                    : { id: 'job-1' },
+                    : table === 'brand_kit'
+                      ? { visual_style: VISUAL_STYLE }
+                      : { id: 'job-1' },
                 error: null
               })
             }
@@ -66,6 +69,15 @@ const run = async (over: Record<string, unknown> = {}) => {
     ...over
   } as never);
 };
+
+describe('lo stile visivo del brand su un clip', () => {
+  it('filmando da un prompt, lo stile del brand arriva al fornitore', async () => {
+    await run({ durationSeconds: 12 });
+
+    const sent = submitAndTrackVideoRender.mock.calls[0][0];
+    expect(sent.render.visualStyle).toBe(VISUAL_STYLE);
+  });
+});
 
 describe('animare un immagine della libreria', () => {
   it('la foto di partenza arriva al fornitore come copertina', async () => {

--- a/src/lib/server/media-generate.without-brand.test.ts
+++ b/src/lib/server/media-generate.without-brand.test.ts
@@ -78,7 +78,7 @@ beforeEach(() => {
   renderPostImage.mockResolvedValue(PNG_DATA_URL);
   storeBrandMediaBytes.mockResolvedValue({});
   insertBrandMedia.mockResolvedValue({ row: { id: 'media-new', kind: 'image', short_code: 'K7BX2MQ4' } });
-  signKnowledgePaths.mockResolvedValue(new Map([['user-1/media/x.png', SIGNED]]));
+  signKnowledgePaths.mockImplementation(async (_c: unknown, paths: string[]) => new Map(paths.map((p) => [p, SIGNED])));
 });
 
 describe('disegnare senza un brand', () => {
@@ -117,10 +117,6 @@ describe('disegnare senza un brand', () => {
   });
 
   it('torna un link firmato e il percorso, perché non c è un id con cui ritrovarlo', async () => {
-    signKnowledgePaths.mockImplementation(async (_c: unknown, paths: string[]) =>
-      new Map(paths.map((p) => [p, SIGNED]))
-    );
-
     const out = await generateImagesWithoutBrand(supabaseThatHasNoBrands(), job);
 
     expect(out.ok && out.media[0].url).toBe(SIGNED);
@@ -146,6 +142,18 @@ describe('disegnare senza un brand', () => {
     const out = await generateImagesWithoutBrand(supabaseThatHasNoBrands(), job);
 
     expect(out.ok && out.costUsd).toBeNull();
+  });
+
+  /**
+   * Senza id, la firma è l'UNICO modo di raggiungere il file: se non arriva, chi legge `ok` si
+   * ritrova un render pagato e niente da aprire. Un successo vuoto è peggio di un errore.
+   */
+  it('una firma che non arriva è un fallimento, non una url nulla', async () => {
+    signKnowledgePaths.mockResolvedValue(new Map());
+
+    const out = await generateImagesWithoutBrand(supabaseThatHasNoBrands(), job);
+
+    expect(out).toEqual({ ok: false, error: 'store_failed' });
   });
 
   it('un render che non torna niente è un fallimento, non un successo vuoto', async () => {

--- a/src/lib/server/media-generate.without-brand.test.ts
+++ b/src/lib/server/media-generate.without-brand.test.ts
@@ -17,6 +17,7 @@ const storeBrandMediaBytes = vi.fn();
 const signKnowledgePaths = vi.fn();
 const withBrandContext = vi.fn();
 const withOrgContext = vi.fn();
+const loadBrandVisualContext = vi.fn();
 
 const PNG_DATA_URL = 'data:image/png;base64,AAAA';
 
@@ -24,7 +25,8 @@ let billedUsd: number | undefined;
 
 vi.mock('$lib/server/content-preview', () => ({
   renderPostImage: (...args: unknown[]) => renderPostImage(...args),
-  buildImageRequest: (_prompt: string, opts: { model?: string }) => ({ model: opts.model ?? null })
+  buildImageRequest: (_prompt: string, opts: { model?: string }) => ({ model: opts.model ?? null }),
+  loadBrandVisualContext: (...args: unknown[]) => loadBrandVisualContext(...args)
 }));
 vi.mock('$lib/server/brand-media', () => ({
   loadLibraryMediaParts: async () => [],
@@ -88,6 +90,17 @@ describe('disegnare senza un brand', () => {
     const out = await generateImagesWithoutBrand(supabaseThatHasNoBrands(), job);
 
     expect(out.ok).toBe(true);
+  });
+
+  it('nessun aspetto di brand entra nella richiesta: non c è un brand da cui prenderlo', async () => {
+    await generateImagesWithoutBrand(supabaseThatHasNoBrands(), job);
+
+    expect(loadBrandVisualContext).not.toHaveBeenCalled();
+
+    const opts = renderPostImage.mock.calls[0][2];
+    expect(opts.visualStyle).toBeUndefined();
+    expect(opts.brandLook).toBeUndefined();
+    expect(opts.logoImage).toBeUndefined();
   });
 
   it('addebita all organizzazione, che è chi paga quando nessun brand paga', async () => {

--- a/src/lib/server/media-generate.without-brand.test.ts
+++ b/src/lib/server/media-generate.without-brand.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * «Puoi generare la img di un gatto?» — e l'agente ha risposto di no. Non aveva torto: ogni strada
+ * verso il generatore passava sotto `/brands/:slug/`, quindi per disegnare un gatto avrebbe dovuto
+ * prima scegliere un'azienda a cui addebitarlo. Qui si misura la strada che non ci passa.
+ *
+ * Il negativo che conta è la lettura di `brands`: se quel percorso la tocca ancora, qualcosa lo
+ * sta ancora ancorando a un brand e l'opzionale è finto. E il positivo che conta è che il brand,
+ * quando c'è, si comporti esattamente come prima — rendere opzionale un parametro è il modo
+ * classico di far sparire in silenzio quello che quel parametro portava.
+ */
+
+const renderPostImage = vi.fn();
+const insertBrandMedia = vi.fn();
+const storeBrandMediaBytes = vi.fn();
+const signKnowledgePaths = vi.fn();
+const withBrandContext = vi.fn();
+const withOrgContext = vi.fn();
+
+const PNG_DATA_URL = 'data:image/png;base64,AAAA';
+
+let billedUsd: number | undefined;
+
+vi.mock('$lib/server/content-preview', () => ({
+  renderPostImage: (...args: unknown[]) => renderPostImage(...args),
+  buildImageRequest: (_prompt: string, opts: { model?: string }) => ({ model: opts.model ?? null })
+}));
+vi.mock('$lib/server/brand-media', () => ({
+  loadLibraryMediaParts: async () => [],
+  insertBrandMedia: (...args: unknown[]) => insertBrandMedia(...args),
+  storeBrandMediaBytes: (...args: unknown[]) => storeBrandMediaBytes(...args),
+  probeImageDimensions: async () => ({ width: 1080, height: 1080 })
+}));
+vi.mock('$lib/server/media-archive', () => ({
+  signKnowledgePaths: (...args: unknown[]) => signKnowledgePaths(...args)
+}));
+vi.mock('$lib/server/content-credentials', () => ({
+  markImage: async (bytes: Buffer) => bytes,
+  DIGITAL_SOURCE_TYPE: { synthetic: 'trainedAlgorithmicMedia' }
+}));
+vi.mock('$lib/server/ai-log', () => ({
+  billedUsdInScope: () => billedUsd,
+  withBrandContext: <T>(brandId: string, fn: () => T) => {
+    withBrandContext(brandId);
+    return fn();
+  },
+  withOrgContext: <T>(orgId: string, fn: () => T) => {
+    withOrgContext(orgId);
+    return fn();
+  }
+}));
+
+import { generateBrandImages, generateImagesWithoutBrand } from './media-generate';
+
+const SIGNED = 'https://storage.test/signed?token=abc';
+
+/** Legge `brands`: qui è un fallimento, non un dato. Un percorso senza brand non deve arrivarci. */
+function supabaseThatHasNoBrands() {
+  return {
+    from: (table: string) => {
+      throw new Error(`ha letto ${table}`);
+    }
+  } as never;
+}
+
+function supabaseWithPrefs(prefs: Record<string, unknown>) {
+  return {
+    from: () => ({
+      select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: { content_prefs: prefs }, error: null }) }) })
+    })
+  } as never;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  billedUsd = 0.0336;
+  renderPostImage.mockResolvedValue(PNG_DATA_URL);
+  storeBrandMediaBytes.mockResolvedValue({});
+  insertBrandMedia.mockResolvedValue({ row: { id: 'media-new', kind: 'image', short_code: 'K7BX2MQ4' } });
+  signKnowledgePaths.mockResolvedValue(new Map([['user-1/media/x.png', SIGNED]]));
+});
+
+describe('disegnare senza un brand', () => {
+  const job = { orgId: 'org-1', userId: 'user-1', prompt: 'un gatto' };
+
+  it('non legge la tabella dei brand: se lo facesse, sarebbe ancora ancorato a uno', async () => {
+    const out = await generateImagesWithoutBrand(supabaseThatHasNoBrands(), job);
+
+    expect(out.ok).toBe(true);
+  });
+
+  it('addebita all organizzazione, che è chi paga quando nessun brand paga', async () => {
+    await generateImagesWithoutBrand(supabaseThatHasNoBrands(), job);
+
+    expect(withOrgContext).toHaveBeenCalledWith('org-1');
+    expect(withBrandContext).not.toHaveBeenCalled();
+  });
+
+  it('non deposita nessuna riga in libreria, e l id non esiste', async () => {
+    const out = await generateImagesWithoutBrand(supabaseThatHasNoBrands(), job);
+
+    expect(insertBrandMedia).not.toHaveBeenCalled();
+    expect(out.ok && out.media[0].id).toBeNull();
+  });
+
+  /**
+   * Le policy di `brand_media` dicono `brand_id in (select auth_brand_ids())`, e `NULL in (…)` vale
+   * NULL, non true: una riga senza brand sarebbe invisibile a tutti e nemmeno inseribile. Il file
+   * però sta in storage, sotto lo user — e lì la policy guarda solo il PRIMO segmento del percorso.
+   */
+  it('il file sta sotto lo user, dove la policy dello storage lo trova', async () => {
+    await generateImagesWithoutBrand(supabaseThatHasNoBrands(), job);
+
+    const [, path] = storeBrandMediaBytes.mock.calls[0];
+    expect(String(path).split('/')[0]).toBe('user-1');
+  });
+
+  it('torna un link firmato e il percorso, perché non c è un id con cui ritrovarlo', async () => {
+    signKnowledgePaths.mockImplementation(async (_c: unknown, paths: string[]) =>
+      new Map(paths.map((p) => [p, SIGNED]))
+    );
+
+    const out = await generateImagesWithoutBrand(supabaseThatHasNoBrands(), job);
+
+    expect(out.ok && out.media[0].url).toBe(SIGNED);
+    expect(out.ok && out.media[0].storage_path).toMatch(/^user-1\/media\//);
+  });
+
+  it('più alternative, più render pagati, e il conto lo dice', async () => {
+    const out = await generateImagesWithoutBrand(supabaseThatHasNoBrands(), { ...job, count: 3 });
+
+    expect(renderPostImage).toHaveBeenCalledTimes(3);
+    expect(out.ok && out.renders).toBe(3);
+  });
+
+  it('dice quanto è costato leggendolo dalle righe, non da un listino accanto', async () => {
+    const out = await generateImagesWithoutBrand(supabaseThatHasNoBrands(), job);
+
+    expect(out.ok && out.costUsd).toBe(0.0336);
+  });
+
+  it('una fattura che non è arrivata resta sconosciuta, non zero', async () => {
+    billedUsd = undefined;
+
+    const out = await generateImagesWithoutBrand(supabaseThatHasNoBrands(), job);
+
+    expect(out.ok && out.costUsd).toBeNull();
+  });
+
+  it('un render che non torna niente è un fallimento, non un successo vuoto', async () => {
+    renderPostImage.mockResolvedValue(undefined);
+
+    const out = await generateImagesWithoutBrand(supabaseThatHasNoBrands(), job);
+
+    expect(out).toEqual({ ok: false, error: 'render_failed' });
+  });
+});
+
+describe('con un brand, niente è cambiato', () => {
+  const job = { brandId: 'brand-1', userId: 'user-1', prompt: 'un banco in noce' };
+
+  it('il modello continua a venire dalle preferenze del brand', async () => {
+    const out = await generateBrandImages(supabaseWithPrefs({ imageModel: 'nano-banana-pro' }), job);
+
+    expect(out.ok && out.model).toBe('nano-banana-pro');
+  });
+
+  it('il render resta avvolto nel contesto del brand: è così che la spesa gli arriva', async () => {
+    await generateBrandImages(supabaseWithPrefs({}), job);
+
+    expect(withBrandContext).toHaveBeenCalledWith('brand-1');
+    expect(withOrgContext).not.toHaveBeenCalled();
+  });
+
+  it('l asset entra ancora in libreria, con un id da passare a create_post', async () => {
+    const out = await generateBrandImages(supabaseWithPrefs({}), job);
+
+    expect(insertBrandMedia).toHaveBeenCalled();
+    expect(out.ok && out.media[0].id).toBe('media-new');
+  });
+});

--- a/src/routes/api/v1/brands/[slug]/media/images/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/media/images/+server.ts
@@ -40,5 +40,14 @@ export const POST: RequestHandler = async ({ request, params }) => {
     );
   }
 
-  return json({ ok: true, media: result.media, model: result.model, renders: result.renders });
+  // `organization` resta null di proposito: qui a pagare è il brand, che il chiamante ha nominato
+  // lui. Il campo serve sulla strada senza brand, dove l'organizzazione l'abbiamo scelta noi.
+  return json({
+    ok: true,
+    media: result.media,
+    model: result.model,
+    renders: result.renders,
+    organization: null,
+    cost_usd: result.costUsd
+  });
 };

--- a/src/routes/api/v1/brands/[slug]/media/images/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/media/images/+server.ts
@@ -29,6 +29,7 @@ export const POST: RequestHandler = async ({ request, params }) => {
     count: parsed.data.count,
     aspectRatio: parsed.data.aspect_ratio,
     model: parsed.data.model,
+    brandStyle: parsed.data.brand_style,
     title: parsed.data.title
   });
 

--- a/src/routes/api/v1/brands/[slug]/media/images/refine/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/media/images/refine/+server.ts
@@ -30,6 +30,7 @@ export const POST: RequestHandler = async ({ request, params }) => {
     baseMediaId: parsed.data.base_media_id,
     count: parsed.data.count,
     model: parsed.data.model,
+    brandStyle: parsed.data.brand_style,
     title: parsed.data.title
   });
 

--- a/src/routes/api/v1/brands/[slug]/media/images/server.images.test.ts
+++ b/src/routes/api/v1/brands/[slug]/media/images/server.images.test.ts
@@ -61,7 +61,13 @@ beforeEach(() => {
     error: null
   } as never);
   vi.mocked(gateAiAction).mockResolvedValue(undefined as never);
-  generateBrandImages.mockResolvedValue({ ok: true, media: [DRAWN], model: 'nano-banana-2-lite', renders: 1 });
+  generateBrandImages.mockResolvedValue({
+    ok: true,
+    media: [DRAWN],
+    model: 'nano-banana-2-lite',
+    renders: 1,
+    costUsd: 0.0336
+  });
   refineBrandImage.mockResolvedValue({ ok: true, media: [DRAWN], model: 'nano-banana-2-pro', renders: 1 });
 });
 
@@ -70,7 +76,15 @@ describe('POST /media/images — generate_image', () => {
     const { res, body } = await generate({ prompt: 'un banco di lavoro in noce' });
 
     expect(res.status).toBe(200);
-    expect(body).toEqual({ ok: true, media: [DRAWN], model: 'nano-banana-2-lite', renders: 1 });
+    expect(body).toEqual({
+      ok: true,
+      media: [DRAWN],
+      model: 'nano-banana-2-lite',
+      renders: 1,
+      // Il brand nomina da sé chi paga: `organization` serve sulla strada senza brand.
+      organization: null,
+      cost_usd: 0.0336
+    });
   });
 
   it('un brand senza crediti non disegna', async () => {

--- a/src/routes/api/v1/brands/[slug]/media/images/server.images.test.ts
+++ b/src/routes/api/v1/brands/[slug]/media/images/server.images.test.ts
@@ -141,6 +141,15 @@ describe('POST /media/images — generate_image', () => {
     );
   });
 
+  it('brand_style arriva al motore invece di fermarsi al parse', async () => {
+    await generate({ prompt: 'uno screenshot di UI', brand_style: 'ignore' });
+
+    expect(generateBrandImages).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ brandStyle: 'ignore' })
+    );
+  });
+
   it('genera per il brand risolto dallo slug, mai per un id che arriva dal corpo', async () => {
     const { res } = await generate({ prompt: 'x', brand_id: 'brand-di-qualcun-altro' });
 
@@ -170,6 +179,19 @@ describe('POST /media/images/refine — refine_image', () => {
     expect(refineBrandImage).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ baseMediaId: 'media-0', prompt: 'sfondo più caldo' })
+    );
+  });
+
+  it('anche rifinendo, brand_style arriva al motore', async () => {
+    await call(REFINE as Handler, 'images/refine', {
+      base_media_id: 'media-0',
+      instruction: 'più caldo',
+      brand_style: 'ignore'
+    });
+
+    expect(refineBrandImage).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ brandStyle: 'ignore' })
     );
   });
 

--- a/src/routes/api/v1/brands/[slug]/registry.test.ts
+++ b/src/routes/api/v1/brands/[slug]/registry.test.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
-import { BRAND_ENDPOINTS, pathFor, type BrandEndpoint } from '@anomalia/api-contracts';
+import { BRAND_ENDPOINTS, pathFor, pathWithoutBrand, type BrandEndpoint } from '@anomalia/api-contracts';
 
 /**
  * IL REGISTRY PROMETTE, LE ROTTE MANTENGONO. Ogni entry di BRAND_ENDPOINTS diventa da sola un
@@ -79,5 +79,36 @@ describe('BRAND_ENDPOINTS', () => {
       .map((e) => `${e.tool} -> spende crediti ma non dichiara credits_exhausted`);
 
     expect(silent).toEqual([]);
+  });
+
+  /**
+   * Una strada senza brand è una seconda promessa dello stesso contratto, e sbaglia allo stesso
+   * modo: dichiararla senza scriverla produce un tool che accetta di essere chiamato senza slug e
+   * risponde 404 — cioè l'agente torna a credere che lo strumento non ci sia.
+   */
+  it('ogni strada senza brand ha la sua rotta, e spende con un cancello che dichiara', () => {
+    const broken: string[] = [];
+
+    for (const endpoint of BRAND_ENDPOINTS) {
+      const url = pathWithoutBrand(endpoint);
+      if (!url) continue;
+
+      const file = `src/routes${url}/+server.ts`;
+      const full = join(REPO_ROOT, file);
+      if (!existsSync(full)) {
+        broken.push(`${endpoint.tool} -> ${file} non esiste`);
+        continue;
+      }
+
+      const source = readFileSync(full, 'utf8');
+      if (!exportsVerb(source, endpoint.method)) {
+        broken.push(`${endpoint.tool} -> ${file} non esporta ${endpoint.method}`);
+      }
+      if (source.includes('gateOrgAiAction') && !endpoint.failures.some((f) => f.error === 'credits_exhausted')) {
+        broken.push(`${endpoint.tool} -> spende crediti ma non dichiara credits_exhausted`);
+      }
+    }
+
+    expect(broken).toEqual([]);
   });
 });

--- a/src/routes/api/v1/images/+server.ts
+++ b/src/routes/api/v1/images/+server.ts
@@ -1,0 +1,80 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { authenticate, gateOrgAiAction, apiKeyIsBrandScoped } from '$lib/server/cli-auth';
+import { ensureOrgForUser } from '$lib/server/org';
+import { generateImagesWithoutBrand } from '$lib/server/media-generate';
+import { GENERATE_IMAGE, statusForFailure } from '@anomalia/api-contracts';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+// Lo stesso tetto della rotta sotto il brand: quattro immagini di fila stanno sotto il minuto, ma
+// non sotto il default.
+export const config = { maxDuration: 300 };
+
+/**
+ * Chi ha pagato, per nome. La risposta lo dice perché il chiamante non l'ha scelto: `slug` assente
+ * significa che l'organizzazione l'abbiamo risolta noi, e un addebito che nessuno ha nominato è un
+ * addebito che nessuno controlla. Andrea ha visto agenti scegliere un brand a caso pur di avere
+ * un'immagine — un gatto poteva finire sul conto di un cliente vero.
+ */
+async function nameOrg(
+  supabase: SupabaseClient,
+  orgId: string
+): Promise<{ id: string; name: string | null }> {
+  const { data } = await supabase
+    .from('organizations')
+    .select('id, name')
+    .eq('id', orgId)
+    .maybeSingle();
+
+  return { id: orgId, name: (data?.name as string | null | undefined) ?? null };
+}
+
+export const POST: RequestHandler = async ({ request }) => {
+  const { supabase, user, error, apiKey } = await authenticate(request);
+  if (error) return error;
+
+  // Una chiave ristretta a certi brand è una restrizione che l'utente ha scelto: qui, dove nessun
+  // brand viene nominato, non c'è niente da restringere — quindi si rifiuta invece di allargarla.
+  if (apiKeyIsBrandScoped(apiKey)) {
+    return json({ error: 'brand_scoped_key' }, { status: 403 });
+  }
+
+  // La stessa regola che decide dove atterra un brand nuovo: pagante prima, poi la più vecchia.
+  // Deterministica di proposito — un utente con più organizzazioni deve ottenere sempre la stessa.
+  const orgId = await ensureOrgForUser(supabase, user as never);
+  if (!orgId) return json({ error: 'no_organization' }, { status: 500 });
+
+  const gate = await gateOrgAiAction(orgId, apiKey);
+  if (gate) return gate;
+
+  const parsed = GENERATE_IMAGE.input.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return json({ error: 'invalid_input', details: parsed.error.issues }, { status: 400 });
+  }
+
+  const result = await generateImagesWithoutBrand(supabase, {
+    orgId,
+    userId: user.id,
+    prompt: parsed.data.prompt,
+    count: parsed.data.count,
+    aspectRatio: parsed.data.aspect_ratio,
+    model: parsed.data.model
+  });
+
+  if (!result.ok) {
+    // L'elenco dei modelli ammessi viaggia col rifiuto: senza, l'agente sa solo di aver sbagliato.
+    return json(
+      { error: result.error, ...('allowed' in result ? { allowed: result.allowed } : {}) },
+      { status: statusForFailure(GENERATE_IMAGE, result.error) }
+    );
+  }
+
+  return json({
+    ok: true,
+    media: result.media,
+    model: result.model,
+    renders: result.renders,
+    organization: await nameOrg(supabase, orgId),
+    cost_usd: result.costUsd
+  });
+};

--- a/src/routes/api/v1/images/+server.ts
+++ b/src/routes/api/v1/images/+server.ts
@@ -52,6 +52,16 @@ export const POST: RequestHandler = async ({ request }) => {
     return json({ error: 'invalid_input', details: parsed.error.issues }, { status: 400 });
   }
 
+  if (parsed.data.brand_style) {
+    return json(
+      {
+        error: 'brand_style_needs_a_brand',
+        reason: 'brand_style governs a brand look, and no brand was named — pass a slug, or drop brand_style.'
+      },
+      { status: statusForFailure(GENERATE_IMAGE, 'brand_style_needs_a_brand') }
+    );
+  }
+
   const result = await generateImagesWithoutBrand(supabase, {
     orgId,
     userId: user.id,

--- a/src/routes/api/v1/images/server.test.ts
+++ b/src/routes/api/v1/images/server.test.ts
@@ -153,6 +153,15 @@ describe('POST /api/v1/images — disegnare senza nominare un brand', () => {
     expect(generateImagesWithoutBrand).not.toHaveBeenCalled();
   });
 
+  it('brand_style senza un brand è rifiutato dicendo la mossa, non ignorato', async () => {
+    const { res, body } = await generate({ prompt: 'un gatto', brand_style: 'apply' });
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('brand_style_needs_a_brand');
+    expect(body.reason).toMatch(/pass a slug, or drop brand_style/);
+    expect(generateImagesWithoutBrand).not.toHaveBeenCalled();
+  });
+
   it('un modello che non sa fare questo mestiere è rifiutato con l elenco di quelli buoni', async () => {
     generateImagesWithoutBrand.mockResolvedValue({
       ok: false,

--- a/src/routes/api/v1/images/server.test.ts
+++ b/src/routes/api/v1/images/server.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * La rotta che non chiede un brand. Quello che conta qui sono i rifiuti e chi paga: un render che
+ * parte quando non doveva è denaro speso, e un render che parte senza dire a chi è stato addebitato
+ * è denaro speso in silenzio — che in una sessione vera voleva dire il gatto di qualcuno sul conto
+ * di un cliente.
+ */
+
+const generateImagesWithoutBrand = vi.fn();
+
+vi.mock('$lib/server/cli-auth', () => ({
+  authenticate: vi.fn(),
+  gateOrgAiAction: vi.fn(),
+  apiKeyIsBrandScoped: vi.fn()
+}));
+vi.mock('$lib/server/org', () => ({
+  ensureOrgForUser: vi.fn()
+}));
+vi.mock('$lib/server/media-generate', () => ({
+  generateImagesWithoutBrand: (...args: unknown[]) => generateImagesWithoutBrand(...args)
+}));
+
+import { POST } from './+server';
+import { authenticate, gateOrgAiAction, apiKeyIsBrandScoped } from '$lib/server/cli-auth';
+import { ensureOrgForUser } from '$lib/server/org';
+
+const DRAWN = {
+  id: null,
+  kind: 'image',
+  mime: 'image/png',
+  width: 1024,
+  height: 1024,
+  url: 'https://storage.test/signed?token=abc',
+  storage_path: 'user-1/media/generated-x.png'
+};
+
+function supabaseWithOrgName(name: string | null) {
+  return {
+    from: () => ({
+      select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: { id: 'org-1', name }, error: null }) }) })
+    })
+  };
+}
+
+async function generate(body: unknown) {
+  const url = new URL('https://anomalia.test/api/v1/images');
+  const res = await (POST as (event: unknown) => Promise<Response>)({
+    request: new Request(url, { method: 'POST', body: JSON.stringify(body) }),
+    url
+  });
+
+  return { res, body: await res.json() };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(authenticate).mockResolvedValue({
+    supabase: supabaseWithOrgName('Acme'),
+    user: { id: 'user-1', email: 'andrea@teta.so' },
+    apiKey: undefined,
+    error: null
+  } as never);
+  vi.mocked(ensureOrgForUser).mockResolvedValue('org-1' as never);
+  vi.mocked(gateOrgAiAction).mockResolvedValue(undefined as never);
+  vi.mocked(apiKeyIsBrandScoped).mockReturnValue(false as never);
+  generateImagesWithoutBrand.mockResolvedValue({
+    ok: true,
+    media: [DRAWN],
+    model: 'nano-banana-2-lite',
+    renders: 1,
+    costUsd: 0.0336
+  });
+});
+
+describe('POST /api/v1/images — disegnare senza nominare un brand', () => {
+  it('disegna, e non serve nessuno slug', async () => {
+    const { res, body } = await generate({ prompt: 'un gatto' });
+
+    expect(res.status).toBe(200);
+    expect(body.media).toEqual([DRAWN]);
+  });
+
+  /**
+   * Il test più importante dei due buchi nei pagamenti, e l'unico che si vede da TypeScript:
+   * senza crediti non si disegna nemmeno quando non c'è un brand da interrogare.
+   */
+  it('senza crediti non disegna, e il render non parte', async () => {
+    vi.mocked(gateOrgAiAction).mockResolvedValue(
+      new Response(JSON.stringify({ error: 'credits_exhausted' }), { status: 402 }) as never
+    );
+
+    const { res } = await generate({ prompt: 'un gatto' });
+
+    expect(res.status).toBe(402);
+    expect(generateImagesWithoutBrand).not.toHaveBeenCalled();
+  });
+
+  it('dice da quale organizzazione sono stati presi i crediti', async () => {
+    const { body } = await generate({ prompt: 'un gatto' });
+
+    expect(body.organization).toEqual({ id: 'org-1', name: 'Acme' });
+  });
+
+  it('addebita all organizzazione risolta, non a una passata dal chiamante', async () => {
+    await generate({ prompt: 'un gatto', org_id: 'org-di-qualcun-altro' });
+
+    expect(generateImagesWithoutBrand).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ orgId: 'org-di-qualcun-altro' })
+    );
+  });
+
+  it('dice quanto è costato, misurato, invece di una tariffa scritta a mano', async () => {
+    const { body } = await generate({ prompt: 'un gatto' });
+
+    expect(body.cost_usd).toBe(0.0336);
+  });
+
+  it('una fattura che non è arrivata resta sconosciuta, non zero', async () => {
+    generateImagesWithoutBrand.mockResolvedValue({
+      ok: true,
+      media: [DRAWN],
+      model: 'nano-banana-2-lite',
+      renders: 1,
+      costUsd: null
+    });
+
+    const { body } = await generate({ prompt: 'un gatto' });
+
+    expect(body.cost_usd).toBeNull();
+  });
+
+  /**
+   * Una chiave ristretta a certi brand è una restrizione che l'utente ha scelto. Lasciarla spendere
+   * fuori da quei brand la allargherebbe in silenzio, proprio mentre si apre una strada nuova.
+   */
+  it('una chiave ristretta a certi brand non spende fuori da quelli', async () => {
+    vi.mocked(apiKeyIsBrandScoped).mockReturnValue(true as never);
+
+    const { res, body } = await generate({ prompt: 'un gatto' });
+
+    expect(res.status).toBe(403);
+    expect(body.error).toBe('brand_scoped_key');
+    expect(generateImagesWithoutBrand).not.toHaveBeenCalled();
+  });
+
+  it('il tetto sulle alternative è applicato senza spendere', async () => {
+    const { res, body } = await generate({ prompt: 'tre direzioni', count: 5 });
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('invalid_input');
+    expect(generateImagesWithoutBrand).not.toHaveBeenCalled();
+  });
+
+  it('un modello che non sa fare questo mestiere è rifiutato con l elenco di quelli buoni', async () => {
+    generateImagesWithoutBrand.mockResolvedValue({
+      ok: false,
+      error: 'model_not_for_slot',
+      allowed: ['nano-banana-2-lite', 'nano-banana-pro']
+    });
+
+    const { res, body } = await generate({ prompt: 'x', model: 'un-modello-che-non-esiste' });
+
+    expect(res.status).toBe(400);
+    expect(body.allowed).toEqual(['nano-banana-2-lite', 'nano-banana-pro']);
+  });
+});


### PR DESCRIPTION
> **Depends on #359** (`ai_calls.org_id` + a `sum_org_ai_cost_usd` that can see a row with no brand). That migration must be **merged and applied to the database** before this ships: deploys here do not run migrations, and without it the credit gate on the new road passes forever. This branch currently carries #359's commit; it disappears on rebase once #359 lands.

## What?

`generate_image` no longer needs a brand. `slug` becomes optional, `POST /api/v1/images` is the road that runs without one, and the tool description is rewritten so a model can tell when a brand is needed and when it is not.

Called **without** `slug` it draws and hands the picture back: `id: null`, a storage path, a signed URL that expires, and the organization that paid **named in the response**. Nothing is filed in any library. Called **with** `slug`, everything behaves exactly as it does today.

## Why?

Andrea connected the MCP server to Claude and asked *«puoi generare la img di un gatto?»*. The answer:

> *«Non ho uno strumento di generazione immagini generico in questa chat … gli strumenti di Anomalia per generare immagini sono pensati per creare contenuti nella libreria media di un brand specifico, non per generare un'immagine generica al volo.»*

He pushed back (*«Sicuro?»*). It re-checked and confirmed it had no such tool. Only on the third ask did it admit:

> *«In realtà sì, tecnicamente potrebbe … solo che la salva nella libreria media di un brand specifico e consuma crediti … se vuoi "sprecare" una generazione per un gatto, tecnicamente si può fare.»*

**The agent was not wrong. It read what we wrote:**

> Draw a NEW image **into the brand media library** from a prompt, then pass the id it returns as media_ids on **create_post** … **BILLS A RENDER PER IMAGE (about 8 credits each…)**

Three anchors in three sentences — a brand's library, the post it feeds, the price — and a perfectly working image generator described so that no agent uses it to generate an image.

**And the two halves do not separate.** An optional parameter the description does not explain gets filled anyway. Andrea watched agents call `list_brands` and then **pick a brand at random**, which spends a real organization's credits and litters a real customer's library. In his own session a cat could have been billed to a client.

## How?

### The road without a brand

`pathWithoutBrand` is one optional field on the same contract, not a parallel family of endpoints. Declaring it is what makes `slug` optional in the MCP tool and what tells the client a second route exists; an endpoint that does **not** declare one now refuses a call without a slug at the client, instead of quietly building `/brands//…` and surfacing an unreadable 404 much later. The registry test holds both roads to the same standard, so a declared brand-free path with no `+server.ts` fails in CI rather than in an agent's hands.

### Who pays, and why it is said out loud

`ensureOrgForUser` — paying org first, then the oldest. Deterministic on purpose: it is the same rule that decides where a new brand lands, so a user who owns several always gets the same one. Refusing when a user owns more than one was considered and rejected: **it is the response naming the organization that makes silence impossible**, and a refusal would just push the agent back to guessing a brand.

### Where the asset goes: nowhere

No `brand_media` row. Not caution — arithmetic. All four policies in `0149` read `brand_id in (select auth_brand_ids())`, and `NULL in (…)` is `NULL`, not `true`: a brand-free row would be **invisible to everyone** and uninsertable besides. So the bytes go to storage under the user, where the policies look only at the **first** path segment, and the answer carries `id: null`, the path, and a two-hour signature. The description says the same thing in the words that matter to a caller: it is in no library, `create_post` will not take it, `list_media` will not find it.

### The two holes in payments that the naive change would have opened

**1 — the credit gate did not run.** `renderPostImage` is the chokepoint: images are ~66% of AI spend, and the quota is enforced there so a loop nobody anticipated stops instead of burning for days. It read `getBrandContext()` alone, and the comment beside it said the rest — *«Senza brand context non c'è gate.»* Taking the slug away literally means **the most expensive point in the product runs with no credit check**.

The scope now carries whichever payer exists, and `gateOrgCredits` goes through the **same billing provider** as `gateCredits` — a self-hosted fork, which has no billing, must not find itself metered on the new road because the road is new. It shares the gate cache, already keyed on the org, so a branded render and a brand-free one read one ledger instead of paying for two copies of the same numbers. Neither payer present — a pre-brand flow such as the onboarding site read — stays ungated exactly as before.

**2 — the spend summed to zero.** `sum_org_ai_cost_usd` joined `ai_calls` **through** `brands`, so a row with `brand_id null` contributed nothing to any organization. The gate above it would have passed forever and brand-free generations would have been free in permanence — with a green suite, because the fake database sums nothing. That half is #359, and it is why this is two PRs.

### The price, said after instead of guessed before

`billedUsdInScope` (#352) lets a route read its own invoice, but the deposit lived in `takeLlmCost`, which **withdraws** it — and withdrawing does not mean a row carries it: `computeCostUsd` discards a flat cost on `ok: false`, so a failed turn left a readable price that `ai_calls` never wrote. That is a price list beside the row, which is the exact thing the number exists to replace. The deposit moves to `logAiCall`, the only caller of `takeLlmCost` and the only place that knows the row's real price; it now also records a flat cost that did not come from the gateway, which is what an image render is. `cost_usd` in the response is that number. `null` when no invoice came back — never `0`.

That is what makes deleting *«about 8 credits each»* safe rather than merely quieter. **That the tool spends is still said everywhere**; the invented number is what goes.

### A security narrowing, deliberate

An API key restricted to certain brands is a restriction the user chose. Where no brand is named there is nothing to check it against, so it is refused (`brand_scoped_key`, 403) rather than silently widened.

### A promise the code does not keep, now denied out loud

`runImageJob` passes only `{model, refineModel, baseImage, aspectRatio}` — no `visualStyle`, `brandLook`, `visualPlaybook`, `logoImage`. **The brand look does not reach `generate_image`**, with a slug or without. The description says so in the negative instead of letting it be inferred.

### Wording, coordinated

The `generate_image` text here is `a6c7b4ca31a1543a2`'s, from the tool-description pass in #358, adopted verbatim plus the `cost_usd` clause — one voice across the register is worth more than two halves each consistent with themselves. They kept the other four generators; I kept this one because the description and the optional parameter do not ship apart.

## Testing?

Written test-first, red observed before green, in the order the risk runs.

**1. No credits, no render — even with no brand.** The one that watches both holes. `src/routes/api/v1/images/server.test.ts` asserts 402 with the generator never called; `src/lib/server/content-preview/gate-without-brand.test.ts` asserts the chokepoint itself asks the org and that the renderer never starts. The SQL half cannot be seen from TypeScript and is proven against the real database below.

**2. The response names the organization.** `organization: { id, name }` on the brand-free road; `null` on the branded one, where the caller named the payer himself.

**3. No read of `brands`.** `media-generate.without-brand.test.ts` passes a client whose `from()` **throws**: if that path still touches the table, something is still anchoring it.

**4. With `slug`, nothing changed.** `imageModelFor(content_prefs)` still governs the model, `withBrandContext(brand.id)` still wraps the render, the asset still lands in the library with an id for `create_post`. Making a parameter optional is the classic way to silently lose what that parameter carried.

**5. A slug that exists but is not yours stays 404**, not 403 — `loadBrandForUser` answers that way on purpose, so a key cannot probe which slugs exist.

`npx vitest run` → **7392 passed**, 14 skipped, **666 test files passed, nothing red**. `bun test cli/` → 80 pass.

Two files were red when this branch started, both on unmodified `dev`. `src/hooks.server.test.ts` needs a `.env`, which this worktree now has (the lesson was already in `LESSONS.md`). The other blocked CI for everyone and is fixed here in its own commit: `cli/mcp/vercel-config.test.ts` (from #353) imported the bun **runtime** for one `git ls-files`, and while `vite.config.ts` aliases `bun:test` to vitest, nothing can alias an executable — so the file failed to **load** and turned the job red with zero failing tests. `execFileSync` does the same work under both runners. The signal and the move are now in `LESSONS.md`.

### Verified in a real browser, on the local stack

Self-hosted Supabase in Docker + this worktree on `:5175`, migration applied locally with `npm run db:migrate`, `test@anomalia.so` seeded with the `demo` brand, **logged out and logged back in through the visible browser** (identity checked against the local issuer, `iss: http://localhost:8000/auth/v1`), then the feature used the way an MCP host uses it.

<details>
<summary>Happy path — the cat that started this, drawn without a brand</summary>

```json
POST /api/v1/images  { "prompt": "una foto di un gatto soriano seduto su un davanzale, luce naturale" }
200 in 5.8s
{
  "ok": true,
  "media": [{
    "id": null,
    "kind": "image", "mime": "image/jpeg", "width": 1024, "height": 1024,
    "url": "http://localhost:8000/storage/v1/object/sign/brand-knowledge/90bc92e3…/media/generated-e5f83a3e….jpg?token=…",
    "storage_path": "90bc92e3-79c0-4a36-89fe-f7ad8c2935b1/media/generated-e5f83a3e….jpg"
  }],
  "model": "gemini-3.1-flash-lite-image",
  "renders": 1,
  "organization": { "id": "0ea75a3a-…", "name": "Demo Org" },
  "cost_usd": 0.0336455
}
```

The signed URL opened in the browser and showed the cat. `id` null, path under the user, org named, cost measured. Repeated a second time with a different prompt — same shape, new file.
</details>

<details>
<summary>The row, and the sum that used to drop it — against the real plpgsql</summary>

```
 label           | provider   | brand_id                             | org_id                               | cost_usd | ok
 renderPostImage | openrouter |                                      | 0ea75a3a-1c8a-4b78-967b-1a2666fbae5e | 0.033646 | t   ← brand-free
 renderPostImage | openrouter | 135bfab8-e378-4d20-9ca4-8fea1aa25182 |                                      | 0.033966 | t   ← branded
```

Never both, as the rule says. And what each shape of the function sees:

```
 what_the_old_join_saw | what_the_gate_sees
 0.668883              | 0.702529            ← 0.668883 + 0.033646, the brand-free row now counted
```

Then a $1000 brand-free row inserted to empty the pool, waited out the 60s gate cache, and asked again on **both** roads:

```
POST /api/v1/images                    → 402 credits_exhausted
POST /api/v1/brands/demo/media/images  → 402 credits_exhausted

 what_the_old_join_saw | what_the_gate_sees | renders_after_the_402
 0.702528              | 1000.769818        | 0
```

Under the old shape the gate would have seen $0.70 — comfortably inside a Pro quota — and let the render through. This is the second hole, closed and shown closing. Fixture rows deleted afterwards; `brand_media` rows with a null brand: **0**.
</details>

<details>
<summary>Refusals, none of which spent anything</summary>

```
{ prompt: "" }                                  → 400 invalid_input
{ prompt: "x", count: 5 }                       → 400 invalid_input          (the 4-alternative ceiling)
{ prompt: "x", model: "un-modello-che-non-esiste" }
                                                → 400 model_not_for_slot
                                                  allowed: [nano-banana-2-lite, nano-banana-2,
                                                            nano-banana-pro, seedream-5-pro,
                                                            gpt-image-2, qwen3-pro]
{ prompt: "x", org_id: "org-di-qualcun-altro" } → 400 invalid_input          (you cannot pick who pays)

POST /api/v1/brands/brand-altrui/media/images   → 404 Brand not found        (a real brand, another tenant's)
POST /api/v1/brands/non-esiste-affatto/…        → 404 Brand not found        (indistinguishable, on purpose)
```

The second tenant was created for the 404 test and deleted afterwards.
</details>

<details>
<summary>The branded road, untouched</summary>

```json
POST /api/v1/brands/demo/media/images  { "prompt": "una tazza di ceramica su un banco di lavoro in noce" }
200 → { "id": "56457677-…", "url": "http://localhost:5175/a/TECCTC59",
        "storage_path": null, "organization": null, "cost_usd": 0.0336445, "renders": 1 }
```

The short code resolved in the browser to the image, stored under `<user>/<brand>/media/` — the library path is intact and the asset is reusable.
</details>

<details>
<summary>What the agent now reads in tools/list</summary>

```
required:    ["prompt"]
slug:        { "description": "Brand URL slug. Optional here: omit it to run without a brand
                               — the tool description says what changes.", "type": "string" }
description: To draw a picture from a description — "an image of a cat", a product shot, a
             background for a slide. … WITHOUT slug this is a one-off drawing … Do NOT call
             list_brands to decide where to draw … It spends credits: one render per image,
             renders in the answer says how many were billed and cost_usd what they actually cost.
```

Read from the real MCP server, not from the source: this is the surface on which the failure was reported.
</details>

No UI changes — this is an endpoint and an MCP tool, so there is nothing to screenshot beyond the two generated images above.

## Anything Else?

- **#358 will go red against this branch, by its author's design.** `cli/skills/findability.test.ts` there bans hand-written tariffs across `BRAND_ENDPOINTS` with one declared exemption, `TARIFF_OWNED_ELSEWHERE = ['generate_image']`, plus a companion test asserting the exemption is still true. Deleting *«about 8 credits each»* is what makes that companion fail — the fix is to **delete the exemption row**, not to work around it, and to add the findability row `{ tool: 'generate_image', question: 'generate an image of a cat', words: ['image','cat','draw'] }`. Whichever of the two lands second does that in its rebase; the words are already in both surfaces here (`SKILL.md` and `references/tools.md`).
- **`refine_image`, `generate_video`, `generate_carousel` still require a brand**, and should: each of them starts from, or feeds, something that lives in a brand's library. Only `generate_image` draws from nothing.
- **The signed URL lives two hours.** Long enough to look at and download, short enough that a leaked link is not a permanent one. Nothing sweeps those files yet — they sit under `media/<userId>/` and are covered by the user's own storage policies. Worth a reaper if the volume ever justifies one.
- **`GeneratedMedia.id` widened to `string | null` only for this tool's result.** `refine_image` and `generate_media` keep their `id: string` promise: they always have a brand and always return an id, and loosening their schema would have removed a guarantee they actually keep.
- **A brand-free drawing whose signature does not come back is `store_failed`, not `url: null`.** Without an id that link is the only way to reach the file, so handing back a null would leave a caller reading `ok: true` with a paid render and nothing to open — the empty success this module refuses everywhere else. It has its own test.
- **`billedUsdInScope`'s seam moved.** Existing behaviour for the captions path is unchanged (same number, same row); the difference is that a failed turn no longer leaves a cost readable that no row carries. Two tests in `ai-log.test.ts` were rewritten to describe the new seam, with the reason in the test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
