### PR TITLE
Give an image generated for a brand the brand's own look

### DIFF
--- a/changelog/2026-09-05-brand-look-reaches-the-mcp-renderer.md
+++ b/changelog/2026-09-05-brand-look-reaches-the-mcp-renderer.md
@@ -1,0 +1,98 @@
+# Il look del brand arriva al renderer anche da MCP
+
+Guardando l'inventario dei tool, Andrea ha chiesto di `generate_image`: *«come fa
+l'ai a mettere le image di reference che vuole? e mettere direttamente le foto dei
+prodotti salvati? e le people del brand?»*
+
+La risposta era «non può», in tutti e tre i modi. Ma sotto la domanda c'era un
+buco più grosso del parametro mancante.
+
+## Il motore regge sette canali, il percorso MCP ne usava zero
+
+`RenderImageOpts` accetta `referenceImages`, `personImages`, `moodImages`,
+`userRefImages`, `logoImage`, `baseImage`, più `visualStyle`, `visualPlaybook` e
+`brandLook`. Le superfici dei post li riempiono tutte: `content-preview/creation.ts`,
+`articles.ts`, `weekly-planner.ts`, `media-generator/agent.ts`.
+
+`runImageJob` — il motore dietro `generate_image`, `refine_image`,
+`generate_carousel` e `generate_media` — passava questo:
+
+```ts
+const opts = { model, refineModel, baseImage, aspectRatio };
+```
+
+Quattro campi su diciassette. Quindi **anche con lo slug, un'immagine generata da
+MCP non aveva l'aspetto del brand**: niente palette, niente font, niente stile
+visivo, niente playbook, niente logo. L'unica cosa che il brand contribuiva alla
+propria immagine era quale modello la disegnava.
+
+Ed era invisibile: nessun test falliva, perché nessun test guardava la richiesta
+costruita. L'immagine tornava, `ok: true`, e il conto era giusto.
+
+## Perché era rimasto indietro
+
+Il montaggio del contesto visivo esisteva in cinque copie, tutte sul percorso dei
+post — leggere `brand_kit`, mappare i font, chiamare `brandVisualDirective`,
+`extractVisualPlaybook`, `loadBrandLogoImagePart`, `loadBrandMoodImageUrls`. Una
+regola scritta in cinque posti diverge al primo posto nuovo, e il percorso MCP è
+nato dopo: non ha divergito, si è semplicemente dimenticato di esistere.
+
+Ora sta in `loadBrandVisualContext` (`content-preview/images.ts`), e il percorso
+MCP lo legge come gli altri. Le cinque copie esistenti non sono state toccate:
+riscriverle nella stessa PR avrebbe mischiato un riordino con un cambio di
+comportamento, che è esattamente ciò che rende impossibile dire quale dei due ha
+rotto cosa.
+
+## Due strade, e solo una si piega
+
+Andrea ha aggiunto la regola che completa il collegamento: *«anche l'opzione da
+parte dell'ai di disattivare o meno l'utilizzo del brand kit nella generazione
+delle img, da disattivare automaticamente se l'ai non setta uno slug»*.
+
+- **Senza slug** (il percorso di `feat/brand-free-image`): non c'è un brand,
+  quindi non c'è un kit. Non è una scelta, è un fatto — `job.brandId` è `null` e
+  non si legge niente.
+- **Con slug**: si applica di default, perché chi genera per un brand vuole che
+  assomigli al brand. `brand_style: 'ignore'` lo spegne per l'immagine che dal
+  brand non deve prendere niente — uno screenshot di UI, un'illustrazione su
+  qualcun altro, uno sfondo neutro, dove palette e font sporcano il risultato.
+
+Un **enum, non un booleano** (`AGENTS.md`): `brand_style: 'ignore'` si legge nella
+chiamata, `use_brand_kit: false` no.
+
+E il caso incoerente **rifiuta**. `brand_style` senza slug è una chiamata basata
+su un fraintendimento: l'agente crede di governare qualcosa che non esiste.
+`brand_style_needs_a_brand`, 400, prima di spendere, e il messaggio nomina la
+mossa — *pass a slug, or drop brand_style* — non solo l'errore, o il modello
+ritenta la stessa cosa.
+
+Accettarlo e ignorarlo sarebbe esattamente come nasce un parametro che sembra
+funzionare e non fa niente.
+
+## Una promessa capovolta, in un commit solo
+
+La descrizione che `feat/brand-free-image` spediva diceva testualmente *«nothing
+about a brand's look reaches the model»*. Era vera, verificata su quelle righe.
+Questa modifica la rende falsa con lo slug, quindi cambia insieme al codice in
+quattro posti: il contratto, il mirror della CLI, `references/tools.md`, e
+`SKILL.md` — che è la superficie letta **per prima**, e che non dicendo niente di
+falso non avrebbe fallito nessun test.
+
+Il test in `brand-free.test.ts` che asseriva la vecchia frase è andato rosso, ed
+era il segnale che il giro era completo. Non è stato cancellato: asserisce la
+verità nuova, e la sua nota dice perché è cambiato — un test la cui rottura
+significa «la funzione è arrivata» è indistinguibile da un test rotto, per chi lo
+legge dopo.
+
+## Cosa resta fuori, di proposito
+
+- **`generate_carousel` e `generate_media` non prendono `brand_style`.** Un
+  carosello è per definizione una serie del brand, e `generate_media` è la porta
+  storica che inoltra alle altre due. Entrambi ricevono il look di default, che è
+  ciò che serviva; il campo si aggiunge con una riga se emerge il caso.
+- **I riferimenti scelti dall'agente** (`reference_media_ids`) e **prodotti e
+  persone citabili per id** sono i punti 2 e 3 del brief, e stanno in un'altra PR.
+  Il punto 1 vale da solo: le immagini del brand smettono di essere generiche
+  senza che nessuno debba chiedere niente.
+- **`generate_video` non è toccato.** Il renderer video non ha un canale per lo
+  stile visivo: la sua strada passa da `video_renders` e dalle sue preferenze.

--- a/changelog/2026-09-05-brand-look-reaches-the-mcp-renderer.md
+++ b/changelog/2026-09-05-brand-look-reaches-the-mcp-renderer.md
@@ -94,5 +94,18 @@ legge dopo.
   persone citabili per id** sono i punti 2 e 3 del brief, e stanno in un'altra PR.
   Il punto 1 vale da solo: le immagini del brand smettono di essere generiche
   senza che nessuno debba chiedere niente.
-- **`generate_video` non è toccato.** Il renderer video non ha un canale per lo
-  stile visivo: la sua strada passa da `video_renders` e dalle sue preferenze.
+- **`generate_video` ha lo stesso buco, e si chiude qui.** `RenderVideoOpts` un
+  canale per lo stile visivo ce l'ha sempre avuto, e il percorso dei post lo
+  riempie (`create-single/+server.ts` passa `visualStyle: profile.visual_style`).
+  `startVideo` no: un clip chiesto da MCP tornava con lo stile di nessuno. Ora
+  legge `brand_kit.visual_style` e lo passa — con una copertina il renderer lo
+  scarta di proposito, perché il look sta già nei pixel del frame da animare, e
+  quel comportamento non è stato toccato.
+
+- **`brand_style` non c'è su `generate_video`, `generate_carousel` e
+  `generate_media`, ma la sua assenza è dichiarata.** Un carosello per definizione
+  è una serie del brand; `generate_media` è la porta storica; su un clip
+  l'interruttore avrebbe un solo ramo dove significa qualcosa. Quello che serviva
+  davvero era una frase per ciascuno che dice che l'interruttore lì non c'è —
+  senza, un agente lo cerca, e il costo di un'asimmetria è la ricerca, non
+  l'asimmetria.

--- a/cli/lib/contracts/posts.ts
+++ b/cli/lib/contracts/posts.ts
@@ -314,7 +314,9 @@ export const GENERATE_MEDIA = {
     'generate alternatives, look at them with list_media, and attach only the one you keep. ' +
     'Images come back ready, up to ' + MAX_MEDIA_ALTERNATIVES + ' per call. A video takes minutes: ' +
     'it comes back as a job_id with status rendering, and check_media_job says when it landed — ' +
-    'do not call this again for the same clip while one is still rendering.',
+    'do not call this again for the same clip while one is still rendering. ' +
+    "With a slug, this brand's look is applied, and it cannot be switched off from this door: " +
+    'generate_image takes brand_style for that.',
   method: 'POST',
   pathUnderBrand: '/media/generate',
   input: z
@@ -685,7 +687,8 @@ export const REFINE_IMAGE = {
     'instruction is the edit. Refining has its own model — get_media_models, slot ' +
     "imageRefineModel — and model here applies to this call only. The brand's own look (its " +
     'colours, its fonts, its visual direction) is applied to the result as it is on ' +
-    'generate_image; brand_style: ignore leaves it out. base_media_id takes a short prefix, like post ids do.',
+    'generate_image, and brand_style: ignore turns it off when the result must take nothing from ' +
+    'the brand. base_media_id takes a short prefix, like post ids do.',
   method: 'POST',
   pathUnderBrand: '/media/images/refine',
   input: z
@@ -735,7 +738,11 @@ export const GENERATE_VIDEO = {
     'heavy one around 210, so read get_media_models (slot videoModel from a prompt, ' +
     'videoImageModel when animating an image) and pass model for this call only. A clip takes ' +
     'minutes: this returns a job_id with status rendering, and check_media_job says when it ' +
-    'landed. Do not call this again for the same clip while one is still rendering.',
+    'landed. Do not call this again for the same clip while one is still rendering. ' +
+    "Filmed from a prompt alone, the clip follows this brand's visual direction, so you do not " +
+    'have to describe it — and it cannot be switched off here. Animating a library image is ' +
+    "different: the image is the clip's first frame, so whatever look it already has comes with " +
+    'it, and the visual direction is deliberately left out of the prompt.',
   method: 'POST',
   pathUnderBrand: '/media/videos',
   input: z
@@ -789,7 +796,9 @@ export const GENERATE_CAROUSEL = {
     'in the calendar: pass the ids to create_post as media_ids, in order. TO CHANGE ONE SLIDE use ' +
     'refine_image on that slide id, and put the continuity_tokens this returns back into your ' +
     'instruction — they are what holds the series together, and an edit that touches palette, ' +
-    'light or the recurring motif without them takes that slide out of the set.',
+    'light or the recurring motif without them takes that slide out of the set. ' +
+    "With a slug, this brand's look is applied to every slide, and there is no way to switch it " +
+    "off here: a series that is not the brand's is not a series.",
   method: 'POST',
   pathUnderBrand: '/media/carousel',
   input: z

--- a/cli/lib/contracts/posts.ts
+++ b/cli/lib/contracts/posts.ts
@@ -575,6 +575,20 @@ const ImageResult = z.object({
 
 const MODEL_FAILURE = { error: 'model_not_for_slot', status: 400 } as const;
 
+const BRAND_STYLE_FAILURE = { error: 'brand_style_needs_a_brand', status: 400 } as const;
+
+const BrandStyleField = z
+  .enum(['apply', 'ignore'])
+  .optional()
+  .describe(
+    "Whether this brand's own look — its colours, its fonts, its visual direction — is applied. " +
+      'Leave it out and it is, which with a slug is almost always what you want. Send `ignore` ' +
+      'when the picture must take nothing from the brand: a plain UI screenshot, an illustration ' +
+      'about somebody else, a neutral background — places where brand colours and fonts spoil ' +
+      'the result. Without a slug there is no brand to apply or ignore, and sending this is ' +
+      'refused as brand_style_needs_a_brand: pass a slug, or drop brand_style.'
+  );
+
 /**
  * Un disegno chiesto senza brand non entra in nessuna libreria, quindi non ha un id da mostrare:
  * `null` è il fatto, e dirlo qui è ciò che impedisce di passarlo a `create_post` e di cercarlo con
@@ -618,8 +632,11 @@ export const GENERATE_IMAGE = {
   title: 'Generate an image',
   description:
     'To draw a picture from a description — "an image of a cat", a product shot, a background ' +
-    "for a slide. The prompt is the whole instruction: nothing about a brand's look reaches " +
-    'the model, so name the style you want. WITHOUT slug this is a one-off drawing — no brand, ' +
+    "for a slide. With a slug, this brand's own look is applied by default — its colours, its " +
+    'fonts and the visual direction it has settled on — so you do not have to describe them; ' +
+    'brand_style: ignore leaves them out. Without a slug there is no brand and none of that ' +
+    'reaches the model, so name the style you want in the prompt. ' +
+    'WITHOUT slug this is a one-off drawing — no brand, ' +
     'nothing filed anywhere, id comes back null and there is nothing to hand to create_post. ' +
     "WITH slug the image lands in that brand's library and its id is what create_post takes as " +
     'media_ids: use it when the picture belongs to a brand, or is going to become a post. Do ' +
@@ -640,6 +657,7 @@ export const GENERATE_IMAGE = {
       count: AlternativesField,
       aspect_ratio: z.enum(['1:1', '4:5', '9:16', '16:9']).optional(),
       model: modelField('imageModel'),
+      brand_style: BrandStyleField,
       title: z.string().optional().describe('The name the asset carries in the library')
     })
     .strict(),
@@ -647,6 +665,7 @@ export const GENERATE_IMAGE = {
   failures: [
     { error: 'credits_exhausted', status: 402 },
     MODEL_FAILURE,
+    BRAND_STYLE_FAILURE,
     { error: 'render_failed', status: 502 },
     { error: 'store_failed', status: 502 }
   ],
@@ -664,7 +683,9 @@ export const REFINE_IMAGE = {
     'Say ' +
     'what should CHANGE, not what the whole picture should be: the source is the subject, the ' +
     'instruction is the edit. Refining has its own model — get_media_models, slot ' +
-    'imageRefineModel — and model here applies to this call only. base_media_id takes a short prefix, like post ids do.',
+    "imageRefineModel — and model here applies to this call only. The brand's own look (its " +
+    'colours, its fonts, its visual direction) is applied to the result as it is on ' +
+    'generate_image; brand_style: ignore leaves it out. base_media_id takes a short prefix, like post ids do.',
   method: 'POST',
   pathUnderBrand: '/media/images/refine',
   input: z
@@ -676,6 +697,7 @@ export const REFINE_IMAGE = {
       instruction: z.string().min(1).describe('What should change about it'),
       count: AlternativesField,
       model: modelField('imageRefineModel'),
+      brand_style: BrandStyleField,
       title: z.string().optional().describe('The name the new asset carries in the library')
     })
     .strict(),

--- a/cli/plugins/anomalia/skills/anomalia/SKILL.md
+++ b/cli/plugins/anomalia/skills/anomalia/SKILL.md
@@ -97,7 +97,9 @@ still has its image the day the original link dies.
 **Draw a new image** → `generate_image` with a prompt — "an image of a cat", a product shot, a
 background. `slug` is OPTIONAL: leave it out for a one-off drawing (no brand, filed nowhere, `id`
 comes back `null`, and a signed `url` that expires), pass it when the picture belongs to a brand
-or is going to become a post. Do NOT call `list_brands` to decide where to draw: if nobody named
+or is going to become a post. With a slug the brand's own look — colours, fonts, visual direction —
+is applied by default; `brand_style: ignore` leaves it out when the picture must take nothing from
+the brand. Do NOT call `list_brands` to decide where to draw: if nobody named
 a brand there is no brand, and guessing one spends a real organisation's credits. It bills a
 render per image and creates nothing in the calendar, so ask for two or three with `count`, look
 at them, keep one.

--- a/cli/plugins/anomalia/skills/anomalia/references/tools.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/tools.md
@@ -180,8 +180,18 @@ the model returning nothing.
 
 `generate_image` draws a picture from a description — "an image of a cat", a product shot, a
 background for a slide. Required: `prompt`. Optional: `slug`, `count` (1-4 alternatives, **each
-one billed**), `aspect_ratio`, `model`, `title`. The prompt is the whole instruction: nothing
-about a brand's look reaches the model, so name the style you want.
+one billed**), `aspect_ratio`, `model`, `brand_style`, `title`. With a slug, that brand's own look
+is applied by default — its colours, its fonts and the visual direction it has settled on — so you
+do not have to describe them. Without a slug there is no brand and none of that reaches the model,
+so name the style you want in the prompt.
+
+**`brand_style` turns that default off, and only a slug gives it a meaning.** Leave it out and the
+brand's look is applied, which with a slug is almost always what you want. Send `ignore` when the
+picture must take nothing from the brand: a plain UI screenshot, an illustration about somebody
+else, a neutral background — places where brand colours and fonts spoil the result. Without a slug
+there is no brand to apply or ignore, and sending it is refused as `brand_style_needs_a_brand`
+rather than quietly dropped: pass a slug, or drop `brand_style`. `refine_image` takes the same
+field, and the brand's look reaches a refinement the same way.
 
 **`slug` is optional, and which way you call it is the only choice to make.** WITHOUT it this is a
 one-off drawing: no brand, nothing filed anywhere, `id` comes back `null` and there is nothing to

--- a/cli/plugins/anomalia/skills/anomalia/references/tools.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/tools.md
@@ -191,7 +191,11 @@ picture must take nothing from the brand: a plain UI screenshot, an illustration
 else, a neutral background — places where brand colours and fonts spoil the result. Without a slug
 there is no brand to apply or ignore, and sending it is refused as `brand_style_needs_a_brand`
 rather than quietly dropped: pass a slug, or drop `brand_style`. `refine_image` takes the same
-field, and the brand's look reaches a refinement the same way.
+field, and the brand's look reaches a refinement the same way. `generate_carousel` and
+`generate_media` apply it too but take no `brand_style`: a series that is not the brand's is not a
+series, and `generate_media` is the old door — call `generate_image` when you need the switch. A
+clip filmed by `generate_video` from a prompt alone follows the brand's visual direction and cannot
+be switched off either; animating a library image takes its look from that image's pixels instead.
 
 **`slug` is optional, and which way you call it is the only choice to make.** WITHOUT it this is a
 one-off drawing: no brand, nothing filed anywhere, `id` comes back `null` and there is nothing to

--- a/cli/skills/anomalia/SKILL.md
+++ b/cli/skills/anomalia/SKILL.md
@@ -97,7 +97,9 @@ still has its image the day the original link dies.
 **Draw a new image** → `generate_image` with a prompt — "an image of a cat", a product shot, a
 background. `slug` is OPTIONAL: leave it out for a one-off drawing (no brand, filed nowhere, `id`
 comes back `null`, and a signed `url` that expires), pass it when the picture belongs to a brand
-or is going to become a post. Do NOT call `list_brands` to decide where to draw: if nobody named
+or is going to become a post. With a slug the brand's own look — colours, fonts, visual direction —
+is applied by default; `brand_style: ignore` leaves it out when the picture must take nothing from
+the brand. Do NOT call `list_brands` to decide where to draw: if nobody named
 a brand there is no brand, and guessing one spends a real organisation's credits. It bills a
 render per image and creates nothing in the calendar, so ask for two or three with `count`, look
 at them, keep one.

--- a/cli/skills/anomalia/references/tools.md
+++ b/cli/skills/anomalia/references/tools.md
@@ -180,8 +180,18 @@ the model returning nothing.
 
 `generate_image` draws a picture from a description — "an image of a cat", a product shot, a
 background for a slide. Required: `prompt`. Optional: `slug`, `count` (1-4 alternatives, **each
-one billed**), `aspect_ratio`, `model`, `title`. The prompt is the whole instruction: nothing
-about a brand's look reaches the model, so name the style you want.
+one billed**), `aspect_ratio`, `model`, `brand_style`, `title`. With a slug, that brand's own look
+is applied by default — its colours, its fonts and the visual direction it has settled on — so you
+do not have to describe them. Without a slug there is no brand and none of that reaches the model,
+so name the style you want in the prompt.
+
+**`brand_style` turns that default off, and only a slug gives it a meaning.** Leave it out and the
+brand's look is applied, which with a slug is almost always what you want. Send `ignore` when the
+picture must take nothing from the brand: a plain UI screenshot, an illustration about somebody
+else, a neutral background — places where brand colours and fonts spoil the result. Without a slug
+there is no brand to apply or ignore, and sending it is refused as `brand_style_needs_a_brand`
+rather than quietly dropped: pass a slug, or drop `brand_style`. `refine_image` takes the same
+field, and the brand's look reaches a refinement the same way.
 
 **`slug` is optional, and which way you call it is the only choice to make.** WITHOUT it this is a
 one-off drawing: no brand, nothing filed anywhere, `id` comes back `null` and there is nothing to

--- a/cli/skills/anomalia/references/tools.md
+++ b/cli/skills/anomalia/references/tools.md
@@ -191,7 +191,11 @@ picture must take nothing from the brand: a plain UI screenshot, an illustration
 else, a neutral background — places where brand colours and fonts spoil the result. Without a slug
 there is no brand to apply or ignore, and sending it is refused as `brand_style_needs_a_brand`
 rather than quietly dropped: pass a slug, or drop `brand_style`. `refine_image` takes the same
-field, and the brand's look reaches a refinement the same way.
+field, and the brand's look reaches a refinement the same way. `generate_carousel` and
+`generate_media` apply it too but take no `brand_style`: a series that is not the brand's is not a
+series, and `generate_media` is the old door — call `generate_image` when you need the switch. A
+clip filmed by `generate_video` from a prompt alone follows the brand's visual direction and cannot
+be switched off either; animating a library image takes its look from that image's pixels instead.
 
 **`slug` is optional, and which way you call it is the only choice to make.** WITHOUT it this is a
 one-off drawing: no brand, nothing filed anywhere, `id` comes back `null` and there is nothing to

--- a/packages/api-contracts/src/brand-free.test.ts
+++ b/packages/api-contracts/src/brand-free.test.ts
@@ -69,18 +69,16 @@ describe('la descrizione di generate_image', () => {
   });
 
   /**
-   * Il look del brand NON raggiunge questo strumento: `runImageJob` passa solo
-   * `{model, refineModel, baseImage, aspectRatio}`. Una descrizione che lascia credere il
-   * contrario promette quello che il codice non fa.
-   *
-   * SE QUESTO TEST DIVENTA ROSSO, NON CANCELLARLO. Il rosso è il segnale che il cablaggio del
-   * contesto visivo è arrivato — `visual_style`, il playbook, `brandLook`, il logo dentro `opts`
-   * — cioè che il giro è completo, non che la regola è caduta. Riscrivi l'asserzione sulla verità
-   * nuova (con lo slug il look arriva, senza slug no) e lasciala qui a sorvegliare quella. Un
-   * test cancellato nel commit che lo fa fallire porta via anche la domanda che faceva.
+   * Prima il look del brand non raggiungeva questo strumento nemmeno con lo slug, e la
+   * descrizione lo diceva. Ora `runImageJob` legge `loadBrandVisualContext`, quindi la promessa
+   * si e' capovolta: con lo slug si applica, senza non c'e' un brand da cui prenderlo, e
+   * `brand_style: ignore` lo spegne. Le tre cose stanno insieme perche' e' la coppia
+   * slug/parametro a decidere, non una sola delle due.
    */
-  it('nega esplicitamente che uno slug compri lo stile del brand', () => {
-    expect(text).toMatch(/nothing about a brand.s look reaches the model/);
+  it('dice che con lo slug lo stile del brand si applica, e senza no', () => {
+    expect(text).toMatch(/this brand.s own look is applied by default/);
+    expect(text).toMatch(/Without a slug there is no brand and none of that reaches the model/);
+    expect(text).toMatch(/brand_style: ignore leaves them out/);
   });
 
   it('tiene la freccia al passo successivo per chi il brand ce l ha', () => {

--- a/packages/api-contracts/src/posts.ts
+++ b/packages/api-contracts/src/posts.ts
@@ -314,7 +314,9 @@ export const GENERATE_MEDIA = {
     'generate alternatives, look at them with list_media, and attach only the one you keep. ' +
     'Images come back ready, up to ' + MAX_MEDIA_ALTERNATIVES + ' per call. A video takes minutes: ' +
     'it comes back as a job_id with status rendering, and check_media_job says when it landed — ' +
-    'do not call this again for the same clip while one is still rendering.',
+    'do not call this again for the same clip while one is still rendering. ' +
+    "With a slug, this brand's look is applied, and it cannot be switched off from this door: " +
+    'generate_image takes brand_style for that.',
   method: 'POST',
   pathUnderBrand: '/media/generate',
   input: z
@@ -685,7 +687,8 @@ export const REFINE_IMAGE = {
     'instruction is the edit. Refining has its own model — get_media_models, slot ' +
     "imageRefineModel — and model here applies to this call only. The brand's own look (its " +
     'colours, its fonts, its visual direction) is applied to the result as it is on ' +
-    'generate_image; brand_style: ignore leaves it out. base_media_id takes a short prefix, like post ids do.',
+    'generate_image, and brand_style: ignore turns it off when the result must take nothing from ' +
+    'the brand. base_media_id takes a short prefix, like post ids do.',
   method: 'POST',
   pathUnderBrand: '/media/images/refine',
   input: z
@@ -735,7 +738,11 @@ export const GENERATE_VIDEO = {
     'heavy one around 210, so read get_media_models (slot videoModel from a prompt, ' +
     'videoImageModel when animating an image) and pass model for this call only. A clip takes ' +
     'minutes: this returns a job_id with status rendering, and check_media_job says when it ' +
-    'landed. Do not call this again for the same clip while one is still rendering.',
+    'landed. Do not call this again for the same clip while one is still rendering. ' +
+    "Filmed from a prompt alone, the clip follows this brand's visual direction, so you do not " +
+    'have to describe it — and it cannot be switched off here. Animating a library image is ' +
+    "different: the image is the clip's first frame, so whatever look it already has comes with " +
+    'it, and the visual direction is deliberately left out of the prompt.',
   method: 'POST',
   pathUnderBrand: '/media/videos',
   input: z
@@ -789,7 +796,9 @@ export const GENERATE_CAROUSEL = {
     'in the calendar: pass the ids to create_post as media_ids, in order. TO CHANGE ONE SLIDE use ' +
     'refine_image on that slide id, and put the continuity_tokens this returns back into your ' +
     'instruction — they are what holds the series together, and an edit that touches palette, ' +
-    'light or the recurring motif without them takes that slide out of the set.',
+    'light or the recurring motif without them takes that slide out of the set. ' +
+    "With a slug, this brand's look is applied to every slide, and there is no way to switch it " +
+    "off here: a series that is not the brand's is not a series.",
   method: 'POST',
   pathUnderBrand: '/media/carousel',
   input: z

--- a/packages/api-contracts/src/posts.ts
+++ b/packages/api-contracts/src/posts.ts
@@ -575,6 +575,20 @@ const ImageResult = z.object({
 
 const MODEL_FAILURE = { error: 'model_not_for_slot', status: 400 } as const;
 
+const BRAND_STYLE_FAILURE = { error: 'brand_style_needs_a_brand', status: 400 } as const;
+
+const BrandStyleField = z
+  .enum(['apply', 'ignore'])
+  .optional()
+  .describe(
+    "Whether this brand's own look — its colours, its fonts, its visual direction — is applied. " +
+      'Leave it out and it is, which with a slug is almost always what you want. Send `ignore` ' +
+      'when the picture must take nothing from the brand: a plain UI screenshot, an illustration ' +
+      'about somebody else, a neutral background — places where brand colours and fonts spoil ' +
+      'the result. Without a slug there is no brand to apply or ignore, and sending this is ' +
+      'refused as brand_style_needs_a_brand: pass a slug, or drop brand_style.'
+  );
+
 /**
  * Un disegno chiesto senza brand non entra in nessuna libreria, quindi non ha un id da mostrare:
  * `null` è il fatto, e dirlo qui è ciò che impedisce di passarlo a `create_post` e di cercarlo con
@@ -618,8 +632,11 @@ export const GENERATE_IMAGE = {
   title: 'Generate an image',
   description:
     'To draw a picture from a description — "an image of a cat", a product shot, a background ' +
-    "for a slide. The prompt is the whole instruction: nothing about a brand's look reaches " +
-    'the model, so name the style you want. WITHOUT slug this is a one-off drawing — no brand, ' +
+    "for a slide. With a slug, this brand's own look is applied by default — its colours, its " +
+    'fonts and the visual direction it has settled on — so you do not have to describe them; ' +
+    'brand_style: ignore leaves them out. Without a slug there is no brand and none of that ' +
+    'reaches the model, so name the style you want in the prompt. ' +
+    'WITHOUT slug this is a one-off drawing — no brand, ' +
     'nothing filed anywhere, id comes back null and there is nothing to hand to create_post. ' +
     "WITH slug the image lands in that brand's library and its id is what create_post takes as " +
     'media_ids: use it when the picture belongs to a brand, or is going to become a post. Do ' +
@@ -640,6 +657,7 @@ export const GENERATE_IMAGE = {
       count: AlternativesField,
       aspect_ratio: z.enum(['1:1', '4:5', '9:16', '16:9']).optional(),
       model: modelField('imageModel'),
+      brand_style: BrandStyleField,
       title: z.string().optional().describe('The name the asset carries in the library')
     })
     .strict(),
@@ -647,6 +665,7 @@ export const GENERATE_IMAGE = {
   failures: [
     { error: 'credits_exhausted', status: 402 },
     MODEL_FAILURE,
+    BRAND_STYLE_FAILURE,
     { error: 'render_failed', status: 502 },
     { error: 'store_failed', status: 502 }
   ],
@@ -664,7 +683,9 @@ export const REFINE_IMAGE = {
     'Say ' +
     'what should CHANGE, not what the whole picture should be: the source is the subject, the ' +
     'instruction is the edit. Refining has its own model — get_media_models, slot ' +
-    'imageRefineModel — and model here applies to this call only. base_media_id takes a short prefix, like post ids do.',
+    "imageRefineModel — and model here applies to this call only. The brand's own look (its " +
+    'colours, its fonts, its visual direction) is applied to the result as it is on ' +
+    'generate_image; brand_style: ignore leaves it out. base_media_id takes a short prefix, like post ids do.',
   method: 'POST',
   pathUnderBrand: '/media/images/refine',
   input: z
@@ -676,6 +697,7 @@ export const REFINE_IMAGE = {
       instruction: z.string().min(1).describe('What should change about it'),
       count: AlternativesField,
       model: modelField('imageRefineModel'),
+      brand_style: BrandStyleField,
       title: z.string().optional().describe('The name the new asset carries in the library')
     })
     .strict(),

--- a/src/lib/content/changelog/2026-09-05-brand-look-in-generated-images.ts
+++ b/src/lib/content/changelog/2026-09-05-brand-look-in-generated-images.ts
@@ -1,0 +1,12 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-05',
+  title: 'Images generated for a brand now look like it',
+  items: [
+    'An image drawn for a brand now carries its colours, its fonts, its visual direction and its logo — before, only images made through a post did.',
+    'Refinements and carousels get the same treatment, so a picture no longer changes look depending on which door it came through.',
+    'Ask for the brand look to be left out when a picture should take nothing from it — a plain screenshot, a neutral background.',
+    'Without a brand there is no brand look to apply, and asking for one now says so instead of quietly doing nothing.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/content/changelog/2026-09-05-brand-look-in-generated-images.ts
+++ b/src/lib/content/changelog/2026-09-05-brand-look-in-generated-images.ts
@@ -6,6 +6,7 @@ export default {
   items: [
     'An image drawn for a brand now carries its colours, its fonts, its visual direction and its logo — before, only images made through a post did.',
     'Refinements and carousels get the same treatment, so a picture no longer changes look depending on which door it came through.',
+    'A clip filmed from a description follows the brand\'s visual direction too, instead of coming back looking like nobody.',
     'Ask for the brand look to be left out when a picture should take nothing from it — a plain screenshot, a neutral background.',
     'Without a brand there is no brand look to apply, and asking for one now says so instead of quietly doing nothing.'
   ]

--- a/src/lib/server/content-preview.ts
+++ b/src/lib/server/content-preview.ts
@@ -43,6 +43,7 @@ export {
   isProduceApproved,
   loadBrandLogoImagePart,
   loadBrandMoodImageUrls,
+  loadBrandVisualContext,
   loadCompetitorThumbUrls,
   loadPlannerMarketSignals,
   markProduceApproved,
@@ -51,7 +52,7 @@ export {
   scrubPersonAppearance,
   uploadPostImage
 } from './content-preview/images';
-export type { AspectRatio, RenderImageOpts } from './content-preview/images';
+export type { AspectRatio, BrandVisualContext, RenderImageOpts } from './content-preview/images';
 
 export {
   editArticleImage,

--- a/src/lib/server/content-preview/images.ts
+++ b/src/lib/server/content-preview/images.ts
@@ -649,6 +649,47 @@ export async function loadMoodRefs(urls: string[] | undefined): Promise<ImagePar
   return parts.length ? parts : undefined;
 }
 
+export type BrandVisualContext = Pick<
+  RenderImageOpts,
+  'visualStyle' | 'visualPlaybook' | 'brandLook' | 'logoImage' | 'moodImages'
+>;
+
+export async function loadBrandVisualContext(
+  supabase: SupabaseClient,
+  brandId: string
+): Promise<BrandVisualContext> {
+  const { data: kit } = await supabase
+    .from('brand_kit')
+    .select('visual_style, ai_context, brand_colors, fonts, logos')
+    .eq('brand_id', brandId)
+    .maybeSingle();
+
+  const fonts = (Array.isArray(kit?.fonts) ? (kit.fonts as AnyRec[]) : [])
+    .map((f) => f?.name)
+    .filter(Boolean) as string[];
+
+  const [logoImage, moodImages] = await Promise.all([
+    loadBrandLogoImagePart(kit?.logos).catch((error) => {
+      swallow('load brand logo part', error);
+      return null;
+    }),
+    loadBrandMoodImageUrls(supabase, brandId)
+      .then(loadMoodRefs)
+      .catch((error) => {
+        swallow('load mood image urls', error);
+        return undefined;
+      })
+  ]);
+
+  return {
+    visualStyle: (kit?.visual_style as string | null) || undefined,
+    visualPlaybook: extractVisualPlaybook(kit?.ai_context) || undefined,
+    brandLook: brandVisualDirective(kit?.brand_colors as string[] | null, fonts) || undefined,
+    logoImage: logoImage ?? undefined,
+    moodImages
+  };
+}
+
 // Larghezza fissa a 1080, altezza calcolata.
 const ASPECT_TARGETS: Record<AspectRatio, { w: number; h: number }> = {
   '1:1':  { w: 1080, h: 1080 },

--- a/src/lib/server/media-generate.brand-style.test.ts
+++ b/src/lib/server/media-generate.brand-style.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const renderPostImage = vi.fn();
+const loadBrandVisualContext = vi.fn();
+const insertBrandMedia = vi.fn();
+const storeBrandMediaBytes = vi.fn();
+
+const PNG_DATA_URL = 'data:image/png;base64,AAAA';
+
+const VISUAL_STYLE = 'monochrome editorial, hard light';
+const BRAND_LOOK = 'BRAND IDENTITY — Colour palette: #0f0f0f';
+const PLAYBOOK = 'WHAT WORKS VISUALLY: close crops';
+const LOGO = { inlineData: { mimeType: 'image/png', data: 'LOGO' } };
+
+vi.mock('$lib/server/content-preview', () => ({
+  renderPostImage: (...args: unknown[]) => renderPostImage(...args),
+  buildImageRequest: (_prompt: string, opts: { model?: string }) => ({ model: opts.model ?? null }),
+  loadBrandVisualContext: (...args: unknown[]) => loadBrandVisualContext(...args)
+}));
+vi.mock('$lib/server/brand-media', () => ({
+  loadLibraryMediaParts: async () => [],
+  insertBrandMedia: (...args: unknown[]) => insertBrandMedia(...args),
+  storeBrandMediaBytes: (...args: unknown[]) => storeBrandMediaBytes(...args),
+  probeImageDimensions: async () => ({ width: 1080, height: 1080 })
+}));
+vi.mock('$lib/server/content-credentials', () => ({
+  markImage: async (bytes: Buffer) => bytes,
+  DIGITAL_SOURCE_TYPE: { synthetic: 'trainedAlgorithmicMedia' }
+}));
+vi.mock('$lib/server/ai-log', () => ({
+  withBrandContext: <T>(_brandId: string, fn: () => T) => fn(),
+  billedUsdInScope: () => null
+}));
+
+import { generateBrandImages } from './media-generate';
+
+const supabase = {
+  from: () => ({
+    select: () => ({
+      eq: () => ({ maybeSingle: async () => ({ data: { content_prefs: {} }, error: null }) })
+    })
+  })
+} as never;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  renderPostImage.mockResolvedValue(PNG_DATA_URL);
+  storeBrandMediaBytes.mockResolvedValue({});
+  insertBrandMedia.mockResolvedValue({ row: { id: 'media-new', kind: 'image' } });
+  loadBrandVisualContext.mockResolvedValue({
+    visualStyle: VISUAL_STYLE,
+    brandLook: BRAND_LOOK,
+    visualPlaybook: PLAYBOOK,
+    logoImage: LOGO
+  });
+});
+
+describe('lo stile del brand nella richiesta di render', () => {
+  it('con un brand, il suo aspetto arriva al renderer', async () => {
+    await generateBrandImages(supabase, {
+      brandId: 'brand-1',
+      userId: 'user-1',
+      prompt: 'un gatto'
+    });
+
+    expect(loadBrandVisualContext).toHaveBeenCalledWith(expect.anything(), 'brand-1');
+
+    const opts = renderPostImage.mock.calls[0][2];
+    expect(opts.visualStyle).toBe(VISUAL_STYLE);
+    expect(opts.brandLook).toBe(BRAND_LOOK);
+    expect(opts.visualPlaybook).toBe(PLAYBOOK);
+    expect(opts.logoImage).toEqual(LOGO);
+  });
+
+  it('brandStyle ignore lo tiene fuori, e il brand non viene nemmeno letto', async () => {
+    await generateBrandImages(supabase, {
+      brandId: 'brand-1',
+      userId: 'user-1',
+      prompt: 'un gatto',
+      brandStyle: 'ignore'
+    });
+
+    expect(loadBrandVisualContext).not.toHaveBeenCalled();
+
+    const opts = renderPostImage.mock.calls[0][2];
+    expect(opts.visualStyle).toBeUndefined();
+    expect(opts.brandLook).toBeUndefined();
+    expect(opts.visualPlaybook).toBeUndefined();
+    expect(opts.logoImage).toBeUndefined();
+  });
+
+  it('un brand senza kit non inventa un aspetto', async () => {
+    loadBrandVisualContext.mockResolvedValue({});
+
+    await generateBrandImages(supabase, {
+      brandId: 'brand-1',
+      userId: 'user-1',
+      prompt: 'un gatto'
+    });
+
+    const opts = renderPostImage.mock.calls[0][2];
+    expect(opts.visualStyle).toBeUndefined();
+    expect(opts.brandLook).toBeUndefined();
+  });
+});

--- a/src/lib/server/media-generate.refine.test.ts
+++ b/src/lib/server/media-generate.refine.test.ts
@@ -28,7 +28,8 @@ vi.mock('$lib/server/content-preview', () => ({
   renderPostImage: (...args: unknown[]) => renderPostImage(...args),
   buildImageRequest: (_prompt: string, opts: { baseImage?: unknown; refineModel?: string; model?: string }) => ({
     model: (opts.baseImage ? opts.refineModel : undefined) ?? opts.model ?? null
-  })
+  }),
+  loadBrandVisualContext: async () => ({})
 }));
 vi.mock('$lib/server/brand-media', () => ({
   loadLibraryMediaParts: (...args: unknown[]) => loadLibraryMediaParts(...args),

--- a/src/lib/server/media-generate.ts
+++ b/src/lib/server/media-generate.ts
@@ -422,6 +422,19 @@ function videoAspect(ratio?: AspectRatio) {
   return VIDEO_ASPECTS.find((a) => a === ratio);
 }
 
+async function brandVisualStyle(
+  admin: SupabaseClient,
+  brandId: string
+): Promise<string | undefined> {
+  const { data } = await admin
+    .from('brand_kit')
+    .select('visual_style')
+    .eq('brand_id', brandId)
+    .maybeSingle();
+
+  return (data?.visual_style as string | null) || undefined;
+}
+
 async function startVideo(opts: GenerateMediaOpts): Promise<GenerateMediaResult> {
   const [{ createAdminClient }, { countOutstandingVideoRenders, submitAndTrackVideoRender }] =
     await Promise.all([
@@ -436,6 +449,8 @@ async function startVideo(opts: GenerateMediaOpts): Promise<GenerateMediaResult>
     .eq('id', opts.brandId)
     .maybeSingle();
   const prefs = (brand?.content_prefs ?? {}) as Record<string, string | number | null>;
+
+  const visualStyle = await brandVisualStyle(admin, opts.brandId);
 
   // Animare una foto e filmare da un prompt sono due MESTIERI, e il catalogo lo sa gia': lo slot
   // cambia, quindi cambia anche l'elenco dei modelli ammessi. Sceglierne uno solo accetterebbe un
@@ -514,6 +529,7 @@ async function startVideo(opts: GenerateMediaOpts): Promise<GenerateMediaResult>
       // e il prompt dirige il MOVIMENTO.
       imageUrl: coverUrl,
       duration: opts.durationSeconds ?? (prefs.videoDuration as number | undefined),
+      visualStyle,
       instructions: prefs.videoInstructions as string | null | undefined,
       resolution: prefs.videoResolution as string | null | undefined,
       model:

--- a/src/lib/server/media-generate.ts
+++ b/src/lib/server/media-generate.ts
@@ -259,7 +259,10 @@ export type ImageJob = {
   model?: string;
   /** L'immagine della libreria da cui partire. Presente → è una modifica. */
   baseMediaId?: string;
+  brandStyle?: BrandStyleUse;
 };
+
+export type BrandStyleUse = 'apply' | 'ignore';
 
 export type ImageJobResult =
   | {
@@ -295,7 +298,7 @@ async function runImageJob(
   job: ImageJob
 ): Promise<ImageJobResult> {
   const [
-    { renderPostImage, buildImageRequest },
+    { renderPostImage, buildImageRequest, loadBrandVisualContext },
     { imageModelFor, imageRefineModelFor },
     { mediaModelSlot, slotAccepts, slotChoices },
     { loadLibraryMediaParts }
@@ -332,7 +335,13 @@ async function runImageJob(
     baseImage = parts[0];
   }
 
+  const brandVisuals =
+    job.brandId && job.brandStyle !== 'ignore'
+      ? await loadBrandVisualContext(supabase, job.brandId)
+      : {};
+
   const opts = {
+    ...brandVisuals,
     model: refining ? imageModelFor(prefs) : (job.model ?? imageModelFor(prefs)),
     refineModel: refining ? (job.model ?? imageRefineModelFor(prefs)) : imageRefineModelFor(prefs),
     baseImage,

--- a/src/lib/server/media-generate.video.test.ts
+++ b/src/lib/server/media-generate.video.test.ts
@@ -27,6 +27,7 @@ vi.mock('$lib/server/ai-log', () => ({ withBrandContext: <T>(_b: string, fn: () 
 
 const FULL_ID = '11111111-2222-3333-4444-555555555555';
 const COVER = 'https://signed.test/gatto-bianco.png';
+const VISUAL_STYLE = 'monochrome editorial, hard light';
 
 let mediaRows: Array<{ id: string; kind: string }> = [];
 
@@ -41,7 +42,9 @@ const admin = {
                 data:
                   table === 'brands'
                     ? { plan: 'pro', timezone: 'Europe/Rome', content_prefs: {} }
-                    : { id: 'job-1' },
+                    : table === 'brand_kit'
+                      ? { visual_style: VISUAL_STYLE }
+                      : { id: 'job-1' },
                 error: null
               })
             }
@@ -66,6 +69,15 @@ const run = async (over: Record<string, unknown> = {}) => {
     ...over
   } as never);
 };
+
+describe('lo stile visivo del brand su un clip', () => {
+  it('filmando da un prompt, lo stile del brand arriva al fornitore', async () => {
+    await run({ durationSeconds: 12 });
+
+    const sent = submitAndTrackVideoRender.mock.calls[0][0];
+    expect(sent.render.visualStyle).toBe(VISUAL_STYLE);
+  });
+});
 
 describe('animare un immagine della libreria', () => {
   it('la foto di partenza arriva al fornitore come copertina', async () => {

--- a/src/lib/server/media-generate.without-brand.test.ts
+++ b/src/lib/server/media-generate.without-brand.test.ts
@@ -17,6 +17,7 @@ const storeBrandMediaBytes = vi.fn();
 const signKnowledgePaths = vi.fn();
 const withBrandContext = vi.fn();
 const withOrgContext = vi.fn();
+const loadBrandVisualContext = vi.fn();
 
 const PNG_DATA_URL = 'data:image/png;base64,AAAA';
 
@@ -24,7 +25,8 @@ let billedUsd: number | undefined;
 
 vi.mock('$lib/server/content-preview', () => ({
   renderPostImage: (...args: unknown[]) => renderPostImage(...args),
-  buildImageRequest: (_prompt: string, opts: { model?: string }) => ({ model: opts.model ?? null })
+  buildImageRequest: (_prompt: string, opts: { model?: string }) => ({ model: opts.model ?? null }),
+  loadBrandVisualContext: (...args: unknown[]) => loadBrandVisualContext(...args)
 }));
 vi.mock('$lib/server/brand-media', () => ({
   loadLibraryMediaParts: async () => [],
@@ -88,6 +90,17 @@ describe('disegnare senza un brand', () => {
     const out = await generateImagesWithoutBrand(supabaseThatHasNoBrands(), job);
 
     expect(out.ok).toBe(true);
+  });
+
+  it('nessun aspetto di brand entra nella richiesta: non c è un brand da cui prenderlo', async () => {
+    await generateImagesWithoutBrand(supabaseThatHasNoBrands(), job);
+
+    expect(loadBrandVisualContext).not.toHaveBeenCalled();
+
+    const opts = renderPostImage.mock.calls[0][2];
+    expect(opts.visualStyle).toBeUndefined();
+    expect(opts.brandLook).toBeUndefined();
+    expect(opts.logoImage).toBeUndefined();
   });
 
   it('addebita all organizzazione, che è chi paga quando nessun brand paga', async () => {

--- a/src/routes/api/v1/brands/[slug]/media/images/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/media/images/+server.ts
@@ -29,6 +29,7 @@ export const POST: RequestHandler = async ({ request, params }) => {
     count: parsed.data.count,
     aspectRatio: parsed.data.aspect_ratio,
     model: parsed.data.model,
+    brandStyle: parsed.data.brand_style,
     title: parsed.data.title
   });
 

--- a/src/routes/api/v1/brands/[slug]/media/images/refine/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/media/images/refine/+server.ts
@@ -30,6 +30,7 @@ export const POST: RequestHandler = async ({ request, params }) => {
     baseMediaId: parsed.data.base_media_id,
     count: parsed.data.count,
     model: parsed.data.model,
+    brandStyle: parsed.data.brand_style,
     title: parsed.data.title
   });
 

--- a/src/routes/api/v1/brands/[slug]/media/images/server.images.test.ts
+++ b/src/routes/api/v1/brands/[slug]/media/images/server.images.test.ts
@@ -141,6 +141,15 @@ describe('POST /media/images — generate_image', () => {
     );
   });
 
+  it('brand_style arriva al motore invece di fermarsi al parse', async () => {
+    await generate({ prompt: 'uno screenshot di UI', brand_style: 'ignore' });
+
+    expect(generateBrandImages).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ brandStyle: 'ignore' })
+    );
+  });
+
   it('genera per il brand risolto dallo slug, mai per un id che arriva dal corpo', async () => {
     const { res } = await generate({ prompt: 'x', brand_id: 'brand-di-qualcun-altro' });
 
@@ -170,6 +179,19 @@ describe('POST /media/images/refine — refine_image', () => {
     expect(refineBrandImage).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ baseMediaId: 'media-0', prompt: 'sfondo più caldo' })
+    );
+  });
+
+  it('anche rifinendo, brand_style arriva al motore', async () => {
+    await call(REFINE as Handler, 'images/refine', {
+      base_media_id: 'media-0',
+      instruction: 'più caldo',
+      brand_style: 'ignore'
+    });
+
+    expect(refineBrandImage).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ brandStyle: 'ignore' })
     );
   });
 

--- a/src/routes/api/v1/images/+server.ts
+++ b/src/routes/api/v1/images/+server.ts
@@ -52,6 +52,16 @@ export const POST: RequestHandler = async ({ request }) => {
     return json({ error: 'invalid_input', details: parsed.error.issues }, { status: 400 });
   }
 
+  if (parsed.data.brand_style) {
+    return json(
+      {
+        error: 'brand_style_needs_a_brand',
+        reason: 'brand_style governs a brand look, and no brand was named — pass a slug, or drop brand_style.'
+      },
+      { status: statusForFailure(GENERATE_IMAGE, 'brand_style_needs_a_brand') }
+    );
+  }
+
   const result = await generateImagesWithoutBrand(supabase, {
     orgId,
     userId: user.id,

--- a/src/routes/api/v1/images/server.test.ts
+++ b/src/routes/api/v1/images/server.test.ts
@@ -153,6 +153,15 @@ describe('POST /api/v1/images — disegnare senza nominare un brand', () => {
     expect(generateImagesWithoutBrand).not.toHaveBeenCalled();
   });
 
+  it('brand_style senza un brand è rifiutato dicendo la mossa, non ignorato', async () => {
+    const { res, body } = await generate({ prompt: 'un gatto', brand_style: 'apply' });
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('brand_style_needs_a_brand');
+    expect(body.reason).toMatch(/pass a slug, or drop brand_style/);
+    expect(generateImagesWithoutBrand).not.toHaveBeenCalled();
+  });
+
   it('un modello che non sa fare questo mestiere è rifiutato con l elenco di quelli buoni', async () => {
     generateImagesWithoutBrand.mockResolvedValue({
       ok: false,


### PR DESCRIPTION
## What?

An image drawn through `generate_image`, `refine_image`, `generate_carousel` or `generate_media` now carries the brand's own look: its palette, its fonts, the visual direction in `visual_style`, the playbook extracted from its best posts, and its actual logo. Before this, `runImageJob` handed the renderer four fields — `{model, refineModel, baseImage, aspectRatio}` — so **even with a slug, the only thing a brand contributed to its own picture was which model drew it**.

An agent can turn that off for one call with `brand_style: 'ignore'`. Without a slug there is no brand look to apply or ignore, and sending the field is refused as `brand_style_needs_a_brand` instead of being accepted and dropped.

The same hole existed on the video path and is closed here too: `RenderVideoOpts` has always had a `visualStyle` channel, the post path fills it, and `startVideo` never did — so a clip asked for over MCP came back styled like nobody.

Stacked on [#360](https://github.com/anomaliaso/anomalia/pull/360) (`feat/brand-free-image`), which this targets. Retarget to `dev` once #360 lands.

## Why?

Andrea, reading the tool inventory, asked how the AI puts reference images, saved product photos and the brand's people into a generation. The answer was "it can't" — but underneath the missing parameter was a bigger hole: the brand context was not reaching the renderer **even when the slug was there**.

That is a different defect from a missing parameter, and worse, because it was invisible. Every test passed: the image came back, `ok: true`, the render count was right. Nothing looked at the request that was built. The five post surfaces (`content-preview/creation.ts`, `articles.ts`, `weekly-planner.ts`, `media-generator/agent.ts`) all assembled the visual context by hand from the same four `brand_kit` columns. The MCP path, born later, simply never learned to.

Andrea then added the rule that completes it: the AI must be able to switch the brand kit off, and it must be off automatically when no brand is named.

## How?

**The assembly moves into one function.** `loadBrandVisualContext(supabase, brandId)` in `content-preview/images.ts` reads `brand_kit` once and returns the `RenderImageOpts` fragment, reusing the helpers that already existed — `brandVisualDirective`, `extractVisualPlaybook`, `loadBrandLogoImagePart`, `loadBrandMoodImageUrls`, `loadMoodRefs`. Nothing was reimplemented.

**The five existing copies were left alone.** Rewriting them in the same PR would mix a reordering with a behaviour change, and then neither can be blamed for the other. They are the obvious follow-up.

**An enum, not a boolean** (`AGENTS.md`): `brand_style: 'apply' | 'ignore'`. `brand_style: 'ignore'` reads in the call; `use_brand_kit: false` does not.

**The two roads stay apart by construction**, not by a check someone can forget: `job.brandId && job.brandStyle !== 'ignore'` gates the load, and on the brand-free path `brandId` is `null`, so there is nothing to read.

**The refusal names the move, not the mistake.** `brand_style_needs_a_brand` (400) carries `reason: "…pass a slug, or drop brand_style"`. A bare error code tells a model it was wrong, not how not to be wrong, so it retries the same call — the `create_post` `media_not_found` / `media_unavailable` pattern.

**A promise was flipped, in the same commit as the code.** #360 ships a description saying, verbatim, *"nothing about a brand's look reaches the model"*. It was true, and verified on the exact lines this PR rewrites. It changes here in **four** places: `packages/api-contracts/src/posts.ts`, its CLI mirror, `cli/skills/anomalia/references/tools.md`, and `cli/skills/anomalia/SKILL.md` — the last of which is read **before** the tool descriptions and states nothing false, so no test would have caught it. The prose is `a6c7b4ca31a1543a2`'s, who holds the description register.

Rejected alternatives:

- **Resolving product/person photos automatically when the prompt names one.** Magic, and wrong in the cases that matter. Explicit ids are the plan for the follow-up — see *Anything Else?*
- **Adding `brand_style` to `generate_carousel`, `generate_media` and `generate_video`.** A carousel is by definition a brand series; `generate_media` is the historic door that forwards to the other two; and on a clip the only branch the style reaches is text-to-video — animating a library image deliberately drops it, because the look already lives in the frame being animated. All three get the look by default, which is what was missing. What they get instead is **a clause each saying the switch is not there**, which is what stops an agent hunting for a flag it will not find — the real cost of an asymmetry is the search, not the asymmetry.

## Testing?

**New, and each one fails if the wiring is cut:**

- `src/lib/server/media-generate.brand-style.test.ts` — with a brand, `visualStyle` / `brandLook` / `visualPlaybook` / `logoImage` reach the renderer; with `brandStyle: 'ignore'` the brand is not even read; a brand with no kit invents nothing. These look at the **request that was built**, not the image that came back.
- `src/lib/server/media-generate.without-brand.test.ts` — no brand, no brand look, and `loadBrandVisualContext` is never called.
- `src/routes/api/v1/images/server.test.ts` — `brand_style` with no slug is a 400 that says the move, and no render starts.
- `src/routes/api/v1/brands/[slug]/media/images/server.images.test.ts` — `brand_style` reaches the engine on both generate and refine, instead of stopping at the parse.
- `src/lib/server/media-generate.video.test.ts` — a clip filmed from a prompt carries the brand's visual direction to the provider.
- `packages/api-contracts/src/brand-free.test.ts` — the assertion that pinned the old sentence went **red**, which was the signal the job was complete. It now asserts the new truth, and its note says why it changed: a test whose failure means "the feature landed" is indistinguishable from a broken test to whoever reads it next.

**Red observed first.** The first run failed on `expected "spy" to be called with arguments: [ Anything, 'brand-1' ]` — `loadBrandVisualContext` was never reached. Then green.

**Run:** `npx vitest run` → **7399 passed**, 14 skipped, 1 suite failed: `src/hooks.server.test.ts`, `TypeError: Invalid URL` from `PUBLIC_SUPABASE_URL` — this worktree has no `.env`. Environmental, not a defect (LESSONS.md), and it passes in a worktree that has one. `bun test cli/` → 80 pass. `npm run typecheck:runtime` → ok.

**Reviewed by running, not reading:** `a3da5610add5c5d4f` ran this branch against #360's own 42 brand-free tests (green) and checked the two ways this is classically got wrong — that the credit gate in `content-preview/images.ts` was untouched (zero lines removed on `gateCredits` / `gateOrgCredits` / `getOrgContext`, despite `loadBrandVisualContext` landing in that file), and that `BrandStyleField` is `.optional()` with **no** `.default('apply')`. A default there would make `parsed.data.brand_style` truthy on every call and 400 the entire brand-free route — and the test that catches it is the one that does not pass the field.

**Not tested, and why:** no browser run. The whole surface is an API/MCP path with no UI, and exercising it end to end means real image renders against real providers — money spent to watch a request get assembled, which the unit tests read directly. No eval run either: this touches the image request, not the chat path, prompts, tools or the model.

## Evidence (screenshots/videos)

No UI changes.

<details>
<summary>The request before and after, as the tests read it</summary>

Before — everything the brand contributes to its own image:

```ts
const opts = { model, refineModel, baseImage, aspectRatio };
```

After, with a slug:

```ts
const brandVisuals =
  job.brandId && job.brandStyle !== 'ignore'
    ? await loadBrandVisualContext(supabase, job.brandId)
    : {};

const opts = { ...brandVisuals, model, refineModel, baseImage, aspectRatio };
```

</details>

<details>
<summary>The refusal, verbatim</summary>

```json
{
  "error": "brand_style_needs_a_brand",
  "reason": "brand_style governs a brand look, and no brand was named — pass a slug, or drop brand_style."
}
```

400, before the render, so nothing is billed.

</details>

## Anything Else?

**This is point 1 of three.** Andrea asked for it first and on its own, because it is the one that pays immediately and needs no decision: brand images stop being generic without anyone asking for anything.

**Point 2 — `reference_media_ids`.** The models accept 8 to 16 references (`maxRefs` in `image-models.ts`) and the agent can pass none. The cap must come from the model, and going over it must be **refused naming the cap**, never truncated in silence — `buildKieImageInput` truncates today and only warns in the log, the same defect as the duration that was reported from inside.

**Point 3 — products and people as citable ids — needs a decision before it is written.** My argument, which Andrea asked for: **explicit `product_ids` / `person_ids` on the generators, not resolution from the prompt.** Resolving "the Aeron chair" by matching names is a fuzzy match on user-entered text, and its failure mode is silent and expensive: the wrong product photo becomes a real render, filed in a real library, and nobody knows a match happened at all. Explicit ids fail the way `base_media_id` already fails — an id from another brand is a clear refusal, and the agent gets to see what it asked for. It also composes with `list_products` / `list_people`, which the agent already calls. There is a second half nobody can skip: `create_product` and `add_person` take no `images`, so a product created through MCP will never have a photo to cite — the write side has to land with the read side or the read side has nothing to read.

**People carry a rule that must not be routed around.** `add_person` has a `consent` field, and `scrubPersonAppearance` (`images.ts`) already strips gender and physique from prompts when person photos are attached, precisely so the text cannot override a real face. Wiring someone's photo into a generator without requiring consent would walk past both. The constraint belongs in the code and in the description.

**Follow-up debt:** the five hand-assembled copies of the visual context in the post paths should collapse onto `loadBrandVisualContext`. Pure reordering, its own PR.

**Landing order agreed with the other agents:** descriptions (`a6c7b4ca31a1543a2`) → slug-optional (#360) → this → the `generate_media` / `refine_media` union (`a34fdb51982bbcdb0`), which absorbs everything. For that union: `brand_style` is **shared across kinds** (a brand look is a brand look), while `reference_media_ids` is likely **per-kind** — a video's references are frames and clips, not fidelity refs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
