### PR TITLE
Ask what the green is evidence of, before quoting it

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -1195,3 +1195,21 @@ vale quanto la frase che stai per spedire a ogni agente che userà il prodotto.
 **Corollario.** Vale in entrambe le direzioni: un fatto che passi tu a un altro agente va marcato
 per quello che è. «Verificato in `file:riga`» e «me l'hanno detto» non sono la stessa cosa, e chi
 riceve non può distinguerle se non gliele distingui tu.
+
+**È la stessa forma a tre distanze diverse, e le abbiamo commesse in tre in una sessione sola.**
+Un agente ha letto un chiamante e ha concluso sul chiamato. Io ho classificato ventidue letture
+come «esprimibili con `query`» leggendone le descrizioni invece delle rotte — due erano sbagliate,
+e una avrebbe fatto uscire dalla memoria del brand le note private di un altro agente. Il terzo ha
+messo una frase dove era comodo, in `references/tools.md`, e il test l'ha dichiarata verde: il test
+leggeva quel file concatenato a `SKILL.md`, mentre la regola che pretendeva di far rispettare era
+«la superficie che si legge PER PRIMA instrada la domanda». Tre volte lo stesso movimento: il
+controllo che ci trovavamo davanti ha detto sì, e abbiamo smesso di guardare.
+
+**La domanda che le prende tutte e tre, e costa una riga:** *di che cosa è prova questo verde?*
+«Il chiamante non lo passa» non è una prova sul chiamato. «La descrizione dice una tabella» non è
+una prova sulla rotta. «`findability` è verde» non è una prova sulla superficie sempre caricata, se
+il test ne legge due concatenate. Va fatta **una volta sola, prima di citare il verde** — non è un
+protocollo, è la ragione per cui verrà davvero eseguita.
+
+Tre errori uguali fatti da tre persone diverse nello stesso giorno non sono tre sbagli: sono la
+forma di un controllo che non guarda dove crede di guardare.

--- a/LESSONS.md
+++ b/LESSONS.md
@@ -1213,3 +1213,20 @@ protocollo, è la ragione per cui verrà davvero eseguita.
 
 Tre errori uguali fatti da tre persone diverse nello stesso giorno non sono tre sbagli: sono la
 forma di un controllo che non guarda dove crede di guardare.
+
+**Due meccanismi, e non coprono lo stesso terreno.** La domanda sopra scala a UNO: prende il caso
+in cui la prova ce l'hai già davanti e non l'hai guardata — «`findability` è verde» con il test che
+legge due file concatenati si smonta da soli, in dieci secondi, senza nessun altro sveglio. È la
+metà che sopravvive quando lavori da solo, ed è la ragione per cui vale scriverla.
+
+Quello che la domanda NON prende è la cosa che non hai motivo di guardare. `get_memory` sembrava
+una lettura di tabella: nessun verde da interrogare, nessun sospetto da inseguire, e chi stava per
+toglierlo non aveva ragione di aprire `brand-memory.ts` — dove ci sono i due filtri che gli
+avrebbero fatto uscire dalla memoria del brand le note private di un altro agente. Lì serve
+qualcun altro, con un contesto diverso, che legga la stessa affermazione.
+
+**E la pratica che l'ha fatto succedere ha un costo, o non è replicabile.** Ha funzionato perché
+chi stava per rimuovere ha detto QUALI TRE tool, prima di toccarli: «rimuovo qualche tool di
+lettura» non avrebbe dato niente da controllare. Quel messaggio si scrive quando il codice non
+esiste ancora — cioè quando viene peggio, e la tentazione è scriverlo dopo, a risposta nota.
+Scritto dopo non serve a niente: è un resoconto, e un resoconto non si può contraddire in tempo.

--- a/LESSONS.md
+++ b/LESSONS.md
@@ -1161,3 +1161,29 @@ rifiuto, così un percorso nuovo che si dimentica di marchiarsi resta chiuso inv
 
 Quattro occorrenze trovate solo perché qualcuno è andato a cercarle: la quinta arriverà, e allora
 il costo di questa lezione è già stato pagato.
+## Il fatto che ti passa un altro agente è un'affermazione, non una prova
+
+**Segnale.** Stai scrivendo una descrizione — o un commento, o un test — su un fatto che non hai
+letto tu, ma che ti è arrivato da chi sta lavorando su quel codice. Sembra la fonte migliore
+possibile: è l'unica persona che lo sta toccando.
+
+**Cosa succede.** In una sessione con quattro agenti sullo stesso contratto, un fatto è girato
+tre volte e si è rivelato falso alla terza. «Il renderer video non ha un canale per lo stile
+visivo»: su quella base ho scritto *«The brand's look does not reach a clip filmed from a prompt
+alone»*, che sarebbe finita in `tools/list`. `RenderVideoOpts.visualStyle` esiste
+(`src/lib/server/video.ts:331`) ed entra nel prompt sul ramo text-to-video (`video.ts:481`). Il
+fatto vero era un altro e più stretto: `startVideo` non lo passava sul percorso MCP mentre il
+percorso dei post sì — un difetto di comportamento, non un'assenza di progetto.
+
+Una descrizione falsa è peggio di una descrizione vaga: quella vaga fa cercare altrove, quella
+falsa fa smettere di cercare. Ed è esattamente il difetto che questo lavoro esisteva per chiudere.
+
+**Mossa.** Il fatto si verifica al call site prima di scriverci sopra una frase, anche quando
+arriva da chi ha le mani in quel file: `grep` del campo, lettura del ramo, e il commento accanto
+alla definizione — in quel caso diceva già tutto («Solo nel prompt di ripiego TEXT-TO-VIDEO: con
+una cover allegata lo stile è già nei pixel», `video.ts:330`). Costa un minuto e vale quanto la
+frase che stai per spedire a ogni agente che userà il prodotto.
+
+**Corollario.** Vale in entrambe le direzioni: un fatto che passi tu a un altro agente va marcato
+per quello che è. «Verificato in `file:riga`» e «me l'hanno detto» non sono la stessa cosa, e chi
+riceve non può distinguerle se non gliele distingui tu.

--- a/LESSONS.md
+++ b/LESSONS.md
@@ -1178,11 +1178,19 @@ percorso dei post sì — un difetto di comportamento, non un'assenza di progett
 Una descrizione falsa è peggio di una descrizione vaga: quella vaga fa cercare altrove, quella
 falsa fa smettere di cercare. Ed è esattamente il difetto che questo lavoro esisteva per chiudere.
 
-**Mossa.** Il fatto si verifica al call site prima di scriverci sopra una frase, anche quando
-arriva da chi ha le mani in quel file: `grep` del campo, lettura del ramo, e il commento accanto
-alla definizione — in quel caso diceva già tutto («Solo nel prompt di ripiego TEXT-TO-VIDEO: con
-una cover allegata lo stile è già nei pixel», `video.ts:330`). Costa un minuto e vale quanto la
-frase che stai per spedire a ogni agente che userà il prodotto.
+**Come nasce, che è la parte utile.** Chi me l'ha passato non se l'è inventato: aveva letto
+`startVideo`, aveva visto che non passa `visualStyle`, e ne ha concluso che il canale non esiste.
+**Ha letto il chiamante e ha concluso sul chiamato.** Quello che sapeva davvero era «`startVideo`
+non lo passa» — verificato, vero, e già di per sé il difetto — ma è arrivato a me nella forma più
+larga e più falsa. Un'assenza in un chiamante non è un'assenza nel chiamato: dice solo che
+quel percorso non la usa.
+
+**Mossa.** Il fatto si verifica dove è DEFINITO, non dove è usato, prima di scriverci sopra una
+frase — anche quando arriva da chi ha le mani in quel file: `grep` del campo, lettura del ramo, e
+il commento accanto alla definizione. In quel caso diceva già tutto («Solo nel prompt di ripiego
+TEXT-TO-VIDEO: con una cover allegata lo stile è già nei pixel», `video.ts:330`), e avrebbe
+prodotto una frase MIGLIORE di quella che mi era stata data, non solo una vera. Costa un minuto e
+vale quanto la frase che stai per spedire a ogni agente che userà il prodotto.
 
 **Corollario.** Vale in entrambe le direzioni: un fatto che passi tu a un altro agente va marcato
 per quello che è. «Verificato in `file:riga`» e «me l'hanno detto» non sono la stessa cosa, e chi


### PR DESCRIPTION
## What?

One lesson in `LESSONS.md`, in three commits: a fact handed to you is a claim until you have read it where the thing is **defined** — and, more generally, ask what a green check is evidence *of* before quoting it.

Started as part of #358 and pushed a moment after that PR merged, so it missed the boat. It grew because the same failure happened twice more the same day, to two other people. Nothing but `LESSONS.md` is in this branch.

## Why?

While rewriting the media tool descriptions, the agent working inside the video renderer told me *"the video renderer has no channel for visual style."* I wrote a tool description on it:

> The brand's look does not reach a clip filmed from a prompt alone — nothing carries it there — so name the style you want.

It is false. `RenderVideoOpts.visualStyle` exists (`src/lib/server/video.ts:331`) and reaches the prompt on the text-to-video branch (`video.ts:481`). The real fact was narrower and different in kind: `startVideo` was not passing it on the MCP path while the post path was — a behaviour defect, not a design absence.

It was caught by a third agent before it shipped. Had it not been, it would have gone into `tools/list` for every agent that uses the product — **and a false description is worse than a vague one: vague makes an agent look elsewhere, false makes it stop looking.** That is the exact failure #358 existed to close, so shipping it inside #358 would have been its own counter-example.

## How?

The move is one line: verify at the call site before writing prose on it, even when the fact comes from the person with their hands in that file. In this case the comment beside the definition already said the whole truth, including the subtlety —

```
// Solo nel prompt di ripiego TEXT-TO-VIDEO: con una cover allegata lo stile è già nei pixel.
visualStyle?: string | null;
```

— so the check cost a minute and would have produced a *better* sentence than the one I was given, not just a true one.

The corollary points the other way too, which is why it is in the lesson: a fact you hand to another agent should be marked for what it is. "Verified at `file:line`" and "someone told me" are not the same claim, and the receiver cannot tell them apart unless you do it for them. Four agents on one contract in one session passed this fact three times before anyone read it.

## The reason it is one entry and not three

By the end of the session the same shape had appeared **three times, from three different agents**:

| Distance | What was read | What was concluded |
|---|---|---|
| Caller → callee | `startVideo` does not pass `visualStyle` | "the video renderer has no style channel" |
| Description → route | `list_products` / `get_memory` / `get_plan` descriptions | "these are one table and a filter" — two were wrong, and one would have leaked another agent's private notes out of brand memory |
| Test → surface | `findability.test.ts` is green | "the always-loaded surface routes this question" — the test read two files concatenated |

Every time, **the check we happened to have said yes, so we stopped looking**, and none of us asked what it was looking at.

So the entry closes with the one question that catches all three and costs a line: **what is this green evidence of?** *"The caller does not pass it"* is not evidence about the callee. *"The description says one table"* is not evidence about the route. *"Findability is green"* is not evidence about the always-loaded surface, when the test reads two files joined together. Asked once, before quoting the green — deliberately not a protocol, because a protocol is the version nobody runs.

Three identical errors by three people in one day are not three mistakes. They are the shape of a check that does not look where it believes it looks.

The framing of that third row is `a8c22181e602c7208`'s, who made the instance and then diagnosed it.

## Two mechanisms, and the entry says which covers what

My first draft of this claimed none of the three could have been caught by more care from whoever made it. `a8c22181e602c7208` pushed back and was right: **that is true of two and false of the third.** The question — *what is this green evidence of?* — would have caught his own `SKILL.md` line alone, in ten seconds, with nobody else awake. `findability` was green; he never asked what it had read.

Left unchallenged, that claim would make this entry read as the weak substitute for having colleagues, which is the worst possible framing for a file people consult alone at 2am. So the entry now separates them:

- **The question scales to one agent.** It catches evidence already in front of you and unexamined. It is the half that survives working alone, and the reason it is worth writing down at all.
- **Announcing scope in enough detail to be contradicted** catches what the question cannot: the thing you have no reason to look at. `get_memory` looked like a table read — no green to interrogate, no suspicion to follow — and the agent about to remove it had no reason to open `brand-memory.ts`, where the two filters live that would otherwise have leaked another agent's private notes out of brand memory. Only different context stops that one.

And the practice has a stated price, or nobody repeats it: it worked because the removal named **which three tools**, before touching them. That message gets written while the code does not yet exist — when it reads worst, and the temptation is to write it afterwards with the answer already known. Written afterwards it is a report, and a report cannot be contradicted in time.

## Testing?

Documentation only — no code, no test, nothing to run. `LESSONS.md` is prose by design.

## Evidence (screenshots/videos)

No UI change.

<details>
<summary>The fact, read rather than relayed</summary>

```
$ grep -n "visualStyle" src/lib/server/video.ts
331:  visualStyle?: string | null;
442:    visualStyle?: string | null;
481:          opts.visualStyle?.trim()
482:            ? `\n\nBRAND VISUAL STYLE to match: ${opts.visualStyle...}`
595:  const style = opts.visualStyle?.trim()
909:    visualStyle: opts.visualStyle,
```

Six hits. The claim was that there were none.
</details>

## Anything Else?

The description that would have carried the false sentence never shipped: the corrected wording lives in #362, written by the agent who found the error. The gate defect from the third row is fixed in #371. This PR is only the lesson — the fixes are each in the branch that owns the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
