### PR TITLE
Say in the skill that a filmed clip follows the brand

### DIFF
--- a/cli/plugins/anomalia/skills/anomalia/SKILL.md
+++ b/cli/plugins/anomalia/skills/anomalia/SKILL.md
@@ -121,7 +121,8 @@ to get a video.
 **Film from nothing** → `generate_video` with a prompt and no `base_media_id`. A clip takes minutes,
 so it returns a `job_id`; `check_media_job` says when it landed. The model moves this bill by more
 than an order of magnitude, so read `get_media_models` (slot `videoModel`, or `videoImageModel` when animating an image) before
-spending.
+spending. With a slug the clip follows this brand's visual direction, so you do not have to
+describe it — and there is no switch for it here.
 
 **CHANGE an image you already have** → `refine_image` with its `base_media_id` and an instruction
 ("make it red", "warmer background"). It starts from that asset, so the result is that picture

--- a/cli/skills/anomalia/SKILL.md
+++ b/cli/skills/anomalia/SKILL.md
@@ -121,7 +121,8 @@ to get a video.
 **Film from nothing** → `generate_video` with a prompt and no `base_media_id`. A clip takes minutes,
 so it returns a `job_id`; `check_media_job` says when it landed. The model moves this bill by more
 than an order of magnitude, so read `get_media_models` (slot `videoModel`, or `videoImageModel` when animating an image) before
-spending.
+spending. With a slug the clip follows this brand's visual direction, so you do not have to
+describe it — and there is no switch for it here.
 
 **CHANGE an image you already have** → `refine_image` with its `base_media_id` and an instruction
 ("make it red", "warmer background"). It starts from that asset, so the result is that picture


### PR DESCRIPTION
## What?

One sentence in `cli/skills/anomalia/SKILL.md` (and its plugin mirror), in the **Film from nothing** block:

> With a slug the clip follows this brand's visual direction, so you do not have to describe it — and there is no switch for it here.

## Why?

#362 made `startVideo` pass `visualStyle`, so a clip filmed from a prompt alone now follows the brand's visual direction. The tool description says so; the skill did not.

The skill is the surface an agent reads **before** any tool description. A correct description losing to a silent skill is exactly how the animation failure survived, and this is the third time today the same shape has appeared. `findability.test.ts` would not have caught it: its rows assert that words are *present*, and no row demands the skill mention brand styling — a guard that only checks presence cannot see an omission nobody declared.

## How?

Wording from `a6c7b4ca31a1543a2`, who holds the description register, so the two surfaces read as one voice instead of two paraphrases. The contrast with animating a library image was deliberately left out: it lives one block above, and repeating it is the completeness sentence that makes a skill longer without removing an error.

## Testing?

`bun test cli/` → 80 pass. `npx vitest run cli packages/api-contracts src/lib/server/media-generate` → 427 pass. `cli/scripts/sync-plugin-skill.sh` keeps the plugin copy identical.

Not run: `cli/skills/findability.test.ts`, which landed on dev in #358 and is not in this base yet. It should be run once this branch sits on dev.

## Evidence (screenshots/videos)

No UI changes.

## Anything Else?

Targets `feat/brand-free-image` because that is where #362 merged. `a3da5610add5c5d4f` is mid-rebase of that branch onto dev; when they force-push, this one commit needs a trivial rebase, and I will do it rather than have them carry it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
