### PR TITLE
Two writes could reach another customer's data

### DIFF
--- a/changelog/2026-09-05-cross-tenant-writes.md
+++ b/changelog/2026-09-05-cross-tenant-writes.md
@@ -1,0 +1,60 @@
+# Il `WHERE` era scopato, il bersaglio no
+
+Due scritture arrivavano nei dati di un altro cliente. Sono lo stesso difetto due volte, e la
+somiglianza è il punto: in entrambe c'è un vincolo di brand scritto bene, e in entrambe non
+copre la cosa che viene toccata davvero.
+
+## Uno: i tag di un articolo si cancellavano da un altro cliente
+
+`src/routes/app/[brand]/site/edit/[id]/+page.server.ts`. L'update dell'articolo era scopato
+(`.eq('id', …).eq('brand_id', brand.id)`) e sembrava difendere ciò che seguiva. Non difendeva
+niente: **un update che non trova righe non è un errore**, quindi `err` era nullo e l'esecuzione
+proseguiva fino a `admin.from('brand_article_tags').delete().eq('article_id', params.id)` — client
+service role, nessuna RLS, nessun brand. `brand_article_tags` non ha `brand_id`: lo scopo può
+passare solo dall'articolo.
+
+Adesso l'update passa da `updateBrandRow`, che c'era già e fa esattamente questo: aggiorna scopato,
+`.select('id')`, e restituisce 404 se non ha toccato niente. Le scritture sui tag sono raggiungibili
+solo dopo quella prova. Il fallimento silenzioso — 200 `{saved:true}` su un articolo che non è tuo —
+è sparito con lo stesso cambiamento.
+
+## Due: una riga di memoria si spostava nel brand di un altro cliente
+
+`src/routes/api/v1/brands/[slug]/studio/memory/[id]/+server.ts`. Il corpo grezzo della richiesta
+finiva intero nel `SET` di un update scopato per `brand_id`. Il `WHERE` trovava la riga nel brand
+di chi chiamava, il `SET` la riscriveva col `brand_id` di un altro: la riga cambiava proprietario e
+da lì in poi alimentava gli agenti della vittima come contesto. Sul percorso a chiave API il client
+è service role, quindi il `WITH CHECK` della RLS che avrebbe fermato la cosa sul percorso JWT non
+girava mai.
+
+Questa era **l'unica rotta dell'albero** che dava un corpo non analizzato a `.update()`: ogni
+sorella (`people/[id]`, `competitors/[id]`, `settings/brand`) passa da un contratto zod `.strict()`.
+Adesso ci passa anche lei — `UPDATE_MEMORY_ENTRY` in `packages/api-contracts/src/memory.ts`, cinque
+campi e nient'altro. Non è un `BrandEndpoint` e non entra in `BRAND_ENDPOINTS`: non nasce un tool
+MCP nuovo, è solo la forma del corpo.
+
+## Le due guardie, e la prova che guardano
+
+`src/no-cross-tenant-writes.test.ts` legge il sorgente di `src/` e fa cadere la build su due forme:
+
+1. una scrittura service role filtrata su un id esterno **senza colonna del tenant nella stessa
+   query**, a meno che prima non ci sia una prova che l'id è di questo brand — una lettura scopata
+   che finisce in `maybeSingle`/`single`, o `updateBrandRow`/`deleteBrandRow`, che contano le righe
+   toccate. **Un update scopato che nessuno conta non vale come prova**, ed è precisamente la
+   distinzione che serviva: senza di essa la regola avrebbe accettato il difetto uno.
+2. un corpo di richiesta non analizzato che viaggia intero fino a un `SET`.
+
+Sono state provate contro il sorgente prima della correzione: la prima trova la delete dei tag, la
+seconda trova la PATCH della memoria, e su questo branch trovano zero. Sono approssimate per
+costruzione — riconoscono il client dal nome (`createAdminClient()`, e `supabase` sotto
+`src/routes/api/`, dove `authenticate()` restituisce service role) e la prova vale per ciò che segue
+nel file. Le sonde a fixture nello stesso file tengono onesta la regola: se smette di riconoscere il
+difetto, cade la prima sonda, non il silenzio.
+
+## Il resto dell'albero
+
+La prima regola ha trovato sei altre scritture della stessa forma, tutte già coperte da una lettura
+scopata che torna 404 prima di scrivere (`studio/documents/[id]`, `studio/people/[id]`,
+`posts/[id]/reschedule`), o dal client con RLS del browser (`settings-actions.ts` su `brands`
+filtrato per slug). La seconda non ha trovato nient'altro. La forma è un incidente ripetuto due
+volte, non un'abitudine — ma finora niente impediva la terza.

--- a/cli/lib/contracts/index.ts
+++ b/cli/lib/contracts/index.ts
@@ -421,7 +421,8 @@ export {
   MEMORY_ENTRIES_MAX,
   MEMORY_USED_MAX,
   RECORD_MEMORY_USED,
-  SAVE_MEMORY
+  SAVE_MEMORY,
+  UPDATE_MEMORY_ENTRY
 } from './memory';
 export type { AgentMemoryCategory } from './memory';
 export { GEO_ACTION, REFRESH_KEYWORDS, SEO_ACTION } from './search';

--- a/cli/lib/contracts/memory.ts
+++ b/cli/lib/contracts/memory.ts
@@ -100,6 +100,21 @@ export const SAVE_MEMORY = {
   destructive: false
 } satisfies BrandEndpoint;
 
+/**
+ * I soli campi che una PATCH può riscrivere. `.strict()` non è cosmesi: il corpo finisce nel SET
+ * di un update scopato per `brand_id`, quindi un campo di troppo — `brand_id` — sposta la riga
+ * nel brand di un altro cliente invece di aggiornarla nel proprio.
+ */
+export const UPDATE_MEMORY_ENTRY = z
+  .object({
+    value: z.string().min(1).optional(),
+    category: z.enum(MEMORY_CATEGORIES).optional(),
+    confidence: z.number().min(0).max(1).optional(),
+    pinned: z.boolean().optional(),
+    importance: z.number().int().min(1).max(5).optional()
+  })
+  .strict();
+
 export const RECORD_MEMORY_USED = {
   tool: 'record_memory_used',
   title: 'Report memory you used',

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -421,7 +421,8 @@ export {
   MEMORY_ENTRIES_MAX,
   MEMORY_USED_MAX,
   RECORD_MEMORY_USED,
-  SAVE_MEMORY
+  SAVE_MEMORY,
+  UPDATE_MEMORY_ENTRY
 } from './memory';
 export type { AgentMemoryCategory } from './memory';
 export { GEO_ACTION, REFRESH_KEYWORDS, SEO_ACTION } from './search';

--- a/packages/api-contracts/src/memory.ts
+++ b/packages/api-contracts/src/memory.ts
@@ -100,6 +100,21 @@ export const SAVE_MEMORY = {
   destructive: false
 } satisfies BrandEndpoint;
 
+/**
+ * I soli campi che una PATCH può riscrivere. `.strict()` non è cosmesi: il corpo finisce nel SET
+ * di un update scopato per `brand_id`, quindi un campo di troppo — `brand_id` — sposta la riga
+ * nel brand di un altro cliente invece di aggiornarla nel proprio.
+ */
+export const UPDATE_MEMORY_ENTRY = z
+  .object({
+    value: z.string().min(1).optional(),
+    category: z.enum(MEMORY_CATEGORIES).optional(),
+    confidence: z.number().min(0).max(1).optional(),
+    pinned: z.boolean().optional(),
+    importance: z.number().int().min(1).max(5).optional()
+  })
+  .strict();
+
 export const RECORD_MEMORY_USED = {
   tool: 'record_memory_used',
   title: 'Report memory you used',

--- a/src/lib/content/changelog/2026-09-05-writes-stay-in-your-brand.ts
+++ b/src/lib/content/changelog/2026-09-05-writes-stay-in-your-brand.ts
@@ -1,0 +1,10 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-05',
+  title: 'Writes stay in your brand',
+  items: [
+    'Saving a blog article now fails with a clear error when the article does not belong to the brand you are working in, instead of quietly reporting success.',
+    'Editing a brand memory entry only accepts the fields it is meant to change, so a malformed request can no longer move the entry somewhere it does not belong.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/no-cross-tenant-writes.test.ts
+++ b/src/no-cross-tenant-writes.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * IL GUARDIANO — il client service role non ha RLS: un id che arriva dall'URL o dal corpo lo
+ * porta nella riga di chiunque, e un `WHERE` che scopa solo la riga sbagliata non basta.
+ *
+ * La regola: una scrittura service role filtrata su un id esterno DEVE portare la colonna del
+ * tenant nella stessa query, oppure essere preceduta da una prova che quell'id è di questo brand
+ * — una lettura scopata che finisce in `maybeSingle`/`single` e da cui si torna indietro, o
+ * `updateBrandRow`/`deleteBrandRow`, che contano le righe toccate. Un update scopato che nessuno
+ * conta NON è una prova: zero righe non è un errore, e l'esecuzione prosegue.
+ *
+ * È approssimato per costruzione: legge il sorgente, riconosce il client dal nome, e la prova
+ * vale per tutto ciò che segue nel file. Le sonde qui sotto tengono la regola onesta — se
+ * smette di riconoscere il difetto, il primo test è quello che cade.
+ *
+ * Quello che NON vede: il caso in cui la colonna del tenant sta nel `SET` invece che nel `WHERE`
+ * — `insert({ brand_id: body.brandId })` su un client service role. Lì non c'è nessun id da
+ * scopare, c'è un `brand_id` da verificare, ed è un'altra regola.
+ */
+const SRC = fileURLToPath(new URL('.', import.meta.url));
+
+const TENANT = "(brand_id|user_id|org_id|organization_id|owner_id|account_id)";
+const TENANT_FILTER = new RegExp(`\\.eq\\(\\s*['"]${TENANT}['"]`);
+const SCOPED_READ = new RegExp(`\\.eq\\(\\s*['"]${TENANT}['"][^;]*?\\.(maybeSingle|single)\\(`);
+const COUNTED_WRITE = /\b(updateBrandRow|deleteBrandRow)\s*\(/;
+const WRITE = /\.(update|delete|upsert)\(/;
+const EXTERNAL_ID = /\.eq\(\s*['"][a-z_]+['"]\s*,\s*(params\.|body[.[]|payload[.[]|input\.|fd\.get)/;
+const BOUND_TO_ADMIN = /(?:const|let)\s+([\w$]+)\s*=\s*(?:\(await import\([^)]*\)\)\.)?createAdminClient\(\)/g;
+const RECEIVER = /([A-Za-z_$][\w$]*)\s*(?:\(\s*\))?\s*$/;
+
+type Finding = { file: string; line: number; chain: string };
+
+function unscopedServiceRoleWrites(file: string, src: string): Finding[] {
+  const serviceRole = new Set(['createAdminClient']);
+  for (const [, name] of src.matchAll(BOUND_TO_ADMIN)) {
+    serviceRole.add(name);
+  }
+  // Sul percorso a chiave API `authenticate()` restituisce un client service role, e lo chiama
+  // `supabase` come ogni rotta del browser chiama il proprio client con RLS.
+  if (file.includes('/src/routes/api/')) {
+    serviceRole.add('supabase');
+  }
+
+  const out: Finding[] = [];
+  for (let at = src.indexOf('.from('); at !== -1; at = src.indexOf('.from(', at + 1)) {
+    const before = src.slice(0, at);
+    const chain = src.slice(at).split(';')[0];
+
+    if (!serviceRole.has(before.match(RECEIVER)?.[1] ?? '')) continue;
+    if (!WRITE.test(chain) || !EXTERNAL_ID.test(chain)) continue;
+    if (TENANT_FILTER.test(chain)) continue;
+    if (SCOPED_READ.test(before) || COUNTED_WRITE.test(before)) continue;
+
+    out.push({ file, line: before.split('\n').length, chain: chain.replace(/\s+/g, ' ').slice(0, 120) });
+  }
+  return out;
+}
+
+const RAW_BODY = /(?:const|let)\s+([A-Za-z_$][\w$]*)\s*=\s*await\s+request\.json\(\)/g;
+const KEYWORD = '(?:if|while|for|switch|catch|return|typeof)';
+
+/**
+ * Il corpo grezzo che viaggia intero: sparso in un `.update()`/`.insert()`, o passato come
+ * argomento a qualcosa che lo scriverà. Il `WHERE` scopato non difende il `SET`, quindi un
+ * `brand_id` in più sposta la riga nel brand di un altro cliente. Il contratto zod `.strict()`
+ * lo rifiuta, e chi lo usa passa `parsed.data`, non `body`.
+ */
+function unparsedBodyIntoWrite(file: string, src: string): Finding[] {
+  const out: Finding[] = [];
+  for (const name of new Set([...src.matchAll(RAW_BODY)].map(([, n]) => n))) {
+    const spread = new RegExp(`\\.(update|insert|upsert)\\(\\s*(\\{[^}]*\\.\\.\\.${name}\\b|${name}\\s*[,)])`);
+    const passedWhole = new RegExp(`\\b(?!${KEYWORD}\\b)[a-zA-Z]\\w*\\([^()]*\\b${name}\\s*\\)`);
+    const hit = src.match(spread) ?? src.match(passedWhole);
+    if (!hit) continue;
+
+    out.push({ file, line: src.slice(0, hit.index).split('\n').length, chain: hit[0].replace(/\s+/g, ' ') });
+  }
+  return out;
+}
+
+function listTsFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...listTsFiles(full));
+    } else if (entry.isFile() && entry.name.endsWith('.ts') && !entry.name.includes('.test.')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+const ADMIN = "const admin = createAdminClient();\n";
+
+describe('la regola riconosce il difetto', () => {
+  it('segnala una delete service role su un id dall\'URL senza vincolo di brand', () => {
+    const src = `${ADMIN}await admin.from('brand_article_tags').delete().eq('article_id', params.id);`;
+
+    expect(unscopedServiceRoleWrites('/src/routes/app/x/+page.server.ts', src)).toHaveLength(1);
+  });
+
+  it('un update scopato che nessuno conta non è una prova', () => {
+    const src =
+      `${ADMIN}const { error: err } = await admin.from('brand_articles').update(patch).eq('id', params.id).eq('brand_id', brand.id);\n` +
+      "if (err) return fail(500, { error: err.message });\n" +
+      "await admin.from('brand_article_tags').delete().eq('article_id', params.id);";
+
+    expect(unscopedServiceRoleWrites('/src/routes/app/x/+page.server.ts', src)).toHaveLength(1);
+  });
+
+  it('accetta la prova per righe toccate', () => {
+    const src =
+      `${ADMIN}const failure = await updateBrandRow(admin, 'brand_articles', brand.id, params.id, patch);\n` +
+      "if (failure) return fail(failure.status, { error: failure.error });\n" +
+      "await admin.from('brand_article_tags').delete().eq('article_id', params.id);";
+
+    expect(unscopedServiceRoleWrites('/src/routes/app/x/+page.server.ts', src)).toEqual([]);
+  });
+
+  it('accetta la prova per lettura scopata', () => {
+    const src =
+      "const { data: doc } = await supabase.from('brand_documents').select('file_url').eq('id', params.id).eq('brand_id', brand.id).maybeSingle();\n" +
+      "if (!doc) return json({ error: 'not_found' }, { status: 404 });\n" +
+      "await supabase.from('brand_documents').delete().eq('id', params.id);";
+
+    expect(unscopedServiceRoleWrites('/src/routes/api/v1/brands/x/+server.ts', src)).toEqual([]);
+  });
+
+  it('lascia stare il client con RLS del browser', () => {
+    const src = "await supabase.from('brands').update({ timezone: tz }).eq('slug', params.brand);";
+
+    expect(unscopedServiceRoleWrites('/src/lib/server/settings-actions.ts', src)).toEqual([]);
+  });
+});
+
+describe('la regola riconosce il corpo grezzo che arriva a un SET', () => {
+  it('segnala il corpo passato intero a chi scrive', () => {
+    const src =
+      'const body = await request.json();\n' +
+      'await updateMemoryEntry(supabase, brand.id, params.id, body);';
+
+    expect(unparsedBodyIntoWrite('/src/routes/api/v1/x/+server.ts', src)).toHaveLength(1);
+  });
+
+  it('segnala il corpo sparso in un update', () => {
+    const src =
+      'const body = await request.json();\n' +
+      "await supabase.from('brand_memory').update({ ...body, updated_at: now }).eq('id', id);";
+
+    expect(unparsedBodyIntoWrite('/src/routes/api/v1/x/+server.ts', src)).toHaveLength(1);
+  });
+
+  it('accetta il corpo passato da un contratto', () => {
+    const src =
+      'const parsed = UPDATE_MEMORY_ENTRY.safeParse(await request.json().catch(() => null));\n' +
+      'if (!parsed.success) return json({ error: '
+      + "'invalid_input' }, { status: 400 });\n" +
+      'await updateMemoryEntry(supabase, brand.id, params.id, parsed.data);';
+
+    expect(unparsedBodyIntoWrite('/src/routes/api/v1/x/+server.ts', src)).toEqual([]);
+  });
+
+  it('non confonde un controllo con una scrittura', () => {
+    const src =
+      'const body = await request.json().catch(() => ({}));\n' +
+      "if (body?.action !== 'promote') return json({ error: 'Unsupported action' }, { status: 400 });";
+
+    expect(unparsedBodyIntoWrite('/src/routes/api/v1/x/+server.ts', src)).toEqual([]);
+  });
+});
+
+describe('src/ non scrive fra clienti diversi', () => {
+  const files = listTsFiles(SRC);
+
+  it('ha trovato file .ts da controllare (il test non passa vuoto per errore)', () => {
+    expect(files.length).toBeGreaterThan(200);
+  });
+
+  const report = (findings: Finding[]) =>
+    findings.map((f) => `${f.file.slice(SRC.length)}:${f.line}\n    ${f.chain}`).join('\n');
+
+  it('nessuna scrittura service role su un id esterno senza vincolo di brand', () => {
+    const findings = files.flatMap((f) => unscopedServiceRoleWrites(f, readFileSync(f, 'utf-8')));
+
+    expect(findings, `il client service role ignora la RLS:\n${report(findings)}`).toEqual([]);
+  });
+
+  it('nessun corpo di richiesta non analizzato dentro un SET', () => {
+    const findings = files.flatMap((f) => unparsedBodyIntoWrite(f, readFileSync(f, 'utf-8')));
+
+    expect(findings, `il WHERE è scopato, il SET no:\n${report(findings)}`).toEqual([]);
+  });
+});
+

--- a/src/routes/api/v1/brands/[slug]/studio/memory/[id]/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/studio/memory/[id]/+server.ts
@@ -1,10 +1,7 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { authenticate, loadBrandForUser, checkApiKeyWriteAccess } from '$lib/server/cli-auth';
-
-// PATCH: update a memory entry (value, category, confidence)
-// POST: promote session → project (body: { action: 'promote' })
-// DELETE: delete a memory entry
+import { UPDATE_MEMORY_ENTRY } from '@anomalia/api-contracts';
 
 export const PATCH: RequestHandler = async ({ request, params }) => {
   const { supabase, error, apiKey } = await authenticate(request);
@@ -15,9 +12,13 @@ export const PATCH: RequestHandler = async ({ request, params }) => {
   const writeDenied = checkApiKeyWriteAccess(apiKey);
   if (writeDenied) return writeDenied;
 
-  const body = await request.json();
+  const parsed = UPDATE_MEMORY_ENTRY.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return json({ error: 'invalid_input', details: parsed.error.issues }, { status: 400 });
+  }
+
   const { updateMemoryEntry } = await import('$lib/server/brand-memory');
-  await updateMemoryEntry(supabase, brand.id, params.id, body);
+  await updateMemoryEntry(supabase, brand.id, params.id, parsed.data);
 
   return json({ ok: true });
 };

--- a/src/routes/api/v1/brands/[slug]/studio/memory/[id]/server.cross-brand.test.ts
+++ b/src/routes/api/v1/brands/[slug]/studio/memory/[id]/server.cross-brand.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('$lib/server/cli-auth', () => ({
+  authenticate: vi.fn(),
+  loadBrandForUser: vi.fn(),
+  checkApiKeyWriteAccess: vi.fn(() => null)
+}));
+
+import { PATCH } from './+server';
+import { authenticate, loadBrandForUser } from '$lib/server/cli-auth';
+
+type Row = Record<string, unknown>;
+
+// Il client sul percorso a chiave API è service role: nessuna RLS trattiene questa scrittura.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function serviceRole(rows: Row[]): any {
+  return {
+    from() {
+      const filters: Array<[string, unknown]> = [];
+      let patch: Row = {};
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const q: any = {
+        update(fields: Row) {
+          patch = fields;
+          return q;
+        },
+        eq(column: string, value: unknown) {
+          filters.push([column, value]);
+          return q;
+        },
+        then: (resolve: (v: { data: null; error: null }) => unknown) => {
+          rows
+            .filter((r) => filters.every(([c, v]) => r[c] === v))
+            .forEach((r) => Object.assign(r, patch));
+          return Promise.resolve(resolve({ data: null, error: null }));
+        }
+      };
+      return q;
+    }
+  };
+}
+
+function patch(rows: Row[], body: unknown) {
+  vi.mocked(authenticate).mockResolvedValue({
+    supabase: serviceRole(rows),
+    apiKey: { id: 'k1' }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  vi.mocked(loadBrandForUser).mockResolvedValue({ brand: { id: 'brand-mio' } } as any);
+
+  return (PATCH as unknown as (event: unknown) => Promise<Response>)({
+    request: new Request('https://example.test/memory/m1', {
+      method: 'PATCH',
+      body: JSON.stringify(body)
+    }),
+    params: { slug: 'mio', id: 'm1' }
+  });
+}
+
+describe('PATCH studio memory entry', () => {
+  it('non sposta la riga nel brand di un altro cliente', async () => {
+    const rows: Row[] = [{ id: 'm1', brand_id: 'brand-mio', value: 'mia', category: 'fact' }];
+
+    const res = await patch(rows, { value: 'iniettata', brand_id: 'brand-vittima' });
+
+    expect(rows[0].brand_id).toBe('brand-mio');
+    expect(res.status).toBe(400);
+  });
+
+  it('aggiorna i campi ammessi', async () => {
+    const rows: Row[] = [{ id: 'm1', brand_id: 'brand-mio', value: 'vecchia', category: 'fact' }];
+
+    const res = await patch(rows, { value: 'nuova', pinned: true });
+
+    expect(res.status).toBe(200);
+    expect(rows[0].value).toBe('nuova');
+    expect(rows[0].pinned).toBe(true);
+  });
+});

--- a/src/routes/app/[brand]/site/edit/[id]/+page.server.ts
+++ b/src/routes/app/[brand]/site/edit/[id]/+page.server.ts
@@ -2,6 +2,7 @@ import { error, fail, redirect } from '@sveltejs/kit';
 import type { PageServerLoad, Actions } from './$types';
 import { createAdminClient } from '$lib/server/supabase-admin';
 import { readUploadImage } from '$lib/server/raster-image';
+import { updateBrandRow } from '$lib/server/brand-rows';
 
 // AI cover generation runs the image model → give it headroom.
 // Tetto condiviso, non budget: il lavoro vero di questa rotta sta in ~120s. Su Vercel ogni
@@ -64,13 +65,12 @@ export const actions: Actions = {
     const tagIds = fd.getAll('tag_ids').map((t) => String(t)).filter(Boolean);
     if (!title) return fail(400, { error: 'title_required' });
     const admin = createAdminClient();
-    const { error: err } = await admin.from('brand_articles').update({
+    const failure = await updateBrandRow(admin, 'brand_articles', brand.id, params.id, {
       title, body_md: bodyMd, meta_title: metaTitle || null, meta_description: metaDescription || null,
       category_id: categoryId, author_id: authorId,
       updated_at: new Date().toISOString()
-    }).eq('id', params.id).eq('brand_id', brand.id);
-    if (err) return fail(500, { error: err.message });
-    // Sync tags: delete existing, insert new
+    });
+    if (failure) return fail(failure.status, { error: failure.error });
     await admin.from('brand_article_tags').delete().eq('article_id', params.id);
     if (tagIds.length) {
       await admin.from('brand_article_tags').insert(tagIds.map((tid) => ({ article_id: params.id, tag_id: tid })));

--- a/src/routes/app/[brand]/site/edit/[id]/page.server.cross-brand.test.ts
+++ b/src/routes/app/[brand]/site/edit/[id]/page.server.cross-brand.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi } from 'vitest';
+
+const tables: Record<string, Row[]> = {};
+
+vi.mock('$lib/server/supabase-admin', () => ({ createAdminClient: () => db() }));
+vi.mock('$lib/server/raster-image', () => ({ readUploadImage: vi.fn() }));
+
+import { actions } from './+page.server';
+
+type Row = Record<string, unknown>;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function db(): any {
+  return {
+    from(table: string) {
+      const all = (tables[table] ??= []);
+      const filters: Array<[string, unknown]> = [];
+      let write: 'update' | 'delete' | null = null;
+      let patch: Row = {};
+
+      const run = () => {
+        const hit = all.filter((r) => filters.every(([c, v]) => r[c] === v));
+        if (write === 'update') {
+          hit.forEach((r) => Object.assign(r, patch));
+        }
+        if (write === 'delete') {
+          hit.forEach((r) => all.splice(all.indexOf(r), 1));
+        }
+        return hit;
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const q: any = {
+        select: () => q,
+        eq(column: string, value: unknown) {
+          filters.push([column, value]);
+          return q;
+        },
+        update(fields: Row) {
+          write = 'update';
+          patch = fields;
+          return q;
+        },
+        delete() {
+          write = 'delete';
+          return q;
+        },
+        insert(rows: Row | Row[]) {
+          all.push(...[rows].flat());
+          return q;
+        },
+        maybeSingle: async () => ({ data: run()[0] ?? null, error: null }),
+        then: (resolve: (v: { data: Row[]; error: null }) => unknown) =>
+          Promise.resolve(resolve({ data: run(), error: null }))
+      };
+      return q;
+    }
+  };
+}
+
+function save(brandSlug: string, articleId: string, fields: Record<string, string | string[]>) {
+  const form = new FormData();
+  for (const [k, v] of Object.entries(fields)) {
+    for (const one of [v].flat()) form.append(k, one);
+  }
+  return (actions.save as (event: unknown) => Promise<unknown>)({
+    request: new Request('https://example.test/save', { method: 'POST', body: form }),
+    params: { brand: brandSlug, id: articleId },
+    locals: { supabase: db() }
+  });
+}
+
+describe('site article save', () => {
+  it('non tocca i tag di un articolo di un altro cliente', async () => {
+    tables.brands = [
+      { id: 'brand-a', slug: 'a' },
+      { id: 'brand-b', slug: 'b' }
+    ];
+    tables.brand_articles = [{ id: 'art-b', brand_id: 'brand-b', title: 'Titolo di B' }];
+    tables.brand_article_tags = [{ article_id: 'art-b', tag_id: 'tag-di-b' }];
+
+    const res = (await save('a', 'art-b', { title: 'preso', tag_ids: ['tag-di-a'] })) as {
+      status?: number;
+    };
+
+    expect(tables.brand_article_tags).toEqual([{ article_id: 'art-b', tag_id: 'tag-di-b' }]);
+    expect(res.status).toBe(404);
+  });
+
+  it('salva i tag del proprio articolo', async () => {
+    tables.brands = [{ id: 'brand-a', slug: 'a' }];
+    tables.brand_articles = [{ id: 'art-a', brand_id: 'brand-a', title: 'vecchio' }];
+    tables.brand_article_tags = [{ article_id: 'art-a', tag_id: 'vecchio-tag' }];
+
+    const res = (await save('a', 'art-a', { title: 'nuovo', tag_ids: ['nuovo-tag'] })) as {
+      saved?: boolean;
+    };
+
+    expect(res.saved).toBe(true);
+    expect(tables.brand_articles[0].title).toBe('nuovo');
+    expect(tables.brand_article_tags).toEqual([{ article_id: 'art-a', tag_id: 'nuovo-tag' }]);
+  });
+});


### PR DESCRIPTION
## What?

Two writes could reach another customer's data. They are the same defect twice — a `WHERE` that is correctly scoped to the brand, protecting something that is not the thing actually being written — and this PR closes both, plus adds a test that fails the build if the shape reappears.

1. **Blog article tags.** Saving an article deleted and re-inserted its tag rows on the service-role client, keyed only on the article id from the URL. The scoped update above it looked like a guard and was not.
2. **Brand memory PATCH.** The raw request body went into the `SET` of an update scoped by `brand_id`, so a field too many changed the row's owner instead of its value.

Nothing else in `src/` matches either shape today. Two findings of a *different* shape came out of the sweep and are **not** in this PR — see *Anything Else?*.

## Why?

Both are tenant boundary failures on a multi-tenant product, and both are reachable by an ordinary authenticated customer with an id they can obtain: article ids appear on the public blog surfaces, and the memory route is reachable with any API key. One rewrote another brand's content metadata; the other moved a memory row into a stranger's brand, where it then fed their agents as context.

The second reason is the one that outlives the two fixes: **nothing in the build could tell the difference between a scope that protects and a scope that only looks like it does.** That is why most of the diff is a guard rather than a patch.

## How?

**Article tags** — `brand_article_tags` has no `brand_id`, so the only tenant proof available is that the scoped update on `brand_articles` actually touched a row. The reason the old code failed is that **an update matching zero rows is not an error**: `err` was null and execution walked on into the unscoped tag writes. `updateBrandRow` already existed and does exactly the right thing — scoped update, `.select('id')`, 404 when nothing matched — so the fix is to route through it and let the tag writes sit behind that gate. Reusing the helper was preferred over hand-rolling a row-count check: the repo already has one place where this rule lives, and a second copy diverges at the first change.

**Memory PATCH** — this was the only route in the tree handing an unparsed body to `.update()`; every sibling (`people/[id]`, `competitors/[id]`, `settings/brand`) already parses through a zod `.strict()` contract. So: `UPDATE_MEMORY_ENTRY` in `packages/api-contracts/src/memory.ts`, five fields and nothing else. It is deliberately **not** a `BrandEndpoint` and stays out of `BRAND_ENDPOINTS`, so no new MCP tool appears; the CLI contract mirror is synced in the same commit.

**The guard** (`src/no-cross-tenant-writes.test.ts`) reads the source of `src/` and enforces two rules:

- A service-role write filtered on an id from the URL or the body must carry the tenant column in the same query — unless the id was already proved to belong to this brand by a scoped read that returns on null, or by `updateBrandRow`/`deleteBrandRow`, which count the rows they touch. **An uncounted scoped update is explicitly not proof.** That single distinction is what makes the rule worth having: without it, it would have accepted defect 1 as safe.
- An unparsed request body must not travel whole into a `SET`.

Rejected alternative: an allowlist of known-good sites. The scan finds seven writes of the first shape across `src/`, six of them genuinely safe, and an allowlist of six entries rots into a rubber stamp the first time someone appends a seventh. Making "a scoped read that returns early" a recognised proof clears all six on their actual merit instead.

The rules are approximate by construction — they read source, identify the client by name, and treat a proof as valid for what follows it in the file. That is stated in the file, along with the blind spot named below.

## Testing?

Unit — full suite green: **665 files, 7384 tests, 0 failures**.

Both defects were written as failing tests *first* and watched fail on the real red, which is the cross-tenant write **succeeding**, not merely "the write is scoped":

```
× site article save > non tocca i tag di un articolo di un altro cliente
  - Expected  "tag_id": "tag-di-b"
  + Received  "tag_id": "tag-di-a"

× PATCH studio memory entry > non sposta la riga nel brand di un altro cliente
  expected 'brand-vittima' to be 'brand-mio'
```

The guard was held to the same standard, because a guard that never failed proves nothing. Run against the source **before** the fixes, rule 1 finds the tag delete and rule 2 finds the memory PATCH; run against this branch, both find zero. Five fixture probes in the same file pin the rules to concrete snippets, so if they ever stop recognising the shape a probe falls instead of the silence passing.

Manual — local self-hosted stack, real browser, real login as the seeded test user, identity verified from the session rather than assumed. Two tenants, the second created for the test and **deleted afterwards** (verified: one brand and one user left, no residue).

- Cross-tenant article save, repeated and 5× concurrent → `404 not_found` every time; the other brand's article title, body and tag row unchanged after all of it.
- Own-brand save through the actual editor form → saved, verified in the database; tag writes land correctly; 5× concurrent saves all succeed.
- Edge cases: empty title `400`, unknown article `404`, unknown brand `404`.
- Memory PATCH on the **service-role (API key) path**, which is where the RLS `WITH CHECK` never runs: the injected `brand_id` is refused `400 unrecognized_keys` and the row is untouched. Allowed fields still update; unknown category, out-of-range confidence, and injected `id`/`updated_at` are all refused; empty body is a no-op; malformed JSON is `400`.

Not tested: no agent evaluation was run. These paths are not the chat path, prompts, tools or the model, so the eval's verdict does not apply here.

## Evidence (screenshots/videos)

No exploit recipe is included, per the brief — the shape and the fix are described above and the regression tests encode them.

<details>
<summary>Cross-tenant article save, from a real browser session on the local stack (5× concurrent)</summary>

```
crossRepeat: [ "FAIL 404 not_found", "FAIL 404 not_found", "FAIL 404 not_found",
               "FAIL 404 not_found", "FAIL 404 not_found" ]
ownRepeat:   [ "success", "success", "success", "success", "success" ]
emptyTitle:  "FAIL 400 title_required"

other brand's article after the attempts:
  [{"title":"Articolo della vittima","body_md":"corpo"}]
other brand's tag row after the attempts:
  [{"tag_id":"ac330147-…"}]        ← unchanged, still theirs
```
</details>

<details>
<summary>Memory PATCH on the API-key (service-role) path</summary>

```
brand_id in body    -> 400 {"error":"invalid_input","details":[{"code":"unrecognized_keys",
                             "keys":["brand_id"], "message":"Unrecognized key: \"brand_id\""}]}
row afterwards      -> [{"brand_id":"135bfab8-… (own brand)","value":"valore originale"}]

allowed fields      -> 200 {"ok":true}
unknown category    -> 400 invalid_value
confidence 9        -> 400 too_big (maximum 1)
injected id         -> 400 unrecognized_keys
injected updated_at -> 400 unrecognized_keys
malformed json      -> 400 invalid_type
```
</details>

<details>
<summary>The guard, run against the source before and after the fixes</summary>

```
=== before the fixes
  /routes/app/[brand]/site/edit/[id]/+page.server.ts:74
      .from('brand_article_tags').delete().eq('article_id', params.id)
  FINDINGS 1                                                   ← rule 1

  /routes/api/v1/brands/[slug]/studio/memory/[id]/+server.ts -> body
  FINDINGS 1                                                   ← rule 2

=== this branch
  FINDINGS 0     FINDINGS 0

src/no-cross-tenant-writes.test.ts  12 tests passed
```
</details>

## Anything Else?

**The sweep found two more, of a different shape, and they are deliberately not fixed here.** The rule above only inspects ids in the `WHERE`. It is blind to the case where **the tenant column itself comes from the body** — `insert({ brand_id: body.brandId })` on a service-role client, where there is no id to scope, there is a `brand_id` to verify. Two live instances:

- `src/lib/server/onboarding-steps.ts:320` — `brandId` arrives raw from the request body and becomes the `brand_id` of a service-role job insert. Reached by four onboarding routes (`competitors`, `research`, `plan/posts`, `preview/images`). The worker then runs the job inside `withBrandContext(brandId)`, so every AI call it makes is logged against that brand.
- `src/lib/server/ai-log.ts:398` — same class reached directly, via `withBrandContext(brandId)` in `onboarding/preview` and `onboarding/recommend-platforms`.

The only gate on those routes is `canEnter`, which its own source describes as a commercial door and not a security boundary. The consequence is not data crossing tenants but **cost** crossing them: `credits.ts` sums exactly those `ai_calls` rows as a brand's consumption. Separate defect, separate shape, separate PR — and the third rule that would catch it belongs in that PR, where it can be watched failing first.

Two smaller things found on the way, neither in scope:

- `src/routes/app/[brand]/site/edit/[id]/+page.server.ts` load selects `website` from `brands` and then reads `brand?.id` from that row, so `blog_categories`, `blog_tags` and `blog_authors` are always queried with an empty brand id. The tag picker in the editor therefore never renders — the tag write path this PR hardens is currently only reachable by a crafted request.
- `updateMemoryEntry` / `deleteMemory` answer `200 {"ok":true}` when they matched no row, so the memory endpoints report success for an id belonging to another brand. No data crosses — the `WHERE` holds — but it is the same "zero rows is not an error" honesty problem that made defect 1 exploitable, and it deserves the `updateBrandRow` treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
