### PR TITLE
The brand was chosen by the caller, and billed to someone else

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -1114,3 +1114,50 @@ girare sotto entrambi i runner.
 
 **La regola dietro**: un file di test che vive sotto due runner può usare solo ciò che entrambi
 hanno. `bun:test` ha un alias; il **runtime** `bun` no, e non può averlo — è un eseguibile.
+## Un client service role più un identificatore che arriva da fuori
+
+**Segnale.** Da qualche parte c'è `createAdminClient()` — o, sul percorso a chiave API, il
+`supabase` che `authenticate()` restituisce, che è la stessa cosa con un altro nome — e nella
+stessa funzione c'è un id preso da `params`, dal corpo della richiesta, o da un `formData`. Il
+codice attorno ha l'aria protetta: un `.eq('brand_id', …)` da qualche parte, un `canEnter`, un
+404 sul brand. Sembra a posto, e in quattro casi su quattro non lo era.
+
+**Cosa succede.** `service_role` ha `bypassrls=true`: le policy non vengono nemmeno valutate.
+Quindi la protezione è solo quella scritta a mano, e si rompe in tre modi che sembrano diversi e
+sono lo stesso:
+
+1. **Il `WHERE` è scopato, il bersaglio no.** L'update sull'articolo porta `brand_id`, la delete
+   sui tag che segue no. La riga vicina protetta fa sembrare protetta anche quella dopo.
+2. **Il `WHERE` è scopato, il `SET` no.** Il corpo grezzo finisce nell'update: la riga si trova
+   nel tuo brand e si riscrive col `brand_id` di un altro.
+3. **Non c'è nessun `WHERE` da scopare: il tenant È il valore che arriva da fuori.**
+   `insert({ brand_id: body.brandId })`. Qui non attraversa il dato, attraversa il **conto** —
+   `credits.ts` somma quelle righe di `ai_calls`, quindi il consumo di uno lo paga un altro.
+
+E il fallimento è muto in tutti e tre: **zero righe toccate non è un errore per PostgREST**,
+quindi un update scopato che non trova niente lascia `error` nullo e il codice prosegue fino alla
+scrittura non scopata che gli sta dietro. Un endpoint che risponde `200 {"ok":true}` su una riga
+che non ha toccato è la stessa disonestà, un gradino più in basso.
+
+Perché nessuno se n'era accorto: il cancello che sembrava un confine non lo era. `canEnter` si
+descrive da sé come *«una porta commerciale, non un confine di sicurezza»* — chi leggeva la route
+vedeva un `403` in cima e smetteva di cercare.
+
+**La mossa.** `src/no-cross-tenant-writes.test.ts`, tre regole sul sorgente, una per forma. Non
+sono state scritte per essere verdi: ognuna è stata provata sul sorgente **prima** della
+correzione e ha trovato il proprio difetto lì — 1, 1 e 6 occorrenze. Una guardia che non è mai
+stata rossa non dimostra niente, e ne abbiamo trovate cinque così in una sola giornata.
+
+Niente allowlist: la prima regola incontra sette scritture di quella forma e sei sono sane, ma
+un'allowlist da sei voci diventa un timbro alla settima. Le sei si sdoganano sul merito — una
+lettura scopata che torna indietro, o `updateBrandRow`/`deleteBrandRow`, che contano le righe che
+hanno toccato. Un update scopato che nessuno conta **non** vale come prova: quella riga sola è la
+differenza fra la regola e un placebo.
+
+Per il caso 3 la verifica sta in `ownsBrand` (`access.ts`): gira la domanda al database col client
+dell'utente, dove le policy di `brands` rispondono con la stessa regola che `loadBrandForUser`
+riapplica a mano. Un client non marchiato `markRlsScoped` riceve `false` — il default è il
+rifiuto, così un percorso nuovo che si dimentica di marchiarsi resta chiuso invece di aprirsi.
+
+Quattro occorrenze trovate solo perché qualcuno è andato a cercarle: la quinta arriverà, e allora
+il costo di questa lezione è già stato pagato.

--- a/changelog/2026-09-05-brand-id-from-the-body.md
+++ b/changelog/2026-09-05-brand-id-from-the-body.md
@@ -1,0 +1,83 @@
+# Il brand lo sceglieva chi chiamava, e il conto lo pagava un altro
+
+La stessa classe delle due scritture chiuse poco fa, presa dall'altro capo. Lì c'era un id da
+scopare in un `WHERE`; qui **non c'è nessun `WHERE`: il tenant È il valore che arriva dal corpo.**
+
+Sei rotte di onboarding leggono `brandId` da `await request.json()` e lo usano senza chiedersi di
+chi sia. Quattro lo passano a `startOnboardingStepJob`, che lo scrive come `brand_id` di una riga
+inserita col client service role; due aprono direttamente `withBrandContext(brandId)`. Da lì in
+poi ogni chiamata AI di quel lavoro viene registrata in `ai_calls` con quel `brand_id` — e
+`credits.ts` somma esattamente quelle righe come consumo del brand.
+
+**Quindi non attraversa il dato: attraversa il conto.** Un utente qualsiasi nomina il brand di un
+altro cliente e gli fa pagare il proprio consumo. `/preview` genera sei immagini per richiesta,
+quindi il costo per chiamata non è simbolico.
+
+## Perché nessuno se n'era accorto
+
+Perché in cima a tutte e sei c'è un `403`, e sembra un confine:
+
+```ts
+if (!(await canEnter(supabase))) return new Response('Forbidden', { status: 403 });
+```
+
+`canEnter` è il flag della beta chiusa, e la sua stessa fonte lo dice:
+*«questa è una porta commerciale, non un confine di sicurezza»*. Chi leggeva la route vedeva un
+cancello e smetteva di cercarne un altro. Il commento diceva la verità e veniva letto al
+contrario.
+
+## La verifica: la domanda si gira al database
+
+`ownsBrand` in `access.ts`. Non c'è niente da dedurre dal valore — arriva da fuori — quindi la
+risposta la danno le policy: la SELECT su `brands` restituisce solo i brand di cui sei
+proprietario dell'org o membro (`brands via org` + `brands member select`), che è **la stessa
+regola** che `loadBrandForUser` riapplica a mano sul percorso a chiave API. Una regola sola, in un
+posto solo.
+
+Un client non marchiato `markRlsScoped` riceve `false` senza nemmeno interrogare: un client che
+scavalca la RLS risponderebbe di sì per il brand di chiunque, e il default deve essere il rifiuto
+— così un percorso nuovo che si dimentica di marchiarsi resta chiuso invece di aprirsi da solo.
+
+Nelle sei rotte la riga sta subito sotto quella di `canEnter`, che è dove un lettore la cerca:
+
+```ts
+if (brandId && !(await ownsBrand(supabase, brandId))) return new Response('Forbidden', { status: 403 });
+```
+
+`brandId &&` non è difensivo: in due rotte (`plan/posts`, `preview/images`) il brand può
+legittimamente non esistere ancora — è onboarding, la bozza precede il brand — e un `brand_id`
+nullo non attraversa niente.
+
+## La terza regola della guardia
+
+`src/no-cross-tenant-writes.test.ts` aveva due regole, entrambe cieche a questa forma: guardano
+l'id nel `WHERE`, e qui il `WHERE` non c'è. La terza guarda il legame che manca: **un valore che
+nomina un tenant** (`brandId`, `orgId`, `userId`, …) **assegnato da qualcosa che viene dal corpo,
+in un file dove nessuno chiama `ownsBrand`.**
+
+Provata sul sorgente prima della correzione trova sei occorrenze, esattamente le sei rotte, e zero
+falsi positivi su tutto `src/`. Dopo, zero. Quattro sonde a fixture la ancorano — segnala il
+`brandId` non verificato, accetta quello verificato, e non confonde né un id che viene da un brand
+già caricato né un campo del corpo che non nomina un tenant.
+
+Nessuna allowlist, per lo stesso motivo di prima: un'allowlist da sei voci diventa un timbro alla
+settima.
+
+## E l'ultimo `200` disonesto
+
+`updateMemoryEntry` e `deleteMemory` rispondevano `200 {"ok":true}` anche quando non toccavano
+niente. Nessun dato attraversava — il `WHERE` regge — ma è **la stessa disonestà che rendeva
+sfruttabile il difetto dei tag**: un update che non tocca nulla e non lo dice fa proseguire il
+codice che gli sta dietro. Adesso passano da `updateBrandRow`/`deleteBrandRow`, che contano le
+righe, e i tre endpoint della memoria rispondono `404` invece di mentire.
+
+`expression-memory-tools.ts` e le azioni di `knowledge/+page.server.ts` ignorano ancora il valore
+di ritorno: nessuna scrittura le segue, quindi il silenzio lì non apre niente. Restano da
+raccogliere quando qualcuno passa di lì.
+
+## Cosa NON è stato toccato
+
+Il `load` di `site/edit/[id]` legge `brand?.id` da una riga che seleziona solo `website`, quindi
+`undefined`, quindi categorie, tag e autori sono sempre interrogati con brand id vuoto e il
+selettore dei tag non si è mai visto. È una funzione rotta, non un problema di sicurezza, e
+ripararla dentro una PR di sicurezza significa farle revertire insieme.

--- a/src/lib/content/changelog/2026-09-05-onboarding-runs-on-your-own-brand.ts
+++ b/src/lib/content/changelog/2026-09-05-onboarding-runs-on-your-own-brand.ts
@@ -1,0 +1,10 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-05',
+  title: 'Onboarding runs on your own brand',
+  items: [
+    'Onboarding steps now check that the brand they were asked to work on is yours, so the credits they spend can only ever come from your own plan.',
+    'Editing or deleting a brand memory entry that does not exist now says so, instead of reporting success.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/access.test.ts
+++ b/src/lib/server/access.test.ts
@@ -128,3 +128,46 @@ describe('userCanEnter', () => {
     expect(await userCanEnter('user-1')).toBe(false);
   });
 });
+
+describe('ownsBrand', () => {
+  /** Le policy di `brands` restituiscono la riga solo a chi è proprietario dell'org o membro. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const brandsVisibleTo = (visible: string[]): any => ({
+    from: () => {
+      let wanted: unknown = null;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const q: any = {
+        select: () => q,
+        eq: (_column: string, value: unknown) => {
+          wanted = value;
+          return q;
+        },
+        maybeSingle: async () => ({
+          data: visible.includes(wanted as string) ? { id: wanted } : null,
+          error: null
+        })
+      };
+      return q;
+    }
+  });
+
+  it('riconosce un brand del chiamante', async () => {
+    const { ownsBrand } = await freshAccess();
+    const { markRlsScoped } = await import('./rls-client');
+
+    expect(await ownsBrand(markRlsScoped(brandsVisibleTo(['brand-mio'])), 'brand-mio')).toBe(true);
+  });
+
+  it('nega un brand che le policy non gli mostrano', async () => {
+    const { ownsBrand } = await freshAccess();
+    const { markRlsScoped } = await import('./rls-client');
+
+    expect(await ownsBrand(markRlsScoped(brandsVisibleTo(['brand-mio'])), 'brand-altrui')).toBe(false);
+  });
+
+  it('nega su un client che non dichiara di essere scoped', async () => {
+    const { ownsBrand } = await freshAccess();
+
+    expect(await ownsBrand(brandsVisibleTo(['brand-altrui']), 'brand-altrui')).toBe(false);
+  });
+});

--- a/src/lib/server/access.ts
+++ b/src/lib/server/access.ts
@@ -1,5 +1,6 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { createAdminClient } from '$lib/server/supabase-admin';
+import { isRlsScoped } from '$lib/server/rls-client';
 
 // can_enter() depends on the caller's session (admin bypass), so it can only be cached per
 // request, not globally. Keyed by the per-request supabase client (WeakMap so entries die
@@ -66,4 +67,21 @@ export async function flagEnabled(
   const value = data === true;
   flagCache.set(cacheKey, { value, expires: Date.now() + FLAG_TTL_MS });
   return value;
+}
+
+/**
+ * Il brand che il chiamante ha nominato nel corpo è suo? La risposta non sta nel valore — arriva
+ * da fuori — ma nelle policy: la SELECT su `brands` restituisce solo i brand di cui sei
+ * proprietario dell'org o membro, ed è la stessa regola che `loadBrandForUser` riapplica a mano
+ * sul percorso a chiave API. Quindi la domanda si gira al database, col client dell'utente.
+ *
+ * Un client non marchiato come scoped è service role, o un percorso nuovo che ha dimenticato di
+ * marchiarsi: in entrambi i casi la risposta è no, perché un client che scavalca la RLS
+ * risponderebbe di sì per il brand di chiunque.
+ */
+export async function ownsBrand(supabase: SupabaseClient, brandId: string): Promise<boolean> {
+  if (!isRlsScoped(supabase)) return false;
+
+  const { data } = await supabase.from('brands').select('id').eq('id', brandId).maybeSingle();
+  return Boolean(data);
 }

--- a/src/lib/server/brand-memory.ts
+++ b/src/lib/server/brand-memory.ts
@@ -1,4 +1,5 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
+import { updateBrandRow, deleteBrandRow, type RowFailure } from './brand-rows';
 import { structured } from './research';
 import { withBrandContext } from './ai-log';
 import { defaultSkillsFor } from './default-skills';
@@ -527,9 +528,14 @@ export async function promoteMemoryToProject(
 // ── Delete / archive ───────────────────────────────────────────────────────────
 
 // brandId is required, not optional: these run under the service-role client on the CLI path, where
-// an id alone would reach any brand's memory.
-export async function deleteMemory(supabase: SupabaseClient, brandId: string, entryId: string): Promise<void> {
-  await supabase.from('brand_memory').delete().eq('id', entryId).eq('brand_id', brandId);
+// an id alone would reach any brand's memory. E chi non tocca niente lo dice: zero righe non e' un
+// errore per PostgREST, quindi senza il conteggio l'endpoint risponde `ok` sulla riga di un altro.
+export async function deleteMemory(
+  supabase: SupabaseClient,
+  brandId: string,
+  entryId: string
+): Promise<RowFailure | null> {
+  return deleteBrandRow(supabase, 'brand_memory', brandId, entryId);
 }
 
 export async function updateMemoryEntry(
@@ -537,10 +543,11 @@ export async function updateMemoryEntry(
   brandId: string,
   entryId: string,
   patch: Partial<Pick<MemoryEntry, 'value' | 'category' | 'confidence' | 'pinned' | 'importance'>>
-): Promise<void> {
-  await supabase.from('brand_memory')
-    .update({ ...patch, updated_at: new Date().toISOString() })
-    .eq('id', entryId).eq('brand_id', brandId);
+): Promise<RowFailure | null> {
+  return updateBrandRow(supabase, 'brand_memory', brandId, entryId, {
+    ...patch,
+    updated_at: new Date().toISOString()
+  });
 }
 
 // ── Conflict detection ─────────────────────────────────────────────────────────

--- a/src/no-cross-tenant-writes.test.ts
+++ b/src/no-cross-tenant-writes.test.ts
@@ -17,9 +17,9 @@ import { fileURLToPath } from 'node:url';
  * vale per tutto ciò che segue nel file. Le sonde qui sotto tengono la regola onesta — se
  * smette di riconoscere il difetto, il primo test è quello che cade.
  *
- * Quello che NON vede: il caso in cui la colonna del tenant sta nel `SET` invece che nel `WHERE`
- * — `insert({ brand_id: body.brandId })` su un client service role. Lì non c'è nessun id da
- * scopare, c'è un `brand_id` da verificare, ed è un'altra regola.
+ * La terza regola prende il caso in cui la colonna del tenant sta nel `SET` invece che nel
+ * `WHERE`: lì non c'è nessun id da scopare, c'è un `brand_id` da verificare. È la forma che
+ * costava di più e si vedeva di meno — non attraversa dati, attraversa il conto.
  */
 const SRC = fileURLToPath(new URL('.', import.meta.url));
 
@@ -78,6 +78,31 @@ function unparsedBodyIntoWrite(file: string, src: string): Finding[] {
     if (!hit) continue;
 
     out.push({ file, line: src.slice(0, hit.index).split('\n').length, chain: hit[0].replace(/\s+/g, ' ') });
+  }
+  return out;
+}
+
+const TENANT_VAR = /(?:const|let)\s+(brandId|orgId|organizationId|userId|ownerId|accountId)\s*=\s*([^;]*)/g;
+const FROM_BODY = /\bbody\b|await\s+request\.json\(\)/;
+const OWNERSHIP_CHECKED = /\bownsBrand\s*\(/;
+
+/**
+ * Il tenant preso dal corpo e mai verificato. Non finisce in un `WHERE` da scopare: diventa il
+ * `brand_id` di una riga scritta col client service role, o lo scope sotto cui gira il lavoro —
+ * e da lì il costo di quel lavoro va sul conto del brand nominato. `canEnter` non lo ferma: è
+ * una porta commerciale, non un confine di sicurezza, e lo dice la sua stessa fonte.
+ */
+function unverifiedTenantFromBody(file: string, src: string): Finding[] {
+  const out: Finding[] = [];
+  for (const match of src.matchAll(TENANT_VAR)) {
+    const [, name, rhs] = match;
+    if (!FROM_BODY.test(rhs) || OWNERSHIP_CHECKED.test(src)) continue;
+
+    out.push({
+      file,
+      line: src.slice(0, match.index).split('\n').length,
+      chain: `${name} = ${rhs.replace(/\s+/g, ' ').slice(0, 90)}`
+    });
   }
   return out;
 }
@@ -174,6 +199,40 @@ describe('la regola riconosce il corpo grezzo che arriva a un SET', () => {
   });
 });
 
+const BRAND_FROM_BODY = "const brandId = typeof body?.brandId === 'string' ? body.brandId : null;\n";
+
+describe('la regola riconosce il tenant preso dal corpo', () => {
+  it('segnala un brandId dal corpo che nessuno verifica', () => {
+    const src =
+      BRAND_FROM_BODY +
+      'if (!(await canEnter(supabase))) return new Response(\'Forbidden\', { status: 403 });\n' +
+      'await startOnboardingStepJob(supabase, { kind, userId: user.id, brandId, input });';
+
+    expect(unverifiedTenantFromBody('/src/routes/app/onboarding/x/+server.ts', src)).toHaveLength(1);
+  });
+
+  it('accetta un brandId verificato contro il client dell utente', () => {
+    const src =
+      BRAND_FROM_BODY +
+      "if (brandId && !(await ownsBrand(supabase, brandId))) return new Response('Forbidden', { status: 403 });\n" +
+      'await startOnboardingStepJob(supabase, { kind, userId: user.id, brandId, input });';
+
+    expect(unverifiedTenantFromBody('/src/routes/app/onboarding/x/+server.ts', src)).toEqual([]);
+  });
+
+  it('lascia stare un id che viene da un brand gia caricato', () => {
+    const src = 'const brandId = brand.id;\nawait withBrandContext(brandId, run);';
+
+    expect(unverifiedTenantFromBody('/src/routes/app/x/+server.ts', src)).toEqual([]);
+  });
+
+  it('lascia stare un campo del corpo che non nomina un tenant', () => {
+    const src = "const draftId = typeof body?.draftId === 'string' ? body.draftId : null;";
+
+    expect(unverifiedTenantFromBody('/src/routes/app/x/+server.ts', src)).toEqual([]);
+  });
+});
+
 describe('src/ non scrive fra clienti diversi', () => {
   const files = listTsFiles(SRC);
 
@@ -194,6 +253,12 @@ describe('src/ non scrive fra clienti diversi', () => {
     const findings = files.flatMap((f) => unparsedBodyIntoWrite(f, readFileSync(f, 'utf-8')));
 
     expect(findings, `il WHERE è scopato, il SET no:\n${report(findings)}`).toEqual([]);
+  });
+
+  it('nessun tenant preso dal corpo senza verifica di proprietà', () => {
+    const findings = files.flatMap((f) => unverifiedTenantFromBody(f, readFileSync(f, 'utf-8')));
+
+    expect(findings, `il brand lo sceglie chi chiama:\n${report(findings)}`).toEqual([]);
   });
 });
 

--- a/src/routes/api/v1/brands/[slug]/studio/memory/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/studio/memory/+server.ts
@@ -75,7 +75,8 @@ export const DELETE: RequestHandler = async ({ request, params }) => {
   if (!id) return json({ error: 'id is required' }, { status: 400 });
 
   const { deleteMemory } = await import('$lib/server/brand-memory');
-  await deleteMemory(supabase, brand.id, id);
+  const failure = await deleteMemory(supabase, brand.id, id);
+  if (failure) return json({ error: failure.error }, { status: failure.status });
 
   return json({ ok: true });
 };

--- a/src/routes/api/v1/brands/[slug]/studio/memory/[id]/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/studio/memory/[id]/+server.ts
@@ -18,7 +18,8 @@ export const PATCH: RequestHandler = async ({ request, params }) => {
   }
 
   const { updateMemoryEntry } = await import('$lib/server/brand-memory');
-  await updateMemoryEntry(supabase, brand.id, params.id, parsed.data);
+  const failure = await updateMemoryEntry(supabase, brand.id, params.id, parsed.data);
+  if (failure) return json({ error: failure.error }, { status: failure.status });
 
   return json({ ok: true });
 };
@@ -52,7 +53,8 @@ export const DELETE: RequestHandler = async ({ request, params }) => {
   if (writeDenied) return writeDenied;
 
   const { deleteMemory } = await import('$lib/server/brand-memory');
-  await deleteMemory(supabase, brand.id, params.id);
+  const failure = await deleteMemory(supabase, brand.id, params.id);
+  if (failure) return json({ error: failure.error }, { status: failure.status });
 
   return json({ ok: true });
 };

--- a/src/routes/api/v1/brands/[slug]/studio/memory/[id]/server.cross-brand.test.ts
+++ b/src/routes/api/v1/brands/[slug]/studio/memory/[id]/server.cross-brand.test.ts
@@ -6,7 +6,7 @@ vi.mock('$lib/server/cli-auth', () => ({
   checkApiKeyWriteAccess: vi.fn(() => null)
 }));
 
-import { PATCH } from './+server';
+import { PATCH, DELETE } from './+server';
 import { authenticate, loadBrandForUser } from '$lib/server/cli-auth';
 
 type Row = Record<string, unknown>;
@@ -18,21 +18,30 @@ function serviceRole(rows: Row[]): any {
     from() {
       const filters: Array<[string, unknown]> = [];
       let patch: Row = {};
+      let removing = false;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const q: any = {
         update(fields: Row) {
           patch = fields;
           return q;
         },
+        delete() {
+          removing = true;
+          return q;
+        },
+        select: () => q,
         eq(column: string, value: unknown) {
           filters.push([column, value]);
           return q;
         },
-        then: (resolve: (v: { data: null; error: null }) => unknown) => {
-          rows
-            .filter((r) => filters.every(([c, v]) => r[c] === v))
-            .forEach((r) => Object.assign(r, patch));
-          return Promise.resolve(resolve({ data: null, error: null }));
+        then: (resolve: (v: { data: Row[]; error: null }) => unknown) => {
+          const hit = rows.filter((r) => filters.every(([c, v]) => r[c] === v));
+          if (removing) {
+            hit.forEach((r) => rows.splice(rows.indexOf(r), 1));
+          } else {
+            hit.forEach((r) => Object.assign(r, patch));
+          }
+          return Promise.resolve(resolve({ data: hit, error: null }));
         }
       };
       return q;
@@ -58,6 +67,21 @@ function patch(rows: Row[], body: unknown) {
   });
 }
 
+function remove(rows: Row[]) {
+  vi.mocked(authenticate).mockResolvedValue({
+    supabase: serviceRole(rows),
+    apiKey: { id: 'k1' }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  vi.mocked(loadBrandForUser).mockResolvedValue({ brand: { id: 'brand-mio' } } as any);
+
+  return (DELETE as unknown as (event: unknown) => Promise<Response>)({
+    request: new Request('https://example.test/memory/m1', { method: 'DELETE' }),
+    params: { slug: 'mio', id: 'm1' }
+  });
+}
+
 describe('PATCH studio memory entry', () => {
   it('non sposta la riga nel brand di un altro cliente', async () => {
     const rows: Row[] = [{ id: 'm1', brand_id: 'brand-mio', value: 'mia', category: 'fact' }];
@@ -68,6 +92,15 @@ describe('PATCH studio memory entry', () => {
     expect(res.status).toBe(400);
   });
 
+  it('non dichiara successo su una riga che non ha toccato', async () => {
+    const rows: Row[] = [{ id: 'm1', brand_id: 'brand-di-un-altro', value: 'sua', category: 'fact' }];
+
+    const res = await patch(rows, { value: 'preso' });
+
+    expect(res.status).toBe(404);
+    expect(rows[0].value).toBe('sua');
+  });
+
   it('aggiorna i campi ammessi', async () => {
     const rows: Row[] = [{ id: 'm1', brand_id: 'brand-mio', value: 'vecchia', category: 'fact' }];
 
@@ -76,5 +109,25 @@ describe('PATCH studio memory entry', () => {
     expect(res.status).toBe(200);
     expect(rows[0].value).toBe('nuova');
     expect(rows[0].pinned).toBe(true);
+  });
+});
+
+describe('DELETE studio memory entry', () => {
+  it('non dichiara successo su una riga che non ha toccato', async () => {
+    const rows: Row[] = [{ id: 'm1', brand_id: 'brand-di-un-altro', value: 'sua' }];
+
+    const res = await remove(rows);
+
+    expect(res.status).toBe(404);
+    expect(rows).toHaveLength(1);
+  });
+
+  it('cancella la propria', async () => {
+    const rows: Row[] = [{ id: 'm1', brand_id: 'brand-mio', value: 'mia' }];
+
+    const res = await remove(rows);
+
+    expect(res.status).toBe(200);
+    expect(rows).toHaveLength(0);
   });
 });

--- a/src/routes/app/onboarding/competitors/+server.ts
+++ b/src/routes/app/onboarding/competitors/+server.ts
@@ -1,6 +1,6 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { canEnter } from '$lib/server/access';
+import { canEnter, ownsBrand } from '$lib/server/access';
 import { localeLanguageName } from '$lib/i18n/locale';
 import {
   startOnboardingStepJob,
@@ -24,6 +24,7 @@ export const POST: RequestHandler = async ({
 
   const body = await request.json().catch(() => ({}));
   const brandId = typeof body?.brandId === 'string' ? body.brandId : null;
+  if (brandId && !(await ownsBrand(supabase, brandId))) return new Response('Forbidden', { status: 403 });
   if (!brandId) return new Response('Missing brandId', { status: 400 });
 
   const draftId = typeof body?.draftId === 'string' ? body.draftId : null;

--- a/src/routes/app/onboarding/plan/posts/+server.ts
+++ b/src/routes/app/onboarding/plan/posts/+server.ts
@@ -1,6 +1,6 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { canEnter } from '$lib/server/access';
+import { canEnter, ownsBrand } from '$lib/server/access';
 import {
   startOnboardingStepJob,
   getOnboardingStepJob,
@@ -23,6 +23,7 @@ export const POST: RequestHandler = async ({
 
   const body = await request.json().catch(() => ({}));
   const brandId = typeof body?.brandId === 'string' ? body.brandId : null;
+  if (brandId && !(await ownsBrand(supabase, brandId))) return new Response('Forbidden', { status: 403 });
   const draftId = typeof body?.draftId === 'string' ? body.draftId : null;
   const force = !!body?.force;
   const profile = body?.profile ?? {};

--- a/src/routes/app/onboarding/preview/+server.ts
+++ b/src/routes/app/onboarding/preview/+server.ts
@@ -1,6 +1,6 @@
 import { swallow } from '$lib/server/swallow';
 import type { RequestHandler } from './$types';
-import { canEnter } from '$lib/server/access';
+import { canEnter, ownsBrand } from '$lib/server/access';
 import { generatePreview } from '$lib/server/content-preview';
 import { scrapeForOnboarding, type ScrapeTarget } from '$lib/server/scrapecreators';
 import { genaiClient, synthesizeBrandContext, synthesizeVisualStyle } from '$lib/server/brand-context';
@@ -36,6 +36,7 @@ export const POST: RequestHandler = async ({ request, locals: { supabase, safeGe
 
   const body = await request.json().catch(() => ({}));
   const brandId = typeof body?.brandId === 'string' ? body.brandId : null;
+  if (brandId && !(await ownsBrand(supabase, brandId))) return new Response('Forbidden', { status: 403 });
   if (!brandId) return new Response('Missing brandId', { status: 400 });
 
   return withBrandContext(brandId, async () => {

--- a/src/routes/app/onboarding/preview/images/+server.ts
+++ b/src/routes/app/onboarding/preview/images/+server.ts
@@ -1,6 +1,6 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { canEnter } from '$lib/server/access';
+import { canEnter, ownsBrand } from '$lib/server/access';
 import {
   startOnboardingStepJob,
   getOnboardingStepJob,
@@ -23,6 +23,7 @@ export const POST: RequestHandler = async ({
 
   const body = await request.json().catch(() => ({}));
   const brandId = typeof body?.brandId === 'string' ? body.brandId : null;
+  if (brandId && !(await ownsBrand(supabase, brandId))) return new Response('Forbidden', { status: 403 });
   const draftId = typeof body?.draftId === 'string' ? body.draftId : null;
   const force = !!body?.force;
   const profile = body?.profile ?? {};

--- a/src/routes/app/onboarding/recommend-platforms/+server.ts
+++ b/src/routes/app/onboarding/recommend-platforms/+server.ts
@@ -1,5 +1,5 @@
 import type { RequestHandler } from './$types';
-import { canEnter } from '$lib/server/access';
+import { canEnter, ownsBrand } from '$lib/server/access';
 import { genaiClient } from '$lib/server/research';
 import { aiStructured } from '$lib/server/ai-text';
 import { localeLanguageName } from '$lib/i18n/locale';
@@ -42,6 +42,7 @@ export const POST: RequestHandler = async ({ request, locals: { supabase, safeGe
 
   const body = await request.json().catch(() => ({}));
   const brandId = typeof body?.brandId === 'string' ? body.brandId : null;
+  if (brandId && !(await ownsBrand(supabase, brandId))) return new Response('Forbidden', { status: 403 });
   if (!brandId) return new Response('Missing brandId', { status: 400 });
   return withBrandContext(brandId, async () => {
     const profile = body?.profile ?? {};

--- a/src/routes/app/onboarding/research/+server.ts
+++ b/src/routes/app/onboarding/research/+server.ts
@@ -1,6 +1,6 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { canEnter } from '$lib/server/access';
+import { canEnter, ownsBrand } from '$lib/server/access';
 import { localeLanguageName } from '$lib/i18n/locale';
 import {
   startOnboardingStepJob,
@@ -25,6 +25,7 @@ export const POST: RequestHandler = async ({
 
   const body = await request.json().catch(() => ({}));
   const brandId = typeof body?.brandId === 'string' ? body.brandId : null;
+  if (brandId && !(await ownsBrand(supabase, brandId))) return new Response('Forbidden', { status: 403 });
   if (!brandId) return new Response('Missing brandId', { status: 400 });
 
   const draftId = typeof body?.draftId === 'string' ? body.draftId : null;

--- a/src/routes/app/onboarding/research/server.cross-brand.test.ts
+++ b/src/routes/app/onboarding/research/server.cross-brand.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { startOnboardingStepJob } = vi.hoisted(() => ({
+  startOnboardingStepJob: vi.fn(async () => ({ jobId: 'j1', reused: false }))
+}));
+
+vi.mock('$lib/server/onboarding-steps', async (orig) => ({
+  ...(await orig<typeof import('$lib/server/onboarding-steps')>()),
+  startOnboardingStepJob,
+  kickOnboardingStepWork: vi.fn()
+}));
+vi.mock('$lib/server/access', async (orig) => ({
+  ...(await orig<typeof import('$lib/server/access')>()),
+  canEnter: vi.fn(async () => true)
+}));
+
+import { POST } from './+server';
+import { markRlsScoped } from '$lib/server/rls-client';
+
+type Row = Record<string, unknown>;
+
+/** Il client del browser: le policy di `brands` restituiscono solo i brand del chiamante. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function browserClient(visibleBrandIds: string[]): any {
+  return markRlsScoped({
+    from() {
+      const filters: Array<[string, unknown]> = [];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const q: any = {
+        select: () => q,
+        eq(column: string, value: unknown) {
+          filters.push([column, value]);
+          return q;
+        },
+        maybeSingle: async () => {
+          const wanted = filters.find(([c]) => c === 'id')?.[1];
+          const hit = visibleBrandIds.includes(wanted as string);
+          return { data: hit ? ({ id: wanted } as Row) : null, error: null };
+        }
+      };
+      return q;
+    }
+  });
+}
+
+function post(brandId: string, visibleBrandIds: string[]) {
+  return (POST as unknown as (event: unknown) => Promise<Response>)({
+    request: new Request('https://example.test/app/onboarding/research', {
+      method: 'POST',
+      body: JSON.stringify({ brandId, profile: {} })
+    }),
+    url: new URL('https://example.test/app/onboarding/research'),
+    platform: undefined,
+    locals: {
+      supabase: browserClient(visibleBrandIds),
+      safeGetSession: async () => ({ session: { id: 's' }, user: { id: 'u1' } }),
+      locale: 'it'
+    }
+  });
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('onboarding research', () => {
+  it('non accoda lavoro sul brand di un altro cliente', async () => {
+    const res = await post('brand-di-un-altro', ['brand-mio']);
+
+    expect(startOnboardingStepJob).not.toHaveBeenCalled();
+    expect(res.status).toBe(403);
+  });
+
+  it('accoda sul proprio brand', async () => {
+    const res = await post('brand-mio', ['brand-mio']);
+
+    expect(startOnboardingStepJob).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ brandId: 'brand-mio' })
+    );
+    expect(res.status).toBe(200);
+  });
+});


### PR DESCRIPTION
> **Stacked on #366** — base is `fix/cross-tenant-writes`, so the guard stays one file with three rules instead of two copies. Merge #366 first; the diff here rebases onto `dev` cleanly once it lands.

## What?

The other two of the four. #366 closed the pair where a scoped `WHERE` protected the wrong thing; this closes the pair where **there is no `WHERE` at all — the tenant *is* the value that arrives from outside.**

Six onboarding routes read `brandId` from `await request.json()` and used it without asking whose it was. Four hand it to `startOnboardingStepJob`, which writes it as the `brand_id` of a service-role insert; two open `withBrandContext(brandId)` directly. It also closes the last dishonest `200` from #366's follow-ups, adds the third guard rule, and records the class in `LESSONS.md`.

## Why?

**Nothing crosses tenants here except the bill, and that is the point, not a mitigation.** Every AI call the work makes is logged into `ai_calls` under that `brand_id`, and `credits.ts` sums exactly those rows as the brand's consumption. So an ordinary logged-in user can name another customer's brand and **charge their own usage to that customer's organisation**. `/preview` renders a six-post image batch per request, so the cost per call is not symbolic. It is the same damage as a $1000 hole read as $0.70, taken from the other end.

Why nobody noticed: all six have a `403` at the top and it looks like a boundary.

```ts
if (!(await canEnter(supabase))) return new Response('Forbidden', { status: 403 });
```

`canEnter` is the closed-beta flag, and its own source says so — *«questa è una porta commerciale, non un confine di sicurezza»*. The comment told the truth and was read backwards. That is the sentence that explains the whole class.

## How?

**`ownsBrand` (`src/lib/server/access.ts`).** There is nothing to deduce from the value — it comes from outside — so the question goes to the database with the caller's own client, where the `brands` policies (`brands via org` + `brands member select`) answer with **the same rule** `loadBrandForUser` re-applies by hand on the API-key path. One rule, one place; no second copy to diverge.

A client not marked `markRlsScoped` gets `false` without a query. That is not belt-and-braces: a service-role client would answer yes for anybody's brand, so refusal has to be the default, and a new path that forgets to mark itself stays shut instead of opening by accident. That marker already existed — `rls-client.ts` — so this reuses the repo's own answer to "which client carries the user's permissions".

The check sits directly under the `canEnter` line, where a reader looks for it:

```ts
if (brandId && !(await ownsBrand(supabase, brandId))) return new Response('Forbidden', { status: 403 });
```

`brandId &&` is not defensive padding: in `plan/posts` and `preview/images` the brand may legitimately not exist yet — it is onboarding, the draft precedes the brand — and a null `brand_id` crosses nothing. Verified below that the draft path still works.

Rejected alternative: putting the check inside `startOnboardingStepJob`. It covers four of six, and it would have to turn a refusal into a thrown error that all four callers then catch — four changes to avoid six one-liners, and the two `withBrandContext` routes still need it at the route.

**The last dishonest 200.** `updateMemoryEntry` and `deleteMemory` answered `200 {"ok":true}` when their scoped write matched nothing. No data crosses — the `WHERE` holds — but it is the same "zero rows is not an error" that made #366's tag defect exploitable. Both now route through `updateBrandRow`/`deleteBrandRow`, the helpers that count rows, and the three memory endpoints answer `404`.

**The third guard rule.** The first two read the id in the `WHERE`, so both were blind here. The third looks for the missing link instead: a variable naming a tenant (`brandId`, `orgId`, `userId`, …), assigned from the request body, in a file where nobody calls `ownsBrand`. No allowlist — six entries become a rubber stamp at the seventh.

## Testing?

Unit — full suite green: **666 files, 7397 tests, 0 failures**.

Tests written first and watched fail on the real red, which is the cross-tenant work **being accepted**:

```
× onboarding research > non accoda lavoro sul brand di un altro cliente
  expected "spy" to not be called at all, but actually been called 1 times

× PATCH studio memory entry > non dichiara successo su una riga che non ha toccato
  expected 200 to be 404

× src/ non scrive fra clienti diversi > nessun tenant preso dal corpo senza verifica
  routes/app/onboarding/{competitors,plan/posts,preview,preview/images,
                          recommend-platforms,research}/+server.ts   ← 6 findings
```

The guard rule was held to the same standard as the first two: red on the pre-fix source with exactly the six real sites and zero false positives across `src/`, green after. Four fixture probes keep it honest.

Manual — local self-hosted stack, real browser, real login, identity read from the session rather than assumed. Second tenant created for the test and **deleted afterwards** (verified: one brand and one user left, no residue). Two running jobs were stopped as soon as they appeared; total AI spend for the verification was **$0.0535**, measured from `ai_calls`.

- All six routes with another tenant's brand id → `403` each.
- Stressed: 26 attempts including two bursts of 10 concurrent → **zero** `onboarding_step_jobs` rows and **zero** `ai_calls` on the victim's brand.
- Own brand still enqueues; `brandId` absent still `400`; **null brand (draft onboarding) still enqueues** — the legitimate path is not broken.
- Memory endpoints on the **service-role (API key) path**: PATCH and DELETE of another brand's row → `404 not_found`, row untouched; unknown id → `404`; own row → `200`; delete-by-body-id of another brand's row → `404`.

Not tested: no agent evaluation. These are onboarding HTTP routes and memory endpoints, not the chat path, prompts, tools or the model.

## Evidence (screenshots/videos)

No exploit recipe, per the brief on #366 — the shape and the fix are described above and the regression tests encode them.

<details>
<summary>All six routes, from a real browser session; then 20 concurrent attempts</summary>

```
/app/onboarding/competitors         403 Forbidden
/app/onboarding/research            403 Forbidden
/app/onboarding/plan/posts          403 Forbidden
/app/onboarding/preview/images      403 Forbidden
/app/onboarding/preview             403 Forbidden
/app/onboarding/recommend-platforms 403 Forbidden

own brand, research                 200 {"jobId":"195703e2-…","reused":false}
missing brandId                     400 Missing brandId
null brandId (draft onboarding)     200

preview  x10 concurrent -> [403 ×10]
research x10 concurrent -> [403 ×10]

after 26 attempts:
  victim onboarding jobs -> []
  victim ai_calls        -> []
  demo jobs (own)        -> [{"kind":"research","status":"running"}]
  null-brand job         -> [{"kind":"plan_posts","status":"running"}]
```
</details>

<details>
<summary>Memory endpoints on the API-key (service-role) path</summary>

```
PATCH  another brand's row  -> 404 {"error":"not_found"}   row unchanged
DELETE another brand's row  -> 404 {"error":"not_found"}   row unchanged
PATCH  unknown id           -> 404 {"error":"not_found"}
PATCH  own row              -> 200 {"ok":true}
DELETE by body id, another's-> 404 {"error":"not_found"}
DELETE own row              -> 200 {"ok":true}

other brand's row afterwards:
  [{"brand_id":"f5fa646c-… (victim)","value":"v"}]
```
</details>

<details>
<summary>The third rule, run against the source before and after</summary>

```
=== before
routes/app/onboarding/competitors/+server.ts:26
    brandId = typeof body?.brandId === 'string' ? body.brandId : null
routes/app/onboarding/plan/posts/+server.ts:25            (same)
routes/app/onboarding/preview/+server.ts:38               (same)
routes/app/onboarding/preview/images/+server.ts:25        (same)
routes/app/onboarding/recommend-platforms/+server.ts:44   (same)
routes/app/onboarding/research/+server.ts:27              (same)
TOTAL 6          — and no false positives anywhere else in src/

=== this branch
TOTAL 0

src/no-cross-tenant-writes.test.ts  17 tests passed (3 rules, 13 fixture probes)
```
</details>

## Anything Else?

**The class is now in `LESSONS.md`.** Four occurrences, three shapes, one signal: *a service-role client plus an identifier that arrives from outside.* They were found only because someone went looking, so the entry names the signal, the three shapes, why `canEnter` misled every reader, and the move — the three rules, each of which was watched failing on the real source before it was allowed to be green.

Left alone on purpose:

- **The editor `load` bug.** `src/routes/app/[brand]/site/edit/[id]/+page.server.ts` selects `website` from `brands` and then reads `brand?.id` off that row, so it is always `undefined` and `blog_categories`, `blog_tags` and `blog_authors` are queried with an empty brand id — the tag picker has never rendered. It is a broken feature to be repaired by looking at it, not a security problem, and fixing it inside a security PR is how both get reverted together.
- `expression-memory-tools.ts` and the `knowledge/+page.server.ts` actions still ignore the row-count failure. No write follows them, so the silence opens nothing; worth collecting next time someone is in there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
