### PR TITLE
Point the refusal at a surface, not at three tool names

### DIFF
--- a/changelog/2026-09-05-refusal-names-a-surface.md
+++ b/changelog/2026-09-05-refusal-names-a-surface.md
@@ -1,0 +1,28 @@
+# Il rifiuto di `query` mandava a cercare tre tool che il chiamante non ha
+
+`NO_SESSION_ERROR.fix` diceva:
+
+> *Use the purpose-built read tools (read_posts, read_brand_kit, read_plan, …) — they scope to this
+> brand by construction.*
+
+I tre nomi esistono davvero: sono tool della **chat**. Ma `query` si nega solo alla service role —
+il percorso a chiave API e la coda — e su quelle superfici quei tre tool non ci sono. Il consiglio
+mandava quindi a cercare nomi che chi lo legge non può vedere, che è il modo più efficace di far
+riprovare la stessa cosa: un modello che non trova il rimedio suggerito conclude che il rimedio non
+esiste, non che sta guardando nel posto sbagliato.
+
+Ed è una lista di nomi dentro un messaggio d'errore, cioè qualcosa che invecchia da solo: i tool di
+lettura si stanno unificando dentro `query`, quindi quei tre nomi sarebbero diventati due, poi uno.
+
+Adesso nomina la **superficie**, che non cambia: «this surface's own read tools — there is one per
+subject». E dice l'altra mossa, quella che risolve davvero il rifiuto invece di aggirarlo: tornare
+con la propria sessione (`anomalia login`), perché è la sessione che manca, non il tool.
+
+## Perché sta in un commit suo
+
+È la regola numero 7 del lavoro sulle descrizioni — *gli errori dicono cosa fare, non cosa è andato
+storto* — applicata al file che quella regola l'aveva inventata. `query-tool.ts` è il modello citato
+in `AGENTS.md`: traduce gli errori PostgREST in mosse. Il suo unico rifiuto scritto a mano era
+l'unico posto dove non la rispettava.
+
+Segnalato da `a8c22181e602c7208` mentre spostava le letture dentro `query`.

--- a/src/lib/server/chat/query-tool.test.ts
+++ b/src/lib/server/chat/query-tool.test.ts
@@ -126,6 +126,25 @@ describe('il cancello: senza sessione utente non si legge', () => {
   it('il rifiuto nomina anche la chiave API, che è più stretta dei brand dell utente', () => {
     expect(NO_SESSION_ERROR.message).toMatch(/brand_ids/);
   });
+
+  /**
+   * Chi legge questo rifiuto NON è nella chat: `query` si nega solo alla service role, cioè al
+   * percorso a chiave API e alla coda. `read_posts`, `read_brand_kit` e `read_plan` esistono
+   * davvero — sono tool della chat — ma su quella superficie non ci sono, quindi il consiglio
+   * mandava a cercare tre nomi che il chiamante non può vedere.
+   *
+   * E una lista di nomi in un messaggio d'errore invecchia da sola: i tool di lettura si stanno
+   * unificando dentro `query`. Il rimedio nomina la SUPERFICIE, che non cambia.
+   */
+  it('il rimedio non manda a cercare tool che il chiamante non ha', () => {
+    for (const chatOnly of ['read_posts', 'read_brand_kit', 'read_plan']) {
+      expect(NO_SESSION_ERROR.fix).not.toContain(chatOnly);
+    }
+  });
+
+  it('il rimedio dice come si torna dentro, non solo che si è fuori', () => {
+    expect(NO_SESSION_ERROR.fix).toMatch(/anomalia login/);
+  });
 });
 
 /**

--- a/src/lib/server/chat/query-tool.ts
+++ b/src/lib/server/chat/query-tool.ts
@@ -95,7 +95,7 @@ export const NO_SESSION_ERROR = {
   error: 'no_user_session',
   message:
     '`query` reads the database AS THIS USER: anon key + their JWT, so Postgres RLS grants the agent exactly the user permissions and nothing more. This client is not user-scoped — it is a background/queue turn or a CLI API-key request, and both hold a service-role client (`bypassrls=true`) that would read EVERY brand in the database. Refusing to read with it. An API key is not promoted to a user session on purpose: a key carries `permissions.brand_ids`, often narrower than the brands its owner belongs to, and RLS cannot see that restriction — minting a session for it would silently widen a deliberately narrow key.',
-  fix: 'Use the purpose-built read tools (read_posts, read_brand_kit, read_plan, …) — they scope to this brand by construction. `query` works wherever the caller signs in as themselves: the app, `anomalia login`, and MCP.'
+  fix: 'Use this surface\'s own read tools — there is one per subject, and each scopes to this brand by construction. Or come back as yourself: `query` reads wherever the caller carries their own session — the app, `anomalia login`, and MCP.'
 } as const;
 
 /**


### PR DESCRIPTION
## What?

`query`'s one hand-written refusal told the caller to use three tools it cannot see. It now names the surface instead, and states the move that actually resolves the refusal.

```diff
- Use the purpose-built read tools (read_posts, read_brand_kit, read_plan, …) — they scope to
- this brand by construction. `query` works wherever the caller signs in as themselves: the app,
- `anomalia login`, and MCP.
+ Use this surface's own read tools — there is one per subject, and each scopes to this brand by
+ construction. Or come back as yourself: `query` reads wherever the caller carries their own
+ session — the app, `anomalia login`, and MCP.
```

One string, one test file. No behaviour change.

## Why?

The three names are real — they are **chat** tools (`src/lib/server/chat/agents.ts:49,56`). But `query` refuses only the service-role path: the `anomalia_` API-key caller and the queue. On those surfaces those three tools do not exist.

That is the worst shape an error message can take. A model that cannot find the remedy it was handed does not conclude it is looking in the wrong place — it concludes the remedy does not exist, and retries the same call. The refusal was spending a turn to produce a dead end.

It was also already rotting. `a8c22181e602c7208` is folding read tools into `query`; three names were about to become two, then one. A list of tool names inside an error message has no guard and no expiry.

This is **rule 7 of the description work** — *an error says what to do, not what went wrong* — applied to the file that rule was taken from. `query-tool.ts` is what `AGENTS.md` cites as the model for translating PostgREST errors into moves, and its single hand-written refusal was the one place it did not follow its own rule.

## How?

Name the **surface**, not its inventory: "this surface's own read tools — there is one per subject". True on MCP, on the CLI, and in the app, and it stays true after the read tools are unified, because a surface having read tools is structural while their names are not.

Then state the second move, which is the one that actually fixes the refusal rather than routing around it: **come back carrying your own session**. What is missing is not a tool, it is a session — the caller holds a service-role client that would read every brand in the database, which is exactly why it is refused.

Rejected: updating the list to the current MCP names. That is the same defect with fresher contents, and it would need re-editing at every step of the read-tool unification.

## Testing?

`npx vitest run src/lib/server/chat/query-tool.test.ts` → **39 passed**.

Test written first, red observed:

```
× il rimedio non manda a cercare tool che il chiamante non ha
  AssertionError: expected 'Use the purpose-built read tools (rea…' not to contain 'read_posts'
  Tests  1 failed | 38 passed
```

Two assertions, and they guard opposite risks. The first forbids chat-only names in the remedy, so the defect cannot come back under different wording. The second demands `anomalia login` survives — it passed before the change, which is the point: it locks in the half of the message that was already right, so a rewrite cannot quietly drop it.

The existing assertions on the refusal (RLS, service-role, `brand_ids`) are untouched and still green.

## Evidence (screenshots/videos)

No UI change. The full message an API-key caller now receives:

<details>
<summary><code>NO_SESSION_ERROR</code> as returned</summary>

```
error:   no_user_session

message: `query` reads the database AS THIS USER: anon key + their JWT, so Postgres RLS grants the
         agent exactly the user permissions and nothing more. This client is not user-scoped — it
         is a background/queue turn or a CLI API-key request, and both hold a service-role client
         (`bypassrls=true`) that would read EVERY brand in the database. Refusing to read with it.
         An API key is not promoted to a user session on purpose: a key carries
         `permissions.brand_ids`, often narrower than the brands its owner belongs to, and RLS
         cannot see that restriction — minting a session for it would silently widen a
         deliberately narrow key.

fix:     Use this surface's own read tools — there is one per subject, and each scopes to this
         brand by construction. Or come back as yourself: `query` reads wherever the caller
         carries their own session — the app, `anomalia login`, and MCP.
```
</details>

## Anything Else?

**Found by `a8c22181e602c7208`**, who flagged it rather than editing it because descriptions were not their scope. That call was right and worth naming: the fix needed a test and a changelog, and folding it into a read-tool-removal PR would have buried a user-visible message change inside a refactor.

**A related gap I checked while here and am not fixing:** `src/routes/api/v1/brands/[slug]/registry.test.ts` runs registry → route in all four of its assertions — every contract has a route, every route exports the declared verb. Nothing runs route → registry. So removing an entry from `BRAND_ENDPOINTS` leaves its `+server.ts` alive and completely undocumented: no tool, no contract, no failing test. That is harmless once and a real problem across a campaign that removes twenty read tools. Reported to the agent running that campaign; it belongs in their PR, with their first removal, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
