### PR TITLE
Fold list_products into query, and make an orphan route declare itself

### DIFF
--- a/.agents/skills/anomalia/references/tools.md
+++ b/.agents/skills/anomalia/references/tools.md
@@ -21,7 +21,6 @@ All tools take a brand `slug` when brand-scoped. Ids accept short unambiguous pr
 | `get_calendar` | `anomalia calendar <slug> [--month YYYY-MM]` |
 | `get_gtm` | `anomalia gtm <slug>` |
 | `get_voice` / `update_voice` | `anomalia voice <slug>` |
-| `list_products` | (studio / products views) |
 | `list_posts` | `anomalia content <slug> [--status …]` |
 | `approve_posts` | `anomalia approve <slug> --all` |
 | `get_post` | `anomalia post <slug> <id>` |

--- a/changelog/2026-09-05-list-products-into-query.md
+++ b/changelog/2026-09-05-list-products-into-query.md
@@ -1,0 +1,103 @@
+# `list_products` rientra dentro `query`, e il perimetro passa da 22 a 6
+
+Il piano in `docs/mcp-tools.md` dice ventidue letture: una tabella e un filtro,
+`query` le fa già. Questo è il primo pezzo eseguito — uno solo, di proposito, per
+misurare il metro prima di applicarlo diciannove volte.
+
+Il metro ha retto e il perimetro no: **delle ventidue, sei sono davvero
+`select … from una_tabella`.** Le altre sedici fanno qualcos'altro, e il
+documento le aveva classificate leggendo le descrizioni invece delle rotte.
+
+## Cosa è stato tolto
+
+`list_products` da `BRAND_ENDPOINTS`. La rotta `GET
+/api/v1/brands/:slug/products` resta viva: `anomalia products` la chiama, e
+togliere una entry dal registro non cancella un file scritto a mano.
+
+Un agente che cerca cosa vende il brand ora legge `products` con `query`, e ne
+riceve **più** di prima: `list_products` mappava `images` in `imageCount` e
+buttava via l'array. `get_studio` continua a restituire gli stessi prodotti con
+i loro id, che è il motivo per cui `studio.ts` non ha più bisogno di nominare
+due sorgenti per lo stesso id.
+
+## Le due che sono state fermate prima di scrivere codice
+
+Andrea ne aveva indicate tre, «le più semplici e più usate». Due non lo erano.
+
+**`get_memory` non si tocca, e non è una questione di forma: è una fuga.** La
+rotta applica due filtri che la riga non porta —
+`loadMemoryEntries(..., { agent: null })` diventa `.is('agent', null)` e
+`.neq('layer', 'session')`. `query` su `brand_memory` restituisce entrambe le
+categorie, e la RLS non lo impedisce perché quelle righe **sono** del brand: il
+filtro è una regola di prodotto, non un permesso. La sostituzione consegnerebbe
+a un agente le note di mestiere di altri agenti e i fatti di una singola
+conversazione, presentati come conoscenza del brand. Nessuna riga di
+`findability` lo avrebbe visto: le parole combaciano tutte.
+
+**`get_plan` legge quattro tabelle e ne calcola due valori che non esistono in
+nessuna colonna.** `getEditorialPlan` prende `editorial_plans` due volte (attivo
+e proposto), `brand_usage` e `brands`, poi calcola `currentWeek` con
+`currentWeekIndex()` sul fuso del brand e `quota.remaining` con
+`postQuota(piano)`. `query` è una tabella per chiamata: diventerebbero quattro
+chiamate più un calcolo di date rifatto nel prompt. Non è unificare, è spostare
+lavoro dentro il modello.
+
+## La classificazione vera delle ventidue
+
+Letta dall'implementazione, non dalla descrizione:
+
+| | tool |
+|---|---|
+| **una tabella e un filtro** (6) | `list_posts`, `list_articles`, `list_ideas`, `get_audit_findings`, `get_keywords`, `list_products` |
+| **compongono** (14) | `list_shares`, `list_web_audits`, `list_web_fixes`, `list_audit_citations`, `get_article`, `get_calendar`, `get_bio`, `get_voice`, `get_gtm`, `get_weekly_plan`, `get_ranks`, `get_goals`, `get_market_field`, `check_media_job` |
+| **regola di prodotto / di piano** (2) | `get_memory`, `get_plan` |
+
+Qualche esempio di cosa vuol dire «compongono», perché il confine non è
+teorico: `get_voice` calcola `studioPct` da tre `count` esatti; `get_calendar`
+fonde tre letture di `posts` e conia `monthLabel`/`prevYM`/`nextYM`;
+`get_bio` incrocia `social_accounts` e `post_links` per scegliere il link più
+cliccato in sette giorni; `get_ranks` fa una seconda query per parola chiave e
+ne ricava il `delta`; `check_media_job` inventa uno stato
+(`CLIP_NOT_IN_LIBRARY`) che nessuna colonna contiene.
+
+Il conto del documento va corretto: −6 letture, non −22. Il grosso della
+riduzione resta nel CRUD e nelle impostazioni.
+
+## Il vincolo che nessuno aveva scritto
+
+**`query` rifiuta il percorso a chiave API.** `authenticate` restituisce un
+client service-role sul percorso `anomalia_`, e `createQueryTool` pretende un
+client marchiato `isRlsScoped`: un tool che «a volte legge tutto» sarebbe
+peggio di uno che a volte non c'è.
+
+Quindi «il tool non c'è più, usa `query`» è vero su MCP (solo OAuth Bearer) e
+sulla CLI loggata (JWT), **mai** per un chiamante REST con una chiave API. È la
+ragione per cui ogni rimozione deve lasciare in piedi la sua rotta, e per cui il
+guard qui sotto non è un dettaglio.
+
+## Il guard: una rotta senza contratto si dichiara
+
+`registry.test.ts` aveva quattro prove e tutte e quattro andavano dal registro
+alla rotta. Nessuna faceva il contrario. Togliere una entry non faceva fallire
+niente: la rotta restava viva, raggiungibile e senza più nessun posto dove è
+descritta.
+
+Una volta è una curiosità. Venti volte è una superficie che nessuno può
+elencare. La prova nuova cammina l'albero delle rotte e pretende che ognuna sia
+o descritta da un contratto o dichiarata in `REST_ONLY` — ventotto c'erano già
+prima di questo lavoro, la ventinovesima l'ha creata questa rimozione.
+
+La lista non porta un motivo per riga: ventotto motivi inventati sarebbero
+peggio del silenzio. Quello che impone è che la riga si aggiunga a mano, in un
+diff che qualcuno legge, con la domanda davanti — **questa rotta cos'è adesso,
+se non è più un tool?** Superficie REST voluta, o codice morto da cancellare.
+Il conto di quelle due risposte dice di più, sulla decisione, del conto delle
+rimozioni.
+
+## Il cancello
+
+`findability.test.ts` ha una riga in più, scritta da chi possiede il test e non
+da chi ha fatto la modifica: «what does this brand sell» deve trovare `query`.
+Rossa prima (su entrambe le superfici — descrizione e skill), verde dopo.
+`table` era stato proposto come terza parola ed è stato rifiutato perché non può
+fallire da solo: la riga `query` che c'era già lo asserisce.

--- a/cli/lib/contracts/index.ts
+++ b/cli/lib/contracts/index.ts
@@ -68,8 +68,7 @@ import {
   GET_STUDIO,
   GET_VOICE,
   GET_WEEKLY_PLAN,
-  LIST_ARTICLES,
-  LIST_PRODUCTS
+  LIST_ARTICLES
 } from './reads';
 import { DIAGNOSE_BRAND, GET_GOALS } from './brand-state';
 import {
@@ -235,7 +234,6 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   LIST_IDEAS,
   LIST_MEDIA,
   LIST_POSTS,
-  LIST_PRODUCTS,
   LIST_SHARES,
   LIST_SOCIAL_ACCOUNTS,
   LIST_WEB_AUDITS,
@@ -374,8 +372,7 @@ export {
   GET_STUDIO,
   GET_VOICE,
   GET_WEEKLY_PLAN,
-  LIST_ARTICLES,
-  LIST_PRODUCTS
+  LIST_ARTICLES
 };
 export { STUDIO_DOCUMENT_MODES } from './reads';
 export type { StudioDocumentMode } from './reads';

--- a/cli/lib/contracts/query.ts
+++ b/cli/lib/contracts/query.ts
@@ -32,7 +32,11 @@ export const QUERY_DATABASE = {
     'attempt. Omit `table` to list every table you can name. Ask for a table with no `columns` to get ' +
     'real rows with every column: the keys of a row ARE the schema. One table per call — no joins, no ' +
     'embeds; read two tables and match the ids yourself. Reach for it when the answer needs a table ' +
-    'nothing else exposes, a count, or a join you do by hand. Costs nothing.',
+    'nothing else exposes, a count, or a join you do by hand. ' +
+    'IT IS ALSO THE READ FOR QUESTIONS THAT HAVE NO TOOL OF THEIR OWN. What this brand SELLS — its ' +
+    'catalogue of products, offers and services — is the `products` table: one row per offer, with ' +
+    '`title`, `kind`, `pricing`, `url`, `featured` and the `images` it carries. ' +
+    'Costs nothing.',
   method: 'POST',
   pathUnderBrand: '/query',
   input: z

--- a/cli/lib/contracts/reads.ts
+++ b/cli/lib/contracts/reads.ts
@@ -385,31 +385,6 @@ export const GET_VOICE = {
   destructive: false
 } satisfies BrandEndpoint;
 
-export const LIST_PRODUCTS = {
-  tool: 'list_products',
-  title: 'List products',
-  description:
-    'What this brand sells — the offers in its catalogue, each with the details a post can ' +
-    'name. create_product adds one by hand. Reads only — no model, no credits.',
-  method: 'GET',
-  pathUnderBrand: '/products',
-  input: NoInput,
-  output: z.object({
-    products: z.array(
-      z.looseObject({
-        id: z.string(),
-        title: z.string(),
-        kind: z.string(),
-        pricing: z.string().nullable(),
-        imageCount: z.number(),
-        featured: z.boolean()
-      })
-    )
-  }),
-  failures: [],
-  destructive: false
-} satisfies BrandEndpoint;
-
 // La dashboard è il brand stesso: `GET /api/v1/brands/:slug`, nessun segmento sotto. Con
 // `pathUnderBrand` vuoto `pathFor` produce già quell'URL — non serve un secondo registro per gli
 // endpoint fuori dal brand, ne resta fuori uno solo (`list_brands`, che di brand non ne ha uno).

--- a/cli/lib/contracts/studio.ts
+++ b/cli/lib/contracts/studio.ts
@@ -1,10 +1,10 @@
 import { z } from 'zod';
 import type { BrandEndpoint } from './index';
 
-const id = z.string().min(1).describe('Row id, verbatim from get_studio or list_products');
+const id = z.string().min(1).describe('Row id, verbatim from get_studio');
 
 // Una cancellazione non accetta prefissi: un prefisso ambiguo colpisce la riga sbagliata e non
-// c'è nessun modo di annullarla. Serve l'UUID pieno, come get_studio e list_products lo danno.
+// c'è nessun modo di annullarla. Serve l'UUID pieno, come get_studio lo dà.
 const OnlyRowUuid = z.object({ id: z.uuid() }).strict();
 
 const PRODUCT_FIELDS = {

--- a/cli/mcp/read-tools.test.ts
+++ b/cli/mcp/read-tools.test.ts
@@ -83,12 +83,6 @@ const MIGRATED_READS = [
     properties: { slug: SLUG_PROPERTY },
     required: ['slug'],
   },
-  {
-    name: 'list_products',
-    title: 'List products',
-    properties: { slug: SLUG_PROPERTY },
-    required: ['slug'],
-  },
 ] as const;
 
 type Tool = {

--- a/cli/plugins/anomalia/skills/anomalia/SKILL.md
+++ b/cli/plugins/anomalia/skills/anomalia/SKILL.md
@@ -69,7 +69,8 @@ the request carries your own session, so Postgres returns exactly the rows the a
 and nothing more. Read only, one table per call, no credits. Omit `table` to list what you can
 name; ask for a table with no `columns` and the keys of a row are the schema. Reach for it for a
 count, a join you do by hand, or a fact none of the tools below returns — instead of three calls
-that approximate it.
+that approximate it. **What this brand sells** has no tool of its own: its catalogue of products,
+offers and services is the `products` table, one row per offer, read with `query`.
 
 **Before you write anything** → two reads, and they answer different questions.
 

--- a/cli/plugins/anomalia/skills/anomalia/references/tools.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/tools.md
@@ -36,6 +36,10 @@ Reach for it when the answer needs a count, a join you do by hand, or a table no
 exposes — that is one call instead of three that approximate it. A refusal comes back as `200`
 with `error`, `message` and often `fix` inside, so you can read why and change move.
 
+It is also the read for questions no tool of its own answers. **What this brand sells** — its
+catalogue of products, offers and services — is the `products` table: one row per offer, with
+`title`, `kind`, `pricing`, `url`, `featured` and the `images` it carries.
+
 ## Brand & posts
 
 | MCP | CLI |
@@ -48,7 +52,6 @@ with `error`, `message` and often `fix` inside, so you can read why and change m
 | `get_goals` | (MCP only) |
 | `get_gtm` | `anomalia gtm <slug>` |
 | `get_voice` / `update_voice` | `anomalia voice <slug>` |
-| `list_products` | (studio / products views) |
 | `list_posts` | `anomalia content <slug> [--status …]` |
 | `get_creation_kit` | (MCP only) |
 | `create_post` | (MCP only) |
@@ -444,7 +447,7 @@ catalog and would erase a hand-made row.
 `update_product`, `update_person` and `update_competitor` change only the fields you send: every
 other column keeps the value it had. An id from another brand answers `not_found`, exactly like
 one that does not exist anywhere. The four deletes want the UUID in full, verbatim from
-`get_studio` or `list_products`.
+`get_studio`, or `query` on the `products` table.
 
 `update_person` cannot attest consent, turn a real person into an AI persona, or touch photos. A
 real person's face stays withheld from every generator until the operator states the consent in

--- a/cli/skills/anomalia/SKILL.md
+++ b/cli/skills/anomalia/SKILL.md
@@ -69,7 +69,8 @@ the request carries your own session, so Postgres returns exactly the rows the a
 and nothing more. Read only, one table per call, no credits. Omit `table` to list what you can
 name; ask for a table with no `columns` and the keys of a row are the schema. Reach for it for a
 count, a join you do by hand, or a fact none of the tools below returns — instead of three calls
-that approximate it.
+that approximate it. **What this brand sells** has no tool of its own: its catalogue of products,
+offers and services is the `products` table, one row per offer, read with `query`.
 
 **Before you write anything** → two reads, and they answer different questions.
 

--- a/cli/skills/anomalia/references/tools.md
+++ b/cli/skills/anomalia/references/tools.md
@@ -36,6 +36,10 @@ Reach for it when the answer needs a count, a join you do by hand, or a table no
 exposes — that is one call instead of three that approximate it. A refusal comes back as `200`
 with `error`, `message` and often `fix` inside, so you can read why and change move.
 
+It is also the read for questions no tool of its own answers. **What this brand sells** — its
+catalogue of products, offers and services — is the `products` table: one row per offer, with
+`title`, `kind`, `pricing`, `url`, `featured` and the `images` it carries.
+
 ## Brand & posts
 
 | MCP | CLI |
@@ -48,7 +52,6 @@ with `error`, `message` and often `fix` inside, so you can read why and change m
 | `get_goals` | (MCP only) |
 | `get_gtm` | `anomalia gtm <slug>` |
 | `get_voice` / `update_voice` | `anomalia voice <slug>` |
-| `list_products` | (studio / products views) |
 | `list_posts` | `anomalia content <slug> [--status …]` |
 | `get_creation_kit` | (MCP only) |
 | `create_post` | (MCP only) |
@@ -444,7 +447,7 @@ catalog and would erase a hand-made row.
 `update_product`, `update_person` and `update_competitor` change only the fields you send: every
 other column keeps the value it had. An id from another brand answers `not_found`, exactly like
 one that does not exist anywhere. The four deletes want the UUID in full, verbatim from
-`get_studio` or `list_products`.
+`get_studio`, or `query` on the `products` table.
 
 `update_person` cannot attest consent, turn a real person into an AI persona, or touch photos. A
 real person's face stays withheld from every generator until the operator states the consent in

--- a/cli/skills/findability.test.ts
+++ b/cli/skills/findability.test.ts
@@ -74,6 +74,11 @@ const ASKED_FOR: ReadonlyArray<{ tool: string; question: string; words: readonly
     tool: 'query',
     question: 'how many posts went out last month',
     words: ['table', 'count', 'read']
+  },
+  {
+    tool: 'query',
+    question: 'what does this brand sell',
+    words: ['sell', 'products']
   }
 ];
 

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -68,8 +68,7 @@ import {
   GET_STUDIO,
   GET_VOICE,
   GET_WEEKLY_PLAN,
-  LIST_ARTICLES,
-  LIST_PRODUCTS
+  LIST_ARTICLES
 } from './reads';
 import { DIAGNOSE_BRAND, GET_GOALS } from './brand-state';
 import {
@@ -235,7 +234,6 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   LIST_IDEAS,
   LIST_MEDIA,
   LIST_POSTS,
-  LIST_PRODUCTS,
   LIST_SHARES,
   LIST_SOCIAL_ACCOUNTS,
   LIST_WEB_AUDITS,
@@ -374,8 +372,7 @@ export {
   GET_STUDIO,
   GET_VOICE,
   GET_WEEKLY_PLAN,
-  LIST_ARTICLES,
-  LIST_PRODUCTS
+  LIST_ARTICLES
 };
 export { STUDIO_DOCUMENT_MODES } from './reads';
 export type { StudioDocumentMode } from './reads';

--- a/packages/api-contracts/src/query.ts
+++ b/packages/api-contracts/src/query.ts
@@ -32,7 +32,11 @@ export const QUERY_DATABASE = {
     'attempt. Omit `table` to list every table you can name. Ask for a table with no `columns` to get ' +
     'real rows with every column: the keys of a row ARE the schema. One table per call — no joins, no ' +
     'embeds; read two tables and match the ids yourself. Reach for it when the answer needs a table ' +
-    'nothing else exposes, a count, or a join you do by hand. Costs nothing.',
+    'nothing else exposes, a count, or a join you do by hand. ' +
+    'IT IS ALSO THE READ FOR QUESTIONS THAT HAVE NO TOOL OF THEIR OWN. What this brand SELLS — its ' +
+    'catalogue of products, offers and services — is the `products` table: one row per offer, with ' +
+    '`title`, `kind`, `pricing`, `url`, `featured` and the `images` it carries. ' +
+    'Costs nothing.',
   method: 'POST',
   pathUnderBrand: '/query',
   input: z

--- a/packages/api-contracts/src/reads.ts
+++ b/packages/api-contracts/src/reads.ts
@@ -385,31 +385,6 @@ export const GET_VOICE = {
   destructive: false
 } satisfies BrandEndpoint;
 
-export const LIST_PRODUCTS = {
-  tool: 'list_products',
-  title: 'List products',
-  description:
-    'What this brand sells — the offers in its catalogue, each with the details a post can ' +
-    'name. create_product adds one by hand. Reads only — no model, no credits.',
-  method: 'GET',
-  pathUnderBrand: '/products',
-  input: NoInput,
-  output: z.object({
-    products: z.array(
-      z.looseObject({
-        id: z.string(),
-        title: z.string(),
-        kind: z.string(),
-        pricing: z.string().nullable(),
-        imageCount: z.number(),
-        featured: z.boolean()
-      })
-    )
-  }),
-  failures: [],
-  destructive: false
-} satisfies BrandEndpoint;
-
 // La dashboard è il brand stesso: `GET /api/v1/brands/:slug`, nessun segmento sotto. Con
 // `pathUnderBrand` vuoto `pathFor` produce già quell'URL — non serve un secondo registro per gli
 // endpoint fuori dal brand, ne resta fuori uno solo (`list_brands`, che di brand non ne ha uno).

--- a/packages/api-contracts/src/studio.ts
+++ b/packages/api-contracts/src/studio.ts
@@ -1,10 +1,10 @@
 import { z } from 'zod';
 import type { BrandEndpoint } from './index';
 
-const id = z.string().min(1).describe('Row id, verbatim from get_studio or list_products');
+const id = z.string().min(1).describe('Row id, verbatim from get_studio');
 
 // Una cancellazione non accetta prefissi: un prefisso ambiguo colpisce la riga sbagliata e non
-// c'è nessun modo di annullarla. Serve l'UUID pieno, come get_studio e list_products lo danno.
+// c'è nessun modo di annullarla. Serve l'UUID pieno, come get_studio lo dà.
 const OnlyRowUuid = z.object({ id: z.uuid() }).strict();
 
 const PRODUCT_FIELDS = {

--- a/src/lib/content/changelog/2026-09-05-products-through-query.ts
+++ b/src/lib/content/changelog/2026-09-05-products-through-query.ts
@@ -1,0 +1,10 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-05',
+  title: 'One less tool in the list, and your AI sees more of your catalogue',
+  items: [
+    'Your AI reads what your brand sells straight from the database now, so it gets every field of every product — including the images each one carries, which the old dedicated tool threw away.',
+    '`anomalia products` and the products views work exactly as before.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/routes/api/v1/brands/[slug]/registry.test.ts
+++ b/src/routes/api/v1/brands/[slug]/registry.test.ts
@@ -149,6 +149,7 @@ const REST_ONLY = [
   'posts/[id]/publish',
   'posts/[id]/revoke',
   'posts/approve-all',
+  'products',
   'publishing',
   'rubrics',
   'rubrics/approve',

--- a/src/routes/api/v1/brands/[slug]/registry.test.ts
+++ b/src/routes/api/v1/brands/[slug]/registry.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
@@ -110,5 +110,88 @@ describe('BRAND_ENDPOINTS', () => {
     }
 
     expect(broken).toEqual([]);
+  });
+});
+
+/**
+ * E L'INVERSO, che finora non lo verificava nessuno: le quattro prove qui sopra vanno tutte dal
+ * registro alla rotta, quindi togliere una entry da BRAND_ENDPOINTS non fa fallire niente. La
+ * rotta resta viva, raggiungibile e senza più nessun posto dove è descritta — nessun tool, nessun
+ * contratto, nessun rosso.
+ *
+ * Una volta è una curiosità. Le letture che stanno rientrando dentro `query` sono venti, e venti
+ * rotte che nessuno può elencare sono il modo in cui il percorso a chiave API diventa in silenzio
+ * l'unica strada per un terzo del prodotto — perché `query` la chiave API la RIFIUTA
+ * (`createQueryTool` pretende un client RLS-scoped, e `authenticate` sul percorso a chiave dà la
+ * service role).
+ *
+ * Quindi una rotta senza contratto si DICHIARA qui. La lista non porta un motivo per riga perché
+ * ventotto di queste esistevano già da prima e inventarne il motivo sarebbe peggio che tacerlo:
+ * quello che la lista impone è che la riga si aggiunga a mano, in un diff che qualcuno legge, con
+ * la domanda giusta davanti — questa rotta cos'è adesso, se non è più un tool? Superficie REST
+ * voluta, o codice morto da cancellare.
+ */
+const REST_ONLY = [
+  'agent-sessions',
+  'agent-sessions/[id]',
+  'api-keys',
+  'api-keys/[id]',
+  'articles',
+  'articles/[id]',
+  'connections',
+  'connections/[id]',
+  'connections/[id]/complete',
+  'connections/catalog',
+  'editorial-plan/update',
+  'gtm/update',
+  'library/scan',
+  'posts/[id]/approve',
+  'posts/[id]/publish',
+  'posts/[id]/revoke',
+  'posts/approve-all',
+  'publishing',
+  'rubrics',
+  'rubrics/approve',
+  'rubrics/propose',
+  'studio/memory',
+  'studio/memory/[id]',
+  'tick',
+  'webhook',
+  'weekly-plan/produce',
+  'weekly-plan/render',
+  'weekly-plan/save'
+];
+
+const BRAND_ROUTES = 'src/routes/api/v1/brands/[slug]';
+
+function serverFilesUnder(dir: string, sub = BRAND_ROUTES): string[] {
+  const out: string[] = [];
+
+  for (const name of readdirSync(dir).sort()) {
+    const full = join(dir, name);
+
+    if (statSync(full).isDirectory()) {
+      out.push(...serverFilesUnder(full, `${sub}/${name}`));
+      continue;
+    }
+    if (name === '+server.ts') out.push(`${sub}/+server.ts`);
+  }
+
+  return out;
+}
+
+describe('le rotte sotto [slug]', () => {
+  const claimed = new Set(BRAND_ENDPOINTS.map(routeFile));
+  const declared = new Set(REST_ONLY.map((r) => `${BRAND_ROUTES}/${r}/+server.ts`));
+  const onDisk = serverFilesUnder(join(REPO_ROOT, BRAND_ROUTES));
+
+  it('o le descrive un contratto, o si dichiarano', () => {
+    expect(onDisk.filter((r) => !claimed.has(r) && !declared.has(r))).toEqual([]);
+  });
+
+  it('non dichiara rotte che non esistono, o che un contratto ha ripreso', () => {
+    const alive = new Set(onDisk);
+
+    expect([...declared].filter((r) => !alive.has(r) || claimed.has(r))).toEqual([]);
   });
 });


### PR DESCRIPTION
## What?

Removes exactly one MCP tool — `list_products` — from `BRAND_ENDPOINTS`, folding
that read into `query`, and adds the guard that makes the next nineteen removals
safe. It is the first executed piece of the aggregation plan in
`docs/mcp-tools.md` §1, run alone on purpose.

It also **corrects the plan's headline number.** The document says twenty-two
reads are "one table and one filter". Read from the route implementations rather
than from the tool descriptions, **six** are. Fourteen compose two or more reads
or coin a value no column holds; two apply a product or plan rule. The reduction
available here is −6, not −22.

## Why?

Three agents in one day gave up in front of capabilities that were present,
because they could not find the name. A long `tools/list` makes the model choose
worse. Folding a genuine table-and-filter read into `query` removes a name
without removing a capability.

Two of the three tools originally picked to start with turned out not to be
table-and-filter reads, and one of them was a content leak:

- **`get_memory`** — the route applies `agent is null` and `layer <> 'session'`
  (`brand-memory.ts:57-65`, `:339`, the latter commented *"never leak session
  chat notes into brand knowledge"*). RLS does not replace those filters: the
  rows belong to the same brand, so the user may read them — the filter is a
  product rule, not a permission. `query` on `brand_memory` would hand an agent
  other agents' working notes and single-thread chat facts, presented as brand
  knowledge. No findability row would have caught it; every word still matches.
- **`get_plan`** — `getEditorialPlan` (`cli-queries.ts:102-140`) reads
  `editorial_plans` twice, `brand_usage` and `brands`, then computes
  `currentWeek` via `currentWeekIndex()` and `quota.remaining` via
  `postQuota(plan)`. Neither value exists in any column. `query` is one table per
  call, so this becomes four calls plus a date computation redone in the prompt.

Both were stopped before any code was written.

## How?

**The removal.** `LIST_PRODUCTS` deleted from `reads.ts` and from the three
places `index.ts` names it; the mirror `cli/lib/contracts/` regenerated with
`bun run sync:contracts`; `cli/mcp/read-tools.test.ts` loses its entry;
`studio.ts` stops naming two sources for the same row id, because `get_studio`
already returns products with their ids.

**The description carries what disappeared, on the surface that is read.**
`query`'s description, `SKILL.md` and `references/tools.md` all gained the same
sentence: *what this brand
sells — its catalogue of products, offers and services — is the `products`
table*, with the columns named. The table names were already exposed: `table` is
a zod enum of `QUERY_TABLE_NAMES`, generated from the migrations, so `tools/list`
ships every nameable table with the schema. An agent does not have to guess
`content_plans` when it is looking for the plan.

An agent now gets **more** than before: `list_products` collapsed `images` into
an `imageCount` and threw the array away.

The `SKILL.md` line was missing at first and is the reason this PR has a third
commit. The sentence landed only in `references/tools.md`, which sits under
*"References (load on demand)"* and may never be opened, while `SKILL.md` always
loads and said nothing about products. The findability gate read the two files
**concatenated**, so it was green on a real first-read regression — zero mentions
on the always-loaded surface, five on the optional one. The gate is being fixed
to assert against `SKILL.md` alone (#371); this branch carries the line it will
ask for, added before the red rather than after.

**The guard, in its own commit.** `registry.test.ts` had four assertions and all
four ran registry → route. Nothing ran route → registry, so removing an entry
failed nothing — the route stayed alive, reachable, and with no place left where
it is described. Across twenty removals that is a surface nobody can enumerate.

The new pair walks the route tree and demands every `+server.ts` under `[slug]`
be either claimed by a contract or declared in `REST_ONLY`, and that nothing
stale sits in the list. The list carries no reason per line: twenty-eight of
these predate this work, and inventing their reasons would be worse than
silence. What it forces is that the line is added by hand, in a diff someone
reads, with the right question in front of it — **what is this route now, if it
is no longer a tool?** Deliberate REST surface, or dead code.

**Rejected alternative:** asserting only that the orphan *count* does not grow.
Cheaper, and weaker — it drifts and it names nothing.

**A constraint that was not written down anywhere, and caps the campaign.**
`query` refuses the API-key path: `authenticate` returns a raw service-role
client on the `anomalia_` path (`cli-auth.ts:131`) and `createQueryTool` requires
an `isRlsScoped` client. So "the tool is gone, use `query`" is true on MCP (OAuth
Bearer only) and on the logged-in CLI (JWT), **never** for a REST caller holding
an API key. That is why every removal must leave its route standing, and why the
guard is not a detail.

## Testing?

Written test-first, both times, with the red observed:

- `findability.test.ts` — the row *«what does this brand sell» → `query`* was red
  on **both** surfaces (tool description and skill prose) before the change,
  green after. `table` was proposed as a third word and **rejected on the
  merits** by the test's owner: the existing `query` row already asserts it, so
  it cannot fail independently.
- `registry.test.ts` — the new assertion was red with exactly
  `src/routes/api/v1/brands/[slug]/products/+server.ts` after the removal, green
  once the route declared itself. The guard is committed **before** the removal,
  where it is green on its own.

Suites run: `bun test ./cli/ ./packages/api-contracts/` → **373 pass, 0 fail**.
`npx vitest run src/routes/api/v1` → **46 files, 472 tests, all pass**.

**Not tested, and why:** no browser run. There is no UI in this change — the
surfaces are `tools/list`, the skill prose and the REST registry, all covered by
the suites above. `anomalia products` and the products views are untouched code
paths (the CLI calls the route by hand-written URL in `cli/lib/api.ts:413`, not
through the registry), so the removal cannot reach them; that is an argument from
the call graph, not an observation, and it is the residual risk here.

## Evidence (screenshots/videos)

<details>
<summary>findability: red before, green after</summary>

```
$ bun test cli/skills/findability.test.ts        # before
error: query ← sell
  Expected to contain: "sell"
  Received: "read any table in the database directly, as you — …"
(fail) «what does this brand sell» trova query nella lista dei tool
(fail) «what does this brand sell» trova query anche nella skill, che si legge prima
 31 pass
 2 fail

$ bun test cli/skills/findability.test.ts        # after
 33 pass
 0 fail
```
</details>

<details>
<summary>the orphan guard: red on exactly the route the removal orphaned</summary>

```
$ npx vitest run "src/routes/api/v1/brands/[slug]/registry.test.ts"
AssertionError: expected [ Array(1) ] to deeply equal []
+ Array [
+   "src/routes/api/v1/brands/[slug]/products/+server.ts",
+ ]
 Tests  1 failed | 5 passed (6)

# after declaring it
 Tests  6 passed (6)
```
</details>

<details>
<summary>the twenty-two, classified from the implementations</summary>

| | tools |
|---|---|
| **one table and one filter** (6) | `list_posts`, `list_articles`, `list_ideas`, `get_audit_findings`, `get_keywords`, `list_products` |
| **compose** (14) | `list_shares`, `list_web_audits`, `list_web_fixes`, `list_audit_citations`, `get_article`, `get_calendar`, `get_bio`, `get_voice`, `get_gtm`, `get_weekly_plan`, `get_ranks`, `get_goals`, `get_market_field`, `check_media_job` |
| **product or plan rule** (2) | `get_memory`, `get_plan` |

Some of what "compose" means, so the boundary is not theoretical: `get_voice`
computes `studioPct` from three exact counts; `get_calendar` merges three `posts`
reads and coins `monthLabel`/`prevYM`/`nextYM`; `get_bio` crosses
`social_accounts` with `post_links` to pick the most-clicked link over seven
days; `get_ranks` runs a second query per keyword to derive `delta`;
`check_media_job` invents a status (`CLIP_NOT_IN_LIBRARY`) that no column holds.
</details>

## Anything Else?

- **The best thing in this PR is the guard, not the removal, and that is a good
  outcome rather than a small one.** The removal deletes one name. The guard
  uncovered **twenty-eight** route files that were already reachable and already
  described nowhere — a hole that predates this work and is larger than the
  campaign that found it.
- **The remaining five** (`list_posts`, `list_articles`, `list_ideas`,
  `get_audit_findings`, `get_keywords`) are mechanical from here, one per commit,
  each answering the guard's question about its own route. Whether they are worth
  five names is Andrea's call, not the plan's: −6 is a different decision from −22.
- `list_ideas` and `get_ranks` run their reads through `createAdminClient()`, so
  brand scoping is an explicit `.eq('brand_id')` rather than RLS. Doesn't change
  the classification, but `list_ideas` is one of the five candidates and that is
  worth knowing before it moves.
- `docs/mcp-tools.md` still carries the −22 figure. It is generated from the
  registry and should be regenerated with the corrected classification rather than
  patched by hand.
- Historical changelog entries still name `list_products`. They are history and
  stay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
