### PR TITLE
Check the surface that is read, not the one loaded on demand

### DIFF
--- a/changelog/2026-09-05-gate-checks-the-first-surface.md
+++ b/changelog/2026-09-05-gate-checks-the-first-surface.md
@@ -1,0 +1,38 @@
+# Il cancello guardava due superfici come se fossero una, e ne bastava la sbagliata
+
+`findability.test.ts` leggeva `SKILL.md` e `references/tools.md` concatenate. Non sono la stessa
+cosa: SKILL.md si carica sempre, tools.md sta sotto «References (load on demand)» e un agente può
+non aprirla mai. Concatenandole, una parola presente solo nel riferimento faceva passare la riga
+mentre **la superficie che si legge davvero taceva** — cioè esattamente il difetto che quella
+tabella esiste per prendere.
+
+Preso sul vivo, non in teoria. Spostando `list_products` dentro `query`, la domanda «what does this
+brand sell» è finita in `tools.md`; `SKILL.md` è rimasta senza né «sell» né «products», e il test
+era **verde**. Un agente che legge solo SKILL.md — il caso normale — passava da avere
+`list_products` nella lista dei tool ad avere niente.
+
+Ora la tabella guarda `SKILL.md` e basta. `tools.md` resta coperta da `tools-coverage.test.ts`, che
+pretende ogni tool documentato lì: non serviva una seconda guardia più debole sopra.
+
+## E le parole da sole non bastavano
+
+Seconda falla, trovata dalla stessa verifica: `search_knowledge` passava con «question», «answer» e
+«documents» — parole che stanno in qualunque pagina di prosa inglese. La riga era verde e SKILL.md
+**non nominava il tool nemmeno una volta**. Una corrispondenza di parole senza il nome non porta da
+nessuna parte: il nome è ciò che trasforma il riconoscimento in una chiamata.
+
+Quindi la riga adesso pretende anche il nome del tool nella skill. Rosso osservato su quattro:
+`search_knowledge`, `render_post`, `regenerate_post_media`, `generate_media` — quattro domande
+d'utente che la superficie letta per prima non sapeva instradare.
+
+## La regola che ne esce, e il suo limite
+
+**Una domanda che sta nella tabella dev'essere instradabile da SKILL.md da sola.** Se un tool non
+merita una riga nella mappa, allora la sua domanda non merita una riga nella tabella: la mappa non
+è un catalogo, ed è la stessa ragione per cui `instructions` non elenca i tool. Le due cose si
+tengono, o la mappa diventa la lista che già esiste due volte.
+
+Le quattro aggiunte a SKILL.md sono instradamenti veri, non parole messe lì per far passare il
+test: `search_knowledge` non aveva alcun percorso dalla mappa, `render_post` e
+`regenerate_post_media` non erano distinguibili l'uno dall'altro né da `refine_image`, e
+`generate_media` è la porta vecchia che ora dichiara di esserlo e manda avanti.

--- a/cli/plugins/anomalia/skills/anomalia/SKILL.md
+++ b/cli/plugins/anomalia/skills/anomalia/SKILL.md
@@ -71,6 +71,11 @@ name; ask for a table with no `columns` and the keys of a row are the schema. Re
 count, a join you do by hand, or a fact none of the tools below returns — instead of three calls
 that approximate it.
 
+**Ask what this brand already knows** → `search_knowledge` with the question. It reads the brand's
+own uploaded documents and returns the passages that answer it, each with the document it came
+from — not the whole corpus. Empty `hits` is not "the brand does not know": `get_knowledge_status`
+says whether anything has been indexed yet. No model, no credits.
+
 **Before you write anything** → two reads, and they answer different questions.
 
 `get_writing_skills` is **how to write**: `humanizer` and `stop-slop` always, `social` or
@@ -107,6 +112,10 @@ a brand there is no brand, and guessing one spends a real organisation's credits
 render per image and creates nothing in the calendar, so ask for two or three with `count`, look
 at them, keep one.
 
+**If you reach for `generate_media`** — the older door — it still works and forwards to
+`generate_image` and `generate_video`. Prefer those two: they name what they do, and changing a
+picture or animating one has its own tool.
+
 **Make a carousel** → `generate_carousel` with a brief. It plans the series, draws every slide and
 returns them in order plus the `continuity_tokens` that hold them together. One render per slide.
 To fix a single slide afterwards, `refine_image` on its id **with those tokens in the instruction** —
@@ -123,6 +132,14 @@ so it returns a `job_id`; `check_media_job` says when it landed. The model moves
 than an order of magnitude, so read `get_media_models` (slot `videoModel`, or `videoImageModel` when animating an image) before
 spending. With a slug the clip follows this brand's visual direction, so you do not have to
 describe it — and there is no switch for it here.
+
+**Give a post the image it is missing** → `render_post`. It draws from the prompt already written
+on that post and attaches it. One render. To draw a picture that is not tied to a post, use
+`generate_image` instead.
+
+**Change the image already on a post** → `regenerate_post_media` with an instruction. It REPLACES
+that post's image — one render, and the old one is gone. When you want to keep the original, use
+`refine_image` on the library asset instead: that files the result as a new asset.
 
 **CHANGE an image you already have** → `refine_image` with its `base_media_id` and an instruction
 ("make it red", "warmer background"). It starts from that asset, so the result is that picture

--- a/cli/skills/anomalia/SKILL.md
+++ b/cli/skills/anomalia/SKILL.md
@@ -71,6 +71,11 @@ name; ask for a table with no `columns` and the keys of a row are the schema. Re
 count, a join you do by hand, or a fact none of the tools below returns — instead of three calls
 that approximate it.
 
+**Ask what this brand already knows** → `search_knowledge` with the question. It reads the brand's
+own uploaded documents and returns the passages that answer it, each with the document it came
+from — not the whole corpus. Empty `hits` is not "the brand does not know": `get_knowledge_status`
+says whether anything has been indexed yet. No model, no credits.
+
 **Before you write anything** → two reads, and they answer different questions.
 
 `get_writing_skills` is **how to write**: `humanizer` and `stop-slop` always, `social` or
@@ -107,6 +112,10 @@ a brand there is no brand, and guessing one spends a real organisation's credits
 render per image and creates nothing in the calendar, so ask for two or three with `count`, look
 at them, keep one.
 
+**If you reach for `generate_media`** — the older door — it still works and forwards to
+`generate_image` and `generate_video`. Prefer those two: they name what they do, and changing a
+picture or animating one has its own tool.
+
 **Make a carousel** → `generate_carousel` with a brief. It plans the series, draws every slide and
 returns them in order plus the `continuity_tokens` that hold them together. One render per slide.
 To fix a single slide afterwards, `refine_image` on its id **with those tokens in the instruction** —
@@ -123,6 +132,14 @@ so it returns a `job_id`; `check_media_job` says when it landed. The model moves
 than an order of magnitude, so read `get_media_models` (slot `videoModel`, or `videoImageModel` when animating an image) before
 spending. With a slug the clip follows this brand's visual direction, so you do not have to
 describe it — and there is no switch for it here.
+
+**Give a post the image it is missing** → `render_post`. It draws from the prompt already written
+on that post and attaches it. One render. To draw a picture that is not tied to a post, use
+`generate_image` instead.
+
+**Change the image already on a post** → `regenerate_post_media` with an instruction. It REPLACES
+that post's image — one render, and the old one is gone. When you want to keep the original, use
+`refine_image` on the library asset instead: that files the result as a new asset.
 
 **CHANGE an image you already have** → `refine_image` with its `base_media_id` and an instruction
 ("make it red", "warmer background"). It starts from that asset, so the result is that picture

--- a/cli/skills/findability.test.ts
+++ b/cli/skills/findability.test.ts
@@ -79,13 +79,22 @@ const ASKED_FOR: ReadonlyArray<{ tool: string; question: string; words: readonly
 
 const HAND_WRITTEN_TARIFF = /\b\d+\s*credits?\b/i;
 
-const SKILL_DIR = fileURLToPath(new URL('./anomalia/', import.meta.url));
-const skillProse = [
-  readFileSync(join(SKILL_DIR, 'SKILL.md'), 'utf8'),
-  readFileSync(join(SKILL_DIR, 'references', 'tools.md'), 'utf8')
-]
-  .join('\n')
-  .toLowerCase();
+/**
+ * `SKILL.md` E BASTA, e non più concatenata a `references/tools.md`.
+ *
+ * Le due non sono la stessa superficie: SKILL.md si carica sempre, tools.md è sotto «References
+ * (load on demand)» e un agente può non aprirla mai. Concatenandole, una parola presente solo nel
+ * riferimento faceva passare la riga mentre la superficie che si legge davvero taceva — che è
+ * ESATTAMENTE il difetto che questa tabella esiste per prendere. Preso sul vivo: togliendo
+ * `list_products` la domanda «what does this brand sell» finiva in tools.md e SKILL.md restava
+ * senza né «sell» né «products», e il test era verde.
+ *
+ * tools.md resta coperta da `tools-coverage.test.ts`, che pretende ogni tool documentato lì.
+ */
+const SKILL = readFileSync(
+  fileURLToPath(new URL('./anomalia/SKILL.md', import.meta.url)),
+  'utf8'
+).toLowerCase();
 
 const describing = (tool: string): string => {
   const found = BRAND_ENDPOINTS.find((e) => e.tool === tool);
@@ -147,8 +156,12 @@ describe('una descrizione si legge cercando il proprio problema', () => {
     });
 
     test(`«${question}» trova ${tool} anche nella skill, che si legge prima`, () => {
+      // Le parole senza il nome del tool non portano da nessuna parte: «answer» e «read» stanno in
+      // qualunque pagina di prosa. Il nome è ciò che rende la corrispondenza una chiamata.
+      expect(SKILL, `skill ← ${tool}`).toContain(tool);
+
       for (const word of words) {
-        expect(skillProse, `skill ← ${tool} ← ${word}`).toContain(word);
+        expect(SKILL, `skill ← ${tool} ← ${word}`).toContain(word);
       }
     });
   }
@@ -175,6 +188,6 @@ describe('una descrizione si legge cercando il proprio problema', () => {
   });
 
   test('nemmeno la skill la scrive: le due superfici dicono la stessa cosa', () => {
-    expect(HAND_WRITTEN_TARIFF.test(skillProse)).toBe(false);
+    expect(HAND_WRITTEN_TARIFF.test(SKILL)).toBe(false);
   });
 });


### PR DESCRIPTION
## What?

`cli/skills/findability.test.ts` read `SKILL.md` and `references/tools.md` **concatenated**, and asserted against the pair. It now reads `SKILL.md` alone, and each row additionally requires the skill to name its tool.

Four questions went red and are now routed from the map: `search_knowledge`, `render_post`, `regenerate_post_media`, `generate_media`.

## Why?

**The two files are not one surface.** `SKILL.md` always loads. `references/tools.md` sits under *"References (load on demand)"* and an agent may never open it. Concatenating them meant a word present only in the reference passed the row **while the surface actually read stayed silent**.

The precise failure matters, because it points at a different repair than "the gate was too loose": **the gate was reading a surface an agent might never meet, while claiming to test the surface an agent meets first.** A loose assertion gets tightened. An assertion pointed at the wrong object gets re-aimed — and this one was green for a year of reasons that had nothing to do with what it promised.

**Caught live, not in theory.** While reviewing #370 (moving `list_products` into `query`), the new sentence landed in `tools.md`; `SKILL.md` kept neither *"sell"* nor *"products"*, and my test was **green**. An agent reading only `SKILL.md` — the normal case — went from having `list_products` in the tool list to having no route to the products question at all. The gate would have waved through a regression on the first-read surface.

**Second hole, found by the same check: words alone prove nothing.** `search_knowledge` passed on *"question"*, *"answer"* and *"documents"* — words that appear in any page of English prose — while `SKILL.md` never named the tool once. A word match without the name leads nowhere: the name is what turns recognition into a call.

## How?

Assert against `SKILL.md` only, and add one line per row requiring the tool's name in it.

`tools.md` loses nothing: `cli/skills/tools-coverage.test.ts` already demands every tool be documented there. A weaker second guard on top of a stronger existing one was buying nothing and costing the accuracy of this one.

**The rule that falls out, and its limit:** *a question in the table must be routable from `SKILL.md` alone.* If a tool does not deserve a line in the map, its question does not deserve a row in the table. The map is not a catalogue — the same reason `instructions` does not list tools. Those two halves hold each other; without the limit, the map degenerates into the list that already exists twice.

The four `SKILL.md` additions are real routing, not keywords added to pass:

- **`search_knowledge`** had no path from the map at all — *"what does this brand know about X"* reached nothing.
- **`render_post`** and **`regenerate_post_media`** were not distinguishable from each other, nor from `refine_image`. The new lines say which one replaces the post's image and which files a new asset.
- **`generate_media`** now declares itself the old door and points at the two tools that name what they do.

Rejected: adding a per-row opt-out so `generate_media` could skip the skill assertion. A flag that lets a row exempt itself is a gate that can be quietly widened, and the honest answer was that the old door does deserve one line in the map — an agent that read older docs will reach for it.

## Testing?

`npx vitest run cli packages src/lib/content/changelog` → **850 passed**.

Red observed first, and it named exactly the four:

```
skill ← generate_media:          expected '---\nname: anomalia…' to contain 'generate_media'
skill ← render_post:             expected '---\nname: anomalia…' to contain 'render_post'
skill ← regenerate_post_media:   expected '---\nname: anomalia…' to contain 'regenerate_post_media'
skill ← search_knowledge:        expected '---\nname: anomalia…' to contain 'search_knowledge'
```

<details>
<summary>The live case that exposed it — verified against #370's branch, not reasoned about</summary>

```
$ git show origin/refactor/reads-into-query:cli/skills/anomalia/SKILL.md | grep -ci products
0
$ git show origin/refactor/reads-into-query:cli/skills/anomalia/references/tools.md | grep -ci products
5
```

Zero on the surface that always loads, five on the one loaded on demand — and the row was green under the old union.
</details>

## Evidence (screenshots/videos)

No UI change. The evidence is the red above and the counts in the collapsible.

## Anything Else?

**This makes #370 red, deliberately, and that ordering is the point.** If this merges first, #370 goes red and gains one line in `SKILL.md` routing the products question. If #370 merges first, it lands a first-read regression and this PR reports it afterwards. Told `a8c22181e602c7208`; their call which order, but the gate is worth more before their campaign than after it.

**Known limit I am not fixing here:** the rows still assert presence, never absence. A guard that checks words are there cannot see a fact nobody declared — it would not catch, say, `SKILL.md` failing to mention that the brand look now reaches generated images. That shape has appeared four times today. If it appears a fifth, the answer is probably a row per behaviour rather than per tool, and that is a different table from this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
