### PR TITLE
Add value checks to the ten tables users write

### DIFF
--- a/changelog/2026-09-05-table-value-checks.md
+++ b/changelog/2026-09-05-table-value-checks.md
@@ -32,35 +32,68 @@ quelli con violazioni non ci sono, e sotto c'è perché.
 Nessuna tabella supera le 1.800 righe: `add constraint` blocca per millisecondi, `not valid` +
 `validate constraint` sarebbe cerimonia senza guadagno.
 
-## Quello che non è entrato, e non per dimenticanza
+## Le cinque decisioni, e cosa è successo a ognuna
 
-**`products.kind` — 247 righe fuori vocabolario.** Il vocabolario è `product | service | project |
-feature`; in produzione ci sono anche `18k gold`, `18k gold / 9K GOLD`, `9kt gold`, `14k gold`.
-Tutte e 247 sono di un brand solo, `pragat-jewels`, e la causa è una riga sola ripetuta in tre
-posti: `kind: p.productType ?? 'product'`, dove `productType` è il `product_type` di Shopify —
-testo libero del merchant. Non basta correggere le righe: finché l'import scrive lì, il vincolo
-farebbe fallire ogni sincronizzazione del catalogo.
+Cinque colonne avevano violazioni o un percorso di codice che il vincolo avrebbe rotto. Quattro
+sono entrate dopo aver corretto la causa; una resta libera per scelta.
 
-**`posts.content_type` — zero righe da correggere, ma tre percorsi da sistemare.** `SHAPES` in
-`post-from-asset.ts` scrive `image` e `carousel`, che non sono content type ma **format** — la
-description del tool stesso lo dice a lettere («NOT carousel/reel/story»). E `upload-media`
-scrive `uploaded_video`, che è legittimo e semplicemente manca da `POST_CONTENT_TYPES`. Il vincolo
-diventa sicuro quando quei tre valori sono a posto, non prima.
+**`products.kind` resta senza vocabolario.** Le 247 righe fuori dai quattro valori attesi
+(`18k gold`, `9kt gold`, …) sono tutte di `pragat-jewels` e non sono dati rotti: sono i nomi di
+categoria di un gioielliere, che l'import Shopify copia dal `product_type` del merchant. Un CHECK
+lì avrebbe fatto fallire ogni sincronizzazione di catalogo per proteggere niente. Resta il tetto
+di lunghezza.
 
-**`brand_kit.theme_color` — zero violazioni, ma per fortuna.** `extractThemeColor` copia il
-contenuto del `<meta name="theme-color">` del sito senza validarlo. Oggi i 13 valori sono tutti
-`#RRGGBB`; un sito che scrive `red` — che è HTML valido — farebbe fallire l'onboarding. Prima si
-sanifica all'ingresso, poi si vincola.
+**`posts.content_type` è entrato, dopo tre correzioni.** `SHAPES` in `post-from-asset.ts`
+scriveva `image` e `carousel`: sono FORMATI, non tipi, e la description del tool lo dice in
+maiuscolo. Ora scrivono `uploaded_image`, che è quello che sono — asset caricati dall'utente.
+`uploaded_video`, che `upload-media` scrive da sempre, era invece legittimo e semplicemente
+mancava da `POST_CONTENT_TYPES`: aggiunto. E `PostAssetShape.contentType` non è più `string` ma
+`PostContentType`, così il compilatore tiene il vocabolario da solo.
 
-**`brand_kit.site_type` (3 righe), `brand_kit.source_url` (9 righe).** Il primo ha `media`,
-`mobile_app`, `service` fuori dai 6 archetipi. Il secondo ha cinque stringhe vuote e tre cose che
-non sono URL: `no celo`, `Mariopuggelli1939`, `biohappy` — utenti che hanno scritto un handle
-Instagram dove si chiedeva un sito. Sono pochi e sono dati di clienti veri: si decide, non si
-decide per loro.
+**`brand_kit.theme_color` è entrato, dopo la sanificazione in ingresso.** `extractThemeColor`
+copia il `<meta name="theme-color">` verbatim, e quel meta ammette qualunque colore CSS: `red` è
+HTML valido. I 13 valori in produzione erano tutti `#RRGGBB` per fortuna, non per costruzione.
+Ora passano da `sanitizeThemeColor`, accanto a `sanitizeBrandColors` e con la stessa regex.
 
-**`competitors.handles`.** Non è un problema di dati ma di forma: tre writer ci mettono un array
-di `{platform, username}`, `chat/job-executor.ts` ci mette un oggetto `{platform: username}`.
-Prima si sceglie una forma nel codice, poi la si vincola.
+**`brand_kit.site_type` è entrato allargato.** `media`, `mobile_app` e `service` non erano dati
+rotti: erano valori legittimi che mancavano dall'elenco. Il tipo sale da 6 a 9, e con lui l'enum
+dello schema JSON che il modello riceve — perché è da lì che arrivano.
+
+**`competitors.handles` è entrato come array, e non era una preferenza.** Tre scrittori ci
+mettevano un array di `{platform, username}`, `chat/job-executor.ts` un oggetto
+`{platform: username}`. La cosa che decide non è il conteggio: **entrambi** i lettori
+(`pickHandles`, `normalizeHandles`) tornano vuoto su qualunque cosa non sia un array. L'oggetto
+era invisibile a tutto il prodotto — il job "ri-cerca i concorrenti" scriveva handle che nessuna
+schermata poteva mostrare. Corretto lo scrittore, vincolata la forma. È anche la forma di
+`brand_social_handles`, e un oggetto non reggerebbe due account sulla stessa piattaforma.
+
+## `Mariopuggelli1939` non era spazzatura: era nel campo sbagliato
+
+Delle nove righe di `brand_kit.source_url` che non erano URL, due erano handle veri —
+`biohappy` e `Mariopuggelli1939` — scritti da qualcuno nel campo dove si chiedeva un sito. Le
+stesse nove stanno anche in `brands.website`, perché è la stessa cosa copiata due volte.
+Annullarle sarebbe stato buttare un dato giusto perché stava nel posto sbagliato.
+
+Quindi la regola è **in ingresso**, in `splitWebsiteOrHandle` accanto alle altre regole dei campi
+del Brand Studio: la chiocciola davanti, oppure una parola senza punti e senza schema, non può
+essere un dominio ed è un handle; va fra gli handle del brand. Uno spazio dentro (`no celo`) non
+è né l'uno né l'altro e si butta, invece di inventarci un profilo. Un dominio nudo prende lo
+schema, non il cestino.
+
+Nell'onboarding il punto è uno solo — `scrapeTargetsFrom(data)` — e legge entrambi i campi, così
+nessuna delle quattro chiamate può dimenticarsene.
+
+**Due trappole trovate provando, non leggendo.** `brand_social_handles` è unica su
+`(brand_id, platform)`, non sullo username: la guardia che avevo scritto controllava la colonna
+sbagliata, e su un brand con un Instagram già dichiarato la insert avrebbe alzato un 23505
+facendo **abortire l'intera migration**. Ora è `on conflict (brand_id, platform) do nothing`, e
+l'handle dichiarato vince su quello dedotto — stessa regola nel codice, dove il campo apposito
+batte il campo sito. La seconda: annullare tutto ciò che non è `^https?://` avrebbe buttato un
+dominio nudo. Oggi nessuna delle nove ha quella forma, ma la migration si applica dopo, e nel
+frattempo una riga nuova arriva.
+
+I 21 `brands.website` che sono domini nudi (`anomalia.so`) NON si toccano qui: sono dati buoni e
+vogliono una decisione loro.
 
 ## Due cose che di proposito restano nel codice
 
@@ -80,9 +113,16 @@ l'autopilot di notte. `format` prende solo un tetto di lunghezza.
 
 Un vincolo senza un test che prova a violarlo è una speranza — e la suite qui mocka Supabase, dove
 un insert finto accetta qualunque stringa (è la lezione già pagata su `brand_media.source`).
-`scripts/constraint-harness.mjs` scrive **davvero**: 61 insert malformati contro un Postgres vero,
+`scripts/constraint-harness.mjs` scrive **davvero**: 67 insert malformati contro un Postgres vero,
 ognuno passa solo se torna il 23514 atteso, tutto dentro una transazione chiusa da un `rollback`.
+I casi nuovi usano i valori che i difetti producevano per davvero — `content_type: 'carousel'`,
+`theme_color: 'red'`, `handles: {"instagram":"acme"}` — non valori inventati.
 
-Prima della migration: **0/61**. Il database accettava ogni singolo valore rotto. Dopo:
-**61/61**. `DATABASE_URL` che non punta a localhost fa uscire lo script con 2 prima di connettersi:
+Prima della migration: **0/67**. Il database accettava ogni singolo valore rotto. Dopo:
+**67/67**. `DATABASE_URL` che non punta a localhost fa uscire lo script con 2 prima di connettersi:
 questo harness scrive, e scrive solo in locale.
+
+La correzione dei dati è stata provata a parte, con ogni forma su un brand pulito e un `rollback`
+in fondo: `Mariopuggelli1939` e `@ciccio` diventano handle, `no celo` e la stringa vuota vanno a
+nullo, `anomalia.so` prende lo schema, `https://ok.com` non si muove, e un Instagram già
+dichiarato sopravvive.

--- a/changelog/2026-09-05-table-value-checks.md
+++ b/changelog/2026-09-05-table-value-checks.md
@@ -1,0 +1,88 @@
+# Che cosa è un valore valido, adesso lo dice il database
+
+L'audit della RLS aveva già dato il verdetto buono: 544 combinazioni su 548, un utente non tocca i
+dati di un altro cliente. La domanda che restava aperta è un'altra — dentro il **proprio** brand,
+che cosa può scrivere? Fino a qui: qualunque cosa. Le regole su cosa è un valore valido stavano nei
+tool, e i tool non sono il database.
+
+Il conto misurato in produzione:
+
+| tabella | colonne | NOT NULL | CHECK |
+|---|---|---|---|
+| `brand_kit` | 21 | 3 | **0** |
+| `products` | 11 | 6 | **0** |
+| `brand_articles` | 24 | 10 | **0** |
+| `content_plans` | 10 | 4 | **0** |
+| `posts` | 50 | 8 | **0** |
+
+`brand_kit` è l'identità visiva del brand — 21 colonne, tre obbligatorie, zero vincoli. E la teoria
+è già diventata pratica: in `brand_colors` c'è un colore che è
+`#00502DKEY_PAD_OR_HEX_MATCH_1_#00502D`, un segnaposto di regex sfuggito da uno scraper e finito
+nel database come se fosse un colore. In `brand_kit.images` c'è un path relativo dove tutti gli
+altri 586 sono URL assoluti. In `brand_news_sources` c'è un subreddit che si chiama
+`transgenderUK/`, con la barra, e il radar non lo troverà mai.
+
+## Il metodo: contare prima, vincolare dopo
+
+`alter table … add constraint … check (…)` fallisce se **una sola** riga esistente lo viola, e qui
+ci sono mesi di dati veri. Quindi ogni vincolo è stato interrogato in produzione in sola lettura e
+contato prima di essere scritto. Nella migration ci sono solo i 42 che hanno **zero** violazioni;
+quelli con violazioni non ci sono, e sotto c'è perché.
+
+Nessuna tabella supera le 1.800 righe: `add constraint` blocca per millisecondi, `not valid` +
+`validate constraint` sarebbe cerimonia senza guadagno.
+
+## Quello che non è entrato, e non per dimenticanza
+
+**`products.kind` — 247 righe fuori vocabolario.** Il vocabolario è `product | service | project |
+feature`; in produzione ci sono anche `18k gold`, `18k gold / 9K GOLD`, `9kt gold`, `14k gold`.
+Tutte e 247 sono di un brand solo, `pragat-jewels`, e la causa è una riga sola ripetuta in tre
+posti: `kind: p.productType ?? 'product'`, dove `productType` è il `product_type` di Shopify —
+testo libero del merchant. Non basta correggere le righe: finché l'import scrive lì, il vincolo
+farebbe fallire ogni sincronizzazione del catalogo.
+
+**`posts.content_type` — zero righe da correggere, ma tre percorsi da sistemare.** `SHAPES` in
+`post-from-asset.ts` scrive `image` e `carousel`, che non sono content type ma **format** — la
+description del tool stesso lo dice a lettere («NOT carousel/reel/story»). E `upload-media`
+scrive `uploaded_video`, che è legittimo e semplicemente manca da `POST_CONTENT_TYPES`. Il vincolo
+diventa sicuro quando quei tre valori sono a posto, non prima.
+
+**`brand_kit.theme_color` — zero violazioni, ma per fortuna.** `extractThemeColor` copia il
+contenuto del `<meta name="theme-color">` del sito senza validarlo. Oggi i 13 valori sono tutti
+`#RRGGBB`; un sito che scrive `red` — che è HTML valido — farebbe fallire l'onboarding. Prima si
+sanifica all'ingresso, poi si vincola.
+
+**`brand_kit.site_type` (3 righe), `brand_kit.source_url` (9 righe).** Il primo ha `media`,
+`mobile_app`, `service` fuori dai 6 archetipi. Il secondo ha cinque stringhe vuote e tre cose che
+non sono URL: `no celo`, `Mariopuggelli1939`, `biohappy` — utenti che hanno scritto un handle
+Instagram dove si chiedeva un sito. Sono pochi e sono dati di clienti veri: si decide, non si
+decide per loro.
+
+**`competitors.handles`.** Non è un problema di dati ma di forma: tre writer ci mettono un array
+di `{platform, username}`, `chat/job-executor.ts` ci mette un oggetto `{platform: username}`.
+Prima si sceglie una forma nel codice, poi la si vincola.
+
+## Due cose che di proposito restano nel codice
+
+**I tetti di piano non sono un CHECK.** Quante fonti radar consente un piano cambia quando cambia
+il listino, e un vincolo da migrare a ogni cambio di prezzo è un impedimento, non una protezione.
+
+**Nemmeno l'elenco delle lingue.** `brand_news_sources.lang` è vincolato nella *forma* — due
+lettere minuscole, oppure `auto` — non nell'elenco delle 12 voci del menu. La prova che è la scelta
+giusta è già nei dati: c'è una riga con `tr`, che nel menu non c'è. La forma regge, l'elenco
+avrebbe fatto fallire la migration.
+
+Stesso ragionamento per `posts.platform`, `posts.platforms` e `posts.format`: i percorsi
+planner/onboarding ci scrivono l'output del modello senza normalizzarlo, e un CHECK lì fermerebbe
+l'autopilot di notte. `format` prende solo un tetto di lunghezza.
+
+## Il test: guardarlo fallire prima
+
+Un vincolo senza un test che prova a violarlo è una speranza — e la suite qui mocka Supabase, dove
+un insert finto accetta qualunque stringa (è la lezione già pagata su `brand_media.source`).
+`scripts/constraint-harness.mjs` scrive **davvero**: 61 insert malformati contro un Postgres vero,
+ognuno passa solo se torna il 23514 atteso, tutto dentro una transazione chiusa da un `rollback`.
+
+Prima della migration: **0/61**. Il database accettava ogni singolo valore rotto. Dopo:
+**61/61**. `DATABASE_URL` che non punta a localhost fa uscire lo script con 2 prima di connettersi:
+questo harness scrive, e scrive solo in locale.

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "oss:export": "node scripts/export-oss.mjs",
     "test:durability": "npm run eval:durability",
     "postinstall": "patch-package",
-    "eval:durability": "vite-node --config scripts/vite-node.config.ts scripts/eval/durability.ts"
+    "eval:durability": "vite-node --config scripts/vite-node.config.ts scripts/eval/durability.ts",
+    "test:constraints": "node scripts/constraint-harness.mjs"
   },
   "devDependencies": {
     "@internationalized/date": "^3.12.0",

--- a/packages/site-analysis/src/crawl.ts
+++ b/packages/site-analysis/src/crawl.ts
@@ -76,7 +76,16 @@ export interface HTMLMetadata {
 
 // The site's business archetype — drives how offerings, spokesperson and content pillars are
 // interpreted. 'ecommerce' is detected from platform/cart signals; the rest from content.
-export type SiteType = 'ecommerce' | 'saas' | 'portfolio' | 'local_service' | 'creator' | 'generic';
+export type SiteType =
+    | 'ecommerce'
+    | 'saas'
+    | 'portfolio'
+    | 'local_service'
+    | 'creator'
+    | 'media'
+    | 'mobile_app'
+    | 'service'
+    | 'generic';
 
 
 export type ProgressCallback = (step: string, message: string) => void;

--- a/scripts/constraint-harness.mjs
+++ b/scripts/constraint-harness.mjs
@@ -44,6 +44,7 @@ const newsSource = (columns, values) => `insert into public.brand_news_sources (
 
 const CASES = [
   { what: 'posts.status fuori vocabolario', sql: post('status', `'nope'`), code: CHECK_VIOLATION },
+  { what: 'posts.content_type con un formato al posto di un tipo', sql: post('content_type', `'carousel'`), code: CHECK_VIOLATION },
   { what: 'posts.source fuori vocabolario', sql: post('source', `'nope'`), code: CHECK_VIOLATION },
   { what: 'posts.video_render_status fuori vocabolario', sql: post('video_render_status', `'nope'`), code: CHECK_VIOLATION },
   { what: 'posts.video_resolution fuori vocabolario', sql: post('video_resolution', `'4k'`), code: CHECK_VIOLATION },
@@ -59,9 +60,13 @@ const CASES = [
   { what: 'products.title oltre il tetto', sql: `insert into public.products (brand_id, title) values ($1, repeat('x', 501))`, code: CHECK_VIOLATION },
   { what: 'products.url non http', sql: product('url', `'nope'`), code: CHECK_VIOLATION },
   { what: 'products.images non array', sql: product('images', `'{}'::jsonb`), code: CHECK_VIOLATION },
+  { what: 'products.kind oltre il tetto', sql: product('kind', `repeat('x', 201)`), code: CHECK_VIOLATION },
   { what: 'products.description oltre il tetto', sql: product('description', `repeat('x', 50001)`), code: CHECK_VIOLATION },
 
   { what: 'brand_kit.favicon_url non http ne data', sql: kit('favicon_url', `'nope'`), code: CHECK_VIOLATION },
+  { what: 'brand_kit.source_url e un handle, non un sito', sql: kit('source_url', `'Mariopuggelli1939'`), code: CHECK_VIOLATION },
+  { what: 'brand_kit.theme_color e un colore CSS, non hex', sql: kit('theme_color', `'red'`), code: CHECK_VIOLATION },
+  { what: 'brand_kit.site_type fuori vocabolario', sql: kit('site_type', `'nope'`), code: CHECK_VIOLATION },
   { what: 'brand_kit.brand_colors non array', sql: kit('brand_colors', `'{}'::jsonb`), code: CHECK_VIOLATION },
   { what: 'brand_kit.logos non array', sql: kit('logos', `'{}'::jsonb`), code: CHECK_VIOLATION },
   { what: 'brand_kit.fonts non array', sql: kit('fonts', `'{}'::jsonb`), code: CHECK_VIOLATION },
@@ -105,6 +110,7 @@ const CASES = [
   { what: 'people.role oltre il tetto', sql: person('role', `repeat('x', 201)`), code: CHECK_VIOLATION },
 
   { what: 'competitors.website non http', sql: competitor('website', `'nope'`), code: CHECK_VIOLATION },
+  { what: 'competitors.handles oggetto invece che array', sql: competitor('handles', `'{"instagram":"acme"}'::jsonb`), code: CHECK_VIOLATION },
   { what: 'competitors.top_posts non array', sql: competitor('top_posts', `'{}'::jsonb`), code: CHECK_VIOLATION },
   { what: 'competitors.top_ads non array', sql: competitor('top_ads', `'{}'::jsonb`), code: CHECK_VIOLATION },
   { what: 'competitors.benchmark non oggetto', sql: competitor('benchmark', `'[]'::jsonb`), code: CHECK_VIOLATION },

--- a/scripts/constraint-harness.mjs
+++ b/scripts/constraint-harness.mjs
@@ -1,0 +1,217 @@
+/**
+ * OGNI VINCOLO, PROVATO CON UN INSERT CHE DEVE FALLIRE.
+ *
+ * Un CHECK dichiarato in una migration e mai provato è una speranza: la suite mocka Supabase,
+ * un insert finto accetta qualunque stringa, e il vincolo resta verde per costruzione (LESSONS.md,
+ * «Un valore che il CHECK rifiuta è invisibile a una suite che mocka il database»). Qui il
+ * database è vero: ogni caso scrive davvero, e il caso passa SOLO se Postgres lo rifiuta con lo
+ * SQLSTATE atteso.
+ *
+ *   23514  check_violation      il CHECK ha morso
+ *   23502  not_null_violation   il NOT NULL ha morso
+ *
+ * Si guarda fallire PRIMA della migration (ogni caso «accettato» = vincolo assente) e passare
+ * dopo. Tutto gira dentro UNA transazione chiusa da un ROLLBACK: non resta una riga.
+ *
+ *   DATABASE_URL=postgres://postgres:<pw>@127.0.0.1:5432/postgres node scripts/constraint-harness.mjs
+ *   npm run test:constraints
+ *
+ * DATABASE_URL deve puntare a localhost: contro un database remoto lo script si rifiuta di partire.
+ *
+ * ponytail: i casi sono dati, non codice — una riga per vincolo, nessuna astrazione per tabella.
+ * Il ceiling è che i valori validi non sono provati (solo quelli rifiutati): il giorno in cui un
+ * vincolo si rivelasse troppo stretto in produzione, il caso «deve passare» si aggiunge qui.
+ */
+import { Client } from 'pg';
+
+const CHECK_VIOLATION = '23514';
+const NOT_NULL_VIOLATION = '23502';
+
+const LOCAL_HOSTS = new Set(['127.0.0.1', 'localhost', '::1', '[::1]']);
+
+const post = (columns, values) => `insert into public.posts (brand_id, ${columns}) values ($1, ${values})`;
+const product = (columns, values) => `insert into public.products (brand_id, title, ${columns}) values ($1, 'ok', ${values})`;
+const kit = (column, value) => `insert into public.brand_kit (brand_id, ${column}) values ($1, ${value})`;
+const article = (columns, values) =>
+  `insert into public.brand_articles (brand_id, slug, title, body_md, ${columns}) values ($1, 'ok', 'ok', 'ok', ${values})`;
+const plan = (columns, values) => `insert into public.content_plans (brand_id, ${columns}) values ($1, ${values})`;
+const person = (columns, values) => `insert into public.people (brand_id, name, kind, ${columns}) values ($1, 'ok', 'real', ${values})`;
+const competitor = (columns, values) => `insert into public.competitors (brand_id, name, ${columns}) values ($1, 'ok', ${values})`;
+const memory = (columns, values) =>
+  `insert into public.brand_memory (brand_id, category, key, value, ${columns}) values ($1, 'fact', 'k', 'v', ${values})`;
+const site = (value) => `insert into public.brand_sites (brand_id, host) values ($1, ${value})`;
+const newsSource = (columns, values) => `insert into public.brand_news_sources (brand_id, kind, ${columns}) values ($1, 'rss', ${values})`;
+
+const CASES = [
+  { what: 'posts.status fuori vocabolario', sql: post('status', `'nope'`), code: CHECK_VIOLATION },
+  { what: 'posts.source fuori vocabolario', sql: post('source', `'nope'`), code: CHECK_VIOLATION },
+  { what: 'posts.video_render_status fuori vocabolario', sql: post('video_render_status', `'nope'`), code: CHECK_VIOLATION },
+  { what: 'posts.video_resolution fuori vocabolario', sql: post('video_resolution', `'4k'`), code: CHECK_VIOLATION },
+  { what: 'posts.video_duration_seconds a zero', sql: post('video_duration_seconds', '0'), code: CHECK_VIOLATION },
+  { what: 'posts.video_duration_seconds oltre un ora', sql: post('video_duration_seconds', '3601'), code: CHECK_VIOLATION },
+  { what: 'posts.revisions_count negativo', sql: post('revisions_count', '-1'), code: CHECK_VIOLATION },
+  { what: 'posts.media_url non http', sql: post('media_url', `'ftp://x'`), code: CHECK_VIOLATION },
+  { what: 'posts.media_urls non array', sql: post('media_urls', `'"x"'::jsonb`), code: CHECK_VIOLATION },
+  { what: 'posts.caption oltre il tetto', sql: post('caption', `repeat('x', 10001)`), code: CHECK_VIOLATION },
+  { what: 'posts.slot oltre il tetto', sql: post('slot', `repeat('x', 101)`), code: CHECK_VIOLATION },
+
+  { what: 'products.title vuoto', sql: `insert into public.products (brand_id, title) values ($1, '   ')`, code: CHECK_VIOLATION },
+  { what: 'products.title oltre il tetto', sql: `insert into public.products (brand_id, title) values ($1, repeat('x', 501))`, code: CHECK_VIOLATION },
+  { what: 'products.url non http', sql: product('url', `'nope'`), code: CHECK_VIOLATION },
+  { what: 'products.images non array', sql: product('images', `'{}'::jsonb`), code: CHECK_VIOLATION },
+  { what: 'products.description oltre il tetto', sql: product('description', `repeat('x', 50001)`), code: CHECK_VIOLATION },
+
+  { what: 'brand_kit.favicon_url non http ne data', sql: kit('favicon_url', `'nope'`), code: CHECK_VIOLATION },
+  { what: 'brand_kit.brand_colors non array', sql: kit('brand_colors', `'{}'::jsonb`), code: CHECK_VIOLATION },
+  { what: 'brand_kit.logos non array', sql: kit('logos', `'{}'::jsonb`), code: CHECK_VIOLATION },
+  { what: 'brand_kit.fonts non array', sql: kit('fonts', `'{}'::jsonb`), code: CHECK_VIOLATION },
+  { what: 'brand_kit.images non array', sql: kit('images', `'{}'::jsonb`), code: CHECK_VIOLATION },
+  { what: 'brand_kit.content_pillars non array', sql: kit('content_pillars', `'{}'::jsonb`), code: CHECK_VIOLATION },
+  { what: 'brand_kit.ai_character non oggetto', sql: kit('ai_character', `'[]'::jsonb`), code: CHECK_VIOLATION },
+  { what: 'brand_kit.graphic_style non oggetto', sql: kit('graphic_style', `'[]'::jsonb`), code: CHECK_VIOLATION },
+  { what: 'brand_kit.about oltre il tetto', sql: kit('about', `repeat('x', 20001)`), code: CHECK_VIOLATION },
+  { what: 'brand_kit.theme_color oltre il tetto', sql: kit('theme_color', `repeat('x', 41)`), code: CHECK_VIOLATION },
+
+  { what: 'brand_articles.status fuori vocabolario', sql: article('status', `'nope'`), code: CHECK_VIOLATION },
+  { what: 'brand_articles.source fuori vocabolario', sql: article('source', `'nope'`), code: CHECK_VIOLATION },
+  {
+    what: 'brand_articles.slug con spazi e maiuscole',
+    sql: `insert into public.brand_articles (brand_id, slug, title, body_md) values ($1, 'Non Uno Slug', 'ok', 'ok')`,
+    code: CHECK_VIOLATION
+  },
+  {
+    what: 'brand_articles.title vuoto',
+    sql: `insert into public.brand_articles (brand_id, slug, title, body_md) values ($1, 'ok', '   ', 'ok')`,
+    code: CHECK_VIOLATION
+  },
+  { what: 'brand_articles.version_seq negativo', sql: article('version_seq', '-1'), code: CHECK_VIOLATION },
+  { what: 'brand_articles.cover_image non http', sql: article('cover_image', `'nope'`), code: CHECK_VIOLATION },
+  { what: 'brand_articles.meta_title oltre il tetto', sql: article('meta_title', `repeat('x', 301)`), code: CHECK_VIOLATION },
+
+  { what: 'content_plans.status fuori vocabolario', sql: plan('status', `'nope'`), code: CHECK_VIOLATION },
+  { what: 'content_plans.source fuori vocabolario', sql: plan('source', `'nope'`), code: CHECK_VIOLATION },
+  { what: 'content_plans.editorial_week negativa', sql: plan('editorial_week', '-1'), code: CHECK_VIOLATION },
+  { what: 'content_plans.editorial_week oltre l anno', sql: plan('editorial_week', '53'), code: CHECK_VIOLATION },
+  { what: 'content_plans.seeds non oggetto', sql: plan('seeds', `'[]'::jsonb`), code: CHECK_VIOLATION },
+  { what: 'content_plans.title oltre il tetto', sql: plan('title', `repeat('x', 301)`), code: CHECK_VIOLATION },
+
+  { what: 'people.consent_source fuori vocabolario', sql: person('consent_source', `'nope'`), code: CHECK_VIOLATION },
+  { what: 'people.images non array', sql: person('images', `'{}'::jsonb`), code: CHECK_VIOLATION },
+  {
+    what: 'people.name vuoto',
+    sql: `insert into public.people (brand_id, name, kind) values ($1, '   ', 'real')`,
+    code: CHECK_VIOLATION
+  },
+  { what: 'people.role oltre il tetto', sql: person('role', `repeat('x', 201)`), code: CHECK_VIOLATION },
+
+  { what: 'competitors.website non http', sql: competitor('website', `'nope'`), code: CHECK_VIOLATION },
+  { what: 'competitors.top_posts non array', sql: competitor('top_posts', `'{}'::jsonb`), code: CHECK_VIOLATION },
+  { what: 'competitors.top_ads non array', sql: competitor('top_ads', `'{}'::jsonb`), code: CHECK_VIOLATION },
+  { what: 'competitors.benchmark non oggetto', sql: competitor('benchmark', `'[]'::jsonb`), code: CHECK_VIOLATION },
+  {
+    what: 'competitors.name vuoto',
+    sql: `insert into public.competitors (brand_id, name) values ($1, '   ')`,
+    code: CHECK_VIOLATION
+  },
+  { what: 'competitors.rationale oltre il tetto', sql: competitor('rationale', `repeat('x', 20001)`), code: CHECK_VIOLATION },
+
+  {
+    what: 'brand_memory.key vuota',
+    sql: `insert into public.brand_memory (brand_id, category, key, value) values ($1, 'fact', '   ', 'v')`,
+    code: CHECK_VIOLATION
+  },
+  {
+    what: 'brand_memory.key oltre il tetto',
+    sql: `insert into public.brand_memory (brand_id, category, key, value) values ($1, 'fact', repeat('x', 201), 'v')`,
+    code: CHECK_VIOLATION
+  },
+  {
+    what: 'brand_memory.value vuoto',
+    sql: `insert into public.brand_memory (brand_id, category, key, value) values ($1, 'fact', 'k', '   ')`,
+    code: CHECK_VIOLATION
+  },
+  {
+    what: 'brand_memory.value oltre il tetto',
+    sql: `insert into public.brand_memory (brand_id, category, key, value) values ($1, 'fact', 'k', repeat('x', 50001))`,
+    code: CHECK_VIOLATION
+  },
+  { what: 'brand_memory.times_reinforced negativo', sql: memory('times_reinforced', '-1'), code: CHECK_VIOLATION },
+  { what: 'brand_memory.times_used negativo', sql: memory('times_used', '-1'), code: CHECK_VIOLATION },
+
+  { what: 'brand_sites.host con schema e maiuscole', sql: site(`'HTTPS://Blog.Brand.Com'`), code: CHECK_VIOLATION },
+  { what: 'brand_sites.host senza punto', sql: site(`'localhost'`), code: CHECK_VIOLATION },
+  { what: 'brand_sites.host con path', sql: site(`'blog.brand.com/feed'`), code: CHECK_VIOLATION },
+
+  { what: 'brand_news_sources.value vuoto', sql: newsSource('value', `'   '`), code: CHECK_VIOLATION },
+  { what: 'brand_news_sources.value oltre il tetto', sql: newsSource('value', `repeat('x', 501)`), code: CHECK_VIOLATION },
+  { what: 'brand_news_sources.lang non un codice', sql: newsSource('value, lang', `'https://x.dev/feed', 'english'`), code: CHECK_VIOLATION }
+];
+
+function localOnly(url) {
+  const { hostname } = new URL(url);
+
+  if (!LOCAL_HOSTS.has(hostname)) {
+    throw new Error(`DATABASE_URL punta a ${hostname}: questo harness scrive, e scrive solo in locale`);
+  }
+}
+
+async function runCase(client, brandId, testCase) {
+  await client.query('savepoint probe');
+
+  try {
+    await client.query(testCase.sql, [brandId]);
+    await client.query('rollback to savepoint probe');
+
+    return { ...testCase, ok: false, got: 'accettato' };
+  } catch (error) {
+    await client.query('rollback to savepoint probe');
+
+    return { ...testCase, ok: error.code === testCase.code, got: error.code };
+  }
+}
+
+async function main() {
+  const url = process.env.DATABASE_URL;
+
+  if (!url) {
+    console.error('DATABASE_URL mancante');
+    process.exit(2);
+  }
+
+  localOnly(url);
+
+  const client = new Client({ connectionString: url });
+  await client.connect();
+  await client.query('begin');
+
+  const brand = await client.query('select id from public.brands limit 1');
+
+  if (!brand.rows[0]?.id) {
+    console.error('nessun brand nel database locale: lancia prima `npm run db:seed`');
+    process.exit(2);
+  }
+
+  const brandId = brand.rows[0].id;
+  await client.query('delete from public.brand_kit where brand_id = $1', [brandId]);
+
+  const results = [];
+  for (const testCase of CASES) {
+    results.push(await runCase(client, brandId, testCase));
+  }
+
+  await client.query('rollback');
+  await client.end();
+
+  for (const result of results) {
+    console.log(`${result.ok ? 'ok  ' : 'FAIL'}  ${result.what}  (atteso ${result.code}, ottenuto ${result.got})`);
+  }
+
+  const failed = results.filter((r) => !r.ok).length;
+  console.log(`\n${results.length - failed}/${results.length} vincoli mordono`);
+  process.exit(failed === 0 ? 0 : 1);
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(2);
+});

--- a/src/lib/brand-fields.test.ts
+++ b/src/lib/brand-fields.test.ts
@@ -3,7 +3,9 @@ import {
   isKnownTimezone,
   normalizeHashtags,
   normalizeWebsite,
-  sanitizeBrandColors
+  sanitizeBrandColors,
+  sanitizeThemeColor,
+  splitWebsiteOrHandle
 } from './brand-fields';
 
 /**
@@ -77,5 +79,39 @@ describe('il fuso orario del brand', () => {
     expect(isKnownTimezone('CET+1')).toBe(false);
     expect(isKnownTimezone('')).toBe(false);
     expect(isKnownTimezone('   ')).toBe(false);
+  });
+});
+
+describe('sanitizeThemeColor', () => {
+  it('tiene la notazione hex e butta i colori CSS che il meta ammette', () => {
+    expect(sanitizeThemeColor('#7c5cff')).toBe('#7c5cff');
+    expect(sanitizeThemeColor(' #abc ')).toBe('#abc');
+    expect(sanitizeThemeColor('red')).toBeNull();
+    expect(sanitizeThemeColor('rgb(0,0,0)')).toBeNull();
+    expect(sanitizeThemeColor(null)).toBeNull();
+  });
+});
+
+describe('splitWebsiteOrHandle', () => {
+  it('un dominio resta un sito, con lo schema davanti', () => {
+    expect(splitWebsiteOrHandle('anomalia.so')).toEqual({ website: 'https://anomalia.so', handle: null });
+    expect(splitWebsiteOrHandle('https://anomalia.so')).toEqual({ website: 'https://anomalia.so', handle: null });
+  });
+
+  it('la chiocciola e la parola senza punti sono handle, non siti', () => {
+    expect(splitWebsiteOrHandle('@biohappy')).toEqual({
+      website: null,
+      handle: { platform: 'instagram', username: 'biohappy' }
+    });
+    expect(splitWebsiteOrHandle('Mariopuggelli1939')).toEqual({
+      website: null,
+      handle: { platform: 'instagram', username: 'Mariopuggelli1939' }
+    });
+  });
+
+  it('quello che non è né un dominio né un handle non diventa un profilo inventato', () => {
+    expect(splitWebsiteOrHandle('no celo')).toEqual({ website: null, handle: null });
+    expect(splitWebsiteOrHandle('   ')).toEqual({ website: null, handle: null });
+    expect(splitWebsiteOrHandle('@')).toEqual({ website: null, handle: null });
   });
 });

--- a/src/lib/brand-fields.ts
+++ b/src/lib/brand-fields.ts
@@ -17,12 +17,24 @@
  * hex. Il tetto conta quanto il formato — senza, un agente ci infila quaranta colori e la
  * direzione visiva smette di dire qualcosa.
  */
+const HEX_COLOR = /^#[0-9a-fA-F]{3,8}$/;
+
 export function sanitizeBrandColors(input: unknown): string[] {
   if (!Array.isArray(input)) return [];
   return input
     .map((c) => String(c).trim())
-    .filter((c) => /^#[0-9a-fA-F]{3,8}$/.test(c))
+    .filter((c) => HEX_COLOR.test(c))
     .slice(0, 8);
+}
+
+/**
+ * Il colore del tema arriva dal `<meta name="theme-color">` del sito analizzato, e quel meta
+ * ammette qualunque colore CSS: `red` è HTML valido e non è un colore che sappiamo usare.
+ * Stessa notazione della palette, perché finiscono negli stessi posti.
+ */
+export function sanitizeThemeColor(input: unknown): string | null {
+  const v = String(input ?? '').trim();
+  return HEX_COLOR.test(v) ? v : null;
 }
 
 /** Un sito digitato a mano diventa un URL cliccabile; vuoto resta null. */
@@ -30,6 +42,35 @@ export function normalizeWebsite(raw: string): string | null {
   const v = String(raw ?? '').trim();
   if (!v) return null;
   return /^https?:\/\//i.test(v) ? v : `https://${v}`;
+}
+
+/**
+ * Nel campo "sito" la gente scrive il proprio handle. `Mariopuggelli1939` e `biohappy` sono in
+ * produzione dentro `brands.website` e `brand_kit.source_url`: non sono spazzatura, sono un dato
+ * giusto nel campo sbagliato, e `https://Mariopuggelli1939` non è un indirizzo che apre niente.
+ *
+ * Due forme sole, quelle che non possono essere un dominio: la chiocciola davanti, oppure una
+ * parola senza punti e senza schema. Il resto è un sito. Uno spazio dentro non è né l'uno né
+ * l'altro (`no celo`), e si butta invece di inventarci un profilo.
+ */
+const HANDLE_DEFAULT_PLATFORM = 'instagram';
+
+export type WebsiteOrHandle = {
+  website: string | null;
+  handle: { platform: string; username: string } | null;
+};
+
+export function splitWebsiteOrHandle(raw: string): WebsiteOrHandle {
+  const v = String(raw ?? '').trim();
+  if (!v) return { website: null, handle: null };
+
+  const looksLikeHandle = v.startsWith('@') || (!/^https?:\/\//i.test(v) && !v.includes('.'));
+  if (!looksLikeHandle) return { website: normalizeWebsite(v), handle: null };
+
+  const username = v.replace(/^@+/, '').replace(/\/+$/, '').trim();
+  if (!username || /\s/.test(username)) return { website: null, handle: null };
+
+  return { website: null, handle: { platform: HANDLE_DEFAULT_PLATFORM, username } };
 }
 
 /**

--- a/src/lib/content/changelog/2026-09-05-table-value-checks.ts
+++ b/src/lib/content/changelog/2026-09-05-table-value-checks.ts
@@ -4,7 +4,8 @@ export default {
   date: '2026-09-05',
   title: 'Your brand data can no longer be saved broken',
   items: [
-    'Brand kit, products, posts, articles, plans, people and competitors now refuse malformed values instead of storing them: a colour has to be a colour, a website has to be a link, a status has to be one the product actually understands.',
-    'A value the system cannot use is now rejected the moment you save it, rather than turning up later as an empty page or a feed that finds nothing.'
+    'Brand kit, products, posts, articles, plans, people and competitors now refuse malformed values instead of storing them: a colour has to be a colour, a website has to be a link, a status has to be one the product understands.',
+    'Typing your social handle where the website goes now files it under your brand handles instead of saving an address that opens nothing — and the handles already saved that way have been moved across.',
+    'Competitor handles found by research now show up on the competitors page: they were being saved in a shape no screen could read.'
   ]
 } satisfies ChangelogEntry;

--- a/src/lib/content/changelog/2026-09-05-table-value-checks.ts
+++ b/src/lib/content/changelog/2026-09-05-table-value-checks.ts
@@ -1,0 +1,10 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-05',
+  title: 'Your brand data can no longer be saved broken',
+  items: [
+    'Brand kit, products, posts, articles, plans, people and competitors now refuse malformed values instead of storing them: a colour has to be a colour, a website has to be a link, a status has to be one the product actually understands.',
+    'A value the system cannot use is now rejected the moment you save it, rather than turning up later as an empty page or a feed that finds nothing.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/contracts/post-tools.ts
+++ b/src/lib/contracts/post-tools.ts
@@ -38,9 +38,11 @@ export const POST_CONTENT_TYPES = [
   'generated_video',
   'generated_graphic',
   'uploaded_image',
+  'uploaded_video',
   'text',
   'link'
 ] as const;
+export type PostContentType = (typeof POST_CONTENT_TYPES)[number];
 
 // ── update_post ──────────────────────────────────────────────────────────────
 

--- a/src/lib/post-from-asset.ts
+++ b/src/lib/post-from-asset.ts
@@ -7,6 +7,8 @@
  * e' un reel che l'editor apre come una foto e che l'utente scopre rotto in pubblicazione, senza
  * un errore da nessuna parte. Scriverli in tre punti diversi e' esattamente come e' successo.
  */
+import type { PostContentType } from './contracts/post-tools';
+
 export const POST_ASSET_TYPES = ['image', 'video', 'carousel'] as const;
 export type PostAssetType = (typeof POST_ASSET_TYPES)[number];
 
@@ -15,16 +17,16 @@ export type PostAssetShape = {
 	mediaKind: 'image' | 'video';
 	/** Quanti asset servono: il carosello e' l'unico che ne vuole piu' di uno. */
 	multiple: boolean;
-	contentType: string;
+	contentType: PostContentType;
 	format: string;
 	/** Cosa il post ricordera' di se stesso — `read_posts` lo rilegge per sapere come modificarlo. */
 	mediaOrigin: string;
 };
 
 const SHAPES: Record<PostAssetType, PostAssetShape> = {
-	image: { mediaKind: 'image', multiple: false, contentType: 'image', format: 'image', mediaOrigin: 'user_uploaded' },
+	image: { mediaKind: 'image', multiple: false, contentType: 'uploaded_image', format: 'image', mediaOrigin: 'user_uploaded' },
 	video: { mediaKind: 'video', multiple: false, contentType: 'generated_video', format: 'video', mediaOrigin: 'video' },
-	carousel: { mediaKind: 'image', multiple: true, contentType: 'carousel', format: 'carousel', mediaOrigin: 'user_uploaded' }
+	carousel: { mediaKind: 'image', multiple: true, contentType: 'uploaded_image', format: 'carousel', mediaOrigin: 'user_uploaded' }
 };
 
 export function postAssetShape(type: unknown): PostAssetShape | undefined {

--- a/src/lib/server/brand-analysis.ts
+++ b/src/lib/server/brand-analysis.ts
@@ -11,6 +11,7 @@
  * package.
  */
 import { swallow } from '$lib/server/swallow';
+import { sanitizeThemeColor } from '$lib/brand-fields';
 import type { GoogleGenAI } from '@google/genai';
 import { browserlessContent, isBrowserlessConfigured } from './browserless';
 import { aiStructured } from '$lib/server/ai-text';
@@ -161,9 +162,9 @@ const brandProfileSchema = {
         category: { type: 'string' as const, description: 'Business category (e.g. "AI Application Development")' },
         site_type: {
             type: 'string' as const,
-            enum: ['ecommerce', 'saas', 'portfolio', 'local_service', 'creator', 'generic'],
+            enum: ['ecommerce', 'saas', 'portfolio', 'local_service', 'creator', 'media', 'mobile_app', 'service', 'generic'],
             description:
-                'The business archetype of this site. ecommerce = sells physical/digital products with a cart; saas = software/tech product with pricing/signup/docs; portfolio = freelancer/creative/agency showcasing work & case-studies; local_service = a physical local business (restaurant, gym, salon, clinic, hotel); creator = personal brand / media / publisher monetising audience; generic = none of these clearly. Use the DETECTED ARCHETYPE hint as a strong prior but decide from the actual content.',
+                'The business archetype of this site. ecommerce = sells physical/digital products with a cart; saas = software/tech product with pricing/signup/docs; portfolio = freelancer/creative/agency showcasing work & case-studies; local_service = a physical local business (restaurant, gym, salon, clinic, hotel); creator = personal brand monetising an audience; media = publisher/newsroom whose product is the content itself; mobile_app = a phone app as the product; service = a service business that is not tied to one place; generic = none of these clearly. Use the DETECTED ARCHETYPE hint as a strong prior but decide from the actual content.',
         },
         content_pillars: {
             type: 'array' as const,
@@ -590,7 +591,7 @@ export async function runBrandAnalysis(
     if (metadata.faviconUrl) profile.favicon_url = metadata.faviconUrl;
     if (metadata.logos.length > 0) profile.logos = metadata.logos;
     if (metadata.fonts.length > 0) profile.fonts = metadata.fonts;
-    if (metadata.themeColor) profile.theme_color = metadata.themeColor;
+    if (metadata.themeColor) profile.theme_color = sanitizeThemeColor(metadata.themeColor) ?? undefined;
 
     // Immagini del sito: OG image + immagini reali raccolte dalla pagina + foto prodotti e-commerce
     const siteImages: string[] = [];

--- a/src/lib/server/chat/job-executor.ts
+++ b/src/lib/server/chat/job-executor.ts
@@ -141,10 +141,8 @@ export async function executeChatToolJob(
       for (const c of competitors) {
         await cancel.assertActive();
         const handles = handleMap.get(c.name) ?? [];
-        const handlesObj: AnyRec = {};
-        for (const h of handles) handlesObj[h.platform] = h.username ?? h.profileUrl;
         await supabase.from('competitors').upsert({
-          brand_id: brandId, name: c.name, website: c.website, kind: c.kind, rationale: c.rationale, handles: handlesObj, source: 'ai'
+          brand_id: brandId, name: c.name, website: c.website, kind: c.kind, rationale: c.rationale, handles, source: 'ai'
         }, { onConflict: 'brand_id,name' });
       }
 

--- a/src/routes/app/onboarding/+page.server.ts
+++ b/src/routes/app/onboarding/+page.server.ts
@@ -6,6 +6,7 @@ import { canEnter } from '$lib/server/access';
 import type { Actions, PageServerLoad } from './$types';
 import { ensureOrgForUser } from '$lib/server/org';
 import { slugifyBrand, uniqueSlug } from '$lib/brand-slug';
+import { splitWebsiteOrHandle } from '$lib/brand-fields';
 import { materializeBrandHistory, type ScrapeTarget } from '$lib/server/scrapecreators';
 import { rebuildBrandContext } from '$lib/server/brand-context';
 import { competitiveDelta } from '$lib/server/research';
@@ -74,6 +75,24 @@ function parseScrapeTargets(raw: string): ScrapeTarget[] {
   } catch {
     return [];
   }
+}
+
+/**
+ * Gli handle che l'onboarding deve salvare: quelli del campo apposito, più quello che l'utente ha
+ * scritto nel campo "sito" quando lì ha messo il proprio profilo invece del dominio. Prima quel
+ * valore finiva in `brands.website` e `brand_kit.source_url` — `Mariopuggelli1939` è in
+ * produzione — e non apriva niente: un dato giusto nel campo sbagliato, non spazzatura.
+ */
+function scrapeTargetsFrom(data: FormData): ScrapeTarget[] {
+  const targets = parseScrapeTargets(String(data.get('handles') ?? ''));
+  const { handle } = splitWebsiteOrHandle(String(data.get('website') ?? ''));
+  if (!handle) return targets;
+
+  // `brand_social_handles` tiene un handle per piattaforma: se il campo apposito ne dichiara già
+  // uno per Instagram, quello vince — è dichiarato, non dedotto da un campo sbagliato.
+  if (targets.some((t) => t.platform === handle.platform)) return targets;
+
+  return [...targets, { platform: handle.platform, username: handle.username, profileUrl: null }];
 }
 
 async function requireAdmin(
@@ -555,7 +574,7 @@ export const actions: Actions = {
   create: async ({ request, url, platform, cookies, locals: { supabase, safeGetSession, locale } }) => {
     const user = await requireAdmin(supabase, safeGetSession);
     const data = await request.formData();
-    const website = String(data.get('website') ?? '').trim() || null;
+    const website = splitWebsiteOrHandle(String(data.get('website') ?? '')).website;
     const profile = parseProfile(data);
     const name = (String(data.get('name') ?? '').trim() || (profile?.name as string) || '').trim();
     if (!name) return fail(400, { error: 'Brand name is required', website });
@@ -590,7 +609,7 @@ export const actions: Actions = {
         .maybeSingle();
       if (bySite) {
         await persistBrandKit(supabase, bySite.id, profile, website, locale, { seedRadar: false });
-        const scrapeTargets = parseScrapeTargets(String(data.get('handles') ?? ''));
+        const scrapeTargets = scrapeTargetsFrom(data);
         await persistHandlesAndContext(supabase, bySite.id, scrapeTargets, '', '', profile, {
           syncHistory: false
         });
@@ -683,7 +702,7 @@ export const actions: Actions = {
     // Kit + handles only — radar seed and ScrapeCreators run in the social-history worker.
     await persistBrandKit(supabase, brand.id, profile, website, locale, { seedRadar: false });
 
-    const scrapeTargets = parseScrapeTargets(String(data.get('handles') ?? ''));
+    const scrapeTargets = scrapeTargetsFrom(data);
     await persistHandlesAndContext(supabase, brand.id, scrapeTargets, '', '', profile, {
       syncHistory: false
     });
@@ -705,7 +724,7 @@ export const actions: Actions = {
   finish: async ({ request, url, platform, cookies, locals: { supabase, safeGetSession, locale } }) => {
     const user = await requireAdmin(supabase, safeGetSession);
     const data = await request.formData();
-    const website = String(data.get('website') ?? '').trim() || null;
+    const website = splitWebsiteOrHandle(String(data.get('website') ?? '')).website;
     const profile = parseProfile(data);
     const name = (String(data.get('name') ?? '').trim() || (profile?.name as string) || '').trim();
     if (!name) return fail(400, { error: 'Brand name is required', website });
@@ -724,7 +743,7 @@ export const actions: Actions = {
 
       const delta = await persistSecondHalf(supabase, brand, data);
       const additionalContext = String(data.get('additional_context') ?? '').trim();
-      const scrapeTargets = parseScrapeTargets(String(data.get('handles') ?? ''));
+      const scrapeTargets = scrapeTargetsFrom(data);
       // Context note + competitive delta → refresh AI context; handles usually already saved.
       if (additionalContext || delta) {
         await persistHandlesAndContext(supabase, brand.id, scrapeTargets, additionalContext, delta, profile);
@@ -797,7 +816,7 @@ export const actions: Actions = {
 
     await persistBrandKit(supabase, brand.id, profile, website, locale);
     const delta = await persistSecondHalf(supabase, brand, data);
-    const scrapeTargets = parseScrapeTargets(String(data.get('handles') ?? ''));
+    const scrapeTargets = scrapeTargetsFrom(data);
     const additionalContext = String(data.get('additional_context') ?? '').trim();
     await persistHandlesAndContext(supabase, brand.id, scrapeTargets, additionalContext, delta, profile);
 

--- a/supabase/migrations/20260905200000_table_value_checks.sql
+++ b/supabase/migrations/20260905200000_table_value_checks.sql
@@ -1,0 +1,203 @@
+-- ── Che cosa è un valore valido, detto dal database ────────────────────────────────────────────
+--
+-- La RLS regge (544 combinazioni su 548): un utente non tocca i dati di un altro cliente. Dentro
+-- il PROPRIO brand però può scrivere qualunque forma di dato, perché le regole su cosa è valido
+-- stanno nei tool e non qui. `brand_kit` — l'identità visiva — ha 21 colonne, 3 obbligatorie e
+-- zero vincoli: un colore poteva essere una frase, e in produzione uno lo è diventato
+-- (`#00502DKEY_PAD_OR_HEX_MATCH_1_#00502D`, un segnaposto di regex finito dentro brand_colors).
+--
+-- Ogni vincolo qui sotto è stato contato in produzione PRIMA di essere scritto: tutti hanno ZERO
+-- righe che li violano. I vincoli con violazioni (products.kind, brand_kit.site_type,
+-- brand_kit.theme_color, brand_kit.source_url, posts.content_type) NON sono qui: aspettano una
+-- decisione sui dati o una correzione nel codice che li scrive, ed è nel changelog interno.
+--
+-- Non ci sono tetti di piano né vocabolari di prodotto che cambiano col listino: quelli restano
+-- nel codice. `brand_news_sources.lang` è vincolato nella FORMA (due lettere o 'auto'), non
+-- nell'elenco delle 12 lingue del menu — l'elenco cambia, la forma no.
+--
+-- Nessuna tabella supera le 1.800 righe: `add constraint` blocca per millisecondi e `not valid`
+-- non serve.
+
+-- ── posts (518 righe) ──────────────────────────────────────────────────────────────────────────
+-- `platform`, `platforms` e `format` restano liberi: i percorsi planner/onboarding ci scrivono
+-- output del modello non normalizzato, e un CHECK lì fermerebbe l'autopilot di notte.
+
+alter table public.posts
+  add constraint posts_status_check
+    check (status in ('pending_user', 'approved', 'scheduled', 'published', 'failed')),
+  add constraint posts_source_check
+    check (source in ('plan', 'manual', 'radar', 'guest_preview')),
+  add constraint posts_video_render_status_check
+    check (video_render_status in ('rendering', 'done', 'failed')),
+  add constraint posts_video_resolution_check
+    check (video_resolution in ('480p', '720p', '1080p')),
+  add constraint posts_video_duration_check
+    check (video_duration_seconds > 0 and video_duration_seconds <= 3600),
+  add constraint posts_revisions_count_check
+    check (revisions_count >= 0),
+  add constraint posts_media_url_check
+    check (media_url ~ '^https?://'),
+  add constraint posts_media_urls_shape
+    check (jsonb_typeof(media_urls) = 'array'),
+  add constraint posts_text_len
+    check (
+      length(caption) <= 10000
+      and length(title) <= 500
+      and length(image_prompt) <= 20000
+      and length(first_comment) <= 5000
+      and length(slot) <= 100
+      and length(pillar) <= 500
+      and length(angle) <= 1000
+      and length(format) <= 60
+      and length(attention_reason) <= 2000
+      and length(campaign_name) <= 200
+      and length(campaign_step) <= 200
+      and length(product_name) <= 500
+      and length(subreddit) <= 100
+    );
+
+-- ── products (1.799 righe) ─────────────────────────────────────────────────────────────────────
+-- `kind` non è qui: 247 righe fuori vocabolario e l'import Shopify ce ne scrive di nuove.
+
+alter table public.products
+  add constraint products_title_check
+    check (btrim(title) <> '' and length(title) <= 500),
+  add constraint products_url_check
+    check (url ~ '^https?://'),
+  add constraint products_images_shape
+    check (jsonb_typeof(images) = 'array'),
+  add constraint products_text_len
+    check (
+      length(description) <= 50000
+      and length(pricing) <= 200
+      and length(external_id) <= 200
+    );
+
+-- ── brand_kit (74 righe, era 21 colonne e zero vincoli) ────────────────────────────────────────
+-- `theme_color` non è qui: `extractThemeColor` copia il `<meta theme-color>` del sito senza
+-- validarlo, e un sito che ci scrive `red` verrebbe rifiutato in onboarding.
+
+alter table public.brand_kit
+  add constraint brand_kit_favicon_url_check
+    check (favicon_url ~ '^(https?://|data:)'),
+  add constraint brand_kit_json_shape
+    check (
+      jsonb_typeof(brand_colors) = 'array'
+      and jsonb_typeof(logos) = 'array'
+      and jsonb_typeof(fonts) = 'array'
+      and jsonb_typeof(images) = 'array'
+      and jsonb_typeof(content_pillars) = 'array'
+      and jsonb_typeof(ai_character) = 'object'
+      and jsonb_typeof(graphic_style) = 'object'
+    ),
+  add constraint brand_kit_text_len
+    check (
+      length(category) <= 200
+      and length(about) <= 20000
+      and length(brand_style) <= 5000
+      and length(target_audience) <= 5000
+      and length(visual_style) <= 50000
+      and length(ai_context) <= 200000
+      and length(site_type) <= 60
+      and length(theme_color) <= 40
+    );
+
+-- ── brand_articles (161 righe) ─────────────────────────────────────────────────────────────────
+-- `body_md` ammette la stringa vuota: un articolo 'planned' nasce senza corpo (36 righe).
+
+alter table public.brand_articles
+  add constraint brand_articles_status_check
+    check (status in ('planned', 'draft', 'approved', 'published')),
+  add constraint brand_articles_source_check
+    check (source in ('plan', 'radar', 'seo', 'ai', 'manual')),
+  add constraint brand_articles_slug_check
+    check (slug ~ '^[a-z0-9-]+$' and length(slug) <= 200),
+  add constraint brand_articles_title_check
+    check (btrim(title) <> '' and length(title) <= 500),
+  add constraint brand_articles_version_seq_check
+    check (version_seq >= 0),
+  add constraint brand_articles_cover_image_check
+    check (cover_image ~ '^https?://'),
+  add constraint brand_articles_text_len
+    check (
+      length(body_md) <= 500000
+      and length(meta_title) <= 300
+      and length(meta_description) <= 1000
+      and length(language) <= 60
+    );
+
+-- ── content_plans (181 righe) ──────────────────────────────────────────────────────────────────
+
+alter table public.content_plans
+  add constraint content_plans_status_check
+    check (status in ('draft', 'proposed', 'produced')),
+  add constraint content_plans_source_check
+    check (source in ('manual', 'manual_single', 'manual_trigger', 'scheduled_cron', 'radar')),
+  add constraint content_plans_editorial_week_check
+    check (editorial_week >= 0 and editorial_week <= 52),
+  add constraint content_plans_seeds_shape
+    check (jsonb_typeof(seeds) = 'object'),
+  add constraint content_plans_title_len
+    check (length(title) <= 300);
+
+-- ── people (3 righe) ───────────────────────────────────────────────────────────────────────────
+-- `import_unattested` è il quarto valore: lo scrive l'import di onboarding, saltando
+-- `personConsentColumns()`. È legittimo, quindi entra nel vincolo.
+
+alter table public.people
+  add constraint people_consent_source_check
+    check (consent_source in ('owner_attested', 'ai_generated', 'legacy_assumed', 'import_unattested')),
+  add constraint people_images_shape
+    check (jsonb_typeof(images) = 'array'),
+  add constraint people_name_check
+    check (btrim(name) <> '' and length(name) <= 200),
+  add constraint people_text_len
+    check (length(role) <= 200 and length(description) <= 20000);
+
+-- ── competitors (202 righe) ────────────────────────────────────────────────────────────────────
+-- `handles` non è vincolato: tre writer ci mettono un array, `chat/job-executor.ts` un oggetto.
+-- Prima si sceglie una forma nel codice, poi la si vincola qui.
+
+alter table public.competitors
+  add constraint competitors_website_check
+    check (website ~ '^https?://'),
+  add constraint competitors_json_shape
+    check (
+      jsonb_typeof(top_posts) = 'array'
+      and jsonb_typeof(top_ads) = 'array'
+      and jsonb_typeof(benchmark) = 'object'
+    ),
+  add constraint competitors_name_check
+    check (btrim(name) <> '' and length(name) <= 300),
+  add constraint competitors_rationale_len
+    check (length(rationale) <= 20000);
+
+-- ── brand_memory (1.461 righe) ─────────────────────────────────────────────────────────────────
+
+alter table public.brand_memory
+  add constraint brand_memory_key_check
+    check (btrim(key) <> '' and length(key) <= 200),
+  add constraint brand_memory_value_check
+    check (btrim(value) <> '' and length(value) <= 50000),
+  add constraint brand_memory_counters_check
+    check (times_reinforced >= 0 and times_used >= 0);
+
+-- ── brand_sites (4 righe) ──────────────────────────────────────────────────────────────────────
+-- Stessa forma che `normalizeHost` già impone nel codice: minuscolo, senza schema, senza porta,
+-- senza path, almeno un punto. Postgres non ha il lookahead, quindi il "non inizia per -" è
+-- scritto nella classe di caratteri.
+
+alter table public.brand_sites
+  add constraint brand_sites_host_check
+    check (
+      host ~ '^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$'
+      and length(host) <= 253
+    );
+
+-- ── brand_news_sources (265 righe) ─────────────────────────────────────────────────────────────
+
+alter table public.brand_news_sources
+  add constraint brand_news_sources_value_check
+    check (btrim(value) <> '' and length(value) <= 500),
+  add constraint brand_news_sources_lang_check
+    check (lang ~ '^([a-z]{2}|auto)$');

--- a/supabase/migrations/20260905200000_table_value_checks.sql
+++ b/supabase/migrations/20260905200000_table_value_checks.sql
@@ -6,25 +6,77 @@
 -- zero vincoli: un colore poteva essere una frase, e in produzione uno lo è diventato
 -- (`#00502DKEY_PAD_OR_HEX_MATCH_1_#00502D`, un segnaposto di regex finito dentro brand_colors).
 --
--- Ogni vincolo qui sotto è stato contato in produzione PRIMA di essere scritto: tutti hanno ZERO
--- righe che li violano. I vincoli con violazioni (products.kind, brand_kit.site_type,
--- brand_kit.theme_color, brand_kit.source_url, posts.content_type) NON sono qui: aspettano una
--- decisione sui dati o una correzione nel codice che li scrive, ed è nel changelog interno.
+-- Ogni vincolo qui sotto è stato contato in produzione PRIMA di essere scritto: dopo la
+-- correzione dei dati in testa al file, tutti hanno ZERO righe che li violano.
+--
+-- Cinque colonne hanno richiesto una decisione. Quattro sono entrate: `posts.content_type` dopo
+-- aver corretto i tre percorsi che ci scrivevano un formato, `brand_kit.theme_color` dopo averlo
+-- sanificato in ingresso, `brand_kit.site_type` allargato ai 9 valori legittimi, e
+-- `brand_kit.source_url` dopo aver spostato gli handle dove vivono. `products.kind` resta LIBERO:
+-- ci scrive l'import Shopify, e vincolarlo romperebbe ogni sincronizzazione di catalogo.
 --
 -- Non ci sono tetti di piano né vocabolari di prodotto che cambiano col listino: quelli restano
 -- nel codice. `brand_news_sources.lang` è vincolato nella FORMA (due lettere o 'auto'), non
--- nell'elenco delle 12 lingue del menu — l'elenco cambia, la forma no.
+-- nell'elenco delle 12 lingue del menu — l'elenco cambia, la forma no, e in produzione c'è già
+-- un `tr` che il menu non offre.
 --
 -- Nessuna tabella supera le 1.800 righe: `add constraint` blocca per millisecondi e `not valid`
 -- non serve.
 
+-- ── Prima dei vincoli: il dato giusto nel campo sbagliato ──────────────────────────────────────
+--
+-- Nove righe di `brand_kit.source_url` non sono URL, e le stesse nove sono anche in
+-- `brands.website`. Due NON sono spazzatura: `biohappy` e `Mariopuggelli1939` sono handle veri,
+-- scritti dove si chiedeva un sito. Vanno spostati fra gli handle del brand, non annullati — è la
+-- stessa regola che `splitWebsiteOrHandle` applica adesso in ingresso.
+--
+-- La regola, identica al codice: la chiocciola davanti, oppure una parola senza punti e senza
+-- schema, è un handle; con uno spazio dentro (`no celo`) non è né un sito né un handle e si butta.
+-- I 21 `brands.website` che sono domini nudi (`anomalia.so`, a cui manca solo `https://`) NON si
+-- toccano: sono dati buoni e vogliono una decisione loro.
+
+-- `brand_social_handles` è unica su (brand_id, platform), non sullo username: un brand che ha già
+-- dichiarato il suo Instagram tiene quello, che è il più affidabile dei due. Senza `on conflict`
+-- questa insert alzerebbe un 23505 e farebbe abortire l'intera migration.
+insert into public.brand_social_handles (brand_id, platform, username)
+select distinct k.brand_id, 'instagram', ltrim(btrim(k.source_url), '@')
+from public.brand_kit k
+where k.source_url is not null
+  and btrim(k.source_url) !~ '^https?://'
+  and btrim(k.source_url) !~ '\s'
+  and (btrim(k.source_url) like '@%' or btrim(k.source_url) !~ '\.')
+  and ltrim(btrim(k.source_url), '@') <> ''
+on conflict (brand_id, platform) do nothing;
+
+-- Un dominio nudo non si butta, gli manca solo lo schema — è la regola di `normalizeWebsite`.
+-- Oggi nessuna delle nove ha questa forma, ma la migration viene applicata dopo, e nel frattempo
+-- una riga nuova può arrivare: annullarla sarebbe perdere un dato buono.
+update public.brand_kit
+  set source_url = case
+    when btrim(source_url) ~ '\.' and btrim(source_url) !~ '\s' then 'https://' || btrim(source_url)
+    else null
+  end
+  where source_url is not null and source_url !~ '^https?://';
+
+update public.brands set website = null
+  where website is not null
+    and website !~ '^https?://'
+    and (btrim(website) = '' or btrim(website) ~ '\s' or btrim(website) !~ '\.');
+
 -- ── posts (518 righe) ──────────────────────────────────────────────────────────────────────────
 -- `platform`, `platforms` e `format` restano liberi: i percorsi planner/onboarding ci scrivono
 -- output del modello non normalizzato, e un CHECK lì fermerebbe l'autopilot di notte.
+-- `uploaded_video` entra nel vocabolario perché `upload-media` lo scrive ed è legittimo; `image`
+-- e `carousel` no: erano formati finiti in una colonna di tipi, e il codice è stato corretto.
 
 alter table public.posts
   add constraint posts_status_check
     check (status in ('pending_user', 'approved', 'scheduled', 'published', 'failed')),
+  add constraint posts_content_type_check
+    check (content_type in (
+      'generated_image', 'generated_video', 'generated_graphic',
+      'uploaded_image', 'uploaded_video', 'text', 'link'
+    )),
   add constraint posts_source_check
     check (source in ('plan', 'manual', 'radar', 'guest_preview')),
   add constraint posts_video_render_status_check
@@ -57,7 +109,10 @@ alter table public.posts
     );
 
 -- ── products (1.799 righe) ─────────────────────────────────────────────────────────────────────
--- `kind` non è qui: 247 righe fuori vocabolario e l'import Shopify ce ne scrive di nuove.
+-- `kind` NON ha un vocabolario, per decisione: l'import Shopify ci scrive il `product_type` del
+-- merchant (`18k gold`), e vincolarlo farebbe fallire ogni sincronizzazione di catalogo. Le 247
+-- righe fuori dai quattro valori attesi non sono dati rotti, sono i nomi di categoria di un
+-- gioielliere. Resta il tetto di lunghezza.
 
 alter table public.products
   add constraint products_title_check
@@ -71,15 +126,28 @@ alter table public.products
       length(description) <= 50000
       and length(pricing) <= 200
       and length(external_id) <= 200
+      and length(kind) <= 200
     );
 
 -- ── brand_kit (74 righe, era 21 colonne e zero vincoli) ────────────────────────────────────────
--- `theme_color` non è qui: `extractThemeColor` copia il `<meta theme-color>` del sito senza
--- validarlo, e un sito che ci scrive `red` verrebbe rifiutato in onboarding.
+-- `theme_color` si può vincolare adesso perché `brand-analysis` lo fa passare da
+-- `sanitizeThemeColor`: il `<meta theme-color>` del sito ammette `red`, che è HTML valido e non è
+-- un colore che sappiamo usare. Stessa notazione della palette.
+-- `site_type` sale da 6 a 9: `media`, `mobile_app` e `service` erano valori legittimi che
+-- mancavano dall'elenco, non dati rotti.
 
 alter table public.brand_kit
   add constraint brand_kit_favicon_url_check
     check (favicon_url ~ '^(https?://|data:)'),
+  add constraint brand_kit_source_url_check
+    check (source_url ~ '^https?://'),
+  add constraint brand_kit_theme_color_check
+    check (theme_color ~ '^#[0-9a-fA-F]{3,8}$'),
+  add constraint brand_kit_site_type_check
+    check (site_type in (
+      'ecommerce', 'saas', 'portfolio', 'local_service', 'creator',
+      'media', 'mobile_app', 'service', 'generic'
+    )),
   add constraint brand_kit_json_shape
     check (
       jsonb_typeof(brand_colors) = 'array'
@@ -98,8 +166,6 @@ alter table public.brand_kit
       and length(target_audience) <= 5000
       and length(visual_style) <= 50000
       and length(ai_context) <= 200000
-      and length(site_type) <= 60
-      and length(theme_color) <= 40
     );
 
 -- ── brand_articles (161 righe) ─────────────────────────────────────────────────────────────────
@@ -155,15 +221,19 @@ alter table public.people
     check (length(role) <= 200 and length(description) <= 20000);
 
 -- ── competitors (202 righe) ────────────────────────────────────────────────────────────────────
--- `handles` non è vincolato: tre writer ci mettono un array, `chat/job-executor.ts` un oggetto.
--- Prima si sceglie una forma nel codice, poi la si vincola qui.
+-- `handles` è un array di `{platform, username, profileUrl}`, e non è una preferenza: ENTRAMBI i
+-- lettori (`pickHandles`, `normalizeHandles`) tornano vuoto su qualunque cosa non sia un array,
+-- quindi l'oggetto che `chat/job-executor.ts` scriveva era invisibile a tutto il prodotto.
+-- Corretto lì, vincolato qui. È anche la forma di `brand_social_handles`, che è dove vivono
+-- gli handle del brand.
 
 alter table public.competitors
   add constraint competitors_website_check
     check (website ~ '^https?://'),
   add constraint competitors_json_shape
     check (
-      jsonb_typeof(top_posts) = 'array'
+      jsonb_typeof(handles) = 'array'
+      and jsonb_typeof(top_posts) = 'array'
       and jsonb_typeof(top_ads) = 'array'
       and jsonb_typeof(benchmark) = 'object'
     ),


### PR DESCRIPTION
## What?

Ten tables that a signed-in user writes to now say, in the database, what a valid value is. This adds **46 CHECK constraints and one missing UNIQUE** across `posts`, `products`, `brand_kit`, `brand_articles`, `content_plans`, `people`, `competitors`, `brand_memory`, `brand_sites` and `brand_news_sources` — closed vocabularies, formats, ranges, JSONB shapes and length ceilings.

It also fixes the five code paths the audit found writing values those constraints would have rejected, and moves two real Instagram handles out of the website field, where users had typed them, into the brand's handles.

The migration is **written, not applied**. Andrea applies it after reviewing, as with the permissions one (#368).

## Why?

The RLS audit closed the cross-tenant question: 544 combinations out of 548 — a user cannot touch another customer's data. What it left open is what a user can write **inside their own brand**, and the answer was: anything. The rules about what counts as a valid value lived in the tools, and the tools are not the database.

| table | columns | NOT NULL | CHECK (before) |
|---|---|---|---|
| `brand_kit` | 21 | 3 | **0** |
| `products` | 11 | 6 | **0** |
| `brand_articles` | 24 | 10 | **0** |
| `content_plans` | 10 | 4 | **0** |
| `posts` | 50 | 8 | **0** |

`brand_kit` is the brand's visual identity: 21 columns, three mandatory, zero constraints. The theory is already practice in production:

- `brand_colors` holds `#00502DKEY_PAD_OR_HEX_MATCH_1_#00502D` — a regex placeholder that leaked out of a scraper and got stored as a colour.
- `brand_kit.images` holds one relative path where the other 586 are absolute URLs.
- `brand_news_sources` holds a subreddit named `transgenderUK/`, with the slash. The radar will never find it.
- `brands.website` and `brand_kit.source_url` hold `Mariopuggelli1939` and `biohappy` — real handles, typed where a website was asked for, saved as addresses that open nothing.

## How?

**Counted before constrained.** `alter table … add constraint` fails if a single existing row violates it, and there are months of real data here. Every predicate was run against production read-only and counted first. Only constraints reaching **zero** violating rows are in the migration. No table exceeds 1 800 rows, so `not valid` + `validate constraint` would be ceremony without gain.

**What deliberately stayed out.** Plan ceilings are not CHECKs: they change with the price list, and a constraint migrated on every pricing change is an impediment, not a protection. `brand_news_sources.lang` is constrained by *shape* (two lowercase letters, or `auto`), not by the language menu's 12 entries — production already holds a `tr` the menu does not offer, so the list would have failed the migration and the shape holds. `posts.platform`, `posts.platforms` and `posts.format` get no vocabulary at all: the planner and onboarding paths write unnormalised model output there, and **a CHECK that stops the autopilot at 3am is worse than the malformed value it prevents**. `format` gets a length cap only.

**The five decisions.** Four went in after the cause was fixed; one stays free.

- **`products.kind` stays free.** The 247 rows outside the vocabulary are all one brand's, and they are a jeweller's category names (`18k gold`) that the Shopify import copies from the merchant's `product_type`. A CHECK would have failed every catalogue sync to protect nothing. Length cap only.
- **`posts.content_type` went in after three writers were fixed.** `SHAPES` in `post-from-asset.ts` wrote `image` and `carousel` — those are *formats*, and the tool's own description says so in capitals — and now writes `uploaded_image`. `uploaded_video`, which `upload-media` has always written, was legitimate and simply missing from `POST_CONTENT_TYPES`. `PostAssetShape.contentType` is now typed `PostContentType`, so the compiler holds the vocabulary by itself.
- **`brand_kit.theme_color` went in after sanitising on the way in.** `extractThemeColor` copies the site's `<meta name="theme-color">` verbatim, and that meta accepts any CSS colour — `red` is valid HTML. The 13 production values were all `#RRGGBB` by luck, not construction. They now pass through `sanitizeThemeColor`, next to `sanitizeBrandColors` and sharing its regex.
- **`brand_kit.site_type` went in widened**, 6 values to 9: `media`, `mobile_app` and `service` were legitimate values missing from the list — in the type and in the JSON schema the model answers with.
- **`competitors` was missing the `unique (brand_id, name)` its own writer upserts on.** `chat/job-executor.ts` calls `upsert(…, { onConflict: 'brand_id,name' })`, but the only unique index on that table is the primary key. Postgres answers **42P10**, and the call never destructures `error` — so the "re-research competitors" job reported the competitors it found and wrote **zero rows**, silently. Reproduced locally on the exact statement. Production has zero duplicates on `(brand_id, name)`, case- and whitespace-insensitive, so the constraint goes on clean and makes the upsert expressible.
- **`competitors.handles` is an array, and the readers decided it, not a head count.** Three writers stored an array, `chat/job-executor.ts` stored an object. **Both** readers (`pickHandles`, `normalizeHandles`) return empty for anything that is not an array — so the object was invisible to the entire product: the "re-research competitors" job wrote handles no screen could show. It is also the shape of `brand_social_handles`, and an object cannot hold two accounts on one platform.

**The handle in the website field is fixed at the source, not just in the data.** `splitWebsiteOrHandle` joins the other Brand Studio field rules in `brand-fields.ts` — the file that exists so a rule lives in exactly one place. An `@` in front, or a word with no dots and no scheme, cannot be a domain and is a handle; whitespace inside (`no celo`) is neither, and gets dropped rather than inventing a profile; a bare domain gets the scheme, not the bin. In onboarding there is a single funnel, `scrapeTargetsFrom(data)`, reading both fields, so none of the four call sites can forget it.

**A compliance regression I introduced and then undid.** My first pass moved `post-from-asset`'s image and carousel shapes to `uploaded_image`. `publish.ts` derives `aiGeneratedMedia: !content_type.startsWith('uploaded')` — that prefix *is* the AI content declaration at publish time. A library asset can be AI-generated or user-uploaded (`brand_media.source` knows; that table does not), and before this branch all three shapes declared. They now write `generated_image`, which preserves the prior behaviour exactly: over-declaring is the safe direction, under-declaring is the risk, as the comment beside that line says.

**Rejected alternatives.** Per-column constant + source-scanning test files (the `brand_media.source` pattern from `LESSONS.md`) — correct, but 15 near-identical files for 15 columns; the harness proves the same property once, against a real database. A `NOT VALID` + `VALIDATE` two-step — pure ceremony at these row counts.

## Testing?

**A constraint without a test that tries to violate it is a hope**, and the unit suite mocks Supabase, where a fake insert accepts any string — that is the paid lesson behind `brand_media.source`.

`scripts/constraint-harness.mjs` (`npm run test:constraints`) writes for real: **68 malformed writes against a real Postgres**, each passing only if it comes back with the SQLSTATE that case expects (`23514`, or `23505` for the unique), all inside one transaction closed by a `rollback`. The new cases use the values the defects actually produced — `content_type: 'carousel'`, `theme_color: 'red'`, `handles: {"instagram":"acme"}` — not invented ones.

- **Before the migration: `0/68`.** The database accepted every single broken value.
- **After: `68/68`.**

It exits 2 before connecting if `DATABASE_URL` is not localhost — verified against the production host. Nothing was ever written to production; every audit query was read-only.

The **data fix was tested separately**, every shape on a clean brand with a `rollback` at the end. Two traps surfaced by running it rather than reading it:

1. `brand_social_handles` is unique on **`(brand_id, platform)`**, not on username. The guard I first wrote checked the wrong key: on a brand with an Instagram handle already declared, the insert would have raised `23505` and **aborted the entire migration**. It is now `on conflict (brand_id, platform) do nothing`, and the declared handle wins over the deduced one — the same rule as the code, where the dedicated field beats the website box.
2. Nulling everything that is not `^https?://` would have thrown away a bare domain. No production row has that shape today, but the migration is applied later, and a new row arrives in between.

`npm run test:unit`: **7 356 passed**. 16 failures in `src/lib/webmcp.test.ts`, which this branch does not touch — **reproduced identically on the main checkout on `dev` with none of these changes**, a zod `toJSONSchema` error resolving out of the parent checkout's `.bun` store. Environment, not diff (`LESSONS.md`).

Not tested: no browser pass. This PR is a database migration plus pure functions; the onboarding wiring is covered by unit tests on `splitWebsiteOrHandle` and by the single-funnel `scrapeTargetsFrom`.

## Evidence (screenshots/videos)

<details>
<summary>Harness against the local self-hosted stack — before and after</summary>

```
--- BEFORE ---
0/68 vincoli mordono
--- AFTER ---
68/68 vincoli mordono
```

And the upsert that used to answer 42P10, after the migration:

```
INSERT 0 1
INSERT 0 1
 righe_scritte | website_aggiornato
---------------+--------------------
             1 | https://acme2.com
```
</details>

<details>
<summary>The production guard refuses to write anywhere but localhost</summary>

```
$ DATABASE_URL="postgres://…@db.<project>.supabase.co:5432/postgres" node scripts/constraint-harness.mjs
DATABASE_URL punta a db.<project>.supabase.co: questo harness scrive, e scrive solo in locale
exit=2
```
</details>

<details>
<summary>Data fix, every shape, rolled back</summary>

```
in='Mariopuggelli1939'   source_url=NULL                 handle=instagram/Mariopuggelli1939
in='biohappy'            source_url=NULL                 handle=instagram/biohappy
in='@ciccio'             source_url=NULL                 handle=instagram/ciccio
in='no celo'             source_url=NULL                 handle=nessun handle
in=''                    source_url=NULL                 handle=nessun handle
in='anomalia.so'         source_url=https://anomalia.so  handle=nessun handle
in='https://ok.com'      source_url=https://ok.com       handle=nessun handle

handle dichiarato sopravvive: quello_vero
```
</details>

<details>
<summary>Violations counted in production, read-only, per constraint</summary>

All 46 CHECK predicates returned `0` before being written into the migration; the four that did not (`products.kind` 247, `brand_kit.site_type` 3, `brand_kit.source_url` 9, `posts.content_type` 0-but-3-bad-writers) are the five decisions above.
</details>

## Anything Else?

**Found, reported, deliberately not touched:**

- **12 duplicate `(brand_id, slug)` groups in `brand_articles`.** A `UNIQUE` constraint wants them first, and that needs a decision about which of the 12 pairs survives. Not in this PR.
- **21 `brands.website` rows are bare domains** (`anomalia.so`) missing only `https://`. They are good data. The migration leaves them alone; `normalizeWebsite` already exists if we decide to backfill.
- **`brands.website` has no CHECK.** It is outside the ten tables in scope and mirrors `brand_kit.source_url`; worth its own pass.

**Known ceiling of the harness:** it proves rejected values are rejected, not that valid values are accepted. If a constraint ever turns out too tight in production, the "must pass" case gets added there.

**Follow-up worth doing:** library assets always declare as AI-generated, even when the user uploaded them. That is the safe direction and it is the pre-existing behaviour, but it is inaccurate — `publishLibraryMediaAsPostMedia` already returns the media row, so `brand_media.source` could decide it properly. Deliberately not done here: changing a publish-time declaration does not belong in a constraints PR.

**Follow-up worth doing:** `posts.platform` and `posts.format` stay unconstrained because the planner writes raw model output. Normalising at those write sites (`normalizePlatforms` and `normalizeContentFormat` already exist and are used elsewhere) would make both columns constrainable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
