### PR TITLE
Send the judge's reasoning effort to the gateway, and rename gemini.ts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,13 +67,12 @@ LLM_MODELS=google/gemini-2.5-flash,google/gemini-2.5-pro
 EMBEDDING_MODEL=google/gemini-embedding-001
 # Gli agenti parlano solo col centralino LLM_*; KIE_API_KEY serve a immagini, clip, voce e probe GEO.
 # CHAT_ACTION_JUDGE=off          # auto-review consequential kit actions before execution
-# Quanto ragionano i giudici Gemini (video review, QC immagini, caption panel, prepublish, motion):
-# low | medium | high. Default high. Dalla 3.x Gemini prende un LIVELLO, non un tetto di token —
-# GEMINI_JUDGE_THINKING_BUDGET e PREPUBLISH_THINKING_BUDGET non arrivano più all'API.
+# Quanto ragionano i giudici (video review, QC immagini, caption panel, prepublish, motion):
+# low | medium | high. Default high. Il valore viaggia come `reasoning.effort` di OpenRouter, non
+# come il `thinkingLevel` di Gemini — le vecchie GEMINI_JUDGE_THINKING_BUDGET e
+# PREPUBLISH_THINKING_BUDGET sono tetti di token, e non arrivano da nessuna parte.
 # I thinking token si pagano al prezzo dell'output: se la spesa dei giudici sale, è questa la leva.
 # GEMINI_JUDGE_THINKING_LEVEL=high
-# Solo il prepublish check (prima girava senza thinking, che 3.7 Flash non sa fare).
-# PREPUBLISH_THINKING_LEVEL=high
 
 # Google PageSpeed Insights API key (free tool /tools/page-speed).
 # Quota: 25k requests/day — the tool-guard cap keeps us well under it.

--- a/changelog/2026-09-05-judge-reasoning-effort.md
+++ b/changelog/2026-09-05-judge-reasoning-effort.md
@@ -1,0 +1,55 @@
+# La manopola dei giudici arriva sul filo, e parla la lingua del gateway
+
+`GEMINI_JUDGE_THINKING_LEVEL` era letta, validata, passata da due giudici
+(`ugc-script-review.ts`, `content-preview/caption-quality.ts`) — e buttata via.
+`aiStructured` la destrutturava in `thinkingLevel: _thinkingLevel` e non la girava
+a `llmStructured`, che mandava sempre e solo il default globale
+`LLM_REASONING_EFFORT`. Chi abbassava la manopola vedeva la stessa spesa e le
+stesse risposte, senza un errore da nessuna parte: il guasto che non fallisce.
+
+Il test che lo riproduce è in `ai-text.test.ts` (l'opt arriva a `llmStructured`) e
+in `llm-reasoning.test.ts` (il valore finisce in `providerOptions.openai.reasoning.effort`,
+e senza richiesta resta il default). Entrambi scritti prima della correzione, e
+visti fallire.
+
+## Perché il tipo si sposta
+
+`GeminiThinkingLevel` viveva in `gemini.ts` e nominava `thinkingLevel`, il
+parametro di Gemini 3.x. Ma nessuna chiamata di questo prodotto manda più quel
+campo: passano tutte da OpenRouter, dove si chiama `reasoning.effort` — ed è
+esattamente il nome che `llm.ts` usava già per il default globale, e `kie.ts` per
+il suo (`KieReasoningEffort`). Due union identiche a tre valori, una col nome di
+Google e una col nome di OpenAI, vive nello stesso codice e scollegate.
+
+Ora è una sola, `ReasoningEffort`, e sta in `llm.ts` accanto a
+`LLM_REASONING_EFFORT`: il vocabolario del trasporto sta col trasporto.
+`judgeThinkingLevel` diventa `judgeReasoningEffort` e si sposta in `ai-text.ts`,
+il centralino da cui i due giudici già passano — la manopola accanto alla porta
+che apre.
+
+Il nome della variabile d'ambiente NON cambia: è già scritta nella configurazione,
+e rinominarla mentre inizia a funzionare sarebbero due cambiamenti in uno.
+
+## `gemini.ts` → `google-models.ts`
+
+Il file non costruisce nessun client Google da quando i due `makeGenaiClient` /
+`googleGenaiClient` sono spariti col loro ultimo chiamante. Restava il nome, che
+prometteva una linea verso Gemini: la stessa bugia di `xiaomi.ts`, già corretta in
+`ai-text.ts`. Il nome nuovo dice di CHI sono i modelli, non con chi parliamo —
+perché con Google non parla più nessuno. Dentro restano solo gli id e le tariffe,
+che servono al registro di cassa: un modello Gemini si paga anche quando a
+servirlo è qualcun altro.
+
+Tolto anche un mock morto in `motion-video/reference-tools.watch.test.ts`, che
+sostituiva il modulo con un `geminiTransport` che non esiste più, e la riga
+`PREPUBLISH_THINKING_LEVEL` di `.env.example`, che nessuno legge.
+
+## Quello che NON è uscito, e perché
+
+`@google/genai` resta fra le dipendenze. Il grafo dice il motivo, e non è
+un'impressione: **19 file di `src/` importano ancora `GoogleGenAI`**, tutti come
+`import type` di un parametro `ai` che a runtime vale `null` — `genaiClient()` in
+`brand-context.ts` è `return null as never`. Toglierlo vuol dire cancellare quel
+parametro da 132 call site in 53 file, che è il lotto che il commento di
+`brand-context.ts` chiama già "solo meccanica". Non è questo lotto: mescolarlo qui
+renderebbe illeggibile la correzione che conta.

--- a/src/lib/content/changelog/2026-09-05-judge-reasoning-effort.ts
+++ b/src/lib/content/changelog/2026-09-05-judge-reasoning-effort.ts
@@ -1,0 +1,9 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-05',
+  title: 'Quality checks think as hard as you ask',
+  items: [
+    'The setting that controls how hard the quality checks think — on captions, videos and images — now actually reaches the model. It was being read and then ignored.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/ai-log.test.ts
+++ b/src/lib/server/ai-log.test.ts
@@ -11,7 +11,7 @@ import {
   withBrandContext,
   withOrgContext
 } from './ai-log';
-import { GEMINI_FLASH, NANO_BANANA_PRO } from './gemini';
+import { GEMINI_FLASH, NANO_BANANA_PRO } from './google-models';
 
 const GO = 'go';
 

--- a/src/lib/server/ai-log.ts
+++ b/src/lib/server/ai-log.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { gatewayRate } from '$lib/server/openrouter-models';
 import { createAdminClient } from '$lib/server/supabase-admin';
-import { GEMINI_FLASH, geminiFlash, isGeminiFlashId, isKieFlashId, kieFlashId, NANO_BANANA_PRO, isNanoBananaProId, geminiVisualCreditShare } from '$lib/server/gemini';
+import { GEMINI_FLASH, geminiFlash, isGeminiFlashId, isKieFlashId, kieFlashId, NANO_BANANA_PRO, isNanoBananaProId, geminiVisualCreditShare } from '$lib/server/google-models';
 
 // Fire-and-forget observability: one ai_calls row per LLM call, written from the shared
 // chokepoints. NEVER throws and never awaited — a missing table or a dead DB must not break AI.

--- a/src/lib/server/ai-text.test.ts
+++ b/src/lib/server/ai-text.test.ts
@@ -160,6 +160,54 @@ describe('routing del lavoro strutturato', () => {
   });
 });
 
+/**
+ * La manopola dei giudici arrivava fino a QUI e finiva nel nulla: `aiStructured` la destrutturava
+ * in `_thinkingLevel` e non la passava a nessuno. Un operatore che abbassava
+ * GEMINI_JUDGE_THINKING_LEVEL vedeva la stessa spesa e lo stesso ragionamento di prima, senza un
+ * errore da nessuna parte.
+ */
+describe('lo sforzo di ragionamento chiesto da un giudice', () => {
+  const SCHEMA = { type: 'object' as const, properties: { plan: { type: 'string' } }, required: ['plan'] };
+
+  beforeEach(() => {
+    for (const k of Object.keys(env)) delete env[k];
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('arriva al gateway invece di fermarsi negli opts', async () => {
+    const { aiStructured, PIN_GATEWAY } = await import('./ai-text');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await aiStructured<any>({} as any, 'prompt', SCHEMA, undefined, 'return_plan', {
+      brandId: 'b',
+      ...PIN_GATEWAY,
+      reasoningEffort: 'low'
+    });
+    expect(M.llmStructured.mock.calls[0][0]).toMatchObject({ reasoningEffort: 'low' });
+  });
+
+  it('senza richiesta il gateway decide da sé: nessuno sforzo inventato qui', async () => {
+    const { aiStructured, PIN_GATEWAY } = await import('./ai-text');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await aiStructured<any>({} as any, 'prompt', SCHEMA, undefined, 'return_plan', { brandId: 'b', ...PIN_GATEWAY });
+    expect(M.llmStructured.mock.calls[0][0].reasoningEffort).toBeUndefined();
+  });
+
+  it('judgeReasoningEffort legge la variabile a ogni chiamata, e ripiega su high', async () => {
+    const { judgeReasoningEffort } = await import('./ai-text');
+    expect(judgeReasoningEffort()).toBe('high');
+    env.GEMINI_JUDGE_THINKING_LEVEL = 'low';
+    expect(judgeReasoningEffort()).toBe('low');
+    env.GEMINI_JUDGE_THINKING_LEVEL = 'MEDIUM';
+    expect(judgeReasoningEffort()).toBe('medium');
+    expect(judgeReasoningEffort('low')).toBe('low');
+    delete env.GEMINI_JUDGE_THINKING_LEVEL;
+    for (const junk of ['1024', 'off', 'max', '', undefined, null]) {
+      expect(judgeReasoningEffort(junk)).toBe('high');
+    }
+  });
+});
+
 describe('satisfiesSchema (guardia del ripiego kie → gateway)', () => {
   const brandProfile = {
     type: 'object',

--- a/src/lib/server/ai-text.ts
+++ b/src/lib/server/ai-text.ts
@@ -1,10 +1,18 @@
 import type { GoogleGenAI } from '@google/genai';
 import { structuredKie, textKie } from '$lib/server/kie';
 import { requireBrandContext } from '$lib/server/ai-log';
-import { type GeminiThinkingLevel } from '$lib/server/gemini';
 import { env } from '$env/dynamic/private';
 import { route } from '$lib/server/model-routing';
-import { llmBaseUrl, llmConfigured, llmImagesFromInline, llmModels, llmStructured, llmText } from '$lib/server/llm';
+import {
+  llmBaseUrl,
+  llmConfigured,
+  llmImagesFromInline,
+  llmModels,
+  llmStructured,
+  llmText,
+  reasoningEffort,
+  type ReasoningEffort
+} from '$lib/server/llm';
 
 // ── Il centralino del testo ─────────────────────────────────────────────────
 // Ogni chiamata di testo e di JSON del prodotto passa da qui e finisce su UNO dei due endpoint vivi:
@@ -50,6 +58,30 @@ export const PIN_GATEWAY = { provider: 'gateway' as const };
 // Extra fields threaded into logAiCall so per-site labels/attribution survive both providers.
 export type AiLogExtras = { brandId?: string; userId?: string; threadId?: string; context?: string };
 
+let warnedStaleBudget = false;
+
+/**
+ * Quanto ragiona ogni chiamata di giudizio / revisione / QC. Letta a ogni chiamata, così una
+ * regressione si disinnesca cambiando la variabile invece che con un deploy.
+ *
+ * Stava in `gemini.ts` e si chiamava `judgeThinkingLevel`, nel vocabolario di Google — ma il valore
+ * viaggia su `reasoning.effort` di OpenRouter, e da lì passa. Il nome vecchio prometteva
+ * `thinkingLevel`, un campo che nessuna chiamata di questo prodotto manda più.
+ *
+ * Le vecchie *_THINKING_BUDGET numeriche sono morte: si avvisa una volta invece di lasciarle
+ * sembrare vive nella configurazione.
+ */
+export function judgeReasoningEffort(rawOverride?: string | null): ReasoningEffort {
+  if (!warnedStaleBudget && (env.GEMINI_JUDGE_THINKING_BUDGET || env.PREPUBLISH_THINKING_BUDGET)) {
+    warnedStaleBudget = true;
+    console.warn(
+      '[AI] GEMINI_JUDGE_THINKING_BUDGET / PREPUBLISH_THINKING_BUDGET are ignored: the gateway takes ' +
+        'reasoning.effort, not a token budget. Use GEMINI_JUDGE_THINKING_LEVEL=low|medium|high.'
+    );
+  }
+  return reasoningEffort(rawOverride ?? env.GEMINI_JUDGE_THINKING_LEVEL);
+}
+
 /**
  * DeepSeek runs in `json_object` mode with the schema in the prompt — valid JSON is guaranteed,
  * conformance is NOT. So check what the caller actually depends on (top-level `required` keys, and
@@ -88,8 +120,8 @@ export async function aiStructured<T>(
     model?: string;
     provider?: 'gateway' | 'kie';
     noFallback?: boolean;
-    /** How hard Gemini reasons (see structuredGemini). Ignored by the non-Gemini providers. */
-    thinkingLevel?: GeminiThinkingLevel;
+    /** Lo sforzo di ragionamento per QUESTA chiamata. Assente = il default del gateway. */
+    reasoningEffort?: ReasoningEffort;
   } & AiLogExtras
 ): Promise<T> {
   const brandId = requireBrandContext(opts);
@@ -100,7 +132,7 @@ export async function aiStructured<T>(
         ? 'kie'
         : 'gateway';
   const t0 = Date.now();
-  const { images, temperature, model, provider: _forced, noFallback, thinkingLevel: _thinkingLevel, ...logExtras } = opts ?? {};
+  const { images, temperature, model, provider: _forced, noFallback, reasoningEffort: effort, ...logExtras } = opts ?? {};
 
   // Un percorso che fallisce sempre e viene sempre salvato da un altro non è un risparmio: è
   // latenza e rumore nei log che nasconde i guasti veri. È il motivo per cui prima DeepSeek e poi
@@ -115,6 +147,7 @@ export async function aiStructured<T>(
       images: llmImagesFromInline(images),
       temperature,
       model,
+      reasoningEffort: effort,
       label: toolName
     });
   try {

--- a/src/lib/server/blog-cost.ts
+++ b/src/lib/server/blog-cost.ts
@@ -27,7 +27,7 @@
  * Sovrastimare è sicuro; sottostimare fa partire un lavoro che non può finire.
  */
 import { computeCostUsd } from '$lib/server/ai-log';
-import { geminiFlash } from '$lib/server/gemini';
+import { geminiFlash } from '$lib/server/google-models';
 
 // Nano Banana 2 — lo stesso id che content-preview.ts usa per le immagini degli articoli
 // (BLOG_IMAGE_MODEL). Importato come stringa e non dal modulo: content-preview si porta dietro

--- a/src/lib/server/content-preview/caption-quality.ts
+++ b/src/lib/server/content-preview/caption-quality.ts
@@ -8,9 +8,8 @@ import { designWallDigestSection } from '$lib/server/wall-digest';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import sharp from 'sharp';
 import { env } from '$env/dynamic/private';
-import { judgeThinkingLevel } from '$lib/server/gemini';
 import { structured } from '$lib/server/research';
-import { aiStructured } from '$lib/server/ai-text';
+import { aiStructured, judgeReasoningEffort } from '$lib/server/ai-text';
 import { PROOF_DISCIPLINE_RULE } from '$lib/server/proof-discipline';
 import { COPY_PANEL_MAX_ROUNDS, COPY_PANEL_SCHEMA, bandOfScore, bestOf, normalizeVerdict, panelSummary, stripJudgeScaffolding, toIterate, toReplace, type PanelVerdict } from '$lib/server/copy-panel';
 import { PLATFORM_CHAR_LIMITS, ensureShortNetworkCuts } from '$lib/platform-limits';
@@ -497,7 +496,7 @@ Keep good captions out of "fixes". A rewrite keeps the post's angle and platform
       label: 'reviewCaptions',
       // Chiamata di verdetto, non prosa da leggere: lasciata libera ragionava 9x l'output che
       // produceva, e il thinking si paga a tariffa output.
-      thinkingLevel: judgeThinkingLevel()
+      reasoningEffort: judgeReasoningEffort()
     });
     const fixes: AnyRec[] = Array.isArray(parsed.fixes) ? parsed.fixes : [];
     for (const fix of fixes) {
@@ -638,7 +637,7 @@ Restituisci JSON.`;
 
       const parsed: AnyRec = await structured(ai, prompt, COPY_PANEL_SCHEMA, undefined, {
         label: `copyPanel:r${round}`,
-        thinkingLevel: judgeThinkingLevel()
+        reasoningEffort: judgeReasoningEffort()
       });
       const verdicts = (Array.isArray(parsed.verdicts) ? parsed.verdicts : [])
         .map(normalizeVerdict)

--- a/src/lib/server/content-preview/images.ts
+++ b/src/lib/server/content-preview/images.ts
@@ -7,7 +7,7 @@ import sharp from 'sharp';
 import { env } from '$env/dynamic/private';
 import { fetchImagePart } from '$lib/server/brand-context';
 import { getBrandContext, getOrgContext } from '$lib/server/ai-log';
-import { NANO_BANANA_2_LITE } from '$lib/server/gemini';
+import { NANO_BANANA_2_LITE } from '$lib/server/google-models';
 import { GEMINI_NANO_BANANA_2, googleImageModel } from '$lib/image-models';
 import { structured } from '$lib/server/research';
 import { signKnowledgePaths } from '$lib/server/media-archive';

--- a/src/lib/server/gemini-transport.test.ts
+++ b/src/lib/server/gemini-transport.test.ts
@@ -87,7 +87,7 @@ describe('la fatturazione di una chiamata passata da kie', () => {
 
   it('non prezza mai a listino Google: 16 volte il costo reale, e senza errori', async () => {
     const { computeCostUsd } = await import('./ai-log');
-    const { GEMINI_FLASH, kieFlashId } = await import('./gemini');
+    const { GEMINI_FLASH, kieFlashId } = await import('./google-models');
     const usage = { ms: 0, ok: true, inputTokens: 100_000, outputTokens: 10_000, thinkingTokens: 20_000 };
     const google = computeCostUsd({ label: 'x', provider: 'gemini', model: GEMINI_FLASH, ...usage });
     const kie = computeCostUsd({ label: 'x', provider: 'gemini', model: kieFlashId(GEMINI_FLASH), ...usage });
@@ -98,7 +98,7 @@ describe('la fatturazione di una chiamata passata da kie', () => {
 
   it('kie non ha il tier di cache: i token ripetuti costano pieni (e più che su Google)', async () => {
     const { computeCostUsd } = await import('./ai-log');
-    const { GEMINI_FLASH, kieFlashId } = await import('./gemini');
+    const { GEMINI_FLASH, kieFlashId } = await import('./google-models');
     const cached = { ms: 0, ok: true, inputTokens: 100_000, cachedTokens: 100_000, outputTokens: 0 };
     const google = computeCostUsd({ label: 'x', provider: 'gemini', model: GEMINI_FLASH, ...cached })!;
     const kie = computeCostUsd({ label: 'x', provider: 'gemini', model: kieFlashId(GEMINI_FLASH), ...cached })!;

--- a/src/lib/server/gemini.test.ts
+++ b/src/lib/server/gemini.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const env: Record<string, string | undefined> = {};
 vi.mock('$env/dynamic/private', () => ({ env }));
 
-const { GEMINI_FLASH, geminiFlash, isGeminiFlashId, NANO_BANANA_PRO, isNanoBananaProId, geminiVisualCreditShare, geminiThinkingLevel, judgeThinkingLevel } = await import('./gemini');
+const { GEMINI_FLASH, geminiFlash, isGeminiFlashId, NANO_BANANA_PRO, isNanoBananaProId, geminiVisualCreditShare } = await import('./gemini');
 
 describe('GEMINI_FLASH', () => {
   it('is a Gemini Flash model id — the default when the env var is unset', () => {
@@ -74,38 +74,5 @@ describe('geminiFlash', () => {
       env.GEMINI_FLASH = v;
       expect(geminiFlash()).toBe(GEMINI_FLASH);
     }
-  });
-});
-
-describe('thinking level', () => {
-  beforeEach(() => {
-    for (const k of Object.keys(env)) delete env[k];
-  });
-
-  it('sends every judge in at high, the level Gemini 3.x speaks', () => {
-    expect(judgeThinkingLevel()).toBe('high');
-  });
-
-  it('takes an env override, per call — no deploy to undo a regression', () => {
-    env.GEMINI_JUDGE_THINKING_LEVEL = 'low';
-    expect(judgeThinkingLevel()).toBe('low');
-    env.GEMINI_JUDGE_THINKING_LEVEL = 'MEDIUM';
-    expect(judgeThinkingLevel()).toBe('medium');
-  });
-
-  it('lets one call site override the shared level (prepublish)', () => {
-    env.GEMINI_JUDGE_THINKING_LEVEL = 'high';
-    expect(judgeThinkingLevel('low')).toBe('low');
-  });
-
-  // A junk value must not 400 a whole review job, and the retired numeric knobs are junk now.
-  it('falls back to high on anything that is not a level', () => {
-    for (const junk of ['1024', '0', 'off', 'max', '', undefined, null]) {
-      expect(geminiThinkingLevel(junk)).toBe('high');
-    }
-  });
-
-  it('il livello resta minuscolo: e` la forma che il centralino manda sul filo', () => {
-    expect(judgeThinkingLevel('high')).toBe('high');
   });
 });

--- a/src/lib/server/gemini.ts
+++ b/src/lib/server/gemini.ts
@@ -39,51 +39,6 @@ export function geminiVisualCreditShare(plan?: string | null): number {
   return 1;
 }
 
-/**
- * Gemini 3.x takes `thinkingLevel`, not a token budget, and `gemini-3.7-flash` has no off switch:
- * low is the floor. Levels are not budgets and thinking bills at the output rate — see
- * docs/24-chat-optimization.md before turning these down.
- */
-export type GeminiThinkingLevel = 'low' | 'medium' | 'high';
-
-const GEMINI_THINKING_LEVELS: GeminiThinkingLevel[] = ['low', 'medium', 'high'];
-
-/** Where every non-chat Gemini call starts. Chat has its own per-tier scale (chat-reasoning.ts). */
-const DEFAULT_GEMINI_THINKING: GeminiThinkingLevel = 'high';
-
-function isThinkingLevel(v: unknown): v is GeminiThinkingLevel {
-  return typeof v === 'string' && (GEMINI_THINKING_LEVELS as string[]).includes(v);
-}
-
-/** Junk falls back rather than 400-ing a whole job. */
-export function geminiThinkingLevel(
-  raw?: string | null,
-  fallback: GeminiThinkingLevel = DEFAULT_GEMINI_THINKING
-): GeminiThinkingLevel {
-  const v = raw?.trim().toLowerCase();
-  if (isThinkingLevel(v)) return v;
-  if (v) console.warn(`[AI] ignoring unknown Gemini thinking level "${raw}" (use low | medium | high)`);
-  return fallback;
-}
-
-let warnedStaleBudget = false;
-
-/**
- * How hard every judge / review / QC call thinks. Read per call so the env var can undo a
- * regression without a deploy. The numeric *_THINKING_BUDGET vars are dead: warn once rather
- * than let them look alive in Vercel.
- */
-export function judgeThinkingLevel(rawOverride?: string | null): GeminiThinkingLevel {
-  if (!warnedStaleBudget && (env.GEMINI_JUDGE_THINKING_BUDGET || env.PREPUBLISH_THINKING_BUDGET)) {
-    warnedStaleBudget = true;
-    console.warn(
-      '[AI] GEMINI_JUDGE_THINKING_BUDGET / PREPUBLISH_THINKING_BUDGET are ignored: Gemini 3.x takes ' +
-        'thinkingLevel, not a token budget. Use GEMINI_JUDGE_THINKING_LEVEL=low|medium|high.'
-    );
-  }
-  return geminiThinkingLevel(rawOverride ?? env.GEMINI_JUDGE_THINKING_LEVEL);
-}
-
 // Qui c'erano i due client Gemini — `makeGenaiClient` (kie o Google) e `googleGenaiClient` (Google
 // sempre) — piu` il trasporto che sceglieva fra i due. Sono spariti con l'ultimo chiamante: ogni
 // pixel passa dallo slot immagini, ogni testo dal centralino, e i due endpoint vivi sono kie e

--- a/src/lib/server/google-models.test.ts
+++ b/src/lib/server/google-models.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const env: Record<string, string | undefined> = {};
 vi.mock('$env/dynamic/private', () => ({ env }));
 
-const { GEMINI_FLASH, geminiFlash, isGeminiFlashId, NANO_BANANA_PRO, isNanoBananaProId, geminiVisualCreditShare } = await import('./gemini');
+const { GEMINI_FLASH, geminiFlash, isGeminiFlashId, NANO_BANANA_PRO, isNanoBananaProId, geminiVisualCreditShare } = await import('./google-models');
 
 describe('GEMINI_FLASH', () => {
   it('is a Gemini Flash model id — the default when the env var is unset', () => {

--- a/src/lib/server/google-models.ts
+++ b/src/lib/server/google-models.ts
@@ -1,3 +1,16 @@
+/**
+ * Gli id dei modelli Google, nelle forme in cui ce li fatturano — e nient'altro.
+ *
+ * Qui c'erano i due client Gemini — `makeGenaiClient` (kie o Google) e `googleGenaiClient` (Google
+ * sempre) — piu` il trasporto che sceglieva fra i due. Sono spariti con l'ultimo chiamante: ogni
+ * pixel passa dallo slot immagini, ogni testo dal centralino, e i due endpoint vivi sono kie e
+ * OpenRouter. Restano gli ID e le tariffe, che servono al registro di cassa: un modello Gemini si
+ * paga anche quando a servirlo e` qualcun altro.
+ *
+ * Si chiamava `gemini.ts`, e prometteva una linea verso Gemini che non c'e` piu`: la stessa bugia
+ * di `xiaomi.ts`, diventato `ai-text.ts`. Il nome di adesso dice di CHI sono i modelli, non con chi
+ * parliamo — perche' con Google non parla piu` nessuno.
+ */
 import { env } from '$env/dynamic/private';
 import { GEMINI_NANO_BANANA_2_LITE, GEMINI_NANO_BANANA_PRO } from '$lib/image-models';
 
@@ -38,12 +51,6 @@ export const NANO_BANANA_2_LITE = GEMINI_NANO_BANANA_2_LITE;
 export function geminiVisualCreditShare(plan?: string | null): number {
   return 1;
 }
-
-// Qui c'erano i due client Gemini — `makeGenaiClient` (kie o Google) e `googleGenaiClient` (Google
-// sempre) — piu` il trasporto che sceglieva fra i due. Sono spariti con l'ultimo chiamante: ogni
-// pixel passa dallo slot immagini, ogni testo dal centralino, e i due endpoint vivi sono kie e
-// OpenRouter. Restano gli ID e le tariffe, che servono al registro di cassa: un modello Gemini si
-// paga anche quando a servirlo e` qualcun altro.
 
 /** `gemini-3.7-flash` → `gemini-3-7-flash`, la forma che accetta il passthrough di kie. */
 export function kieFlashId(modelId: string): string {

--- a/src/lib/server/llm-reasoning.test.ts
+++ b/src/lib/server/llm-reasoning.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Lo sforzo di ragionamento che un chiamante CHIEDE deve finire sul filo.
+ *
+ * `LLM_REASONING_EFFORT` copre il default globale, e c'e` gia` un test suo. Qui si guarda l'altro
+ * verso: un giudice che chiede 'low' per la sua chiamata deve ottenere 'low', non il default. E`
+ * lo stesso guasto dei `plugins` scartati in silenzio — un campo che non arriva non fallisce,
+ * risponde bene e misura un'altra cosa.
+ */
+const M = vi.hoisted(() => ({
+	env: {} as Record<string, string | undefined>,
+	generateObject: vi.fn(async () => ({ object: { ok: true }, usage: {} })),
+	generateText: vi.fn(async () => ({ text: 'ciao', usage: {} }))
+}));
+
+vi.mock('$env/dynamic/private', () => ({ env: M.env }));
+vi.mock('$lib/server/chat-model-catalog', () => ({ defaultChatModelId: () => null }));
+vi.mock('$lib/server/ai-log', () => ({
+	logAiCall: vi.fn(),
+	extractSdkUsage: () => ({}),
+	noteLlmCost: vi.fn()
+}));
+vi.mock('ai', async () => ({
+	...(await vi.importActual<typeof import('ai')>('ai')),
+	generateObject: M.generateObject,
+	generateText: M.generateText
+}));
+
+const SCHEMA = { type: 'object' as const, properties: { ok: { type: 'boolean' as const } } };
+
+describe('lo sforzo di ragionamento chiesto dal call site', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.resetModules();
+		for (const k of Object.keys(M.env)) delete M.env[k];
+		Object.assign(M.env, { LLM_API_KEY: 'k', LLM_DEFAULT_MODEL: 'google/gemini-3.7-flash' });
+	});
+
+	it('llmStructured manda l\'effort del chiamante, non il default globale', async () => {
+		const { llmStructured } = await import('./llm');
+		await llmStructured({ prompt: 'p', schema: SCHEMA, reasoningEffort: 'low' });
+		expect(M.generateObject.mock.calls[0][0]).toMatchObject({
+			providerOptions: { openai: { reasoning: { effort: 'low' } } }
+		});
+	});
+
+	it('senza richiesta resta il default dichiarato', async () => {
+		M.env.LLM_REASONING_EFFORT = 'medium';
+		const { llmStructured } = await import('./llm');
+		await llmStructured({ prompt: 'p', schema: SCHEMA });
+		expect(M.generateObject.mock.calls[0][0]).toMatchObject({
+			providerOptions: { openai: { reasoning: { effort: 'medium' } } }
+		});
+	});
+
+	it('llmText onora la stessa richiesta', async () => {
+		const { llmText } = await import('./llm');
+		await llmText({ prompt: 'p', reasoningEffort: 'low' });
+		expect(M.generateText.mock.calls[0][0]).toMatchObject({
+			providerOptions: { openai: { reasoning: { effort: 'low' } } }
+		});
+	});
+});

--- a/src/lib/server/llm.ts
+++ b/src/lib/server/llm.ts
@@ -193,13 +193,30 @@ function userContent(
  * Su questo modello il reasoning non si può nemmeno spegnere: `{enabled:false}` risponde 400,
  * «Reasoning is mandatory for this endpoint».
  */
-export const LLM_REASONING_EFFORT = (() => {
-  const raw = env.LLM_REASONING_EFFORT?.trim().toLowerCase();
-  return raw === 'low' || raw === 'medium' || raw === 'high' ? raw : 'high';
-})();
+export type ReasoningEffort = 'low' | 'medium' | 'high';
 
-/** Il corpo extra che ogni chiamata porta con sé, mai vuoto: v. LLM_REASONING_EFFORT. */
-const reasoningOptions = () => ({ reasoning: { effort: LLM_REASONING_EFFORT } });
+const EFFORTS: ReasoningEffort[] = ['low', 'medium', 'high'];
+
+/**
+ * Un valore qualunque letto come effort. Fuori vocabolario ripiega invece di 400-are il lavoro:
+ * qui arrivano anche i vecchi budget numerici, che per il gateway sono spazzatura.
+ */
+export function reasoningEffort(raw: unknown, fallback: ReasoningEffort = 'high'): ReasoningEffort {
+  const v = typeof raw === 'string' ? raw.trim().toLowerCase() : '';
+  return (EFFORTS as string[]).includes(v) ? (v as ReasoningEffort) : fallback;
+}
+
+export const LLM_REASONING_EFFORT: ReasoningEffort = reasoningEffort(env.LLM_REASONING_EFFORT);
+
+/**
+ * Il corpo extra che ogni chiamata porta con sé, mai vuoto: v. LLM_REASONING_EFFORT.
+ *
+ * Il chiamante può chiedere il SUO sforzo — un giudice che rilegge una didascalia non deve pensare
+ * quanto un pianificatore. Se non chiede niente decide il default, che resta dichiarato.
+ */
+const reasoningOptions = (asked?: ReasoningEffort) => ({
+  reasoning: { effort: asked ?? LLM_REASONING_EFFORT }
+});
 
 /**
  * Quanto si aspetta una risposta dal centralino prima di considerarla persa.
@@ -227,6 +244,7 @@ export async function llmStructured<T>(opts: {
 	images?: LlmMediaPart[];
 	file?: LlmMediaPart;
 	temperature?: number;
+	reasoningEffort?: ReasoningEffort;
 	label?: string;
 }): Promise<T> {
 	const modelId = opts.model ?? llmDefaultModel();
@@ -239,7 +257,7 @@ export async function llmStructured<T>(opts: {
 			system: opts.system,
 			temperature: opts.temperature,
 			abortSignal: AbortSignal.timeout(LLM_TIMEOUT_MS),
-			providerOptions: { openai: reasoningOptions() },
+			providerOptions: { openai: reasoningOptions(opts.reasoningEffort) },
 			messages: [{ role: 'user', content: userContent(opts.prompt, opts.images, opts.file) }]
 		});
 		logAiCall({
@@ -321,6 +339,7 @@ export async function llmText(opts: {
 	file?: LlmMediaPart;
 	/** Google Search nativo su un Gemini via OpenRouter (`plugins: web, engine: native`). */
 	webSearch?: boolean;
+	reasoningEffort?: ReasoningEffort;
 	label?: string;
 }): Promise<{ text: string; citations: Array<{ uri: string; title: string }> }> {
 	const modelId = opts.model ?? (opts.webSearch ? llmGeminiSearchModel() : llmDefaultModel());
@@ -346,7 +365,7 @@ export async function llmText(opts: {
 			system: opts.system,
 			abortSignal: AbortSignal.timeout(LLM_TIMEOUT_MS),
 			messages: [{ role: 'user', content: userContent(opts.prompt, opts.images, opts.file) }],
-			providerOptions: { openai: reasoningOptions() }
+			providerOptions: { openai: reasoningOptions(opts.reasoningEffort) }
 		});
 		logAiCall({
 			label,

--- a/src/lib/server/motion-video/reference-tools.watch.test.ts
+++ b/src/lib/server/motion-video/reference-tools.watch.test.ts
@@ -51,7 +51,6 @@ vi.mock('$lib/server/motion-references', () => ({
 	})
 }));
 vi.mock('$lib/server/posts-design', () => ({ isPostsDesignEnabled: () => true }));
-vi.mock('$lib/server/gemini', () => ({ geminiTransport: () => 'google' }));
 
 import { createMotionReferenceTools, type ReferenceStudy } from './reference-tools';
 

--- a/src/lib/server/research.ts
+++ b/src/lib/server/research.ts
@@ -5,10 +5,9 @@ import { fetchPage } from '$lib/server/brand-analysis';
 import { scrapeForOnboarding, type ScrapeTarget, type ScrapedPost } from '$lib/server/scrapecreators';
 import { aiStructured, aiText, parallelVariants } from '$lib/server/ai-text';
 import { requireBrandContext } from '$lib/server/ai-log';
-import { type GeminiThinkingLevel } from '$lib/server/gemini';
 import { exaConfigured, exaGroundedAnswer } from '$lib/server/exa';
 import { tavilyConfigured, tavilyGroundedAnswer } from '$lib/server/tavily';
-import { llmGeminiSearchModel, llmImagesFromInline, llmStructured, llmText } from '$lib/server/llm';
+import { llmGeminiSearchModel, llmImagesFromInline, llmStructured, llmText, type ReasoningEffort } from '$lib/server/llm';
 
 // Deep-research module for onboarding: discover competitors (web-grounded), resolve their social
 // handles, scrape + benchmark their posts, and synthesise a strategy report that both the user
@@ -108,7 +107,7 @@ export async function structuredGemini<T>(
     label?: string;
     images?: Array<{ inlineData: { mimeType: string; data: string } }>;
     temperature?: number;
-    thinkingLevel?: GeminiThinkingLevel;
+    reasoningEffort?: ReasoningEffort;
     brandId?: string;
     userId?: string;
     threadId?: string;
@@ -116,7 +115,7 @@ export async function structuredGemini<T>(
   }
 ): Promise<T> {
   requireBrandContext(opts);
-  const { label = 'structured', images, temperature } = opts ?? {};
+  const { label = 'structured', images, temperature, reasoningEffort } = opts ?? {};
   try {
     return await llmStructured<T>({
       prompt,
@@ -124,6 +123,7 @@ export async function structuredGemini<T>(
       system: systemInstruction,
       images: llmImagesFromInline(images),
       temperature,
+      reasoningEffort,
       label
     });
   } catch {
@@ -147,8 +147,7 @@ export async function structured<T>(
     model?: string;
     provider?: 'gateway' | 'kie';
     noFallback?: boolean;
-    /** How hard Gemini reasons on judge-style calls — see structuredGemini. */
-    thinkingLevel?: GeminiThinkingLevel;
+    reasoningEffort?: ReasoningEffort;
     brandId?: string;
     userId?: string;
     threadId?: string;

--- a/src/lib/server/ugc-script-review.ts
+++ b/src/lib/server/ugc-script-review.ts
@@ -25,7 +25,7 @@ import {
   type UgcScript
 } from '$lib/server/ugc';
 import { UGC_ORGANIC_MAX_DURATION, UGC_AD_DURATION } from '$lib/server/video';
-import { judgeThinkingLevel } from '$lib/server/gemini';
+import { judgeReasoningEffort } from '$lib/server/ai-text';
 
 export type UgcScriptSeed = {
   format?: string;
@@ -168,7 +168,7 @@ Return JSON.`;
 
     const parsed = await structured(ai, prompt, SCRIPT_REVIEW_SCHEMA, undefined, {
       label: 'reviewUgcScripts',
-      thinkingLevel: judgeThinkingLevel()
+      reasoningEffort: judgeReasoningEffort()
     });
     const fixes: Array<Record<string, unknown>> = Array.isArray((parsed as { fixes?: unknown }).fixes)
       ? ((parsed as { fixes: Array<Record<string, unknown>> }).fixes)

--- a/src/routes/start/preview/+server.ts
+++ b/src/routes/start/preview/+server.ts
@@ -4,7 +4,7 @@ import { assertPublicUrl, guardTool } from '$lib/server/tool-guard';
 import { runBrandAnalysis } from '$lib/server/brand-analysis';
 import { planPreviewPosts, renderPreviewImages } from '$lib/server/content-preview/weekly-planner';
 import { createAdminClient } from '$lib/server/supabase-admin';
-import { NANO_BANANA_2_LITE } from '$lib/server/gemini';
+import { NANO_BANANA_2_LITE } from '$lib/server/google-models';
 import { localeLanguageName } from '$lib/i18n/locale';
 
 /**

--- a/src/routes/start/preview/server.test.ts
+++ b/src/routes/start/preview/server.test.ts
@@ -14,7 +14,7 @@ const lookupMock = vi.fn(async (host: string) => {
 });
 vi.mock('node:dns/promises', () => ({ lookup: (host: string) => lookupMock(host) }));
 vi.mock('$lib/server/supabase-admin', () => ({ createAdminClient: vi.fn(() => ({})) }));
-vi.mock('$lib/server/gemini', async (orig) => ({
+vi.mock('$lib/server/google-models', async (orig) => ({
   ...(await orig<Record<string, unknown>>()),
   NANO_BANANA_2_LITE: 'gemini-3.1-flash-lite-image'
 }));


### PR DESCRIPTION
## What?

Two changes, one theme: the Google vocabulary stops describing calls that no longer go to Google.

1. **A judge knob that was read and then dropped now reaches the wire.** `GEMINI_JUDGE_THINKING_LEVEL` was parsed, validated, and passed by both judges (`ugc-script-review.ts`, `content-preview/caption-quality.ts`) into `aiStructured` — which destructured it into `thinkingLevel: _thinkingLevel` and never forwarded it. `llmStructured` always sent the global `LLM_REASONING_EFFORT` instead.
2. **`src/lib/server/gemini.ts` → `src/lib/server/google-models.ts`**, and the thinking-level type moves out of it into `llm.ts` as `ReasoningEffort`.

## Why?

The knob failed the way that costs the most: silently. An operator turning the judges down saw identical spend and identical answers, with nothing erroring anywhere — the same class of defect as the `plugins` field OpenRouter was silently discarding on the GEO audit.

The type was also speaking the wrong language. `thinkingLevel` is Gemini 3.x's parameter; every call this product makes leaves through OpenRouter, where the field is `reasoning.effort`. `llm.ts` already used that name for the global default and `kie.ts` for its own (`KieReasoningEffort`) — so the codebase carried two identical three-value unions, one named after Google and one after OpenAI, alive at the same time and disconnected.

And `gemini.ts` has built no Google client since `makeGenaiClient` / `googleGenaiClient` left with their last caller. What remained was the name, promising a line to Gemini that does not exist — the same lie as `xiaomi.ts`, already corrected to `ai-text.ts`.

## How?

- `ReasoningEffort` + a junk-tolerant `reasoningEffort()` parser live in `llm.ts`, next to `LLM_REASONING_EFFORT`: the transport's vocabulary sits with the transport. `llmStructured` and `llmText` take an optional `reasoningEffort`; absent, the declared default still wins.
- `judgeThinkingLevel` becomes `judgeReasoningEffort` in `ai-text.ts`, the switchboard both judges already route through — the knob next to the door it opens. It keeps reading `GEMINI_JUDGE_THINKING_LEVEL`: **the env var name deliberately does not change**, because renaming a variable in production config while it starts working for the first time is two changes in one.
- The rename is a separate commit from the behaviour change, so a bisect can tell which one moved what.

**Rejected:** deleting the knob outright. It does nothing today and YAGNI would allow it, but it is a QC-path escape hatch with two live call sites, and wiring it costs ~10 lines against removing an operator's only per-judge lever.

**Also rejected:** removing `@google/genai` in this PR — see *Anything Else?*.

## Testing?

Written before the fix and watched fail (4 red, for the right reasons):

- `src/lib/server/ai-text.test.ts` — the requested effort reaches `llmStructured` instead of stopping in the opts; absent, nothing is invented; `judgeReasoningEffort` re-reads the env var per call and falls back to `high` on junk.
- `src/lib/server/llm-reasoning.test.ts` (new) — the value lands in `providerOptions.openai.reasoning.effort` on both `generateObject` and `generateText`, and the declared default holds when no caller asks.

<details><summary>Red, before the fix</summary>

```
× llmStructured manda l'effort del chiamante, non il default globale
× llmText onora la stessa richiesta
× arriva al gateway invece di fermarsi negli opts
  AssertionError: expected { prompt: 'prompt', …(6) } to match object { reasoningEffort: 'low' }
× judgeReasoningEffort legge la variabile a ogni chiamata, e ripiega su high
  TypeError: judgeReasoningEffort is not a function
```
</details>

<details><summary>Green, after — full suite and build</summary>

```
Test Files  673 passed | 4 skipped (677)
     Tests  7463 passed | 14 skipped (7477)

typecheck-runtime: ok (ignored 312 non-fatal type error(s))
✓ built in 55.88s
✓ built in 1m 12s
```

A fresh worktree fails `src/hooks.server.test.ts` on a missing `.env` (`PUBLIC_SUPABASE_URL` → `Invalid URL`); with `.env` present it passes. Not related to this change.
</details>

**Not tested:** no browser run and no eval. This touches no prompt, no model choice and no chat path — the only behaviour change is a field that now arrives where it was already meant to. **Risk:** with the default (`high`, unchanged on both sides) nothing moves; only an operator who has set `GEMINI_JUDGE_THINKING_LEVEL` sees a difference, which is the fix.

## Evidence (screenshots/videos)

No UI surface changes.

## Anything Else?

**`@google/genai` stays a dependency, and the graph says why — not an impression.** 19 files in `src/` still `import type { GoogleGenAI }`, every one of them for an `ai` parameter that is `null` at runtime: `genaiClient()` in `brand-context.ts` is `return null as never`. Removing the package means deleting that parameter from **132 call sites across 53 files** — the batch `brand-context.ts`'s own comment already parks as "solo meccanica". Folding it in here would bury the correction that matters under a mechanical diff. It is the obvious next PR.

Two smaller residues left deliberately: `gemini-transport.test.ts` is now named after a transport that no longer exists (its own header already says the transport tests moved to `no-side-doors.test.ts`), and `structuredGemini` in `research.ts` keeps a name from the same era. Both are rename-only, and belong with the `GoogleGenAI` batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY