### PR TITLE
Undo an AI-disclosure regression on dev, and add the unique competitors upserts on

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -760,13 +760,15 @@ riga accanto va letta prima di toccarlo. Il default in caso di dubbio lo dice gi
 accanto a quella riga: sovra-dichiarare non è un rischio, sotto-dichiarare sì.
 
 **Il corollario sul metodo.** A trovarlo non è stato un vincolo né la suite: è stato un altro
-agente che leggeva la riga accanto per un lavoro diverso. Due letture indipendenti dello stesso
-codice hanno preso due difetti (questo e il 42P10 qui sotto) che nessuna delle due suite vedeva.
+agente che leggeva la riga accanto per un lavoro diverso. E non e' «due persone attente»: ognuno
+ha preso il difetto dell'ALTRO, mai il proprio. Chi scrive la modifica la rilegge da autore, e la
+riga accanto la vede solo chi non ha una posta in gioco su quella modifica.
 
-## Un `upsert` con `onConflict` senza indice unico non scrive, e non lo dice
+## Un `onConflict` sbagliato ha due facce: una non scrive, l'altra cancella
 
-**Segnale.** Una funzione riporta di aver salvato N righe e la tabella non le ha. Nessun log,
-nessuna eccezione, il chiamante riceve un risultato positivo.
+**Segnale.** Due segnali opposti, stessa causa. O una funzione riporta di aver salvato N righe e la
+tabella non le ha — nessun log, nessuna eccezione, risultato positivo al chiamante. Oppure la
+scrittura riesce e una riga che c'era prima non c'è più.
 
 **Cosa succede.** `onConflict: 'brand_id,name'` esige un indice UNIQUE su quella coppia. Se non
 c'è, Postgres risponde **42P10** (*no unique or exclusion constraint matching the ON CONFLICT
@@ -776,8 +778,24 @@ destruttura `error` non se ne accorge: su `competitors` esisteva solo `competito
 zero righe. Non è un caso raro: `create index` e `create unique index` si leggono uguali di
 sfuggita, e l'`onConflict` viene scritto guardando le colonne, non gli indici.
 
-**La mossa.** Ogni `onConflict` va verificato contro `pg_indexes` della tabella, non contro
-l'intenzione: `select indexdef from pg_indexes where tablename = '<t>'` e cercare `UNIQUE`. È una
+**L'altra faccia, che è la peggiore.** Se l'indice unico c'è ma è su una coppia DIVERSA da quella
+che hai in testa, non c'è nessun errore: l'upsert riesce e **sovrascrive**. `brand_social_handles`
+è unica su `(brand_id, platform)` — un handle per rete, non uno per nome — quindi scrivere un
+secondo handle Instagram per lo stesso brand non ne aggiunge uno: cancella quello che c'era. È
+stata una quasi-vittima in questa stessa PR, in due punti: la migration che spostava gli handle dal
+campo sito (guardia scritta su `username`, cioè sulla colonna sbagliata: sarebbe morta con un 23505
+abortendo TUTTA la migration) e il codice che li raccoglie in onboarding, che avrebbe silenziosamente
+rimpiazzato un handle dichiarato dall'utente con uno dedotto da un campo compilato male. Il primo
+caso fa rumore, il secondo no.
+
+**La mossa per questa faccia.** Prima di un `onConflict`, leggi la coppia unica REALE e chiediti
+cosa significa come regola di prodotto: `(brand_id, platform)` non è un dettaglio di indice, dice
+«un brand ha un solo account per rete». Se la tua scrittura può produrre due righe che collidono su
+quella coppia, stai scegliendo quale delle due sopravvive — quindi scegli esplicitamente
+(`do nothing` per tenere l'esistente, `do update` per sostituirlo) invece di scoprirlo dopo.
+
+**La mossa, per entrambe.** Ogni `onConflict` va verificato contro `pg_indexes` della tabella, non
+contro l'intenzione: `select indexdef from pg_indexes where tablename = '<t>'` e cercare `UNIQUE`. È una
 riga di SQL contro un difetto che non lascia tracce. E l'errore va **letto**: `const { error } =
 await supabase.from(...).upsert(...)`, sempre — vale per il 42P10 come per il 23514.
 

--- a/LESSONS.md
+++ b/LESSONS.md
@@ -100,6 +100,34 @@ git merge-base --is-ancestor <merge-commit> origin/dev && echo LANDED || echo NE
 ```
 Se la pila si abbandona, le PR che ci stavano sopra non si chiudono da sole: vanno riportate a mano sul branch di destinazione (cherry-pick del merge commit, che essendo squash ha un solo genitore), e la risoluzione dei conflitti è il prezzo di averlo scoperto tardi.
 
+### Un difetto e la sua correzione nello stesso ramo sono una trappola armata
+La #372 aveva cinque commit, e il terzo annullava una regressione introdotta dal secondo: una
+dichiarazione di contenuto AI spenta senza volerlo (`content_type` che perde il prefisso
+`uploaded`, e `publish.ts` che da quel prefisso ricava se dichiarare). Il merge è stato fatto **al
+secondo commit**. Risultato: su `dev` è finito il difetto senza la correzione, e chi lo aveva
+scritto lo dava per consegnato perché sul SUO ramo era a posto.
+
+Non è un errore di verifica del merge — quello è il sintomo, ed è coperto dalla lezione qui sopra.
+La causa è la **forma della consegna**: una PR non è un'unità atomica, e chi la scrive non decide
+dove viene tagliata. Cinque commit sono cinque stati possibili del ramo base, e se il commit N
+introduce un difetto che il commit N+2 ripara, due di quei tagli lasciano il prodotto **peggio di
+non aver mergiato niente**. La trappola resta armata finché qualcuno non preme merge nel punto
+sbagliato, e nessuna review la vede: il diff completo della PR è corretto.
+
+Segnale: nel ramo esiste un commit il cui messaggio dice «fix», «undo», «revert» o «restore» di
+qualcosa che un commit precedente **dello stesso ramo** ha fatto.
+
+Mossa: **nessun commit lascia il ramo in uno stato peggiore del precedente.** Se una tua correzione
+annulla un tuo difetto introdotto prima nello stesso ramo, i due si fondono con `rebase -i` *prima*
+della review, così non esiste taglio che possa separarli. È la regola di Kent Beck che questo repo
+già ha — riordino separato dal cambio di comportamento — applicata al ramo invece che al singolo
+commit. Il controllo, prima di chiedere la review:
+```bash
+git log --oneline <base>..HEAD    # ogni prefisso di questa lista è uno stato che può finire in produzione
+```
+Questa lezione è più forte delle altre due che l'hanno accompagnata, perché quelle dipendono da
+qualcuno che si ricordi di controllare; questa toglie la possibilità che il taglio sia dannoso.
+
 ## Test: distinguere il tuo difetto dal rumore
 
 ### CI rossa con zero test falliti è una promessa non attesa, non un test tuo

--- a/LESSONS.md
+++ b/LESSONS.md
@@ -123,8 +123,21 @@ della review, così non esiste taglio che possa separarli. È la regola di Kent 
 già ha — riordino separato dal cambio di comportamento — applicata al ramo invece che al singolo
 commit. Il controllo, prima di chiedere la review:
 ```bash
-git log --oneline <base>..HEAD    # ogni prefisso di questa lista è uno stato che può finire in produzione
+git log --oneline <base>..HEAD              # ogni prefisso è uno stato che può finire in produzione
+git show --format= --name-only <commit>     # quali commit toccano il file che porta il rischio
 ```
+**La domanda giusta è sulla STRUTTURA, non sul contenuto**: *quali commit toccano il file
+rischioso*, non *quale stringa ci compare*. Se quel file è toccato da un commit solo, la trappola è
+impossibile per costruzione — ogni prefisso lo contiene — e non serve leggere una riga. Se è
+toccato da due e il secondo ripara il primo, è armata comunque, qualunque cosa dica il grep.
+
+**E il controllo si sceglie perché non oscilla, non perché è breve.** Verificando proprio questa
+cosa, `grep` su un `git cat-file` in un `for` ha dato a due persone tre risposte diverse alla stessa
+domanda (`5, 2, 0, 0`, poi zero ovunque, poi righe di diff al posto del contenuto). `--name-only`
+non oscilla: risponde con l'elenco dei file, che è un fatto del commit e non del modo in cui lo
+interroghi. Un controllo che devi rifare per credergli non è un controllo — e qui la lezione sul
+non fidarsi del proprio ramo stava per essere depositata sulla base di un loop mai testato.
+
 Questa lezione è più forte delle altre due che l'hanno accompagnata, perché quelle dipendono da
 qualcuno che si ricordi di controllare; questa toglie la possibilità che il taglio sia dannoso.
 

--- a/LESSONS.md
+++ b/LESSONS.md
@@ -738,6 +738,49 @@ dove non lo è: resta non fatale, smette di essere muto.
 vincolo nemmeno volendo: è gestione d'errore che non può funzionare. L'errore va letto dal valore
 risolto.
 
+## Il vocabolario di una colonna non si decide senza sapere CHI la legge
+
+**Segnale.** Una correzione ovvia: un valore fuori dall'enum, sostituito con quello «giusto»
+guardando la costante. Nessun test rosso, il vincolo passa, la PR sembra più pulita di prima.
+
+**Cosa succede.** `posts.content_type` sembrava nomenclatura, e `post-from-asset.ts` ci scriveva
+`image` e `carousel` — che sono FORMATI, non tipi. Sostituirli con `uploaded_image` era corretto
+guardando `POST_CONTENT_TYPES` e sbagliato guardando `publish.ts:380`, che fa
+`aiGeneratedMedia: !content_type.startsWith('uploaded')`: quel prefisso **è** la dichiarazione di
+contenuto AI al momento della pubblicazione. Prima di quella modifica tutte e tre le forme
+dichiaravano; dopo, immagini e caroselli presi dalla libreria smettevano di dichiarare. Un enum
+allineato e una conformità spenta, nello stesso commit, senza un solo test rosso — perché nessun
+test lega il prefisso di una stringa a ciò che viene dichiarato a un social.
+
+**La mossa.** Prima di cambiare un valore in una colonna, `grep` di chi la **legge**, non solo di
+chi la scrive — e in particolare di chi ne legge un *pezzo* (`startsWith`, `includes`, uno `split`),
+perché quello non compare cercando il valore intero. Se un lettore ne ricava una decisione di
+conformità, di pagamento o di pubblicazione, il valore non è nomenclatura: è un contratto, e la
+riga accanto va letta prima di toccarlo. Il default in caso di dubbio lo dice già il commento
+accanto a quella riga: sovra-dichiarare non è un rischio, sotto-dichiarare sì.
+
+**Il corollario sul metodo.** A trovarlo non è stato un vincolo né la suite: è stato un altro
+agente che leggeva la riga accanto per un lavoro diverso. Due letture indipendenti dello stesso
+codice hanno preso due difetti (questo e il 42P10 qui sotto) che nessuna delle due suite vedeva.
+
+## Un `upsert` con `onConflict` senza indice unico non scrive, e non lo dice
+
+**Segnale.** Una funzione riporta di aver salvato N righe e la tabella non le ha. Nessun log,
+nessuna eccezione, il chiamante riceve un risultato positivo.
+
+**Cosa succede.** `onConflict: 'brand_id,name'` esige un indice UNIQUE su quella coppia. Se non
+c'è, Postgres risponde **42P10** (*no unique or exclusion constraint matching the ON CONFLICT
+specification*) e `supabase-js` **risolve** con `{ error }` — non rigetta. Una chiamata che non
+destruttura `error` non se ne accorge: su `competitors` esisteva solo `competitors_brand_idx`, che
+è un indice normale, e il job «ri-cerca i concorrenti» riportava i concorrenti trovati scrivendo
+zero righe. Non è un caso raro: `create index` e `create unique index` si leggono uguali di
+sfuggita, e l'`onConflict` viene scritto guardando le colonne, non gli indici.
+
+**La mossa.** Ogni `onConflict` va verificato contro `pg_indexes` della tabella, non contro
+l'intenzione: `select indexdef from pg_indexes where tablename = '<t>'` e cercare `UNIQUE`. È una
+riga di SQL contro un difetto che non lascia tracce. E l'errore va **letto**: `const { error } =
+await supabase.from(...).upsert(...)`, sempre — vale per il 42P10 come per il 23514.
+
 ## Un `catch` muto su un percorso di ricavi nasconde il difetto finché non lo cerchi a mano
 
 **Segnale.** Nessun errore, nessun allarme, tutto verde — e un limite che non limita niente. Qui:

--- a/changelog/2026-09-05-table-value-checks.md
+++ b/changelog/2026-09-05-table-value-checks.md
@@ -45,7 +45,14 @@ di lunghezza.
 
 **`posts.content_type` è entrato, dopo tre correzioni.** `SHAPES` in `post-from-asset.ts`
 scriveva `image` e `carousel`: sono FORMATI, non tipi, e la description del tool lo dice in
-maiuscolo. Ora scrivono `uploaded_image`, che è quello che sono — asset caricati dall'utente.
+maiuscolo. Ora scrivono `generated_image`.
+
+Il primo tentativo era `uploaded_image`, e sarebbe stata una regressione di conformità: `publish.ts`
+ricava `aiGeneratedMedia: !content_type.startsWith('uploaded')`, quindi quel prefisso **decide la
+dichiarazione di contenuto AI**. Un asset preso dalla libreria può essere generato o caricato — la
+libreria lo sa (`brand_media.source`), quella tabella no — e prima della PR tutte e tre le forme
+dichiaravano. `generated_image` tiene esattamente il comportamento precedente: sovra-dichiarare è
+il verso prudente, sotto-dichiarare è il rischio, e lo dice il commento accanto a quella riga.
 `uploaded_video`, che `upload-media` scrive da sempre, era invece legittimo e semplicemente
 mancava da `POST_CONTENT_TYPES`: aggiunto. E `PostAssetShape.contentType` non è più `string` ma
 `PostContentType`, così il compilatore tiene il vocabolario da solo.
@@ -58,6 +65,14 @@ Ora passano da `sanitizeThemeColor`, accanto a `sanitizeBrandColors` e con la st
 **`brand_kit.site_type` è entrato allargato.** `media`, `mobile_app` e `service` non erano dati
 rotti: erano valori legittimi che mancavano dall'elenco. Il tipo sale da 6 a 9, e con lui l'enum
 dello schema JSON che il modello riceve — perché è da lì che arrivano.
+
+**`competitors` ha preso anche il `unique (brand_id, name)` che mancava.** `chat/job-executor.ts`
+fa `upsert(..., { onConflict: 'brand_id,name' })`, ma su quella tabella l'unico indice unico era
+la primary key: Postgres risponde **42P10** e la chiamata non legge `error`. Il job «ri-cerca i
+concorrenti» riportava i concorrenti trovati e scriveva **zero righe**, in silenzio — provato in
+locale sulla stessa istruzione. Correggere la forma degli handle non bastava: la scrittura non
+atterrava proprio. Zero duplicati su `(brand_id, name)` in produzione, anche ignorando maiuscole e
+spazi, quindi il vincolo entra pulito e rende l'upsert esprimibile.
 
 **`competitors.handles` è entrato come array, e non era una preferenza.** Tre scrittori ci
 mettevano un array di `{platform, username}`, `chat/job-executor.ts` un oggetto
@@ -113,13 +128,13 @@ l'autopilot di notte. `format` prende solo un tetto di lunghezza.
 
 Un vincolo senza un test che prova a violarlo è una speranza — e la suite qui mocka Supabase, dove
 un insert finto accetta qualunque stringa (è la lezione già pagata su `brand_media.source`).
-`scripts/constraint-harness.mjs` scrive **davvero**: 67 insert malformati contro un Postgres vero,
-ognuno passa solo se torna il 23514 atteso, tutto dentro una transazione chiusa da un `rollback`.
+`scripts/constraint-harness.mjs` scrive **davvero**: 68 scritture malformate contro un Postgres vero,
+ognuna passa solo se torna lo SQLSTATE atteso (23514, o 23505 per il vincolo unico), tutto dentro una transazione chiusa da un `rollback`.
 I casi nuovi usano i valori che i difetti producevano per davvero — `content_type: 'carousel'`,
 `theme_color: 'red'`, `handles: {"instagram":"acme"}` — non valori inventati.
 
-Prima della migration: **0/67**. Il database accettava ogni singolo valore rotto. Dopo:
-**67/67**. `DATABASE_URL` che non punta a localhost fa uscire lo script con 2 prima di connettersi:
+Prima della migration: **0/68**. Il database accettava ogni singolo valore rotto. Dopo:
+**68/68**. `DATABASE_URL` che non punta a localhost fa uscire lo script con 2 prima di connettersi:
 questo harness scrive, e scrive solo in locale.
 
 La correzione dei dati è stata provata a parte, con ogni forma su un brand pulito e un `rollback`

--- a/scripts/constraint-harness.mjs
+++ b/scripts/constraint-harness.mjs
@@ -26,6 +26,7 @@ import { Client } from 'pg';
 
 const CHECK_VIOLATION = '23514';
 const NOT_NULL_VIOLATION = '23502';
+const UNIQUE_VIOLATION = '23505';
 
 const LOCAL_HOSTS = new Set(['127.0.0.1', 'localhost', '::1', '[::1]']);
 
@@ -109,6 +110,11 @@ const CASES = [
   },
   { what: 'people.role oltre il tetto', sql: person('role', `repeat('x', 201)`), code: CHECK_VIOLATION },
 
+  {
+    what: 'competitors: due volte lo stesso nome per un brand',
+    sql: `insert into public.competitors (brand_id, name) select $1, 'Doppione' from generate_series(1, 2)`,
+    code: UNIQUE_VIOLATION
+  },
   { what: 'competitors.website non http', sql: competitor('website', `'nope'`), code: CHECK_VIOLATION },
   { what: 'competitors.handles oggetto invece che array', sql: competitor('handles', `'{"instagram":"acme"}'::jsonb`), code: CHECK_VIOLATION },
   { what: 'competitors.top_posts non array', sql: competitor('top_posts', `'{}'::jsonb`), code: CHECK_VIOLATION },

--- a/src/lib/content/changelog/2026-09-05-table-value-checks.ts
+++ b/src/lib/content/changelog/2026-09-05-table-value-checks.ts
@@ -6,6 +6,7 @@ export default {
   items: [
     'Brand kit, products, posts, articles, plans, people and competitors now refuse malformed values instead of storing them: a colour has to be a colour, a website has to be a link, a status has to be one the product understands.',
     'Typing your social handle where the website goes now files it under your brand handles instead of saving an address that opens nothing — and the handles already saved that way have been moved across.',
+    'Re-researching your competitors now actually saves them: the write was failing silently, so the chat reported competitors it had not stored.',
     'Competitor handles found by research now show up on the competitors page: they were being saved in a shape no screen could read.'
   ]
 } satisfies ChangelogEntry;

--- a/src/lib/post-from-asset.ts
+++ b/src/lib/post-from-asset.ts
@@ -6,6 +6,12 @@
  * `media_origin` devono muoversi INSIEME. Un post con un mp4 in `media_url` ma `format: 'image'`
  * e' un reel che l'editor apre come una foto e che l'utente scopre rotto in pubblicazione, senza
  * un errore da nessuna parte. Scriverli in tre punti diversi e' esattamente come e' successo.
+ *
+ * Il prefisso di `contentType` NON e' un'etichetta: `publish.ts` ne ricava
+ * `aiGeneratedMedia: !content_type.startsWith('uploaded')`, cioe' la dichiarazione di contenuto AI
+ * al momento della pubblicazione. Un asset preso dalla libreria puo' essere AI o caricato
+ * dall'utente — la libreria lo sa (`brand_media.source`), questa tabella no — quindi qui si
+ * dichiara SEMPRE, che e' il verso prudente: sotto-dichiarare e' il rischio, sovra-dichiarare no.
  */
 import type { PostContentType } from './contracts/post-tools';
 
@@ -24,9 +30,9 @@ export type PostAssetShape = {
 };
 
 const SHAPES: Record<PostAssetType, PostAssetShape> = {
-	image: { mediaKind: 'image', multiple: false, contentType: 'uploaded_image', format: 'image', mediaOrigin: 'user_uploaded' },
+	image: { mediaKind: 'image', multiple: false, contentType: 'generated_image', format: 'image', mediaOrigin: 'user_uploaded' },
 	video: { mediaKind: 'video', multiple: false, contentType: 'generated_video', format: 'video', mediaOrigin: 'video' },
-	carousel: { mediaKind: 'image', multiple: true, contentType: 'uploaded_image', format: 'carousel', mediaOrigin: 'user_uploaded' }
+	carousel: { mediaKind: 'image', multiple: true, contentType: 'generated_image', format: 'carousel', mediaOrigin: 'user_uploaded' }
 };
 
 export function postAssetShape(type: unknown): PostAssetShape | undefined {

--- a/supabase/migrations/20260905200000_table_value_checks.sql
+++ b/supabase/migrations/20260905200000_table_value_checks.sql
@@ -227,6 +227,15 @@ alter table public.people
 -- Corretto lì, vincolato qui. È anche la forma di `brand_social_handles`, che è dove vivono
 -- gli handle del brand.
 
+-- `chat/job-executor.ts` fa `upsert(..., { onConflict: 'brand_id,name' })` su questa tabella, ma
+-- l'unico indice unico e' la primary key: Postgres risponde 42P10 («no unique or exclusion
+-- constraint matching the ON CONFLICT specification») e la chiamata non legge `error`. Il job
+-- "ri-cerca i concorrenti" riporta i concorrenti trovati e scrive ZERO righe, in silenzio. Il
+-- vincolo che mancava e' questo, non una correzione nel writer: 0 duplicati su (brand_id, name)
+-- in produzione, anche ignorando maiuscole e spazi.
+alter table public.competitors
+  add constraint competitors_brand_id_name_key unique (brand_id, name);
+
 alter table public.competitors
   add constraint competitors_website_check
     check (website ~ '^https?://'),


### PR DESCRIPTION
> **Merge this before the next deploy.** PR #372 was merged at commit `0b51e7b7`, which is two of my five commits. The three that follow did not land, and one of them undoes a compliance regression that is **on `dev` right now**.

## What?

Three commits that were pushed to `chore/table-checks` after #372 was merged:

1. **Undoes an AI-disclosure regression currently on `dev`** (the urgent one).
2. Adds the `unique (brand_id, name)` on `competitors` that its own writer upserts on — without it, the "re-research competitors" job writes zero rows and says it succeeded.
3. Records both lessons in `LESSONS.md`.

## Why?

**The regression, precisely.** `publish.ts:380` computes the AI content declaration from the *prefix* of `content_type`:

```ts
aiGeneratedMedia: !String(post.content_type ?? '').startsWith('uploaded')
```

In #372 I changed `post-from-asset.ts` to write `uploaded_image` for the `image` and `carousel` shapes. That was correct against `POST_CONTENT_TYPES` and wrong against `publish.ts`: it flips `aiGeneratedMedia` from `true` to `false`. `create_post_from_asset` pulls from the brand's **media library**, which holds AI-generated media as well as uploads — so an AI image posted through that tool now publishes **without the AI content declaration**.

Before this branch, all three shapes wrote values that do not start with `uploaded` (`image`, `carousel`, `generated_video`) — they all declared. `generated_image` restores exactly that. The comment beside that line states the asymmetry: under-declaring is the risk, over-declaring is not.

This is code, not the migration, so it ships on the next deploy of `dev` regardless of when the migration is applied.

**The missing unique.** `chat/job-executor.ts` calls `upsert(…, { onConflict: 'brand_id,name' })`, but `competitors` has only `competitors_pkey(id)` and the non-unique `competitors_brand_idx`. Postgres answers **42P10**, and the call never destructures `error`, so the job reports the competitors it found and writes nothing. Reproduced on the exact statement. Production has zero duplicates on `(brand_id, name)`, case- and whitespace-insensitive.

## How?

`SHAPES.image` and `SHAPES.carousel` go to `generated_image`; `video` was already on the safe side and is untouched. The file gains a comment explaining that the prefix is not a label but the declaration, so the next person does not repeat it.

`competitors_brand_id_name_key unique (brand_id, name)` joins the migration — the constraint that makes the existing upsert expressible, rather than rewriting the writer.

The proper fix for the declaration — deriving it from `brand_media.source`, which `publishLibraryMediaAsPostMedia` already returns — is deliberately **not** here: it is a compliance decision about which of the eight sources count as the user's own bytes, and it belongs with the `posts` write-point work, not in a constraints PR.

## Testing?

`npm run test:constraints` — the harness is now **68 cases**, and the new one is a unique violation, so it checks the SQLSTATE each case expects (`23514`, or `23505`) rather than assuming one.

- Before the migration: **0/68**.
- After: **68/68**.

The upsert that answered 42P10, after applying the migration locally:

```
INSERT 0 1
INSERT 0 1
 righe_scritte | website_aggiornato
---------------+--------------------
             1 | https://acme2.com
```

976 tests green across `post-from-asset`, `contracts`, `chat` and `publish`. The 16 `webmcp` failures remain pre-existing on `dev`, reproduced on the main checkout with none of these changes.

## Evidence (screenshots/videos)

<details>
<summary>The regression, as it stands on <code>dev</code> at the time of writing</summary>

```
$ git show origin/dev:src/lib/post-from-asset.ts | sed -n '26,29p'
	image:    { … contentType: 'uploaded_image', format: 'image',    … },
	video:    { … contentType: 'generated_video', format: 'video',   … },
	carousel: { … contentType: 'uploaded_image', format: 'carousel', … }
```

`uploaded_image` → `startsWith('uploaded')` → `aiGeneratedMedia: false` → no AI declaration.
</details>

<details>
<summary>42P10 on the statement job-executor issues, before the unique</summary>

```
ERROR:  there is no unique or exclusion constraint matching the ON CONFLICT specification
```
</details>

## Anything Else?

**Every cut of this PR is safe, and that is structural rather than measured.** Exactly one commit touches the file that carries the risk — `src/lib/post-from-asset.ts` — and it is the first. Every other commit on this branch touches `LESSONS.md` and nothing else.

So every prefix contains that commit, which carries both the revert and the `unique`, and the trap is impossible by construction — without reading a line of the file. **Merge it at any depth.** The property holds until someone touches that file a second time, which is precisely the dangerous condition; it does not need re-checking each time a commit is added. Verify it in one command:

```bash
git log --oneline dev..HEAD -- src/lib/post-from-asset.ts   # exactly one commit
```
That is deliberate, and it is the lesson #372 paid for. A PR is not an atomic unit of delivery, and its author does not choose where it gets cut: #372's five commits were five possible states of `dev`, and two of them left the product worse than merging nothing, because commit 3 repaired what commit 2 broke. No review catches that — the PR's full diff was correct. The rule now in `LESSONS.md`: **no commit leaves the branch in a worse state than the one before it**; a fix that undoes your own earlier defect on the same branch gets squashed into it before review, so no cut can separate them. It is Kent Beck's rule the repo already has — reordering separated from behaviour change — applied to the branch instead of the commit.

**How this got through, since it is the more useful part.** No constraint and no test caught either defect. Nothing ties a `startsWith` on a string to what gets declared to a social network, and a resolved `{ error }` nobody reads leaves no trace. Both were found by a second agent reading adjacent lines for unrelated work — and each of us caught the *other's* defect, never our own. Both are now in `LESSONS.md`, with the move that generalises: **grep who reads a *piece* of a column** (`startsWith`, `includes`, `split`), because searching for the whole value never finds a contract disguised as nomenclature.

The migration in #372 is unchanged by this except for the added `unique`; if you have not applied it yet, apply the version on this branch and you get both in one pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
