### PR TITLE
Derive posts.source from the code: the migration is missing 'external'

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -123,13 +123,20 @@ della review, così non esiste taglio che possa separarli. È la regola di Kent 
 già ha — riordino separato dal cambio di comportamento — applicata al ramo invece che al singolo
 commit. Il controllo, prima di chiedere la review:
 ```bash
-git log --oneline <base>..HEAD              # ogni prefisso è uno stato che può finire in produzione
-git show --format= --name-only <commit>     # quali commit toccano il file che porta il rischio
+git log --oneline <base>..HEAD                    # ogni prefisso è uno stato che può finire in produzione
+git log --oneline <base>..HEAD -- <file-rischioso>   # quanti commit lo toccano: uno solo = sicuro per costruzione
 ```
 **La domanda giusta è sulla STRUTTURA, non sul contenuto**: *quali commit toccano il file
-rischioso*, non *quale stringa ci compare*. Se quel file è toccato da un commit solo, la trappola è
+rischioso*, non *quale stringa ci compare*. Il secondo comando risponde in una riga, senza loop e
+senza pipe da cui possa uscire qualcosa di diverso a ogni giro. Se quel file è toccato da un commit solo, la trappola è
 impossibile per costruzione — ogni prefisso lo contiene — e non serve leggere una riga. Se è
 toccato da due e il secondo ripara il primo, è armata comunque, qualunque cosa dica il grep.
+
+**E la stessa cura vale per come si SCRIVE il risultato.** «Solo il primo di quattro commit tocca
+quel file» invecchia al quinto commit e obbliga a riverificare; «un solo commit tocca quel file»
+resta vero finché nessuno lo tocca una seconda volta — che è esattamente la condizione di pericolo.
+Un'affermazione che nomina un conteggio va rifatta a ogni push, una che nomina la proprietà si
+difende da sola.
 
 **E il controllo si sceglie perché non oscilla, non perché è breve.** Verificando proprio questa
 cosa, `grep` su un `git cat-file` in un `for` ha dato a due persone tre risposte diverse alla stessa
@@ -779,7 +786,7 @@ dove non lo è: resta non fatale, smette di essere muto.
 vincolo nemmeno volendo: è gestione d'errore che non può funzionare. L'errore va letto dal valore
 risolto.
 
-## Il vocabolario di una colonna non si decide senza sapere CHI la legge
+## Il vocabolario di una colonna si deriva dal CODICE, non dalle righe che ci sono
 
 **Segnale.** Una correzione ovvia: un valore fuori dall'enum, sostituito con quello «giusto»
 guardando la costante. Nessun test rosso, il vincolo passa, la PR sembra più pulita di prima.
@@ -799,6 +806,25 @@ perché quello non compare cercando il valore intero. Se un lettore ne ricava un
 conformità, di pagamento o di pubblicazione, il valore non è nomenclatura: è un contratto, e la
 riga accanto va letta prima di toccarlo. Il default in caso di dubbio lo dice già il commento
 accanto a quella riga: sovra-dichiarare non è un rischio, sotto-dichiarare sì.
+
+**E l'altra metà della stessa regola: nemmeno chi la SCRIVE.** Lo stesso giorno, nella stessa PR,
+il vincolo `posts.source in ('plan','manual','radar','guest_preview')` è stato costruito contando
+le righe di produzione — zero violazioni, elenco confermato. Ma due percorsi vivi scrivono
+`cross_post` (il clone cross-post) e `founder` (la consegna video dall'admin): sono rari e non
+avevano ancora prodotto righe. Il vincolo sarebbe morto con un 23514 alla prima esecuzione di uno
+dei due, cioè avrebbe rotto quello che il codice scrive oggi.
+
+**Un vocabolario convalidato contro i dati esistenti non è convalidato contro il codice.** Le righe
+dicono soltanto se la migration passa adesso; non dicono se il vincolo è giusto. L'elenco si deriva
+dai punti di SCRITTURA — e qui lo strumento c'è già: la sezione C di `scripts/schema-drift-check.mjs`
+confronta ogni literal del codice con le liste `CHECK` dei file di migration e stampa file e riga.
+
+**E conta QUANDO la lanci: prima di decidere, non prima di aprire la PR.** Non è una sfumatura.
+Lanciata prima di scegliere il vocabolario, ti dice qual è la lista ammessa: è un input. Lanciata
+quando la lista l'hai già scelta, ti dice solo se per caso avevi ragione — e a quel punto la leggi
+da autore, cioè cercando conferma. Qui è stata lanciata dopo il merge, ed è esattamente per questo
+che il difetto è passato: lo strumento aveva la risposta dal primo minuto, io sono arrivato con una
+tesi da difendere. Il momento in cui guardi decide se stai leggendo o se ti stai dando ragione.
 
 **Il corollario sul metodo.** A trovarlo non è stato un vincolo né la suite: è stato un altro
 agente che leggeva la riga accanto per un lavoro diverso. E non e' «due persone attente»: ognuno

--- a/changelog/2026-09-05-table-value-checks.md
+++ b/changelog/2026-09-05-table-value-checks.md
@@ -124,6 +124,53 @@ Stesso ragionamento per `posts.platform`, `posts.platforms` e `posts.format`: i 
 planner/onboarding ci scrivono l'output del modello senza normalizzarlo, e un CHECK lì fermerebbe
 l'autopilot di notte. `format` prende solo un tetto di lunghezza.
 
+## `external` non lo trova nessun grep, e il motivo cambia il metodo
+
+`cross_post` e `founder` erano letterali scritti nel punto dell'insert, quindi una ricerca testuale
+li trova. `external` no: al punto dell'insert (`manual-posting.ts:306`) c'è una **variabile**
+— `opts.input.source ?? 'manual'` — e il valore nasce in
+`POST /api/v1/brands/:slug/posts`, l'endpoint con cui un agente esterno deposita un post già
+scritto. Il vincolo senza `external` gli avrebbe dato 23514 su **ogni** chiamata, e in produzione
+non si sarebbe visto applicando la migration: `posts.source` ha solo `plan`, `radar` e `manual`,
+quindi l'`add constraint` riesce lo stesso. Si sarebbe visto alla prima scrittura.
+
+Quindi la domanda giusta non è «manca un valore?» ma **«su quali colonne vincolate il valore
+arriva da un parametro invece che da una costante?»** — e per ognuna si risale ai chiamanti fino
+alla costante vera. Rifatto il giro su tutte le colonne della migration, sono uscite altre tre
+cose, nessuna delle quali era un valore mancante:
+
+- **`posts.video_resolution` non è un vocabolario, è una forma.** Il valore arriva da
+  `KIE_VIDEO_RESOLUTION` e `KIE_VIDEO_UPSCALE_RESOLUTION`, cioè dalla configurazione, e
+  `clampVideoResolution` restituisce il default d'ambiente quando l'input non è in elenco. Un
+  elenco chiuso si sarebbe rotto al primo cambio di env — la stessa ragione per cui i tetti di
+  piano non stanno nel database. Ora è `^[0-9]{3,4}p$`.
+- **`brand_news_sources.lang` idem, e per un motivo peggiore.** Il form
+  (`settings/radar/+page.server.ts:83`) prende il valore grezzo e lo taglia a cinque caratteri
+  senza allowlist: il menu ha dodici voci, l'endpoint accetta qualunque cosa, e un `pt-BR` sarebbe
+  arrivato alla colonna. Ora è `^[A-Za-z-]{2,5}$`.
+- **`brand_kit.site_type` era un cast, non un controllo.** `(profile.site_type as SiteType)` non
+  guarda niente: il modello risponde su uno schema con `enum`, ma resta un modello, e un decimo
+  valore avrebbe fatto fallire l'onboarding invece di degradare a `generic`. Ora passa da
+  `clampSiteType`, accanto a `sanitizeThemeColor`.
+
+`posts.content_type` invece regge: tutte le vie che ci arrivano da variabile
+(`manual-posting`, `scheduler`, `async-jobs`, `createSingleContent`) risolvono dentro i sette.
+
+## Un test che rompe da solo, invece di un caso in più
+
+Un caso in più nell'harness copre un valore in più; non fallisce il giorno in cui il codice ne
+impara un settimo. `src/lib/db-vocabularies.test.ts` confronta l'insieme dichiarato nel codice con
+quello ammesso dalla migration, per `posts.status`, `posts.content_type`, `posts.source` e
+`brand_kit.site_type`, e rompe **in entrambe le direzioni**: valore nuovo nel codice e CHECK
+fermo, oppure CHECK allargato e costante rimasta indietro. Visto rosso in tutte e due prima di
+essere verde, e con la guardia contro il passaggio a vuoto (una scansione che non trova più niente
+fallisce, non passa).
+
+Perché funzioni serviva l'elenco unico che non c'era: `POST_SOURCES` in `contracts/post-tools.ts`,
+da cui il CHECK è derivato. E `PostAuthorship` adesso è
+`['manual','external'] as const satisfies readonly PostSource[]`: se un giorno esce dall'elenco, lo
+dice il compilatore qui invece di Postgres in produzione.
+
 ## Il test: guardarlo fallire prima
 
 Un vincolo senza un test che prova a violarlo è una speranza — e la suite qui mocka Supabase, dove

--- a/src/lib/brand-fields.ts
+++ b/src/lib/brand-fields.ts
@@ -37,6 +37,30 @@ export function sanitizeThemeColor(input: unknown): string | null {
   return HEX_COLOR.test(v) ? v : null;
 }
 
+/**
+ * Gli archetipi che `brand_kit.site_type` ammette — ed è da QUESTO elenco che il CHECK del
+ * database è derivato, non viceversa. Il valore arriva da un modello: risponde su uno schema con
+ * `enum`, ma resta un modello, e prima c'era un cast (`as SiteType`) che non guardava niente. Un
+ * decimo valore inventato arriverebbe alla colonna e la farebbe rifiutare, cioè romperebbe
+ * l'onboarding invece di degradare a `generic`.
+ */
+export const SITE_TYPES = [
+  'ecommerce',
+  'saas',
+  'portfolio',
+  'local_service',
+  'creator',
+  'media',
+  'mobile_app',
+  'service',
+  'generic'
+] as const;
+
+export function clampSiteType(value: unknown): (typeof SITE_TYPES)[number] | undefined {
+  const v = String(value ?? '').trim();
+  return (SITE_TYPES as readonly string[]).includes(v) ? (v as (typeof SITE_TYPES)[number]) : undefined;
+}
+
 /** Un sito digitato a mano diventa un URL cliccabile; vuoto resta null. */
 export function normalizeWebsite(raw: string): string | null {
   const v = String(raw ?? '').trim();

--- a/src/lib/content/changelog/2026-09-05-table-value-checks.ts
+++ b/src/lib/content/changelog/2026-09-05-table-value-checks.ts
@@ -7,6 +7,7 @@ export default {
     'Brand kit, products, posts, articles, plans, people and competitors now refuse malformed values instead of storing them: a colour has to be a colour, a website has to be a link, a status has to be one the product understands.',
     'Typing your social handle where the website goes now files it under your brand handles instead of saving an address that opens nothing — and the handles already saved that way have been moved across.',
     'Re-researching your competitors now actually saves them: the write was failing silently, so the chat reported competitors it had not stored.',
-    'Competitor handles found by research now show up on the competitors page: they were being saved in a shape no screen could read.'
+    'Competitor handles found by research now show up on the competitors page: they were being saved in a shape no screen could read.',
+    'Posts filed through the API by an external agent keep working: the new checks were about to reject every one of them.'
   ]
 } satisfies ChangelogEntry;

--- a/src/lib/contracts/post-tools.ts
+++ b/src/lib/contracts/post-tools.ts
@@ -44,6 +44,23 @@ export const POST_CONTENT_TYPES = [
 ] as const;
 export type PostContentType = (typeof POST_CONTENT_TYPES)[number];
 
+/**
+ * I valori che `posts.source` assume davvero. Non è deducibile da un grep: al punto dell'insert
+ * (`manual-posting.ts`) c'è una variabile, e `external` — l'agente esterno che deposita un post
+ * via `POST /api/v1/brands/:slug/posts` — nasce quattordici file più in là. L'elenco sta qui
+ * perché il CHECK del database è derivato da QUESTO, e un test lo tiene onesto.
+ */
+export const POST_SOURCES = [
+  'plan',
+  'manual',
+  'radar',
+  'guest_preview',
+  'cross_post',
+  'founder',
+  'external'
+] as const;
+export type PostSource = (typeof POST_SOURCES)[number];
+
 // ── update_post ──────────────────────────────────────────────────────────────
 
 export type UpdatePostResult = {

--- a/src/lib/db-vocabularies.test.ts
+++ b/src/lib/db-vocabularies.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { POST_STATUSES, POST_CONTENT_TYPES, POST_SOURCES } from './contracts/post-tools';
+import { SITE_TYPES } from './brand-fields';
+
+/**
+ * Il CHECK vive nel database, l'elenco vive nel codice, e i due divergono in silenzio: la suite
+ * mocka Supabase, quindi un insert finto accetta qualunque stringa e il test è verde per
+ * costruzione (LESSONS.md, `brand_media.source`).
+ *
+ * `constraint-harness.mjs` prova che un valore fuori elenco viene RIFIUTATO, ma un caso in più
+ * copre un valore in più: non fallisce il giorno in cui il codice ne impara un settimo. Questo
+ * invece sì — confronta l'insieme dichiarato nel codice con quello ammesso dalla migration, e
+ * rompe in entrambe le direzioni: valore nuovo nel codice e CHECK non aggiornato, oppure CHECK
+ * allargato e costante rimasta indietro.
+ *
+ * `posts.source` è il motivo per cui esiste: `external` non era in nessun grep di letterali —
+ * al punto dell'insert c'è una variabile e il valore nasce quattordici file più in là — e
+ * sarebbe arrivato in produzione come un 23514 su ogni chiamata di
+ * `POST /api/v1/brands/:slug/posts`.
+ */
+
+const ROOT = fileURLToPath(new URL('../../', import.meta.url));
+const MIGRATIONS = join(ROOT, 'supabase/migrations');
+
+function allowedByTheDatabase(constraint: string): string[] {
+  let allowed: string[] = [];
+
+  for (const file of readdirSync(MIGRATIONS).filter((f) => f.endsWith('.sql')).sort()) {
+    const sql = readFileSync(join(MIGRATIONS, file), 'utf8');
+    const at = sql.lastIndexOf(`add constraint ${constraint}`);
+    if (at < 0) continue;
+
+    const open = sql.indexOf('(', sql.indexOf('check', at));
+    let depth = 0;
+    let end = open;
+    for (let i = open; i < sql.length; i++) {
+      if (sql[i] === '(') depth++;
+      else if (sql[i] === ')' && --depth === 0) {
+        end = i;
+        break;
+      }
+    }
+    allowed = [...sql.slice(open, end).matchAll(/'([a-z_]+)'/g)].map((m) => m[1]);
+  }
+
+  return allowed;
+}
+
+const VOCABULARIES = [
+  { constraint: 'posts_status_check', declared: POST_STATUSES },
+  { constraint: 'posts_content_type_check', declared: POST_CONTENT_TYPES },
+  { constraint: 'posts_source_check', declared: POST_SOURCES },
+  { constraint: 'brand_kit_site_type_check', declared: SITE_TYPES }
+] as const;
+
+describe('il vocabolario del codice e quello del database sono lo stesso insieme', () => {
+  for (const { constraint, declared } of VOCABULARIES) {
+    it(`${constraint} ammette esattamente i valori dichiarati nel codice`, () => {
+      const allowed = allowedByTheDatabase(constraint);
+
+      expect(allowed.length, `nessun valore letto da ${constraint}: la scansione è passata a vuoto`).toBeGreaterThan(1);
+      expect([...allowed].sort()).toEqual([...declared].sort());
+    });
+  }
+});

--- a/src/lib/server/brand-analysis.ts
+++ b/src/lib/server/brand-analysis.ts
@@ -11,7 +11,7 @@
  * package.
  */
 import { swallow } from '$lib/server/swallow';
-import { sanitizeThemeColor } from '$lib/brand-fields';
+import { SITE_TYPES, clampSiteType, sanitizeThemeColor } from '$lib/brand-fields';
 import type { GoogleGenAI } from '@google/genai';
 import { browserlessContent, isBrowserlessConfigured } from './browserless';
 import { aiStructured } from '$lib/server/ai-text';
@@ -162,7 +162,7 @@ const brandProfileSchema = {
         category: { type: 'string' as const, description: 'Business category (e.g. "AI Application Development")' },
         site_type: {
             type: 'string' as const,
-            enum: ['ecommerce', 'saas', 'portfolio', 'local_service', 'creator', 'media', 'mobile_app', 'service', 'generic'],
+            enum: [...SITE_TYPES],
             description:
                 'The business archetype of this site. ecommerce = sells physical/digital products with a cart; saas = software/tech product with pricing/signup/docs; portfolio = freelancer/creative/agency showcasing work & case-studies; local_service = a physical local business (restaurant, gym, salon, clinic, hotel); creator = personal brand monetising an audience; media = publisher/newsroom whose product is the content itself; mobile_app = a phone app as the product; service = a service business that is not tied to one place; generic = none of these clearly. Use the DETECTED ARCHETYPE hint as a strong prior but decide from the actual content.',
         },
@@ -587,7 +587,7 @@ export async function runBrandAnalysis(
     // the model returned nothing usable.
     profile.site_type = ecommerceProducts.length > 0
         ? 'ecommerce'
-        : ((profile.site_type as SiteType) ?? archetypeHint);
+        : (clampSiteType(profile.site_type) ?? archetypeHint);
     if (metadata.faviconUrl) profile.favicon_url = metadata.faviconUrl;
     if (metadata.logos.length > 0) profile.logos = metadata.logos;
     if (metadata.fonts.length > 0) profile.fonts = metadata.fonts;

--- a/src/lib/server/manual-posting.ts
+++ b/src/lib/server/manual-posting.ts
@@ -1,4 +1,5 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
+import type { PostSource } from '$lib/contracts/post-tools';
 import { structured } from '$lib/server/research';
 import { withBrandContext } from '$lib/server/ai-log';
 import { aiActCopyGuardrail } from '$lib/ai-act';
@@ -29,7 +30,10 @@ export type ManualPostMode = 'now' | 'schedule' | 'draft' | 'propose';
 
 export type ManualPostOutcome = 'pending_user' | 'scheduled' | 'published';
 
-export type PostAuthorship = 'manual' | 'external';
+/** Chi deposita il post. `satisfies` è il punto: se uno di questi esce da `POST_SOURCES`, e
+ *  quindi dal CHECK, il compilatore lo dice qui invece che Postgres in produzione. */
+const POST_AUTHORSHIPS = ['manual', 'external'] as const satisfies readonly PostSource[];
+export type PostAuthorship = (typeof POST_AUTHORSHIPS)[number];
 
 type DateSource = (input: CreateManualPostInput, tz: string) => string | null;
 

--- a/supabase/migrations/20260905200000_table_value_checks.sql
+++ b/supabase/migrations/20260905200000_table_value_checks.sql
@@ -68,6 +68,21 @@ update public.brands set website = null
 -- output del modello non normalizzato, e un CHECK lì fermerebbe l'autopilot di notte.
 -- `uploaded_video` entra nel vocabolario perché `upload-media` lo scrive ed è legittimo; `image`
 -- e `carousel` no: erano formati finiti in una colonna di tipi, e il codice è stato corretto.
+-- `cross_post` e `founder` in `source` sono la stessa storia: nessuna riga in produzione, ma due
+-- percorsi vivi che li scrivono (il clone di `cross_post` e la consegna video dall'admin). Un
+-- vincolo che li rifiuta è il vincolo sbagliato, non i dati — li ha trovati la sezione C di
+-- `schema-drift-check.mjs`, che confronta i literal del codice con le liste di questo file.
+--
+-- `external` invece NON lo trova nessun grep di literal: al punto dell'insert
+-- (`manual-posting.ts:306`) c'è una variabile, e il valore nasce in
+-- `POST /api/v1/brands/:slug/posts`, l'endpoint con cui un agente esterno deposita un post. La
+-- fonte vera è il tipo `PostAuthorship`, e ora `POST_SOURCES` in `contracts/post-tools.ts` è
+-- l'elenco unico da cui questo `check` è derivato — con un test che fallisce se i due divergono.
+--
+-- `video_resolution` non ha un vocabolario ma una FORMA: il valore arriva da
+-- `KIE_VIDEO_RESOLUTION` / `KIE_VIDEO_UPSCALE_RESOLUTION`, cioè da configurazione. Un elenco
+-- chiuso qui si romperebbe al primo cambio di env, che è la stessa ragione per cui i tetti di
+-- piano non stanno nel database.
 
 alter table public.posts
   add constraint posts_status_check
@@ -78,11 +93,11 @@ alter table public.posts
       'uploaded_image', 'uploaded_video', 'text', 'link'
     )),
   add constraint posts_source_check
-    check (source in ('plan', 'manual', 'radar', 'guest_preview')),
+    check (source in ('plan', 'manual', 'radar', 'guest_preview', 'cross_post', 'founder', 'external')),
   add constraint posts_video_render_status_check
     check (video_render_status in ('rendering', 'done', 'failed')),
   add constraint posts_video_resolution_check
-    check (video_resolution in ('480p', '720p', '1080p')),
+    check (video_resolution ~ '^[0-9]{3,4}p$'),
   add constraint posts_video_duration_check
     check (video_duration_seconds > 0 and video_duration_seconds <= 3600),
   add constraint posts_revisions_count_check
@@ -275,8 +290,12 @@ alter table public.brand_sites
 
 -- ── brand_news_sources (265 righe) ─────────────────────────────────────────────────────────────
 
+-- `lang` è una FORMA, non l'elenco delle 12 voci del menu: il form
+-- (`settings/radar/+page.server.ts:83`) prende il valore grezzo e lo taglia a 5 caratteri senza
+-- allowlist, quindi un `pt-BR` arriva alla colonna. In produzione c'è già un `tr` che il menu non
+-- offre. Due-cinque lettere o trattino: blocca la spazzatura, non blocca il form.
 alter table public.brand_news_sources
   add constraint brand_news_sources_value_check
     check (btrim(value) <> '' and length(value) <= 500),
   add constraint brand_news_sources_lang_check
-    check (lang ~ '^([a-z]{2}|auto)$');
+    check (lang ~ '^[A-Za-z-]{2,5}$');


### PR DESCRIPTION
> **Do not apply the merged migration.** It is missing `'external'`, and applied as it stands it answers 23514 on every call to `POST /api/v1/brands/:slug/posts` — the endpoint an external agent uses to file a post.

## What?

Two commits, rebased onto current `dev`. **Exactly one touches the migration**, so no cut of this PR can apply a half-corrected constraint:

```
$ git log --oneline dev..HEAD -- supabase/migrations/
18be4963 Derive posts.source from the code, not from a grep of literals
```

1. `posts.source` admits `'external'`; `video_resolution` and `lang` become shape checks; `site_type` gets clamped instead of cast; `POST_SOURCES` becomes the single list the CHECK is derived from; a test that breaks when the two diverge.
2. The four `LESSONS.md` entries this branch paid for.

## Why?

`'external'` reaches `posts.source` through a variable, so no search for literals could find it:

```
api/v1/brands/[slug]/posts/+server.ts:63   source: 'external'  → createManualPost
lib/server/manual-posting.ts:306           source: opts.input.source ?? 'manual'
lib/server/manual-posting.ts:32            type PostAuthorship = 'manual' | 'external'
```

`cross_post` and `founder` were literals *at the insert*, which is why a text search reached those two and not this one. **And applying the migration would not have revealed it**: production holds only `plan` (291), `radar` (123), `manual` (104), so the `ALTER` succeeds. It fails at the first write — the worst way to find out.

So the question is not *"is a value missing"* but **"which constrained columns take their value from a parameter rather than a constant?"** — and for each, walk the callers back to the constant that governs it. Where a type already enumerates the allowed values, that type is the source and the CHECK must be derived from it, or the two lists diverge silently at the first change.

Re-running that sweep over **every** column in the migration turned up three more, and none was a missing value — each was a constraint wrong *in kind*:

| column | what it actually is | now |
|---|---|---|
| `posts.video_resolution` | config, not vocabulary — `KIE_VIDEO_RESOLUTION` / `KIE_VIDEO_UPSCALE_RESOLUTION`, and `publish.ts:164` writes the env value to the column | `~ '^[0-9]{3,4}p$'` |
| `brand_news_sources.lang` | `settings/radar/+page.server.ts:83` takes the raw form field, slices to 5 chars, no allowlist — the menu shows 12 options, the endpoint accepts `pt-BR` | `~ '^[A-Za-z-]{2,5}$'` |
| `brand_kit.site_type` | `(profile.site_type as SiteType)` is a **cast**: it inspects nothing, so a tenth model value fails onboarding instead of degrading to `generic` | `clampSiteType`, beside `sanitizeThemeColor` |

`posts.content_type` holds: every variable path (`manual-posting`, `scheduler`, `async-jobs`, `createSingleContent`) resolves inside the seven.

## How?

**The guard is not another harness case.** One more case covers one more value and still misses the seventh. `src/lib/db-vocabularies.test.ts` compares the set the code declares against the list the migration admits, for `posts.status`, `posts.content_type`, `posts.source` and `brand_kit.site_type`, and breaks **both ways** — a value the code learns without the check, or a check widened without the constant. Plus a guard so an empty scan fails rather than passes.

That needed the single list that did not exist: **`POST_SOURCES`** in `contracts/post-tools.ts`, from which the CHECK is derived. `PostAuthorship` is now `['manual','external'] as const satisfies readonly PostSource[]`, so containment is the compiler's job rather than Postgres's.

`SITE_TYPES` went into `src/lib/brand-fields.ts` rather than the `site-analysis` package: `@anomalia/*` resolves from the main checkout, so a package change cannot be verified from a worktree — and not shipping what you cannot verify is the rule this branch has already paid for twice.

## Testing?

- **`db-vocabularies.test.ts` watched red in both directions**, then green: migration without `external` → red; code learning a value the check lacks → red.
- **`npm run test:constraints`: 0/68 before the migration, 68/68 after.**
- The values that *must* be accepted, checked against the local stack in a rolled-back transaction: `external`, `1080p`, `pt-BR`, `mobile_app` — all four insert.
- **`npm run test:unit`: 7 376 passed, 0 failed.** The 16 `webmcp` failures I reported earlier as environmental are **gone**, which confirms it: they came from `@anomalia/*` and zod resolving out of the main checkout's `.bun` store. This worktree now has its own `node_modules`.
- `node scripts/schema-drift-check.mjs`: no rejected values; 1 divergence remains, the pre-existing unapplied `ai_calls_org_id`.

Not tested: no browser pass — this is a migration plus pure functions.

## Evidence (screenshots/videos)

<details>
<summary>The test failing in the direction that matters — the code learns a value, the check does not</summary>

```
× posts_source_check ammette esattamente i valori dichiarati nel codice
  → expected [ 'cross_post', 'founder', …(4) ] to deeply equal [ 'cross_post', 'external', …(5) ]
```
</details>

<details>
<summary>Values that must keep working, on the local stack</summary>

```
insert posts(source='external')                → INSERT 0 1
insert posts(video_resolution='1080p')         → INSERT 0 1
insert brand_news_sources(lang='pt-BR')        → INSERT 0 1
insert brand_kit(site_type='mobile_app')       → INSERT 0 1
```
</details>

## Anything Else?

**Production is still untouched** — 10 pre-existing checks, zero of the 46, no `competitors_brand_id_name_key`, the two handles still in the website field. Deploys do not run migrations, and `schema-drift-check.mjs` cannot tell you otherwise: it probes columns, and a constraint-only migration adds none. It says so itself — *"46 migration cambiano solo vincoli/policy/funzioni: la loro applicazione non è deducibile da fuori"*.

**This is the second time a constraint in this migration was wrong because I derived a vocabulary from data instead of code.** The first was `cross_post`/`founder`, found by the drift check's section C after I had dismissed that script on a `grep` that silently returned zero. This one section C could not find either, because the value is not a literal. Both are now one `LESSONS.md` entry, and the test above is the part that does not depend on anyone remembering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
