### PR TITLE
Close cross-tenant writes on the media bucket

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -1332,3 +1332,33 @@ chi stava per rimuovere ha detto QUALI TRE tool, prima di toccarli: «rimuovo qu
 lettura» non avrebbe dato niente da controllare. Quel messaggio si scrive quando il codice non
 esiste ancora — cioè quando viene peggio, e la tentazione è scriverlo dopo, a risposta nota.
 Scritto dopo non serve a niente: è un resoconto, e un resoconto non si può contraddire in tempo.
+
+## Una policy permissiva può solo aggiungere accesso, e quella nata dalla dashboard non è in nessun file
+
+Un red team ha scritto un file nella cartella di un altro utente sul bucket `media`, con un account
+autoregistrato. In `supabase/migrations` non c'era niente di sbagliato: `media insert own folder`
+(0004) chiedeva `(storage.foldername(name))[1] = auth.uid()::text` dal primo giorno. Accanto, creata
+a mano dalla dashboard e in nessun file del repo, c'era `Allow authenticated uploads to media
+bucket` — `with check (bucket_id = 'media')`, nessuna condizione sulla cartella.
+
+**Segnale**: la policy stretta esiste, la leggi, sembra giusta, e l'attacco passa lo stesso. Oppure:
+`npm run db:migrate` su un database pulito produce uno schema che si comporta **diversamente** dalla
+produzione, e nessuno dei due è rotto.
+
+**Mossa**: quando una policy «non difende», non rileggerla — **elencale tutte**, sullo stesso
+oggetto:
+
+```sql
+select policyname, roles::text, cmd, qual, with_check
+from pg_policies where schemaname = 'storage' and tablename = 'objects';
+```
+
+e confronta l'elenco con quello che le migration creano. Vale anche per i bucket
+(`storage.buckets`): `email-assets` esiste in produzione e in nessuna migration.
+`scripts/schema-drift-check.mjs` guarda tabelle e colonne, **non** policy e bucket.
+
+**La regola dietro**: le policy permissive si sommano in **OR**. Una policy permissiva non può
+restringere niente — la più larga vince sempre, e ogni policy stretta che le sta accanto è
+decorativa. Quindi «aggiungo una policy più stretta» non è mai una fix: la fix è togliere la larga.
+E un test che verifica una policy deve prima **ricreare la deriva** che la produzione ha davvero,
+altrimenti misura un database che non è mai esistito e passa mentre il buco resta aperto.

--- a/changelog/2026-09-05-storage-tenant-isolation.md
+++ b/changelog/2026-09-05-storage-tenant-isolation.md
@@ -1,0 +1,104 @@
+# Lo storage torna a essere del suo tenant, e la deriva che l'aveva aperto
+
+Un red team, con un account autoregistrato, ha scritto un file da 20 MB **dentro la cartella di un
+altro utente** sul bucket `media`, e ha fatto servire un SVG con dentro `<script>` da un URL
+pubblico. Non c'era nessun bug nel codice: la policy che lo permetteva non è in nessuna migration.
+
+`Allow authenticated uploads to media bucket` — INSERT, `authenticated`, `with check (bucket_id =
+'media')`, nessuna condizione sulla cartella — è stata creata a mano dalla dashboard. Le policy
+permissive si sommano in OR, quindi quella riga rendeva decorativa `media insert own folder` (0004),
+che c'era dal primo giorno e non ha mai difeso niente: una policy permissiva può solo aggiungere
+accesso, mai toglierlo. Stessa storia per il bucket `email-assets`, che esiste in produzione e in
+nessun file: `npm run db:migrate` su un database pulito non ha mai prodotto lo schema che gira
+davvero.
+
+## Il censimento prima della policy, perché la cartella non è sempre l'utente
+
+La tentazione era `(storage.foldername(name))[1] = auth.uid()::text` e via. Sarebbe stata
+un'interruzione, non una fix: **due prefissi sono legittimi**, e ognuno è dimostrato due volte, dagli
+oggetti in produzione e dal codice che li scrive.
+
+- `${userId}/…` — upload della chat, cover e immagini inline del blog, avatar, logo di onboarding,
+  still generati, thumbnail YouTube, clip di riferimento. 2 018 oggetti.
+- `${brandId}/…` — motion video, voiceover, musica. 1 010 oggetti. E **non** è un cron: le rotte
+  `app/[brand]/motion-video/+server.ts` e `.../render/+server.ts` passano `locals.supabase` dentro
+  `render-tools.ts` e `gemini-audio.ts`, quindi la policy le vede. Una policy sul solo `auth.uid()`
+  avrebbe spento il motion video il giorno stesso.
+
+Un terzo caso — `${brandId}/onboarding/`, 920 oggetti, ancora scritti oggi — nasce da
+`uploadPostImage(admin, brand.id, …)`: `scheduler.ts` e `articles.ts` passano un brand id nel
+parametro che si chiama `userId`. Gira solo con la chiave di servizio, quindi la RLS non lo vede,
+ma il nome mente e vale la pena saperlo.
+
+La policy nuova chiede la seconda domanda con `auth_brand_ids()`, che è la funzione che il resto
+dello schema usa già per «i brand su cui questo chiamante può agire» (`brand-knowledge read
+shared`, 0090). Una domanda sola, scritta in un posto solo.
+
+## I numeri sono misurati, non scelti
+
+`media`: 3 089 oggetti, p50 647 kB, p99 8.4 MB, **max 44 MB** (un mp4 generato). I 12 MB di `wall`
+avrebbero rifiutato i video: il limite è 64 MB, sopra l'oggetto più grande che esiste davvero.
+`email-assets`: 864 oggetti, max 1.9 MB, e l'unico scrittore già rifiuta sopra i 2 MB — 5 MB è
+margine, non un obiettivo.
+
+## SVG: allowlist sul bucket, e il tipo lo decidiamo noi
+
+Due strade. **Normalizzare il content-type in scrittura** avrebbe voluto dire toccare quindici punti
+di upload e sperare che il sedicesimo si ricordasse: una regola sparsa in quindici file diverge al
+primo cambiamento. **L'allowlist sul bucket** è invece un posto solo, la vede ogni scrittore —
+compresi il browser che carica in diretta e i signed upload — e vale anche per la chiave di
+servizio. Su `media` non c'è **nessun** SVG in produzione, quindi non si spegne niente di
+legittimo; su `email-assets` ce n'è esattamente uno, ed è il bug: `trends/….jpg`, servito come
+`image/svg+xml`, `owner_id` nullo — cioè raccolto da un sito esterno dal recap settimanale.
+
+Storage non ha una denylist, quindi le immagini sono elencate una per una e video e audio restano
+wildcard: così ogni contenitore che un telefono può produrre continua a passare senza doverlo
+nominare.
+
+Le due cose insieme non bastavano però, perché l'allowlist confronta **l'header intero**:
+`image/png` in lista non ammette `image/png;charset=UTF-8`, e in produzione un oggetto così c'è. Da
+qui la seconda metà: `weekly-recap.ts` non inoltra più il content-type del server remoto, lo
+**nomina lui** a partire da una tabella di formati che sappiamo riservire. È anche la fix di
+radice — il tipo di un file nostro non lo decide un sito che non controlliamo — e ha tolto due
+ternari e una `startsWith` invece di aggiungere codice.
+
+## Tassonomia del blog: quattro policy che nessuno leggeva
+
+`blog_categories`, `blog_tags`, `blog_authors` e `brand_article_tags` avevano una `*_public_read`
+con `USING (true)`: un client anonimo leggeva il `brand_id` di ogni brand che avesse mai creato un
+tag, cioè l'elenco dei tenant. In cambio di niente, perché il blog pubblico non le usa: `blog-site.ts`
+legge ogni pagina pubblica con la chiave di servizio, e lo dice nella sua prima riga. `brand_articles`
+non è mai stato pubblico, quindi la tassonomia pendeva da righe che anon non poteva vedere comunque.
+
+Scartata la restrizione a livello di colonna (lasciare `name`/`slug` e togliere `brand_id`): più
+fragile, e risolve un problema che dopo il drop non esiste più. Le policy owner sono `FOR ALL` e
+tengono i membri.
+
+## `/a/<code>`: revoca sì, scadenza no
+
+Qui il report chiedeva di legare il link alla membership. **Non l'ho fatto**, e vale la pena dirlo:
+l'accesso pubblico di `/a/<code>` è una decisione presa il giorno prima e scritta in
+`20260905090000_brand_media_short_code.sql` — «Andrea ha scelto l'accesso PUBBLICO». Ribaltarla di
+nascosto dentro una PR di sicurezza sarebbe stato peggio del buco.
+
+Quello che mancava davvero è ciò che `shared_views` ha e questo non aveva: **un modo di spegnere un
+link senza distruggere l'asset**. Oggi l'unica revoca è cancellare il file, che lo toglie anche a
+chi doveva tenerlo. `link_revoked_at` è la stessa risposta di `shared_views` — una riga che si
+revoca, riletta a ogni richiesta invece che creduta una volta sola — meno la scadenza, che
+romperebbe il motivo per cui il codice corto esiste.
+
+Resta aperto: la revoca non ha ancora una superficie (niente UI, niente CLI), e togliere un membro
+da un brand non revoca i link che ha già in mano.
+
+## Il test che poteva fallire
+
+La suite mocka Supabase: un insert finto accetta qualunque cosa e non vede una policy, un limite di
+dimensione o una allowlist, perché nessuna delle tre vive nel nostro codice.
+`scripts/storage-policy-harness.mjs` alza un Postgres vero, gotrue e **storage-api vero**, applica
+tutte le migration, **ricrea a mano la deriva della dashboard** — senza quel passo misurerebbe un
+database che la produzione non ha mai avuto — e poi rigioca le mosse del red team via HTTP.
+
+Con `--skip-fix` fallisce in otto punti, e sono esattamente quelli del report. Ha anche trovato un
+mio errore: il primo controllo «il proprietario legge ancora la sua tassonomia» passava grazie alla
+policy che stavo togliendo, perché il seed non scriveva in `org_members`. Un test che passa per il
+motivo sbagliato è il difetto che questo repository ha già pagato cinque volte.

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "test:durability": "npm run eval:durability",
     "postinstall": "patch-package",
     "eval:durability": "vite-node --config scripts/vite-node.config.ts scripts/eval/durability.ts",
-    "test:constraints": "node scripts/constraint-harness.mjs"
+    "test:constraints": "node scripts/constraint-harness.mjs",
+    "test:storage-policies": "node scripts/storage-policy-harness.mjs"
   },
   "devDependencies": {
     "@internationalized/date": "^3.12.0",

--- a/scripts/storage-policy-harness.mjs
+++ b/scripts/storage-policy-harness.mjs
@@ -1,0 +1,487 @@
+/**
+ * Storage policy harness: replays, against a REAL Postgres and a REAL storage-api, the moves a red
+ * team actually landed on production.
+ *
+ * The unit suite mocks Supabase, so a storage insert there accepts anything — it cannot see an RLS
+ * predicate, a bucket's mime allowlist or a size limit, because none of those live in our code.
+ * They live in the database and in supabase/storage-api, so the only test that can fail for the
+ * right reason is one that talks to both. Same shape as scripts/realtime-policy-harness.mjs: a
+ * throwaway compose stack, assertions, and a teardown that runs even when an assertion throws.
+ *
+ * The DB assertions run inside a transaction closed by `rollback`; the HTTP ones cannot, so the
+ * stack is destroyed with its volumes at the end instead.
+ *
+ *   npm run test:storage-policies
+ */
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { createHmac, randomUUID } from 'node:crypto';
+import { Client } from 'pg';
+import { listMigrationFiles, applyOne } from './db-migrate.mjs';
+
+const ROOT = fileURLToPath(new URL('..', import.meta.url));
+const JWT_SECRET = 'storage-policy-harness-jwt-secret-at-least-32-chars';
+const POSTGRES_PASSWORD = 'storage-policy-harness';
+const PROJECT = `anomalia-storage-policies-${process.pid}-${Date.now()}`;
+const TEMP = mkdtempSync(join(tmpdir(), 'anomalia-storage-policies-'));
+const COMPOSE = join(TEMP, 'compose.yml');
+const ROLES = join(ROOT, 'infra/compose/volumes/db/roles.sql');
+const JWT = join(ROOT, 'infra/compose/volumes/db/jwt.sql');
+const ADMIN_PASSWORD = join(TEMP, 'supabase-admin-password.sql');
+
+// 20260827130000_selfhost_schema_parity.sql does `set role supabase_admin`, and the image leaves
+// that role without a password — so the migrator cannot log in as it. roles.sql is vendored
+// verbatim from upstream and must not be edited; this is the one extra line, kept next to it.
+writeFileSync(
+  ADMIN_PASSWORD,
+  "\\set pgpass `echo \"$POSTGRES_PASSWORD\"`\nALTER USER supabase_admin WITH PASSWORD :'pgpass';\n"
+);
+
+const HOUR = 3600;
+const b64 = (value) => Buffer.from(JSON.stringify(value)).toString('base64url');
+
+function mintJwt(claims) {
+  const header = b64({ alg: 'HS256', typ: 'JWT' });
+  const payload = b64({
+    iss: 'supabase',
+    iat: Math.floor(Date.now() / 1000),
+    exp: Math.floor(Date.now() / 1000) + HOUR,
+    ...claims
+  });
+  const signature = createHmac('sha256', JWT_SECRET)
+    .update(`${header}.${payload}`)
+    .digest('base64url');
+  return `${header}.${payload}.${signature}`;
+}
+
+const ANON_KEY = mintJwt({ role: 'anon' });
+const SERVICE_KEY = mintJwt({ role: 'service_role' });
+
+const compose = `
+services:
+  db:
+    image: supabase/postgres:17.6.1.136
+    environment:
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: postgres
+      PGPORT: 5432
+      JWT_SECRET: ${JWT_SECRET}
+      JWT_EXP: ${HOUR}
+    volumes:
+      - ${ROLES}:/docker-entrypoint-initdb.d/init-scripts/99-roles.sql:ro
+      - ${JWT}:/docker-entrypoint-initdb.d/init-scripts/99-jwt.sql:ro
+      - ${ADMIN_PASSWORD}:/docker-entrypoint-initdb.d/init-scripts/99-zz-harness.sql:ro
+      - db-data:/var/lib/postgresql/data
+    ports:
+      - '127.0.0.1::5432'
+    healthcheck:
+      test: ['CMD', 'pg_isready', '-U', 'postgres', '-h', 'localhost']
+      interval: 2s
+      timeout: 2s
+      retries: 40
+
+  auth:
+    image: supabase/gotrue:v2.189.0
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      GOTRUE_API_HOST: 0.0.0.0
+      GOTRUE_API_PORT: 9999
+      API_EXTERNAL_URL: http://localhost:9999
+      GOTRUE_DB_DRIVER: postgres
+      GOTRUE_DB_DATABASE_URL: postgres://supabase_auth_admin:${POSTGRES_PASSWORD}@db:5432/postgres?search_path=auth
+      GOTRUE_SITE_URL: http://localhost:5173
+      GOTRUE_JWT_ADMIN_ROLES: service_role
+      GOTRUE_JWT_AUD: authenticated
+      GOTRUE_JWT_DEFAULT_GROUP_NAME: authenticated
+      GOTRUE_JWT_EXP: ${HOUR}
+      GOTRUE_JWT_SECRET: ${JWT_SECRET}
+      GOTRUE_MAILER_AUTOCONFIRM: 'true'
+
+  rest:
+    image: postgrest/postgrest:v14.12
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      PGRST_DB_URI: postgres://authenticator:${POSTGRES_PASSWORD}@db:5432/postgres
+      PGRST_DB_SCHEMAS: public,storage
+      PGRST_DB_ANON_ROLE: anon
+      PGRST_JWT_SECRET: ${JWT_SECRET}
+      PGRST_DB_USE_LEGACY_GUCS: 'false'
+
+  storage:
+    image: supabase/storage-api:v1.60.4
+    depends_on:
+      db:
+        condition: service_healthy
+      rest:
+        condition: service_started
+    environment:
+      ANON_KEY: ${ANON_KEY}
+      SERVICE_KEY: ${SERVICE_KEY}
+      POSTGREST_URL: http://rest:3000
+      AUTH_JWT_SECRET: ${JWT_SECRET}
+      DATABASE_URL: postgres://supabase_storage_admin:${POSTGRES_PASSWORD}@db:5432/postgres
+      STORAGE_PUBLIC_URL: http://localhost:5000
+      FILE_SIZE_LIMIT: 524288000
+      STORAGE_BACKEND: file
+      GLOBAL_S3_BUCKET: stub
+      FILE_STORAGE_BACKEND_PATH: /var/lib/storage
+      TENANT_ID: stub
+      REGION: stub
+      ENABLE_IMAGE_TRANSFORMATION: 'false'
+    ports:
+      - '127.0.0.1::5000'
+
+volumes:
+  db-data:
+`;
+
+writeFileSync(COMPOSE, compose);
+
+function composeRun(args, allowFailure = false) {
+  const result = spawnSync(
+    'docker',
+    ['compose', '--project-name', PROJECT, '--file', COMPOSE, ...args],
+    { cwd: ROOT, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 }
+  );
+  if (result.status !== 0 && !allowFailure) {
+    throw new Error(`${args.join(' ')}\n${result.stdout}${result.stderr}`);
+  }
+  return `${result.stdout}${result.stderr}`;
+}
+
+/** The image has no wget, so a compose healthcheck cannot see /status — poll it from here. */
+async function waitForStatus(url, attempts = 60) {
+  for (let i = 0; i < attempts; i += 1) {
+    try {
+      const res = await fetch(`${url}/status`);
+      if (res.ok) return;
+    } catch {
+      /* not listening yet */
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+  throw new Error(`storage-api never answered ${url}/status`);
+}
+
+// storage-api's own words for the two refusals that matter, pinned so an unrelated 400 (a missing
+// bucket, a duplicate key) can never be mistaken for a policy doing its job.
+const DENIED = '400 Unauthorized';
+const BAD_MIME = '400 invalid_mime_type';
+
+const failures = [];
+
+function check(label, actual, expected) {
+  const ok = actual === expected;
+  if (!ok) failures.push(`${label}: expected ${expected}, received ${actual}`);
+  console.log(`${ok ? '  ok  ' : ' FAIL '} ${label}${ok ? '' : ` (expected ${expected}, got ${actual})`}`);
+}
+
+/** A user client is the anon key plus the user's JWT — exactly what the browser and hooks.server.ts
+ *  send. The outcome is the status plus storage-api's own error name: a bare 400 would let "refused
+ *  because the policy said no" and "refused because the bucket does not exist" look identical, and
+ *  a test that cannot tell those apart passes for the wrong reason. */
+async function upload(storageUrl, bucket, path, jwt, { contentType = 'image/png', bytes = 8 } = {}) {
+  const res = await fetch(`${storageUrl}/object/${bucket}/${path}`, {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${jwt}`,
+      apikey: ANON_KEY,
+      'content-type': contentType,
+      'x-upsert': 'false'
+    },
+    body: Buffer.alloc(bytes, 1)
+  });
+  if (res.ok) return 'ok';
+  const body = await res.json().catch(() => ({}));
+  return `${res.status} ${body.error ?? body.message ?? 'unknown'}`;
+}
+
+const MIGRATION_UNDER_TEST = '20260905140000_storage_tenant_isolation.sql';
+const SKIP_FIX = process.argv.includes('--skip-fix');
+
+/** What the dashboard put on production by hand, and no migration ever wrote down. Reproducing it
+ *  is the whole point: without it this harness measures a database production has never run, and
+ *  every check below would pass while the real hole stayed open. */
+async function applyProductionDrift(client) {
+  await client.query(`
+    create policy "Allow authenticated uploads to media bucket" on storage.objects
+      for insert to authenticated with check (bucket_id = 'media');
+
+    insert into storage.buckets (id, name, public)
+      values ('email-assets', 'email-assets', true) on conflict (id) do nothing;
+
+    create policy "email_assets_public_read" on storage.objects
+      for select to anon, authenticated using (bucket_id = 'email-assets');
+    create policy "email_assets_service_upload" on storage.objects
+      for insert to service_role with check (bucket_id = 'email-assets');
+  `);
+}
+
+/** Production is "every migration, then the drift, then whatever Andrea applies next" — so the
+ *  migration under test is applied last, after the drift, exactly as it will be applied for real. */
+async function applyMigrations(dbPort) {
+  const client = new Client({
+    connectionString: `postgres://supabase_admin:${POSTGRES_PASSWORD}@127.0.0.1:${dbPort}/postgres`
+  });
+  await client.connect();
+  try {
+    await client.query(
+      'create table if not exists app_schema_migrations (filename text primary key, applied_at timestamptz not null default now())'
+    );
+    const files = listMigrationFiles();
+    if (!files.includes(MIGRATION_UNDER_TEST)) {
+      throw new Error(`${MIGRATION_UNDER_TEST} is not in supabase/migrations`);
+    }
+    for (const file of files.filter((f) => f !== MIGRATION_UNDER_TEST)) {
+      await applyOne(client, file);
+    }
+    await applyProductionDrift(client);
+    if (!SKIP_FIX) await applyOne(client, MIGRATION_UNDER_TEST);
+  } finally {
+    await client.end();
+  }
+}
+
+/** Two tenants that share nothing: the shape the red team used — a self-registered account against
+ *  a stranger's folder. `member` is in owner's org, `outsider` is in its own. */
+const OWNER = randomUUID();
+const OUTSIDER = randomUUID();
+const OWNER_ORG = randomUUID();
+const OWNER_BRAND = randomUUID();
+const OUTSIDER_ORG = randomUUID();
+
+async function seed(client) {
+  const user = (id, email) => client.query(
+    `insert into auth.users (id, instance_id, aud, role, email, encrypted_password, email_confirmed_at, created_at, updated_at)
+     values ($1, '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', $2, '', now(), now(), now())`,
+    [id, email]
+  );
+  await user(OWNER, 'owner@harness.test');
+  await user(OUTSIDER, 'outsider@harness.test');
+
+  await client.query(
+    `insert into public.organizations (id, name, owner_id) values ($1, 'Owner Org', $2), ($3, 'Outsider Org', $4)`,
+    [OWNER_ORG, OWNER, OUTSIDER_ORG, OUTSIDER]
+  );
+  // Both memberships, because the schema asks the question two ways: auth_brand_ids() (the media
+  // policy) goes through organizations.owner_id, the blog taxonomy's owner policy goes through
+  // org_members. Seeding only one makes a check pass for a reason that has nothing to do with it.
+  await client.query(
+    `insert into public.org_members (org_id, user_id, role) values ($1, $2, 'owner'), ($3, $4, 'owner')`,
+    [OWNER_ORG, OWNER, OUTSIDER_ORG, OUTSIDER]
+  );
+  await client.query(
+    `insert into public.brands (id, org_id, slug, name) values ($1, $2, 'harness-brand', 'Harness Brand')`,
+    [OWNER_BRAND, OWNER_ORG]
+  );
+}
+
+/** The blog taxonomy leak, asserted where it lives: as the `anon` role, inside a rollback. */
+async function anonSeesTaxonomy(client) {
+  await client.query('begin');
+  try {
+    await client.query(
+      `insert into public.blog_categories (brand_id, name, slug) values ($1, 'Secret Section', 'secret')`,
+      [OWNER_BRAND]
+    );
+    await client.query(
+      `insert into public.blog_tags (brand_id, name, slug) values ($1, 'Secret Tag', 'secret')`,
+      [OWNER_BRAND]
+    );
+    await client.query(
+      `insert into public.blog_authors (brand_id, name, slug) values ($1, 'Secret Author', 'secret')`,
+      [OWNER_BRAND]
+    );
+    await client.query(`set local role anon`);
+    // Two outcomes count as closed: no rows (the policy is gone) or no privilege at all (the grant
+    // is gone too). The second is the stronger one, so it is what this asserts.
+    const rows = await client.query(
+      `select (select count(*) from public.blog_categories)
+            + (select count(*) from public.blog_tags)
+            + (select count(*) from public.blog_authors) as n`
+    ).catch((err) => (err.code === '42501' ? null : Promise.reject(err)));
+    return rows === null ? 'denied' : Number(rows.rows[0].n);
+  } finally {
+    await client.query('rollback');
+  }
+}
+
+/** A member of the brand's org still has to be able to manage its own taxonomy. */
+async function memberSeesTaxonomy(client) {
+  await client.query('begin');
+  try {
+    await client.query(
+      `insert into public.blog_categories (brand_id, name, slug) values ($1, 'Own Section', 'own')`,
+      [OWNER_BRAND]
+    );
+    await client.query(`set local role authenticated`);
+    await client.query(`select set_config('request.jwt.claims', $1, true)`, [
+      JSON.stringify({ sub: OWNER, role: 'authenticated' })
+    ]);
+    const rows = await client.query(`select count(*) as n from public.blog_categories`);
+    return Number(rows.rows[0].n);
+  } finally {
+    await client.query('rollback');
+  }
+}
+
+async function bucketRow(client, id) {
+  const { rows } = await client.query(
+    `select file_size_limit, allowed_mime_types from storage.buckets where id = $1`,
+    [id]
+  );
+  return { exists: rows.length === 1, ...rows[0] };
+}
+
+try {
+  console.log('booting db …');
+  composeRun(['up', '--detach', '--wait', 'db']);
+  const dbPort = Number(composeRun(['port', 'db', '5432']).trim().split(':').pop());
+
+  // storage-api owns storage.objects / storage.buckets / storage.foldername — the supabase/postgres
+  // image does NOT ship them, so it has to run its own migrations before ours can reference them.
+  // GoTrue owns the auth schema the migrations lean on (0001 calls auth.jwt() on line 66).
+  console.log('booting gotrue (owns the auth schema) …');
+  composeRun(['up', '--detach', 'auth']);
+
+  console.log('booting storage-api (creates the storage schema) …');
+  composeRun(['up', '--detach', 'storage']);
+  const storageUrl = `http://127.0.0.1:${composeRun(['port', 'storage', '5000']).trim().split(':').pop()}`;
+  await waitForStatus(storageUrl);
+
+  console.log('applying every migration …');
+  await applyMigrations(dbPort);
+
+  const client = new Client({
+    connectionString: `postgres://postgres:${POSTGRES_PASSWORD}@127.0.0.1:${dbPort}/postgres`
+  });
+  await client.connect();
+
+  try {
+    await seed(client);
+
+    const ownerJwt = mintJwt({ sub: OWNER, role: 'authenticated', aud: 'authenticated' });
+    const outsiderJwt = mintJwt({ sub: OUTSIDER, role: 'authenticated', aud: 'authenticated' });
+
+    console.log('\nmedia bucket — who may write where');
+    check(
+      'owner writes its own folder',
+      await upload(storageUrl, 'media', `${OWNER}/uploads/${randomUUID()}.png`, ownerJwt),
+      'ok'
+    );
+    check(
+      "outsider writes into the owner's folder",
+      await upload(storageUrl, 'media', `${OWNER}/uploads/${randomUUID()}.png`, outsiderJwt),
+      DENIED
+    );
+    check(
+      'brand member writes the brand folder (motion video)',
+      await upload(storageUrl, 'media', `${OWNER_BRAND}/motion/${randomUUID()}.mp4`, ownerJwt, {
+        contentType: 'video/mp4'
+      }),
+      'ok'
+    );
+    check(
+      "outsider writes the brand's folder",
+      await upload(storageUrl, 'media', `${OWNER_BRAND}/motion/${randomUUID()}.mp4`, outsiderJwt, {
+        contentType: 'video/mp4'
+      }),
+      DENIED
+    );
+    check(
+      'outsider writes the bucket root',
+      await upload(storageUrl, 'media', `${randomUUID()}.png`, outsiderJwt),
+      DENIED
+    );
+
+    console.log('\npublic buckets — what may be served back');
+    check(
+      'svg into media',
+      await upload(storageUrl, 'media', `${OWNER}/uploads/${randomUUID()}.svg`, ownerJwt, {
+        contentType: 'image/svg+xml'
+      }),
+      BAD_MIME
+    );
+    check(
+      'svg into email-assets (service role, the weekly-recap scraper)',
+      await upload(storageUrl, 'email-assets', `trends/${randomUUID()}.jpg`, SERVICE_KEY, {
+        contentType: 'image/svg+xml'
+      }),
+      BAD_MIME
+    );
+    // Storage matches the allowlist on the WHOLE header, parameters included: `image/png` in the
+    // list does not admit `image/png;charset=UTF-8`. Production holds one such object, scraped from
+    // a remote site — which is why weekly-recap.ts now names the type itself instead of forwarding
+    // whatever the remote server said. Pinned here so nobody "fixes" the list by adding variants.
+    check(
+      'a content-type carrying a charset parameter is refused, so the scraper must name its own',
+      await upload(storageUrl, 'email-assets', `trends/${randomUUID()}.png`, SERVICE_KEY, {
+        contentType: 'image/png;charset=UTF-8'
+      }),
+      BAD_MIME
+    );
+    check(
+      'the canonical type weekly-recap now sends does land',
+      await upload(storageUrl, 'email-assets', `trends/${randomUUID()}.png`, SERVICE_KEY, {
+        contentType: 'image/png'
+      }),
+      'ok'
+    );
+    check(
+      'mp4 into media stays allowed',
+      await upload(storageUrl, 'media', `${OWNER}/generated/${randomUUID()}.mp4`, ownerJwt, {
+        contentType: 'video/mp4'
+      }),
+      'ok'
+    );
+    check(
+      'wav into media stays allowed',
+      await upload(storageUrl, 'media', `${OWNER_BRAND}/voiceover/${randomUUID()}.wav`, ownerJwt, {
+        contentType: 'audio/wav'
+      }),
+      'ok'
+    );
+
+    console.log('\nbucket limits');
+    const media = await bucketRow(client, 'media');
+    const emailAssets = await bucketRow(client, 'email-assets');
+    // `bucketRow` returns {} for a bucket that does not exist, and `undefined > n` is false rather
+    // than an error — so the row has to be proved present before any comparison means anything.
+    check('the media bucket row exists', media.exists, true);
+    check('the email-assets bucket row exists', emailAssets.exists, true);
+    check(
+      'media size limit is set and clears the largest object in production (44 MB)',
+      Number(media.file_size_limit) > 46_390_775,
+      true
+    );
+    check(
+      'email-assets size limit is set and clears the scraper cap (2 MB)',
+      Number(emailAssets.file_size_limit) > 2_000_000,
+      true
+    );
+
+    console.log('\nblog taxonomy — the tenant enumeration primitive');
+    check('an anonymous visitor reading the taxonomy', await anonSeesTaxonomy(client), 'denied');
+    check('rows the brand owner can still read', await memberSeesTaxonomy(client), 1);
+  } finally {
+    await client.end();
+  }
+
+  if (failures.length) {
+    throw new Error(`\n${failures.length} check(s) failed:\n  ${failures.join('\n  ')}`);
+  }
+  console.log('\nStorage policies hold: cross-tenant writes refused, svg refused, taxonomy closed.');
+} catch (error) {
+  console.error(composeRun(['logs', '--no-color', '--tail', '80', 'db', 'storage'], true));
+  throw error;
+} finally {
+  composeRun(['down', '--volumes', '--remove-orphans'], true);
+  rmSync(TEMP, { recursive: true, force: true });
+}

--- a/scripts/storage-policy-harness.mjs
+++ b/scripts/storage-policy-harness.mjs
@@ -208,9 +208,36 @@ const SKIP_FIX = process.argv.includes('--skip-fix');
 
 /** What the dashboard put on production by hand, and no migration ever wrote down. Reproducing it
  *  is the whole point: without it this harness measures a database production has never run, and
- *  every check below would pass while the real hole stayed open. */
+ *  every check below would pass while the real hole stayed open.
+ *
+ *  It runs BEFORE the migrations, because that is the order production has: the hand-made objects
+ *  were already there when the later migrations landed, and one of them
+ *  (20260905120000_secdef_least_privilege.sql) revokes on `rls_auto_enable` — a function its own
+ *  comment says "vive solo in produzione". Without it here, that migration cannot apply to a fresh
+ *  database at all. Copied verbatim from production, event trigger included. */
 async function applyProductionDrift(client) {
   await client.query(`
+    create or replace function public.rls_auto_enable() returns event_trigger
+      language plpgsql security definer set search_path to 'pg_catalog' as $fn$
+      declare cmd record;
+      begin
+        for cmd in
+          select * from pg_event_trigger_ddl_commands()
+          where command_tag in ('CREATE TABLE', 'CREATE TABLE AS', 'SELECT INTO')
+            and object_type in ('table', 'partitioned table')
+        loop
+          if cmd.schema_name = 'public' then
+            begin
+              execute format('alter table if exists %s enable row level security', cmd.object_identity);
+            exception when others then null;
+            end;
+          end if;
+        end loop;
+      end; $fn$;
+
+    drop event trigger if exists ensure_rls;
+    create event trigger ensure_rls on ddl_command_end execute function public.rls_auto_enable();
+
     create policy "Allow authenticated uploads to media bucket" on storage.objects
       for insert to authenticated with check (bucket_id = 'media');
 
@@ -239,10 +266,10 @@ async function applyMigrations(dbPort) {
     if (!files.includes(MIGRATION_UNDER_TEST)) {
       throw new Error(`${MIGRATION_UNDER_TEST} is not in supabase/migrations`);
     }
+    await applyProductionDrift(client);
     for (const file of files.filter((f) => f !== MIGRATION_UNDER_TEST)) {
       await applyOne(client, file);
     }
-    await applyProductionDrift(client);
     if (!SKIP_FIX) await applyOne(client, MIGRATION_UNDER_TEST);
   } finally {
     await client.end();

--- a/src/lib/content/changelog/2026-09-05-storage-tenant-isolation.ts
+++ b/src/lib/content/changelog/2026-09-05-storage-tenant-isolation.ts
@@ -1,0 +1,10 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-05',
+  title: 'Your files stay inside your own space',
+  items: [
+    'Every upload is now checked against the account and the brand it belongs to, so a file can only ever land in a space you own.',
+    'Image uploads accept the formats a browser draws as pictures — JPEG, PNG, WebP, GIF, HEIC — and refuse SVG, which a browser can also run as code.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/weekly-recap.test.ts
+++ b/src/lib/server/weekly-recap.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { hostedImageType } from './weekly-recap';
+
+// The weekly recap embeds a picture scraped off whatever page a trend links to, and used to store
+// it under the content-type that remote server chose. Production still holds the result: an object
+// named `.jpg` and served back as `image/svg+xml` from a public bucket — script, on our own URL,
+// put there by a site we do not control.
+describe('hostedImageType', () => {
+  it('names the type itself for each raster format we host', () => {
+    expect(hostedImageType('image/png')).toEqual({ ext: 'png', contentType: 'image/png' });
+    expect(hostedImageType('image/webp')).toEqual({ ext: 'webp', contentType: 'image/webp' });
+    expect(hostedImageType('image/jpeg')).toEqual({ ext: 'jpg', contentType: 'image/jpeg' });
+  });
+
+  it('refuses svg, whatever the remote server calls it', () => {
+    expect(hostedImageType('image/svg+xml')).toBeNull();
+  });
+
+  it('refuses anything that is not an image', () => {
+    expect(hostedImageType('text/html')).toBeNull();
+    expect(hostedImageType('')).toBeNull();
+  });
+
+  // Storage matches its mime allowlist on the whole header, so a forwarded `;charset=` is refused
+  // at upload. The parameter is the remote server's business, not ours: strip it and keep the type.
+  it('drops the parameters a remote server tacks on', () => {
+    expect(hostedImageType('image/png;charset=UTF-8')).toEqual({
+      ext: 'png',
+      contentType: 'image/png'
+    });
+    expect(hostedImageType('IMAGE/JPEG; q=0.9')).toEqual({ ext: 'jpg', contentType: 'image/jpeg' });
+  });
+});

--- a/src/lib/server/weekly-recap.ts
+++ b/src/lib/server/weekly-recap.ts
@@ -407,6 +407,22 @@ async function gatherRecapData(
 
 // ─── AI generation ─────────────────────────────────────────────────────────
 
+// The formats we are willing to re-serve from our own public bucket, and the name we give each one.
+// The remote server's header decides nothing beyond which row it selects: forwarding it is how an
+// `image/svg+xml` ended up on a public URL of ours, and how a `;charset=` parameter ended up in a
+// stored content type. One table, so the next format is a row and not a fourth ternary.
+const HOSTED_IMAGE_TYPES: Record<string, { ext: string; contentType: string }> = {
+  'image/png': { ext: 'png', contentType: 'image/png' },
+  'image/webp': { ext: 'webp', contentType: 'image/webp' },
+  'image/jpeg': { ext: 'jpg', contentType: 'image/jpeg' },
+  'image/jpg': { ext: 'jpg', contentType: 'image/jpeg' },
+  'image/gif': { ext: 'gif', contentType: 'image/gif' }
+};
+
+export function hostedImageType(header: string): { ext: string; contentType: string } | null {
+  return HOSTED_IMAGE_TYPES[header.split(';')[0].trim().toLowerCase()] ?? null;
+}
+
 // Fetch an image from a URL and host it on Supabase Storage for email embedding.
 // Tries OG image first, then falls back to the first large image on the page.
 async function fetchAndHostOgImage(supabase: SupabaseClient, url: string): Promise<string | null> {
@@ -427,15 +443,14 @@ async function fetchAndHostOgImage(supabase: SupabaseClient, url: string): Promi
     const absoluteUrl = new URL(imgUrl, url).href;
     const imgRes = await fetch(absoluteUrl, { signal: AbortSignal.timeout(8000) });
     if (!imgRes.ok) return null;
-    const contentType = imgRes.headers.get('content-type') ?? 'image/jpeg';
-    if (!contentType.startsWith('image/')) return null;
+    const hosted = hostedImageType(imgRes.headers.get('content-type') ?? '');
+    if (!hosted) return null;
     const buf = await imgRes.arrayBuffer();
     if (buf.byteLength > 2_000_000) return null;
 
-    const ext = contentType.includes('png') ? 'png' : contentType.includes('webp') ? 'webp' : 'jpg';
-    const path = `trends/${crypto.randomUUID()}.${ext}`;
+    const path = `trends/${crypto.randomUUID()}.${hosted.ext}`;
     const { error } = await supabase.storage.from('email-assets').upload(path, Buffer.from(buf), {
-      contentType,
+      contentType: hosted.contentType,
       upsert: false
     });
     if (error) return null;

--- a/src/routes/a/[id]/+server.ts
+++ b/src/routes/a/[id]/+server.ts
@@ -11,7 +11,8 @@ const SIGN_TTL_SECONDS = 60 * 60 * 2;
 //
 // Public by decision: the code is the only credential, which is why it is 8 chars of a 32-symbol
 // alphabet rather than something shorter. No session, no cookies, no auth — a shared link works
-// for whoever holds it, and revoking one means deleting the asset.
+// for whoever holds it, so `link_revoked_at` is the only way to take one back: the same answer
+// shared_views gives, a row you can revoke, read on every request instead of trusted once.
 //
 // The uuid form is accepted too: the media tools have always returned `id`, so an agent can
 // reasonably assemble /a/<uuid> on its own, and refusing it would break a link for nothing.
@@ -23,10 +24,10 @@ export const GET: RequestHandler = async ({ params }) => {
   const admin = createAdminClient();
   const { data: media } = await admin
     .from('brand_media')
-    .select('storage_path')
+    .select('storage_path, link_revoked_at')
     .eq(column, id)
     .maybeSingle();
-  if (!media?.storage_path) return new Response('Not found', { status: 404 });
+  if (!media?.storage_path || media.link_revoked_at) return new Response('Not found', { status: 404 });
 
   const { data: signed } = await admin.storage
     .from(BUCKET)

--- a/src/routes/a/[id]/server.test.ts
+++ b/src/routes/a/[id]/server.test.ts
@@ -25,7 +25,10 @@ const UUID = 'b4583d8d-6774-4bc9-a09f-693ee0fef464';
 
 beforeEach(() => {
   vi.clearAllMocks();
-  maybeSingle.mockResolvedValue({ data: { storage_path: 'brand/x.jpg' }, error: null });
+  maybeSingle.mockResolvedValue({
+    data: { storage_path: 'brand/x.jpg', link_revoked_at: null },
+    error: null
+  });
 });
 
 describe('/a/[id]', () => {
@@ -67,6 +70,20 @@ describe('/a/[id]', () => {
     const res = await call(CODE);
 
     expect(res.headers.get('Cache-Control')).toBe('no-store');
+  });
+
+  // The code is the only credential and it never expires, so revocation is the only way to take a
+  // handed-out link back — from a departed member, from the wrong group chat, from a leaked output.
+  it('404s a revoked link without signing anything', async () => {
+    maybeSingle.mockResolvedValue({
+      data: { storage_path: 'brand/x.jpg', link_revoked_at: '2026-09-04T10:00:00Z' },
+      error: null
+    });
+
+    const res = await call(CODE);
+
+    expect(res.status).toBe(404);
+    expect(createSignedUrl).not.toHaveBeenCalled();
   });
 
   it('404s when signing fails, rather than redirecting to nothing', async () => {

--- a/supabase/migrations/20260905140000_storage_tenant_isolation.sql
+++ b/supabase/migrations/20260905140000_storage_tenant_isolation.sql
@@ -1,0 +1,122 @@
+-- Storage, closed to the tenant it belongs to — and the dashboard drift that opened it.
+--
+-- A red team, with a self-registered account, wrote a 20 MB file INTO ANOTHER USER'S FOLDER on the
+-- `media` bucket, and served an SVG carrying a <script> back from a public URL. Neither the policy
+-- that allowed it nor the bucket that stored the second one is in any migration: both were made by
+-- hand in the dashboard, so `npm run db:migrate` on a fresh database has never produced the schema
+-- production actually runs.
+--
+--   `Allow authenticated uploads to media bucket`  INSERT · authenticated · with check
+--   (bucket_id = 'media') — no folder condition at all. Permissive policies are OR'd, so this one
+--   made `media insert own folder` (0004) decorative: it could only ever add access, never remove
+--   it. The narrow policy was there the whole time and defended nothing.
+--
+-- Everything below is written to converge BOTH databases: it drops what the dashboard added and
+-- creates what the dashboard created, so a fresh self-host ends where production ends.
+
+-- ── media: one policy, both legitimate prefixes ──────────────────────────────────────────────────
+--
+-- Two shapes are real, and each is proved twice — by the objects in production and by the code:
+--
+--   `${userId}/…`   uploads, blog covers and inline images, profile avatars, onboarding logos,
+--                   generated stills, youtube thumbnails, chat reference clips.
+--   `${brandId}/…`  motion video, voiceover, music. Written by the USER client, not a cron:
+--                   routes/app/[brand]/motion-video/+server.ts and .../render/+server.ts pass
+--                   `locals.supabase` into render-tools.ts and gemini-audio.ts.
+--
+-- So a policy keyed on auth.uid() alone is not "stricter", it is broken — it would refuse every
+-- motion video a user renders. `auth_brand_ids()` is the predicate the rest of the schema already
+-- uses for "the brands this caller may act on" (see "brand-knowledge read shared", 0090); asking
+-- the same question the same way is what keeps the answer in one place.
+
+drop policy if exists "Allow authenticated uploads to media bucket" on storage.objects;
+drop policy if exists "media insert own folder" on storage.objects;
+
+create policy "media insert own scope" on storage.objects for insert to authenticated
+  with check (
+    bucket_id = 'media'
+    and (
+      (storage.foldername(name))[1] = auth.uid()::text
+      or (storage.foldername(name))[1] in (select b::text from public.auth_brand_ids() b)
+    )
+  );
+
+-- ── the public buckets: a ceiling, and nothing the browser will execute ──────────────────────────
+--
+-- Sizes are measured, not guessed. In production today `media` holds 3 089 objects: p50 647 kB,
+-- p99 8.4 MB, max 44 MB (a generated mp4) — so `wall`'s 12 MB would reject video outright. 64 MB
+-- leaves room above the largest real object without leaving the bucket unbounded. `email-assets`
+-- holds 864 objects, max 1.9 MB, and the only writer already refuses anything over 2 MB
+-- (weekly-recap.ts), so 5 MB is slack, not a target.
+--
+-- The mime list exists for ONE reason: `image/svg+xml` is served back with its own content type
+-- from a public URL, which makes any bucket that accepts it a place to host script. Storage already
+-- demotes text/html to text/plain; SVG is the hole it leaves. There is no denylist in Storage, so
+-- the allowlist enumerates images explicitly and falls back to wildcards for video and audio —
+-- which keeps every container and codec a phone can produce working (quicktime, webm, m4a, aac)
+-- without naming them. `media` holds zero SVGs today, so nothing legitimate is being locked out.
+
+insert into storage.buckets (id, name, public) values ('email-assets', 'email-assets', true)
+  on conflict (id) do nothing;
+
+update storage.buckets set
+  file_size_limit = 67108864,
+  allowed_mime_types = array[
+    'image/jpeg', 'image/jpg', 'image/png', 'image/webp', 'image/gif',
+    'image/avif', 'image/heic', 'image/heif', 'image/bmp', 'image/tiff',
+    'video/*', 'audio/*', 'application/pdf'
+  ]
+where id = 'media';
+
+update storage.buckets set
+  file_size_limit = 5242880,
+  allowed_mime_types = array['image/jpeg', 'image/jpg', 'image/png', 'image/webp', 'image/gif']
+where id = 'email-assets';
+
+-- The two policies the dashboard made for email-assets, written down so a fresh database has them.
+-- Read is open because the bucket is public and the URLs go out inside emails; writing is the
+-- weekly recap alone, which runs with the service key.
+drop policy if exists "email_assets_public_read" on storage.objects;
+create policy "email_assets_public_read" on storage.objects for select to anon, authenticated
+  using (bucket_id = 'email-assets');
+
+drop policy if exists "email_assets_service_upload" on storage.objects;
+create policy "email_assets_service_upload" on storage.objects for insert to service_role
+  with check (bucket_id = 'email-assets');
+
+-- ── the blog taxonomy: four USING (true) policies nobody reads ───────────────────────────────────
+--
+-- 0079 and 0080 gave categories, tags, authors and the article/tag join a `public_read` policy so
+-- the hosted blog could render for a stranger. It never used them: blog-site.ts reads every public
+-- page through the service key, by design ("the visitor is anonymous, so everything reads through
+-- the admin client"). What the policies did instead was let an anonymous client read `brand_id` for
+-- every brand that has ever created a tag — an enumeration of the tenant list, in exchange for
+-- nothing. `brand_articles` itself was never public, so the taxonomy hung off rows anon cannot see.
+--
+-- Dropping them is the whole fix; the owner policies are FOR ALL and keep members working.
+
+drop policy if exists "blog_categories_public_read" on public.blog_categories;
+drop policy if exists "blog_tags_public_read" on public.blog_tags;
+drop policy if exists "blog_authors_public_read" on public.blog_authors;
+drop policy if exists "article_tags_public_read" on public.brand_article_tags;
+
+-- Defence in depth, the same shape shared_views uses: without the table privilege, a future policy
+-- written badly still cannot open these to a visitor. The public blog does not pass here.
+revoke all on public.blog_categories from anon;
+revoke all on public.blog_tags from anon;
+revoke all on public.blog_authors from anon;
+revoke all on public.brand_article_tags from anon;
+
+-- ── /a/<code>: a link you can take back ──────────────────────────────────────────────────────────
+--
+-- The short code is public by decision (20260905090000): whoever holds the link may read the file,
+-- because those links travel through the output of external agents and must survive being copied.
+-- The decision that was never made is what to do when a link has to stop working — today the only
+-- answer is deleting the asset, which also destroys it for the people who should still have it.
+--
+-- shared_views already answers this, and its answer is the one the red team could not break: a row
+-- with a revocation stamp, read on EVERY request rather than trusted once. Same thing here, minus
+-- the expiry — a code that expires would break the reason the code exists.
+
+alter table public.brand_media
+  add column if not exists link_revoked_at timestamptz;


### PR DESCRIPTION
## What?

Closes the four storage holes a red team landed on production, and writes down the dashboard drift that opened two of them.

- **`media` cross-tenant writes.** `Allow authenticated uploads to media bucket` (INSERT · `authenticated` · `with check (bucket_id = 'media')`, no folder condition) is replaced by one policy that admits only the prefixes a caller owns. That policy exists in **no migration** — it was created by hand in the dashboard.
- **Public buckets served executable content.** `media` and `email-assets` get a measured `file_size_limit` and a mime allowlist that excludes `image/svg+xml`; `weekly-recap.ts` stops forwarding a remote server's content type.
- **Blog taxonomy leaked the tenant list.** The four `*_public_read` policies (`USING (true)`) are dropped and the tables revoked from `anon`.
- **`/a/<code>` could not be taken back.** `brand_media.link_revoked_at`, honoured on every request.

Also written down for the first time: the `email-assets` bucket and its two policies, which exist in production and in no migration.

## Why?

The narrow policy `media insert own folder` has been in `0004` since day one and defended nothing, because **permissive policies are OR'd** — the widest one always wins, and any strict policy beside it is decorative. So the strict policy being present was not evidence of anything, and adding a stricter one would not have been a fix either. The wide one had to go.

The blog taxonomy policies bought nothing: `blog-site.ts` renders every public page through the service key, and says so in its first line. What they actually did was let an anonymous client read `brand_id` for every brand that ever created a tag.

The SVG matters less than it looks — storage is served from `*.supabase.co`, a different origin from the app, so it cannot reach an app session — but it is a script-hosting surface on a domain that reads as ours, and closing it costs one bucket column.

## How?

**The census came before the policy.** The obvious `(storage.foldername(name))[1] = auth.uid()::text` would have been an outage, not a fix. Two prefixes are legitimate, each proved twice — by objects in production and by the code that writes them:

| prefix | what writes it | client | objects |
|---|---|---|---|
| `${userId}/…` | chat uploads, blog covers and inline images, avatars, onboarding logo, generated stills, YouTube thumbs, chat refs | user (`locals.supabase`, browser, cli-auth JWT) | 2 018 |
| `${brandId}/…` | motion video, voiceover, music | **user** — `app/[brand]/motion-video/{,render}/+server.ts` pass `locals.supabase` into `render-tools.ts` / `gemini-audio.ts` | 1 010 |
| `${brandId}/onboarding/…` | `uploadPostImage(admin, brand.id, …)` from `scheduler.ts` and `articles.ts` | service role only | 920 |

The third is a `userId` parameter being handed a brand id. It bypasses RLS, so the policy never sees it — but the name lies, and it is still written today. Not fixed here (behaviour change on the autopilot path, unrelated blast radius).

The brand branch asks the question with `auth_brand_ids()`, the predicate `brand-knowledge read shared` (0090) already uses. One question, one place.

**Numbers are measured, not copied.** `wall`'s 12 MB would have rejected video outright:

| bucket | objects | p50 | p99 | max | limit chosen |
|---|---|---|---|---|---|
| `media` | 3 089 | 647 kB | 8.4 MB | **44 MB** (generated mp4) | 64 MB |
| `email-assets` | 864 | 121 kB | 1.7 MB | 1.9 MB | 5 MB |

**SVG: allowlist over normalisation.** Normalising the content type in writing would have meant touching fifteen upload sites and trusting the sixteenth to remember — a rule spread across fifteen files diverges at the first change. The bucket allowlist is one place, and every writer passes it: browser uploads, signed uploads, and the service role. `media` holds **zero** SVGs, so nothing legitimate is locked out. Storage has no denylist, so images are enumerated and video/audio stay wildcards, which keeps every container a phone produces working without naming it.

That alone was not enough: the allowlist matches the **whole header**, so `image/png` does not admit `image/png;charset=UTF-8` — and production holds one such object. So `weekly-recap.ts` now names the type itself from a table of formats we are willing to re-serve. That is the root cause (the type of a file of ours should not be decided by a site we do not control) and it *removed* two ternaries and a `startsWith` rather than adding code.

**`/a/<code>`: revocation, not membership.** See *Anything Else* — this deliberately does not do what the report asked.

## Testing?

**New: `npm run test:storage-policies`** (`scripts/storage-policy-harness.mjs`), modelled on the existing `realtime-policy-harness.mjs`. It brings up a real Postgres, gotrue and **real storage-api**, applies every migration, **recreates the dashboard drift by hand**, then replays the red team's moves over HTTP. Without recreating the drift it would measure a database production has never run and pass while the hole stayed open.

Red, with `--skip-fix` — these are the report's findings, reproduced:

```
 FAIL  outsider writes into the owner's folder (expected 400 Unauthorized, got ok)
 FAIL  outsider writes the brand's folder (expected 400 Unauthorized, got ok)
 FAIL  outsider writes the bucket root (expected 400 Unauthorized, got ok)
 FAIL  svg into media (expected 400 invalid_mime_type, got ok)
 FAIL  svg into email-assets (expected 400 invalid_mime_type, got ok)
 FAIL  a content-type carrying a charset parameter is refused (expected …, got ok)
 FAIL  media size limit clears the largest object in production (44 MB)
 FAIL  email-assets size limit clears the scraper cap (2 MB)
 FAIL  an anonymous visitor reading the taxonomy (expected denied, got 3)
```

Green with the migration applied — including the regression guards that matter: *owner writes its own folder*, *brand member writes the brand folder (motion video)*, *mp4 stays allowed*, *wav stays allowed*, *the brand owner still reads its own taxonomy*.

The harness caught a defect **in my own test**: "the brand owner can still read its taxonomy" first passed thanks to the very policy I was dropping, because the seed never wrote `org_members`. A test that passes for the wrong reason is a defect this repo has already paid for five times.

Unit, both written first and watched fail:
- `src/routes/a/[id]/server.test.ts` — "404s a revoked link without signing anything" (red: `expected 302 to be 404`).
- `src/lib/server/weekly-recap.test.ts` — `hostedImageType`, 4/4 red before the change.

Full suite on the rebased base: `Test Files 674 passed | 4 skipped`, `Tests 7476 passed | 14 skipped` — **nothing failing**. (On the first run `src/hooks.server.test.ts` failed to *load* with `TypeError: Invalid URL`; that is the missing-`.env` case LESSONS.md documents, and it went green once the worktree had an `.env` for the browser pass.) `npm run typecheck:runtime`: ok.

**Not tested, and why:**
- **Nothing was applied to production.** The migration ships in this PR; Andrea applies it. Production was only ever read (`select`).
- **Browser pass: done** — see Evidence. What it did *not* do is render an actual motion video or run a real agent turn: that spends model budget, and the storage write is what this PR changes, not the generation above it.
- **`/admin/videos` `uploadToSignedUrl`** — `/admin/videos` signs an upload into *another* user's folder with the service role and the browser consumes it with the anon client. Signed-token uploads are authorised by the token, not RLS, so this should be unaffected; **I did not test it**, and it is the one legitimate flow that deliberately writes outside the caller's folder.
- **API-key callers of `/api/v1/**`** run as **service role** (`cli-auth.ts` builds the client with the service key for the API-key path). RLS does not apply to them at all, so a green API-key test would prove nothing about this policy either way.
- Size limits are asserted as bucket rows, not by pushing a 64 MB body through storage-api.

## Evidence

<details><summary>Production state, read-only, before the change</summary>

```
policyname                                   | roles           | cmd    | with_check
Allow authenticated uploads to media bucket  | {authenticated} | INSERT | (bucket_id = 'media'::text)
media insert own folder                      | {authenticated} | INSERT | (bucket_id = 'media' AND (storage.foldername(name))[1] = auth.uid()::text)

bucket        | public | file_size_limit | allowed_mime_types
media         | t      | NULL            | NULL
email-assets  | t      | NULL            | NULL
wall          | t      | 12582912        | {image/webp,image/jpeg,image/png,image/gif}
```

Mime census — `media` holds no SVG at all; `email-assets` holds exactly one, and it is the bug:

```
name                                        | mime            | owner_id
trends/c7396404-80e8-40a1-958f-5fe29e01d9eb.jpg | image/svg+xml | null
```

An object named `.jpg`, served as `image/svg+xml`, with no owner — scraped from an external site by the weekly recap.

**This object is still live, and the migration does not remove it** — `allowed_mime_types` only gates new uploads. One command, for Andrea:

```bash
curl -X DELETE \
  -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY" \
  "https://kszazivzwievqixcnanp.supabase.co/storage/v1/object/email-assets/trends/c7396404-80e8-40a1-958f-5fe29e01d9eb.jpg"
```

It is the only object that needs it. Two other rows would also be refused by the new allowlist (`image/png;charset=UTF-8` and `image/bmp`, both under `trends/`) but neither is executable, so both can stay. The image will 404 inside one already-sent weekly recap email from 10 August.

</details>

<details><summary>Browser pass — local self-host stack, real login, brand <code>demo</code></summary>

Local `infra/compose` stack (db, gotrue, kong, rest, storage-api), app served from this worktree, `.env` repointed at `http://localhost:8000` — **nothing in this run touched production**. Migration applied to the local database first; the local database already carried the same dashboard drift as production (`Allow authenticated uploads to media bucket` was present before, gone after).

Signed in as `test@anomalia.so` — confirmed in the page, not assumed:

```js
const sb = (await import('/src/lib/supabase/client.ts')).createSupabaseBrowserClient();
(await sb.auth.getUser()).data.user      // → test@anomalia.so · 90bc92e3-79c0-4a36-89fe-f7ad8c2935b1
```

**Through the UI**, twice, with a full page reload between the two: the motion-video composer's attachment input, real file, real signed upload — the "Clip di riferimento" chip appears both times, no console errors. Both objects are in the bucket:

```
90bc92e3-.../chat-refs/e1cdeac1-....mp4 | 40 bytes   ← second attempt, after reload
90bc92e3-.../chat-refs/2616f702-....mp4 | 40 bytes   ← first attempt
```

**The five writes that decide this PR**, run with the app's own browser client and the real session:

```
motion video render        ${brandId}/motion/…mp4        uploaded
voiceover take             ${brandId}/voiceover/…wav     uploaded
chat reference clip        ${userId}/chat-refs/…mp4      uploaded
ATTACK — stranger folder   00000000-…-ff/uploads/…png    REFUSED: new row violates row-level security policy
ATTACK — svg, own folder   ${userId}/uploads/…svg        REFUSED: mime type image/svg+xml is not supported
```

The brand-prefix write was repeated three more times after a reload — `uploaded` each time. The two refusals left no rows behind, confirmed in `storage.objects`.

</details>

<details><summary>Harness output, green</summary>

```
media bucket — who may write where
  ok   owner writes its own folder
  ok   outsider writes into the owner's folder
  ok   brand member writes the brand folder (motion video)
  ok   outsider writes the brand's folder
  ok   outsider writes the bucket root

public buckets — what may be served back
  ok   svg into media
  ok   svg into email-assets (service role, the weekly-recap scraper)
  ok   a content-type carrying a charset parameter is refused, so the scraper must name its own
  ok   the canonical type weekly-recap now sends does land
  ok   mp4 into media stays allowed
  ok   wav into media stays allowed

bucket limits
  ok   the media bucket row exists
  ok   the email-assets bucket row exists
  ok   media size limit is set and clears the largest object in production (44 MB)
  ok   email-assets size limit is set and clears the scraper cap (2 MB)

blog taxonomy — the tenant enumeration primitive
  ok   an anonymous visitor reading the taxonomy
  ok   rows the brand owner can still read

Storage policies hold: cross-tenant writes refused, svg refused, taxonomy closed.
```

</details>

## Anything Else?

**I did not do what the report asked for `/a/<code>`, on purpose.** It asked to bind the link to something revocable via membership. But public access there is a decision taken the day before and written into `20260905090000_brand_media_short_code.sql` — *"Andrea chose PUBLIC access — whoever holds the link may read the file"* — precisely because those links travel through external agents' output and must survive being copied. Reversing that quietly inside a security PR would have been worse than the hole. What was genuinely missing is what `shared_views` has and this did not: a way to switch one link off without destroying the asset for everyone. That is `link_revoked_at`, read on every request.

> **Still open, and it needs Andrea's decision: a member removed from a brand keeps working `/a/<code>` links to that brand's assets.** Nothing revokes them, because the link is deliberately bound to the code and not to a session — that is what makes it survive an agent's output. Closing it means either binding the link to membership (reversing the decision in `20260905090000`) or revoking a departing member's links on removal. `link_revoked_at` makes both possible; it chooses neither.

**One correction to an earlier claim of mine**: I wrote that `constraint-harness.mjs` does not exist. It does — it landed on `dev` with #374 while I was working, and my branch was behind. The choice of model stands for a different reason: `constraint-harness.mjs` asserts SQLSTATEs from column constraints, which is not the shape of a storage policy, so this harness follows `realtime-policy-harness.mjs` (a compose stack with real services) instead. Both now exist side by side.

**One thing the report got wrong**: the blog taxonomy has **four** `USING (true)` policies, not three — `brand_article_tags` too.

Known debt, not addressed here:
- **`link_revoked_at` has no surface** — no UI, no CLI, no endpoint. Revoking is an `UPDATE` today.
- **`media` has no SELECT policy at all**, so `.list()` on the user client returns nothing — `voice-gate.ts:62` lists `${brandId}/voiceover/` and already gets an empty answer on the user path. Pre-existing, untouched, and out of scope for a PR about writes.
- **`scripts/schema-drift-check.mjs` checks tables and columns, not policies or buckets.** Both holes here were invisible to it. A drift check over `pg_policies` and `storage.buckets` would have caught this months ago.
- `uploadPostImage`'s `userId` parameter receives a brand id from two callers.
- **`20260905120000_secdef_least_privilege.sql` cannot be applied to a fresh database.** It revokes execute on `public.rls_auto_enable()`, which its own comment says "vive solo in produzione" — so `npm run db:migrate` against a clean Postgres dies there. Found while rebasing, because the harness does exactly that. Not mine to fix; the harness now recreates the function as part of the production drift it models. Worth a one-line `create or replace` in that migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
