### PR TITLE
Let a user decide only what is theirs to decide

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -1388,3 +1388,51 @@ restringere niente — la più larga vince sempre, e ogni policy stretta che le 
 decorativa. Quindi «aggiungo una policy più stretta» non è mai una fix: la fix è togliere la larga.
 E un test che verifica una policy deve prima **ricreare la deriva** che la produzione ha davvero,
 altrimenti misura un database che non è mai esistito e passa mentre il buco resta aperto.
+
+## Una policy RLS vincola la riga, non la colonna
+
+`profiles` aveva due policy e basta, e la seconda diceva `for update using (id = auth.uid()) with
+check (id = auth.uid())`. Letta di corsa sembra completa: «puoi scrivere solo la tua riga». È vera,
+ed è insufficiente — perché la riga contiene `approved_at`, che è il cancello della beta chiusa, e
+`with check` non ha niente da dire su QUALE colonna stai scrivendo. `PATCH
+/rest/v1/profiles?id=eq.<sé> {"approved_at":"..."}` risponde 200. La stessa forma su
+`organizations` (`org owner all`, `ALL`, `owner_id = auth.uid()`) vale soldi: `plan = 'pro'` porta
+la quota da 400 a 11.250 crediti senza passare da Stripe, perché `resolveOrgBilling` legge
+`organizations.plan` per primo e non lo confronta con niente.
+
+**Segnale**: una tabella con una policy `ALL` o `UPDATE` senza restrizione di colonna, e fra le
+colonne almeno una che **decide un diritto** invece di descrivere un dato — `approved_at`, `plan`,
+`status`, `activated_at`, `stripe_subscription_id`. Il confine che manca non è fra tenant: quello
+regge. È fra ciò che un utente **possiede** e ciò che un utente **può decidere di sé**, e non
+somiglia a un'intrusione perché è il proprietario che modifica il proprio oggetto — motivo per cui
+un red team che attacca il confine fra clienti non lo trova.
+
+**Mossa**: il livello che sa distinguere le colonne è il GRANT, non la policy. `revoke update on
+<t> from authenticated` e poi `grant update (<colonne>) on <t> to authenticated`, con lo stesso
+gesto su `insert` — una policy `ALL` lascia anche NASCERE una riga già `pro`. E l'elenco sta in UN
+posto per tutte le tabelle, non uno per tabella: tre registri in tre file divergono al primo
+cambiamento, e divergono in silenzio.
+
+**La regola dietro**: quando si aggiunge una colonna, la domanda «chi la decide?» va posta prima,
+non dopo. Il grant per colonna la pone da solo — una colonna nuova nasce non scrivibile, e il
+percorso che ne ha bisogno si rompe subito e a voce alta. Il contrario (nasce scrivibile, e si
+scopre quando qualcuno la usa) è il difetto che si è pagato qui due volte.
+
+## Un `revoke` in una migration non è uno stato: è un evento
+
+Le quattro `SECURITY DEFINER` senza controllo nel corpo — `brand_provider_spend_usd`, le tre
+`agent_kit_*` — hanno tutte la loro `revoke ... from public, anon, authenticated` scritta nella
+migration che le ha create. In produzione ha attecchito: otto combinazioni su otto false, verificate
+con `has_function_privilege`. Sullo stack self-hosted locale, stesse migration, **otto su otto
+vere**: `proacl` mostra `=X/...`, cioè PUBLIC con `execute`, su tutte e quattro.
+
+**Segnale**: due database che dicono di avere le stesse migration applicate e rispondono in modo
+diverso a `has_function_privilege('anon', '<fn>(...)', 'execute')`. Il record in
+`app_schema_migrations` dice che il file è passato, non che il suo effetto è ancora lì: un
+ripristino, una dashboard, uno strumento che ricrea la funzione e le rimette i grant di default
+lasciano il record intatto e l'ACL no — e `db:migrate` non ripasserà mai su quel file.
+
+**Mossa**: il grant si rimette, ma non è la difesa. La difesa è il filtro DENTRO il corpo, che
+regge anche se il grant torna — la forma è in `20260905120000_secdef_least_privilege.sql`. E lo
+stato vero si guarda in `pg_proc.proacl`, non nell'elenco delle migration applicate;
+`npm run test:privileges` fa esattamente quella domanda contro un Postgres vero.

--- a/changelog/2026-09-05-self-write-columns.md
+++ b/changelog/2026-09-05-self-write-columns.md
@@ -1,0 +1,124 @@
+# Una policy vincola la riga, non la colonna — e fra quelle colonne c'era il piano
+
+Tre tabelle avevano la stessa forma: una policy che dice «puoi scrivere solo la tua roba», e nessuna
+che dica **quali campi** della tua roba puoi decidere. `profiles self update` con
+`with check (id = auth.uid())`, `org owner all` e `brands via org` con `ALL` e il vincolo
+sull'appartenenza. Tutte e tre vere e tutte e tre insufficienti, perché fra le colonne della propria
+riga ce n'erano che decidono un diritto invece di descrivere un dato.
+
+## Cosa apriva, misurato
+
+**`profiles.approved_at`** è quello che legge `is_approved()`, che è quello che legge `can_enter()`,
+cioè il cancello della beta chiusa. `PATCH /rest/v1/profiles?id=eq.<sé> {"approved_at": "…"}`
+rispondeva 200 e l'utente si approvava da solo.
+
+Va detto con la sua misura, che non è quella di un incendio: in produzione `app_flags` ha
+`closed_beta = false`, quindi `can_enter()` risponde sì a chiunque e la scalata **oggi non apre
+niente**. È una mina, e il giorno in cui qualcuno riaccende il flag — l'unico gesto per cui il
+cancello esiste — il cancello è già scavalcabile e nessuno lo segnala.
+
+**`organizations.plan`** non è latente. `resolveOrgBilling` (credits.ts:205) restituisce
+`org.plan ?? paying?.plan`: la colonna vince per prima e non viene mai confrontata con Stripe.
+`creditQuota` (credits.ts:42) è una lettura in una mappa, e la mappa dice 400 crediti per il piano
+vuoto, 11.250 per `pro`. `PATCH /rest/v1/organizations?id=eq.<la propria> {"plan":"pro"}` valeva
+**28 volte la quota, gratis**. `stripe_subscription_id`, `activated_at`, `brands.plan` e
+`brands.status` erano scrivibili dalla stessa policy, e una policy `ALL` lascia anche NASCERE la
+riga già `pro`: `insert into brands (…, plan)` passa il `with check`, che guarda `org_id`.
+
+## Il confine che mancava non era fra clienti
+
+Quello regge: la RLS lo tiene, su tutte le tabelle. Il confine assente era fra **ciò che un utente
+possiede** e **ciò che un utente può decidere di sé** — e non somiglia a un'intrusione, perché è il
+proprietario che modifica il proprio oggetto. È il motivo per cui un red team che attacca il confine
+fra tenant non lo trova.
+
+## Il grant per colonna, non un trigger
+
+Il livello che sa distinguere le colonne è il GRANT: Postgres non ha un `with check` per colonna.
+Fra le due strade si è presa quella dichiarativa perché la regola resta leggibile senza aprire il
+codice — `information_schema.column_privileges` la racconta in una query — mentre un trigger sarebbe
+codice da ritrovare e una condizione in più da ricordare a ogni colonna nuova. E il default cade nel
+verso giusto: una colonna nuova nasce **non** scrivibile, e il percorso che ne ha bisogno si rompe
+subito e a voce alta invece di restare aperto in silenzio.
+
+L'elenco sta in **un posto solo** per tutte e tre le tabelle
+(`20260905210000_self_write_columns.sql`). Tre registri in tre file divergono al primo cambiamento,
+e divergono senza dirlo.
+
+## Due colonne sono passate al service role, e non sono soldi
+
+`brands.stripe_customer_id` e `brands.zernio_profile_id` erano scritte col client dell'utente
+(`ensureBrandCustomer`, `ensureBrandProfile`). Non sono soldi di per sé, ma scriverci il valore di un
+ALTRO cliente ne eredita la capacità: il trigger della 0007 aggancia la sottoscrizione proprio per
+`stripe_customer_id` (`where b.stripe_customer_id = NEW.customer`), e `zernio_profile_id` è il
+profilo con cui si pubblica sui social collegati. Le due funzioni ora scrivono con la chiave di
+servizio: l'utente le fa nascere, non le sceglie.
+
+## Il grant non era la difesa: quattro `SECURITY DEFINER` senza controllo nel corpo
+
+`brand_provider_spend_usd`, `agent_kit_claim_run`, `agent_kit_close_run`,
+`agent_kit_wait_for_approval` non guardano né `auth.uid()`, né `auth.role()`, né
+`auth_brand_ids()`. In produzione reggono perché `anon` e `authenticated` non hanno `execute` —
+verificato, otto combinazioni su otto false. **Sullo stack self-hosted locale, stesse migration,
+otto su otto vere**: `proacl` mostra `=X/…`, cioè PUBLIC con `execute`, su tutte e quattro. Un
+`revoke` in una migration è un evento, non uno stato: il record in `app_schema_migrations` dice che
+il file è passato, non che il suo effetto è ancora lì, e `db:migrate` non ripasserà mai su quel file.
+
+Quindi il filtro va **dentro il corpo**, che è la forma già scelta in
+`20260905120000_secdef_least_privilege.sql`. Due forme, perché le funzioni non si somigliano:
+
+- `brand_provider_spend_usd` prende un `brand_id`, quindi il tenant è nell'argomento: il filtro è
+  quello che la sorella `sum_brand_ai_cost_usd` (0164) ha già.
+- Le tre `agent_kit_*` prendono un `run_id`. Non si risale al tenant perché non serve: l'unico
+  chiamante a runtime è la service role (`run-store.ts` riceve il client, e i soli percorsi che lo
+  costruiscono sono in `scripts/eval/durability.ts` con `createAdminClient()`; `runTurn` non ha
+  chiamanti fuori dai suoi test, e in `src/` non c'è una chiamata a queste tre RPC). Il controllo è
+  `if auth.role() <> 'service_role' then raise`, la forma che `append_thread_event` ha già.
+
+Onestà su `agent_kit_wait_for_approval`: oggi una chiamata estranea non depositava niente comunque,
+ma **per caso** — l'insert in `agent_kit_approval_requests` finisce in `append_thread_event`, che
+alza, e l'intera chiamata torna indietro. L'`update … set state = 'waiting_takeover'` in cima
+partiva lo stesso, e il giorno in cui `thread_id` diventasse opzionale resterebbe scoperto.
+
+## Il test che si rompe da solo
+
+Vitest mocka Supabase: un update finto accetta qualunque cosa, quindi policy, grant e corpi di
+SECURITY DEFINER lì non si misurano. `scripts/privilege-harness.mjs` (`npm run test:privileges`) è
+il gemello di `constraint-harness.mjs`: scrive davvero contro un Postgres locale, dentro una
+transazione chiusa da `rollback`, con `set local role authenticated` e le claim del JWT.
+
+Tre proprietà, e la terza è quella che vale nel tempo:
+
+1. la scalata deve essere **rifiutata** (42501 sulle colonne, P0001 dentro le funzioni);
+2. il percorso legittimo deve **continuare a funzionare** — nome, lingua, avatar, fuso,
+   piattaforme, e il service role che prende, mette in attesa e chiude un run;
+3. **ogni colonna delle tre tabelle deve essere classificata** nel registro. Una colonna nuova non
+   classificata rende rosso l'harness e la nomina — provato aggiungendo `organizations.can_publish`
+   dentro la transazione: `FAIL … non classificate: can_publish`.
+
+Le SECURITY DEFINER si provano col grant **rimesso** dentro la transazione, di proposito: la domanda
+non è «authenticated può eseguirla?» — quella la decide un grant, e un grant torna — ma «se la
+eseguisse, cosa otterrebbe?».
+
+Rosso prima: 4/14. Verde dopo l'aggiunta delle tabelle e delle asserzioni: 29/29.
+
+## Niente changelog pubblico
+
+Per chi usa il prodotto non cambia niente: nome, lingua, avatar, impostazioni del brand si salvano
+come prima, e l'unica differenza è per chi stava scavalcando. Annunciarla darebbe istruzioni, non
+notizie.
+
+## Quello che resta aperto, e dove ho guardato
+
+Tutte le 78 policy di scrittura dello schema sono per riga, nessuna per colonna. La grande
+maggioranza sono tabelle di contenuto per brand, dove ogni colonna descrive un dato. Quelle in cui
+una colonna somiglia a un diritto, e che NON sono in questa PR:
+
+- **`brand_usage.posts_count` / `videos_count`** — i contatori dei tetti mensili del piano, scritti
+  sotto una policy `ALL` per brand. Non sono i crediti (quelli si contano da `ai_calls`), ma un
+  utente che li azzera si rialza i tetti di post e video.
+- **`api_keys.permissions`** — `api_keys self manage`. Una chiave non può superare i diritti del suo
+  proprietario (`cli-auth` ricontrolla la proprietà del brand), quindi non è una scalata; resta una
+  colonna che descrive un permesso sotto una policy che guarda la riga.
+- **`shared_views.token_hash` / `expires_at` / `revoked_at`** — l'autore può già creare e revocare
+  le proprie viste, ma può anche far tornare viva una vista revocata riscrivendo `revoked_at`.

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "postinstall": "patch-package",
     "eval:durability": "vite-node --config scripts/vite-node.config.ts scripts/eval/durability.ts",
     "test:constraints": "node scripts/constraint-harness.mjs",
-    "test:storage-policies": "node scripts/storage-policy-harness.mjs"
+    "test:storage-policies": "node scripts/storage-policy-harness.mjs",
+    "test:privileges": "node scripts/privilege-harness.mjs"
   },
   "devDependencies": {
     "@internationalized/date": "^3.12.0",

--- a/scripts/privilege-harness.mjs
+++ b/scripts/privilege-harness.mjs
@@ -1,0 +1,552 @@
+/**
+ * OGNI PRIVILEGIO, PROVATO COL RUOLO VERO.
+ *
+ * Il gemello `constraint-harness.mjs` chiede «il CHECK morde?». Qui la domanda è un'altra: «con
+ * la sessione di un cliente, cosa riesco a scrivere e cosa riesco a leggere?». Una policy, un
+ * grant per colonna e il corpo di una SECURITY DEFINER non si misurano in vitest — la suite mocka
+ * Supabase, un insert finto accetta qualunque cosa, e il cancello resta verde mentre è
+ * scavalcabile. Qui il ruolo è vero (`set local role authenticated` con le claim del JWT), la RLS
+ * si valuta, e il rifiuto è uno SQLSTATE di Postgres, non un'aspettativa.
+ *
+ * Le SECURITY DEFINER si provano col grant RIMESSO dentro la transazione, di proposito: la
+ * domanda non è «authenticated può eseguirla?» — quella la decide un grant, e un grant torna —
+ * ma «se la eseguisse, cosa otterrebbe?».
+ *
+ * Si guarda fallire PRIMA delle migration in `FIX_MIGRATIONS` (che l'harness applica dentro la
+ * transazione se esistono) e passare dopo. Tutto gira dentro UNA transazione chiusa da un
+ * ROLLBACK: non resta una riga.
+ *
+ *   DATABASE_URL=postgres://postgres:<pw>@127.0.0.1:5432/postgres node scripts/privilege-harness.mjs
+ *   npm run test:privileges
+ *
+ * DATABASE_URL deve puntare a localhost: contro un database remoto lo script si rifiuta di partire.
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Client } from 'pg';
+
+const INSUFFICIENT_PRIVILEGE = '42501';
+const RAISE_EXCEPTION = 'P0001';
+
+const LOCAL_HOSTS = new Set(['127.0.0.1', 'localhost', '::1', '[::1]']);
+
+const MIGRATIONS_DIR = join(fileURLToPath(new URL('..', import.meta.url)), 'supabase/migrations');
+const REGISTRY_MIGRATION = '20260905210000_self_write_columns.sql';
+const FIX_MIGRATIONS = [REGISTRY_MIGRATION, '20260905220000_secdef_run_and_spend_filters.sql'];
+
+/**
+ * Lo specchio del registro che vive in `REGISTRY_MIGRATION`: `insert` e `update` sono le colonne
+ * che l'utente decide di sé, `system` quelle che decide il sistema. Le tre liste insieme devono
+ * fare TUTTA la tabella, e `system` non può sovrapporsi alle altre due: una colonna nuova non
+ * classificata rende rosso l'harness, che è il solo modo perché la domanda «e questa, chi la
+ * decide?» venga posta prima e non dopo.
+ */
+const SELF_WRITE = {
+  profiles: {
+    insert: [],
+    update: ['full_name', 'avatar_url', 'locale'],
+    system: ['id', 'email', 'utm', 'created_at', 'approved_at']
+  },
+  organizations: {
+    insert: ['name', 'owner_id'],
+    update: [],
+    system: ['id', 'stripe_customer_id', 'stripe_subscription_id', 'plan', 'activated_at', 'created_at']
+  },
+  brands: {
+    insert: [
+      'id', 'org_id', 'created_by', 'name', 'website', 'slug', 'target_platforms', 'content_prefs',
+      'onboarding_completed_at'
+    ],
+    update: [
+      'name', 'website', 'timezone', 'target_platforms', 'content_prefs', 'ads_settings',
+      'chat_default_tier', 'launched_at', 'setup_step', 'setup_completed_at', 'onboarding_state',
+      'onboarding_completed_at', 'own_history_at'
+    ],
+    system: [
+      'status', 'plan', 'stripe_subscription_id', 'stripe_customer_id', 'trial_ends_at',
+      'zernio_profile_id', 'paused_at', 'created_at', 'activated_at', 'autopilot_enabled',
+      'last_autopilot_run_at', 'autopilot_failure_count', 'onboarding_status', 'blog_slug',
+      'blog_config', 'last_rank_check_at', 'last_crawl_at', 'last_review_at', 'last_visual_at',
+      'last_digest_sent_at'
+    ]
+  }
+};
+
+const GUARDED_FUNCTIONS = [
+  'brand_provider_spend_usd',
+  'agent_kit_claim_run',
+  'agent_kit_close_run',
+  'agent_kit_wait_for_approval'
+];
+
+const RESTORED_GRANTS = [
+  'public.brand_provider_spend_usd(uuid, text, timestamptz)',
+  'public.agent_kit_claim_run(uuid, text, timestamptz, timestamptz)',
+  'public.agent_kit_close_run(uuid, text, text, bigint, text, jsonb, jsonb)',
+  'public.agent_kit_wait_for_approval(uuid, text, text, text, jsonb, text, text, jsonb, jsonb)'
+];
+
+const OWNER = '11111111-1111-4111-8111-111111111111';
+const OUTSIDER = '22222222-2222-4222-8222-222222222222';
+const SPENT_USD = 7.25;
+const LEASE_OWNER = 'worker-legittimo';
+
+function localOnly(url) {
+  const { hostname } = new URL(url);
+
+  if (!LOCAL_HOSTS.has(hostname)) {
+    throw new Error(`DATABASE_URL punta a ${hostname}: questo harness scrive, e scrive solo in locale`);
+  }
+}
+
+async function attempt(client, sql, params = []) {
+  await client.query('savepoint probe');
+
+  try {
+    const { rowCount, rows } = await client.query(sql, params);
+    await client.query('release savepoint probe');
+
+    return { accepted: true, rowCount, rows };
+  } catch (error) {
+    await client.query('rollback to savepoint probe');
+    await client.query('release savepoint probe');
+
+    return { accepted: false, code: error.code, message: error.message };
+  }
+}
+
+async function becomes(client, role, uid) {
+  await client.query(`set local role ${role}`);
+  await client.query('select set_config($1, $2, true)', [
+    'request.jwt.claims',
+    JSON.stringify({ sub: uid, role })
+  ]);
+}
+
+async function becomesOwner(client) {
+  await client.query('set local role none');
+  await client.query('select set_config($1, $2, true)', ['request.jwt.claims', '']);
+}
+
+async function scalar(client, sql, params = []) {
+  const { rows } = await client.query(sql, params);
+
+  return rows[0] ? Object.values(rows[0])[0] : null;
+}
+
+async function applyFixes(client) {
+  for (const file of FIX_MIGRATIONS) {
+    const path = join(MIGRATIONS_DIR, file);
+
+    if (!existsSync(path)) {
+      console.log(`(assente, si misura lo schema com'è) ${file}`);
+      continue;
+    }
+
+    await client.query(readFileSync(path, 'utf8'));
+    console.log(`(applicata nella transazione)          ${file}`);
+  }
+}
+
+async function seed(client) {
+  await client.query(
+    `insert into auth.users (id, email) values ($1, 'owner@harness.test'), ($2, 'outsider@harness.test')`,
+    [OWNER, OUTSIDER]
+  );
+
+  const orgId = await scalar(
+    client,
+    `insert into public.organizations (name, owner_id) values ('Harness Org', $1) returning id`,
+    [OWNER]
+  );
+  const brandId = await scalar(
+    client,
+    `insert into public.brands (org_id, name, slug) values ($1, 'Harness Brand', 'harness-brand') returning id`,
+    [orgId]
+  );
+
+  await client.query(
+    `insert into public.ai_calls (brand_id, label, provider, ms, ok, cost_usd)
+     values ($1, 'harness', 'dataforseo', 1, true, $2)`,
+    [brandId, SPENT_USD]
+  );
+
+  const threadId = await scalar(
+    client,
+    `insert into public.chat_threads (brand_id, user_id) values ($1, $2) returning id`,
+    [brandId, OWNER]
+  );
+  const runId = await scalar(
+    client,
+    `insert into public.agent_kit_runs (brand_id, thread_id, agent_id, user_id, state)
+     values ($1, $2, 'auto', $3, 'queued') returning id`,
+    [brandId, threadId, OWNER]
+  );
+
+  return { orgId, brandId, runId };
+}
+
+async function billingFacts(client, orgId, brandId) {
+  const facts = [];
+
+  await becomes(client, 'authenticated', OWNER);
+
+  const upgrade = await attempt(client, `update public.organizations set plan = 'pro' where id = $1`, [orgId]);
+  facts.push({
+    what: "authenticated non si regala il piano dell'organizzazione",
+    ok: upgrade.code === INSUFFICIENT_PRIVILEGE,
+    got: upgrade.accepted ? `accettato, righe ${upgrade.rowCount}` : upgrade.code
+  });
+
+  const subscription = await attempt(
+    client,
+    `update public.organizations set stripe_subscription_id = 'sub_finto', activated_at = now() where id = $1`,
+    [orgId]
+  );
+  facts.push({
+    what: 'authenticated non si inventa un abbonamento Stripe',
+    ok: subscription.code === INSUFFICIENT_PRIVILEGE,
+    got: subscription.accepted ? 'accettato' : subscription.code
+  });
+
+  const activate = await attempt(
+    client,
+    `update public.brands set plan = 'pro', status = 'active' where id = $1`,
+    [brandId]
+  );
+  facts.push({
+    what: 'authenticated non attiva il brand da sé',
+    ok: activate.code === INSUFFICIENT_PRIVILEGE,
+    got: activate.accepted ? 'accettato' : activate.code
+  });
+
+  const bornPro = await attempt(
+    client,
+    `insert into public.brands (org_id, name, slug, plan) values ($1, 'Furbo', 'furbo', 'pro')`,
+    [orgId]
+  );
+  facts.push({
+    what: 'authenticated non fa nascere un brand già pro',
+    ok: bornPro.code === INSUFFICIENT_PRIVILEGE,
+    got: bornPro.accepted ? 'accettato' : bornPro.code
+  });
+
+  const orgBornPro = await attempt(
+    client,
+    `insert into public.organizations (name, owner_id, plan) values ('Furba', $1, 'pro')`,
+    [OWNER]
+  );
+  facts.push({
+    what: "authenticated non fa nascere un'organizzazione già pro",
+    ok: orgBornPro.code === INSUFFICIENT_PRIVILEGE,
+    got: orgBornPro.accepted ? 'accettato' : orgBornPro.code
+  });
+
+  await becomesOwner(client);
+
+  const plan = await scalar(client, 'select plan from public.organizations where id = $1', [orgId]);
+  facts.push({ what: "il piano dell'organizzazione è ancora quello di prima", ok: plan === null, got: plan });
+
+  return facts;
+}
+
+async function profileFacts(client) {
+  const facts = [];
+
+  facts.push({
+    what: 'il trigger di signup crea il profilo',
+    ok: (await scalar(client, 'select count(*)::int from public.profiles where id = $1', [OWNER])) === 1
+  });
+
+  await becomes(client, 'authenticated', OWNER);
+
+  const selfApprove = await attempt(client, 'update public.profiles set approved_at = now() where id = $1', [OWNER]);
+  facts.push({
+    what: 'authenticated non si scrive approved_at addosso',
+    ok: selfApprove.code === INSUFFICIENT_PRIVILEGE,
+    got: selfApprove.accepted ? `accettato, righe ${selfApprove.rowCount}` : selfApprove.code
+  });
+
+  const rewriteEmail = await attempt(
+    client,
+    `update public.profiles set email = 'chiunque@altrove.test' where id = $1`,
+    [OWNER]
+  );
+  facts.push({
+    what: 'authenticated non riscrive la propria email',
+    ok: rewriteEmail.code === INSUFFICIENT_PRIVILEGE,
+    got: rewriteEmail.accepted ? 'accettato' : rewriteEmail.code
+  });
+
+  const ownFields = await attempt(
+    client,
+    `update public.profiles set full_name = 'Nome Cognome', locale = 'it', avatar_url = 'https://x/y.png'
+     where id = $1`,
+    [OWNER]
+  );
+  facts.push({
+    what: 'authenticated cambia nome, lingua e avatar come prima',
+    ok: ownFields.accepted && ownFields.rowCount === 1,
+    got: ownFields.accepted ? `righe ${ownFields.rowCount}` : ownFields.code
+  });
+
+  const approved = await scalar(client, 'select public.is_approved()');
+  facts.push({ what: 'is_approved() resta falso dopo il tentativo', ok: approved === false, got: approved });
+
+  await becomesOwner(client);
+
+  return facts;
+}
+
+async function columnsOf(client, table) {
+  const { rows } = await client.query(
+    `select column_name from information_schema.columns where table_schema = 'public' and table_name = $1`,
+    [table]
+  );
+
+  return rows.map((r) => r.column_name);
+}
+
+async function grantedTo(client, table, privilege) {
+  const { rows } = await client.query(
+    `select column_name from information_schema.column_privileges
+     where table_schema = 'public' and table_name = $1 and grantee = 'authenticated' and privilege_type = $2`,
+    [table, privilege]
+  );
+
+  return rows.map((r) => r.column_name);
+}
+
+function missing(expected, actual) {
+  const seen = new Set(actual);
+
+  return expected.filter((x) => !seen.has(x));
+}
+
+async function registryFacts(client) {
+  const facts = [];
+
+  for (const [table, registry] of Object.entries(SELF_WRITE)) {
+    const userDecides = [...new Set([...registry.insert, ...registry.update])];
+    const real = await columnsOf(client, table);
+    const unclassified = missing(real, [...userDecides, ...registry.system]);
+    const bothWays = registry.system.filter((c) => userDecides.includes(c));
+
+    facts.push({
+      what: `${table}: ogni colonna è classificata in ${REGISTRY_MIGRATION}`,
+      ok: unclassified.length === 0 && bothWays.length === 0,
+      got: unclassified.length
+        ? `non classificate: ${unclassified.join(', ')}`
+        : bothWays.length
+          ? `classificate due volte: ${bothWays.join(', ')}`
+          : `${real.length} colonne`
+    });
+
+    for (const [privilege, expected] of [
+      ['UPDATE', registry.update],
+      ['INSERT', registry.insert]
+    ]) {
+      const granted = await grantedTo(client, table, privilege);
+      facts.push({
+        what: `${table}: authenticated ${privilege === 'UPDATE' ? 'aggiorna' : 'inserisce'} solo ciò che decide di sé`,
+        ok: missing(granted, expected).length === 0 && missing(expected, granted).length === 0,
+        got: granted.sort().join(', ') || 'niente'
+      });
+    }
+  }
+
+  return facts;
+}
+
+async function grantFacts(client) {
+  const open = await scalar(
+    client,
+    `select count(*)::int
+     from pg_proc p, unnest(array['anon', 'authenticated']) as r(rolname)
+     where p.pronamespace = 'public'::regnamespace
+       and p.proname = any($1)
+       and has_function_privilege(r.rolname, p.oid, 'execute')`,
+    [GUARDED_FUNCTIONS]
+  );
+
+  return [
+    {
+      what: 'nessuna delle quattro è eseguibile da anon o authenticated',
+      ok: open === 0,
+      got: `${open} combinazioni aperte`
+    }
+  ];
+}
+
+async function spendFacts(client, brandId) {
+  const leaked = await attempt(
+    client,
+    `select public.brand_provider_spend_usd($1, 'dataforseo', now() - interval '1 day') as usd`,
+    [brandId]
+  );
+  const leakedUsd = leaked.accepted ? Number(leaked.rows[0].usd) : null;
+
+  await becomesOwner(client);
+  await becomes(client, 'service_role', OWNER);
+  const real = Number(await scalar(client, `select public.brand_provider_spend_usd($1, 'dataforseo', now() - interval '1 day')`, [brandId]));
+  await becomesOwner(client);
+
+  return [
+    {
+      what: 'la spesa per fornitore di un brand altrui non esce',
+      ok: leakedUsd === 0,
+      got: leaked.accepted ? `$${leakedUsd}` : leaked.code
+    },
+    { what: 'il service role legge ancora la spesa vera', ok: real === SPENT_USD, got: `$${real}` }
+  ];
+}
+
+async function runState(client, runId) {
+  return scalar(client, 'select state from public.agent_kit_runs where id = $1', [runId]);
+}
+
+async function fence(client, runId) {
+  return scalar(client, 'select lease_fence from public.agent_kit_runs where id = $1', [runId]);
+}
+
+async function runFacts(client, runId) {
+  const facts = [];
+
+  const stolenClaim = await attempt(
+    client,
+    `select public.agent_kit_claim_run($1, 'ladro', now(), now() + interval '5 minutes')`,
+    [runId]
+  );
+  await becomesOwner(client);
+  facts.push({
+    what: 'authenticated non prende il run di un altro tenant',
+    ok: stolenClaim.code === RAISE_EXCEPTION && (await runState(client, runId)) === 'queued',
+    got: stolenClaim.accepted ? `preso, stato ${await runState(client, runId)}` : stolenClaim.code
+  });
+
+  await becomes(client, 'service_role', OWNER);
+  const claimed = await attempt(
+    client,
+    `select public.agent_kit_claim_run($1, $2, now(), now() + interval '5 minutes')`,
+    [runId, LEASE_OWNER]
+  );
+  await becomesOwner(client);
+  facts.push({
+    what: 'il service role prende il run come prima',
+    ok: claimed.accepted && (await runState(client, runId)) === 'running',
+    got: claimed.accepted ? await runState(client, runId) : claimed.code
+  });
+
+  const held = await fence(client, runId);
+
+  await becomes(client, 'authenticated', OUTSIDER);
+  const stolenClose = await attempt(
+    client,
+    `select public.agent_kit_close_run($1, 'aborted', $2, $3, 'rubato', null, null)`,
+    [runId, LEASE_OWNER, held]
+  );
+  const stolenWait = await attempt(
+    client,
+    `select public.agent_kit_wait_for_approval($1, 'a1', 't1', 'tool', '{}'::jsonb, 'h1', 'perché', '{}'::jsonb, null)`,
+    [runId]
+  );
+  await becomesOwner(client);
+  facts.push({
+    what: 'authenticated non chiude il run di un altro tenant',
+    ok: stolenClose.code === RAISE_EXCEPTION && (await runState(client, runId)) === 'running',
+    got: stolenClose.accepted ? `chiuso, stato ${await runState(client, runId)}` : stolenClose.code
+  });
+  facts.push({
+    what: 'authenticated non mette il run di un altro in attesa di approvazione',
+    ok:
+      stolenWait.code === RAISE_EXCEPTION &&
+      stolenWait.message.startsWith('agent_kit_wait_for_approval:') &&
+      (await scalar(client, 'select count(*)::int from public.agent_kit_approval_requests')) === 0,
+    got: stolenWait.accepted ? `stato ${await runState(client, runId)}` : stolenWait.message
+  });
+
+  await becomes(client, 'service_role', OWNER);
+  const waited = await attempt(
+    client,
+    `select public.agent_kit_wait_for_approval($1, 'a1', 't1', 'tool', '{}'::jsonb, 'h1', 'perché', '{}'::jsonb, null)`,
+    [runId]
+  );
+  await becomesOwner(client);
+  facts.push({
+    what: 'il service role mette il run in attesa come prima',
+    ok: waited.accepted && (await runState(client, runId)) === 'waiting_takeover',
+    got: waited.accepted ? await runState(client, runId) : waited.code
+  });
+
+  await becomes(client, 'service_role', OWNER);
+  await client.query(`select public.agent_kit_claim_run($1, $2, now(), now() + interval '5 minutes')`, [runId, LEASE_OWNER]);
+  const closed = await attempt(
+    client,
+    `select public.agent_kit_close_run($1, 'done', $2, $3, 'completed', null, null) as out`,
+    [runId, LEASE_OWNER, await fence(client, runId)]
+  );
+  await becomesOwner(client);
+  facts.push({
+    what: 'il service role chiude il run come prima',
+    ok: closed.accepted && closed.rows[0].out.closed === true && (await runState(client, runId)) === 'done',
+    got: closed.accepted ? JSON.stringify(closed.rows[0].out) : closed.code
+  });
+
+  return facts;
+}
+
+async function main() {
+  const url = process.env.DATABASE_URL;
+
+  if (!url) {
+    console.error('DATABASE_URL mancante');
+    process.exit(2);
+  }
+
+  localOnly(url);
+
+  const client = new Client({ connectionString: url });
+  await client.connect();
+  await client.query('begin');
+
+  let facts = [];
+
+  try {
+    await applyFixes(client);
+
+    const { orgId, brandId, runId } = await seed(client);
+
+    facts = facts.concat(await profileFacts(client));
+    facts = facts.concat(await billingFacts(client, orgId, brandId));
+    facts = facts.concat(await registryFacts(client));
+    facts = facts.concat(await grantFacts(client));
+
+    for (const signature of RESTORED_GRANTS) {
+      await client.query(`grant execute on function ${signature} to authenticated`);
+    }
+
+    await becomes(client, 'authenticated', OUTSIDER);
+    facts = facts.concat(await spendFacts(client, brandId));
+
+    await becomes(client, 'authenticated', OUTSIDER);
+    facts = facts.concat(await runFacts(client, runId));
+  } finally {
+    await client.query('rollback');
+    await client.end();
+  }
+
+  console.log('');
+  for (const fact of facts) {
+    console.log(`${fact.ok ? 'ok  ' : 'FAIL'}  ${fact.what}  (${fact.got ?? 'sì'})`);
+  }
+
+  const failed = facts.filter((f) => !f.ok).length;
+  console.log(`\n${facts.length - failed}/${facts.length} privilegi tengono`);
+  process.exit(failed === 0 ? 0 : 1);
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(2);
+});

--- a/src/lib/server/stripe.ts
+++ b/src/lib/server/stripe.ts
@@ -1,6 +1,6 @@
 import { env } from '$env/dynamic/private';
-import type { SupabaseClient } from '@supabase/supabase-js';
 import Stripe from 'stripe';
+import { createAdminClient } from './supabase-admin';
 import type { Currency } from '$lib/plans';
 
 let client: Stripe | null = null;
@@ -71,18 +71,23 @@ export function geoCouponFor(country: string | null | undefined): string | undef
  * A brand's Stripe customer, created on first need. The id on the row is what migration 0007's
  * trigger joins on to mirror the subscription back into `brands.plan` / `brands.status`, so it
  * has to be written before checkout, not after it.
+ *
+ * Written with the service role and not with the caller's session: that join key is a right, not a
+ * preference — another customer's id on this row would mirror their subscription onto this brand.
+ * `20260905210000_self_write_columns.sql` keeps `authenticated` out of the column.
  */
-export async function ensureBrandCustomer(
-  supabase: SupabaseClient,
-  brand: { id: string; name: string; stripe_customer_id: string | null }
-): Promise<string> {
+export async function ensureBrandCustomer(brand: {
+  id: string;
+  name: string;
+  stripe_customer_id: string | null;
+}): Promise<string> {
   if (brand.stripe_customer_id) return brand.stripe_customer_id;
 
   const customer = await stripe().customers.create({
     name: brand.name,
     metadata: { brand_id: brand.id }
   });
-  await supabase.from('brands').update({ stripe_customer_id: customer.id }).eq('id', brand.id);
+  await createAdminClient().from('brands').update({ stripe_customer_id: customer.id }).eq('id', brand.id);
 
   return customer.id;
 }

--- a/src/lib/server/zernio.ts
+++ b/src/lib/server/zernio.ts
@@ -24,14 +24,20 @@ export type { LinkedInOrg, PendingOAuthData, FacebookPage };
 
 type BrandRef = { id: string; name: string; zernio_profile_id: string | null };
 
-export async function ensureBrandProfile(supabase: SupabaseClient, brand: BrandRef): Promise<string> {
+/**
+ * Written with the service role and not with the caller's session: this id is the profile the brand
+ * publishes THROUGH, so another tenant's value on this row would inherit their connected accounts.
+ * `20260905210000_self_write_columns.sql` keeps `authenticated` out of the column.
+ */
+export async function ensureBrandProfile(brand: BrandRef): Promise<string> {
   if (brand.zernio_profile_id) return brand.zernio_profile_id;
 
   const profileId = await publisher.createProfile({
     name: `Anomalia · ${brand.name}`,
     description: `Anomalia brand ${brand.id}`
   });
-  await supabase.from('brands').update({ zernio_profile_id: profileId }).eq('id', brand.id);
+  const { createAdminClient } = await import('./supabase-admin');
+  await createAdminClient().from('brands').update({ zernio_profile_id: profileId }).eq('id', brand.id);
   return profileId;
 }
 

--- a/src/routes/app/[brand]/activate/+page.server.ts
+++ b/src/routes/app/[brand]/activate/+page.server.ts
@@ -50,7 +50,7 @@ export const actions: Actions = {
     if (!brand) throw redirect(303, '/app');
 
     const checkoutUrl = await createCheckoutSession({
-      customerId: await ensureBrandCustomer(supabase, brand),
+      customerId: await ensureBrandCustomer(brand),
       brandId: brand.id,
       plan,
       priceId,

--- a/src/routes/app/[brand]/ads/connect/[channel]/+server.ts
+++ b/src/routes/app/[brand]/ads/connect/[channel]/+server.ts
@@ -32,7 +32,7 @@ export const GET: RequestHandler = async ({ params, url, locals: { supabase, saf
   if (!brand) throw error(404, 'Brand not found');
   if (!adsAvailable(brand.plan, user?.email)) throw redirect(303, `/app/${params.brand}/settings/ads/accounts`);
 
-  const profileId = await ensureBrandProfile(supabase, brand);
+  const profileId = await ensureBrandProfile(brand);
   // Land back in Settings → Ads accounts so connect/manage lives next to social accounts.
   // ?connected=1 triggers syncAdAccounts on that page.
   const accountsUrl = `/app/${params.brand}/settings/ads/accounts`;

--- a/src/routes/app/[brand]/settings/connect/[platform]/+server.ts
+++ b/src/routes/app/[brand]/settings/connect/[platform]/+server.ts
@@ -34,7 +34,7 @@ export const GET: RequestHandler = async ({ params, url, locals: { supabase, saf
     throw redirect(303, `/app/${params.brand}/settings/connected-accounts?error=limit`);
   }
 
-  const profileId = await ensureBrandProfile(supabase, brand);
+  const profileId = await ensureBrandProfile(brand);
   // After authorising on Zernio, come back INTO our app (not stranded on Zernio). ?connected=1
   // triggers an immediate account sync. The onboarding setup flow returns to /activate so it can
   // resume at the connect step; everywhere else returns to Settings.

--- a/supabase/migrations/20260905210000_self_write_columns.sql
+++ b/supabase/migrations/20260905210000_self_write_columns.sql
@@ -1,0 +1,128 @@
+-- IL REGISTRO DI CHI DECIDE COSA. Sta qui, per tutte e tre le tabelle, e da nessun'altra parte.
+--
+-- Una policy RLS vincola la RIGA, non la COLONNA. `profiles self update` dice
+-- `using (id = auth.uid()) with check (id = auth.uid())`; `org owner all` e `brands via org` dicono
+-- la stessa cosa per ALL. Letto di corsa sembra completo — «puoi scrivere solo la tua roba» — ed è
+-- vero e insufficiente, perché fra le colonne della propria roba ce ne sono che **decidono un
+-- diritto** invece di descrivere un dato, e un `with check` non ha niente da dire su QUALE colonna
+-- stai scrivendo.
+--
+-- Cosa apre, misurato e non supposto:
+--
+--   `PATCH /rest/v1/profiles?id=eq.<sé> {"approved_at":"…"}` → 200. `approved_at` è ciò che legge
+--   `is_approved()`, che è ciò che legge `can_enter()`, cioè il cancello della beta chiusa. Oggi in
+--   produzione `app_flags.closed_beta = false`, quindi la scalata non apre niente: è una mina, non
+--   un incendio. Il giorno in cui il flag si riaccende — l'unico gesto per cui il cancello esiste —
+--   è già scavalcabile da chiunque abbia un account, e niente lo segnala.
+--
+--   `PATCH /rest/v1/organizations?id=eq.<la propria> {"plan":"pro"}` → 200, e questo NON è latente.
+--   `resolveOrgBilling` (credits.ts:205) restituisce `org.plan ?? paying?.plan`:
+--   `organizations.plan` vince per primo e non viene mai confrontato con Stripe. `creditQuota`
+--   (credits.ts:42) è una lettura in una mappa, e la mappa dice 400 crediti per il piano vuoto e
+--   11.250 per `pro` (plans.ts). Ventotto volte la quota, senza toccare Stripe.
+--
+--   E una policy `ALL` lascia anche NASCERE la riga già `pro`: `insert into brands (…, plan)` passa
+--   il `with check`, che guarda `org_id`, non `plan`.
+--
+-- Il confine che mancava non è quello fra clienti — quello regge, la RLS lo tiene. È quello fra ciò
+-- che un utente **possiede** e ciò che un utente **può decidere di sé**, e non somiglia a
+-- un'intrusione: è il proprietario che modifica il proprio oggetto.
+--
+-- ── Perché il grant per colonna, e non un trigger ────────────────────────────────────────────
+--
+-- Il livello che sa distinguere le colonne è il GRANT. Fra le due strade si prende questa perché la
+-- regola resta LEGGIBILE senza aprire il codice:
+--
+--   select table_name, column_name, privilege_type from information_schema.column_privileges
+--   where grantee = 'authenticated' and table_name in ('profiles', 'organizations', 'brands');
+--
+-- Un trigger sarebbe codice che il prossimo deve prima trovare, e una condizione in più da
+-- ricordare a ogni colonna nuova. Qui l'elenco È la regola, e il default cade nel verso giusto: una
+-- colonna nuova nasce non scrivibile, e il percorso che ne ha bisogno si rompe subito e a voce alta
+-- invece di restare aperto in silenzio.
+--
+-- `npm run test:privileges` (`scripts/privilege-harness.mjs`) tiene lo specchio di questo elenco e
+-- diventa rosso in tre casi: una colonna nuova non classificata, un grant più largo di quanto è
+-- dichiarato qui, un tentativo di scalata che riesce.
+--
+-- Niente di tutto questo tocca il service role: `/admin/users` approva, il trigger
+-- `sync_brand_from_stripe_subscription` (0007) scrive `plan`/`status`/`activated_at`, i cron
+-- scrivono i loro cursori. E dentro una SECURITY DEFINER il `current_user` è il proprietario della
+-- funzione, non `authenticated`: `accept_brand_invite` continua a scrivere l'`approved_at` di chi
+-- accetta un invito, e `handle_new_user` a creare il profilo con la sua email.
+
+-- ── profiles ────────────────────────────────────────────────────────────────────────────────
+--
+-- Decide l'utente: `full_name` (settings-actions.updateProfile), `avatar_url` (carica e rimuovi la
+-- foto), `locale` (`+layout.server.ts` alla prima visita, `POST /api/v1/locale`).
+--
+-- Decide il sistema: `approved_at` (il cancello), `email` (la scrive solo `handle_new_user`,
+-- copiandola da `auth.users`), `id`, `utm`, `created_at`.
+--
+-- `email` non decide nessun accesso, ed è stato cercato prima di dirlo: `is_admin()` e
+-- `accept_brand_invite` confrontano con l'email del JWT, `is_user_approved` con quella di
+-- `auth.users`, e nessuno cerca un profilo PER email — chi la legge la usa come indirizzo a cui
+-- spedire o come stringa da mostrare. Resta fuori lo stesso, per una ragione che non è la scalata:
+-- `/admin/users` la mostra alla persona che approva, e un indirizzo riscritto dall'utente le mente.
+--
+-- L'INSERT non ha una policy, quindi la RLS lo rifiuta già; il grant si toglie perché l'elenco resti
+-- vero a colpo d'occhio, non perché apra qualcosa.
+
+revoke insert, update on public.profiles from anon, authenticated;
+grant update (full_name, avatar_url, locale) on public.profiles to authenticated;
+
+-- ── organizations ───────────────────────────────────────────────────────────────────────────
+--
+-- Decide l'utente: solo la nascita del proprio workspace (`ensureOrgForUser`, org.ts:51), con
+-- `name` e `owner_id` — e `owner_id` la policy lo inchioda già a `auth.uid()`.
+--
+-- Decide il sistema: `plan`, `activated_at`, `stripe_customer_id`, `stripe_subscription_id`. Sono
+-- il piano e la sua prova, e li scrive Stripe attraverso il service role.
+--
+-- Nessun UPDATE: in tutto il repository non c'è un percorso che aggiorni `organizations` col client
+-- dell'utente. Il giorno che si vorrà rinominare un workspace dall'interfaccia si aggiunge qui
+-- `grant update (name)`, e il test lo pretende.
+
+revoke insert, update on public.organizations from anon, authenticated;
+grant insert (name, owner_id) on public.organizations to authenticated;
+
+-- ── brands ──────────────────────────────────────────────────────────────────────────────────
+--
+-- Decide l'utente, alla nascita: `id` (l'onboarding conia l'uuid nel browser, brand-create.ts),
+-- `org_id`, `slug`, `created_by`, più i campi che il wizard raccoglie.
+--
+-- Decide l'utente, dopo: le impostazioni e il contenuto — nome, sito, fuso, piattaforme,
+-- preferenze, annunci, modello della chat — più i segnaposto del percorso di setup (`setup_step`,
+-- `onboarding_state`, `launched_at`) e il cursore dell'import storico (`own_history_at`, che il
+-- load di /analytics scrive col client dell'utente).
+--
+-- Decide il sistema, e sono i soldi: `plan`, `status`, `activated_at`, `trial_ends_at`,
+-- `paused_at`, `stripe_subscription_id`. Li scrive il trigger della 0007 leggendo
+-- `stripe.subscriptions`.
+--
+-- Decide il sistema, e sono chiavi di identità esterna: `stripe_customer_id` e `zernio_profile_id`.
+-- Non sono soldi di per sé, ma scriverci il valore di un ALTRO cliente ne eredita la capacità: il
+-- trigger della 0007 aggancia la sottoscrizione proprio per `stripe_customer_id`
+-- (`where b.stripe_customer_id = NEW.customer`), e `zernio_profile_id` è il profilo con cui si
+-- pubblica sui social collegati. Le due funzioni che li coniano — `ensureBrandCustomer`,
+-- `ensureBrandProfile` — passano alla chiave di servizio nello stesso commit: l'utente le fa
+-- nascere, non le sceglie.
+--
+-- Decide il sistema, e sono cursori di cron: `last_rank_check_at`, `last_crawl_at`,
+-- `last_review_at`, `last_visual_at`, `last_digest_sent_at`, `last_autopilot_run_at`,
+-- `autopilot_failure_count`, `blog_slug`, `blog_config` — tutti scritti con `createAdminClient()`.
+-- E `autopilot_enabled`, che è ritirato (job-roster.ts): nessuno lo scrive più.
+--
+-- La DELETE resta intera: `settings-actions.deleteBrand` cancella il brand col client dell'utente, e
+-- una riga si cancella o no — non per colonne.
+
+revoke insert, update on public.brands from anon, authenticated;
+grant insert (
+  id, org_id, created_by, name, website, slug, target_platforms, content_prefs,
+  onboarding_completed_at
+) on public.brands to authenticated;
+grant update (
+  name, website, timezone, target_platforms, content_prefs, ads_settings, chat_default_tier,
+  launched_at, setup_step, setup_completed_at, onboarding_state, onboarding_completed_at,
+  own_history_at
+) on public.brands to authenticated;

--- a/supabase/migrations/20260905220000_secdef_run_and_spend_filters.sql
+++ b/supabase/migrations/20260905220000_secdef_run_and_spend_filters.sql
@@ -1,0 +1,305 @@
+-- Il grant non è una difesa: è una porta che qualcuno può riaprire.
+--
+-- `20260905120000_secdef_least_privilege.sql` ha già fatto questo lavoro per le funzioni sorelle,
+-- e il criterio è lì. Queste quattro erano rimaste fuori, e sono il caso che il criterio serve a
+-- coprire: SECURITY DEFINER di un proprietario con `rolbypassrls`, e nel corpo NESSUN controllo —
+-- né `auth.uid()`, né `auth.role()`, né `auth_brand_ids()`. Reggono soltanto perché `anon` e
+-- `authenticated` non hanno `execute`.
+--
+-- In produzione oggi non ce l'hanno: verificato con `has_function_privilege`, otto combinazioni su
+-- otto false. Quindi NON sono buchi aperti, e questa migration non ripara un incendio. Ripara la
+-- dipendenza da una condizione che non è nostra: su uno stack costruito con gli strumenti di
+-- questo repository le stesse otto combinazioni sono TUTTE vere (`npm run test:privileges` lo
+-- misura, e lo ha misurato). Basta un grant di troppo — una dashboard, un ripristino, uno
+-- strumento che ricrea la funzione e le rimette i grant di default — e da
+-- `brand_provider_spend_usd` esce la spesa per fornitore di un tenant qualunque con la sola chiave
+-- pubblica, e dalle `agent_kit_*` esce una SCRITTURA cross-tenant su un run di cui si conosca
+-- l'uuid. Col filtro dentro, la funzione regge anche se il grant torna.
+--
+-- Due forme, perché le funzioni non si somigliano.
+--
+-- `brand_provider_spend_usd` prende un `brand_id`, quindi il tenant è nell'argomento: il filtro è
+-- quello che la sorella `sum_brand_ai_cost_usd` (0164) ha già, copiato senza inventare niente.
+-- `authenticated` non riprende `execute`: l'unico chiamante è `rank-tracker.ts`, che gira in un
+-- cron con `createAdminClient()`.
+--
+-- Le tre `agent_kit_*` prendono un `run_id`, non un brand — e non si risale al tenant, perché non
+-- serve: l'unico chiamante a runtime è la service role. `run-store.ts` le chiama con il `db` che
+-- riceve, e i soli percorsi che lo costruiscono sono `scripts/eval/durability.ts` con
+-- `createAdminClient()`; `runTurn` non ha chiamanti fuori dai suoi test, e in `src/` non c'è una
+-- sola chiamata a queste tre RPC. Aggiungere `or <brand> in (select auth_brand_ids())` sarebbe
+-- complessità pagata per un chiamante che non esiste: quando arriverà, la riga si aggiunge.
+--
+-- La forma del controllo è quella di `append_thread_event`, che ce l'ha già:
+-- `if auth.role() <> 'service_role' then raise`. Con `auth.role()` nullo — una connessione diretta
+-- a Postgres, cioè qualcuno che possiede già tutto — il confronto è nullo e non alza: identico al
+-- gemello, e nessuna manutenzione dal vivo cambia comportamento.
+--
+-- Nota su `agent_kit_wait_for_approval`, perché il rapporto non la racconti peggio di com'è: oggi
+-- una chiamata estranea non deposita niente comunque, ma per caso — l'`insert` in
+-- `agent_kit_approval_requests` finisce in `append_thread_event`, che alza, e l'intera chiamata
+-- torna indietro. Il `update ... set state = 'waiting_takeover'` in cima parte lo stesso, e il
+-- giorno in cui `thread_id` diventa opzionale o quel controllo si sposta, resta scoperto.
+
+create or replace function public.agent_kit_claim_run(
+  p_run_id uuid,
+  p_owner text,
+  p_now timestamptz,
+  p_lease_until timestamptz
+) returns public.agent_kit_runs
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_run public.agent_kit_runs%rowtype;
+begin
+  if auth.role() <> 'service_role' then
+    raise exception 'agent_kit_claim_run: solo il service role';
+  end if;
+
+  update public.agent_kit_runs
+  set state = 'running',
+      lease_owner = p_owner,
+      lease_fence = lease_fence + 1,
+      attempt = attempt + 1,
+      lease_until = p_lease_until,
+      heartbeat_at = p_now,
+      updated_at = now()
+  where id = p_run_id
+    and (
+      state in ('queued', 'waiting_input', 'waiting_takeover')
+      or (state = 'running' and (lease_until is null or lease_until <= p_now))
+    )
+  returning * into v_run;
+
+  return v_run;
+end;
+$$;
+
+revoke all on function public.agent_kit_claim_run(uuid, text, timestamptz, timestamptz) from public, anon, authenticated;
+grant execute on function public.agent_kit_claim_run(uuid, text, timestamptz, timestamptz) to service_role;
+
+create or replace function public.agent_kit_close_run(
+  p_run_id uuid,
+  p_to_state text,
+  -- I parametri col default DEVONO stare in fondo, quindi il lease passa davanti. Chi chiama usa
+  -- i nomi (supabase-js manda un oggetto), perciò l'ordine non tocca nessuno.
+  p_owner text,
+  p_fence bigint,
+  p_reason text default null,
+  p_question jsonb default null,
+  p_message jsonb default null
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_run public.agent_kit_runs%rowtype;
+  v_message public.chat_messages%rowtype;
+begin
+  if auth.role() <> 'service_role' then
+    raise exception 'agent_kit_close_run: solo il service role';
+  end if;
+
+  if p_to_state not in ('waiting_input', 'done', 'failed', 'aborted') then
+    raise exception 'agent_kit_close_run: state is not allowed';
+  end if;
+
+  update public.agent_kit_runs
+  set state = p_to_state,
+      reason = coalesce(p_reason, reason),
+      question = coalesce(p_question, question),
+      harness_continue_state = null,
+      updated_at = now()
+  where id = p_run_id
+    and state = 'running'
+    and lease_owner = p_owner
+    and lease_fence = p_fence
+  returning * into v_run;
+
+  if v_run.id is null then
+    return jsonb_build_object('closed', false);
+  end if;
+
+  if p_message is not null then
+    insert into public.chat_messages (brand_id, user_id, thread_id, role, content, reasoning, tool_calls, attachments, name)
+    values (
+      v_run.brand_id,
+      v_run.user_id,
+      v_run.thread_id,
+      'assistant',
+      coalesce(p_message->>'content', ''),
+      p_message->>'reasoning',
+      p_message->'tool_calls',
+      p_message->'attachments',
+      p_message->>'name'
+    )
+    returning * into v_message;
+
+    update public.agent_kit_runs
+    set partial_saved_msg_id = v_message.id
+    where id = p_run_id;
+
+  end if;
+
+  if v_run.thread_id is not null then
+    perform public.append_thread_event(
+      v_run.thread_id,
+      'run:' || p_run_id || ':state:' || p_to_state,
+      'progress',
+      jsonb_build_object(
+        'runId', p_run_id,
+        'status', p_to_state,
+        'reason', p_reason,
+        'question', p_question
+      )
+    );
+  end if;
+
+  return jsonb_build_object('closed', true, 'message_id', v_message.id);
+end;
+$$;
+
+revoke all on function public.agent_kit_close_run(uuid, text, text, bigint, text, jsonb, jsonb) from public, anon, authenticated;
+grant execute on function public.agent_kit_close_run(uuid, text, text, bigint, text, jsonb, jsonb) to service_role;
+
+create or replace function public.agent_kit_wait_for_approval(
+  p_run_id uuid,
+  p_harness_approval_id text,
+  p_tool_call_id text,
+  p_tool_name text,
+  p_tool_input jsonb,
+  p_input_hash text,
+  p_reason text,
+  p_continue_state jsonb,
+  p_message jsonb default null
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_run public.agent_kit_runs%rowtype;
+  v_approval public.agent_kit_approval_requests%rowtype;
+  v_message public.chat_messages%rowtype;
+  v_message_payload jsonb;
+begin
+  if auth.role() <> 'service_role' then
+    raise exception 'agent_kit_wait_for_approval: solo il service role';
+  end if;
+
+  update public.agent_kit_runs
+  set state = 'waiting_takeover',
+      harness_continue_state = p_continue_state,
+      question = null,
+      updated_at = now()
+  where id = p_run_id and state = 'running'
+  returning * into v_run;
+
+  if v_run.id is null then
+    return jsonb_build_object('closed', false);
+  end if;
+
+  insert into public.agent_kit_approval_requests (
+    brand_id, thread_id, run_id, user_id, harness_approval_id,
+    tool_call_id, tool_name, tool_input, input_hash, reason
+  ) values (
+    v_run.brand_id, v_run.thread_id, v_run.id, v_run.user_id, p_harness_approval_id,
+    p_tool_call_id, p_tool_name, p_tool_input, p_input_hash, p_reason
+  )
+  returning * into v_approval;
+
+  if p_message is not null then
+    v_message_payload := p_message;
+    if jsonb_typeof(p_message->'tool_calls') = 'array' then
+      v_message_payload := jsonb_set(
+        v_message_payload,
+        '{tool_calls}',
+        (
+          select coalesce(
+            jsonb_agg(
+              case
+                when part->>'type' = 'tool-approval-request'
+                  and part->>'approvalId' = p_harness_approval_id
+                then part || jsonb_build_object('approvalId', v_approval.id::text)
+                else part
+              end
+              order by item.ord
+            ),
+            '[]'::jsonb
+          )
+          from jsonb_array_elements(p_message->'tool_calls') with ordinality as item(part, ord)
+        )
+      );
+    end if;
+
+    insert into public.chat_messages (brand_id, user_id, thread_id, role, content, reasoning, tool_calls, attachments, name)
+    values (
+      v_run.brand_id,
+      v_run.user_id,
+      v_run.thread_id,
+      'assistant',
+      coalesce(v_message_payload->>'content', ''),
+      v_message_payload->>'reasoning',
+      v_message_payload->'tool_calls',
+      v_message_payload->'attachments',
+      v_message_payload->>'name'
+    )
+    returning * into v_message;
+
+    update public.agent_kit_runs
+    set partial_saved_msg_id = v_message.id
+    where id = p_run_id;
+  end if;
+
+  if v_run.thread_id is not null then
+    perform public.append_thread_event(
+      v_run.thread_id,
+      'run:' || p_run_id || ':state:waiting_takeover',
+      'progress',
+      jsonb_build_object(
+        'runId', p_run_id,
+        'status', 'waiting_takeover',
+        'approvalId', v_approval.id
+      )
+    );
+  end if;
+
+  return jsonb_build_object(
+    'closed', true,
+    'approval_id', v_approval.id,
+    'harness_approval_id', v_approval.harness_approval_id,
+    'message_id', v_message.id
+  );
+end;
+$$;
+
+revoke all on function public.agent_kit_wait_for_approval(uuid, text, text, text, jsonb, text, text, jsonb, jsonb) from public, anon, authenticated;
+grant execute on function public.agent_kit_wait_for_approval(uuid, text, text, text, jsonb, text, text, jsonb, jsonb) to service_role;
+
+create or replace function public.brand_provider_spend_usd(
+  p_brand_id uuid,
+  p_provider text,
+  p_since timestamptz
+)
+returns numeric
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select coalesce(sum(cost_usd), 0)::numeric
+  from public.ai_calls
+  where brand_id = p_brand_id
+    and provider = p_provider
+    and created_at >= p_since
+    and (
+      auth.role() = 'service_role'
+      or p_brand_id in (select public.auth_brand_ids())
+    )
+$$;
+
+revoke all on function public.brand_provider_spend_usd(uuid, text, timestamptz) from public, anon, authenticated;
+grant execute on function public.brand_provider_spend_usd(uuid, text, timestamptz) to service_role;


### PR DESCRIPTION
## What?

Three tables — `profiles`, `organizations`, `brands` — had a row-scoped RLS policy and no
column-scoped anything. `profiles self update` says `with check (id = auth.uid())`; `org owner all`
and `brands via org` say the equivalent for `ALL`. All three are true, and all three are
insufficient: among the columns of your own row there are some that **decide a right** instead of
describing a datum, and a `with check` has nothing to say about *which* column you are writing.

This PR puts the rule where the columns are visible — a per-column `GRANT`, one registry migration
for all three tables — and adds the in-body filter to four `SECURITY DEFINER` functions that today
are held up by nothing but a grant.

**Two of the holes are not the same size, and the PR should not pretend they are.**

- `profiles.approved_at` is **latent**. It is what `is_approved()` reads, which is what
  `can_enter()` reads, so `PATCH /rest/v1/profiles?id=eq.<self> {"approved_at":"…"}` self-approves.
  But in production `app_flags.closed_beta = false`, so `can_enter()` already says yes to everyone
  and the climb opens nothing today. It is a mine, not a fire — armed the day someone turns the
  flag back on, which is the only reason the gate exists.
- `organizations.plan` is **live, and it is revenue**. `resolveOrgBilling` (`credits.ts:205`)
  returns `org.plan ?? paying?.plan` — the column wins first and is never compared with Stripe —
  and `creditQuota` (`credits.ts:42`) is a map lookup: 400 credits for the empty plan, 11.250 for
  `pro` (`plans.ts`). `PATCH /rest/v1/organizations?id=eq.<own> {"plan":"pro"}` was **28× the quota,
  free, without touching Stripe**. `stripe_subscription_id`, `activated_at`, `brands.plan` and
  `brands.status` were writable by the same policy, and an `ALL` policy also lets the row be **born**
  `pro`: `insert into brands (…, plan)` passes a `with check` that looks at `org_id`.

## Why?

The boundary that was missing is not the one between customers. That one holds — RLS keeps it, on
every table. The missing one is between **what a user owns** and **what a user may decide about
themselves**, and it does not look like an intrusion: it is the owner editing their own object.
That is why an attack aimed at the cross-tenant boundary walks straight past it.

The four `SECURITY DEFINER` functions are the same problem one level down. `brand_provider_spend_usd`,
`agent_kit_claim_run`, `agent_kit_close_run`, `agent_kit_wait_for_approval` check nothing in their
bodies — not `auth.uid()`, not `auth.role()`, not `auth_brand_ids()`. **In production they are not
open**: `has_function_privilege` says false for `anon` and `authenticated`, eight combinations out
of eight. They are in this PR because that safety is not ours to rely on — see Testing for the
measurement that changed my mind about it.

## How?

**One registry, three tables** — `supabase/migrations/20260905210000_self_write_columns.sql`.
Postgres has no per-column `with check`, so the level that can tell columns apart is the `GRANT`.
Between the two available roads — per-column grant, or a trigger that refuses the change — the grant
wins on a measurable property: the rule stays readable without opening any code
(`select column_name from information_schema.column_privileges where grantee = 'authenticated' …`),
while a trigger is code the next person has to find first, plus one more condition to remember at
every new column. And the default falls the right way: **a new column is born unwritable**, so the
path that needs it breaks immediately and loudly instead of staying open in silence.

The list lives in **one file for all three tables**, not one per table. Three registries in three
places diverge at the first change, and diverge quietly.

| table | user decides (insert) | user decides (update) |
|---|---|---|
| `profiles` | — | `full_name`, `avatar_url`, `locale` |
| `organizations` | `name`, `owner_id` | — |
| `brands` | `id`, `org_id`, `created_by`, `name`, `website`, `slug`, `target_platforms`, `content_prefs`, `onboarding_completed_at` | `name`, `website`, `timezone`, `target_platforms`, `content_prefs`, `ads_settings`, `chat_default_tier`, `launched_at`, `setup_step`, `setup_completed_at`, `onboarding_state`, `onboarding_completed_at`, `own_history_at` |

Those lists are not guessed: every write to `brands` and `organizations` in `src/`, `cli/`,
`scripts/` and `packages/` was traced back to the client that issues it (user session vs
`createAdminClient()`), dynamic patch objects followed to where they are built. `organizations` has
**no** user-client `UPDATE` anywhere in the repo, which is why it gets none.

**Two columns moved to the service role** (`src/lib/server/stripe.ts`, `src/lib/server/zernio.ts`).
`stripe_customer_id` and `zernio_profile_id` were written with the user's session by
`ensureBrandCustomer` / `ensureBrandProfile`. They are not money in themselves, but another
customer's value on those rows inherits their capability: the 0007 trigger joins the subscription
mirror on exactly that key (`where b.stripe_customer_id = NEW.customer`), and `zernio_profile_id` is
the profile the brand publishes through. The user makes them be born; the user does not choose them.

**The filter goes inside the four function bodies** —
`supabase/migrations/20260905220000_secdef_run_and_spend_filters.sql` — following the shape and the
criterion already set in `20260905120000_secdef_least_privilege.sql`. Two shapes, because the
functions are not alike:

- `brand_provider_spend_usd` takes a `brand_id`, so the tenant is in the argument: the filter is the
  one its sister `sum_brand_ai_cost_usd` (0164) already carries. `authenticated` does not get
  `execute` back — the only caller is `rank-tracker.ts`, in a cron with `createAdminClient()`.
- The three `agent_kit_*` take a `run_id`, and there is nothing to trace back to the tenant for,
  because **the only runtime caller is the service role**. `run-store.ts` uses the client it is
  handed, and the only paths that build one are in `scripts/eval/durability.ts` with
  `createAdminClient()`; `runTurn` has no callers outside its own tests, and `src/` contains no call
  to these three RPCs at all. So the guard is `if auth.role() <> 'service_role' then raise` — the
  form `append_thread_event` already has, including its behaviour on a null claim (a direct psql
  connection already owns everything). Adding `or <brand> in (select auth_brand_ids())` would be
  complexity bought for a caller that does not exist.

### Rejected

- **A trigger per table.** Same effect, invisible rule, and it would have to be remembered at every
  new column instead of enforcing itself.
- **Extending `scripts/constraint-harness.mjs`.** Its whole model is a data table of
  `{what, sql, code}` executed as one role. Role switching, before/after state and function calls
  would have bent it out of shape; the new harness is a sibling that follows all of its conventions
  (localhost guard, one transaction, `rollback`, SQLSTATE constants, output format).
- **Giving `brand_provider_spend_usd` back to `authenticated`.** No caller needs it.

## Testing?

**Red → green, captured.** `npm run test:privileges` runs `scripts/privilege-harness.mjs` against a
real Postgres, inside one transaction closed by `rollback`, with `set local role authenticated` and
the JWT claims — because vitest mocks Supabase, and a fake update accepts anything, so a policy, a
column grant and a `SECURITY DEFINER` body stay green there by construction. The harness applies the
two new migrations inside the transaction; if a file is absent it says so and measures the schema
as it stands, which is how the red run below was taken.

<details>
<summary>RED — before the fix, 4/14</summary>

```
(assente, si misura lo schema com'è) 20260905210000_self_write_columns.sql
(assente, si misura lo schema com'è) 20260905220000_secdef_run_and_spend_filters.sql

ok    il trigger di signup crea il profilo  (sì)
FAIL  authenticated non si scrive approved_at addosso  (accettato, righe 1)
FAIL  authenticated non riscrive la propria email  (accettato)
ok    authenticated cambia nome, lingua e avatar come prima  (righe 1)
FAIL  is_approved() resta falso dopo il tentativo  (true)
FAIL  nessuna delle quattro è eseguibile da anon o authenticated  (8 combinazioni aperte)
FAIL  la spesa per fornitore di un brand altrui non esce  ($7.25)
ok    il service role legge ancora la spesa vera  ($7.25)
FAIL  authenticated non prende il run di un altro tenant  (preso, stato running)
ok    il service role prende il run come prima  (running)
FAIL  authenticated non chiude il run di un altro tenant  (chiuso, stato running)
...
4/14 privilegi tengono
```

With the billing and registry assertions added, before the fix: **17/29**, with every one of
`plan`, `stripe_subscription_id`, `brands.plan/status`, born-pro brand and born-pro organization
`accettato`.
</details>

<details>
<summary>GREEN — after the fix, 29/29</summary>

```
ok    authenticated non si scrive approved_at addosso  (42501)
ok    authenticated non riscrive la propria email  (42501)
ok    authenticated cambia nome, lingua e avatar come prima  (righe 1)
ok    is_approved() resta falso dopo il tentativo  (false)
ok    authenticated non si regala il piano dell'organizzazione  (42501)
ok    authenticated non si inventa un abbonamento Stripe  (42501)
ok    authenticated non attiva il brand da sé  (42501)
ok    authenticated non fa nascere un brand già pro  (42501)
ok    authenticated non fa nascere un'organizzazione già pro  (42501)
ok    il piano dell'organizzazione è ancora quello di prima  (sì)
ok    profiles: ogni colonna è classificata in 20260905210000_self_write_columns.sql  (8 colonne)
ok    profiles: authenticated aggiorna solo ciò che decide di sé  (avatar_url, full_name, locale)
ok    profiles: authenticated inserisce solo ciò che decide di sé  (niente)
ok    organizations: ogni colonna è classificata …  (8 colonne)
ok    organizations: authenticated aggiorna solo ciò che decide di sé  (niente)
ok    organizations: authenticated inserisce solo ciò che decide di sé  (name, owner_id)
ok    brands: ogni colonna è classificata …  (37 colonne)
ok    brands: authenticated aggiorna solo ciò che decide di sé  (ads_settings, chat_default_tier, …)
ok    brands: authenticated inserisce solo ciò che decide di sé  (content_prefs, created_by, id, …)
ok    nessuna delle quattro è eseguibile da anon o authenticated  (0 combinazioni aperte)
ok    la spesa per fornitore di un brand altrui non esce  ($0)
ok    il service role legge ancora la spesa vera  ($7.25)
ok    authenticated non prende il run di un altro tenant  (P0001)
ok    il service role prende il run come prima  (running)
ok    authenticated non chiude il run di un altro tenant  (P0001)
ok    authenticated non mette il run di un altro in attesa …  (agent_kit_wait_for_approval: solo il service role)
ok    il service role mette il run in attesa come prima  (waiting_takeover)
ok    il service role chiude il run come prima  ({"closed":true,"message_id":null})

29/29 privilegi tengono
```
</details>

**The test that breaks by itself.** "The user cannot write `plan`" only covers `plan`. The harness
also starts from the table's **real columns** and demands that every one of them is classified in
the registry. Proven, not asserted: adding `organizations.can_publish` inside the transaction turns
it red and names the column —

```
FAIL  organizations: ogni colonna è classificata in 20260905210000_self_write_columns.sql  (non classificate: can_publish)
28/29 privilegi tengono
```

**The functions are tested with the grant put BACK.** Inside the transaction the harness re-grants
`execute` to `authenticated` on all four, on purpose: the question is not "can `authenticated`
execute it?" — a grant decides that, and a grant comes back — but "if it did, what would it get?".

**Why that matters, measured.** In production none of the four is executable by `anon` or
`authenticated`; I re-verified it. On the self-hosted stack in `infra/compose`, with the same
migrations recorded as applied, **all eight combinations are true**: `pg_proc.proacl` shows
`=X/…`, i.e. PUBLIC with `execute`, on all four — while `notify_admin_email` and `waitlist_position`,
revoked by the migration applied separately later, correctly show no PUBLIC entry. A `revoke` in a
migration is an event, not a state, and `db:migrate` will never pass over that file again. I did
**not** determine the exact mechanism that lost those particular revokes on that database, and I am
not going to invent one — the point stands either way, which is precisely why the defence moved into
the body.

**Browser, on the local architecture** — self-hosted Supabase (`infra/compose`, port 5432/8000), the
worktree's dev server on 5188, both new migrations applied to the **local** database only, logged in
as `test@anomalia.so` on the `demo` brand (identity confirmed on screen).

<details>
<summary>The attack, run from the logged-in page's own <code>fetch</code> with the real session JWT</summary>

```
approve_self  : 403 {"code":"42501", … "GRANT UPDATE ON public.profiles TO authenticated;"}
rewrite_email : 403 {"code":"42501", … public.profiles}
org_pro       : 403 {"code":"42501", … public.organizations}
fake_sub      : 403 {"code":"42501", … public.organizations}
brand_pro     : 403 {"code":"42501", … public.brands}
rename_ok     : 204                                    ← the legitimate write still passes
born_pro_brand: 403
born_pro_org  : 403
spend         : 403 permission denied for function brand_provider_spend_usd
claim         : 403 permission denied for function agent_kit_claim_run
```
</details>

Exercised as a user, repeatedly, with the row checked in the database after each one: profile name
saved ("Profile saved.", `full_name = 'Andrea Buttarelli'`), saved **again** after a reload
(`'Ripetuto'`), language switched EN → IT (`locale = 'it'`, and the whole UI came back in Italian),
brand timezone saved ("Fuso orario salvato.", `timezone = 'Europe/London'`), platforms saved
(`target_platforms = {instagram}`). `plan` and `status` on the demo brand never moved. Local seed
restored afterwards.

`npx vitest run`: **7470 passed, 0 failed**. One suite fails to load — `src/hooks.server.test.ts`,
`TypeError: Invalid URL` — which is the known missing-`.env`-in-a-worktree failure already written
down in `LESSONS.md`, not a regression from this branch. `node scripts/typecheck-runtime.mjs`: ok.

### What I did NOT test, and the risk

- **The Stripe checkout path end to end.** `ensureBrandCustomer` changed signature and now writes
  with the service role, but the demo brand is already `active`, so `/activate` redirects away, and
  the local stack has no `STRIPE_SECRET_KEY`. The change is one client swap and one argument removed
  at the single call site (`activate/+page.server.ts:53`); typecheck and the suite are green.
  **The risk is that the first real checkout after deploy fails to persist `stripe_customer_id`** if
  the service role client cannot be built in that context — worth watching on the first live
  activation.
- **The Zernio connect path end to end**, for the same reason: `ensureBrandProfile` changed the same
  way, and connecting a social account needs Zernio credentials the local stack does not have.
- **The migrations against production.** Nothing was applied by hand anywhere but the local
  self-hosted database; the migration ships in this PR for you to apply.
- **How many accounts today carry a `plan` that Stripe does not confirm.** I could not measure it:
  that query needs production, and I have not touched it. It is the one number this PR cannot
  supply, and it is the number worth having — a `select` joining `organizations.plan` and
  `brands.plan` against `stripe.subscriptions` would say whether the live hole was ever used. **Run
  it before or after applying, but run it**: the fix closes the door, it does not tell you who
  already walked through.
- **`brands` DELETE.** Untouched, and column grants have nothing to say about it: a row is deleted
  or it is not.

## Evidence (screenshots/videos)

Local architecture, `test@anomalia.so`, brand `demo`, both migrations applied to the local database.
The legitimate path still works after the grant narrows:

*Settings → Profile on `localhost:5188`, signed in as `test@anomalia.so`, brand `demo`: typing a
name and pressing Save returns **"Profile saved."** and the row shows `full_name = 'Andrea
Buttarelli'` — with `authenticated` holding `UPDATE` on only `full_name`, `avatar_url`, `locale`.
Repeated after a reload it saves again. Switching the language to IT flips `locale` to `it` and the
whole UI comes back in Italian. On Brand Kit, the timezone save shows **"Fuso orario salvato."**
(`timezone = 'Europe/London'`) and the platform save writes `target_platforms = {instagram}`, while
`plan` and `status` never move.*

*(Screenshots were taken during the session but this PR body cannot carry image attachments — the
assertions above are each backed by the database read quoted next to them, and by the
`fetch` transcript in the collapsible block.)*

The refusals and the 204 on the legitimate write are in the collapsible block above — they are the
page's own `fetch`, with the session's real JWT, against the local PostgREST.

## Anything Else?

**No public changelog.** Nothing a customer can notice changes: name, language, avatar, brand
settings all save exactly as before. The only difference is for whoever was climbing over the gate,
and announcing that would be instructions rather than news.

**Where else I looked, without fixing.** All 78 write policies in the schema are row-scoped; none is
column-scoped. The large majority are per-brand content tables where every column describes a datum.
The ones where a column resembles a right, and which are deliberately **not** in this PR:

- **`brand_usage.posts_count` / `videos_count`** — the monthly plan caps' counters, under an `ALL`
  per-brand policy. Not credits (those are counted from `ai_calls`), but a user who zeroes them
  raises their own post and video ceilings.
- **`api_keys.permissions`** — under `api_keys self manage`. A key cannot exceed its owner's rights
  (`cli-auth` re-checks brand ownership), so it is not an escalation; it is still a column that
  describes a permission under a policy that only looks at the row.
- **`shared_views.revoked_at` / `expires_at` / `token_hash`** — the author can already create and
  revoke their own views, but can equally bring a revoked view back to life by rewriting
  `revoked_at`.

**One honest correction about `agent_kit_wait_for_approval`.** Calling it as a stranger did not
actually persist anything even before this PR — but by accident: the insert into
`agent_kit_approval_requests` reaches `append_thread_event`, which raises, and the whole call rolls
back. The `update … set state = 'waiting_takeover'` at the top ran regardless, and the day
`thread_id` becomes optional or that check moves, it is uncovered. The other two —
`agent_kit_claim_run` and `agent_kit_close_run` — did persist a cross-tenant write, and the red run
above shows the claim succeeding.

**Deliberate follow-up, not done here.** `20260905120000_secdef_least_privilege.sql` left
`sum_brand_ai_cost_usd` and `is_user_approved` with PUBLIC `execute` on that same local stack.
Both already carry their own in-body filter, so they are not holes; they are evidence that the
`revoke`-only approach drifts, and re-asserting their grants belongs in a sweep of its own rather
than smuggled into this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
