### PR TITLE
Create rls_auto_enable in the migration that revokes it

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -786,6 +786,33 @@ dove non lo è: resta non fatale, smette di essere muto.
 vincolo nemmeno volendo: è gestione d'errore che non può funzionare. L'errore va letto dal valore
 risolto.
 
+## Un presidio creato a mano in produzione costa due volte, e la seconda non fa rumore
+
+**Segnale.** Una migrazione che gira da settimane in produzione uccide `db:migrate` su un database
+pulito, con un errore che nomina un oggetto che nessuno ha mai scritto in un file: qui
+`42883 — function public.rls_auto_enable() does not exist`, da una `revoke` su una funzione che
+esisteva solo in produzione perché era stata creata dalla dashboard.
+
+**Cosa succede.** Il primo costo si vede: la catena si ferma, e siccome ogni file gira nella sua
+transazione non si perde una riga, si perde tutto quello che viene dopo. Il secondo costo non si
+vede ed è più caro: **un ambiente nuovo nasce senza il presidio**. `ensure_rls` accende la row level
+security su ogni tabella nuova di `public`; senza, ogni tabella creata da lì in poi resta scoperta
+finché qualcuno non legge `pg_class`. Un controllo di sicurezza che esiste in un ambiente solo non
+è un controllo: è una coincidenza che regge finché non si ricrea il database.
+
+**Perché la suite non lo vede.** Gira su Supabase mockato, dove nessuna migrazione viene applicata
+davvero. A trovarlo è stato un agente che ricostruiva un database da zero per un altro lavoro — cioè
+l'unica cosa che esercita l'ordine reale di applicazione. Vale la regola generale già pagata qui: chi
+scrive la modifica la rilegge da autore, e la riga accanto la vede solo chi non ha una posta in gioco
+su quella modifica.
+
+**La mossa.** Quando `psql` o la dashboard creano qualcosa che deve esistere sempre — una funzione, un
+event trigger, una policy, un bucket — quella cosa entra in una migrazione **nello stesso giorno**, in
+forma idempotente: `create or replace` per una funzione, e per ciò che non ha un `if not exists`
+(gli event trigger non ce l'hanno) una guardia sul catalogo. E la prova che serve non è che il file
+gira in produzione, dove l'oggetto c'è già: è che gira su un database **vuoto**. Un database usa e
+getta e due `psql` sono dieci minuti, e sono l'unico posto dove il difetto è visibile.
+
 ## Il vocabolario di una colonna si deriva dal CODICE, non dalle righe che ci sono
 
 **Segnale.** Una correzione ovvia: un valore fuori dall'enum, sostituito con quello «giusto»

--- a/changelog/2026-09-05-rls-auto-enable-in-migration.md
+++ b/changelog/2026-09-05-rls-auto-enable-in-migration.md
@@ -1,0 +1,32 @@
+# Il presidio che accende la RLS entra in una migrazione
+
+`public.rls_auto_enable()` e il suo event trigger `ensure_rls` accendono la row level security su
+ogni tabella nuova di `public`. Erano stati creati a mano in produzione e non stavano in nessuna
+migrazione, e questo costava due volte:
+
+- **`npm run db:migrate` moriva su un database pulito.** `20260905120000_secdef_least_privilege.sql`
+  fa `revoke execute on function public.rls_auto_enable()`, e su un database che non ha la funzione
+  Postgres risponde `42883 — function public.rls_auto_enable() does not exist`. La migrazione gira
+  dentro una transazione per file, quindi non si rompeva solo quella riga: si fermava la catena.
+- **Un ambiente nuovo nasceva senza il presidio.** Che è il costo peggiore, perché non fa rumore:
+  ogni tabella creata dopo resta senza RLS finché qualcuno non se ne accorge leggendo `pg_class`.
+
+Il corpo è quello di produzione meno quattro condizioni impossibili — chiesto `schema_name = 'public'`,
+i confronti con `pg_catalog`, `information_schema`, `pg_toast%` e `pg_temp%` non possono essere veri.
+`create or replace` lo rende un nulla di fatto dove la funzione esiste già, e `create event trigger`
+non ha un `if not exists`, quindi il trigger passa da una guardia su `pg_event_trigger`.
+
+**Come è saltato fuori.** Non da un test: da un agente che stava lavorando sullo storage e ha visto
+il proprio banco di prova morire lì mentre ricostruiva un database da zero. La suite non poteva
+vederlo — gira su Supabase mockato, dove nessuna migrazione viene applicata davvero.
+
+**Verificato su Postgres vero**, database usa e getta dentro il container self-host:
+
+```
+ROSSO  revoke su un db senza la funzione   ERROR: function public.rls_auto_enable() does not exist  (exit 3)
+VERDE  il blocco nuovo                     CREATE FUNCTION / DO / REVOKE                            (exit 0)
+       rigirato una seconda volta          idem, nessun errore
+       create table public.probe_nuova     relrowsecurity = t
+       grant residui                       anon f, authenticated f
+       event trigger ensure_rls            1, non 2
+```

--- a/src/lib/content/changelog/2026-09-05-rls-auto-enable-in-migration.ts
+++ b/src/lib/content/changelog/2026-09-05-rls-auto-enable-in-migration.ts
@@ -1,0 +1,9 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-05',
+  title: 'Self-hosted setup applies every migration on a clean database',
+  items: [
+    'Row level security switches itself on for every new table in a fresh install, not only in ours.'
+  ]
+} satisfies ChangelogEntry;

--- a/supabase/migrations/20260905120000_secdef_least_privilege.sql
+++ b/supabase/migrations/20260905120000_secdef_least_privilege.sql
@@ -50,7 +50,50 @@ revoke execute on function public.tg_notify_new_user() from public, anon, authen
 
 -- `rls_auto_enable` restituisce `event_trigger`: Postgres rifiuta la chiamata diretta con 0A000
 -- ("trigger functions can only be called as triggers"). È un presidio, non un buco — accende la
--- RLS su ogni tabella nuova di `public` — e non è in nessuna migrazione: vive solo in produzione.
+-- RLS su ogni tabella nuova di `public`.
+--
+-- Viveva solo in produzione, creato a mano e in nessuna migrazione, e questo costava due volte:
+-- la `revoke` qui sotto uccideva `db:migrate` su un database pulito, e un ambiente nuovo nasceva
+-- senza il presidio — cioè con ogni tabella futura scoperta, in silenzio. Il corpo è quello di
+-- produzione, meno quattro condizioni che non potevano essere false una volta chiesto
+-- `schema_name = 'public'`; `create or replace` lo rende un nulla di fatto dove esiste già.
+create or replace function public.rls_auto_enable()
+returns event_trigger language plpgsql security definer set search_path = pg_catalog as $function$
+declare
+  cmd record;
+begin
+  for cmd in
+    select *
+    from pg_event_trigger_ddl_commands()
+    where command_tag in ('CREATE TABLE', 'CREATE TABLE AS', 'SELECT INTO')
+      and object_type in ('table', 'partitioned table')
+  loop
+    if cmd.schema_name = 'public' then
+      begin
+        execute format('alter table if exists %s enable row level security', cmd.object_identity);
+        raise log 'rls_auto_enable: enabled RLS on %', cmd.object_identity;
+      exception
+        when others then
+          raise log 'rls_auto_enable: failed to enable RLS on %', cmd.object_identity;
+      end;
+    else
+      raise log 'rls_auto_enable: skip % (schema %)', cmd.object_identity, cmd.schema_name;
+    end if;
+  end loop;
+end;
+$function$;
+
+-- `create event trigger` non ha `if not exists`, e il trigger si chiama `ensure_rls` in produzione.
+do $$
+begin
+  if not exists (select 1 from pg_event_trigger where evtname = 'ensure_rls') then
+    create event trigger ensure_rls on ddl_command_end
+      when tag in ('CREATE TABLE', 'CREATE TABLE AS', 'SELECT INTO')
+      execute function public.rls_auto_enable();
+  end if;
+end;
+$$;
+
 revoke execute on function public.rls_auto_enable() from public, anon, authenticated;
 
 -- ── 4. Il grant serve, il controllo dentro no: si aggiunge il controllo, non si toglie il grant ──


### PR DESCRIPTION
## What?

`public.rls_auto_enable()` and its `ensure_rls` event trigger switch row level security on for
every new table in `public`. They were created by hand in production and lived in **no migration**.
`20260905120000_secdef_least_privilege.sql` revokes execute on that function — so on a database
that does not have it, the migration dies:

```
ERROR:  function public.rls_auto_enable() does not exist   (42883)
```

This PR creates the function and the trigger, idempotently, immediately before the revoke that
needs them. Four lines of comment become a block; nothing else in the file changes.

## Why?

It cost twice, and the second cost is the one that matters.

**`npm run db:migrate` died on a clean database.** Each file runs in its own transaction, so the
failure did not skip a line — it stopped the chain there. Anyone standing up a fresh environment,
self-hoster included, got no further.

**And a fresh environment was born without the guard.** That is the expensive half, because it is
silent: every table created after setup stays without RLS until somebody thinks to read `pg_class`.
A security control that exists in one environment only is not a control — it is a coincidence that
holds until the database is rebuilt.

Found by an agent rebuilding a database from scratch for unrelated storage work. The unit suite
could not have found it: it runs on a mocked Supabase, where no migration is ever applied.

## How?

**The body is production's, minus four conditions that cannot be false.** Production asks
`schema_name IS NOT NULL AND schema_name IN ('public') AND schema_name NOT IN ('pg_catalog',
'information_schema') AND NOT LIKE 'pg_toast%' AND NOT LIKE 'pg_temp%'`. Once `schema_name =
'public'` is asked, the other four are unreachable. Same behaviour, one condition.

**`create or replace` where it exists, a catalog guard where it cannot.** The function is a no-op in
production, which already has it. `create event trigger` has no `if not exists`, so the trigger goes
through `if not exists (select 1 from pg_event_trigger where evtname = 'ensure_rls')` — the reason
it is a `do $$` block and not a bare statement.

**Rejected — a new migration with a later timestamp.** The revoke fails *first*; anything ordered
after it never runs. The fix has to sit above the line that needs it.

**Rejected — making the revoke tolerant** (`do $$ ... exception when undefined_function`). That
would unblock `db:migrate` and leave the real defect in place: the fresh environment would still
come up with no auto-RLS, and the workaround would read like the problem was the revoke.

## Testing?

Throwaway database inside the self-host container, never production, never the shared clone. Red
observed before green:

```
ROSSO  revoke alone, db without the function
       ERROR:  function public.rls_auto_enable() does not exist        exit 3

VERDE  the new block                       CREATE FUNCTION / DO / REVOKE   exit 0
       the same block a second time        no error (idempotent)
       create table public.probe_nuova     relrowsecurity = t
       has_function_privilege              anon f, authenticated f
       select count(*) ... 'ensure_rls'    1, not 2
```

`src/lib/content/changelog/index.test.ts` — 3 passed.

**Not tested:** the full migration chain end to end. `db:migrate` against bare Postgres stops at
`0001_foundations.sql` with `schema "auth" does not exist` — the self-host flow expects a
Supabase-initialised database, which predates this PR and is unrelated to it. What is proved is the
statement that was failing, and the guard it protects, against real Postgres.

**Not applied to production**, which already carries both objects; this file is recorded there as
applied under `20260905115057` / `20260905115334`, so editing it changes nothing live.

## Evidence (screenshots/videos)

No UI. The database evidence is the red→green block above.

## Anything Else?

**The same drift is probably not alone.** This function was found because a revoke tripped over it.
Anything else created from the dashboard — a policy, a bucket, a trigger — is invisible until
something touches it. Two already known: the `media` bucket's blanket INSERT policy and the
`email-assets` bucket, neither in any migration (both handled in #377).

**`schema-drift-check.mjs` cannot see this class.** It probes names through PostgREST; a function
that exists only in production reads as perfectly fine from outside, and a constraint-only or
function-only migration cannot be confirmed applied at all. It says so itself.