### PR TITLE
Make the SEO audit reachable from the MCP tool

### DIFF
--- a/changelog/2026-09-05-seo-audit-reachable.md
+++ b/changelog/2026-09-05-seo-audit-reachable.md
@@ -1,0 +1,66 @@
+# L'audit SEO era irraggiungibile dal tool MCP: un vocabolario tradotto in un posto solo su due
+
+`seo_action` dichiarava `action: z.enum(['run', …])`, l'handler di `/seo` si ramifica su
+`if (action === 'audit')` e chiude con `Unknown action` → 400. L'intersezione fra ciò che lo schema
+permette e ciò che la rotta gestisce **non conteneva l'audit**: `run` prendeva 400, `audit` lo
+rifiutava zod prima ancora di partire. Le altre quattro azioni funzionavano; quella per cui il tool
+esiste, no. In produzione.
+
+## Perché nessuno se n'era accorto
+
+`cli/commands/seo.ts` aveva una mappa: `{ run: 'audit', plan: 'plan', more: 'more', asset: 'asset',
+article: 'article' }`. La CLI **traduceva** prima di chiamare, quindi da terminale l'audit partiva.
+Il tool MCP è generato dal registro e manda il valore così com'è.
+
+Stessa rotta, due vocabolari, e la traduzione esisteva **solo sul percorso che un umano prova a
+mano**. Su quello dell'agente no — e l'agente è l'unico che non si lamenta. Vale la pena notare
+anche la forma della mappa: quattro voci su cinque erano l'identità, e servivano solo a nascondere
+la quinta. Una mappa che traduce `plan` in `plan` non traduce: mimetizza.
+
+## Perché `audit` e non `run`
+
+La cura non è aggiungere `audit` all'enum accanto a `run`: due nomi per la stessa cosa è il
+difetto, non il rimedio — è la regola scritta in due posti che diverge al primo cambiamento. Si
+sceglie un vocabolario e vale su tutti e tre i lati.
+
+`audit` per tre ragioni, in ordine di peso:
+
+1. **È quello che l'handler ha sempre gestito.** Spostare l'handler significherebbe cambiare il
+   comportamento di una rotta che funziona per riparare una descrizione che non funziona.
+2. **`geo_action` lo chiama già così** — `z.enum(['audit', 'fix'])`, e lì contratto e handler sono
+   allineati. Un secondo vocabolario per la stessa idea, fra due tool fratelli, è come è cominciato
+   questo difetto.
+3. **A un modello che legge l'enum, `audit` dice cosa succede.** `run` non dice niente: eseguire
+   cosa?
+
+`run` resta una parola da terminale — `anomalia seo <slug> run` continua a funzionare — ma come
+**alias**, non come vocabolario parallelo. E la CLI non tiene più una copia dell'elenco: importa
+`SEO_ACTIONS` dal contratto, così l'unico posto dove il vocabolario può divergere è sparito.
+
+## Il test non è «`audit` funziona»
+
+Quello sarebbe passato anche prima, con `run` scritto al posto giusto. Serve quello che si rompe
+quando i due elenchi divergono **di nuovo**, e in entrambe le direzioni: un valore dichiarato che
+la rotta non gestisce, e un ramo della rotta che lo schema non permette di raggiungere.
+
+Sta in `registry.test.ts`, accanto all'altro guardiano che confronta il registro con le rotte su
+disco, ed è la stessa forma di `db-vocabularies.test.ts`: un elenco **derivato** da una fonte sola
+invece che due copiati a mano. Per ogni endpoint con un `action`, legge i valori dichiarati
+dall'enum di zod e i rami `action === '…'` / `case '…':` del suo `+server.ts`, e pretende che siano
+lo stesso insieme.
+
+Ed è **generalizzato**, perché la stessa struttura ce l'hanno anche `ads_action` e `geo_action`:
+i tre sono controllati tutti, e i tre passano solo perché `ads_action` è stato tipizzato poco
+prima. Due asserzioni difendono il test da sé stesso — che l'elenco dei tool con `action` non si
+svuoti (o non misura più niente) e che ogni `action` sia un elenco chiuso e non una stringa libera
+(o non c'è niente da confrontare).
+
+Rosso prima su `seo_action` soltanto, verde dopo. `ads_action` e `geo_action` erano già allineati.
+
+## Una nota su un test che pinnava il difetto
+
+`cli/mcp/migrated-writes.test.ts` fissava `enum: ['run', …]` come la forma da conservare
+attraverso la migrazione al registro. Faceva il suo lavoro — accorgersi che lo schema cambiava — ma
+il valore che custodiva era quello che prendeva 400. È aggiornato con accanto il perché: un test
+che pinna una forma la conserva anche quando è sbagliata, e la nota è l'unica cosa che impedisce
+al prossimo di ripristinarla.

--- a/cli/commands/seo.ts
+++ b/cli/commands/seo.ts
@@ -2,6 +2,15 @@ import { requireSession } from '../lib/auth.ts';
 import { api, type SeoInitiative } from '../lib/api.ts';
 import { section, table, c, info, ok, fail } from '../lib/display.ts';
 import { resolveByPrefix } from '../lib/select.ts';
+import { SEO_ACTIONS } from '../lib/contracts/search.ts';
+
+/**
+ * `run` è una parola da terminale, non un'azione: sta qui e non nel contratto, perché il
+ * vocabolario dell'API è uno solo — quello dell'handler. La mappa che stava qui traduceva ogni
+ * azione, e nel farlo NASCONDEVA che il contratto dicesse `run` dove la rotta legge `audit`:
+ * l'agente MCP, che quella traduzione non ce l'ha, prendeva 400 sull'unica azione che conta.
+ */
+const TERMINAL_ALIASES: Record<string, string> = { run: 'audit' };
 
 type Opts = { action: string; id?: string; guidance?: string };
 
@@ -9,9 +18,11 @@ export async function cmdSeo(slug: string, opts: Opts) {
   const { access_token: t } = await requireSession();
 
   if (opts.action !== 'show') {
-    const map: Record<string, string> = { run: 'audit', plan: 'plan', more: 'more', asset: 'asset', article: 'article' };
-    const action = map[opts.action];
-    if (!action) { fail(`Azione sconosciuta: ${opts.action} (show, run, plan, more, asset, article)`); process.exit(1); }
+    const action = TERMINAL_ALIASES[opts.action] ?? opts.action;
+    if (!(SEO_ACTIONS as readonly string[]).includes(action)) {
+      fail(`Azione sconosciuta: ${opts.action} (show, ${['run', ...SEO_ACTIONS].join(', ')})`);
+      process.exit(1);
+    }
     let initiativeId = opts.id;
     if (action === 'asset' || action === 'article') {
       if (!initiativeId) { fail('Serve --id <initiativeId>'); process.exit(1); }

--- a/cli/lib/contracts/index.ts
+++ b/cli/lib/contracts/index.ts
@@ -427,7 +427,7 @@ export {
   UPDATE_MEMORY_ENTRY
 } from './memory';
 export type { AgentMemoryCategory } from './memory';
-export { GEO_ACTION, REFRESH_KEYWORDS, SEO_ACTION } from './search';
+export { GEO_ACTION, REFRESH_KEYWORDS, SEO_ACTION, SEO_ACTIONS } from './search';
 export { GET_BACKLINKS, GET_GSC, GET_RANKS } from './web-metrics';
 export {
   GET_WRITING_SKILLS,

--- a/cli/lib/contracts/search.ts
+++ b/cli/lib/contracts/search.ts
@@ -1,11 +1,21 @@
 import { z } from 'zod';
 import type { BrandEndpoint } from './index';
 
+/**
+ * Le azioni che la rotta `/seo` si ramifica su, e non una parola in più.
+ *
+ * Diceva `run` dove l'handler legge `audit`: l'intersezione fra i due elenchi non conteneva
+ * l'audit, cioè il lavoro per cui il tool esiste. `audit` e non `run` perché è ciò che l'handler
+ * ha sempre gestito, perché `geo_action` lo chiama già così, e perché a un modello che legge
+ * l'enum dice cosa succede — `run` non dice niente.
+ */
+export const SEO_ACTIONS = ['audit', 'plan', 'more', 'asset', 'article'] as const;
+
 export const SEO_ACTION = {
   tool: 'seo_action',
   title: 'SEO action',
   description:
-    'Do something about the brand\'s search ranking: `run` audits the website\'s technical ' +
+    'Do something about the brand\'s search ranking: `audit` checks the website\'s technical ' +
     'health, `plan` drafts the improvements worth making, `more` appends further ones (say ' +
     'what you want in `guidance`), and `asset` or `article` writes one of them out — those ' +
     'two need the `initiativeId` they belong to. Every action here spends credits. get_seo ' +
@@ -14,7 +24,7 @@ export const SEO_ACTION = {
   pathUnderBrand: '/seo',
   input: z
     .object({
-      action: z.enum(['run', 'plan', 'more', 'asset', 'article']),
+      action: z.enum(SEO_ACTIONS),
       initiativeId: z.string().optional(),
       guidance: z.string().optional().describe('Optional guidance when action=more')
     })

--- a/cli/mcp/migrated-writes.test.ts
+++ b/cli/mcp/migrated-writes.test.ts
@@ -52,7 +52,9 @@ const MIGRATED_WRITES = [
     title: 'SEO action',
     properties: {
       slug: SLUG,
-      action: { type: 'string', enum: ['run', 'plan', 'more', 'asset', 'article'] },
+      // `run` fino al 2026-09-05, e non era la forma da conservare: l'handler si e' sempre
+      // ramificato su `audit`, quindi il valore pinnato qui era quello che prendeva 400.
+      action: { type: 'string', enum: ['audit', 'plan', 'more', 'asset', 'article'] },
       initiativeId: { type: 'string' },
       guidance: { type: 'string', description: 'Optional guidance when action=more' },
     },

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -427,7 +427,7 @@ export {
   UPDATE_MEMORY_ENTRY
 } from './memory';
 export type { AgentMemoryCategory } from './memory';
-export { GEO_ACTION, REFRESH_KEYWORDS, SEO_ACTION } from './search';
+export { GEO_ACTION, REFRESH_KEYWORDS, SEO_ACTION, SEO_ACTIONS } from './search';
 export { GET_BACKLINKS, GET_GSC, GET_RANKS } from './web-metrics';
 export {
   GET_WRITING_SKILLS,

--- a/packages/api-contracts/src/search.ts
+++ b/packages/api-contracts/src/search.ts
@@ -1,11 +1,21 @@
 import { z } from 'zod';
 import type { BrandEndpoint } from './index';
 
+/**
+ * Le azioni che la rotta `/seo` si ramifica su, e non una parola in più.
+ *
+ * Diceva `run` dove l'handler legge `audit`: l'intersezione fra i due elenchi non conteneva
+ * l'audit, cioè il lavoro per cui il tool esiste. `audit` e non `run` perché è ciò che l'handler
+ * ha sempre gestito, perché `geo_action` lo chiama già così, e perché a un modello che legge
+ * l'enum dice cosa succede — `run` non dice niente.
+ */
+export const SEO_ACTIONS = ['audit', 'plan', 'more', 'asset', 'article'] as const;
+
 export const SEO_ACTION = {
   tool: 'seo_action',
   title: 'SEO action',
   description:
-    'Do something about the brand\'s search ranking: `run` audits the website\'s technical ' +
+    'Do something about the brand\'s search ranking: `audit` checks the website\'s technical ' +
     'health, `plan` drafts the improvements worth making, `more` appends further ones (say ' +
     'what you want in `guidance`), and `asset` or `article` writes one of them out — those ' +
     'two need the `initiativeId` they belong to. Every action here spends credits. get_seo ' +
@@ -14,7 +24,7 @@ export const SEO_ACTION = {
   pathUnderBrand: '/seo',
   input: z
     .object({
-      action: z.enum(['run', 'plan', 'more', 'asset', 'article']),
+      action: z.enum(SEO_ACTIONS),
       initiativeId: z.string().optional(),
       guidance: z.string().optional().describe('Optional guidance when action=more')
     })

--- a/src/lib/content/changelog/2026-09-05-seo-audit-from-agents.ts
+++ b/src/lib/content/changelog/2026-09-05-seo-audit-from-agents.ts
@@ -1,0 +1,9 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-05',
+  title: 'Agents can run the SEO audit again',
+  items: [
+    'Connected agents can now start the technical SEO audit. The action they were offered was not the one the server accepted, so every attempt came back as an error — the other SEO actions were unaffected, and the audit always worked from the command line.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/routes/api/v1/brands/[slug]/registry.test.ts
+++ b/src/routes/api/v1/brands/[slug]/registry.test.ts
@@ -198,3 +198,62 @@ describe('le rotte sotto [slug]', () => {
     expect([...declared].filter((r) => !alive.has(r) || claimed.has(r))).toEqual([]);
   });
 });
+
+/**
+ * UN VOCABOLARIO SOLO PER ROTTA, O L'AZIONE È IRRAGGIUNGIBILE.
+ *
+ * `seo_action` dichiarava `run` e l'handler si ramificava su `audit`: l'intersezione fra ciò che
+ * lo schema permette e ciò che la rotta gestisce non conteneva l'audit, cioè la cosa che quel tool
+ * esiste per fare. `run` prendeva 400, `audit` lo rifiutava zod. In produzione, per un mese.
+ *
+ * Nessuno se n'era accorto perché la CLI aveva una mappa — `{ run: 'audit', … }` in
+ * `cli/commands/seo.ts` — che traduceva prima di chiamare. La traduzione esisteva solo sul
+ * percorso che un umano prova a mano; su quello dell'agente no, e l'agente è l'unico che non si
+ * lamenta.
+ *
+ * Il test non verifica che `audit` funzioni: verifica che i due elenchi siano lo STESSO insieme,
+ * e si rompe in entrambe le direzioni — un valore dichiarato che la rotta non gestisce, e un ramo
+ * della rotta che lo schema non permette di raggiungere.
+ */
+const ACTION_BRANCH = /action\s*===\s*'([a-z_]+)'|case\s+'([a-z_]+)'\s*:/g;
+
+function actionsHandledBy(source: string): string[] {
+  return [...new Set([...source.matchAll(ACTION_BRANCH)].map((m) => m[1] ?? m[2]))].sort();
+}
+
+function declaredActions(endpoint: BrandEndpoint): string[] | null {
+  const field = (endpoint.input.shape as Record<string, unknown>).action;
+  const options = (field as { options?: unknown })?.options;
+
+  return Array.isArray(options) ? [...(options as string[])].sort() : null;
+}
+
+describe('il vocabolario del contratto e quello dell’handler sono lo stesso insieme', () => {
+  const withAction = BRAND_ENDPOINTS.filter(
+    (e) => 'action' in (e.input.shape as Record<string, unknown>)
+  );
+
+  it('ogni tool con un `action` lo dichiara come elenco chiuso, non come stringa libera', () => {
+    const untyped = withAction.filter((e) => declaredActions(e) === null).map((e) => e.tool);
+
+    expect(untyped, 'una stringa libera davanti a un elenco chiuso fa scoprire i valori sbagliando').toEqual([]);
+  });
+
+  // Se questo elenco si svuota, il test sopra non misura più niente e va capito perché.
+  it('trova i tool con un `action` da controllare', () => {
+    expect(withAction.map((e) => e.tool).sort()).toEqual(['ads_action', 'geo_action', 'seo_action']);
+  });
+
+  for (const endpoint of withAction) {
+    it(`${endpoint.tool}: la rotta gestisce esattamente le azioni che il contratto permette`, () => {
+      const declared = declaredActions(endpoint);
+      if (!declared) return;
+
+      const source = readFileSync(join(REPO_ROOT, routeFile(endpoint)), 'utf8');
+      const handled = actionsHandledBy(source);
+
+      expect(handled.length, `nessun ramo letto da ${routeFile(endpoint)}: la scansione è passata a vuoto`).toBeGreaterThan(1);
+      expect(handled).toEqual(declared);
+    });
+  }
+});


### PR DESCRIPTION
## What?

`seo_action` offered `action: 'run'`. The `/seo` handler branches on `action === 'audit'` and closes with `Unknown action` → 400. So the intersection of what the schema allowed and what the route handled **did not contain the audit**: `run` got a 400, `audit` was rejected by zod before the request left. The other four actions worked. The one the tool exists for did not — in production.

One vocabulary now, on all three sides, plus a guard that breaks when any `action` tool diverges again.

> **Stacked on #383** (which typed `ads_action`'s `action` as an enum — the generalised guard needs that to have anything to compare). Based on and targeting `refactor/reads-into-query-two`; GitHub retargets to `dev` when #383 merges. The fix itself is independent — say the word and I rebase it straight onto `dev`.

## Why?

Nobody noticed because `cli/commands/seo.ts` carried a translation table:

```ts
const map = { run: 'audit', plan: 'plan', more: 'more', asset: 'asset', article: 'article' };
```

The CLI translated before calling, so the audit started from the terminal. The MCP tool is generated from the registry and sends the value as declared. **Same route, two vocabularies, and the translation existed only on the path a human tries by hand.** The agent's path had none, and the agent is the one that never complains.

Worth noting the shape of that map: four of its five entries were the identity. A map that translates `plan` into `plan` is not translating — it is camouflaging the fifth entry.

## How?

**`audit`, not `run`** — the cure is not adding `audit` beside `run`, because two names for one thing is the defect, not the remedy. Three reasons, in order of weight:

1. It is what the handler has always accepted. Moving the handler would change the behaviour of a route that works, to repair a description that does not.
2. **`geo_action` already declares `z.enum(['audit', 'fix'])`**, contract and handler aligned. A second vocabulary for the same idea between two sibling tools is exactly how this started.
3. To a model reading the enum, `audit` says what will happen. `run` says nothing — run what?

`run` survives as a **terminal alias**, where it is a word for humans. And the CLI stops keeping its own copy of the list: it imports `SEO_ACTIONS` from the contract, so the place where the two could diverge no longer exists.

**The guard is generalised, not seo-specific.** For every endpoint whose input declares an `action`, it reads the values from the zod enum and the `action === '…'` / `case '…':` branches of that route's `+server.ts`, and demands the same set — both directions. It lives in `registry.test.ts`, beside the guard that already compares the registry against the routes on disk, and it is the same shape as `db-vocabularies.test.ts`: a list **derived** from one source rather than two copied by hand.

Two assertions defend it against passing vacuously — the list of `action` tools must not be empty, and every `action` must be a closed enum rather than free text. That second one is why this is stacked on #383.

**Rejected:** adding `audit` as a second accepted value. It would have made the symptom go away and left the divergence in place, with a test that could never see it.

## Testing?

Test written first and watched fail — **one failure, `seo_action` only**; `ads_action` and `geo_action` passed, which is the evidence the generalisation is correct rather than merely broad.

```
× seo_action: the route handles exactly the actions the contract allows
  → expected [ 'article', 'asset', 'audit', 'more', 'plan' ]
       to equal [ 'article', 'asset', 'more', 'plan', 'run' ]
```

- Green after the fix. Full app suite **7 498 passed**, CLI/MCP **119 passed**, `npm run build` clean, `npm run dev` serves 200.
- **Verified through the real transport**, not just the schema: `tools/list` after an `initialize` now advertises `["audit","plan","more","asset","article"]`, and `SEO_ACTION.input` accepts `audit` and rejects `run`.
- Swept every other caller: only `cli/commands/seo.ts` ever sent this action. No app page, chat tool or agent path constructs it.

**What was NOT tested, and the risk.** **No real audit was run.** Proving it end to end means `geoTickForBrand` fetching a live site and `generateSeoPlan` calling a model — real money against a real domain, on a route whose own comment budgets 1–2 minutes. What is proven is that the value now reaches the branch; what is not is that the branch still succeeds, which was never in question since the CLI has been exercising it all along. **A client that cached `tools/list` will keep sending `run` until it reconnects**, and will now get a zod rejection rather than the handler's 400 — a clearer error, still an error.

## Evidence (screenshots/videos)

<details>
<summary>The two lists, before</summary>

```
packages/api-contracts/src/search.ts:17   z.enum(['run', 'plan', 'more', 'asset', 'article'])
src/routes/api/v1/brands/[slug]/seo/+server.ts:43   if (action === 'audit')
                                              :83   Unknown action: ${action}  → 400

declared ∩ handled = { plan, more, asset, article }        the audit is in neither list's overlap
```
</details>

<details>
<summary>tools/list after the fix, through handleMcpFetch</summary>

```
tools/list advertises: ["audit","plan","more","asset","article"]
SEO_ACTION.input.safeParse({ action: 'audit' })  → success
SEO_ACTION.input.safeParse({ action: 'run'   })  → rejected
```
</details>

<details>
<summary>A test that pinned the defect</summary>

`cli/mcp/migrated-writes.test.ts` pinned `enum: ['run', …]` as the shape to preserve across the migration to the registry. It was doing its job — noticing the schema changing — but the value it guarded was the one that returned 400. Updated with the reason beside it, since a test that pins a shape preserves it even when it is wrong.
</details>

## Anything Else?

- **The same divergence cannot recur silently** on `ads_action` or `geo_action`: they are in the same loop.
- **Correction to something I asserted here earlier, before anyone acts on it.** I first wrote that `/seo` skips `checkApiKeyWriteAccess`. **That is wrong twice.** `/seo` calls it explicitly at line 31 — and it would be covered anyway, because `gateAiAction` calls `checkApiKeyWriteAccess` itself as its first statement. So *every* route that gates AI is already closed to a read-only API key, and any list built by grepping for the explicit call is all false positives.
- **The real gap is a different set, and it is exactly four.** These call a model and have **neither** guard — no `gateAiAction`, no `checkApiKeyWriteAccess` — so a read-only API key can start them *and* they are not credit-gated either:

  | route | what it spends on |
  |---|---|
  | `editorial-plan/propose` | `proposeFirstPlan` → `proposePlan`, several `aiStructured` calls (variants plus a selector) |
  | `editorial-plan/revise` | same path |
  | `editorial-plan/replan-week` | same path |
  | `weekly-plan/plan` | `planWeekStrategy` in `content-preview` |

  That matches the report's count of four. `weekly-plan/render` is also unguarded but reaches `renderPreviewImages`, which I did not trace to a model call — worth confirming rather than assuming. **I did not fix any of them:** it is a permission and billing change on live routes, and it belongs to the run you said you want to start next, not smuggled into a vocabulary fix.
- `/geo` is fine on this axis: it calls both guards explicitly, and its contract and handler vocabularies already agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
