### PR TITLE
Stop update_brand_kit erasing unsent fields, and make tools/list cost 109.837 instead of 129.212

### DIFF
--- a/changelog/2026-09-06-brand-kit-non-si-azzera.md
+++ b/changelog/2026-09-06-brand-kit-non-si-azzera.md
@@ -1,0 +1,33 @@
+# Correggere la categoria non cancella più quello che il brand dice di sé
+
+`update_brand_kit` promette, nella sua descrizione, *«Only the fields you send change»*. Il
+handler faceva il contrario: l'upsert spediva sempre tutte e quattro le colonne del kit con
+`about ?? null`, e `ON CONFLICT (brand_id) DO UPDATE` le scriveva tutte. Una chiamata con il solo
+`{ category: "bakery" }` metteva NULL su `about`, `target_audience` e `brand_style`.
+
+Quei tre campi sono i fatti da cui è scritto **ogni post generato**. Sparivano senza un errore e
+senza una schermata: la risposta era `ok: true`. `brand_colors` si è salvato solo perché non
+compariva nel payload — fortuna, non disegno.
+
+Ora il patch si costruisce dalle chiavi **presenti** nel corpo (`'about' in body`), non dal loro
+valore: un `null` esplicito continua a cancellare, un campo assente resta com'era. Se il corpo
+porta solo `language`, il kit non viene toccato affatto.
+
+`in body` e non `!== undefined` perché sono due domande diverse: la prima chiede se il chiamante
+ha nominato il campo, la seconda anche se lo ha nominato con un valore che JSON non sa
+trasportare. La distinzione fra «cancellalo» e «lascialo stare» è tutta lì.
+
+Il difetto è emerso rileggendo gli handler delle scritture marcate `destructive: false`, mentre si
+verificava se quel flag dice la verità. È l'unico che **cancella** dati che il chiamante non ha
+nominato; gli altri sostituiscono cose che le loro descrizioni dichiarano di sostituire.
+
+Tre contraddizioni descrizione/handler restano aperte e non sono toccate qui, perché ognuna è una
+decisione a sé:
+
+- **`reschedule_post`** dice *«it only changes when»*, e invece scrive anche `status: 'approved'` e
+  azzera `external_post_id` e `published_url`;
+- **`propose_plan`** dice *«It lands as a proposal and changes nothing»*, ma porta a `rejected` la
+  proposta pendente che c'era (il piano *attivo* è davvero intatto; quello in attesa no —
+  `save_plan` e `revise_plan` lo dichiarano, questo no);
+- **`plan_week`** dice *«replaces the week draft in review»* e invece inserisce una riga nuova,
+  lasciando la vecchia in tabella: vince la più recente, ma la vecchia resta.

--- a/changelog/2026-09-06-tools-list-costa-meno.md
+++ b/changelog/2026-09-06-tools-list-costa-meno.md
@@ -1,0 +1,109 @@
+# `tools/list` costa 109.837 caratteri invece di 129.212
+
+La superficie MCP si paga a ogni sessione e nessuno l'aveva misurata. Sul transport vero —
+`initialize`, poi `tools/list`, `JSON.stringify(result).length` — erano **129.212 caratteri, circa
+32.300 token** prima che l'agente chiedesse qualunque cosa. Ora sono **109.837, circa 27.500**:
+**−19.375, −15,0%**, con 119 tool identici e nessuna capacità tolta.
+
+Il confronto con #383, che ha ritirato sette tool, è la lezione vera: **quei sette pesavano 2.747
+caratteri, 686 token, il 2%.** Le descrizioni ne tolgono dieci volte tanto. Il problema non era
+quanti tool ci sono — era quanto scrive ciascuno.
+
+Due conteggi che sembravano in disaccordo di dieci caratteri erano lo stesso conteggio: uno misura
+`result`, l'altro il solo array. `{"tools":` più `}` fa esattamente 10. Qui si misura `result`.
+
+Si misura il transport e non i sorgenti. Il conto sui sorgenti è già stato sbagliato due volte in
+un giorno, e il motivo è strutturale: lo schema JSON che il protocollo spedisce non somiglia allo
+zod da cui nasce — un `z.enum` di 150 nomi è una riga nel sorgente e tremila caratteri sul filo.
+`cli/mcp/tool-surface-cost.test.ts` fa quella misura e tiene un tetto, perché la superficie
+ricresce da sola: ogni tool nuovo porta la sua descrizione e nessuno somma.
+
+## Due chiavi che nessun client legge — 10.948 caratteri, l'8,5%
+
+L'SDK aggiunge a ogni tool `$schema: "http://json-schema.org/draft-07/schema#"` e
+`execution: { taskSupport: "forbidden" }`. Il primo dichiara il dialetto di uno schema che il
+protocollo dichiara già JSON Schema; il secondo è il valore che l'**assenza** del campo significa
+(`taskSupport` è opzionale, e nessun tool qui accetta un task). Moltiplicati per 119 fanno l'8,5%
+della lista, e togliere una chiave che nessuno legge non costa niente a nessuno.
+
+Si decorano una volta sola: `trimListedTools` avvolge l'unico punto in cui l'SDK installa il suo
+handler di `tools/list`, prima che i tool lo creino. Non è una riscrittura della conversione zod →
+JSON Schema — quella resta dell'SDK, con le sue unioni e le sue pipe.
+
+## Le descrizioni — 8.427 caratteri, e nessun tool è cresciuto
+
+La regola del taglio è una sola: **una frase resta se toglie un errore osservato, esce se sta lì
+per completezza.** Prima di togliere qualcosa l'ho cercata con `git log -S`, perché parecchie sono
+state scritte in risposta a un difetto vero e il changelog lo dice.
+
+**Uscite, e perché:**
+
+- **`id accepts a short prefix.`**, quindici volte. È una regola del server, non di un tool, e sta
+  già nelle `instructions` del handshake che il client mostra una volta per sessione:
+  *«Post and article ids accept short unambiguous prefixes from any list tool.»* Scritta in due
+  posti, quindici volte in uno solo. Ora `findability.test.ts` pretende che la regola stia nel
+  handshake, che è dove si legge per prima.
+- **`.describe('Brand URL slug')` sul parametro `slug`**, su ogni tool che prende un brand. Ripete il nome del campo. La
+  variante *opzionale* resta intera: quella nasce da un difetto (un opzionale che non si dichiara
+  viene riempito comunque, e con un brand a caso).
+- **Tetti ripetuti tre volte.** `search_knowledge` diceva «`limit` is 6 by default and 20 at most»
+  nella descrizione, nella `.describe()` del campo e nel `max()` dello schema — tre copie nello
+  stesso messaggio. Resta quella sul campo che il tetto lo impone davvero.
+- **Prosa che spiega il prodotto invece del tool**: il modello che *«cambia no brand setting»*
+  spiegato in quattro righe cinque volte, il `brand_style` in nove righe due volte, l'esempio
+  Roma/New York sul fuso orario. Il fatto che ci sta sotto — i post già programmati non si spostano
+  — resta.
+- **Un aforisma** (*«you do not win by arriving last»*) e una giustificazione preventiva
+  (*«Reading it costs a few thousand tokens»*). Il 409 con i due valori resta: quello è il fatto.
+
+**La dichiarazione del costo non è uscita, si è accorciata.** «Reads only — no model, no credits.»
+e le sue otto varianti diventano **`Free.`** — 5 caratteri invece di 34, sessantasei volte. La
+regola 3 di [`2026-09-05-tool-descriptions-say-the-problem.md`](2026-09-05-tool-descriptions-say-the-problem.md)
+è esplicita e nasce da un difetto vero: un agente ha chiamato «spreco» una generazione richiesta
+dall'utente, e *«un agente prudente evita ciò di cui non conosce il prezzo»*. Cancellare la frase
+avrebbe riaperto quel difetto per risparmiare 1.900 caratteri; accorciarla ne risparmia 1.600 e non
+riapre niente.
+
+**Restate perché rispondono a un difetto**, verificate una per una in `git log`:
+
+| frase | difetto |
+|---|---|
+| `media_not_found` (400) vs `media_unavailable` (502), su `create_post` | un modello esterno ha bruciato sei tentativi correggendo un id contro uno Storage rotto — il 400 gli diceva che l'input era sbagliato |
+| `a ninth is refused, not dropped` | il troncamento silenzioso è solo della UI; il contratto rifiuta la richiesta intera |
+| `Do NOT call list_brands to decide where to draw` | agenti che chiamavano `list_brands` e sceglievano un brand a caso: crediti di un'organizzazione vera, libreria di un cliente vero |
+| `WITHOUT slug this is a one-off drawing`, `id comes back null` | *«puoi generare la img di un gatto?»* → *«non ho uno strumento di generazione immagini»* |
+| `Do NOT reach for generate_image to alter something` | un'immagine da rendere rossa ridisegnata da zero |
+| `continuity_tokens` su `generate_carousel` | una slide modificata senza i gettoni esce dalla serie, e nessun errore lo dice |
+| `there is no field for arbitrary JavaScript`, `ONLY on a verified custom domain` | `/blog/<slug>` è l'origine di anomalia.so, accanto alle sessioni `/app`, e non esiste CSP |
+| `consent` — `Never infer it` | l'API scriveva `consent = true` senza che nessuno lo attestasse |
+| `it works precisely when credits are gone` (link Stripe) | un agente senza crediti salta il tool che serve proprio a comprarli |
+| `not_in_library` su `check_media_job` | un clip pagato ed esistente che, chiamato `failed`, verrebbe ricomprato |
+| `IT IS ALSO THE READ FOR QUESTIONS THAT HAVE NO TOOL OF THEIR OWN` / `products` (su `query`) | `list_products` è stato tolto: senza queste parole la capacità è irraggiungibile |
+| `Turning one OFF spends nothing` | l'asimmetria fra accendere (spende per sempre) e spegnere è l'unica cosa che un agente legge prima di chiamare |
+
+## Tre test che citavano una formulazione ora chiedono il concetto
+
+`check_content` e `get_creation_kit` pretendevano le parole `spends no credits` e
+`no model, no credits`; `get_post` pretendeva `id accepts a short prefix`. Un test che cita la
+prosa alla lettera rende ogni riscrittura una modifica in due posti — è la stessa ragione per cui
+le copie testuali delle descrizioni erano già state tolte da `read-tools.test.ts`. Ora chiedono
+`/free/i`, e la regola del prefisso è verificata dove adesso vive: il handshake.
+
+## Non toccati, e perché
+
+`ads.ts` e `search.ts`, `set_appearance`, `edit_post`: sono in PR aperte (#383, #385). Ci passo
+sopra quando mergiano — `set_appearance` da solo pesa 1.835 caratteri e ha almeno una frase di
+default (*«renders as Inter with nothing said»*) che è documentazione, non un difetto.
+
+## Quello che resta, con il suo numero
+
+Lo **schema** pesa più delle descrizioni, e quasi tutto è forma dell'API, non prosa:
+`save_week_seeds`, `save_plan`, `set_blog_settings` sono i tre più grossi.
+
+L'oggetto singolo più pesante che resta è **l'enum delle tabelle di `query`: ~2.955 caratteri**,
+150 nomi spediti a ogni sessione — mentre la descrizione dello stesso tool dice già *«Omit `table`
+to list every table you can name»*. **Resta**, e la ragione è quella che ha guidato tutto il resto:
+la contropartita è un modello che indovina un nome di tabella, cioè la classe di fallimento
+silenzioso che questo lavoro esiste per togliere, e un giro in più costa meno di una risposta
+sbagliata. Se quel peso va recuperato, la domanda è se servono davvero tutte e 150 le tabelle in
+quell'elenco — non se serve l'elenco.

--- a/cli/lib/contracts/articles.ts
+++ b/cli/lib/contracts/articles.ts
@@ -102,7 +102,7 @@ export const GET_ARTICLE = {
   description:
     'One blog article in full, in any state — draft, planned, approved or published: body, SEO ' +
     'fields, cover, category, tags, author, language, schedule and status. Read it before ' +
-    'editing, and read it after to see what changed. Calls no model and spends no credits.',
+    'editing, and after, to see what changed. Free.',
   method: 'GET',
   pathUnderBrand: '/web/article',
   input: GetArticleInputSchema,
@@ -116,10 +116,10 @@ export const UPDATE_ARTICLE = {
   title: 'Update article',
   description:
     'Write text and metadata you already have onto an article: title, markdown body, meta title, ' +
-    'meta description, category, tags, author, language, schedule. Anomalia calls no model and ' +
-    'spends no credits — nothing is rewritten, regenerated or reformatted. A field you do not ' +
-    'send is left exactly as it was, so changing the title never touches the body, the cover or ' +
-    'the description. A published article is refused: what is live is not edited in place.',
+    'meta description, category, tags, author, language, schedule. Nothing is rewritten, ' +
+    'regenerated or reformatted. A field you do not send is left exactly as it was, so changing ' +
+    'the title never touches the body, the cover or the description. A published article is ' +
+    'refused: what is live is not edited in place. Free.',
   method: 'POST',
   pathUnderBrand: '/web/article',
   input: UpdateArticleInputSchema,
@@ -167,8 +167,8 @@ export const OPTIMIZE_ARTICLE = {
   title: 'Optimize article',
   description:
     'Rewrite an article so it ranks better in search, meta title and description included. It ' +
-    'spends credits and REPLACES the text that is there; keep a copy if you might want it ' +
-    'back. It does not publish. id accepts a short prefix.',
+    'spends credits and REPLACES the text that is there; keep a copy if you might want it back. ' +
+    'It does not publish.',
   method: 'POST',
   pathUnderBrand: '/web/article/:id/optimize',
   resource: 'article',
@@ -182,8 +182,8 @@ export const PUBLISH_ARTICLE = {
   tool: 'publish_article',
   title: 'Publish article',
   description:
-    'Put a blog article live on the brand\'s site. unpublish_article takes it down again ' +
-    'without losing it. No model, no credits. id accepts a short prefix.',
+    'Put a blog article live on the brand\'s site. unpublish_article takes it down again without ' +
+    'losing it. Free.',
   method: 'POST',
   pathUnderBrand: '/web/article/:id/publish',
   resource: 'article',
@@ -197,9 +197,9 @@ export const UNPUBLISH_ARTICLE = {
   tool: 'unpublish_article',
   title: 'Unpublish article',
   description:
-    'Take a live article off the site while keeping it: it becomes a draft again and nothing ' +
-    'is deleted. This is also what you do before editing one — update_article refuses a ' +
-    'published article. id accepts a short prefix.',
+    'Take a live article off the site while keeping it: it becomes a draft again and nothing is ' +
+    'deleted. This is also what you do before editing one — update_article refuses a published ' +
+    'article.',
   method: 'POST',
   pathUnderBrand: '/web/article/:id/unpublish',
   resource: 'article',
@@ -213,8 +213,8 @@ export const DELETE_ARTICLE = {
   tool: 'delete_article',
   title: 'Delete article',
   description:
-    'Delete one blog article for good. It does not come back. To take a live article off the ' +
-    'site without losing it, use unpublish_article instead. id accepts a short prefix.',
+    'Delete one blog article for good. It does not come back. To take a live article off the site ' +
+    'without losing it, use unpublish_article instead.',
   method: 'DELETE',
   pathUnderBrand: '/web/article/:id',
   resource: 'article',

--- a/cli/lib/contracts/automations.ts
+++ b/cli/lib/contracts/automations.ts
@@ -44,11 +44,11 @@ export const GET_AUTOMATIONS = {
   title: 'Recurring jobs',
   description:
     'The recurring jobs included with the product and whether this brand runs them: what each ' +
-    'one does, how often, whether it is on, how it went last time, and how many times it ' +
-    'actually ran in the last 30 days. Read it before set_automation — `runs_30d` with `cadence` ' +
-    'is how you tell what turning one on commits the brand to. What it CANNOT tell you is the ' +
-    'money: AI spend is recorded per call, with no column naming the job that made it, so no ' +
-    'clean read attributes dollars to one automation. The brand-wide bill is on the usage page.',
+    'does, how often, whether it is on, how it went last time, and how many times it ran in the ' +
+    'last 30 days. Read it before set_automation — `runs_30d` with `cadence` is how you tell what ' +
+    'turning one on commits the brand to. What it CANNOT tell you is the money: AI spend is ' +
+    'recorded per call, with no column naming the job that made it, so no clean read attributes ' +
+    'dollars to one automation. The brand-wide bill is on the usage page.',
   method: 'GET',
   pathUnderBrand: '/settings/automations',
   input: z.object({}).strict(),
@@ -67,14 +67,13 @@ export const SET_AUTOMATION = {
   tool: 'set_automation',
   title: 'Turn a recurring job on or off',
   description:
-    'Turn one recurring job on or off for this brand. ' +
-    'Turning one ON is a spending decision, not a preference: from that moment the job runs BY ' +
-    'ITSELF on its cadence, and every run calls AI models and spends the brand’s credits, with ' +
-    'nobody looking. Say which job, how often it will run, and that it spends — before you turn ' +
-    'it on, and to the person whose credits they are. Turning one OFF spends nothing and is the ' +
-    'safe direction: it takes effect at the next tick and destroys nothing. ' +
-    'A brand without a paid plan runs none of them, however many are on. The call itself calls ' +
-    'no model and spends no credits.',
+    'Turn one recurring job on or off for this brand. Turning one ON is a spending decision, not ' +
+    'a preference: from that moment the job runs BY ITSELF on its cadence, and every run calls AI ' +
+    'models and spends the brand\'s credits, with nobody looking. Say which job, how often it will ' +
+    'run, and that it spends — before you turn it on, and to the person whose credits they are. ' +
+    'Turning one OFF spends nothing and is the safe direction: it takes effect at the next tick ' +
+    'and destroys nothing. A brand without a paid plan runs none of them, however many are on. ' +
+    'Free.',
   method: 'PUT',
   pathUnderBrand: '/settings/automations',
   input: z.object({ job, enabled: z.boolean().describe('true starts it running by itself') }).strict(),

--- a/cli/lib/contracts/billing.ts
+++ b/cli/lib/contracts/billing.ts
@@ -50,12 +50,12 @@ export const BILLING_PORTAL_LINK = {
   tool: 'create_billing_portal_link',
   title: 'Billing portal link',
   description:
-    'Mint a one-time link to this organization Stripe billing portal and hand it to the account ' +
+    'Mint a one-time link to this organization\'s Stripe billing portal and hand it to the account ' +
     'owner. On that page THEY can read invoices, change the card, switch plan and CANCEL the ' +
-    'subscription — you never open it and never act inside it, you return the URL and stop. ' +
-    'Treat the URL as a credential: whoever holds it reaches that customer billing, so give it ' +
-    'to the owner once, in the reply, and never store or repeat it. Only the organization owner ' +
-    'can mint one. Calls no model and spends no credits: it works precisely when credits are gone.',
+    'subscription — you never open it and never act inside it. Treat the URL as a credential: ' +
+    'whoever holds it reaches that customer\'s billing, so give it to the owner once, in the ' +
+    'reply, and never store or repeat it. Only the organization owner can mint one. Free: it ' +
+    'works precisely when credits are gone.',
   method: 'POST',
   pathUnderBrand: '/billing/portal',
   input: PortalInputSchema,
@@ -68,13 +68,14 @@ export const CHECKOUT_LINK = {
   tool: 'create_checkout_link',
   title: 'Checkout link',
   description:
-    'Mint a one-time link where the human picks a paid plan and pays, on Stripe own hosted page. ' +
-    'You never pay, never change a plan and never apply a discount: you return the URL, they ' +
-    'complete it. The same page can also CANCEL the subscription, so treat the URL as the owner ' +
-    'credential — whoever holds it reaches that customer billing — and hand it over once, never ' +
-    'stored, never repeated. Only the organization owner can mint one. Calls no model and spends ' +
-    'no credits. An organization that never subscribed has no Stripe customer to check out ' +
-    'against: the refusal carries app_billing_url, which is where the human starts.',
+    'Mint a one-time link where the human picks a paid plan and pays, on Stripe\'s own hosted ' +
+    'page. You never pay, never change a plan and never apply a discount: you return the URL, ' +
+    'they complete it. The same page can also CANCEL the subscription, so treat the URL as the ' +
+    'owner credential — whoever holds it reaches that customer\'s billing — and hand it over once, ' +
+    'never stored, never repeated. Only the organization owner can mint one. Free: it works ' +
+    'precisely when credits are gone. An organization that never subscribed has no Stripe ' +
+    'customer to check out against: the refusal carries app_billing_url, which is where the human ' +
+    'starts.',
   method: 'POST',
   pathUnderBrand: '/billing/checkout',
   input: CheckoutInputSchema,

--- a/cli/lib/contracts/blog-settings.ts
+++ b/cli/lib/contracts/blog-settings.ts
@@ -76,12 +76,11 @@ export const GET_BLOG_SETTINGS = {
   tool: 'get_blog_settings',
   title: 'Blog settings',
   description:
-    'How the brand’s blog looks and how it writes: the public site’s name, colour, font and ' +
-    'layout, the style brief the AI follows, how many articles a week it produces, the ' +
-    'languages, and the categories, tags and authors an article can be filed under. Read it ' +
-    'before set_blog_settings and before add_blog_term — it carries the fonts, layouts and ' +
-    'locales that are accepted, and the plan’s ceiling on articles per week and on extra ' +
-    'languages.',
+    'How the brand\'s blog looks and how it writes: the public site\'s name, colour, font and ' +
+    'layout, the style brief the AI follows, how many articles a week it produces, the languages, ' +
+    'and the categories, tags and authors an article can be filed under. Read it before ' +
+    'set_blog_settings and before add_blog_term — it carries the fonts, layouts and locales that ' +
+    'are accepted, and the plan\'s ceiling on articles per week and on extra languages.',
   method: 'GET',
   pathUnderBrand: '/settings/blog',
   input: z.object({}).strict(),
@@ -122,17 +121,15 @@ export const SET_BLOG_SETTINGS = {
   tool: 'set_blog_settings',
   title: 'Change the blog settings',
   description:
-    'Change how the blog looks and how it writes. Only the fields you send change; every other ' +
-    'one keeps its value. `articles_per_week` is CLAMPED to the plan’s ceiling rather than ' +
-    'refused, and the answer says what was actually saved — read it back instead of assuming ' +
-    'your number was taken. `locales`, `navbar_links` and `analytics` replace their whole list. ' +
-    'Turning `enabled` off takes the public blog down; it deletes no article. The blog icon and an ' +
-    'author’s avatar are images and cannot be set here. `analytics` takes a CLOSED list of ' +
-    'providers with their measurement id — there is no field for arbitrary JavaScript, and asking ' +
-    'for one is refused: a script tag here would run on every visitor’s page. Those trackers load ' +
-    'ONLY on a verified custom domain and ONLY after the visitor accepts cookies; on the default ' +
-    '/blog/<slug> address they are stored and never emitted, because that address is Anomalia’s ' +
-    'own origin. Calls no model and spends no credits.',
+    'Change how the blog looks and how it writes. Only the fields you send change. ' +
+    '`articles_per_week` is CLAMPED to the plan\'s ceiling rather than refused, and the answer ' +
+    'says what was actually saved — read it back instead of assuming your number was taken. ' +
+    '`locales`, `navbar_links` and `analytics` replace their whole list. Turning `enabled` off ' +
+    'takes the public blog down; it deletes no article. The blog icon and an author\'s avatar are ' +
+    'images and cannot be set here. `analytics` takes a CLOSED list of providers with their ' +
+    'measurement id — there is no field for arbitrary JavaScript, and asking for one is refused: ' +
+    'a script tag here would run on every visitor\'s page. Those trackers load ONLY on a verified ' +
+    'custom domain and ONLY after the visitor accepts cookies. Free.',
   method: 'PUT',
   pathUnderBrand: '/settings/blog',
   input: z

--- a/cli/lib/contracts/brand-settings.ts
+++ b/cli/lib/contracts/brand-settings.ts
@@ -61,15 +61,12 @@ export const SET_BRAND_SETTINGS = {
   description:
     'Change the posting timezone, the target platforms, the per-platform hashtags, or the voice ' +
     'examples. Only the fields you send change. `hashtags` and `voice_examples` REPLACE the whole ' +
-    'list, so send the full list you want, not a delta; `[]` and `{}` clear one. Calls no model ' +
-    'and spends no credits. ' +
-    'Two consequences worth knowing before you call it. Changing `timezone` does NOT move posts ' +
-    'that already have a time: they keep firing at the same absolute instant, so their local hour ' +
-    'shifts by the offset difference — a post set for 18:00 in Rome reads as 12:00 once the brand ' +
-    'moves to New York. Only new scheduling uses the new zone. Removing a platform from ' +
-    '`platforms` does NOT cancel posts already scheduled on it: the target list decides what NEW ' +
-    'posts are made for, never what publishes, and an existing post still goes out while its ' +
-    'account is connected.',
+    'list, so send the full list you want, not a delta; `[]` and `{}` clear one. Changing ' +
+    '`timezone` does NOT move posts that already have a time: they keep firing at the same ' +
+    'absolute instant, so their local hour shifts by the offset difference. Only new scheduling ' +
+    'uses the new zone. Removing a platform from `platforms` does NOT cancel posts already ' +
+    'scheduled on it: the target list decides what NEW posts are made for, never what publishes. ' +
+    'Free.',
   method: 'PUT',
   pathUnderBrand: '/settings/brand',
   input: z

--- a/cli/lib/contracts/brand-state.ts
+++ b/cli/lib/contracts/brand-state.ts
@@ -54,10 +54,9 @@ export const GET_GOALS = {
   tool: 'get_goals',
   title: 'Chat goals',
   description:
-    'How the brand\'s goal chases have gone, measured: how many were met on the first pass, ' +
-    'how many came back to the person, how many automatic laps were spent, and the reason ' +
-    'each one stopped — plus the goals themselves with their diary. Reads only — no model, no ' +
-    'credits.',
+    'How the brand\'s goal chases have gone, measured: how many were met on the first pass, how ' +
+    'many came back to the person, how many automatic laps were spent, and the reason each one ' +
+    'stopped — plus the goals themselves with their diary. Free.',
   method: 'GET',
   pathUnderBrand: '/goals',
   input: z

--- a/cli/lib/contracts/captions.ts
+++ b/cli/lib/contracts/captions.ts
@@ -27,11 +27,10 @@ export const GENERATE_CAPTIONS = {
     'Write captions — text only, no media, and NO post is created: pass a caption to create_post ' +
     'when you want to publish it. By default every platform gets its own caption, written for ' +
     'that platform and inside its character limit, instead of one text cut nine ways. Pass ' +
-    'platforms to get only those, each written to its own limit with no extra shortening. ' +
-    'format "thread" lets X and Threads come back as a numbered sequence of posts rather than ' +
-    'one — good to paste by hand, but create_post publishes a single post per platform, so a ' +
-    'sequence is not publishable from here. It writes in the brand\'s voice. It spends credits, ' +
-    'and cost_usd in the answer says what the model actually cost.',
+    '`platforms` to get only those. `format: "thread"` lets X and Threads come back as a numbered ' +
+    'sequence of posts rather than one — good to paste by hand, but create_post publishes a ' +
+    'single post per platform, so a sequence is not publishable from here. It writes in the ' +
+    'brand\'s voice. It spends credits.',
   method: 'POST',
   pathUnderBrand: '/captions/generate',
   input: z

--- a/cli/lib/contracts/content.ts
+++ b/cli/lib/contracts/content.ts
@@ -64,9 +64,9 @@ export const CHECK_CONTENT = {
   description:
     'Run the checks Anomalia runs on its own copy against a spec you wrote, before you create ' +
     'anything. Returns blocking errors, warnings and a 0-100 quality score per platform, each ' +
-    'naming the field to repair. Deterministic: it calls no model, spends no credits, writes ' +
-    'nothing, and the same spec always returns the same verdict. Perceptual review of an image ' +
-    'or a video is a separate, explicitly paid action — this never looks at pixels.',
+    'naming the field to repair. Deterministic: it writes nothing, and the same spec always ' +
+    'returns the same verdict. Perceptual review of an image or a video is a separate, explicitly ' +
+    'paid action — this never looks at pixels. Free.',
   method: 'POST',
   pathUnderBrand: '/content/check',
   input: CheckContentInputSchema,

--- a/cli/lib/contracts/creation-kit.ts
+++ b/cli/lib/contracts/creation-kit.ts
@@ -102,14 +102,13 @@ export const GET_CREATION_KIT = {
   tool: 'get_creation_kit',
   title: 'Creation kit',
   description:
-    'The smallest brief you need before writing one post: what the platform allows, the ' +
-    'brand\'s own facts and its approved voice, the checklist your copy will be judged ' +
-    'against, ONE worked example chosen for this goal and format, the rewrites this brand\'s ' +
-    'own team wrote, what has already worked here, and which calendar minutes are taken. It ' +
-    'is a SELECTION, not the whole library: empty sections are absent, and the whole thing is ' +
-    'capped so it never floods your context. Reads only — no model, no credits, nothing ' +
-    'written. Pictures live in list_media; checking a draft before you create it is ' +
-    'check_content.',
+    'The smallest brief you need before writing one post: what the platform allows, the brand\'s ' +
+    'own facts and its approved voice, the checklist your copy will be judged against, ONE worked ' +
+    'example chosen for this goal and format, the rewrites this brand\'s own team wrote, what has ' +
+    'already worked here, and which calendar minutes are taken. It is a SELECTION, not the whole ' +
+    'library: empty sections are absent, and the whole thing is capped so it never floods your ' +
+    'context. Pictures live in list_media; checking a draft before you create it is ' +
+    'check_content. Free.',
   method: 'GET',
   pathUnderBrand: '/creation-kit',
   input: GetCreationKitInputSchema,

--- a/cli/lib/contracts/evidence.ts
+++ b/cli/lib/contracts/evidence.ts
@@ -82,16 +82,13 @@ export type WebAuditFindings = z.infer<typeof AuditFindings>;
 export type AuditCitationRow = z.infer<typeof CitationRow>;
 export type WebFixRow = z.infer<typeof FixRow>;
 
-const COSTS_NOTHING =
-  'Reads what was already measured. It calls no model, spends no credits and writes nothing.';
-
 export const LIST_WEB_AUDITS = {
   tool: 'list_web_audits',
   title: 'List web audits',
   description:
     "Every audit Anomalia has run on this brand's website and its visibility in AI answers, newest " +
     'first, one line each: when it ran, the scores it measured, and how much it observed. Take an id ' +
-    `from here to open one audit instead of paying for a new one. ${COSTS_NOTHING}`,
+    'from here to open one audit instead of paying for a new one. Free.',
   method: 'GET',
   pathUnderBrand: '/web/audits',
   input: z.object({ limit: limitUpTo(WEB_AUDITS_MAX, WEB_AUDITS_DEFAULT), offset }).strict(),
@@ -104,9 +101,9 @@ export const GET_AUDIT_FINDINGS = {
   tool: 'get_audit_findings',
   title: 'Read one audit',
   description:
-    'What one audit observed, exactly as it was recorded: the technical findings on the site, the ' +
-    'search and backlink figures, and the Google AI Overview sampling. Without audit_id you get the ' +
-    `most recent audit, never an older one that happens to hold more data. ${COSTS_NOTHING}`,
+    'What one audit observed, exactly as recorded: the technical findings on the site, the search ' +
+    'and backlink figures, and the Google AI Overview sampling. Without audit_id you get the most ' +
+    'recent audit, never an older one that happens to hold more data. Free.',
   method: 'GET',
   pathUnderBrand: '/web/audits/findings',
   input: z.object({ audit_id: auditId }).strict(),
@@ -122,7 +119,7 @@ export const LIST_AUDIT_CITATIONS = {
     'The questions Anomalia put to answer engines during one audit, and what came back: which engine, ' +
     'the question verbatim, whether the brand was named and in which position, the competitors named ' +
     'instead, and the domains the answer cited. This is the evidence behind the share-of-voice number. ' +
-    `Without audit_id you get the most recent audit. ${COSTS_NOTHING}`,
+    'Without audit_id you get the most recent audit. Free.',
   method: 'GET',
   pathUnderBrand: '/web/audits/citations',
   input: z
@@ -150,7 +147,7 @@ export const LIST_WEB_FIXES = {
   description:
     'The fixes Anomalia wrote from its audits — FAQ blocks, structured data, llms.txt, landing copy — ' +
     'with the body complete and ready to publish. Ask for one fix_id when you know which one you want: ' +
-    `bodies are long, so few come back per call. ${COSTS_NOTHING}`,
+    'bodies are long, so few come back per call. Free.',
   method: 'GET',
   pathUnderBrand: '/web/fixes',
   input: z

--- a/cli/lib/contracts/knowledge.ts
+++ b/cli/lib/contracts/knowledge.ts
@@ -32,10 +32,13 @@ export const SEARCH_KNOWLEDGE = {
   tool: 'search_knowledge',
   title: 'Search brand knowledge',
   description:
-    "Ask the brand's own documents a question and get back the passages that answer it, each with the document and heading it came from. " +
-    'Hybrid retrieval over what is already indexed: keywords first, and a single embedding of the question only when keywords come up short — no credits are spent and nothing is written. ' +
-    `Each passage is cut at ${KNOWLEDGE_EXCERPT_CHARS} characters (\`truncated\` says when there is more); \`limit\` is ${KNOWLEDGE_HITS_DEFAULT} by default and ${KNOWLEDGE_HITS_MAX} at most. ` +
-    'Narrow with `collection` when you know the shelf. An empty `hits` means the indexed corpus has no answer — which is not the same as the brand not knowing it, so read `get_knowledge_status` before concluding anything: a document still queued has nothing to find.',
+    "Ask the brand's own documents a question and get back the passages that answer it, each with " +
+    'the document and heading it came from. Hybrid retrieval over what is already indexed: keywords ' +
+    'first, one embedding of the question only when keywords come up short. ' +
+    `Each passage is cut at ${KNOWLEDGE_EXCERPT_CHARS} characters (\`truncated\` says when there is more). ` +
+    'Narrow with `collection` when you know the shelf. Empty `hits` means the INDEXED corpus has no ' +
+    'answer, which is not the same as the brand not knowing it — read `get_knowledge_status` before ' +
+    'concluding anything: a document still queued has nothing to find. Free.',
   method: 'GET',
   pathUnderBrand: '/knowledge/search',
   input: z
@@ -77,10 +80,15 @@ export const GET_KNOWLEDGE_STATUS = {
   tool: 'get_knowledge_status',
   title: 'Knowledge status',
   description:
-    'Whether the brand\'s knowledge is USABLE, not just uploaded. Read it whenever `search_knowledge` comes back empty: an indexed corpus with no answer means the brand does not know the thing, a queued or failed one means nobody has read it yet — opposite situations needing opposite actions. ' +
-    '`documents` counts the pipeline stage by stage (`pending` → `processing` → `ready` | `failed`) and `indexed` is the only number retrieval can see: a `ready` document with zero chunks is not searchable. ' +
-    '`chunks.embedded` below `chunks.total` means retrieval is running on keywords alone, so paraphrases miss. ' +
-    `\`failures\` names each broken document and WHY it broke (${KNOWLEDGE_FAILURES_MAX} at most), \`collections\` says which shelves \`search_knowledge\` can usefully narrow to, and \`sources\` says which connected apps feed the corpus and when each last synced. No credits, no writes.`,
+    "Whether the brand's knowledge is USABLE, not just uploaded. Read it whenever `search_knowledge` " +
+    'comes back empty: an indexed corpus with no answer means the brand does not know the thing, a ' +
+    'queued or failed one means nobody has read it yet — opposite situations needing opposite ' +
+    'actions. `documents` counts the pipeline stage by stage (`pending` → `processing` → `ready` | ' +
+    '`failed`) and `indexed` is the only number retrieval can see: a `ready` document with zero ' +
+    'chunks is not searchable. `chunks.embedded` below `chunks.total` means retrieval runs on ' +
+    'keywords alone, so paraphrases miss. `failures` names each broken document and why it broke, ' +
+    '`collections` says which shelves `search_knowledge` can narrow to, and `sources` says which ' +
+    'connected apps feed the corpus and when each last synced. Free.',
   method: 'GET',
   pathUnderBrand: '/knowledge',
   input: z.object({}).strict(),

--- a/cli/lib/contracts/market.ts
+++ b/cli/lib/contracts/market.ts
@@ -50,8 +50,7 @@ export const GET_MARKET_FIELD = {
   title: 'Field watch',
   description:
     'What is moving in this brand\'s field right now: the topics being watched, the pattern ' +
-    'distilled from them, and the posts catalogued with a teardown of why each one spread. ' +
-    'Reads what was already gathered — no model, no credits.',
+    'distilled from them, and the posts catalogued with a teardown of why each one spread. Free.',
   method: 'GET',
   pathUnderBrand: '/market/field',
   input: z.object({ limit: limitUpTo(MARKET_FIELD_MAX, MARKET_FIELD_DEFAULT) }).strict(),
@@ -84,7 +83,9 @@ export const DIAGNOSE_RADAR = {
   tool: 'diagnose_radar',
   title: 'Radar diagnosis',
   description:
-    'Why Radar finds nothing: fetches every configured source live and reports, per source, how many items came back or why it was skipped — source off, plan, platform toggle, endpoint error. Reads only, spends no credits, and can take seconds per source.',
+    'Why Radar finds nothing: fetches every configured source live and reports, per source, how ' +
+    'many items came back or why it was skipped — source off, plan, platform toggle, endpoint ' +
+    'error. It can take seconds per source. Free.',
   method: 'GET',
   pathUnderBrand: '/radar/diagnose',
   input: z.object({}).strict(),

--- a/cli/lib/contracts/media-models.ts
+++ b/cli/lib/contracts/media-models.ts
@@ -63,11 +63,11 @@ export const SET_MEDIA_MODEL = {
   tool: 'set_media_model',
   title: 'Choose a media model',
   description:
-    'Pin the model that serves one job for this brand — image generation, image refinement, ' +
-    'video from text, animating a still, video refinement, motion transfer. Only the models ' +
-    'that job accepts are taken: anything else comes back as model_not_for_slot with the list ' +
-    'that would have been accepted. Send model: null to drop the choice and go back to the ' +
-    'platform default. Calls no model and spends no credits; it takes effect on the next render.',
+    'Pin the model that serves one job for this brand — image generation, image refinement, video ' +
+    'from text, animating a still, video refinement, motion transfer. Only the models that job ' +
+    'accepts are taken: anything else comes back as model_not_for_slot with the list that would ' +
+    'have been accepted. Send model: null to drop the choice and go back to the platform default. ' +
+    'Free; it takes effect on the next render.',
   method: 'PUT',
   pathUnderBrand: '/settings/models',
   input: z

--- a/cli/lib/contracts/memory.ts
+++ b/cli/lib/contracts/memory.ts
@@ -32,8 +32,9 @@ export const SAVE_MEMORY = {
   description:
     'Record something you learned about this brand so the next conversation starts from it. ' +
     `Writable categories: ${AGENT_MEMORY_CATEGORIES.join(', ')}. \`voice\` and \`constraint\` are NOT writable here — they govern everything downstream and only the brand's own people set them. ` +
-    'A `key` that already holds a DIFFERENT value answers 409 with both values and writes nothing: you take it to the person, you do not win by arriving last. Sending the same value again reinforces it. ' +
-    'Entries land as brand knowledge, never scoped to a chat, and arrive with the confidence of something a model inferred rather than something a person stated.',
+    'A `key` that already holds a DIFFERENT value answers 409 with both values and writes nothing: ' +
+    'take it to the person. Sending the same value again reinforces it. Entries land as brand ' +
+    'knowledge, never scoped to a chat.',
   method: 'POST',
   pathUnderBrand: '/memory',
   input: z

--- a/cli/lib/contracts/plans.ts
+++ b/cli/lib/contracts/plans.ts
@@ -80,10 +80,10 @@ export const SAVE_PLAN = {
   tool: 'save_plan',
   title: 'Save an editorial plan',
   description:
-    'Store an editorial plan you wrote yourself. Anomalia calls no model and spends no credits. ' +
-    'It lands as the pending proposal, exactly where propose_plan leaves a generated one: the ' +
-    'brand active plan is left untouched and approve_plan remains the step that activates it. ' +
-    'Saving replaces an earlier pending proposal.',
+    'Store an editorial plan you wrote yourself. It lands as the pending proposal, exactly where ' +
+    'propose_plan leaves a generated one: the brand active plan is left untouched and ' +
+    'approve_plan remains the step that activates it. Saving replaces an earlier pending ' +
+    'proposal. Free.',
   method: 'POST',
   pathUnderBrand: '/editorial-plan/save',
   input: SavePlanInputSchema,
@@ -154,11 +154,10 @@ export const SAVE_WEEK_SEEDS = {
   tool: 'save_week_seeds',
   title: 'Save weekly content seeds',
   description:
-    'Store the week rows you planned yourself — one per post, no copy and no image yet. ' +
-    'Anomalia calls no model and spends no credits. The rows land as the week draft, exactly ' +
-    'where plan_week leaves generated ones: the plan page shows them, they are editable, and ' +
-    'produce_week is the separate (paid) step that turns them into posts. A brand keeps one ' +
-    'draft, so saving replaces the one in review.',
+    'Store the week rows you planned yourself — one per post, no copy and no image yet. The rows ' +
+    'land as the week draft, exactly where plan_week leaves generated ones: the plan page shows ' +
+    'them, they are editable, and produce_week is the separate (paid) step that turns them into ' +
+    'posts. A brand keeps one draft, so saving replaces the one in review. Free.',
   method: 'POST',
   pathUnderBrand: '/weekly-plan/seeds',
   input: SaveWeekSeedsInputSchema,
@@ -209,9 +208,9 @@ export const APPROVE_PLAN = {
   tool: 'approve_plan',
   title: 'Approve editorial plan',
   description:
-    'Make the proposed editorial plan the one this brand actually follows, replacing the ' +
-    'active one. Ask the person before doing it unless they clearly asked. discard_plan ' +
-    'throws the proposal away instead. No model, no credits.',
+    'Make the proposed editorial plan the one this brand actually follows, replacing the active ' +
+    'one. Ask the person before doing it unless they clearly asked. discard_plan throws the ' +
+    'proposal away instead. Free.',
   method: 'POST',
   pathUnderBrand: '/editorial-plan/approve',
   input: NoInput,
@@ -224,8 +223,8 @@ export const DISCARD_PLAN = {
   tool: 'discard_plan',
   title: 'Discard editorial plan',
   description:
-    'Throw away the proposed editorial plan and leave the active one exactly as it is. It ' +
-    'does not come back. No model, no credits.',
+    'Throw away the proposed editorial plan and leave the active one exactly as it is. It does ' +
+    'not come back. Free.',
   method: 'POST',
   pathUnderBrand: '/editorial-plan/discard',
   input: NoInput,
@@ -245,9 +244,9 @@ export const SAVE_BRIEF = {
   tool: 'save_brief',
   title: 'Save week brief',
   description:
-    'Write down what one week should be about, so whoever produces it works from your ' +
-    'direction instead of guessing. `week` is 0 for the current week; name the products to ' +
-    'feature if some matter. No model, no credits.',
+    'Write down what one week should be about, so whoever produces it works from your direction ' +
+    'instead of guessing. `week` is 0 for the current week; name the products to feature if some ' +
+    'matter. Free.',
   method: 'POST',
   pathUnderBrand: '/editorial-plan/save-brief',
   input: z

--- a/cli/lib/contracts/posts.ts
+++ b/cli/lib/contracts/posts.ts
@@ -69,14 +69,13 @@ export const CREATE_POST = {
   tool: 'create_post',
   title: 'Create post',
   description:
-    'Store copy you already wrote as one pending post for review. Anomalia calls no model and ' +
-    'spends no credits. It does not publish and does not schedule: `scheduled_for` is the ' +
-    'proposed calendar time, and approve_post remains the action that authorizes distribution. ' +
-    'Text-capable platforms only — instagram and tiktok need an image, youtube needs a video. ' +
-    'Two different media failures: `media_not_found` (400) means the id is not this brand — ' +
-    'check it with list_media, and pass the full id, never a prefix; `media_unavailable` (502) ' +
-    'means the id is yours and Anomalia could not attach it, so retrying other ids is wasted ' +
-    'work — retry later or leave the media out.',
+    'Store copy you already wrote as one pending post for review. It does not publish and does ' +
+    'not schedule: `scheduled_for` is the proposed calendar time, and approve_post remains the ' +
+    'action that authorizes distribution. Text-capable platforms only — instagram and tiktok need ' +
+    'an image, youtube needs a video. Two different media failures: `media_not_found` (400) means ' +
+    'the id is not this brand — check it with list_media, and pass the full id, never a prefix; ' +
+    '`media_unavailable` (502) means the id is yours and Anomalia could not attach it, so ' +
+    'retrying other ids is wasted work — retry later or leave the media out. Free.',
   method: 'POST',
   pathUnderBrand: '/posts',
   input: CreatePostInputSchema,
@@ -100,9 +99,9 @@ export const LIST_POSTS = {
   tool: 'list_posts',
   title: 'List posts',
   description:
-    'The brand\'s posts, newest first. Filter by `status` to find what is waiting for a person ' +
-    'to approve it (`pending_user`), what is scheduled, or what already went out. get_post ' +
-    'opens one in full. Reads only — no model, no credits.',
+    'The brand\'s posts, newest first. Filter by `status` to find what is waiting for a person to ' +
+    'approve it (`pending_user`), what is scheduled, or what already went out. get_post opens one ' +
+    'in full. Free.',
   method: 'GET',
   pathUnderBrand: '/posts',
   input: z.object({
@@ -133,8 +132,8 @@ export const GET_POST = {
   tool: 'get_post',
   title: 'Get post',
   description:
-    'Open one post in full: its copy, its status, and the state of its image, video or ' +
-    'carousel slides. Reads only — no model, no credits. id accepts a short prefix.',
+    'Open one post in full: its copy, its status, and the state of its image, video or carousel ' +
+    'slides. Free.',
   method: 'GET',
   pathUnderBrand: '/posts/:id/media',
   resource: 'post',
@@ -148,9 +147,8 @@ export const RESCHEDULE_POST = {
   tool: 'reschedule_post',
   title: 'Reschedule post',
   description:
-    'Move a post to a different date and time. `scheduled_for` is an ISO datetime. It does ' +
-    'not publish and does not approve — it only changes when. No model, no credits. id ' +
-    'accepts a short prefix.',
+    'Move a post to a different date and time. `scheduled_for` is an ISO datetime. It does not ' +
+    'publish and does not approve — it only changes when. Free.',
   method: 'POST',
   pathUnderBrand: '/posts/:id/reschedule',
   resource: 'post',
@@ -171,9 +169,9 @@ export const RENDER_POST = {
   tool: 'render_post',
   title: 'Render post image',
   description:
-    'Draw the image a post is missing, from the prompt already written on it, and attach it. ' +
-    'It spends credits: one render. To draw a picture that is not tied to a post, use ' +
-    'generate_image. id accepts a short prefix.',
+    'Draw the image a post is missing, from the prompt already written on it, and attach it. It ' +
+    'spends credits: one render. To draw a picture that is not tied to a post, use ' +
+    'generate_image.',
   method: 'POST',
   pathUnderBrand: '/posts/:id/render',
   resource: 'post',
@@ -190,9 +188,8 @@ export const GET_CALENDAR = {
   tool: 'get_calendar',
   title: 'Calendar',
   description:
-    'What this brand is posting and when, for one month. Posts with a date appear in the ' +
-    'month they are dated for; drafts with no date come back flagged `isDraft`. Reads only — ' +
-    'no model, no credits.',
+    'What this brand is posting and when, for one month. Posts with a date appear in the month ' +
+    'they are dated for; drafts with no date come back flagged `isDraft`. Free.',
   method: 'GET',
   pathUnderBrand: '/calendar',
   input: z.object({
@@ -277,10 +274,9 @@ export const IMPORT_MEDIA_URL = {
   title: 'Import media from a URL',
   description:
     'Copy an image or video you produced elsewhere into the brand media library, then use the id ' +
-    'it returns as media_ids on create_post. Anomalia calls no model and spends no credits: the ' +
-    'file is copied, not generated. The URL must be public https and stay public across every ' +
-    'redirect; jpeg, png, webp and gif up to 12MB, mp4, mov and webm up to 64MB. Anything else ' +
-    'is refused and nothing is stored.',
+    'it returns as media_ids on create_post. The file is copied, not generated. The URL must be ' +
+    'public https and stay public across every redirect; jpeg, png, webp and gif up to 12MB, mp4, ' +
+    'mov and webm up to 64MB. Anything else is refused and nothing is stored. Free.',
   method: 'POST',
   pathUnderBrand: '/media',
   input: ImportMediaUrlInputSchema,
@@ -319,14 +315,14 @@ export const GENERATE_MEDIA = {
   description:
     'To make a picture or a clip — the older door, kept working. Prefer generate_image or ' +
     'generate_video: they name what they do, and changing a picture or animating one has its own ' +
-    'tool. kind picks image (the default) or video, and everything here forwards to those two. ' +
-    'It spends credits. It creates nothing in the calendar and publishes nothing; pass the id ' +
-    'you keep to create_post as media_ids. Images come back ready, up to ' +
+    'tool. `kind` picks image (the default) or video, and everything here forwards to those two. ' +
+    'It spends credits. It creates nothing in the calendar and publishes nothing; pass the id you ' +
+    'keep to create_post as media_ids. Images come back ready, up to ' +
     MAX_MEDIA_ALTERNATIVES + ' per call; a clip takes minutes and returns a job_id, and ' +
-    'check_media_job says when it landed — calling this again for the same clip bills a second one.' +
-    "With a slug, this brand's look is applied, and it cannot be switched off from this door: " +
-    'generate_image takes brand_style for that, and refine_media is the one that CHANGES an asset '
-    + 'you already made instead of drawing another.',
+    'check_media_job says when it landed — calling this again for the same clip bills a second ' +
+    "one. With a slug this brand's look is applied and cannot be switched off from this door: " +
+    'generate_image takes brand_style for that, and refine_media CHANGES an asset you already ' +
+    'made instead of drawing another.',
   method: 'POST',
   pathUnderBrand: '/media/generate',
   input: z
@@ -349,9 +345,9 @@ export const GENERATE_MEDIA = {
         .min(1)
         .optional()
         .describe(
-          'Model id for THIS call only — it changes no brand setting. Omit to use the brand’s ' +
-            'choice. Accepted ids come from get_media_models (slot imageModel for an image, ' +
-            'videoModel for a video); anything else is refused as model_not_for_slot.'
+          'For THIS call only; it changes no brand setting. Omit for the brand’s choice. Ids from ' +
+            'get_media_models (slot imageModel for an image, videoModel for a video); anything ' +
+            'else is refused as model_not_for_slot.'
         ),
       title: z.string().optional().describe('The name the asset carries in the library')
     })
@@ -382,11 +378,11 @@ export const CHECK_MEDIA_JOB = {
   title: 'Check a media generation job',
   description:
     'Where a video you started has got to — the ones from generate_video or generate_media, ' +
-    'newest first. `status` is `rendering` while the clip is being made and `done` once it is ' +
-    'in the library; then `media_id` is the id create_post accepts as `media_ids`. `failed` ' +
-    'says why. `not_in_library` means the clip was rendered and paid for but never filed, so ' +
-    'there is no media_id and rendering it again buys a second copy. Poll this rather than ' +
-    'starting the clip again. No model, no credits.',
+    'newest first. `status` is `rendering` while the clip is being made and `done` once it is in ' +
+    'the library; then `media_id` is the id create_post accepts as `media_ids`. `failed` says ' +
+    'why. `not_in_library` means the clip was rendered and paid for but never filed, so there is ' +
+    'no media_id and rendering it again buys a second copy. Poll this rather than starting the ' +
+    'clip again. Free.',
   method: 'GET',
   pathUnderBrand: '/media/generate',
   input: z
@@ -424,10 +420,10 @@ export const REGENERATE_POST_MEDIA = {
   tool: 'regenerate_post_media',
   title: 'Regenerate post media',
   description:
-    'Change the image already on a post, in place — give an instruction like "make it ' +
-    'warmer", not a whole new prompt. The old image is REPLACED. It spends credits: one ' +
-    'render. To change a library image or clip and keep the original, use refine_media, which ' +
-    'files the result as a new asset instead. id accepts a short prefix.',
+    'Change the image already on a post, in place — give an instruction like "make it warmer", ' +
+    'not a whole new prompt. The old image is REPLACED. It spends credits: one render. To change ' +
+    'a library image or clip and keep the original, use refine_media, which files the result as ' +
+    'a new asset instead.',
   method: 'POST',
   pathUnderBrand: '/posts/:id/media/regenerate',
   resource: 'post',
@@ -443,9 +439,8 @@ export const REGENERATE_SLIDE = {
   tool: 'regenerate_slide',
   title: 'Regenerate carousel slide',
   description:
-    'Redraw one slide of a carousel — index 0 is the cover. Only that slide changes. It ' +
-    'spends credits: one render. reorder_slides moves or drops slides for free. id accepts a ' +
-    'short prefix.',
+    'Redraw one slide of a carousel — index 0 is the cover. Only that slide changes. It spends ' +
+    'credits: one render. reorder_slides moves or drops slides for free.',
   method: 'POST',
   pathUnderBrand: '/posts/:id/media/slide',
   resource: 'post',
@@ -471,7 +466,7 @@ export const REORDER_SLIDES = {
   description:
     'Change the order of a carousel\'s slides, or drop some, without redrawing anything and ' +
     'without spending credits. `order` lists the slides you want kept, in the order you want ' +
-    'them: [0,2,1]. Anything left out is dropped. id accepts a short prefix.',
+    'them: [0,2,1]. Anything left out is dropped.',
   method: 'POST',
   pathUnderBrand: '/posts/:id/media/order',
   resource: 'post',
@@ -489,12 +484,11 @@ export const MAKE_VIDEO = {
   tool: 'make_video',
   title: 'Animate post to video',
   description:
-    'To turn a post you already have into a video: this animates that post’s cover image and ' +
-    'attaches the clip back to the same post (it also retries a video that fell back to a ' +
-    'photo). It needs an existing post. To animate a photo on its own, or make any clip that is ' +
-    'not going on a post, use generate_video — that one needs no post at all. It spends credits: ' +
-    'one clip. It does not publish, and the post keeps the status it had. id accepts a short ' +
-    'prefix.',
+    'To turn a post you already have into a video: this animates that post\'s cover image and ' +
+    'attaches the clip back to the same post (it also retries a video that fell back to a photo). ' +
+    'It needs an existing post. To animate a photo on its own, or make any clip that is not going ' +
+    'on a post, use generate_video — that one needs no post at all. It spends credits: one clip. ' +
+    'It does not publish, and the post keeps the status it had.',
   method: 'POST',
   pathUnderBrand: '/posts/:id/media/video',
   resource: 'post',
@@ -586,9 +580,8 @@ function modelField(slot: string) {
     .min(1)
     .optional()
     .describe(
-      'Model id for THIS call only — it changes no brand setting. Omit to use the brand’s ' +
-        'choice. The ids this job accepts, and what each costs, come from get_media_models ' +
-        '(slot ' + slot + '); anything else is refused as model_not_for_slot.'
+      'For THIS call only; it changes no brand setting. Omit for the brand’s choice. Ids from ' +
+        'get_media_models (slot ' + slot + '); anything else is refused as model_not_for_slot.'
     );
 }
 
@@ -610,12 +603,10 @@ const BrandStyleField = z
   .enum(['apply', 'ignore'])
   .optional()
   .describe(
-    "Whether this brand's own look — its colours, its fonts, its visual direction — is applied. " +
-      'Leave it out and it is, which with a slug is almost always what you want. Send `ignore` ' +
-      'when the picture must take nothing from the brand: a plain UI screenshot, an illustration ' +
-      'about somebody else, a neutral background — places where brand colours and fonts spoil ' +
-      'the result. Without a slug there is no brand to apply or ignore, and sending this is ' +
-      'refused as brand_style_needs_a_brand: pass a slug, or drop brand_style.'
+    "Whether this brand's own look — colours, fonts, visual direction — is applied. Omit it and " +
+      'it is. Send `ignore` when the picture must take nothing from the brand: a UI screenshot, ' +
+      'an illustration about somebody else, a neutral background. Without a slug there is no ' +
+      'brand to apply or ignore: refused as brand_style_needs_a_brand.'
   );
 
 /**
@@ -660,23 +651,21 @@ export const GENERATE_IMAGE = {
   tool: 'generate_image',
   title: 'Generate an image',
   description:
-    'To draw a picture from a description — "an image of a cat", a product shot, a background ' +
-    "for a slide. With a slug, this brand's own look is applied by default — its colours, its " +
-    'fonts and the visual direction it has settled on — so you do not have to describe them; ' +
-    'brand_style: ignore leaves them out. Without a slug there is no brand and none of that ' +
-    'reaches the model, so name the style you want in the prompt. ' +
-    'WITHOUT slug this is a one-off drawing — no brand, ' +
-    'nothing filed anywhere, id comes back null and there is nothing to hand to create_post. ' +
-    "WITH slug the image lands in that brand's library and its id is what create_post takes as " +
-    'media_ids: use it when the picture belongs to a brand, or is going to become a post. Do ' +
+    'To draw a picture from a description — "an image of a cat", a product shot, a background for ' +
+    "a slide. With a slug, this brand's own look is applied by default — its colours, its fonts, " +
+    'its visual direction — so you do not have to describe them; brand_style: ignore leaves them ' +
+    'out. Without a slug there is no brand and none of that reaches the model, so name the style ' +
+    'you want in the prompt. WITHOUT slug this is a one-off drawing: no brand, nothing filed ' +
+    'anywhere, id comes back null and there is nothing to hand to create_post. WITH slug the ' +
+    "image lands in that brand's library and its id is what create_post takes as media_ids. Do " +
     'NOT call list_brands to decide where to draw — if nobody named a brand there is no brand, ' +
-    "and guessing one spends a real organisation's credits and litters a real library. It " +
-    'spends credits: one render per image, renders in the answer says how many were billed and ' +
-    'cost_usd what they actually cost. It creates nothing in the calendar and publishes nothing, ' +
-    'so ask for two or three with count, look at them, keep one. To CHANGE a picture that ' +
-    'already exists use refine_media — correcting one drawing beats redrawing until it is ' +
-    'right. To pick the model read get_media_models and pass model, for this call only; ' +
-    'set_media_model is the one that changes the brand from now on.',
+    "and guessing one spends a real organisation's credits and litters a real library. It spends " +
+    'credits: one render per image, and `renders` in the answer says how many were billed, ' +
+    'cost_usd what they cost. It creates nothing in the calendar and publishes nothing, so ask ' +
+    'for two or three with `count`, look at them, keep one. To CHANGE a picture that already ' +
+    'exists use refine_media — correcting one drawing beats redrawing until it is right. To pick ' +
+    'the model read get_media_models and pass `model`, for this call only; set_media_model ' +
+    'changes the brand from now on.',
   method: 'POST',
   pathUnderBrand: '/media/images',
   pathWithoutBrand: '/images',
@@ -781,15 +770,15 @@ export const GENERATE_VIDEO = {
   title: 'Generate a video',
   description:
     'To make a video: animate a photo you already have, or film a clip from a prompt alone. ' +
-    '"Animate this photo", "a 5 second video of this image" — that is base_media_id pointing at ' +
-    'a library image plus a prompt for the movement, and it needs NO post. It spends credits, ' +
-    'and the model moves that bill by more than an order of magnitude, so read get_media_models ' +
-    '(slot videoModel from a prompt, videoImageModel when animating an image) and pass model for ' +
-    'this call only. A clip takes minutes: this returns a job_id with status rendering, and ' +
+    '"Animate this photo", "a 5 second video of this image" — that is `base_media_id` pointing at ' +
+    'a library image plus a prompt for the movement, and it needs NO post. It spends credits, and ' +
+    'the model moves that bill by more than an order of magnitude, so read get_media_models (slot ' +
+    'videoModel from a prompt, videoImageModel when animating an image) and pass `model` for this ' +
+    'call only. A clip takes minutes: this returns a job_id with status rendering, and ' +
     'check_media_job says when it landed — calling this again for the same clip bills a second ' +
-    'one. It creates nothing in the calendar and publishes nothing; when the clip lands, pass ' +
-    'its media_id to create_post as media_ids. To animate the cover of a post you already have, ' +
-    'make_video does that in one step.',
+    'one. It creates nothing in the calendar and publishes nothing; when the clip lands, pass its ' +
+    'media_id to create_post as media_ids. To animate the cover of a post you already have, ' +
+    'make_video does it in one step.',
   method: 'POST',
   pathUnderBrand: '/media/videos',
   input: z
@@ -839,14 +828,12 @@ export const GENERATE_CAROUSEL = {
     'To make a carousel — a SERIES of images that read as one object, not N unrelated pictures. ' +
     'Slide 1 is the cover and must work at thumbnail size; every later slide advances the angle ' +
     'one concrete step and carries exactly one idea. It spends credits: one render per slide, so ' +
-    'a 5-slide carousel is five renders — ask for the count you mean. It creates nothing in the ' +
-    'calendar and publishes nothing: pass the ids to create_post as media_ids, in order. TO ' +
-    'CHANGE ONE SLIDE use ' +
-    'refine_media on that slide id, and put the continuity_tokens this returns back into your ' +
+    'a 5-slide carousel is five renders. It creates nothing in the calendar and publishes ' +
+    'nothing: pass the ids to create_post as media_ids, in order. TO CHANGE ONE SLIDE use ' +
+    'refine_media on that slide id, and put the `continuity_tokens` this returns back into your ' +
     'instruction — they are what holds the series together, and an edit that touches palette, ' +
-    'light or the recurring motif without them takes that slide out of the set. ' +
-    "With a slug, this brand's look is applied to every slide, and there is no way to switch it " +
-    "off here: a series that is not the brand's is not a series.",
+    'light or the recurring motif without them takes that slide out of the set. With a slug, this ' +
+    'brand\'s look is applied to every slide and there is no way to switch it off here.',
   method: 'POST',
   pathUnderBrand: '/media/carousel',
   input: z

--- a/cli/lib/contracts/query.ts
+++ b/cli/lib/contracts/query.ts
@@ -25,18 +25,20 @@ export const QUERY_DATABASE = {
   tool: 'query',
   title: 'Query the database',
   description:
-    'Read ANY table in the database directly, AS YOU — the request runs with the anon key plus your ' +
-    'own session, so Postgres RLS returns exactly the rows you would see in the app, and nothing more. ' +
-    'READ ONLY: there is no SQL here. You name a table, columns and filters, and it issues one ' +
-    'PostgREST read, so a write has nowhere to go — no INSERT, no CTE, no function call, nothing to ' +
-    'attempt. Omit `table` to list every table you can name. Ask for a table with no `columns` to get ' +
-    'real rows with every column: the keys of a row ARE the schema. THEN NAME THE COLUMNS YOU NEED: a read with no `columns` carries every column, the 20,000-character cap cuts whole rows to fit, and you get a short answer with no sign that you asked for a long one — 50 rows of `posts` come back as nine, the same 50 rows come back whole with five columns named. One table per call — no joins, no ' +
-    'embeds; read two tables and match the ids yourself. Reach for it when the answer needs a table ' +
-    'nothing else exposes, a count, or a join you do by hand. ' +
-    'IT IS ALSO THE READ FOR QUESTIONS THAT HAVE NO TOOL OF THEIR OWN. What this brand SELLS — its ' +
-    'catalogue of products, offers and services — is the `products` table: one row per offer, with ' +
-    '`title`, `kind`, `pricing`, `url`, `featured` and the `images` it carries. ' +
-    'Costs nothing.',
+    'Read ANY table in the database directly, AS YOU — the request runs with the anon key plus ' +
+    'your own session, so Postgres RLS returns exactly the rows you would see in the app, and ' +
+    'nothing more. READ ONLY: there is no SQL here. You name a table, columns and filters, and it ' +
+    'issues one PostgREST read, so a write has nowhere to go. Omit `table` to list every table ' +
+    'you can name. Ask for a table with no `columns` to get real rows with every column: the keys ' +
+    'of a row ARE the schema. THEN NAME THE COLUMNS YOU NEED: a read with no `columns` carries ' +
+    'every column, the 20,000-character cap cuts whole rows to fit, and you get a short answer ' +
+    'with no sign that you asked for a long one — 50 rows of `posts` come back as nine, the same ' +
+    '50 rows come back whole with five columns named. One table per call — no joins, no embeds; ' +
+    'read two tables and match the ids yourself. Reach for it when the answer needs a table ' +
+    'nothing else exposes, a count, or a join you do by hand. IT IS ALSO THE READ FOR QUESTIONS ' +
+    'THAT HAVE NO TOOL OF THEIR OWN. What this brand SELLS — its catalogue of products, offers ' +
+    'and services — is the `products` table: one row per offer, with `title`, `kind`, `pricing`, ' +
+    '`url`, `featured` and the `images` it carries. Free.',
   method: 'POST',
   pathUnderBrand: '/query',
   input: z

--- a/cli/lib/contracts/radar.ts
+++ b/cli/lib/contracts/radar.ts
@@ -78,7 +78,7 @@ export const SET_RADAR_PLATFORM = {
   description:
     'Switch one platform on or off for this brand’s Radar. Turning one off narrows what Radar ' +
     'finds; it deletes no source and no result already found. Threads, X and LinkedIn need the ' +
-    'Pro plan and answer plan_required below it. Calls no model and spends no credits.',
+    'Pro plan and answer plan_required below it. Free.',
   method: 'PUT',
   pathUnderBrand: '/settings/radar',
   input: z.object({ platform, enabled: z.boolean() }).strict(),
@@ -99,8 +99,7 @@ export const ADD_RADAR_SOURCE = {
     'Threads / X / LinkedIn search. A source already there is left as it is rather than ' +
     'duplicated — the pair (kind, value) is its identity, and it is what remove_radar_source ' +
     'takes. Read get_radar first: the plan decides which kinds are allowed (plan_required) and ' +
-    'how many sources fit (source_limit). Adding a source calls no model and spends no credits, ' +
-    'but Radar reads it on every run from then on.',
+    'how many sources fit (source_limit). Radar reads the source on every run from then on. Free.',
   method: 'POST',
   pathUnderBrand: '/settings/radar/sources',
   input: z

--- a/cli/lib/contracts/reads.ts
+++ b/cli/lib/contracts/reads.ts
@@ -13,10 +13,9 @@ export const GET_PLAN = {
   tool: 'get_plan',
   title: 'Editorial plan',
   description:
-    'What this brand has decided to post about: the active editorial plan, plus any proposal ' +
-    'still waiting for someone to approve it. Read it before writing anything, so the copy ' +
-    'follows the plan already agreed. propose_plan writes a new one, approve_plan is what ' +
-    'makes a proposal active. Reads only — no model, no credits.',
+    'The active editorial plan, plus any proposal still waiting for approval. Read it before ' +
+    'writing copy, so what you write follows the plan already agreed. propose_plan writes a new ' +
+    'one, approve_plan activates a proposal. Free.',
   method: 'GET',
   pathUnderBrand: '/editorial-plan',
   input: NoInput,
@@ -35,9 +34,9 @@ export const GET_WEEKLY_PLAN = {
   tool: 'get_weekly_plan',
   title: 'Weekly plan',
   description:
-    'What is lined up for the coming weeks: the seeds planned for each week — one per ' +
-    'intended post — and the posts already made from them. plan_week generates seeds, ' +
-    'save_week_seeds stores ones you wrote yourself. Reads only — no model, no credits.',
+    'What is lined up for the coming weeks: the seeds planned for each week — one per intended ' +
+    'post — and the posts already made from them. plan_week generates seeds, save_week_seeds ' +
+    'stores ones you wrote yourself. Free.',
   method: 'GET',
   pathUnderBrand: '/weekly-plan',
   input: NoInput,
@@ -146,15 +145,12 @@ export const GET_STUDIO = {
   tool: 'get_studio',
   title: 'Studio',
   description:
-    'Everything the brand knows about itself, in one call: its own facts, the people who may ' +
-    'appear in its content, the documents it has uploaded, its competitors, its products, and ' +
-    'a summary of what it has posted before. Each document carries `status` and `chunkCount` ' +
-    '(one that is not `ready` with at least one chunk exists here but is invisible to ' +
-    '`search_knowledge`) and `textBytes`, which says how much text it holds. The text itself ' +
-    'is NOT included: to answer a question, ask `search_knowledge` — it returns the passages ' +
-    'that answer it with the document each came from, instead of the whole corpus. ' +
-    '`documents: "full"` restores the complete text of every document; it exists for callers ' +
-    'that were reading it before and is almost never what you want.',
+    'Everything the brand knows about itself: its own facts, the people who may appear in its ' +
+    'content, its uploaded documents, its competitors, its products, and a summary of what it has ' +
+    'posted. Document text is NOT included — search_knowledge returns the passages that answer a ' +
+    'question, with the document each came from. A document that is not `ready`, or whose ' +
+    '`chunkCount` is 0, is listed here and invisible to search_knowledge. `documents: "full"` ' +
+    'returns every document whole and is almost never what you want.',
   method: 'GET',
   pathUnderBrand: '/studio',
   input: z
@@ -195,9 +191,9 @@ export const GET_SEO = {
   tool: 'get_seo',
   title: 'SEO overview',
   description:
-    'How the brand\'s website is doing in Google: the technical score, the search performance, ' +
-    'an overall grade, and the improvements worth making. Reads what was already measured — ' +
-    'seo_action is what runs a fresh audit and spends credits. No model, no credits.',
+    'How the brand\'s website is doing in Google: the technical score, the search performance, an ' +
+    'overall grade, and the improvements worth making. Reads the last audit — seo_action runs a ' +
+    'fresh one and spends credits. Free.',
   method: 'GET',
   pathUnderBrand: '/seo',
   input: NoInput,
@@ -216,9 +212,8 @@ export const GET_GEO = {
   title: 'GEO overview',
   description:
     'Whether this brand gets named when someone asks ChatGPT, Perplexity or Google\'s AI: its ' +
-    'share of voice, the answers that cited it, and fixes already written and ready to ' +
-    'publish. Reads what was already measured — geo_action runs a fresh check and spends ' +
-    'credits. No model, no credits.',
+    'share of voice, the answers that cited it, and fixes already written and ready to publish. ' +
+    'Reads the last check — geo_action runs a fresh one and spends credits. Free.',
   method: 'GET',
   pathUnderBrand: '/geo',
   input: NoInput,
@@ -243,9 +238,9 @@ export const GET_KEYWORDS = {
   tool: 'get_keywords',
   title: 'Keywords',
   description:
-    'The search terms worth writing for: each one\'s monthly volume, how hard it is to rank ' +
-    'for, the opportunity it carries, and what to do about it. refresh_keywords redoes the ' +
-    'research and spends credits; this only reads. No model, no credits.',
+    'The search terms worth writing for: monthly volume, how hard each is to rank for, the ' +
+    'opportunity it carries, and what to do about it. refresh_keywords redoes the research and ' +
+    'spends credits. Free.',
   method: 'GET',
   pathUnderBrand: '/keywords',
   input: NoInput,
@@ -263,8 +258,7 @@ export const GET_ADS = {
   title: 'Ads overview',
   description:
     'The brand\'s paid campaigns: what is running, what has been proposed and is waiting, and ' +
-    'which advertising accounts are connected. ads_action is what changes any of it. Reads ' +
-    'only — no model, no credits.',
+    'which advertising accounts are connected. ads_action is what changes any of it. Free.',
   method: 'GET',
   pathUnderBrand: '/ads',
   input: NoInput,
@@ -284,9 +278,9 @@ export const GET_ANALYTICS = {
   tool: 'get_analytics',
   title: 'Analytics',
   description:
-    'How the brand\'s published posts are actually doing: totals, engagement, and recent ' +
-    'activity. This is what happened after publishing, not the website\'s search traffic — ' +
-    'that one is get_gsc. Reads only — no model, no credits.',
+    'How the brand\'s published posts are actually doing: totals, engagement, recent activity. ' +
+    'This is what happened after publishing, not the website\'s search traffic — that one is ' +
+    'get_gsc. Free.',
   method: 'GET',
   pathUnderBrand: '/analytics',
   input: NoInput,
@@ -311,8 +305,7 @@ export const GET_GTM = {
   tool: 'get_gtm',
   title: 'GTM roadmap',
   description:
-    'The go-to-market roadmap: what this brand plans to do to reach its market, in order. ' +
-    'Reads only — no model, no credits.',
+    'The go-to-market roadmap: what this brand plans to do to reach its market, in order. Free.',
   method: 'GET',
   pathUnderBrand: '/gtm',
   input: NoInput,
@@ -335,8 +328,7 @@ export const GET_VOICE = {
   description:
     'How this brand is supposed to sound: mood, tone, register, the words it avoids, and the ' +
     'rules that change from one platform to another. Read it before writing any copy — ' +
-    'get_writing_skills is the craft, this is the brand. update_voice changes it. Reads only ' +
-    '— no model, no credits.',
+    'get_writing_skills is the craft, this is the brand. update_voice changes it. Free.',
   method: 'GET',
   pathUnderBrand: '/voice',
   input: NoInput,
@@ -360,10 +352,9 @@ export const GET_DASHBOARD = {
   tool: 'get_dashboard',
   title: 'Brand dashboard',
   description:
-    'Where this brand stands right now, in one call: how many posts are waiting for approval, ' +
-    'the active plan, the products, the connected social accounts, the brand\'s own facts, and ' +
-    'how the recurring jobs went last time. Start here when you do not know what to look at. ' +
-    'Reads only — no model, no credits.',
+    'Where this brand stands right now, in one call: posts waiting for approval, the active plan, ' +
+    'the products, the connected social accounts, the brand\'s own facts, and how the recurring ' +
+    'jobs went last time. Start here when you do not know what to look at. Free.',
   method: 'GET',
   pathUnderBrand: '',
   input: z.object({}).strict(),

--- a/cli/lib/contracts/social.ts
+++ b/cli/lib/contracts/social.ts
@@ -45,13 +45,13 @@ export const LIST_SOCIAL_ACCOUNTS = {
   tool: 'list_social_accounts',
   title: 'Connected social accounts',
   description:
-    'The social accounts this brand can publish to, one row each: platform, the handle it actually ' +
-    'posts as, and whether it still works. Read it before promising anything will go out — a ' +
-    'target platform with no active account produces posts that sit forever. It also says whether ' +
-    'the plan allows connecting at all and how many slots are left, which is what decides if ' +
-    'create_social_connect_link can help. get_brand_settings carries the same connected_platforms ' +
-    'summary for the platform vocabulary; this is the account-level truth behind it, and the only ' +
-    'place a broken connection shows up. Calls no model and spends no credits.',
+    'The social accounts this brand can publish to, one row each: platform, the handle it ' +
+    'actually posts as, and whether it still works. Read it before promising anything will go out ' +
+    '— a target platform with no active account produces posts that sit forever. It also says ' +
+    'whether the plan allows connecting at all and how many slots are left, which is what decides ' +
+    'if create_social_connect_link can help. get_brand_settings carries the same ' +
+    'connected_platforms summary; this is the account-level truth behind it, and the only place a ' +
+    'broken connection shows up. Free.',
   method: 'GET',
   pathUnderBrand: '/social/accounts',
   input: z.object({}).strict(),
@@ -80,13 +80,12 @@ export const SOCIAL_CONNECT_LINK = {
     'Mint the link a HUMAN opens to authorise one social platform for this brand, and stop there. ' +
     'You never run the OAuth, never see a token and never connect anything: the person clicks, ' +
     'signs in on that platform, and the account appears. The URL is a page of our own app behind ' +
-    'their login, not a credential — but it is useless to anyone who cannot already reach the ' +
-    'brand, so hand it over and let them go. Call list_social_accounts first: this refuses when ' +
-    'the plan connects no accounts (plan_cannot_connect) or every slot is taken (account_limit), ' +
-    'and those are two different problems with two different remedies. Minting a link for a ' +
-    'platform that is already connected is allowed and returns already_connected: it is how a ' +
-    'expired account gets re-authorised, or a second account added. Calls no model and spends no ' +
-    'credits: it works precisely when credits are gone.',
+    'their login, not a credential, but it is useless to anyone who cannot already reach the ' +
+    'brand. Call list_social_accounts first: this refuses when the plan connects no accounts ' +
+    '(plan_cannot_connect) or every slot is taken (account_limit), two different problems with ' +
+    'two different remedies. Minting a link for a platform already connected is allowed and ' +
+    'returns already_connected: it is how an expired account is re-authorised, or a second one ' +
+    'added. Free: it works precisely when credits are gone.',
   method: 'POST',
   pathUnderBrand: '/social/connect',
   input: z

--- a/cli/lib/contracts/studio.ts
+++ b/cli/lib/contracts/studio.ts
@@ -50,9 +50,9 @@ export const CREATE_PRODUCT = {
   tool: 'create_product',
   title: 'Create product',
   description:
-    'Add one offer to the brand catalog. Deterministic: it calls no model and spends no ' +
-    'credits. Use it when the catalog does not come from a connected store — sync_products ' +
-    'replaces the whole catalog from Shopify or WooCommerce and would erase a hand-made row.',
+    'Add one offer to the brand catalog. Use it when the catalog does not come from a connected ' +
+    'store — sync_products replaces the whole catalog from Shopify or WooCommerce and would erase ' +
+    'a hand-made row. Free.',
   method: 'POST',
   pathUnderBrand: '/studio/products',
   input: CreateProductInputSchema,
@@ -77,7 +77,7 @@ export const UPDATE_PRODUCT = {
   title: 'Update product',
   description:
     'Correct one offer in place. Only the fields you send change; every other column keeps the ' +
-    'value it had. Calls no model and spends no credits.',
+    'value it had. Free.',
   method: 'PUT',
   pathUnderBrand: '/products/:id',
   resource: 'product',
@@ -169,7 +169,7 @@ export const UPDATE_PERSON = {
   description:
     'Correct the name, role, description or attributes of a person already registered on this ' +
     'brand. It cannot attest consent, turn a real person into an invented one, or touch their ' +
-    'photos — those stay with the person who owns the brand. No model, no credits.',
+    'photos — those stay with the person who owns the brand. Free.',
   method: 'PUT',
   pathUnderBrand: '/people/:id',
   resource: 'person',
@@ -196,9 +196,8 @@ export const UPDATE_COMPETITOR = {
   tool: 'update_competitor',
   title: 'Update competitor',
   description:
-    'Correct a company already on this brand\'s competitor list: a wrong website, a reason ' +
-    'that no longer holds, direct versus indirect. Only the fields you send change. No model, ' +
-    'no credits.',
+    'Correct a company already on this brand\'s competitor list: a wrong website, a reason that no ' +
+    'longer holds, direct versus indirect. Only the fields you send change. Free.',
   method: 'PUT',
   pathUnderBrand: '/studio/competitors/:id',
   resource: 'competitor',
@@ -258,8 +257,8 @@ export const UPDATE_BRAND_KIT = {
   title: 'Update brand kit',
   description:
     'Change what this brand IS: what it does, its category, who it speaks to, its style, its ' +
-    'language. These are the facts every generated post is written from, so a wrong one is ' +
-    'wrong everywhere. Only the fields you send change. No model, no credits.',
+    'language. These are the facts every generated post is written from, so a wrong one is wrong ' +
+    'everywhere. Only the fields you send change. Free.',
   method: 'PUT',
   pathUnderBrand: '/studio/kit',
   input: z
@@ -281,8 +280,8 @@ export const UPDATE_VOICE = {
   title: 'Update voice',
   description:
     'Change how this brand sounds: mood, tone, register, the words it must avoid, and the ' +
-    'instructions that differ per platform. Only the fields you send change. get_voice reads ' +
-    'it back. No model, no credits.',
+    'instructions that differ per platform. Only the fields you send change. get_voice reads it ' +
+    'back. Free.',
   method: 'POST',
   pathUnderBrand: '/voice/update',
   input: z
@@ -307,8 +306,8 @@ export const ADD_COMPETITOR = {
   title: 'Add competitor',
   description:
     'Add a company this brand competes with, so research and posts can take it into account. ' +
-    'update_competitor corrects one already there; research_competitors finds them for you ' +
-    'and spends credits. No model, no credits.',
+    'update_competitor corrects one already there; research_competitors finds them for you and ' +
+    'spends credits. Free.',
   method: 'POST',
   pathUnderBrand: '/studio/competitors',
   input: z
@@ -372,9 +371,8 @@ export const ADD_NOTE = {
   title: 'Add knowledge note',
   description:
     'Save something this brand knows — a note, a policy, a transcript, a document — so the AI ' +
-    'writes from it instead of guessing. It is indexed for search: search_knowledge is how it ' +
-    'comes back, and get_knowledge_status says when it is ready to be found. No model, no ' +
-    'credits.',
+    'writes from it instead of guessing. search_knowledge is how it comes back; ' +
+    'get_knowledge_status says when it is ready to be found. Free.',
   method: 'POST',
   pathUnderBrand: '/studio/documents',
   input: z.object({ text: z.string().min(1), title: z.string().optional() }).strict(),
@@ -392,7 +390,7 @@ export const SET_COLORS = {
   description:
     'Set the colours every graphic for this brand is drawn with, as hex values: ' +
     '["#7c5cff","#ffffff"]. Three or six digits, up to 8 colours. The list REPLACES the whole ' +
-    'palette, so send all the colours you want, not just the new one. No model, no credits.',
+    'palette, so send all the colours you want, not just the new one. Free.',
   method: 'PUT',
   pathUnderBrand: '/studio/colors',
   // Stessa forma che la rotta salva: un `#aabbccdd` che passa di qui e prende un 400 di là
@@ -420,9 +418,8 @@ export const ADD_PERSON = {
   title: 'Add person',
   description:
     'Register a real person who may appear in this brand\'s images and videos. Their face is ' +
-    'withheld from every generator until consent is attested, so `consent` must be true and ' +
-    'only the person\'s own operator can state it — never assume it on someone\'s behalf. No ' +
-    'model, no credits.',
+    'withheld from every generator until consent is attested, so `consent` must be true and only ' +
+    'the person\'s own operator can state it — never assume it on someone\'s behalf. Free.',
   method: 'POST',
   pathUnderBrand: '/studio/people',
   input: z

--- a/cli/lib/contracts/web-metrics.ts
+++ b/cli/lib/contracts/web-metrics.ts
@@ -13,10 +13,9 @@ export const GET_GSC = {
   tool: 'get_gsc',
   title: 'Search Console',
   description:
-    'How this brand\'s website does in Google search over the last 28 days: clicks, ' +
-    'impressions, the queries people arrived on and the pages they landed on — and whether ' +
-    'the property is connected at all. This is website traffic, not post engagement; that one ' +
-    'is get_analytics. Reads only — no model, no credits.',
+    'How this brand\'s website does in Google search over the last 28 days: clicks, impressions, ' +
+    'the queries people arrived on, the pages they landed on, and whether the property is ' +
+    'connected at all. Website traffic, not post engagement — that one is get_analytics. Free.',
   method: 'GET',
   pathUnderBrand: '/gsc',
   input: NoInput,
@@ -39,9 +38,9 @@ export const GET_RANKS = {
   tool: 'get_ranks',
   title: 'Rank tracking',
   description:
-    'Where this brand actually sits in Google for the keywords it tracks: the current ' +
-    'position, the previous one, the move between them, the page that ranks, and whether an ' +
-    'AI Overview appeared above it. Reads only — no model, no credits.',
+    'Where this brand actually sits in Google for the keywords it tracks: the current position, ' +
+    'the previous one, the move between them, the page that ranks, and whether an AI Overview ' +
+    'appeared above it. Free.',
   method: 'GET',
   pathUnderBrand: '/ranks',
   input: NoInput,
@@ -85,8 +84,8 @@ export const GET_BACKLINKS = {
   title: 'Backlink network',
   description:
     'Who links to this brand\'s site and who it links to, plus the exchanges still open and ' +
-    'whether the network is unlocked for this brand at all (Starter plan or above, and opted ' +
-    'in). Reads only — no model, no credits.',
+    'whether the network is unlocked for this brand at all (Starter plan or above, and opted in). ' +
+    'Free.',
   method: 'GET',
   pathUnderBrand: '/backlinks',
   input: NoInput,

--- a/cli/lib/contracts/writing-skills.ts
+++ b/cli/lib/contracts/writing-skills.ts
@@ -20,11 +20,13 @@ export const GET_WRITING_SKILLS = {
   tool: 'get_writing_skills',
   title: 'Writing skills',
   description:
-    'READ THIS BEFORE WRITING ANY COPY FOR THE BRAND — a caption, a carousel, a script, an article, a bio. ' +
-    'It returns the actual craft text Anomalia writes with: `humanizer` and `stop-slop` always (why the output must not read as a chatbot), plus `social` or `seo-audit` depending on `agent`. ' +
-    'It also returns the built-in production skills for that agent — the ones naming the gates that refuse a render — and this brand\'s OWN procedures, the ones its team wrote or the system distilled. `source` says product from brand, and a brand procedure overrules a product skill when they disagree. ' +
-    'Bodies come inline; each skill lists its `references` by path without sending them, and you fetch one by passing `reference: "<skill>/<path>"`, which then returns that file alone. ' +
-    'No credits, no writes. Reading it costs a few thousand tokens and is the difference between copy a person would publish and copy that reads as generated.',
+    'READ THIS BEFORE WRITING ANY COPY FOR THE BRAND — a caption, a carousel, a script, an ' +
+    'article, a bio. It returns the craft text Anomalia writes with: `humanizer` and `stop-slop` ' +
+    'always, plus `social` or `seo-audit` depending on `agent`. It also returns the built-in ' +
+    'production skills for that agent — the ones naming the gates that refuse a render — and this ' +
+    'brand\'s OWN procedures, and a brand procedure overrules a product skill when they disagree. ' +
+    'Bodies come inline; each skill lists its `references` by path without sending them, and ' +
+    '`reference: "<skill>/<path>"` returns that one file alone. Free.',
   method: 'GET',
   pathUnderBrand: '/writing-skills',
   input: z

--- a/cli/mcp/create-post.test.ts
+++ b/cli/mcp/create-post.test.ts
@@ -137,7 +137,7 @@ describe('i tool di brand derivati dal registry', () => {
     );
     expect((check.inputSchema?.required ?? []).sort()).toEqual(['caption', 'platforms', 'slug']);
     expect(check.annotations?.destructiveHint).toBe(false);
-    expect(check.description ?? '').toContain('spends no credits');
+    expect(check.description ?? '').toMatch(/free/i);
   });
 
   test('import_media_url compare come scrittura, e chiede solo un URL', async () => {
@@ -156,7 +156,7 @@ describe('i tool di brand derivati dal registry', () => {
     expect(Object.keys(kit.inputSchema?.properties ?? {}).sort()).toEqual(['format', 'goal', 'platforms', 'slug']);
     expect((kit.inputSchema?.required ?? []).sort()).toEqual(['format', 'goal', 'platforms', 'slug']);
     expect(kit.annotations?.readOnlyHint).toBe(true);
-    expect(kit.description ?? '').toMatch(/no model, no credits/i);
+    expect(kit.description ?? '').toMatch(/free/i);
   });
 
   test('nessun tool è registrato due volte dopo la migrazione', async () => {
@@ -173,7 +173,6 @@ describe('i tool sul singolo post', () => {
     expect(Object.keys(getPost.inputSchema?.properties ?? {}).sort()).toEqual(['id', 'slug']);
     expect((getPost.inputSchema?.required ?? []).sort()).toEqual(['id', 'slug']);
     expect(getPost.annotations?.readOnlyHint).toBe(true);
-    expect(getPost.description ?? '').toContain('id accepts a short prefix');
   });
 
   test('reschedule_post chiede anche la data e non si dichiara distruttivo', async () => {

--- a/cli/mcp/migrated-writes.test.ts
+++ b/cli/mcp/migrated-writes.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { BRAND_ENDPOINTS } from '../lib/contracts/index.ts';
 import { handleMcpFetch } from './http-app.ts';
 
-const SLUG = { type: 'string', minLength: 1, description: 'Brand URL slug' };
+const SLUG = { type: 'string', minLength: 1 };
 
 const NOT_DESTRUCTIVE = { readOnlyHint: false, destructiveHint: false };
 const DESTRUCTIVE = { readOnlyHint: false, destructiveHint: true };

--- a/cli/mcp/read-tools.test.ts
+++ b/cli/mcp/read-tools.test.ts
@@ -3,7 +3,7 @@ import { BRAND_ENDPOINTS } from '../lib/contracts/index.ts';
 import { handleMcpFetch } from './http-app.ts';
 import { MCP_INSTRUCTIONS } from './server.ts';
 
-const SLUG_PROPERTY = { type: 'string', minLength: 1, description: 'Brand URL slug' };
+const SLUG_PROPERTY = { type: 'string', minLength: 1 };
 
 const MIGRATED_READS = [
   {

--- a/cli/mcp/server.ts
+++ b/cli/mcp/server.ts
@@ -42,7 +42,7 @@ function withoutKeysNoClientReads(result: unknown): unknown {
  * L'SDK aggiunge a ogni tool due chiavi che nessun client legge, e le paghiamo a ogni sessione:
  * `$schema` dichiara il dialetto di uno schema che il protocollo dichiara già JSON Schema, e
  * `execution.taskSupport: 'forbidden'` è esattamente ciò che l'assenza del campo significa.
- * Erano 13.356 caratteri, il 10% di `tools/list`.
+ * Erano 10.948 caratteri, l'8,5% di `tools/list`.
  *
  * Si decora l'unico punto in cui l'SDK installa il suo handler, prima che i tool lo creino.
  */

--- a/cli/mcp/server.ts
+++ b/cli/mcp/server.ts
@@ -1,4 +1,5 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { registerAuthTools } from './tools/auth.ts';
 import { registerBrandTools } from './tools/brand-content.ts';
 import { registerPlanTools } from './tools/plan.ts';
@@ -24,6 +25,39 @@ export const MCP_INSTRUCTIONS = [
   'Signing in is not a tool: over HTTP the host does the OAuth round and sends the Bearer; locally run `anomalia login` once — the CLI and this server share one session file. No API keys.'
 ].join(' ');
 
+type ListedTool = { inputSchema?: Record<string, unknown> };
+
+function withoutKeysNoClientReads(result: unknown): unknown {
+  const { tools } = result as { tools: ListedTool[] };
+
+  return {
+    tools: tools.map(({ inputSchema, ...tool }) => {
+      const { $schema, ...schema } = inputSchema ?? {};
+      return { ...tool, execution: undefined, inputSchema: schema };
+    }),
+  };
+}
+
+/**
+ * L'SDK aggiunge a ogni tool due chiavi che nessun client legge, e le paghiamo a ogni sessione:
+ * `$schema` dichiara il dialetto di uno schema che il protocollo dichiara già JSON Schema, e
+ * `execution.taskSupport: 'forbidden'` è esattamente ciò che l'assenza del campo significa.
+ * Erano 13.356 caratteri, il 10% di `tools/list`.
+ *
+ * Si decora l'unico punto in cui l'SDK installa il suo handler, prima che i tool lo creino.
+ */
+function trimListedTools(server: McpServer): void {
+  const inner = server.server;
+  const install = inner.setRequestHandler.bind(inner);
+
+  inner.setRequestHandler = ((schema: unknown, handler: (...args: unknown[]) => unknown) => {
+    if (schema !== ListToolsRequestSchema) return install(schema as never, handler as never);
+
+    return install(schema as never, (async (...args: unknown[]) =>
+      withoutKeysNoClientReads(await handler(...args))) as never);
+  }) as typeof inner.setRequestHandler;
+}
+
 export function createAnomaliaMcpServer(): McpServer {
   const server = new McpServer(
     {
@@ -34,6 +68,8 @@ export function createAnomaliaMcpServer(): McpServer {
     },
     { instructions: MCP_INSTRUCTIONS },
   );
+
+  trimListedTools(server);
 
   registerAuthTools(server);
   registerBrandTools(server);

--- a/cli/mcp/tool-surface-cost.test.ts
+++ b/cli/mcp/tool-surface-cost.test.ts
@@ -3,14 +3,16 @@ import { handleMcpFetch } from './http-app.ts';
 
 /**
  * `tools/list` si paga a ogni sessione, come le istruzioni del handshake, e nessuno lo guardava:
- * misurato sul transport vero era 131.959 caratteri — circa 33.000 token prima che l'agente
- * chieda qualunque cosa. Il budget qui sotto è quel numero dopo il taglio, e il test esiste
- * perché ricresce da solo: ogni tool nuovo porta la sua descrizione, e nessuno somma.
+ * misurato sul transport vero era 129.212 caratteri — circa 32.300 token prima che l'agente
+ * chieda qualunque cosa. Oggi sono 109.837, e il tetto lascia il margine di qualche tool nuovo:
+ * quando lo sfonda, la superficie va guardata di nuovo invece di crescere in silenzio.
  *
  * Si misura il TRANSPORT, non i sorgenti: il conto dei sorgenti ha già sbagliato due volte,
- * perché lo schema JSON che il protocollo spedisce non somiglia allo zod da cui nasce.
+ * perché lo schema JSON che il protocollo spedisce non somiglia allo zod da cui nasce. E si misura
+ * `result` intero, wrapper `{"tools":…}` compreso: contare il solo array dà 10 caratteri in meno,
+ * ed è la differenza esatta fra due conteggi che sembravano in disaccordo.
  */
-const TOOLS_LIST_MAX_CHARS = 96_000;
+const TOOLS_LIST_MAX_CHARS = 113_000;
 
 async function listedTools(): Promise<{ tools: Array<Record<string, unknown>>; chars: number }> {
   const post = (body: unknown) =>
@@ -51,7 +53,7 @@ describe('la lista dei tool sta dentro il suo budget', () => {
   /**
    * Due chiavi che l'SDK aggiunge da sé e che nessun client legge: `$schema` dichiara il dialetto
    * di uno schema che il protocollo dichiara già JSON Schema, e `taskSupport: 'forbidden'` è il
-   * valore che l'assenza del campo significa. Costavano 13.356 caratteri — il 10% della lista.
+   * valore che l'assenza del campo significa. Costavano 10.948 caratteri — l'8,5% della lista.
    */
   test('non ripete il dialetto dello schema a ogni tool', async () => {
     const { tools } = await listedTools();

--- a/cli/mcp/tool-surface-cost.test.ts
+++ b/cli/mcp/tool-surface-cost.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from 'bun:test';
+import { handleMcpFetch } from './http-app.ts';
+
+/**
+ * `tools/list` si paga a ogni sessione, come le istruzioni del handshake, e nessuno lo guardava:
+ * misurato sul transport vero era 131.959 caratteri — circa 33.000 token prima che l'agente
+ * chieda qualunque cosa. Il budget qui sotto è quel numero dopo il taglio, e il test esiste
+ * perché ricresce da solo: ogni tool nuovo porta la sua descrizione, e nessuno somma.
+ *
+ * Si misura il TRANSPORT, non i sorgenti: il conto dei sorgenti ha già sbagliato due volte,
+ * perché lo schema JSON che il protocollo spedisce non somiglia allo zod da cui nasce.
+ */
+const TOOLS_LIST_MAX_CHARS = 96_000;
+
+async function listedTools(): Promise<{ tools: Array<Record<string, unknown>>; chars: number }> {
+  const post = (body: unknown) =>
+    handleMcpFetch(
+      new Request('http://localhost/mcp', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json, text/event-stream',
+        },
+        body: JSON.stringify(body),
+      }),
+    );
+
+  await post({
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'cost', version: '0.0.1' },
+    },
+  });
+
+  const body = await (await post({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} })).json();
+
+  return { tools: body.result.tools, chars: JSON.stringify(body.result).length };
+}
+
+describe('la lista dei tool sta dentro il suo budget', () => {
+  test('un client la riceve intera prima di poter chiedere qualcosa', async () => {
+    const { chars } = await listedTools();
+
+    expect(chars).toBeLessThanOrEqual(TOOLS_LIST_MAX_CHARS);
+  });
+
+  /**
+   * Due chiavi che l'SDK aggiunge da sé e che nessun client legge: `$schema` dichiara il dialetto
+   * di uno schema che il protocollo dichiara già JSON Schema, e `taskSupport: 'forbidden'` è il
+   * valore che l'assenza del campo significa. Costavano 13.356 caratteri — il 10% della lista.
+   */
+  test('non ripete il dialetto dello schema a ogni tool', async () => {
+    const { tools } = await listedTools();
+
+    for (const tool of tools) {
+      expect(tool.inputSchema).not.toHaveProperty('$schema');
+    }
+  });
+
+  test('non dichiara taskSupport: nessun tool qui accetta un task', async () => {
+    const { tools } = await listedTools();
+
+    for (const tool of tools) {
+      expect(tool).not.toHaveProperty('execution');
+    }
+  });
+});

--- a/cli/mcp/tools/auth.ts
+++ b/cli/mcp/tools/auth.ts
@@ -24,10 +24,9 @@ export function registerAuthTools(server: McpServer) {
     {
       title: 'List brands',
       description:
-        'Which brands this person can work on, and the slug each one is called by — every other ' +
-        'tool needs that slug. Each row says the plan it is on, how many posts wait for approval, ' +
-        'and whether its recurring jobs are running. Start here when you do not know the slug. ' +
-        'Reads only — no model, no credits.',
+        'Which brands this person can work on, and the slug each one is called by — every other tool ' +
+        'needs that slug. Each row says the plan it is on, how many posts wait for approval, and ' +
+        'whether its recurring jobs are running. Start here when you do not know the slug. Free.',
       inputSchema: z.object({}),
       annotations: { readOnlyHint: true },
     },

--- a/cli/mcp/tools/brand-content.ts
+++ b/cli/mcp/tools/brand-content.ts
@@ -9,7 +9,7 @@ import {
 } from '../../lib/contracts/index.ts';
 import { resolvePostId, resolveResourceId, withAuth } from '../util.ts';
 
-const slug = z.string().min(1).describe('Brand URL slug');
+const slug = z.string().min(1);
 
 /**
  * Il registro dichiara una strada che non passa da un brand: qui diventa un `slug` che si può
@@ -72,9 +72,9 @@ export function registerBrandTools(server: McpServer) {
     {
       title: 'Brand status',
       description:
-        'How this brand is doing right now, in one short answer: how many posts wait for someone ' +
-        'to approve them, whether the plan still has room, and how the last recurring jobs went. ' +
-        'get_dashboard is the fuller picture. Reads only — no model, no credits.',
+        'How this brand is doing right now, in one short answer: how many posts wait for someone to ' +
+        'approve them, whether the plan still has room, and how the last recurring jobs went. ' +
+        'get_dashboard is the fuller picture. Free.',
       inputSchema: z.object({ slug }),
       annotations: { readOnlyHint: true },
     },
@@ -104,9 +104,9 @@ export function registerBrandTools(server: McpServer) {
     {
       title: 'Approve all pending posts',
       description:
-        'Say yes to every post waiting for approval, in one go — they are published or scheduled ' +
-        'from that moment. This is the irreversible one: ask the person first unless they clearly ' +
-        'said "approve them all". approve_post takes one at a time. No model, no credits.',
+        'Say yes to every post waiting for approval, in one go — they are published or scheduled from ' +
+        'that moment. This is the irreversible one: ask the person first unless they clearly said ' +
+        '"approve them all". approve_post takes one at a time. Free.',
       inputSchema: z.object({ slug }),
       annotations: { readOnlyHint: false, destructiveHint: true },
     },
@@ -119,8 +119,8 @@ export function registerBrandTools(server: McpServer) {
       title: 'Approve post',
       description:
         'Say yes to one post waiting for approval, so it goes out. Read it first with get_post — ' +
-        'approving is what authorises distribution, and it does not come back. edit_post changes ' +
-        'the copy before you do. id accepts a short prefix. No model, no credits.',
+        'approving is what authorises distribution, and it does not come back. edit_post changes the ' +
+        'copy before you do. Free.',
       inputSchema: z.object({
         slug,
         id: z.string().min(1),
@@ -140,8 +140,7 @@ export function registerBrandTools(server: McpServer) {
       title: 'Publish post',
       description:
         'Put one post out NOW, skipping its scheduled time. There is no undo from here: what a ' +
-        'platform has received is on the platform. reschedule_post moves it instead. id accepts a ' +
-        'short prefix. No model, no credits.',
+        'platform has received is on the platform. reschedule_post moves it instead. Free.',
       inputSchema: z.object({
         slug,
         id: z.string().min(1),
@@ -160,8 +159,8 @@ export function registerBrandTools(server: McpServer) {
     {
       title: 'Reject / delete post',
       description:
-        'Throw away one post that has not gone out yet. It does not come back, and its copy goes ' +
-        'with it. A post already published cannot be deleted from here. id accepts a short prefix.',
+        'Throw away one post that has not gone out yet. It does not come back, and its copy goes with ' +
+        'it. A post already published cannot be deleted from here.',
       inputSchema: z.object({
         slug,
         id: z.string().min(1),

--- a/cli/mcp/tools/plan.ts
+++ b/cli/mcp/tools/plan.ts
@@ -3,7 +3,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { api } from '../../lib/api.ts';
 import { withAuth } from '../util.ts';
 
-const slug = z.string().min(1).describe('Brand URL slug');
+const slug = z.string().min(1);
 
 export function registerPlanTools(server: McpServer) {
     server.registerTool(

--- a/cli/mcp/tools/studio.ts
+++ b/cli/mcp/tools/studio.ts
@@ -3,7 +3,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { api } from '../../lib/api.ts';
 import { withAuth } from '../util.ts';
 
-const slug = z.string().min(1).describe('Brand URL slug');
+const slug = z.string().min(1);
 
 export function registerStudioTools(server: McpServer) {
     server.registerTool(

--- a/cli/skills/findability.test.ts
+++ b/cli/skills/findability.test.ts
@@ -149,6 +149,15 @@ describe('le istruzioni del server sono una mappa, non un ordine', () => {
     expect(MCP_INSTRUCTIONS).toMatch(/credits/i);
   });
 
+  /**
+   * Il prefisso corto valeva per una quindicina di tool e ognuno se lo ripeteva. È una regola del
+   * server, non di un tool: sta qui, dove si legge una volta per sessione, e le descrizioni non la
+   * pagano più quindici volte.
+   */
+  test('dicono che gli id accettano un prefisso corto', () => {
+    expect(MCP_INSTRUCTIONS).toMatch(/prefix/i);
+  });
+
   test('nessuna tariffa scritta a mano, come sulle altre due superfici', () => {
     expect(HAND_WRITTEN_TARIFF.test(MCP_INSTRUCTIONS)).toBe(false);
   });

--- a/packages/api-contracts/src/articles.ts
+++ b/packages/api-contracts/src/articles.ts
@@ -102,7 +102,7 @@ export const GET_ARTICLE = {
   description:
     'One blog article in full, in any state — draft, planned, approved or published: body, SEO ' +
     'fields, cover, category, tags, author, language, schedule and status. Read it before ' +
-    'editing, and read it after to see what changed. Calls no model and spends no credits.',
+    'editing, and after, to see what changed. Free.',
   method: 'GET',
   pathUnderBrand: '/web/article',
   input: GetArticleInputSchema,
@@ -116,10 +116,10 @@ export const UPDATE_ARTICLE = {
   title: 'Update article',
   description:
     'Write text and metadata you already have onto an article: title, markdown body, meta title, ' +
-    'meta description, category, tags, author, language, schedule. Anomalia calls no model and ' +
-    'spends no credits — nothing is rewritten, regenerated or reformatted. A field you do not ' +
-    'send is left exactly as it was, so changing the title never touches the body, the cover or ' +
-    'the description. A published article is refused: what is live is not edited in place.',
+    'meta description, category, tags, author, language, schedule. Nothing is rewritten, ' +
+    'regenerated or reformatted. A field you do not send is left exactly as it was, so changing ' +
+    'the title never touches the body, the cover or the description. A published article is ' +
+    'refused: what is live is not edited in place. Free.',
   method: 'POST',
   pathUnderBrand: '/web/article',
   input: UpdateArticleInputSchema,
@@ -167,8 +167,8 @@ export const OPTIMIZE_ARTICLE = {
   title: 'Optimize article',
   description:
     'Rewrite an article so it ranks better in search, meta title and description included. It ' +
-    'spends credits and REPLACES the text that is there; keep a copy if you might want it ' +
-    'back. It does not publish. id accepts a short prefix.',
+    'spends credits and REPLACES the text that is there; keep a copy if you might want it back. ' +
+    'It does not publish.',
   method: 'POST',
   pathUnderBrand: '/web/article/:id/optimize',
   resource: 'article',
@@ -182,8 +182,8 @@ export const PUBLISH_ARTICLE = {
   tool: 'publish_article',
   title: 'Publish article',
   description:
-    'Put a blog article live on the brand\'s site. unpublish_article takes it down again ' +
-    'without losing it. No model, no credits. id accepts a short prefix.',
+    'Put a blog article live on the brand\'s site. unpublish_article takes it down again without ' +
+    'losing it. Free.',
   method: 'POST',
   pathUnderBrand: '/web/article/:id/publish',
   resource: 'article',
@@ -197,9 +197,9 @@ export const UNPUBLISH_ARTICLE = {
   tool: 'unpublish_article',
   title: 'Unpublish article',
   description:
-    'Take a live article off the site while keeping it: it becomes a draft again and nothing ' +
-    'is deleted. This is also what you do before editing one — update_article refuses a ' +
-    'published article. id accepts a short prefix.',
+    'Take a live article off the site while keeping it: it becomes a draft again and nothing is ' +
+    'deleted. This is also what you do before editing one — update_article refuses a published ' +
+    'article.',
   method: 'POST',
   pathUnderBrand: '/web/article/:id/unpublish',
   resource: 'article',
@@ -213,8 +213,8 @@ export const DELETE_ARTICLE = {
   tool: 'delete_article',
   title: 'Delete article',
   description:
-    'Delete one blog article for good. It does not come back. To take a live article off the ' +
-    'site without losing it, use unpublish_article instead. id accepts a short prefix.',
+    'Delete one blog article for good. It does not come back. To take a live article off the site ' +
+    'without losing it, use unpublish_article instead.',
   method: 'DELETE',
   pathUnderBrand: '/web/article/:id',
   resource: 'article',

--- a/packages/api-contracts/src/automations.ts
+++ b/packages/api-contracts/src/automations.ts
@@ -44,11 +44,11 @@ export const GET_AUTOMATIONS = {
   title: 'Recurring jobs',
   description:
     'The recurring jobs included with the product and whether this brand runs them: what each ' +
-    'one does, how often, whether it is on, how it went last time, and how many times it ' +
-    'actually ran in the last 30 days. Read it before set_automation — `runs_30d` with `cadence` ' +
-    'is how you tell what turning one on commits the brand to. What it CANNOT tell you is the ' +
-    'money: AI spend is recorded per call, with no column naming the job that made it, so no ' +
-    'clean read attributes dollars to one automation. The brand-wide bill is on the usage page.',
+    'does, how often, whether it is on, how it went last time, and how many times it ran in the ' +
+    'last 30 days. Read it before set_automation — `runs_30d` with `cadence` is how you tell what ' +
+    'turning one on commits the brand to. What it CANNOT tell you is the money: AI spend is ' +
+    'recorded per call, with no column naming the job that made it, so no clean read attributes ' +
+    'dollars to one automation. The brand-wide bill is on the usage page.',
   method: 'GET',
   pathUnderBrand: '/settings/automations',
   input: z.object({}).strict(),
@@ -67,14 +67,13 @@ export const SET_AUTOMATION = {
   tool: 'set_automation',
   title: 'Turn a recurring job on or off',
   description:
-    'Turn one recurring job on or off for this brand. ' +
-    'Turning one ON is a spending decision, not a preference: from that moment the job runs BY ' +
-    'ITSELF on its cadence, and every run calls AI models and spends the brand’s credits, with ' +
-    'nobody looking. Say which job, how often it will run, and that it spends — before you turn ' +
-    'it on, and to the person whose credits they are. Turning one OFF spends nothing and is the ' +
-    'safe direction: it takes effect at the next tick and destroys nothing. ' +
-    'A brand without a paid plan runs none of them, however many are on. The call itself calls ' +
-    'no model and spends no credits.',
+    'Turn one recurring job on or off for this brand. Turning one ON is a spending decision, not ' +
+    'a preference: from that moment the job runs BY ITSELF on its cadence, and every run calls AI ' +
+    'models and spends the brand\'s credits, with nobody looking. Say which job, how often it will ' +
+    'run, and that it spends — before you turn it on, and to the person whose credits they are. ' +
+    'Turning one OFF spends nothing and is the safe direction: it takes effect at the next tick ' +
+    'and destroys nothing. A brand without a paid plan runs none of them, however many are on. ' +
+    'Free.',
   method: 'PUT',
   pathUnderBrand: '/settings/automations',
   input: z.object({ job, enabled: z.boolean().describe('true starts it running by itself') }).strict(),

--- a/packages/api-contracts/src/billing.ts
+++ b/packages/api-contracts/src/billing.ts
@@ -50,12 +50,12 @@ export const BILLING_PORTAL_LINK = {
   tool: 'create_billing_portal_link',
   title: 'Billing portal link',
   description:
-    'Mint a one-time link to this organization Stripe billing portal and hand it to the account ' +
+    'Mint a one-time link to this organization\'s Stripe billing portal and hand it to the account ' +
     'owner. On that page THEY can read invoices, change the card, switch plan and CANCEL the ' +
-    'subscription — you never open it and never act inside it, you return the URL and stop. ' +
-    'Treat the URL as a credential: whoever holds it reaches that customer billing, so give it ' +
-    'to the owner once, in the reply, and never store or repeat it. Only the organization owner ' +
-    'can mint one. Calls no model and spends no credits: it works precisely when credits are gone.',
+    'subscription — you never open it and never act inside it. Treat the URL as a credential: ' +
+    'whoever holds it reaches that customer\'s billing, so give it to the owner once, in the ' +
+    'reply, and never store or repeat it. Only the organization owner can mint one. Free: it ' +
+    'works precisely when credits are gone.',
   method: 'POST',
   pathUnderBrand: '/billing/portal',
   input: PortalInputSchema,
@@ -68,13 +68,14 @@ export const CHECKOUT_LINK = {
   tool: 'create_checkout_link',
   title: 'Checkout link',
   description:
-    'Mint a one-time link where the human picks a paid plan and pays, on Stripe own hosted page. ' +
-    'You never pay, never change a plan and never apply a discount: you return the URL, they ' +
-    'complete it. The same page can also CANCEL the subscription, so treat the URL as the owner ' +
-    'credential — whoever holds it reaches that customer billing — and hand it over once, never ' +
-    'stored, never repeated. Only the organization owner can mint one. Calls no model and spends ' +
-    'no credits. An organization that never subscribed has no Stripe customer to check out ' +
-    'against: the refusal carries app_billing_url, which is where the human starts.',
+    'Mint a one-time link where the human picks a paid plan and pays, on Stripe\'s own hosted ' +
+    'page. You never pay, never change a plan and never apply a discount: you return the URL, ' +
+    'they complete it. The same page can also CANCEL the subscription, so treat the URL as the ' +
+    'owner credential — whoever holds it reaches that customer\'s billing — and hand it over once, ' +
+    'never stored, never repeated. Only the organization owner can mint one. Free: it works ' +
+    'precisely when credits are gone. An organization that never subscribed has no Stripe ' +
+    'customer to check out against: the refusal carries app_billing_url, which is where the human ' +
+    'starts.',
   method: 'POST',
   pathUnderBrand: '/billing/checkout',
   input: CheckoutInputSchema,

--- a/packages/api-contracts/src/blog-settings.ts
+++ b/packages/api-contracts/src/blog-settings.ts
@@ -76,12 +76,11 @@ export const GET_BLOG_SETTINGS = {
   tool: 'get_blog_settings',
   title: 'Blog settings',
   description:
-    'How the brand’s blog looks and how it writes: the public site’s name, colour, font and ' +
-    'layout, the style brief the AI follows, how many articles a week it produces, the ' +
-    'languages, and the categories, tags and authors an article can be filed under. Read it ' +
-    'before set_blog_settings and before add_blog_term — it carries the fonts, layouts and ' +
-    'locales that are accepted, and the plan’s ceiling on articles per week and on extra ' +
-    'languages.',
+    'How the brand\'s blog looks and how it writes: the public site\'s name, colour, font and ' +
+    'layout, the style brief the AI follows, how many articles a week it produces, the languages, ' +
+    'and the categories, tags and authors an article can be filed under. Read it before ' +
+    'set_blog_settings and before add_blog_term — it carries the fonts, layouts and locales that ' +
+    'are accepted, and the plan\'s ceiling on articles per week and on extra languages.',
   method: 'GET',
   pathUnderBrand: '/settings/blog',
   input: z.object({}).strict(),
@@ -122,17 +121,15 @@ export const SET_BLOG_SETTINGS = {
   tool: 'set_blog_settings',
   title: 'Change the blog settings',
   description:
-    'Change how the blog looks and how it writes. Only the fields you send change; every other ' +
-    'one keeps its value. `articles_per_week` is CLAMPED to the plan’s ceiling rather than ' +
-    'refused, and the answer says what was actually saved — read it back instead of assuming ' +
-    'your number was taken. `locales`, `navbar_links` and `analytics` replace their whole list. ' +
-    'Turning `enabled` off takes the public blog down; it deletes no article. The blog icon and an ' +
-    'author’s avatar are images and cannot be set here. `analytics` takes a CLOSED list of ' +
-    'providers with their measurement id — there is no field for arbitrary JavaScript, and asking ' +
-    'for one is refused: a script tag here would run on every visitor’s page. Those trackers load ' +
-    'ONLY on a verified custom domain and ONLY after the visitor accepts cookies; on the default ' +
-    '/blog/<slug> address they are stored and never emitted, because that address is Anomalia’s ' +
-    'own origin. Calls no model and spends no credits.',
+    'Change how the blog looks and how it writes. Only the fields you send change. ' +
+    '`articles_per_week` is CLAMPED to the plan\'s ceiling rather than refused, and the answer ' +
+    'says what was actually saved — read it back instead of assuming your number was taken. ' +
+    '`locales`, `navbar_links` and `analytics` replace their whole list. Turning `enabled` off ' +
+    'takes the public blog down; it deletes no article. The blog icon and an author\'s avatar are ' +
+    'images and cannot be set here. `analytics` takes a CLOSED list of providers with their ' +
+    'measurement id — there is no field for arbitrary JavaScript, and asking for one is refused: ' +
+    'a script tag here would run on every visitor\'s page. Those trackers load ONLY on a verified ' +
+    'custom domain and ONLY after the visitor accepts cookies. Free.',
   method: 'PUT',
   pathUnderBrand: '/settings/blog',
   input: z

--- a/packages/api-contracts/src/brand-settings.ts
+++ b/packages/api-contracts/src/brand-settings.ts
@@ -61,15 +61,12 @@ export const SET_BRAND_SETTINGS = {
   description:
     'Change the posting timezone, the target platforms, the per-platform hashtags, or the voice ' +
     'examples. Only the fields you send change. `hashtags` and `voice_examples` REPLACE the whole ' +
-    'list, so send the full list you want, not a delta; `[]` and `{}` clear one. Calls no model ' +
-    'and spends no credits. ' +
-    'Two consequences worth knowing before you call it. Changing `timezone` does NOT move posts ' +
-    'that already have a time: they keep firing at the same absolute instant, so their local hour ' +
-    'shifts by the offset difference — a post set for 18:00 in Rome reads as 12:00 once the brand ' +
-    'moves to New York. Only new scheduling uses the new zone. Removing a platform from ' +
-    '`platforms` does NOT cancel posts already scheduled on it: the target list decides what NEW ' +
-    'posts are made for, never what publishes, and an existing post still goes out while its ' +
-    'account is connected.',
+    'list, so send the full list you want, not a delta; `[]` and `{}` clear one. Changing ' +
+    '`timezone` does NOT move posts that already have a time: they keep firing at the same ' +
+    'absolute instant, so their local hour shifts by the offset difference. Only new scheduling ' +
+    'uses the new zone. Removing a platform from `platforms` does NOT cancel posts already ' +
+    'scheduled on it: the target list decides what NEW posts are made for, never what publishes. ' +
+    'Free.',
   method: 'PUT',
   pathUnderBrand: '/settings/brand',
   input: z

--- a/packages/api-contracts/src/brand-state.ts
+++ b/packages/api-contracts/src/brand-state.ts
@@ -54,10 +54,9 @@ export const GET_GOALS = {
   tool: 'get_goals',
   title: 'Chat goals',
   description:
-    'How the brand\'s goal chases have gone, measured: how many were met on the first pass, ' +
-    'how many came back to the person, how many automatic laps were spent, and the reason ' +
-    'each one stopped — plus the goals themselves with their diary. Reads only — no model, no ' +
-    'credits.',
+    'How the brand\'s goal chases have gone, measured: how many were met on the first pass, how ' +
+    'many came back to the person, how many automatic laps were spent, and the reason each one ' +
+    'stopped — plus the goals themselves with their diary. Free.',
   method: 'GET',
   pathUnderBrand: '/goals',
   input: z

--- a/packages/api-contracts/src/captions.ts
+++ b/packages/api-contracts/src/captions.ts
@@ -27,11 +27,10 @@ export const GENERATE_CAPTIONS = {
     'Write captions — text only, no media, and NO post is created: pass a caption to create_post ' +
     'when you want to publish it. By default every platform gets its own caption, written for ' +
     'that platform and inside its character limit, instead of one text cut nine ways. Pass ' +
-    'platforms to get only those, each written to its own limit with no extra shortening. ' +
-    'format "thread" lets X and Threads come back as a numbered sequence of posts rather than ' +
-    'one — good to paste by hand, but create_post publishes a single post per platform, so a ' +
-    'sequence is not publishable from here. It writes in the brand\'s voice. It spends credits, ' +
-    'and cost_usd in the answer says what the model actually cost.',
+    '`platforms` to get only those. `format: "thread"` lets X and Threads come back as a numbered ' +
+    'sequence of posts rather than one — good to paste by hand, but create_post publishes a ' +
+    'single post per platform, so a sequence is not publishable from here. It writes in the ' +
+    'brand\'s voice. It spends credits.',
   method: 'POST',
   pathUnderBrand: '/captions/generate',
   input: z

--- a/packages/api-contracts/src/content.ts
+++ b/packages/api-contracts/src/content.ts
@@ -64,9 +64,9 @@ export const CHECK_CONTENT = {
   description:
     'Run the checks Anomalia runs on its own copy against a spec you wrote, before you create ' +
     'anything. Returns blocking errors, warnings and a 0-100 quality score per platform, each ' +
-    'naming the field to repair. Deterministic: it calls no model, spends no credits, writes ' +
-    'nothing, and the same spec always returns the same verdict. Perceptual review of an image ' +
-    'or a video is a separate, explicitly paid action — this never looks at pixels.',
+    'naming the field to repair. Deterministic: it writes nothing, and the same spec always ' +
+    'returns the same verdict. Perceptual review of an image or a video is a separate, explicitly ' +
+    'paid action — this never looks at pixels. Free.',
   method: 'POST',
   pathUnderBrand: '/content/check',
   input: CheckContentInputSchema,

--- a/packages/api-contracts/src/creation-kit.ts
+++ b/packages/api-contracts/src/creation-kit.ts
@@ -102,14 +102,13 @@ export const GET_CREATION_KIT = {
   tool: 'get_creation_kit',
   title: 'Creation kit',
   description:
-    'The smallest brief you need before writing one post: what the platform allows, the ' +
-    'brand\'s own facts and its approved voice, the checklist your copy will be judged ' +
-    'against, ONE worked example chosen for this goal and format, the rewrites this brand\'s ' +
-    'own team wrote, what has already worked here, and which calendar minutes are taken. It ' +
-    'is a SELECTION, not the whole library: empty sections are absent, and the whole thing is ' +
-    'capped so it never floods your context. Reads only — no model, no credits, nothing ' +
-    'written. Pictures live in list_media; checking a draft before you create it is ' +
-    'check_content.',
+    'The smallest brief you need before writing one post: what the platform allows, the brand\'s ' +
+    'own facts and its approved voice, the checklist your copy will be judged against, ONE worked ' +
+    'example chosen for this goal and format, the rewrites this brand\'s own team wrote, what has ' +
+    'already worked here, and which calendar minutes are taken. It is a SELECTION, not the whole ' +
+    'library: empty sections are absent, and the whole thing is capped so it never floods your ' +
+    'context. Pictures live in list_media; checking a draft before you create it is ' +
+    'check_content. Free.',
   method: 'GET',
   pathUnderBrand: '/creation-kit',
   input: GetCreationKitInputSchema,

--- a/packages/api-contracts/src/evidence.ts
+++ b/packages/api-contracts/src/evidence.ts
@@ -82,16 +82,13 @@ export type WebAuditFindings = z.infer<typeof AuditFindings>;
 export type AuditCitationRow = z.infer<typeof CitationRow>;
 export type WebFixRow = z.infer<typeof FixRow>;
 
-const COSTS_NOTHING =
-  'Reads what was already measured. It calls no model, spends no credits and writes nothing.';
-
 export const LIST_WEB_AUDITS = {
   tool: 'list_web_audits',
   title: 'List web audits',
   description:
     "Every audit Anomalia has run on this brand's website and its visibility in AI answers, newest " +
     'first, one line each: when it ran, the scores it measured, and how much it observed. Take an id ' +
-    `from here to open one audit instead of paying for a new one. ${COSTS_NOTHING}`,
+    'from here to open one audit instead of paying for a new one. Free.',
   method: 'GET',
   pathUnderBrand: '/web/audits',
   input: z.object({ limit: limitUpTo(WEB_AUDITS_MAX, WEB_AUDITS_DEFAULT), offset }).strict(),
@@ -104,9 +101,9 @@ export const GET_AUDIT_FINDINGS = {
   tool: 'get_audit_findings',
   title: 'Read one audit',
   description:
-    'What one audit observed, exactly as it was recorded: the technical findings on the site, the ' +
-    'search and backlink figures, and the Google AI Overview sampling. Without audit_id you get the ' +
-    `most recent audit, never an older one that happens to hold more data. ${COSTS_NOTHING}`,
+    'What one audit observed, exactly as recorded: the technical findings on the site, the search ' +
+    'and backlink figures, and the Google AI Overview sampling. Without audit_id you get the most ' +
+    'recent audit, never an older one that happens to hold more data. Free.',
   method: 'GET',
   pathUnderBrand: '/web/audits/findings',
   input: z.object({ audit_id: auditId }).strict(),
@@ -122,7 +119,7 @@ export const LIST_AUDIT_CITATIONS = {
     'The questions Anomalia put to answer engines during one audit, and what came back: which engine, ' +
     'the question verbatim, whether the brand was named and in which position, the competitors named ' +
     'instead, and the domains the answer cited. This is the evidence behind the share-of-voice number. ' +
-    `Without audit_id you get the most recent audit. ${COSTS_NOTHING}`,
+    'Without audit_id you get the most recent audit. Free.',
   method: 'GET',
   pathUnderBrand: '/web/audits/citations',
   input: z
@@ -150,7 +147,7 @@ export const LIST_WEB_FIXES = {
   description:
     'The fixes Anomalia wrote from its audits — FAQ blocks, structured data, llms.txt, landing copy — ' +
     'with the body complete and ready to publish. Ask for one fix_id when you know which one you want: ' +
-    `bodies are long, so few come back per call. ${COSTS_NOTHING}`,
+    'bodies are long, so few come back per call. Free.',
   method: 'GET',
   pathUnderBrand: '/web/fixes',
   input: z

--- a/packages/api-contracts/src/knowledge.test.ts
+++ b/packages/api-contracts/src/knowledge.test.ts
@@ -43,13 +43,15 @@ describe('il contratto della ricerca nella conoscenza', () => {
   });
 
   /**
-   * La descrizione è l'unica documentazione che un modello esterno legge prima di chiamare.
-   * Se non dice il prezzo e il tetto, li scopre riempiendosi la finestra.
+   * `tools/list` è l'unica documentazione che un modello esterno legge prima di chiamare, e ci
+   * arriva intera: descrizione e schema nello stesso messaggio. Il prezzo e il taglio del passo
+   * stanno nella descrizione, il tetto sul numero di passi sta nel campo che lo impone — scriverlo
+   * in tutti e due i posti è la copia che diverge alla prima modifica, non una garanzia in più.
    */
-  it('la descrizione dice il prezzo e il tetto, perché è tutto ciò che il modello legge', () => {
-    expect(SEARCH_KNOWLEDGE.description).toContain('no credits');
+  it('il modello legge il prezzo, il taglio del passo e il tetto senza chiamare niente', () => {
+    expect(SEARCH_KNOWLEDGE.description).toMatch(/free/i);
     expect(SEARCH_KNOWLEDGE.description).toContain(String(KNOWLEDGE_EXCERPT_CHARS));
-    expect(SEARCH_KNOWLEDGE.description).toContain(String(KNOWLEDGE_HITS_MAX));
+    expect(SEARCH_KNOWLEDGE.input.shape.limit.description).toContain(String(KNOWLEDGE_HITS_MAX));
   });
 
   it('il campo di ogni passo dice da dove viene, o la citazione non è verificabile', () => {

--- a/packages/api-contracts/src/knowledge.ts
+++ b/packages/api-contracts/src/knowledge.ts
@@ -32,10 +32,13 @@ export const SEARCH_KNOWLEDGE = {
   tool: 'search_knowledge',
   title: 'Search brand knowledge',
   description:
-    "Ask the brand's own documents a question and get back the passages that answer it, each with the document and heading it came from. " +
-    'Hybrid retrieval over what is already indexed: keywords first, and a single embedding of the question only when keywords come up short — no credits are spent and nothing is written. ' +
-    `Each passage is cut at ${KNOWLEDGE_EXCERPT_CHARS} characters (\`truncated\` says when there is more); \`limit\` is ${KNOWLEDGE_HITS_DEFAULT} by default and ${KNOWLEDGE_HITS_MAX} at most. ` +
-    'Narrow with `collection` when you know the shelf. An empty `hits` means the indexed corpus has no answer — which is not the same as the brand not knowing it, so read `get_knowledge_status` before concluding anything: a document still queued has nothing to find.',
+    "Ask the brand's own documents a question and get back the passages that answer it, each with " +
+    'the document and heading it came from. Hybrid retrieval over what is already indexed: keywords ' +
+    'first, one embedding of the question only when keywords come up short. ' +
+    `Each passage is cut at ${KNOWLEDGE_EXCERPT_CHARS} characters (\`truncated\` says when there is more). ` +
+    'Narrow with `collection` when you know the shelf. Empty `hits` means the INDEXED corpus has no ' +
+    'answer, which is not the same as the brand not knowing it — read `get_knowledge_status` before ' +
+    'concluding anything: a document still queued has nothing to find. Free.',
   method: 'GET',
   pathUnderBrand: '/knowledge/search',
   input: z
@@ -77,10 +80,15 @@ export const GET_KNOWLEDGE_STATUS = {
   tool: 'get_knowledge_status',
   title: 'Knowledge status',
   description:
-    'Whether the brand\'s knowledge is USABLE, not just uploaded. Read it whenever `search_knowledge` comes back empty: an indexed corpus with no answer means the brand does not know the thing, a queued or failed one means nobody has read it yet — opposite situations needing opposite actions. ' +
-    '`documents` counts the pipeline stage by stage (`pending` → `processing` → `ready` | `failed`) and `indexed` is the only number retrieval can see: a `ready` document with zero chunks is not searchable. ' +
-    '`chunks.embedded` below `chunks.total` means retrieval is running on keywords alone, so paraphrases miss. ' +
-    `\`failures\` names each broken document and WHY it broke (${KNOWLEDGE_FAILURES_MAX} at most), \`collections\` says which shelves \`search_knowledge\` can usefully narrow to, and \`sources\` says which connected apps feed the corpus and when each last synced. No credits, no writes.`,
+    "Whether the brand's knowledge is USABLE, not just uploaded. Read it whenever `search_knowledge` " +
+    'comes back empty: an indexed corpus with no answer means the brand does not know the thing, a ' +
+    'queued or failed one means nobody has read it yet — opposite situations needing opposite ' +
+    'actions. `documents` counts the pipeline stage by stage (`pending` → `processing` → `ready` | ' +
+    '`failed`) and `indexed` is the only number retrieval can see: a `ready` document with zero ' +
+    'chunks is not searchable. `chunks.embedded` below `chunks.total` means retrieval runs on ' +
+    'keywords alone, so paraphrases miss. `failures` names each broken document and why it broke, ' +
+    '`collections` says which shelves `search_knowledge` can narrow to, and `sources` says which ' +
+    'connected apps feed the corpus and when each last synced. Free.',
   method: 'GET',
   pathUnderBrand: '/knowledge',
   input: z.object({}).strict(),

--- a/packages/api-contracts/src/market.ts
+++ b/packages/api-contracts/src/market.ts
@@ -50,8 +50,7 @@ export const GET_MARKET_FIELD = {
   title: 'Field watch',
   description:
     'What is moving in this brand\'s field right now: the topics being watched, the pattern ' +
-    'distilled from them, and the posts catalogued with a teardown of why each one spread. ' +
-    'Reads what was already gathered — no model, no credits.',
+    'distilled from them, and the posts catalogued with a teardown of why each one spread. Free.',
   method: 'GET',
   pathUnderBrand: '/market/field',
   input: z.object({ limit: limitUpTo(MARKET_FIELD_MAX, MARKET_FIELD_DEFAULT) }).strict(),
@@ -84,7 +83,9 @@ export const DIAGNOSE_RADAR = {
   tool: 'diagnose_radar',
   title: 'Radar diagnosis',
   description:
-    'Why Radar finds nothing: fetches every configured source live and reports, per source, how many items came back or why it was skipped — source off, plan, platform toggle, endpoint error. Reads only, spends no credits, and can take seconds per source.',
+    'Why Radar finds nothing: fetches every configured source live and reports, per source, how ' +
+    'many items came back or why it was skipped — source off, plan, platform toggle, endpoint ' +
+    'error. It can take seconds per source. Free.',
   method: 'GET',
   pathUnderBrand: '/radar/diagnose',
   input: z.object({}).strict(),

--- a/packages/api-contracts/src/media-models.ts
+++ b/packages/api-contracts/src/media-models.ts
@@ -63,11 +63,11 @@ export const SET_MEDIA_MODEL = {
   tool: 'set_media_model',
   title: 'Choose a media model',
   description:
-    'Pin the model that serves one job for this brand — image generation, image refinement, ' +
-    'video from text, animating a still, video refinement, motion transfer. Only the models ' +
-    'that job accepts are taken: anything else comes back as model_not_for_slot with the list ' +
-    'that would have been accepted. Send model: null to drop the choice and go back to the ' +
-    'platform default. Calls no model and spends no credits; it takes effect on the next render.',
+    'Pin the model that serves one job for this brand — image generation, image refinement, video ' +
+    'from text, animating a still, video refinement, motion transfer. Only the models that job ' +
+    'accepts are taken: anything else comes back as model_not_for_slot with the list that would ' +
+    'have been accepted. Send model: null to drop the choice and go back to the platform default. ' +
+    'Free; it takes effect on the next render.',
   method: 'PUT',
   pathUnderBrand: '/settings/models',
   input: z

--- a/packages/api-contracts/src/memory.ts
+++ b/packages/api-contracts/src/memory.ts
@@ -32,8 +32,9 @@ export const SAVE_MEMORY = {
   description:
     'Record something you learned about this brand so the next conversation starts from it. ' +
     `Writable categories: ${AGENT_MEMORY_CATEGORIES.join(', ')}. \`voice\` and \`constraint\` are NOT writable here — they govern everything downstream and only the brand's own people set them. ` +
-    'A `key` that already holds a DIFFERENT value answers 409 with both values and writes nothing: you take it to the person, you do not win by arriving last. Sending the same value again reinforces it. ' +
-    'Entries land as brand knowledge, never scoped to a chat, and arrive with the confidence of something a model inferred rather than something a person stated.',
+    'A `key` that already holds a DIFFERENT value answers 409 with both values and writes nothing: ' +
+    'take it to the person. Sending the same value again reinforces it. Entries land as brand ' +
+    'knowledge, never scoped to a chat.',
   method: 'POST',
   pathUnderBrand: '/memory',
   input: z

--- a/packages/api-contracts/src/plans.ts
+++ b/packages/api-contracts/src/plans.ts
@@ -80,10 +80,10 @@ export const SAVE_PLAN = {
   tool: 'save_plan',
   title: 'Save an editorial plan',
   description:
-    'Store an editorial plan you wrote yourself. Anomalia calls no model and spends no credits. ' +
-    'It lands as the pending proposal, exactly where propose_plan leaves a generated one: the ' +
-    'brand active plan is left untouched and approve_plan remains the step that activates it. ' +
-    'Saving replaces an earlier pending proposal.',
+    'Store an editorial plan you wrote yourself. It lands as the pending proposal, exactly where ' +
+    'propose_plan leaves a generated one: the brand active plan is left untouched and ' +
+    'approve_plan remains the step that activates it. Saving replaces an earlier pending ' +
+    'proposal. Free.',
   method: 'POST',
   pathUnderBrand: '/editorial-plan/save',
   input: SavePlanInputSchema,
@@ -154,11 +154,10 @@ export const SAVE_WEEK_SEEDS = {
   tool: 'save_week_seeds',
   title: 'Save weekly content seeds',
   description:
-    'Store the week rows you planned yourself — one per post, no copy and no image yet. ' +
-    'Anomalia calls no model and spends no credits. The rows land as the week draft, exactly ' +
-    'where plan_week leaves generated ones: the plan page shows them, they are editable, and ' +
-    'produce_week is the separate (paid) step that turns them into posts. A brand keeps one ' +
-    'draft, so saving replaces the one in review.',
+    'Store the week rows you planned yourself — one per post, no copy and no image yet. The rows ' +
+    'land as the week draft, exactly where plan_week leaves generated ones: the plan page shows ' +
+    'them, they are editable, and produce_week is the separate (paid) step that turns them into ' +
+    'posts. A brand keeps one draft, so saving replaces the one in review. Free.',
   method: 'POST',
   pathUnderBrand: '/weekly-plan/seeds',
   input: SaveWeekSeedsInputSchema,
@@ -209,9 +208,9 @@ export const APPROVE_PLAN = {
   tool: 'approve_plan',
   title: 'Approve editorial plan',
   description:
-    'Make the proposed editorial plan the one this brand actually follows, replacing the ' +
-    'active one. Ask the person before doing it unless they clearly asked. discard_plan ' +
-    'throws the proposal away instead. No model, no credits.',
+    'Make the proposed editorial plan the one this brand actually follows, replacing the active ' +
+    'one. Ask the person before doing it unless they clearly asked. discard_plan throws the ' +
+    'proposal away instead. Free.',
   method: 'POST',
   pathUnderBrand: '/editorial-plan/approve',
   input: NoInput,
@@ -224,8 +223,8 @@ export const DISCARD_PLAN = {
   tool: 'discard_plan',
   title: 'Discard editorial plan',
   description:
-    'Throw away the proposed editorial plan and leave the active one exactly as it is. It ' +
-    'does not come back. No model, no credits.',
+    'Throw away the proposed editorial plan and leave the active one exactly as it is. It does ' +
+    'not come back. Free.',
   method: 'POST',
   pathUnderBrand: '/editorial-plan/discard',
   input: NoInput,
@@ -245,9 +244,9 @@ export const SAVE_BRIEF = {
   tool: 'save_brief',
   title: 'Save week brief',
   description:
-    'Write down what one week should be about, so whoever produces it works from your ' +
-    'direction instead of guessing. `week` is 0 for the current week; name the products to ' +
-    'feature if some matter. No model, no credits.',
+    'Write down what one week should be about, so whoever produces it works from your direction ' +
+    'instead of guessing. `week` is 0 for the current week; name the products to feature if some ' +
+    'matter. Free.',
   method: 'POST',
   pathUnderBrand: '/editorial-plan/save-brief',
   input: z

--- a/packages/api-contracts/src/posts.ts
+++ b/packages/api-contracts/src/posts.ts
@@ -69,14 +69,13 @@ export const CREATE_POST = {
   tool: 'create_post',
   title: 'Create post',
   description:
-    'Store copy you already wrote as one pending post for review. Anomalia calls no model and ' +
-    'spends no credits. It does not publish and does not schedule: `scheduled_for` is the ' +
-    'proposed calendar time, and approve_post remains the action that authorizes distribution. ' +
-    'Text-capable platforms only — instagram and tiktok need an image, youtube needs a video. ' +
-    'Two different media failures: `media_not_found` (400) means the id is not this brand — ' +
-    'check it with list_media, and pass the full id, never a prefix; `media_unavailable` (502) ' +
-    'means the id is yours and Anomalia could not attach it, so retrying other ids is wasted ' +
-    'work — retry later or leave the media out.',
+    'Store copy you already wrote as one pending post for review. It does not publish and does ' +
+    'not schedule: `scheduled_for` is the proposed calendar time, and approve_post remains the ' +
+    'action that authorizes distribution. Text-capable platforms only — instagram and tiktok need ' +
+    'an image, youtube needs a video. Two different media failures: `media_not_found` (400) means ' +
+    'the id is not this brand — check it with list_media, and pass the full id, never a prefix; ' +
+    '`media_unavailable` (502) means the id is yours and Anomalia could not attach it, so ' +
+    'retrying other ids is wasted work — retry later or leave the media out. Free.',
   method: 'POST',
   pathUnderBrand: '/posts',
   input: CreatePostInputSchema,
@@ -100,9 +99,9 @@ export const LIST_POSTS = {
   tool: 'list_posts',
   title: 'List posts',
   description:
-    'The brand\'s posts, newest first. Filter by `status` to find what is waiting for a person ' +
-    'to approve it (`pending_user`), what is scheduled, or what already went out. get_post ' +
-    'opens one in full. Reads only — no model, no credits.',
+    'The brand\'s posts, newest first. Filter by `status` to find what is waiting for a person to ' +
+    'approve it (`pending_user`), what is scheduled, or what already went out. get_post opens one ' +
+    'in full. Free.',
   method: 'GET',
   pathUnderBrand: '/posts',
   input: z.object({
@@ -133,8 +132,8 @@ export const GET_POST = {
   tool: 'get_post',
   title: 'Get post',
   description:
-    'Open one post in full: its copy, its status, and the state of its image, video or ' +
-    'carousel slides. Reads only — no model, no credits. id accepts a short prefix.',
+    'Open one post in full: its copy, its status, and the state of its image, video or carousel ' +
+    'slides. Free.',
   method: 'GET',
   pathUnderBrand: '/posts/:id/media',
   resource: 'post',
@@ -148,9 +147,8 @@ export const RESCHEDULE_POST = {
   tool: 'reschedule_post',
   title: 'Reschedule post',
   description:
-    'Move a post to a different date and time. `scheduled_for` is an ISO datetime. It does ' +
-    'not publish and does not approve — it only changes when. No model, no credits. id ' +
-    'accepts a short prefix.',
+    'Move a post to a different date and time. `scheduled_for` is an ISO datetime. It does not ' +
+    'publish and does not approve — it only changes when. Free.',
   method: 'POST',
   pathUnderBrand: '/posts/:id/reschedule',
   resource: 'post',
@@ -171,9 +169,9 @@ export const RENDER_POST = {
   tool: 'render_post',
   title: 'Render post image',
   description:
-    'Draw the image a post is missing, from the prompt already written on it, and attach it. ' +
-    'It spends credits: one render. To draw a picture that is not tied to a post, use ' +
-    'generate_image. id accepts a short prefix.',
+    'Draw the image a post is missing, from the prompt already written on it, and attach it. It ' +
+    'spends credits: one render. To draw a picture that is not tied to a post, use ' +
+    'generate_image.',
   method: 'POST',
   pathUnderBrand: '/posts/:id/render',
   resource: 'post',
@@ -190,9 +188,8 @@ export const GET_CALENDAR = {
   tool: 'get_calendar',
   title: 'Calendar',
   description:
-    'What this brand is posting and when, for one month. Posts with a date appear in the ' +
-    'month they are dated for; drafts with no date come back flagged `isDraft`. Reads only — ' +
-    'no model, no credits.',
+    'What this brand is posting and when, for one month. Posts with a date appear in the month ' +
+    'they are dated for; drafts with no date come back flagged `isDraft`. Free.',
   method: 'GET',
   pathUnderBrand: '/calendar',
   input: z.object({
@@ -277,10 +274,9 @@ export const IMPORT_MEDIA_URL = {
   title: 'Import media from a URL',
   description:
     'Copy an image or video you produced elsewhere into the brand media library, then use the id ' +
-    'it returns as media_ids on create_post. Anomalia calls no model and spends no credits: the ' +
-    'file is copied, not generated. The URL must be public https and stay public across every ' +
-    'redirect; jpeg, png, webp and gif up to 12MB, mp4, mov and webm up to 64MB. Anything else ' +
-    'is refused and nothing is stored.',
+    'it returns as media_ids on create_post. The file is copied, not generated. The URL must be ' +
+    'public https and stay public across every redirect; jpeg, png, webp and gif up to 12MB, mp4, ' +
+    'mov and webm up to 64MB. Anything else is refused and nothing is stored. Free.',
   method: 'POST',
   pathUnderBrand: '/media',
   input: ImportMediaUrlInputSchema,
@@ -319,14 +315,14 @@ export const GENERATE_MEDIA = {
   description:
     'To make a picture or a clip — the older door, kept working. Prefer generate_image or ' +
     'generate_video: they name what they do, and changing a picture or animating one has its own ' +
-    'tool. kind picks image (the default) or video, and everything here forwards to those two. ' +
-    'It spends credits. It creates nothing in the calendar and publishes nothing; pass the id ' +
-    'you keep to create_post as media_ids. Images come back ready, up to ' +
+    'tool. `kind` picks image (the default) or video, and everything here forwards to those two. ' +
+    'It spends credits. It creates nothing in the calendar and publishes nothing; pass the id you ' +
+    'keep to create_post as media_ids. Images come back ready, up to ' +
     MAX_MEDIA_ALTERNATIVES + ' per call; a clip takes minutes and returns a job_id, and ' +
-    'check_media_job says when it landed — calling this again for the same clip bills a second one.' +
-    "With a slug, this brand's look is applied, and it cannot be switched off from this door: " +
-    'generate_image takes brand_style for that, and refine_media is the one that CHANGES an asset '
-    + 'you already made instead of drawing another.',
+    'check_media_job says when it landed — calling this again for the same clip bills a second ' +
+    "one. With a slug this brand's look is applied and cannot be switched off from this door: " +
+    'generate_image takes brand_style for that, and refine_media CHANGES an asset you already ' +
+    'made instead of drawing another.',
   method: 'POST',
   pathUnderBrand: '/media/generate',
   input: z
@@ -349,9 +345,9 @@ export const GENERATE_MEDIA = {
         .min(1)
         .optional()
         .describe(
-          'Model id for THIS call only — it changes no brand setting. Omit to use the brand’s ' +
-            'choice. Accepted ids come from get_media_models (slot imageModel for an image, ' +
-            'videoModel for a video); anything else is refused as model_not_for_slot.'
+          'For THIS call only; it changes no brand setting. Omit for the brand’s choice. Ids from ' +
+            'get_media_models (slot imageModel for an image, videoModel for a video); anything ' +
+            'else is refused as model_not_for_slot.'
         ),
       title: z.string().optional().describe('The name the asset carries in the library')
     })
@@ -382,11 +378,11 @@ export const CHECK_MEDIA_JOB = {
   title: 'Check a media generation job',
   description:
     'Where a video you started has got to — the ones from generate_video or generate_media, ' +
-    'newest first. `status` is `rendering` while the clip is being made and `done` once it is ' +
-    'in the library; then `media_id` is the id create_post accepts as `media_ids`. `failed` ' +
-    'says why. `not_in_library` means the clip was rendered and paid for but never filed, so ' +
-    'there is no media_id and rendering it again buys a second copy. Poll this rather than ' +
-    'starting the clip again. No model, no credits.',
+    'newest first. `status` is `rendering` while the clip is being made and `done` once it is in ' +
+    'the library; then `media_id` is the id create_post accepts as `media_ids`. `failed` says ' +
+    'why. `not_in_library` means the clip was rendered and paid for but never filed, so there is ' +
+    'no media_id and rendering it again buys a second copy. Poll this rather than starting the ' +
+    'clip again. Free.',
   method: 'GET',
   pathUnderBrand: '/media/generate',
   input: z
@@ -424,10 +420,10 @@ export const REGENERATE_POST_MEDIA = {
   tool: 'regenerate_post_media',
   title: 'Regenerate post media',
   description:
-    'Change the image already on a post, in place — give an instruction like "make it ' +
-    'warmer", not a whole new prompt. The old image is REPLACED. It spends credits: one ' +
-    'render. To change a library image or clip and keep the original, use refine_media, which ' +
-    'files the result as a new asset instead. id accepts a short prefix.',
+    'Change the image already on a post, in place — give an instruction like "make it warmer", ' +
+    'not a whole new prompt. The old image is REPLACED. It spends credits: one render. To change ' +
+    'a library image or clip and keep the original, use refine_media, which files the result as ' +
+    'a new asset instead.',
   method: 'POST',
   pathUnderBrand: '/posts/:id/media/regenerate',
   resource: 'post',
@@ -443,9 +439,8 @@ export const REGENERATE_SLIDE = {
   tool: 'regenerate_slide',
   title: 'Regenerate carousel slide',
   description:
-    'Redraw one slide of a carousel — index 0 is the cover. Only that slide changes. It ' +
-    'spends credits: one render. reorder_slides moves or drops slides for free. id accepts a ' +
-    'short prefix.',
+    'Redraw one slide of a carousel — index 0 is the cover. Only that slide changes. It spends ' +
+    'credits: one render. reorder_slides moves or drops slides for free.',
   method: 'POST',
   pathUnderBrand: '/posts/:id/media/slide',
   resource: 'post',
@@ -471,7 +466,7 @@ export const REORDER_SLIDES = {
   description:
     'Change the order of a carousel\'s slides, or drop some, without redrawing anything and ' +
     'without spending credits. `order` lists the slides you want kept, in the order you want ' +
-    'them: [0,2,1]. Anything left out is dropped. id accepts a short prefix.',
+    'them: [0,2,1]. Anything left out is dropped.',
   method: 'POST',
   pathUnderBrand: '/posts/:id/media/order',
   resource: 'post',
@@ -489,12 +484,11 @@ export const MAKE_VIDEO = {
   tool: 'make_video',
   title: 'Animate post to video',
   description:
-    'To turn a post you already have into a video: this animates that post’s cover image and ' +
-    'attaches the clip back to the same post (it also retries a video that fell back to a ' +
-    'photo). It needs an existing post. To animate a photo on its own, or make any clip that is ' +
-    'not going on a post, use generate_video — that one needs no post at all. It spends credits: ' +
-    'one clip. It does not publish, and the post keeps the status it had. id accepts a short ' +
-    'prefix.',
+    'To turn a post you already have into a video: this animates that post\'s cover image and ' +
+    'attaches the clip back to the same post (it also retries a video that fell back to a photo). ' +
+    'It needs an existing post. To animate a photo on its own, or make any clip that is not going ' +
+    'on a post, use generate_video — that one needs no post at all. It spends credits: one clip. ' +
+    'It does not publish, and the post keeps the status it had.',
   method: 'POST',
   pathUnderBrand: '/posts/:id/media/video',
   resource: 'post',
@@ -586,9 +580,8 @@ function modelField(slot: string) {
     .min(1)
     .optional()
     .describe(
-      'Model id for THIS call only — it changes no brand setting. Omit to use the brand’s ' +
-        'choice. The ids this job accepts, and what each costs, come from get_media_models ' +
-        '(slot ' + slot + '); anything else is refused as model_not_for_slot.'
+      'For THIS call only; it changes no brand setting. Omit for the brand’s choice. Ids from ' +
+        'get_media_models (slot ' + slot + '); anything else is refused as model_not_for_slot.'
     );
 }
 
@@ -610,12 +603,10 @@ const BrandStyleField = z
   .enum(['apply', 'ignore'])
   .optional()
   .describe(
-    "Whether this brand's own look — its colours, its fonts, its visual direction — is applied. " +
-      'Leave it out and it is, which with a slug is almost always what you want. Send `ignore` ' +
-      'when the picture must take nothing from the brand: a plain UI screenshot, an illustration ' +
-      'about somebody else, a neutral background — places where brand colours and fonts spoil ' +
-      'the result. Without a slug there is no brand to apply or ignore, and sending this is ' +
-      'refused as brand_style_needs_a_brand: pass a slug, or drop brand_style.'
+    "Whether this brand's own look — colours, fonts, visual direction — is applied. Omit it and " +
+      'it is. Send `ignore` when the picture must take nothing from the brand: a UI screenshot, ' +
+      'an illustration about somebody else, a neutral background. Without a slug there is no ' +
+      'brand to apply or ignore: refused as brand_style_needs_a_brand.'
   );
 
 /**
@@ -660,23 +651,21 @@ export const GENERATE_IMAGE = {
   tool: 'generate_image',
   title: 'Generate an image',
   description:
-    'To draw a picture from a description — "an image of a cat", a product shot, a background ' +
-    "for a slide. With a slug, this brand's own look is applied by default — its colours, its " +
-    'fonts and the visual direction it has settled on — so you do not have to describe them; ' +
-    'brand_style: ignore leaves them out. Without a slug there is no brand and none of that ' +
-    'reaches the model, so name the style you want in the prompt. ' +
-    'WITHOUT slug this is a one-off drawing — no brand, ' +
-    'nothing filed anywhere, id comes back null and there is nothing to hand to create_post. ' +
-    "WITH slug the image lands in that brand's library and its id is what create_post takes as " +
-    'media_ids: use it when the picture belongs to a brand, or is going to become a post. Do ' +
+    'To draw a picture from a description — "an image of a cat", a product shot, a background for ' +
+    "a slide. With a slug, this brand's own look is applied by default — its colours, its fonts, " +
+    'its visual direction — so you do not have to describe them; brand_style: ignore leaves them ' +
+    'out. Without a slug there is no brand and none of that reaches the model, so name the style ' +
+    'you want in the prompt. WITHOUT slug this is a one-off drawing: no brand, nothing filed ' +
+    'anywhere, id comes back null and there is nothing to hand to create_post. WITH slug the ' +
+    "image lands in that brand's library and its id is what create_post takes as media_ids. Do " +
     'NOT call list_brands to decide where to draw — if nobody named a brand there is no brand, ' +
-    "and guessing one spends a real organisation's credits and litters a real library. It " +
-    'spends credits: one render per image, renders in the answer says how many were billed and ' +
-    'cost_usd what they actually cost. It creates nothing in the calendar and publishes nothing, ' +
-    'so ask for two or three with count, look at them, keep one. To CHANGE a picture that ' +
-    'already exists use refine_media — correcting one drawing beats redrawing until it is ' +
-    'right. To pick the model read get_media_models and pass model, for this call only; ' +
-    'set_media_model is the one that changes the brand from now on.',
+    "and guessing one spends a real organisation's credits and litters a real library. It spends " +
+    'credits: one render per image, and `renders` in the answer says how many were billed, ' +
+    'cost_usd what they cost. It creates nothing in the calendar and publishes nothing, so ask ' +
+    'for two or three with `count`, look at them, keep one. To CHANGE a picture that already ' +
+    'exists use refine_media — correcting one drawing beats redrawing until it is right. To pick ' +
+    'the model read get_media_models and pass `model`, for this call only; set_media_model ' +
+    'changes the brand from now on.',
   method: 'POST',
   pathUnderBrand: '/media/images',
   pathWithoutBrand: '/images',
@@ -781,15 +770,15 @@ export const GENERATE_VIDEO = {
   title: 'Generate a video',
   description:
     'To make a video: animate a photo you already have, or film a clip from a prompt alone. ' +
-    '"Animate this photo", "a 5 second video of this image" — that is base_media_id pointing at ' +
-    'a library image plus a prompt for the movement, and it needs NO post. It spends credits, ' +
-    'and the model moves that bill by more than an order of magnitude, so read get_media_models ' +
-    '(slot videoModel from a prompt, videoImageModel when animating an image) and pass model for ' +
-    'this call only. A clip takes minutes: this returns a job_id with status rendering, and ' +
+    '"Animate this photo", "a 5 second video of this image" — that is `base_media_id` pointing at ' +
+    'a library image plus a prompt for the movement, and it needs NO post. It spends credits, and ' +
+    'the model moves that bill by more than an order of magnitude, so read get_media_models (slot ' +
+    'videoModel from a prompt, videoImageModel when animating an image) and pass `model` for this ' +
+    'call only. A clip takes minutes: this returns a job_id with status rendering, and ' +
     'check_media_job says when it landed — calling this again for the same clip bills a second ' +
-    'one. It creates nothing in the calendar and publishes nothing; when the clip lands, pass ' +
-    'its media_id to create_post as media_ids. To animate the cover of a post you already have, ' +
-    'make_video does that in one step.',
+    'one. It creates nothing in the calendar and publishes nothing; when the clip lands, pass its ' +
+    'media_id to create_post as media_ids. To animate the cover of a post you already have, ' +
+    'make_video does it in one step.',
   method: 'POST',
   pathUnderBrand: '/media/videos',
   input: z
@@ -839,14 +828,12 @@ export const GENERATE_CAROUSEL = {
     'To make a carousel — a SERIES of images that read as one object, not N unrelated pictures. ' +
     'Slide 1 is the cover and must work at thumbnail size; every later slide advances the angle ' +
     'one concrete step and carries exactly one idea. It spends credits: one render per slide, so ' +
-    'a 5-slide carousel is five renders — ask for the count you mean. It creates nothing in the ' +
-    'calendar and publishes nothing: pass the ids to create_post as media_ids, in order. TO ' +
-    'CHANGE ONE SLIDE use ' +
-    'refine_media on that slide id, and put the continuity_tokens this returns back into your ' +
+    'a 5-slide carousel is five renders. It creates nothing in the calendar and publishes ' +
+    'nothing: pass the ids to create_post as media_ids, in order. TO CHANGE ONE SLIDE use ' +
+    'refine_media on that slide id, and put the `continuity_tokens` this returns back into your ' +
     'instruction — they are what holds the series together, and an edit that touches palette, ' +
-    'light or the recurring motif without them takes that slide out of the set. ' +
-    "With a slug, this brand's look is applied to every slide, and there is no way to switch it " +
-    "off here: a series that is not the brand's is not a series.",
+    'light or the recurring motif without them takes that slide out of the set. With a slug, this ' +
+    'brand\'s look is applied to every slide and there is no way to switch it off here.',
   method: 'POST',
   pathUnderBrand: '/media/carousel',
   input: z

--- a/packages/api-contracts/src/query.ts
+++ b/packages/api-contracts/src/query.ts
@@ -25,18 +25,20 @@ export const QUERY_DATABASE = {
   tool: 'query',
   title: 'Query the database',
   description:
-    'Read ANY table in the database directly, AS YOU — the request runs with the anon key plus your ' +
-    'own session, so Postgres RLS returns exactly the rows you would see in the app, and nothing more. ' +
-    'READ ONLY: there is no SQL here. You name a table, columns and filters, and it issues one ' +
-    'PostgREST read, so a write has nowhere to go — no INSERT, no CTE, no function call, nothing to ' +
-    'attempt. Omit `table` to list every table you can name. Ask for a table with no `columns` to get ' +
-    'real rows with every column: the keys of a row ARE the schema. THEN NAME THE COLUMNS YOU NEED: a read with no `columns` carries every column, the 20,000-character cap cuts whole rows to fit, and you get a short answer with no sign that you asked for a long one — 50 rows of `posts` come back as nine, the same 50 rows come back whole with five columns named. One table per call — no joins, no ' +
-    'embeds; read two tables and match the ids yourself. Reach for it when the answer needs a table ' +
-    'nothing else exposes, a count, or a join you do by hand. ' +
-    'IT IS ALSO THE READ FOR QUESTIONS THAT HAVE NO TOOL OF THEIR OWN. What this brand SELLS — its ' +
-    'catalogue of products, offers and services — is the `products` table: one row per offer, with ' +
-    '`title`, `kind`, `pricing`, `url`, `featured` and the `images` it carries. ' +
-    'Costs nothing.',
+    'Read ANY table in the database directly, AS YOU — the request runs with the anon key plus ' +
+    'your own session, so Postgres RLS returns exactly the rows you would see in the app, and ' +
+    'nothing more. READ ONLY: there is no SQL here. You name a table, columns and filters, and it ' +
+    'issues one PostgREST read, so a write has nowhere to go. Omit `table` to list every table ' +
+    'you can name. Ask for a table with no `columns` to get real rows with every column: the keys ' +
+    'of a row ARE the schema. THEN NAME THE COLUMNS YOU NEED: a read with no `columns` carries ' +
+    'every column, the 20,000-character cap cuts whole rows to fit, and you get a short answer ' +
+    'with no sign that you asked for a long one — 50 rows of `posts` come back as nine, the same ' +
+    '50 rows come back whole with five columns named. One table per call — no joins, no embeds; ' +
+    'read two tables and match the ids yourself. Reach for it when the answer needs a table ' +
+    'nothing else exposes, a count, or a join you do by hand. IT IS ALSO THE READ FOR QUESTIONS ' +
+    'THAT HAVE NO TOOL OF THEIR OWN. What this brand SELLS — its catalogue of products, offers ' +
+    'and services — is the `products` table: one row per offer, with `title`, `kind`, `pricing`, ' +
+    '`url`, `featured` and the `images` it carries. Free.',
   method: 'POST',
   pathUnderBrand: '/query',
   input: z

--- a/packages/api-contracts/src/radar.ts
+++ b/packages/api-contracts/src/radar.ts
@@ -78,7 +78,7 @@ export const SET_RADAR_PLATFORM = {
   description:
     'Switch one platform on or off for this brand’s Radar. Turning one off narrows what Radar ' +
     'finds; it deletes no source and no result already found. Threads, X and LinkedIn need the ' +
-    'Pro plan and answer plan_required below it. Calls no model and spends no credits.',
+    'Pro plan and answer plan_required below it. Free.',
   method: 'PUT',
   pathUnderBrand: '/settings/radar',
   input: z.object({ platform, enabled: z.boolean() }).strict(),
@@ -99,8 +99,7 @@ export const ADD_RADAR_SOURCE = {
     'Threads / X / LinkedIn search. A source already there is left as it is rather than ' +
     'duplicated — the pair (kind, value) is its identity, and it is what remove_radar_source ' +
     'takes. Read get_radar first: the plan decides which kinds are allowed (plan_required) and ' +
-    'how many sources fit (source_limit). Adding a source calls no model and spends no credits, ' +
-    'but Radar reads it on every run from then on.',
+    'how many sources fit (source_limit). Radar reads the source on every run from then on. Free.',
   method: 'POST',
   pathUnderBrand: '/settings/radar/sources',
   input: z

--- a/packages/api-contracts/src/reads.ts
+++ b/packages/api-contracts/src/reads.ts
@@ -13,10 +13,9 @@ export const GET_PLAN = {
   tool: 'get_plan',
   title: 'Editorial plan',
   description:
-    'What this brand has decided to post about: the active editorial plan, plus any proposal ' +
-    'still waiting for someone to approve it. Read it before writing anything, so the copy ' +
-    'follows the plan already agreed. propose_plan writes a new one, approve_plan is what ' +
-    'makes a proposal active. Reads only — no model, no credits.',
+    'The active editorial plan, plus any proposal still waiting for approval. Read it before ' +
+    'writing copy, so what you write follows the plan already agreed. propose_plan writes a new ' +
+    'one, approve_plan activates a proposal. Free.',
   method: 'GET',
   pathUnderBrand: '/editorial-plan',
   input: NoInput,
@@ -35,9 +34,9 @@ export const GET_WEEKLY_PLAN = {
   tool: 'get_weekly_plan',
   title: 'Weekly plan',
   description:
-    'What is lined up for the coming weeks: the seeds planned for each week — one per ' +
-    'intended post — and the posts already made from them. plan_week generates seeds, ' +
-    'save_week_seeds stores ones you wrote yourself. Reads only — no model, no credits.',
+    'What is lined up for the coming weeks: the seeds planned for each week — one per intended ' +
+    'post — and the posts already made from them. plan_week generates seeds, save_week_seeds ' +
+    'stores ones you wrote yourself. Free.',
   method: 'GET',
   pathUnderBrand: '/weekly-plan',
   input: NoInput,
@@ -146,15 +145,12 @@ export const GET_STUDIO = {
   tool: 'get_studio',
   title: 'Studio',
   description:
-    'Everything the brand knows about itself, in one call: its own facts, the people who may ' +
-    'appear in its content, the documents it has uploaded, its competitors, its products, and ' +
-    'a summary of what it has posted before. Each document carries `status` and `chunkCount` ' +
-    '(one that is not `ready` with at least one chunk exists here but is invisible to ' +
-    '`search_knowledge`) and `textBytes`, which says how much text it holds. The text itself ' +
-    'is NOT included: to answer a question, ask `search_knowledge` — it returns the passages ' +
-    'that answer it with the document each came from, instead of the whole corpus. ' +
-    '`documents: "full"` restores the complete text of every document; it exists for callers ' +
-    'that were reading it before and is almost never what you want.',
+    'Everything the brand knows about itself: its own facts, the people who may appear in its ' +
+    'content, its uploaded documents, its competitors, its products, and a summary of what it has ' +
+    'posted. Document text is NOT included — search_knowledge returns the passages that answer a ' +
+    'question, with the document each came from. A document that is not `ready`, or whose ' +
+    '`chunkCount` is 0, is listed here and invisible to search_knowledge. `documents: "full"` ' +
+    'returns every document whole and is almost never what you want.',
   method: 'GET',
   pathUnderBrand: '/studio',
   input: z
@@ -195,9 +191,9 @@ export const GET_SEO = {
   tool: 'get_seo',
   title: 'SEO overview',
   description:
-    'How the brand\'s website is doing in Google: the technical score, the search performance, ' +
-    'an overall grade, and the improvements worth making. Reads what was already measured — ' +
-    'seo_action is what runs a fresh audit and spends credits. No model, no credits.',
+    'How the brand\'s website is doing in Google: the technical score, the search performance, an ' +
+    'overall grade, and the improvements worth making. Reads the last audit — seo_action runs a ' +
+    'fresh one and spends credits. Free.',
   method: 'GET',
   pathUnderBrand: '/seo',
   input: NoInput,
@@ -216,9 +212,8 @@ export const GET_GEO = {
   title: 'GEO overview',
   description:
     'Whether this brand gets named when someone asks ChatGPT, Perplexity or Google\'s AI: its ' +
-    'share of voice, the answers that cited it, and fixes already written and ready to ' +
-    'publish. Reads what was already measured — geo_action runs a fresh check and spends ' +
-    'credits. No model, no credits.',
+    'share of voice, the answers that cited it, and fixes already written and ready to publish. ' +
+    'Reads the last check — geo_action runs a fresh one and spends credits. Free.',
   method: 'GET',
   pathUnderBrand: '/geo',
   input: NoInput,
@@ -243,9 +238,9 @@ export const GET_KEYWORDS = {
   tool: 'get_keywords',
   title: 'Keywords',
   description:
-    'The search terms worth writing for: each one\'s monthly volume, how hard it is to rank ' +
-    'for, the opportunity it carries, and what to do about it. refresh_keywords redoes the ' +
-    'research and spends credits; this only reads. No model, no credits.',
+    'The search terms worth writing for: monthly volume, how hard each is to rank for, the ' +
+    'opportunity it carries, and what to do about it. refresh_keywords redoes the research and ' +
+    'spends credits. Free.',
   method: 'GET',
   pathUnderBrand: '/keywords',
   input: NoInput,
@@ -263,8 +258,7 @@ export const GET_ADS = {
   title: 'Ads overview',
   description:
     'The brand\'s paid campaigns: what is running, what has been proposed and is waiting, and ' +
-    'which advertising accounts are connected. ads_action is what changes any of it. Reads ' +
-    'only — no model, no credits.',
+    'which advertising accounts are connected. ads_action is what changes any of it. Free.',
   method: 'GET',
   pathUnderBrand: '/ads',
   input: NoInput,
@@ -284,9 +278,9 @@ export const GET_ANALYTICS = {
   tool: 'get_analytics',
   title: 'Analytics',
   description:
-    'How the brand\'s published posts are actually doing: totals, engagement, and recent ' +
-    'activity. This is what happened after publishing, not the website\'s search traffic — ' +
-    'that one is get_gsc. Reads only — no model, no credits.',
+    'How the brand\'s published posts are actually doing: totals, engagement, recent activity. ' +
+    'This is what happened after publishing, not the website\'s search traffic — that one is ' +
+    'get_gsc. Free.',
   method: 'GET',
   pathUnderBrand: '/analytics',
   input: NoInput,
@@ -311,8 +305,7 @@ export const GET_GTM = {
   tool: 'get_gtm',
   title: 'GTM roadmap',
   description:
-    'The go-to-market roadmap: what this brand plans to do to reach its market, in order. ' +
-    'Reads only — no model, no credits.',
+    'The go-to-market roadmap: what this brand plans to do to reach its market, in order. Free.',
   method: 'GET',
   pathUnderBrand: '/gtm',
   input: NoInput,
@@ -335,8 +328,7 @@ export const GET_VOICE = {
   description:
     'How this brand is supposed to sound: mood, tone, register, the words it avoids, and the ' +
     'rules that change from one platform to another. Read it before writing any copy — ' +
-    'get_writing_skills is the craft, this is the brand. update_voice changes it. Reads only ' +
-    '— no model, no credits.',
+    'get_writing_skills is the craft, this is the brand. update_voice changes it. Free.',
   method: 'GET',
   pathUnderBrand: '/voice',
   input: NoInput,
@@ -360,10 +352,9 @@ export const GET_DASHBOARD = {
   tool: 'get_dashboard',
   title: 'Brand dashboard',
   description:
-    'Where this brand stands right now, in one call: how many posts are waiting for approval, ' +
-    'the active plan, the products, the connected social accounts, the brand\'s own facts, and ' +
-    'how the recurring jobs went last time. Start here when you do not know what to look at. ' +
-    'Reads only — no model, no credits.',
+    'Where this brand stands right now, in one call: posts waiting for approval, the active plan, ' +
+    'the products, the connected social accounts, the brand\'s own facts, and how the recurring ' +
+    'jobs went last time. Start here when you do not know what to look at. Free.',
   method: 'GET',
   pathUnderBrand: '',
   input: z.object({}).strict(),

--- a/packages/api-contracts/src/social.ts
+++ b/packages/api-contracts/src/social.ts
@@ -45,13 +45,13 @@ export const LIST_SOCIAL_ACCOUNTS = {
   tool: 'list_social_accounts',
   title: 'Connected social accounts',
   description:
-    'The social accounts this brand can publish to, one row each: platform, the handle it actually ' +
-    'posts as, and whether it still works. Read it before promising anything will go out — a ' +
-    'target platform with no active account produces posts that sit forever. It also says whether ' +
-    'the plan allows connecting at all and how many slots are left, which is what decides if ' +
-    'create_social_connect_link can help. get_brand_settings carries the same connected_platforms ' +
-    'summary for the platform vocabulary; this is the account-level truth behind it, and the only ' +
-    'place a broken connection shows up. Calls no model and spends no credits.',
+    'The social accounts this brand can publish to, one row each: platform, the handle it ' +
+    'actually posts as, and whether it still works. Read it before promising anything will go out ' +
+    '— a target platform with no active account produces posts that sit forever. It also says ' +
+    'whether the plan allows connecting at all and how many slots are left, which is what decides ' +
+    'if create_social_connect_link can help. get_brand_settings carries the same ' +
+    'connected_platforms summary; this is the account-level truth behind it, and the only place a ' +
+    'broken connection shows up. Free.',
   method: 'GET',
   pathUnderBrand: '/social/accounts',
   input: z.object({}).strict(),
@@ -80,13 +80,12 @@ export const SOCIAL_CONNECT_LINK = {
     'Mint the link a HUMAN opens to authorise one social platform for this brand, and stop there. ' +
     'You never run the OAuth, never see a token and never connect anything: the person clicks, ' +
     'signs in on that platform, and the account appears. The URL is a page of our own app behind ' +
-    'their login, not a credential — but it is useless to anyone who cannot already reach the ' +
-    'brand, so hand it over and let them go. Call list_social_accounts first: this refuses when ' +
-    'the plan connects no accounts (plan_cannot_connect) or every slot is taken (account_limit), ' +
-    'and those are two different problems with two different remedies. Minting a link for a ' +
-    'platform that is already connected is allowed and returns already_connected: it is how a ' +
-    'expired account gets re-authorised, or a second account added. Calls no model and spends no ' +
-    'credits: it works precisely when credits are gone.',
+    'their login, not a credential, but it is useless to anyone who cannot already reach the ' +
+    'brand. Call list_social_accounts first: this refuses when the plan connects no accounts ' +
+    '(plan_cannot_connect) or every slot is taken (account_limit), two different problems with ' +
+    'two different remedies. Minting a link for a platform already connected is allowed and ' +
+    'returns already_connected: it is how an expired account is re-authorised, or a second one ' +
+    'added. Free: it works precisely when credits are gone.',
   method: 'POST',
   pathUnderBrand: '/social/connect',
   input: z

--- a/packages/api-contracts/src/studio.ts
+++ b/packages/api-contracts/src/studio.ts
@@ -50,9 +50,9 @@ export const CREATE_PRODUCT = {
   tool: 'create_product',
   title: 'Create product',
   description:
-    'Add one offer to the brand catalog. Deterministic: it calls no model and spends no ' +
-    'credits. Use it when the catalog does not come from a connected store — sync_products ' +
-    'replaces the whole catalog from Shopify or WooCommerce and would erase a hand-made row.',
+    'Add one offer to the brand catalog. Use it when the catalog does not come from a connected ' +
+    'store — sync_products replaces the whole catalog from Shopify or WooCommerce and would erase ' +
+    'a hand-made row. Free.',
   method: 'POST',
   pathUnderBrand: '/studio/products',
   input: CreateProductInputSchema,
@@ -77,7 +77,7 @@ export const UPDATE_PRODUCT = {
   title: 'Update product',
   description:
     'Correct one offer in place. Only the fields you send change; every other column keeps the ' +
-    'value it had. Calls no model and spends no credits.',
+    'value it had. Free.',
   method: 'PUT',
   pathUnderBrand: '/products/:id',
   resource: 'product',
@@ -169,7 +169,7 @@ export const UPDATE_PERSON = {
   description:
     'Correct the name, role, description or attributes of a person already registered on this ' +
     'brand. It cannot attest consent, turn a real person into an invented one, or touch their ' +
-    'photos — those stay with the person who owns the brand. No model, no credits.',
+    'photos — those stay with the person who owns the brand. Free.',
   method: 'PUT',
   pathUnderBrand: '/people/:id',
   resource: 'person',
@@ -196,9 +196,8 @@ export const UPDATE_COMPETITOR = {
   tool: 'update_competitor',
   title: 'Update competitor',
   description:
-    'Correct a company already on this brand\'s competitor list: a wrong website, a reason ' +
-    'that no longer holds, direct versus indirect. Only the fields you send change. No model, ' +
-    'no credits.',
+    'Correct a company already on this brand\'s competitor list: a wrong website, a reason that no ' +
+    'longer holds, direct versus indirect. Only the fields you send change. Free.',
   method: 'PUT',
   pathUnderBrand: '/studio/competitors/:id',
   resource: 'competitor',
@@ -258,8 +257,8 @@ export const UPDATE_BRAND_KIT = {
   title: 'Update brand kit',
   description:
     'Change what this brand IS: what it does, its category, who it speaks to, its style, its ' +
-    'language. These are the facts every generated post is written from, so a wrong one is ' +
-    'wrong everywhere. Only the fields you send change. No model, no credits.',
+    'language. These are the facts every generated post is written from, so a wrong one is wrong ' +
+    'everywhere. Only the fields you send change. Free.',
   method: 'PUT',
   pathUnderBrand: '/studio/kit',
   input: z
@@ -281,8 +280,8 @@ export const UPDATE_VOICE = {
   title: 'Update voice',
   description:
     'Change how this brand sounds: mood, tone, register, the words it must avoid, and the ' +
-    'instructions that differ per platform. Only the fields you send change. get_voice reads ' +
-    'it back. No model, no credits.',
+    'instructions that differ per platform. Only the fields you send change. get_voice reads it ' +
+    'back. Free.',
   method: 'POST',
   pathUnderBrand: '/voice/update',
   input: z
@@ -307,8 +306,8 @@ export const ADD_COMPETITOR = {
   title: 'Add competitor',
   description:
     'Add a company this brand competes with, so research and posts can take it into account. ' +
-    'update_competitor corrects one already there; research_competitors finds them for you ' +
-    'and spends credits. No model, no credits.',
+    'update_competitor corrects one already there; research_competitors finds them for you and ' +
+    'spends credits. Free.',
   method: 'POST',
   pathUnderBrand: '/studio/competitors',
   input: z
@@ -372,9 +371,8 @@ export const ADD_NOTE = {
   title: 'Add knowledge note',
   description:
     'Save something this brand knows — a note, a policy, a transcript, a document — so the AI ' +
-    'writes from it instead of guessing. It is indexed for search: search_knowledge is how it ' +
-    'comes back, and get_knowledge_status says when it is ready to be found. No model, no ' +
-    'credits.',
+    'writes from it instead of guessing. search_knowledge is how it comes back; ' +
+    'get_knowledge_status says when it is ready to be found. Free.',
   method: 'POST',
   pathUnderBrand: '/studio/documents',
   input: z.object({ text: z.string().min(1), title: z.string().optional() }).strict(),
@@ -392,7 +390,7 @@ export const SET_COLORS = {
   description:
     'Set the colours every graphic for this brand is drawn with, as hex values: ' +
     '["#7c5cff","#ffffff"]. Three or six digits, up to 8 colours. The list REPLACES the whole ' +
-    'palette, so send all the colours you want, not just the new one. No model, no credits.',
+    'palette, so send all the colours you want, not just the new one. Free.',
   method: 'PUT',
   pathUnderBrand: '/studio/colors',
   // Stessa forma che la rotta salva: un `#aabbccdd` che passa di qui e prende un 400 di là
@@ -420,9 +418,8 @@ export const ADD_PERSON = {
   title: 'Add person',
   description:
     'Register a real person who may appear in this brand\'s images and videos. Their face is ' +
-    'withheld from every generator until consent is attested, so `consent` must be true and ' +
-    'only the person\'s own operator can state it — never assume it on someone\'s behalf. No ' +
-    'model, no credits.',
+    'withheld from every generator until consent is attested, so `consent` must be true and only ' +
+    'the person\'s own operator can state it — never assume it on someone\'s behalf. Free.',
   method: 'POST',
   pathUnderBrand: '/studio/people',
   input: z

--- a/packages/api-contracts/src/web-metrics.ts
+++ b/packages/api-contracts/src/web-metrics.ts
@@ -13,10 +13,9 @@ export const GET_GSC = {
   tool: 'get_gsc',
   title: 'Search Console',
   description:
-    'How this brand\'s website does in Google search over the last 28 days: clicks, ' +
-    'impressions, the queries people arrived on and the pages they landed on — and whether ' +
-    'the property is connected at all. This is website traffic, not post engagement; that one ' +
-    'is get_analytics. Reads only — no model, no credits.',
+    'How this brand\'s website does in Google search over the last 28 days: clicks, impressions, ' +
+    'the queries people arrived on, the pages they landed on, and whether the property is ' +
+    'connected at all. Website traffic, not post engagement — that one is get_analytics. Free.',
   method: 'GET',
   pathUnderBrand: '/gsc',
   input: NoInput,
@@ -39,9 +38,9 @@ export const GET_RANKS = {
   tool: 'get_ranks',
   title: 'Rank tracking',
   description:
-    'Where this brand actually sits in Google for the keywords it tracks: the current ' +
-    'position, the previous one, the move between them, the page that ranks, and whether an ' +
-    'AI Overview appeared above it. Reads only — no model, no credits.',
+    'Where this brand actually sits in Google for the keywords it tracks: the current position, ' +
+    'the previous one, the move between them, the page that ranks, and whether an AI Overview ' +
+    'appeared above it. Free.',
   method: 'GET',
   pathUnderBrand: '/ranks',
   input: NoInput,
@@ -85,8 +84,8 @@ export const GET_BACKLINKS = {
   title: 'Backlink network',
   description:
     'Who links to this brand\'s site and who it links to, plus the exchanges still open and ' +
-    'whether the network is unlocked for this brand at all (Starter plan or above, and opted ' +
-    'in). Reads only — no model, no credits.',
+    'whether the network is unlocked for this brand at all (Starter plan or above, and opted in). ' +
+    'Free.',
   method: 'GET',
   pathUnderBrand: '/backlinks',
   input: NoInput,

--- a/packages/api-contracts/src/writing-skills.test.ts
+++ b/packages/api-contracts/src/writing-skills.test.ts
@@ -38,7 +38,7 @@ describe('il contratto delle skill di scrittura', () => {
    */
   it('dice quando va chiamato, o non verrà chiamato', () => {
     expect(GET_WRITING_SKILLS.description).toContain('BEFORE WRITING');
-    expect(GET_WRITING_SKILLS.description).toMatch(/no credits/i);
+    expect(GET_WRITING_SKILLS.description).toMatch(/free/i);
   });
 
   it('distingue una skill di prodotto da una procedura del brand', () => {

--- a/packages/api-contracts/src/writing-skills.ts
+++ b/packages/api-contracts/src/writing-skills.ts
@@ -20,11 +20,13 @@ export const GET_WRITING_SKILLS = {
   tool: 'get_writing_skills',
   title: 'Writing skills',
   description:
-    'READ THIS BEFORE WRITING ANY COPY FOR THE BRAND — a caption, a carousel, a script, an article, a bio. ' +
-    'It returns the actual craft text Anomalia writes with: `humanizer` and `stop-slop` always (why the output must not read as a chatbot), plus `social` or `seo-audit` depending on `agent`. ' +
-    'It also returns the built-in production skills for that agent — the ones naming the gates that refuse a render — and this brand\'s OWN procedures, the ones its team wrote or the system distilled. `source` says product from brand, and a brand procedure overrules a product skill when they disagree. ' +
-    'Bodies come inline; each skill lists its `references` by path without sending them, and you fetch one by passing `reference: "<skill>/<path>"`, which then returns that file alone. ' +
-    'No credits, no writes. Reading it costs a few thousand tokens and is the difference between copy a person would publish and copy that reads as generated.',
+    'READ THIS BEFORE WRITING ANY COPY FOR THE BRAND — a caption, a carousel, a script, an ' +
+    'article, a bio. It returns the craft text Anomalia writes with: `humanizer` and `stop-slop` ' +
+    'always, plus `social` or `seo-audit` depending on `agent`. It also returns the built-in ' +
+    'production skills for that agent — the ones naming the gates that refuse a render — and this ' +
+    'brand\'s OWN procedures, and a brand procedure overrules a product skill when they disagree. ' +
+    'Bodies come inline; each skill lists its `references` by path without sending them, and ' +
+    '`reference: "<skill>/<path>"` returns that one file alone. Free.',
   method: 'GET',
   pathUnderBrand: '/writing-skills',
   input: z

--- a/src/lib/content/changelog/2026-09-06-a-lighter-tool-list.ts
+++ b/src/lib/content/changelog/2026-09-06-a-lighter-tool-list.ts
@@ -1,0 +1,10 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-06',
+  title: 'A lighter tool list',
+  items: [
+    'Connecting Anomalia to Claude, Cursor or any other MCP client now sends 15% less on every session: the same tools, described in fewer words, so more of the conversation is left for your work.',
+    'Changing one field of your brand kit from an agent or the command line no longer blanks the others: correcting the category used to erase what your brand says about itself, who it speaks to and its style.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/routes/api/v1/brands/[slug]/studio/kit/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/studio/kit/+server.ts
@@ -3,6 +3,8 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { authenticate, loadBrandForUser, checkApiKeyWriteAccess } from '$lib/server/cli-auth';
 
+const KIT_COLUMNS = ['about', 'category', 'target_audience', 'brand_style'] as const;
+
 export const PUT: RequestHandler = async ({ request, params }) => {
   const { supabase, user, error, apiKey } = await authenticate(request);
   if (error) return error;
@@ -13,22 +15,20 @@ export const PUT: RequestHandler = async ({ request, params }) => {
   if (writeDenied) return writeDenied;
 
   const body = await request.json();
-  const { about, category, target_audience, brand_style, language } = body;
+  const { language } = body;
 
-  // Update brand_kit
-  const { error: kitError } = await supabase
-    .from('brand_kit')
-    .upsert({
-      brand_id: brand.id,
-      about: about ?? null,
-      category: category ?? null,
-      target_audience: target_audience ?? null,
-      brand_style: brand_style ?? null,
-    }, { onConflict: 'brand_id' });
+  const kit = Object.fromEntries(
+    KIT_COLUMNS.filter((column) => column in body).map((column) => [column, body[column] ?? null])
+  );
 
-  if (kitError) return json({ error: kitError.message }, { status: 500 });
+  if (Object.keys(kit).length > 0) {
+    const { error: kitError } = await supabase
+      .from('brand_kit')
+      .upsert({ brand_id: brand.id, ...kit }, { onConflict: 'brand_id' });
 
-  // Update language in content_prefs
+    if (kitError) return json({ error: kitError.message }, { status: 500 });
+  }
+
   if (language !== undefined) {
     const { data: brandData } = await supabase
       .from('brands').select('content_prefs').eq('id', brand.id).maybeSingle();
@@ -37,7 +37,6 @@ export const PUT: RequestHandler = async ({ request, params }) => {
     await supabase.from('brands').update({ content_prefs: prefs }).eq('id', brand.id);
   }
 
-  // Rebuild brand context (best-effort)
   try {
     const { rebuildBrandContext } = await import('$lib/server/brand-context');
     await rebuildBrandContext(supabase, brand.id);

--- a/src/routes/api/v1/brands/[slug]/studio/kit/server.test.ts
+++ b/src/routes/api/v1/brands/[slug]/studio/kit/server.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('$lib/server/cli-auth', () => ({
+  authenticate: vi.fn(),
+  loadBrandForUser: vi.fn(),
+  checkApiKeyWriteAccess: vi.fn(() => null)
+}));
+
+import { PUT } from './+server';
+import { authenticate, loadBrandForUser } from '$lib/server/cli-auth';
+
+type Row = Record<string, unknown>;
+
+const upserted: Row[] = [];
+
+function fakeSupabase() {
+  return {
+    from(table: string) {
+      const q = {
+        upsert: async (row: Row) => {
+          if (table === 'brand_kit') upserted.push(row);
+          return { error: null };
+        },
+        select: () => q,
+        eq: () => q,
+        update: () => q,
+        maybeSingle: async () => ({ data: { content_prefs: {} }, error: null }),
+        then: (resolve: (v: { data: null; error: null }) => unknown) => resolve({ data: null, error: null })
+      };
+      return q;
+    }
+  };
+}
+
+function signedIn() {
+  vi.mocked(authenticate).mockResolvedValue({
+    supabase: fakeSupabase(),
+    user: { id: 'user-1' },
+    apiKey: undefined,
+    error: null
+  } as never);
+  vi.mocked(loadBrandForUser).mockResolvedValue({
+    brand: { id: 'brand-1', slug: 'demo', name: 'Demo Brand' },
+    error: null
+  } as never);
+}
+
+function put(body: Row) {
+  return (PUT as (event: unknown) => Promise<Response>)({
+    request: new Request('https://anomalia.test/api/v1/brands/demo/studio/kit', {
+      method: 'PUT',
+      body: JSON.stringify(body)
+    }),
+    params: { slug: 'demo' }
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  upserted.length = 0;
+});
+
+describe('PUT /studio/kit', () => {
+  /**
+   * `update_brand_kit` promette «Only the fields you send change», e l'upsert spediva tutte e
+   * quattro le colonne con `about ?? null`: correggere la categoria cancellava quello che il brand
+   * dice di sé, il pubblico a cui parla e il suo stile — i fatti da cui è scritto ogni post
+   * generato. Nessun errore, nessuna schermata: la riga tornava `ok: true`.
+   */
+  it('non azzera i campi che non hai mandato', async () => {
+    signedIn();
+
+    const res = await put({ category: 'bakery' });
+
+    expect(res.status).toBe(200);
+    expect(upserted).toHaveLength(1);
+    expect(upserted[0]).toEqual({ brand_id: 'brand-1', category: 'bakery' });
+  });
+
+  it('scrive null solo quando null è quello che hai mandato', async () => {
+    signedIn();
+
+    await put({ about: null, target_audience: 'chi cucina la domenica' });
+
+    expect(upserted[0]).toEqual({
+      brand_id: 'brand-1',
+      about: null,
+      target_audience: 'chi cucina la domenica'
+    });
+  });
+
+  it('non tocca il kit quando cambi soltanto la lingua', async () => {
+    signedIn();
+
+    const res = await put({ language: 'it' });
+
+    expect(res.status).toBe(200);
+    expect(upserted).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## What?

**`update_brand_kit` was losing data silently, and this stops it.** Sending
`{ category: "bakery" }` wrote NULL over what the brand says about itself, who it speaks to and its
style — the facts every generated post is written from — while the tool's own description promised
*"Only the fields you send change"*. No error, no screen: the call answered `ok: true`.
`brand_colors` survived only by not being in the payload; luck, not design. Found by reading the
handlers behind every write marked `destructive: false`, to see whether that flag tells the truth.

Then the thing the branch set out to do: **`tools/list` — the MCP payload every client downloads
before it can call anything — goes from 129.212 characters to 109.837**, about **32.300 tokens to
27.500**: **−19.375, −15,0%**, with the same 119 tools, the same schemas and no capability removed.

Two things did it, and they are separate commits:

1. **Two keys the SDK adds and no client reads** (−10.948, 8,5%): `$schema` declares the dialect of
   a schema the protocol already declares JSON Schema, and `execution.taskSupport: "forbidden"` is
   exactly what the field's absence means. Both on all 119 tools.
2. **The repetitions in the prose** (−8.427): `id accepts a short prefix` fifteen times when the
   handshake already says it once; `Brand URL slug` on a parameter named `slug`, on every tool that
   takes a brand; a retrieval cap written in the description, in the field describe and in the
   `max()` that enforces it; five copies of a four-line paragraph about model scoping.

## Why?

The surface is paid on every session, before the agent asks anything, and nobody had measured it.
It is also the surface that decides whether a model finds the right tool: three real sessions have
already failed with the right tool in the list, and a wall of prose is not more informative than a
sentence — it is less readable, for a model too.

**The comparison with #383 is the lesson.** Retiring seven tools removed 2.747 characters, 686
tokens, 2%. Cutting the prose removes ten times that. The problem was never how many tools there
are — it is how much each one writes.

## How?

**Measured on the transport, never on the sources.** `initialize`, then `tools/list`, then
`JSON.stringify(result).length`. The source count has already been wrong twice on this surface, and
the reason is structural: a `z.enum` of 150 names is one line in the source and three thousand
characters on the wire. Two counts that looked ten characters apart were the same count: one
measures `result`, the other the array alone, and `{"tools":` plus `}` is exactly 10.
`cli/mcp/tool-surface-cost.test.ts` makes the measurement, says which one it takes, and holds a
budget — the surface regrows by itself, every new tool bringing its description with nobody adding
them up.

**The two SDK keys** are stripped in one place: `trimListedTools` decorates the single point where
the SDK installs its `tools/list` handler, before the tools create it. Rejected: reimplementing the
zod → JSON Schema conversion, which would have to reproduce the SDK's unions and pipes to save the
same characters.

**The cut rule was one:** a sentence stays if it removes an observed error, goes if it is there for
completeness. Every candidate was looked up with `git log -S` first, because many were written in
answer to a real defect and the changelog says so. Twelve came back load-bearing and are listed —
with the defect each answers — in [`changelog/2026-09-06-tools-list-costa-meno.md`](changelog/2026-09-06-tools-list-costa-meno.md).

**The credit declaration did not go, it got shorter.** `Reads only — no model, no credits.` and its
eight variants become **`Free.`** — 5 characters instead of 34, sixty-six times. Rule 3 of
`2026-09-05-tool-descriptions-say-the-problem.md` exists because an agent called a requested
generation "a waste": *a cautious agent avoids what it does not know the price of*. Deleting the
sentence would have reopened that defect to save 1.900 characters; shortening it saves 1.600 and
reopens nothing.

**The brand kit patch is built from the keys present in the body** (`'about' in body`), not from
their value. `in body` and not `!== undefined` because they are two different questions: the first
asks whether the caller named the field, the second also whether they named it with a value JSON
cannot carry. The difference between "clear it" and "leave it alone" is exactly there.

**Rebased onto #383, and two of the five conflicts were merged rather than chosen.** `query` gained
the named-columns lesson (*a read with no `columns` carries every column, the 20,000-character cap
cuts whole rows, 50 rows of `posts` come back as nine*) — defect-driven, from a real measurement —
and it is kept whole, with the trim applied around it. `posts` carried the rename of `refine_image`
to `refine_media`: for `refine_media` the new text is taken as it stands, because it documents a
capability this branch never saw (video refinement, `videoRefineModel`, `no_refine_model`), and the
shortening this branch would have applied would have deleted it. The three deletions (`get_memory`,
`list_ideas`, `list_articles`) win over a shorter description with no tool left to belong to.

## Testing?

**Tested, after the rebase**

- `cli`: `bun test` → **128 pass, 0 fail**.
- Full suite: `npx vitest run` → **7.518 pass, 0 fail, exit 0**. The `query-tables.ts` failure
  (149 tables vs 150) that was red on the previous round is **gone**: #383 carried its fix, and it
  covers the case.
- `npm run build` → exit 0.
- `npm run dev` → up; `/` and `/changelog` answer 200 and the changelog page renders the new entry.
- **The measurement re-run over real HTTP**, not the in-process handler: `bun run mcp/http.ts` plus
  `curl` for `initialize` and `tools/list` → 119 tools, **109.837 characters on the wire**,
  `$schema` absent, `execution` absent, zero `Brand URL slug`, `refine_media` present.
- Six contract tests went red on the rewrite and each was judged one by one: four guarded a real
  fact and the prose was **restored** (`Turning one OFF spends nothing`, `Without a slug there is
  no brand and none of that reaches the model`, `cost_usd`, `NOT included`); two quoted a
  formulation and now ask for the concept.
- **The brand kit fix, red first**: `server.test.ts` written and watched fail on all three cases
  before the handler was touched, green after.
- **The assumption under that fix, proven against a real PostgREST**, not asserted: on the local
  self-hosted stack, a partial upsert with `on_conflict=id` and `resolution=merge-duplicates`
  returned `{"id":"p1","a":"keep-a","b":"changed-b","c":"keep-c"}` — only the column in the payload
  moved. Probe table dropped afterwards.

**NOT tested, and the risk**

- **No browser walkthrough with a real login.** There is no app UI in this change beyond one
  changelog entry, which was checked over HTTP. Risk: none for the app; the surface that matters
  here is the MCP payload, and that was verified on the wire.
- **No end-to-end `anomalia studio update-brand-kit` against a seeded local brand.** The local
  `.env` points at a hosted project and I would not write to it. Covered instead by the handler
  test (the exact payload shape) plus the PostgREST proof above (the semantics). Residual risk:
  something between `cli/lib/api.ts` and the route re-adds the missing keys — the contract's zod
  input is `.strict()` with all four optional, so it cannot.
- **No agent-quality evaluation.** `npm run eval:durability` measures work not being lost, not
  whether a model still picks the right tool. The real question this change raises — *does a model
  still choose correctly after the cut?* — is answered here only by `findability.test.ts` (the
  table of requests that actually arrived in chat → the tool that owes them an answer → the words
  the description must contain), which is green, plus the twelve defect-driven sentences kept
  deliberately. That is a word check, not a behavioural one.
- **`ads.ts`, `search.ts`, `set_appearance`, `edit_post` untouched** — #385 is still open on them.
  They are still carrying their old prose; `set_appearance` alone is 1.835 characters.
- **The `refine_media` description was not audited with `git log -S`** the way the others were. It
  arrived with #383 while this branch was in flight and is taken as written.

## Evidence (screenshots/videos)

<details>
<summary>The measurement, on the wire, before and after</summary>

```
dev (79dee5bc)   tools/list = 129.212 characters ≈ 32.300 tokens
                   42 read  →  8.464 tokens (26%)
                   77 write → 23.807 tokens (74%)

this branch      tools/list = 109.837 characters ≈ 27.500 tokens
                   42 read  →  6.685 tokens (24%)
                   77 write → 20.742 tokens (76%)
```

`curl` against `bun run mcp/http.ts`, the same transport a client uses:

```
initialize → 200
tools: 119 | chars on the wire: 109837
$schema present: False
execution present: False
slug describes left: 0
refine_media present: True
```

For scale: the seven tools #383 retired were worth 2.747 characters — 686 tokens, 2%.
</details>

<details>
<summary>The ten biggest per-tool savings (whole tool object, both levers)</summary>

| tool | before | after | −chars |
|---|---:|---:|---:|
| `generate_image` | 3139 | 2689 | 450 |
| `get_writing_skills` | 1656 | 1218 | 438 |
| `refine_media` | 3259 | 2892 | 367 |
| `get_studio` | 1278 | 916 | 362 |
| `set_brand_settings` | 2102 | 1749 | 353 |
| `set_blog_settings` | 3457 | 3151 | 306 |
| `generate_carousel` | 1924 | 1662 | 262 |
| `save_memory` | 1365 | 1105 | 260 |
| `generate_captions` | 1600 | 1364 | 236 |
| `search_knowledge` | 1469 | 1251 | 218 |

**No tool grew. No tool stayed the same.** `query` shrank too, despite gaining #383's
named-columns lesson whole.
</details>

<details>
<summary>The sentences kept, and the defect each answers</summary>

| sentence | defect |
|---|---|
| `media_not_found` (400) vs `media_unavailable` (502), on `create_post` | an external model burned six attempts correcting an id against broken Storage — the 400 told it the input was wrong |
| `a ninth is refused, not dropped` | silent truncation is the UI's; the contract fails the whole request |
| `Do NOT call list_brands to decide where to draw` | agents calling `list_brands` and picking a brand at random: a real organisation's credits, a real client's library |
| `WITHOUT slug this is a one-off drawing`, `id comes back null` | *"puoi generare la img di un gatto?"* → *"non ho uno strumento di generazione immagini"* |
| `Do NOT reach for generate_image to alter something` | a library image asked to be red, redrawn from scratch |
| `continuity_tokens` on `generate_carousel` | a slide edited without the tokens leaves the series, and nothing errors |
| `there is no field for arbitrary JavaScript`, `ONLY on a verified custom domain` | `/blog/<slug>` is anomalia.so's own origin, next to signed-in `/app` sessions, and there is no CSP |
| `consent` — `Never infer it` | the API wrote `consent = true` with nobody attesting it |
| `it works precisely when credits are gone` (Stripe links) | an agent out of credits skipping the tool that exists to buy them |
| `not_in_library` on `check_media_job` | a paid, existing clip that, called `failed`, would be bought twice |
| `IT IS ALSO THE READ FOR QUESTIONS THAT HAVE NO TOOL OF THEIR OWN` / `products` on `query` | `list_products` was removed: without these words the capability is unreachable |
| `Turning one OFF spends nothing` | the asymmetry between switching on (spends forever) and off is all an agent reads before calling |
</details>

<details>
<summary>The brand kit defect, and the proof of the fix</summary>

`src/routes/api/v1/brands/[slug]/studio/kit/+server.ts`, before:

```ts
.upsert({
  brand_id: brand.id,
  about: about ?? null,
  category: category ?? null,
  target_audience: target_audience ?? null,
  brand_style: brand_style ?? null,
}, { onConflict: 'brand_id' });
```

All four columns always in the payload, so `ON CONFLICT DO UPDATE` set all four:
`{ category: "bakery" }` wrote NULL over the other three.

Red before the fix:

```
× PUT /studio/kit > non azzera i campi che non hai mandato
  → expected { brand_id: 'brand-1', …(4) } to deeply equal { brand_id: 'brand-1', …(1) }
× PUT /studio/kit > scrive null solo quando null è quello che hai mandato
× PUT /studio/kit > non tocca il kit quando cambi soltanto la lingua
Tests  3 failed (3)
```

Green after, and the PostgREST semantics the fix depends on, checked against the local stack:

```
POST /rest/v1/upsert_probe?on_conflict=id   {"id":"p1","b":"changed-b"}
→ [{"id":"p1","a":"keep-a","b":"changed-b","c":"keep-c"}]
```
</details>

## Anything Else?

### `query`'s table enum stays, deliberately

2.955 characters, 150 table names shipped every session, 2,7% of the surface — while the same
tool's description already says *"Omit `table` to list every table you can name"*. It stays: the
alternative is a model guessing a table name, which is the class of silent failure this work exists
to remove, and one extra round trip costs less than a wrong answer. If that weight has to come
back, the question is whether all 150 tables belong in the list — not whether the list belongs.

### The `destructiveHint` audit — a product decision, with its numbers

Reading the handlers behind the writes marked `destructive: false`: **9 are genuinely ADDITIVE, 8
MERGE, 19 REPLACE existing content, and 1 CLEARED unsent fields** (fixed in this PR). Under the MCP
definition — *"performs only additive updates"* — the 19 REPLACE ones are mislabelled.

**They are deliberately not flipped**, and the reason is the one `docs/mcp-tools.md` already
argues: marking almost every write destructive produces the warning people learn to click through,
which is worse than no warning at all. Flipping them would make a client prompt on
`set_blog_settings`, `save_plan`, `optimize_article`, `regenerate_post_media` and sixteen others —
tools whose whole job is to replace something the caller asked to replace, and whose descriptions
say so. The flag would stop distinguishing anything.

So the choice on the table is between three positions, and it belongs to whoever owns the product:
leave the 19 as they are and accept that `destructiveHint: false` here means *"replaces only what
you asked it to"* rather than the spec's *"additive"*; flip them and accept a warning nobody reads;
or split the difference by flipping only the ones that replace something the caller did **not**
name (`propose_plan` rejecting a pending proposal, `reschedule_post` nulling the publish pointers).
The third is the only one that adds information, and it is also the one that needs a decision
rather than a rule.

Three description/handler contradictions came out of the same reading and are **not** fixed here,
because each is its own decision (all three recorded in
[`changelog/2026-09-06-brand-kit-non-si-azzera.md`](changelog/2026-09-06-brand-kit-non-si-azzera.md)):

- `reschedule_post` says *"it only changes when"* and also writes `status: 'approved'`, nulling
  `external_post_id` and `published_url`;
- `propose_plan` says *"It lands as a proposal and changes nothing"* but flips the pending proposal
  to `rejected` (the *active* plan is genuinely safe; `save_plan` and `revise_plan` declare this,
  it does not);
- `plan_week` says *"replaces the week draft in review"* and instead inserts a new row, leaving the
  old one in the table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
