### PR TITLE
Send database-sourced URLs through the guard we already had

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -1489,3 +1489,28 @@ richiesta vera prima di deciderlo), `redirect: 'manual'` con ogni salto validato
 un nome DNS che risolve lì. Quando l'insieme legittimo è noto — qui era un host solo su 530 valori
 reali in produzione — la allowlist è insieme più corta da scrivere e più stretta di qualunque
 elenco di divieti.
+
+## Validare alla creazione non è validare alla consegna
+
+`brand_webhooks.url` passava da `validateWebhookUrl` quando la riga nasceva, e da lì in poi da
+niente: `attemptDelivery` faceva `fetch(webhook.url)` mesi dopo, seguendo i redirect. Fra il
+controllo e l'uso può cambiare tutto ciò che il controllo aveva verificato — il record DNS di un
+nome pubblico può iniziare a rispondere `127.0.0.1`, e l'endpoint può rispondere `302` verso un
+indirizzo interno. Il valore controllato non è quello usato: è quello che *era* al momento del
+controllo.
+
+**Segnale**: una validazione che vive in un handler di form o in un `POST` di creazione, e un
+consumo dello stesso campo in un altro file — un cron, una coda, un retry. La distanza fra i due
+si misura in mesi, non in millisecondi, e nel mezzo c'è un resolver che nessuno di noi controlla.
+Il caso peggiore non è la riga scritta in malafede: è quella scritta in buona fede e diventata
+pericolosa dopo.
+
+**Mossa**: il controllo va **dove il valore viene usato**, dentro il `try` che già registra il
+fallimento, così un rifiuto diventa una consegna fallita e non un'eccezione che risale. Quello
+alla creazione si tiene solo per dare un errore immediato nel form, e deve **delegare alla stessa
+funzione** invece di tenersi una copia della regola: qui erano undici regex su intervalli privati
+che duplicavano peggio ciò che `assertPublicUrl` fa risolvendo il nome davvero.
+
+**La regola dietro**: quando un controllo e il suo uso stanno in due momenti diversi, il controllo
+è un suggerimento. Se una sola delle due posizioni può esistere, è quella accanto all'uso — un
+form senza validazione dà un errore brutto, una consegna senza validazione apre la rete interna.

--- a/LESSONS.md
+++ b/LESSONS.md
@@ -1514,3 +1514,17 @@ che duplicavano peggio ciò che `assertPublicUrl` fa risolvendo il nome davvero.
 **La regola dietro**: quando un controllo e il suo uso stanno in due momenti diversi, il controllo
 è un suggerimento. Se una sola delle due posizioni può esistere, è quella accanto all'uso — un
 form senza validazione dà un errore brutto, una consegna senza validazione apre la rete interna.
+
+## `Test Files 1 failed` con `Tests 0 failed` è un worktree senza `.env`
+
+Un worktree nuovo si porta dietro il codice, non l'ambiente. Senza `.env`, `hooks.server.ts`
+esplode a tempo di import — `new URL(publicEnv.PUBLIC_SUPABASE_URL)` su una stringa vuota è
+`TypeError: Invalid URL` — e `src/hooks.server.test.ts` non arriva a collezionare un solo test.
+
+**Segnale**: il riepilogo si contraddice — `Test Files 1 failed | 681 passed` accanto a
+`Tests 7516 passed`, zero test rossi. Un file che fallisce senza test falliti non è
+un'asserzione: è un modulo che non si è caricato. Cercare l'asserzione rotta è tempo buttato.
+
+**Mossa**: `cp <checkout-principale>/.env .env` nel worktree, come già si fa con `node_modules`
+(stessa famiglia di trappola, poco sopra in questo file). E prima di dare la colpa al proprio
+diff: `git diff --name-only origin/dev...HEAD` sul file incriminato — se non lo tocchi, non è tuo.

--- a/changelog/2026-09-06-db-url-fetch-ssrf.md
+++ b/changelog/2026-09-06-db-url-fetch-ssrf.md
@@ -1,0 +1,63 @@
+# Gli URL che arrivano dal database passano dalla guardia che esisteva già
+
+Cinque punti facevano `fetch` su un URL letto da una riga del database senza controllare dove
+andava, e ognuno seguiva i redirect per conto suo. La forma è la stessa chiusa nel download dei
+media, ma il bersaglio consentito è diverso: lì l'insieme legittimo è **solo lo storage del
+brand**, qui è **qualunque host pubblico** — la miniatura di un concorrente vive davvero su una
+CDN esterna, e un'allowlist la romperebbe.
+
+Quindi le regole restano due, e ognuna in un posto solo:
+
+- `isOwnMediaUrl` (`chat-media.ts`) — «deve essere roba nostra». Usata dal download dei media.
+- `assertPublicUrl` / `safeFetchBytes` / `safeFetchUrl` (`tool-guard.ts`) — «può essere di
+  chiunque, ma non della nostra rete interna». Risolve il DNS, rifiuta loopback, reti private e
+  link-local, ricontrolla **ogni salto** del redirect, e conosce gli IPv4 incapsulati in IPv6
+  (`::ffff:127.0.0.1`, 6to4, NAT64) che sono il modo con cui si aggira un controllo scritto in
+  fretta.
+
+Non ho scritto niente di nuovo: `tool-guard.ts` era già la risposta giusta, semplicemente nessuno
+di questi cinque ci passava.
+
+## I punti
+
+`fetchImagePart` (`brand-context.ts`) è il più importante: è un helper condiviso da una ventina di
+chiamanti, fra cui `read-tools.ts` che gli passa **lo stesso `posts.media_url`** scrivibile
+dall'utente. Il filtro `/^https?:\/\//i` che aveva davanti non è un controllo di destinazione. Il
+`content-type: image/*` limitava il difetto ma non lo chiudeva: `res.ok` da solo è già un oracolo
+sulla raggiungibilità della rete interna, e i byte finiscono nel contesto del modello, che poi
+parla.
+
+Stessa sostituzione per `fetchLogoPart` (`content-preview/images.ts`) e `logoDataUrl`
+(`motion-video/run-turn.ts`): ognuno tiene il **suo** tetto di byte e il suo timeout, che erano
+già decisioni prese e non c'era motivo di uniformare.
+
+`brands.website` era copiato in due punti — `chat/job-executor.ts` e l'endpoint `products` — che
+scaricavano la homepage senza guardia. I prodotti a valle erano già protetti da
+`isUrlSafeToFetch` nel package `site-analysis`; era solo la prima richiesta a non esserlo.
+
+## Il webhook: il controllo era nel momento sbagliato
+
+`brand_webhooks.url` era validato alla **creazione della riga** e mai più. Fra quel momento e la
+consegna può cambiare tutto: il record DNS di un nome pubblico può puntare a `127.0.0.1`, e
+l'endpoint può rispondere `302` verso un indirizzo interno che `fetch` seguiva da solo, ripetendo
+la POST — firmata da noi — su un bersaglio che nessuno aveva approvato.
+
+Adesso `assertPublicUrl` gira **a ogni consegna**, dentro il `try` che già registra il fallimento,
+e la POST usa `redirect: 'error'`: un endpoint che redirige non è un endpoint, è un rimbalzo.
+
+E `validateWebhookUrl` non tiene più la propria lista di intervalli privati scritta a mano —
+undici regex che duplicavano, peggio, quello che `assertPublicUrl` fa risolvendo davvero il nome.
+Ora delega. Resta alla creazione perché un errore immediato nel form vale, ma non è più la
+difesa: la difesa è alla consegna, dove il valore viene usato.
+
+## Cosa ho lasciato fuori
+
+Il `signal` di cancellazione nel `sync_products` di `job-executor`: `safeFetchUrl` ha il suo
+timeout e `cancel.assertActive()` resta subito prima. Un job annullato durante quei secondi
+finisce la richiesta invece di troncarla — costa una richiesta, non una riga.
+
+Su uno stack self-hosted interamente in loopback (`http://localhost:8000`) `fetchImagePart` ora
+rifiuta anche lo storage locale, perché è loopback. Non tocca nessun deployment reale — pubblico o
+self-host — dove lo storage è raggiungibile pubblicamente, e le funzioni sono tutte best-effort
+(tornano `null`), quindi non rompe: non legge le immagini in locale. Se un giorno servisse, la
+composizione onesta è «nostro storage OPPURE pubblico», non un allentamento di `assertPublicUrl`.

--- a/src/lib/content/changelog/2026-09-06-external-addresses-checked.ts
+++ b/src/lib/content/changelog/2026-09-06-external-addresses-checked.ts
@@ -1,0 +1,10 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-06',
+  title: 'Outgoing requests check where they land',
+  items: [
+    'Images the agents read — post media, brand logos, competitor thumbnails — and the product sync are now fetched only from addresses reachable on the public internet.',
+    'Webhook endpoints are checked on every delivery, not only when you save them, and a delivery is never forwarded somewhere else.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/brand-context.ssrf.test.ts
+++ b/src/lib/server/brand-context.ssrf.test.ts
@@ -1,0 +1,96 @@
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+vi.mock('$env/static/public', () => ({ PUBLIC_SUPABASE_URL: 'https://example.supabase.co' }));
+vi.mock('$env/dynamic/public', () => ({ env: { PUBLIC_SUPABASE_URL: 'https://example.supabase.co' } }));
+vi.mock('$env/dynamic/private', () => ({ env: {} }));
+
+vi.mock('node:dns/promises', () => ({
+  lookup: vi.fn(async (host: string) =>
+    /^\d+\.\d+\.\d+\.\d+$/.test(host)
+      ? [{ address: host, family: 4 }]
+      : [{ address: '93.184.216.34', family: 4 }]
+  )
+}));
+
+import { fetchImagePart } from './brand-context';
+
+const PUBLIC_ORIGIN = 'https://cdn.example.com';
+const SECRET = 'INTERNAL-ONLY-PAYLOAD';
+const SECRET_PATH = '/latest/meta-data/iam/credentials';
+const IMAGE_PATH = '/photo.jpg';
+const REDIRECTING_PATH = '/moved.jpg';
+
+let server: Server;
+let origin: string;
+let hits: string[] = [];
+
+const realFetch = globalThis.fetch;
+
+function resolvingPublicHostToLocalServer(): typeof fetch {
+  return ((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = new URL(String(input));
+    const target = url.origin === PUBLIC_ORIGIN ? `${origin}${url.pathname}${url.search}` : String(input);
+    return realFetch(target, init);
+  }) as typeof fetch;
+}
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    hits.push(req.url ?? '');
+
+    if (req.url === SECRET_PATH) {
+      res.writeHead(200, { 'content-type': 'image/jpeg' });
+      res.end(SECRET);
+      return;
+    }
+    if (req.url === REDIRECTING_PATH) {
+      res.writeHead(302, { location: `${origin}${SECRET_PATH}` });
+      res.end();
+      return;
+    }
+    if (req.url === IMAGE_PATH) {
+      res.writeHead(200, { 'content-type': 'image/jpeg' });
+      res.end('REAL-PHOTO-BYTES');
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  origin = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  globalThis.fetch = resolvingPublicHostToLocalServer();
+});
+
+afterAll(async () => {
+  globalThis.fetch = realFetch;
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+describe('fetchImagePart', () => {
+  it('non apre un socket verso il loopback', async () => {
+    hits = [];
+    const part = await fetchImagePart(`${origin}${SECRET_PATH}`);
+
+    expect(hits).toEqual([]);
+    expect(part).toBeNull();
+  });
+
+  it('non segue un redirect da un host pubblico verso il loopback', async () => {
+    hits = [];
+    const part = await fetchImagePart(`${PUBLIC_ORIGIN}${REDIRECTING_PATH}`);
+
+    expect(hits).not.toContain(SECRET_PATH);
+    expect(part).toBeNull();
+  });
+
+  it('continua a leggere una miniatura su una CDN pubblica', async () => {
+    hits = [];
+    const part = await fetchImagePart(`${PUBLIC_ORIGIN}${IMAGE_PATH}`);
+
+    expect(part?.inlineData.mimeType).toBe('image/jpeg');
+    expect(Buffer.from(part!.inlineData.data, 'base64').toString()).toBe('REAL-PHOTO-BYTES');
+  });
+});

--- a/src/lib/server/brand-context.ts
+++ b/src/lib/server/brand-context.ts
@@ -1,4 +1,5 @@
 import { swallow } from '$lib/server/swallow';
+import { safeFetchBytes } from '$lib/server/tool-guard';
 import type { GoogleGenAI } from '@google/genai';
 import { structured } from '$lib/server/research';
 import type { SupabaseClient } from '@supabase/supabase-js';
@@ -190,18 +191,18 @@ export async function synthesizeBrandContext(input: ContextInputs): Promise<stri
   }
 }
 
+const IMAGE_PART_MAX_BYTES = 6_000_000;
+
 // Download an image URL into a Gemini inlineData part. Best-effort: null on any failure / non-image
 // / oversized payload, so a bad thumbnail never breaks style synthesis. Also reused to feed a
 // product photo to the image generator as a reference.
 export async function fetchImagePart(url: string): Promise<{ inlineData: { mimeType: string; data: string } } | null> {
   try {
-    const res = await fetch(url);
+    const res = await safeFetchBytes(url, { maxBytes: IMAGE_PART_MAX_BYTES });
     if (!res.ok) return null;
-    const mimeType = (res.headers.get('content-type') ?? '').split(';')[0] || 'image/jpeg';
+    const mimeType = res.mime || 'image/jpeg';
     if (!mimeType.startsWith('image/')) return null;
-    const buf = await res.arrayBuffer();
-    if (buf.byteLength > 6_000_000) return null;
-    return { inlineData: { mimeType, data: Buffer.from(buf).toString('base64') } };
+    return { inlineData: { mimeType, data: res.bytes.toString('base64') } };
   } catch {
     return null;
   }

--- a/src/lib/server/brand-webhooks.delivery.test.ts
+++ b/src/lib/server/brand-webhooks.delivery.test.ts
@@ -1,0 +1,128 @@
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+vi.mock('$env/dynamic/private', () => ({ env: {} }));
+
+vi.mock('node:dns/promises', () => ({
+  lookup: vi.fn(async (host: string) =>
+    host === 'rebound.acme.com'
+      ? [{ address: '127.0.0.1', family: 4 }]
+      : /^\d+\.\d+\.\d+\.\d+$/.test(host)
+        ? [{ address: host, family: 4 }]
+        : [{ address: '93.184.216.34', family: 4 }]
+  )
+}));
+
+import { attemptDelivery, type BrandWebhookRow, type DeliveryRow } from './brand-webhooks';
+
+const PUBLIC_ORIGIN = 'https://hooks.acme.com';
+const REBOUND_ORIGIN = 'https://rebound.acme.com';
+const INTERNAL_PATH = '/latest/meta-data/iam/credentials';
+const REDIRECTING_PATH = '/hook-moved';
+const HOOK_PATH = '/hook';
+
+let server: Server;
+let origin: string;
+let hits: string[] = [];
+
+const realFetch = globalThis.fetch;
+
+function resolvingPublicHostToLocalServer(): typeof fetch {
+  return ((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = new URL(String(input));
+    const local = url.origin === PUBLIC_ORIGIN || url.origin === REBOUND_ORIGIN;
+    return realFetch(local ? `${origin}${url.pathname}${url.search}` : String(input), init);
+  }) as typeof fetch;
+}
+
+function supabaseStub() {
+  const updates: Array<Record<string, unknown>> = [];
+  const chain = {
+    update(values: Record<string, unknown>) {
+      updates.push(values);
+      return chain;
+    },
+    eq: () => chain,
+    then: (resolve: (v: unknown) => unknown) => resolve({ data: null, error: null })
+  };
+  return { updates, client: { from: () => chain } };
+}
+
+const webhook = (url: string): BrandWebhookRow => ({
+  id: 'wh-1',
+  brand_id: 'b-1',
+  url,
+  secret: 'whsec_test',
+  events: ['*'],
+  status: 'active',
+  failure_count: 0,
+  last_delivery_at: null,
+  last_error: null,
+  created_at: '2026-01-01T00:00:00Z'
+});
+
+const delivery: DeliveryRow = {
+  id: 'd-1',
+  brand_id: 'b-1',
+  webhook_id: 'wh-1',
+  event_id: 'e-1',
+  trigger_slug: 'post.published',
+  payload: { hello: 'world' },
+  attempts: 0
+};
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    hits.push(req.url ?? '');
+
+    if (req.url === REDIRECTING_PATH) {
+      res.writeHead(302, { location: `${origin}${INTERNAL_PATH}` });
+      res.end();
+      return;
+    }
+    res.writeHead(200);
+    res.end('ok');
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  origin = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  globalThis.fetch = resolvingPublicHostToLocalServer();
+});
+
+afterAll(async () => {
+  globalThis.fetch = realFetch;
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+describe('attemptDelivery', () => {
+  it('non consegna a un host che passa la validazione ma risolve nella rete interna', async () => {
+    hits = [];
+    const { client } = supabaseStub();
+
+    const ok = await attemptDelivery(client as never, delivery, webhook(`${REBOUND_ORIGIN}${HOOK_PATH}`));
+
+    expect(hits).toEqual([]);
+    expect(ok).toBe(false);
+  });
+
+  it('non segue un redirect verso la rete interna', async () => {
+    hits = [];
+    const { client } = supabaseStub();
+
+    const ok = await attemptDelivery(client as never, delivery, webhook(`${PUBLIC_ORIGIN}${REDIRECTING_PATH}`));
+
+    expect(hits).not.toContain(INTERNAL_PATH);
+    expect(ok).toBe(false);
+  });
+
+  it('consegna ancora a un endpoint pubblico', async () => {
+    hits = [];
+    const { client } = supabaseStub();
+
+    const ok = await attemptDelivery(client as never, delivery, webhook(`${PUBLIC_ORIGIN}${HOOK_PATH}`));
+
+    expect(hits).toEqual([HOOK_PATH]);
+    expect(ok).toBe(true);
+  });
+});

--- a/src/lib/server/brand-webhooks.test.ts
+++ b/src/lib/server/brand-webhooks.test.ts
@@ -2,6 +2,20 @@ import { describe, expect, it, vi } from 'vitest';
 
 vi.mock('$env/dynamic/private', () => ({ env: { COMPOSIO_API_KEY: 'ak_test' } }));
 
+// È il resolver a decidere se un nome è interno, quindi il test lo detta invece di dipendere dal
+// DNS della macchina: un indirizzo letterale risponde se stesso, un nome risponde pubblico —
+// tranne quello che questi casi vogliono interno.
+vi.mock('node:dns/promises', () => ({
+  lookup: vi.fn(async (host: string) => {
+    if (host.endsWith('.internal') || host.endsWith('.local') || host === 'localhost') {
+      return [{ address: '127.0.0.1', family: 4 }];
+    }
+    return /^[\d.]+$/.test(host)
+      ? [{ address: host, family: 4 }]
+      : [{ address: '93.184.216.34', family: 4 }];
+  })
+}));
+
 import {
   backoffMs,
   eventBody,
@@ -19,14 +33,14 @@ import {
 import { createHmac } from 'node:crypto';
 
 describe('validateWebhookUrl', () => {
-  it('accepts a public https endpoint', () => {
-    expect(validateWebhookUrl(' https://hooks.acme.com/anomalia ')).toEqual({
+  it('accepts a public https endpoint', async () => {
+    expect(await validateWebhookUrl(' https://hooks.acme.com/anomalia ')).toEqual({
       ok: true,
       url: 'https://hooks.acme.com/anomalia'
     });
   });
 
-  it('refuses anything we should not be POSTing to', () => {
+  it('refuses anything we should not be POSTing to', async () => {
     // http is a plaintext secret on the wire; the rest are our own network.
     for (const bad of [
       'http://hooks.acme.com',
@@ -39,7 +53,7 @@ describe('validateWebhookUrl', () => {
       'https://db.internal/hook',
       'not a url'
     ]) {
-      expect(validateWebhookUrl(bad).ok, bad).toBe(false);
+      expect((await validateWebhookUrl(bad)).ok, bad).toBe(false);
     }
   });
 });

--- a/src/lib/server/brand-webhooks.ts
+++ b/src/lib/server/brand-webhooks.ts
@@ -7,6 +7,7 @@
 import { createHmac, randomBytes } from 'node:crypto';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { ComposioTriggerEvent } from '$lib/server/composio';
+import { assertPublicUrl } from '$lib/server/tool-guard';
 
 export const MAX_DELIVERY_ATTEMPTS = 6;
 /** Consecutive failures before the endpoint is parked; a dead URL must stop costing us retries. */
@@ -66,8 +67,17 @@ export function wantsEvent(webhook: { events: string[] }, triggerSlug: string): 
   return webhook.events.length === 0 || webhook.events.includes(triggerSlug);
 }
 
-/** A URL we will actually POST to: https only, no loopback, no private space. */
-export function validateWebhookUrl(raw: string): { ok: true; url: string } | { ok: false; error: string } {
+/**
+ * A URL we will actually POST to: https only, no loopback, no private space.
+ *
+ * This runs when the row is saved, so it buys an immediate error in the form — not safety. What
+ * a name resolves to today it need not resolve to at delivery time, which is why `attemptDelivery`
+ * asks `assertPublicUrl` again, every time. Both ask the same function on purpose: a second copy
+ * of the private-range list here is a copy that drifts.
+ */
+export async function validateWebhookUrl(
+  raw: string
+): Promise<{ ok: true; url: string } | { ok: false; error: string }> {
   let parsed: URL;
   try {
     parsed = new URL(raw.trim());
@@ -77,19 +87,9 @@ export function validateWebhookUrl(raw: string): { ok: true; url: string } | { o
   if (parsed.protocol !== 'https:') {
     return { ok: false, error: 'The endpoint must be https.' };
   }
-  const host = parsed.hostname.toLowerCase();
-  const privateHost =
-    host === 'localhost' ||
-    host.endsWith('.localhost') ||
-    host === '::1' ||
-    /^127\./.test(host) ||
-    /^10\./.test(host) ||
-    /^192\.168\./.test(host) ||
-    /^172\.(1[6-9]|2\d|3[01])\./.test(host) ||
-    /^169\.254\./.test(host) ||
-    host.endsWith('.internal') ||
-    host.endsWith('.local');
-  if (privateHost) {
+  try {
+    await assertPublicUrl(parsed, 'https-only');
+  } catch {
     return { ok: false, error: 'The endpoint must be reachable on the public internet.' };
   }
   return { ok: true, url: parsed.toString() };
@@ -180,8 +180,10 @@ export async function attemptDelivery(
   let failure: string | null = null;
 
   try {
+    await assertPublicUrl(new URL(webhook.url), 'https-only');
     const res = await fetch(webhook.url, {
       method: 'POST',
+      redirect: 'error',
       headers: {
         'content-type': 'application/json',
         'user-agent': 'Anomalia-Webhooks/1',

--- a/src/lib/server/chat/brand-studio-tools.test.ts
+++ b/src/lib/server/chat/brand-studio-tools.test.ts
@@ -1,4 +1,14 @@
 import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
+
+// `fetch` è finto, ma la guardia SSRF davanti a esso risolve l'host per davvero: senza dettare il
+// resolver, `cdn.example` non risolve e l'immagine sparisce — un rosso che parla della macchina su
+// cui gira la suite, non del codice.
+vi.mock('node:dns/promises', () => ({
+  lookup: vi.fn(async (host: string) =>
+    /^[\d.]+$/.test(host) ? [{ address: host, family: 4 }] : [{ address: '93.184.216.34', family: 4 }]
+  )
+}));
+
 import { noteRead, resetReadReceipts } from './read-guards';
 
 /**

--- a/src/lib/server/chat/job-executor.ts
+++ b/src/lib/server/chat/job-executor.ts
@@ -5,6 +5,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { JobCancellation } from '$lib/server/chat/job-cancel';
 import { hasWebHub, isPaidPlan } from '$lib/server/plans';
+import { safeFetchUrl } from '$lib/server/tool-guard';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyRec = Record<string, any>;
@@ -272,8 +273,7 @@ export async function executeChatToolJob(
       if (!brand?.website) return { error: 'No website URL set.' };
 
       await cancel.assertActive();
-      const res = await fetch(brand.website, { signal: cancel.signal });
-      const html = await res.text();
+      const { body: html } = await safeFetchUrl(brand.website);
 
       let products: AnyRec[] = [];
       if (isShopifySite(html)) products = await fetchShopifyProducts(brand.website);

--- a/src/lib/server/content-preview/images.ts
+++ b/src/lib/server/content-preview/images.ts
@@ -5,6 +5,7 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 import sharp from 'sharp';
 import { env } from '$env/dynamic/private';
 import { fetchImagePart } from '$lib/server/brand-context';
+import { safeFetchBytes } from '$lib/server/tool-guard';
 import { getBrandContext, getOrgContext } from '$lib/server/ai-log';
 import { NANO_BANANA_2_LITE } from '$lib/server/google-models';
 import { GEMINI_NANO_BANANA_2, googleImageModel } from '$lib/image-models';
@@ -23,15 +24,18 @@ import { designWallDigestSection } from '$lib/server/wall-digest';
 // Image MIME types Gemini ingests directly (SVG is rasterised via svgToPng).
 const RASTER_IMAGE_MIME = new Set(['image/png', 'image/jpeg', 'image/webp', 'image/heic', 'image/heif']);
 
+const LOGO_MAX_BYTES = 6_000_000;
+const LOGO_TIMEOUT_MS = 10_000;
+
 // Best-effort: un logo mancante o strano non deve mai rompere la generazione.
 export async function fetchLogoPart(url: string): Promise<ImagePart | null> {
   try {
-    const r = await fetch(url, { signal: AbortSignal.timeout(10_000) });
+    const r = await safeFetchBytes(url, { maxBytes: LOGO_MAX_BYTES, timeoutMs: LOGO_TIMEOUT_MS });
     if (!r.ok) return null;
-    let mime = (r.headers.get('content-type') ?? '').split(';')[0].trim().toLowerCase() || 'image/png';
+    let mime = r.mime || 'image/png';
     if (mime === 'image/jpg') mime = 'image/jpeg';
-    const buf = Buffer.from(await r.arrayBuffer());
-    if (!buf.length || buf.length > 6_000_000) return null;
+    const buf = r.bytes;
+    if (!buf.length) return null;
     if (mime === 'image/svg+xml' || /\.svg(\?|$)/i.test(url)) {
       const png = await svgToPng(buf);
       return png ? { inlineData: { mimeType: 'image/png', data: png.toString('base64') } } : null;

--- a/src/lib/server/motion-video/run-turn.ts
+++ b/src/lib/server/motion-video/run-turn.ts
@@ -4,6 +4,7 @@
  */
 import { env } from '$env/dynamic/private';
 import { swallow } from '$lib/server/swallow';
+import { safeFetchBytes } from '$lib/server/tool-guard';
 import { loadDesignDoc } from '$lib/server/brand-design-doc';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { UIMessage } from 'ai';
@@ -36,17 +37,19 @@ export type MotionTurnAds = Array<{
 	libraryUrl?: string | null;
 }>;
 
+const LOGO_MAX_BYTES = 1_500_000;
+const LOGO_TIMEOUT_MS = 8000;
+
 async function logoDataUrl(url: string | null): Promise<string | null> {
 	if (!url) return null;
 	if (url.startsWith('data:image/') && !url.startsWith('data:image/svg')) return url;
 	try {
-		const res = await fetch(url, { signal: AbortSignal.timeout(8000) });
+		const res = await safeFetchBytes(url, { maxBytes: LOGO_MAX_BYTES, timeoutMs: LOGO_TIMEOUT_MS });
 		if (!res.ok) return null;
-		const mime = (res.headers.get('content-type') || '').split(';')[0].trim().toLowerCase();
+		const mime = res.mime;
 		if (!mime.startsWith('image/') || mime.includes('svg')) return null;
-		const buf = Buffer.from(await res.arrayBuffer());
-		if (!buf.length || buf.length > 1_500_000) return null;
-		return `data:${mime};base64,${buf.toString('base64')}`;
+		if (!res.bytes.length) return null;
+		return `data:${mime};base64,${res.bytes.toString('base64')}`;
 	} catch {
 		return null;
 	}

--- a/src/routes/api/v1/brands/[slug]/products/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/products/+server.ts
@@ -1,6 +1,7 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { authenticate, loadBrandForUser, checkApiKeyWriteAccess } from '$lib/server/cli-auth';
+import { safeFetchUrl } from '$lib/server/tool-guard';
 
 // GET: list all products (title, category/kind, price, image count, featured).
 export const GET: RequestHandler = async ({ request, params }) => {
@@ -44,8 +45,7 @@ export const POST: RequestHandler = async ({ request, params }) => {
 
   try {
     const { isShopifySite, fetchShopifyProducts, isWooCommerceSite, fetchWooCommerceProducts } = await import('$lib/server/brand-analysis');
-    const res = await fetch(brandRow.website);
-    const html = await res.text();
+    const { body: html } = await safeFetchUrl(brandRow.website);
 
     let products: any[] = [];
     let platform = '';

--- a/src/routes/api/v1/brands/[slug]/webhook/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/webhook/+server.ts
@@ -70,7 +70,7 @@ export const PUT: RequestHandler = async ({ request, params }) => {
     return json({ error: 'Invalid JSON' }, { status: 400 });
   }
 
-  const validated = validateWebhookUrl(String(body.url ?? ''));
+  const validated = await validateWebhookUrl(String(body.url ?? ''));
   if (!validated.ok) return json({ error: validated.error }, { status: 400 });
   const events = Array.isArray(body.events)
     ? body.events.map((e) => String(e).trim().toUpperCase()).filter(Boolean)

--- a/src/routes/app/[brand]/settings/connectors/+page.server.ts
+++ b/src/routes/app/[brand]/settings/connectors/+page.server.ts
@@ -109,7 +109,7 @@ export const actions: Actions = {
     if (!brandId) return fail(404, { error: 'Brand not found' });
     const { user } = await locals.safeGetSession();
     const form = await request.formData();
-    const validated = validateWebhookUrl(String(form.get('url') ?? ''));
+    const validated = await validateWebhookUrl(String(form.get('url') ?? ''));
     if (!validated.ok) return fail(400, { error: validated.error });
 
     const existing = await loadBrandWebhook(supabase, brandId).catch((error) => { swallow('load brand webhook', error); return null; });


### PR DESCRIPTION
## What?

Five server-side `fetch` calls took their URL from a database row and never checked where it pointed, each following redirects on its own. This PR routes all five through `tool-guard.ts`, the guard this repo already had, and moves the webhook check from row-creation time to delivery time, where the value is actually used.

## Why?

This is the sibling of #386, but the allowed set is different and that difference is the whole design. In #386 the legitimate target is **only the brand's own storage**, so the rule is an allowlist (`isOwnMediaUrl`). Here a competitor thumbnail genuinely lives on an external CDN, so the rule is **any public host, but never our internal network** — `assertPublicUrl`.

So there are two rules, not one, and each keeps living in exactly one place:

| Rule | Question | Home | Used by |
|---|---|---|---|
| `isOwnMediaUrl` | "is this ours?" | `src/lib/chat-media.ts` | media ZIP download (#386), chat embeds |
| `assertPublicUrl` / `safeFetchBytes` / `safeFetchUrl` | "is this public, and not us?" | `src/lib/server/tool-guard.ts` | everything in this PR |

`tool-guard.ts` was already the right answer and nothing here used it. It resolves the host, rejects loopback / private / link-local, **re-checks every redirect hop**, and already handles the IPv4-in-IPv6 shapes (`::ffff:127.0.0.1`, 6to4, NAT64) that defeat a check written in a hurry. I wrote no new rule.

**The sinks:**

- `src/lib/server/brand-context.ts:196` — `fetchImagePart`, a shared helper with ~20 callers. `src/lib/agent/tools/read-tools.ts:576` hands it the very same user-writable `posts.media_url` that #386 covers, filtered only by `/^https?:\/\//i`, which is not a destination check. The `content-type: image/*` requirement narrowed the defect without closing it: `res.ok` alone is already an oracle for what is reachable inside our network, and the bytes land in the model's context, which then talks.
- `src/lib/server/content-preview/images.ts:29` (`fetchLogoPart`) and `src/lib/server/motion-video/run-turn.ts:43` (`logoDataUrl`) — brand-kit logos.
- `src/lib/server/chat/job-executor.ts:275` and `src/routes/api/v1/brands/[slug]/products/+server.ts:47` — `brands.website`, the same six lines copied twice. The product calls downstream were already guarded by `isUrlSafeToFetch` in the `site-analysis` package; only the first homepage request was not.
- `src/lib/server/brand-webhooks.ts:183` — see below.

**The webhook was a different defect: the check was at the wrong moment.** `brand_webhooks.url` was validated when the row was saved and never again. Between that moment and a delivery months later, everything the check verified can change: a public name's DNS record can start answering `127.0.0.1`, and the endpoint can answer `302` toward an internal address, which `fetch` followed on its own — replaying our signed POST at a target nobody approved.

## How?

Each sink keeps **its own** byte ceiling and timeout — those were existing decisions and uniformity was not worth a behaviour change. Only the transport moved.

`attemptDelivery` now calls `assertPublicUrl` on every attempt, inside the `try` that already records failures, so a refusal becomes a failed delivery rather than an exception climbing out. The POST uses `redirect: 'error'`: an endpoint that redirects is not an endpoint, it is a bounce.

`validateWebhookUrl` no longer keeps its own hand-written private-range list — eleven regexes that duplicated, worse, what `assertPublicUrl` does by actually resolving the name. It now delegates. It stays at creation time because an immediate error in the form is worth having, and its docblock says plainly that it buys a good error and not safety, so the next reader does not mistake it for the gate again.

## Testing?

**Written first and watched fail**, same shape as #386: an ephemeral HTTP server on a free port inside the test, and the resolver dictated with the `node:dns/promises` mock that `tool-guard.test.ts` already established — so nothing depends on the machine's DNS or on anything running locally.

`src/lib/server/brand-context.ssrf.test.ts`
- a `media_url` at loopback: the server must record **zero** requests;
- a public CDN host answering `302` toward loopback: not followed;
- a real thumbnail on a public CDN: still read, bytes intact — the case that must not regress.

`src/lib/server/brand-webhooks.delivery.test.ts`
- a host that passes creation-time validation but **resolves** to `127.0.0.1`: never POSTed to;
- a public endpoint that answers `302` toward an internal path: not followed;
- an ordinary public endpoint: still delivered.

Before the fix: 2 of 3 red in each file, with the public-path test green in both, which is what proves the guard is not simply refusing everything.

**One existing test broke, and it was worth breaking.** `brand-studio-tools.test.ts` (`#8 read_posts allega le immagini come image-data`) stubs `fetch` but not the resolver, so once a real guard sat in front, `cdn.example` failed to resolve and the image vanished. Adding the same resolver mock fixes it and makes that test stop depending on the DNS of whatever machine runs it.

Full suite on this branch, rebased onto current `dev`: **7517 passed, 0 failed** (682 files). The `query-tool.test.ts` red I saw before the rebase was #383's, and #383 is now in `dev`. `npm run build` passes.

**Not tested:** no browser click-through — these are server-side paths with no direct UI surface, and the one user-visible behaviour (a webhook form rejecting a bad endpoint) needs a logged-in session I cannot create.

## Evidence

<details>
<summary>Red before — brand-context</summary>

```
AssertionError: expected [ '/latest/meta-data/iam/credentials' ] to deeply equal []
AssertionError: expected [ '/moved.jpg', …(1) ] to not include '/latest/meta-data/iam/credentials'

 Test Files  1 failed (1)
      Tests  2 failed | 1 passed (3)
```

The one that passed is the public-CDN read, before and after.
</details>

<details>
<summary>Red before — webhook delivery</summary>

```
AssertionError: expected [ '/hook' ] to deeply equal []
AssertionError: expected [ '/hook-moved', …(1) ] to not include '/latest/meta-data/iam/credentials'

 Test Files  1 failed (1)
      Tests  2 failed | 1 passed (3)
```

The first is the DNS-rebinding case: the endpoint passed `validateWebhookUrl` when it was saved and resolved internally at delivery.
</details>

<details>
<summary>Green after</summary>

```
 ✓ src/lib/server/brand-webhooks.test.ts (11 tests)
 ✓ src/lib/server/brand-webhooks.delivery.test.ts (3 tests)
 ✓ src/lib/server/brand-context.ssrf.test.ts (3 tests)
 ✓ src/lib/server/chat/brand-studio-tools.test.ts (37 tests)
```
</details>

## Anything Else?

**Deliberately left out.** The cancellation `signal` in `job-executor`'s `sync_products`: `safeFetchUrl` carries its own timeout and `cancel.assertActive()` still runs immediately before. A job cancelled during those seconds finishes the request instead of aborting it — that costs one request, not a row.

**A narrow local-dev regression, stated plainly.** On a self-hosted stack running entirely on loopback (`http://localhost:8000`), `fetchImagePart` now refuses the local storage too, because it *is* loopback. No real deployment is affected — ours or a public self-host, storage is publicly reachable — and every one of these functions is best-effort (`null` on refusal), so nothing breaks; images simply are not read locally. If that ever matters, the honest composition is "our own storage **or** public", not a loosening of `assertPublicUrl`.

**Merge order, and a real overlap that needs a decision.** `fix/tenant-references` ("Keep an external identity inside one tenant") edits the same `attemptDelivery` and is fixing **the same defect**: it too moved the check to delivery time and added `redirect: 'error'`. The two are not equivalent, so whoever rebases must not simply take one side:

- that branch calls the **synchronous** `validateWebhookUrl(webhook.url)`, which matches hostname *patterns*;
- this branch calls **`assertPublicUrl`**, which resolves the name and checks the addresses it actually gets.

A public hostname whose DNS record answers `127.0.0.1` passes a pattern match and fails a resolution — and that DNS-rebinding case is precisely the one a delivery-time check exists to catch, since it is the thing that can change after the row was saved. `brand-webhooks.delivery.test.ts` here covers it explicitly. **On conflict, the resolving check is the one to keep**; the rest of that branch's shape (recording `endpoint.error` as the failure, reusing the normalised URL) composes with it fine, and `validateWebhookUrl` is async on this branch, so a merged version wants `await`.

`LESSONS.md` will also conflict — both branches append. Both entries are keepers; the fix is to keep both, as I did rebasing this branch onto #386.

No conflict with #386 or #389, which touch different files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
