### PR TITLE
Compare the configured storage origin, not a hardcoded scheme

### DIFF
--- a/src/lib/chat-media.selfhost.test.ts
+++ b/src/lib/chat-media.selfhost.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('$env/static/public', async (originale) => ({
+  ...((await originale()) as Record<string, string>),
+  PUBLIC_SUPABASE_URL: 'http://localhost:8000'
+}));
+
+vi.mock('$env/dynamic/public', () => ({ env: { PUBLIC_SUPABASE_URL: 'http://localhost:8000' } }));
+
+import { isShowableMediaUrl } from './chat-media';
+
+const SELF_HOSTED = 'http://localhost:8000';
+
+describe('isOwnMediaUrl segue l origine configurata, non uno schema scritto a mano', () => {
+  it('accetta lo storage di un self-host servito in http', () => {
+    expect(isShowableMediaUrl(`${SELF_HOSTED}/storage/v1/object/public/media/u/a.png`)).toBe(true);
+  });
+
+  it('rifiuta un altro host anche quando l origine configurata e http', () => {
+    expect(isShowableMediaUrl('http://evil.example.com/storage/v1/object/public/media/a.png')).toBe(false);
+    expect(isShowableMediaUrl('https://localhost:8000/storage/v1/object/public/media/a.png')).toBe(false);
+  });
+});

--- a/src/lib/chat-media.test.ts
+++ b/src/lib/chat-media.test.ts
@@ -38,9 +38,13 @@ describe('isShowableMediaUrl', () => {
     expect(isShowableMediaUrl(signed)).toBe(true);
   });
 
-  it('refuses anything that is not ours — including a lookalike host and a plain http url', () => {
+  it('refuses any origin that is not the configured one — a lookalike host, or our host on another scheme', () => {
     expect(isShowableMediaUrl('https://evil.example.com/pixel.png')).toBe(false);
     expect(isShowableMediaUrl('https://other-project.supabase.co/storage/v1/object/public/media/a.png')).toBe(false);
+    // Qui l'origine configurata è https, quindi http sullo stesso host è un'ALTRA origine. Il
+    // motivo del rifiuto è quello, non «http è vietato»: su un self-host configurato in http lo
+    // storage è http e deve passare — lo fissa chat-media.selfhost.test.ts. Non riscrivere questa
+    // riga come un divieto di schema: tornerebbe a rompere il self-host.
     expect(isShowableMediaUrl(`${HOST.replace('https', 'http')}/storage/v1/object/public/media/a.png`)).toBe(false);
     // Nostro host ma non uno storage path: l'API del progetto non è un media.
     expect(isShowableMediaUrl(`${HOST}/rest/v1/posts?select=*`)).toBe(false);

--- a/src/lib/chat-media.ts
+++ b/src/lib/chat-media.ts
@@ -10,8 +10,10 @@
  * letto una pagina web, o ricevuto l'output di un tool esterno, ha in mano stringhe che non ha
  * scelto lui: incorporarle significa far caricare al browser dell'utente una risorsa scelta da
  * terzi — nel caso benigno un pixel di tracciamento con IP e referrer. Quindi si mostra solo
- * quello che è NOSTRO: lo storage del progetto, `/storage/v1/object/...` sull'host di questo
- * progetto Supabase (pubblico o firmato, è lo stesso host). Tutto il resto si rifiuta, e
+ * quello che è NOSTRO: lo storage del progetto, `/storage/v1/object/...` sull'ORIGINE con cui
+ * questo progetto Supabase è configurato — schema compreso, perché un self-host servito in http
+ * ha quello come unico storage che esiste, e su un deployment pubblico l'origine è https e http
+ * resta rifiutato da solo (pubblico o firmato, è la stessa origine). Tutto il resto si rifiuta, e
  * all'agente si dice cosa fare invece — pubblicarlo come artefatto, che scarica i byte da noi.
  *
  * E non ci si fida dell'estensione per decidere se una cosa è sicura: l'estensione decide solo
@@ -32,21 +34,20 @@ export type ChatMediaItem = {
 /** Oltre questo un blocco non è più "guarda questo", è una galleria: il posto è la libreria. */
 export const MAX_CHAT_MEDIA = 8;
 
-const OWN_HOST = (() => {
+const OWN_ORIGIN = (() => {
   try {
-    return new URL(publicEnv.PUBLIC_SUPABASE_URL).host;
+    return new URL(publicEnv.PUBLIC_SUPABASE_URL).origin;
   } catch {
     return '';
   }
 })();
 
-/** Viene da noi? Host dello storage del progetto + un percorso di storage, e nient'altro. */
+/** Viene da noi? L'ORIGINE configurata dello storage + un percorso di storage, e nient'altro. */
 export function isOwnMediaUrl(url: unknown): boolean {
   if (typeof url !== 'string' || !url) return false;
   try {
     const u = new URL(url);
-    if (u.protocol !== 'https:') return false;
-    if (!OWN_HOST || u.host !== OWN_HOST) return false;
+    if (!OWN_ORIGIN || u.origin !== OWN_ORIGIN) return false;
     return u.pathname.startsWith('/storage/v1/object/');
   } catch {
     return false;


### PR DESCRIPTION
## What?

`isOwnMediaUrl` now compares the whole configured storage **origin** instead of deriving the host from `PUBLIC_SUPABASE_URL` and hardcoding `https` beside it.

This commit was written for #386 and pushed about seven minutes after that PR was merged, so it never reached `dev`. Nothing else from #386 is missing — only this.

## Why?

The old rule was wrong in **both** directions at once:

- **Too strict.** A self-hosted instance served over plain `http` (the local Docker stack defaults to `http://localhost:8000`) had every media rejected, because its only storage *is* http. This repo ships a self-host path, so that is a real deployment, not a hypothetical.
- **Too loose.** `https://<our host>` was *accepted* even when the configured origin was `http://<our host>`, because the scheme was never compared against configuration at all — only asserted to be `https`. An origin that is not the configured one was passing.

On a public deployment `PUBLIC_SUPABASE_URL` is `https`, so `http` stays refused exactly as before. Nothing is relaxed there; the rule simply follows configuration in both halves instead of one.

## How?

One comparison replaces two. `new URL(PUBLIC_SUPABASE_URL).origin` versus `new URL(url).origin`, and the storage-path check is unchanged.

`isOwnMediaUrl` is shared by the chat media embed and, since #386, by the post-media ZIP download, so both pick this up. The file's docblock now says why the scheme comes from configuration rather than from a literal.

## Testing?

**Red first, both halves.** `src/lib/chat-media.selfhost.test.ts` mocks `PUBLIC_SUPABASE_URL` to `http://localhost:8000` and asserts that the configured origin is accepted while every other one is refused — including `https://localhost:8000`, which is the case that exposed the "too loose" half. Both assertions failed before the change; the second failed with `expected false, received true`.

`chat-media.test.ts:44` asserted "http is refused", which was an indirect way of saying "not our origin" and stopped being true once configuration decides the scheme. It now asserts what actually governs, with the reason written beside it and a pointer to the self-host test, so the next reader does not restore a scheme ban and break self-host again.

Suite on this branch: `chat-media`, `chat-media.selfhost`, `chat-markdown`, `download-post-media`, `query-tool` — 72 passed. `query-tool` is green here because this branch is cut from current `dev`, which has #383.

## Evidence

<details>
<summary>Red before — the "too loose" half</summary>

```
 ❯ src/lib/chat-media.selfhost.test.ts:21
     expect(isShowableMediaUrl('https://localhost:8000/storage/v1/object/public/media/a.png'))

- false
+ true
```

With `PUBLIC_SUPABASE_URL = http://localhost:8000`, an https origin on the same host was treated as ours.
</details>

## Anything Else?

Cut from current `dev` (`79dee5bc`), so it carries #383 and CI has no unrelated red. No overlap with #388, which touches different files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
