### PR TITLE
Add insert_row and update_row, the write side of query

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -1571,3 +1571,37 @@ e un `with check` che ne nomina una sola. Il worker poi legge la seconda per `id
 E dove nessun percorso legittimo scrive quella coda col client dell'utente (`webhook_deliveries`: le
 uniche scritture sono l'ingress di Composio e il cron, tutte e due con `createAdminClient()`), il
 `revoke insert, update` toglie il problema invece di controllarlo.
+
+## Un errore di scrittura non ha lo stesso codice del suo gemello in lettura
+
+**Segnale.** Un ripiego copiato dal codice di lettura non scatta mai: il caso che doveva coprire
+arriva, e il tool risponde con l'errore grezzo invece che col rimedio. Qui: `insert_row` doveva
+riprovare senza `brand_id` sulle tabelle che non ce l'hanno, la condizione era `code === '42703'`
+copiata da `query`, e ogni insert su `profiles` moriva dicendo «la colonna brand_id non esiste».
+
+**Cosa succede.** PostgREST risolve i nomi di colonna in due posti diversi. In un **filtro** li
+manda a Postgres, che risponde **42703**. Nel **corpo di una scrittura** li cerca nella propria
+schema cache, e risponde **PGRST204** (`Could not find the 'x' column of 'y' in the schema cache`)
+senza aver mai interrogato il database. Sono lo stesso fatto per chi scrive il codice e due codici
+diversi sul filo, e il secondo non esiste affatto nel percorso di lettura da cui si copia.
+
+**La mossa.** La domanda «questa tabella ha quella colonna?» si scrive **una volta sola**, in una
+funzione che accetta entrambi i codici. Scritta due volte diverge alla prima, e diverge in silenzio:
+il ramo mai preso non fallisce, semplicemente non c'è. E il caso si prova col codice VERO — un client
+finto risponde quello che gli si dice, quindi un test scritto sul codice sbagliato è verde per
+costruzione.
+
+## `head: true` su una richiesta PostgREST si porta via anche il corpo dell'errore
+
+**Segnale.** Un rifiuto che non si riconosce: `{"error":"db_error","message":""}`, senza codice e
+senza testo, su una chiamata che poco prima funzionava.
+
+**Cosa succede.** `select('*', { count: 'exact', head: true })` è la forma ovvia per contare senza
+trasferire righe — PostgREST manda un `HEAD` e il conteggio sta in `Content-Range`. Ma un `HEAD`
+**non ha corpo**, e il corpo è dove PostgREST mette `{code, message, details, hint}` quando la
+richiesta fallisce: `supabase-js` consegna un errore con tutti i campi vuoti. Il conteggio riesce
+benissimo; è il fallimento a diventare muto, quindi la sonda sembra corretta finché tutto va bene.
+
+**La mossa.** Contare con `count: 'exact'` e `.limit(1)`. Una riga di traffico è il prezzo di un
+messaggio d'errore leggibile, e un rifiuto anonimo costa molto di più: non si riconosce, quindi non
+si spiega, quindi il giro dopo è identico al primo.

--- a/changelog/2026-09-06-generic-write.md
+++ b/changelog/2026-09-06-generic-write.md
@@ -1,0 +1,139 @@
+# `insert_row` e `update_row`: `query` girato, con i confini che la scrittura richiede in più
+
+`query` legge qualunque tabella coi permessi dell'utente. La coda infinita delle scritture aveva lo
+stesso problema e nessuna risposta: una riga in una tabella senza tool restava irraggiungibile, e la
+lista dei tool cresceva di un `add_*` alla volta.
+
+## Perché due tool e non uno
+
+Un solo `write(op: 'insert' | 'update')` è la forma ovvia, e non può dire la verità. `destructiveHint`
+è un'annotazione **per tool** (`cli/mcp/tools/brand-content.ts`, `destructiveHint: endpoint.destructive`)
+e il protocollo non sa esprimere «distruttivo solo quando `op = update`». Restano due scelte, e
+mentono entrambe: marcato distruttivo avvisa anche sugli insert — che non tolgono niente a nessuno —
+e la gente impara a cliccare via l'avviso; marcato non distruttivo tace proprio sugli update, che
+sostituiscono valori che c'erano. È l'argomento di `docs/mcp-tools.md` §3, misurato su `ads_action`,
+e non dipende da come è scritta una descrizione.
+
+Due tool riportano l'annotazione a dire il vero su entrambi (`insert_row` false, `update_row` true) e
+rimettono il verbo nel **nome**, che è da dove un modello sceglie prima di leggere qualunque schema.
+
+## I confini, e perché sono più stretti della lettura
+
+- **Niente delete, niente SQL, niente `.rpc()`.** Come per `query` non è un controllo: è che la forma
+  non esiste. Un test legge il sorgente e verifica che il modulo non nomini `.delete(`, `.rpc(`,
+  `.upsert(`. Le tredici cancellazioni restano tool espliciti dove si vedono.
+- **Niente upsert, ed è una decisione, non una dimenticanza.** `LESSONS.md` racconta le due facce di
+  un `onConflict` sbagliato: o non scrive niente (42P10 che supabase-js *risolve* invece di rigettare
+  — `competitors` riportava successo scrivendo zero righe), o **sovrascrive** una riga che c'era,
+  quando la coppia unica vera è diversa da quella che hai in testa. La prima faccia si chiude
+  verificando la chiave contro `pg_indexes`. La seconda no: la chiave può essere reale e non essere
+  quella che intendevi, e allora l'insert diventa una sostituzione — cioè esattamente ciò che
+  `destructiveHint: false` su `insert_row` giurerebbe di non fare. Il giro in più (23505 che nomina
+  il vincolo, poi `update_row` su quelle colonne) rende la sostituzione **scelta** invece che
+  scoperta.
+- **Il brand si impone, e uno sbagliato è un rifiuto.** `query` aggiunge il filtro quando manca. Qui
+  un `brand_id` diverso da quello della conversazione **non viene corretto**: correggerlo direbbe
+  «fatto» a chi credeva di scrivere altrove, ed è un errore che si scopre solo rileggendo la tabella.
+- **`where` obbligatorio e tetto a 50 righe, contate PRIMA di scrivere.** Un update senza filtro è la
+  cancellazione appena vietata, travestita. PostgREST non sa mettere un `LIMIT` su un update, quindi
+  il tetto o vive nel conteggio o non esiste. Il conteggio è anche l'unico modo di distinguere «zero
+  righe» da «scritto»: un update che non trova niente risponde 200 con l'array vuoto.
+
+## Gli errori: il registro generato dalle migrazioni
+
+Uno SQLSTATE nudo è un giro sprecato. `packages/api-contracts/src/write-rules.ts` è generato dallo
+stesso script che genera l'elenco delle tabelle, e porta due cose che l'errore non dice:
+
+- **`TABLE_CHECKS`** — 81 vincoli con la loro espressione, quindi un 23514 risponde
+  `Constraint products_url_check allows only: url ~ '^https?://'` invece del nome secco.
+- **`WRITABLE_COLUMNS`** — i grant per colonna su `profiles`, `organizations`, `brands`, quindi un
+  42501 da grant elenca cosa si può scrivere davvero. E il 42501 **da RLS** ha un messaggio diverso:
+  sono due cause che si scrivono uguali e si riparano al contrario, e sceglierne una a caso manda il
+  modello a riprovare dove non c'è niente da riprovare.
+
+`scripts/privilege-harness.mjs` tiene il registro onesto contro il **catalogo vero**: ogni nome di
+vincolo deve esistere in `pg_constraint`, e le colonne dichiarate devono essere esattamente quelle di
+`information_schema.column_privileges`. Un registro generato dalle migrazioni e mai confrontato col
+database è una speranza scritta in TypeScript.
+
+## La semantica dell'update parziale, provata invece che data per buona
+
+`update_brand_kit` mandava tutte le colonne con `?? null`, quindi `{category: "bakery"}` scriveva
+NULL sopra ciò che il brand dice di sé, del suo pubblico e del suo stile — con `ok: true` e nessuno
+schermo. Un update PostgREST parziale tocca solo le colonne inviate, e questo lavoro **non lo
+assume**: l'harness scrive una riga di `brand_kit` con quattro campi, ne cambia uno da
+`authenticated`, e rilegge gli altri tre.
+
+## Due difetti che solo il browser ha trovato
+
+La suite era verde su entrambi, e su entrambi era verde perché il client finto rispondeva quello che
+gli avevo detto io.
+
+1. **PostgREST non risponde 42703 a una colonna inesistente in scrittura: risponde `PGRST204`.** Il
+   ripiego «questa tabella non ha `brand_id`, riprova senza» conosceva solo il primo codice, quindi
+   ogni insert su una tabella senza `brand_id` moriva dicendo che `brand_id` non esiste — vero e
+   inutile. La regola ora vive in un posto solo (`missesBrandColumn`).
+2. **`head: true` sul conteggio si porta via il corpo dell'errore.** Senza corpo supabase-js
+   consegna `{ message: '', code: undefined }`, e ogni update su una tabella senza `brand_id`
+   rispondeva `{"error":"db_error","message":""}`. Un rifiuto che non si riconosce è peggio di uno
+   SQLSTATE nudo. Il conteggio ora chiede una riga: è il prezzo del messaggio.
+
+## Il peso
+
+Misurato sul transport (`tools/list` dopo `initialize`), non sui sorgenti:
+
+| | caratteri | tool |
+|---|---|---|
+| `dev` | 109.837 | 119 |
+| con `insert_row` e `update_row` | 112.789 | 121 |
+
+**+2.952.** I due tool non si portano dietro l'enum delle 149 tabelle che `query` ha: là costa ~2.700
+caratteri e li vale, perché una lettura si scopre indovinando un nome, mentre chi sta per scrivere ha
+appena letto — e la descrizione rimanda a `query` per l'elenco. Il rientro è il censimento qui sotto.
+
+## Il censimento dei 71 handler di scrittura
+
+Aperti tutti. La domanda per ognuno: **cosa fa l'handler oltre a scrivere la riga?**
+
+**Quattro sono `insert`/`update` di una riga e nient'altro — 3.794 caratteri:**
+
+| tool | l'handler, per intero |
+|---|---|
+| `create_product` | `insert({ brand_id, ...input })` |
+| `update_product` | `updateBrandRow` → `.update(patch).eq('id').eq('brand_id')` |
+| `update_person` | idem |
+| `update_competitor` | idem, più il prefisso `https://` sul sito — che è **già** un CHECK (`competitors_website_check: website ~ '^https?://'`), quindi la regola non sparisce: smette di essere indovinata. `example.com` oggi diventa in silenzio un URL che nessuno ha scritto; con `update_row` viene rifiutato con il vincolo e il suo pattern |
+
+Toglierli è una decisione separata, e questa PR non li toglie: quando atterra, `tools/list` scende
+sotto il numero di partenza.
+
+**Quelli che sembrano CRUD e non lo sono — il motivo, per ognuno:**
+
+| tool | cosa si perderebbe |
+|---|---|
+| `add_competitor` | scrive `source: 'user'`. Il default della colonna è `'ai'`: una riga generica registrerebbe come «trovato dall'AI» un concorrente aggiunto da una persona, e non se ne accorge nessuno |
+| `set_colors` | mette il `#` mancante e valida l'esadecimale. `brand_kit_json_shape` controlla solo che sia un array |
+| `add_blog_term` | deriva lo `slug` (slugify con strip degli accenti) e sceglie fra tre tabelle |
+| `save_brief` | trova il piano `status='active'`, poi rimpiazza `weeks[i]` dentro l'array intero |
+| `add_note`, `delete_document` | `rebuildBrandContext` — sintesi col modello |
+| `add_person` | le colonne del consenso derivate; con `kind: 'ai'` genera prima le immagini |
+| `update_brand_kit` | seconda tabella (`brands.content_prefs`) più il rebuild del contesto |
+| `update_voice`, `set_blog_settings`, `set_brand_settings`, `set_media_model`, `set_radar_platform` | **leggono-fondono-riscrivono una colonna jsonb**. Un `update_row` su `content_prefs` cancellerebbe quello che le altre feature ci hanno messo dentro |
+| `set_appearance` | scarica il logo con la guardia SSRF e lo mette nello storage |
+| `set_bio` | risolve la riga da `(brand, platform)`: l'id non ce l'ha chi chiama |
+| `save_memory` | `detectConflict` può **rifiutare** una scrittura che contraddice un fatto messo da una persona; rinforza invece di duplicare |
+| `record_memory_used` | è una `rpc` che incrementa in modo atomico: leggere-sommare-riscrivere perde colpi |
+| `create_share` | lo `snapshot` È la feature, e il token si conia e non si salva mai in chiaro |
+| `add_radar_source` | tetto per piano sul numero di sorgenti, che nessun vincolo del database porta |
+| `set_automation` | `enabled: true` **cancella** la riga, `false` la scrive |
+| `create_post`, `edit_post`, `reschedule_post`, `reorder_slides`, `render_post` | slot dal fuso del brand, `content_type` dedotto, revisioni, apprendimento della voce dal diff, e il giro su Zernio |
+| `import_media_url` | fetch con guardia SSRF e upload: la riga è la ricevuta |
+| `save_plan` | prima retrocede il piano `proposed` esistente, poi inserisce |
+| `save_week_seeds` | conia gli id dei seed e normalizza i formati |
+| `update_article` | transizione di stato derivata da `scheduled_for`, e la seconda tabella dei tag |
+| tutti i `generate_*`, `*_action`, `publish_*`, `optimize_*`, `refine_media`, `produce_week` | `gateAiAction`, il modello, o un servizio esterno |
+| `create_checkout_link`, `create_billing_portal_link` | Stripe |
+
+`discard_plan` e `unpublish_article` **sono** update secchi, ma sono marcati distruttivi e restano
+per la stessa ragione delle cancellazioni: un verbo che disfa qualcosa tiene il proprio nome, dove
+si vede.

--- a/changelog/2026-09-06-generic-write.md
+++ b/changelog/2026-09-06-generic-write.md
@@ -84,10 +84,10 @@ Misurato sul transport (`tools/list` dopo `initialize`), non sui sorgenti:
 
 | | caratteri | tool |
 |---|---|---|
-| `dev` | 109.837 | 119 |
-| con `insert_row` e `update_row` | 112.789 | 121 |
+| `dev` | 91.163 | 86 |
+| con `insert_row` e `update_row` | 94.215 | 88 |
 
-**+2.952.** I due tool non si portano dietro l'enum delle 149 tabelle che `query` ha: là costa ~2.700
+**+3.052.** I due tool non si portano dietro l'enum delle 149 tabelle che `query` ha: là costa ~2.700
 caratteri e li vale, perché una lettura si scopre indovinando un nome, mentre chi sta per scrivere ha
 appena letto — e la descrizione rimanda a `query` per l'elenco. Il rientro è il censimento qui sotto.
 

--- a/cli/lib/contracts/index.ts
+++ b/cli/lib/contracts/index.ts
@@ -14,6 +14,7 @@ import {
 } from './articles';
 import { CHECK_CONTENT } from './content';
 import { QUERY_DATABASE } from './query';
+import { INSERT_ROW, UPDATE_ROW } from './write';
 import { GET_CREATION_KIT } from './creation-kit';
 import {
   APPROVE_PLAN,
@@ -173,6 +174,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   GET_MEDIA_MODELS,
   GET_WRITING_SKILLS,
   IMPORT_MEDIA_URL,
+  INSERT_ROW,
   MAKE_VIDEO,
   OPTIMIZE_ARTICLE,
   PLAN_WEEK,
@@ -215,6 +217,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   UPDATE_COMPETITOR,
   UPDATE_PERSON,
   UPDATE_PRODUCT,
+  UPDATE_ROW,
   UPDATE_VOICE,
 ];
 
@@ -442,3 +445,5 @@ export {
 export type { SavePlanInput, SavePlanResult, SaveWeekSeedsInput, SaveWeekSeedsResult } from './plans';
 export type { CreateProductInput, CreateProductResult } from './studio';
 export type { CreateShareInput, CreateShareResult, SharedViewType } from './shares';
+export { INSERT_ROW, UPDATE_ROW, UPDATE_MAX_ROWS } from './write';
+export { TABLE_CHECKS, WRITABLE_COLUMNS } from './write-rules';

--- a/cli/lib/contracts/write-rules.ts
+++ b/cli/lib/contracts/write-rules.ts
@@ -1,0 +1,138 @@
+/**
+ * GENERATO — non si modifica a mano: `node scripts/query-tables-from-migrations.mjs --write`.
+ *
+ * Le due risposte che uno SQLSTATE nudo non dà a chi scrive: quali valori un CHECK ammette (23514)
+ * e quali colonne un grant lascia scrivere (42501). Vengono dalle migrazioni, come l'elenco delle
+ * tabelle, e per la stessa ragione. `write-tool.test.ts` rigenera e confronta: una migrazione che
+ * aggiunge un vincolo o stringe un grant fa fallire il test finché questo file non è rigenerato,
+ * e l'agente non si trova davanti a un rifiuto che nessuno sa spiegare.
+ */
+export const TABLE_CHECKS: Record<string, string> = {
+  "agent_templates_avatar_face_check": "avatar_face is null or avatar_face in ( 'wide', 'dot', 'wink', 'sleepy', 'squint', 'curious', 'smile', 'grin', 'happy', 'laugh', 'sad', 'visor', 'focus', 'surprise' )",
+  "benchmark_runs_kind_check": "kind in ('live', 'golden', 'market')",
+  "brand_app_connections_status_check": "status in ('active', 'pending', 'error', 'disconnected')",
+  "brand_articles_cover_image_check": "cover_image ~ '^https?://'",
+  "brand_articles_slug_check": "slug ~ '^[a-z0-9-]+$' and length(slug) <= 200",
+  "brand_articles_source_check": "source in ('plan', 'radar', 'seo', 'ai', 'manual')",
+  "brand_articles_status_check": "status in ('planned', 'draft', 'approved', 'published')",
+  "brand_articles_text_len": "length(body_md) <= 500000 and length(meta_title) <= 300 and length(meta_description) <= 1000 and length(language) <= 60",
+  "brand_articles_title_check": "btrim(title) <> '' and length(title) <= 500",
+  "brand_articles_version_seq_check": "version_seq >= 0",
+  "brand_documents_kind_check": "kind in ('note', 'document', 'image', 'plan')",
+  "brand_documents_status_check": "status in ('pending','processing','ready','failed')",
+  "brand_kit_favicon_url_check": "favicon_url ~ '^(https?://|data:)'",
+  "brand_kit_json_shape": "jsonb_typeof(brand_colors) = 'array' and jsonb_typeof(logos) = 'array' and jsonb_typeof(fonts) = 'array' and jsonb_typeof(images) = 'array' and jsonb_typeof(content_pillars) = 'array' and jsonb_typeof(ai_character) = 'object' and jsonb_typeof(graphic_style) = 'object'",
+  "brand_kit_site_type_check": "site_type in ( 'ecommerce', 'saas', 'portfolio', 'local_service', 'creator', 'media', 'mobile_app', 'service', 'generic' )",
+  "brand_kit_source_url_check": "source_url ~ '^https?://'",
+  "brand_kit_text_len": "length(category) <= 200 and length(about) <= 20000 and length(brand_style) <= 5000 and length(target_audience) <= 5000 and length(visual_style) <= 50000 and length(ai_context) <= 200000",
+  "brand_kit_theme_color_check": "theme_color ~ '^#[0-9a-fA-F]{3,8}$'",
+  "brand_media_catalog_status_check": "catalog_status in ('pending', 'ready', 'failed')",
+  "brand_media_source_check": "source = any (array['upload','chat_drop','shoot','generate','remotion_export','post_render','website_capture','agent'])",
+  "brand_memory_category_check": "category in ('voice', 'constraint', 'fact', 'preference', 'insight', 'skill')",
+  "brand_memory_counters_check": "times_reinforced >= 0 and times_used >= 0",
+  "brand_memory_importance_check": "importance between 1 and 5",
+  "brand_memory_key_check": "btrim(key) <> '' and length(key) <= 200",
+  "brand_memory_session_scope": "layer <> 'session' or thread_id is not null",
+  "brand_memory_value_check": "btrim(value) <> '' and length(value) <= 50000",
+  "brand_news_sources_kind_check": "kind in ('gnews_query', 'rss', 'subreddit', 'threads_query', 'x_community', 'reddit_query', 'linkedin_query')",
+  "brand_news_sources_lang_check": "lang ~ '^[A-Za-z-]{2,5}$'",
+  "brand_news_sources_value_check": "btrim(value) <> '' and length(value) <= 500",
+  "brand_sites_host_check": "host ~ '^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$' and length(host) <= 253",
+  "brands_chat_default_tier_check": "chat_default_tier is null or chat_default_tier ~ '^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._:-]*$'",
+  "chat_jobs_status_check": "status in ('pending', 'running', 'done', 'failed', 'cancelled')",
+  "chat_messages_feedback_check": "feedback in (-1, 1)",
+  "competitors_json_shape": "jsonb_typeof(handles) = 'array' and jsonb_typeof(top_posts) = 'array' and jsonb_typeof(top_ads) = 'array' and jsonb_typeof(benchmark) = 'object'",
+  "competitors_name_check": "btrim(name) <> '' and length(name) <= 300",
+  "competitors_rationale_len": "length(rationale) <= 20000",
+  "competitors_website_check": "website ~ '^https?://'",
+  "content_plans_editorial_week_check": "editorial_week >= 0 and editorial_week <= 52",
+  "content_plans_seeds_shape": "jsonb_typeof(seeds) = 'object'",
+  "content_plans_source_check": "source in ('manual', 'manual_single', 'manual_trigger', 'scheduled_cron', 'radar')",
+  "content_plans_status_check": "status in ('draft', 'proposed', 'produced')",
+  "content_plans_title_len": "length(title) <= 300",
+  "content_quality_samples_anchored": "post_id is not null or run_id is not null",
+  "credit_grants_one_target": "(brand_id is null) <> (org_id is null)",
+  "custom_agent_schedules_avatar_color_chk": "avatar_color is null or avatar_color ~ '^#[0-9a-f]{6}$'",
+  "custom_agent_schedules_avatar_face_chk": "avatar_face is null or avatar_face in ( 'wide', 'dot', 'wink', 'sleepy', 'squint', 'curious', 'smile', 'grin', 'happy', 'laugh', 'sad', 'visor', 'focus', 'surprise' )",
+  "custom_agent_schedules_days": "cardinality(days_of_week) between 1 and 7 and days_of_week <@ array[0, 1, 2, 3, 4, 5, 6]::smallint[]",
+  "custom_agent_schedules_name_len": "char_length(btrim(name)) between 1 and 80",
+  "custom_agent_schedules_prompt_len": "char_length(btrim(prompt)) between 1 and 8000",
+  "custom_agent_schedules_times_len": "cardinality(times) between 1 and 12",
+  "custom_agents_avatar_color_chk": "avatar_color is null or avatar_color ~ '^#[0-9a-f]{6}$'",
+  "custom_agents_avatar_face_chk": "avatar_face is null or avatar_face in ('wide', 'dot', 'wink', 'sleepy', 'smile', 'happy', 'visor', 'surprise')",
+  "custom_agents_name_len": "char_length(btrim(name)) between 1 and 80",
+  "custom_agents_prompt_len": "char_length(btrim(prompt)) between 1 and 8000",
+  "editorial_plans_source_check": "source = any (array['onboarding','revision','rollover','manual','analytics_review','autopilot'])",
+  "gtm_plans_horizon_check": "horizon in ('90d', '6m')",
+  "gtm_plans_source_check": "source = any (array['manual','revision','phase_review','onboarding','analytics_review','autopilot'])",
+  "onboarding_step_jobs_kind_check": "kind in ('competitors', 'research', 'plan_posts', 'preview_images')",
+  "people_consent_source_check": "consent_source in ('owner_attested', 'ai_generated', 'legacy_assumed', 'import_unattested')",
+  "people_images_shape": "jsonb_typeof(images) = 'array'",
+  "people_name_check": "btrim(name) <> '' and length(name) <= 200",
+  "people_text_len": "length(role) <= 200 and length(description) <= 20000",
+  "posts_content_type_check": "content_type in ( 'generated_image', 'generated_video', 'generated_graphic', 'uploaded_image', 'uploaded_video', 'text', 'link' )",
+  "posts_media_url_check": "media_url ~ '^https?://'",
+  "posts_media_urls_shape": "jsonb_typeof(media_urls) = 'array'",
+  "posts_revisions_count_check": "revisions_count >= 0",
+  "posts_source_check": "source in ('plan', 'manual', 'radar', 'guest_preview', 'cross_post', 'founder', 'external')",
+  "posts_status_check": "status in ('pending_user', 'approved', 'scheduled', 'published', 'failed')",
+  "posts_text_len": "length(caption) <= 10000 and length(title) <= 500 and length(image_prompt) <= 20000 and length(first_comment) <= 5000 and length(slot) <= 100 and length(pillar) <= 500 and length(angle) <= 1000 and length(format) <= 60 and length(attention_reason) <= 2000 and length(campaign_name) <= 200 and length(campaign_step) <= 200 and length(product_name) <= 500 and length(subreddit) <= 100",
+  "posts_video_duration_check": "video_duration_seconds > 0 and video_duration_seconds <= 3600",
+  "posts_video_render_status_check": "video_render_status in ('rendering', 'done', 'failed')",
+  "posts_video_resolution_check": "video_resolution ~ '^[0-9]{3,4}p$'",
+  "products_images_shape": "jsonb_typeof(images) = 'array'",
+  "products_text_len": "length(description) <= 50000 and length(pricing) <= 200 and length(external_id) <= 200 and length(kind) <= 200",
+  "products_title_check": "btrim(title) <> '' and length(title) <= 500",
+  "products_url_check": "url ~ '^https?://'",
+  "referral_codes_code_format": "code ~ '^[a-z0-9]{6,12}$'",
+  "shared_views_view_type_check": "view_type in ('calendar', 'dashboard', 'monthly_report', 'strategy', 'workspace')",
+  "talents_body_type_check": "body_type is null or body_type in ('slim', 'athletic', 'athletic_slim', 'average', 'curvy', 'plus', 'muscular')",
+  "talents_gender_check": "gender is null or gender in ('man', 'woman', 'trans_man', 'trans_woman', 'nonbinary')",
+  "talents_height_band_check": "height_band is null or height_band in ('short', 'average', 'tall')"
+};
+
+export const WRITABLE_COLUMNS: Record<string, { insert: string[]; update: string[] }> = {
+  "brands": {
+    "insert": [
+      "id",
+      "org_id",
+      "created_by",
+      "name",
+      "website",
+      "slug",
+      "target_platforms",
+      "content_prefs",
+      "onboarding_completed_at"
+    ],
+    "update": [
+      "name",
+      "website",
+      "timezone",
+      "target_platforms",
+      "content_prefs",
+      "ads_settings",
+      "chat_default_tier",
+      "launched_at",
+      "setup_step",
+      "setup_completed_at",
+      "onboarding_state",
+      "onboarding_completed_at",
+      "own_history_at"
+    ]
+  },
+  "organizations": {
+    "insert": [
+      "name",
+      "owner_id"
+    ],
+    "update": []
+  },
+  "profiles": {
+    "insert": [],
+    "update": [
+      "full_name",
+      "avatar_url",
+      "locale"
+    ]
+  }
+};

--- a/cli/lib/contracts/write.ts
+++ b/cli/lib/contracts/write.ts
@@ -1,0 +1,113 @@
+import { z } from 'zod';
+import type { BrandEndpoint } from './index';
+import { QUERY_OPS } from './query';
+
+/**
+ * Il tetto sulle righe che UN update può toccare. Non è una preferenza: un update senza filtro è
+ * la cancellazione che questo tool non espone, travestita, e un filtro largo la riproduce da capo.
+ * Le righe si contano PRIMA di scrivere, quindi il tetto morde invece di essere una speranza.
+ */
+export const UPDATE_MAX_ROWS = 50;
+
+const Filter = z.object({
+  column: z.string().describe('A bare column name'),
+  op: z.enum(QUERY_OPS),
+  value: z.union([z.string(), z.number(), z.boolean(), z.null(), z.array(z.union([z.string(), z.number()]))]),
+  negate: z.boolean().optional().describe('Invert this one filter: `is null` becomes `is not null`')
+});
+
+/**
+ * `values` è di forma libera perché lo sono le tabelle: un `z.record` invece di un oggetto
+ * tipizzato è la stessa scelta che `query` fa per le righe che restituisce, e per lo stesso motivo.
+ * Chi sbaglia una colonna non lo scopre da qui ma dall'errore, che gliela elenca.
+ */
+const Values = z
+  .record(z.string(), z.unknown())
+  .describe('Column name → value. Only the columns you name are written.');
+
+/**
+ * QUI IL VERBO STA NEL NOME, E NON È ESTETICA.
+ *
+ * `destructiveHint` è un'annotazione PER TOOL — `destructiveHint: endpoint.destructive` in
+ * `cli/mcp/tools/brand-content.ts` — e il protocollo non sa dire «distruttivo solo quando
+ * `op = update`». Un solo `write(op: 'insert' | 'update')` avrebbe quindi due sole scelte, e
+ * mentono entrambe: marcato distruttivo avvisa anche sugli insert, che non tolgono niente a
+ * nessuno, e la gente impara a cliccare via l'avviso; marcato non distruttivo tace proprio sugli
+ * update, che sostituiscono valori che c'erano. `docs/mcp-tools.md` §3 lo dimostra su `ads_action`.
+ *
+ * Due tool riportano l'annotazione a dire il vero su entrambi, e in più rimettono il verbo dove un
+ * modello sceglie davvero: il nome, che legge PRIMA di aprire qualunque schema.
+ */
+export const INSERT_ROW = {
+  tool: 'insert_row',
+  title: 'Insert a row',
+  description:
+    'Add ONE row to any table, AS YOU: anon key plus your own session, so Postgres RLS decides ' +
+    'whether that row may exist at all — there is no way to write into a brand you do not belong ' +
+    'to. Table names are the ones `query` takes: call `query` with no `table` to list them, and ' +
+    'with only a `table` to get a real row back, whose keys are the columns you can name here. ' +
+    '`brand_id` is filled in with this brand for you; naming a different one is refused, not ' +
+    'quietly corrected. It NEVER replaces anything: a row that already exists comes back as a ' +
+    'collision that names the key you hit, and changing it is `update_row`. Use it for the things ' +
+    'that have no tool of their own — an idea, a note, a row in a table nothing else writes. ' +
+    'Free, and nothing is published.',
+  method: 'POST',
+  pathUnderBrand: '/rows',
+  input: z
+    .object({
+      table: z.string().describe('Table name, bare. The same names `query` reads.'),
+      values: Values
+    })
+    .strict(),
+  output: z.object({
+    table: z.string().optional(),
+    row: z.record(z.string(), z.unknown()).optional(),
+    inserted: z.number().optional(),
+    note: z.string().optional(),
+    error: z.string().optional(),
+    message: z.string().optional(),
+    fix: z.string().optional(),
+    columns_available: z.array(z.string()).optional()
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const UPDATE_ROW = {
+  tool: 'update_row',
+  title: 'Update rows',
+  description:
+    'Change columns on rows that ALREADY EXIST, as you. ONLY the columns you send are touched — ' +
+    'the rest of the row is left exactly as it was, so a partial change is safe by construction ' +
+    'and you never have to resend fields you are not changing. `where` is REQUIRED and may not be ' +
+    'empty: an update with no filter rewrites every row you can reach. At most ' +
+    `${UPDATE_MAX_ROWS} rows per call, counted BEFORE anything is written and reported back to ` +
+    'you. THE OLD VALUES ARE GONE — read the rows with `query` first when you are not certain ' +
+    'which ones you are about to hit. It cannot delete a row: deleting has its own named tools. ' +
+    'Free.',
+  method: 'PUT',
+  pathUnderBrand: '/rows',
+  input: z
+    .object({
+      table: z.string().describe('Table name, bare. The same names `query` reads.'),
+      where: z
+        .array(Filter)
+        .min(1, 'where may not be empty: an update with no filter rewrites every row of the table')
+        .describe('Filters, ANDed. Required: without one this would rewrite the whole table.'),
+      values: Values
+    })
+    .strict(),
+  output: z.object({
+    table: z.string().optional(),
+    rows: z.array(z.record(z.string(), z.unknown())).optional(),
+    updated: z.number().optional(),
+    matched: z.number().optional(),
+    note: z.string().optional(),
+    error: z.string().optional(),
+    message: z.string().optional(),
+    fix: z.string().optional(),
+    columns_available: z.array(z.string()).optional()
+  }),
+  failures: [],
+  destructive: true
+} satisfies BrandEndpoint;

--- a/cli/mcp/tool-surface-cost.test.ts
+++ b/cli/mcp/tool-surface-cost.test.ts
@@ -4,8 +4,16 @@ import { handleMcpFetch } from './http-app.ts';
 /**
  * `tools/list` si paga a ogni sessione, come le istruzioni del handshake, e nessuno lo guardava:
  * misurato sul transport vero era 129.212 caratteri — circa 32.300 token prima che l'agente
- * chieda qualunque cosa. Oggi sono 109.837, e il tetto lascia il margine di qualche tool nuovo:
+ * chieda qualunque cosa. Oggi sono 112.789, e il tetto lascia il margine di qualche tool nuovo:
  * quando lo sfonda, la superficie va guardata di nuovo invece di crescere in silenzio.
+ *
+ * I 2.952 in più sono `insert_row` e `update_row`, e il conto va detto per intero perché il tetto
+ * da solo lo nasconde: NON portano via l'enum delle 149 tabelle che `query` si porta dietro — lì
+ * costa 2.700 caratteri e li vale, perché una lettura si scopre indovinando il nome, mentre chi
+ * sta per scrivere ha appena letto. Il rientro è il censimento dei 71 handler di scrittura, che
+ * ne trova quattro — `create_product`, `update_product`, `update_person`, `update_competitor`,
+ * 3.794 caratteri — che sono `insert`/`update` di una riga e nient'altro. Toglierli è una
+ * decisione separata: quando atterra, questo numero scende sotto quello di partenza.
  *
  * Si misura il TRANSPORT, non i sorgenti: il conto dei sorgenti ha già sbagliato due volte,
  * perché lo schema JSON che il protocollo spedisce non somiglia allo zod da cui nasce. E si misura

--- a/cli/mcp/tool-surface-cost.test.ts
+++ b/cli/mcp/tool-surface-cost.test.ts
@@ -4,23 +4,25 @@ import { handleMcpFetch } from './http-app.ts';
 /**
  * `tools/list` si paga a ogni sessione, come le istruzioni del handshake, e nessuno lo guardava:
  * misurato sul transport vero era 129.212 caratteri — circa 32.300 token prima che l'agente
- * chieda qualunque cosa. Oggi sono 112.789, e il tetto lascia il margine di qualche tool nuovo:
- * quando lo sfonda, la superficie va guardata di nuovo invece di crescere in silenzio.
+ * chieda qualunque cosa. Oggi sono 94.215, e il tetto lascia il margine di qualche tool nuovo:
+ * quando lo sfonda, la superficie va guardata di nuovo invece di crescere in silenzio. E scende
+ * insieme al numero, o smette di essere una guardia: 19.000 caratteri di margine non fermano nulla.
  *
- * I 2.952 in più sono `insert_row` e `update_row`, e il conto va detto per intero perché il tetto
- * da solo lo nasconde: NON portano via l'enum delle 149 tabelle che `query` si porta dietro — lì
- * costa 2.700 caratteri e li vale, perché una lettura si scopre indovinando il nome, mentre chi
- * sta per scrivere ha appena letto. Il rientro è il censimento dei 71 handler di scrittura, che
- * ne trova quattro — `create_product`, `update_product`, `update_person`, `update_competitor`,
- * 3.794 caratteri — che sono `insert`/`update` di una riga e nient'altro. Toglierli è una
- * decisione separata: quando atterra, questo numero scende sotto quello di partenza.
+ * I 3.052 in più rispetto a `dev` (91.163) sono `insert_row` e `update_row`, e il conto va detto
+ * per intero perché il tetto da solo lo nasconde: NON portano via l'enum delle 149 tabelle che
+ * `query` si porta dietro — lì costa ~2.700 caratteri e li vale, perché una lettura si scopre
+ * indovinando il nome, mentre chi sta per scrivere ha appena letto. Il rientro è il censimento dei
+ * 71 handler di scrittura, che ne trova quattro — `create_product`, `update_product`,
+ * `update_person`, `update_competitor`, 3.794 caratteri — che sono `insert`/`update` di una riga e
+ * nient'altro. Toglierli è una decisione separata: quando atterra, questo numero scende sotto
+ * quello di partenza.
  *
  * Si misura il TRANSPORT, non i sorgenti: il conto dei sorgenti ha già sbagliato due volte,
  * perché lo schema JSON che il protocollo spedisce non somiglia allo zod da cui nasce. E si misura
  * `result` intero, wrapper `{"tools":…}` compreso: contare il solo array dà 10 caratteri in meno,
  * ed è la differenza esatta fra due conteggi che sembravano in disaccordo.
  */
-const TOOLS_LIST_MAX_CHARS = 113_000;
+const TOOLS_LIST_MAX_CHARS = 97_000;
 
 async function listedTools(): Promise<{ tools: Array<Record<string, unknown>>; chars: number }> {
   const post = (body: unknown) =>

--- a/cli/plugins/anomalia/skills/anomalia/SKILL.md
+++ b/cli/plugins/anomalia/skills/anomalia/SKILL.md
@@ -129,6 +129,15 @@ Nine tools remain, and not one of them is a select. Reach for them by subject:
 `get_creation_kit`, `get_gsc`, `get_ads` (campaign fatigue), `get_media_models`.
 Anything else you remember calling is now a `query`.
 
+**A row in a table nothing else writes** → `insert_row` and `update_row`, `query` turned around.
+`insert_row({table, values})` adds one row and fills in `brand_id` for you; a row that already
+exists comes back naming the key you hit instead of replacing it. `update_row({table, where,
+values})` touches **only the columns you send** and leaves the rest of the row alone, needs a
+`where` that is never empty, and moves at most 50 rows a call — counted before writing, so
+"nothing matched" is a refusal and not a quiet success. Neither can delete: deleting has its own
+named tools. Prefer a named write when one exists — those also derive a field, attribute a source
+or set off the side effect that the bare row does not carry.
+
 **Ask what this brand already knows** → `search_knowledge` with the question. It reads the brand's
 own uploaded documents and returns the passages that answer it, each with the document it came
 from — not the whole corpus. Empty `hits` is not "the brand does not know": count the embedded

--- a/cli/plugins/anomalia/skills/anomalia/references/tools.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/tools.md
@@ -101,6 +101,38 @@ Nine reads are NOT a query, because not one of them is a select: `list_brands`, 
 `diagnose_radar`, `search_knowledge`, `get_writing_skills`, `get_creation_kit`, `get_gsc`,
 `get_ads` and `get_media_models`. Each has its own section below. Anything else you remember
 calling is a `query`.
+### Writing a row that has no tool of its own
+
+| MCP | CLI |
+|-----|-----|
+| `insert_row` | (MCP only) |
+| `update_row` | (MCP only) |
+
+`insert_row` and `update_row` are `query` turned around: the same session, the same tables, the
+same absence of SQL — and the same consequence, that what they cannot express does not happen.
+There is no delete here and no upsert. **Deleting keeps its own named tools**, because a wrong read
+hands you wrong rows while a wrong write takes yours away.
+
+`insert_row({ table, values })` adds one row. `brand_id` is filled in with the brand you are on;
+naming a different one is refused rather than quietly corrected. It never replaces anything: a row
+that is already there comes back as a collision naming the key you hit, and changing it is the
+other tool.
+
+`update_row({ table, where, values })` changes rows that exist. **Only the columns you send are
+touched** — everything else in the row is left exactly as it was, so you never resend a field you
+are not changing, and you cannot blank one by omitting it. `where` is required and may not be
+empty, at most 50 rows move per call, and the rows are counted before anything is written, so
+"nothing matched" comes back as a refusal instead of a cheerful success.
+
+Both refuse with `200` and an `error`, `message` and `fix` you can act on: a rejected value is
+answered with the constraint AND the values it admits, a collision with the key you hit, a denial
+with the columns this session may actually write. Read the row with `query` first when you are not
+sure what you are about to overwrite — the old values do not come back.
+
+Prefer a named tool when one exists. The named ones do more than the row: they derive a field,
+attribute a source, kick a side effect. `add_competitor` records that a person added it and not
+the AI; `add_note` rebuilds the brand context; `create_post` computes the slot from the calendar
+date and the brand timezone. Reach for these two when nothing else covers the table.
 
 ## Brand & posts
 

--- a/cli/skills/anomalia/SKILL.md
+++ b/cli/skills/anomalia/SKILL.md
@@ -129,6 +129,15 @@ Nine tools remain, and not one of them is a select. Reach for them by subject:
 `get_creation_kit`, `get_gsc`, `get_ads` (campaign fatigue), `get_media_models`.
 Anything else you remember calling is now a `query`.
 
+**A row in a table nothing else writes** → `insert_row` and `update_row`, `query` turned around.
+`insert_row({table, values})` adds one row and fills in `brand_id` for you; a row that already
+exists comes back naming the key you hit instead of replacing it. `update_row({table, where,
+values})` touches **only the columns you send** and leaves the rest of the row alone, needs a
+`where` that is never empty, and moves at most 50 rows a call — counted before writing, so
+"nothing matched" is a refusal and not a quiet success. Neither can delete: deleting has its own
+named tools. Prefer a named write when one exists — those also derive a field, attribute a source
+or set off the side effect that the bare row does not carry.
+
 **Ask what this brand already knows** → `search_knowledge` with the question. It reads the brand's
 own uploaded documents and returns the passages that answer it, each with the document it came
 from — not the whole corpus. Empty `hits` is not "the brand does not know": count the embedded

--- a/cli/skills/anomalia/references/tools.md
+++ b/cli/skills/anomalia/references/tools.md
@@ -101,6 +101,38 @@ Nine reads are NOT a query, because not one of them is a select: `list_brands`, 
 `diagnose_radar`, `search_knowledge`, `get_writing_skills`, `get_creation_kit`, `get_gsc`,
 `get_ads` and `get_media_models`. Each has its own section below. Anything else you remember
 calling is a `query`.
+### Writing a row that has no tool of its own
+
+| MCP | CLI |
+|-----|-----|
+| `insert_row` | (MCP only) |
+| `update_row` | (MCP only) |
+
+`insert_row` and `update_row` are `query` turned around: the same session, the same tables, the
+same absence of SQL — and the same consequence, that what they cannot express does not happen.
+There is no delete here and no upsert. **Deleting keeps its own named tools**, because a wrong read
+hands you wrong rows while a wrong write takes yours away.
+
+`insert_row({ table, values })` adds one row. `brand_id` is filled in with the brand you are on;
+naming a different one is refused rather than quietly corrected. It never replaces anything: a row
+that is already there comes back as a collision naming the key you hit, and changing it is the
+other tool.
+
+`update_row({ table, where, values })` changes rows that exist. **Only the columns you send are
+touched** — everything else in the row is left exactly as it was, so you never resend a field you
+are not changing, and you cannot blank one by omitting it. `where` is required and may not be
+empty, at most 50 rows move per call, and the rows are counted before anything is written, so
+"nothing matched" comes back as a refusal instead of a cheerful success.
+
+Both refuse with `200` and an `error`, `message` and `fix` you can act on: a rejected value is
+answered with the constraint AND the values it admits, a collision with the key you hit, a denial
+with the columns this session may actually write. Read the row with `query` first when you are not
+sure what you are about to overwrite — the old values do not come back.
+
+Prefer a named tool when one exists. The named ones do more than the row: they derive a field,
+attribute a source, kick a side effect. `add_competitor` records that a person added it and not
+the AI; `add_note` rebuilds the brand context; `create_post` computes the slot from the calendar
+date and the brand timezone. Reach for these two when nothing else covers the table.
 
 ## Brand & posts
 

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -451,6 +451,33 @@ raggruppare», enuncia il costo — *«un agente che cerca "aggiungi un concorre
 righe dopo propone di pagarlo: *«le sei famiglie CRUD diventano `*_action`»*. È la ragione per cui
 il piano è stato scritto e mai eseguito.
 
+#### L'eccezione che è stata poi costruita, e che non contraddice quanto segue
+
+Il piano ritirato era «le sei famiglie CRUD diventano `competitor_action(op)`, `person_action(op)`,
+…». Quello resta ritirato, e i due argomenti qui sotto restano il perché.
+
+Ciò che è stato costruito è un'altra cosa: **`insert_row` e `update_row`**, la primitiva generica
+che sta a `query` come la scrittura sta alla lettura. Non collassa una famiglia dentro un enum —
+collassa il *livello*, che è la mossa di Supabase con `execute_sql`. E supera entrambi gli argomenti
+invece di aggirarli:
+
+- **`destructiveHint` torna a dire il vero**, perché i tool sono due e non uno. `insert_row` aggiunge
+  una riga e non toglie niente (`false`); `update_row` sostituisce valori che c'erano (`true`). Un
+  `write(op: 'insert' | 'update')` avrebbe avuto il difetto identico di `ads_action` — ed è
+  esattamente per questo che non esiste.
+- **Il verbo resta nel nome**, che è da dove un modello sceglie prima di aprire uno schema. Nessuna
+  capacità sparisce dentro un enum: c'è un nome per creare e un nome per modificare.
+
+E si ferma dove l'asimmetria comincia: **nessun delete, nessun upsert**. Le tredici cancellazioni
+tengono il proprio nome, per la regola in fondo a questo documento; l'upsert è escluso perché un
+insert che *può* sostituire rimette dentro esattamente la bugia che i due tool tolgono.
+
+Il censimento che l'ha accompagnato — aperti tutti i 71 handler del registro — conferma i verdetti
+qui sotto e ne aggiunge quattro: `create_product`, `update_product`, `update_person`,
+`update_competitor` sono un `insert`/`update` di una riga e nient'altro. Sono i soli quattro su 71,
+e valgono 3.794 caratteri contro i 2.952 che i due tool aggiungono a `tools/list`. Il motivo per
+ognuno degli altri sta in `changelog/2026-09-06-generic-write.md`.
+
 #### Primo argomento: collassare distrugge `destructiveHint`, e questo non è opinabile
 
 L'annotazione è **per tool** — `destructiveHint: endpoint.destructive` in

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -475,7 +475,7 @@ insert che *può* sostituire rimette dentro esattamente la bugia che i due tool 
 Il censimento che l'ha accompagnato — aperti tutti i 71 handler del registro — conferma i verdetti
 qui sotto e ne aggiunge quattro: `create_product`, `update_product`, `update_person`,
 `update_competitor` sono un `insert`/`update` di una riga e nient'altro. Sono i soli quattro su 71,
-e valgono 3.794 caratteri contro i 2.952 che i due tool aggiungono a `tools/list`. Il motivo per
+e valgono 3.794 caratteri contro i 3.052 che i due tool aggiungono a `tools/list`. Il motivo per
 ognuno degli altri sta in `changelog/2026-09-06-generic-write.md`.
 
 #### Primo argomento: collassare distrugge `destructiveHint`, e questo non è opinabile

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -14,6 +14,7 @@ import {
 } from './articles';
 import { CHECK_CONTENT } from './content';
 import { QUERY_DATABASE } from './query';
+import { INSERT_ROW, UPDATE_ROW } from './write';
 import { GET_CREATION_KIT } from './creation-kit';
 import {
   APPROVE_PLAN,
@@ -173,6 +174,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   GET_MEDIA_MODELS,
   GET_WRITING_SKILLS,
   IMPORT_MEDIA_URL,
+  INSERT_ROW,
   MAKE_VIDEO,
   OPTIMIZE_ARTICLE,
   PLAN_WEEK,
@@ -215,6 +217,7 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   UPDATE_COMPETITOR,
   UPDATE_PERSON,
   UPDATE_PRODUCT,
+  UPDATE_ROW,
   UPDATE_VOICE,
 ];
 
@@ -442,3 +445,5 @@ export {
 export type { SavePlanInput, SavePlanResult, SaveWeekSeedsInput, SaveWeekSeedsResult } from './plans';
 export type { CreateProductInput, CreateProductResult } from './studio';
 export type { CreateShareInput, CreateShareResult, SharedViewType } from './shares';
+export { INSERT_ROW, UPDATE_ROW, UPDATE_MAX_ROWS } from './write';
+export { TABLE_CHECKS, WRITABLE_COLUMNS } from './write-rules';

--- a/packages/api-contracts/src/write-rules.ts
+++ b/packages/api-contracts/src/write-rules.ts
@@ -1,0 +1,138 @@
+/**
+ * GENERATO — non si modifica a mano: `node scripts/query-tables-from-migrations.mjs --write`.
+ *
+ * Le due risposte che uno SQLSTATE nudo non dà a chi scrive: quali valori un CHECK ammette (23514)
+ * e quali colonne un grant lascia scrivere (42501). Vengono dalle migrazioni, come l'elenco delle
+ * tabelle, e per la stessa ragione. `write-tool.test.ts` rigenera e confronta: una migrazione che
+ * aggiunge un vincolo o stringe un grant fa fallire il test finché questo file non è rigenerato,
+ * e l'agente non si trova davanti a un rifiuto che nessuno sa spiegare.
+ */
+export const TABLE_CHECKS: Record<string, string> = {
+  "agent_templates_avatar_face_check": "avatar_face is null or avatar_face in ( 'wide', 'dot', 'wink', 'sleepy', 'squint', 'curious', 'smile', 'grin', 'happy', 'laugh', 'sad', 'visor', 'focus', 'surprise' )",
+  "benchmark_runs_kind_check": "kind in ('live', 'golden', 'market')",
+  "brand_app_connections_status_check": "status in ('active', 'pending', 'error', 'disconnected')",
+  "brand_articles_cover_image_check": "cover_image ~ '^https?://'",
+  "brand_articles_slug_check": "slug ~ '^[a-z0-9-]+$' and length(slug) <= 200",
+  "brand_articles_source_check": "source in ('plan', 'radar', 'seo', 'ai', 'manual')",
+  "brand_articles_status_check": "status in ('planned', 'draft', 'approved', 'published')",
+  "brand_articles_text_len": "length(body_md) <= 500000 and length(meta_title) <= 300 and length(meta_description) <= 1000 and length(language) <= 60",
+  "brand_articles_title_check": "btrim(title) <> '' and length(title) <= 500",
+  "brand_articles_version_seq_check": "version_seq >= 0",
+  "brand_documents_kind_check": "kind in ('note', 'document', 'image', 'plan')",
+  "brand_documents_status_check": "status in ('pending','processing','ready','failed')",
+  "brand_kit_favicon_url_check": "favicon_url ~ '^(https?://|data:)'",
+  "brand_kit_json_shape": "jsonb_typeof(brand_colors) = 'array' and jsonb_typeof(logos) = 'array' and jsonb_typeof(fonts) = 'array' and jsonb_typeof(images) = 'array' and jsonb_typeof(content_pillars) = 'array' and jsonb_typeof(ai_character) = 'object' and jsonb_typeof(graphic_style) = 'object'",
+  "brand_kit_site_type_check": "site_type in ( 'ecommerce', 'saas', 'portfolio', 'local_service', 'creator', 'media', 'mobile_app', 'service', 'generic' )",
+  "brand_kit_source_url_check": "source_url ~ '^https?://'",
+  "brand_kit_text_len": "length(category) <= 200 and length(about) <= 20000 and length(brand_style) <= 5000 and length(target_audience) <= 5000 and length(visual_style) <= 50000 and length(ai_context) <= 200000",
+  "brand_kit_theme_color_check": "theme_color ~ '^#[0-9a-fA-F]{3,8}$'",
+  "brand_media_catalog_status_check": "catalog_status in ('pending', 'ready', 'failed')",
+  "brand_media_source_check": "source = any (array['upload','chat_drop','shoot','generate','remotion_export','post_render','website_capture','agent'])",
+  "brand_memory_category_check": "category in ('voice', 'constraint', 'fact', 'preference', 'insight', 'skill')",
+  "brand_memory_counters_check": "times_reinforced >= 0 and times_used >= 0",
+  "brand_memory_importance_check": "importance between 1 and 5",
+  "brand_memory_key_check": "btrim(key) <> '' and length(key) <= 200",
+  "brand_memory_session_scope": "layer <> 'session' or thread_id is not null",
+  "brand_memory_value_check": "btrim(value) <> '' and length(value) <= 50000",
+  "brand_news_sources_kind_check": "kind in ('gnews_query', 'rss', 'subreddit', 'threads_query', 'x_community', 'reddit_query', 'linkedin_query')",
+  "brand_news_sources_lang_check": "lang ~ '^[A-Za-z-]{2,5}$'",
+  "brand_news_sources_value_check": "btrim(value) <> '' and length(value) <= 500",
+  "brand_sites_host_check": "host ~ '^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$' and length(host) <= 253",
+  "brands_chat_default_tier_check": "chat_default_tier is null or chat_default_tier ~ '^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._:-]*$'",
+  "chat_jobs_status_check": "status in ('pending', 'running', 'done', 'failed', 'cancelled')",
+  "chat_messages_feedback_check": "feedback in (-1, 1)",
+  "competitors_json_shape": "jsonb_typeof(handles) = 'array' and jsonb_typeof(top_posts) = 'array' and jsonb_typeof(top_ads) = 'array' and jsonb_typeof(benchmark) = 'object'",
+  "competitors_name_check": "btrim(name) <> '' and length(name) <= 300",
+  "competitors_rationale_len": "length(rationale) <= 20000",
+  "competitors_website_check": "website ~ '^https?://'",
+  "content_plans_editorial_week_check": "editorial_week >= 0 and editorial_week <= 52",
+  "content_plans_seeds_shape": "jsonb_typeof(seeds) = 'object'",
+  "content_plans_source_check": "source in ('manual', 'manual_single', 'manual_trigger', 'scheduled_cron', 'radar')",
+  "content_plans_status_check": "status in ('draft', 'proposed', 'produced')",
+  "content_plans_title_len": "length(title) <= 300",
+  "content_quality_samples_anchored": "post_id is not null or run_id is not null",
+  "credit_grants_one_target": "(brand_id is null) <> (org_id is null)",
+  "custom_agent_schedules_avatar_color_chk": "avatar_color is null or avatar_color ~ '^#[0-9a-f]{6}$'",
+  "custom_agent_schedules_avatar_face_chk": "avatar_face is null or avatar_face in ( 'wide', 'dot', 'wink', 'sleepy', 'squint', 'curious', 'smile', 'grin', 'happy', 'laugh', 'sad', 'visor', 'focus', 'surprise' )",
+  "custom_agent_schedules_days": "cardinality(days_of_week) between 1 and 7 and days_of_week <@ array[0, 1, 2, 3, 4, 5, 6]::smallint[]",
+  "custom_agent_schedules_name_len": "char_length(btrim(name)) between 1 and 80",
+  "custom_agent_schedules_prompt_len": "char_length(btrim(prompt)) between 1 and 8000",
+  "custom_agent_schedules_times_len": "cardinality(times) between 1 and 12",
+  "custom_agents_avatar_color_chk": "avatar_color is null or avatar_color ~ '^#[0-9a-f]{6}$'",
+  "custom_agents_avatar_face_chk": "avatar_face is null or avatar_face in ('wide', 'dot', 'wink', 'sleepy', 'smile', 'happy', 'visor', 'surprise')",
+  "custom_agents_name_len": "char_length(btrim(name)) between 1 and 80",
+  "custom_agents_prompt_len": "char_length(btrim(prompt)) between 1 and 8000",
+  "editorial_plans_source_check": "source = any (array['onboarding','revision','rollover','manual','analytics_review','autopilot'])",
+  "gtm_plans_horizon_check": "horizon in ('90d', '6m')",
+  "gtm_plans_source_check": "source = any (array['manual','revision','phase_review','onboarding','analytics_review','autopilot'])",
+  "onboarding_step_jobs_kind_check": "kind in ('competitors', 'research', 'plan_posts', 'preview_images')",
+  "people_consent_source_check": "consent_source in ('owner_attested', 'ai_generated', 'legacy_assumed', 'import_unattested')",
+  "people_images_shape": "jsonb_typeof(images) = 'array'",
+  "people_name_check": "btrim(name) <> '' and length(name) <= 200",
+  "people_text_len": "length(role) <= 200 and length(description) <= 20000",
+  "posts_content_type_check": "content_type in ( 'generated_image', 'generated_video', 'generated_graphic', 'uploaded_image', 'uploaded_video', 'text', 'link' )",
+  "posts_media_url_check": "media_url ~ '^https?://'",
+  "posts_media_urls_shape": "jsonb_typeof(media_urls) = 'array'",
+  "posts_revisions_count_check": "revisions_count >= 0",
+  "posts_source_check": "source in ('plan', 'manual', 'radar', 'guest_preview', 'cross_post', 'founder', 'external')",
+  "posts_status_check": "status in ('pending_user', 'approved', 'scheduled', 'published', 'failed')",
+  "posts_text_len": "length(caption) <= 10000 and length(title) <= 500 and length(image_prompt) <= 20000 and length(first_comment) <= 5000 and length(slot) <= 100 and length(pillar) <= 500 and length(angle) <= 1000 and length(format) <= 60 and length(attention_reason) <= 2000 and length(campaign_name) <= 200 and length(campaign_step) <= 200 and length(product_name) <= 500 and length(subreddit) <= 100",
+  "posts_video_duration_check": "video_duration_seconds > 0 and video_duration_seconds <= 3600",
+  "posts_video_render_status_check": "video_render_status in ('rendering', 'done', 'failed')",
+  "posts_video_resolution_check": "video_resolution ~ '^[0-9]{3,4}p$'",
+  "products_images_shape": "jsonb_typeof(images) = 'array'",
+  "products_text_len": "length(description) <= 50000 and length(pricing) <= 200 and length(external_id) <= 200 and length(kind) <= 200",
+  "products_title_check": "btrim(title) <> '' and length(title) <= 500",
+  "products_url_check": "url ~ '^https?://'",
+  "referral_codes_code_format": "code ~ '^[a-z0-9]{6,12}$'",
+  "shared_views_view_type_check": "view_type in ('calendar', 'dashboard', 'monthly_report', 'strategy', 'workspace')",
+  "talents_body_type_check": "body_type is null or body_type in ('slim', 'athletic', 'athletic_slim', 'average', 'curvy', 'plus', 'muscular')",
+  "talents_gender_check": "gender is null or gender in ('man', 'woman', 'trans_man', 'trans_woman', 'nonbinary')",
+  "talents_height_band_check": "height_band is null or height_band in ('short', 'average', 'tall')"
+};
+
+export const WRITABLE_COLUMNS: Record<string, { insert: string[]; update: string[] }> = {
+  "brands": {
+    "insert": [
+      "id",
+      "org_id",
+      "created_by",
+      "name",
+      "website",
+      "slug",
+      "target_platforms",
+      "content_prefs",
+      "onboarding_completed_at"
+    ],
+    "update": [
+      "name",
+      "website",
+      "timezone",
+      "target_platforms",
+      "content_prefs",
+      "ads_settings",
+      "chat_default_tier",
+      "launched_at",
+      "setup_step",
+      "setup_completed_at",
+      "onboarding_state",
+      "onboarding_completed_at",
+      "own_history_at"
+    ]
+  },
+  "organizations": {
+    "insert": [
+      "name",
+      "owner_id"
+    ],
+    "update": []
+  },
+  "profiles": {
+    "insert": [],
+    "update": [
+      "full_name",
+      "avatar_url",
+      "locale"
+    ]
+  }
+};

--- a/packages/api-contracts/src/write.ts
+++ b/packages/api-contracts/src/write.ts
@@ -1,0 +1,113 @@
+import { z } from 'zod';
+import type { BrandEndpoint } from './index';
+import { QUERY_OPS } from './query';
+
+/**
+ * Il tetto sulle righe che UN update può toccare. Non è una preferenza: un update senza filtro è
+ * la cancellazione che questo tool non espone, travestita, e un filtro largo la riproduce da capo.
+ * Le righe si contano PRIMA di scrivere, quindi il tetto morde invece di essere una speranza.
+ */
+export const UPDATE_MAX_ROWS = 50;
+
+const Filter = z.object({
+  column: z.string().describe('A bare column name'),
+  op: z.enum(QUERY_OPS),
+  value: z.union([z.string(), z.number(), z.boolean(), z.null(), z.array(z.union([z.string(), z.number()]))]),
+  negate: z.boolean().optional().describe('Invert this one filter: `is null` becomes `is not null`')
+});
+
+/**
+ * `values` è di forma libera perché lo sono le tabelle: un `z.record` invece di un oggetto
+ * tipizzato è la stessa scelta che `query` fa per le righe che restituisce, e per lo stesso motivo.
+ * Chi sbaglia una colonna non lo scopre da qui ma dall'errore, che gliela elenca.
+ */
+const Values = z
+  .record(z.string(), z.unknown())
+  .describe('Column name → value. Only the columns you name are written.');
+
+/**
+ * QUI IL VERBO STA NEL NOME, E NON È ESTETICA.
+ *
+ * `destructiveHint` è un'annotazione PER TOOL — `destructiveHint: endpoint.destructive` in
+ * `cli/mcp/tools/brand-content.ts` — e il protocollo non sa dire «distruttivo solo quando
+ * `op = update`». Un solo `write(op: 'insert' | 'update')` avrebbe quindi due sole scelte, e
+ * mentono entrambe: marcato distruttivo avvisa anche sugli insert, che non tolgono niente a
+ * nessuno, e la gente impara a cliccare via l'avviso; marcato non distruttivo tace proprio sugli
+ * update, che sostituiscono valori che c'erano. `docs/mcp-tools.md` §3 lo dimostra su `ads_action`.
+ *
+ * Due tool riportano l'annotazione a dire il vero su entrambi, e in più rimettono il verbo dove un
+ * modello sceglie davvero: il nome, che legge PRIMA di aprire qualunque schema.
+ */
+export const INSERT_ROW = {
+  tool: 'insert_row',
+  title: 'Insert a row',
+  description:
+    'Add ONE row to any table, AS YOU: anon key plus your own session, so Postgres RLS decides ' +
+    'whether that row may exist at all — there is no way to write into a brand you do not belong ' +
+    'to. Table names are the ones `query` takes: call `query` with no `table` to list them, and ' +
+    'with only a `table` to get a real row back, whose keys are the columns you can name here. ' +
+    '`brand_id` is filled in with this brand for you; naming a different one is refused, not ' +
+    'quietly corrected. It NEVER replaces anything: a row that already exists comes back as a ' +
+    'collision that names the key you hit, and changing it is `update_row`. Use it for the things ' +
+    'that have no tool of their own — an idea, a note, a row in a table nothing else writes. ' +
+    'Free, and nothing is published.',
+  method: 'POST',
+  pathUnderBrand: '/rows',
+  input: z
+    .object({
+      table: z.string().describe('Table name, bare. The same names `query` reads.'),
+      values: Values
+    })
+    .strict(),
+  output: z.object({
+    table: z.string().optional(),
+    row: z.record(z.string(), z.unknown()).optional(),
+    inserted: z.number().optional(),
+    note: z.string().optional(),
+    error: z.string().optional(),
+    message: z.string().optional(),
+    fix: z.string().optional(),
+    columns_available: z.array(z.string()).optional()
+  }),
+  failures: [],
+  destructive: false
+} satisfies BrandEndpoint;
+
+export const UPDATE_ROW = {
+  tool: 'update_row',
+  title: 'Update rows',
+  description:
+    'Change columns on rows that ALREADY EXIST, as you. ONLY the columns you send are touched — ' +
+    'the rest of the row is left exactly as it was, so a partial change is safe by construction ' +
+    'and you never have to resend fields you are not changing. `where` is REQUIRED and may not be ' +
+    'empty: an update with no filter rewrites every row you can reach. At most ' +
+    `${UPDATE_MAX_ROWS} rows per call, counted BEFORE anything is written and reported back to ` +
+    'you. THE OLD VALUES ARE GONE — read the rows with `query` first when you are not certain ' +
+    'which ones you are about to hit. It cannot delete a row: deleting has its own named tools. ' +
+    'Free.',
+  method: 'PUT',
+  pathUnderBrand: '/rows',
+  input: z
+    .object({
+      table: z.string().describe('Table name, bare. The same names `query` reads.'),
+      where: z
+        .array(Filter)
+        .min(1, 'where may not be empty: an update with no filter rewrites every row of the table')
+        .describe('Filters, ANDed. Required: without one this would rewrite the whole table.'),
+      values: Values
+    })
+    .strict(),
+  output: z.object({
+    table: z.string().optional(),
+    rows: z.array(z.record(z.string(), z.unknown())).optional(),
+    updated: z.number().optional(),
+    matched: z.number().optional(),
+    note: z.string().optional(),
+    error: z.string().optional(),
+    message: z.string().optional(),
+    fix: z.string().optional(),
+    columns_available: z.array(z.string()).optional()
+  }),
+  failures: [],
+  destructive: true
+} satisfies BrandEndpoint;

--- a/scripts/privilege-harness.mjs
+++ b/scripts/privilege-harness.mjs
@@ -40,6 +40,7 @@ const FIX_MIGRATIONS = [
 ];
 
 const UNIQUE_VIOLATION = '23505';
+const CHECK_VIOLATION = '23514';
 
 /**
  * Lo specchio del registro che vive in `20260906120000_external_ids_one_tenant.sql`: la colonna che
@@ -282,6 +283,129 @@ async function externalIdFacts(client, outsiderBrandId) {
   });
 
   await becomesOwner(client);
+
+  return facts;
+}
+
+/**
+ * Il registro generato da cui `insert_row`/`update_row` pescano le loro spiegazioni, confrontato
+ * col CATALOGO VERO. Se divergono, il tool non sbaglia una scrittura: dice al modello «questa
+ * colonna la puoi scrivere» quando non la può scrivere, ed è un rifiuto che nessun giro successivo
+ * risolve. Un registro generato dalle migrazioni e mai confrontato col database è una speranza
+ * scritta in TypeScript.
+ */
+function generatedConstant(source, name) {
+  // `= {`, non la prima graffa: l'annotazione di tipo ne contiene una sua
+  // (`Record<string, { insert: string[] }>`), e chi parte da lì legge il tipo invece del valore.
+  const start = source.indexOf(`export const ${name}`);
+  const open = source.indexOf('= {', start) + 2;
+  let depth = 0;
+
+  for (let i = open; i < source.length; i++) {
+    if (source[i] === '{') depth++;
+    if (source[i] === '}' && --depth === 0) return JSON.parse(source.slice(open, i + 1));
+  }
+
+  throw new Error(`${name} non si legge da write-rules.ts`);
+}
+
+async function writeRegistryFacts(client) {
+  const source = readFileSync(join(MIGRATIONS_DIR, '..', '..', 'packages/api-contracts/src/write-rules.ts'), 'utf8');
+  const checks = generatedConstant(source, 'TABLE_CHECKS');
+  const writable = generatedConstant(source, 'WRITABLE_COLUMNS');
+  const facts = [];
+
+  const { rows: real } = await client.query(
+    `select conname from pg_constraint where contype = 'c' and connamespace = 'public'::regnamespace`
+  );
+  const known = new Set(real.map((r) => r.conname));
+  const invented = Object.keys(checks).filter((name) => !known.has(name));
+  facts.push({
+    what: 'ogni vincolo che il registro spiega esiste davvero nel catalogo',
+    ok: invented.length === 0,
+    got: invented.length ? `inventati: ${invented.join(', ')}` : `${Object.keys(checks).length} nomi`
+  });
+
+  const { rows: grants } = await client.query(
+    `select table_name, lower(privilege_type) as privilege, column_name
+       from information_schema.column_privileges
+      where grantee = 'authenticated' and table_schema = 'public'
+        and privilege_type in ('INSERT', 'UPDATE')
+        and table_name in (select unnest($1::text[]))`,
+    [Object.keys(writable)]
+  );
+
+  for (const [table, declared] of Object.entries(writable)) {
+    for (const privilege of ['insert', 'update']) {
+      const actual = grants
+        .filter((g) => g.table_name === table && g.privilege === privilege)
+        .map((g) => g.column_name)
+        .sort();
+      const said = [...declared[privilege]].sort();
+      facts.push({
+        what: `${table}: le colonne ${privilege} che il registro dichiara sono quelle che il database concede`,
+        ok: actual.join(',') === said.join(','),
+        got: actual.join(',') === said.join(',') ? said.length : `db [${actual}] vs registro [${said}]`
+      });
+    }
+  }
+
+  return facts;
+}
+
+/**
+ * LA SEMANTICA SU CUI POGGIA `update_row`, PROVATA INVECE CHE DATA PER BUONA. `update_brand_kit`
+ * mandava tutte le colonne con `?? null`, quindi `{category: "bakery"}` scriveva NULL sopra ciò che
+ * il brand dice di sé, del suo pubblico e del suo stile — con `ok: true` e nessuno schermo. Un
+ * update parziale tocca solo le colonne inviate: qui si guarda che le altre siano ancora lì.
+ */
+async function partialUpdateFacts(client, brandId) {
+  const facts = [];
+
+  await client.query(
+    `insert into public.brand_kit (brand_id, category, about, target_audience, brand_style)
+     values ($1, 'cafe', 'Chi siamo', 'Chi ci compra', 'Come parliamo')
+     on conflict (brand_id) do update set category = excluded.category, about = excluded.about,
+       target_audience = excluded.target_audience, brand_style = excluded.brand_style`,
+    [brandId]
+  );
+
+  await becomes(client, 'authenticated', OWNER);
+  const partial = await attempt(client, `update public.brand_kit set category = 'bakery' where brand_id = $1`, [
+    brandId
+  ]);
+  await becomesOwner(client);
+
+  const { rows } = await client.query(
+    'select category, about, target_audience, brand_style from public.brand_kit where brand_id = $1',
+    [brandId]
+  );
+  const row = rows[0] ?? {};
+
+  facts.push({
+    what: 'un update parziale non azzera le colonne che non ha nominato',
+    ok:
+      partial.accepted &&
+      row.category === 'bakery' &&
+      row.about === 'Chi siamo' &&
+      row.target_audience === 'Chi ci compra' &&
+      row.brand_style === 'Come parliamo',
+    got: partial.accepted ? JSON.stringify(row) : partial.code
+  });
+
+  await becomes(client, 'authenticated', OWNER);
+  const badUrl = await attempt(
+    client,
+    `insert into public.products (brand_id, title, url) values ($1, 'Espresso', 'example.com')`,
+    [brandId]
+  );
+  await becomesOwner(client);
+
+  facts.push({
+    what: 'il CHECK che il registro spiega è quello che morde davvero',
+    ok: badUrl.code === CHECK_VIOLATION && badUrl.message.includes('products_url_check'),
+    got: badUrl.accepted ? 'accettato' : `${badUrl.code} ${badUrl.message.slice(0, 60)}`
+  });
 
   return facts;
 }
@@ -665,6 +789,8 @@ async function main() {
     facts = facts.concat(await grantFacts(client));
     facts = facts.concat(await externalIdFacts(client, outsiderBrandId));
     facts = facts.concat(await deliveryQueueFacts(client, brandId, outsiderBrandId));
+    facts = facts.concat(await writeRegistryFacts(client));
+    facts = facts.concat(await partialUpdateFacts(client, brandId));
 
     for (const signature of RESTORED_GRANTS) {
       await client.query(`grant execute on function ${signature} to authenticated`);

--- a/scripts/query-tables-from-migrations.mjs
+++ b/scripts/query-tables-from-migrations.mjs
@@ -13,8 +13,14 @@
  * Vale solo `public`: un `create table stripe.subscriptions` non entra, ed è il limite «solo
  * public» applicato dove si genera invece che raccomandato nella descrizione del tool.
  *
+ * LO STESSO ELENCO SERVE ALLA SCRITTURA, e per lei non basta il nome della tabella: quando
+ * Postgres rifiuta, `insert_row` deve poter dire QUALI valori quel vincolo ammette e QUALI colonne
+ * quel ruolo può scrivere, o il modello indovina il giro dopo. Anche quelle due risposte stanno
+ * nelle migrazioni — `check (status in (…))` e `grant insert (…) on … to authenticated` — e da lì
+ * si generano, nello stesso passaggio e con la stessa regola.
+ *
  *   node scripts/query-tables-from-migrations.mjs          # stampa l'elenco
- *   node scripts/query-tables-from-migrations.mjs --write   # riscrive query-tables.ts
+ *   node scripts/query-tables-from-migrations.mjs --write   # riscrive query-tables.ts e write-rules.ts
  */
 import { readFileSync, readdirSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
@@ -23,6 +29,7 @@ import { fileURLToPath } from 'node:url';
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const MIGRATIONS = join(ROOT, 'supabase', 'migrations');
 const GENERATED = join(ROOT, 'packages', 'api-contracts', 'src', 'query-tables.ts');
+const GENERATED_WRITE_RULES = join(ROOT, 'packages', 'api-contracts', 'src', 'write-rules.ts');
 
 const NAME = String.raw`"?[a-z_][a-z0-9_]*"?(?:\s*\.\s*"?[a-z_][a-z0-9_]*"?)?`;
 const STATEMENT = new RegExp(
@@ -117,11 +124,128 @@ ${lines.join('\n')}
 `;
 }
 
+/**
+ * I valori ammessi vivono DENTRO le stringhe — `check (status in ('approved', …))` — quindi qui i
+ * letterali restano e spariscono solo i commenti. L'ordine è quello di `withoutStringLiterals`, e
+ * per la stessa ragione: i commenti sono in italiano e i loro apostrofi non sono letterali.
+ */
+function withoutComments(sql) {
+  return sql.replace(/--[^\n]*/g, '').replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+/**
+ * Le parentesi si contano, non si cercano: `check (media_url ~ '^https?://(a|b)')` chiude la sua
+ * prima parentesi dentro un letterale, e un `.*?\)` pigro taglierebbe l'espressione a metà —
+ * dicendo al modello che sono ammessi valori che non lo sono.
+ */
+function balanced(sql, open) {
+  let depth = 0;
+  let quoted = false;
+
+  for (let i = open; i < sql.length; i++) {
+    const c = sql[i];
+    if (c === "'") quoted = !quoted;
+    if (quoted) continue;
+    if (c === '(') depth++;
+    if (c === ')' && --depth === 0) return sql.slice(open + 1, i);
+  }
+
+  return null;
+}
+
+const CONSTRAINT = /constraint\s+"?([a-z_][a-z0-9_]*)"?\s+check\s*\(/gi;
+const DROP_CONSTRAINT = /drop\s+constraint\s+(?:if\s+exists\s+)?"?([a-z_][a-z0-9_]*)"?/gi;
+
+/** Nome del vincolo → la sua espressione, ripiegata su una riga: è ciò che il 23514 non dice. */
+export function checksFromMigrations(dir = MIGRATIONS) {
+  const files = readdirSync(dir).filter((f) => f.endsWith('.sql')).sort();
+  const checks = new Map();
+
+  for (const file of files) {
+    const sql = withoutComments(readFileSync(join(dir, file), 'utf8'));
+
+    for (const match of sql.matchAll(DROP_CONSTRAINT)) checks.delete(match[1].toLowerCase());
+
+    for (const match of sql.matchAll(CONSTRAINT)) {
+      const body = balanced(sql, match.index + match[0].length - 1);
+      if (body) checks.set(match[1].toLowerCase(), body.replace(/\s+/g, ' ').trim());
+    }
+  }
+
+  return Object.fromEntries([...checks].sort(([a], [b]) => a.localeCompare(b)));
+}
+
+const GRANT = /(grant|revoke)\s+([a-z, ]+?)\s*(?:\(([^)]*)\))?\s+on\s+(?:table\s+)?"?(?:public\.)?"?([a-z_][a-z0-9_]*)"?\s+(?:to|from)\s+([a-z_, ]+)/gi;
+
+/**
+ * Le colonne che `authenticated` può scrivere, per tabella, quando un grant per colonna le
+ * restringe. Una tabella che non compare qui NON è senza permessi: è senza restrizione di colonna,
+ * e il suo 42501 viene dalla RLS — che è una riga sbagliata, non una colonna vietata. Distinguere
+ * i due è tutto il valore di questo elenco: il rimedio è opposto.
+ */
+export function writableColumnsFromMigrations(dir = MIGRATIONS) {
+  const files = readdirSync(dir).filter((f) => f.endsWith('.sql')).sort();
+  const grants = new Map();
+
+  for (const file of files) {
+    const sql = withoutComments(readFileSync(join(dir, file), 'utf8'));
+
+    for (const [, verb, privileges, columns, table, roles] of sql.matchAll(GRANT)) {
+      if (!roles.split(',').some((r) => r.trim().toLowerCase() === 'authenticated')) continue;
+
+      const acts = privileges
+        .split(',')
+        .map((p) => p.trim().toLowerCase())
+        .filter((p) => p === 'insert' || p === 'update');
+      if (!acts.length) continue;
+
+      const entry = grants.get(table.toLowerCase()) ?? { insert: null, update: null };
+      for (const act of acts) {
+        entry[act] =
+          verb.toLowerCase() === 'revoke' || !columns
+            ? null
+            : columns.split(',').map((c) => c.trim().replace(/"/g, '')).filter(Boolean);
+      }
+      grants.set(table.toLowerCase(), entry);
+    }
+  }
+
+  return Object.fromEntries(
+    [...grants]
+      .filter(([, e]) => e.insert || e.update)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([table, e]) => [table, { insert: e.insert ?? [], update: e.update ?? [] }])
+  );
+}
+
+function renderWriteRules(checks, writable) {
+  return `/**
+ * GENERATO — non si modifica a mano: \`node scripts/query-tables-from-migrations.mjs --write\`.
+ *
+ * Le due risposte che uno SQLSTATE nudo non dà a chi scrive: quali valori un CHECK ammette (23514)
+ * e quali colonne un grant lascia scrivere (42501). Vengono dalle migrazioni, come l'elenco delle
+ * tabelle, e per la stessa ragione. \`write-tool.test.ts\` rigenera e confronta: una migrazione che
+ * aggiunge un vincolo o stringe un grant fa fallire il test finché questo file non è rigenerato,
+ * e l'agente non si trova davanti a un rifiuto che nessuno sa spiegare.
+ */
+export const TABLE_CHECKS: Record<string, string> = ${JSON.stringify(checks, null, 2)};
+
+export const WRITABLE_COLUMNS: Record<string, { insert: string[]; update: string[] }> = ${JSON.stringify(writable, null, 2)};
+`;
+}
+
 const tables = tablesFromMigrations();
 
 if (process.argv.includes('--write')) {
+  const checks = checksFromMigrations();
+  const writable = writableColumnsFromMigrations();
+
   writeFileSync(GENERATED, render(tables));
+  writeFileSync(GENERATED_WRITE_RULES, renderWriteRules(checks, writable));
   console.log(`query-tables.ts: ${tables.length} tabelle`);
+  console.log(
+    `write-rules.ts: ${Object.keys(checks).length} vincoli, ${Object.keys(writable).length} tabelle con grant per colonna`
+  );
 } else if (import.meta.url === `file://${process.argv[1]}`) {
   console.log(tables.join('\n'));
 }

--- a/src/lib/content/changelog/2026-09-06-write-any-row.ts
+++ b/src/lib/content/changelog/2026-09-06-write-any-row.ts
@@ -1,0 +1,12 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-06',
+  title: 'Agents can write a row in any table, not only the ones with a tool',
+  items: [
+    'Agents connected over MCP can now add a row to any table with `insert_row` and change one with `update_row`, so a competitor, a note, an idea or a blog term no longer needs a tool of its own.',
+    'A change only touches the fields it sends: editing one detail of your brand kit can no longer blank the rest of it.',
+    'Writing runs with your own permissions, never a shortcut around them, and it can never delete — deleting still has its own named tools.',
+    'A rejected write now says what would be accepted: which values a field allows, which row you collided with, which fields your account may set.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/chat/write-tool.test.ts
+++ b/src/lib/server/chat/write-tool.test.ts
@@ -1,0 +1,379 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createWriteTools,
+  explainWriteError,
+  NO_SESSION_WRITE_ERROR,
+  UPDATE_MAX_ROWS
+} from './write-tool';
+import { markRlsScoped } from '$lib/server/rls-client';
+
+vi.mock('$lib/server/ai-log', () => ({ logAiCall: vi.fn() }));
+
+const SRC = readFileSync(new URL('./write-tool.ts', import.meta.url), 'utf8');
+
+type Step = {
+  rows?: Array<Record<string, unknown>>;
+  count?: number;
+  error?: { code: string; message: string; details?: string | null; hint?: string | null };
+};
+
+type Recorded = {
+  table: string;
+  verb: 'select' | 'insert' | 'update';
+  payload?: Record<string, unknown>;
+  filters: string[][];
+  head?: boolean;
+};
+
+/**
+ * PostgREST finto che risponde una cosa DIVERSA a ogni chiamata: un update ne fa due in uno step
+ * (il conteggio, poi la scrittura), e un client che sa rispondere una cosa sola non saprebbe
+ * distinguere «zero righe corrispondono» da «la scrittura è andata a vuoto».
+ */
+function fakeClient(script: Step[], opts: { authority?: 'user' | 'service' } = {}) {
+  const calls: Recorded[] = [];
+  let i = 0;
+
+  const settle = () => {
+    const step = script[i++] ?? {};
+    return Promise.resolve({
+      data: step.error ? null : (step.rows ?? []),
+      error: step.error ?? null,
+      count: step.count ?? null
+    });
+  };
+
+  const chain = (rec: Recorded) => {
+    calls.push(rec);
+    const b: Record<string, unknown> = {};
+    b.filter = (c: string, op: string, v: string) => {
+      rec.filters.push([c, op, v]);
+      return b;
+    };
+    b.not = (c: string, op: string, v: string) => {
+      rec.filters.push(['not', c, op, v]);
+      return b;
+    };
+    b.eq = (c: string, v: string) => {
+      rec.filters.push([c, 'eq', v]);
+      return b;
+    };
+    b.select = () => b;
+    b.limit = () => b;
+    b.abortSignal = () => settle();
+    b.then = (resolve: (v: unknown) => unknown) => settle().then(resolve);
+    return b;
+  };
+
+  const client = {
+    from: (table: string) => ({
+      select: (_cols: string, options?: { head?: boolean }) =>
+        chain({ table, verb: 'select', filters: [], head: options?.head }),
+      insert: (payload: Record<string, unknown>) => chain({ table, verb: 'insert', payload, filters: [] }),
+      update: (payload: Record<string, unknown>) => chain({ table, verb: 'update', payload, filters: [] })
+    })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+
+  return { calls, client: opts.authority === 'service' ? client : markRlsScoped(client) };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tools = (client: any) => createWriteTools({ supabase: client, brandId: 'b1', userId: 'u1', threadId: 't1' });
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const insert = (client: any, input: Record<string, unknown>): Promise<any> => tools(client).insertRow(input as never);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const update = (client: any, input: Record<string, unknown>): Promise<any> => tools(client).updateRow(input as never);
+
+describe('una cancellazione non è rifiutata: è inesprimibile', () => {
+  it('il modulo non nomina nessun metodo che cancella o che esegue SQL', () => {
+    const body = SRC.slice(SRC.indexOf('export function createWriteTools'));
+    for (const m of ['.delete(', '.rpc(', '.upsert(']) {
+      expect(body).not.toContain(m);
+    }
+  });
+
+  it('un nome di tabella che imita SQL non fa partire nessuna richiesta', async () => {
+    const { client, calls } = fakeClient([]);
+    for (const table of ['posts; delete from posts', 'posts) --', 'rpc/notify_admin_email']) {
+      const out = await insert(client, { table, values: { title: 'x' } });
+      expect(out.error).toBe('not_an_identifier');
+    }
+    expect(calls).toHaveLength(0);
+  });
+
+  it('una colonna che imita SQL non fa partire nessuna richiesta', async () => {
+    const { client, calls } = fakeClient([]);
+    const out = await insert(client, { table: 'products', values: { 'title = x; delete from products': 1 } });
+    expect(out.error).toBe('not_an_identifier');
+    expect(calls).toHaveLength(0);
+  });
+
+  it('una tabella che nessuna migrazione crea non parte', async () => {
+    const { client, calls } = fakeClient([]);
+    const out = await insert(client, { table: 'pg_shadow', values: { x: 1 } });
+    expect(out.error).toBe('unknown_table');
+    expect(calls).toHaveLength(0);
+  });
+});
+
+describe('il cancello: senza i permessi dell utente non si scrive', () => {
+  it('un client service-role viene respinto e non tocca il database', async () => {
+    const { client, calls } = fakeClient([], { authority: 'service' });
+    const out = await insert(client, { table: 'products', values: { title: 'x' } });
+    expect(out.error).toBe(NO_SESSION_WRITE_ERROR.error);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('vale identico per update', async () => {
+    const { client, calls } = fakeClient([], { authority: 'service' });
+    const out = await update(client, {
+      table: 'products',
+      where: [{ column: 'id', op: 'eq', value: 'p1' }],
+      values: { title: 'x' }
+    });
+    expect(out.error).toBe(NO_SESSION_WRITE_ERROR.error);
+    expect(calls).toHaveLength(0);
+  });
+});
+
+describe('il confine del brand in scrittura: si impone, e uno sbagliato è un rifiuto', () => {
+  it('brand_id assente lo mette il server', async () => {
+    const { client, calls } = fakeClient([{ rows: [{ id: 'p1' }] }]);
+    await insert(client, { table: 'products', values: { title: 'Espresso' } });
+    expect(calls[0].payload).toEqual({ title: 'Espresso', brand_id: 'b1' });
+  });
+
+  it('il brand_id di un altro NON viene corretto in silenzio: la riga non parte', async () => {
+    const { client, calls } = fakeClient([]);
+    const out = await insert(client, { table: 'products', values: { title: 'x', brand_id: 'b2' } });
+    expect(out.error).toBe('wrong_brand');
+    expect(calls).toHaveLength(0);
+  });
+
+  it('lo stesso brand esplicito passa, e non si duplica', async () => {
+    const { client, calls } = fakeClient([{ rows: [{ id: 'p1' }] }]);
+    await insert(client, { table: 'products', values: { title: 'x', brand_id: 'b1' } });
+    expect(calls[0].payload).toEqual({ title: 'x', brand_id: 'b1' });
+  });
+
+  /**
+   * PostgREST NON risponde 42703 a un insert su una colonna che non c'è: risponde PGRST204, che è
+   * un'altra cosa e arriva dalla schema cache. Il client finto rispondeva 42703 perché lo diceva
+   * il gemello in lettura, e su `profiles` — la prima tabella senza `brand_id` provata davvero —
+   * la scrittura moriva con «la colonna brand_id non esiste», che è vero e inutile.
+   */
+  it.each([
+    ['42703', 'column "brand_id" of relation "profiles" does not exist'],
+    ['PGRST204', "Could not find the 'brand_id' column of 'profiles' in the schema cache"]
+  ])('una tabella senza brand_id si riprova senza (%s)', async (code, message) => {
+    const { client, calls } = fakeClient([{ error: { code, message } }, { rows: [{ id: 'u1' }] }]);
+    const out = await insert(client, { table: 'profiles', values: { full_name: 'Andrea' } });
+    expect(out.error).toBeUndefined();
+    expect(calls[1].payload).toEqual({ full_name: 'Andrea' });
+  });
+
+  it('update: il filtro sul brand lo aggiunge il server', async () => {
+    const { client, calls } = fakeClient([{ count: 1 }, { rows: [{ id: 'p1' }] }]);
+    await update(client, {
+      table: 'products',
+      where: [{ column: 'id', op: 'eq', value: 'p1' }],
+      values: { title: 'x' }
+    });
+    expect(calls[0].filters).toContainEqual(['brand_id', 'eq', 'b1']);
+    expect(calls[1].filters).toContainEqual(['brand_id', 'eq', 'b1']);
+  });
+});
+
+describe('un update senza filtro è la cancellazione appena vietata, travestita', () => {
+  it('where vuoto è rifiutato e non tocca il database', async () => {
+    const { client, calls } = fakeClient([]);
+    const out = await update(client, { table: 'products', where: [], values: { title: 'x' } });
+    expect(out.error).toBe('where_required');
+    expect(calls).toHaveLength(0);
+  });
+
+  it('le righe si contano PRIMA di scrivere, e oltre il tetto non si scrive', async () => {
+    const { client, calls } = fakeClient([{ count: UPDATE_MAX_ROWS + 1 }]);
+    const out = await update(client, {
+      table: 'posts',
+      where: [{ column: 'status', op: 'eq', value: 'pending_user' }],
+      values: { status: 'approved' }
+    });
+    expect(out.error).toBe('too_many_rows');
+    expect(out.matched).toBe(UPDATE_MAX_ROWS + 1);
+    expect(calls.filter((c) => c.verb === 'update')).toHaveLength(0);
+  });
+
+  /**
+   * Il conteggio NON chiede la testa. Con `head: true` PostgREST non manda un corpo, quindi
+   * quando la richiesta fallisce supabase-js consegna un errore senza codice e senza messaggio:
+   * `{"error":"db_error","message":""}`. Un update su una tabella senza `brand_id` finiva così —
+   * un rifiuto che non dice niente è peggio di uno SQLSTATE nudo, perché nemmeno si riconosce.
+   */
+  it('il conteggio non chiede la testa: senza corpo sparisce anche il messaggio d errore', async () => {
+    const { client, calls } = fakeClient([{ count: 2 }, { rows: [{ id: 'p1' }, { id: 'p2' }] }]);
+    await update(client, {
+      table: 'products',
+      where: [{ column: 'featured', op: 'eq', value: true }],
+      values: { featured: false }
+    });
+    expect(calls[0].verb).toBe('select');
+    expect(calls[0].head).not.toBe(true);
+  });
+
+  it('un update su una tabella senza brand_id perde il filtro imposto, non il messaggio', async () => {
+    const { client, calls } = fakeClient([
+      { error: { code: '42703', message: 'column profiles.brand_id does not exist' } },
+      { count: 1 },
+      { rows: [{ id: 'u1' }] }
+    ]);
+    const out = await update(client, {
+      table: 'profiles',
+      where: [{ column: 'id', op: 'eq', value: 'u1' }],
+      values: { full_name: 'Andrea' }
+    });
+    expect(out.error).toBeUndefined();
+    expect(calls[2].filters).toEqual([['id', 'eq', 'u1']]);
+  });
+
+  /**
+   * `negate` esiste nel gemello in lettura, e un filtro che qui non lo capisse selezionerebbe le
+   * righe SBAGLIATE per una scrittura: `is null` invece di `is not null` è l'insieme complementare.
+   */
+  it('negate su un filtro diventa un .not(), non un filtro qualunque', async () => {
+    const { client, calls } = fakeClient([{ count: 1 }, { rows: [{ id: 'p1' }] }]);
+    await update(client, {
+      table: 'posts',
+      where: [{ column: 'published_at', op: 'is', value: null, negate: true }],
+      values: { status: 'approved' }
+    });
+    expect(calls[0].filters).toContainEqual(['not', 'published_at', 'is', 'null']);
+    expect(calls[1].filters).toContainEqual(['not', 'published_at', 'is', 'null']);
+  });
+
+  it('zero righe corrispondenti non è un successo muto', async () => {
+    const { client } = fakeClient([{ count: 0 }]);
+    const out = await update(client, {
+      table: 'products',
+      where: [{ column: 'id', op: 'eq', value: 'non-esiste' }],
+      values: { title: 'x' }
+    });
+    expect(out.error).toBe('no_rows_matched');
+  });
+});
+
+describe('un update parziale tocca solo le colonne inviate', () => {
+  it('nel payload finisce quello che il chiamante ha mandato, e nientaltro', async () => {
+    const { client, calls } = fakeClient([{ count: 1 }, { rows: [{ id: 'k1' }] }]);
+    await update(client, {
+      table: 'brand_kit',
+      where: [{ column: 'brand_id', op: 'eq', value: 'b1' }],
+      values: { category: 'bakery' }
+    });
+    const write = calls.find((c) => c.verb === 'update');
+    expect(write?.payload).toEqual({ category: 'bakery' });
+    expect(Object.keys(write?.payload ?? {})).toHaveLength(1);
+  });
+
+  it('valori vuoti non sono una scrittura: si rifiuta invece di toccare zero colonne', async () => {
+    const { client, calls } = fakeClient([]);
+    const out = await update(client, {
+      table: 'products',
+      where: [{ column: 'id', op: 'eq', value: 'p1' }],
+      values: {}
+    });
+    expect(out.error).toBe('no_values');
+    expect(calls).toHaveLength(0);
+  });
+});
+
+describe('un rifiuto del database torna utilizzabile, non come uno SQLSTATE nudo', () => {
+  it('23514 nomina il vincolo E i valori che ammette', () => {
+    const fix = explainWriteError(
+      '23514',
+      'new row for relation "posts" violates check constraint "posts_status_check"',
+      null,
+      'posts'
+    );
+    expect(fix).toContain('posts_status_check');
+    expect(fix).toContain('pending_user');
+    expect(fix).toContain('published');
+  });
+
+  it('23505 dice su quale chiave hai colliso e che il rimedio è update_row', () => {
+    const fix = explainWriteError(
+      '23505',
+      'duplicate key value violates unique constraint "products_brand_title_key"',
+      'Key (brand_id, title)=(b1, Espresso) already exists.',
+      'products'
+    );
+    expect(fix).toContain('Key (brand_id, title)');
+    expect(fix).toContain('update_row');
+  });
+
+  it('23505 senza `details` nomina comunque il vincolo: le colonne stanno nel suo nome', () => {
+    const fix = explainWriteError(
+      '23505',
+      'duplicate key value violates unique constraint "brand_news_sources_brand_id_kind_value_key"',
+      null,
+      'brand_news_sources'
+    );
+    expect(fix).toContain('brand_news_sources_brand_id_kind_value_key');
+    expect(fix).toContain('update_row');
+  });
+
+  it('42501 da grant per colonna elenca le colonne davvero scrivibili', () => {
+    const fix = explainWriteError('42501', 'permission denied for table organizations', null, 'organizations');
+    expect(fix).toContain('name');
+    expect(fix).toContain('owner_id');
+    expect(fix).not.toContain('row-level');
+  });
+
+  it('42501 da RLS non parla di colonne: la riga è di un altro', () => {
+    const fix = explainWriteError(
+      '42501',
+      'new row violates row-level security policy for table "posts"',
+      null,
+      'posts'
+    );
+    expect(fix).toContain('RLS');
+    expect(fix).not.toContain('Column grants');
+  });
+
+  it('23502 nomina la colonna obbligatoria che manca', () => {
+    const fix = explainWriteError(
+      '23502',
+      'null value in column "title" of relation "products" violates not-null constraint',
+      null,
+      'products'
+    );
+    expect(fix).toContain('title');
+  });
+});
+
+describe('una colonna inventata si elenca, non si ritenta', () => {
+  it('la scrittura NON si rifà con le colonne vere: solo una lettura si può ritentare', async () => {
+    const { client, calls } = fakeClient([
+      { error: { code: 'PGRST204', message: "Could not find the 'colour' column of 'products' in the schema cache" } },
+      { rows: [{ id: 'p1', title: 'x', pricing: null }] }
+    ]);
+    const out = await insert(client, { table: 'products', values: { colour: 'red' } });
+    expect(out.error).toBe('PGRST204');
+    expect(out.columns_available).toEqual(['id', 'title', 'pricing']);
+    expect(calls.filter((c) => c.verb === 'insert')).toHaveLength(1);
+  });
+});
+
+describe('il registro dei vincoli e dei grant si genera, non si batte a mano', () => {
+  it('rigenerato dalle migrazioni dà lo stesso file', () => {
+    const generated = new URL('../../../../packages/api-contracts/src/write-rules.ts', import.meta.url);
+    const before = readFileSync(generated, 'utf8');
+    execFileSync('node', ['scripts/query-tables-from-migrations.mjs', '--write'], {
+      cwd: new URL('../../../../', import.meta.url).pathname
+    });
+    expect(readFileSync(generated, 'utf8')).toBe(before);
+  });
+});

--- a/src/lib/server/chat/write-tool.ts
+++ b/src/lib/server/chat/write-tool.ts
@@ -1,0 +1,424 @@
+/**
+ * `insert_row` e `update_row` — SCRITTURA DIRETTA DEL DATABASE, COI PERMESSI DELL'UTENTE E DI
+ * NESSUN ALTRO. Il gemello in lettura è `query-tool.ts`, e quasi ogni decisione qui è la sua,
+ * ripresa perché la coppia sia comprensibile a chi ne conosce uno solo.
+ *
+ * 1. LO STESSO CANCELLO, E VALE DI PIÙ. La chiave anon più il JWT dell'utente fa valutare la RLS a
+ *    Postgres: l'agente non può scrivere niente che l'utente non potrebbe scrivere dall'app. Il
+ *    client service-role — coda e percorso a chiave API — è RIFIUTATO, e in scrittura il motivo si
+ *    aggrava: con `bypassrls=true` una riga finirebbe in un brand qualunque, non solo letta.
+ *
+ * 2. LA CANCELLAZIONE NON È RIFIUTATA, È INESPRIMIBILE. Qui non c'è nessuna stringa SQL: si parla
+ *    PostgREST (`.from(t).insert()` / `.update()`), e in questo file non esiste `.delete()`, non
+ *    esiste `.rpc()`, non esiste `.upsert()` — un test lo verifica leggendo il sorgente. È la
+ *    stessa proprietà di `query` girata: là una scrittura non ha un posto dove andare, qui una
+ *    cancellazione. Le tredici cancellazioni restano tool espliciti, dove si vedono, perché
+ *    l'asimmetria non la toglie nessuna difesa: una lettura sbagliata restituisce dati sbagliati,
+ *    una scrittura sbagliata distrugge i tuoi.
+ *
+ * 3. NIENTE UPSERT, E NON È UNA DIMENTICANZA. Un `onConflict` ha due facce (LESSONS.md): o non
+ *    scrive niente — 42P10 che supabase-js RISOLVE invece di rigettare, e `competitors` riportava
+ *    successo scrivendo zero righe — o sovrascrive una riga che c'era, quando la coppia unica vera
+ *    è diversa da quella che hai in testa. La prima faccia si chiude verificando la chiave contro
+ *    `pg_indexes`; la seconda NO: la chiave può essere reale e non essere quella che intendevi, e
+ *    allora l'insert diventa una sostituzione — cioè esattamente ciò che `destructiveHint: false`
+ *    su `insert_row` giurerebbe di non fare. Il giro in più (23505 che nomina la chiave, poi
+ *    `update_row` su quella chiave) rende la sostituzione SCELTA invece che scoperta.
+ *
+ * 4. IL FILTRO DEL BRAND VALE IL DOPPIO. `query` lo aggiunge quando manca: in lettura una
+ *    dimenticanza restituisce troppo. Qui mette la riga nel brand sbagliato, quindi su `insert_row`
+ *    un `brand_id` diverso da quello della conversazione è un RIFIUTO e non una correzione muta —
+ *    correggerlo direbbe «fatto» a chi credeva di scrivere altrove.
+ *
+ * 5. UN RIFIUTO DEVE DIRE COSA SI PUÒ FARE. Uno SQLSTATE nudo è un giro sprecato: 23514 nomina il
+ *    vincolo e i valori che ammette, 23505 la chiave su cui hai colliso, 42501 distingue il grant
+ *    per colonna (e le elenca) dalla RLS (che è una riga di un altro, e non si aggira). Vincoli e
+ *    grant vengono da `write-rules.ts`, generato dalle migrazioni.
+ */
+import { QUERY_TABLES, UPDATE_MAX_ROWS } from '@anomalia/api-contracts';
+import { TABLE_CHECKS, WRITABLE_COLUMNS } from '@anomalia/api-contracts';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { isRlsScoped } from '$lib/server/rls-client';
+import { logAiCall } from '$lib/server/ai-log';
+
+export { UPDATE_MAX_ROWS };
+
+/** Il guinzaglio sulla connessione HTTP. Il database molla da solo prima (8s sul ruolo). */
+export const WRITE_ABORT_MS = 12_000;
+
+/** Lo stesso identificatore non virgolettato che accetta `query`: qui non entra nessun SQL. */
+const IDENT = /^[a-z_][a-z0-9_]{0,62}$/;
+
+const TABLES = new Set(QUERY_TABLES.split(' '));
+
+const CONSTRAINT_NAME = /violates check constraint "([^"]+)"/;
+const UNIQUE_NAME = /violates unique constraint "([^"]+)"/;
+
+export const NO_SESSION_WRITE_ERROR = {
+  error: 'no_user_session',
+  message:
+    '`insert_row` and `update_row` write the database AS THIS USER: anon key + their JWT, so Postgres RLS lets the agent write exactly where the user could and nowhere else. This client is not user-scoped — it is a background/queue turn or a CLI API-key request, and both hold a service-role client (`bypassrls=true`) that would write into ANY brand in the database. Refusing to write with it, and refusing harder than the read does: a read with the wrong client returns rows that are not yours, a write leaves them behind.',
+  fix: 'Use this surface\'s own write tools — each one scopes to this brand by construction. Or come back as yourself: these write wherever the caller carries their own session — the app, `anomalia login`, and MCP.'
+} as const;
+
+type Filter = {
+  column: string;
+  op: string;
+  value: string | number | boolean | null | Array<string | number>;
+  negate?: boolean;
+};
+
+/**
+ * «Questa tabella non ha `brand_id`», detto in un posto solo. Postgres e PostgREST lo dicono con
+ * due codici diversi e due frasi diverse — 42703 quando il nome sta in un filtro, PGRST204 quando
+ * sta nel corpo di una scrittura, perché lì la colonna la cerca la schema cache — e la regola
+ * scritta due volte è diventata subito una regola divergente: l'insert conosceva solo il primo, e
+ * su `profiles` moriva dicendo che `brand_id` non esiste invece di riprovare senza.
+ */
+function missesBrandColumn(error: { code?: string; message?: string } | null): boolean {
+  if (!error) return false;
+  if (error.code !== '42703' && error.code !== 'PGRST204') return false;
+  return String(error.message ?? '').includes('brand_id');
+}
+
+function wireValue(op: string, value: Filter['value']): string {
+  if (op === 'in') {
+    const items = Array.isArray(value) ? value : [value as string | number];
+    return `(${items.map((v) => String(v)).join(',')})`;
+  }
+  if (value === null) return 'null';
+  return String(value);
+}
+
+/**
+ * Il 42501 ha due cause che si scrivono uguali e si riparano al contrario: un grant per colonna
+ * («questa colonna la decide il sistema, quest'altra tu») e la RLS («questa riga non è tua»).
+ * Il messaggio di Postgres è l'unica cosa che le distingue, e sceglierne una a caso manda il
+ * modello a riprovare dove non c'è niente da riprovare.
+ */
+function explainDenied(message: string, table: string): string {
+  if (message.includes('row-level security')) {
+    return `RLS refused this row: this user is not allowed to own it — wrong brand, wrong organisation, or a table only the system writes. There is nothing to retry. Read ${table} with \`query\` to see which rows are reachable at all.`;
+  }
+
+  const grant = WRITABLE_COLUMNS[table];
+  if (!grant) {
+    return `Postgres denied the write on ${table} for this role. There is no way around it from here.`;
+  }
+
+  return `Column grants on ${table}: this user may insert [${grant.insert.join(', ') || 'nothing'}] and update [${grant.update.join(', ') || 'nothing'}]. Every other column of that table is decided by the system — billing, approval and cron cursors live there — and no retry changes it.`;
+}
+
+export function explainWriteError(
+  code: string | undefined,
+  message: string,
+  details: string | null | undefined,
+  table: string
+): string {
+  switch (code) {
+    case '23514': {
+      const name = CONSTRAINT_NAME.exec(message)?.[1] ?? '';
+      const definition = TABLE_CHECKS[name];
+      return definition
+        ? `Constraint ${name} allows only: ${definition}. Send a value that satisfies it.`
+        : `A CHECK constraint (${name || 'unnamed'}) refused this value. Read one existing row of ${table} with \`query\` to see what shape the column really takes.`;
+    }
+    // `details` porta «Key (brand_id, title)=(…) already exists» quando c'è, e spesso NON c'è:
+    // allora le colonne le dice il nome del vincolo, che non manca mai.
+    case '23505':
+      return `${details ? details + ' ' : ''}That row is already there, and nothing was replaced — on purpose. The unique key is ${UNIQUE_NAME.exec(message)?.[1] ?? 'the one named in the message'}: change the existing row with update_row filtering on those columns, or send values that do not collide.`;
+    case '23502':
+      return `${message} That column has no default: send it, or the row cannot exist.`;
+    case '23503':
+      return `${details ? details + ' ' : ''}A foreign key points at a row that does not exist. Read the parent table with \`query\` and use an id it really has.`;
+    case '42501':
+      return explainDenied(message, table);
+    case '22P02':
+    case '22007':
+      return `A value has the wrong type for its column. Read one row of ${table} with \`query\`: the values you get back show the shape each column takes.`;
+    case '57014':
+      return 'The database gave up: statement_timeout is 8s on this role. Narrow the filter so fewer rows are touched.';
+    case 'PGRST205':
+      return `No table called ${table}. Call \`query\` with no table to list every name.`;
+    default:
+      return `Unrecognized database error. Read one row of ${table} with \`query\` — its keys are the columns, its values the shapes. Raw: ${message}`;
+  }
+}
+
+export type WriteToolDeps = {
+  supabase: SupabaseClient;
+  brandId: string;
+  userId?: string;
+  threadId?: string;
+};
+
+type InsertInput = { table: string; values: Record<string, unknown> };
+type UpdateInput = { table: string; where: Filter[]; values: Record<string, unknown> };
+
+type Refusal = { error: string; message: string; fix?: string };
+
+function badIdentifier(table: string, values: Record<string, unknown>, where: Filter[]): Refusal | null {
+  if (!IDENT.test(table.trim())) {
+    return {
+      error: 'not_an_identifier',
+      message: `"${table}" is not a table name. There is no SQL here — no statement, no CTE, no function call — so a DELETE or a DROP has nowhere to go. Give a bare table name.`,
+      fix: 'Call `query` with no table to see the valid names.'
+    };
+  }
+
+  const column = [...Object.keys(values), ...where.map((f) => String(f.column))].find(
+    (c) => !IDENT.test(String(c).trim())
+  );
+  if (column !== undefined) {
+    return {
+      error: 'not_an_identifier',
+      message: `"${column}" is not a column name. Columns are bare identifiers — no expressions, no functions, no SQL.`,
+      fix: `Call query({ table: "${table}" }) with no columns to see what this table actually has.`
+    };
+  }
+
+  if (!TABLES.has(table.trim())) {
+    return {
+      error: 'unknown_table',
+      message: `No table "${table}" is created by any migration, so it does not exist in a fresh install even if production happens to have one.`,
+      fix: 'Call `query` with no table to list every name you can write to.'
+    };
+  }
+
+  return null;
+}
+
+export function createWriteTools({ supabase, brandId, userId, threadId }: WriteToolDeps) {
+  const finish = <T extends Record<string, unknown>>(out: T, note: string, t0: number): T => {
+    logAiCall({
+      label: 'db_write',
+      provider: 'internal',
+      ms: Date.now() - t0,
+      ok: !('error' in out),
+      error: 'error' in out ? String(out.error) : undefined,
+      context: note.slice(0, 400),
+      brandId,
+      userId: userId || undefined,
+      threadId
+    });
+    return out;
+  };
+
+  /**
+   * Lo schema non si spiega, si va a prendere: una riga con tutte le colonne È lo schema. E qui,
+   * al contrario di `query`, la scrittura NON si rifà con i nomi giusti — indovinare una colonna
+   * per conto di chi scrive è mettere in tabella un valore che nessuno ha chiesto.
+   */
+  const columnsOf = async (table: string): Promise<string[]> => {
+    const probe = await supabase.from(table).select('*').limit(1).abortSignal(AbortSignal.timeout(WRITE_ABORT_MS));
+    const sample = (probe.data ?? [])[0] as Record<string, unknown> | undefined;
+    return sample ? Object.keys(sample) : [];
+  };
+
+  const failed = async (
+    table: string,
+    error: { code?: string; message: string; details?: string | null },
+    note: string,
+    t0: number
+  ) => {
+    const wrongColumn = error.code === '42703' || error.code === 'PGRST204';
+    const available = wrongColumn ? await columnsOf(table) : [];
+
+    return finish(
+      {
+        error: error.code || 'db_error',
+        message: error.message,
+        fix: available.length
+          ? `A column you named does not exist on ${table}, and the write was NOT retried with a guess — that is the difference between a read and a write. Real columns: ${available.join(', ')}.`
+          : explainWriteError(error.code, error.message, error.details, table),
+        ...(available.length ? { columns_available: available } : {})
+      },
+      note,
+      t0
+    );
+  };
+
+  const insertRow = async (input: InsertInput) => {
+    const t0 = Date.now();
+    const values = input.values ?? {};
+
+    if (!isRlsScoped(supabase)) return finish({ ...NO_SESSION_WRITE_ERROR }, 'db_write:refused:no_session', t0);
+
+    const refusal = badIdentifier(input.table, values, []);
+    if (refusal) return finish(refusal, `db_write:refused:${refusal.error}`, t0);
+
+    if (!Object.keys(values).length) {
+      return finish(
+        {
+          error: 'no_values',
+          message: 'An insert with no columns is an empty row, not a row.',
+          fix: `Read one row of ${input.table} with \`query\` and send the columns that matter.`
+        },
+        'db_write:refused:no_values',
+        t0
+      );
+    }
+
+    // Il brand SI IMPONE, e uno diverso è un rifiuto: correggerlo in silenzio direbbe «fatto» a
+    // chi credeva di scrivere altrove, ed è un errore che si scopre solo leggendo la tabella dopo.
+    const named = values.brand_id;
+    if (named !== undefined && named !== null && String(named) !== brandId) {
+      return finish(
+        {
+          error: 'wrong_brand',
+          message: `This conversation is brand ${brandId}, and the row names ${String(named)}. Nothing was written and nothing was corrected for you.`,
+          fix: `Drop \`brand_id\` — it is filled in with ${brandId} — or open the conversation on the brand you meant.`
+        },
+        'db_write:refused:wrong_brand',
+        t0
+      );
+    }
+
+    const table = input.table.trim();
+    const run = (withBrand: boolean) =>
+      supabase
+        .from(table)
+        .insert(withBrand ? { ...values, brand_id: brandId } : values)
+        .select()
+        .abortSignal(AbortSignal.timeout(WRITE_ABORT_MS));
+
+    let { data, error } = await run(true);
+    if (missesBrandColumn(error)) ({ data, error } = await run(false));
+
+    if (error) return failed(table, error, `db_write:${table}:insert:err:${error.code ?? '?'}`, t0);
+
+    const rows = (data ?? []) as Array<Record<string, unknown>>;
+    return finish(
+      { table, row: rows[0], inserted: rows.length },
+      `db_write:${table}:insert:cols=${Object.keys(values).length}`,
+      t0
+    );
+  };
+
+  const updateRow = async (input: UpdateInput) => {
+    const t0 = Date.now();
+    const values = input.values ?? {};
+    const where = input.where ?? [];
+
+    if (!isRlsScoped(supabase)) return finish({ ...NO_SESSION_WRITE_ERROR }, 'db_write:refused:no_session', t0);
+
+    const refusal = badIdentifier(input.table, values, where);
+    if (refusal) return finish(refusal, `db_write:refused:${refusal.error}`, t0);
+
+    if (!where.length) {
+      return finish(
+        {
+          error: 'where_required',
+          message:
+            'An update with no filter rewrites every row this user can reach in that table. That is the deletion this tool does not expose, wearing a different name.',
+          fix: 'Name the rows: where: [{ column: "id", op: "eq", value: "<the id>" }]. Read them with `query` first if you are not sure which ones you mean.'
+        },
+        'db_write:refused:where_required',
+        t0
+      );
+    }
+
+    if (!Object.keys(values).length) {
+      return finish(
+        {
+          error: 'no_values',
+          message: 'An update with no columns changes nothing and would still report success.',
+          fix: 'Send the columns you want to change. The ones you leave out are not touched.'
+        },
+        'db_write:refused:no_values',
+        t0
+      );
+    }
+
+    const table = input.table.trim();
+    const brandNamed = where.some((f) => String(f.column).trim() === 'brand_id');
+
+    // `negate` non è un dettaglio del gemello in lettura da ricopiare per simmetria: ignorarlo qui
+    // sceglierebbe l'insieme COMPLEMENTARE di righe, e le scriverebbe.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    type Filterable = { filter: (c: string, o: string, v: string) => any; not: (c: string, o: string, v: string) => any };
+    const filtered = <T extends Filterable>(q: T, withBrand: boolean) => {
+      let out = q;
+      for (const f of where) {
+        const column = String(f.column).trim();
+        const value = wireValue(f.op, f.value);
+        out = f.negate ? out.not(column, f.op, value) : out.filter(column, f.op, value);
+      }
+      if (withBrand) out = out.filter('brand_id', 'eq', brandId);
+      return out;
+    };
+
+    // SI CONTA PRIMA DI SCRIVERE. PostgREST non sa mettere un LIMIT su un update, quindi il tetto
+    // o vive qui o non esiste — e senza, un filtro largo è la stessa riga di codice di un filtro
+    // stretto. Il conteggio è anche l'unico modo di distinguere «zero righe» da «scritto»: un
+    // update che non trova niente risponde 200 con l'array vuoto.
+    //
+    // E NON si chiede `head: true`, che sarebbe la forma ovvia: senza corpo nella risposta non
+    // torna nemmeno il corpo dell'ERRORE, e supabase-js consegna `{ message: '', code: undefined }`.
+    // Un rifiuto che non si riconosce è peggio di uno SQLSTATE nudo. Una riga sola di traffico è il
+    // prezzo del messaggio.
+    let withBrand = !brandNamed;
+    const counted = async () =>
+      filtered(supabase.from(table).select('*', { count: 'exact' }), withBrand)
+        .limit(1)
+        .abortSignal(AbortSignal.timeout(WRITE_ABORT_MS));
+
+    let count = await counted();
+    if (withBrand && missesBrandColumn(count.error)) {
+      withBrand = false;
+      count = await counted();
+    }
+
+    if (count.error) return failed(table, count.error, `db_write:${table}:count:err:${count.error.code ?? '?'}`, t0);
+
+    const matched = count.count ?? 0;
+    if (matched === 0) {
+      return finish(
+        {
+          error: 'no_rows_matched',
+          message: `No row of ${table} matches that filter inside this brand, so nothing was written.`,
+          fix: 'Read the rows with `query` using the same filter: either the id is wrong, or the row belongs to another brand and RLS hides it.',
+          matched: 0
+        },
+        `db_write:${table}:update:no_rows`,
+        t0
+      );
+    }
+
+    if (matched > UPDATE_MAX_ROWS) {
+      return finish(
+        {
+          error: 'too_many_rows',
+          message: `That filter matches ${matched} rows and the ceiling is ${UPDATE_MAX_ROWS}. Nothing was written.`,
+          fix: 'Narrow the filter, or change the rows in batches by adding a filter that splits them.',
+          matched
+        },
+        `db_write:${table}:update:too_many:${matched}`,
+        t0
+      );
+    }
+
+    const written = await filtered(supabase.from(table).update(values), withBrand)
+      .select()
+      .abortSignal(AbortSignal.timeout(WRITE_ABORT_MS));
+
+    if (written.error) {
+      return failed(table, written.error, `db_write:${table}:update:err:${written.error.code ?? '?'}`, t0);
+    }
+
+    const rows = (written.data ?? []) as Array<Record<string, unknown>>;
+    return finish(
+      {
+        table,
+        rows,
+        updated: rows.length,
+        matched,
+        note: `Only ${Object.keys(values).join(', ')} changed — every other column of those rows is untouched.`
+      },
+      `db_write:${table}:update:rows=${rows.length}/${matched}`,
+      t0
+    );
+  };
+
+  return { insertRow, updateRow };
+}

--- a/src/routes/api/v1/brands/[slug]/rows/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/rows/+server.ts
@@ -1,0 +1,44 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { authenticate, loadBrandForUser } from '$lib/server/cli-auth';
+import { INSERT_ROW, UPDATE_ROW } from '@anomalia/api-contracts';
+import { createWriteTools } from '$lib/server/chat/write-tool';
+
+/**
+ * `insert_row` e `update_row` sopra REST, e quindi sopra CLI e MCP. Come la rotta di `query`, non
+ * riscrive niente: monta lo STESSO codice, quindi cancello, confine del brand, tetto sulle righe e
+ * traduzione degli errori sono un pezzo solo che non può divergere.
+ *
+ * `authenticate` restituisce il client dell'utente sul percorso JWT e la service role su quello a
+ * chiave API: nel secondo caso lo strumento si rifiuta da solo. Non c'è nessun `checkApiKeyWriteAccess`
+ * qui perché non ci arriverebbe mai — quel percorso è già chiuso a monte, e un secondo cancello
+ * sulla stessa porta è una condizione in più da tenere allineata, non una difesa in più.
+ *
+ * POST inserisce, PUT aggiorna: il verbo HTTP è quello dell'operazione, e il registro ne ricava
+ * `destructive` per tool — false sull'una, true sull'altra.
+ */
+const write = async (request: Request, slug: string, op: 'insert' | 'update') => {
+  const { supabase, error, user, apiKey } = await authenticate(request);
+  if (error) return error;
+
+  const { brand, error: brandError } = await loadBrandForUser(supabase, slug, apiKey);
+  if (brandError) return brandError;
+
+  const contract = op === 'insert' ? INSERT_ROW : UPDATE_ROW;
+  const parsed = contract.input.safeParse(await request.json().catch(() => ({})));
+  if (!parsed.success) {
+    return json({ error: 'invalid_input', details: parsed.error.issues }, { status: 400 });
+  }
+
+  const tools = createWriteTools({ supabase, brandId: brand.id, userId: user.id });
+
+  return json(
+    op === 'insert'
+      ? await tools.insertRow(parsed.data as Parameters<typeof tools.insertRow>[0])
+      : await tools.updateRow(parsed.data as Parameters<typeof tools.updateRow>[0])
+  );
+};
+
+export const POST: RequestHandler = ({ request, params }) => write(request, params.slug, 'insert');
+
+export const PUT: RequestHandler = ({ request, params }) => write(request, params.slug, 'update');


### PR DESCRIPTION
## What?

Two new MCP tools, `insert_row` and `update_row`, are the write side of `query`: one PostgREST
`.insert()` or `.update()` on any table in `public`, run with the caller's own session so Postgres
RLS decides what may happen. They collapse the level, not a family — the row in a table that has no
tool of its own is now writable without adding a thirty-first `add_*`.

They stop where writing stops being symmetric with reading: **no delete, no SQL, no `.rpc()`, no
upsert**. A test reads the module source and fails if any of those method names appears in it.

The PR also brings the census of all 71 write handlers the owner asked for (below, and in full in
`changelog/2026-09-06-generic-write.md`) and removes **no** tool: the removals it identifies are a
separate, approved step.

## Why?

`query` answered the endless tail of reads by exposing the level a model already knows. Writes had
the same shape and no answer, so every new writable thing cost a tool, and 149 tables had between
them roughly thirty write tools. The measured cost of a long list is not the characters: three real
sessions in one day gave up on a capability that was present because they did not find its name.

Doing it now is defensible only because the boundary was built this week and this work leans on all
three parts of it: per-column grants on `profiles` / `organizations` / `brands` (an update no longer
constrains the row while leaving the column open), 118 CHECK constraints, and unique indexes on
external identifiers (#390). **RLS defends rows, not the values inside them** — where one of those
three layers is missing, this tool is not covered either, and the census says exactly where.

## How?

**Two tools, not one, and the reason is mechanical.** `destructiveHint` is a per-tool annotation
(`destructiveHint: endpoint.destructive`, `cli/mcp/tools/brand-content.ts`) and the protocol cannot
express "destructive only when `op = update`". A single `write(op: 'insert' | 'update')` has two
choices and both lie: marked destructive it warns on inserts, which take nothing from anyone, and
people learn to click the warning away; marked non-destructive it is silent on updates, which
replace. That is `ads_action` today, and `docs/mcp-tools.md` §3 proves it. Split, the annotation is
true on both — and the verb goes back into the **name**, which is where a model chooses, before it
reads any enum.

**Rejected: an upsert.** `LESSONS.md` gives a wrong `onConflict` two faces — one writes nothing
(42P10, which `supabase-js` *resolves* instead of rejecting: `competitors` reported success writing
zero rows), the other overwrites a row that was there when the real unique pair differs from the one
you had in mind. The first face closes by validating the key against `pg_indexes`. The second does
not: the key can be real and still not be the one you meant, and then an insert becomes a
replacement — exactly what `destructiveHint: false` on `insert_row` would be swearing not to do. The
extra round trip (a 23505 that names the constraint, then `update_row` on those columns) makes the
replacement **chosen** instead of discovered.

**The brand filter is stricter than the read's.** `query` adds `brand_id` when the model forgets. On
a write, forgetting puts the row in the wrong brand, so a `brand_id` that is not this conversation's
is **refused, not corrected** — correcting it would answer "done" to someone who believed they were
writing elsewhere.

**`where` is mandatory and 50 rows is the ceiling, counted before writing.** An update with no filter
is the deletion this tool does not expose, in disguise. PostgREST cannot put a `LIMIT` on an update,
so the ceiling either lives in a count or does not exist; the count is also the only way to tell
"nothing matched" from "written", since an update that finds nothing answers 200 with an empty array.

**Errors come back usable, from a registry generated by the migrations.**
`packages/api-contracts/src/write-rules.ts` is emitted by the same script that generates the table
list: `TABLE_CHECKS` (81 constraints with their expressions) turns a 23514 into
`Constraint products_url_check allows only: url ~ '^https?://'`, and `WRITABLE_COLUMNS` turns a 42501
from a column grant into the list of columns this session may actually write. A 42501 from **RLS**
gets a different message — same code, opposite remedy, and picking one at random sends the model to
retry where there is nothing to retry.

**Not mounted in the chat agent.** The implementation lives beside `query-tool.ts` and the REST route
mounts it exactly as the `query` route does, so caps, gate, brand boundary and error translation are
one piece of code. Putting it in the chat toolset is a separate decision with a different risk
profile, and this PR does not take it.

## Testing?

**Unit — 27 new, full suite 7 563 passed / 14 skipped, `npm run build` green.** The failing test came
first every time, including for the two defects below. Covered: the delete/rpc/upsert absence read
from the source; identifiers that imitate SQL producing zero network calls; the service-role refusal;
`brand_id` imposed, and a different one refused; `where` required; the ceiling counted before writing;
zero matches not reported as success; a partial update carrying only the columns sent; and each error
branch.

**Against real Postgres — `npm run test:privileges`, 45/45.** vitest mocks Supabase and a fake insert
accepts anything, so three facts are proved in a real transaction closed by `rollback`:

<details><summary>the three new facts</summary>

```
ok  ogni vincolo che il registro spiega esiste davvero nel catalogo  (81 nomi)
ok  brands: le colonne insert che il registro dichiara sono quelle che il database concede  (9)
ok  brands: le colonne update che il registro dichiara sono quelle che il database concede  (13)
ok  organizations: le colonne insert … (2)   ok  organizations: le colonne update … (0)
ok  profiles: le colonne insert … (0)        ok  profiles: le colonne update … (3)
ok  un update parziale non azzera le colonne che non ha nominato
    ({"category":"bakery","about":"Chi siamo","target_audience":"Chi ci compra","brand_style":"Come parliamo"})
ok  il CHECK che il registro spiega è quello che morde davvero  (23514 … "products_url_check")
```

The last two matter most: a registry generated from migrations and never compared with the catalogue
is a hope written in TypeScript, and `update_brand_kit` sending every column with `?? null` is the
defect that wrote NULL over what a brand says about itself, with `ok: true` and no screen. The
partial-update semantics are now measured, not assumed.

</details>

**End to end on the local stack, signed in as a real user.** Self-hosted Supabase on `:5432/:8000`,
migrations applied, `npm run dev`, browser at `/app/demo` confirmed as `test@anomalia.so`, and every
call issued from that page against `/api/v1/brands/demo/rows`.

<details><summary>what was exercised, and what came back</summary>

| case | result |
|---|---|
| insert a product | row created, `brand_id` filled in by the server |
| **partial update** | `title` changed; `kind: "drink"` and `pricing: "2.50 EUR"` still there |
| `brand_id` of another brand | `wrong_brand` — nothing written, nothing corrected |
| bad value (`url: "example.com"`) | `Constraint products_url_check allows only: url ~ '^https?://'` |
| unknown column | `PGRST204`, real columns listed, and "the write was NOT retried with a guess" |
| unknown table | `unknown_table` before any request leaves |
| duplicate radar source | `23505`, naming `brand_news_sources_brand_id_kind_value_key` |
| `profiles.approved_at` (the closed-beta gate) | `42501` + "may update [full_name, avatar_url, locale]" |
| `organizations.plan` (400 → 11 250 credits) | `42501` + "may update [nothing]" |
| another user's `organizations` row | `42501` from **RLS**, different message |
| `where: []` | 400 with the reason, from the contract |
| filter matching 0 rows | `no_rows_matched`, not a quiet success |
| **55 concurrent inserts** | 55/55 written, no errors |
| filter matching all 55 | `too_many_rows`, `matched: 55`, nothing written |
| narrower filter | 11 rows updated |

Test rows were deleted afterwards; the demo brand is as it was.

</details>

**Two defects the browser found and the green suite did not** — both because the fake client answered
what I had told it to. Test first, watched fail, then fixed; both are now in `LESSONS.md`:

1. **PostgREST answers `PGRST204`, not `42703`, for an unknown column in a write body** (it resolves
   write columns in its schema cache, never reaching Postgres). The "this table has no `brand_id`,
   retry without" fallback was copied from `query` and knew only the first code, so every insert into
   a table without `brand_id` died saying `brand_id` does not exist. The rule now lives in one place.
2. **`head: true` on the count takes the error body with it.** No body means no
   `{code, message, details}`, so `supabase-js` hands back `{ message: '', code: undefined }` and
   every update on such a table answered `{"error":"db_error","message":""}`. The count now fetches
   one row; that is the price of a legible refusal.

**Not tested:** the chat surface (the tools are not mounted there); MCP over the remote HTTP transport
against a deployed instance (only the local REST path and `tools/list` on the real transport); tables
whose RLS policy is `SECURITY DEFINER`-mediated; and `npm run eval:durability`, which this PR does not
touch the chat path of. The 50-row ceiling and the 12s abort are declared, not stress-tested against a
slow database.

## Evidence (screenshots/videos)

No UI change — the surface is MCP and REST. The evidence is the two `<details>` above: real SQLSTATEs
from the local stack, and 45/45 from the privilege harness. Both were produced against the local
self-hosted Supabase, never a hosted instance.

<details><summary>the weight, measured on the transport before and after</summary>

`tools/list` after `initialize`, counting `result` whole:

| | characters | tools |
|---|---|---|
| `dev` (after #391) | 91 163 | 86 |
| this branch | 94 215 | 88 |

**+3 052.** Neither tool carries the 149-name table enum that `query` has: there it costs ~2 700
characters and earns them, because a read discovers itself by guessing a name, while whoever is about
to write has just read — the descriptions point at `query` for the list instead.

</details>

## Anything Else?

**Rebased onto #391**, which landed mid-flight and retired 33 reads into `query`. Two consequences
were carried in rather than ignored: the read filters gained `negate`, so the write filters take it
too — a write filter that dropped it would select the *complementary* set of rows and then write to
them — and the tool-list ceiling, left at 113 000 while the real number fell to 91 163, comes down
with it, because 19 000 characters of headroom stop being a guard.


**The census — all 71 write handlers opened, and no tool removed here.** Four are an `insert`/`update`
of one row and nothing else, worth **3 794 characters**, which is more than the 3 052 this PR adds:

| tool | the whole handler |
|---|---|
| `create_product` | `insert({ brand_id, ...input })` |
| `update_product` | `updateBrandRow` → `.update(patch).eq('id').eq('brand_id')` |
| `update_person` | same |
| `update_competitor` | same, plus prefixing `https://` on the website — which is **already** `competitors_website_check: website ~ '^https?://'`, so the rule does not disappear, it stops being guessed. Today `example.com` silently becomes a URL nobody typed; through `update_row` it is refused with the constraint and its pattern |

Removing them is the follow-up: one line each, and `tools/list` then lands **below** where it started.

**What looks like CRUD and is not** — the reasons, because a generic writer would lose these in
silence: `add_competitor` writes `source: 'user'` while the column defaults to `'ai'` (a
person-added competitor would be recorded as AI-found, invisibly); `set_colors` adds the missing `#`;
`add_blog_term` derives the slug and picks one of three tables; `save_brief` finds the active plan and
patches one entry of a `weeks` array; `update_voice`, `set_blog_settings`, `set_brand_settings`,
`set_media_model` and `set_radar_platform` all **read-merge-write a jsonb column**, so a raw
`update_row` on `content_prefs` would erase what the other features keep there; `save_memory` can
*refuse* a write that contradicts a human-set fact; `record_memory_used` is an atomic `rpc`;
`create_share` mints a token it deliberately never stores; `add_radar_source` enforces a plan cap no
constraint carries; `create_post` computes the slot from the brand timezone; `import_media_url` is the
receipt of an SSRF-guarded fetch. Everything with `gateAiAction`, a model, Stripe or Zernio behind it
stays by definition.

**`discard_plan` and `unpublish_article` are bare updates but stay**, for the reason the deletions
stay: a verb that undoes something keeps its own name, where it can be seen.

**Known ceilings.** The CHECK registry covers the 81 **named** constraints; an anonymous inline check
falls back to "read a row with `query`". Column grants exist on three tables today, and the message
for a table without them says only that Postgres refused. Neither is a guess that misleads — both say
what they do not know.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
