### PR TITLE
Collapse the brand identity write family into one tool

### DIFF
--- a/changelog/2026-09-07-write-families.md
+++ b/changelog/2026-09-07-write-families.md
@@ -1,0 +1,140 @@
+# Le quattro famiglie di scrittura additiva, pesate una per una: ne collassa una
+
+`docs/mcp-tools.md` §3 sconsigliava di collassare le scritture e `changelog/2026-09-05-writes-stay-separate.md`
+ritirava il piano. **Quel verdetto era giusto per il motivo sbagliato**, e la distinzione decide
+tutto: l'argomento forte — `destructiveHint` è un'annotazione per tool, e il protocollo non sa dire
+«distruttivo solo quando `action = delete`» — morde solo una famiglia che **contiene** un verbo che
+distrugge. Su 71 scritture le distruttive sono 13. Quattro famiglie non ne hanno nessuna, e lì il
+primo argomento non dice niente.
+
+Resta il secondo, che è vero e che qui si paga per intero: un modello sceglie dal **nome** e legge
+l'enum solo **dopo** aver aperto il tool. Quindi il lavoro non era «collassare», era **pesare**: si
+paga dove rende, non dove capita.
+
+## I tre criteri, e la misura invece dell'intuizione
+
+Una famiglia passa solo se supera tutti e tre:
+
+1. **I fratelli tornano forme abbastanza simili da stare in un tipo solo?** Due scritture che
+   tornano oggetti diversi non sono una famiglia: sono due tool con un prefisso in comune.
+2. **Il nome di famiglia dice già cosa fa?** Se il nome unificato è più vago di quelli che
+   sostituisce, il collasso costa e non rende.
+3. **Un membro può fallire in un modo che gli altri non conoscono?** Allora non è un membro: chi
+   chiama non può prevedere la risposta dal tool che ha aperto. È il criterio che tiene fuori
+   `set_bio`, ed è quello che ha deciso tre famiglie su quattro.
+
+Misurato sul registro, non supposto:
+
+| famiglia | tool | forme di risposta diverse | fallimenti comuni a tutti | esito |
+|---|---|---|---|---|
+| identità | 5 | 4/5 | 0 | **collassata a 2** |
+| media | 7 | 6/7 | 0 | separata, −1 doppione |
+| impostazioni | 5 | 5/5 | 0 | separata |
+| post | 7 | 7/7 | 0 | separata |
+
+## L'identità del brand: quattro porte sulle stesse due righe
+
+`update_brand_kit`, `update_voice`, `set_colors` e `set_appearance` scrivevano `brand_kit` e
+`brands.content_prefs` — due righe, quattro tool. Le loro risposte sono `{ok}`, `{ok}`,
+`{ok, colors}` e `{ok, appearance}`: lo stesso tipo più un'eco, che si fondono senza perdere
+niente. Il nome unificato, `update_brand_identity`, non è più vago di `update_brand_kit` — che è
+opaco: un «kit» cos'è? Nessuno dei quattro spende, chiama un modello o distrugge.
+
+**E la divisione confondeva davvero, con una prova già scritta**: chi cercava «cambia i colori del
+brand» apriva il tool che si chiama `set_appearance` e **non trovava nessun campo colore**, perché
+la palette era in `set_colors`. Il 2026-09-05 la toppa era stata un rimando nella descrizione. Qui
+il difetto non si rimanda: sparisce, perché non ci sono più due porte.
+
+Cercando la stessa forma altrove ne è saltata fuori un'altra: i post passati che il generatore
+imita sono `voice_examples`, e stanno su `set_brand_settings`, non su `update_voice`. Quella non si
+ripara unendo — spezzerebbe `set_brand_settings` in due — quindi si ripara col rimando, che è
+esattamente il trattamento che meritava.
+
+**`set_bio` resta fuori**, ed è il criterio 3 al lavoro: scrive `social_accounts`, non il brand, e
+risponde `No active social account` quando nessun account è collegato. Un fallimento che nessun
+altro membro può produrre non appartiene alla famiglia.
+
+## Media: si separano, ma la porta vecchia esce
+
+`generate_image`, `generate_video`, `generate_carousel` e `refine_media` erano stati tenuti
+separati con motivi misurati, e reggono: `generate_image` è l'**unico** che lavora senza brand
+(`pathWithoutBrand`, e torna `id: null`, `storage_path`, `organization`, `cost_usd`);
+`generate_video` non torna nemmeno un asset ma un `job_id`, e ha la finestra di durata per modello
+con `duration_out_of_range` invece di un arrotondamento muto, perché una clip si paga al secondo;
+`generate_carousel` pianifica la serie e torna i `continuity_tokens` che la tengono insieme.
+`import_media_url` **non spende niente** mentre gli altri cinque spendono, e il segnale di costo
+vive nel nome. Sei forme di risposta su sette, e ogni membro con un vocabolario di errori che
+nessun altro conosce: `brand_style_needs_a_brand`, `no_refine_model`, `video_budget_exhausted`,
+`not_https`. Un tipo solo qui vuol dire togliere a ognuno la promessa che mantiene.
+
+Quello che invece esce è **`generate_media`**: la sua stessa descrizione diceva *«prefer
+`generate_image` or `generate_video` … this one stays and keeps working, forwarding to those
+two»*. Non collassa una famiglia in un enum — è il contrario, è una porta che si toglie da davanti
+a due nomi migliori. Ogni suo campo (`prompt`, `count`, `aspect_ratio`, `model`, `title`) resta
+raggiungibile, e un test lo verifica campo per campo. La rotta REST resta, dichiarata in
+`REST_ONLY`.
+
+## Impostazioni: cinque `set_*`, e i nomi SONO il discriminante
+
+Cinque forme di risposta su cinque, e cinque vocabolari di errore disgiunti: `plan_required`,
+`model_not_for_slot`, `unknown_locale`, `unknown_timezone`, `toggle_failed`. Ma la ragione dura è
+un'altra, e si vede solo aprendo gli schemi: **`enabled` compare tre volte con tre significati
+diversi** — accendere un lavoro ricorrente, accendere una piattaforma del Radar, mettere online il
+blog pubblico. E il primo dei tre non è una preferenza: da quel momento il lavoro gira **da solo**
+sulla sua cadenza e ogni giro spende i crediti del brand, con nessuno che guarda. Un modello che
+sbaglia campo in un tool unico accende una spesa autonoma credendo di pubblicare un blog.
+
+In più il nome unificato collide con un membro: `set_brand_settings` esiste già.
+
+## Post: il collasso che sembrava ovvio nasconde un cambio di stato
+
+Sette forme di risposta su sette, `reorder_slides` gratuito accanto a quattro che pagano un render,
+e `regenerate_post_media` che **sostituisce** l'immagine che c'era.
+
+Ma il fatto che chiude il discorso l'ha trovato la lettura dell'handler, non lo schema:
+**`reschedule_post` non sposta soltanto l'ora.** `POST /posts/:id/reschedule` scrive
+`status: 'approved'`, azzera `external_post_id` e `published_url` e richiama
+`publishApprovedPost`. Rischedulare un post in `pending_user` lo **approva** e lo manda al
+publisher. La sua descrizione dice *«It does not publish and does not approve»*, e `edit_post`
+dice la stessa cosa — vera per lui. Fondere i due, che era il collasso più ovvio dei quattro (e
+riparerebbe la trappola vera di `edit_post`: `slot` è il giorno di calendario, `scheduled_for`
+l'istante di uscita), metterebbe un'approvazione dentro un tool che promette di non approvare.
+
+**Il difetto non è stato corretto qui**: è un cambiamento di comportamento sulla pubblicazione, non
+una correzione di contratto, e va deciso per conto suo. Sta scritto perché il prossimo che apre la
+famiglia lo trovi già trovato.
+
+## Come è costruita: una famiglia è un CAMPO che sceglie, non un verbo in un parametro
+
+`packages/api-contracts/src/families.ts` è una tabella, e la differenza con un `*_action` è tutta
+lì: nessun enum di verbi, quindi `destructiveHint` resta capace di dire la verità, e nessuna
+capacità sparisce dentro un parametro. Il registrar chiama **solo** le rotte di cui il chiamante ha
+nominato almeno un campo, in fila e non in parallelo — scrivono la stessa riga, e `set_appearance`
+la rilegge per non perdere il font che non gli hai mandato. Le risposte si fondono; senza nessun
+campo non tocca niente e lo dice.
+
+`OWN_TOOL_ENDPOINTS` — il registro meno chi è in una famiglia — sta scritto in un posto solo,
+perché lo leggono il registrar e i quattro test che confrontano `tools/list` col registro. Una
+sottrazione ripetuta in cinque posti diverge al primo che qualcuno dimentica.
+
+**Le rotte REST restano tutte**: qui esce il tool MCP, non l'endpoint. La CLI e WebMCP continuano a
+leggere `BRAND_ENDPOINTS` e non cambiano.
+
+## Il flag additivo, verificato invece che creduto
+
+`docs/mcp-tool-review.md` §10 dice che 13 tool sostituiscono contenuto dichiarando
+`destructive: false`, e `set_colors` è nella lista. Aperti gli handler: sostituisce la palette, che
+è il campo che il chiamante ha nominato — non i campi che ha taciuto, che era il difetto di
+`update_brand_kit` corretto in #387 (`KIT_COLUMNS.filter((c) => c in body)`, verificato). Additiva
+per campo, tutte e quattro.
+
+Un effetto che nessuna descrizione dichiarava: `update_voice` scrive `voiceMode = 'manual'` senza
+che nessuno lo chieda. È il senso del tool — una modifica a mano spegne la voce automatica — ma
+taceva. Ora lo dice la descrizione.
+
+## Il conto, misurato sul transport
+
+Da **88 tool / 94.215 caratteri** a **84 / 91.053**: −4 tool, −3.162 caratteri, e nessuna capacità
+persa. Il tetto in `tool-surface-cost.test.ts` scende da 97.000 a 93.000, o smette di essere una
+guardia. `MCP_INSTRUCTIONS` non è stato toccato: non nominava nessuno dei nomi ritirati, e il suo
+budget di 1.700 caratteri si paga a ogni sessione.

--- a/cli/lib/contracts/families.ts
+++ b/cli/lib/contracts/families.ts
@@ -1,0 +1,99 @@
+import { z } from 'zod';
+import { SET_APPEARANCE } from './appearance';
+import type { BrandEndpoint, ResourcelessEndpoint } from './index';
+import { SET_COLORS, UPDATE_BRAND_KIT, UPDATE_VOICE } from './studio';
+
+/**
+ * Una famiglia e' un tool solo davanti a piu' rotte, e il campo che il chiamante manda dice quale.
+ * NON e' un `*_action`: non c'e' nessun verbo dentro un parametro, quindi `destructiveHint` resta
+ * capace di dire la verita' — una famiglia si forma solo fra scritture che non distruggono niente,
+ * e il collasso muore appena una di loro toglie qualcosa.
+ *
+ * Le regole che una famiglia deve superare, tutte e tre, stanno in `docs/mcp-tools.md`: forme di
+ * risposta compatibili, un nome di famiglia non piu' vago di quelli che sostituisce, e nessun
+ * danno peggiore quando il modello sbaglia campo di quando sbagliava tool.
+ */
+export type BrandFamily = {
+  readonly tool: string;
+  readonly title: string;
+  readonly description: string;
+  /**
+   * Solo scritture a livello di brand. Una rotta che nomina una riga vuole un id, e un id in una
+   * famiglia sarebbe un secondo campo che sceglie: quale riga, oltre a quale rotta. Il tipo lo
+   * vieta invece di lasciarlo scoprire a chi lo prova.
+   */
+  readonly members: readonly ResourcelessEndpoint[];
+};
+
+/**
+ * Il look, i fatti e la voce del brand vivono in due righe sole — `brand_kit` e
+ * `brands.content_prefs` — e quattro tool ci scrivevano da quattro porte. La divisione non era
+ * neutra: chi cercava «cambia i colori del brand» apriva `set_appearance`, che di campi colore non
+ * ne aveva nessuno, e la palette stava in `set_colors`. Qui unire non peggiora la trovabilita': la
+ * ripara.
+ *
+ * `set_bio` non entra: scrive `social_accounts`, non il brand, e risponde 404 quando nessun account
+ * e' collegato — un fallimento che nessun altro membro puo' avere.
+ */
+export const UPDATE_BRAND_IDENTITY = {
+  tool: 'update_brand_identity',
+  title: 'Change what the brand is, how it sounds and how it looks',
+  description:
+    'Change what this brand IS, how it SOUNDS and how it LOOKS: its facts and language, its voice, ' +
+    'its colours, its logo, its fonts and its visual brief. One door for all of it — it replaces ' +
+    '`update_brand_kit`, `update_voice`, `set_colors` and `set_appearance`, which are gone. Only ' +
+    'the fields you send change, and at least one is required. `colors` REPLACES the whole ' +
+    'palette, so send every colour you want to keep: three or six hex digits, up to 8. `logo_url` ' +
+    'and `favicon_url` are DOWNLOADED and re-hosted, not linked, so a private, redirecting or ' +
+    'oversized address is refused rather than half-saved, and the answer carries the address we ' +
+    'stored; `remove_logo` clears it. `display_font` and `body_font` go together and must be ' +
+    'families Google Fonts actually serves — a name it will not serve renders as Inter with ' +
+    'nothing said, so they are checked before anything is written. Setting `visual_style` LOCKS ' +
+    'it: the nightly rebuild stops rewriting the brand’s visual brief until someone regenerates ' +
+    'it from the browser. Sending any voice field switches the brand OFF automatic voice: from ' +
+    'then on nobody rewrites it for you. The past posts the writer imitates are `voice_examples` on ' +
+    '`set_brand_settings`, not here. To read the look it has NOW: query({ table: "brand_kit" }). ' +
+    'Calls no model and spends nothing.',
+  members: [UPDATE_BRAND_KIT, UPDATE_VOICE, SET_COLORS, SET_APPEARANCE]
+} satisfies BrandFamily;
+
+export const BRAND_FAMILIES: readonly BrandFamily[] = [UPDATE_BRAND_IDENTITY];
+
+const MEMBER_TOOLS = new Set(BRAND_FAMILIES.flatMap((f) => f.members.map((m) => m.tool)));
+
+/** Un membro non si registra piu' da solo: il suo tool e' la famiglia. La rotta REST resta. */
+export function inAFamily(endpoint: BrandEndpoint): boolean {
+  return MEMBER_TOOLS.has(endpoint.tool);
+}
+
+export function familyFields(family: BrandFamily): z.ZodRawShape {
+  return family.members.reduce<z.ZodRawShape>(
+    (shape, member) => ({ ...shape, ...member.input.partial().shape }),
+    {}
+  );
+}
+
+export function familyInput(family: BrandFamily): z.ZodObject<z.ZodRawShape> {
+  return z.strictObject(familyFields(family));
+}
+
+/**
+ * Le rotte da chiamare, nell'ordine dichiarato: solo quelle di cui il chiamante ha nominato almeno
+ * un campo. Chiamarle tutte manderebbe un corpo vuoto a chi risponde `no_fields`, e la meta' di
+ * una scrittura riuscita e' peggio di un rifiuto.
+ */
+export function familyCalls(
+  family: BrandFamily,
+  input: Record<string, unknown>
+): { endpoint: ResourcelessEndpoint; body: Record<string, unknown> }[] {
+  return family.members
+    .map((endpoint) => ({
+      endpoint,
+      body: Object.fromEntries(
+        Object.keys(endpoint.input.shape)
+          .filter((field) => input[field] !== undefined)
+          .map((field) => [field, input[field]])
+      )
+    }))
+    .filter(({ body }) => Object.keys(body).length > 0);
+}

--- a/cli/lib/contracts/index.ts
+++ b/cli/lib/contracts/index.ts
@@ -1,4 +1,5 @@
 import type { z } from 'zod';
+import { inAFamily } from './families';
 import { ADS_ACTION, ADS_REMIX } from './ads';
 import { SET_APPEARANCE } from './appearance';
 import { SET_AUTOMATION } from './automations';
@@ -166,7 +167,6 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   GENERATE_CAROUSEL,
   GENERATE_IMAGE,
   GENERATE_VIDEO,
-  GENERATE_MEDIA,
   GEO_ACTION,
   GET_ADS,
   GET_CREATION_KIT,
@@ -220,6 +220,25 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   UPDATE_ROW,
   UPDATE_VOICE,
 ];
+
+export {
+  BRAND_FAMILIES,
+  familyCalls,
+  familyInput,
+  inAFamily,
+  UPDATE_BRAND_IDENTITY
+} from './families';
+export type { BrandFamily } from './families';
+
+/**
+ * Gli endpoint che diventano un tool per conto proprio: il registro meno chi e' finito in una
+ * famiglia. Sta scritto qui una volta perche' lo leggono il registrar e ogni test che confronta
+ * `tools/list` col registro — e una sottrazione ripetuta in cinque posti diverge al primo che
+ * qualcuno dimentica.
+ */
+export const OWN_TOOL_ENDPOINTS: readonly BrandEndpoint[] = BRAND_ENDPOINTS.filter(
+  (endpoint) => !inAFamily(endpoint)
+);
 
 export function pathFor(endpoint: ResourcelessEndpoint, slug: string): string;
 export function pathFor(endpoint: ResourceEndpoint, slug: string, id: string): string;

--- a/cli/lib/contracts/posts.ts
+++ b/cli/lib/contracts/posts.ts
@@ -540,9 +540,9 @@ const BrandStyleField = z
 /**
  * Un disegno chiesto senza brand non entra in nessuna libreria, quindi non ha un id da mostrare:
  * `null` è il fatto, e dirlo qui è ciò che impedisce di passarlo a `create_post` e di cercarlo con
- * `list_media`. Non è la stessa forma di `refine_media` o `generate_media`, che un brand ce
- * l'hanno sempre e un id lo restituiscono sempre — allargare anche il loro schema significherebbe
- * togliere una promessa che quei due mantengono.
+ * `list_media`. Non è la stessa forma di `refine_media`, che un brand ce l'ha sempre e un id
+ * lo restituisce sempre — allargare anche il suo schema significherebbe togliere una promessa
+ * che mantiene.
  */
 const DrawnMediaSchema = GeneratedMediaSchema.extend({
   id: z
@@ -634,9 +634,9 @@ export const REFINE_MEDIA = {
     'it, and a short prefix works. It starts FROM that asset: the picture you already made comes ' +
     'back changed, not redrawn. Say what should CHANGE, not what the whole thing should be. ' +
     'The result is filed as a NEW asset, so a wrong edit costs one render and never your ' +
-    'original. Do NOT reach for generate_image, generate_video or generate_media to alter ' +
-    'something: those three start from nothing and give you a different subject, which is the ' +
-    'mistake this tool exists to end. It spends credits, and the answer says how many renders ' +
+    'original. Do NOT reach for generate_image or generate_video to alter something: those two ' +
+    'start from nothing and give you a different subject, which is the mistake this tool ' +
+    'exists to end. It spends credits, and the answer says how many renders ' +
     'were billed. It creates nothing in the calendar and publishes nothing; pass the id it ' +
     'returns to create_post as media_ids when you want a post. Each kind has its own model — ' +
     'get_media_models, slot imageRefineModel for a picture and videoRefineModel for a clip — and ' +

--- a/cli/mcp/brand-free-tools.test.ts
+++ b/cli/mcp/brand-free-tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { BRAND_ENDPOINTS } from '../lib/contracts/index.ts';
+import { OWN_TOOL_ENDPOINTS } from '../lib/contracts/index.ts';
 import { handleMcpFetch } from './http-app.ts';
 
 /**
@@ -64,7 +64,7 @@ describe('slug opzionale, e solo dove il registro lo dichiara', () => {
   test('ogni altro endpoint del registro tiene slug obbligatorio', async () => {
     const all = await tools();
 
-    for (const endpoint of BRAND_ENDPOINTS) {
+    for (const endpoint of OWN_TOOL_ENDPOINTS) {
       const required = find(all, endpoint.tool).inputSchema?.required ?? [];
 
       expect(required.includes('slug'), endpoint.tool).toBe(!endpoint.pathWithoutBrand);

--- a/cli/mcp/migrated-writes.test.ts
+++ b/cli/mcp/migrated-writes.test.ts
@@ -67,41 +67,6 @@ const MIGRATED_WRITES = [
     annotations: NOT_DESTRUCTIVE,
   },
   {
-    name: 'update_brand_kit',
-    title: 'Update brand kit',
-    properties: {
-      slug: SLUG,
-      about: { type: 'string' },
-      category: { type: 'string' },
-      target_audience: { type: 'string' },
-      brand_style: { type: 'string' },
-      language: { type: 'string' },
-    },
-    required: ['slug'],
-    annotations: NOT_DESTRUCTIVE,
-  },
-  {
-    name: 'update_voice',
-    title: 'Update voice',
-    properties: {
-      slug: SLUG,
-      mood: { type: 'string' },
-      tone: { type: 'string' },
-      register: { type: 'number' },
-      emotion: { type: 'string' },
-      character: { type: 'string' },
-      syntax: { type: 'string' },
-      avoid: { type: 'array', items: { type: 'string' } },
-      platform_instructions: {
-        type: 'object',
-        propertyNames: { type: 'string' },
-        additionalProperties: { type: 'string' },
-      },
-    },
-    required: ['slug'],
-    annotations: NOT_DESTRUCTIVE,
-  },
-  {
     name: 'add_competitor',
     title: 'Add competitor',
     properties: {

--- a/cli/mcp/read-tools.test.ts
+++ b/cli/mcp/read-tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { BRAND_ENDPOINTS } from '../lib/contracts/index.ts';
+import { BRAND_ENDPOINTS, OWN_TOOL_ENDPOINTS } from '../lib/contracts/index.ts';
 import { handleMcpFetch } from './http-app.ts';
 import { MCP_INSTRUCTIONS } from './server.ts';
 
@@ -44,7 +44,7 @@ describe('i tool sono quello che il registry dichiara', () => {
   test('ogni endpoint del registry esiste in tools/list come lo dichiara', async () => {
     const all = await tools();
 
-    for (const endpoint of BRAND_ENDPOINTS) {
+    for (const endpoint of OWN_TOOL_ENDPOINTS) {
       const tool = find(all, endpoint.tool);
 
       expect(tool.title, endpoint.tool).toBe(endpoint.title);

--- a/cli/mcp/refine-media.test.ts
+++ b/cli/mcp/refine-media.test.ts
@@ -39,7 +39,8 @@ describe('refine_media in tools/list', () => {
     // Il modello che aveva ridisegnato un gatto rosso invece di arrossare il suo aveva letto la
     // lista e non aveva trovato la rifinitura. Qui deve trovarla, e deve leggere che generare NON
     // e' la strada — nominato, non sottinteso.
-    expect(description).toMatch(/generate_media/);
+    expect(description).toMatch(/generate_image/);
+    expect(description).toMatch(/generate_video/);
     expect(description.toLowerCase()).toMatch(/video/);
     expect(description.toLowerCase()).toMatch(/new asset|nuovo/);
   });

--- a/cli/mcp/studio-writes.test.ts
+++ b/cli/mcp/studio-writes.test.ts
@@ -99,12 +99,12 @@ describe('le scritture dello studio esposte dal registry', () => {
  * prima di partire. E' che TUTTO cio' che il tool accetta, una volta normalizzato, la rotta lo
  * salvi. Niente puo' passare di qui per morire di la'.
  */
-describe('set_colors non accetta niente che la rotta rifiuti', () => {
+describe('i colori di update_brand_identity non accettano niente che la rotta rifiuti', () => {
   const ROUTE_HEX = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
   const normalize = (c: string) => (c.startsWith('#') ? c : `#${c}`);
 
   test('quello che il tool lascia passare, la rotta lo salva', async () => {
-    const schema = find(await tools(), 'set_colors').inputSchema as {
+    const schema = find(await tools(), 'update_brand_identity').inputSchema as {
       properties: { colors: { items: { pattern?: string } } };
     };
     const pattern = schema.properties.colors.items.pattern;

--- a/cli/mcp/tool-surface-cost.test.ts
+++ b/cli/mcp/tool-surface-cost.test.ts
@@ -4,25 +4,24 @@ import { handleMcpFetch } from './http-app.ts';
 /**
  * `tools/list` si paga a ogni sessione, come le istruzioni del handshake, e nessuno lo guardava:
  * misurato sul transport vero era 129.212 caratteri — circa 32.300 token prima che l'agente
- * chieda qualunque cosa. Oggi sono 94.215, e il tetto lascia il margine di qualche tool nuovo:
- * quando lo sfonda, la superficie va guardata di nuovo invece di crescere in silenzio. E scende
- * insieme al numero, o smette di essere una guardia: 19.000 caratteri di margine non fermano nulla.
+ * chieda qualunque cosa. Oggi sono 91.053 su 84 tool, e il tetto lascia il margine di qualche tool
+ * nuovo: quando lo sfonda, la superficie va guardata di nuovo invece di crescere in silenzio. E
+ * scende insieme al numero, o smette di essere una guardia: 19.000 caratteri di margine non
+ * fermano nulla.
  *
- * I 3.052 in più rispetto a `dev` (91.163) sono `insert_row` e `update_row`, e il conto va detto
- * per intero perché il tetto da solo lo nasconde: NON portano via l'enum delle 149 tabelle che
- * `query` si porta dietro — lì costa ~2.700 caratteri e li vale, perché una lettura si scopre
- * indovinando il nome, mentre chi sta per scrivere ha appena letto. Il rientro è il censimento dei
- * 71 handler di scrittura, che ne trova quattro — `create_product`, `update_product`,
- * `update_person`, `update_competitor`, 3.794 caratteri — che sono `insert`/`update` di una riga e
- * nient'altro. Toglierli è una decisione separata: quando atterra, questo numero scende sotto
- * quello di partenza.
+ * Il rientro promesso qui è arrivato per un'altra strada. `insert_row` e `update_row` avevano
+ * portato la lista a 94.215 su 88, e il censimento diceva che sarebbero rientrati togliendo i
+ * quattro CRUD di una riga. Quelli sono usciti con #392; questi 3.162 in meno sono un'altra cosa:
+ * `update_brand_identity` prende il posto di quattro tool che scrivevano le stesse due righe, e
+ * `generate_media` — la porta vecchia che inoltrava a `generate_image` e `generate_video` — esce.
+ * Quattro tool in meno, e nessuna capacità con loro.
  *
  * Si misura il TRANSPORT, non i sorgenti: il conto dei sorgenti ha già sbagliato due volte,
  * perché lo schema JSON che il protocollo spedisce non somiglia allo zod da cui nasce. E si misura
  * `result` intero, wrapper `{"tools":…}` compreso: contare il solo array dà 10 caratteri in meno,
  * ed è la differenza esatta fra due conteggi che sembravano in disaccordo.
  */
-const TOOLS_LIST_MAX_CHARS = 97_000;
+const TOOLS_LIST_MAX_CHARS = 93_000;
 
 async function listedTools(): Promise<{ tools: Array<Record<string, unknown>>; chars: number }> {
   const post = (body: unknown) =>

--- a/cli/mcp/tools/brand-content.ts
+++ b/cli/mcp/tools/brand-content.ts
@@ -3,8 +3,11 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { api, callEndpoint } from '../../lib/api.ts';
 import {
   acceptsIdPrefix,
-  BRAND_ENDPOINTS,
+  BRAND_FAMILIES,
   BRAND_RESOURCES,
+  familyCalls,
+  familyInput,
+  OWN_TOOL_ENDPOINTS,
   type BrandResource,
 } from '../../lib/contracts/index.ts';
 import { resolvePostId, resolveResourceId, withAuth } from '../util.ts';
@@ -24,8 +27,37 @@ const optionalSlug = slug
 const resourceId = (resource: BrandResource) =>
   z.string().min(1).describe(`${BRAND_RESOURCES[resource]} id or unambiguous prefix`);
 
+/**
+ * Le rotte di una famiglia si chiamano in fila, non in parallelo: scrivono la stessa riga, e
+ * `set_appearance` la rilegge per non perdere il font che non gli hai mandato.
+ */
+function registerFamilies(server: McpServer) {
+  for (const family of BRAND_FAMILIES) {
+    server.registerTool(
+      family.tool,
+      {
+        title: family.title,
+        description: family.description,
+        inputSchema: familyInput(family).extend({ slug }),
+        annotations: { readOnlyHint: false, destructiveHint: false },
+      },
+      async ({ slug: brandSlug, ...input }) =>
+        withAuth(async (token) => {
+          const calls = familyCalls(family, input);
+          if (calls.length === 0) throw new Error('no_fields: name at least one field to change');
+
+          let answer: Record<string, unknown> = {};
+          for (const { endpoint, body } of calls) {
+            answer = { ...answer, ...(await callEndpoint<Record<string, unknown>>(endpoint, token, brandSlug as string, body)) };
+          }
+          return answer;
+        }),
+    );
+  }
+}
+
 function registerDeclaredEndpoints(server: McpServer) {
-  for (const endpoint of BRAND_ENDPOINTS) {
+  for (const endpoint of OWN_TOOL_ENDPOINTS) {
     const byPrefix = acceptsIdPrefix(endpoint);
     server.registerTool(
       endpoint.tool,
@@ -66,6 +98,7 @@ function registerDeclaredEndpoints(server: McpServer) {
 
 export function registerBrandTools(server: McpServer) {
   registerDeclaredEndpoints(server);
+  registerFamilies(server);
 
   server.registerTool(
     'approve_posts',

--- a/cli/mcp/write-families.test.ts
+++ b/cli/mcp/write-families.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, test } from 'bun:test';
+import { runWithRequestAuth } from './context.ts';
+import { handleMcpFetch } from './http-app.ts';
+
+async function rpc(method: string, params: unknown, id = 1) {
+  const res = await handleMcpFetch(
+    new Request('http://localhost/mcp', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json, text/event-stream' },
+      body: JSON.stringify({ jsonrpc: '2.0', id, method, params }),
+    }),
+  );
+  return (await res.json()) as { result?: Record<string, unknown> };
+}
+
+type Tool = {
+  name: string;
+  description?: string;
+  inputSchema?: { properties?: Record<string, unknown> };
+  annotations?: Record<string, unknown>;
+};
+
+async function tools(): Promise<Tool[]> {
+  await rpc('initialize', {
+    protocolVersion: '2024-11-05',
+    capabilities: {},
+    clientInfo: { name: 'families', version: '0.0.1' },
+  });
+  return ((await rpc('tools/list', {}, 2)).result?.tools ?? []) as Tool[];
+}
+
+const find = async (name: string): Promise<Tool> => {
+  const tool = (await tools()).find((t) => t.name === name);
+  if (!tool) throw new Error(`tool ${name} non registrato`);
+  return tool;
+};
+
+const fields = (tool: Tool): string[] => Object.keys(tool.inputSchema?.properties ?? {});
+
+type ApiCall = { method: string; path: string; body: Record<string, unknown> };
+
+/** Ogni chiamata che il tool fa davvero: il fan-out si misura sulle rotte toccate, non sullo schema. */
+async function callTool(
+  name: string,
+  args: Record<string, unknown>,
+  reply: (path: string) => unknown = () => ({ ok: true }),
+): Promise<{ calls: ApiCall[]; structured: Record<string, unknown>; isError: boolean }> {
+  const calls: ApiCall[] = [];
+  const realFetch = globalThis.fetch;
+
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = new URL(typeof input === 'string' ? input : input.toString());
+    calls.push({
+      method: init?.method ?? 'GET',
+      path: url.pathname,
+      body: typeof init?.body === 'string' ? JSON.parse(init.body) : {},
+    });
+    return new Response(JSON.stringify(reply(url.pathname)), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }) as typeof fetch;
+
+  try {
+    const res = await runWithRequestAuth(
+      { access_token: 'tok', user: { id: 'u1', email: 'u@example.com' }, source: 'bearer' },
+      async () => {
+        await rpc('initialize', {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: 'families', version: '0.0.1' },
+        });
+        return rpc('tools/call', { name, arguments: args }, 3);
+      },
+    );
+    return {
+      calls,
+      structured: (res.result?.structuredContent ?? {}) as Record<string, unknown>,
+      isError: res.result?.isError === true,
+    };
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+}
+
+const RETIRED = ['update_brand_kit', 'update_voice', 'set_colors', 'set_appearance'] as const;
+
+describe('update_brand_identity: una porta sola per cosa il brand è, come suona e come appare', () => {
+  test('i quattro nomi non sono più in tools/list, e il nuovo sì', async () => {
+    const names = (await tools()).map((t) => t.name);
+
+    expect(names).toContain('update_brand_identity');
+    for (const gone of RETIRED) expect(names, gone).not.toContain(gone);
+  });
+
+  /**
+   * Il conto delle capacità, non delle parole: ogni campo che i quattro accettavano deve stare
+   * nello schema del nuovo, o il collasso ha tolto qualcosa invece di unirlo.
+   */
+  test('accetta ogni campo che i quattro accettavano', async () => {
+    const props = fields(await find('update_brand_identity'));
+
+    for (const field of [
+      'about', 'category', 'target_audience', 'brand_style', 'language',
+      'mood', 'tone', 'register', 'emotion', 'character', 'syntax', 'avoid', 'platform_instructions',
+      'colors',
+      'logo_url', 'favicon_url', 'remove_logo', 'display_font', 'body_font',
+      'graphic_instructions', 'visual_style',
+    ]) {
+      expect(props, field).toContain(field);
+    }
+  });
+
+  test('nessun campo è obbligatorio: si manda solo quello che cambia', async () => {
+    const schema = (await find('update_brand_identity')).inputSchema as { required?: string[] };
+
+    expect(schema.required ?? []).toEqual(['slug']);
+  });
+
+  test('manda ogni campo alla rotta che lo sa scrivere, in una chiamata sola', async () => {
+    const { calls } = await callTool('update_brand_identity', {
+      slug: 'demo',
+      language: 'it',
+      tone: 'warm',
+      colors: ['#7c5cff'],
+      display_font: 'Inter',
+      body_font: 'Inter',
+    });
+
+    const routed = Object.fromEntries(calls.map((c) => [c.path.replace('/api/v1/brands/demo', ''), c.body]));
+
+    expect(routed['/studio/kit']).toEqual({ language: 'it' });
+    expect(routed['/voice/update']).toEqual({ tone: 'warm' });
+    expect(routed['/studio/colors']).toEqual({ colors: ['#7c5cff'] });
+    expect(routed['/studio/appearance']).toEqual({ display_font: 'Inter', body_font: 'Inter' });
+  });
+
+  test('non chiama la rotta di cui non hai nominato nessun campo', async () => {
+    const { calls } = await callTool('update_brand_identity', { slug: 'demo', colors: ['#000'] });
+
+    expect(calls.map((c) => c.path)).toEqual(['/api/v1/brands/demo/studio/colors']);
+  });
+
+  test('il metodo di ogni rotta resta quello che il contratto dichiara', async () => {
+    const { calls } = await callTool('update_brand_identity', { slug: 'demo', tone: 'warm', colors: ['#000'] });
+
+    const byPath = Object.fromEntries(calls.map((c) => [c.path, c.method]));
+    expect(byPath['/api/v1/brands/demo/voice/update']).toBe('POST');
+    expect(byPath['/api/v1/brands/demo/studio/colors']).toBe('PUT');
+  });
+
+  /** Gli echi che i quattro davano — il `#` aggiunto ai colori, la vista dell'aspetto — restano. */
+  test('la risposta porta gli echi delle rotte che hanno scritto', async () => {
+    const { structured } = await callTool(
+      'update_brand_identity',
+      { slug: 'demo', colors: ['7c5cff'], visual_style: 'x'.repeat(30) },
+      (path) =>
+        path.endsWith('/studio/colors')
+          ? { ok: true, colors: ['#7c5cff'] }
+          : { ok: true, appearance: { colors: ['#7c5cff'], visual_style_locked: true } },
+    );
+
+    expect(structured.ok).toBe(true);
+    expect(structured.colors).toEqual(['#7c5cff']);
+    expect((structured.appearance as { visual_style_locked: boolean }).visual_style_locked).toBe(true);
+  });
+
+  test('senza nessun campo non tocca niente e lo dice', async () => {
+    const { calls, isError } = await callTool('update_brand_identity', { slug: 'demo' });
+
+    expect(calls).toEqual([]);
+    expect(isError).toBe(true);
+  });
+
+  /**
+   * Chi conosceva i quattro nomi deve atterrare qui leggendo la lista, non scoprendo un 404: sono
+   * i nomi con cui cercherà, e la palette è la ricerca che si è già persa una volta.
+   */
+  test('la descrizione nomina i quattro nomi ritirati e la parola con cui li si cerca', async () => {
+    const description = (await find('update_brand_identity')).description ?? '';
+
+    for (const gone of RETIRED) expect(description, gone).toContain(gone);
+    expect(description.toLowerCase()).toContain('colour');
+    expect(description.toLowerCase()).toContain('logo');
+    expect(description.toLowerCase()).toContain('voice');
+  });
+
+  test('non distrugge niente: è additivo campo per campo', async () => {
+    expect((await find('update_brand_identity')).annotations).toMatchObject({
+      readOnlyHint: false,
+      destructiveHint: false,
+    });
+  });
+
+  /**
+   * `set_bio` scrive `social_accounts`, non il brand, e risponde 404 quando nessun account è
+   * collegato: unirlo qui darebbe alla famiglia un fallimento che nessuno degli altri può avere.
+   */
+  test('set_bio resta il suo tool: scrive un account social, non il brand', async () => {
+    expect((await tools()).map((t) => t.name)).toContain('set_bio');
+  });
+});
+
+describe('generate_media è ritirato: era la porta vecchia che inoltrava alle altre due', () => {
+  test('non è più in tools/list, e le due a cui inoltrava ci sono', async () => {
+    const names = (await tools()).map((t) => t.name);
+
+    expect(names).not.toContain('generate_media');
+    expect(names).toContain('generate_image');
+    expect(names).toContain('generate_video');
+  });
+
+  test('ogni campo che accettava resta raggiungibile dai due che restano', async () => {
+    const image = fields(await find('generate_image'));
+    const video = fields(await find('generate_video'));
+
+    for (const field of ['prompt', 'count', 'aspect_ratio', 'model', 'title']) {
+      expect(image, field).toContain(field);
+    }
+    for (const field of ['prompt', 'aspect_ratio', 'model', 'title']) {
+      expect(video, field).toContain(field);
+    }
+  });
+
+  test('nessuna descrizione manda più a un tool che non esiste', async () => {
+    for (const tool of await tools()) {
+      expect(tool.description ?? '', tool.name).not.toContain('generate_media');
+    }
+  });
+});

--- a/cli/plugins/anomalia/skills/anomalia/SKILL.md
+++ b/cli/plugins/anomalia/skills/anomalia/SKILL.md
@@ -179,10 +179,6 @@ a brand there is no brand, and guessing one spends a real organisation's credits
 render per image and creates nothing in the calendar, so ask for two or three with `count`, look
 at them, keep one.
 
-**If you reach for `generate_media`** — the older door — it still works and forwards to
-`generate_image` and `generate_video`. Prefer those two: they name what they do. And changing
-something that already exists is neither of them: that is `refine_media`.
-
 **Make a carousel** → `generate_carousel` with a brief. It plans the series, draws every slide and
 returns them in order plus the `continuity_tokens` that hold them together. One render per slide.
 To fix a single slide afterwards, `refine_media` on its id **with those tokens in the instruction** —
@@ -212,7 +208,7 @@ that post's image — one render, and the old one is gone. When you want to keep
 instruction ("make it red", "warmer background", "keep the movement but make it night"). One door
 for every kind: an image or a video from the brand's **library**, and the asset's own kind picks
 the engine — you never say which it is. It starts from that asset, so the result is that picture
-or that clip changed. Do NOT reach for `generate_image`, `generate_video` or `generate_media` to
+or that clip changed. Do NOT reach for `generate_image` or `generate_video` to
 alter something: a new prompt starts from nothing, pays for a fresh render, and gives you a
 different subject — the commonest and most expensive mistake on this surface. The original is
 never overwritten: refining files a new asset, so a wrong edit costs one render and not your
@@ -270,13 +266,19 @@ byline. `analytics` takes a closed list of providers (`ga4`, `meta_pixel`, `plau
 with their id — there is no field for arbitrary JavaScript, and those trackers load only on a
 verified custom domain, only after the visitor accepts cookies.
 
-**Change how the brand looks** → `set_appearance` changes the logo, favicon, graphic fonts and
-visual brief; read what they are now from `brand_kit` with `query` (recipe under Quick workflows —
-the real logo is the entry whose `type` is not `og-image`). A logo is
-given as a URL and is DOWNLOADED and re-hosted, so read back the address it answers with. Fonts go
-in pairs and are checked against Google Fonts before saving — a family it will not serve is refused
-rather than rendered as Inter. Setting `visual_style` locks it against the nightly rebuild.
-Colours stay with `set_colors`.
+**Change what the brand IS, how it SOUNDS, how it LOOKS** → `update_brand_identity`, one door for
+all of it: the facts every post is written from (`about`, `category`, `target_audience`,
+`brand_style`, `language`), the voice (`mood`, `tone`, `register`, `avoid`,
+`platform_instructions`), the `colors`, and the look — logo, favicon, graphic fonts, visual brief.
+It took four tools — `update_brand_kit`, `update_voice`, `set_colors`, `set_appearance` — and the
+split is why "change the brand's colours" opened the tool called appearance and found no colour
+field. Only the fields you send change. `colors` REPLACES the whole palette, so send every colour
+you want kept. A logo is given as a URL and is DOWNLOADED and re-hosted, so read back the address
+it answers with. Fonts go in pairs and are checked against Google Fonts before saving — a family
+it will not serve is refused rather than rendered as Inter. Setting `visual_style` locks it against
+the nightly rebuild. Read what they are now from `brand_kit` with `query` (recipe under Quick
+workflows — the real logo is the entry whose `type` is not `og-image`). The past posts the writer
+imitates are `voice_examples` on `set_brand_settings`, not here. Free.
 
 **Choose which model draws and which films** → `get_media_models` lists the six jobs (image
 generation, image refinement, video from text, animating a still, video refinement, motion
@@ -311,7 +313,7 @@ access to the brand.
 
 **Make the copy sound like this brand** → `query` on `brands.content_prefs` for how it is supposed
 to sound — mood, tone, register, the words it avoids, the rules that change per platform — and
-`update_voice` to change any of them. This is the brand; `get_writing_skills` is the craft. Read both before writing.
+`update_brand_identity` to change any of them. This is the brand; `get_writing_skills` is the craft. Read both before writing.
 
 **Do ChatGPT, Perplexity and Google's AI mention this brand?** → `query` on `brand_geo_audits`
 reads the last answer for free: `share_of_voice`, and `citations` is the question-by-question

--- a/cli/plugins/anomalia/skills/anomalia/references/tools.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/tools.md
@@ -139,13 +139,11 @@ date and the brand timezone. Reach for these two when nothing else covers the ta
 | MCP | CLI |
 |-----|-----|
 | `diagnose_brand` | (MCP only) |
-| `update_voice` | `anomalia voice <slug>` |
 | `get_creation_kit` | (MCP only) |
 | `create_post` | (MCP only) |
 | `check_content` | (MCP only) |
 | `generate_captions` | (MCP only) |
 | `import_media_url` | (MCP only) |
-| `generate_media` | (MCP only) |
 | `generate_image` | (MCP only) |
 | `refine_media` | (MCP only) |
 | `generate_video` | (MCP only) |
@@ -220,18 +218,17 @@ before a byte is stored, so a rejected import leaves nothing behind. The result 
 the resolved `source_url` kept as the asset's origin, and a `signed_url` you can open to check
 that the right file arrived.
 
-`generate_media` makes a NEW image or video and puts it straight into the brand library — no
-post, nothing in the calendar. Required: `slug`, `prompt`; optional `kind` (`image` default, or
-`video`), `count`, `aspect_ratio`, `title`. **This spends credits**, unlike `import_media_url`:
-every image is a paid render and every video a paid clip. `count` draws up to 4 alternatives in
+`generate_image` and `generate_video` make a NEW image or clip and put it straight into the brand
+library — no post, nothing in the calendar. **They spend credits**, unlike `import_media_url`:
+every image is a paid render and every clip a paid render. `count` draws up to 4 alternatives in
 one call and bills each one, so generate a few, look at them with a `query` on `brand_media`, and
 pass only the id you keep to `create_post` as `media_ids` — the calendar stays clean either way.
 
-An image comes back finished: `status` is `ready` and `media` carries the rows, each with a
-`signed_url` you can open. A video cannot: it takes minutes, longer than any single call may
-last, so it comes back with `status` `rendering` and a `job_id`, and a `query` on `video_renders`
-says where it got to. Do not call `generate_media` again for the same clip while one is rendering —
-that bills a second one. Refusals: `credits_exhausted` (402) means the brand's pool is empty and
+An image comes back finished: `media` carries the rows, each with a `signed_url` you can open. A
+video cannot: it takes minutes, longer than any single call may last, so it comes back with
+`status` `rendering` and a `job_id`, and a `query` on `video_renders` says where it got to. Do not
+call `generate_video` again for the same clip while one is rendering — that bills a second one.
+Refusals: `credits_exhausted` (402) means the brand's pool is empty and
 nothing was drawn; `video_budget_exhausted` (400) means the monthly video allowance is used up,
 counting the clips still rendering; `render_failed` (502) is the model returning nothing, and
 nothing is stored; `store_failed` (502) means it was drawn but could not be filed.
@@ -273,9 +270,9 @@ picture must take nothing from the brand: a plain UI screenshot, an illustration
 else, a neutral background — places where brand colours and fonts spoil the result. Without a slug
 there is no brand to apply or ignore, and sending it is refused as `brand_style_needs_a_brand`
 rather than quietly dropped: pass a slug, or drop `brand_style`. `refine_media` takes the same
-field, and the brand's look reaches a refinement the same way. `generate_carousel` and
-`generate_media` apply it too but take no `brand_style`: a series that is not the brand's is not a
-series, and `generate_media` is the old door — call `generate_image` when you need the switch. A
+field, and the brand's look reaches a refinement the same way. `generate_carousel` applies
+it too but takes no `brand_style`: a series that is not the brand's is not a series — call
+`generate_image` when you need the switch. A
 clip filmed by `generate_video` from a prompt alone follows the brand's visual direction and cannot
 be switched off either; animating a library image takes its look from that image's pixels instead.
 
@@ -531,7 +528,7 @@ deck. No credits, no writes.
 
 | MCP | CLI |
 |-----|-----|
-| `update_brand_kit` / `set_colors` | `anomalia studio <slug> kit-update\|colors …` |
+| `update_brand_identity` | `anomalia studio <slug> kit-update\|colors …`, `anomalia voice <slug>` |
 | `add_note` / `delete_document` | `anomalia studio <slug> add-note\|delete-doc …` |
 | `add_person` / `generate_person` / `delete_person` | `anomalia studio <slug> people-*` |
 | `update_person` | (MCP only) |
@@ -625,7 +622,7 @@ exists. Say so when it happens, and read `social_accounts` with `query` — `pla
 `status` — which is where *why* a platform is missing becomes visible.
 
 An unknown IANA zone is refused (`unknown_timezone`), and so is a platform outside the list —
-`twitter` is not a name here, it is `x`. The post language lives on `update_brand_kit`, not here.
+`twitter` is not a name here, it is `x`. The post language lives on `update_brand_identity`, not here.
 
 ## Recurring jobs
 
@@ -725,7 +722,7 @@ The blog icon and an author's avatar are images and cannot be set through these 
 
 | MCP | CLI |
 |-----|-----|
-| `set_appearance` | (MCP only) |
+| `update_brand_identity` | (MCP only) |
 
 The look every render follows: logo, favicon, colour palette, the two Google Fonts graphics are
 composed with, and the visual brief. It is one row of `brand_kit`, so it is read with `query`:
@@ -750,7 +747,10 @@ the two cannot be combined (`logo_conflict`). `display_font` and `body_font` go 
 which names the missing family). Setting `visual_style` **locks** it: the nightly rebuild stops
 rewriting the brand's visual brief until someone regenerates it from the browser.
 
-Colours stay with `set_colors` (three or six hex digits, up to 8 — the list replaces the palette).
+The colours live on the same tool: `colors`, three or six hex digits, up to 8, and the list
+REPLACES the palette. `update_brand_identity` took the place of `set_appearance`, `set_colors`,
+`update_brand_kit` and `update_voice` — the four wrote the same two rows, and the split is why
+"change the brand's colours" opened the tool called appearance and found no colour field.
 
 ## Media models
 

--- a/cli/skills/anomalia/SKILL.md
+++ b/cli/skills/anomalia/SKILL.md
@@ -179,10 +179,6 @@ a brand there is no brand, and guessing one spends a real organisation's credits
 render per image and creates nothing in the calendar, so ask for two or three with `count`, look
 at them, keep one.
 
-**If you reach for `generate_media`** — the older door — it still works and forwards to
-`generate_image` and `generate_video`. Prefer those two: they name what they do. And changing
-something that already exists is neither of them: that is `refine_media`.
-
 **Make a carousel** → `generate_carousel` with a brief. It plans the series, draws every slide and
 returns them in order plus the `continuity_tokens` that hold them together. One render per slide.
 To fix a single slide afterwards, `refine_media` on its id **with those tokens in the instruction** —
@@ -212,7 +208,7 @@ that post's image — one render, and the old one is gone. When you want to keep
 instruction ("make it red", "warmer background", "keep the movement but make it night"). One door
 for every kind: an image or a video from the brand's **library**, and the asset's own kind picks
 the engine — you never say which it is. It starts from that asset, so the result is that picture
-or that clip changed. Do NOT reach for `generate_image`, `generate_video` or `generate_media` to
+or that clip changed. Do NOT reach for `generate_image` or `generate_video` to
 alter something: a new prompt starts from nothing, pays for a fresh render, and gives you a
 different subject — the commonest and most expensive mistake on this surface. The original is
 never overwritten: refining files a new asset, so a wrong edit costs one render and not your
@@ -270,13 +266,19 @@ byline. `analytics` takes a closed list of providers (`ga4`, `meta_pixel`, `plau
 with their id — there is no field for arbitrary JavaScript, and those trackers load only on a
 verified custom domain, only after the visitor accepts cookies.
 
-**Change how the brand looks** → `set_appearance` changes the logo, favicon, graphic fonts and
-visual brief; read what they are now from `brand_kit` with `query` (recipe under Quick workflows —
-the real logo is the entry whose `type` is not `og-image`). A logo is
-given as a URL and is DOWNLOADED and re-hosted, so read back the address it answers with. Fonts go
-in pairs and are checked against Google Fonts before saving — a family it will not serve is refused
-rather than rendered as Inter. Setting `visual_style` locks it against the nightly rebuild.
-Colours stay with `set_colors`.
+**Change what the brand IS, how it SOUNDS, how it LOOKS** → `update_brand_identity`, one door for
+all of it: the facts every post is written from (`about`, `category`, `target_audience`,
+`brand_style`, `language`), the voice (`mood`, `tone`, `register`, `avoid`,
+`platform_instructions`), the `colors`, and the look — logo, favicon, graphic fonts, visual brief.
+It took four tools — `update_brand_kit`, `update_voice`, `set_colors`, `set_appearance` — and the
+split is why "change the brand's colours" opened the tool called appearance and found no colour
+field. Only the fields you send change. `colors` REPLACES the whole palette, so send every colour
+you want kept. A logo is given as a URL and is DOWNLOADED and re-hosted, so read back the address
+it answers with. Fonts go in pairs and are checked against Google Fonts before saving — a family
+it will not serve is refused rather than rendered as Inter. Setting `visual_style` locks it against
+the nightly rebuild. Read what they are now from `brand_kit` with `query` (recipe under Quick
+workflows — the real logo is the entry whose `type` is not `og-image`). The past posts the writer
+imitates are `voice_examples` on `set_brand_settings`, not here. Free.
 
 **Choose which model draws and which films** → `get_media_models` lists the six jobs (image
 generation, image refinement, video from text, animating a still, video refinement, motion
@@ -311,7 +313,7 @@ access to the brand.
 
 **Make the copy sound like this brand** → `query` on `brands.content_prefs` for how it is supposed
 to sound — mood, tone, register, the words it avoids, the rules that change per platform — and
-`update_voice` to change any of them. This is the brand; `get_writing_skills` is the craft. Read both before writing.
+`update_brand_identity` to change any of them. This is the brand; `get_writing_skills` is the craft. Read both before writing.
 
 **Do ChatGPT, Perplexity and Google's AI mention this brand?** → `query` on `brand_geo_audits`
 reads the last answer for free: `share_of_voice`, and `citations` is the question-by-question

--- a/cli/skills/anomalia/references/tools.md
+++ b/cli/skills/anomalia/references/tools.md
@@ -139,13 +139,11 @@ date and the brand timezone. Reach for these two when nothing else covers the ta
 | MCP | CLI |
 |-----|-----|
 | `diagnose_brand` | (MCP only) |
-| `update_voice` | `anomalia voice <slug>` |
 | `get_creation_kit` | (MCP only) |
 | `create_post` | (MCP only) |
 | `check_content` | (MCP only) |
 | `generate_captions` | (MCP only) |
 | `import_media_url` | (MCP only) |
-| `generate_media` | (MCP only) |
 | `generate_image` | (MCP only) |
 | `refine_media` | (MCP only) |
 | `generate_video` | (MCP only) |
@@ -220,18 +218,17 @@ before a byte is stored, so a rejected import leaves nothing behind. The result 
 the resolved `source_url` kept as the asset's origin, and a `signed_url` you can open to check
 that the right file arrived.
 
-`generate_media` makes a NEW image or video and puts it straight into the brand library — no
-post, nothing in the calendar. Required: `slug`, `prompt`; optional `kind` (`image` default, or
-`video`), `count`, `aspect_ratio`, `title`. **This spends credits**, unlike `import_media_url`:
-every image is a paid render and every video a paid clip. `count` draws up to 4 alternatives in
+`generate_image` and `generate_video` make a NEW image or clip and put it straight into the brand
+library — no post, nothing in the calendar. **They spend credits**, unlike `import_media_url`:
+every image is a paid render and every clip a paid render. `count` draws up to 4 alternatives in
 one call and bills each one, so generate a few, look at them with a `query` on `brand_media`, and
 pass only the id you keep to `create_post` as `media_ids` — the calendar stays clean either way.
 
-An image comes back finished: `status` is `ready` and `media` carries the rows, each with a
-`signed_url` you can open. A video cannot: it takes minutes, longer than any single call may
-last, so it comes back with `status` `rendering` and a `job_id`, and a `query` on `video_renders`
-says where it got to. Do not call `generate_media` again for the same clip while one is rendering —
-that bills a second one. Refusals: `credits_exhausted` (402) means the brand's pool is empty and
+An image comes back finished: `media` carries the rows, each with a `signed_url` you can open. A
+video cannot: it takes minutes, longer than any single call may last, so it comes back with
+`status` `rendering` and a `job_id`, and a `query` on `video_renders` says where it got to. Do not
+call `generate_video` again for the same clip while one is rendering — that bills a second one.
+Refusals: `credits_exhausted` (402) means the brand's pool is empty and
 nothing was drawn; `video_budget_exhausted` (400) means the monthly video allowance is used up,
 counting the clips still rendering; `render_failed` (502) is the model returning nothing, and
 nothing is stored; `store_failed` (502) means it was drawn but could not be filed.
@@ -273,9 +270,9 @@ picture must take nothing from the brand: a plain UI screenshot, an illustration
 else, a neutral background — places where brand colours and fonts spoil the result. Without a slug
 there is no brand to apply or ignore, and sending it is refused as `brand_style_needs_a_brand`
 rather than quietly dropped: pass a slug, or drop `brand_style`. `refine_media` takes the same
-field, and the brand's look reaches a refinement the same way. `generate_carousel` and
-`generate_media` apply it too but take no `brand_style`: a series that is not the brand's is not a
-series, and `generate_media` is the old door — call `generate_image` when you need the switch. A
+field, and the brand's look reaches a refinement the same way. `generate_carousel` applies
+it too but takes no `brand_style`: a series that is not the brand's is not a series — call
+`generate_image` when you need the switch. A
 clip filmed by `generate_video` from a prompt alone follows the brand's visual direction and cannot
 be switched off either; animating a library image takes its look from that image's pixels instead.
 
@@ -531,7 +528,7 @@ deck. No credits, no writes.
 
 | MCP | CLI |
 |-----|-----|
-| `update_brand_kit` / `set_colors` | `anomalia studio <slug> kit-update\|colors …` |
+| `update_brand_identity` | `anomalia studio <slug> kit-update\|colors …`, `anomalia voice <slug>` |
 | `add_note` / `delete_document` | `anomalia studio <slug> add-note\|delete-doc …` |
 | `add_person` / `generate_person` / `delete_person` | `anomalia studio <slug> people-*` |
 | `update_person` | (MCP only) |
@@ -625,7 +622,7 @@ exists. Say so when it happens, and read `social_accounts` with `query` — `pla
 `status` — which is where *why* a platform is missing becomes visible.
 
 An unknown IANA zone is refused (`unknown_timezone`), and so is a platform outside the list —
-`twitter` is not a name here, it is `x`. The post language lives on `update_brand_kit`, not here.
+`twitter` is not a name here, it is `x`. The post language lives on `update_brand_identity`, not here.
 
 ## Recurring jobs
 
@@ -725,7 +722,7 @@ The blog icon and an author's avatar are images and cannot be set through these 
 
 | MCP | CLI |
 |-----|-----|
-| `set_appearance` | (MCP only) |
+| `update_brand_identity` | (MCP only) |
 
 The look every render follows: logo, favicon, colour palette, the two Google Fonts graphics are
 composed with, and the visual brief. It is one row of `brand_kit`, so it is read with `query`:
@@ -750,7 +747,10 @@ the two cannot be combined (`logo_conflict`). `display_font` and `body_font` go 
 which names the missing family). Setting `visual_style` **locks** it: the nightly rebuild stops
 rewriting the brand's visual brief until someone regenerates it from the browser.
 
-Colours stay with `set_colors` (three or six hex digits, up to 8 — the list replaces the palette).
+The colours live on the same tool: `colors`, three or six hex digits, up to 8, and the list
+REPLACES the palette. `update_brand_identity` took the place of `set_appearance`, `set_colors`,
+`update_brand_kit` and `update_voice` — the four wrote the same two rows, and the split is why
+"change the brand's colours" opened the tool called appearance and found no colour field.
 
 ## Media models
 

--- a/cli/skills/findability.test.ts
+++ b/cli/skills/findability.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import { fileURLToPath } from 'url';
-import { BRAND_ENDPOINTS } from '../lib/contracts/index.ts';
+import { BRAND_ENDPOINTS, BRAND_FAMILIES } from '../lib/contracts/index.ts';
 import { MCP_INSTRUCTIONS } from '../mcp/server.ts';
 
 /**
@@ -43,11 +43,6 @@ const ASKED_FOR: ReadonlyArray<{ tool: string; question: string; words: readonly
     words: ['animate', 'photo', 'video', 'clip']
   },
   { tool: 'make_video', question: 'turn this post into a video', words: ['post', 'video', 'animate'] },
-  {
-    tool: 'generate_media',
-    question: 'generate an image or a video',
-    words: ['image', 'video', 'generate_image', 'generate_video']
-  },
   {
     tool: 'render_post',
     question: 'this post has no image, draw it',
@@ -190,7 +185,7 @@ describe('una descrizione si legge cercando il proprio problema', () => {
   }
 
   test('nessuna descrizione scrive una tariffa a mano: il prezzo lo misura la risposta', () => {
-    for (const endpoint of BRAND_ENDPOINTS) {
+    for (const endpoint of [...BRAND_ENDPOINTS, ...BRAND_FAMILIES]) {
       expect(HAND_WRITTEN_TARIFF.test(endpoint.description), endpoint.tool).toBe(false);
     }
   });

--- a/cli/skills/tools-coverage.test.ts
+++ b/cli/skills/tools-coverage.test.ts
@@ -2,10 +2,9 @@ import { describe, expect, test } from 'bun:test';
 import { readdirSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { fileURLToPath } from 'url';
+import { BRAND_ENDPOINTS, BRAND_FAMILIES, inAFamily } from '../lib/contracts/index.ts';
 
 const CLI = fileURLToPath(new URL('../', import.meta.url));
-const REPO = join(CLI, '..');
-const CONTRACTS = join(REPO, 'packages', 'api-contracts', 'src');
 const MCP_TOOLS = join(CLI, 'mcp', 'tools');
 const REFERENCE = join(CLI, 'skills', 'anomalia', 'references', 'tools.md');
 
@@ -36,8 +35,17 @@ function sourceOf(dir: string): string {
     .join('\n');
 }
 
+/**
+ * La superficie, non la dichiarazione: un contratto puo' restare nel registro senza essere un tool
+ * — perche' una famiglia lo ha assorbito, o perche' la sua rotta e' rimasta REST e basta — e un
+ * estrattore che legge `tool:` dai sorgenti pretenderebbe che la skill nomini un nome che nessun
+ * agente vedra' mai.
+ */
 function registryTools(): Set<string> {
-  return new Set(names(/tool:\s*'([a-z][a-z0-9_]*)'/g, sourceOf(CONTRACTS)));
+  return new Set([
+    ...BRAND_ENDPOINTS.filter((endpoint) => !inAFamily(endpoint)).map((endpoint) => endpoint.tool),
+    ...BRAND_FAMILIES.map((family) => family.tool)
+  ]);
 }
 
 function handRegisteredTools(): Set<string> {

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -504,6 +504,15 @@ toglie **i nomi**, che sono l'unica cosa che oggi funziona.
 
 #### Il verdetto, famiglia per famiglia
 
+**Rivisto il 2026-09-07 per una sola riga.** I due argomenti qui sopra restano interi, ma il primo
+— quello del `destructiveHint`, che non si discute — vale solo dove la famiglia CONTIENE un verbo
+che distrugge. Su 71 scritture le distruttive sono 13, e ci sono famiglie che non ne hanno nessuna:
+lì il primo argomento non dice niente, e resta solo il secondo, che è un costo da pesare invece di
+un divieto. Pesato famiglia per famiglia con tre criteri misurabili — forme di risposta compatibili,
+un nome non più vago di quelli che sostituisce, nessun membro che fallisce in un modo che gli altri
+non conoscono — una sola famiglia lo supera: l'identità del brand. La misura sta in
+`changelog/2026-09-07-write-families.md`.
+
 | famiglia | tool | collassare? |
 |---|---|---|
 | Piano editoriale | `propose_plan` `revise_plan` `save_plan` `approve_plan` `discard_plan` | **peggio, due volte.** `approve_plan` sostituisce il piano attivo, `discard_plan` butta la proposta e «non torna indietro»: due distruzioni permanenti **diverse** dietro un enum |
@@ -512,7 +521,7 @@ toglie **i nomi**, che sono l'unica cosa che oggi funziona.
 | Post, ciclo di vita | `approve_post` `approve_posts` `reject_post` `publish_post` | peggio. `approve_post(all: true)` è un booleano il cui valore sbagliato pubblica tutta la coda |
 | Articoli | `generate_article` `update_article` `optimize_article` `publish_article` `unpublish_article` `delete_article` | peggio. Tre verbi permanenti; sono i nomi migliori del repo |
 | Studio CRUD | 11 tool fra competitor, person, product, document | peggio — ed è qui che il documento si contraddiceva |
-| Identità del brand | `update_brand_kit` `update_voice` `set_colors` `set_appearance` | peggio. Una trappola vera c'è, ma si ripara con una descrizione |
+| Identità del brand | `update_brand_kit` `update_voice` `set_colors` `set_appearance` | **collassati, 2026-09-07.** Il verdetto qui sotto era sbagliato e il perché sta in `changelog/2026-09-07-write-families.md`: i due argomenti valgono, ma nessuno dei due morde una famiglia senza verbi distruttivi. Ora è `update_brand_identity`, e `set_bio` resta fuori perché scrive `social_accounts` |
 | Impostazioni | 6 × `set_*` | peggio. I nomi **sono già** il discriminante, e sono buoni |
 | blog_term · radar_source · share | coppie add/remove | peggio. Ogni coppia è una creazione più una distruzione |
 | seo · geo · ads | i tre `*_action` che esistono già | qui sta la misura che manca — sotto |
@@ -582,8 +591,12 @@ niente, e va aspettato invece che forzato.
 | −3 tool di autenticazione (`login`, `logout`, `whoami`) | 119 |
 | −33 letture, servite da `query` | **86** |
 
-E finisce lì, salvo `generate_media` — l'unica cancellazione a cui questo documento si impegnava
-già, in corso su un altro ramo.
+| −3 identità dentro `update_brand_identity` | 83 |
+| −1 `generate_media`, la porta vecchia | **82** |
+
+Il conto sopra è quello di allora e non conosce `insert_row`/`update_row` (#392, +2 tool e −4 CRUD
+di una riga). Sul transport, che è l'unica misura che vale, il 2026-09-07 si passa da **88 tool /
+94.215 caratteri** a **84 / 91.053**.
 
 Le due righe che stavano qui — «−9 se il CRUD va da 15 a 6», «−7/8 se le impostazioni vanno da 10 a
 2/3» — erano stime scritte prima di aprire gli handler; aperti i 72 handler di scrittura, le

--- a/packages/api-contracts/src/families.ts
+++ b/packages/api-contracts/src/families.ts
@@ -1,0 +1,99 @@
+import { z } from 'zod';
+import { SET_APPEARANCE } from './appearance';
+import type { BrandEndpoint, ResourcelessEndpoint } from './index';
+import { SET_COLORS, UPDATE_BRAND_KIT, UPDATE_VOICE } from './studio';
+
+/**
+ * Una famiglia e' un tool solo davanti a piu' rotte, e il campo che il chiamante manda dice quale.
+ * NON e' un `*_action`: non c'e' nessun verbo dentro un parametro, quindi `destructiveHint` resta
+ * capace di dire la verita' — una famiglia si forma solo fra scritture che non distruggono niente,
+ * e il collasso muore appena una di loro toglie qualcosa.
+ *
+ * Le regole che una famiglia deve superare, tutte e tre, stanno in `docs/mcp-tools.md`: forme di
+ * risposta compatibili, un nome di famiglia non piu' vago di quelli che sostituisce, e nessun
+ * danno peggiore quando il modello sbaglia campo di quando sbagliava tool.
+ */
+export type BrandFamily = {
+  readonly tool: string;
+  readonly title: string;
+  readonly description: string;
+  /**
+   * Solo scritture a livello di brand. Una rotta che nomina una riga vuole un id, e un id in una
+   * famiglia sarebbe un secondo campo che sceglie: quale riga, oltre a quale rotta. Il tipo lo
+   * vieta invece di lasciarlo scoprire a chi lo prova.
+   */
+  readonly members: readonly ResourcelessEndpoint[];
+};
+
+/**
+ * Il look, i fatti e la voce del brand vivono in due righe sole — `brand_kit` e
+ * `brands.content_prefs` — e quattro tool ci scrivevano da quattro porte. La divisione non era
+ * neutra: chi cercava «cambia i colori del brand» apriva `set_appearance`, che di campi colore non
+ * ne aveva nessuno, e la palette stava in `set_colors`. Qui unire non peggiora la trovabilita': la
+ * ripara.
+ *
+ * `set_bio` non entra: scrive `social_accounts`, non il brand, e risponde 404 quando nessun account
+ * e' collegato — un fallimento che nessun altro membro puo' avere.
+ */
+export const UPDATE_BRAND_IDENTITY = {
+  tool: 'update_brand_identity',
+  title: 'Change what the brand is, how it sounds and how it looks',
+  description:
+    'Change what this brand IS, how it SOUNDS and how it LOOKS: its facts and language, its voice, ' +
+    'its colours, its logo, its fonts and its visual brief. One door for all of it — it replaces ' +
+    '`update_brand_kit`, `update_voice`, `set_colors` and `set_appearance`, which are gone. Only ' +
+    'the fields you send change, and at least one is required. `colors` REPLACES the whole ' +
+    'palette, so send every colour you want to keep: three or six hex digits, up to 8. `logo_url` ' +
+    'and `favicon_url` are DOWNLOADED and re-hosted, not linked, so a private, redirecting or ' +
+    'oversized address is refused rather than half-saved, and the answer carries the address we ' +
+    'stored; `remove_logo` clears it. `display_font` and `body_font` go together and must be ' +
+    'families Google Fonts actually serves — a name it will not serve renders as Inter with ' +
+    'nothing said, so they are checked before anything is written. Setting `visual_style` LOCKS ' +
+    'it: the nightly rebuild stops rewriting the brand’s visual brief until someone regenerates ' +
+    'it from the browser. Sending any voice field switches the brand OFF automatic voice: from ' +
+    'then on nobody rewrites it for you. The past posts the writer imitates are `voice_examples` on ' +
+    '`set_brand_settings`, not here. To read the look it has NOW: query({ table: "brand_kit" }). ' +
+    'Calls no model and spends nothing.',
+  members: [UPDATE_BRAND_KIT, UPDATE_VOICE, SET_COLORS, SET_APPEARANCE]
+} satisfies BrandFamily;
+
+export const BRAND_FAMILIES: readonly BrandFamily[] = [UPDATE_BRAND_IDENTITY];
+
+const MEMBER_TOOLS = new Set(BRAND_FAMILIES.flatMap((f) => f.members.map((m) => m.tool)));
+
+/** Un membro non si registra piu' da solo: il suo tool e' la famiglia. La rotta REST resta. */
+export function inAFamily(endpoint: BrandEndpoint): boolean {
+  return MEMBER_TOOLS.has(endpoint.tool);
+}
+
+export function familyFields(family: BrandFamily): z.ZodRawShape {
+  return family.members.reduce<z.ZodRawShape>(
+    (shape, member) => ({ ...shape, ...member.input.partial().shape }),
+    {}
+  );
+}
+
+export function familyInput(family: BrandFamily): z.ZodObject<z.ZodRawShape> {
+  return z.strictObject(familyFields(family));
+}
+
+/**
+ * Le rotte da chiamare, nell'ordine dichiarato: solo quelle di cui il chiamante ha nominato almeno
+ * un campo. Chiamarle tutte manderebbe un corpo vuoto a chi risponde `no_fields`, e la meta' di
+ * una scrittura riuscita e' peggio di un rifiuto.
+ */
+export function familyCalls(
+  family: BrandFamily,
+  input: Record<string, unknown>
+): { endpoint: ResourcelessEndpoint; body: Record<string, unknown> }[] {
+  return family.members
+    .map((endpoint) => ({
+      endpoint,
+      body: Object.fromEntries(
+        Object.keys(endpoint.input.shape)
+          .filter((field) => input[field] !== undefined)
+          .map((field) => [field, input[field]])
+      )
+    }))
+    .filter(({ body }) => Object.keys(body).length > 0);
+}

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -1,4 +1,5 @@
 import type { z } from 'zod';
+import { inAFamily } from './families';
 import { ADS_ACTION, ADS_REMIX } from './ads';
 import { SET_APPEARANCE } from './appearance';
 import { SET_AUTOMATION } from './automations';
@@ -166,7 +167,6 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   GENERATE_CAROUSEL,
   GENERATE_IMAGE,
   GENERATE_VIDEO,
-  GENERATE_MEDIA,
   GEO_ACTION,
   GET_ADS,
   GET_CREATION_KIT,
@@ -220,6 +220,25 @@ export const BRAND_ENDPOINTS: readonly BrandEndpoint[] = [
   UPDATE_ROW,
   UPDATE_VOICE,
 ];
+
+export {
+  BRAND_FAMILIES,
+  familyCalls,
+  familyInput,
+  inAFamily,
+  UPDATE_BRAND_IDENTITY
+} from './families';
+export type { BrandFamily } from './families';
+
+/**
+ * Gli endpoint che diventano un tool per conto proprio: il registro meno chi e' finito in una
+ * famiglia. Sta scritto qui una volta perche' lo leggono il registrar e ogni test che confronta
+ * `tools/list` col registro — e una sottrazione ripetuta in cinque posti diverge al primo che
+ * qualcuno dimentica.
+ */
+export const OWN_TOOL_ENDPOINTS: readonly BrandEndpoint[] = BRAND_ENDPOINTS.filter(
+  (endpoint) => !inAFamily(endpoint)
+);
 
 export function pathFor(endpoint: ResourcelessEndpoint, slug: string): string;
 export function pathFor(endpoint: ResourceEndpoint, slug: string, id: string): string;

--- a/packages/api-contracts/src/posts.ts
+++ b/packages/api-contracts/src/posts.ts
@@ -540,9 +540,9 @@ const BrandStyleField = z
 /**
  * Un disegno chiesto senza brand non entra in nessuna libreria, quindi non ha un id da mostrare:
  * `null` è il fatto, e dirlo qui è ciò che impedisce di passarlo a `create_post` e di cercarlo con
- * `list_media`. Non è la stessa forma di `refine_media` o `generate_media`, che un brand ce
- * l'hanno sempre e un id lo restituiscono sempre — allargare anche il loro schema significherebbe
- * togliere una promessa che quei due mantengono.
+ * `list_media`. Non è la stessa forma di `refine_media`, che un brand ce l'ha sempre e un id
+ * lo restituisce sempre — allargare anche il suo schema significherebbe togliere una promessa
+ * che mantiene.
  */
 const DrawnMediaSchema = GeneratedMediaSchema.extend({
   id: z
@@ -634,9 +634,9 @@ export const REFINE_MEDIA = {
     'it, and a short prefix works. It starts FROM that asset: the picture you already made comes ' +
     'back changed, not redrawn. Say what should CHANGE, not what the whole thing should be. ' +
     'The result is filed as a NEW asset, so a wrong edit costs one render and never your ' +
-    'original. Do NOT reach for generate_image, generate_video or generate_media to alter ' +
-    'something: those three start from nothing and give you a different subject, which is the ' +
-    'mistake this tool exists to end. It spends credits, and the answer says how many renders ' +
+    'original. Do NOT reach for generate_image or generate_video to alter something: those two ' +
+    'start from nothing and give you a different subject, which is the mistake this tool ' +
+    'exists to end. It spends credits, and the answer says how many renders ' +
     'were billed. It creates nothing in the calendar and publishes nothing; pass the id it ' +
     'returns to create_post as media_ids when you want a post. Each kind has its own model — ' +
     'get_media_models, slot imageRefineModel for a picture and videoRefineModel for a clip — and ' +

--- a/src/lib/content/changelog/2026-09-07-brand-identity-one-tool.ts
+++ b/src/lib/content/changelog/2026-09-07-brand-identity-one-tool.ts
@@ -1,0 +1,13 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-07',
+  title: 'One tool changes what your brand is, how it sounds and how it looks',
+  items: [
+    'Agents connected over MCP now change your brand identity through `update_brand_identity`: the facts posts are written from, the voice, the colours, the logo, the fonts and the visual brief — one place instead of four.',
+    'Asking an agent to change your brand colours now works the first time: the palette used to live apart from the logo and the fonts, so agents opened the tool named after appearance and found no colour field.',
+    'Only the fields sent change, so correcting one detail of your identity can never blank the rest of it.',
+    'Changing the voice now says out loud that it switches your brand off automatic voice, instead of doing it silently.',
+    'Generating media has one door fewer: `generate_image` and `generate_video` say what they do, and the older `generate_media` that just forwarded to them is gone.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/routes/api/v1/brands/[slug]/registry.test.ts
+++ b/src/routes/api/v1/brands/[slug]/registry.test.ts
@@ -158,6 +158,9 @@ const REST_ONLY = [
   'knowledge',
   'library/scan',
   'market/field',
+  // `generate_media` era la porta vecchia: inoltrava a `generate_image` e `generate_video` e la
+  // sua stessa descrizione diceva di preferirli. Il tool esce, la rotta resta per chi l'ha cablata.
+  'media/generate',
   'posts/[id]/approve',
   'posts/[id]/media',
   'posts/[id]/publish',


### PR DESCRIPTION
## What?

Four MCP tools that wrote the same two rows — `update_brand_kit`, `update_voice`, `set_colors`,
`set_appearance` — become one, `update_brand_identity`. `generate_media`, the older door whose own
description told you to prefer `generate_image` and `generate_video`, is retired. The other three
additive write families were opened, weighed and **left separate**, each with the technical reason
written next to it.

Measured on the transport, which is the only count that means anything: **88 tools / 94.215
characters → 84 / 91.053**. No capability leaves with them, and every REST route stays.

## Why?

`docs/mcp-tools.md` §3 advised against collapsing the writes and `changelog/2026-09-05-writes-stay-separate.md`
withdrew the plan. That verdict was right, for a reason that does not reach this far.

The hard argument is `destructiveHint`: it is an annotation **per tool**, and the protocol cannot
say "destructive only when `action = delete`". A family that holds a destructive verb marks the
harmless siblings dangerous, and people learn to click the warning away. It is mechanical and it is
not arguable — **but it only bites a family that HOLDS one**. Thirteen of seventy-one writes are
destructive; four families hold none.

What survives is the second argument, and it is a cost to weigh rather than a ban: a model picks
from the **name** and reads the enum only after it has already chosen. So the work was not
"collapse", it was **weigh** — pay it where it returns something.

On identity it returns something documented: someone asking to change the brand's colours opened
the tool called *appearance* and found **no colour field**, because the palette was in
`set_colors`. On 2026-09-05 that was patched with a cross-reference in the description. Here the
defect does not get referred onward — it stops existing, because there is no longer a second door.

## How?

**A family is a table, and a FIELD chooses the route — never a verb inside a parameter.** That is
the whole difference from an `*_action`, and it is what keeps `destructiveHint` able to tell the
truth: the tool holds no destructive member, so `false` is simply true. `packages/api-contracts/src/families.ts`
declares `BrandFamily`; the registrar calls only the routes whose fields the caller actually named,
**in order and not in parallel** — they write the same row, and `set_appearance` re-reads it to
avoid dropping a font nobody sent. The answers merge; naming no field touches nothing and says so.

`members` is typed `ResourcelessEndpoint`, not `BrandEndpoint`: a route that names a row wants an
id, and an id would be a second thing choosing — which row, on top of which route. The type
forbids it instead of letting the next person discover it. (`tsc` caught this; it was a real hole.)

`OWN_TOOL_ENDPOINTS` — the registry minus whoever joined a family — is written **once**, because
the registrar and the four tests that compare `tools/list` against the registry all read it. A
subtraction repeated in five places diverges at the first one somebody forgets.

**Three criteria, applied to all four families, measured off the registry rather than guessed:**
compatible response shapes; a family name no vaguer than the ones it replaces; and no member that
can fail in a way the others cannot — because then the caller cannot predict the answer from the
tool they opened.

| family | tools | response shapes | failures common to all | verdict |
|---|---|---|---|---|
| identity | 5 | 4/5 | 0 | **collapsed to 2** |
| media | 7 | 6/7 | 0 | separate, −1 duplicate |
| settings | 5 | 5/5 | 0 | separate |
| post | 7 | 7/7 | 0 | separate |

**Media stays split**, and the reasons that were measured yesterday hold: `generate_image` is the
only one that runs **without a brand** (`pathWithoutBrand`, returning `id: null`, `storage_path`,
`organization`, `cost_usd`); `generate_video` returns no asset at all but a `job_id`, with a
per-model duration window that refuses `duration_out_of_range` instead of rounding silently,
because a clip bills per second; `generate_carousel` plans the series and returns the
`continuity_tokens` that hold it together; `import_media_url` **spends nothing** while the other
five spend, and that signal lives in the name. One type here means taking from each the promise it
currently keeps.

What does go is `generate_media`, and this is not a collapse into an enum — it is the opposite, a
door removed from in front of two better names. Every field it took (`prompt`, `count`,
`aspect_ratio`, `model`, `title`) stays reachable, and a test checks them one by one.

**Settings stays split** for a reason only the schemas show: **`enabled` appears three times with
three meanings** — start a recurring job, switch on a Radar platform, put the public blog live. The
first is not a preference: from that moment the job runs **by itself** and every run spends the
brand's credits with nobody watching. A model that picks the wrong field in a merged tool starts
autonomous spending while believing it published a blog. The merged name would also collide with
an existing member, `set_brand_settings`.

**Post stays split** for something the handler gave up and the schema hides. `reschedule_post`
does not only move the time: `POST /posts/:id/reschedule` writes `status: 'approved'`, clears
`external_post_id` and `published_url`, and calls `publishApprovedPost`. Rescheduling a
`pending_user` post **approves it** and sends it to the publisher — while its description says
*"It does not publish and does not approve"*. Folding it into `edit_post`, which was the most
obvious of the four collapses and would have repaired `edit_post`'s real trap (`slot` is the
calendar day, `scheduled_for` the publish instant), would put an approval inside a tool that
promises not to approve. **Not fixed here**: that is a publishing behaviour change, not a contract
correction, and it deserves its own decision.

**The additive flag was verified, not believed.** `docs/mcp-tool-review.md` §10 lists thirteen
tools that replace content while declaring `destructive: false`, and `set_colors` is on it. Opened
the handlers: it replaces the palette, which is the field the caller **named** — not the fields
they left out, which was `update_brand_kit`'s defect fixed in #387 (`KIT_COLUMNS.filter((c) => c in body)`,
confirmed still in place). All four are additive per field. One undeclared effect did turn up:
`update_voice` writes `voiceMode = 'manual'` without being asked. It is the point of the tool, but
it was silent — the description now says it.

## Testing?

**The test was written first and watched fail** (11 of 14 red), then made green.
`cli/mcp/write-families.test.ts` drives `tools/list` and `tools/call` through `handleMcpFetch` — the
real transport, not the source arrays — and checks **absences and presences both**, plus that every
capability of the removed tools is reachable from the new one.

- unit: **7.558 pass / 0 fail** (`npx vitest run`), **135 pass / 0 fail** (`bun test` in `cli/`)
- `npm run build` — clean. `cli/ npx tsc --noEmit` — clean (it caught the `ResourcelessEndpoint` hole)
- `npm run dev` on a fresh `node_modules` in this worktree: **HTTP 200**
- the fan-out is measured on the routes it actually hits: a colour goes to `/studio/colors`, a font
  to `/studio/appearance`, the language to `/studio/kit`, the tone to `/voice/update`, in one call,
  with the methods the contracts declare
- the five target routes were hit live on the dev server and answer **401, not 404** — they exist,
  including `/media/generate`, kept after its tool went

**Not tested, and why.** No end-to-end call with a real Supabase session against a seeded brand:
the routes are unchanged by this PR and the fan-out test asserts the exact paths, methods and
bodies, so an integration run would exercise code nobody here touched. No browser verification:
this changes an agent tool surface with no UI. `npm run eval:durability` was not run — nothing here
touches the chat path, prompts, tools of the harness, or the model. The removal of `generate_media`
**breaks anyone who hardcoded it**; the analysis records that no client calls it, but that is read
from the code, not from traffic.

## Evidence (screenshots/videos)

No UI changed. The surface measurement, taken through `handleMcpFetch` on the real transport:

<details>
<summary>Tool count and <code>tools/list</code> size, before and after</summary>

```
before   tools: 88   chars: 94215
after    tools: 84   chars: 91053
                     −4 tools, −3.162 characters
```

The ceiling in `cli/mcp/tool-surface-cost.test.ts` drops 97.000 → 93.000 with the reason beside it:
a ceiling that does not come down with the number stops being a guard.
</details>

<details>
<summary>Family cohesion, measured off the registry</summary>

```
### identity (5)
  update_brand_kit    out=["ok"]                    fail=[]
  update_voice        out=["ok"]                    fail=[]
  set_colors          out=["colors","ok"]           fail=[colors must be an array of max 8 hex strings]
  set_appearance      out=["appearance","ok"]       fail=[font_not_available, font_pair_incomplete, …]
  set_bio             out=["bioUrl","ok"]           fail=[No active social account, …]   ← the outlier

### media (7)
  import_media_url    spends=no   fail=[blocked_host, not_https, too_large, unsupported_type, …]
  generate_image      spends=yes  brandFree=YES  fail=[brand_style_needs_a_brand, …]
  generate_video      spends=yes  out=["job_id","status","duration_seconds",…]
  generate_carousel   spends=yes  out=["continuity_tokens",…]
  refine_media        spends=yes  fail=[no_refine_model, kind_not_refinable, …]
  → 6 different response shapes out of 7, 0 failures shared by all

### settings (5) → 5 shapes out of 5, 0 shared failures
### post (7)     → 7 shapes out of 7, 0 shared failures
```
</details>

<details>
<summary>Live routes on the dev server after the tools were removed</summary>

```
PUT  /api/v1/brands/demo/studio/kit         -> 401
POST /api/v1/brands/demo/voice/update       -> 401
PUT  /api/v1/brands/demo/studio/colors      -> 401
PUT  /api/v1/brands/demo/studio/appearance  -> 401
POST /api/v1/brands/demo/media/generate     -> 401
```

401 and not 404: the endpoints are alive. `media/generate` is now declared in `REST_ONLY` in
`registry.test.ts`, which is the guard that forces a route losing its contract to be declared by
hand in a diff somebody reads.
</details>

## Anything Else?

- **`reschedule_post` approves and re-publishes while its description denies both.** Found here,
  deliberately not fixed — it changes publishing behaviour. It is the reason the post family did
  not collapse, and it is worth its own issue.
- **`voice_examples` is the same defect as the palette, one layer along**: the past posts the
  writer imitates live on `set_brand_settings`, not with the rest of the voice. Repaired with a
  cross-reference rather than a merge, because merging would split `set_brand_settings` in two.
- **WebMCP and the CLI are untouched** and still read `BRAND_ENDPOINTS` 1:1. The family is an MCP
  surface decision; WebMCP has no `destructiveHint` at all, and the CLI already uses different
  names (`anomalia studio <slug> colors`).
- **`MCP_INSTRUCTIONS` was not touched.** It named none of the retired tools, so nothing there
  became false, and its 1.700-character budget is paid every session.
- The family machinery exists for one family. It earns its keep by being the table that says which
  endpoints stop being their own tool — but if a second family never arrives, it is fair to ask
  whether the indirection should collapse back into the registrar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
