### PR TITLE
Say when DataForSEO metrics did not arrive

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -1605,3 +1605,27 @@ benissimo; è il fallimento a diventare muto, quindi la sonda sembra corretta fi
 **La mossa.** Contare con `count: 'exact'` e `.limit(1)`. Una riga di traffico è il prezzo di un
 messaggio d'errore leggibile, e un rifiuto anonimo costa molto di più: non si riconosce, quindi non
 si spiega, quindi il giro dopo è identico al primo.
+
+## Un fornitore che risponde `200` può avere già detto di no
+
+**Segnale.** Le metriche di un fornitore mancano da settimane e `ai_calls` non mostra niente: la
+percentuale di successo è alta, il prodotto risponde, e il numero che arriva al cliente è uno zero
+che sembra una diagnosi. Oppure il contrario: `ai_calls` mostra il 96% di fallimenti su una label
+e nessuno se ne accorge, perché ogni chiamante traduce il rifiuto in `null` e ogni lettore traduce
+`null` in «non c'è nessun dato per questo dominio».
+
+**Cosa succede.** Due cose insieme, e si coprono a vicenda. La prima: leggere solo `res.ok` non
+basta. DataForSEO — ma è la norma nelle API a task — risponde `HTTP 200` con il verdetto vero
+dentro il task (`status_code: 40200 Payment Required.`), e quel caso viene loggato come successo
+mentre torna zero righe. La seconda: `catch { return null }` e `catch { return [] }` cancellano la
+differenza fra «ha risposto, non c'è niente» e «non ha risposto». Sono la stessa forma, e chi legge
+— soprattutto se chi legge è un modello che scrive l'analisi al cliente — sceglie la lettura
+sbagliata con la stessa sicurezza della giusta.
+
+**La mossa.** Leggere il verdetto **dove nasce** — una funzione sola, quella che fa la POST — e
+tenere dentro il log la frase del fornitore, non lo status: `Payment Required.` chiude la diagnosi,
+`HTTP 402` la comincia soltanto. Poi far arrivare il rifiuto a chi legge sotto forma di frase, come
+`truncated` dichiara una lista tagliata: un risultato vuoto che non dice perché è vuoto è una
+bugia con la stessa faccia della verità. E prima di dare la colpa al codice, chiedere il saldo:
+quasi ogni fornitore ha un endpoint gratuito che dice quanto credito resta (`appendix/user_data`),
+e un `402` non si debugga, si ricarica.

--- a/changelog/2026-09-11-dataforseo-refusal-declares-itself.md
+++ b/changelog/2026-09-11-dataforseo-refusal-declares-itself.md
@@ -1,0 +1,87 @@
+# Il rifiuto di DataForSEO si dichiara: 96% di fallimenti che nessuno vedeva
+
+`searchMetrics` in produzione: 89 chiamate su 93 fallite negli ultimi sette giorni. Non è un
+campione sfortunato — settimana per settimana, da `ai_calls`:
+
+| settimana | chiamate | fallite |
+|---|---|---|
+| 2026-07-27 | 15 | 0 |
+| 2026-08-03 | 78 | 22 |
+| 2026-08-10 | 101 | **101** |
+| 2026-08-17 | 70 | **70** |
+| 2026-08-24 | 130 | **130** |
+| 2026-08-31 | 99 | 95 |
+| 2026-09-07 | 89 | **89** |
+
+Un solo messaggio d'errore, ripetuto 507 volte su nove endpoint diversi: `HTTP 402`.
+
+## La causa non è nostra
+
+Le credenziali sono valide. Chiesto conto all'endpoint gratuito `appendix/user_data`:
+
+```
+"money": { "total": 1, "balance": -0.050788 }
+```
+
+Il saldo dell'account DataForSEO (`andrea@teta.so`) è a **meno cinque centesimi**. Depositato in
+tutto: un dollaro. Ogni task risponde `40200 Payment Required.` e costa zero, il che spiega perché
+la cosa non è mai arrivata su una fattura. Ricaricare l'account è una decisione di prodotto, non
+una riga di codice: qui si chiude solo la metà che è nostra.
+
+## La metà che è nostra: il fallimento non arrivava a chi legge
+
+Il difetto vero non è la chiamata rotta — è che tre forme diverse di «vuoto» erano indistinguibili
+dal «rifiutato», e ognuna finiva davanti a un lettore che ne traeva la conclusione sbagliata.
+
+**Uno.** `fetchSearchPerformance` fa due chiamate. Bastava che *una* rispondesse perché il pannello
+si costruisse comunque, e tutti i numeri di testa (`organicKeywords`, `estMonthlyTraffic`,
+`keywordsTop10`) vengono da `overview`: se era quella a essere rifiutata, il cliente riceveva
+`0 / 0 / 0` sotto il commento «keep the zeros: "you're invisible on Google" is exactly the
+diagnosis worth showing». Non era una diagnosi. Era nessuno che aveva contato. Ora senza `overview`
+non c'è pannello.
+
+**Due.** `post()` leggeva solo la busta HTTP. DataForSEO però risponde `HTTP 200` con il verdetto
+vero sul task (`status_code: 40501`, `40400`, e anche `40200`): quel caso veniva loggato `ok: true`
+e tornava `null`, cioè arrivava al chiamante identico a «questo dominio non ha dati». Un fallimento
+che le metriche stesse non mostravano. Ora entrambe le forme rispondono in `refusalOf`, in un posto
+solo.
+
+**Tre.** I nove tool DataForSEO dell'agente rispondevano `{ gaps: [] }`, `{ keywords: [] }`,
+`{ suggestions: [] }`. Il modello che scrive l'analisi SEO del cliente legge una lista vuota e
+scrive «non hai keyword» — risposta sbagliata, indistinguibile da quella giusta. Ora ogni tool
+passa da `declareUnavailable` e il rifiuto arriva come una frase da leggere, con dentro la
+sentenza del fornitore: `Payment Required.`, non `HTTP 402`.
+
+## Perché AsyncLocalStorage e non un throw
+
+La strada ovvia era togliere i `catch { return null }` e lasciar propagare l'errore. Scartata: le
+dieci `fetch*` hanno un contratto dichiarato in testa al file — «never throw into a request
+handler» — e i chiamanti ci contano. `rank-tracker.checkKeyword` in particolare *deve* timbrare
+`last_checked_at` anche quando la query fallisce, altrimenti la keyword rotta resta prima in coda
+per sempre e brucia uno slot a ogni tick. Un throw lì avrebbe scambiato un difetto silenzioso con
+uno rumoroso e più caro.
+
+`AsyncLocalStorage` è già l'idioma di casa per far viaggiare un fatto lungo una catena async senza
+infilarlo in dieci firme (`ai-log.ts` ne usa due). In più esprime una cosa che un throw non
+esprime: la perdita **parziale**, cioè due chiamate di cui una rifiutata — che è esattamente il
+caso uno. Zero firme cambiate, zero chiamanti a rischio.
+
+Il nome del campo è `unavailable` per stare accanto a `truncated` di `query`/`read_posts`: stessa
+idea, stessa forma — il risultato più la dichiarazione di cosa gli manca.
+
+## Il test
+
+Cinque test rossi prima della correzione, e quello che conta di più è l'ultimo:
+`fetchSearchPerformance` con `overview` rifiutato e `ranked` buono tornava
+`{ organicKeywords: 0, estMonthlyTraffic: 0, keywordsTop10: 0 }`. La prova che il cliente riceveva
+una diagnosi costruita su una chiamata fallita. Il corpo 402 nel test è quello vero, catturato dal
+fornitore l'11/09/2026, non inventato.
+
+Poi nove test, uno per tool: nessuno dei nove può più rispondere «nessun dato» quando il dato è
+stato rifiutato.
+
+## Rimane fuori
+
+`read_file` (111 fallimenti in 14 giorni) logga `error: null` — un fallimento registrato senza
+motivo. Causa strutturalmente diversa, PR sua. `pagespeed` mescola `HTTP 400`, `500` e `network` su
+numeri piccoli. `scrape` aveva 905 `HTTP 402` ma si è fermato da solo il 02/09.

--- a/src/lib/content/changelog/2026-09-11-seo-metrics-say-when-missing.ts
+++ b/src/lib/content/changelog/2026-09-11-seo-metrics-say-when-missing.ts
@@ -1,0 +1,10 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-11',
+  title: 'SEO metrics now say when they did not arrive',
+  items: [
+    'When the search data provider does not answer, the SEO analysis says so instead of reporting zero keywords and zero traffic as if the numbers were measured.',
+    'A search-performance panel is no longer built from half an answer: if the traffic figures did not arrive, the panel is absent rather than empty.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/dataforseo-tools.ts
+++ b/src/lib/server/dataforseo-tools.ts
@@ -6,6 +6,7 @@ import { tool } from 'ai';
 import { z } from 'zod';
 import {
   dataforseoConfigured,
+  declareUnavailable,
   fetchBacklinkHistory,
   fetchBacklinkSummary,
   fetchDomainOverview,
@@ -59,6 +60,17 @@ async function resolveLang(opts: DataForSeoToolsOpts): Promise<string | null> {
   if (opts.language) return opts.language;
   if (opts.resolveLanguage) return opts.resolveLanguage();
   return null;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function declaring<T extends Record<string, any>>(tools: T): T {
+  return Object.fromEntries(
+    Object.entries(tools).map(([key, t]) => [
+      key,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { ...t, execute: (args: any, opts: any) => declareUnavailable(async () => t.execute(args, opts)) }
+    ])
+  ) as T;
 }
 
 /**
@@ -199,9 +211,9 @@ export function createDataForSeoTools(opts: DataForSeoToolsOpts = {}) {
     })
   };
 
-  if (!opts.allowHistory) return tools;
+  if (!opts.allowHistory) return declaring(tools);
 
-  return {
+  return declaring({
     ...tools,
     dfs_traffic_history: tool({
       description:
@@ -236,5 +248,5 @@ export function createDataForSeoTools(opts: DataForSeoToolsOpts = {}) {
         return history ? { history } : { error: 'No backlink history' };
       }
     })
-  };
+  });
 }

--- a/src/lib/server/dataforseo.test.ts
+++ b/src/lib/server/dataforseo.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const env: Record<string, string | undefined> = {
+  DATAFORSEO_USERNAME: 'user',
+  DATAFORSEO_PASSWORD: 'pass'
+};
+vi.mock('$env/dynamic/private', () => ({ env }));
+
+const logAiCall = vi.fn();
+vi.mock('$lib/server/ai-log', () => ({ logAiCall }));
+
+const { declareUnavailable, fetchKeywordGap, fetchSearchPerformance } = await import('./dataforseo');
+const { createDataForSeoTools } = await import('./dataforseo-tools');
+
+/** The body DataForSEO really returns when the account balance is spent (captured 2026-09-11). */
+const PAYMENT_REQUIRED = {
+  status_code: 20000,
+  status_message: 'Ok.',
+  tasks: [{ status_code: 40200, status_message: 'Payment Required.', result: null }]
+};
+
+function answers(...responses: Array<{ status: number; body: unknown }>) {
+  let call = 0;
+  return vi.fn(async () => {
+    const r = responses[Math.min(call++, responses.length - 1)];
+    return { ok: r.status >= 200 && r.status < 300, status: r.status, json: async () => r.body } as Response;
+  });
+}
+
+describe('quando DataForSEO rifiuta, chi legge lo sa', () => {
+  beforeEach(() => {
+    logAiCall.mockClear();
+  });
+
+  it('402: il risultato dichiara il rifiuto invece di sembrare «nessun gap trovato»', async () => {
+    vi.stubGlobal('fetch', answers({ status: 402, body: PAYMENT_REQUIRED }));
+
+    const result = await declareUnavailable(async () => ({
+      gaps: await fetchKeywordGap('brand.com', 'rival.com')
+    }));
+
+    expect(result.gaps).toEqual([]);
+    expect(result.unavailable).toBeTruthy();
+    expect(result.unavailable).toContain('Payment Required');
+  });
+
+  it('una risposta buona non porta nessuna dichiarazione da leggere', async () => {
+    vi.stubGlobal('fetch', answers({ status: 200, body: { tasks: [{ status_code: 20000, result: [{ items: [] }] }] } }));
+
+    const result = await declareUnavailable(async () => ({
+      gaps: await fetchKeywordGap('brand.com', 'rival.com')
+    }));
+
+    expect(result).not.toHaveProperty('unavailable');
+  });
+
+  it('il rifiuto sul task viaggia su HTTP 200: non può passare per «nessun dato»', async () => {
+    vi.stubGlobal('fetch', answers({ status: 200, body: PAYMENT_REQUIRED }));
+
+    const result = await declareUnavailable(async () => ({
+      gaps: await fetchKeywordGap('brand.com', 'rival.com')
+    }));
+
+    expect(result.unavailable).toContain('Payment Required');
+    expect(logAiCall).toHaveBeenCalledWith(expect.objectContaining({ ok: false }));
+  });
+
+  it('una risposta che cambia forma non passa per «nessun dato»', async () => {
+    vi.stubGlobal('fetch', answers({ status: 200, body: { tasks: [] } }));
+
+    const result = await declareUnavailable(async () => ({
+      gaps: await fetchKeywordGap('brand.com', 'rival.com')
+    }));
+
+    expect(result.unavailable).toContain('unreadable response');
+  });
+
+  it('ai_calls porta il messaggio del fornitore, non solo lo status', async () => {
+    vi.stubGlobal('fetch', answers({ status: 402, body: PAYMENT_REQUIRED }));
+
+    await fetchKeywordGap('brand.com', 'rival.com').catch(() => []);
+
+    expect(logAiCall).toHaveBeenCalledWith(
+      expect.objectContaining({ ok: false, error: expect.stringContaining('Payment Required') })
+    );
+  });
+
+  it('mezza risposta non diventa una diagnosi: senza overview nessun pannello a zero', async () => {
+    vi.stubGlobal(
+      'fetch',
+      answers(
+        { status: 402, body: PAYMENT_REQUIRED },
+        { status: 200, body: { tasks: [{ status_code: 20000, result: [{ items: [{ keyword_data: { keyword: 'scarpe' } }] }] }] } }
+      )
+    );
+
+    expect(await fetchSearchPerformance('brand.com')).toBeNull();
+  });
+});
+
+/**
+ * Il lettore vero è il modello che scrive l'analisi SEO del cliente. Se il tool gli passa una lista
+ * vuota, lui scrive «non hai keyword»: è la risposta sbagliata, ed è indistinguibile da quella
+ * giusta. Ogni tool del pacchetto deve dire che il fornitore non ha risposto.
+ */
+describe('il pacchetto tool dichiara il rifiuto a ogni strumento', () => {
+  const tools = createDataForSeoTools({ defaultUrl: 'brand.com', allowHistory: true, maxCalls: 99 });
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', answers({ status: 402, body: PAYMENT_REQUIRED }));
+  });
+
+  const inputs: Record<string, unknown> = {
+    dfs_domain_overview: {},
+    dfs_search_performance: {},
+    dfs_keyword_metrics: { keywords: ['scarpe'] },
+    dfs_keyword_suggestions: { seed: 'scarpe' },
+    dfs_keyword_gap: { competitorUrl: 'rival.com' },
+    dfs_serp: { keyword: 'scarpe' },
+    dfs_backlinks: {},
+    dfs_traffic_history: {},
+    dfs_backlink_history: {}
+  };
+
+  for (const [key, input] of Object.entries(inputs)) {
+    it(`${key} non risponde «nessun dato» quando il dato è stato rifiutato`, async () => {
+      const result = await tools[key as keyof typeof tools].execute!(input as never, {} as never);
+      expect(result, key).toHaveProperty('unavailable');
+      expect(String((result as { unavailable: string }).unavailable), key).toContain('Payment Required');
+    });
+  }
+});

--- a/src/lib/server/dataforseo.ts
+++ b/src/lib/server/dataforseo.ts
@@ -2,6 +2,7 @@
 // (the foundation AI engines pull from). Two DataForSEO Labs "live" calls per run: domain rank
 // overview (organic keyword count, estimated traffic, top-10 count) + ranked keywords (the table).
 // Basic-auth, plain fetch, no SDK. Best-effort: null on any failure or when creds aren't set.
+import { AsyncLocalStorage } from 'node:async_hooks';
 import { swallow } from '$lib/server/swallow';
 import { env } from '$env/dynamic/private';
 import { logAiCall } from '$lib/server/ai-log';
@@ -77,6 +78,29 @@ function market(lang?: string | null): { location_code: number; language_code: s
     : { location_code: 2840, language_code: 'en' };
 }
 
+const DFS_TASK_OK = 20000;
+
+function refusalOf(res: Response, task: any): string | null {
+  const message = String(task?.status_message ?? '').trim();
+  if (!res.ok) return `HTTP ${res.status}${message ? ` ${message}` : ''}`;
+  if (!task) return 'HTTP 200 without a task — unreadable response';
+  const code = Number(task.status_code ?? DFS_TASK_OK);
+  if (code === DFS_TASK_OK) return null;
+  return `task ${code}${message ? ` ${message}` : ''}`;
+}
+
+const refusals = new AsyncLocalStorage<string[]>();
+
+export async function declareUnavailable<T extends Record<string, unknown>>(read: () => Promise<T>): Promise<T & { unavailable?: string }> {
+  const seen: string[] = [];
+  const result = await refusals.run(seen, read);
+  if (!seen.length) return result;
+  return {
+    ...result,
+    unavailable: `DataForSEO refused ${seen.length} call(s) — ${seen.join('; ')}. Whatever is empty or zero above is missing because the provider did not answer, not because nothing was found: tell the user the SEO metrics are unavailable instead of reporting these numbers.`
+  };
+}
+
 async function post(path: string, body: unknown, costUsd = DFS_CALL_COST_USD): Promise<any> {
   const auth = Buffer.from(`${env.DATAFORSEO_USERNAME}:${env.DATAFORSEO_PASSWORD}`).toString('base64');
   const t0 = Date.now();
@@ -86,10 +110,17 @@ async function post(path: string, body: unknown, costUsd = DFS_CALL_COST_USD): P
     body: JSON.stringify([body]),
     signal: AbortSignal.timeout(45_000)
   });
-  logAiCall({ label: 'searchMetrics', provider: 'dataforseo', ms: Date.now() - t0, ok: res.ok, error: res.ok ? undefined : `HTTP ${res.status}`, context: path.slice(0, 120), flatCostUsd: costUsd });
-  if (!res.ok) throw new Error(`dataforseo ${path} ${res.status}`);
-  const json = await res.json();
-  return json?.tasks?.[0]?.result?.[0] ?? null;
+  const json = await res.json().catch(() => null);
+  const task = json?.tasks?.[0];
+  const refusal = refusalOf(res, task);
+
+  logAiCall({ label: 'searchMetrics', provider: 'dataforseo', ms: Date.now() - t0, ok: !refusal, error: refusal ?? undefined, context: path.slice(0, 120), flatCostUsd: costUsd });
+
+  if (refusal) {
+    refusals.getStore()?.push(`${path}: ${refusal}`);
+    throw new Error(`dataforseo ${path} ${refusal}`);
+  }
+  return task?.result?.[0] ?? null;
 }
 
 // Strip to the bare registrable host — DataForSEO wants the bare domain, not a URL with scheme/path.
@@ -112,6 +143,8 @@ export async function fetchSearchPerformance(url: string, lang?: string | null):
       }).catch((error) => { swallow('dataforseo call', error); return null; })
     ]);
 
+    if (!overview) return null;
+
     const org = overview?.items?.[0]?.metrics?.organic ?? {};
     const topKeywords = (ranked?.items ?? []).slice(0, 10).map((it: any) => {
       const kd = it?.keyword_data ?? {};
@@ -124,10 +157,6 @@ export async function fetchSearchPerformance(url: string, lang?: string | null):
         intent: String(kd?.search_intent_info?.main_intent ?? '')
       };
     }).filter((k: { keyword: string }) => k.keyword);
-
-    // Both calls failed (creds/network) → no panel. If they answered but the domain simply doesn't
-    // rank, keep the zeros: "you're invisible on Google" is exactly the diagnosis worth showing.
-    if (!overview && !ranked) return null;
 
     const organicKeywords = Number(org?.count ?? 0) || 0;
     const estMonthlyTraffic = Math.round(Number(org?.etv ?? 0) || 0);


### PR DESCRIPTION
## What?

`searchMetrics` — every DataForSEO call in the product — has been failing **96% of the time in production since 10 August 2026**, and nothing said so. The provider's account balance is spent, so it answers `402 Payment Required.` and charges nothing; meanwhile the product kept returning SEO analyses that looked complete.

This PR does **not** fix the provider (that is a top-up, and a decision for you — see *Anything Else?*). It closes the half that is ours: a refused call now reaches whoever reads it as a sentence, instead of disappearing into a `[]`, a `null` or a zero.

Three separate hiding places:

1. **`fetchSearchPerformance` built a panel from half an answer.** It makes two calls and proceeded if *either* answered. Every headline number — `organicKeywords`, `estMonthlyTraffic`, `keywordsTop10` — comes from the overview call, so when that was the refused one the customer got `0 / 0 / 0` under a comment reading *"keep the zeros: 'you're invisible on Google' is exactly the diagnosis worth showing"*. It was not a diagnosis. Nobody had counted. Without the overview there is now no panel.
2. **`post()` read only the HTTP envelope.** DataForSEO also answers `HTTP 200` carrying the real verdict on the task (`status_code: 40200`, `40501`, …). That kind was logged `ok: true` and returned no rows — arriving at the caller identical to *"this domain has no data"*. A failure the failure metrics themselves could not see.
3. **The nine agent tools answered `{ gaps: [] }`, `{ keywords: [] }`, `{ suggestions: [] }`.** The model that writes the customer's SEO analysis reads an empty list and writes *"you have no keywords"* — the wrong answer, wearing the face of the right one.

## Why?

25 brands have GEO audits. **Zero** of them have search metrics in their latest audit. Five of those 25 still show numbers on the SEO page, because `buildSeoMetrics` falls back to the newest audit that *has* search — for those five, **2–3 August**. Five customers have spent forty days reading traffic and keyword figures presented as current.

The broken call is the cheap part of that. The expensive part is that a missing metric was indistinguishable from a measured zero, at every layer, so the product stayed confident and nobody — us or the customer — had a way to notice.

## How?

**One place decides, in `post()`.** `refusalOf(res, task)` answers for all three shapes of "no": a non-2xx status, a task-level `status_code`, and a 200 whose body has no task at all. The provider's own sentence travels with the verdict, so `ai_calls.error` now stores `HTTP 402 Payment Required.` instead of `HTTP 402` — the next diagnosis is a log read, not a curl.

**`declareUnavailable`, reusing the `truncated` idea.** `query` and `read_posts` already declare a cut list in prose rather than silently returning nine rows of fifty. Same shape here: the result, plus a sentence saying what is missing and why the zeros are not data. The ten DataForSEO tools go through it in **one** wrapper, `declaring()`, rather than nine edited `execute` bodies.

**AsyncLocalStorage, not a propagating throw.** *Rejected:* removing the `catch { return null }` blocks and letting the error fly. The ten `fetch*` functions carry a contract stated at the top of the file — *never throw into a request handler* — and callers rely on it. `rank-tracker.checkKeyword` in particular **must** stamp `last_checked_at` even when the query fails, or the broken keyword stays first in the rotation forever and burns a paid slot every tick. A throw there would have swapped a silent defect for a loud, more expensive one.

ALS is already the house idiom for carrying a fact along an async chain without threading it through ten signatures (`ai-log.ts` runs two). It also expresses something a throw cannot: **partial** loss — two calls, one refused — which is exactly defect #1. Zero signatures changed, zero callers at risk.

## Testing?

**Written first, watched fail: 5 red before the fix.** The one that matters is `fetchSearchPerformance` with the overview refused and ranked keywords fine — it returned `{ organicKeywords: 0, estMonthlyTraffic: 0, keywordsTop10: 0 }`. That is the customer receiving a diagnosis built on a failed call, reproduced.

The 402 body in the test is the **real one**, captured from the provider on 11/09/2026, not invented.

Then nine more, one per tool: none of the nine can answer "no data" when the data was refused.

**What was NOT tested, and the risk that carries:**

- **The provider's success path was never exercised.** It cannot be: the account is at **-$0.05**, so every live call returns 402. Every green assertion here runs against a mocked `fetch`. If DataForSEO's success payload has drifted in some way unrelated to the refusal handling, this PR would not catch it — and neither would anything else until the account is topped up. **This is the main risk of the change.**
- **No browser verification.** The change is server-side and provider-facing, and the customer-visible surface (the SEO panel) cannot be made to show a *successful* DataForSEO fetch while the balance is negative. The stale-fallback behaviour described in *Why?* is untouched by this PR.
- Full unit suite green: **7573 passed, 0 failed, 14 skipped, 0 failing files**. `npm run check` reports no new errors in the touched files (the repo's 346 pre-existing ones are untouched). `npm run build` green — CI does not run it.

## Evidence (screenshots/videos)

<details>
<summary>Production, <code>ai_calls</code> — week by week, not a bad sample</summary>

| week | calls | failed |
|---|---|---|
| 2026-07-27 | 15 | 0 |
| 2026-08-03 | 78 | 22 |
| 2026-08-10 | 101 | **101** |
| 2026-08-17 | 70 | **70** |
| 2026-08-24 | 130 | **130** |
| 2026-08-31 | 99 | 95 |
| 2026-09-07 | 89 | **89** |

507 refusals across nine endpoints. One error message, repeated every time: `HTTP 402`.
</details>

<details>
<summary>The cause, from the provider's own free endpoint (read-only)</summary>

```
GET https://api.dataforseo.com/v3/appendix/user_data
{ "login": "andrea@teta.so",
  "money": { "total": 1, "balance": -0.050788 } }
```

Credentials are valid (`status_code: 20000`). The account is five cents overdrawn; one dollar was ever deposited.
</details>

<details>
<summary>The real error message we were throwing away</summary>

```
POST /v3/dataforseo_labs/google/domain_rank_overview/live  →  HTTP 402
{"tasks":[{"status_code":40200,"status_message":"Payment Required.","cost":0,"result":null}]}
```

`cost: 0` — which is why no invoice ever flagged it, and why failed calls were never billed to any brand (`cost_usd` is null on every one of the 485 failed rows).
</details>

<details>
<summary>What the customer was getting — the red test, before the fix</summary>

```
FAIL  mezza risposta non diventa una diagnosi: senza overview nessun pannello a zero
AssertionError: expected { domain: 'brand.com', …(4) } to be null

+ Received:
  { "domain": "brand.com",
    "estMonthlyTraffic": 0,
    "keywordsTop10": 0,
    "organicKeywords": 0,
    "topKeywords": [ { "keyword": "scarpe", "position": 0, "volume": 0, … } ] }

Test Files  1 failed (1)
     Tests  5 failed (5)
```
</details>

<details>
<summary>After — 15 green, including one per tool</summary>

```
✓ src/lib/server/dataforseo.test.ts (15 tests)
  ✓ 402: il risultato dichiara il rifiuto invece di sembrare «nessun gap trovato»
  ✓ il rifiuto sul task viaggia su HTTP 200: non può passare per «nessun dato»
  ✓ una risposta che cambia forma non passa per «nessun dato»
  ✓ ai_calls porta il messaggio del fornitore, non solo lo status
  ✓ mezza risposta non diventa una diagnosi: senza overview nessun pannello a zero
  ✓ dfs_domain_overview … dfs_backlink_history  (9 tools, one each)
```

And the swallowed log now names the cause on sight:
`[swallowed] dataforseo call: dataforseo …/domain_rank_overview/live HTTP 402 Payment Required.`
</details>

## Anything Else?

**The decision that is yours, not the code's.** The DataForSEO balance is negative. Until it is topped up, every SEO metric in the product is unavailable — the difference this PR makes is that the product now *says so* instead of reporting zeros. Three ways out, and only you can pick: top the account up, replace the provider, or declare the feature degraded and hide the panels. Nothing here assumes any of the three.

**Left deliberately for a separate change — five customers are reading forty-day-old numbers.** `buildSeoMetrics` falls back to the newest audit that has search data, however old, and the page shows no date. Fixing it honestly means showing *"as of 2 August"* on the panel — a visual change that wants a preview before a PR, not a decision buried in this one.

**Not in this PR, structurally different causes:** `read_file` logs `error: null` on 111 failures in 14 days — a failure recorded without a reason, which is its own defect and its own PR. `pagespeed` mixes `HTTP 400`, `500` and `network` across small numbers. `scrape` had 905 `HTTP 402` but stopped on its own on 02/09.

**One flake worth recording.** `motion-output-mount.test.ts` timed out twice while another suite was saturating the machine, then passed on an idle run — it imports the entire chat tool graph and its own comment already records the timeout being raised once for that reason. It also cannot reach this change: `createDataForSeoTools` returns `{}` before `declaring()` when credentials are absent, which is every test environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
