### PR TITLE
Build the answer after knowing how the write went

### DIFF
--- a/changelog/2026-09-11-tools-that-lie.md
+++ b/changelog/2026-09-11-tools-that-lie.md
@@ -1,0 +1,101 @@
+# Un successo si costruisce dopo aver saputo com'è andata
+
+`render_post` e `approve_plan` rispondevano `ok: true` senza aver mai guardato l'esito della
+scrittura. È la classe di difetto che è già costata la rimozione di `logout` — quello che
+restituiva `{loggedOut: true}` dopo un `unlinkSync` fallito e ingoiato da un `catch {}`. Un errore
+che si vede costa un giro; un successo falso costa tutto il lavoro che l'agente costruisce sopra,
+e si manifesta più in là, dove nessuno lo collega alla causa.
+
+## `render_post`: pagato, fallito, dichiarato riuscito
+
+La rotta è dietro `gateAiAction`, quindi quando si arriva in fondo i crediti sono già usciti. Se il
+renderer non produceva l'immagine, `renderError` veniva valorizzato, `url` restava `null` — e la
+risposta era `{ ok: true, url: null, error: '...' }`, HTTP 200. Il livello MCP avvolge quella
+risposta con `ok()`, che **non** marca `isError`: un modello che guarda `ok` leggeva un successo,
+aveva pagato, e non aveva l'immagine.
+
+Ora un render senza immagine è un `502` che nomina il motivo. E porta `credits_spent: true`, perché
+il chiamante ha una decisione da prendere che dipende da quel fatto: **riprovare costa una seconda
+volta**. La descrizione del tool lo dice per esteso, così il modello lo sa prima di chiamare e non
+solo dopo aver fallito.
+
+Stessa cosa per la scrittura di `media_url`: il suo `error` non era letto, quindi un render
+riuscito e non salvato era indistinguibile da uno riuscito e salvato.
+
+## `approve_plan`: tre scritture, nessuna guardata
+
+`activatePlan` faceva due `update` e costruiva la risposta dall'oggetto che aveva già in memoria
+invece che da ciò che era stato scritto. La rotta scartava perfino quel valore di ritorno,
+aggiungeva una terza scrittura non controllata, e rispondeva `ok: true`.
+
+Il fallimento non è teorico: l'indice unico parziale `editorial_plans_active_uniq` (0034) ammette
+**una sola** riga `active` per brand. Se il primo `update` non manda in `superseded` il piano
+attivo, il secondo viola l'indice e fallisce. Nessuno leggeva quell'errore: il tool rispondeva
+`ok: true`, il brand continuava a seguire il piano vecchio, e l'agente riferiva alla persona che il
+nuovo era attivo.
+
+Adesso `activatePlan` alza su entrambe le scritture, e su quella di `syncPrefsFromPlan`. Alzare
+invece di tornare un risultato è la strada più corta per **tutti e sette** i chiamanti, non solo
+per questa rotta: i tre che ignoravano il valore di ritorno (lo scheduler, l'onboarding, il job di
+chat) smettono di dichiarare attivato un piano che non lo è, senza toccarli. Nello scheduler il
+`throw` è già contenuto dai suoi `try/catch` per brand, che è dove un fallimento di un brand deve
+fermarsi.
+
+**Due scritture della rotta sono sparite invece di essere corrette**, perché erano duplicati:
+
+- la supersessione esplicita di `oldActive` — `activatePlan` già supera ogni riga `active` del
+  brand tranne quella che sta attivando;
+- `syncPrefsFromPlan(proposed)` — `activatePlan` già sincronizza, e lo fa con il piano
+  **normalizzato** (`normWeek` + `stampWeekStarts`); la rotta passava la riga **grezza**, quindi
+  la seconda chiamata riscriveva le preferenze da un oggetto diverso da quello attivato.
+
+Con loro se ne va `loadActivePlan`, che serviva solo a una delle due.
+
+## `update_voice`: l'effetto c'è, ed è già dichiarato — ma non in tutte e due le descrizioni
+
+`/voice/update` mette `voiceMode = 'manual'` a ogni chiamata, e non è un dettaglio interno: la
+pipeline legge `voiceFramework` **solo** quando il modo è manuale, quindi da quel momento nessuno
+riscrive più la voce del brand da solo.
+
+Dopo #393 il tool MCP `update_voice` non esiste più — è dentro `update_brand_identity`, la cui
+descrizione l'effetto lo dichiara: *«Sending any voice field switches the brand OFF automatic
+voice»*. Restava però la descrizione del membro, che diceva solo *«Only the fields you send
+change»*. Non raggiunge `tools/list`, ma è il contratto della rotta e lo leggono la CLI e chiunque
+apra `packages/api-contracts`. Ora dicono la stessa cosa.
+
+## `reschedule_post`: trovato, verificato, **non** corretto
+
+La sua descrizione dice *«It does not publish and does not approve — it only changes when»*.
+L'handler scrive `status: 'approved'`, azzera `external_post_id` e `published_url`, e chiama
+`publishApprovedPost`. Rischedulare un post in `pending_user` lo approva e lo manda al publisher.
+
+Non è un difetto della stessa classe degli altri — quella rotta il suo `updateError` lo legge, e un
+publish fallito è un `500` onesto. È una contraddizione fra descrizione e comportamento, e
+risolverla è una **decisione di pubblicazione**: allineare la descrizione al comportamento tiene in
+piedi chi oggi usa `reschedule_post` per approvare e mandare in onda; allineare il comportamento
+alla descrizione smette di pubblicare post che oggi escono. Le due strade cambiano cosa va in onda,
+quindi la scelta non è di chi corregge il codice. Resta scritta qui perché il prossimo che apre la
+famiglia la trovi già trovata.
+
+## Il test è quello che simula il fallimento
+
+Un test del solo percorso felice non può accorgersi di questa classe — è esattamente il motivo per
+cui il difetto è arrivato fin qui con la suite verde. Quelli aggiunti usano `failNext` del testkit
+per far fallire **la scrittura**, e misurano una cosa sola: che la risposta NON dica `ok: true`.
+Visti fallire prima della correzione, tutti e cinque.
+
+E poiché la suite mocka Supabase — dove un insert finto accetta qualunque cosa — il vincolo vero
+è provato dove si scrive davvero: `scripts/constraint-harness.mjs` ha adesso il caso «due piani
+attivi per lo stesso brand», che deve tornare `23505`. È la prova che il fallimento di
+`approve_plan` era raggiungibile, non ipotetico.
+
+## Altri diciannove con la stessa forma, fuori da questa PR
+
+La stessa ricerca su tutte le rotte `api/v1` ne ha trovati altri diciannove: `sync_products` che
+cancella il catalogo e poi risponde `synced: 47` senza aver letto l'insert, `publish_post` che
+scarta interamente il `PublishResult` mentre il suo gemello `approvePost` in `cli-queries.ts` si
+ramifica esattamente sui due casi che questa rotta ignora, `optimize_article` che risponde `ok`
+identico sia che abbia riscritto l'articolo sia che il modello abbia fallito, `weekly-plan/render`
+che costruisce `ok: true` dal risultato in memoria e non dalla scrittura. Stanno in una PR loro:
+sono altre decisioni, alcune su soldi e una su un consenso (le immagini di una persona reale che
+restano nel bucket dopo un `ok: true`).

--- a/cli/lib/contracts/posts.ts
+++ b/cli/lib/contracts/posts.ts
@@ -138,14 +138,15 @@ export const RENDER_POST = {
   title: 'Render post image',
   description:
     'Draw the image a post is missing, from the prompt already written on it, and attach it. It ' +
-    'spends credits: one render. To draw a picture that is not tied to a post, use ' +
-    'generate_image.',
+    'spends credits: one render. A render that produces no image FAILS instead of answering ok, ' +
+    'and says `credits_spent`: the charge happened before the failure, so a retry pays again. To ' +
+    'draw a picture that is not tied to a post, use generate_image.',
   method: 'POST',
   pathUnderBrand: '/posts/:id/render',
   resource: 'post',
   input: z.object({}).strict(),
   output: z.union([
-    z.object({ ok: z.literal(true), url: z.string().nullable(), error: z.string().nullable() }),
+    z.object({ ok: z.literal(true), url: z.string(), error: z.null() }),
     z.object({ error: z.string(), url: z.string() })
   ]),
   failures: [{ error: 'credits_exhausted', status: 402 }],

--- a/cli/lib/contracts/studio.ts
+++ b/cli/lib/contracts/studio.ts
@@ -259,8 +259,9 @@ export const UPDATE_VOICE = {
   title: 'Update voice',
   description:
     'Change how this brand sounds: mood, tone, register, the words it must avoid, and the ' +
-    'instructions that differ per platform. Only the fields you send change. get_voice reads it ' +
-    'back. Free.',
+    'instructions that differ per platform. Only the fields you send change. Sending ANY of them ' +
+    'switches the brand OFF automatic voice: from then on nobody rewrites it for you. get_voice ' +
+    'reads it back. Free.',
   method: 'POST',
   pathUnderBrand: '/voice/update',
   input: z

--- a/docs/mcp-tool-review.md
+++ b/docs/mcp-tool-review.md
@@ -273,6 +273,11 @@ primo cambiamento»: qui è scritta in ventinove, e ne mancano quindici.
 
 ## 4. `approve_plan` dichiara attivato un piano che può essere rimasto proposto
 
+> **Corretto in #399.** `activatePlan` alza su entrambe le scritture e sulla sincronizzazione
+> delle preferenze; la rotta ha perso le due scritture duplicate. Il vincolo che rendeva il
+> fallimento raggiungibile è provato in `scripts/constraint-harness.mjs`. La diagnosi qui sotto
+> resta per il metodo: il comportamento non è più questo.
+
 **Gravità: critica.** È il difetto della classe `logout`, sul tool che se lo può permettere meno —
 l'unico della famiglia piani annotato `destructive: true`.
 
@@ -386,6 +391,10 @@ passato, non un patch con tutte le colonne»*. Per `brand_kit` non c'è: **nessu
 ---
 
 ## 6. `render_post` fa pagare il render, fallisce, e risponde `ok: true`
+
+> **Corretto in #399.** Un render senza immagine è un `502` che nomina il motivo e porta
+> `credits_spent`, perché riprovare paga una seconda volta; anche l'errore della scrittura di
+> `media_url` viene letto. La descrizione lo dichiara.
 
 **Gravità: alta.**
 

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -4,7 +4,7 @@
 > Non si modifica a mano: il prossimo che rigenera cancella le correzioni.
 
 **80 tool** — 9 in lettura, 53 in scrittura, 18 che distruggono.
-Il payload di `tools/list` pesa **87.350 caratteri**, circa **21.838 token**, ed e' il costo che ogni sessione paga prima di dire una parola.
+Il payload di `tools/list` pesa **87.502 caratteri**, circa **21.876 token**, ed e' il costo che ogni sessione paga prima di dire una parola.
 
 | gruppo | tool |
 |---|---:|
@@ -166,7 +166,7 @@ Throw away one post that has not gone out yet. It does not come back, and its co
 
 *Render post image*
 
-Draw the image a post is missing, from the prompt already written on it, and attach it. It spends credits: one render. To draw a picture that is not tied to a post, use generate_image.
+Draw the image a post is missing, from the prompt already written on it, and attach it. It spends credits: one render. A render that produces no image FAILS instead of answering ok, and says `credits_spent`: the charge happened before the failure, so a retry pays again. To draw a picture that is not tied to a post, use generate_image.
 
 | campo | tipo | |
 |---|---|---|

--- a/packages/api-contracts/src/posts.ts
+++ b/packages/api-contracts/src/posts.ts
@@ -138,14 +138,15 @@ export const RENDER_POST = {
   title: 'Render post image',
   description:
     'Draw the image a post is missing, from the prompt already written on it, and attach it. It ' +
-    'spends credits: one render. To draw a picture that is not tied to a post, use ' +
-    'generate_image.',
+    'spends credits: one render. A render that produces no image FAILS instead of answering ok, ' +
+    'and says `credits_spent`: the charge happened before the failure, so a retry pays again. To ' +
+    'draw a picture that is not tied to a post, use generate_image.',
   method: 'POST',
   pathUnderBrand: '/posts/:id/render',
   resource: 'post',
   input: z.object({}).strict(),
   output: z.union([
-    z.object({ ok: z.literal(true), url: z.string().nullable(), error: z.string().nullable() }),
+    z.object({ ok: z.literal(true), url: z.string(), error: z.null() }),
     z.object({ error: z.string(), url: z.string() })
   ]),
   failures: [{ error: 'credits_exhausted', status: 402 }],

--- a/packages/api-contracts/src/studio.ts
+++ b/packages/api-contracts/src/studio.ts
@@ -259,8 +259,9 @@ export const UPDATE_VOICE = {
   title: 'Update voice',
   description:
     'Change how this brand sounds: mood, tone, register, the words it must avoid, and the ' +
-    'instructions that differ per platform. Only the fields you send change. get_voice reads it ' +
-    'back. Free.',
+    'instructions that differ per platform. Only the fields you send change. Sending ANY of them ' +
+    'switches the brand OFF automatic voice: from then on nobody rewrites it for you. get_voice ' +
+    'reads it back. Free.',
   method: 'POST',
   pathUnderBrand: '/voice/update',
   input: z

--- a/scripts/constraint-harness.mjs
+++ b/scripts/constraint-harness.mjs
@@ -94,6 +94,13 @@ const CASES = [
   { what: 'brand_articles.cover_image non http', sql: article('cover_image', `'nope'`), code: CHECK_VIOLATION },
   { what: 'brand_articles.meta_title oltre il tetto', sql: article('meta_title', `repeat('x', 301)`), code: CHECK_VIOLATION },
 
+  {
+    what: 'editorial_plans: due piani attivi per lo stesso brand',
+    sql: `insert into public.editorial_plans (brand_id, status) select $1, 'active' from generate_series(1, 2)`,
+    code: UNIQUE_VIOLATION
+  },
+  { what: 'editorial_plans.status fuori vocabolario', sql: `insert into public.editorial_plans (brand_id, status) values ($1, 'nope')`, code: CHECK_VIOLATION },
+
   { what: 'content_plans.status fuori vocabolario', sql: plan('status', `'nope'`), code: CHECK_VIOLATION },
   { what: 'content_plans.source fuori vocabolario', sql: plan('source', `'nope'`), code: CHECK_VIOLATION },
   { what: 'content_plans.editorial_week negativa', sql: plan('editorial_week', '-1'), code: CHECK_VIOLATION },

--- a/src/lib/content/changelog/2026-09-11-tools-that-lie.ts
+++ b/src/lib/content/changelog/2026-09-11-tools-that-lie.ts
@@ -1,0 +1,10 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-11',
+  title: 'When something fails, we now say so',
+  items: [
+    'A post render that produces no image now fails with the reason instead of reporting success, and tells you the credits were already spent so a retry costs again.',
+    'Approving an editorial plan now confirms only once the plan is really the active one — before, a failed switch still came back as approved while the brand kept following the old plan.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/editorial-plan.ts
+++ b/src/lib/server/editorial-plan.ts
@@ -899,7 +899,11 @@ Return JSON.`;
 export async function syncPrefsFromPlan(supabase: SupabaseClient, brandId: string, plan: EditorialPlan): Promise<void> {
   const { data: brand } = await supabase.from('brands').select('content_prefs').eq('id', brandId).maybeSingle();
   const existing = (brand?.content_prefs as ContentPrefs) ?? {};
-  await supabase.from('brands').update({ content_prefs: prefsFromPlan(plan, existing) }).eq('id', brandId);
+  const { error } = await supabase
+    .from('brands')
+    .update({ content_prefs: prefsFromPlan(plan, existing) })
+    .eq('id', brandId);
+  if (error) throw new Error(`content_prefs sync failed: ${error.message}`);
 }
 
 export type ProposalSaved = { ok: true; id: string } | { ok: false; error: 'insert_failed'; message: string };
@@ -961,17 +965,20 @@ export async function activatePlan(
   };
   const weeks = stampWeekStarts(plan.weeks, tz, now);
 
-  // Supersede whatever is active first — the partial unique index allows only one 'active' row.
-  await supabase
+  const { error: supersedeError } = await supabase
     .from('editorial_plans')
     .update({ status: 'superseded', updated_at: new Date().toISOString() })
     .eq('brand_id', brandId)
     .eq('status', 'active')
     .neq('id', planId);
-  await supabase
+  if (supersedeError) throw new Error(`supersede failed: ${supersedeError.message}`);
+
+  const { error: activateError } = await supabase
     .from('editorial_plans')
     .update({ status: 'active', weeks, activated_at: new Date().toISOString(), updated_at: new Date().toISOString() })
     .eq('id', planId);
+  if (activateError) throw new Error(`activation failed: ${activateError.message}`);
+
   const activated = { ...plan, weeks, status: 'active' };
   await syncPrefsFromPlan(supabase, brandId, activated);
   return activated;

--- a/src/routes/api/v1/brands/[slug]/editorial-plan/approve/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/editorial-plan/approve/+server.ts
@@ -12,31 +12,16 @@ export const POST: RequestHandler = async ({ request, params }) => {
   if (writeDenied) return writeDenied;
 
   try {
-    const { loadActivePlan, activatePlan, syncPrefsFromPlan } = await import('$lib/server/editorial-plan');
+    const { activatePlan } = await import('$lib/server/editorial-plan');
 
-    // Find the proposed plan
     const { data: proposed } = await supabase
-      .from('editorial_plans').select('*')
+      .from('editorial_plans').select('id')
       .eq('brand_id', brand.id).eq('status', 'proposed')
       .order('created_at', { ascending: false }).limit(1).maybeSingle();
 
     if (!proposed) return json({ error: 'No proposed plan to approve' }, { status: 404 });
 
-    // Load current active plan (if any) to get the old ID
-    const oldActive = await loadActivePlan(supabase, brand.id);
-
-    // Activate the proposed plan
     await activatePlan(supabase, brand.id, proposed.id, brand.timezone as string);
-
-    // Supersede old plan
-    if (oldActive) {
-      await supabase.from('editorial_plans')
-        .update({ status: 'superseded' })
-        .eq('id', oldActive.id);
-    }
-
-    // Sync prefs
-    await syncPrefsFromPlan(supabase, brand.id, proposed);
 
     return json({ ok: true });
   } catch (e) {

--- a/src/routes/api/v1/brands/[slug]/editorial-plan/approve/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/editorial-plan/approve/+server.ts
@@ -21,10 +21,11 @@ export const POST: RequestHandler = async ({ request, params }) => {
 
     if (!proposed) return json({ error: 'No proposed plan to approve' }, { status: 404 });
 
-    await activatePlan(supabase, brand.id, proposed.id, brand.timezone as string);
+    const activated = await activatePlan(supabase, brand.id, proposed.id, brand.timezone as string);
+    if (!activated) return json({ error: 'Proposed plan disappeared before activation' }, { status: 409 });
 
     return json({ ok: true });
   } catch (e) {
-    return json({ error: `Approve failed: ${String(e)}` }, { status: 500 });
+    return json({ error: `Approve failed: ${e instanceof Error ? e.message : String(e)}` }, { status: 500 });
   }
 };

--- a/src/routes/api/v1/brands/[slug]/editorial-plan/approve/server.test.ts
+++ b/src/routes/api/v1/brands/[slug]/editorial-plan/approve/server.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTestSupabase, type TestSupabase } from '$lib/testkit/supabase';
+
+vi.mock('$lib/server/cli-auth', () => ({
+  authenticate: vi.fn(),
+  loadBrandForUser: vi.fn(),
+  checkApiKeyWriteAccess: vi.fn(() => undefined)
+}));
+vi.mock('$lib/server/research', () => ({ structured: vi.fn(), benchmarkDigest: vi.fn() }));
+
+const activatePlan = vi.fn();
+vi.mock('$lib/server/editorial-plan', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('$lib/server/editorial-plan')>()),
+  activatePlan: (...args: unknown[]) => activatePlan(...args)
+}));
+
+import { POST } from './+server';
+import { authenticate, loadBrandForUser } from '$lib/server/cli-auth';
+
+const BRAND = { id: 'brand-1', slug: 'demo', name: 'Demo', plan: 'pro', timezone: 'Europe/Rome' };
+
+const WEEK = {
+  index: 0,
+  theme: 'Il banco di lavoro',
+  focus: 'Mostrare il montaggio a mano',
+  content_mix: [{ type: 'behind the scenes', count: 3 }],
+  rationale: 'La gente compra da chi vede lavorare'
+};
+
+const PROPOSED = {
+  id: 'plan-new',
+  brand_id: 'brand-1',
+  status: 'proposed',
+  strategy: 'Il lavoro vero, in vetrina.',
+  voice: { mood: 'diretto', tone: 'asciutto', goal: 'far provare', personality: 'un artigiano' },
+  cadence: '3/week',
+  platform_mix: [{ platform: 'instagram', share: '70%', role: 'vetrina' }],
+  gtm: null,
+  weeks: [WEEK],
+  created_at: '2026-09-10T09:00:00.000Z'
+};
+
+const ACTIVE = {
+  id: 'plan-old',
+  brand_id: 'brand-1',
+  status: 'active',
+  strategy: 'Il piano di prima.',
+  voice: { mood: 'tiepido', tone: 'generico', goal: 'esserci', personality: 'nessuna' },
+  cadence: '5/week',
+  platform_mix: [],
+  gtm: null,
+  weeks: [],
+  created_at: '2026-08-01T09:00:00.000Z'
+};
+
+function seed(): TestSupabase {
+  return createTestSupabase({
+    editorial_plans: [{ ...ACTIVE }, { ...PROPOSED }],
+    brands: [{ id: 'brand-1', content_prefs: { mood: 'tiepido', frequency: '5/week' } }]
+  });
+}
+
+function call(prepare?: (kit: TestSupabase) => void) {
+  const kit = seed();
+  prepare?.(kit);
+  vi.mocked(authenticate).mockResolvedValue({
+    supabase: kit.client,
+    user: { id: 'user-1' },
+    apiKey: undefined,
+    error: null
+  } as never);
+  vi.mocked(loadBrandForUser).mockResolvedValue({ brand: BRAND, error: null } as never);
+
+  const url = new URL('https://anomalia.test/api/v1/brands/demo/editorial-plan/approve');
+  return (POST as (event: unknown) => Promise<Response>)({
+    request: new Request(url, { method: 'POST' }),
+    params: { slug: 'demo' },
+    url
+  }).then(async (res) => ({ res, body: await res.json(), kit }));
+}
+
+const planById = (kit: TestSupabase, id: string) =>
+  kit.tables.get('editorial_plans')?.find((row) => row.id === id);
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  const real = await vi.importActual<typeof import('$lib/server/editorial-plan')>(
+    '$lib/server/editorial-plan'
+  );
+  activatePlan.mockImplementation(real.activatePlan);
+});
+
+describe('POST /api/v1/brands/:slug/editorial-plan/approve', () => {
+  it('attiva la proposta, supera il piano vecchio e sincronizza le preferenze', async () => {
+    const { res, body, kit } = await call();
+
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(planById(kit, 'plan-new')?.status).toBe('active');
+    expect(planById(kit, 'plan-old')?.status).toBe('superseded');
+    expect(kit.tables.get('brands')?.[0].content_prefs).toMatchObject({
+      mood: 'diretto',
+      frequency: '3/week'
+    });
+  });
+
+  it('una scrittura fallita non diventa ok: true', async () => {
+    const { res, body } = await call((kit) =>
+      kit.failNext(
+        'editorial_plans',
+        'duplicate key value violates unique constraint "editorial_plans_active_uniq"',
+        'update'
+      )
+    );
+
+    expect(res.ok).toBe(false);
+    expect(body.ok).not.toBe(true);
+    expect(body.error).toContain('editorial_plans_active_uniq');
+  });
+
+  it('un piano che sparisce fra la lettura e l attivazione non diventa ok: true', async () => {
+    activatePlan.mockResolvedValue(null);
+
+    const { res, body, kit } = await call();
+
+    expect(res.ok).toBe(false);
+    expect(body.ok).not.toBe(true);
+    expect(planById(kit, 'plan-old')?.status).toBe('active');
+  });
+
+  it('sincronizza le preferenze dal piano normalizzato, una volta sola', async () => {
+    const { kit } = await call();
+    const writes = kit.calls.filter((c) => c.table === 'brands' && c.op === 'update');
+
+    expect(writes).toHaveLength(1);
+    expect(planById(kit, 'plan-new')?.weeks?.[0]).toHaveProperty('week_start');
+  });
+});

--- a/src/routes/api/v1/brands/[slug]/posts/[id]/render/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/posts/[id]/render/+server.ts
@@ -100,14 +100,20 @@ export const POST: RequestHandler = async ({ request, params }) => {
         }
       });
 
-      // Reload to get the image URL
       const { data: updated } = await supabase
         .from('posts').select('media_url')
         .eq('id', post.id).maybeSingle();
 
-      return json({ ok: true, url: updated?.media_url ?? null, error: updated?.media_url ? null : renderError });
+      if (!updated?.media_url) {
+        return json({ error: renderError ?? 'no image produced', credits_spent: true }, { status: 502 });
+      }
+
+      return json({ ok: true, url: updated.media_url, error: null });
     } catch (e) {
-      return json({ error: `Render failed: ${String(e)}` }, { status: 500 });
+      return json(
+        { error: `Render failed: ${e instanceof Error ? e.message : String(e)}`, credits_spent: true },
+        { status: 500 }
+      );
     }
   });
 };

--- a/src/routes/api/v1/brands/[slug]/posts/[id]/render/server.test.ts
+++ b/src/routes/api/v1/brands/[slug]/posts/[id]/render/server.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { createTestSupabase } from '$lib/testkit/supabase';
+import { createTestSupabase, type TestSupabase } from '$lib/testkit/supabase';
 import type { ApiKeyInfo } from '$lib/server/cli-auth';
 
 const gateCredits = vi.fn();
@@ -58,8 +58,9 @@ const READ_ONLY_KEY: ApiKeyInfo = {
   permissions: { brand_ids: '*', scopes: ['read'] }
 };
 
-function call(apiKey?: ApiKeyInfo) {
+function call(apiKey?: ApiKeyInfo, prepare?: (kit: TestSupabase) => void) {
   const kit = createTestSupabase({ posts: [{ ...POST_ROW }], brand_kit: [], products: [] });
+  prepare?.(kit);
   vi.mocked(authenticate).mockResolvedValue({
     supabase: kit.client,
     user: { id: 'user-1' },
@@ -114,5 +115,42 @@ describe('POST /api/v1/brands/:slug/posts/:id/render', () => {
     expect(gateCredits).toHaveBeenCalledWith('brand-1');
     expect(brandContexts).toEqual(['brand-1']);
     expect(kit.tables.get('posts')?.[0].media_url).toBe('https://cdn.test/a.png');
+  });
+
+  it('un render senza immagine non è ok: true, e dice che i crediti sono già usciti', async () => {
+    renderPreviewImages.mockImplementation(
+      async (_profile: unknown, _posts: unknown, opts: { onPost: (p: unknown) => Promise<void> }) => {
+        await opts.onPost({ imageUrl: null, __renderError: 'il modello ha rifiutato il prompt' });
+      }
+    );
+
+    const { res, body } = await call();
+
+    expect(res.ok).toBe(false);
+    expect(body.ok).not.toBe(true);
+    expect(body.error).toContain('il modello ha rifiutato il prompt');
+    expect(body.credits_spent).toBe(true);
+  });
+
+  it('un renderer che alza non è ok: true, e dice che i crediti sono già usciti', async () => {
+    renderPreviewImages.mockRejectedValue(new Error('il fornitore ha chiuso la connessione'));
+
+    const { res, body } = await call();
+
+    expect(res.ok).toBe(false);
+    expect(body.ok).not.toBe(true);
+    expect(body.error).toContain('il fornitore ha chiuso la connessione');
+    expect(body.credits_spent).toBe(true);
+  });
+
+  it('una scrittura fallita non è ok: true, e dice che i crediti sono già usciti', async () => {
+    const { res, body } = await call(undefined, (kit) =>
+      kit.failNext('posts', 'permission denied for table posts', 'update')
+    );
+
+    expect(res.ok).toBe(false);
+    expect(body.ok).not.toBe(true);
+    expect(body.error).toContain('permission denied for table posts');
+    expect(body.credits_spent).toBe(true);
   });
 });

--- a/src/routes/app/[brand]/editorial/+page.server.ts
+++ b/src/routes/app/[brand]/editorial/+page.server.ts
@@ -148,7 +148,11 @@ export const actions: Actions = {
         .eq('brand_id', brand.id)
         .eq('status', 'active');
       if (err) return fail(500, { error: err.message });
-      await syncPrefsFromPlan(supabase, brand.id, incoming);
+      try {
+        await syncPrefsFromPlan(supabase, brand.id, incoming);
+      } catch (e) {
+        return fail(500, { error: e instanceof Error ? e.message : 'prefs_sync_failed' });
+      }
       return { saved: true };
     });
   },
@@ -289,9 +293,13 @@ export const actions: Actions = {
     return withBrand(supabase, params.brand, async (brand) => {
       const data = await request.formData();
       const planId = String(data.get('plan_id') ?? '');
-      const activated = await activatePlan(supabase, brand.id, planId, brand.timezone);
-      if (!activated) return fail(404, { error: 'plan_not_found' });
-      return { approved: true };
+      try {
+        const activated = await activatePlan(supabase, brand.id, planId, brand.timezone);
+        if (!activated) return fail(404, { error: 'plan_not_found' });
+        return { approved: true };
+      } catch (e) {
+        return fail(500, { error: e instanceof Error ? e.message : 'approve_failed' });
+      }
     });
   },
 


### PR DESCRIPTION
## What?

Two MCP tools answered `ok: true` without ever having looked at the outcome of their own writes. They now build the answer after knowing how it went.

- **`render_post`** — a render that produced no image returned HTTP 200 with `{ ok: true, url: null, error: '…' }`. The endpoint sits behind `gateAiAction`, so reaching that line means the credits are already gone, and the MCP layer wraps the body with `ok()`, which does **not** set `isError`. A model reading `ok` saw a success it had paid for and did not have. It now fails with the reason and carries `credits_spent`, because a retry pays a second time. The `media_url` write's own error is read too.
- **`approve_plan`** — `activatePlan` ran two updates without reading either error and built its return value from the object it already had in memory; the route threw that value away, added a third unchecked write, and answered `ok: true`. `activatePlan` now throws on both writes and on the `content_prefs` sync.

Two more of the four reported were verified and handled differently, and the difference matters:

- **`update_voice`** still sets `voiceMode = 'manual'` on every call. #393 already declared that on `update_brand_identity`, the family that absorbed it — the only description a MCP client ever sees. What was still silent was the **member's own** description, which the CLI and `packages/api-contracts` carry. Both now say it.
- **`reschedule_post`** is real and is **deliberately not fixed here**. See *Anything Else?*.

A separate commit removes two writes from the approve route that had no effect of their own, before anything changes behaviour.

## Why?

An error you can see costs one round. A false success costs everything the agent builds on top of it, and it does not surface as an error — it surfaces later as a wrong result, somewhere nobody connects to the cause. This is the class that already cost the removal of `logout`, which returned `{loggedOut: true}` after an `unlinkSync` that failed inside a bare `catch {}`.

The `approve_plan` failure is reachable, not hypothetical. `editorial_plans_active_uniq` (migration `0034`, line 33) is a partial unique index admitting **one** `active` row per brand. If the supersede does not take, the activation violates it and fails. Nobody read that error: the tool answered `ok: true`, the brand kept following the old plan, and the agent told the person the new one was live — while the description promises *«Make the proposed editorial plan the one this brand actually follows»*.

The `render_post` case costs money on top: the caller has paid, has no image, has been told it worked, and has no way to know that retrying pays again. `LESSONS.md` already carries an entry on consumption being charged to the wrong account for a neighbouring reason.

## How?

**The criterion, one only: the return value is built after knowing how it went.** Every write reads its own `error`, every catch that swallowed one either reports it or stops swallowing, and where the tool **spends** before failing, the response says so.

**`activatePlan` throws rather than returning a result object.** It has seven callers and three of them — the scheduler, the onboarding endpoint, the chat job — discard its return value entirely, so a result object would have fixed one caller and left three lying. A throw fixes all of them where they already route through, which is the smaller diff *and* the wider fix. Checked before choosing it: the scheduler's two call sites are inside per-brand `try/catch` blocks that already contain a failure to one brand; the chat job runner catches and marks the job failed, instead of answering `{ success: true, activated: true }`; `plan/+page.server.ts` already wrapped its call. Only `editorial/+page.server.ts` did not, so it gets a `try/catch` returning `fail(500)` in the same shape as its two siblings — otherwise a failed approval would have become a raw 500 page instead of a form error.

**`render_post` fails with 502, not 200.** `request()` in `cli/lib/api.ts` throws on any non-2xx, so the MCP layer marks `isError` and the body text — including `credits_spent` — reaches the model in the message. Rejected: keeping HTTP 200 and flipping `ok` to `false`. The contract a tool exposes is `ok`, and a transport that cannot distinguish the two is the thing that let this ship.

**Rejected: a `renderStarted` flag** so the outer `catch` could report `credits_spent` precisely. The only things that can throw before the renderer is invoked are two dynamic `import`s of bundled modules. A guard for a contingency that never arrives is complexity paid today; the branch would also have been untestable.

**Two writes deleted rather than corrected** (first commit, behaviour-preserving): the route's explicit supersede of `oldActive` — `activatePlan` already supersedes every `active` row of the brand except the one it is activating — and its second `syncPrefsFromPlan`, which `activatePlan` had already done with the **normalised** plan (`normWeek` + `stampWeekStarts`) while the route passed the **raw** row. `loadActivePlan` goes with them.

## Testing?

**The test simulates the write failing and asserts the answer is not `ok: true`.** That shape is the point: a happy-path test cannot see this class, which is exactly how the defect arrived with a green suite. The testkit's `failNext(table, message, op)` injects the PostgREST error. All five were **watched fail before the fix**:

| test | what it forces |
|---|---|
| `un render senza immagine non è ok: true…` | the renderer returns no `imageUrl` |
| `un renderer che alza non è ok: true…` | `renderPreviewImages` rejects |
| `una scrittura fallita non è ok: true…` | the `posts` update fails |
| `una scrittura fallita non diventa ok: true` | the `editorial_plans` update fails with the unique-index message |
| `un piano che sparisce fra la lettura e l'attivazione…` | `activatePlan` resolves `null` |

Plus two that pin the tidy: `attiva la proposta, supera il piano vecchio e sincronizza le preferenze`, and `sincronizza le preferenze dal piano normalizzato, una volta sola` — the second was red before the duplicate sync was removed.

**The real constraint, against real Postgres.** The suite mocks Supabase, where a fake insert accepts anything, so the unique index is proved where writes are real: `scripts/constraint-harness.mjs` gains `editorial_plans: due piani attivi per lo stesso brand`, expecting `23505`. Run against the local Docker stack inside a transaction closed by `rollback`.

**What was NOT tested, and the risk.**

- **The browser gate is not green, and nothing here claims it is.** The dev server started from the worktree and login as `test@anomalia.so` worked, but the repo's `.env` points at a hosted Supabase project, where the brand is not `demo` — and exercising writes against a hosted instance is not a substitute, it is the thing the rule forbids. Rewiring the app to the local self-hosted stack means copying its anon and service-role keys out of another worktree's `.env`, which I stopped short of. **Risk**: the `editorial/+page.server.ts` `fail(500)` path is reasoned from its two siblings in the same file, not seen rendered.
- **No agent evaluation run.** Nothing here touches prompts, tools, the chat path or the model.
- **The three other `activatePlan` callers are covered by their existing suites, not by new tests** of their own throw path: the scheduler (`scheduler.test.ts`, 12 green), the chat job drain (`tool-job-drain.test.ts`, 16 green), and `onboarding/+server.ts`, which has none. **Risk**: on the onboarding endpoint a failed activation is now an uncaught 500 rather than a silent success. That is the intended direction — it used to mark the section `approved` on a failed activation — but the response shape is SvelteKit's, not the endpoint's.
- **`reschedule_post` is untouched**, so its contradiction stands exactly as it did.

**Green:** `npm run build` (CI does not run it); `cli` bun suite 135/135; `constraint-harness` 70/70 against the local stack. Full `vitest`: **7236 passed, 0 test failures**, with 3 `[vitest-worker]: Timeout calling "onTaskUpdate"` RPC errors on `brand-memory.test.ts` — a file this branch does not touch, under a machine running two builds at once. The 10 "failed files" in that line are the reporting casualties of those timeouts, not assertions; `LESSONS.md` already carries this signal.

## Evidence (screenshots/videos)

No UI changed, so there are no before/after screenshots — and no hosted screenshots are offered in their place.

<details>
<summary>The tests, red before the fix</summary>

```
 × render > un render senza immagine non è ok: true, e dice che i crediti sono già usciti
   → expected true to be false
 × render > una scrittura fallita non è ok: true, e dice che i crediti sono già usciti
   → expected true to be false
 × approve > una scrittura fallita non diventa ok: true
   → expected true to be false
 × approve > un piano che sparisce fra la lettura e l attivazione non diventa ok: true
   → expected true to be false
 × approve > sincronizza le preferenze dal piano normalizzato, una volta sola
   → expected [ … ] to have a length of 1 but got 2
```

</details>

<details>
<summary>The same tests, green after</summary>

```
 ✓ src/routes/api/v1/brands/[slug]/posts/[id]/render/server.test.ts (6 tests)
 ✓ src/routes/api/v1/brands/[slug]/editorial-plan/approve/server.test.ts (4 tests)
 Test Files  2 passed (2)
      Tests  10 passed (10)
```

</details>

<details>
<summary>The unique index bites, against the local Postgres</summary>

```
$ DATABASE_URL=postgres://…@127.0.0.1:5432/postgres node scripts/constraint-harness.mjs
ok    editorial_plans: due piani attivi per lo stesso brand  (atteso 23505, ottenuto 23505)
ok    editorial_plans.status fuori vocabolario  (atteso 23514, ottenuto 23514)
…
70/70 vincoli mordono
```

This is the whole premise of the `approve_plan` defect: the failure the code did not read is one Postgres really produces.

</details>

## Anything Else?

**`reschedule_post` needs a decision that is not mine to take, and it is the most delicate of the four.**

Its description says *«It does not publish and does not approve — it only changes when»*. `POST /posts/:id/reschedule` writes `status: 'approved'`, clears `external_post_id` and `published_url`, and calls `publishApprovedPost`. Rescheduling a post in `pending_user` **approves it and sends it to the publisher**. Note this is not the same defect as the other two — that route reads its `updateError`, and a failed publish is an honest 500. It is a contradiction between the description and the behaviour, and resolving it changes what goes on air:

- **Align the description to the behaviour.** Nothing stops going out. Whoever uses `reschedule_post` today to approve-and-schedule in one call keeps working. Cost: the tool stays a verb hidden behind a name that does not carry it, `edit_post` promises the opposite and means it, and merging the two — the most obvious collapse of the post family — would put an approval inside a tool that promises not to approve.
- **Align the behaviour to the description.** It only moves `scheduled_for`. Cost: **a post that goes out today may stop going out.** Any caller that relied on the side effect now has to call `approve_post` as well, and a queue rescheduled by an agent stays in `pending_user` until someone approves it. Every automation built on the current behaviour changes silently.

Whichever way it goes, the `destructive` annotation and the family plan should be decided in the same pass.

**Nineteen more of the same shape were found across `api/v1` and are not fixed here** — each is a decision of its own, some about money and one about consent. The worst:

- `sync_products` (`studio/products/+server.ts:58-59`) deletes the whole catalogue then inserts, reads neither error, and answers `synced: 47`. supabase-js returns errors rather than throwing, so the surrounding `try/catch` never fires.
- `publish_post` (`posts/[id]/publish/+server.ts:22`) discards `PublishResult` entirely and answers `status: 'published'` — while `approvePost` in `cli-queries.ts:565` branches on exactly the two cases it ignores, with a comment naming this as a false success.
- `optimize_article` answers the same `ok` whether it rewrote the article or the model failed, after `gateAiAction` plus image generation.
- `weekly-plan/render` builds `ok: true` per post from the in-memory render result, not from the write, and that route has no credits gate at all.
- `studio/people/[id]` deletes the row but never reads `storage.remove()`, so a real person's images stay in the bucket behind an `ok: true` — a consent and retention question, not a leak.

**Known debt left behind:** `render_post`'s new 502 is not declared in the contract's `failures`, because the route answers prose and that list holds codes (`credits_exhausted`); giving those routes error codes is its own pass, and §12 of `docs/mcp-tool-review.md` already tracks it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
