### PR TITLE
Gate the four planning routes on credits

### DIFF
--- a/changelog/2026-09-11-plan-routes-gate.md
+++ b/changelog/2026-09-11-plan-routes-gate.md
@@ -1,0 +1,39 @@
+# Le quattro rotte che pianificano passano dal cancello
+
+`propose`, `revise`, `replan-week` e `weekly-plan/plan` arrivano tutte a un modello —
+`proposePlan`, `revisePlan`, `replanWeek`, `planWeekStrategy` — e nessuna delle quattro chiamava
+`gateAiAction`. Sono le etichette più care che abbiamo: negli ultimi sette giorni `reviewCaptions`
+$13,54, `planStrategy` $11,50, `reviewSeeds` $8,10. Il saldo crediti non le fermava, e la
+restrizione di scrittura di una chiave API non le raggiungeva dalla rotta (la raggiunge da
+`authenticate`, che dal 2026-08 nega ogni non-GET a una chiave di sola lettura: il cancello per
+rotta è la seconda linea, quella che regge se domani qualcuno cambia idea sul metodo).
+
+Il cancello sta subito dopo `loadBrandForUser`, prima di leggere il corpo: crediti finiti è 402
+prima di «feedback is required», non dopo. I quattro contratti dichiarano `credits_exhausted`,
+perché `statusForFailure` degrada a 500 un 402 non dichiarato — che si legge come «guasto nostro»
+invece che «crediti finiti».
+
+## Cosa NON è stato toccato, e perché
+
+**`/ads` non chiama nessun modello.** Era nella lista delle cinque rotte che spendono senza
+cancello: non lo è. `ads.ts`, `ads-fatigue.ts` e `zernio-ads.ts` non importano niente che parli a
+un modello — `proposeBoosts` è ranking e insert, `proposeStandalone` prende la creatività dal
+corpo. La POST ha già `checkApiKeyWriteAccess`, e l'unica azione che spende davvero (`approve`, la
+fee di gestione) controlla già il saldo con `canAffordAdsCredits`. La proposta di ads con l'AI
+vive in `/ads/remix`, che il cancello ce l'ha da sempre. Mettere `gateAiAction` qui avrebbe
+addebitato un controllo crediti a un'operazione gratuita.
+
+Resta un difetto vicino, non chiuso qui: `approve` risponde `credits_exhausted:<servono>:<restano>`
+con **400**, e il contratto non lo dichiara affatto. Stringa dinamica, quindi non entra nella lista
+`failures` così com'è: va deciso se normalizzarla a 402 + campi, ed è un cambio di forma della
+risposta su una rotta viva.
+
+**L'esenzione onboarding non esiste.** `gateCreditsCore` chiama `isCreditExempt()` e esce subito,
+ma `withCreditExempt` — l'unica cosa che può accenderla — non ha **nessun** call site in tutto il
+repository. `isCreditExempt()` in produzione risponde sempre falso. Quindi aggiungere il cancello
+non poteva spegnere l'onboarding per quella strada; e l'onboarding non passa comunque da queste
+rotte, che sono la superficie CLI/MCP: la prima proposta di piano la fanno
+`app/[brand]/plan/+page.server.ts` e `app/[brand]/editorial/+page.server.ts`, la prima settimana
+`app/[brand]/setup/+server.ts`, tutti e tre chiamando le funzioni direttamente. Quelle strade
+restano senza cancello proprio, e questo è un buco vero che questa PR non tocca: toccare il
+percorso di iscrizione è caro da sbagliare e merita il suo diff.

--- a/cli/lib/contracts/plans.ts
+++ b/cli/lib/contracts/plans.ts
@@ -173,6 +173,9 @@ export const SAVE_WEEK_SEEDS = {
 const NoInput = z.object({}).strict();
 const Ok = z.object({ ok: z.literal(true) });
 
+/** Le quattro strade che arrivano a un modello passano tutte dallo stesso cancello: `gateAiAction`. */
+const CREDITS_EXHAUSTED = { error: 'credits_exhausted', status: 402 };
+
 export const PROPOSE_PLAN = {
   tool: 'propose_plan',
   title: 'Propose editorial plan',
@@ -185,7 +188,7 @@ export const PROPOSE_PLAN = {
   pathUnderBrand: '/editorial-plan/propose',
   input: NoInput,
   output: z.object({ ok: z.literal(true), plan: z.unknown() }),
-  failures: [],
+  failures: [CREDITS_EXHAUSTED],
   destructive: false
 } satisfies BrandEndpoint;
 
@@ -200,7 +203,7 @@ export const REVISE_PLAN = {
   pathUnderBrand: '/editorial-plan/revise',
   input: z.object({ feedback: z.string().min(1) }).strict(),
   output: z.object({ ok: z.literal(true), plan: z.unknown() }),
-  failures: [],
+  failures: [CREDITS_EXHAUSTED],
   destructive: false
 } satisfies BrandEndpoint;
 
@@ -276,7 +279,8 @@ export const REPLAN_WEEK = {
     WEEK_REQUIRED,
     { error: 'brief is required', status: 400 },
     { error: 'no active editorial plan', status: 404 },
-    { error: 'invalid week_index', status: 400 }
+    { error: 'invalid week_index', status: 400 },
+    CREDITS_EXHAUSTED
   ],
   destructive: false
 } satisfies BrandEndpoint;
@@ -293,6 +297,6 @@ export const PLAN_WEEK = {
   pathUnderBrand: '/weekly-plan/plan',
   input: z.object({ week }).strict(),
   output: z.object({ ok: z.literal(true), draft: z.unknown() }),
-  failures: [WEEK_REQUIRED, NO_ACTIVE_PLAN],
+  failures: [WEEK_REQUIRED, NO_ACTIVE_PLAN, CREDITS_EXHAUSTED],
   destructive: false
 } satisfies BrandEndpoint;

--- a/packages/api-contracts/src/plans.ts
+++ b/packages/api-contracts/src/plans.ts
@@ -173,6 +173,9 @@ export const SAVE_WEEK_SEEDS = {
 const NoInput = z.object({}).strict();
 const Ok = z.object({ ok: z.literal(true) });
 
+/** Le quattro strade che arrivano a un modello passano tutte dallo stesso cancello: `gateAiAction`. */
+const CREDITS_EXHAUSTED = { error: 'credits_exhausted', status: 402 };
+
 export const PROPOSE_PLAN = {
   tool: 'propose_plan',
   title: 'Propose editorial plan',
@@ -185,7 +188,7 @@ export const PROPOSE_PLAN = {
   pathUnderBrand: '/editorial-plan/propose',
   input: NoInput,
   output: z.object({ ok: z.literal(true), plan: z.unknown() }),
-  failures: [],
+  failures: [CREDITS_EXHAUSTED],
   destructive: false
 } satisfies BrandEndpoint;
 
@@ -200,7 +203,7 @@ export const REVISE_PLAN = {
   pathUnderBrand: '/editorial-plan/revise',
   input: z.object({ feedback: z.string().min(1) }).strict(),
   output: z.object({ ok: z.literal(true), plan: z.unknown() }),
-  failures: [],
+  failures: [CREDITS_EXHAUSTED],
   destructive: false
 } satisfies BrandEndpoint;
 
@@ -276,7 +279,8 @@ export const REPLAN_WEEK = {
     WEEK_REQUIRED,
     { error: 'brief is required', status: 400 },
     { error: 'no active editorial plan', status: 404 },
-    { error: 'invalid week_index', status: 400 }
+    { error: 'invalid week_index', status: 400 },
+    CREDITS_EXHAUSTED
   ],
   destructive: false
 } satisfies BrandEndpoint;
@@ -293,6 +297,6 @@ export const PLAN_WEEK = {
   pathUnderBrand: '/weekly-plan/plan',
   input: z.object({ week }).strict(),
   output: z.object({ ok: z.literal(true), draft: z.unknown() }),
-  failures: [WEEK_REQUIRED, NO_ACTIVE_PLAN],
+  failures: [WEEK_REQUIRED, NO_ACTIVE_PLAN, CREDITS_EXHAUSTED],
   destructive: false
 } satisfies BrandEndpoint;

--- a/src/lib/content/changelog/2026-09-11-plan-routes-gate.ts
+++ b/src/lib/content/changelog/2026-09-11-plan-routes-gate.ts
@@ -1,0 +1,10 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-11',
+  title: 'Planning with AI now respects your credit limit',
+  items: [
+    'Proposing a plan, revising it, replanning a week and generating weekly seeds now stop when the credits for the period are gone, and say so, instead of spending past the limit.',
+    'A read-only API key can no longer start any of those four, on the route itself as well as at the door.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/routes/api/v1/brands/[slug]/editorial-plan/propose/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/editorial-plan/propose/+server.ts
@@ -1,6 +1,6 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { authenticate, loadBrandForUser } from '$lib/server/cli-auth';
+import { authenticate, loadBrandForUser, gateAiAction } from '$lib/server/cli-auth';
 import { proposeFirstPlan } from '$lib/server/planner-inputs';
 
 export const POST: RequestHandler = async ({ request, params }) => {
@@ -9,6 +9,9 @@ export const POST: RequestHandler = async ({ request, params }) => {
 
   const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
   if (brandError) return brandError;
+
+  const gate = await gateAiAction(brand, apiKey);
+  if (gate) return gate;
 
   try {
     const result = await proposeFirstPlan(supabase, brand, null);

--- a/src/routes/api/v1/brands/[slug]/editorial-plan/replan-week/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/editorial-plan/replan-week/+server.ts
@@ -1,6 +1,6 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { authenticate, loadBrandForUser } from '$lib/server/cli-auth';
+import { authenticate, loadBrandForUser, gateAiAction } from '$lib/server/cli-auth';
 import { cadenceAllowed, loadActivePlan, replanWeek } from '$lib/server/editorial-plan';
 import { localeLanguageName } from '$lib/i18n/locale';
 import { plannerProfile, planEvidence } from '$lib/server/planner-inputs';
@@ -11,6 +11,9 @@ export const POST: RequestHandler = async ({ request, params }) => {
 
   const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
   if (brandError) return brandError;
+
+  const gate = await gateAiAction(brand, apiKey);
+  if (gate) return gate;
 
   const body = await request.json();
   const { brief } = body;

--- a/src/routes/api/v1/brands/[slug]/editorial-plan/revise/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/editorial-plan/revise/+server.ts
@@ -1,7 +1,7 @@
 import { swallow } from '$lib/server/swallow';
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { authenticate, loadBrandForUser } from '$lib/server/cli-auth';
+import { authenticate, loadBrandForUser, gateAiAction } from '$lib/server/cli-auth';
 import { cadenceAllowed, loadActivePlan, revisePlan } from '$lib/server/editorial-plan';
 import { activeGtmBrief } from '$lib/server/gtm';
 import { localeLanguageName } from '$lib/i18n/locale';
@@ -13,6 +13,9 @@ export const POST: RequestHandler = async ({ request, params }) => {
 
   const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
   if (brandError) return brandError;
+
+  const gate = await gateAiAction(brand, apiKey);
+  if (gate) return gate;
 
   const { feedback } = await request.json();
   if (!feedback) return json({ error: 'feedback is required' }, { status: 400 });

--- a/src/routes/api/v1/brands/[slug]/plan-spend.test.ts
+++ b/src/routes/api/v1/brands/[slug]/plan-spend.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTestSupabase } from '$lib/testkit/supabase';
+import type { ApiKeyInfo } from '$lib/server/cli-auth';
+
+/**
+ * LE QUATTRO ROTTE CHE PIANIFICANO SPENDONO. Ognuna arriva a un modello — `proposePlan`,
+ * `revisePlan`, `replanWeek`, `planWeekStrategy` — e nessuna delle quattro passava dal cancello:
+ * una chiave di sola lettura le faceva partire, e un brand a crediti finiti pure. Sono le
+ * etichette più care che abbiamo (`planStrategy`, `reviewSeeds`, `reviewCaptions`).
+ *
+ * `gateAiAction` e `checkApiKeyWriteAccess` restano quelli veri: il difetto era che la rotta non
+ * li chiamava, e un mock del cancello non avrebbe potuto accorgersene.
+ */
+
+const gateCredits = vi.fn();
+const proposeFirstPlan = vi.fn();
+const revisePlan = vi.fn();
+const replanWeek = vi.fn();
+const planWeekStrategy = vi.fn();
+
+class CreditsExhaustedError extends Error {}
+
+vi.mock('$lib/server/access', () => ({ userCanEnter: async () => true }));
+vi.mock('@supabase/ssr', () => ({ createServerClient: () => ({}) }));
+vi.mock('$lib/server/credits', () => ({
+  gateCredits: (...args: unknown[]) => gateCredits(...args),
+  CreditsExhaustedError
+}));
+vi.mock('$lib/server/planner-inputs', () => ({
+  proposeFirstPlan: (...args: unknown[]) => proposeFirstPlan(...args),
+  plannerProfile: async () => ({}),
+  planEvidence: async () => ({ benchmark: null, topPosts: [], strategyBrief: '', historyCount: 0 })
+}));
+vi.mock('$lib/server/editorial-plan', () => ({
+  cadenceAllowed: () => [],
+  loadActivePlan: async () => ({ id: 'plan-1', weeks: [{}] }),
+  revisePlan: (...args: unknown[]) => revisePlan(...args),
+  replanWeek: (...args: unknown[]) => replanWeek(...args),
+  weekStrategyBrief: () => '',
+  postsForWeek: () => 3,
+  selectFeaturableProducts: () => []
+}));
+vi.mock('$lib/server/content-preview', () => ({
+  planWeekStrategy: (...args: unknown[]) => planWeekStrategy(...args),
+  carouselMaxPerBatch: () => 0,
+  loadPlannerMarketSignals: async () => ({ marketBrief: '', competitorThumbUrls: [] })
+}));
+vi.mock('$lib/server/content-library', () => ({ attachBrandPages: async () => [] }));
+vi.mock('$lib/server/gtm', () => ({ activeGtmBrief: async () => '' }));
+vi.mock('$lib/server/rubrics', () => ({ loadApprovedRubrics: async () => [] }));
+vi.mock('$lib/server/cli-auth', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('$lib/server/cli-auth')>()),
+  authenticate: vi.fn(),
+  loadBrandForUser: vi.fn()
+}));
+
+import { POST as propose } from './editorial-plan/propose/+server';
+import { POST as revise } from './editorial-plan/revise/+server';
+import { POST as replan } from './editorial-plan/replan-week/+server';
+import { POST as planWeek } from './weekly-plan/plan/+server';
+import { authenticate, loadBrandForUser } from '$lib/server/cli-auth';
+
+const BRAND = { id: 'brand-1', org_id: 'org-1', slug: 'demo', name: 'Demo', plan: 'pro', timezone: 'Europe/Rome' };
+
+const READ_ONLY_KEY: ApiKeyInfo = {
+  id: 'key-1',
+  name: 'read only',
+  user_id: 'user-1',
+  permissions: { brand_ids: '*', scopes: ['read'] }
+};
+
+type Handler = (event: unknown) => Promise<Response>;
+
+const ROUTES = [
+  { name: 'editorial-plan/propose', handler: propose as Handler, body: {}, spends: proposeFirstPlan },
+  { name: 'editorial-plan/revise', handler: revise as Handler, body: { feedback: 'più prodotto' }, spends: revisePlan },
+  { name: 'editorial-plan/replan-week', handler: replan as Handler, body: { week_index: 0, brief: 'x' }, spends: replanWeek },
+  { name: 'weekly-plan/plan', handler: planWeek as Handler, body: { week_index: 0 }, spends: planWeekStrategy }
+];
+
+function call(route: (typeof ROUTES)[number], apiKey?: ApiKeyInfo) {
+  const kit = createTestSupabase({ brands: [{ ...BRAND }], brand_kit: [], products: [], editorial_plans: [], gtm_plans: [], social_accounts: [], content_plans: [] });
+  vi.mocked(authenticate).mockResolvedValue({
+    supabase: kit.client,
+    user: { id: 'user-1' },
+    apiKey,
+    error: null
+  } as never);
+  vi.mocked(loadBrandForUser).mockResolvedValue({ brand: BRAND, error: null } as never);
+
+  const url = new URL(`https://anomalia.test/api/v1/brands/demo/${route.name}`);
+  return route
+    .handler({
+      request: new Request(url, { method: 'POST', body: JSON.stringify(route.body) }),
+      params: { slug: 'demo' },
+      url
+    })
+    .then(async (res) => ({ res, body: await res.json() }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  gateCredits.mockResolvedValue(undefined);
+});
+
+describe('le rotte che pianificano passano dal cancello', () => {
+  for (const route of ROUTES) {
+    describe(route.name, () => {
+      it('nega una API key di sola lettura, e non chiama il modello', async () => {
+        const { res, body } = await call(route, READ_ONLY_KEY);
+
+        expect(res.status).toBe(403);
+        expect(body.error).toBe('API key is read-only');
+        expect(route.spends).not.toHaveBeenCalled();
+      });
+
+      it('nega un brand senza crediti, e non chiama il modello', async () => {
+        gateCredits.mockRejectedValue(new CreditsExhaustedError('no credits'));
+
+        const { res, body } = await call(route);
+
+        expect(res.status).toBe(402);
+        expect(body.error).toBe('credits_exhausted');
+        expect(route.spends).not.toHaveBeenCalled();
+      });
+
+      it('conta la spesa sul brand quando il cancello passa', async () => {
+        await call(route);
+
+        expect(gateCredits).toHaveBeenCalledWith('brand-1');
+      });
+    });
+  }
+});

--- a/src/routes/api/v1/brands/[slug]/week-field.test.ts
+++ b/src/routes/api/v1/brands/[slug]/week-field.test.ts
@@ -3,7 +3,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 vi.mock('$lib/server/cli-auth', () => ({
   authenticate: vi.fn(),
   loadBrandForUser: vi.fn(),
-  checkApiKeyWriteAccess: vi.fn(() => null)
+  checkApiKeyWriteAccess: vi.fn(() => null),
+  gateAiAction: vi.fn(async () => undefined)
 }));
 vi.mock('$lib/server/brand-context', () => ({ genaiClient: () => ({}) }));
 vi.mock('$lib/server/editorial-plan', () => ({

--- a/src/routes/api/v1/brands/[slug]/weekly-plan/plan/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/weekly-plan/plan/+server.ts
@@ -1,7 +1,7 @@
 import { swallow } from '$lib/server/swallow';
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { authenticate, loadBrandForUser } from '$lib/server/cli-auth';
+import { authenticate, loadBrandForUser, gateAiAction } from '$lib/server/cli-auth';
 import { normalizeContentFormat } from '$lib/content-formats';
 
 export const POST: RequestHandler = async ({ request, params }) => {
@@ -10,6 +10,9 @@ export const POST: RequestHandler = async ({ request, params }) => {
 
   const { brand, error: brandError } = await loadBrandForUser(supabase, params.slug, apiKey);
   if (brandError) return brandError;
+
+  const gate = await gateAiAction(brand, apiKey);
+  if (gate) return gate;
 
   const body = await request.json();
   const week_index = body.week_index ?? body.week;


### PR DESCRIPTION
## What?

Four API routes reach a model and none of them passed through the credit gate.
`editorial-plan/propose`, `editorial-plan/revise`, `editorial-plan/replan-week` and
`weekly-plan/plan` now call `gateAiAction` right after `loadBrandForUser`, and their four
contracts declare `credits_exhausted`.

A brand with no credits left now gets **402**; a read-only API key gets **403** from the route
itself, not only from the door.

`/ads` — the fifth route in the original report — is deliberately **not** changed. See *Anything
Else?*: it reaches no model at all.

## Why?

These are the most expensive labels in the product. Over the last seven days: `reviewCaptions`
$13.54, `planStrategy` $11.50, `reviewSeeds` $8.10. The credit quota is the circuit breaker that
exists precisely because one crash-looping job once burned ~$365 in 42h (incident 2026-07-13), and
these four stood outside it — a brand could keep planning long past the limit it is paying for,
and nothing would stop it or say why.

The second half is the contract. `statusForFailure` degrades an undeclared 402 to **500**, so an
agent reading the failure variants to decide what to do next is told "our fault" when the truth is
"your credits are gone". Gate first, declare second: the reverse order ships a lie.

## How?

The gate goes **before the body is parsed**, so an exhausted brand gets `credits_exhausted`
instead of `feedback is required`. `gateAiAction` already calls `checkApiKeyWriteAccess` as its
first instruction, so one call closes both holes.

`credits_exhausted` is declared once as a constant in `plans.ts` and referenced four times, the
convention the file already uses for `NO_ACTIVE_PLAN` and `WEEK_REQUIRED`. The mirror in
`cli/lib/contracts` is regenerated with `bun run sync:contracts`, never by hand.

**Rejected**: putting the gate inside `proposeFirstPlan` / `planWeekStrategy` themselves. Those
functions are also called by the onboarding pages, which are the sign-up path — a gate there would
change the sign-up flow in the same diff that changes billing on four API routes. Separate concern,
separate PR (and see *Anything Else?*).

## Testing?

**Written first, watched fail.** `src/routes/api/v1/brands/[slug]/plan-spend.test.ts` — 12 tests,
all 12 red before the change, all 12 green after. For each of the four routes: a read-only key is
403 *and the model function is never called*; an exhausted brand is 402 *and the model function is
never called*; a passing gate charges `brand-1`. `gateAiAction` and `checkApiKeyWriteAccess` are
the real ones — the defect was that the route never called them, and a mocked gate could not have
noticed.

Also run: full `npx vitest run` (7566 tests), `node scripts/typecheck-runtime.mjs`, `npm run build`.

**Not tested**: no live exercise against a local Supabase with a real exhausted-credit brand and a
real read-only API key. The 402/403 paths are covered by the route tests with the real gate
functions and a mocked credits module, not by an end-to-end HTTP round trip. Risk: if
`gateCredits` itself changed shape, these tests would not see it — `credits-fail-open.test.ts` and
`credits-org-scope.test.ts` cover that side and are unchanged and green.

No UI surface changed, so there are no screenshots.

## Evidence (screenshots/videos)

<details>
<summary>Red before the fix — 12/12</summary>

```
 FAIL  plan-spend.test.ts > editorial-plan/propose > nega una API key di sola lettura
AssertionError: expected 200 to be 403
 FAIL  plan-spend.test.ts > weekly-plan/plan > nega un brand senza crediti
AssertionError: expected 200 to be 402
 Test Files  1 failed (1)
      Tests  12 failed (12)
```
</details>

<details>
<summary>Green after — with the registry and week-field suites</summary>

```
 ✓ src/routes/api/v1/brands/[slug]/registry.test.ts (6 tests)
 ✓ src/routes/api/v1/brands/[slug]/plan-spend.test.ts (12 tests)
 ✓ src/routes/api/v1/brands/[slug]/week-field.test.ts (2 tests)
 Test Files  3 passed (3)
      Tests  20 passed (20)
```

`registry.test.ts` is the one that matters second: it fails if a route calls `gateAiAction`
without its contract declaring `credits_exhausted`. It went red when the gate landed and green
when the four contracts were updated.
</details>

## Anything Else?

**`/ads` reaches no model.** It was reported as the fifth ungated spender; it is not one.
`ads.ts`, `ads-fatigue.ts` and `zernio-ads.ts` import nothing that talks to a model — `proposeBoosts`
is ranking plus inserts, `proposeStandalone` takes the creative from the request body. The POST
already has `checkApiKeyWriteAccess`, and the only action that actually spends (`approve`, the 12%
management fee) already checks the balance with `canAffordAdsCredits`. AI ad proposals live in
`/ads/remix`, which has had the gate all along. Adding `gateAiAction` to `/ads` would bill a credit
check to a free operation.

**A nearby defect left open on purpose**: `/ads` `approve` answers
`credits_exhausted:<needed>:<remaining>` with **400**, and the contract does not declare it at all.
The string is dynamic, so it cannot go into `failures` as-is; normalising it to a 402 with fields
changes the response shape of a live route and deserves its own diff.

**The onboarding exemption does not exist.** `gateCreditsCore` checks `isCreditExempt()` and
returns early, but `withCreditExempt` — the only thing that can turn it on — has **zero call sites
in the whole repository**. In production `isCreditExempt()` is always false. So this change could
not have silenced onboarding through that door; and onboarding does not go through these routes
anyway, which are the CLI/MCP surface.

**A real hole this PR does not close**: the browser paths *do* reach these same functions without
a gate — `app/[brand]/plan/+page.server.ts` and `app/[brand]/editorial/+page.server.ts` call
`proposeFirstPlan`, `app/[brand]/setup/+server.ts` calls `planWeekStrategy`. They are the sign-up
path, which is expensive to get wrong, and they deserve a diff someone reads on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
