### PR TITLE
Insert the new catalog before dropping the old one

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -1629,3 +1629,55 @@ tenere dentro il log la frase del fornitore, non lo status: `Payment Required.` 
 bugia con la stessa faccia della verità. E prima di dare la colpa al codice, chiedere il saldo:
 quasi ogni fornitore ha un endpoint gratuito che dice quanto credito resta (`appendix/user_data`),
 e un `402` non si debugga, si ricarica.
+## Un vincolo nuovo rende raggiungibile ogni `catch` muto sulla stessa tabella
+
+**Segnale.** Una funzione che ha sempre funzionato comincia a perdere dati, e nel diff del giorno
+in cui è cambiata non c'è. Il commit che l'ha rotta è quello che ha aggiunto un `CHECK` a una
+tabella che quella funzione scrive — e quel commit, da solo, era corretto.
+
+**Cosa succede.** `sync_products` cancellava il catalogo del brand e poi inseriva quello nuovo,
+senza leggere l'`error` di nessuna delle due scritture:
+
+```ts
+await supabase.from('products').delete().eq('brand_id', brand.id);
+await supabase.from('products').insert(products.map(...));
+return json({ ok: true, platform, synced: products.length });
+```
+
+Per mesi è stato un difetto **latente**: l'insert passava quasi sempre, quindi il `delete` senza
+rete non si vedeva. Poi sono arrivati i `CHECK` su `products` — `products_title_check`,
+`products_url_check`, `products_images_shape`, `products_text_len` — e i titoli e gli URL li
+prende uno scraper da un sito che non controlliamo. Un prodotto senza titolo, o con `example.com`
+invece di `https://example.com`, adesso fa fallire l'insert; ed è un INSERT solo con tutte le
+righe, che in Postgres è atomico: **una riga malformata su quaranta e non ne entra nessuna**. Il
+catalogo è già cancellato, e la risposta dice `synced: 47`.
+
+Nessuna delle due PR poteva vederlo. Quella dei vincoli guardava se i valori erano validi, non chi
+leggeva l'errore quando non lo erano. Quella della sincronizzazione è di mesi prima, quando quel
+fallimento non esisteva. **Le due cose si scrivono in PR diverse, da persone diverse, e la
+combinazione non è il diff di nessuna delle due.**
+
+**La mossa, in tre parti.**
+
+1. **Quando aggiungi un vincolo a una tabella, cerca chi ci scrive senza leggere l'`error`.** È
+   un `grep` sulla tabella, non una revisione: `from('<tabella>')` seguito da `insert`, `update`,
+   `upsert` o `delete` di cui nessuno guarda l'esito. Quella lista è l'elenco dei difetti che il
+   tuo vincolo ha appena reso raggiungibili, e va nella stessa PR o in quella subito dopo.
+2. **Cancellare e riscrivere non si fa in quest'ordine.** PostgREST non ha transazioni, quindi
+   `delete` + `insert` sono due viaggi e il fallimento del secondo lascia fatto il primo. Si
+   inserisce prima e si cancella il vecchio dopo: un insert che fallisce lascia il catalogo di
+   prima esattamente dov'era. Per un istante esistono entrambi gli insiemi — va verificato che
+   nessun vincolo unico lo vieti e che i lettori siano `select`, ma un conteggio doppio per una
+   frazione di secondo non si paragona a un catalogo perso.
+3. **La riga malformata non deve far cadere le altre, e non si scarta in silenzio.** Il lotto che
+   fallisce si ritenta riga per riga: chi passa entra, chi no torna al chiamante **col motivo che
+   ha dato il database**. I vincoli non si riscrivono in TypeScript per filtrare prima — una
+   regola scritta in due posti diverge al primo cambiamento della migration, e qui il posto giusto
+   è uno solo: la migration li dichiara, Postgres giudica.
+
+**Perché il test non è in vitest.** La suite mocka Supabase e un insert finto accetta qualunque
+cosa, quindi il vincolo lì è verde per costruzione. Che i `CHECK` mordano davvero lo prova
+`scripts/constraint-harness.mjs` contro un Postgres vero. Quello che invece vitest **può** provare,
+ed è il difetto vero, è l'**ordine**: con la scrittura che fallisce, il catalogo di prima deve
+essere ancora in tabella e la risposta non deve dire `synced`. Un test del solo percorso felice non
+vede niente di tutto questo — è per quello che il difetto è arrivato fin qui con la suite verde.

--- a/changelog/2026-09-11-sync-products-non-perde-il-catalogo.md
+++ b/changelog/2026-09-11-sync-products-non-perde-il-catalogo.md
@@ -1,0 +1,84 @@
+# Il catalogo entra prima di uscire
+
+`sync_products` cancellava il catalogo del brand e poi inseriva quello nuovo, senza leggere
+l'`error` di nessuna delle due scritture, e rispondeva `{ ok: true, synced: 47 }`:
+
+```ts
+await supabase.from('products').delete().eq('brand_id', brand.id);
+await supabase.from('products').insert(products.map(...));
+```
+
+Per mesi è stato un difetto **latente**: l'insert passava quasi sempre. Cinque giorni fa sono
+arrivati i `CHECK` su `products` — `products_title_check`, `products_url_check`,
+`products_images_shape`, `products_text_len` — e i titoli e gli URL li prende uno scraper da un
+sito che non controlliamo. Un prodotto senza titolo, o con `example.com` invece di
+`https://example.com`, adesso fa fallire l'insert. Ed è un INSERT solo con tutte le righe, che in
+Postgres è atomico: **una riga malformata su quaranta e non ne entra nessuna**. Il catalogo è già
+cancellato.
+
+**Nessuna delle due PR poteva vederlo.** Quella dei vincoli guardava se i valori erano validi, non
+chi leggeva l'errore quando non lo erano; quella della sincronizzazione è di mesi prima, quando
+quel fallimento non esisteva. La lezione generale — *un vincolo nuovo rende raggiungibile ogni
+`catch` muto sulla stessa tabella* — sta in [`LESSONS.md`](../LESSONS.md), perché è la cosa che si
+ripeterà.
+
+## L'ordine, scelto misurando
+
+`replaceBrandCatalog` (`src/lib/server/product-catalog.ts`) inserisce prima e cancella dopo. Un
+insert che fallisce lascia il catalogo di prima esattamente dov'era.
+
+**Perché non una funzione plpgsql**, che darebbe una transazione vera e l'atomicità gratis: **i
+deploy di questo repo non eseguono le migration.** Una funzione nuova non esisterebbe in
+produzione finché qualcuno non lancia `db:migrate` — e una correzione contro la perdita di dati
+che non è viva il giorno del merge non è una correzione. L'ordine invertito non chiede SQL nuovo
+ed è attivo appena il deploy passa.
+
+**Cosa si rompe con entrambi gli insiemi presenti per un istante**, verificato e non supposto:
+
+- **Nessun vincolo lo vieta.** `products` non ha un unico su `(brand_id, external_id)` — la
+  tabella è `0002_brand_kit_products.sql` e nessuna migration successiva ne aggiunge uno. Se ci
+  fosse, questa strada sarebbe chiusa e servirebbe la transazione.
+- **Tutti i lettori del catalogo sono `select`**: conteggi (`hub-overview`, `setup-checklist`,
+  `growth-readiness`, `cli-queries`), titoli e immagini per i prompt (`radar`, `seo-agent`,
+  `brand-file`, `system-prompt`, `creation-kit`). Nessuno riscrive quello che legge.
+- Il peggio che può succedere è un conteggio doppio, o una lista prodotti duplicata in un prompt,
+  per il tempo di un viaggio HTTP, durante una sincronizzazione che l'utente ha chiesto. Contro un
+  catalogo cancellato per sempre non è un confronto.
+
+La cancellazione del vecchio va a blocchi di 100 id: `delete().in('id', [...])` finisce
+nell'URL, e un catalogo Shopify da 500 prodotti sfonderebbe il limite del proxy.
+
+## La riga malformata non fa cadere le altre, e si dice quale
+
+Il lotto parte intero — un viaggio, come prima. **Se fallisce**, si ritenta riga per riga: chi
+passa entra, chi no torna al chiamante col **motivo che ha dato il database**. Il costo per riga
+si paga solo quando qualcosa è già andato storto.
+
+I vincoli **non sono riscritti in TypeScript** per filtrare prima. Sarebbe la stessa regola in due
+posti, e una regola in due posti diverge al primo cambiamento della migration — in silenzio,
+perché il ramo sbagliato non fallisce, semplicemente scarta la riga di troppo. Qui il posto è uno
+solo: la migration dichiara, Postgres giudica, noi riportiamo.
+
+E si riporta davvero: `rejected: [{title, reason}]` nella risposta REST, `products_rejected` nei
+due job di chat, una riga rossa per scarto in `anomalia products <slug> sync`. Scartare in
+silenzio sarebbe lo stesso difetto spostato di un metro.
+
+Quando **non entra niente**, la rotta risponde `502` e dice che il catalogo di prima è intatto:
+non è un successo parziale, ed è l'unico caso in cui il brand non ha ricevuto niente di nuovo.
+
+## Tre chiamanti, una funzione
+
+Lo stesso `delete`-poi-`insert` stava in tre posti: la rotta REST, il `sync_products` della chat e
+la parte prodotti di `analyze_brand` (`job-executor.ts`). Correggere solo quello segnalato ne
+avrebbe lasciati due a perdere cataloghi. Ora passano tutti da `replaceBrandCatalog`.
+
+## Il test
+
+`product-catalog.test.ts` e `products/server.sync.test.ts` fanno fallire **la scrittura** con
+`failNext` del testkit e misurano due cose: che il catalogo di prima sia ancora in tabella, e che
+la risposta non dica `synced`. Visti falliri sul codice vecchio — i tre della rotta rossi, con
+`ok: true` e `synced: 2` su un catalogo appena cancellato.
+
+Nell'harness dei vincoli è entrato il fatto che spiega la gravità: **una riga malformata rifiuta
+tutto il lotto** (`23514`). Non si deduce leggendo `insert([...])` di supabase-js, e trasforma «un
+prodotto rotto» in «zero prodotti». Gli altri sei `CHECK` su `products` erano già provati lì.

--- a/cli/commands/products.ts
+++ b/cli/commands/products.ts
@@ -50,4 +50,8 @@ async function syncProducts(token: string, slug: string) {
   console.log(c.yellow('Reimportazione prodotti dal sito…'));
   const result = await api.syncProducts(token, slug);
   ok(`${result.synced} prodotti importati da ${result.platform}.`);
+
+  for (const { title, reason } of result.rejected ?? []) {
+    console.log(c.red(`  scartato: ${title || '(senza titolo)'} — ${reason}`));
+  }
 }

--- a/cli/lib/api.ts
+++ b/cli/lib/api.ts
@@ -443,7 +443,12 @@ export const api = {
     get<{ products: { id: string; title: string; kind: string; pricing: string | null; imageCount: number; featured: boolean }[] }>(`/api/v1/brands/${slug}/products`, t),
 
   syncProducts: (t: string, slug: string) =>
-    post<{ ok: boolean; platform: string; synced: number }>(`/api/v1/brands/${slug}/products`, t),
+    post<{
+      ok: boolean;
+      platform: string;
+      synced: number;
+      rejected: { title: string; reason: string }[];
+    }>(`/api/v1/brands/${slug}/products`, t),
 
   deletePostsByStatus: (t: string, slug: string, status: string) =>
     request<{ ok: boolean; deleted: number }>(`/api/v1/brands/${slug}/posts?status=${encodeURIComponent(status)}`, t, { method: 'DELETE' }),

--- a/scripts/constraint-harness.mjs
+++ b/scripts/constraint-harness.mjs
@@ -63,6 +63,14 @@ const CASES = [
   { what: 'products.images non array', sql: product('images', `'{}'::jsonb`), code: CHECK_VIOLATION },
   { what: 'products.kind oltre il tetto', sql: product('kind', `repeat('x', 201)`), code: CHECK_VIOLATION },
   { what: 'products.description oltre il tetto', sql: product('description', `repeat('x', 50001)`), code: CHECK_VIOLATION },
+  // UNA riga malformata rifiuta l'INTERO lotto: `insert([...])` di supabase-js e` un solo INSERT,
+  // e un INSERT in Postgres e` atomico. E` il fatto che trasforma «un prodotto senza schema
+  // nell'URL» in «zero prodotti su quaranta», e non si deduce leggendo il client.
+  {
+    what: 'products: una riga malformata rifiuta tutto il lotto',
+    sql: `insert into public.products (brand_id, title, url) values ($1, 'Moka', 'https://shop.test/moka'), ($1, 'Senza schema', 'shop.test/rotto')`,
+    code: CHECK_VIOLATION
+  },
 
   { what: 'brand_kit.favicon_url non http ne data', sql: kit('favicon_url', `'nope'`), code: CHECK_VIOLATION },
   { what: 'brand_kit.source_url e un handle, non un sito', sql: kit('source_url', `'Mariopuggelli1939'`), code: CHECK_VIOLATION },

--- a/src/lib/content/changelog/2026-09-11-product-sync-keeps-your-catalog.ts
+++ b/src/lib/content/changelog/2026-09-11-product-sync-keeps-your-catalog.ts
@@ -1,0 +1,10 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-11',
+  title: 'Syncing products can no longer empty your catalog',
+  items: [
+    'A product sync that fails now leaves the catalog you already had exactly where it was, instead of clearing it first and reporting success.',
+    'One malformed product on your store no longer stops the other thirty-nine from importing — the ones that could not be saved are listed by name, with the reason.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/chat/job-executor.ts
+++ b/src/lib/server/chat/job-executor.ts
@@ -192,8 +192,10 @@ export async function executeChatToolJob(
       }, { onConflict: 'brand_id' });
 
       if (profile.products?.length) {
-        await supabase.from('products').delete().eq('brand_id', brandId);
-        await supabase.from('products').insert(
+        const { replaceBrandCatalog } = await import('$lib/server/product-catalog');
+        await replaceBrandCatalog(
+          supabase,
+          brandId,
           profile.products.map((p: AnyRec) => ({
             brand_id: brandId, title: p.name ?? p.title, description: p.description ?? '', pricing: p.pricing ?? null, kind: p.productType ?? p.kind ?? 'product', images: p.images ?? null, url: p.url ?? null
           }))
@@ -283,8 +285,10 @@ export async function executeChatToolJob(
       if (!products.length) return { error: 'No products found.' };
 
       await cancel.assertActive();
-      await supabase.from('products').delete().eq('brand_id', brandId);
-      await supabase.from('products').insert(
+      const { replaceBrandCatalog } = await import('$lib/server/product-catalog');
+      await replaceBrandCatalog(
+        supabase,
+        brandId,
         products.map((p) => ({
           brand_id: brandId, title: p.name, description: p.description ?? '', pricing: p.pricing ?? null, kind: p.productType ?? 'product', images: p.images ?? null, url: p.url ?? null
         }))

--- a/src/lib/server/chat/job-executor.ts
+++ b/src/lib/server/chat/job-executor.ts
@@ -191,9 +191,10 @@ export async function executeChatToolJob(
         images: profile.images ?? null
       }, { onConflict: 'brand_id' });
 
+      let catalog = { inserted: 0, rejected: [] as { title: string; reason: string }[], replaced: false };
       if (profile.products?.length) {
         const { replaceBrandCatalog } = await import('$lib/server/product-catalog');
-        await replaceBrandCatalog(
+        catalog = await replaceBrandCatalog(
           supabase,
           brandId,
           profile.products.map((p: AnyRec) => ({
@@ -210,6 +211,8 @@ export async function executeChatToolJob(
         name: profile.name,
         category: profile.category,
         products_found: profile.products?.length ?? 0,
+        products_saved: catalog.inserted,
+        products_rejected: catalog.rejected,
         site_type: profile.site_type,
         studio_approved: studio.approved || studio.already,
         instruction: studio.approved
@@ -286,7 +289,7 @@ export async function executeChatToolJob(
 
       await cancel.assertActive();
       const { replaceBrandCatalog } = await import('$lib/server/product-catalog');
-      await replaceBrandCatalog(
+      const catalog = await replaceBrandCatalog(
         supabase,
         brandId,
         products.map((p) => ({
@@ -294,7 +297,16 @@ export async function executeChatToolJob(
         }))
       );
 
-      return { success: true, platform: isShopifySite(html) ? 'Shopify' : 'WooCommerce', products_synced: products.length };
+      if (!catalog.replaced) {
+        return { error: 'No product could be saved. The catalog you had is untouched.', rejected: catalog.rejected };
+      }
+
+      return {
+        success: true,
+        platform: isShopifySite(html) ? 'Shopify' : 'WooCommerce',
+        products_synced: catalog.inserted,
+        products_rejected: catalog.rejected
+      };
     }
 
     case 'generate_video': {

--- a/src/lib/server/product-catalog.test.ts
+++ b/src/lib/server/product-catalog.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createTestSupabase, type TestSupabase } from '$lib/testkit/supabase';
+import { replaceBrandCatalog } from './product-catalog';
+
+const OLD = [
+  { id: 'old-1', brand_id: 'brand-1', title: 'Tazza blu', url: 'https://shop.test/tazza' },
+  { id: 'old-2', brand_id: 'brand-1', title: 'Tazza rossa', url: 'https://shop.test/rossa' }
+];
+
+const SCRAPED = [
+  { brand_id: 'brand-1', title: 'Moka 3 tazze', url: 'https://shop.test/moka' },
+  { brand_id: 'brand-1', title: 'Senza schema', url: 'shop.test/rotto' },
+  { brand_id: 'brand-1', title: 'Filtro', url: 'https://shop.test/filtro' }
+];
+
+let kit: TestSupabase;
+
+const titles = () => (kit.tables.get('products') ?? []).map((r) => r.title).sort();
+
+beforeEach(() => {
+  kit = createTestSupabase({ products: OLD.map((r) => ({ ...r })) });
+});
+
+describe('replaceBrandCatalog', () => {
+  it('sostituisce il catalogo quando ogni riga entra', async () => {
+    const result = await replaceBrandCatalog(kit.client, 'brand-1', SCRAPED);
+
+    expect(result).toEqual({ inserted: 3, rejected: [], replaced: true });
+    expect(titles()).toEqual(['Filtro', 'Moka 3 tazze', 'Senza schema']);
+  });
+
+  it('una riga rifiutata non fa cadere le altre, e viene nominata col motivo', async () => {
+    kit.failNext('products', 'batch rejected', 'insert');
+    kit.failNext('products', 'violates check constraint "products_url_check"', 'insert');
+
+    const result = await replaceBrandCatalog(kit.client, 'brand-1', SCRAPED);
+
+    expect(result.inserted).toBe(2);
+    expect(result.replaced).toBe(true);
+    expect(result.rejected).toEqual([
+      { title: 'Moka 3 tazze', reason: 'violates check constraint "products_url_check"' }
+    ]);
+    expect(titles()).toEqual(['Filtro', 'Senza schema']);
+  });
+
+  it('quando non entra niente il catalogo di prima resta dov era', async () => {
+    for (let i = 0; i <= SCRAPED.length; i++) {
+      kit.failNext('products', 'permission denied for table products', 'insert');
+    }
+
+    const result = await replaceBrandCatalog(kit.client, 'brand-1', SCRAPED);
+
+    expect(result.inserted).toBe(0);
+    expect(result.replaced).toBe(false);
+    expect(result.rejected).toHaveLength(3);
+    expect(titles()).toEqual(['Tazza blu', 'Tazza rossa']);
+  });
+
+  it('non cancella niente prima di sapere che il nuovo catalogo è entrato', async () => {
+    await replaceBrandCatalog(kit.client, 'brand-1', SCRAPED);
+
+    const ops = kit.calls.filter((c) => c.table === 'products' && c.op !== 'select');
+
+    expect(ops[0].op).toBe('insert');
+    expect(ops[ops.length - 1].op).toBe('delete');
+  });
+
+  it('una cancellazione fallita si dichiara invece di sparire', async () => {
+    kit.failNext('products', 'deadlock detected', 'delete');
+
+    await expect(replaceBrandCatalog(kit.client, 'brand-1', SCRAPED)).rejects.toThrow(/deadlock/);
+  });
+});

--- a/src/lib/server/product-catalog.test.ts
+++ b/src/lib/server/product-catalog.test.ts
@@ -65,6 +65,20 @@ describe('replaceBrandCatalog', () => {
     expect(ops[ops.length - 1].op).toBe('delete');
   });
 
+  it('toglie ogni riga vecchia anche quando non stanno in un blocco solo', async () => {
+    kit = createTestSupabase({
+      products: Array.from({ length: 250 }, (_, i) => ({
+        id: `old-${i}`,
+        brand_id: 'brand-1',
+        title: `Vecchio ${i}`
+      }))
+    });
+
+    await replaceBrandCatalog(kit.client, 'brand-1', SCRAPED);
+
+    expect(titles()).toEqual(['Filtro', 'Moka 3 tazze', 'Senza schema']);
+  });
+
   it('una cancellazione fallita si dichiara invece di sparire', async () => {
     kit.failNext('products', 'deadlock detected', 'delete');
 

--- a/src/lib/server/product-catalog.ts
+++ b/src/lib/server/product-catalog.ts
@@ -1,11 +1,74 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 
-/** Sostituire il catalogo di un brand. Tre chiamanti scrivevano queste due righe per conto loro. */
+/**
+ * Sostituire il catalogo di un brand: prima entra il nuovo, poi esce il vecchio.
+ *
+ *   vecchio ordine:  delete(tutto) → insert(tutte le righe)   un insert che fallisce = catalogo perso
+ *   questo ordine:   insert(nuove) → delete(le vecchie)       un insert che fallisce = catalogo intatto
+ *
+ * I due passi non stanno in una transazione — PostgREST non ne ha una — quindi per un istante
+ * esistono entrambi gli insiemi. Nessun vincolo lo vieta (`products` non ha un unico su
+ * `(brand_id, external_id)`), ogni lettore del catalogo è una `select`, e un conteggio doppio per
+ * una frazione di secondo non è paragonabile a un catalogo cancellato per sempre.
+ *
+ * Le righe arrivano da uno scraper su un sito che non controlliamo, e i CHECK su `products` sono
+ * veri: una riga malformata fa fallire l'INSERT, che in Postgres è atomico — una su quaranta e non
+ * ne entra nessuna. Per questo il lotto che fallisce viene ritentato riga per riga: chi passa
+ * entra, chi no torna al chiamante col motivo che ha dato il database. I vincoli NON sono
+ * riscritti qui: li dichiara la migration, e giudica Postgres.
+ */
+
+const DELETE_CHUNK = 100;
+
+export type RejectedProduct = { title: string; reason: string };
+
+export type CatalogReplacement = {
+  inserted: number;
+  rejected: RejectedProduct[];
+  /** false quando non è entrata nessuna riga: il catalogo di prima è ancora quello buono. */
+  replaced: boolean;
+};
+
+type ProductRow = Record<string, unknown>;
+
+async function insertSalvagingRows(
+  supabase: SupabaseClient,
+  rows: ProductRow[]
+): Promise<RejectedProduct[]> {
+  const { error } = await supabase.from('products').insert(rows);
+  if (!error) return [];
+
+  const rejected: RejectedProduct[] = [];
+  for (const row of rows) {
+    const { error: rowError } = await supabase.from('products').insert(row);
+    if (rowError) rejected.push({ title: String(row.title ?? ''), reason: rowError.message });
+  }
+  return rejected;
+}
+
 export async function replaceBrandCatalog(
   supabase: SupabaseClient,
   brandId: string,
-  rows: Record<string, unknown>[]
-): Promise<void> {
-  await supabase.from('products').delete().eq('brand_id', brandId);
-  await supabase.from('products').insert(rows);
+  rows: ProductRow[]
+): Promise<CatalogReplacement> {
+  const { data: stale, error: readError } = await supabase
+    .from('products')
+    .select('id')
+    .eq('brand_id', brandId);
+  if (readError) throw new Error(`catalog read failed: ${readError.message}`);
+
+  const rejected = await insertSalvagingRows(supabase, rows);
+  const inserted = rows.length - rejected.length;
+  if (!inserted) return { inserted, rejected, replaced: false };
+
+  const staleIds = (stale ?? []).map((row) => String(row.id));
+  for (let i = 0; i < staleIds.length; i += DELETE_CHUNK) {
+    const { error } = await supabase
+      .from('products')
+      .delete()
+      .in('id', staleIds.slice(i, i + DELETE_CHUNK));
+    if (error) throw new Error(`old catalog left next to the new one: ${error.message}`);
+  }
+
+  return { inserted, rejected, replaced: true };
 }

--- a/src/lib/server/product-catalog.ts
+++ b/src/lib/server/product-catalog.ts
@@ -1,0 +1,11 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+/** Sostituire il catalogo di un brand. Tre chiamanti scrivevano queste due righe per conto loro. */
+export async function replaceBrandCatalog(
+  supabase: SupabaseClient,
+  brandId: string,
+  rows: Record<string, unknown>[]
+): Promise<void> {
+  await supabase.from('products').delete().eq('brand_id', brandId);
+  await supabase.from('products').insert(rows);
+}

--- a/src/routes/api/v1/brands/[slug]/products/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/products/+server.ts
@@ -55,8 +55,10 @@ export const POST: RequestHandler = async ({ request, params }) => {
 
     if (!products.length) return json({ error: 'No products found on the site.' }, { status: 400 });
 
-    await supabase.from('products').delete().eq('brand_id', brand.id);
-    await supabase.from('products').insert(
+    const { replaceBrandCatalog } = await import('$lib/server/product-catalog');
+    await replaceBrandCatalog(
+      supabase,
+      brand.id,
       products.map((p: any) => ({
         brand_id: brand.id,
         title: p.name,

--- a/src/routes/api/v1/brands/[slug]/products/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/products/+server.ts
@@ -56,7 +56,7 @@ export const POST: RequestHandler = async ({ request, params }) => {
     if (!products.length) return json({ error: 'No products found on the site.' }, { status: 400 });
 
     const { replaceBrandCatalog } = await import('$lib/server/product-catalog');
-    await replaceBrandCatalog(
+    const { inserted, rejected, replaced } = await replaceBrandCatalog(
       supabase,
       brand.id,
       products.map((p: any) => ({
@@ -69,8 +69,15 @@ export const POST: RequestHandler = async ({ request, params }) => {
       }))
     );
 
-    return json({ ok: true, platform, synced: products.length });
+    if (!replaced) {
+      return json(
+        { error: 'No product could be saved. The catalog you had is untouched.', rejected },
+        { status: 502 }
+      );
+    }
+
+    return json({ ok: true, platform, synced: inserted, rejected });
   } catch (e) {
-    return json({ error: `Sync failed: ${String(e)}` }, { status: 500 });
+    return json({ error: `Sync failed: ${e instanceof Error ? e.message : String(e)}` }, { status: 500 });
   }
 };

--- a/src/routes/api/v1/brands/[slug]/products/server.sync.test.ts
+++ b/src/routes/api/v1/brands/[slug]/products/server.sync.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTestSupabase, type TestSupabase } from '$lib/testkit/supabase';
+
+vi.mock('$lib/server/cli-auth', () => ({
+  authenticate: vi.fn(),
+  loadBrandForUser: vi.fn(),
+  checkApiKeyWriteAccess: vi.fn(() => undefined)
+}));
+vi.mock('$lib/server/tool-guard', () => ({
+  safeFetchUrl: async () => ({ body: '<html>Shopify.theme</html>' })
+}));
+vi.mock('$lib/server/brand-analysis', () => ({
+  isShopifySite: () => true,
+  isWooCommerceSite: () => false,
+  fetchShopifyProducts: async () => SCRAPED,
+  fetchWooCommerceProducts: async () => []
+}));
+
+import { POST } from './+server';
+import { authenticate, loadBrandForUser } from '$lib/server/cli-auth';
+
+const SCRAPED = [
+  { name: 'Moka 3 tazze', description: 'alluminio', pricing: '29€', productType: 'moka', images: [] },
+  { name: 'Filtro', description: 'carta', pricing: '4€', productType: 'filtri', images: [] }
+];
+
+const OLD = [
+  { id: 'old-1', brand_id: 'brand-1', title: 'Tazza blu' },
+  { id: 'old-2', brand_id: 'brand-1', title: 'Tazza rossa' }
+];
+
+let kit: TestSupabase;
+
+function call(prepare?: (kit: TestSupabase) => void) {
+  kit = createTestSupabase({
+    products: OLD.map((r) => ({ ...r })),
+    brands: [{ id: 'brand-1', website: 'https://shop.test' }]
+  });
+  prepare?.(kit);
+  vi.mocked(authenticate).mockResolvedValue({
+    supabase: kit.client,
+    user: { id: 'user-1' },
+    apiKey: undefined,
+    error: null
+  } as never);
+  vi.mocked(loadBrandForUser).mockResolvedValue({
+    brand: { id: 'brand-1', slug: 'demo', name: 'Demo' },
+    error: null
+  } as never);
+
+  const url = new URL('https://anomalia.test/api/v1/brands/demo/products');
+  return (POST as (event: unknown) => Promise<Response>)({
+    request: new Request(url, { method: 'POST' }),
+    params: { slug: 'demo' },
+    url
+  }).then(async (res) => ({ res, body: await res.json() }));
+}
+
+const titles = () => (kit.tables.get('products') ?? []).map((r) => r.title).sort();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('POST /api/v1/brands/:slug/products', () => {
+  it('importa il catalogo nuovo e toglie quello vecchio', async () => {
+    const { res, body } = await call();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ ok: true, platform: 'Shopify', synced: 2, rejected: [] });
+    expect(titles()).toEqual(['Filtro', 'Moka 3 tazze']);
+  });
+
+  it('un insert che fallisce non lascia il brand senza catalogo, e non dice synced', async () => {
+    const { res, body } = await call((k) => {
+      k.failNext('products', 'batch rejected', 'insert');
+      k.failNext('products', 'violates check constraint "products_url_check"', 'insert');
+      k.failNext('products', 'violates check constraint "products_url_check"', 'insert');
+    });
+
+    expect(res.ok).toBe(false);
+    expect(body.ok).not.toBe(true);
+    expect(body.synced).toBeUndefined();
+    expect(body.rejected).toHaveLength(2);
+    expect(body.rejected[0].reason).toContain('products_url_check');
+    expect(titles()).toEqual(['Tazza blu', 'Tazza rossa']);
+  });
+
+  it('conta le righe entrate, non quelle trovate sul sito', async () => {
+    const { body } = await call((k) => {
+      k.failNext('products', 'batch rejected', 'insert');
+      k.failNext('products', 'violates check constraint "products_title_check"', 'insert');
+    });
+
+    expect(body.synced).toBe(1);
+    expect(body.rejected).toEqual([
+      { title: 'Moka 3 tazze', reason: 'violates check constraint "products_title_check"' }
+    ]);
+    expect(titles()).toEqual(['Filtro']);
+  });
+});


### PR DESCRIPTION
## What?

`sync_products` deleted a brand's whole catalog, inserted the new one, read neither `error`, and answered `{ ok: true, synced: 47 }`:

```ts
await supabase.from('products').delete().eq('brand_id', brand.id);
await supabase.from('products').insert(products.map(...));
return json({ ok: true, platform, synced: products.length });
```

The order is now **insert first, drop the old rows after**, so a failed insert leaves the catalog exactly where it was. A rejected row no longer takes the other thirty-nine with it, and the ones that could not be saved come back named, with the reason Postgres gave. The same replacement lived in **three** places — the REST route, the chat `sync_products` job, and the products half of `analyze_brand` — and all three now go through one function.

A separate first commit moves those two statements into that one function without changing anything they do.

## Why?

**This was latent for months and we made it reachable five days ago.** The insert almost always passed, so the unguarded `delete` never showed. Then the `CHECK`s landed on `products`:

```
products_title_check   btrim(title) <> '' and length(title) <= 500
products_url_check     url ~ '^https?://'
products_images_shape  jsonb_typeof(images) = 'array'
products_text_len      description / pricing / external_id / kind within limits
```

Titles and URLs come from a scraper on a site we do not control. A product with no title, or `example.com` instead of `https://example.com`, now **fails the insert** — and `insert([...])` in supabase-js is one INSERT with every row, which in Postgres is atomic. **One malformed product out of forty and none of them land.** The catalog is already deleted, and the tool answers `synced: 47`.

Neither PR could have seen it. The constraints PR asked whether values were valid, not who read the error when they were not. The sync is months older, from before that failure existed. **The combination is nobody's diff** — which is exactly why it is in `LESSONS.md` as a general rule rather than only as a fix: *a new constraint makes every mute catch on the same table reachable*, and the move is a `grep` for unread writes on that table in the same PR that adds the constraint.

## How?

**Insert-then-delete, not plpgsql — and the reason is deployment, not taste.** A plpgsql function would give a real transaction and atomicity for free. But **this repo's deploys do not run migrations** (CLAUDE.md; it is why `schema-drift-check.mjs` exists). A new function would not exist in production until someone remembered `db:migrate`, and a data-loss fix that is not live on merge day is not a fix. The inverted order needs no SQL and is active the moment the deploy lands.

**What breaks with both sets present for one round trip — checked, not assumed:**

- **Nothing forbids the overlap.** `products` has no unique on `(brand_id, external_id)`: the table is `0002_brand_kit_products.sql` and no later migration adds one. If there were one this road would be closed and the transaction would be required — flagging it explicitly because it changes the answer.
- **Every catalog reader is a `select`** — counts (`hub-overview`, `setup-checklist`, `growth-readiness`, `cli-queries`), titles and images for prompts (`radar`, `seo-agent`, `brand-file`, `system-prompt`, `creation-kit`, `rubrics-feasibility`). None writes back what it reads.
- Worst case is a doubled count, or a duplicated product list in one prompt, for the length of one HTTP round trip, during a sync the user asked for. Against a catalog deleted forever, it is not a comparison.

**Dropping the old rows goes in chunks of 100 ids.** `delete().in('id', [...])` ends up in the URL, and a 500-product Shopify catalog would blow past the proxy's limit.

**Salvage, and no constraints restated in TypeScript.** The batch goes first — one round trip, the cost it had. Only *if it fails* is it retried row by row: the ones that pass land, the ones that do not come back with the database's own message. Validating client-side to filter first was rejected: it is the same rule in two places, and a rule in two places diverges the first time the migration changes — silently, because the wrong branch does not fail, it just drops one row too many. The migration declares, Postgres judges, we report.

Reported everywhere it goes: `rejected: [{title, reason}]` on the REST response, `products_rejected` on both chat jobs, one red line per dropped product in `anomalia products <slug> sync`. Dropping silently would be the same defect moved a metre. When **nothing** lands, the route answers `502` and says the previous catalog is untouched — that is not a partial success.

## Testing?

**Watched fail on the old code.** The three route tests are red against `dev`'s handler, for the right reason:

```
× importa il catalogo nuovo e toglie quello vecchio        → missing `rejected`
× un insert che fallisce non lascia il brand senza catalogo → expected true to be false  (ok: true)
× conta le righe entrate, non quelle trovate sul sito       → expected 2 to be 1          (synced: 2)
```

Eight tests in two files, all driving the write to fail with the testkit's `failNext` and asserting two things: the previous catalog is **still in the table**, and the answer does **not** say `synced`. `non cancella niente prima di sapere che il nuovo catalogo è entrato` pins the order itself by asserting the first products write is an `insert` and the last is a `delete`.

`toglie ogni riga vecchia anche quando non stanno in un blocco solo` seeds 250 stale rows, because every other test seeded two and the chunked delete ran its loop exactly once — its slice arithmetic was green by accident. Checked that it can fail: shortening the slice by one turns it red. The bug it guards is the same family as the defect being fixed — old products silently left behind while the sync reports the right count.

**Why the red is in vitest and not in the harness.** The case you described (an existing catalog, an insert containing one row violating `products_url_check`, assert the old catalog survived) **cannot be red in `constraint-harness.mjs`**, and I would rather say so than add a test that passes before and after. The harness speaks `pg`; the shipped code speaks supabase-js, so the harness cannot run the function whose ordering is the fix. Transcribing my TypeScript into SQL there would assert my transcription, not the code — and once a statement fails, Postgres has already discarded its rows, so "the old catalog survived" is a property of the language, green whichever order I write. The six `products` CHECK cases you cited were **already** in the file (lines 60-65), including `products.url non http`.

This was discussed and settled: the review asked for that assertion in the harness, and the harness is the wrong instrument for it — it would have verified a transcription rather than the shipped ordering, and the surviving-catalog property holds in either order because Postgres discards a failed statement's rows on its own. Said here so a reviewer does not read the missing case as an oversight.

What I added instead is the one fact that was genuinely missing and is not obvious from reading `insert([...])`: **one malformed row rejects the whole batch** (`23514`). That is what turns "a product with a broken URL" into "zero products", and it is the entire justification for the row-by-row salvage. `69/69 vincoli mordono` against the local stack.

**What was NOT tested, and the risk.**

- **No browser verification.** The repo `.env` points at a hosted Supabase project, and exercising a catalog replacement there is the thing the rule forbids; wiring the app to the local self-hosted stack means copying its service-role key out of another worktree's `.env`, which I did not do. **Risk**: the CLI's new rejected-lines output and the chat jobs' `products_rejected` are reasoned from their call sites, not seen on screen.
- **The overlap window is argued from a census of readers, not measured under load.** I enumerated every `from('products').select(...)` and they are all reads; I did not run two clients concurrently to watch a doubled count.
- **The row-by-row salvage is not exercised against real Postgres**, only against the testkit, where the per-row rejection is injected rather than produced by a real CHECK. The messages a caller sees in production are Postgres's, and their exact text is unverified.
- **`analyze_brand`'s new `products_rejected` is not asserted by a test** — `tool-job-drain.test.ts` and `tool-job-background.test.ts` stay green but do not reach that branch.

**Green:** 8 new tests plus the suites around the changed files (`tool-job-drain` 16, `tool-job-background` 8, `subagent-async` 12, `product-context` 2, `products/[id]` edit 9); `cli` bun 135/135 and `bun run typecheck` clean; `constraint-harness` 69/69. `npm run build` was still running when this was opened — CI's `test` job covers the suite either way.

## Evidence (screenshots/videos)

No UI changed.

<details>
<summary>The route tests against dev's handler — the defect, reproduced</summary>

```
 × POST /api/v1/brands/:slug/products > un insert che fallisce non lascia il brand senza catalogo, e non dice synced
   → expected true to be false

 × POST /api/v1/brands/:slug/products > conta le righe entrate, non quelle trovate sul sito
   → expected 2 to be 1
```

`ok: true` and `synced: 2` over a catalog the handler had just deleted.

</details>

<details>
<summary>The batch fact, against the local Postgres</summary>

```
$ DATABASE_URL=postgres://…@127.0.0.1:5432/postgres node scripts/constraint-harness.mjs
ok    products: una riga malformata rifiuta tutto il lotto  (atteso 23514, ottenuto 23514)
…
69/69 vincoli mordono
```

Two rows, one with `shop.test/rotto` as its URL: the statement is rejected whole. This is what makes one bad product cost the whole sync.

</details>

## Anything Else?

**The question that orders the rest of the list.** Eighteen more handlers answer success without reading their writes (found while auditing `render_post` and `approve_plan` in #399). The useful sort is not severity by eye, it is: *is there a new constraint on that table that just made its mute catch reachable?* `20260905200000_table_value_checks.sql` touched `posts`, `products`, `brand_kit`, `brand_articles`, `content_plans`, `people`, `competitors`, `brand_memory`, `brand_sites`, `brand_news_sources` — every unread write to those tables moved from latent to reachable on the same day, and that is where the next pass should start.

**Not fixed here, same shape, next round:** `publish_post` discarding `PublishResult` while its twin `approvePost` branches on exactly the cases it ignores; `optimize_article` answering identically whether it rewrote or the model failed, after paying; `weekly-plan/render` building `ok: true` per post from the in-memory result rather than from the write; `studio/people/[id]` leaving a real person's images in the bucket behind an `ok: true`.

**Known debt:** the REST route still does not write `url` on synced products (both chat paths do), so `products_url_check` is unreachable from that one endpoint and its product links stay empty. That is a field-mapping gap, older than this defect, and deliberately left alone rather than folded into a data-loss fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY

