### PR TITLE
Refine a large source instead of calling it missing

### DIFF
--- a/changelog/2026-09-11-refine-large-source.md
+++ b/changelog/2026-09-11-refine-large-source.md
@@ -1,0 +1,76 @@
+# `refine_media` raffina una foto grande, e quando non può lo dice per davvero
+
+Un caso reale: `refine_media` su un asset da **7.836.963 byte** rispondeva `404
+source_not_found`. L'asset c'era — `kind: 'image'`, brand giusto, file nel bucket. Il 404 era
+falso, e costava: l'agente esterno lo leggeva come «l'immagine non esiste» e **rigenerava da
+zero**, cioè esattamente il danno che quel tool è stato costruito per impedire. L'originale del
+cliente restava lì, un render nuovo veniva pagato, e la foto consegnata era un altro soggetto.
+
+La catena era questa:
+
+```
+media-generate  resolveLibraryId      → l'asset lo trova (non era questo il not_found)
+media-generate  loadLibraryMediaParts → resolveBrandImageIds → firma il path
+brand-context   fetchImagePart        → tetto a 6.000.000 byte → null
+media-generate  if (!parts.length)    → 'source_not_found'
+```
+
+`fetchImagePart` tornava `null` per tre motivi diversi — troppo grande, non è un'immagine, la rete
+è caduta — e chi chiamava riceveva soltanto una lista vuota. Qualunque messaggio preciso richiedeva
+che quella funzione smettesse di buttare via il perché.
+
+## Cosa è cambiato
+
+**`imagePartFor` dichiara il rifiuto** (`too_large` | `not_an_image` | `fetch_failed`);
+`fetchImagePart` resta la stessa firma per i suoi quindici chiamanti ed è ora un involucro di due
+righe. `loadLibraryMediaPart` porta l'esito fino a `runImageJob`, dove una tabella — `SOURCE_REFUSAL`,
+una riga per motivo — decide l'errore: il tetto diventa `source_too_large` (413) con il **peso**
+letto da `brand_media.bytes` e il **tetto**, tutto il resto resta `source_not_found`.
+
+**Il tetto si aggira, non si alza.** 6 MB esiste per non far esplodere il contesto del modello, e
+alzarlo sposterebbe il problema al primo file da 12 MB. Una sorgente sopra il tetto ora viene
+**ridimensionata** prima di partire: si scarica fino a `RASTER_SOURCE_MAX_BYTES` (20 MB, il tetto
+di ciò che accettiamo di decodificare) e si passa da `rasterToJpeg`, che era già in casa —
+ridimensiona a lato lungo, riprova la qualità a scendere e si ferma sotto il budget di byte.
+Nessuna dipendenza nuova: `sharp` era già qui, e `raster-image.ts` faceva già questo mestiere per
+gli upload HEIC.
+
+**2048 px di lato lungo**, non «sotto i 6 MB», perché la domanda giusta è quale risoluzione il
+modello accetta davvero. La rotta viva dello slot immagini è OpenRouter (`SLOT_DEFAULT.image =
+nano-banana@openrouter`, e `AI_ROUTE_IMAGE` non è impostata): lì non mandiamo NESSUN campo di
+dimensione — solo `image_config.aspect_ratio` — e il modello torna alla sua taglia, dell'ordine di
+1K. Sul ripiego kie la taglia è `resolution`, e in questo ambiente `KIE_IMAGE_RESOLUTION=2K`.
+Quindi 2048 è il doppio dell'uscita sulla rotta viva e pari pari quella del ripiego: la piena
+risoluzione di una foto da 24 megapixel non la vede nessuno dei due, e su OpenRouter la base
+viaggia inline in base64 dentro il corpo JSON, cioè un terzo più pesante dei byte veri.
+
+Il ridimensionamento sta in `imagePartFor`, cioè **dove la sorgente viene preparata per il
+modello**, non all'import: l'originale del cliente resta com'è in libreria. Ne beneficiano anche
+gli altri quattordici chiamanti — mood board, foto prodotto, riferimenti utente, catalogo — dove
+una foto grande oggi spariva in silenzio.
+
+## `import_media_url` non serve toccarlo
+
+L'import ammette immagini fino a 12 MB, e la rifinitura ora ne decodifica 20: ogni file che
+l'import deposita, il tool gemello lo sa leggere. Il buco si chiude da sé, quindi l'import non
+avverte di niente e non cambia. Ciò che resta è un **test che tiene l'invariante**
+(`IMAGE_MAX_BYTES <= RASTER_SOURCE_MAX_BYTES`): se domani qualcuno alza il tetto dell'import, il
+test cade prima che un cliente ci trovi dentro un'altra foto «non trovata».
+
+## Scartato
+
+- **Alzare `IMAGE_PART_MAX_BYTES`**: sposta il muro, non lo toglie, e il contesto del modello lo
+  paga su ogni riferimento, non solo su quello grande.
+- **Ridimensionare all'import**: sostituirebbe l'originale del cliente con una copia più piccola.
+  Chi importa un master lo importa apposta.
+- **Cambiare la forma di `loadLibraryMediaParts`**: cinque chiamanti, quattro dei quali del motivo
+  non sanno che farsene. La versione singolare che lo porta è nuova e la usa solo chi lo legge.
+- **Un errore distinto per la rete caduta**: `fetch_failed` resta `source_not_found` come prima.
+  È lo stesso genere di bugia, ma di un grado diverso, e va misurata con il suo caso prima di
+  darle un nome.
+
+## Il prezzo noto
+
+Una PNG con trasparenza sopra i 6 MB esce da `rasterToJpeg` come JPEG, quindi su fondo nero. Prima
+spariva del tutto, quindi è comunque meglio; se un giorno capiterà su un logo vero, la strada è un
+ramo PNG dentro `rasterToJpeg`, non un secondo ridimensionatore qui.

--- a/cli/lib/contracts/posts.ts
+++ b/cli/lib/contracts/posts.ts
@@ -643,7 +643,10 @@ export const REFINE_MEDIA = {
     'get_media_models, slot imageRefineModel for a picture and videoRefineModel for a clip — and ' +
     'model here applies to this call only. A clip has no refine model until the brand picks one, ' +
     'and until then a video comes back no_refine_model rather than quietly redrawn. The brand ' +
-    'look is applied as it is on generate_image; brand_style: ignore leaves it out, pictures only.',
+    'look is applied as it is on generate_image; brand_style: ignore leaves it out, pictures only. ' +
+    'source_too_large means the file is heavier than a model can be handed — the answer names its ' +
+    'weight and the ceiling. The asset IS there: shrink it or import a lighter copy, never ' +
+    'generate a replacement.',
   method: 'POST',
   pathUnderBrand: '/media/refine',
   input: z
@@ -675,6 +678,7 @@ export const REFINE_MEDIA = {
     { error: 'credits_exhausted', status: 402 },
     MODEL_FAILURE,
     { error: 'source_not_found', status: 404 },
+    { error: 'source_too_large', status: 413 },
     { error: 'kind_not_refinable', status: 400 },
     { error: 'no_refine_model', status: 400 },
     { error: 'render_failed', status: 502 },

--- a/cli/plugins/anomalia/skills/anomalia/references/tools.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/tools.md
@@ -320,6 +320,12 @@ filming a new clip for someone who asked to correct theirs is the exact mistake 
 `kind_not_refinable` (400) means the asset is neither. `count` draws alternatives for a picture; a
 clip always comes back as one.
 
+`source_too_large` (413) is not `source_not_found`: the asset is there, it is just heavier than a
+model can be handed, and the answer carries its `bytes` and the `limit`. An oversized source is
+shrunk before the model sees it, so this only reaches you for a file beyond even that — import a
+lighter copy. **Never answer it by generating a replacement**: the original is still the customer's
+and a fresh render is a different picture.
+
 `generate_video` films a NEW clip into the library. Required: `slug`, `prompt`; optional
 `base_media_id`, `duration`, `aspect_ratio`, `model`, `title`. **`base_media_id` pointing at a
 library IMAGE is how you animate a photo** — the image becomes the clip's first frame, so subject,

--- a/cli/skills/anomalia/references/tools.md
+++ b/cli/skills/anomalia/references/tools.md
@@ -320,6 +320,12 @@ filming a new clip for someone who asked to correct theirs is the exact mistake 
 `kind_not_refinable` (400) means the asset is neither. `count` draws alternatives for a picture; a
 clip always comes back as one.
 
+`source_too_large` (413) is not `source_not_found`: the asset is there, it is just heavier than a
+model can be handed, and the answer carries its `bytes` and the `limit`. An oversized source is
+shrunk before the model sees it, so this only reaches you for a file beyond even that — import a
+lighter copy. **Never answer it by generating a replacement**: the original is still the customer's
+and a fresh render is a different picture.
+
 `generate_video` films a NEW clip into the library. Required: `slug`, `prompt`; optional
 `base_media_id`, `duration`, `aspect_ratio`, `model`, `title`. **`base_media_id` pointing at a
 library IMAGE is how you animate a photo** — the image becomes the clip's first frame, so subject,

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -4,7 +4,7 @@
 > Non si modifica a mano: il prossimo che rigenera cancella le correzioni.
 
 **80 tool** — 9 in lettura, 53 in scrittura, 18 che distruggono.
-Il payload di `tools/list` pesa **87.502 caratteri**, circa **21.876 token**, ed e' il costo che ogni sessione paga prima di dire una parola.
+Il payload di `tools/list` pesa **87.705 caratteri**, circa **21.926 token**, ed e' il costo che ogni sessione paga prima di dire una parola.
 
 | gruppo | tool |
 |---|---:|
@@ -791,7 +791,7 @@ To turn a post you already have into a video: this animates that post's cover im
 
 *Refine media you already made*
 
-To change a photo or a video you already have — "make it red", "warmer background", "remove the cup on the left", "keep the movement but make it night" — instead of making a new one. base_media_id is any asset in this brand’s library, image or video alike; list_media finds it, and a short prefix works. It starts FROM that asset: the picture you already made comes back changed, not redrawn. Say what should CHANGE, not what the whole thing should be. The result is filed as a NEW asset, so a wrong edit costs one render and never your original. Do NOT reach for generate_image or generate_video to alter something: those two start from nothing and give you a different subject, which is the mistake this tool exists to end. It spends credits, and the answer says how many renders were billed. It creates nothing in the calendar and publishes nothing; pass the id it returns to create_post as media_ids when you want a post. Each kind has its own model — get_media_models, slot imageRefineModel for a picture and videoRefineModel for a clip — and model here applies to this call only. A clip has no refine model until the brand picks one, and until then a video comes back no_refine_model rather than quietly redrawn. The brand look is applied as it is on generate_image; brand_style: ignore leaves it out, pictures only.
+To change a photo or a video you already have — "make it red", "warmer background", "remove the cup on the left", "keep the movement but make it night" — instead of making a new one. base_media_id is any asset in this brand’s library, image or video alike; list_media finds it, and a short prefix works. It starts FROM that asset: the picture you already made comes back changed, not redrawn. Say what should CHANGE, not what the whole thing should be. The result is filed as a NEW asset, so a wrong edit costs one render and never your original. Do NOT reach for generate_image or generate_video to alter something: those two start from nothing and give you a different subject, which is the mistake this tool exists to end. It spends credits, and the answer says how many renders were billed. It creates nothing in the calendar and publishes nothing; pass the id it returns to create_post as media_ids when you want a post. Each kind has its own model — get_media_models, slot imageRefineModel for a picture and videoRefineModel for a clip — and model here applies to this call only. A clip has no refine model until the brand picks one, and until then a video comes back no_refine_model rather than quietly redrawn. The brand look is applied as it is on generate_image; brand_style: ignore leaves it out, pictures only. source_too_large means the file is heavier than a model can be handed — the answer names its weight and the ceiling. The asset IS there: shrink it or import a lighter copy, never generate a replacement.
 
 | campo | tipo | |
 |---|---|---|

--- a/packages/api-contracts/src/posts.ts
+++ b/packages/api-contracts/src/posts.ts
@@ -643,7 +643,10 @@ export const REFINE_MEDIA = {
     'get_media_models, slot imageRefineModel for a picture and videoRefineModel for a clip — and ' +
     'model here applies to this call only. A clip has no refine model until the brand picks one, ' +
     'and until then a video comes back no_refine_model rather than quietly redrawn. The brand ' +
-    'look is applied as it is on generate_image; brand_style: ignore leaves it out, pictures only.',
+    'look is applied as it is on generate_image; brand_style: ignore leaves it out, pictures only. ' +
+    'source_too_large means the file is heavier than a model can be handed — the answer names its ' +
+    'weight and the ceiling. The asset IS there: shrink it or import a lighter copy, never ' +
+    'generate a replacement.',
   method: 'POST',
   pathUnderBrand: '/media/refine',
   input: z
@@ -675,6 +678,7 @@ export const REFINE_MEDIA = {
     { error: 'credits_exhausted', status: 402 },
     MODEL_FAILURE,
     { error: 'source_not_found', status: 404 },
+    { error: 'source_too_large', status: 413 },
     { error: 'kind_not_refinable', status: 400 },
     { error: 'no_refine_model', status: 400 },
     { error: 'render_failed', status: 502 },

--- a/src/lib/content/changelog/2026-09-11-refine-large-source.ts
+++ b/src/lib/content/changelog/2026-09-11-refine-large-source.ts
@@ -1,0 +1,10 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-11',
+  title: 'Refining a large photo now works',
+  items: [
+    'Refining a photo heavier than a model can take now works: the picture is scaled down on the way in, and the original stays in your library untouched.',
+    'When a source really is too heavy, the answer says so and names its size — instead of "not found", which had agents redrawing the picture from scratch.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/raster-image.ts
+++ b/src/lib/raster-image.ts
@@ -7,6 +7,9 @@ export const RASTER_JPEG_MAX_EDGE = 4096;
 /** Ceiling for one image handed to a model inline. */
 export const IMAGE_PART_MAX_BYTES = 6_000_000;
 
+/** Longest edge a source is shrunk to before a model sees it. */
+export const IMAGE_PART_MAX_EDGE = 2048;
+
 /** File pickers that take photos (includes HEIC so desktop dialogs show iPhone files). */
 export const RASTER_IMAGE_ACCEPT = 'image/*,image/heic,image/heif,.heic,.heif';
 

--- a/src/lib/raster-image.ts
+++ b/src/lib/raster-image.ts
@@ -4,6 +4,9 @@ export const RASTER_SOURCE_MAX_BYTES = 20 * 1024 * 1024;
 /** Longest edge when encoding a converted JPEG (not YouTube-specific). */
 export const RASTER_JPEG_MAX_EDGE = 4096;
 
+/** Ceiling for one image handed to a model inline. */
+export const IMAGE_PART_MAX_BYTES = 6_000_000;
+
 /** File pickers that take photos (includes HEIC so desktop dialogs show iPhone files). */
 export const RASTER_IMAGE_ACCEPT = 'image/*,image/heic,image/heif,.heic,.heif';
 

--- a/src/lib/server/brand-context.oversize.test.ts
+++ b/src/lib/server/brand-context.oversize.test.ts
@@ -1,0 +1,160 @@
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import sharp from 'sharp';
+
+/**
+ * Il caso vero: una foto importata da un cliente, 7,4 MB, sopra il tetto della parte inline.
+ * Prima tornava `null`, la lista a valle restava vuota e `refine_media` rispondeva
+ * `source_not_found` — l'agente leggeva «non c'è» e RIGENERAVA da zero, che è il danno che quel
+ * tool esiste per impedire.
+ *
+ * Il tetto non si alza: si ridimensiona prima di spedire. Il render esce comunque alla dimensione
+ * del modello, quindi la piena risoluzione della sorgente non la vede nessuno.
+ */
+vi.mock('$env/static/public', () => ({ PUBLIC_SUPABASE_URL: 'https://example.supabase.co' }));
+vi.mock('$env/dynamic/public', () => ({ env: { PUBLIC_SUPABASE_URL: 'https://example.supabase.co' } }));
+vi.mock('$env/dynamic/private', () => ({ env: {} }));
+
+vi.mock('node:dns/promises', () => ({
+  lookup: vi.fn(async (host: string) =>
+    /^\d+\.\d+\.\d+\.\d+$/.test(host)
+      ? [{ address: host, family: 4 }]
+      : [{ address: '93.184.216.34', family: 4 }]
+  )
+}));
+
+import { IMAGE_PART_MAX_BYTES, IMAGE_PART_MAX_EDGE } from '$lib/raster-image';
+import { fetchImagePart, imagePartFor } from './brand-context';
+
+const PUBLIC_ORIGIN = 'https://cdn.example.com';
+const BIG_PHOTO_PATH = '/customer-photo.jpg';
+const SMALL_PHOTO_PATH = '/thumb.jpg';
+const BEYOND_CEILING_PATH = '/master.jpg';
+const NOT_AN_IMAGE_PATH = '/brief.pdf';
+
+/** Le misure del caso in produzione: 7,4 MB, appena sopra il tetto di 6 MB. */
+const BIG_PHOTO = { width: 3400, height: 2550, quality: 92 };
+
+const SMALL_PHOTO = { width: 800, height: 600, quality: 80 };
+
+/** 24 MB: oltre il tetto di ciò che accettiamo di decodificare, quindi nemmeno scaricato. */
+const BEYOND_CEILING = { width: 5600, height: 4200, quality: 95 };
+
+let server: Server;
+let origin: string;
+let photos: Record<string, Buffer>;
+
+const realFetch = globalThis.fetch;
+
+function noisyJpeg(spec: { width: number; height: number; quality: number }): Promise<Buffer> {
+  return sharp({
+    create: {
+      width: spec.width,
+      height: spec.height,
+      channels: 3,
+      noise: { type: 'gaussian', mean: 128, sigma: 90 }
+    }
+  })
+    .jpeg({ quality: spec.quality })
+    .toBuffer();
+}
+
+function resolvingPublicHostToLocalServer(): typeof fetch {
+  return ((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = new URL(String(input));
+    const target = url.origin === PUBLIC_ORIGIN ? `${origin}${url.pathname}${url.search}` : String(input);
+    return realFetch(target, init);
+  }) as typeof fetch;
+}
+
+beforeAll(async () => {
+  const [big, small, beyond] = await Promise.all([
+    noisyJpeg(BIG_PHOTO),
+    noisyJpeg(SMALL_PHOTO),
+    noisyJpeg(BEYOND_CEILING)
+  ]);
+  photos = {
+    [BIG_PHOTO_PATH]: big,
+    [SMALL_PHOTO_PATH]: small,
+    [BEYOND_CEILING_PATH]: beyond
+  };
+
+  server = createServer((req, res) => {
+    const bytes = photos[req.url ?? ''];
+    if (bytes) {
+      res.writeHead(200, { 'content-type': 'image/jpeg', 'content-length': String(bytes.length) });
+      res.end(bytes);
+      return;
+    }
+    if (req.url === NOT_AN_IMAGE_PATH) {
+      res.writeHead(200, { 'content-type': 'application/pdf' });
+      res.end('%PDF-1.4');
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  origin = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  globalThis.fetch = resolvingPublicHostToLocalServer();
+}, 60_000);
+
+afterAll(async () => {
+  globalThis.fetch = realFetch;
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+describe('una foto più grande del tetto della parte inline', () => {
+  it('la sorgente pesa davvero più del tetto', () => {
+    expect(photos[BIG_PHOTO_PATH].length).toBeGreaterThan(IMAGE_PART_MAX_BYTES);
+  });
+
+  it('arriva al modello ridimensionata, non sparisce', async () => {
+    const part = await fetchImagePart(`${PUBLIC_ORIGIN}${BIG_PHOTO_PATH}`);
+
+    expect(part).not.toBeNull();
+    const bytes = Buffer.from(part!.inlineData.data, 'base64');
+    expect(bytes.length).toBeLessThanOrEqual(IMAGE_PART_MAX_BYTES);
+
+    const meta = await sharp(bytes).metadata();
+    expect(Math.max(meta.width ?? 0, meta.height ?? 0)).toBeLessThanOrEqual(IMAGE_PART_MAX_EDGE);
+  }, 60_000);
+
+  it('resta la stessa foto: proporzioni invariate', async () => {
+    const part = await fetchImagePart(`${PUBLIC_ORIGIN}${BIG_PHOTO_PATH}`);
+    const meta = await sharp(Buffer.from(part!.inlineData.data, 'base64')).metadata();
+
+    expect((meta.width ?? 0) / (meta.height ?? 1)).toBeCloseTo(BIG_PHOTO.width / BIG_PHOTO.height, 2);
+  }, 60_000);
+
+  it('una foto già sotto il tetto passa intatta, senza ricomprimerla', async () => {
+    const part = await fetchImagePart(`${PUBLIC_ORIGIN}${SMALL_PHOTO_PATH}`);
+
+    expect(Buffer.from(part!.inlineData.data, 'base64')).toEqual(photos[SMALL_PHOTO_PATH]);
+  }, 60_000);
+});
+
+describe('il motivo per cui una parte manca non si butta via', () => {
+  it('un file oltre il tetto di ciò che decodifichiamo dice too_large', async () => {
+    const outcome = await imagePartFor(`${PUBLIC_ORIGIN}${BEYOND_CEILING_PATH}`);
+
+    expect(outcome.ok).toBe(false);
+    expect(!outcome.ok && outcome.reason).toBe('too_large');
+  }, 60_000);
+
+  it('un PDF non è un file troppo grande: dice not_an_image', async () => {
+    const outcome = await imagePartFor(`${PUBLIC_ORIGIN}${NOT_AN_IMAGE_PATH}`);
+
+    expect(outcome.ok).toBe(false);
+    expect(!outcome.ok && outcome.reason).toBe('not_an_image');
+  });
+
+  it('un file che non esiste non è né troppo grande né non-immagine', async () => {
+    const outcome = await imagePartFor(`${PUBLIC_ORIGIN}/assente.jpg`);
+
+    expect(outcome.ok).toBe(false);
+    expect(!outcome.ok && outcome.reason).toBe('fetch_failed');
+  });
+});

--- a/src/lib/server/brand-context.ts
+++ b/src/lib/server/brand-context.ts
@@ -1,6 +1,7 @@
 import { swallow } from '$lib/server/swallow';
 import { safeFetchBytes, SafeFetchError } from '$lib/server/tool-guard';
-import { IMAGE_PART_MAX_BYTES } from '$lib/raster-image';
+import { IMAGE_PART_MAX_BYTES, IMAGE_PART_MAX_EDGE, RASTER_SOURCE_MAX_BYTES } from '$lib/raster-image';
+import type { RasterJpegError } from '$lib/server/raster-image';
 import type { GoogleGenAI } from '@google/genai';
 import { structured } from '$lib/server/research';
 import type { SupabaseClient } from '@supabase/supabase-js';
@@ -200,6 +201,12 @@ export type ImagePartOutcome =
   | { ok: true; part: ImagePart }
   | { ok: false; reason: ImagePartRefusal };
 
+const REFUSAL_BY_CONVERSION: Record<RasterJpegError, ImagePartRefusal> = {
+  not_image: 'not_an_image',
+  convert_failed: 'not_an_image',
+  too_large: 'too_large'
+};
+
 function inlinePart(mimeType: string, bytes: Buffer): ImagePart {
   return { inlineData: { mimeType, data: bytes.toString('base64') } };
 }
@@ -207,7 +214,7 @@ function inlinePart(mimeType: string, bytes: Buffer): ImagePart {
 export async function imagePartFor(url: string): Promise<ImagePartOutcome> {
   let fetched;
   try {
-    fetched = await safeFetchBytes(url, { maxBytes: IMAGE_PART_MAX_BYTES });
+    fetched = await safeFetchBytes(url, { maxBytes: RASTER_SOURCE_MAX_BYTES });
   } catch (e) {
     const tooLarge = e instanceof SafeFetchError && e.reason === 'too_large';
     return { ok: false, reason: tooLarge ? 'too_large' : 'fetch_failed' };
@@ -216,8 +223,20 @@ export async function imagePartFor(url: string): Promise<ImagePartOutcome> {
 
   const mimeType = fetched.mime || 'image/jpeg';
   if (!mimeType.startsWith('image/')) return { ok: false, reason: 'not_an_image' };
+  if (fetched.bytes.length <= IMAGE_PART_MAX_BYTES) {
+    return { ok: true, part: inlinePart(mimeType, fetched.bytes) };
+  }
 
-  return { ok: true, part: inlinePart(mimeType, fetched.bytes) };
+  const { rasterToJpeg } = await import('$lib/server/raster-image');
+  const shrunk = await rasterToJpeg(fetched.bytes, {
+    always: true,
+    mime: mimeType,
+    maxBytes: IMAGE_PART_MAX_BYTES,
+    maxEdge: IMAGE_PART_MAX_EDGE
+  });
+  if (!shrunk.ok) return { ok: false, reason: REFUSAL_BY_CONVERSION[shrunk.error] };
+
+  return { ok: true, part: inlinePart('image/jpeg', shrunk.bytes) };
 }
 
 export async function fetchImagePart(url: string): Promise<ImagePart | null> {

--- a/src/lib/server/brand-context.ts
+++ b/src/lib/server/brand-context.ts
@@ -1,5 +1,6 @@
 import { swallow } from '$lib/server/swallow';
-import { safeFetchBytes } from '$lib/server/tool-guard';
+import { safeFetchBytes, SafeFetchError } from '$lib/server/tool-guard';
+import { IMAGE_PART_MAX_BYTES } from '$lib/raster-image';
 import type { GoogleGenAI } from '@google/genai';
 import { structured } from '$lib/server/research';
 import type { SupabaseClient } from '@supabase/supabase-js';
@@ -191,21 +192,38 @@ export async function synthesizeBrandContext(input: ContextInputs): Promise<stri
   }
 }
 
-const IMAGE_PART_MAX_BYTES = 6_000_000;
+export type ImagePart = { inlineData: { mimeType: string; data: string } };
 
-// Download an image URL into a Gemini inlineData part. Best-effort: null on any failure / non-image
-// / oversized payload, so a bad thumbnail never breaks style synthesis. Also reused to feed a
-// product photo to the image generator as a reference.
-export async function fetchImagePart(url: string): Promise<{ inlineData: { mimeType: string; data: string } } | null> {
+export type ImagePartRefusal = 'too_large' | 'not_an_image' | 'fetch_failed';
+
+export type ImagePartOutcome =
+  | { ok: true; part: ImagePart }
+  | { ok: false; reason: ImagePartRefusal };
+
+function inlinePart(mimeType: string, bytes: Buffer): ImagePart {
+  return { inlineData: { mimeType, data: bytes.toString('base64') } };
+}
+
+export async function imagePartFor(url: string): Promise<ImagePartOutcome> {
+  let fetched;
   try {
-    const res = await safeFetchBytes(url, { maxBytes: IMAGE_PART_MAX_BYTES });
-    if (!res.ok) return null;
-    const mimeType = res.mime || 'image/jpeg';
-    if (!mimeType.startsWith('image/')) return null;
-    return { inlineData: { mimeType, data: res.bytes.toString('base64') } };
-  } catch {
-    return null;
+    fetched = await safeFetchBytes(url, { maxBytes: IMAGE_PART_MAX_BYTES });
+  } catch (e) {
+    const tooLarge = e instanceof SafeFetchError && e.reason === 'too_large';
+    return { ok: false, reason: tooLarge ? 'too_large' : 'fetch_failed' };
   }
+  if (!fetched.ok) return { ok: false, reason: 'fetch_failed' };
+
+  const mimeType = fetched.mime || 'image/jpeg';
+  if (!mimeType.startsWith('image/')) return { ok: false, reason: 'not_an_image' };
+
+  return { ok: true, part: inlinePart(mimeType, fetched.bytes) };
+}
+
+export async function fetchImagePart(url: string): Promise<ImagePart | null> {
+  const outcome = await imagePartFor(url);
+
+  return outcome.ok ? outcome.part : null;
 }
 
 // Synthesise a VISUAL STYLE brief by actually looking at brand imagery (multimodal). Normally fed

--- a/src/lib/server/brand-media.ts
+++ b/src/lib/server/brand-media.ts
@@ -5,7 +5,7 @@
 import { swallow } from '$lib/server/swallow';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import sharp from 'sharp';
-import { fetchImagePart } from '$lib/server/brand-context';
+import { fetchImagePart, imagePartFor, type ImagePartOutcome } from '$lib/server/brand-context';
 import { signKnowledgePaths } from '$lib/server/media-archive';
 import { structured } from '$lib/server/research';
 
@@ -828,6 +828,17 @@ export async function saveRenderedVideoToLibrary(
     return { error: error ?? 'could not register the clip in the library' };
   }
   return { mediaId: row.id };
+}
+
+export async function loadLibraryMediaPart(
+  supabase: SupabaseClient,
+  brandId: string,
+  mediaId: string
+): Promise<ImagePartOutcome> {
+  const [url] = await resolveBrandImageIds(supabase, brandId, [mediaId]);
+  if (!url) return { ok: false, reason: 'fetch_failed' };
+
+  return imagePartFor(url);
 }
 
 /** Load library images as Gemini inline parts (for composite / reference mode). */

--- a/src/lib/server/media-generate.brand-style.test.ts
+++ b/src/lib/server/media-generate.brand-style.test.ts
@@ -18,7 +18,7 @@ vi.mock('$lib/server/content-preview', () => ({
   loadBrandVisualContext: (...args: unknown[]) => loadBrandVisualContext(...args)
 }));
 vi.mock('$lib/server/brand-media', () => ({
-  loadLibraryMediaParts: async () => [],
+  loadLibraryMediaPart: async () => ({ ok: false, reason: 'fetch_failed' }),
   insertBrandMedia: (...args: unknown[]) => insertBrandMedia(...args),
   storeBrandMediaBytes: (...args: unknown[]) => storeBrandMediaBytes(...args),
   probeImageDimensions: async () => ({ width: 1080, height: 1080 })

--- a/src/lib/server/media-generate.refine-video.test.ts
+++ b/src/lib/server/media-generate.refine-video.test.ts
@@ -27,7 +27,7 @@ vi.mock('$lib/server/video', () => ({
 }));
 vi.mock('$lib/server/brand-media', () => ({
   saveRenderedVideoToLibrary: (...args: unknown[]) => saveRenderedVideoToLibrary(...args),
-  loadLibraryMediaParts: async () => [],
+  loadLibraryMediaPart: async () => ({ ok: false, reason: 'fetch_failed' }),
   insertBrandMedia: async () => ({ row: null }),
   storeBrandMediaBytes: async () => ({}),
   probeImageDimensions: async () => ({ width: null, height: null })

--- a/src/lib/server/media-generate.refine.test.ts
+++ b/src/lib/server/media-generate.refine.test.ts
@@ -10,10 +10,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
  * E il negativo che conta: un id che non esiste, o di un altro brand, deve FERMARSI. Ricadere
  * sulla generazione sarebbe il difetto travestito da rimedio — l'agente pagherebbe un disegno
  * nuovo credendo di aver modificato il suo.
+ *
+ * E il negativo che MENTIVA: una sorgente troppo pesante tornava `source_not_found`. L'agente
+ * leggeva «non c'e'» e rigenerava da zero — lo stesso danno, per una ragione diversa.
  */
 
 const renderPostImage = vi.fn();
-const loadLibraryMediaParts = vi.fn();
+const loadLibraryMediaPart = vi.fn();
 const insertBrandMedia = vi.fn();
 const storeBrandMediaBytes = vi.fn();
 
@@ -32,7 +35,7 @@ vi.mock('$lib/server/content-preview', () => ({
   loadBrandVisualContext: async () => ({})
 }));
 vi.mock('$lib/server/brand-media', () => ({
-  loadLibraryMediaParts: (...args: unknown[]) => loadLibraryMediaParts(...args),
+  loadLibraryMediaPart: (...args: unknown[]) => loadLibraryMediaPart(...args),
   insertBrandMedia: (...args: unknown[]) => insertBrandMedia(...args),
   storeBrandMediaBytes: (...args: unknown[]) => storeBrandMediaBytes(...args),
   probeImageDimensions: async () => ({ width: 1080, height: 1080 })
@@ -49,15 +52,19 @@ vi.mock('$lib/server/ai-log', () => ({
   withBrandContext: <T>(_brandId: string, fn: () => T) => fn()
 }));
 
+import { IMAGE_PART_MAX_BYTES } from '$lib/raster-image';
 import { refineBrandMedia, generateBrandImages } from './media-generate';
 
 const REFINE_MODEL = 'gemini-3.1-flash-image';
 
 const FULL_ID = '11111111-2222-3333-4444-555555555555';
 
+/** Il peso dell'asset che in produzione e' tornato «non trovato»: 7,47 MB. */
+const REAL_CASE_BYTES = 7_836_963;
+
 function supabaseWith(
   prefs: Record<string, unknown>,
-  media: Array<{ id: string; kind?: string }> = [{ id: FULL_ID, kind: 'image' }]
+  media: Array<{ id: string; kind?: string; bytes?: number | null }> = [{ id: FULL_ID, kind: 'image' }]
 ) {
   return {
     from: (table: string) => ({
@@ -74,7 +81,7 @@ function supabaseWith(
 beforeEach(() => {
   vi.clearAllMocks();
   renderPostImage.mockResolvedValue(PNG_DATA_URL);
-  loadLibraryMediaParts.mockResolvedValue([ORIGINAL]);
+  loadLibraryMediaPart.mockResolvedValue({ ok: true, part: ORIGINAL });
   storeBrandMediaBytes.mockResolvedValue({});
   insertBrandMedia.mockResolvedValue({ row: { id: 'media-new', kind: 'image' } });
 });
@@ -89,12 +96,7 @@ describe('rifinire un asset della libreria', () => {
     });
 
     expect(out.ok).toBe(true);
-    expect(loadLibraryMediaParts).toHaveBeenCalledWith(
-      expect.anything(),
-      'brand-1',
-      [FULL_ID],
-      1
-    );
+    expect(loadLibraryMediaPart).toHaveBeenCalledWith(expect.anything(), 'brand-1', FULL_ID);
 
     const opts = renderPostImage.mock.calls[0][1];
     // Questa è la riga che distingue «rendilo rosso» da «disegna un gatto rosso».
@@ -112,7 +114,7 @@ describe('rifinire un asset della libreria', () => {
   });
 
   it('un asset che non esiste FERMA la richiesta invece di disegnarne uno nuovo', async () => {
-    loadLibraryMediaParts.mockResolvedValue([]);
+    loadLibraryMediaPart.mockResolvedValue({ ok: false, reason: 'fetch_failed' });
 
     const out = await refineBrandMedia(supabaseWith({}, []), {
       brandId: 'brand-1',
@@ -126,6 +128,36 @@ describe('rifinire un asset della libreria', () => {
     expect(renderPostImage).not.toHaveBeenCalled();
   });
 
+  it('una sorgente troppo pesante non si traveste da «non trovata»', async () => {
+    loadLibraryMediaPart.mockResolvedValue({ ok: false, reason: 'too_large' });
+
+    const out = await refineBrandMedia(
+      supabaseWith({}, [{ id: FULL_ID, kind: 'image', bytes: REAL_CASE_BYTES }]),
+      { brandId: 'brand-1', userId: 'user-1', instruction: 'più caldo', baseMediaId: FULL_ID }
+    );
+
+    expect(out).toEqual({
+      ok: false,
+      error: 'source_too_large',
+      bytes: REAL_CASE_BYTES,
+      limit: IMAGE_PART_MAX_BYTES
+    });
+    expect(renderPostImage).not.toHaveBeenCalled();
+  });
+
+  it('un asset senza peso registrato dichiara comunque il tetto', async () => {
+    loadLibraryMediaPart.mockResolvedValue({ ok: false, reason: 'too_large' });
+
+    const out = await refineBrandMedia(supabaseWith({}, [{ id: FULL_ID, kind: 'image', bytes: null }]), {
+      brandId: 'brand-1',
+      userId: 'user-1',
+      instruction: 'più caldo',
+      baseMediaId: FULL_ID
+    });
+
+    expect(out).toEqual({ ok: false, error: 'source_too_large', bytes: null, limit: IMAGE_PART_MAX_BYTES });
+  });
+
   it('generare senza sorgente non tocca il ramo di rifinitura', async () => {
     await generateBrandImages(supabaseWith({ imageRefineModel: REFINE_MODEL }), {
       brandId: 'brand-1',
@@ -135,7 +167,7 @@ describe('rifinire un asset della libreria', () => {
 
     const opts = renderPostImage.mock.calls[0][1];
     expect(opts.baseImage).toBeUndefined();
-    expect(loadLibraryMediaParts).not.toHaveBeenCalled();
+    expect(loadLibraryMediaPart).not.toHaveBeenCalled();
   });
 
   it('accetta un prefisso corto, come gli id dei post', async () => {
@@ -146,7 +178,7 @@ describe('rifinire un asset della libreria', () => {
       baseMediaId: '1111'
     });
 
-    expect(loadLibraryMediaParts).toHaveBeenCalledWith(expect.anything(), 'brand-1', [FULL_ID], 1);
+    expect(loadLibraryMediaPart).toHaveBeenCalledWith(expect.anything(), 'brand-1', FULL_ID);
   });
 
   it('un prefisso che combacia con due asset non ne sceglie uno a caso', async () => {

--- a/src/lib/server/media-generate.ts
+++ b/src/lib/server/media-generate.ts
@@ -22,6 +22,8 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 import { insertBrandMedia, storeBrandMediaBytes, probeImageDimensions } from '$lib/server/brand-media';
 import { signKnowledgePaths } from '$lib/server/media-archive';
 import { mediaUrl } from '$lib/media-url';
+import { IMAGE_PART_MAX_BYTES } from '$lib/raster-image';
+import type { ImagePart, ImagePartRefusal } from '$lib/server/brand-context';
 import { safeProviderReason } from '$lib/server/provider-reason';
 import { markImage, DIGITAL_SOURCE_TYPE } from '$lib/server/content-credentials';
 import type { AspectRatio } from '$lib/server/content-preview';
@@ -96,8 +98,33 @@ const IMAGE_MIME = 'image/png';
 
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-/** Quanti asset si guardano per sciogliere un prefisso: gli id soltanto, quindi una lettura corta. */
+/** Quanti asset si guardano per sciogliere un prefisso: id, tipo e peso, quindi una lettura corta. */
 const PREFIX_SCAN = 500;
+
+type LibrarySource = { id: string; kind: string; bytes: number | null };
+
+export type SourceTooLarge = {
+  ok: false;
+  error: 'source_too_large';
+  bytes: number | null;
+  limit: number;
+};
+
+const SOURCE_REFUSAL: Record<ImagePartRefusal, 'source_too_large' | 'source_not_found'> = {
+  too_large: 'source_too_large',
+  not_an_image: 'source_not_found',
+  fetch_failed: 'source_not_found'
+};
+
+function refusedSource(
+  reason: ImagePartRefusal,
+  source: LibrarySource
+): SourceTooLarge | { ok: false; error: 'source_not_found' } {
+  const error = SOURCE_REFUSAL[reason];
+  if (error === 'source_not_found') return { ok: false, error };
+
+  return { ok: false, error, bytes: source.bytes, limit: IMAGE_PART_MAX_BYTES };
+}
 
 /**
  * Un prefisso corto come lo accettano gli id dei post, ma risolto QUI e non nel livello MCP: li'
@@ -111,7 +138,7 @@ async function resolveLibraryId(
   supabase: SupabaseClient,
   brandId: string,
   idOrPrefix: string
-): Promise<{ id: string; kind: string } | null> {
+): Promise<LibrarySource | null> {
   const want = idOrPrefix.trim().toLowerCase();
   if (!want) return null;
 
@@ -120,13 +147,14 @@ async function resolveLibraryId(
   // «non e' tua» — e un id di un altro inquilino tornava con l'errore sbagliato.
   const { data } = await supabase
     .from('brand_media')
-    .select('id, kind')
+    .select('id, kind, bytes')
     .eq('brand_id', brandId)
     .limit(PREFIX_SCAN);
-  const rows = (data ?? []) as Array<{ id: string; kind: string }>;
+  const rows = (data ?? []) as Array<{ id: string; kind: string; bytes: number | null }>;
   const hits = rows.filter((r) => String(r.id).toLowerCase().startsWith(want));
+  if (hits.length !== 1) return null;
 
-  return hits.length === 1 ? { id: String(hits[0].id), kind: String(hits[0].kind) } : null;
+  return { id: String(hits[0].id), kind: String(hits[0].kind), bytes: hits[0].bytes ?? null };
 }
 
 function dataUrlBytes(dataUrl: string): { bytes: Buffer; mime: string } | null {
@@ -278,6 +306,7 @@ export type ImageJobResult =
       costUsd: number | null;
     }
   | { ok: false; error: 'render_failed' | 'store_failed' | 'source_not_found' }
+  | SourceTooLarge
   | { ok: false; error: 'model_not_for_slot'; allowed: string[] };
 
 async function brandContentPrefs(
@@ -301,7 +330,7 @@ async function runImageJob(
     { renderPostImage, buildImageRequest, loadBrandVisualContext },
     { imageModelFor, imageRefineModelFor },
     { mediaModelSlot, slotAccepts, slotChoices },
-    { loadLibraryMediaParts }
+    { loadLibraryMediaPart }
   ] = await Promise.all([
     import('$lib/server/content-preview'),
     import('$lib/image-models'),
@@ -323,16 +352,16 @@ async function runImageJob(
   // racconta che questo percorso un brand ce l'ha ancora.
   const prefs = job.brandId ? await brandContentPrefs(supabase, job.brandId) : {};
 
-  // `loadLibraryMediaParts` filtra per brand_id: l'id di un altro inquilino non risolve nulla, e
+  // `loadLibraryMediaPart` filtra per brand_id: l'id di un altro inquilino non risolve nulla, e
   // il confine resta nella query invece che in un controllo che qualcuno dimenticherà.
-  let baseImage: { inlineData: { mimeType: string; data: string } } | undefined;
+  let baseImage: ImagePart | undefined;
   if (job.baseMediaId && job.brandId) {
     const source = await resolveLibraryId(supabase, job.brandId, job.baseMediaId);
     if (!source) return { ok: false, error: 'source_not_found' };
 
-    const parts = await loadLibraryMediaParts(supabase, job.brandId, [source.id], 1);
-    if (!parts.length) return { ok: false, error: 'source_not_found' };
-    baseImage = parts[0];
+    const outcome = await loadLibraryMediaPart(supabase, job.brandId, source.id);
+    if (!outcome.ok) return refusedSource(outcome.reason, source);
+    baseImage = outcome.part;
   }
 
   const brandVisuals =
@@ -423,6 +452,7 @@ export type RefineMediaResult =
       ok: false;
       error: 'source_not_found' | 'kind_not_refinable' | 'no_refine_model' | 'render_failed' | 'store_failed';
     }
+  | SourceTooLarge
   | { ok: false; error: 'model_not_for_slot'; allowed: string[] };
 
 type Refiner = (

--- a/src/lib/server/media-generate.without-brand.test.ts
+++ b/src/lib/server/media-generate.without-brand.test.ts
@@ -29,7 +29,7 @@ vi.mock('$lib/server/content-preview', () => ({
   loadBrandVisualContext: (...args: unknown[]) => loadBrandVisualContext(...args)
 }));
 vi.mock('$lib/server/brand-media', () => ({
-  loadLibraryMediaParts: async () => [],
+  loadLibraryMediaPart: async () => ({ ok: false, reason: 'fetch_failed' }),
   insertBrandMedia: (...args: unknown[]) => insertBrandMedia(...args),
   storeBrandMediaBytes: (...args: unknown[]) => storeBrandMediaBytes(...args),
   probeImageDimensions: async () => ({ width: 1080, height: 1080 })

--- a/src/lib/server/media-import.test.ts
+++ b/src/lib/server/media-import.test.ts
@@ -5,7 +5,8 @@ vi.mock('$env/dynamic/private', () => ({ env: {} }));
 vi.mock('node:dns/promises', () => ({ lookup: vi.fn() }));
 
 import { lookup } from 'node:dns/promises';
-import { importBrandMediaFromUrl } from './media-import';
+import { RASTER_SOURCE_MAX_BYTES } from '$lib/raster-image';
+import { importBrandMediaFromUrl, IMAGE_MAX_BYTES } from './media-import';
 
 const PNG = Buffer.from('89504e470d0a1a0a0000000d49484452', 'hex');
 const OVER_IMAGE_CEILING = Buffer.alloc(13_000_000, 1);
@@ -259,6 +260,15 @@ describe('importare un media da un URL pubblico', () => {
 
     expect(result).toEqual({ ok: false, error: 'too_large' });
     expect(uploads).toEqual([]);
+  });
+
+  /**
+   * Il tool gemello deve saper leggere ciò che questo deposita. Quando non era così — 12 MB
+   * ammessi all'import, 6 MB leggibili dalla rifinitura — `refine_media` rispondeva
+   * `source_not_found` su una foto che c'era, e l'agente la rigenerava da zero.
+   */
+  it('ciò che l import ammette, la rifinitura lo sa ancora leggere', () => {
+    expect(IMAGE_MAX_BYTES).toBeLessThanOrEqual(RASTER_SOURCE_MAX_BYTES);
   });
 
   it('un video regge un peso che a un immagine sarebbe negato', async () => {

--- a/src/lib/server/media-import.ts
+++ b/src/lib/server/media-import.ts
@@ -23,7 +23,7 @@ import {
 } from '$lib/server/brand-media';
 import { mediaUrl } from '$lib/media-url';
 
-const IMAGE_MAX_BYTES = 12_000_000;
+export const IMAGE_MAX_BYTES = 12_000_000;
 /**
  * Il download è bufferizzato, quindi questo tetto è un vincolo reale sulla memoria della
  * funzione, non una preferenza: una clip social sta sotto, un master no.

--- a/src/routes/api/v1/brands/[slug]/media/refine/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/media/refine/+server.ts
@@ -34,7 +34,11 @@ export const POST: RequestHandler = async ({ request, params }) => {
 
   if (!result.ok) {
     return json(
-      { error: result.error, ...('allowed' in result ? { allowed: result.allowed } : {}) },
+      {
+        error: result.error,
+        ...('allowed' in result ? { allowed: result.allowed } : {}),
+        ...('limit' in result ? { bytes: result.bytes, limit: result.limit } : {})
+      },
       { status: statusForFailure(REFINE_MEDIA, result.error) }
     );
   }

--- a/src/routes/api/v1/brands/[slug]/media/refine/server.refine.test.ts
+++ b/src/routes/api/v1/brands/[slug]/media/refine/server.refine.test.ts
@@ -118,6 +118,20 @@ describe('POST /media/refine — refine_media', () => {
     expect(body.error).toBe('source_not_found');
   });
 
+  it('una sorgente troppo pesante porta il peso e il tetto, e non e\' un 404', async () => {
+    refineBrandMedia.mockResolvedValue({
+      ok: false,
+      error: 'source_too_large',
+      bytes: 7_836_963,
+      limit: 6_000_000
+    });
+
+    const { res, body } = await refine({ base_media_id: 'media-0', instruction: 'x' });
+
+    expect(res.status).toBe(413);
+    expect(body).toEqual({ error: 'source_too_large', bytes: 7_836_963, limit: 6_000_000 });
+  });
+
   it('una clip senza modello di refine si rifiuta con 400, non con un render', async () => {
     refineBrandMedia.mockResolvedValue({ ok: false, error: 'no_refine_model' });
 


### PR DESCRIPTION
## What?

`refine_media` answered `404 source_not_found` on a library asset that exists. The asset was fine
in every respect — `kind: 'image'`, the right `brand_id`, a `storage_path` present in
`brand-knowledge`, `source: 'agent'`. It weighed **7.836.963 bytes (7,47 MB)**, over the 6 MB
ceiling on an inline image part, and `fetchImagePart` answered `null`. The empty list downstream
became "not found".

Three changes, one per commit:

1. **The message tells the truth.** `imagePartFor` now returns *why* a part is missing
   (`too_large` | `not_an_image` | `fetch_failed`) instead of collapsing all three into `null`.
   `refine_media` turns `too_large` into a new failure, **`source_too_large` (413)**, carrying the
   asset's `bytes` and the `limit`.
2. **The ceiling is worked around, not raised.** A source over 6 MB is now **scaled down** before
   the model sees it — long edge 2048, re-encoded until it fits — instead of being dropped.
3. **`import_media_url` needs no change**, and the commit says why: with (2) in place the gap it
   opened closes on its own. What it adds is one test pinning the invariant.

## Why?

The 404 was not cosmetic, it was expensive. An external agent reads "the image does not exist" and
**regenerates from scratch** — which is precisely the damage `refine_media` was built to prevent.
The customer's original stays untouched in the library while a fresh render is billed and a
*different* subject comes back. The agent has no way to know it destroyed the intent: every answer
it got was consistent with an asset that was never there.

And a message can only be precise if the information survives the call. `fetchImagePart` returned
`null` whether the file was too heavy, was not an image, or the network fell over. No caller could
distinguish them, so no caller could say anything true. Same shape of defect `query` fixed by
declaring its truncation instead of quietly returning fewer rows.

## How?

**The chain, as read in the code:**

```
media-generate  resolveLibraryId      → finds the asset (this was never the not_found)
media-generate  loadLibraryMediaParts → resolveBrandImageIds → signs the path
brand-context   fetchImagePart        → 6.000.000 byte ceiling → null
media-generate  if (!parts.length)    → 'source_not_found'
```

**The reason survives.** `imagePartFor(url): ImagePartOutcome` is the new function;
`fetchImagePart` keeps its signature for its fifteen callers and is now a two-line wrapper. A new
`loadLibraryMediaPart` (singular) carries the outcome to `runImageJob`. `loadLibraryMediaParts`
(plural) is untouched — its four other callers have no use for a reason, and changing its shape
would have churned them for nothing.

**The exceptions live in one place.** `SOURCE_REFUSAL` in `media-generate.ts` is a row per reason;
`REFUSAL_BY_CONVERSION` in `brand-context.ts` maps the three `rasterToJpeg` errors. Adding a
reason is a row, not another `if` somewhere.

**The weight comes from the row, not from the fetch.** `resolveLibraryId` already reads
`brand_media`; it now also selects `bytes`. That is the number the diagnosis used, it is right even
when the file was refused before a single byte was downloaded, and it cost one word in a `select`
instead of a new field threaded through the guard.

**The resize was already in the house.** `rasterToJpeg` (`src/lib/server/raster-image.ts`) has fit
a long edge, walked JPEG quality down and stopped under a byte budget since the HEIC upload work.
`sharp` is already a dependency and already used in `brand-media.ts`. **No new dependency**, and the
call is a dynamic `import` so the happy path does not load sharp.

**Which resolution the model actually accepts** — the question that decided 2048 rather than "under
6 MB":

- The live route for the image slot is **OpenRouter** (`SLOT_DEFAULT.image =
  nano-banana@openrouter`, `AI_ROUTE_IMAGE` unset). There we send **no size field at all** — only
  `image_config.aspect_ratio` — and the model returns at its own size, on the order of 1K. The base
  image travels **inline as a base64 data URL in the JSON body**, i.e. a third heavier than the
  bytes themselves, which is the second reason a byte ceiling has to stay.
- On the kie fallback the size is `resolution`, and in this environment `KIE_IMAGE_RESOLUTION=2K`.

So 2048 is twice the output of the live route and exactly the output of the fallback. Full
resolution of a 24-megapixel original is seen by neither.

**Where the resize sits** matters as much as that it exists: in `imagePartFor`, the path that
prepares a source *for the model* — never at import, where it would replace the customer's original
with a smaller copy. The other fourteen callers get the same benefit: mood boards, product shots,
user references, the media catalog, all places where a big photo used to vanish without a word.

**Rejected:**

- *Raising `IMAGE_PART_MAX_BYTES`* — moves the wall to the first 12 MB file, and every reference
  pays for it in the model's context, not just the big one.
- *Resizing at import* — someone who imports a master imports it on purpose.
- *Changing `loadLibraryMediaParts`' shape* — five callers, four of which have no use for the
  reason.
- *A distinct error for a dropped connection* — `fetch_failed` still maps to `source_not_found`.
  It is the same kind of lie in a milder degree, and it deserves its own reproduced case before it
  gets a name.

## Testing?

**The two reds that had to be watched fail, and were:**

1. *A 7,4 MB photo refines.* `src/lib/server/brand-context.oversize.test.ts` builds a real JPEG
   with sharp at 3400×2550 / q92 — 7.733.307 bytes, the size of the production case — serves it
   over a local HTTP server through the real guard, and asserts a part comes back, under the
   ceiling, at ≤2048 px, with the aspect ratio intact. **Before the fix: `expected null not to be
   null`.**
2. *A size failure does not disguise itself as "not found".*
   `src/lib/server/media-generate.refine.test.ts` asserts `source_too_large` with the real case's
   7.836.963 bytes and the ceiling, and that **no render is called**. Before the fix the same
   input produced `source_not_found`.

Plus: `imagePartFor` separating `too_large` / `not_an_image` / `fetch_failed` on three distinct
sources; a photo already under the ceiling passing through **byte-identical** (no needless
recompression); the 413 and the `bytes`/`limit` body at the route; and
`IMAGE_MAX_BYTES <= RASTER_SOURCE_MAX_BYTES` in `media-import.test.ts`, which fails if someone
reopens the gap from the import side.

**No test spends credits.** The provider never runs: `renderPostImage` is mocked at the service
level, and the oversize test exercises real sharp and a real local socket, nothing remote.

**Ran:** `npx vitest run` (688 files, 7569 passing), `bun test` in `cli/` (135 passing, contracts
copy byte-identical), `node scripts/typecheck-runtime.mjs`, `node scripts/schema-drift-check.mjs`
(green — `brand_media.bytes`, the column the weight is read from, exists in the database),
`npm run build`, and `npm run dev` with the endpoint probed (401 without a token, 401 with a bad
key: the route is served and gated).

**NOT tested, and this is the main risk:** a large image has **not** been refined against the real
model. Nothing here has produced an actual render from an oversized source, so what is unproven is
the last link — that a 2048 px JPEG re-encode of a customer's photo makes a refinement the model
handles as well as the original would have. Everything up to the request body is measured; the
answer from the provider is not.

Also not exercised end-to-end: the browser. The changed surface is
`POST /api/v1/brands/:slug/media/refine` — a CLI/MCP endpoint with no UI of its own — and the app
boots and serves the route, but no session went through the media library to trigger a refine.

## Evidence (screenshots/videos)

<details>
<summary>Red before the fix — <code>fetchImagePart</code> drops the 7,4 MB photo</summary>

```
 ❯ src/lib/server/brand-context.oversize.test.ts (7 tests | 6 failed)
   × una foto più grande del tetto della parte inline > la sorgente pesa davvero più del tetto
     → expected value must be number or bigint, received "undefined"
   × una foto più grande del tetto della parte inline > arriva al modello ridimensionata, non sparisce
     → expected null not to be null
   × una foto più grande del tetto della parte inline > resta la stessa foto: proporzioni invariate
     → Cannot read properties of null (reading 'inlineData')
   ✓ una foto già sotto il tetto passa intatta, senza ricomprimerla
   × il motivo per cui una parte manca non si butta via > ... → imagePartFor is not a function
```

`expected null not to be null` on line 116 is the production defect, reproduced.
</details>

<details>
<summary>Green after — the same photo arrives scaled</summary>

```
 ✓ src/lib/server/brand-context.oversize.test.ts (7 tests) 3513ms
   ✓ arriva al modello ridimensionata, non sparisce 919ms
   ✓ resta la stessa foto: proporzioni invariate 978ms
   ✓ una foto già sotto il tetto passa intatta, senza ricomprimerla 540ms
 ✓ src/lib/server/brand-context.ssrf.test.ts (3 tests)
```

The SSRF suite stays green: the guard and its redirect gating are untouched, the source ceiling
moved from 6 MB to what we already accept to decode.
</details>

<details>
<summary>The refusal now names the weight and the ceiling</summary>

```
 ✓ src/lib/server/media-generate.refine.test.ts (11 tests)
   ✓ una sorgente troppo pesante non si traveste da «non trovata»
   ✓ un asset senza peso registrato dichiara comunque il tetto
 ✓ src/routes/api/v1/brands/[slug]/media/refine/server.refine.test.ts (9 tests)
   ✓ una sorgente troppo pesante porta il peso e il tetto, e non e' un 404
```

The body an agent reads: `{"error":"source_too_large","bytes":7836963,"limit":6000000}` with
status 413. The MCP client surfaces the body verbatim, so the weight and the ceiling reach the
model that has to decide what to do next.
</details>

<details>
<summary>Full suite and build</summary>

```
 Test Files  688 passed | 4 skipped (692)
      Tests  7569 passed | 14 skipped (7583)
```
</details>

## Anything Else?

- **A PNG with transparency over 6 MB** comes out of `rasterToJpeg` as a JPEG, hence on a black
  background. Until now it disappeared entirely, so this is strictly better; if it ever lands on a
  real logo the fix is a PNG branch inside `rasterToJpeg`, not a second resizer here.
- **Peak memory** per image part went from 6 MB to `RASTER_SOURCE_MAX_BYTES` (20 MB) while the
  buffer is alive. The guard still rejects early on a declared `content-length` over the ceiling,
  so only a server that lies about its length actually buffers that much; the multi-image callers
  fetch CDN thumbnails, not masters. Worth a look if a function ever starts running out of memory
  on `synthesizeVisualStyle`.
- **`fetch_failed` is still reported as `source_not_found`.** One lie fixed, one degree left.
- **A library asset above 20 MB** — reachable only through the browser upload, which has no
  server-side byte ceiling of its own — now comes back as `source_too_large` with its weight,
  instead of "not found". That is the honest answer, not a fix: nothing shrinks it.
- Touched `docs/mcp-tools.md` (regenerated with `node scripts/mcp-inventory.mjs --write`) and the
  contracts. Two other agents are working in the same files; whoever lands second rebases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
