### PR TITLE
Fill mcp_logs user_id and brand_slug too

### DIFF
--- a/changelog/2026-09-11-tool-attribution.md
+++ b/changelog/2026-09-11-tool-attribution.md
@@ -1,21 +1,49 @@
-# Quale tool ha causato la spesa
+# Chi ha chiamato quale tool, su quale brand, e quanto è costato
 
-`mcp_logs` ha zero righe in produzione. I motivi erano due, distinti, e questo ne chiude uno: il
-campo `tool_name` esiste da sempre e **nessuno in `cli/mcp/` lo riempiva** — `grep -rn toolName
-cli/mcp/` fuori da `observability.ts` non trovava niente. L'altro motivo è una variabile
-d'ambiente mancante al progetto Vercel dell'MCP, che non sta qui dentro; ma il **silenzio** con cui
-`mcpLog` usciva quando manca, quello sì.
+`mcp_logs` aveva zero righe in produzione, per due motivi distinti. Il secondo — una variabile
+d'ambiente mancante al progetto Vercel dell'MCP — l'ha messa Andrea a mano, e dopo il deploy la
+tabella è passata da zero a 162 righe. Solo che quelle righe raccontano il **transport** e non cosa
+succede dentro:
+
+```
+09:00   11 richieste   11 non autorizzate    0 ok
+10:00   58 richieste   15 non autorizzate   40 ok
+```
+
+Alle nove non passava nessuno — un client configurato male che non completava l'OAuth. Alle dieci,
+quaranta risposte a buon fine. Quello che manca è **chi**, **quale tool**, **su quale brand**: tre
+colonne che `observability.ts` scrive già fra le sue quindici e che arrivavano sempre `null`,
+perché nessuno in `cli/mcp/` le passava. `grep -rn toolName cli/mcp/` fuori da `observability.ts`
+non trovava niente, e lo stesso valeva per `userId` e `brandSlug`.
+
+Ventisei richieste su sessantanove finiscono 401. Con `user_id` quel numero si separa in «un
+cliente non riesce a collegarsi» e «qualcuno sta sperimentando», che vogliono risposte opposte. Con
+`brand_slug` un errore diventa attribuibile al brand, che è l'unità su cui questo prodotto ragiona.
+Con `tool_name` si risponde a «questo tool vale quello che costa».
 
 ## Una riga per chiamata, e non è il tool a scriverla
 
 `recordToolCalls` decora `registerTool` una volta sola, prima che i quattro moduli registrino —
-lo stesso punto e la stessa tecnica di `trimListedTools`, che già stava lì. Quindi un tool nuovo è
-strumentato per il fatto di esistere, e la riga non dipende da chi si ricorda di scriverla. La
-riga porta nome del tool, brand, utente, durata, ed è `warn` quando il tool torna un errore: un
+lo stesso punto e la stessa tecnica di `trimListedTools`, che già stava lì. Le tre colonne si
+riempiono dove il tool viene eseguito, che è un posto solo: un lavoro solo, non tre. E un tool
+nuovo è strumentato per il fatto di esistere, non perché qualcuno si ricorda di scrivere la riga.
+La riga porta nome del tool, brand, utente, durata, ed è `warn` quando il tool torna un errore: un
 tool che fallisce è quello che più di tutti si vuole nei log, e prima non lasciava niente.
 
+**`user_id` è l'identificatore, e si ferma lì.** L'identità arriva a questo punto con l'email
+accanto — `getRequestAuth()` la porta entrambe — e il percorso comodo la infilerebbe nella riga
+senza che nessuno se ne accorga. La tabella la leggerà chi non ha motivo di vedere l'indirizzo di
+un cliente, quindi un test verifica che nella riga non compaia nemmeno una chiocciola.
+
+**E niente di tutto questo può rovesciare la chiamata che sta descrivendo.** Gira dentro il server
+MCP, adesso su *ogni* tool: `mcpLog` faceva `void mcpLogAsync(entry)`, e una promise respinta
+lasciata così è una unhandled rejection — in Node abbatte il processo, cioè la richiesta di un
+cliente, per non essere riuscita a descriverla. Ora il rifiuto finisce in un `console.error`, come
+tutto il resto di quel file. Il test lo riproduce con un `context` circolare, che fa fallire il
+`JSON.stringify` prima di qualunque rete.
+
 Il test guarda la riga che arriva a PostgREST — un server HTTP vero, alzato dal test — e non la
-funzione che la chiama. `mcpLog` invocato col nome giusto ma senza destinazione non prova niente,
+funzione che la chiama. `mcpLog` invocato coi campi giusti ma senza destinazione non prova niente,
 ed era esattamente il caso che ci ha portati fin qui.
 
 ## E il collegamento con la spesa, che è la parte che serviva davvero

--- a/cli/mcp/observability.test.ts
+++ b/cli/mcp/observability.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { mcpLogAsync } from './observability.ts';
+import { mcpLog, mcpLogAsync } from './observability.ts';
 import { routeMcpHttp } from './http-router.ts';
 
 async function logWithoutEnv(times: number): Promise<string[]> {
@@ -39,6 +39,33 @@ describe('mcp observability', () => {
 
     expect(warnings).toHaveLength(1);
     expect(warnings[0]).toContain('SUPABASE_SERVICE_ROLE_KEY');
+  });
+
+  /**
+   * Questo gira DENTRO il server MCP, ora su ogni chiamata a un tool. Un `void` su una promise
+   * respinta è una unhandled rejection, che in Node abbatte il processo: l'osservabilità
+   * rovescerebbe la richiesta di un cliente per non essere riuscita a descriverla.
+   */
+  test('un guasto del log non rovescia la chiamata che stava descrivendo', async () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
+    const escaped: unknown[] = [];
+    const onEscape = (e: unknown) => void escaped.push(e);
+    process.on('unhandledRejection', onEscape);
+
+    const realError = console.error;
+    console.error = () => {};
+
+    try {
+      expect(() => mcpLog({ level: 'info', event: 'test.event', message: 'hi', context: circular })).not.toThrow();
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    } finally {
+      console.error = realError;
+      process.off('unhandledRejection', onEscape);
+    }
+
+    expect(escaped).toEqual([]);
   });
 });
 

--- a/cli/mcp/observability.ts
+++ b/cli/mcp/observability.ts
@@ -73,9 +73,15 @@ function errorFields(error: unknown): { error_name?: string; error_stack?: strin
   return { error_name: typeof error, message: String(error) };
 }
 
-/** Fire-and-forget structured log to stderr + Sentry + Supabase mcp_logs. */
+/**
+ * Fire-and-forget structured log to stderr + Sentry + Supabase mcp_logs.
+ *
+ * Nessun guasto risale a chi ha chiamato: questo gira DENTRO il server MCP, e un'osservabilità che
+ * rompe ciò che osserva è peggio di una che tace. `void` su una promise respinta è una unhandled
+ * rejection, che in Node abbatte il processo — cioè la richiesta di un cliente.
+ */
 export function mcpLog(entry: McpLogEvent): void {
-  void mcpLogAsync(entry);
+  void mcpLogAsync(entry).catch((e) => console.error('[mcp] log failed', e));
 }
 
 export async function mcpLogAsync(entry: McpLogEvent): Promise<void> {

--- a/cli/mcp/server.ts
+++ b/cli/mcp/server.ts
@@ -69,12 +69,19 @@ function brandSlugOf(args: unknown[]): string | undefined {
 }
 
 /**
- * OGNI CHIAMATA A UN TOOL LASCIA IL SUO NOME. `mcp_logs` ha il campo `tool_name` da sempre e
- * nessuno lo riempiva: quarantadue letture tolte e i tool riscritti sono stati decisi ragionando,
- * perché la tabella non sapeva dire quale tool fosse stato chiamato nemmeno una volta.
+ * LE TRE COLONNE CHE ARRIVAVANO SEMPRE VUOTE. `observability.ts` scrive `tool_name`, `user_id` e
+ * `brand_slug` da sempre, e nessuno in `cli/mcp/` le passava. Il posto dove riempirle è uno solo —
+ * dove un tool viene eseguito — quindi è un lavoro solo, non tre. Senza, di una richiesta finita
+ * 401 non si sa dire se sia un cliente che non riesce a collegarsi o qualcuno che sta provando, e
+ * quelle due vogliono risposte opposte.
+ *
+ * `user_id` è l'IDENTIFICATORE e si ferma lì: l'identità arriva qui con l'email accanto, e la
+ * tabella la leggerà chi non ha motivo di vedere l'indirizzo di un cliente.
  *
  * Si decora `registerTool` una volta sola, prima che i quattro moduli registrino: un tool nuovo è
  * strumentato per il fatto di esistere, e la riga non dipende da chi si ricorda di scriverla.
+ * Niente qui può rovesciare la chiamata che sta descrivendo: `mcpLog` non torna mai un guasto a
+ * chi lo chiama, e i due campi letti dalla richiesta sono letture e basta.
  *
  * Lo stesso scope porta il nome fino alle chiamate HTTP che il tool fa (`asTool`), dove diventa
  * l'intestazione che lega la spesa in `ai_calls` al tool che l'ha causata.

--- a/cli/mcp/tool-calls.test.ts
+++ b/cli/mcp/tool-calls.test.ts
@@ -1,69 +1,106 @@
 import { afterAll, beforeEach, describe, expect, test } from 'bun:test';
-import { createServer, type Server } from 'node:http';
+import { createServer, type IncomingMessage, type Server } from 'node:http';
 import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { AddressInfo } from 'node:net';
 
 /**
- * `mcp_logs` ha zero righe in produzione, e uno dei due motivi è qui: il campo `tool_name` esiste
- * da sempre e nessuno in `cli/mcp/` lo riempiva. Finché resta vuoto, nessuna decisione sui tool
- * può essere presa sui dati — le letture tolte e i tool riscritti sono stati decisi ragionando, e
- * non sapremo mai se ha funzionato.
+ * `mcp_logs` aveva zero righe, e uno dei due motivi era qui: `tool_name`, `user_id` e `brand_slug`
+ * esistono nello schema e `observability.ts` le scrive già fra le sue quindici colonne — ma nessuno
+ * in `cli/mcp/` le passava, quindi arrivavano sempre `null`. Adesso che la tabella riceve le righe
+ * sappiamo raccontare il transport e non cosa succede dentro:
+ *
+ *   26 richieste su 69 finiscono 401 — ma è un cliente che non riesce a collegarsi o qualcuno che
+ *   sta provando? `user_id` separa le due, e vogliono risposte opposte.
  *
  * Si guarda la RIGA che arriva a PostgREST, non la funzione che la chiama: un `mcpLog` invocato
- * col nome giusto ma senza destinazione non prova niente, ed era esattamente il caso.
+ * con i campi giusti ma senza destinazione non prova niente, ed era esattamente il caso.
  */
 
-const rows: Record<string, unknown>[] = [];
+const USER_ID = '3f1c9a52-0d47-4c8b-9e21-5b7d0a2f6c84';
+const USER_EMAIL = 'test@anomalia.so';
+const BEARER = 'access-token-for-the-test';
 
-const supabase: Server = createServer((req, res) => {
+const rows: Record<string, unknown>[] = [];
+const apiCalls: { path: string; tool: string | null }[] = [];
+
+const fake: Server = createServer((req: IncomingMessage, res) => {
   const chunks: Buffer[] = [];
   req.on('data', (c) => chunks.push(c as Buffer));
   req.on('end', () => {
-    if (req.url?.includes('mcp_logs')) {
+    const path = req.url ?? '';
+
+    // Il guardiano del bearer: il token vale, e l'identità che ne esce è questa.
+    if (path.startsWith('/auth/v1/user')) {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ id: USER_ID, email: USER_EMAIL, aud: 'authenticated', role: 'authenticated' }));
+      return;
+    }
+
+    if (path.includes('mcp_logs')) {
       const body = JSON.parse(Buffer.concat(chunks).toString() || '{}');
       rows.push(...(Array.isArray(body) ? body : [body]));
     }
-    res.writeHead(201, { 'Content-Type': 'application/json' });
+
+    // Le chiamate che il tool fa all'app: è lì che si vede se il nome viaggia con la richiesta.
+    if (path.startsWith('/api/')) {
+      apiCalls.push({ path, tool: (req.headers['x-anomalia-tool'] as string | undefined) ?? null });
+    }
+
+    res.writeHead(200, { 'Content-Type': 'application/json' });
     res.end('[]');
   });
 });
 
-await new Promise<void>((resolve) => supabase.listen(0, '127.0.0.1', resolve));
+await new Promise<void>((resolve) => fake.listen(0, '127.0.0.1', resolve));
 
-process.env.PUBLIC_SUPABASE_URL = `http://127.0.0.1:${(supabase.address() as AddressInfo).port}`;
+const origin = `http://127.0.0.1:${(fake.address() as AddressInfo).port}`;
+process.env.PUBLIC_SUPABASE_URL = origin;
+process.env.PUBLIC_SUPABASE_ANON_KEY = 'anon-key-for-the-test';
 process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-for-the-test';
-// Nessuna sessione CLI da trovare: il tool si ferma su `requireAuth` e non parla con nessuno. La
-// riga deve esserci comunque — un tool che fallisce è quello che più di tutti si vuole nei log.
+process.env.PUBLIC_APP_URL = origin;
+// Nessuna sessione CLI su disco: senza bearer il tool si ferma su `requireAuth` e non parla con
+// nessuno. La riga deve esserci comunque — un tool che fallisce è quello che più di tutti si vuole
+// nei log, e prima non lasciava niente.
 process.env.HOME = mkdtempSync(join(tmpdir(), 'anomalia-mcp-'));
-process.env.PUBLIC_APP_URL = 'http://127.0.0.1:1';
 
 const { handleMcpFetch } = await import('./http-app.ts');
 
-afterAll(() => supabase.close());
+afterAll(() => fake.close());
 
-const post = (body: unknown) =>
+const post = (body: unknown, headers: Record<string, string> = {}) =>
   handleMcpFetch(
-    new Request('http://localhost/mcp', {
+    new Request(`${origin}/mcp`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', Accept: 'application/json, text/event-stream' },
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+        ...headers,
+      },
       body: JSON.stringify(body),
     }),
   );
 
-async function callTool(name: string, args: Record<string, unknown>): Promise<void> {
-  await post({
-    jsonrpc: '2.0',
-    id: 1,
-    method: 'initialize',
-    params: {
-      protocolVersion: '2024-11-05',
-      capabilities: {},
-      clientInfo: { name: 'tool-calls', version: '0.0.1' },
+async function callTool(
+  name: string,
+  args: Record<string, unknown>,
+  headers: Record<string, string> = {},
+): Promise<void> {
+  await post(
+    {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'tool-calls', version: '0.0.1' },
+      },
     },
-  });
-  await post({ jsonrpc: '2.0', id: 2, method: 'tools/call', params: { name, arguments: args } });
+    headers,
+  );
+  await post({ jsonrpc: '2.0', id: 2, method: 'tools/call', params: { name, arguments: args } }, headers);
 
   // La scrittura è fire-and-forget: la risposta non la aspetta, il test sì.
   const deadline = Date.now() + 5000;
@@ -74,17 +111,38 @@ async function callTool(name: string, args: Record<string, unknown>): Promise<vo
 
 const toolCall = (): Record<string, unknown> | undefined => rows.find((r) => r.event === 'tool.call');
 
+const signedIn = { Authorization: `Bearer ${BEARER}` };
+
 beforeEach(() => {
   rows.length = 0;
+  apiCalls.length = 0;
 });
 
-describe('ogni chiamata a un tool lascia il suo nome', () => {
-  test('la riga nomina il tool e il brand su cui è stato chiamato', async () => {
+describe('ogni chiamata a un tool riempie le tre colonne vuote', () => {
+  test('il tool e il brand su cui è stato chiamato', async () => {
     await callTool('approve_posts', { slug: 'demo' });
 
     expect(toolCall()?.tool_name).toBe('approve_posts');
     expect(toolCall()?.brand_slug).toBe('demo');
     expect(typeof toolCall()?.duration_ms).toBe('number');
+  });
+
+  test('chi ha chiamato, quando il client si è autenticato davvero', async () => {
+    await callTool('list_brands', {}, signedIn);
+
+    expect(toolCall()?.user_id).toBe(USER_ID);
+  });
+
+  /**
+   * `user_id` è un identificatore, e si ferma lì. La tabella la leggeranno persone che non hanno
+   * motivo di vedere l'indirizzo di un cliente, e l'identità arriva qui con l'email accanto: il
+   * percorso comodo la porterebbe dentro senza che nessuno se ne accorga.
+   */
+  test('l’identificatore e nient’altro: nessuna email finisce nella riga', async () => {
+    await callTool('list_brands', {}, signedIn);
+
+    expect(JSON.stringify(toolCall())).not.toContain(USER_EMAIL);
+    expect(JSON.stringify(toolCall())).not.toContain('@');
   });
 
   test('un tool che torna un errore lascia un avviso, non il silenzio', async () => {
@@ -97,5 +155,24 @@ describe('ogni chiamata a un tool lascia il suo nome', () => {
     await callTool('list_brands', {});
 
     expect(toolCall()?.tool_name).toBe('list_brands');
+  });
+});
+
+describe('il nome del tool viaggia con le chiamate che il tool fa', () => {
+  /**
+   * Il pezzo che lega `mcp_logs` a `ai_calls`: senza questa intestazione la spesa resta attribuita
+   * a un'etichetta condivisa fra l'autopilot, la chat e gli agenti esterni — cioè a nessuno.
+   */
+  test('la richiesta all’app porta x-anomalia-tool', async () => {
+    await callTool('list_brands', {}, signedIn);
+
+    expect(apiCalls).toContainEqual({ path: '/api/v1/brands', tool: 'list_brands' });
+  });
+
+  test('fuori da un tool non parte nessuna intestazione inventata', async () => {
+    const { api } = await import('../lib/api.ts');
+    await api.listBrands(BEARER);
+
+    expect(apiCalls.at(-1)).toEqual({ path: '/api/v1/brands', tool: null });
   });
 });

--- a/src/lib/content/changelog/2026-09-11-tool-attribution.ts
+++ b/src/lib/content/changelog/2026-09-11-tool-attribution.ts
@@ -2,8 +2,8 @@ import type { ChangelogEntry } from './index';
 
 export default {
   date: '2026-09-11',
-  title: 'Spending now says which tool caused it',
+  title: 'Every agent action is now on the record',
   items: [
-    'Work an external agent asks for through MCP is recorded against the tool that asked for it, so what a tool costs can finally be told apart from what every other tool costs.'
+    'Work an external agent asks for through MCP is recorded against the tool that asked for it, the brand it touched and the person signed in — so what a tool costs can finally be told apart from what every other tool costs, and a connection that never worked from someone just trying things out.'
   ]
 } satisfies ChangelogEntry;


### PR DESCRIPTION
## What?

Follow-up to #401, which landed before this could join it. That PR filled `mcp_logs.tool_name`;
the columns arriving `null` were **three**, not one:

| column | written at `observability.ts:131-133` | passed by anyone in `cli/mcp/` |
|---|---|---|
| `tool_name` | `entry.toolName ?? null` | now yes (#401) |
| `user_id` | `entry.userId ?? null` | **no** |
| `brand_slug` | `entry.brandSlug ?? null` | **no** |

This fills the other two, at the same seam — `user_id` from the verified bearer, `brand_slug` from
the tool's own `slug` argument. It also stops `mcpLog` from being able to take down the request it
is describing.

## Why?

`mcp_logs` now receives rows (zero → 162 after the env vars landed on the MCP Vercel project), and
they describe the transport but not what happened inside it:

```
09:00   11 requests   11 unauthorized    0 ok
10:00   58 requests   15 unauthorized   40 ok
```

**26 of 69 requests end 401.** Without `user_id` that is one undifferentiated number; with it, it
splits into "a customer cannot connect" and "someone is experimenting" — and those want opposite
responses. `brand_slug` makes a failure attributable to the brand, which is the unit this product
reasons in.

The second half is a hazard this PR closes rather than adds: `mcpLog` did
`void mcpLogAsync(entry)`. A rejected promise left like that is an unhandled rejection, and in Node
that takes the process down — a customer's request dropped because we failed to *describe* it.
That code now runs on **every tool call**, so the exposure went up the moment #401 merged.

## How?

Both columns are filled in `recordToolCalls`, the decorator #401 already installed: the place a
tool runs is the one place that knows all three, so it is one piece of work and not three.
`user_id` comes from `getRequestAuth()`, `brand_slug` from `args[0].slug` when the tool declares
one.

**`user_id` is the identifier and stops there.** The identity reaches this point with the email
beside it — `RequestAuth` carries `{ id, email }` — and the convenient path would slide the address
into the row unnoticed. The table will be read by people with no reason to see it, so a test
asserts the row contains no `@` at all.

**The log cannot break what it observes.** `mcpLog` now catches, into `console.error`, exactly like
every other failure path in that file. The two fields read off the request are reads and nothing
more, so nothing else in the decorator can throw either.

**Rejected**: logging the email alongside the id "for support" — it is a personal detail with no
question it answers that the id does not; a `try/catch` wrapped around the whole decorator — the
only thing in it that could reject is `mcpLog`, and guarding it at the source covers every other
caller too.

## Testing?

Watched fail first, both of them.

- `cli/mcp/tool-calls.test.ts` grows from 3 to 7 tests, still asserting on **the row that reaches
  PostgREST** through a real HTTP server the test starts. That server now also answers
  `/auth/v1/user`, so the bearer path is real and `user_id` is the id GoTrue returned. New: the
  `user_id` on the row; **no email anywhere in the row**; `x-anomalia-tool` on the outgoing API
  request; and no header at all when the same API call is made outside a tool.
- `cli/mcp/observability.test.ts` gains the rejection case: a circular `context` makes
  `JSON.stringify` throw before any network, and the test asserts nothing escapes as an unhandled
  rejection and nothing throws at the caller. It is red with `void mcpLogAsync(entry)` restored.

Full suite: **689 files, 7576 tests, 0 failures, no `Errors` section** (checked explicitly, per
LESSONS.md). Plus `npm run dev` starting and answering on the API routes.

**Not tested**: no run against the deployed MCP — the rows have only been seen in the test's
PostgREST stand-in, never in the real `mcp_logs`. `npm run build` was not re-run for this commit:
it touches `cli/**` (a separate Vercel project, outside `vite build`) plus two changelog files, and
the build was green on the identical SvelteKit surface in #401.

## Evidence (screenshots/videos)

No UI surface changed.

<details>
<summary>Red first — the rejection guard</summary>

```
 FAIL  cli/mcp/observability.test.ts > un guasto del log non rovescia la chiamata che stava descrivendo
AssertionError: expected [ …(1) ] to deeply equal []
      Tests  1 failed | 2 passed (3)
```
</details>

<details>
<summary>The row a tool call writes now</summary>

With a bearer, as it reaches `mcp_logs`: `tool_name: "list_brands"`,
`user_id: "3f1c9a52-…-5b7d0a2f6c84"`, `duration_ms: <n>`, and no `@` anywhere in the row. Without
one, `approve_posts` on brand `demo` still writes `tool_name: "approve_posts"`,
`brand_slug: "demo"`, `level: "warn"` — a tool that fails is the one you most want in the logs.

The outgoing call is recorded as `{ path: '/api/v1/brands', tool: 'list_brands' }`; the same call
made outside a tool is `{ path: '/api/v1/brands', tool: null }`.
</details>

## Anything Else?

Unchanged from #401, and still open:

- **The in-app chat** does not go through `cli/lib/api.ts`, so its rows carry no `tool:` tag. The
  missing piece is a `withToolContext` around chat tool execution.
- **Rows that already carry a `context`** (kie jobs, openrouter images, music, sandbox) lose the
  tool name; fixing that needs the dedicated `ai_calls` column, which needs a migration applied
  before the deploy.
- **`request_id`, `status_code` and `path`** stay null on `tool.call` rows — they have no HTTP
  request of their own to name. Joining a tool call to the transport row that carried it would mean
  threading the request id through `runWithRequestAuth`; worth doing only if someone wants that
  join.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
