### PR TITLE
Film, draw a series and correct without naming a brand

### DIFF
--- a/changelog/2026-09-11-brand-free-media.md
+++ b/changelog/2026-09-11-brand-free-media.md
@@ -1,0 +1,125 @@
+# Video, carosello e rifinitura senza nominare un brand
+
+`generate_image` sapeva già disegnare senza uno slug (`POST /api/v1/images`, commit `015c8406`).
+Gli altri tre no, e non per una decisione di prodotto: il lavoro non era stato finito. Un agente a
+cui si chiedeva un video doveva prima scegliere un'azienda a cui addebitarlo — e sceglierla a caso
+è esattamente ciò che quella rotta esisteva per togliere.
+
+## Le tre risposte, riusate invece di riscritte
+
+La rotta delle immagini aveva già risolto le tre domande che una strada senza brand solleva, e le
+aveva risolte dentro sé stessa. Alla quarta copia sarebbero state quattro versioni divergenti,
+quindi sono diventate una funzione: `orgScopeFor` in `cli-auth.ts`, con `openOrgScope(request)`
+sopra.
+
+- **Chi paga.** L'organizzazione dell'utente, con la stessa regola con cui atterra un brand nuovo
+  (`ensureOrgForUser`: pagante prima, poi la più vecchia). Nessuna → `no_organization`, e ci si
+  ferma.
+- **Le chiavi ristrette.** Una chiave limitata a certi brand si rifiuta (`brand_scoped_key`): dove
+  nessun brand si nomina non c'è niente da confrontare, e lasciarla passare allargherebbe in
+  silenzio una restrizione che l'utente ha scelto.
+- **Lo stile del brand.** `brandStyleRefusal` — `brand_style_needs_a_brand`, che dice la mossa
+  invece di applicare un default silenzioso.
+
+`authenticate` e la decisione sono due mestieri: tenerli insieme rendeva i rifiuti raggiungibili
+solo passando da una chiave API vera, quindi non si provavano. `orgScopeFor(caller)` è dove si
+provano, uno per uno.
+
+## Dove atterra un video senza brand
+
+Era l'unica vera incognita. Un'immagine risponde sincrona e consegna un percorso; un clip no: kie
+ci mette minuti, la richiesta è finita da un pezzo, e a chiuderlo è un cron che ha in mano la sola
+riga di `video_renders` — una riga in cui ogni risposta era un brand.
+
+Il file non era il problema: `persistMp4` scrive da sempre sotto `${userId}/generated/…`, nel
+bucket pubblico `media`, senza toccare nessun brand. Il problema era tutto ciò che veniva dopo.
+
+La strada scelta è quella che `ai_calls` ha già preso, perché prenderne un'altra darebbe a questa
+tabella un secondo vocabolario per la stessa domanda:
+
+```
+con un brand   →  video_renders.brand_id → brands.org_id → il pool
+senza          →  video_renders.org_id ─────────────────→ lo stesso pool
+```
+
+`brand_id` diventa nullable, `org_id` si aggiunge, e `video_renders_one_payer` impone che ne sia
+scritto esattamente uno. Il clip senza brand atterra **sulla riga stessa**: `media_url` è dove
+sta il file, e `GET /api/v1/videos` lo consegna.
+
+Quello che un clip senza brand NON prende, e perché:
+
+- **nessuna riga in `brand_media`** — la policy di quella tabella dice
+  `brand_id in (select auth_brand_ids())`, e `NULL in (…)` vale NULL, non true: una riga senza
+  brand sarebbe invisibile a tutti, non visibile a tutti. È lo stesso motivo per cui il disegno
+  senza brand consegna un percorso invece di un id;
+- **nessuna allocazione mensile** — il numero di video è del PIANO di un brand. Qui il tetto è il
+  saldo crediti dell'organizzazione, lo stesso cancello che passa il disegno senza brand;
+- **nessun post, nessun thread** — erano già nullable, e questo percorso non li scrive mai.
+
+La policy RLS prende un secondo braccio (`org_id in (select auth_org_ids())`): senza, una riga
+senza brand sarebbe leggibile da nessuno — il render avviene, il denaro esce, e la riga è una
+scatola nera.
+
+## Come si nomina una sorgente quando una libreria non c'è
+
+Il nodo di `refine_media`. Sotto un brand `base_media_id` è «qualunque asset della libreria di
+questo brand», e la risoluzione filtra per `brand_id`. Senza brand non c'è una libreria da cui
+pescare.
+
+La maniglia è quella che la strada senza brand consegna già: `storage_path` per un disegno, l'URL
+pubblico per un clip. Tutte e due dicono lo stesso percorso, e il suo **primo segmento è lo user** —
+la stessa cosa che guarda la policy dello Storage (`media insert own scope`, migration
+`20260905140000`). Il percorso di un altro non risolve, esattamente come l'id di un altro inquilino
+non risolve sotto il brand. `ownStoragePath` è quella regola, in un posto solo.
+
+**Un URL scelto da chi chiama è stato scartato.** Sarebbe stato un fetch lato server verso un
+indirizzo arbitrario — la SSRF appena chiusa in sei punti — e in cambio di una capacità che nessuno
+ha chiesto. Qui non si scarica niente da un host esterno: si firma un percorso del nostro bucket.
+Una stringa che non è un nostro percorso cade come `source_not_found`.
+
+Il TIPO della sorgente lo dice il file (`storedKind`): senza una riga di libreria il percorso è
+tutto ciò che c'è, e un mp4 mandato al motore delle immagini è il difetto che questo percorso
+toglie. La tabella `REFINERS` resta una riga per tipo, com'era.
+
+## L'esito con il motivo, ereditato invece di rifatto
+
+Durante questo lavoro `#403` ha corretto un difetto che Andrea aveva trovato usando il prodotto:
+una sorgente da 7,47 MB superava il tetto di 6 MB, `fetchImagePart` tornava `null`, e il tool
+rispondeva `source_not_found` — «non trovata» per una cosa che c'era. L'agente lo leggeva e
+rigenerava da zero, cioè esattamente il danno che `refine_media` esiste per impedire. La correzione
+è `loadLibraryMediaPart`, che restituisce un esito col motivo (`too_large` | `not_an_image` |
+`fetch_failed`), tradotto in `source_too_large` (413) col peso e il tetto.
+
+La prima stesura di questo ramo faceva l'opposto: `storedImagePart` tornava una parte o
+`undefined`, e `runImageJob` schiacciava ogni motivo su `source_not_found`. Fondendola così il
+percorso senza brand sarebbe nato con la bugia appena tolta — e peggio, perché lì le sorgenti sono
+file che l'utente ha appena caricato, quindi grandi per definizione.
+
+Quindi la forma di `#403` vale su **entrambi** i rami: `libraryImageSource` e `storedImageSource`
+tornano lo stesso `SourceOutcome`, e il ramo senza brand eredita gratis sia il messaggio vero sia
+il ridimensionamento a 2048px. `refusedSource` prende il peso invece della riga di libreria, perché
+senza libreria il peso non è scritto da nessuna parte: `null` è il fatto, e il tetto resta detto.
+
+## Il cancello dei crediti dentro `video.ts`
+
+Tre punti di `video.ts` spendevano guardando `getBrandContext()` soltanto. Sotto uno scope di
+organizzazione quella domanda risponde `null`, quindi il cancello sarebbe stato saltato: una clip
+pagata da un saldo che nessuno ha guardato. `gateScopedCredits()` è la stessa domanda per tutti e
+tre — il brand quando c'è, l'organizzazione quando non c'è.
+
+## Il branch che non è stato ripreso
+
+`feat/brand-free-media` (due commit, mai aperto in PR, 156 commit indietro) portava la migration
+`ai_calls_org_id` e lo split di `credits.ts`. Entrambi sono già in `dev` — `readOrgBillingById`,
+`orgCreditsUsage`, `gateOrgCredits` e la `sum_org_ai_cost_usd` con il join esterno. Nulla è andato
+perso per quella strada; il branch si può cancellare.
+
+## Quello che resta fuori
+
+`regenerate_slide`, `reorder_slides`, `regenerate_post_media` e `make_video` lavorano su una riga
+di `posts`, che appartiene a un brand: senza brand non c'è il post da modificare. Restano ancorati,
+e un test lo dichiara invece di lasciarlo all'interpretazione.
+
+La lettura di un clip senza brand è REST (`GET /api/v1/videos`), non un tool MCP: `check_media_job`
+è stato ritirato apposta dalla superficie dei tool e `query` legge un brand. Un agente collegato
+solo via MCP riceve il `job_id` e l'indirizzo dove ritirarlo, ma non ha un tool per interrogarlo.

--- a/cli/lib/contracts/posts.ts
+++ b/cli/lib/contracts/posts.ts
@@ -528,6 +528,16 @@ const MODEL_FAILURE = { error: 'model_not_for_slot', status: 400 } as const;
 
 const BRAND_STYLE_FAILURE = { error: 'brand_style_needs_a_brand', status: 400 } as const;
 
+/**
+ * I due rifiuti che una strada senza brand porta con sé, ovunque esista. `brand_scoped_key` non è
+ * un permesso mancante da allargare: è una restrizione che l'utente ha scelto, e dove nessun brand
+ * si nomina non c'è niente da confrontarci.
+ */
+const BRAND_FREE_FAILURES = [
+  { error: 'brand_scoped_key', status: 403 },
+  { error: 'no_organization', status: 500 }
+] as const;
+
 const BrandStyleField = z
   .enum(['apply', 'ignore'])
   .optional()
@@ -539,12 +549,22 @@ const BrandStyleField = z
   );
 
 /**
- * Un disegno chiesto senza brand non entra in nessuna libreria, quindi non ha un id da mostrare:
- * `null` è il fatto, e dirlo qui è ciò che impedisce di passarlo a `create_post` e di cercarlo con
- * `list_media`. Non è la stessa forma di `refine_media`, che un brand ce l'ha sempre e un id
- * lo restituisce sempre — allargare anche il suo schema significherebbe togliere una promessa
- * che mantiene.
+ * La forma di OGNI asset prodotto senza nominare un brand — disegno, slide di carosello,
+ * rifinitura. Non entra in nessuna libreria, quindi non ha un id da mostrare: `null` è il fatto, e
+ * dirlo qui è ciò che impedisce di passarlo a `create_post` e di cercarlo con `list_media`.
  */
+/**
+ * Chi ha pagato, per nome. Serve dove il chiamante NON ha scelto: senza slug l'organizzazione
+ * l'abbiamo risolta noi, e un addebito che nessuno ha nominato è un addebito che nessuno controlla.
+ * Con lo slug è `null`, perché il brand nomina il suo pagante da sé.
+ */
+const OrganizationField = z
+  .object({ id: z.string(), name: z.string().nullable() })
+  .nullable()
+  .describe(
+    'Whose credits paid, named — set when no brand was given, null when one was (the brand names its own payer).'
+  );
+
 const DrawnMediaSchema = GeneratedMediaSchema.extend({
   id: z
     .string()
@@ -564,12 +584,7 @@ const DrawnImageResult = z.object({
   media: z.array(DrawnMediaSchema),
   model: ImageResult.shape.model,
   renders: ImageResult.shape.renders,
-  organization: z
-    .object({ id: z.string(), name: z.string().nullable() })
-    .nullable()
-    .describe(
-      'Whose credits paid, named — set when no brand was given, null when one was (the brand names its own payer).'
-    ),
+  organization: OrganizationField,
   cost_usd: z
     .number()
     .nullable()
@@ -587,8 +602,8 @@ export const GENERATE_IMAGE = {
     'you want in the prompt. WITHOUT slug this is a one-off drawing: no brand, nothing filed ' +
     'anywhere, id comes back null and there is nothing to hand to create_post. WITH slug the ' +
     "image lands in that brand's library and its id is what create_post takes as media_ids. Do " +
-    'NOT call list_brands to decide where to draw — if nobody named a brand there is no brand, ' +
-    "and guessing one spends a real organisation's credits and litters a real library. It spends " +
+    "NOT call list_brands to find a slug: guessing a brand spends a real organisation's credits " +
+    'and litters a real library. It spends ' +
     'credits: one render per image, and `renders` in the answer says how many were billed, ' +
     'cost_usd what they cost. It creates nothing in the calendar and publishes nothing, so ask ' +
     'for two or three with `count`, look at them, keep one. To CHANGE a picture that already ' +
@@ -613,6 +628,7 @@ export const GENERATE_IMAGE = {
     { error: 'credits_exhausted', status: 402 },
     MODEL_FAILURE,
     BRAND_STYLE_FAILURE,
+    ...BRAND_FREE_FAILURES,
     { error: 'render_failed', status: 502 },
     { error: 'store_failed', status: 502 }
   ],
@@ -646,17 +662,22 @@ export const REFINE_MEDIA = {
     'look is applied as it is on generate_image; brand_style: ignore leaves it out, pictures only. ' +
     'source_too_large means the file is heavier than a model can be handed — the answer names its ' +
     'weight and the ceiling. The asset IS there: shrink it or import a lighter copy, never ' +
-    'generate a replacement.',
+    'generate a replacement. WITHOUT slug base_media_id is instead the storage_path or url a ' +
+    'brand-free generate handed you — never a library id, never a web address (refused as ' +
+    'source_not_found). Nothing is filed, brand_style is refused, and a clip needs `model`. ' +
+    "Do NOT call list_brands to find a slug: guessing a brand spends someone else's credits.",
   method: 'POST',
   pathUnderBrand: '/media/refine',
+  pathWithoutBrand: '/refine',
   input: z
     .object({
       base_media_id: z
         .string()
         .min(1)
         .describe(
-          'The library asset to start from — an id from list_media, or an unambiguous prefix. Its ' +
-            'own kind decides how it is refined: you do not say whether it is a picture or a clip.'
+          'WITH slug: a library id from list_media, or an unambiguous prefix. WITHOUT slug: the ' +
+            'storage_path or url a brand-free generate handed back. Its own kind decides how it ' +
+            'is refined: you never say which.'
         ),
       instruction: z.string().min(1).describe('What should change about it'),
       count: AlternativesField,
@@ -670,13 +691,16 @@ export const REFINE_MEDIA = {
     kind: z
       .enum(['image', 'video'])
       .describe('What was refined, read from the source asset — never from what you asked for'),
-    media: z.array(GeneratedMediaSchema),
+    media: z.array(DrawnMediaSchema),
     model: z.string().nullable().describe('The model that ACTUALLY made it'),
-    renders: z.number().describe('How many renders were BILLED')
+    renders: z.number().describe('How many renders were BILLED'),
+    organization: OrganizationField
   }),
   failures: [
     { error: 'credits_exhausted', status: 402 },
     MODEL_FAILURE,
+    BRAND_STYLE_FAILURE,
+    ...BRAND_FREE_FAILURES,
     { error: 'source_not_found', status: 404 },
     { error: 'source_too_large', status: 413 },
     { error: 'kind_not_refinable', status: 400 },
@@ -691,6 +715,7 @@ const VideoJobResult = z.object({
   ok: z.literal(true),
   status: z.literal('rendering'),
   job_id: z.string(),
+  organization: OrganizationField,
   model: z.string().nullable().describe('The model that is filming it; null when the platform default chose'),
   duration_seconds: z
     .number()
@@ -711,9 +736,13 @@ export const GENERATE_VIDEO = {
     'check_media_job says when it landed — calling this again for the same clip bills a second ' +
     'one. It creates nothing in the calendar and publishes nothing; when the clip lands, pass its ' +
     'media_id to create_post as media_ids. To animate the cover of a post you already have, ' +
-    'make_video does it in one step.',
+    'make_video does it in one step. WITHOUT slug the clip is filed nowhere and has no media_id: ' +
+    'it lands on the job itself, at GET /api/v1/videos (?job_id= for one), whose media_url is ' +
+    'the file. base_media_id is then the storage_path or url a brand-free generate handed back. ' +
+    "Do NOT call list_brands to find a slug: guessing a brand spends someone else's credits.",
   method: 'POST',
   pathUnderBrand: '/media/videos',
+  pathWithoutBrand: '/videos',
   input: z
     .object({
       prompt: z.string().min(1).describe('What the clip should show, or how the image should move'),
@@ -722,7 +751,9 @@ export const GENERATE_VIDEO = {
         .min(1)
         .optional()
         .describe(
-          'A library IMAGE to animate, from list_media — an id or an unambiguous prefix. Omit to film from the prompt alone.'
+          'An IMAGE to animate. WITH slug: a library id from list_media, or an unambiguous ' +
+            'prefix. WITHOUT slug: the storage_path or url a brand-free generate handed back. ' +
+            'Omit to film from the prompt alone.'
         ),
       duration: z.coerce
         .number()
@@ -744,6 +775,7 @@ export const GENERATE_VIDEO = {
   failures: [
     { error: 'credits_exhausted', status: 402 },
     MODEL_FAILURE,
+    ...BRAND_FREE_FAILURES,
     { error: 'video_budget_exhausted', status: 400 },
     { error: 'source_not_found', status: 404 },
     { error: 'source_not_an_image', status: 400 },
@@ -766,9 +798,13 @@ export const GENERATE_CAROUSEL = {
     'refine_media on that slide id, and put the `continuity_tokens` this returns back into your ' +
     'instruction — they are what holds the series together, and an edit that touches palette, ' +
     'light or the recurring motif without them takes that slide out of the set. With a slug, this ' +
-    'brand\'s look is applied to every slide and there is no way to switch it off here.',
+    'brand\'s look is applied to every slide and there is no way to switch it off here. WITHOUT ' +
+    'slug no brand look reaches the slides — name the style in the brief — and the ids come back ' +
+    "null. Do NOT call list_brands to find a slug: guessing a brand spends someone else's " +
+    "credits.",
   method: 'POST',
   pathUnderBrand: '/media/carousel',
+  pathWithoutBrand: '/carousel',
   input: z
     .object({
       brief: z.string().min(1).describe('What the carousel should say, as a whole'),
@@ -780,16 +816,18 @@ export const GENERATE_CAROUSEL = {
     .strict(),
   output: z.object({
     ok: z.literal(true),
-    media: z.array(GeneratedMediaSchema).describe('The slides, in order — slide 1 first'),
+    media: z.array(DrawnMediaSchema).describe('The slides, in order — slide 1 first'),
     continuity_tokens: z
       .array(z.string())
       .describe('The literal tokens repeated in every slide. Put them back into a refine_media instruction or that slide leaves the series.'),
     model: z.string().nullable(),
-    renders: z.number().describe('How many renders were BILLED — one per slide attempted')
+    renders: z.number().describe('How many renders were BILLED — one per slide attempted'),
+    organization: OrganizationField
   }),
   failures: [
     { error: 'credits_exhausted', status: 402 },
     MODEL_FAILURE,
+    ...BRAND_FREE_FAILURES,
     { error: 'plan_failed', status: 502 },
     { error: 'render_failed', status: 502 },
     { error: 'store_failed', status: 502 }

--- a/cli/lib/contracts/write-rules.ts
+++ b/cli/lib/contracts/write-rules.ts
@@ -88,7 +88,8 @@ export const TABLE_CHECKS: Record<string, string> = {
   "shared_views_view_type_check": "view_type in ('calendar', 'dashboard', 'monthly_report', 'strategy', 'workspace')",
   "talents_body_type_check": "body_type is null or body_type in ('slim', 'athletic', 'athletic_slim', 'average', 'curvy', 'plus', 'muscular')",
   "talents_gender_check": "gender is null or gender in ('man', 'woman', 'trans_man', 'trans_woman', 'nonbinary')",
-  "talents_height_band_check": "height_band is null or height_band in ('short', 'average', 'tall')"
+  "talents_height_band_check": "height_band is null or height_band in ('short', 'average', 'tall')",
+  "video_renders_one_payer": "num_nonnulls(brand_id, org_id) = 1"
 };
 
 export const WRITABLE_COLUMNS: Record<string, { insert: string[]; update: string[] }> = {

--- a/cli/mcp/brand-free-tools.test.ts
+++ b/cli/mcp/brand-free-tools.test.ts
@@ -55,10 +55,24 @@ describe('slug opzionale, e solo dove il registro lo dichiara', () => {
     expect(tool.inputSchema?.properties?.slug?.description).toMatch(/omit/i);
   });
 
-  test('refine_media continua a pretendere il brand: la sorgente vive nella sua libreria', async () => {
-    const tool = find(await tools(), 'refine_media');
+  test('anche gli altri motori si chiamano senza nominare un brand', async () => {
+    const all = await tools();
 
-    expect(tool.inputSchema?.required ?? []).toContain('slug');
+    for (const name of ['generate_video', 'generate_carousel', 'refine_media']) {
+      expect(find(all, name).inputSchema?.required ?? [], name).not.toContain('slug');
+    }
+  });
+
+  /**
+   * Un post appartiene a un brand, quindi chi lo modifica resta ancorato. Non è una dimenticanza:
+   * senza brand non c'è il post da modificare.
+   */
+  test('chi lavora su un post continua a pretendere il brand', async () => {
+    const all = await tools();
+
+    for (const name of ['regenerate_slide', 'reorder_slides', 'regenerate_post_media']) {
+      expect(find(all, name).inputSchema?.required ?? [], name).toContain('slug');
+    }
   });
 
   test('ogni altro endpoint del registro tiene slug obbligatorio', async () => {

--- a/cli/plugins/anomalia/skills/anomalia/SKILL.md
+++ b/cli/plugins/anomalia/skills/anomalia/SKILL.md
@@ -182,7 +182,9 @@ at them, keep one.
 **Make a carousel** → `generate_carousel` with a brief. It plans the series, draws every slide and
 returns them in order plus the `continuity_tokens` that hold them together. One render per slide.
 To fix a single slide afterwards, `refine_media` on its id **with those tokens in the instruction** —
-without them that slide drifts out of the series.
+without them that slide drifts out of the series. `slug` is OPTIONAL here too: without it the
+slides take nothing from any brand (name the look in the brief), are filed nowhere, and their
+`id`s come back `null`.
 
 **Animate an image you already have** → `generate_video` with its `base_media_id`. That is how
 "make a 5s clip of this photo" works, and it needs **no post**: the clip lands in the library and
@@ -195,6 +197,13 @@ so it returns a `job_id`; `query` on `video_renders` says when it landed. The mo
 than an order of magnitude, so read `get_media_models` (slot `videoModel`, or `videoImageModel` when animating an image) before
 spending. With a slug the clip follows this brand's visual direction, so you do not have to
 describe it — and there is no switch for it here.
+
+**Film without a brand** → `generate_video` with no `slug`. Same tool, and what changes is where
+the clip ends up: no brand, no library, no `media_id` and nothing for `create_post`. The finished
+clip lands on the job itself — `GET /api/v1/videos` (add `?job_id=` for one) and its `media_url`
+is where the file is. `query` cannot see it: that tool reads a brand. Without a slug
+`base_media_id` is the `storage_path` or `url` a brand-free generate handed you, never a library
+id and never a web address.
 
 **Give a post the image it is missing** → `render_post`. It draws from the prompt already written
 on that post and attaches it. One render. To draw a picture that is not tied to a post, use
@@ -214,6 +223,13 @@ different subject — the commonest and most expensive mistake on this surface. 
 never overwritten: refining files a new asset, so a wrong edit costs one render and not your
 source. A clip needs the brand to have chosen a video refine model; until it has, `refine_media`
 says `no_refine_model` instead of quietly filming a new one.
+
+`slug` is OPTIONAL on `refine_media` as well, and then `base_media_id` means something else: the
+`storage_path` (a picture) or the `url` (a clip) that a brand-free `generate_image`,
+`generate_carousel` or `generate_video` handed back. Nothing else resolves — a library id has no
+brand to be looked up in, and a web address is refused as `source_not_found` rather than fetched.
+The result is filed nowhere either, `brand_style` is refused because there is no brand to apply,
+and a clip has no brand preference to read, so pass `model` or it comes back `no_refine_model`.
 
 **Check your copy before you create it** → `check_content` with the same spec you would send to
 `create_post`. It returns blocking errors, warnings and a 0–100 score per platform, each naming

--- a/cli/plugins/anomalia/skills/anomalia/references/tools.md
+++ b/cli/plugins/anomalia/skills/anomalia/references/tools.md
@@ -302,11 +302,21 @@ there is no quality control, no critic that rejects a bad frame, no retry you di
 What comes back is what was billed, however crooked. Judging it is YOUR job — open the
 `signed_url`, look, and if it is wrong send it to `refine_media` rather than prompting again.
 
-`refine_media` changes something that is already in the library — an image or a video — and files
-the result as a **new** asset, so the original is never overwritten and a refinement cannot destroy
-what it started from. Required: `slug`, `base_media_id` (from `brand_media`, and it must belong to
-this brand — anything else is `source_not_found`), `instruction`. Say what should CHANGE, not what
+`refine_media` changes something you already made — an image or a video — and files the result as a
+**new** asset, so the original is never overwritten and a refinement cannot destroy what it started
+from. Required: `base_media_id`, `instruction`; optional `slug`. Say what should CHANGE, not what
 the whole thing should be.
+
+**`slug` decides what `base_media_id` means, and there is no overlap.** WITH it: an id from
+`brand_media` that belongs to that brand — anything else is `source_not_found`. WITHOUT it: the
+`storage_path` (a picture) or the `url` (a clip) that a brand-free `generate_image`,
+`generate_carousel` or `generate_video` handed back. A library id cannot be resolved without a
+brand to look it up in, and a web address of your own choosing is refused as `source_not_found`
+rather than fetched — the source is always something we handed you, from our own storage. Without
+a slug nothing is filed anywhere either (`id` comes back `null`), `brand_style` is refused as
+`brand_style_needs_a_brand`, and a clip has no brand preference to read so you must pass `model`
+or it comes back `no_refine_model`. The credits come from your organisation, named in
+`organization`.
 
 **You do not say what kind it is.** The asset's own kind, read from the library row, picks the
 engine: a picture goes to the image refiner, a clip to the video one, and the answer says which in
@@ -324,10 +334,12 @@ clip always comes back as one.
 model can be handed, and the answer carries its `bytes` and the `limit`. An oversized source is
 shrunk before the model sees it, so this only reaches you for a file beyond even that — import a
 lighter copy. **Never answer it by generating a replacement**: the original is still the customer's
-and a fresh render is a different picture.
+and a fresh render is a different picture. Without a slug the same applies to a `storage_path` you
+were handed, and `bytes` comes back `null` there — no library row carries the weight — while the
+`limit` still does.
 
-`generate_video` films a NEW clip into the library. Required: `slug`, `prompt`; optional
-`base_media_id`, `duration`, `aspect_ratio`, `model`, `title`. **`base_media_id` pointing at a
+`generate_video` films a NEW clip. Required: `prompt`; optional `slug`, `base_media_id`,
+`duration`, `aspect_ratio`, `model`, `title`. **`base_media_id` pointing at a
 library IMAGE is how you animate a photo** — the image becomes the clip's first frame, so subject,
 scene and style come from those pixels and the prompt directs the movement only. Without it the clip
 is filmed from the prompt alone. It creates nothing in the calendar; when the clip lands, pass its
@@ -336,6 +348,15 @@ is filmed from the prompt alone. It creates nothing in the calendar; when the cl
 A clip takes minutes, so this returns `status: rendering` and a `job_id`, and a `query` on
 `video_renders` says when it is done — do not call it again for the same clip while one is
 rendering, that bills a second.
+
+**Without `slug` the clip has nowhere to be filed, so it lands on the job itself.** No brand, no
+library, no `media_id`, nothing for `create_post`: `GET /api/v1/videos` (add `?job_id=` for one)
+returns the job and its `media_url` is where the file is. `query` will not find it — that tool
+reads a brand. `base_media_id` without a slug is the `storage_path` or `url` a brand-free generate
+handed you; a web address is refused as `source_not_found`. The monthly video allowance belongs to
+a brand's plan, so it is not checked here: the only ceiling is the organisation's credit balance,
+and `organization` in the answer names who paid. Do NOT call `list_brands` to find a slug — if
+nobody named a brand there is no brand, and guessing one spends someone else's credits.
 Animating and filming are two different jobs with two different model lists (`videoImageModel` and
 `videoModel`): a model valid for one is refused for the other with `model_not_for_slot` and the
 accepted list. Refusals: `source_not_found` (404) means the id is not this brand's or does not
@@ -347,8 +368,10 @@ names the nearest it accepts. A refusal from the provider comes back as `render_
 buys the same refusal. The success response carries `duration_seconds`, the seconds actually
 submitted: a clip is billed per second, so read it rather than assuming your number was taken.
 
-`generate_carousel` draws a SERIES that reads as one object. Required: `slug`, `brief`; optional
-`slides` (3-8), `aspect_ratio`, `model`, `title`. **It bills a render per slide** — five slides is
+`generate_carousel` draws a SERIES that reads as one object. Required: `brief`; optional `slug`,
+`slides` (3-8), `aspect_ratio`, `model`, `title`. Without a slug nothing of a brand look reaches
+the slides — name the style you want in the brief — nothing is filed anywhere, the `id`s come back
+`null`, and `organization` names whose credits paid. Do NOT call `list_brands` to find a slug. **It bills a render per slide** — five slides is
 five renders — and files them in order, slide 1 first. Pass the ids to `create_post` as `media_ids`
 in that order.
 

--- a/cli/skills/anomalia/SKILL.md
+++ b/cli/skills/anomalia/SKILL.md
@@ -182,7 +182,9 @@ at them, keep one.
 **Make a carousel** → `generate_carousel` with a brief. It plans the series, draws every slide and
 returns them in order plus the `continuity_tokens` that hold them together. One render per slide.
 To fix a single slide afterwards, `refine_media` on its id **with those tokens in the instruction** —
-without them that slide drifts out of the series.
+without them that slide drifts out of the series. `slug` is OPTIONAL here too: without it the
+slides take nothing from any brand (name the look in the brief), are filed nowhere, and their
+`id`s come back `null`.
 
 **Animate an image you already have** → `generate_video` with its `base_media_id`. That is how
 "make a 5s clip of this photo" works, and it needs **no post**: the clip lands in the library and
@@ -195,6 +197,13 @@ so it returns a `job_id`; `query` on `video_renders` says when it landed. The mo
 than an order of magnitude, so read `get_media_models` (slot `videoModel`, or `videoImageModel` when animating an image) before
 spending. With a slug the clip follows this brand's visual direction, so you do not have to
 describe it — and there is no switch for it here.
+
+**Film without a brand** → `generate_video` with no `slug`. Same tool, and what changes is where
+the clip ends up: no brand, no library, no `media_id` and nothing for `create_post`. The finished
+clip lands on the job itself — `GET /api/v1/videos` (add `?job_id=` for one) and its `media_url`
+is where the file is. `query` cannot see it: that tool reads a brand. Without a slug
+`base_media_id` is the `storage_path` or `url` a brand-free generate handed you, never a library
+id and never a web address.
 
 **Give a post the image it is missing** → `render_post`. It draws from the prompt already written
 on that post and attaches it. One render. To draw a picture that is not tied to a post, use
@@ -214,6 +223,13 @@ different subject — the commonest and most expensive mistake on this surface. 
 never overwritten: refining files a new asset, so a wrong edit costs one render and not your
 source. A clip needs the brand to have chosen a video refine model; until it has, `refine_media`
 says `no_refine_model` instead of quietly filming a new one.
+
+`slug` is OPTIONAL on `refine_media` as well, and then `base_media_id` means something else: the
+`storage_path` (a picture) or the `url` (a clip) that a brand-free `generate_image`,
+`generate_carousel` or `generate_video` handed back. Nothing else resolves — a library id has no
+brand to be looked up in, and a web address is refused as `source_not_found` rather than fetched.
+The result is filed nowhere either, `brand_style` is refused because there is no brand to apply,
+and a clip has no brand preference to read, so pass `model` or it comes back `no_refine_model`.
 
 **Check your copy before you create it** → `check_content` with the same spec you would send to
 `create_post`. It returns blocking errors, warnings and a 0–100 score per platform, each naming

--- a/cli/skills/anomalia/references/tools.md
+++ b/cli/skills/anomalia/references/tools.md
@@ -302,11 +302,21 @@ there is no quality control, no critic that rejects a bad frame, no retry you di
 What comes back is what was billed, however crooked. Judging it is YOUR job — open the
 `signed_url`, look, and if it is wrong send it to `refine_media` rather than prompting again.
 
-`refine_media` changes something that is already in the library — an image or a video — and files
-the result as a **new** asset, so the original is never overwritten and a refinement cannot destroy
-what it started from. Required: `slug`, `base_media_id` (from `brand_media`, and it must belong to
-this brand — anything else is `source_not_found`), `instruction`. Say what should CHANGE, not what
+`refine_media` changes something you already made — an image or a video — and files the result as a
+**new** asset, so the original is never overwritten and a refinement cannot destroy what it started
+from. Required: `base_media_id`, `instruction`; optional `slug`. Say what should CHANGE, not what
 the whole thing should be.
+
+**`slug` decides what `base_media_id` means, and there is no overlap.** WITH it: an id from
+`brand_media` that belongs to that brand — anything else is `source_not_found`. WITHOUT it: the
+`storage_path` (a picture) or the `url` (a clip) that a brand-free `generate_image`,
+`generate_carousel` or `generate_video` handed back. A library id cannot be resolved without a
+brand to look it up in, and a web address of your own choosing is refused as `source_not_found`
+rather than fetched — the source is always something we handed you, from our own storage. Without
+a slug nothing is filed anywhere either (`id` comes back `null`), `brand_style` is refused as
+`brand_style_needs_a_brand`, and a clip has no brand preference to read so you must pass `model`
+or it comes back `no_refine_model`. The credits come from your organisation, named in
+`organization`.
 
 **You do not say what kind it is.** The asset's own kind, read from the library row, picks the
 engine: a picture goes to the image refiner, a clip to the video one, and the answer says which in
@@ -324,10 +334,12 @@ clip always comes back as one.
 model can be handed, and the answer carries its `bytes` and the `limit`. An oversized source is
 shrunk before the model sees it, so this only reaches you for a file beyond even that — import a
 lighter copy. **Never answer it by generating a replacement**: the original is still the customer's
-and a fresh render is a different picture.
+and a fresh render is a different picture. Without a slug the same applies to a `storage_path` you
+were handed, and `bytes` comes back `null` there — no library row carries the weight — while the
+`limit` still does.
 
-`generate_video` films a NEW clip into the library. Required: `slug`, `prompt`; optional
-`base_media_id`, `duration`, `aspect_ratio`, `model`, `title`. **`base_media_id` pointing at a
+`generate_video` films a NEW clip. Required: `prompt`; optional `slug`, `base_media_id`,
+`duration`, `aspect_ratio`, `model`, `title`. **`base_media_id` pointing at a
 library IMAGE is how you animate a photo** — the image becomes the clip's first frame, so subject,
 scene and style come from those pixels and the prompt directs the movement only. Without it the clip
 is filmed from the prompt alone. It creates nothing in the calendar; when the clip lands, pass its
@@ -336,6 +348,15 @@ is filmed from the prompt alone. It creates nothing in the calendar; when the cl
 A clip takes minutes, so this returns `status: rendering` and a `job_id`, and a `query` on
 `video_renders` says when it is done — do not call it again for the same clip while one is
 rendering, that bills a second.
+
+**Without `slug` the clip has nowhere to be filed, so it lands on the job itself.** No brand, no
+library, no `media_id`, nothing for `create_post`: `GET /api/v1/videos` (add `?job_id=` for one)
+returns the job and its `media_url` is where the file is. `query` will not find it — that tool
+reads a brand. `base_media_id` without a slug is the `storage_path` or `url` a brand-free generate
+handed you; a web address is refused as `source_not_found`. The monthly video allowance belongs to
+a brand's plan, so it is not checked here: the only ceiling is the organisation's credit balance,
+and `organization` in the answer names who paid. Do NOT call `list_brands` to find a slug — if
+nobody named a brand there is no brand, and guessing one spends someone else's credits.
 Animating and filming are two different jobs with two different model lists (`videoImageModel` and
 `videoModel`): a model valid for one is refused for the other with `model_not_for_slot` and the
 accepted list. Refusals: `source_not_found` (404) means the id is not this brand's or does not
@@ -347,8 +368,10 @@ names the nearest it accepts. A refusal from the provider comes back as `render_
 buys the same refusal. The success response carries `duration_seconds`, the seconds actually
 submitted: a clip is billed per second, so read it rather than assuming your number was taken.
 
-`generate_carousel` draws a SERIES that reads as one object. Required: `slug`, `brief`; optional
-`slides` (3-8), `aspect_ratio`, `model`, `title`. **It bills a render per slide** — five slides is
+`generate_carousel` draws a SERIES that reads as one object. Required: `brief`; optional `slug`,
+`slides` (3-8), `aspect_ratio`, `model`, `title`. Without a slug nothing of a brand look reaches
+the slides — name the style you want in the brief — nothing is filed anywhere, the `id`s come back
+`null`, and `organization` names whose credits paid. Do NOT call `list_brands` to find a slug. **It bills a render per slide** — five slides is
 five renders — and files them in order, slide 1 first. Pass the ids to `create_post` as `media_ids`
 in that order.
 

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -4,7 +4,7 @@
 > Non si modifica a mano: il prossimo che rigenera cancella le correzioni.
 
 **80 tool** — 9 in lettura, 53 in scrittura, 18 che distruggono.
-Il payload di `tools/list` pesa **87.705 caratteri**, circa **21.926 token**, ed e' il costo che ogni sessione paga prima di dire una parola.
+Il payload di `tools/list` pesa **88.948 caratteri**, circa **22.237 token**, ed e' il costo che ogni sessione paga prima di dire una parola.
 
 | gruppo | tool |
 |---|---:|
@@ -104,7 +104,7 @@ Write captions — text only, no media, and NO post is created: pass a caption t
 
 *Generate a carousel*
 
-To make a carousel — a SERIES of images that read as one object, not N unrelated pictures. Slide 1 is the cover and must work at thumbnail size; every later slide advances the angle one concrete step and carries exactly one idea. It spends credits: one render per slide, so a 5-slide carousel is five renders. It creates nothing in the calendar and publishes nothing: pass the ids to create_post as media_ids, in order. TO CHANGE ONE SLIDE use refine_media on that slide id, and put the `continuity_tokens` this returns back into your instruction — they are what holds the series together, and an edit that touches palette, light or the recurring motif without them takes that slide out of the set. With a slug, this brand's look is applied to every slide and there is no way to switch it off here.
+To make a carousel — a SERIES of images that read as one object, not N unrelated pictures. Slide 1 is the cover and must work at thumbnail size; every later slide advances the angle one concrete step and carries exactly one idea. It spends credits: one render per slide, so a 5-slide carousel is five renders. It creates nothing in the calendar and publishes nothing: pass the ids to create_post as media_ids, in order. TO CHANGE ONE SLIDE use refine_media on that slide id, and put the `continuity_tokens` this returns back into your instruction — they are what holds the series together, and an edit that touches palette, light or the recurring motif without them takes that slide out of the set. With a slug, this brand's look is applied to every slide and there is no way to switch it off here. WITHOUT slug no brand look reaches the slides — name the style in the brief — and the ids come back null. Do NOT call list_brands to find a slug: guessing a brand spends someone else's credits.
 
 | campo | tipo | |
 |---|---|---|
@@ -113,7 +113,7 @@ To make a carousel — a SERIES of images that read as one object, not N unrelat
 | `aspect_ratio`? | `1:1` \| `4:5` \| `9:16` \| `16:9` |  |
 | `model`? | string | For THIS call only; it changes no brand setting. Omit for the brand’s choice. Ids from get_media_models (slot imageModel); anything else is refused as model_not_for_slot. |
 | `title`? | string | The name the slides carry in the library |
-| `slug` | string |  |
+| `slug`? | string | Brand URL slug. Optional here: omit it to run without a brand — the tool description says what changes. |
 
 ### `publish_post` · D
 
@@ -723,7 +723,7 @@ Import this brand's past social posts so the AI can imitate how it already write
 
 *Generate an image*
 
-To draw a picture from a description — "an image of a cat", a product shot, a background for a slide. With a slug, this brand's own look is applied by default — its colours, its fonts, its visual direction — so you do not have to describe them; brand_style: ignore leaves them out. Without a slug there is no brand and none of that reaches the model, so name the style you want in the prompt. WITHOUT slug this is a one-off drawing: no brand, nothing filed anywhere, id comes back null and there is nothing to hand to create_post. WITH slug the image lands in that brand's library and its id is what create_post takes as media_ids. Do NOT call list_brands to decide where to draw — if nobody named a brand there is no brand, and guessing one spends a real organisation's credits and litters a real library. It spends credits: one render per image, and `renders` in the answer says how many were billed, cost_usd what they cost. It creates nothing in the calendar and publishes nothing, so ask for two or three with `count`, look at them, keep one. To CHANGE a picture that already exists use refine_media — correcting one drawing beats redrawing until it is right. To pick the model read get_media_models and pass `model`, for this call only; set_media_model changes the brand from now on.
+To draw a picture from a description — "an image of a cat", a product shot, a background for a slide. With a slug, this brand's own look is applied by default — its colours, its fonts, its visual direction — so you do not have to describe them; brand_style: ignore leaves them out. Without a slug there is no brand and none of that reaches the model, so name the style you want in the prompt. WITHOUT slug this is a one-off drawing: no brand, nothing filed anywhere, id comes back null and there is nothing to hand to create_post. WITH slug the image lands in that brand's library and its id is what create_post takes as media_ids. Do NOT call list_brands to find a slug: guessing a brand spends a real organisation's credits and litters a real library. It spends credits: one render per image, and `renders` in the answer says how many were billed, cost_usd what they cost. It creates nothing in the calendar and publishes nothing, so ask for two or three with `count`, look at them, keep one. To CHANGE a picture that already exists use refine_media — correcting one drawing beats redrawing until it is right. To pick the model read get_media_models and pass `model`, for this call only; set_media_model changes the brand from now on.
 
 | campo | tipo | |
 |---|---|---|
@@ -739,17 +739,17 @@ To draw a picture from a description — "an image of a cat", a product shot, a 
 
 *Generate a video*
 
-To make a video: animate a photo you already have, or film a clip from a prompt alone. "Animate this photo", "a 5 second video of this image" — that is `base_media_id` pointing at a library image plus a prompt for the movement, and it needs NO post. It spends credits, and the model moves that bill by more than an order of magnitude, so read get_media_models (slot videoModel from a prompt, videoImageModel when animating an image) and pass `model` for this call only. A clip takes minutes: this returns a job_id with status rendering, and check_media_job says when it landed — calling this again for the same clip bills a second one. It creates nothing in the calendar and publishes nothing; when the clip lands, pass its media_id to create_post as media_ids. To animate the cover of a post you already have, make_video does it in one step.
+To make a video: animate a photo you already have, or film a clip from a prompt alone. "Animate this photo", "a 5 second video of this image" — that is `base_media_id` pointing at a library image plus a prompt for the movement, and it needs NO post. It spends credits, and the model moves that bill by more than an order of magnitude, so read get_media_models (slot videoModel from a prompt, videoImageModel when animating an image) and pass `model` for this call only. A clip takes minutes: this returns a job_id with status rendering, and check_media_job says when it landed — calling this again for the same clip bills a second one. It creates nothing in the calendar and publishes nothing; when the clip lands, pass its media_id to create_post as media_ids. To animate the cover of a post you already have, make_video does it in one step. WITHOUT slug the clip is filed nowhere and has no media_id: it lands on the job itself, at GET /api/v1/videos (?job_id= for one), whose media_url is the file. base_media_id is then the storage_path or url a brand-free generate handed back. Do NOT call list_brands to find a slug: guessing a brand spends someone else's credits.
 
 | campo | tipo | |
 |---|---|---|
 | `prompt` | string | What the clip should show, or how the image should move |
-| `base_media_id`? | string | A library IMAGE to animate, from list_media — an id or an unambiguous prefix. Omit to film from the prompt alone. |
+| `base_media_id`? | string | An IMAGE to animate. WITH slug: a library id from list_media, or an unambiguous prefix. WITHOUT slug: the storage_path or url a brand-free generate handed back. Omit to film from the prompt alone. |
 | `duration`? | integer | Seconds. Each model accepts its own window and most will not go below 10 — a duration outside it is refused as duration_out_of_range naming the nearest it accepts, rather than quietly rounded up, because a clip is billed per second. |
 | `aspect_ratio`? | `1:1` \| `9:16` \| `16:9` |  |
 | `model`? | string | For THIS call only; it changes no brand setting. Omit for the brand’s choice. Ids from get_media_models (slot videoModel, or videoImageModel when base_media_id is set); anything else is refused as model_not_for_slot. |
 | `title`? | string | The name the clip carries in the library |
-| `slug` | string |  |
+| `slug`? | string | Brand URL slug. Optional here: omit it to run without a brand — the tool description says what changes. |
 
 ### `get_media_models` · R
 
@@ -791,17 +791,17 @@ To turn a post you already have into a video: this animates that post's cover im
 
 *Refine media you already made*
 
-To change a photo or a video you already have — "make it red", "warmer background", "remove the cup on the left", "keep the movement but make it night" — instead of making a new one. base_media_id is any asset in this brand’s library, image or video alike; list_media finds it, and a short prefix works. It starts FROM that asset: the picture you already made comes back changed, not redrawn. Say what should CHANGE, not what the whole thing should be. The result is filed as a NEW asset, so a wrong edit costs one render and never your original. Do NOT reach for generate_image or generate_video to alter something: those two start from nothing and give you a different subject, which is the mistake this tool exists to end. It spends credits, and the answer says how many renders were billed. It creates nothing in the calendar and publishes nothing; pass the id it returns to create_post as media_ids when you want a post. Each kind has its own model — get_media_models, slot imageRefineModel for a picture and videoRefineModel for a clip — and model here applies to this call only. A clip has no refine model until the brand picks one, and until then a video comes back no_refine_model rather than quietly redrawn. The brand look is applied as it is on generate_image; brand_style: ignore leaves it out, pictures only. source_too_large means the file is heavier than a model can be handed — the answer names its weight and the ceiling. The asset IS there: shrink it or import a lighter copy, never generate a replacement.
+To change a photo or a video you already have — "make it red", "warmer background", "remove the cup on the left", "keep the movement but make it night" — instead of making a new one. base_media_id is any asset in this brand’s library, image or video alike; list_media finds it, and a short prefix works. It starts FROM that asset: the picture you already made comes back changed, not redrawn. Say what should CHANGE, not what the whole thing should be. The result is filed as a NEW asset, so a wrong edit costs one render and never your original. Do NOT reach for generate_image or generate_video to alter something: those two start from nothing and give you a different subject, which is the mistake this tool exists to end. It spends credits, and the answer says how many renders were billed. It creates nothing in the calendar and publishes nothing; pass the id it returns to create_post as media_ids when you want a post. Each kind has its own model — get_media_models, slot imageRefineModel for a picture and videoRefineModel for a clip — and model here applies to this call only. A clip has no refine model until the brand picks one, and until then a video comes back no_refine_model rather than quietly redrawn. The brand look is applied as it is on generate_image; brand_style: ignore leaves it out, pictures only. source_too_large means the file is heavier than a model can be handed — the answer names its weight and the ceiling. The asset IS there: shrink it or import a lighter copy, never generate a replacement. WITHOUT slug base_media_id is instead the storage_path or url a brand-free generate handed you — never a library id, never a web address (refused as source_not_found). Nothing is filed, brand_style is refused, and a clip needs `model`. Do NOT call list_brands to find a slug: guessing a brand spends someone else's credits.
 
 | campo | tipo | |
 |---|---|---|
-| `base_media_id` | string | The library asset to start from — an id from list_media, or an unambiguous prefix. Its own kind decides how it is refined: you do not say whether it is a picture or a clip. |
+| `base_media_id` | string | WITH slug: a library id from list_media, or an unambiguous prefix. WITHOUT slug: the storage_path or url a brand-free generate handed back. Its own kind decides how it is refined: you never say which. |
 | `instruction` | string | What should change about it |
 | `count`? | integer | How many alternatives to draw, 1-4. Each one bills a render. Defaults to 1. |
 | `model`? | string | For THIS call only; it changes no brand setting. Omit for the brand’s choice. Ids from get_media_models (slot imageRefineModel for a picture, videoRefineModel for a clip); anything else is refused as model_not_for_slot. |
 | `brand_style`? | `apply` \| `ignore` | Whether this brand's own look — colours, fonts, visual direction — is applied. Omit it and it is. Send `ignore` when the picture must take nothing from the brand: a UI screenshot, an illustration about somebody else, a neutral background. Without a slug there is no brand to apply or ignore: refused as brand_style_needs_a_brand. |
 | `title`? | string | The name the new asset carries in the library |
-| `slug` | string |  |
+| `slug`? | string | Brand URL slug. Optional here: omit it to run without a brand — the tool description says what changes. |
 
 ### `set_media_model` · W
 

--- a/packages/api-contracts/src/brand-free.test.ts
+++ b/packages/api-contracts/src/brand-free.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import { BRAND_ENDPOINTS, GENERATE_IMAGE, pathFor, pathWithoutBrand } from './index';
+import {
+  BRAND_ENDPOINTS,
+  GENERATE_CAROUSEL,
+  GENERATE_IMAGE,
+  GENERATE_VIDEO,
+  REFINE_MEDIA,
+  pathFor,
+  pathWithoutBrand
+} from './index';
 
 /**
  * Un generatore raggiungibile solo sotto un brand è un generatore che, per disegnare un gatto,
@@ -10,26 +18,93 @@ import { BRAND_ENDPOINTS, GENERATE_IMAGE, pathFor, pathWithoutBrand } from './in
  * Le due metà si tengono. Un `slug` opzionale che la descrizione non spiega viene riempito lo
  * stesso — con un brand a caso, i cui crediti sono di qualcun altro.
  */
-describe('generate_image senza un brand', () => {
-  it('dichiara una strada che non passa da nessun brand', () => {
+describe('generare senza un brand', () => {
+  it('ogni motore dichiara una strada che non passa da nessun brand', () => {
     expect(pathWithoutBrand(GENERATE_IMAGE)).toBe('/api/v1/images');
+    expect(pathWithoutBrand(GENERATE_VIDEO)).toBe('/api/v1/videos');
+    expect(pathWithoutBrand(GENERATE_CAROUSEL)).toBe('/api/v1/carousel');
+    expect(pathWithoutBrand(REFINE_MEDIA)).toBe('/api/v1/refine');
   });
 
-  it('tiene la strada del brand esattamente dov era', () => {
+  it('tiene le strade del brand esattamente dov erano', () => {
     expect(pathFor(GENERATE_IMAGE, 'demo')).toBe('/api/v1/brands/demo/media/images');
+    expect(pathFor(GENERATE_VIDEO, 'demo')).toBe('/api/v1/brands/demo/media/videos');
+    expect(pathFor(GENERATE_CAROUSEL, 'demo')).toBe('/api/v1/brands/demo/media/carousel');
+    expect(pathFor(REFINE_MEDIA, 'demo')).toBe('/api/v1/brands/demo/media/refine');
   });
 
-  it('è l unico endpoint che dichiara di saperne fare a meno', () => {
+  /**
+   * I quattro motori, e soltanto loro. Un `slug` opzionale sparso altrove toglierebbe il confine
+   * invece di aprire una porta: `pathWithoutBrand` è ciò che rende opzionale lo slug su MCP.
+   */
+  it('sono i quattro motori a saperne fare a meno, e nessun altro', () => {
     const brandFree = BRAND_ENDPOINTS.filter((e) => e.pathWithoutBrand);
 
-    expect(brandFree.map((e) => e.tool)).toEqual(['generate_image']);
+    expect(brandFree.map((e) => e.tool).sort()).toEqual([
+      'generate_carousel',
+      'generate_image',
+      'generate_video',
+      'refine_media'
+    ]);
   });
 
-  it('un endpoint che non lo dichiara non ha una strada senza brand', () => {
-    const anchored = BRAND_ENDPOINTS.find((e) => e.tool === 'refine_media');
+  /**
+   * Gli editor di un post restano ancorati, e non per dimenticanza: lavorano su una riga di
+   * `posts`, che appartiene a un brand. Senza brand non c'è il post da modificare, quindi non c'è
+   * niente da aprire — dichiararli sarebbe una porta su una stanza che non esiste.
+   */
+  it('chi lavora su un post resta ancorato al brand del post', () => {
+    for (const tool of ['regenerate_slide', 'reorder_slides', 'regenerate_post_media', 'make_video']) {
+      const anchored = BRAND_ENDPOINTS.find((e) => e.tool === tool);
 
-    expect(pathWithoutBrand(anchored!)).toBeNull();
+      expect(pathWithoutBrand(anchored!), tool).toBeNull();
+    }
   });
+});
+
+/**
+ * La descrizione è metà del lavoro: uno slug reso opzionale senza dirlo nel campo è il difetto già
+ * pagato — un modello lo riempie comunque, scegliendo un brand a caso, con i crediti di qualcun
+ * altro. Ogni motore deve dire che cosa cambia quando lo slug non c'è.
+ */
+describe('le descrizioni dicono che cosa cambia senza slug', () => {
+  for (const endpoint of [GENERATE_IMAGE, GENERATE_VIDEO, GENERATE_CAROUSEL, REFINE_MEDIA]) {
+    it(`${endpoint.tool} dice che senza slug non c e un brand`, () => {
+      expect(endpoint.description).toMatch(/WITHOUT slug/);
+    });
+
+    it(`${endpoint.tool} vieta di cercare un brand per decidere dove generare`, () => {
+      expect(endpoint.description).toMatch(/Do NOT call list_brands/);
+    });
+  }
+
+  it('generate_video dice dove si ritrova un clip che nessuna libreria reclama', () => {
+    expect(GENERATE_VIDEO.description).toMatch(/GET \/api\/v1\/videos/);
+  });
+
+  it('refine_media dice che la sorgente è la maniglia consegnata, non un indirizzo', () => {
+    expect(REFINE_MEDIA.input.shape.base_media_id.description).toMatch(/storage_path/);
+    expect(REFINE_MEDIA.description).toMatch(/never a web address/);
+  });
+});
+
+/**
+ * Chi paga viene DETTO, su ogni strada senza brand: il chiamante non l'ha scelto, e un addebito
+ * che nessuno ha nominato è un addebito che nessuno controlla.
+ */
+describe('chi paga è nominato in ogni risposta', () => {
+  for (const endpoint of [GENERATE_IMAGE, GENERATE_VIDEO, GENERATE_CAROUSEL, REFINE_MEDIA]) {
+    it(`${endpoint.tool} porta l organizzazione nella risposta`, () => {
+      expect((endpoint.output as { shape: Record<string, unknown> }).shape.organization).toBeDefined();
+    });
+
+    it(`${endpoint.tool} dichiara i rifiuti della strada senza brand`, () => {
+      const errors = endpoint.failures.map((f) => f.error);
+
+      expect(errors).toContain('brand_scoped_key');
+      expect(errors).toContain('no_organization');
+    });
+  }
 });
 
 /**

--- a/packages/api-contracts/src/posts.ts
+++ b/packages/api-contracts/src/posts.ts
@@ -528,6 +528,16 @@ const MODEL_FAILURE = { error: 'model_not_for_slot', status: 400 } as const;
 
 const BRAND_STYLE_FAILURE = { error: 'brand_style_needs_a_brand', status: 400 } as const;
 
+/**
+ * I due rifiuti che una strada senza brand porta con sé, ovunque esista. `brand_scoped_key` non è
+ * un permesso mancante da allargare: è una restrizione che l'utente ha scelto, e dove nessun brand
+ * si nomina non c'è niente da confrontarci.
+ */
+const BRAND_FREE_FAILURES = [
+  { error: 'brand_scoped_key', status: 403 },
+  { error: 'no_organization', status: 500 }
+] as const;
+
 const BrandStyleField = z
   .enum(['apply', 'ignore'])
   .optional()
@@ -539,12 +549,22 @@ const BrandStyleField = z
   );
 
 /**
- * Un disegno chiesto senza brand non entra in nessuna libreria, quindi non ha un id da mostrare:
- * `null` è il fatto, e dirlo qui è ciò che impedisce di passarlo a `create_post` e di cercarlo con
- * `list_media`. Non è la stessa forma di `refine_media`, che un brand ce l'ha sempre e un id
- * lo restituisce sempre — allargare anche il suo schema significherebbe togliere una promessa
- * che mantiene.
+ * La forma di OGNI asset prodotto senza nominare un brand — disegno, slide di carosello,
+ * rifinitura. Non entra in nessuna libreria, quindi non ha un id da mostrare: `null` è il fatto, e
+ * dirlo qui è ciò che impedisce di passarlo a `create_post` e di cercarlo con `list_media`.
  */
+/**
+ * Chi ha pagato, per nome. Serve dove il chiamante NON ha scelto: senza slug l'organizzazione
+ * l'abbiamo risolta noi, e un addebito che nessuno ha nominato è un addebito che nessuno controlla.
+ * Con lo slug è `null`, perché il brand nomina il suo pagante da sé.
+ */
+const OrganizationField = z
+  .object({ id: z.string(), name: z.string().nullable() })
+  .nullable()
+  .describe(
+    'Whose credits paid, named — set when no brand was given, null when one was (the brand names its own payer).'
+  );
+
 const DrawnMediaSchema = GeneratedMediaSchema.extend({
   id: z
     .string()
@@ -564,12 +584,7 @@ const DrawnImageResult = z.object({
   media: z.array(DrawnMediaSchema),
   model: ImageResult.shape.model,
   renders: ImageResult.shape.renders,
-  organization: z
-    .object({ id: z.string(), name: z.string().nullable() })
-    .nullable()
-    .describe(
-      'Whose credits paid, named — set when no brand was given, null when one was (the brand names its own payer).'
-    ),
+  organization: OrganizationField,
   cost_usd: z
     .number()
     .nullable()
@@ -587,8 +602,8 @@ export const GENERATE_IMAGE = {
     'you want in the prompt. WITHOUT slug this is a one-off drawing: no brand, nothing filed ' +
     'anywhere, id comes back null and there is nothing to hand to create_post. WITH slug the ' +
     "image lands in that brand's library and its id is what create_post takes as media_ids. Do " +
-    'NOT call list_brands to decide where to draw — if nobody named a brand there is no brand, ' +
-    "and guessing one spends a real organisation's credits and litters a real library. It spends " +
+    "NOT call list_brands to find a slug: guessing a brand spends a real organisation's credits " +
+    'and litters a real library. It spends ' +
     'credits: one render per image, and `renders` in the answer says how many were billed, ' +
     'cost_usd what they cost. It creates nothing in the calendar and publishes nothing, so ask ' +
     'for two or three with `count`, look at them, keep one. To CHANGE a picture that already ' +
@@ -613,6 +628,7 @@ export const GENERATE_IMAGE = {
     { error: 'credits_exhausted', status: 402 },
     MODEL_FAILURE,
     BRAND_STYLE_FAILURE,
+    ...BRAND_FREE_FAILURES,
     { error: 'render_failed', status: 502 },
     { error: 'store_failed', status: 502 }
   ],
@@ -646,17 +662,22 @@ export const REFINE_MEDIA = {
     'look is applied as it is on generate_image; brand_style: ignore leaves it out, pictures only. ' +
     'source_too_large means the file is heavier than a model can be handed — the answer names its ' +
     'weight and the ceiling. The asset IS there: shrink it or import a lighter copy, never ' +
-    'generate a replacement.',
+    'generate a replacement. WITHOUT slug base_media_id is instead the storage_path or url a ' +
+    'brand-free generate handed you — never a library id, never a web address (refused as ' +
+    'source_not_found). Nothing is filed, brand_style is refused, and a clip needs `model`. ' +
+    "Do NOT call list_brands to find a slug: guessing a brand spends someone else's credits.",
   method: 'POST',
   pathUnderBrand: '/media/refine',
+  pathWithoutBrand: '/refine',
   input: z
     .object({
       base_media_id: z
         .string()
         .min(1)
         .describe(
-          'The library asset to start from — an id from list_media, or an unambiguous prefix. Its ' +
-            'own kind decides how it is refined: you do not say whether it is a picture or a clip.'
+          'WITH slug: a library id from list_media, or an unambiguous prefix. WITHOUT slug: the ' +
+            'storage_path or url a brand-free generate handed back. Its own kind decides how it ' +
+            'is refined: you never say which.'
         ),
       instruction: z.string().min(1).describe('What should change about it'),
       count: AlternativesField,
@@ -670,13 +691,16 @@ export const REFINE_MEDIA = {
     kind: z
       .enum(['image', 'video'])
       .describe('What was refined, read from the source asset — never from what you asked for'),
-    media: z.array(GeneratedMediaSchema),
+    media: z.array(DrawnMediaSchema),
     model: z.string().nullable().describe('The model that ACTUALLY made it'),
-    renders: z.number().describe('How many renders were BILLED')
+    renders: z.number().describe('How many renders were BILLED'),
+    organization: OrganizationField
   }),
   failures: [
     { error: 'credits_exhausted', status: 402 },
     MODEL_FAILURE,
+    BRAND_STYLE_FAILURE,
+    ...BRAND_FREE_FAILURES,
     { error: 'source_not_found', status: 404 },
     { error: 'source_too_large', status: 413 },
     { error: 'kind_not_refinable', status: 400 },
@@ -691,6 +715,7 @@ const VideoJobResult = z.object({
   ok: z.literal(true),
   status: z.literal('rendering'),
   job_id: z.string(),
+  organization: OrganizationField,
   model: z.string().nullable().describe('The model that is filming it; null when the platform default chose'),
   duration_seconds: z
     .number()
@@ -711,9 +736,13 @@ export const GENERATE_VIDEO = {
     'check_media_job says when it landed — calling this again for the same clip bills a second ' +
     'one. It creates nothing in the calendar and publishes nothing; when the clip lands, pass its ' +
     'media_id to create_post as media_ids. To animate the cover of a post you already have, ' +
-    'make_video does it in one step.',
+    'make_video does it in one step. WITHOUT slug the clip is filed nowhere and has no media_id: ' +
+    'it lands on the job itself, at GET /api/v1/videos (?job_id= for one), whose media_url is ' +
+    'the file. base_media_id is then the storage_path or url a brand-free generate handed back. ' +
+    "Do NOT call list_brands to find a slug: guessing a brand spends someone else's credits.",
   method: 'POST',
   pathUnderBrand: '/media/videos',
+  pathWithoutBrand: '/videos',
   input: z
     .object({
       prompt: z.string().min(1).describe('What the clip should show, or how the image should move'),
@@ -722,7 +751,9 @@ export const GENERATE_VIDEO = {
         .min(1)
         .optional()
         .describe(
-          'A library IMAGE to animate, from list_media — an id or an unambiguous prefix. Omit to film from the prompt alone.'
+          'An IMAGE to animate. WITH slug: a library id from list_media, or an unambiguous ' +
+            'prefix. WITHOUT slug: the storage_path or url a brand-free generate handed back. ' +
+            'Omit to film from the prompt alone.'
         ),
       duration: z.coerce
         .number()
@@ -744,6 +775,7 @@ export const GENERATE_VIDEO = {
   failures: [
     { error: 'credits_exhausted', status: 402 },
     MODEL_FAILURE,
+    ...BRAND_FREE_FAILURES,
     { error: 'video_budget_exhausted', status: 400 },
     { error: 'source_not_found', status: 404 },
     { error: 'source_not_an_image', status: 400 },
@@ -766,9 +798,13 @@ export const GENERATE_CAROUSEL = {
     'refine_media on that slide id, and put the `continuity_tokens` this returns back into your ' +
     'instruction — they are what holds the series together, and an edit that touches palette, ' +
     'light or the recurring motif without them takes that slide out of the set. With a slug, this ' +
-    'brand\'s look is applied to every slide and there is no way to switch it off here.',
+    'brand\'s look is applied to every slide and there is no way to switch it off here. WITHOUT ' +
+    'slug no brand look reaches the slides — name the style in the brief — and the ids come back ' +
+    "null. Do NOT call list_brands to find a slug: guessing a brand spends someone else's " +
+    "credits.",
   method: 'POST',
   pathUnderBrand: '/media/carousel',
+  pathWithoutBrand: '/carousel',
   input: z
     .object({
       brief: z.string().min(1).describe('What the carousel should say, as a whole'),
@@ -780,16 +816,18 @@ export const GENERATE_CAROUSEL = {
     .strict(),
   output: z.object({
     ok: z.literal(true),
-    media: z.array(GeneratedMediaSchema).describe('The slides, in order — slide 1 first'),
+    media: z.array(DrawnMediaSchema).describe('The slides, in order — slide 1 first'),
     continuity_tokens: z
       .array(z.string())
       .describe('The literal tokens repeated in every slide. Put them back into a refine_media instruction or that slide leaves the series.'),
     model: z.string().nullable(),
-    renders: z.number().describe('How many renders were BILLED — one per slide attempted')
+    renders: z.number().describe('How many renders were BILLED — one per slide attempted'),
+    organization: OrganizationField
   }),
   failures: [
     { error: 'credits_exhausted', status: 402 },
     MODEL_FAILURE,
+    ...BRAND_FREE_FAILURES,
     { error: 'plan_failed', status: 502 },
     { error: 'render_failed', status: 502 },
     { error: 'store_failed', status: 502 }

--- a/packages/api-contracts/src/write-rules.ts
+++ b/packages/api-contracts/src/write-rules.ts
@@ -88,7 +88,8 @@ export const TABLE_CHECKS: Record<string, string> = {
   "shared_views_view_type_check": "view_type in ('calendar', 'dashboard', 'monthly_report', 'strategy', 'workspace')",
   "talents_body_type_check": "body_type is null or body_type in ('slim', 'athletic', 'athletic_slim', 'average', 'curvy', 'plus', 'muscular')",
   "talents_gender_check": "gender is null or gender in ('man', 'woman', 'trans_man', 'trans_woman', 'nonbinary')",
-  "talents_height_band_check": "height_band is null or height_band in ('short', 'average', 'tall')"
+  "talents_height_band_check": "height_band is null or height_band in ('short', 'average', 'tall')",
+  "video_renders_one_payer": "num_nonnulls(brand_id, org_id) = 1"
 };
 
 export const WRITABLE_COLUMNS: Record<string, { insert: string[]; update: string[] }> = {

--- a/src/lib/content/changelog/2026-09-11-brand-free-media.ts
+++ b/src/lib/content/changelog/2026-09-11-brand-free-media.ts
@@ -1,0 +1,12 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-11',
+  title: 'Videos, carousels and edits without naming a brand',
+  items: [
+    'Agents can now film a video, draw a carousel or change something they already made without naming a brand — until now only a single image could be made that way.',
+    'A brand-free video lands on its own job instead of a library, and the answer says where to collect it.',
+    'Every brand-free answer names the organisation whose credits paid, so no render is billed anonymously.',
+    'An API key restricted to certain brands is refused on these routes rather than quietly widened.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/server/carousel-generate.ts
+++ b/src/lib/server/carousel-generate.ts
@@ -76,7 +76,7 @@ export function buildCarouselPlanPrompt(opts: { brief: string; slides: number })
 
 export async function planCarousel(
   supabase: SupabaseClient,
-  opts: { brandId: string; brief: string; slides: number }
+  opts: { brandId: string | null; brief: string; slides: number }
 ): Promise<CarouselPlan | { error: 'plan_failed' }> {
   const { aiStructured } = await import('$lib/server/ai-text');
   void supabase;

--- a/src/lib/server/cli-auth.org-scope.test.ts
+++ b/src/lib/server/cli-auth.org-scope.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * L'ingresso di ogni strada senza brand, in un posto solo.
+ *
+ * Quando queste risposte erano scritte dentro UNA rotta, la seconda rotta che nasceva le copiava —
+ * e la terza ne copiava una versione vecchia. Qui si misurano una volta, ed è il motivo per cui
+ * esistono: un render che parte quando non doveva è denaro speso, e uno che parte senza dire a chi
+ * è stato addebitato è denaro speso in silenzio.
+ */
+
+const ensureOrgForUser = vi.fn();
+const gateOrgCredits = vi.fn();
+
+vi.mock('$lib/server/access', () => ({ userCanEnter: async () => true }));
+vi.mock('$lib/server/org', () => ({ ensureOrgForUser: (...a: unknown[]) => ensureOrgForUser(...a) }));
+vi.mock('./credits', () => ({
+  gateOrgCredits: (...a: unknown[]) => gateOrgCredits(...a),
+  CreditsExhaustedError: class CreditsExhaustedError extends Error {}
+}));
+
+import { orgScopeFor, brandStyleRefusal, apiKeyIsBrandScoped, type ApiKeyInfo } from './cli-auth';
+
+function supabaseNaming(name: string | null) {
+  return {
+    from: () => ({
+      select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: { id: 'org-1', name }, error: null }) }) })
+    })
+  };
+}
+
+const scopedKey: ApiKeyInfo = {
+  id: 'key-1',
+  name: 'solo acme',
+  user_id: 'user-1',
+  permissions: { brand_ids: ['brand-1'], scopes: ['write'] }
+};
+
+function caller(over: Record<string, unknown> = {}) {
+  return {
+    supabase: supabaseNaming('Acme'),
+    user: { id: 'user-1', email: 'andrea@teta.so' },
+    apiKey: undefined,
+    error: undefined,
+    ...over
+  } as never;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  ensureOrgForUser.mockResolvedValue('org-1');
+  gateOrgCredits.mockResolvedValue(undefined);
+});
+
+describe('orgScopeFor', () => {
+  it('nomina chi paga, perché il chiamante non l ha scelto', async () => {
+    const { scope } = await orgScopeFor(caller());
+
+    expect(scope?.orgId).toBe('org-1');
+    expect(scope?.organization).toEqual({ id: 'org-1', name: 'Acme' });
+  });
+
+  /**
+   * Andrea ha visto agenti scegliere un brand a caso pur di avere un addebito che nessuno
+   * controlla. Senza un'organizzazione ci si FERMA: non si cerca un ripiego.
+   */
+  it('senza un organizzazione si ferma, invece di cercarne una a caso', async () => {
+    ensureOrgForUser.mockResolvedValue(null);
+
+    const { scope, error } = await orgScopeFor(caller());
+
+    expect(scope).toBeUndefined();
+    expect(error?.status).toBe(500);
+    expect(await error?.json()).toEqual({ error: 'no_organization' });
+  });
+
+  /**
+   * Una chiave ristretta a certi brand è una restrizione che l'utente ha scelto. Lasciarla spendere
+   * fuori da quei brand la allargherebbe in silenzio, proprio mentre si apre una strada nuova.
+   */
+  it('una chiave ristretta a certi brand si rifiuta, non si allarga', async () => {
+    const { error } = await orgScopeFor(caller({ apiKey: scopedKey }));
+
+    expect(error?.status).toBe(403);
+    expect(await error?.json()).toEqual({ error: 'brand_scoped_key' });
+    expect(ensureOrgForUser).not.toHaveBeenCalled();
+  });
+
+  it('una chiave che vale per tutti i brand passa', async () => {
+    const wide = { ...scopedKey, permissions: { brand_ids: '*' as const, scopes: ['write'] } };
+
+    const { scope } = await orgScopeFor(caller({ apiKey: wide }));
+
+    expect(scope?.orgId).toBe('org-1');
+  });
+
+  it('senza crediti non si apre niente', async () => {
+    const { CreditsExhaustedError } = await import('./credits');
+    gateOrgCredits.mockRejectedValue(new CreditsExhaustedError({} as never));
+
+    const { scope, error } = await orgScopeFor(caller());
+
+    expect(scope).toBeUndefined();
+    expect(error?.status).toBe(402);
+  });
+
+  it('un autenticazione fallita non arriva mai a scegliere un organizzazione', async () => {
+    const { error } = await orgScopeFor(caller({ error: new Response('no', { status: 401 }) }));
+
+    expect(error?.status).toBe(401);
+    expect(ensureOrgForUser).not.toHaveBeenCalled();
+  });
+});
+
+describe('apiKeyIsBrandScoped', () => {
+  it('una chiave assente non è ristretta a niente', () => {
+    expect(apiKeyIsBrandScoped(undefined)).toBe(false);
+  });
+});
+
+describe('brandStyleRefusal', () => {
+  it('senza brand_style non c è niente da rifiutare', () => {
+    expect(brandStyleRefusal(undefined)).toBeUndefined();
+  });
+
+  it('chiedere lo stile di un brand che non c è dice la mossa, non viene ignorato', async () => {
+    const refusal = brandStyleRefusal('apply');
+
+    expect(refusal?.status).toBe(400);
+    expect(await refusal?.json()).toMatchObject({
+      error: 'brand_style_needs_a_brand',
+      reason: expect.stringMatching(/pass a slug, or drop brand_style/)
+    });
+  });
+
+  it('anche ignore è una risposta su un brand che non c è', () => {
+    expect(brandStyleRefusal('ignore')?.status).toBe(400);
+  });
+});

--- a/src/lib/server/cli-auth.ts
+++ b/src/lib/server/cli-auth.ts
@@ -273,6 +273,85 @@ export function apiKeyIsBrandScoped(apiKey: ApiKeyInfo | undefined): boolean {
   return !!apiKey && apiKey.permissions.brand_ids !== '*';
 }
 
+export type OrgScope = {
+  supabase: SupabaseClient;
+  user: { id: string; email?: string };
+  orgId: string;
+  /** Chi ha pagato, per nome: il chiamante non l'ha scelto, quindi la risposta glielo dice. */
+  organization: { id: string; name: string | null };
+  apiKey?: ApiKeyInfo;
+};
+
+/**
+ * L'ingresso di OGNI rotta che genera senza un brand, in un posto solo — perché le domande che una
+ * strada senza brand solleva hanno una risposta sola, e scritta quattro volte divergerebbe al
+ * primo cambio:
+ *
+ *   chi paga         →  l'organizzazione dell'utente, con la stessa regola con cui atterra un
+ *                       brand nuovo (pagante prima, poi la più vecchia). Nessuna → ci si ferma.
+ *                       Andrea ha visto agenti scegliere un brand a caso pur di avere un addebito
+ *                       che nessuno controlla: è il motivo per cui questa strada esiste.
+ *   chiave ristretta →  si RIFIUTA, non si allarga: è una restrizione che l'utente ha scelto.
+ *   crediti          →  lo stesso cancello del brand, sul saldo dell'organizzazione.
+ */
+export async function openOrgScope(
+  request: Request
+): Promise<{ scope: OrgScope; error?: undefined } | { scope?: undefined; error: Response }> {
+  return orgScopeFor(await authenticate(request));
+}
+
+/**
+ * La parte che DECIDE, separata da quella che autentica. Sono due mestieri, e tenerli insieme
+ * rendeva i rifiuti raggiungibili solo passando da una chiave API vera: qui si provano per quello
+ * che sono, uno per uno.
+ */
+export async function orgScopeFor(
+  caller: Caller
+): Promise<{ scope: OrgScope; error?: undefined } | { scope?: undefined; error: Response }> {
+  const { supabase, user, error, apiKey } = caller;
+  if (error) return { error };
+
+  if (apiKeyIsBrandScoped(apiKey)) {
+    return { error: json({ error: 'brand_scoped_key' }, { status: 403 }) };
+  }
+
+  const { ensureOrgForUser } = await import('./org');
+  const orgId = await ensureOrgForUser(supabase, user as never);
+  if (!orgId) return { error: json({ error: 'no_organization' }, { status: 500 }) };
+
+  const gate = await gateOrgAiAction(orgId, apiKey);
+  if (gate) return { error: gate };
+
+  const { data } = await supabase.from('organizations').select('id, name').eq('id', orgId).maybeSingle();
+
+  return {
+    scope: {
+      supabase,
+      user,
+      orgId,
+      organization: { id: orgId, name: (data?.name as string | null | undefined) ?? null },
+      apiKey
+    }
+  };
+}
+
+/**
+ * Lo stile di un brand chiesto dove un brand non c'è. Un default silenzioso consegnerebbe qualcosa
+ * che nessuno ha chiesto: qui si dice la mossa, identica su ogni rotta che accetta il campo.
+ */
+export function brandStyleRefusal(brandStyle: string | undefined): Response | undefined {
+  if (!brandStyle) return undefined;
+
+  return json(
+    {
+      error: 'brand_style_needs_a_brand',
+      reason:
+        'brand_style governs a brand look, and no brand was named — pass a slug, or drop brand_style.'
+    },
+    { status: 400 }
+  );
+}
+
 /** The columns loadBrandForUser selects — typed, so callers don't get `unknown` everywhere. */
 export type CliBrand = {
   id: string;

--- a/src/lib/server/media-generate.brand-free-media.test.ts
+++ b/src/lib/server/media-generate.brand-free-media.test.ts
@@ -1,0 +1,382 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Il disegno senza brand esisteva già; il video, il carosello e la rifinitura no — e non era una
+ * decisione di prodotto, era un lavoro non finito. Qui si misurano le tre risposte che la strada
+ * senza brand deve dare identiche per tutte e quattro: chi paga, che cosa non esiste (la libreria),
+ * e come si nomina una sorgente quando una libreria non c'è.
+ *
+ * Il negativo che conta resta la lettura di `brands`: se un percorso senza brand la tocca ancora,
+ * è ancora ancorato a uno e l'opzionale è finto.
+ */
+
+const renderPostImage = vi.fn();
+const insertBrandMedia = vi.fn();
+const storeBrandMediaBytes = vi.fn();
+const signKnowledgePaths = vi.fn();
+const withBrandContext = vi.fn();
+const withOrgContext = vi.fn();
+const planCarousel = vi.fn();
+const submitAndTrackVideoRender = vi.fn();
+const countOutstandingVideoRenders = vi.fn();
+const imagePartFor = vi.fn();
+const transformVideo = vi.fn();
+const persistExternalVideo = vi.fn();
+const remaining = vi.fn();
+
+const PNG_DATA_URL = 'data:image/png;base64,AAAA';
+const SIGNED = 'https://storage.test/signed?token=abc';
+
+vi.mock('$lib/server/content-preview', () => ({
+  renderPostImage: (...args: unknown[]) => renderPostImage(...args),
+  buildImageRequest: (_prompt: string, opts: { model?: string }) => ({ model: opts.model ?? null }),
+  loadBrandVisualContext: vi.fn()
+}));
+vi.mock('$lib/server/brand-media', () => ({
+  loadLibraryMediaParts: async () => [],
+  insertBrandMedia: (...args: unknown[]) => insertBrandMedia(...args),
+  storeBrandMediaBytes: (...args: unknown[]) => storeBrandMediaBytes(...args),
+  probeImageDimensions: async () => ({ width: 1080, height: 1080 }),
+  resolveBrandImageIds: async () => [],
+  saveRenderedVideoToLibrary: vi.fn()
+}));
+vi.mock('$lib/server/brand-context', () => ({
+  imagePartFor: (...args: unknown[]) => imagePartFor(...args)
+}));
+vi.mock('$lib/server/media-archive', () => ({
+  signKnowledgePaths: (...args: unknown[]) => signKnowledgePaths(...args)
+}));
+vi.mock('$lib/server/content-credentials', () => ({
+  markImage: async (bytes: Buffer) => bytes,
+  DIGITAL_SOURCE_TYPE: { synthetic: 'trainedAlgorithmicMedia' }
+}));
+vi.mock('$lib/server/ai-log', () => ({
+  billedUsdInScope: () => 0.05,
+  withBrandContext: <T>(brandId: string, fn: () => T) => {
+    withBrandContext(brandId);
+    return fn();
+  },
+  withOrgContext: <T>(orgId: string, fn: () => T) => {
+    withOrgContext(orgId);
+    return fn();
+  }
+}));
+vi.mock('$lib/server/carousel-generate', () => ({
+  planCarousel: (...args: unknown[]) => planCarousel(...args),
+  clampSlideCount: (n?: number) => n ?? 5
+}));
+vi.mock('$lib/server/video-render-queue', () => ({
+  submitAndTrackVideoRender: (...args: unknown[]) => submitAndTrackVideoRender(...args),
+  countOutstandingVideoRenders: (...args: unknown[]) => countOutstandingVideoRenders(...args)
+}));
+vi.mock('$lib/server/video', () => ({
+  transformVideo: (...args: unknown[]) => transformVideo(...args),
+  persistExternalVideo: (...args: unknown[]) => persistExternalVideo(...args),
+  resolveVideoModel: () => 'bytedance/seedance-2-5',
+  clampVideoDuration: (d: number) => d
+}));
+vi.mock('$lib/server/usage', () => ({ remaining: (...args: unknown[]) => remaining(...args) }));
+vi.mock('$lib/server/supabase-admin', () => ({ createAdminClient: () => adminClient }));
+
+import {
+  generateCarouselWithoutBrand,
+  generateVideoWithoutBrand,
+  refineMediaWithoutBrand,
+  listOrgMediaJobs
+} from './media-generate';
+
+/** Legge `brands`: qui è un fallimento, non un dato. Un percorso senza brand non deve arrivarci. */
+function noBrands() {
+  return {
+    from: (table: string) => {
+      if (table === 'brands' || table === 'brand_kit' || table === 'brand_media') {
+        throw new Error(`ha letto ${table}`);
+      }
+      throw new Error(`ha letto ${table}`);
+    }
+  } as never;
+}
+
+/** L'admin del percorso video: legge la coda, e su ogni tabella di brand fallisce apposta. */
+function adminForVideo() {
+  return {
+    from: (table: string) => {
+      if (table !== 'video_renders') throw new Error(`ha letto ${table}`);
+      return {
+        select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: { id: 'job-1' }, error: null }) }) })
+      };
+    }
+  } as never;
+}
+
+let adminClient: unknown = adminForVideo();
+
+function jobsClient(rows: Array<Record<string, unknown>>) {
+  const api: Record<string, unknown> = {
+    select: () => api,
+    eq: () => api,
+    is: () => api,
+    order: () => api,
+    limit: () => api,
+    then: (res: (v: unknown) => unknown) => Promise.resolve(res({ data: rows, error: null }))
+  };
+  return { from: () => api } as never;
+}
+
+const ORG = 'org-1';
+const USER = 'user-1';
+const OWN_IMAGE = `${USER}/media/generated-a1.png`;
+const OWN_CLIP = `${USER}/generated/a1b2.mp4`;
+const SOMEONE_ELSE = 'user-2/media/generated-a1.png';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  adminClient = adminForVideo();
+  renderPostImage.mockResolvedValue(PNG_DATA_URL);
+  storeBrandMediaBytes.mockResolvedValue({});
+  signKnowledgePaths.mockImplementation(
+    async (_c: unknown, paths: string[]) => new Map(paths.map((p) => [p, SIGNED]))
+  );
+  imagePartFor.mockResolvedValue({ ok: true, part: { inlineData: { mimeType: 'image/png', data: 'AAAA' } } });
+  planCarousel.mockResolvedValue({
+    slidePrompts: ['slide uno', 'slide due', 'slide tre'],
+    continuityTokens: ['ocra', 'luce radente']
+  });
+  submitAndTrackVideoRender.mockResolvedValue({
+    taskId: 'kie-1',
+    model: 'bytedance/seedance-2-5',
+    durationSeconds: 8
+  });
+  countOutstandingVideoRenders.mockResolvedValue(0);
+  remaining.mockResolvedValue({ videos: 10 });
+});
+
+describe('un carosello senza brand', () => {
+  const job = { orgId: ORG, userId: USER, brief: 'tre motivi per cambiare sedia' };
+
+  it('non legge la tabella dei brand', async () => {
+    const out = await generateCarouselWithoutBrand(noBrands(), job);
+
+    expect(out.ok).toBe(true);
+  });
+
+  it('addebita all organizzazione, che è chi paga quando nessun brand paga', async () => {
+    await generateCarouselWithoutBrand(noBrands(), job);
+
+    expect(withOrgContext).toHaveBeenCalledWith(ORG);
+    expect(withBrandContext).not.toHaveBeenCalled();
+  });
+
+  it('consegna una slide per prompt, e nessuna entra in una libreria', async () => {
+    const out = await generateCarouselWithoutBrand(noBrands(), job);
+
+    expect(out.ok && out.media).toHaveLength(3);
+    expect(out.ok && out.renders).toBe(3);
+    expect(insertBrandMedia).not.toHaveBeenCalled();
+    expect(out.ok && out.media.every((m) => m.id === null)).toBe(true);
+  });
+
+  it('tiene i gettoni di continuità: senza, una slide rifinita esce dalla serie', async () => {
+    const out = await generateCarouselWithoutBrand(noBrands(), job);
+
+    expect(out.ok && out.continuityTokens).toEqual(['ocra', 'luce radente']);
+  });
+
+  it('una serie incompleta è un carosello mancato, non uno più corto', async () => {
+    renderPostImage.mockResolvedValueOnce(PNG_DATA_URL).mockResolvedValue(undefined);
+
+    const out = await generateCarouselWithoutBrand(noBrands(), job);
+
+    expect(out.ok).toBe(false);
+  });
+});
+
+describe('un video senza brand', () => {
+  const job = { orgId: ORG, userId: USER, prompt: 'un gatto che salta' };
+
+  it('non legge la tabella dei brand', async () => {
+    const out = await generateVideoWithoutBrand(job);
+
+    expect(out.ok).toBe(true);
+  });
+
+  it('addebita all organizzazione, che è chi paga quando nessun brand paga', async () => {
+    await generateVideoWithoutBrand(job);
+
+    expect(withOrgContext).toHaveBeenCalledWith(ORG);
+    expect(withBrandContext).not.toHaveBeenCalled();
+  });
+
+  /** La riga della coda porta il padrone addosso: è l'unica cosa che il cron avrà in mano. */
+  it('scrive l organizzazione sulla riga della coda, e nessun brand', async () => {
+    await generateVideoWithoutBrand(job);
+
+    expect(submitAndTrackVideoRender).toHaveBeenCalledWith(
+      expect.objectContaining({ brandId: null, orgId: ORG })
+    );
+  });
+
+  /** L'allocazione mensile è del piano di un brand: qui non c'è un piano da interrogare. */
+  it('non interroga l allocazione mensile di nessuno', async () => {
+    await generateVideoWithoutBrand(job);
+
+    expect(remaining).not.toHaveBeenCalled();
+    expect(countOutstandingVideoRenders).not.toHaveBeenCalled();
+  });
+
+  it('anima il percorso che il generatore senza brand ha consegnato', async () => {
+    await generateVideoWithoutBrand({ ...job, baseMediaId: OWN_IMAGE });
+
+    expect(submitAndTrackVideoRender).toHaveBeenCalledWith(
+      expect.objectContaining({ render: expect.objectContaining({ imageUrl: SIGNED }) })
+    );
+  });
+
+  /**
+   * Il primo segmento del percorso è lo user, ed è la stessa cosa che guarda la policy dello
+   * storage. Il percorso di un altro non risolve — esattamente come l'id di un altro inquilino non
+   * risolve sotto il brand. Fermarsi qui è il punto: filmare da zero chi ha chiesto di animare la
+   * SUA foto è il difetto travestito da rimedio.
+   */
+  it('il percorso di un altro utente non risolve, e il render non parte', async () => {
+    const out = await generateVideoWithoutBrand({ ...job, baseMediaId: SOMEONE_ELSE });
+
+    expect(out).toMatchObject({ ok: false, error: 'source_not_found' });
+    expect(submitAndTrackVideoRender).not.toHaveBeenCalled();
+  });
+
+  it('un indirizzo scelto da chi chiama non è una sorgente', async () => {
+    const out = await generateVideoWithoutBrand({ ...job, baseMediaId: 'https://evil.test/a.png' });
+
+    expect(out).toMatchObject({ ok: false, error: 'source_not_found' });
+    expect(submitAndTrackVideoRender).not.toHaveBeenCalled();
+  });
+
+  it('torna un job da seguire, perché un clip non è mai pronto subito', async () => {
+    const out = await generateVideoWithoutBrand(job);
+
+    expect(out.ok && out.status).toBe('rendering');
+    expect(out.ok && out.jobId).toBeTruthy();
+  });
+});
+
+describe('rifinire senza brand', () => {
+  const job = { orgId: ORG, userId: USER, baseMediaId: OWN_IMAGE, instruction: 'più caldo' };
+
+  it('parte dal percorso consegnato dal generatore, non da zero', async () => {
+    const out = await refineMediaWithoutBrand(noBrands(), job);
+
+    expect(out.ok).toBe(true);
+    expect(imagePartFor).toHaveBeenCalledWith(SIGNED);
+    const opts = renderPostImage.mock.calls[0][1];
+    expect(opts.baseImage).toBeDefined();
+  });
+
+  it('addebita all organizzazione, che è chi paga quando nessun brand paga', async () => {
+    await refineMediaWithoutBrand(noBrands(), job);
+
+    expect(withOrgContext).toHaveBeenCalledWith(ORG);
+    expect(withBrandContext).not.toHaveBeenCalled();
+  });
+
+  it('il percorso di un altro utente non risolve, e il render non parte', async () => {
+    const out = await refineMediaWithoutBrand(noBrands(), { ...job, baseMediaId: SOMEONE_ELSE });
+
+    expect(out).toMatchObject({ ok: false, error: 'source_not_found' });
+    expect(renderPostImage).not.toHaveBeenCalled();
+  });
+
+  /**
+   * Il difetto che #403 ha chiuso, e che questo ramo non deve rifare. Un file più pesante del
+   * tetto tornava `source_not_found` — «non trovata» per una cosa che c'era — e l'agente
+   * rigenerava da zero, cioè esattamente il danno che refine_media esiste per impedire. Qui le
+   * sorgenti sono file appena caricati dall'utente: grandi per definizione.
+   */
+  it('un file troppo pesante si dice pesante, non introvabile', async () => {
+    imagePartFor.mockResolvedValue({ ok: false, reason: 'too_large' });
+
+    const out = await refineMediaWithoutBrand(noBrands(), job);
+
+    expect(out).toMatchObject({ ok: false, error: 'source_too_large' });
+    expect(out.ok === false && 'limit' in out && out.limit).toBeGreaterThan(0);
+    expect(renderPostImage).not.toHaveBeenCalled();
+  });
+
+  /** Il peso non c'è dove nessuna riga lo scrive: `null` è il fatto, il tetto resta detto. */
+  it('senza una riga di libreria il peso è sconosciuto, non inventato', async () => {
+    imagePartFor.mockResolvedValue({ ok: false, reason: 'too_large' });
+
+    const out = await refineMediaWithoutBrand(noBrands(), job);
+
+    expect(out.ok === false && 'bytes' in out && out.bytes).toBeNull();
+  });
+
+  it('una sorgente che non è un immagine resta introvabile, non pesante', async () => {
+    imagePartFor.mockResolvedValue({ ok: false, reason: 'not_an_image' });
+
+    const out = await refineMediaWithoutBrand(noBrands(), job);
+
+    expect(out).toMatchObject({ ok: false, error: 'source_not_found' });
+  });
+
+  it('un indirizzo scelto da chi chiama non è una sorgente', async () => {
+    const out = await refineMediaWithoutBrand(noBrands(), {
+      ...job,
+      baseMediaId: 'https://evil.test/a.png'
+    });
+
+    expect(out).toMatchObject({ ok: false, error: 'source_not_found' });
+    expect(renderPostImage).not.toHaveBeenCalled();
+  });
+
+  it('risalire di una cartella non è il proprio percorso', async () => {
+    const out = await refineMediaWithoutBrand(noBrands(), {
+      ...job,
+      baseMediaId: `${USER}/../user-2/media/x.png`
+    });
+
+    expect(out).toMatchObject({ ok: false, error: 'source_not_found' });
+  });
+
+  /**
+   * Il tipo lo dice il FILE, non chi chiama: senza una riga di libreria il percorso è tutto ciò che
+   * c'è, e un mp4 mandato al motore delle immagini è il difetto che questo percorso toglie.
+   */
+  it('un clip lo rifinisce il motore dei video, letto dal percorso', async () => {
+    transformVideo.mockResolvedValue({ url: 'https://cdn/refined.mp4', taskId: 't-1', model: 'runway/aleph' });
+
+    const out = await refineMediaWithoutBrand(noBrands(), { ...job, baseMediaId: OWN_CLIP, model: 'runway/aleph' });
+
+    expect(out.ok && out.kind).toBe('video');
+    expect(renderPostImage).not.toHaveBeenCalled();
+  });
+
+  /** Senza preferenze di brand non c'è un modello scelto: rifilmare da capo sarebbe un altro clip. */
+  it('un clip senza un modello di rifinitura si rifiuta invece di rifilmare', async () => {
+    const out = await refineMediaWithoutBrand(noBrands(), { ...job, baseMediaId: OWN_CLIP });
+
+    expect(out).toMatchObject({ ok: false, error: 'no_refine_model' });
+    expect(transformVideo).not.toHaveBeenCalled();
+  });
+});
+
+describe('i lavori di un organizzazione', () => {
+  it('legge i clip senza brand, e consegna dove sono invece di un id di libreria', async () => {
+    const jobs = await listOrgMediaJobs(
+      jobsClient([
+        { id: 'job-1', status: 'done', error: null, submitted_at: '2026-09-11T10:00:00Z', media_url: 'https://cdn/clip.mp4' }
+      ]),
+      ORG
+    );
+
+    expect(jobs).toEqual([
+      {
+        id: 'job-1',
+        status: 'done',
+        error: null,
+        submitted_at: '2026-09-11T10:00:00Z',
+        media_url: 'https://cdn/clip.mp4'
+      }
+    ]);
+  });
+});

--- a/src/lib/server/media-generate.ts
+++ b/src/lib/server/media-generate.ts
@@ -46,7 +46,9 @@ export type GeneratedMedia = {
 };
 
 export type GenerateMediaOpts = {
-  brandId: string;
+  /** `null` = nessun brand nominato: paga `orgId`, e non c'è una libreria in cui archiviare. */
+  brandId: string | null;
+  orgId?: string;
   userId: string;
   prompt: string;
   kind?: 'image' | 'video';
@@ -55,7 +57,7 @@ export type GenerateMediaOpts = {
   title?: string;
   /** Vale per QUESTA chiamata soltanto: nessuna preferenza del brand viene toccata. */
   model?: string;
-  /** Un'IMMAGINE della libreria da animare. Presente → image-to-video, ed e' «anima questa foto». */
+  /** Un'IMMAGINE da animare: l'id della libreria sotto un brand, il percorso consegnato senza. */
   baseMediaId?: string;
   /** Secondi. Assente → la preferenza del brand. */
   durationSeconds?: number;
@@ -118,12 +120,12 @@ const SOURCE_REFUSAL: Record<ImagePartRefusal, 'source_too_large' | 'source_not_
 
 function refusedSource(
   reason: ImagePartRefusal,
-  source: LibrarySource
+  bytes: number | null
 ): SourceTooLarge | { ok: false; error: 'source_not_found' } {
   const error = SOURCE_REFUSAL[reason];
   if (error === 'source_not_found') return { ok: false, error };
 
-  return { ok: false, error, bytes: source.bytes, limit: IMAGE_PART_MAX_BYTES };
+  return { ok: false, error, bytes, limit: IMAGE_PART_MAX_BYTES };
 }
 
 /**
@@ -155,6 +157,43 @@ async function resolveLibraryId(
   if (hits.length !== 1) return null;
 
   return { id: String(hits[0].id), kind: String(hits[0].kind), bytes: hits[0].bytes ?? null };
+}
+
+/** Il prefisso con cui lo Storage pubblica un oggetto del bucket: l'URL che consegniamo lo porta. */
+const PUBLIC_MEDIA = '/storage/v1/object/public/media/';
+
+/** Un percorso che finisce così è un clip. Senza una riga di libreria, il file è tutto ciò che c'è. */
+const CLIP_EXTENSION = /\.(mp4|mov|webm|m4v)$/i;
+
+/**
+ * Come si nomina una sorgente quando una libreria non c'è.
+ *
+ * La strada senza brand consegna due maniglie e nient'altro: `storage_path` per un disegno, l'URL
+ * pubblico per un clip. Tutte e due dicono lo stesso percorso, e il suo PRIMO segmento è lo user —
+ * la stessa cosa che guarda la policy dello Storage. Il percorso di un altro non risolve,
+ * esattamente come l'id di un altro inquilino non risolve sotto il brand.
+ *
+ * Un indirizzo qualunque NON è una sorgente: qui non si scarica niente da un host scelto da chi
+ * chiama: si firma un percorso del NOSTRO bucket. Una stringa che non è un nostro percorso cade.
+ */
+function ownStoragePath(userId: string, handle: string): string | null {
+  const raw = handle.trim();
+  const tail = raw.includes(PUBLIC_MEDIA) ? raw.split(PUBLIC_MEDIA)[1] : raw;
+  const path = tail.split('?')[0].replace(/^\/+/, '');
+  const segments = path.split('/');
+  if (segments[0] !== userId) return null;
+  if (segments.some((s) => s === '..' || s === '.' || !s)) return null;
+
+  return path;
+}
+
+function storedKind(path: string): RefinedKind {
+  return CLIP_EXTENSION.test(path) ? 'video' : 'image';
+}
+
+/** Una firma per un percorso del bucket. L'unico modo di leggere un oggetto privato, e il solo qui. */
+async function signedPath(supabase: SupabaseClient, path: string): Promise<string | null> {
+  return (await signKnowledgePaths(supabase, [path])).get(path) ?? null;
 }
 
 function dataUrlBytes(dataUrl: string): { bytes: Buffer; mime: string } | null {
@@ -322,6 +361,53 @@ async function brandContentPrefs(
   return (data?.content_prefs ?? {}) as Record<string, unknown>;
 }
 
+/**
+ * L'esito di `imagePartFor`, più il peso quando lo conosciamo. Il MOTIVO viaggia fino in fondo:
+ * schiacciarlo su «non trovata» è ciò che faceva rigenerare da zero una sorgente che c'era
+ * eccome — il difetto che #403 ha chiuso, e che un secondo ramo non deve reintrodurre.
+ */
+type SourceOutcome =
+  | { ok: true; part: ImagePart }
+  | { ok: false; reason: ImagePartRefusal; bytes: number | null };
+
+const SOURCE_MISSING = { ok: false, reason: 'fetch_failed', bytes: null } as const;
+
+async function libraryImageSource(
+  supabase: SupabaseClient,
+  brandId: string,
+  idOrPrefix: string
+): Promise<SourceOutcome> {
+  const { loadLibraryMediaPart } = await import('$lib/server/brand-media');
+  const source = await resolveLibraryId(supabase, brandId, idOrPrefix);
+  if (!source) return SOURCE_MISSING;
+
+  const outcome = await loadLibraryMediaPart(supabase, brandId, source.id);
+
+  return outcome.ok ? outcome : { ...outcome, bytes: source.bytes };
+}
+
+/**
+ * Senza libreria il peso non è scritto da nessuna parte — non c'è una riga che lo porti — ma il
+ * motivo sì, e vale lo stesso ridimensionamento a 2048px: sono file appena caricati dall'utente,
+ * quindi grandi per definizione, ed è il ramo che ne ha più bisogno.
+ */
+async function storedImageSource(
+  supabase: SupabaseClient,
+  userId: string,
+  handle: string
+): Promise<SourceOutcome> {
+  const path = ownStoragePath(userId, handle);
+  if (!path) return SOURCE_MISSING;
+
+  const url = await signedPath(supabase, path);
+  if (!url) return SOURCE_MISSING;
+
+  const { imagePartFor } = await import('$lib/server/brand-context');
+  const outcome = await imagePartFor(url);
+
+  return outcome.ok ? outcome : { ...outcome, bytes: null };
+}
+
 async function runImageJob(
   supabase: SupabaseClient,
   job: ImageJob
@@ -329,13 +415,11 @@ async function runImageJob(
   const [
     { renderPostImage, buildImageRequest, loadBrandVisualContext },
     { imageModelFor, imageRefineModelFor },
-    { mediaModelSlot, slotAccepts, slotChoices },
-    { loadLibraryMediaPart }
+    { mediaModelSlot, slotAccepts, slotChoices }
   ] = await Promise.all([
     import('$lib/server/content-preview'),
     import('$lib/image-models'),
-    import('$lib/media-model-slots'),
-    import('$lib/server/brand-media')
+    import('$lib/media-model-slots')
   ]);
 
   // Il catalogo è quello vero, lo stesso che governa set_media_model: un secondo elenco
@@ -352,16 +436,16 @@ async function runImageJob(
   // racconta che questo percorso un brand ce l'ha ancora.
   const prefs = job.brandId ? await brandContentPrefs(supabase, job.brandId) : {};
 
-  // `loadLibraryMediaPart` filtra per brand_id: l'id di un altro inquilino non risolve nulla, e
-  // il confine resta nella query invece che in un controllo che qualcuno dimenticherà.
+  // Due confini, ognuno nella sua query. Sotto il brand `loadLibraryMediaPart` filtra per
+  // brand_id, quindi l'id di un altro inquilino non risolve; senza brand il confine è il primo
+  // segmento del percorso, che è lo user — la stessa cosa che guarda la policy dello Storage.
   let baseImage: ImagePart | undefined;
-  if (job.baseMediaId && job.brandId) {
-    const source = await resolveLibraryId(supabase, job.brandId, job.baseMediaId);
-    if (!source) return { ok: false, error: 'source_not_found' };
-
-    const outcome = await loadLibraryMediaPart(supabase, job.brandId, source.id);
-    if (!outcome.ok) return refusedSource(outcome.reason, source);
-    baseImage = outcome.part;
+  if (job.baseMediaId) {
+    const found = job.brandId
+      ? await libraryImageSource(supabase, job.brandId, job.baseMediaId)
+      : await storedImageSource(supabase, job.userId, job.baseMediaId);
+    if (!found.ok) return refusedSource(found.reason, found.bytes);
+    baseImage = found.part;
   }
 
   const brandVisuals =
@@ -433,7 +517,8 @@ export async function generateImagesWithoutBrand(
 }
 
 export type RefineMediaJob = {
-  brandId: string;
+  /** `null` = nessun brand: la sorgente è un percorso consegnato, non una riga di libreria. */
+  brandId: string | null;
   userId: string;
   /** L'asset di partenza. Il SUO tipo sceglie il motore: non lo dichiara chi chiama. */
   baseMediaId: string;
@@ -500,7 +585,7 @@ async function signedSourceUrl(
   const path = String(data?.storage_path ?? '');
   if (!path) return null;
 
-  return (await signKnowledgePaths(supabase, [path])).get(path) ?? null;
+  return signedPath(supabase, path);
 }
 
 /**
@@ -534,10 +619,14 @@ async function refineLibraryVideo(
     return { ok: false, error: 'model_not_for_slot', allowed: slotChoices(slot).map((c) => c.id) };
   }
 
-  const prefs = await brandContentPrefs(supabase, job.brandId);
+  // Senza brand non c'è un `content_prefs` da leggere: il modello lo nomina chi chiama, o si
+  // rifiuta — rifilmare da capo consegnerebbe un clip nuovo a chi ha chiesto di correggere il suo.
+  const prefs = job.brandId ? await brandContentPrefs(supabase, job.brandId) : {};
   if (!job.model && !videoModelForRole(prefs, 'refine')) return { ok: false, error: 'no_refine_model' };
 
-  const videoUrl = await signedSourceUrl(supabase, job.brandId, job.sourceId);
+  const videoUrl = job.brandId
+    ? await signedSourceUrl(supabase, job.brandId, job.sourceId)
+    : await signedPath(supabase, job.sourceId);
   if (!videoUrl) return { ok: false, error: 'source_not_found' };
 
   const { transformVideo } = await import('$lib/server/video');
@@ -552,6 +641,18 @@ async function refineLibraryVideo(
     abortSignal: AbortSignal.timeout(VIDEO_REFINE_BUDGET_MS)
   });
   if (!out) return { ok: false, error: 'render_failed' };
+
+  // `transformVideo` riospita già il montaggio sotto lo user e torna un URL permanente: senza una
+  // libreria in cui depositarlo, quell'URL È il clip — e vale come maniglia per rifinirlo ancora.
+  if (!job.brandId) {
+    return {
+      ok: true,
+      kind: 'video',
+      media: [{ id: null, kind: 'video', mime: 'video/mp4', width: null, height: null, url: out.url }],
+      model: out.model,
+      renders: 1
+    };
+  }
 
   const { saveRenderedVideoToLibrary } = await import('$lib/server/brand-media');
   const saved = await saveRenderedVideoToLibrary(supabase, {
@@ -597,7 +698,7 @@ const REFINERS: Record<string, Refiner> = {
 
 export async function refineBrandMedia(
   supabase: SupabaseClient,
-  job: RefineMediaJob
+  job: RefineMediaJob & { brandId: string }
 ): Promise<RefineMediaResult> {
   const source = await resolveLibraryId(supabase, job.brandId, job.baseMediaId);
   if (!source) return { ok: false, error: 'source_not_found' };
@@ -608,6 +709,25 @@ export async function refineBrandMedia(
   const { withBrandContext } = await import('$lib/server/ai-log');
 
   return withBrandContext(job.brandId, () => refine(supabase, { ...job, sourceId: source.id }));
+}
+
+/**
+ * Rifinire quando una libreria non c'è. Cambia SOLO da dove viene la sorgente — un percorso
+ * consegnato invece di una riga — e chi paga. I due motori sotto sono gli stessi: il tipo lo dice
+ * il file, mai chi chiama, esattamente come sotto il brand lo dice la riga.
+ */
+export async function refineMediaWithoutBrand(
+  supabase: SupabaseClient,
+  job: Omit<RefineMediaJob, 'brandId' | 'brandStyle' | 'title'> & { orgId: string }
+): Promise<RefineMediaResult> {
+  const path = ownStoragePath(job.userId, job.baseMediaId);
+  if (!path) return { ok: false, error: 'source_not_found' };
+
+  const { withOrgContext } = await import('$lib/server/ai-log');
+
+  return withOrgContext(job.orgId, () =>
+    REFINERS[storedKind(path)](supabase, { ...job, brandId: null, sourceId: path })
+  );
 }
 
 /**
@@ -633,7 +753,58 @@ async function brandVisualStyle(
   return (data?.visual_style as string | null) || undefined;
 }
 
-async function startVideo(opts: GenerateMediaOpts): Promise<GenerateMediaResult> {
+type CoverLookup = { url: string } | { ok: false; error: 'source_not_found' | 'source_not_an_image' };
+
+async function libraryCoverUrl(
+  admin: SupabaseClient,
+  brandId: string,
+  idOrPrefix: string
+): Promise<CoverLookup> {
+  const source = await resolveLibraryId(admin, brandId, idOrPrefix);
+  if (!source) return { ok: false, error: 'source_not_found' };
+  if (source.kind !== 'image') return { ok: false, error: 'source_not_an_image' };
+
+  const { resolveBrandImageIds } = await import('$lib/server/brand-media');
+  const urls = await resolveBrandImageIds(admin, brandId, [source.id]);
+  // resolveBrandImageIds guarda solo `kind = 'image'`: un id che esiste ma e' un video non
+  // risolve, e va detto con un errore suo invece che confuso con «non esiste».
+  if (!urls.length) return { ok: false, error: 'source_not_an_image' };
+
+  return { url: urls[0] };
+}
+
+async function storedCoverUrl(
+  admin: SupabaseClient,
+  userId: string,
+  handle: string
+): Promise<CoverLookup> {
+  const path = ownStoragePath(userId, handle);
+  if (!path) return { ok: false, error: 'source_not_found' };
+  if (storedKind(path) !== 'image') return { ok: false, error: 'source_not_an_image' };
+
+  const url = await signedPath(admin, path);
+
+  return url ? { url } : { ok: false, error: 'source_not_found' };
+}
+
+/**
+ * Un clip non torna mai pronto: la risposta è sempre un lavoro da seguire. Dichiararlo qui è ciò
+ * che permette a chi legge di scrivere `durationSeconds` — i secondi DAVVERO mandati, e un clip si
+ * paga al secondo — senza restringere a mano un'unione che comprende anche l'immagine.
+ */
+export type VideoJobResult =
+  | {
+      ok: true;
+      status: 'rendering';
+      media: [];
+      jobId: string;
+      model: string | null;
+      renders: 0;
+      durationSeconds: number | null;
+    }
+  | Extract<GenerateMediaResult, { ok: false }>;
+
+async function startVideo(opts: GenerateMediaOpts): Promise<VideoJobResult> {
   const [{ createAdminClient }, { countOutstandingVideoRenders, submitAndTrackVideoRender }] =
     await Promise.all([
       import('$lib/server/supabase-admin'),
@@ -641,14 +812,19 @@ async function startVideo(opts: GenerateMediaOpts): Promise<GenerateMediaResult>
     ]);
   const admin = createAdminClient();
 
-  const { data: brand } = await admin
-    .from('brands')
-    .select('plan, timezone, content_prefs')
-    .eq('id', opts.brandId)
-    .maybeSingle();
+  // Senza brand non c'è niente da leggere: valgono i default del prodotto. Andarci lo stesso
+  // sarebbe l'ancora rimasta attaccata — un `.eq('id', null)` che non trova nulla e intanto
+  // racconta che questo percorso un brand ce l'ha ancora.
+  const { data: brand } = opts.brandId
+    ? await admin
+        .from('brands')
+        .select('plan, timezone, content_prefs')
+        .eq('id', opts.brandId)
+        .maybeSingle()
+    : { data: null };
   const prefs = (brand?.content_prefs ?? {}) as Record<string, string | number | null>;
 
-  const visualStyle = await brandVisualStyle(admin, opts.brandId);
+  const visualStyle = opts.brandId ? await brandVisualStyle(admin, opts.brandId) : undefined;
 
   // Animare una foto e filmare da un prompt sono due MESTIERI, e il catalogo lo sa gia': lo slot
   // cambia, quindi cambia anche l'elenco dei modelli ammessi. Sceglierne uno solo accetterebbe un
@@ -663,18 +839,16 @@ async function startVideo(opts: GenerateMediaOpts): Promise<GenerateMediaResult>
   // passa da resolveBrandImageIds, che filtra `brand_id` nella query e per un id di un altro
   // inquilino non restituisce niente. Non trovarla FERMA la richiesta: filmare da zero un prompt
   // quando qualcuno ha chiesto di animare la sua foto e' il difetto travestito da rimedio.
+  //
+  // Senza brand la stessa domanda ha un'altra risposta e lo stesso confine: la maniglia è il
+  // percorso consegnato, e il suo primo segmento è lo user.
   let coverUrl: string | undefined;
   if (opts.baseMediaId) {
-    const source = await resolveLibraryId(admin, opts.brandId, opts.baseMediaId);
-    if (!source) return { ok: false, error: 'source_not_found' };
-    if (source.kind !== 'image') return { ok: false, error: 'source_not_an_image' };
-
-    const { resolveBrandImageIds } = await import('$lib/server/brand-media');
-    const urls = await resolveBrandImageIds(admin, opts.brandId, [source.id]);
-    // resolveBrandImageIds guarda solo `kind = 'image'`: un id che esiste ma e' un video non
-    // risolve, e va detto con un errore suo invece che confuso con «non esiste».
-    if (!urls.length) return { ok: false, error: 'source_not_an_image' };
-    coverUrl = urls[0];
+    const cover = opts.brandId
+      ? await libraryCoverUrl(admin, opts.brandId, opts.baseMediaId)
+      : await storedCoverUrl(admin, opts.userId, opts.baseMediaId);
+    if ('error' in cover) return cover;
+    coverUrl = cover.url;
   }
 
   // La durata si CONTRATTA prima di inviare. `clampVideoDuration` alzerebbe in silenzio 5 a 10 —
@@ -699,13 +873,17 @@ async function startVideo(opts: GenerateMediaOpts): Promise<GenerateMediaResult>
     }
   }
 
-  const { remaining } = await import('$lib/server/usage');
-  const budget = await remaining(admin, opts.brandId, brand?.plan, brand?.timezone ?? 'Europe/Rome');
+  // L'allocazione mensile dei video è del PIANO di un brand. Senza brand non c'è un piano da
+  // interrogare: il tetto è il saldo crediti dell'organizzazione, che la rotta guarda prima di qui.
+  if (opts.brandId) {
+    const { remaining } = await import('$lib/server/usage');
+    const budget = await remaining(admin, opts.brandId, brand?.plan, brand?.timezone ?? 'Europe/Rome');
 
-  // I render in volo contano sull'allowance: il numero mensile si addebita quando il clip atterra,
-  // e guardare solo `usage` lascerebbe spendere lo stesso budget più volte di fila.
-  const inFlight = await countOutstandingVideoRenders(admin, opts.brandId);
-  if (budget.videos - inFlight <= 0) return { ok: false, error: 'video_budget_exhausted' };
+    // I render in volo contano sull'allowance: il numero mensile si addebita quando il clip atterra,
+    // e guardare solo `usage` lascerebbe spendere lo stesso budget più volte di fila.
+    const inFlight = await countOutstandingVideoRenders(admin, opts.brandId);
+    if (budget.videos - inFlight <= 0) return { ok: false, error: 'video_budget_exhausted' };
+  }
 
   let submitReason: string | undefined;
   const submitted = await submitAndTrackVideoRender({
@@ -714,6 +892,7 @@ async function startVideo(opts: GenerateMediaOpts): Promise<GenerateMediaResult>
       submitReason = safeProviderReason(why);
     },
     brandId: opts.brandId,
+    orgId: opts.orgId,
     userId: opts.userId,
     postId: null,
     threadId: null,
@@ -755,94 +934,112 @@ async function startVideo(opts: GenerateMediaOpts): Promise<GenerateMediaResult>
   };
 }
 
-/**
- * La porta d'ingresso storica, tenuta viva. Non fa piu' il lavoro: lo inoltra a generate_image e
- * generate_video, che sono i due tool che un agente dovrebbe chiamare. Cancellarla mentre stiamo
- * moltiplicando le capacita' toglierebbe una capacita' a chi la sta gia' usando.
- */
-/**
- * Un clip verso la LIBRERIA, senza post. Con `baseMediaId` e' «anima questa foto»: la strada che
- * mancava, e per cui l'agente esterno rispondeva che serviva prima una bozza.
- */
+export type CarouselJob = {
+  brandId: string | null;
+  userId: string;
+  brief: string;
+  slides?: number;
+  aspectRatio?: AspectRatio;
+  model?: string;
+  title?: string;
+};
+
+export type CarouselResult =
+  | { ok: true; media: GeneratedMedia[]; continuityTokens: string[]; model: string | null; renders: number }
+  | { ok: false; error: 'plan_failed' | 'render_failed' | 'store_failed' }
+  | { ok: false; error: 'model_not_for_slot'; allowed: string[] };
+
 /**
  * Un carosello: N slide che si leggono come una serie. Si pianifica una volta (i gettoni di
  * continuita' nascono li'), poi si rende una slide per prompt riusando lo stesso motore delle
  * immagini singole — un render per slide, e il conto lo dice.
  */
-export async function generateBrandCarousel(
-  supabase: SupabaseClient,
-  opts: {
-    brandId: string;
-    userId: string;
-    brief: string;
-    slides?: number;
-    aspectRatio?: AspectRatio;
-    model?: string;
-    title?: string;
-  }
-): Promise<
-  | { ok: true; media: GeneratedMedia[]; continuityTokens: string[]; model: string | null; renders: number }
-  | { ok: false; error: 'plan_failed' | 'render_failed' | 'store_failed' }
-  | { ok: false; error: 'model_not_for_slot'; allowed: string[] }
-> {
-  const { withBrandContext } = await import('$lib/server/ai-log');
+async function runCarousel(supabase: SupabaseClient, opts: CarouselJob): Promise<CarouselResult> {
   const { planCarousel, clampSlideCount } = await import('$lib/server/carousel-generate');
 
-  return withBrandContext(opts.brandId, async () => {
-    const slides = clampSlideCount(opts.slides);
-    const plan = await planCarousel(supabase, {
-      brandId: opts.brandId,
-      brief: opts.brief,
-      slides
-    });
-    if ('error' in plan) return { ok: false, error: 'plan_failed' };
-
-    const media: GeneratedMedia[] = [];
-    let renders = 0;
-    let model: string | null = null;
-
-    for (const [index, prompt] of plan.slidePrompts.entries()) {
-      const out = await runImageJob(supabase, {
-        brandId: opts.brandId,
-        userId: opts.userId,
-        prompt,
-        aspectRatio: opts.aspectRatio,
-        model: opts.model,
-        title: opts.title ? `${opts.title} ${index + 1}` : undefined
-      });
-      // Un modello rifiutato lo e' per tutte le slide: fermarsi alla prima evita di pagarne altre.
-      if (!out.ok && out.error === 'model_not_for_slot') return out;
-      if (!out.ok) break;
-
-      renders += out.renders;
-      model = out.model;
-      media.push(...out.media);
-    }
-
-    // Una serie sotto il minimo non e' un carosello piu' corto: e' un carosello mancato, e dirlo
-    // riuscito lascerebbe il chiamante a comporre un post con meno slide di quante ne ha pagate.
-    if (media.length < plan.slidePrompts.length) {
-      return { ok: false, error: media.length ? 'store_failed' : 'render_failed' };
-    }
-
-    return { ok: true, media, continuityTokens: plan.continuityTokens, model, renders };
+  const slides = clampSlideCount(opts.slides);
+  const plan = await planCarousel(supabase, {
+    brandId: opts.brandId,
+    brief: opts.brief,
+    slides
   });
+  if ('error' in plan) return { ok: false, error: 'plan_failed' };
+
+  const media: GeneratedMedia[] = [];
+  let renders = 0;
+  let model: string | null = null;
+
+  for (const [index, prompt] of plan.slidePrompts.entries()) {
+    const out = await runImageJob(supabase, {
+      brandId: opts.brandId,
+      userId: opts.userId,
+      prompt,
+      aspectRatio: opts.aspectRatio,
+      model: opts.model,
+      title: opts.title ? `${opts.title} ${index + 1}` : undefined
+    });
+    // Un modello rifiutato lo e' per tutte le slide: fermarsi alla prima evita di pagarne altre.
+    if (!out.ok && out.error === 'model_not_for_slot') return out;
+    if (!out.ok) break;
+
+    renders += out.renders;
+    model = out.model;
+    media.push(...out.media);
+  }
+
+  // Una serie sotto il minimo non e' un carosello piu' corto: e' un carosello mancato, e dirlo
+  // riuscito lascerebbe il chiamante a comporre un post con meno slide di quante ne ha pagate.
+  if (media.length < plan.slidePrompts.length) {
+    return { ok: false, error: media.length ? 'store_failed' : 'render_failed' };
+  }
+
+  return { ok: true, media, continuityTokens: plan.continuityTokens, model, renders };
 }
 
-export async function generateBrandVideo(opts: GenerateMediaOpts): Promise<GenerateMediaResult> {
+export async function generateBrandCarousel(
+  supabase: SupabaseClient,
+  opts: CarouselJob & { brandId: string }
+): Promise<CarouselResult> {
+  const { withBrandContext } = await import('$lib/server/ai-log');
+
+  return withBrandContext(opts.brandId, () => runCarousel(supabase, opts));
+}
+
+export async function generateCarouselWithoutBrand(
+  supabase: SupabaseClient,
+  opts: Omit<CarouselJob, 'brandId' | 'title'> & { orgId: string }
+): Promise<CarouselResult> {
+  const { withOrgContext } = await import('$lib/server/ai-log');
+
+  return withOrgContext(opts.orgId, () => runCarousel(supabase, { ...opts, brandId: null }));
+}
+
+export async function generateBrandVideo(
+  opts: GenerateMediaOpts & { brandId: string }
+): Promise<VideoJobResult> {
   const { withBrandContext } = await import('$lib/server/ai-log');
 
   return withBrandContext(opts.brandId, () => startVideo(opts));
 }
 
+/**
+ * Un clip senza brand. Non torna pronto — kie ci mette minuti — e non c'è una libreria in cui
+ * depositarlo: il risultato vive sulla riga della coda, che porta addosso chi paga, ed è da lì che
+ * `GET /api/v1/videos` lo ritrova quando è atterrato.
+ */
+export async function generateVideoWithoutBrand(
+  opts: Omit<GenerateMediaOpts, 'brandId' | 'kind' | 'title'> & { orgId: string }
+): Promise<VideoJobResult> {
+  const { withOrgContext } = await import('$lib/server/ai-log');
+
+  return withOrgContext(opts.orgId, () => startVideo({ ...opts, brandId: null, kind: 'video' }));
+}
+
 export async function generateBrandMedia(
   supabase: SupabaseClient,
-  opts: GenerateMediaOpts
+  opts: GenerateMediaOpts & { brandId: string }
 ): Promise<GenerateMediaResult> {
-  if (opts.kind === 'video') {
-    const { withBrandContext } = await import('$lib/server/ai-log');
-    return withBrandContext(opts.brandId, () => startVideo(opts));
-  }
+  if (opts.kind === 'video') return generateBrandVideo(opts);
 
   const out = await generateBrandImages(supabase, opts);
   if (!out.ok) return out;
@@ -904,4 +1101,41 @@ export async function listMediaJobs(
 
     return { ...r, media_id: null, status: CLIP_NOT_IN_LIBRARY, error: NOTHING_CLAIMED_IT };
   });
+}
+
+export type OrgMediaJob = {
+  id: string;
+  status: string;
+  /** Dov'è il clip. Prende il posto di `media_id`: senza brand non c'è una libreria da indicizzare. */
+  media_url: string | null;
+  error: string | null;
+  submitted_at: string | null;
+};
+
+/**
+ * I lavori di questa organizzazione, e SOLO suoi: l'id arriva da `ensureOrgForUser`, mai dal
+ * chiamante, quindi un job_id indovinato di un'altra organizzazione non trova niente.
+ */
+export async function listOrgMediaJobs(
+  supabase: SupabaseClient,
+  orgId: string,
+  jobId?: string
+): Promise<OrgMediaJob[]> {
+  let query = supabase
+    .from('video_renders')
+    .select('id, status, error, submitted_at, media_url')
+    .eq('org_id', orgId)
+    .order('submitted_at', { ascending: false })
+    .limit(JOBS_PAGE);
+  if (jobId) query = query.eq('id', jobId);
+
+  const { data } = await query;
+
+  return ((data ?? []) as OrgMediaJob[]).map((r) => ({
+    id: r.id,
+    status: r.status,
+    media_url: r.media_url ?? null,
+    error: r.error ?? null,
+    submitted_at: r.submitted_at ?? null
+  }));
 }

--- a/src/lib/server/video-render-queue.brand-free.test.ts
+++ b/src/lib/server/video-render-queue.brand-free.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Un clip chiesto senza nominare un brand: dove atterra, e su quale conto.
+ *
+ * L'immagine risponde subito e consegna un percorso, quindi non deve ricordarsi di niente. Il clip
+ * no: kie ci mette minuti, la richiesta è finita da un pezzo, e a chiuderlo è un cron che ha in
+ * mano la sola riga. Finché ogni risposta di quella riga era un brand, un clip senza brand non
+ * aveva un posto dove atterrare.
+ *
+ * Il test che conta di più è il terzo: uno scope sbagliato scrive una riga in `ai_calls` che nessuna
+ * organizzazione somma, e una generazione che non viene contata è denaro che esce senza che nessuno
+ * lo veda. È la forma esatta del difetto DataForSEO — il fornitore non addebitava, quindi nessuna
+ * fattura segnalava niente.
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Row = Record<string, any>;
+
+const finishVideoRender = vi.fn();
+const withBrandContext = vi.fn();
+const withOrgContext = vi.fn();
+const saveRenderedVideoToLibrary = vi.fn();
+const addUsage = vi.fn();
+
+vi.mock('$lib/server/video', () => ({
+  finishVideoRender: (...args: unknown[]) => finishVideoRender(...args),
+  videoTaskProvider: () => 'kie'
+}));
+vi.mock('$lib/server/ai-log', () => ({
+  withBrandContext: <T>(brandId: string, fn: () => T) => {
+    withBrandContext(brandId);
+    return fn();
+  },
+  withOrgContext: <T>(orgId: string, fn: () => T) => {
+    withOrgContext(orgId);
+    return fn();
+  }
+}));
+vi.mock('$lib/server/brand-media', () => ({
+  saveRenderedVideoToLibrary: (...args: unknown[]) => saveRenderedVideoToLibrary(...args)
+}));
+vi.mock('$lib/server/usage', () => ({
+  addUsage: (...args: unknown[]) => addUsage(...args),
+  monthKey: () => '2026-09'
+}));
+
+function makeDb(seed: Record<string, Row[]>) {
+  const tables: Record<string, Row[]> = {};
+  for (const [name, rows] of Object.entries(seed)) tables[name] = rows.map((r) => ({ ...r }));
+
+  function build(name: string, mode: 'select' | 'update', patch?: Row) {
+    const table = (tables[name] ??= []);
+    const filters: Array<(r: Row) => boolean> = [];
+    let limit = Infinity;
+
+    const run = () => {
+      const hits = table.filter((r) => filters.every((f) => f(r))).slice(0, limit);
+      if (mode === 'update') hits.forEach((r) => Object.assign(r, patch));
+      return hits;
+    };
+
+    const api: Row = {
+      eq: (c: string, v: unknown) => (filters.push((r) => r[c] === v), api),
+      is: (c: string, v: unknown) => (filters.push((r) => (r[c] ?? null) === v), api),
+      in: (c: string, v: unknown[]) => (filters.push((r) => v.includes(r[c])), api),
+      lt: (c: string, v: string) => (filters.push((r) => r[c] != null && r[c] < v), api),
+      order: () => api,
+      limit: (n: number) => ((limit = n), api),
+      select: () => api,
+      maybeSingle: async () => ({ data: run()[0] ?? null, error: null }),
+      then: (res?: (v: { data: Row[]; error: null }) => unknown, rej?: (e: unknown) => unknown) => {
+        try {
+          const value = { data: run(), error: null };
+          return Promise.resolve(res ? res(value) : value);
+        } catch (e) {
+          return rej ? Promise.resolve(rej(e)) : Promise.reject(e);
+        }
+      }
+    };
+    return api;
+  }
+
+  return {
+    tables,
+    client: {
+      from: (name: string) => ({
+        select: () => build(name, 'select'),
+        update: (patch: Row) => build(name, 'update', patch),
+        insert: (row: Row) => {
+          const created = { id: `row-${(tables[name] ??= []).length + 1}`, ...row };
+          tables[name].push(created);
+          return { select: () => ({ maybeSingle: async () => ({ data: created, error: null }) }) };
+        }
+      })
+    }
+  };
+}
+
+function orgRow(over: Row = {}): Row {
+  return {
+    id: 'render-1',
+    brand_id: null,
+    org_id: 'org-1',
+    user_id: 'user-1',
+    post_id: null,
+    thread_id: null,
+    task_id: 'kie-task-1',
+    model: 'bytedance/seedance-2-5',
+    status: 'rendering',
+    duration_seconds: 8,
+    resolution: '720p',
+    cover_url: null,
+    prompt: 'un gatto che salta',
+    persist_opts: { captions: false, tighten: false },
+    submitted_at: new Date(Date.now() - 30_000).toISOString(),
+    attempts: 0,
+    ...over
+  };
+}
+
+async function reconcile(client: unknown) {
+  const { reconcileVideoRenders } = await import('./video-render-queue');
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return reconcileVideoRenders(client as any);
+}
+
+const LANDED = {
+  status: 'done',
+  url: 'https://cdn/clip.mp4',
+  durationSeconds: 8,
+  resolution: '720p'
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  finishVideoRender.mockResolvedValue(LANDED);
+  saveRenderedVideoToLibrary.mockResolvedValue({ mediaId: 'media-1' });
+  addUsage.mockResolvedValue(undefined);
+});
+
+describe('un clip senza brand', () => {
+  it('atterra sulla riga stessa: è lì che il clip si ritrova', async () => {
+    const { tables, client } = makeDb({ video_renders: [orgRow()] });
+
+    expect(await reconcile(client)).toMatchObject({ done: 1, failed: 0, expired: 0 });
+    expect(tables.video_renders[0]).toMatchObject({
+      status: 'done',
+      media_url: 'https://cdn/clip.mp4'
+    });
+  });
+
+  /**
+   * `brand_media` dice `brand_id in (select auth_brand_ids())`, e `NULL in (…)` vale NULL: una riga
+   * senza brand sarebbe invisibile a tutti, non visibile a tutti. Lo stesso motivo per cui il
+   * disegno senza brand consegna un percorso invece di un id.
+   */
+  it('non deposita niente in una libreria che non esiste', async () => {
+    const { client } = makeDb({ video_renders: [orgRow()] });
+
+    await reconcile(client);
+
+    expect(saveRenderedVideoToLibrary).not.toHaveBeenCalled();
+  });
+
+  /**
+   * IL TEST CHE CONTA. Lo scope decide dove finisce la riga di `ai_calls` che `finishVideoRender`
+   * scrive: col brand sbagliato o senza scope, `sum_org_ai_cost_usd` non la vede e il cancello dei
+   * crediti passa per sempre su una spesa vera.
+   */
+  it('addebita all organizzazione, che è chi paga quando nessun brand paga', async () => {
+    const { client } = makeDb({ video_renders: [orgRow()] });
+
+    await reconcile(client);
+
+    expect(withOrgContext).toHaveBeenCalledWith('org-1');
+    expect(withBrandContext).not.toHaveBeenCalled();
+  });
+
+  /** L'allocazione mensile dei video è del PIANO di un brand. Qui non c'è un piano da consumare. */
+  it('non consuma l allocazione mensile di nessuno', async () => {
+    const { client } = makeDb({ video_renders: [orgRow()] });
+
+    await reconcile(client);
+
+    expect(addUsage).not.toHaveBeenCalled();
+  });
+
+  it('un fallimento resta un fallimento, con il motivo scritto sulla riga', async () => {
+    finishVideoRender.mockResolvedValue({ status: 'failed', error: 'kie ha rifiutato' });
+    const { tables, client } = makeDb({ video_renders: [orgRow()] });
+
+    expect(await reconcile(client)).toMatchObject({ failed: 1 });
+    expect(tables.video_renders[0]).toMatchObject({ status: 'failed', error: 'kie ha rifiutato' });
+  });
+});
+
+describe('con un brand, niente è cambiato', () => {
+  const branded = orgRow({ brand_id: 'brand-1', org_id: null });
+
+  it('deposita in libreria e addebita il mese del brand', async () => {
+    const { client } = makeDb({ video_renders: [branded], brands: [{ id: 'brand-1', timezone: 'Europe/Rome' }] });
+
+    await reconcile(client);
+
+    expect(saveRenderedVideoToLibrary).toHaveBeenCalled();
+    expect(addUsage).toHaveBeenCalled();
+  });
+
+  it('resta nello scope del brand: è così che la spesa gli arriva', async () => {
+    const { client } = makeDb({ video_renders: [branded], brands: [{ id: 'brand-1', timezone: 'Europe/Rome' }] });
+
+    await reconcile(client);
+
+    expect(withBrandContext).toHaveBeenCalledWith('brand-1');
+    expect(withOrgContext).not.toHaveBeenCalled();
+  });
+});
+
+describe('enqueueVideoRender', () => {
+  const submitted = {
+    taskId: 'kie-task-9',
+    model: 'bytedance/seedance-2-5',
+    prompt: 'un gatto',
+    durationSeconds: 8,
+    resolution: '720p',
+    persistOpts: { captions: false, tighten: false },
+    submittedAt: Date.now()
+  };
+
+  it('scrive l organizzazione e lascia il brand vuoto', async () => {
+    const { tables, client } = makeDb({ video_renders: [] });
+    const { enqueueVideoRender } = await import('./video-render-queue');
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await enqueueVideoRender(client as any, { brandId: null, orgId: 'org-1', userId: 'user-1', submitted });
+
+    expect(tables.video_renders[0]).toMatchObject({ brand_id: null, org_id: 'org-1' });
+  });
+
+  it('col brand continua a scrivere il brand, e nessuna organizzazione', async () => {
+    const { tables, client } = makeDb({ video_renders: [] });
+    const { enqueueVideoRender } = await import('./video-render-queue');
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await enqueueVideoRender(client as any, { brandId: 'brand-1', userId: 'user-1', submitted });
+
+    expect(tables.video_renders[0]).toMatchObject({ brand_id: 'brand-1', org_id: null });
+  });
+});

--- a/src/lib/server/video-render-queue.ts
+++ b/src/lib/server/video-render-queue.ts
@@ -18,7 +18,7 @@ import {
 	type SubmittedVideoRender,
 	type VideoPersistOpts
 } from '$lib/server/video';
-import { withBrandContext } from '$lib/server/ai-log';
+import { withBrandContext, withOrgContext } from '$lib/server/ai-log';
 
 /** Give up on a task kie never resolves. Generous: each check costs one cheap HTTP call. */
 export const VIDEO_RENDER_MAX_AGE_MS = 60 * 60_000;
@@ -44,7 +44,9 @@ export const VIDEO_RENDER_MAX_ATTEMPTS = 8;
 
 export type VideoRenderRow = {
 	id: string;
-	brand_id: string;
+	/** `null` su un clip chiesto senza nominare un brand: allora paga `org_id`, e la libreria non c'è. */
+	brand_id: string | null;
+	org_id: string | null;
 	user_id: string;
 	post_id: string | null;
 	thread_id: string | null;
@@ -66,7 +68,9 @@ export type VideoRenderRow = {
 export async function enqueueVideoRender(
 	admin: SupabaseClient,
 	opts: {
-		brandId: string;
+		brandId: string | null;
+		/** Chi paga quando non c'è un brand. `video_renders_one_payer` esige esattamente uno dei due. */
+		orgId?: string | null;
 		userId: string;
 		postId?: string | null;
 		threadId?: string | null;
@@ -78,6 +82,7 @@ export async function enqueueVideoRender(
 		.from('video_renders')
 		.insert({
 			brand_id: opts.brandId,
+			org_id: opts.brandId ? null : (opts.orgId ?? null),
 			user_id: opts.userId,
 			post_id: opts.postId ?? null,
 			thread_id: opts.threadId ?? null,
@@ -111,7 +116,8 @@ export async function enqueueVideoRender(
  */
 export async function submitAndTrackVideoRender(opts: {
 	admin: SupabaseClient;
-	brandId: string;
+	brandId: string | null;
+	orgId?: string | null;
 	userId: string;
 	postId?: string | null;
 	threadId?: string | null;
@@ -135,6 +141,7 @@ export async function submitAndTrackVideoRender(opts: {
 
 	const id = await enqueueVideoRender(opts.admin, {
 		brandId: opts.brandId,
+		orgId: opts.orgId,
 		userId: opts.userId,
 		postId: opts.postId ?? null,
 		threadId: opts.threadId ?? null,
@@ -172,6 +179,16 @@ export async function countOutstandingVideoRenders(
 		return Number.MAX_SAFE_INTEGER;
 	}
 	return count ?? 0;
+}
+
+/**
+ * Chi paga questa riga. Esattamente uno dei due è scritto — `video_renders_one_payer` lo impone —
+ * e un brand nomina la sua organizzazione da sé, mentre una riga senza brand la porta addosso.
+ */
+function inPayerScope<T>(row: VideoRenderRow, fn: () => Promise<T>): Promise<T> {
+	if (row.brand_id) return withBrandContext(row.brand_id, fn);
+
+	return withOrgContext(String(row.org_id), fn);
 }
 
 function rowToSubmitted(row: VideoRenderRow): SubmittedVideoRender {
@@ -225,7 +242,7 @@ async function applyToLibrary(
 ): Promise<string | null> {
 	const { saveRenderedVideoToLibrary } = await import('$lib/server/brand-media');
 	const saved = await saveRenderedVideoToLibrary(admin, {
-		brandId: row.brand_id,
+		brandId: String(row.brand_id),
 		userId: row.user_id,
 		url,
 		title: row.prompt?.trim().slice(0, 80) || 'Generated clip',
@@ -245,6 +262,10 @@ async function applyToLibrary(
  * lascerebbe che dieci render rifiutati si mangino il margine di un mese.
  */
 async function chargeMonthlyVideo(admin: SupabaseClient, row: VideoRenderRow): Promise<void> {
+	// L'allocazione è del PIANO di un brand. Una riga senza brand non ha un piano da consumare: la
+	// paga il saldo crediti dell'organizzazione, che il cancello ha già guardato prima dell'invio.
+	if (!row.brand_id) return;
+
 	try {
 		const { addUsage, monthKey } = await import('$lib/server/usage');
 		const { data: brand } = await admin
@@ -260,13 +281,18 @@ async function chargeMonthlyVideo(admin: SupabaseClient, row: VideoRenderRow): P
 	}
 }
 
+/**
+ * Dove si reclama un clip atterrato, una riga per padrone. Senza brand non c'è una libreria in cui
+ * depositarlo — `brand_media` dice `brand_id in (select auth_brand_ids())`, e `NULL in (…)` vale
+ * NULL — quindi il clip si ritrova sulla riga stessa, che `settle` chiude con `media_url`.
+ */
 async function landClip(
 	admin: SupabaseClient,
 	row: VideoRenderRow,
 	url: string,
 	thumbnailUrl?: string
 ): Promise<string | null> {
-	if (!row.post_id) return applyToLibrary(admin, row, url);
+	if (!row.post_id) return row.brand_id ? applyToLibrary(admin, row, url) : null;
 	// `.select('id')` so a zero-row match is visible: an UPDATE that hits nothing reports no error,
 	// so without this an orphaned render — post insert rolled back, post since deleted — would be
 	// billed, settled `done`, and reported to the user as attached to a post that does not exist.
@@ -307,7 +333,9 @@ async function notifyThread(
 	outcome: string,
 	origin: string
 ) {
-	if (!row.thread_id) return;
+	// Un thread appartiene a un brand: senza brand non c'è una conversazione a cui riportare, e
+	// questo percorso non ne apre una.
+	if (!row.thread_id || !row.brand_id) return;
 	try {
 		const { data: thread } = await admin
 			.from('chat_threads')
@@ -378,7 +406,7 @@ export async function reconcileVideoRenders(
 	const { data: rows } = await admin
 		.from('video_renders')
 		.select(
-			'id, brand_id, user_id, post_id, thread_id, task_id, model, status, duration_seconds, resolution, cover_url, prompt, persist_opts, submitted_at, attempts, error'
+			'id, brand_id, org_id, user_id, post_id, thread_id, task_id, model, status, duration_seconds, resolution, cover_url, prompt, persist_opts, submitted_at, attempts, error'
 		)
 		.eq('status', 'rendering')
 		.order('submitted_at', { ascending: true })
@@ -427,9 +455,9 @@ export async function reconcileVideoRenders(
 
 		checked += 1;
 		try {
-			// Brand scope so the billing inside finishVideoRender lands on the right ledger — the
-			// AsyncLocalStorage context every other AI entry point establishes.
-			const outcome = await withBrandContext(raw.brand_id, () =>
+			// Lo scope di chi paga, così la fattura dentro finishVideoRender atterra sul suo registro.
+			// Sbagliarlo scrive una riga in `ai_calls` che nessuna somma trova: spesa vera, invisibile.
+			const outcome = await inPayerScope(raw, () =>
 				finishVideoRender(admin, raw.user_id, rowToSubmitted(raw))
 			);
 

--- a/src/lib/server/video.openrouter.test.ts
+++ b/src/lib/server/video.openrouter.test.ts
@@ -18,6 +18,7 @@ vi.mock('$env/dynamic/private', () => ({ env: M.env }));
 vi.mock('$lib/server/ai-log', () => ({
   logAiCall: (e: Record<string, unknown>) => void M.logged.push(e),
   getBrandContext: () => null,
+  getOrgContext: () => null,
   withBrandContext: <T>(_b: string, fn: () => T) => fn()
 }));
 

--- a/src/lib/server/video.ts
+++ b/src/lib/server/video.ts
@@ -2,7 +2,7 @@ import { UGC_AD_SECONDS, UGC_ORGANIC_SECONDS } from '$lib/ugc-formats';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { env } from '$env/dynamic/private';
 import { videoModel } from '$lib/server/model-routing';
-import { getBrandContext, logAiCall } from '$lib/server/ai-log';
+import { getBrandContext, getOrgContext, logAiCall } from '$lib/server/ai-log';
 import { isVideoUrl } from '$lib/content-formats';
 import { KIE_CREDIT_USD } from '$lib/server/kie';
 // Il polling dei job di kie, l'estrazione dei crediti e la lettura dell'errore stanno in un file
@@ -316,6 +316,23 @@ const POLL_TIMEOUT_MS = 600000;
 // ponytail: bounded by wall-clock inside the request; if bulk approves with many clips start
 // timing out, move the upscale to a `videos/work` cron like radar/knowledge already use.
 const UPSCALE_TIMEOUT_MS = 60000;
+
+/**
+ * Il cancello dei crediti di CHI paga questo scope: il brand quando c'è, l'organizzazione quando
+ * nessun brand è stato nominato. Scritto una volta perché i tre punti che spendono qui sotto
+ * facevano la stessa domanda, e uno solo dei tre che dimentica l'organizzazione è una clip pagata
+ * da un saldo che nessuno ha guardato.
+ *
+ * L'import dinamico evita il ciclo crediti↔ai-log.
+ */
+async function gateScopedCredits(): Promise<void> {
+  const brandId = getBrandContext();
+  const orgId = brandId ? null : getOrgContext();
+  if (!brandId && !orgId) return;
+
+  const { gateCredits, gateOrgCredits } = await import('$lib/server/credits');
+  await (brandId ? gateCredits(brandId) : gateOrgCredits(orgId as string));
+}
 
 export type RenderVideoOpts = {
   // Desired clip length in seconds. Clamped into the CHOSEN model's supported window.
@@ -853,15 +870,10 @@ async function prepareVideoRender(
     throw new Error('KIE_API_KEY not configured');
   }
 
-  // Una clip è la cosa più cara che il motore possa comprare: un brand a crediti esauriti non deve
-  // poterci spendere da NESSUN percorso. L'import dinamico evita il ciclo crediti↔ai-log, e
-  // `CreditsExhaustedError` si propaga — l'utente deve sapere che è a secco, non vedere una cover
-  // come se il modello avesse fallito.
-  const gateBrand = getBrandContext();
-  if (gateBrand) {
-    const { gateCredits } = await import('$lib/server/credits');
-    await gateCredits(gateBrand);
-  }
+  // Una clip è la cosa più cara che il motore possa comprare: chi ha i crediti esauriti non deve
+  // poterci spendere da NESSUN percorso. `CreditsExhaustedError` si propaga — l'utente deve sapere
+  // che è a secco, non vedere una cover come se il modello avesse fallito.
+  await gateScopedCredits();
 
   // `image_urls` / `first_frame_url` accettano solo still: un post che porta già una clip non deve
   // finire lì dentro come riferimento immagine.
@@ -1074,11 +1086,7 @@ export async function transformVideo(opts: {
   const model = opts.model?.trim() || videoModelForRole(opts.prefs, opts.role);
   if (!model) return undefined;
 
-  const gateBrand = getBrandContext();
-  if (gateBrand) {
-    const { gateCredits } = await import('$lib/server/credits');
-    await gateCredits(gateBrand);
-  }
+  await gateScopedCredits();
 
   const spec = videoModelSpec(model);
   const input = buildTransformInput(model, opts.role, {
@@ -1405,17 +1413,13 @@ export async function upscaleVideo(
   // have no matching upscale path — skip rather than burn a round-trip that will fail.
   if (!videoModelCaps(envModelI2V()).supportsUpscale) return undefined;
 
-  // Same runaway-spend gate as generation: an exhausted brand must not buy pixels either.
-  const gateBrand = getBrandContext();
-  if (gateBrand) {
-    try {
-      const { gateCredits } = await import('$lib/server/credits');
-      await gateCredits(gateBrand);
-    } catch {
-      // Unlike generation, an exhausted quota here is NOT worth failing the publish over — the
-      // draft-resolution clip is already a complete, publishable post. Degrade silently.
-      return undefined;
-    }
+  // Same runaway-spend gate as generation: an exhausted payer must not buy pixels either.
+  try {
+    await gateScopedCredits();
+  } catch {
+    // Unlike generation, an exhausted quota here is NOT worth failing the publish over — the
+    // draft-resolution clip is already a complete, publishable post. Degrade silently.
+    return undefined;
   }
 
   const t0 = Date.now();

--- a/src/routes/api/v1/carousel/+server.ts
+++ b/src/routes/api/v1/carousel/+server.ts
@@ -1,0 +1,43 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { openOrgScope } from '$lib/server/cli-auth';
+import { generateCarouselWithoutBrand } from '$lib/server/media-generate';
+import { GENERATE_CAROUSEL, statusForFailure } from '@anomalia/api-contracts';
+
+// Otto slide di fila sono otto render: sotto il minuto, ma non sotto il default.
+export const config = { maxDuration: 300 };
+
+export const POST: RequestHandler = async ({ request }) => {
+  const { scope, error } = await openOrgScope(request);
+  if (error) return error;
+
+  const parsed = GENERATE_CAROUSEL.input.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return json({ error: 'invalid_input', details: parsed.error.issues }, { status: 400 });
+  }
+
+  const result = await generateCarouselWithoutBrand(scope.supabase, {
+    orgId: scope.orgId,
+    userId: scope.user.id,
+    brief: parsed.data.brief,
+    slides: parsed.data.slides,
+    aspectRatio: parsed.data.aspect_ratio,
+    model: parsed.data.model
+  });
+
+  if (!result.ok) {
+    return json(
+      { error: result.error, ...('allowed' in result ? { allowed: result.allowed } : {}) },
+      { status: statusForFailure(GENERATE_CAROUSEL, result.error) }
+    );
+  }
+
+  return json({
+    ok: true,
+    media: result.media,
+    continuity_tokens: result.continuityTokens,
+    model: result.model,
+    renders: result.renders,
+    organization: scope.organization
+  });
+};

--- a/src/routes/api/v1/carousel/server.test.ts
+++ b/src/routes/api/v1/carousel/server.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const generateCarouselWithoutBrand = vi.fn();
+const openOrgScope = vi.fn();
+
+vi.mock('$lib/server/cli-auth', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, openOrgScope: (...args: unknown[]) => openOrgScope(...args) };
+});
+vi.mock('$lib/server/media-generate', () => ({
+  generateCarouselWithoutBrand: (...args: unknown[]) => generateCarouselWithoutBrand(...args)
+}));
+
+import { POST } from './+server';
+
+const ORG = { id: 'org-1', name: 'Acme' };
+const SLIDE = { id: null, kind: 'image', mime: 'image/png', width: 1080, height: 1350, url: 'https://s/1' };
+
+async function make(body: unknown) {
+  const url = new URL('https://anomalia.test/api/v1/carousel');
+  const res = await (POST as (event: unknown) => Promise<Response>)({
+    request: new Request(url, { method: 'POST', body: JSON.stringify(body) }),
+    url
+  });
+
+  return { res, body: await res.json() };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  openOrgScope.mockResolvedValue({
+    scope: { supabase: {}, user: { id: 'user-1' }, orgId: 'org-1', organization: ORG }
+  });
+  generateCarouselWithoutBrand.mockResolvedValue({
+    ok: true,
+    media: [SLIDE, SLIDE, SLIDE],
+    continuityTokens: ['ocra', 'luce radente'],
+    model: 'nano-banana-2-lite',
+    renders: 3
+  });
+});
+
+describe('POST /api/v1/carousel — una serie senza nominare un brand', () => {
+  it('consegna le slide in ordine e dice quanti render sono stati pagati', async () => {
+    const { res, body } = await make({ brief: 'tre motivi per cambiare sedia' });
+
+    expect(res.status).toBe(200);
+    expect(body.media).toHaveLength(3);
+    expect(body.renders).toBe(3);
+  });
+
+  /** Senza i gettoni, una slide rifinita esce dalla serie: sono metà del prodotto. */
+  it('porta i gettoni di continuità, che tengono insieme la serie', async () => {
+    const { body } = await make({ brief: 'x' });
+
+    expect(body.continuity_tokens).toEqual(['ocra', 'luce radente']);
+  });
+
+  it('dice da quale organizzazione sono stati presi i crediti', async () => {
+    const { body } = await make({ brief: 'x' });
+
+    expect(body.organization).toEqual(ORG);
+  });
+
+  it('un rifiuto dello scope ferma la spesa invece di seguirla', async () => {
+    openOrgScope.mockResolvedValue({
+      error: new Response(JSON.stringify({ error: 'no_organization' }), { status: 500 })
+    });
+
+    const { res } = await make({ brief: 'x' });
+
+    expect(res.status).toBe(500);
+    expect(generateCarouselWithoutBrand).not.toHaveBeenCalled();
+  });
+
+  it('il tetto sulle slide è applicato senza spendere', async () => {
+    const { res, body } = await make({ brief: 'x', slides: 20 });
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('invalid_input');
+    expect(generateCarouselWithoutBrand).not.toHaveBeenCalled();
+  });
+
+  /** Una serie incompleta è un carosello mancato: dirlo riuscito lascerebbe comporre meno slide. */
+  it('una serie incompleta è un fallimento, non un successo più corto', async () => {
+    generateCarouselWithoutBrand.mockResolvedValue({ ok: false, error: 'store_failed' });
+
+    const { res, body } = await make({ brief: 'x' });
+
+    expect(res.status).toBe(502);
+    expect(body.error).toBe('store_failed');
+  });
+});

--- a/src/routes/api/v1/images/+server.ts
+++ b/src/routes/api/v1/images/+server.ts
@@ -1,70 +1,28 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { authenticate, gateOrgAiAction, apiKeyIsBrandScoped } from '$lib/server/cli-auth';
-import { ensureOrgForUser } from '$lib/server/org';
+import { openOrgScope, brandStyleRefusal } from '$lib/server/cli-auth';
 import { generateImagesWithoutBrand } from '$lib/server/media-generate';
 import { GENERATE_IMAGE, statusForFailure } from '@anomalia/api-contracts';
-import type { SupabaseClient } from '@supabase/supabase-js';
 
 // Lo stesso tetto della rotta sotto il brand: quattro immagini di fila stanno sotto il minuto, ma
 // non sotto il default.
 export const config = { maxDuration: 300 };
 
-/**
- * Chi ha pagato, per nome. La risposta lo dice perché il chiamante non l'ha scelto: `slug` assente
- * significa che l'organizzazione l'abbiamo risolta noi, e un addebito che nessuno ha nominato è un
- * addebito che nessuno controlla. Andrea ha visto agenti scegliere un brand a caso pur di avere
- * un'immagine — un gatto poteva finire sul conto di un cliente vero.
- */
-async function nameOrg(
-  supabase: SupabaseClient,
-  orgId: string
-): Promise<{ id: string; name: string | null }> {
-  const { data } = await supabase
-    .from('organizations')
-    .select('id, name')
-    .eq('id', orgId)
-    .maybeSingle();
-
-  return { id: orgId, name: (data?.name as string | null | undefined) ?? null };
-}
-
 export const POST: RequestHandler = async ({ request }) => {
-  const { supabase, user, error, apiKey } = await authenticate(request);
+  const { scope, error } = await openOrgScope(request);
   if (error) return error;
-
-  // Una chiave ristretta a certi brand è una restrizione che l'utente ha scelto: qui, dove nessun
-  // brand viene nominato, non c'è niente da restringere — quindi si rifiuta invece di allargarla.
-  if (apiKeyIsBrandScoped(apiKey)) {
-    return json({ error: 'brand_scoped_key' }, { status: 403 });
-  }
-
-  // La stessa regola che decide dove atterra un brand nuovo: pagante prima, poi la più vecchia.
-  // Deterministica di proposito — un utente con più organizzazioni deve ottenere sempre la stessa.
-  const orgId = await ensureOrgForUser(supabase, user as never);
-  if (!orgId) return json({ error: 'no_organization' }, { status: 500 });
-
-  const gate = await gateOrgAiAction(orgId, apiKey);
-  if (gate) return gate;
 
   const parsed = GENERATE_IMAGE.input.safeParse(await request.json().catch(() => null));
   if (!parsed.success) {
     return json({ error: 'invalid_input', details: parsed.error.issues }, { status: 400 });
   }
 
-  if (parsed.data.brand_style) {
-    return json(
-      {
-        error: 'brand_style_needs_a_brand',
-        reason: 'brand_style governs a brand look, and no brand was named — pass a slug, or drop brand_style.'
-      },
-      { status: statusForFailure(GENERATE_IMAGE, 'brand_style_needs_a_brand') }
-    );
-  }
+  const refused = brandStyleRefusal(parsed.data.brand_style);
+  if (refused) return refused;
 
-  const result = await generateImagesWithoutBrand(supabase, {
-    orgId,
-    userId: user.id,
+  const result = await generateImagesWithoutBrand(scope.supabase, {
+    orgId: scope.orgId,
+    userId: scope.user.id,
     prompt: parsed.data.prompt,
     count: parsed.data.count,
     aspectRatio: parsed.data.aspect_ratio,
@@ -84,7 +42,7 @@ export const POST: RequestHandler = async ({ request }) => {
     media: result.media,
     model: result.model,
     renders: result.renders,
-    organization: await nameOrg(supabase, orgId),
+    organization: scope.organization,
     cost_usd: result.costUsd
   });
 };

--- a/src/routes/api/v1/images/server.test.ts
+++ b/src/routes/api/v1/images/server.test.ts
@@ -1,29 +1,24 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 /**
- * La rotta che non chiede un brand. Quello che conta qui sono i rifiuti e chi paga: un render che
- * parte quando non doveva è denaro speso, e un render che parte senza dire a chi è stato addebitato
- * è denaro speso in silenzio — che in una sessione vera voleva dire il gatto di qualcuno sul conto
- * di un cliente.
+ * La rotta che non chiede un brand. I rifiuti condivisi — nessuna organizzazione, chiave ristretta,
+ * crediti — vivono in `orgScopeFor` e si provano lì, una volta sola. Qui conta che questa rotta li
+ * metta PRIMA di spendere, e che dica chi ha pagato: un render che parte quando non doveva è denaro
+ * speso, e uno che parte senza dire a chi è stato addebitato è denaro speso in silenzio.
  */
 
 const generateImagesWithoutBrand = vi.fn();
+const openOrgScope = vi.fn();
 
-vi.mock('$lib/server/cli-auth', () => ({
-  authenticate: vi.fn(),
-  gateOrgAiAction: vi.fn(),
-  apiKeyIsBrandScoped: vi.fn()
-}));
-vi.mock('$lib/server/org', () => ({
-  ensureOrgForUser: vi.fn()
-}));
+vi.mock('$lib/server/cli-auth', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, openOrgScope: (...args: unknown[]) => openOrgScope(...args) };
+});
 vi.mock('$lib/server/media-generate', () => ({
   generateImagesWithoutBrand: (...args: unknown[]) => generateImagesWithoutBrand(...args)
 }));
 
 import { POST } from './+server';
-import { authenticate, gateOrgAiAction, apiKeyIsBrandScoped } from '$lib/server/cli-auth';
-import { ensureOrgForUser } from '$lib/server/org';
 
 const DRAWN = {
   id: null,
@@ -35,13 +30,7 @@ const DRAWN = {
   storage_path: 'user-1/media/generated-x.png'
 };
 
-function supabaseWithOrgName(name: string | null) {
-  return {
-    from: () => ({
-      select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: { id: 'org-1', name }, error: null }) }) })
-    })
-  };
-}
+const ORG = { id: 'org-1', name: 'Acme' };
 
 async function generate(body: unknown) {
   const url = new URL('https://anomalia.test/api/v1/images');
@@ -55,15 +44,9 @@ async function generate(body: unknown) {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  vi.mocked(authenticate).mockResolvedValue({
-    supabase: supabaseWithOrgName('Acme'),
-    user: { id: 'user-1', email: 'andrea@teta.so' },
-    apiKey: undefined,
-    error: null
-  } as never);
-  vi.mocked(ensureOrgForUser).mockResolvedValue('org-1' as never);
-  vi.mocked(gateOrgAiAction).mockResolvedValue(undefined as never);
-  vi.mocked(apiKeyIsBrandScoped).mockReturnValue(false as never);
+  openOrgScope.mockResolvedValue({
+    scope: { supabase: {}, user: { id: 'user-1' }, orgId: 'org-1', organization: ORG }
+  });
   generateImagesWithoutBrand.mockResolvedValue({
     ok: true,
     media: [DRAWN],
@@ -81,25 +64,22 @@ describe('POST /api/v1/images — disegnare senza nominare un brand', () => {
     expect(body.media).toEqual([DRAWN]);
   });
 
-  /**
-   * Il test più importante dei due buchi nei pagamenti, e l'unico che si vede da TypeScript:
-   * senza crediti non si disegna nemmeno quando non c'è un brand da interrogare.
-   */
-  it('senza crediti non disegna, e il render non parte', async () => {
-    vi.mocked(gateOrgAiAction).mockResolvedValue(
-      new Response(JSON.stringify({ error: 'credits_exhausted' }), { status: 402 }) as never
-    );
+  it('dice da quale organizzazione sono stati presi i crediti', async () => {
+    const { body } = await generate({ prompt: 'un gatto' });
+
+    expect(body.organization).toEqual(ORG);
+  });
+
+  /** Il rifiuto dello scope arriva PRIMA del render: dopo, sarebbe già stato pagato. */
+  it('un rifiuto dello scope ferma la spesa invece di seguirla', async () => {
+    openOrgScope.mockResolvedValue({
+      error: new Response(JSON.stringify({ error: 'credits_exhausted' }), { status: 402 })
+    });
 
     const { res } = await generate({ prompt: 'un gatto' });
 
     expect(res.status).toBe(402);
     expect(generateImagesWithoutBrand).not.toHaveBeenCalled();
-  });
-
-  it('dice da quale organizzazione sono stati presi i crediti', async () => {
-    const { body } = await generate({ prompt: 'un gatto' });
-
-    expect(body.organization).toEqual({ id: 'org-1', name: 'Acme' });
   });
 
   it('addebita all organizzazione risolta, non a una passata dal chiamante', async () => {
@@ -129,20 +109,6 @@ describe('POST /api/v1/images — disegnare senza nominare un brand', () => {
     const { body } = await generate({ prompt: 'un gatto' });
 
     expect(body.cost_usd).toBeNull();
-  });
-
-  /**
-   * Una chiave ristretta a certi brand è una restrizione che l'utente ha scelto. Lasciarla spendere
-   * fuori da quei brand la allargherebbe in silenzio, proprio mentre si apre una strada nuova.
-   */
-  it('una chiave ristretta a certi brand non spende fuori da quelli', async () => {
-    vi.mocked(apiKeyIsBrandScoped).mockReturnValue(true as never);
-
-    const { res, body } = await generate({ prompt: 'un gatto' });
-
-    expect(res.status).toBe(403);
-    expect(body.error).toBe('brand_scoped_key');
-    expect(generateImagesWithoutBrand).not.toHaveBeenCalled();
   });
 
   it('il tetto sulle alternative è applicato senza spendere', async () => {

--- a/src/routes/api/v1/refine/+server.ts
+++ b/src/routes/api/v1/refine/+server.ts
@@ -1,0 +1,49 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { openOrgScope, brandStyleRefusal } from '$lib/server/cli-auth';
+import { refineMediaWithoutBrand } from '$lib/server/media-generate';
+import { REFINE_MEDIA, statusForFailure } from '@anomalia/api-contracts';
+
+export const config = { maxDuration: 300 };
+
+export const POST: RequestHandler = async ({ request }) => {
+  const { scope, error } = await openOrgScope(request);
+  if (error) return error;
+
+  const parsed = REFINE_MEDIA.input.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return json({ error: 'invalid_input', details: parsed.error.issues }, { status: 400 });
+  }
+
+  const refused = brandStyleRefusal(parsed.data.brand_style);
+  if (refused) return refused;
+
+  const result = await refineMediaWithoutBrand(scope.supabase, {
+    orgId: scope.orgId,
+    userId: scope.user.id,
+    baseMediaId: parsed.data.base_media_id,
+    instruction: parsed.data.instruction,
+    count: parsed.data.count,
+    model: parsed.data.model
+  });
+
+  if (!result.ok) {
+    return json(
+      {
+        error: result.error,
+        ...('allowed' in result ? { allowed: result.allowed } : {}),
+        ...('limit' in result ? { bytes: result.bytes, limit: result.limit } : {})
+      },
+      { status: statusForFailure(REFINE_MEDIA, result.error) }
+    );
+  }
+
+  return json({
+    ok: true,
+    kind: result.kind,
+    media: result.media,
+    model: result.model,
+    renders: result.renders,
+    organization: scope.organization
+  });
+};

--- a/src/routes/api/v1/refine/server.test.ts
+++ b/src/routes/api/v1/refine/server.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const refineMediaWithoutBrand = vi.fn();
+const openOrgScope = vi.fn();
+
+vi.mock('$lib/server/cli-auth', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, openOrgScope: (...args: unknown[]) => openOrgScope(...args) };
+});
+vi.mock('$lib/server/media-generate', () => ({
+  refineMediaWithoutBrand: (...args: unknown[]) => refineMediaWithoutBrand(...args)
+}));
+
+import { POST } from './+server';
+
+const ORG = { id: 'org-1', name: 'Acme' };
+const OWN = 'user-1/media/generated-a1.png';
+
+async function refine(body: unknown) {
+  const url = new URL('https://anomalia.test/api/v1/refine');
+  const res = await (POST as (event: unknown) => Promise<Response>)({
+    request: new Request(url, { method: 'POST', body: JSON.stringify(body) }),
+    url
+  });
+
+  return { res, body: await res.json() };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  openOrgScope.mockResolvedValue({
+    scope: { supabase: {}, user: { id: 'user-1' }, orgId: 'org-1', organization: ORG }
+  });
+  refineMediaWithoutBrand.mockResolvedValue({
+    ok: true,
+    kind: 'image',
+    media: [{ id: null, kind: 'image', mime: 'image/png', width: 1, height: 1, url: 'https://s/1' }],
+    model: 'nano-banana-2-lite',
+    renders: 1
+  });
+});
+
+describe('POST /api/v1/refine — correggere senza nominare un brand', () => {
+  it('rifinisce la maniglia consegnata, e dice che tipo era', async () => {
+    const { res, body } = await refine({ base_media_id: OWN, instruction: 'più caldo' });
+
+    expect(res.status).toBe(200);
+    expect(body.kind).toBe('image');
+    expect(body.media[0].id).toBeNull();
+  });
+
+  it('dice da quale organizzazione sono stati presi i crediti', async () => {
+    const { body } = await refine({ base_media_id: OWN, instruction: 'x' });
+
+    expect(body.organization).toEqual(ORG);
+  });
+
+  it('un rifiuto dello scope ferma la spesa invece di seguirla', async () => {
+    openOrgScope.mockResolvedValue({
+      error: new Response(JSON.stringify({ error: 'credits_exhausted' }), { status: 402 })
+    });
+
+    const { res } = await refine({ base_media_id: OWN, instruction: 'x' });
+
+    expect(res.status).toBe(402);
+    expect(refineMediaWithoutBrand).not.toHaveBeenCalled();
+  });
+
+  it('brand_style senza un brand è rifiutato dicendo la mossa, non ignorato', async () => {
+    const { res, body } = await refine({ base_media_id: OWN, instruction: 'x', brand_style: 'apply' });
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('brand_style_needs_a_brand');
+    expect(refineMediaWithoutBrand).not.toHaveBeenCalled();
+  });
+
+  /**
+   * Una sorgente che non è una maniglia nostra non risolve, e il render NON parte: ricadere sulla
+   * generazione — disegnare da zero credendo di modificare — è il difetto che questa rotta toglie.
+   */
+  it('una sorgente che non risolve è 404, e niente è stato pagato', async () => {
+    refineMediaWithoutBrand.mockResolvedValue({ ok: false, error: 'source_not_found' });
+
+    const { res, body } = await refine({ base_media_id: 'https://evil.test/a.png', instruction: 'x' });
+
+    expect(res.status).toBe(404);
+    expect(body.error).toBe('source_not_found');
+  });
+
+  /**
+   * `source_not_found` su un file che c'è manda l'agente a rigenerare da zero — il difetto chiuso
+   * da #403. Il peso e il tetto viaggiano col rifiuto, o resta un 413 che non dice cosa fare.
+   */
+  it('un file troppo pesante torna 413 col tetto, non un 404', async () => {
+    refineMediaWithoutBrand.mockResolvedValue({
+      ok: false,
+      error: 'source_too_large',
+      bytes: null,
+      limit: 6_291_456
+    });
+
+    const { res, body } = await refine({ base_media_id: OWN, instruction: 'x' });
+
+    expect(res.status).toBe(413);
+    expect(body).toMatchObject({ error: 'source_too_large', bytes: null, limit: 6_291_456 });
+  });
+
+  /** Senza preferenze di brand non c'è un modello di rifinitura video: si dice, non si rifilma. */
+  it('un clip senza modello di rifinitura si rifiuta invece di rifilmare', async () => {
+    refineMediaWithoutBrand.mockResolvedValue({ ok: false, error: 'no_refine_model' });
+
+    const { res, body } = await refine({ base_media_id: 'user-1/generated/a.mp4', instruction: 'x' });
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('no_refine_model');
+  });
+});

--- a/src/routes/api/v1/videos/+server.ts
+++ b/src/routes/api/v1/videos/+server.ts
@@ -1,0 +1,66 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { openOrgScope } from '$lib/server/cli-auth';
+import { generateVideoWithoutBrand, listOrgMediaJobs } from '$lib/server/media-generate';
+import { CHECK_MEDIA_JOB_READ, GENERATE_VIDEO, statusForFailure } from '@anomalia/api-contracts';
+
+/**
+ * Dove si ritrova un clip che nessuna libreria reclama.
+ *
+ * Un'immagine torna col file già in mano; un clip no — kie ci mette minuti e la richiesta è finita
+ * da un pezzo quando atterra. Senza un brand non c'è una libreria in cui depositarlo, quindi il
+ * risultato resta sulla riga della coda, che porta scritto chi paga: `media_url` è il clip.
+ */
+export const GET: RequestHandler = async ({ request, url }) => {
+  const { scope, error } = await openOrgScope(request);
+  if (error) return error;
+
+  const parsed = CHECK_MEDIA_JOB_READ.input.safeParse(Object.fromEntries(url.searchParams));
+  if (!parsed.success) {
+    return json({ error: 'invalid_input', details: parsed.error.issues }, { status: 400 });
+  }
+
+  return json({ jobs: await listOrgMediaJobs(scope.supabase, scope.orgId, parsed.data.job_id) });
+};
+
+export const POST: RequestHandler = async ({ request }) => {
+  const { scope, error } = await openOrgScope(request);
+  if (error) return error;
+
+  const parsed = GENERATE_VIDEO.input.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return json({ error: 'invalid_input', details: parsed.error.issues }, { status: 400 });
+  }
+
+  const result = await generateVideoWithoutBrand({
+    orgId: scope.orgId,
+    userId: scope.user.id,
+    prompt: parsed.data.prompt,
+    baseMediaId: parsed.data.base_media_id,
+    durationSeconds: parsed.data.duration,
+    aspectRatio: parsed.data.aspect_ratio,
+    model: parsed.data.model
+  });
+
+  if (!result.ok) {
+    // Il MOTIVO del fornitore risale fino a qui: un `render_failed` nudo dice che e' fallito e
+    // nasconde l'unica cosa che serviva per decidere se riprovare.
+    return json(
+      {
+        error: result.error,
+        ...('allowed' in result ? { allowed: result.allowed } : {}),
+        ...('reason' in result && result.reason ? { reason: result.reason } : {})
+      },
+      { status: statusForFailure(GENERATE_VIDEO, result.error) }
+    );
+  }
+
+  return json({
+    ok: true,
+    status: 'rendering',
+    job_id: result.jobId,
+    model: result.model,
+    duration_seconds: result.durationSeconds,
+    organization: scope.organization
+  });
+};

--- a/src/routes/api/v1/videos/server.test.ts
+++ b/src/routes/api/v1/videos/server.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Il clip che nessun brand reclama. Non torna mai pronto, quindi la rotta ha due metà: quella che
+ * lo manda in coda e quella che dice dov'è finito — e senza la seconda un clip pagato resterebbe
+ * irraggiungibile, che è la forma esatta di `CLIP_NOT_IN_LIBRARY`.
+ */
+
+const generateVideoWithoutBrand = vi.fn();
+const listOrgMediaJobs = vi.fn();
+const openOrgScope = vi.fn();
+
+vi.mock('$lib/server/cli-auth', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, openOrgScope: (...args: unknown[]) => openOrgScope(...args) };
+});
+vi.mock('$lib/server/media-generate', () => ({
+  generateVideoWithoutBrand: (...args: unknown[]) => generateVideoWithoutBrand(...args),
+  listOrgMediaJobs: (...args: unknown[]) => listOrgMediaJobs(...args)
+}));
+
+import { GET, POST } from './+server';
+
+const ORG = { id: 'org-1', name: 'Acme' };
+
+async function film(body: unknown) {
+  const url = new URL('https://anomalia.test/api/v1/videos');
+  const res = await (POST as (event: unknown) => Promise<Response>)({
+    request: new Request(url, { method: 'POST', body: JSON.stringify(body) }),
+    url
+  });
+
+  return { res, body: await res.json() };
+}
+
+async function check(query = '') {
+  const url = new URL(`https://anomalia.test/api/v1/videos${query}`);
+  const res = await (GET as (event: unknown) => Promise<Response>)({
+    request: new Request(url),
+    url
+  });
+
+  return { res, body: await res.json() };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  openOrgScope.mockResolvedValue({
+    scope: { supabase: {}, user: { id: 'user-1' }, orgId: 'org-1', organization: ORG }
+  });
+  generateVideoWithoutBrand.mockResolvedValue({
+    ok: true,
+    status: 'rendering',
+    media: [],
+    jobId: 'job-1',
+    model: 'bytedance/seedance-2-5',
+    renders: 0,
+    durationSeconds: 8
+  });
+  listOrgMediaJobs.mockResolvedValue([
+    { id: 'job-1', status: 'done', media_url: 'https://cdn/clip.mp4', error: null, submitted_at: '2026-09-11T10:00:00Z' }
+  ]);
+});
+
+describe('POST /api/v1/videos — filmare senza nominare un brand', () => {
+  it('torna un lavoro da seguire, non un clip: kie ci mette minuti', async () => {
+    const { res, body } = await film({ prompt: 'un gatto che salta' });
+
+    expect(res.status).toBe(200);
+    expect(body).toMatchObject({ status: 'rendering', job_id: 'job-1' });
+  });
+
+  it('dice da quale organizzazione sono stati presi i crediti', async () => {
+    const { body } = await film({ prompt: 'un gatto' });
+
+    expect(body.organization).toEqual(ORG);
+  });
+
+  /** I secondi DAVVERO mandati: un clip si paga al secondo, e il modello ha una sua finestra. */
+  it('dice quanti secondi sono stati mandati, non quanti ne sono stati chiesti', async () => {
+    const { body } = await film({ prompt: 'un gatto', duration: 8 });
+
+    expect(body.duration_seconds).toBe(8);
+  });
+
+  it('un rifiuto dello scope ferma la spesa invece di seguirla', async () => {
+    openOrgScope.mockResolvedValue({
+      error: new Response(JSON.stringify({ error: 'brand_scoped_key' }), { status: 403 })
+    });
+
+    const { res } = await film({ prompt: 'un gatto' });
+
+    expect(res.status).toBe(403);
+    expect(generateVideoWithoutBrand).not.toHaveBeenCalled();
+  });
+
+  /** Chi paga lo risolve lo scope, mai il corpo: un campo in piu' cade prima di spendere. */
+  it('un organizzazione passata dal chiamante non è una scelta: si rifiuta', async () => {
+    const { res } = await film({ prompt: 'un gatto', org_id: 'org-di-qualcun-altro' });
+
+    expect(res.status).toBe(400);
+    expect(generateVideoWithoutBrand).not.toHaveBeenCalled();
+  });
+
+  it('addebita all organizzazione risolta dallo scope', async () => {
+    await film({ prompt: 'un gatto' });
+
+    expect(generateVideoWithoutBrand).toHaveBeenCalledWith(expect.objectContaining({ orgId: 'org-1' }));
+  });
+
+  /** Il motivo del fornitore risale: un `render_failed` nudo nasconde l'unica cosa che serviva. */
+  it('porta su il motivo del rifiuto del fornitore', async () => {
+    generateVideoWithoutBrand.mockResolvedValue({
+      ok: false,
+      error: 'render_failed',
+      reason: 'il modello ha rifiutato il prompt'
+    });
+
+    const { res, body } = await film({ prompt: 'x' });
+
+    expect(res.status).toBe(502);
+    expect(body.reason).toBe('il modello ha rifiutato il prompt');
+  });
+
+  it('una durata fuori finestra si rifiuta senza spendere', async () => {
+    const { res, body } = await film({ prompt: 'x', duration: 99 });
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('invalid_input');
+    expect(generateVideoWithoutBrand).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /api/v1/videos — dove è finito il clip', () => {
+  it('consegna dove sono i clip, non un id di libreria che non esiste', async () => {
+    const { res, body } = await check();
+
+    expect(res.status).toBe(200);
+    expect(body.jobs[0].media_url).toBe('https://cdn/clip.mp4');
+  });
+
+  it('un job alla volta, quando se ne nomina uno', async () => {
+    await check('?job_id=job-1');
+
+    expect(listOrgMediaJobs).toHaveBeenCalledWith(expect.anything(), 'org-1', 'job-1');
+  });
+
+  /** L'organizzazione la risolve lo scope, mai la querystring: un id indovinato non apre niente. */
+  it('un organizzazione nella querystring si rifiuta, non si segue', async () => {
+    const { res } = await check('?job_id=job-1&org_id=org-di-qualcun-altro');
+
+    expect(res.status).toBe(400);
+    expect(listOrgMediaJobs).not.toHaveBeenCalled();
+  });
+});

--- a/supabase/migrations/20260911120000_video_renders_org_id.sql
+++ b/supabase/migrations/20260911120000_video_renders_org_id.sql
@@ -1,0 +1,53 @@
+-- A clip asked for without a brand: who does the reconciler report it to?
+--
+-- An image answers synchronously and hands back a storage path, so nothing has to remember it. A
+-- clip does not: kie takes minutes, the request is gone, and a cron finishes the job from the row
+-- alone. Every column that row used to answer with was a brand — brand_id NOT NULL, the library it
+-- deposits into, the monthly allowance it charges, the RLS predicate that lets the user watch it.
+--
+-- The answer is the one ai_calls already took, and taking a different one would give this table a
+-- second vocabulary for the same question:
+--
+--   with a brand   →  video_renders.brand_id → brands.org_id → the pool
+--   without one    →  video_renders.org_id ─────────────────→ the same pool
+--
+-- Exactly one of the two, never both and never neither: a row with both invites the reconciler's
+-- two branches to disagree about which one it is.
+--
+-- What a brand-free clip does NOT get, and why:
+--
+--   no brand_media row  — that table's policy is `brand_id in (select auth_brand_ids())`, and
+--                         `NULL in (…)` is NULL, not true. A row without a brand would be
+--                         invisible to everyone rather than visible to everyone. Same reason the
+--                         brand-free image hands back a path instead of an id.
+--   no monthly charge   — the videos allowance belongs to a brand's plan. Here the limit is the
+--                         org's credit balance, the same gate the brand-free image passes.
+--   no post, no thread  — post_id and thread_id were already nullable; this path never sets them.
+--
+-- The mp4 itself needed nothing: persistMp4 has always written `${userId}/generated/…`, under the
+-- user and never under the brand. media_url on this row is where the clip is, and it is enough.
+
+alter table public.video_renders alter column brand_id drop not null;
+
+alter table public.video_renders
+  add column if not exists org_id uuid references public.organizations (id) on delete cascade;
+
+alter table public.video_renders drop constraint if exists video_renders_one_payer;
+alter table public.video_renders
+  add constraint video_renders_one_payer check (num_nonnulls(brand_id, org_id) = 1);
+
+-- The brand-free read: a caller's own recent jobs, newest first. Mirrors video_renders_pending_idx
+-- for the other half of the table.
+create index if not exists video_renders_org_idx
+  on public.video_renders (org_id, submitted_at desc)
+  where org_id is not null;
+
+-- A user must be able to watch a clip they paid for. Without the second arm a brand-free row is
+-- readable by nobody — the render happens, the money leaves, and the row is a black box.
+drop policy if exists video_renders_select on public.video_renders;
+create policy video_renders_select on public.video_renders
+  for select
+  using (
+    brand_id in (select public.auth_brand_ids())
+    or org_id in (select public.auth_org_ids())
+  );


### PR DESCRIPTION
## What?

Three of the four media generators could only be reached under a brand. This adds the brand-free
road for the other three and for the editor, so all four work the same way:

| tool | before | now |
| --- | --- | --- |
| `generate_image` | `POST /api/v1/images` | unchanged |
| `generate_video` | brand only | `POST /api/v1/videos` (+ `GET` to collect the clip) |
| `generate_carousel` | brand only | `POST /api/v1/carousel` |
| `refine_media` | brand only | `POST /api/v1/refine` |

Declaring `pathWithoutBrand` on an endpoint is all it takes for MCP to make `slug` optional and
for the CLI to route there, so the three new contracts carry it — and every one of the four
descriptions now says what changes when the slug is left out.

One migration comes with it (`20260911120000_video_renders_org_id.sql`). **This repo's deploys do
not run migrations: it has to be applied by hand.** Until it is, the brand-free video route is the
only thing that fails; everything else in this PR works without it.

Rebased onto `dev` after #403 merged — see *Merging with #403* below, which is the one conflict
that was not mechanical.

## Why?

It was never a product decision. `generate_image` learnt to draw without a brand in `015c8406`
because Andrea watched an agent answer that it had no tool to draw a cat, and then watched agents
pick a brand at random just to have something to bill. The other three were left half done, so an
agent asked for a video still has to choose a company to charge first — the exact behaviour that
commit exists to end.

## How?

### The three answers, reused rather than rewritten

`src/routes/api/v1/images/+server.ts` had already settled who pays (the user's org, paying one
first then oldest — none means `no_organization` and stop), what a brand-scoped API key may do
(refused as `brand_scoped_key`, never widened: it is a restriction the user chose), and what
`brand_style` means with no brand (`brand_style_needs_a_brand`, not a silent default). It settled
them inside itself. A fourth copy would have been four versions that diverge at the first change,
so they are now `orgScopeFor` / `openOrgScope` / `brandStyleRefusal` in `cli-auth.ts`.

`authenticate` and the decision are two different jobs, and `orgScopeFor(caller)` exists because
of the test: reaching those refusals through `openOrgScope(request)` required a real API key, so
they were never exercised one at a time.

### Where a brand-free video lands — the only real unknown

An image answers synchronously and hands back a path, so nothing has to remember it. A clip does
not: kie takes minutes, the request is long gone, and a cron finishes it from the `video_renders`
row alone — a row whose every answer was a brand (`brand_id NOT NULL`, the library it deposits
into, the monthly allowance it charges, the RLS predicate that lets the user watch it).

The file was never the problem: `persistMp4` has always written `${userId}/generated/…` into the
public `media` bucket, under the user and never under a brand. Everything after it was.

The shape chosen is the one `ai_calls` already took, because a different one would give this table
a second vocabulary for the same question:

```
with a brand   →  video_renders.brand_id → brands.org_id → the pool
without one    →  video_renders.org_id ─────────────────→ the same pool
```

`brand_id` becomes nullable, `org_id` is added, `video_renders_one_payer` enforces exactly one of
the two, and the RLS policy grows a second arm (`org_id in (select auth_org_ids())`) — without it a
brand-free row is readable by nobody: the render happens, the money leaves, the row is a black box.

A brand-free clip lands **on the row itself**: `media_url` is the file, and `GET /api/v1/videos`
hands it back. What it deliberately does not get:

- **no `brand_media` row** — that table's policy is `brand_id in (select auth_brand_ids())` and
  `NULL in (…)` is NULL, not true. Such a row would be invisible to everyone rather than visible to
  everyone. Same reason the brand-free drawing returns a path instead of an id.
- **no monthly charge** — the videos allowance belongs to a brand's *plan*. Here the ceiling is the
  org's credit balance, the same gate the brand-free image passes.
- **no post, no thread** — both were already nullable and this path never sets them.

Rejected: a synchronous brand-free video. kie's poll reaches 600s against a 300s function wall, so
whoever waits dies halfway — that is why the queue exists at all.

### How a source is named when there is no library

The knot in `refine_media`. Under a brand `base_media_id` is any asset of that brand's library and
the resolution filters on `brand_id`; with no brand there is no library to draw from.

The handle is the one the brand-free road already hands back: `storage_path` for a drawing, the
public url for a clip. Both name the same path, and its **first segment is the user** — the same
thing the Storage policy looks at (`media insert own scope`, `20260905140000`). Somebody else's
path resolves to nothing, exactly as another tenant's id resolves to nothing under a brand.
`ownStoragePath` is that rule, in one place, and it also rejects `.`/`..` segments.

**A caller-chosen URL was rejected**, not routed through `assertPublicUrl`. It would be a
server-side fetch at an arbitrary address — the SSRF just closed in six places — bought for a
capability nobody asked for. Nothing external is fetched here: a path in our own bucket is signed,
and a string that is not one of our paths falls as `source_not_found`.

The source's KIND comes from the file (`storedKind`), never from the caller: without a library row
the path is all there is, and an mp4 handed to the image engine is the defect this tool removes.
The `REFINERS` table stays one row per kind.

### Merging with #403

#403 landed while this was open, and it fixed a defect Andrea found using the product: a 7.47 MB
source blew the 6 MB ceiling, `fetchImagePart` returned `null`, and the tool answered
**`source_not_found`** — *not found*, for something that was plainly there. The agent read that and
regenerated from scratch: the exact harm `refine_media` exists to prevent. The fix was
`loadLibraryMediaPart` returning an outcome that carries the reason (`too_large` | `not_an_image` |
`fetch_failed`), translated into `source_too_large` (413) with the weight and the ceiling.

This branch's first draft did the opposite on its own half — `storedImagePart` returned a part or
`undefined`, and every reason was flattened back to `source_not_found`. Merged that way the
brand-free path would have been born carrying the lie just removed, and worse there: its sources
are files the user has only just uploaded, large by definition.

So #403's shape holds on **both** halves. `libraryImageSource` and `storedImageSource` return the
same `SourceOutcome`, so the brand-free path inherits the true message *and* the 2048px shrink for
free. `refusedSource` now takes the weight rather than the library row, because with no library
nothing carries the weight: `bytes: null` is the fact, and the `limit` is still stated. Two tests
pin it, both watched go red against the flattened version.

The other five conflicts were mechanical: `packages/api-contracts/src/posts.ts` needed both sides'
text, and `cli/lib/contracts/posts.ts`, the two `references/tools.md` and `docs/mcp-tools.md` are
generated — regenerated with `sync-contracts.sh`, `sync-plugin-skill.sh` and
`mcp-inventory.mjs --write`, never merged by hand.

### The credit gates inside `video.ts`

Three places in `video.ts` spent while asking `getBrandContext()` alone. Under an org scope that
answers `null`, so a brand-free clip would have walked past every one of them — a clip paid out of
a balance nobody looked at, which is the DataForSEO shape: spend that no invoice reports.
`gateScopedCredits()` asks the question once, for both payers.

### What stays anchored

`regenerate_slide`, `reorder_slides`, `regenerate_post_media` and `make_video` work on a `posts`
row, which belongs to a brand: with no brand there is no post to edit. They stay brand-only, and a
test declares it rather than leaving it to be inferred.

### The abandoned branch

`feat/brand-free-media` (two commits, never opened as a PR, 156 commits behind) carried the
`ai_calls_org_id` migration and the `credits.ts` split. **Both are already on `dev`** —
`readOrgBillingById`, `orgCreditsUsage`, `gateOrgCredits` and `sum_org_ai_cost_usd` with the outer
join. Nothing was lost down that road; the branch can be deleted.

## Testing?

**Unit — 7 715 pass, 0 fail, 0 errors** (`npx vitest run`, 701 files; `Errors` checked too, per
LESSONS.md). New, all written red first:

- `src/lib/server/video-render-queue.brand-free.test.ts` — a brand-free clip settles on its own
  row, files nothing in a library, charges nobody's monthly allowance, and **bills the org**. That
  last one is the test that matters: a wrong scope writes an `ai_calls` row no org sums, and a
  generation nobody counts is money leaving unseen. Tampered on purpose (`inPayerScope` forced back
  to `withBrandContext`) and watched go red.
- `src/lib/server/media-generate.brand-free-media.test.ts` — 24 cases. The negative that counts is
  reading the `brands` table: the fake client throws on it, so a path still anchored to a brand
  fails. Plus another user's path refused, a web address refused, `..` refused, a clip refused with
  `no_refine_model` instead of being quietly re-filmed, and — after the #403 merge — an oversized
  source answered `source_too_large` with the ceiling rather than `source_not_found`. Tampered
  (`storedImageSource` flattened back to "missing") and watched two go red.
- `src/lib/server/cli-auth.org-scope.test.ts` — the four refusals, once.
- Route tests for all four endpoints; `packages/api-contracts/src/brand-free.test.ts` now covers
  the four tools, their descriptions, their `organization` field and their shared failures;
  `cli/mcp/brand-free-tools.test.ts` checks `slug` is optional on exactly those four and still
  required on the post editors.

**CLI (`bun test` in `cli/`)** — the tests this PR touches pass. The whole CLI suite reports 6
failures, and they are **not this branch's**: a clean `origin/dev` worktree reports the same six,
and `mcp/tool-calls.test.ts` passes alone on both. It is the order-dependent leak LESSONS.md
already describes ("Un timeout nella suite completa non è un difetto finché non lo riproduci da
solo"), arriving with #404.

**Build** — `npm run build`, exit 0, and judged on the artifact, not the exit code:
`.svelte-kit/output/server/entries/endpoints/api/v1/{images,videos,carousel,refine}/_server.ts.js`
are all present. One build at a time.

**Dev server** — `npm run dev` starts; all four new routes answer and refuse an unauthenticated
call.

**`node scripts/schema-drift-check.mjs`** — the only divergence it reports is this PR's own
migration, unapplied. Nothing else moved.

**What I did NOT test, and the risk.** No end-to-end run against a live provider: every scenario
here simulates kie and the image models, so nothing in this PR spent a cent, and nothing proves a
real brand-free clip completes end to end. The migration is not applied, so that path cannot be
exercised until it is — apply it, then film one clip without a slug and read it back from
`GET /api/v1/videos`. Nothing was verified in a browser either: this PR has no UI.

## Evidence (screenshots/videos)

No UI changes. Backend evidence below.

<details>
<summary>The four routes exist in the build artifact</summary>

```
.svelte-kit/output/server/entries/endpoints/api/v1/carousel/_server.ts.js       1.91 kB
.svelte-kit/output/server/entries/endpoints/api/v1/refine/_server.ts.js         1.98 kB
.svelte-kit/output/server/entries/endpoints/api/v1/images/_server.ts.js         1.99 kB
.svelte-kit/output/server/entries/endpoints/api/v1/videos/_server.ts.js         2.48 kB
.svelte-kit/output/server/entries/endpoints/api/v1/videos/render/work/_server.ts.js  1.55 kB
```
</details>

<details>
<summary>The new routes answer on the local dev server</summary>

```
$ curl -s -X POST localhost:5199/api/v1/videos   -d '{"prompt":"un gatto"}'
{"error":"Missing or invalid Authorization header"}
$ curl -s -X POST localhost:5199/api/v1/carousel -d '{"brief":"x"}'
{"error":"Missing or invalid Authorization header"}
$ curl -s -X POST localhost:5199/api/v1/refine   -d '{"base_media_id":"x","instruction":"y"}'
{"error":"Missing or invalid Authorization header"}
$ curl -s        localhost:5199/api/v1/videos
{"error":"Missing or invalid Authorization header"}
```
</details>

<details>
<summary>The payer test bites when the scope is broken</summary>

```
$ # inPayerScope forced back to withBrandContext(String(row.brand_id), fn)
$ npx vitest run src/lib/server/video-render-queue.brand-free.test.ts
 × un clip senza brand > addebita all organizzazione, che è chi paga quando nessun brand paga
      Tests  1 failed | 8 passed (9)
```
</details>

<details>
<summary>schema-drift-check: only this PR's migration is outstanding</summary>

```
MIGRATION SCRITTE MA NON APPLICATE (1) — le applica una persona, non questo script
  supabase/migrations/20260911120000_video_renders_org_id.sql

ROSSO — 1 divergenze.
```
</details>

## Anything Else?

**An MCP-only agent cannot poll a brand-free clip.** It gets the `job_id` and the address to
collect it from, but `GET /api/v1/videos` is REST, not a tool: `check_media_job` was deliberately
withdrawn from the tool surface and `query` reads a brand (it force-filters `brand_id` when the
caller does not). Closing that means either a brand-free `query` — which changes that tool's
tenant-narrowing safety property — or re-admitting a brand-free-only tool, which needs
`ResourcelessEndpoint` to stop requiring `pathUnderBrand`. Both are decisions about the tool
surface, and two other branches are working there right now.

**`tools/list` is at 88 958 of 89 000 characters — 42 left.** #403 added text to `refine_media`'s
description, so after the rebase this was 137 over. I trimmed rather than raised the cap: that
guard exists precisely so the surface gets looked at instead of growing in silence. What was cut is
wording, not a promise — every phrase the contract tests assert is still there, including
`generate_image`'s `Do NOT call list_brands`, which was rephrased to the shorter form the other
three use. **The next description that grows has to trim something, or make the case for the cap in
a comment next to it.**

**One pre-existing type error sits in a file this PR edits**, and it is #403's, not this branch's:
`generateBrandMedia` returns `GenerateMediaResult`, which does not include #403's `SourceTooLarge`,
so `return out` on line 1045 does not type-check. `git show origin/dev` has the identical shape. I
left it rather than widen a union that belongs to another change — but it means `generate_media`
would report an oversized source as a 500.

**A brand-free clip has no monthly ceiling**, only the org's credit balance — same as the
brand-free image. If that turns out to be too loose for video, the place to put a ceiling is the
org, not the brand's plan.

**`docs/api/` documents none of the media endpoints**, brand-scoped ones included, so nothing was
added there. `docs/mcp-tools.md` is generated and was regenerated.

**`feat/brand-free-media` can be deleted** — everything it carried is already on `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY
