### PR TITLE
Give the blog its row in the sidebar back

### DIFF
--- a/changelog/2026-09-11-sidebar-blog.md
+++ b/changelog/2026-09-11-sidebar-blog.md
@@ -1,0 +1,16 @@
+# Il blog torna nella sidebar
+
+La barra laterale del brand era stata portata alle sei voci del mockup, e il blog
+(`/site`, «Auto blog») era finito in `NAV_OFF_SIDEBAR`: la pagina esisteva ancora,
+la apriva ⌘K, la aprivano i link degli agenti — ma nessuna riga ci portava. Per
+chi usa il prodotto significa che non c'era: il blog si raggiunge tutti i giorni,
+non si cerca in una palette.
+
+Torna fra gli Spazi, subito dopo il Calendario, perché è l'altra superficie di
+pubblicazione: quello che il calendario è per i social, il blog lo è per il sito.
+Le voci diventano sette e i due test che le inchiodavano — l'ordine della sidebar
+e l'elenco di ciò che ha perso la riga — sono stati aggiornati insieme, e visti
+fallire prima della modifica.
+
+`NAV_OFF_SIDEBAR` resta l'inventario di ciò che una riga non ce l'ha: toglierne
+una voce è l'unico modo perché la lista continui a dire la verità.

--- a/src/lib/content/changelog/2026-09-11-sidebar-blog.ts
+++ b/src/lib/content/changelog/2026-09-11-sidebar-blog.ts
@@ -1,0 +1,9 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-11',
+  title: 'The blog is back in the sidebar',
+  items: [
+    'Your brand blog has its own row again, right under the calendar — no more reaching it only from the command palette.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/workbench-paths.test.ts
+++ b/src/lib/workbench-paths.test.ts
@@ -110,16 +110,17 @@ describe('la nav del brand', () => {
   });
 
   /**
-   * La sidebar per intero: sei righe, in quest'ordine, più l'ingranaggio in fondo (che non è una
-   * voce e quindi non sta qui). È l'unica cosa che un test può tenere ferma di una barra —
+   * La sidebar per intero: sette righe, in quest'ordine, più l'ingranaggio in fondo (che non è
+   * una voce e quindi non sta qui). È l'unica cosa che un test può tenere ferma di una barra —
    * l'inventario lo sorveglia il caso qui sopra, l'aspetto nessuno.
    */
-  it('gli Spazi sono le sei voci della sidebar, in ordine', () => {
+  it('gli Spazi sono le sette voci della sidebar, in ordine', () => {
     expect(NAV_TEAM_SPACES.map((t) => [t.path, t.labelKey])).toEqual([
       ['', 'app.nav2.home'],
       ['/media', 'app.nav2.materials'],
       ['/strategy', 'app.hub.strategy.label'],
       ['/calendar', 'app.hub.publish.calendar'],
+      ['/site', 'app.nav2.site'],
       ['/radar', 'app.nav2.newsRadar'],
       ['/analytics', 'app.nav2.results']
     ]);
@@ -137,7 +138,6 @@ describe('la nav del brand', () => {
   it('sa esattamente quali destinazioni hanno perso la riga in sidebar', () => {
     expect(NAV_OFF_SIDEBAR.map((t) => t.path)).toEqual([
       '/leads',
-      '/site',
       '/seo',
       '/keywords',
       '/backlinks',

--- a/src/lib/workbench-paths.ts
+++ b/src/lib/workbench-paths.ts
@@ -227,6 +227,9 @@ export const NAV_TEAM_SPACES: NavTeamItem[] = [
     badge: 'content',
     also: ['/content', '/approvals', '/publish']
   },
+  // Il blog ha una riga sua: e' una superficie di pubblicazione come il calendario, e senza
+  // riga ci si arrivava solo da ⌘K — cioe' non ci arrivava nessuno.
+  { path: '/site', labelKey: 'app.nav2.site' },
   // News Radar sale fra gli Spazi: e' l'unica delle pagine-strumento che si guarda tutti i
   // giorni, ed e' la sola voce che la sidebar tiene fuori dalle cinque del mockup.
   { path: '/radar', labelKey: 'app.nav2.newsRadar' },
@@ -246,7 +249,6 @@ export const NAV_TEAM_SPACES: NavTeamItem[] = [
  */
 export const NAV_OFF_SIDEBAR: NavTeamItem[] = [
   { path: '/leads', labelKey: 'app.hub.automations.leads', badge: 'leads' },
-  { path: '/site', labelKey: 'app.nav2.site' },
   // SEO e GEO sono una voce sola: la ricerca e la citabilità dai modelli sono la stessa domanda
   // ("ci trovano?") fatta a due motori. `/geo`, `/seo-geo` e `/citations` restano rotte vere —
   // si aprono da qui dentro e da ⌘K, che elenca ogni pagina del brand — ma non hanno una riga

--- a/src/routes/app/[brand]/+layout.svelte
+++ b/src/routes/app/[brand]/+layout.svelte
@@ -10,6 +10,7 @@
   import Images from '@lucide/svelte/icons/images';
   import Target from '@lucide/svelte/icons/target';
   import CalendarDays from '@lucide/svelte/icons/calendar-days';
+  import Newspaper from '@lucide/svelte/icons/newspaper';
   import BarChart3 from '@lucide/svelte/icons/chart-column';
   import Radio from '@lucide/svelte/icons/radio';
   import { setCredits, refreshCredits } from '$lib/stores/credits';
@@ -208,7 +209,7 @@
             : undefined
     };
   }
-  const SPACE_ICONS = [House, Images, Target, CalendarDays, Radio, BarChart3];
+  const SPACE_ICONS = [House, Images, Target, CalendarDays, Newspaper, Radio, BarChart3];
   // Una sola sezione, senza intestazione: sei voci non hanno bisogno di essere raggruppate, e
   // «Impostazioni» non e' una riga — e' l'ingranaggio in fondo alla barra, che ha gia' il suo
   // nome accessibile (`aria-label` + `title` in DashboardSidebar).


### PR DESCRIPTION
## What?

The brand sidebar shows the blog again. `/site` («Auto blog») moves from
`NAV_OFF_SIDEBAR` back into `NAV_TEAM_SPACES`, right under Calendar, with a
newspaper icon. The bar goes from six rows to seven; everything else in the
shell is untouched.

## Why?

When the sidebar was cut to the six rows of the mockup, the blog went with the
cut. The page kept working — ⌘K opened it, agent links opened it — but nothing
in the bar pointed at it, and a surface you publish to every day is not one you
look up in a palette. It read as a removed feature.

## How?

The nav structure lives in one place, `src/lib/workbench-paths.ts`, and the two
lists are complementary by design: `NAV_TEAM_SPACES` is what the bar shows,
`NAV_OFF_SIDEBAR` is the written inventory of what has no row. Moving the entry
between them is the whole change; a test asserts the two never overlap.

The blog sits after the calendar rather than at the end because it is the other
publishing surface: what the calendar is for social, the blog is for the site.

`SPACE_ICONS` in the layout is positional, so it gains a seventh icon
(`Newspaper`) at the matching index.

Rejected: leaving it in `NAV_OFF_SIDEBAR` and adding a link from the Web hub —
that keeps the row count at six but leaves the same problem, one click deeper.

## Testing?

Both tests that pinned the old shape were edited **first** and watched fail —
`gli Spazi sono le sette voci della sidebar, in ordine` (the order) and `sa
esattamente quali destinazioni hanno perso la riga in sidebar` (the inventory):

```
Test Files  1 failed | 1 passed (2)
      Tests  2 failed | 44 passed (46)
```

After the change, green:

```
✓ src/lib/workbench-paths.test.ts (6 tests)
✓ src/lib/shortcuts.test.ts (40 tests)
  Tests  46 passed (46)
```

`shortcuts.test.ts` matters here: `GO_TARGETS` takes `g s` → `/site` and reads
its label from the nav lists, so a move between them would have broken the
shortcut silently. It did not.

## Evidence (screenshots/videos)

Local dev server from this worktree (`:5291`), signed in, brand `nebulae-verify`:

- Sidebar now reads Home · Materiali · Strategia · Calendario · **Auto blog** ·
  News Radar · Risultati, the new row carrying the newspaper icon.
- Clicking it navigates to `/app/nebulae-verify/site`, the page renders
  («Blog — Anteprima del blog, articoli e pubblicazione») and the row stays
  highlighted as active.

## Anything Else?

The comments in `workbench-paths.ts` that said «le sei voci del mockup» are now
one row out of date in spirit — they were updated where they describe the bar,
but the design note behind the six-row decision lives in the git history, not in
the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY