### PR TITLE
Make the brand home draw itself again

### DIFF
--- a/changelog/2026-09-12-app-home-ui.md
+++ b/changelog/2026-09-12-app-home-ui.md
@@ -1,0 +1,43 @@
+# La home del brand torna a disegnarsi
+
+Quattro cose sulla stessa pagina, e una sola contava davvero.
+
+## Lo shimmer che non finiva mai
+
+La home restava sul caricamento per sempre. Il sospetto naturale era la promessa in streaming
+di `loadHomeOverview`: sbagliato, e la sonda lo ha detto in un minuto — la promessa si risolve
+(805 ms, dati completi, entrambi i chunk nel `__data.json`) e uno `$state` scritto dal suo `.then`
+si aggiornava regolarmente.
+
+A morire era il ramo `:then`. `HomeWorkbench` lanciava `ReferenceError: seoGauge is not defined`
+mentre si disegnava: Svelte butta via il ramo a metà costruzione, lascia in piedi quello in attesa
+e l'errore finisce solo in console. Da fuori è indistinguibile da una promessa che non arriva.
+
+Le due variabili (`seoGauge`/`seoGaugeLabel`, `geoGauge`/`geoGaugeLabel`) erano state dichiarate
+insieme ai tre gauge grandi — setup, SEO, GEO — e sono sparite con loro quando quel blocco è stato
+tolto in favore della lista «cose da fare». I due `mini-ring` dentro le card della sezione Web,
+però, sono rimasti nel markup con il loro CSS.
+
+Il calcolo ora sta in `$lib/home-gauges.ts`, puro e sotto test come `home-todos` accanto: il
+riempimento è il punteggio tecnico, l'etichetta è il voto, e **un anello vuoto non è uno zero
+misurato** — senza analisi l'etichetta è un trattino, perché «0%» si legge come un risultato.
+
+Perché `npm run check` non l'ha fermato: lo dice, ma in mezzo a **349 errori preesistenti**. Un
+controllo che fallisce sempre non ferma niente.
+
+## Le altre tre
+
+- **«Panoramica» via dalla sidebar.** Portava a `/app/<slug>`, cioè dove porta «Home» due righe
+  sotto: la stessa destinazione elencata due volte. Resta il guscio dell'header, che serve a
+  tenere l'altezza della top bar e il filo allineato.
+- **La guida MCP non era chiusa: era schiacciata.** La home è una colonna flex e la guida non
+  dichiarava `flex: none`, quindi lo shimmer sotto la comprimeva a 194px di 537 — si vedeva un
+  terzo del primo comando e sembrava un box da aprire. Con l'occasione ha preso una gerarchia:
+  i tre modi numerati, l'accento dove serve a leggere, il bottone che diventa accento quando ha
+  copiato.
+- **La pillola delle notifiche non aveva una regola base.** C'erano solo i tre fondi per severità:
+  niente raggio, niente padding, niente `font-size` — la cifra usciva a 16px su una striscia
+  colorata. Ora è un cerchio che si allunga in pillola a due cifre.
+
+E una riga di contorno: `GrowthReadiness` passava i valori solo alla descrizione e non
+all'etichetta, quindi «Storico post ({detail})» arrivava a schermo con il segnaposto in chiaro.

--- a/src/lib/components/DashboardSidebar.svelte
+++ b/src/lib/components/DashboardSidebar.svelte
@@ -21,7 +21,6 @@
     Sun,
     Moon,
     LogOut,
-    UserPlus,
     LayoutGrid,
     Key,
     ArrowUpRight,
@@ -175,16 +174,11 @@
     'font-semibold data-[active=true]:bg-[color:var(--nav-on)] data-[active=true]:hover:bg-[color:var(--nav-on-hover)] active:bg-[var(--paper)]';
   /** Vertical spacing between sidebar nav rows. */
   const navMenuGapClass = $derived(mobile ? 'gap-1.5' : 'gap-2');
-  const overviewHref = $derived(brandSlug ? `/app/${brandSlug}` : '');
   const activateHref = $derived(brandSlug ? `/app/${brandSlug}/activate` : '');
   const showUpgrade = $derived(!!brandSlug && !isPaidPlan(brandPlan));
-  const overviewActive = $derived(
-    !!overviewHref &&
-      ($page.url.pathname === overviewHref || $page.url.pathname === `${overviewHref}/`)
-  );
   /** Path of in-flight navigation — highlights the destination row immediately. */
   const pendingPath = $derived(navigating.to?.url.pathname ?? null);
-  /** Exact for brand-root Overview (`/app/{slug}`); prefix for nested hub routes. */
+  /** Esatto per la home del brand (`/app/{slug}`); a prefisso per le rotte annidate. */
   function isNavPending(href: string, exact = false) {
     if (!pendingPath || !href) return false;
     if (exact) return pendingPath === href || pendingPath === `${href}/`;
@@ -384,41 +378,12 @@
          bordi sono una riga sola che attraversa la finestra invece di due tratti sfalsati.
          Nessun padding orizzontale sul guscio — il filo va da lato a lato; il rientro se lo
          tiene la riga dentro, dove serve a incolonnare l'etichetta con la nav. -->
-    <Sidebar.Header class="shell-top-header shell-top-divider justify-center gap-0 p-0">
-      <Sidebar.Group class="w-full p-0 px-2.5 group-data-[collapsible=icon]:px-2">
-        <Sidebar.Menu class={navMenuGapClass}>
-          <Sidebar.MenuItem>
-            {@const overviewPending = isNavPending(overviewHref, true)}
-            {@const overviewOn = overviewPending || (overviewActive && !pendingPath)}
-            <Sidebar.MenuButton
-              isActive={overviewOn}
-              tooltipContent={$_('app.nav.homeOverview')}
-              size={mobile ? 'default' : 'sm'}
-              class={cn(
-                overviewOn ? navOnClass : 'hover:bg-black/[0.04] dark:hover:bg-white/[0.06] active:bg-[var(--paper)]',
-                menuBtnMobileClass
-              )}
-              style={overviewOn ? 'color: var(--accent-ink)' : undefined}
-            >
-              {#snippet child({ props })}
-                <a
-                  href={overviewHref}
-                  {...props}
-                  onclick={() => {
-                    if (sidebar.isMobile && sidebar.openMobile) {
-                      sidebar.setOpenMobile(false);
-                    }
-                  }}
-                >
-                  <UserPlus class={iconClass} strokeWidth={1.7} />
-                  <span class={cn(labelClass, 'group-data-[collapsible=icon]:hidden')}>{$_('app.nav.homeOverview')}</span>
-                </a>
-              {/snippet}
-            </Sidebar.MenuButton>
-          </Sidebar.MenuItem>
-        </Sidebar.Menu>
-      </Sidebar.Group>
-    </Sidebar.Header>
+    <!-- Resta il guscio, non la voce: «Panoramica» portava a `/app/<slug>`, che e' dove porta
+         «Home» due righe sotto — la stessa destinazione elencata due volte. Quello che l'header
+         faceva oltre a quello serve ancora: tiene l'altezza della top bar delle pagine
+         (`--shell-top-h`) e lo stesso filo, cosi' i due bordi sono una riga sola che attraversa
+         la finestra invece di due tratti sfalsati. -->
+    <Sidebar.Header class="shell-top-header shell-top-divider p-0" />
   {/if}
 
   <Sidebar.Content class="flex-1 gap-0 overflow-y-auto px-2.5 py-3 group-data-[collapsible=icon]:px-2 group-data-[collapsible=icon]:py-2.5 group-data-[collapsible=icon]:overflow-visible">
@@ -761,6 +726,31 @@
     --nav-on-hover: color-mix(in srgb, var(--accent) 24%, transparent);
   }
 
+
+  /* Un cerchio, non un numero grande su una striscia colorata: qui non c'era nessuna regola base
+     — solo i tre fondi per severita' — quindi la cifra usciva a 16px senza raggio ne' padding.
+     `min-width` pari all'altezza tiene il cerchio a una cifra e lo allunga in pillola a due; il
+     bordo della barra laterale lo stacca dal campanello che gli sta sotto. */
+  .um-bell-count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 16px;
+    height: 16px;
+    padding: 0 4px;
+    border-radius: 999px;
+    box-shadow: 0 0 0 2px var(--sidebar-bg, var(--paper));
+    color: #fff;
+    font-size: 10px;
+    font-weight: 700;
+    line-height: 1;
+    font-variant-numeric: tabular-nums;
+  }
+  .um-bell-count.mobile {
+    min-width: 18px;
+    height: 18px;
+    font-size: 11px;
+  }
 
   .um-bell-count.sev-error {
     background: #ef4444;

--- a/src/lib/components/GrowthReadiness.svelte
+++ b/src/lib/components/GrowthReadiness.svelte
@@ -59,7 +59,11 @@
               {#if c.ok}<Check size={13} />{:else if c.blocking}<AlertTriangle size={13} />{:else}<Minus size={13} />{/if}
             </span>
             <span class="txt">
-              <span class="lb">{$_(`app.growthReadiness.checks.${c.key}.label`)}</span>
+              <!-- Anche l'etichetta ha il suo `{detail}` (`Storico post ({detail})`): senza i valori
+                   la parentesi restava con il segnaposto dentro, in chiaro, sotto gli occhi di tutti. -->
+              <span class="lb"
+                >{$_(`app.growthReadiness.checks.${c.key}.label`, { values: { detail: c.detail ?? '' } })}</span
+              >
               <span class="ds">
                 {$_(`app.growthReadiness.checks.${c.key}.${c.ok ? 'ok' : 'todo'}`, {
                   values: { detail: c.detail ?? '' }

--- a/src/lib/components/HomeWorkbench.svelte
+++ b/src/lib/components/HomeWorkbench.svelte
@@ -5,6 +5,7 @@
   import GrowthReadiness from '$lib/components/GrowthReadiness.svelte';
   import { fmtCompactNum } from '$lib/fmt-num';
   import { homeTodos } from '$lib/home-todos';
+  import { webGauges } from '$lib/home-gauges';
 
   type Extras = {
     pendingCount?: number;
@@ -135,6 +136,12 @@
   // traduzione. Ha preso il posto di tre gauge (setup, SEO, GEO) e di una coda paginata dei
   // singoli post: i primi erano ornamento, la seconda diceva la stessa cosa della riga
   // «N da approvare» con un clic in più e una paginazione da mantenere.
+  /* I due anelli della sezione Web. Le loro variabili stavano insieme ai tre gauge grandi e sono
+     sparite con quelli, ma gli anelli erano rimasti nel markup: il componente moriva a
+     `seoGauge is not defined`, il ramo che disegna la home non veniva mai creato e la pagina
+     restava sullo shimmer per sempre. Il calcolo ora sta in `$lib/home-gauges`, sotto test. */
+  const gauges = $derived(webGauges(overview.web));
+
   const todos = $derived(
     homeTodos({
       queue: { pending: pendingPostCount },
@@ -449,8 +456,8 @@
     <div class="metric-grid metric-grid-wide">
       <a class="metric-card has-viz" href={`${base}/seo`}>
         <div class="metric-top">
-          <div class="mini-ring" style={`--v:${Math.round(seoGauge)}`} aria-hidden="true">
-            <span>{seoGaugeLabel}</span>
+          <div class="mini-ring" style={`--v:${gauges.seoFill}`} aria-hidden="true">
+            <span>{gauges.seoLabel}</span>
           </div>
           <div class="metric-text">
             <span class="metric-l">{$_('app.home.overview.seo')}</span>
@@ -490,8 +497,8 @@
         href={`${base}/geo`}
       >
         <div class="metric-top">
-          <div class="mini-ring" style={`--v:${Math.round(geoGauge)}`} aria-hidden="true">
-            <span>{geoGaugeLabel}</span>
+          <div class="mini-ring" style={`--v:${gauges.geoFill}`} aria-hidden="true">
+            <span>{gauges.geoLabel}</span>
           </div>
           <div class="metric-text">
             <span class="metric-l">{$_('app.home.overview.geo')}</span>

--- a/src/lib/components/McpGuide.svelte
+++ b/src/lib/components/McpGuide.svelte
@@ -54,13 +54,13 @@ anomalia login`;
   </summary>
 
   <div class="body">
-    {#each STEPS as step (step.id)}
+    {#each STEPS as step, i (step.id)}
       <section>
-        <h3>{$_(`app.mcpGuide.${step.key}Title`)}</h3>
+        <h3><span class="n">{i + 1}</span>{$_(`app.mcpGuide.${step.key}Title`)}</h3>
         <p class="muted">{$_(`app.mcpGuide.${step.key}Note`)}</p>
         <div class="snippet">
           <pre><code>{step.snippet}</code></pre>
-          <button type="button" onclick={() => copy(step.id, step.snippet)}>
+          <button type="button" class:done={copied === step.id} onclick={() => copy(step.id, step.snippet)}>
             {copied === step.id ? $_('app.mcpGuide.copied') : $_('app.mcpGuide.copy')}
           </button>
         </div>
@@ -76,10 +76,15 @@ anomalia login`;
 
 <style>
   /* La palette è quella del guscio (`--paper`, `--ink`, `--line`): la guida arriva da /v2, che
-     aveva i suoi token, e due palette nella stessa pagina si vedono. */
+     aveva i suoi token, e due palette nella stessa pagina si vedono. L'accento entra solo dove
+     serve a leggere — il numero del passo, il filo in testa, il bottone che ha copiato — perché
+     tre blocchi di codice in scala di grigio si guardano tutti uguali e non si legge nessuno. */
   .mcp {
+    /* La home è una colonna flex: senza questo la guida veniva schiacciata dallo shimmer sotto e
+       si vedeva un terzo del primo comando, come se fosse chiusa. */
+    flex: none;
     border: 1px solid var(--line);
-    border-radius: 14px;
+    border-radius: 16px;
     background: var(--paper);
     overflow: hidden;
     margin-bottom: 20px;
@@ -87,8 +92,8 @@ anomalia login`;
   summary {
     display: flex;
     align-items: center;
-    gap: 8px;
-    padding: 12px 14px;
+    gap: 9px;
+    padding: 13px 16px;
     cursor: pointer;
     list-style: none;
     font-size: 13.5px;
@@ -99,9 +104,22 @@ anomalia login`;
   summary:hover {
     background: var(--paper-2);
   }
+  summary strong {
+    font-size: 14px;
+    font-weight: 650;
+    letter-spacing: -0.01em;
+  }
   .chev {
-    color: var(--ink-faint);
-    transition: transform 140ms ease;
+    display: inline-grid;
+    place-items: center;
+    width: 20px;
+    height: 20px;
+    flex: none;
+    border-radius: 6px;
+    background: rgba(var(--accent-rgb), 0.14);
+    color: var(--accent);
+    font-size: 13px;
+    transition: transform 160ms ease;
   }
   .mcp[open] .chev {
     transform: rotate(90deg);
@@ -112,35 +130,55 @@ anomalia login`;
   .body {
     display: flex;
     flex-direction: column;
-    gap: 16px;
+    gap: 20px;
     border-top: 1px solid var(--line);
-    padding: 16px 14px;
+    padding: 18px 16px 16px;
   }
   section {
     display: flex;
     flex-direction: column;
-    gap: 5px;
+    gap: 6px;
   }
   h3 {
+    display: flex;
+    align-items: center;
+    gap: 9px;
     margin: 0;
     font-size: 13.5px;
-    font-weight: 600;
+    font-weight: 650;
     color: var(--ink);
+  }
+  /* Il numero dice che i tre blocchi sono strade alternative in ordine di comodità, non tre
+     passaggi da fare tutti: è l'unica gerarchia che mancava per capirci qualcosa al primo sguardo. */
+  .n {
+    display: inline-grid;
+    place-items: center;
+    width: 19px;
+    height: 19px;
+    flex: none;
+    border-radius: 50%;
+    background: rgba(var(--accent-rgb), 0.14);
+    color: var(--accent);
+    font-size: 11px;
+    font-weight: 700;
   }
   p {
     margin: 0;
     font-size: 12.5px;
     line-height: 1.5;
   }
+  section > .muted {
+    padding-left: 28px;
+  }
   .snippet {
     display: flex;
     align-items: flex-start;
     gap: 8px;
+    margin: 5px 0 0 28px;
     border: 1px solid var(--line);
-    border-radius: 10px;
+    border-radius: 12px;
     background: var(--paper-2);
-    padding: 8px;
-    margin-top: 3px;
+    padding: 10px 10px 10px 12px;
   }
   /* Il blocco scorre da solo: la pagina non deve mai scorrere in orizzontale per un comando. */
   pre {
@@ -148,23 +186,34 @@ anomalia login`;
     min-width: 0;
     margin: 0;
     overflow-x: auto;
+    font-family: var(--mono);
     font-size: 12px;
-    line-height: 1.55;
+    line-height: 1.6;
+    color: var(--ink);
   }
   button {
     flex: none;
     border: 1px solid var(--line);
-    border-radius: 8px;
+    border-radius: 999px;
     background: var(--paper);
     color: var(--ink-soft);
-    padding: 4px 8px;
-    font-size: 12px;
+    padding: 5px 12px;
+    font-size: 11.5px;
+    font-weight: 600;
     cursor: pointer;
+    transition: color 140ms ease, border-color 140ms ease, background 140ms ease;
   }
   button:hover {
     color: var(--ink);
+    border-color: var(--line-2);
+  }
+  button.done {
+    color: var(--accent);
+    border-color: rgba(var(--accent-rgb), 0.4);
+    background: rgba(var(--accent-rgb), 0.1);
   }
   .foot {
+    padding-left: 28px;
     font-size: 11.5px;
   }
   .foot a {

--- a/src/lib/content/changelog/2026-09-12-app-home-ui.ts
+++ b/src/lib/content/changelog/2026-09-12-app-home-ui.ts
@@ -1,0 +1,12 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-12',
+  title: 'The brand home loads again',
+  items: [
+    'The home of a brand no longer sits on a loading placeholder forever: it was crashing while drawing itself, which from the outside looked exactly like data that never arrived.',
+    'The «connect your agent» box opens on all three ways in, numbered and readable, instead of being squeezed to a third of the first command.',
+    'The sidebar drops the duplicate «Overview» row — it went where «Home» goes — and the notification count is a circle again instead of an oversized number.',
+    'The growth checklist shows its real counts instead of a placeholder in the label.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/home-gauges.test.ts
+++ b/src/lib/home-gauges.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { webGauges } from './home-gauges';
+
+/**
+ * I due anelli della sezione Web della home. Sono spariti una volta: le loro variabili erano
+ * dichiarate insieme ai tre gauge grandi, quei gauge sono stati tolti e le variabili con loro —
+ * ma gli anelli erano rimasti nel markup. Il componente esplodeva a `seoGauge is not defined`, e
+ * il ramo che disegna la home non veniva mai creato: shimmer per sempre, senza un errore visibile.
+ *
+ * Qui sta il calcolo, puro: cosa mostra l'anello quando il dato c'è, e cosa quando non c'è.
+ */
+describe('webGauges', () => {
+  it('il voto SEO riempie con il punteggio tecnico e si etichetta col voto', () => {
+    const g = webGauges({ techScore: 72, seoGrade: 'B+', citationsMentioned: 0, citationsTotal: 0, shareOfVoice: null });
+    expect(g.seoFill).toBe(72);
+    expect(g.seoLabel).toBe('B+');
+  });
+
+  it('senza analisi SEO l’anello è vuoto e lo dice con un trattino', () => {
+    const g = webGauges({ techScore: null, seoGrade: null, citationsMentioned: 0, citationsTotal: 0, shareOfVoice: null });
+    expect(g.seoFill).toBe(0);
+    expect(g.seoLabel).toBe('—');
+  });
+
+  it('il GEO conta le citazioni in cui il brand è nominato', () => {
+    const g = webGauges({ techScore: null, seoGrade: null, citationsMentioned: 3, citationsTotal: 12, shareOfVoice: 40 });
+    expect(g.geoFill).toBe(25);
+    expect(g.geoLabel).toBe('25%');
+  });
+
+  it('senza citazioni ripiega sulla quota di voce', () => {
+    const g = webGauges({ techScore: null, seoGrade: null, citationsMentioned: 0, citationsTotal: 0, shareOfVoice: 40 });
+    expect(g.geoFill).toBe(40);
+    expect(g.geoLabel).toBe('40%');
+  });
+
+  it('senza niente da mostrare non inventa uno zero che sembra misurato', () => {
+    const g = webGauges({ techScore: null, seoGrade: null, citationsMentioned: 0, citationsTotal: 0, shareOfVoice: null });
+    expect(g.geoFill).toBe(0);
+    expect(g.geoLabel).toBe('—');
+  });
+
+  it('il riempimento resta fra 0 e 100 anche se il dato esce dai binari', () => {
+    const g = webGauges({ techScore: 140, seoGrade: 'A', citationsMentioned: 9, citationsTotal: 3, shareOfVoice: null });
+    expect(g.seoFill).toBe(100);
+    expect(g.geoFill).toBe(100);
+  });
+});

--- a/src/lib/home-gauges.ts
+++ b/src/lib/home-gauges.ts
@@ -1,0 +1,43 @@
+/**
+ * I due anelli della sezione Web della home: quanto sono pieni e cosa scrivono dentro.
+ *
+ * Stanno qui e non nel componente per la stessa ragione per cui ci sta `home-todos`: è il
+ * calcolo, ed è l'unica parte che si può mettere sotto test senza un browser. Il componente
+ * disegna e basta.
+ *
+ * La regola che li governa è una: **un anello vuoto non è uno zero misurato**. Quando l'analisi
+ * non è mai stata fatta l'etichetta è un trattino, non «0%» — che si legge come un risultato.
+ */
+export type WebGaugeInput = {
+  techScore: number | null;
+  seoGrade: string | null;
+  citationsMentioned: number;
+  citationsTotal: number;
+  shareOfVoice: number | null;
+};
+
+export type WebGauges = {
+  seoFill: number;
+  seoLabel: string;
+  geoFill: number;
+  geoLabel: string;
+};
+
+const NOT_MEASURED = '—';
+
+/** Il riempimento è una percentuale: fuori dai binari l'anello mente, quindi si taglia. */
+function pct(value: number): number {
+  return Math.max(0, Math.min(100, Math.round(value)));
+}
+
+export function webGauges(web: WebGaugeInput): WebGauges {
+  const mentioned = web.citationsTotal > 0 ? (web.citationsMentioned / web.citationsTotal) * 100 : null;
+  const geo = mentioned ?? web.shareOfVoice;
+
+  return {
+    seoFill: web.techScore == null ? 0 : pct(web.techScore),
+    seoLabel: web.seoGrade ?? NOT_MEASURED,
+    geoFill: geo == null ? 0 : pct(geo),
+    geoLabel: geo == null ? NOT_MEASURED : `${pct(geo)}%`
+  };
+}

--- a/src/routes/app/[brand]/workbench/+page.svelte
+++ b/src/routes/app/[brand]/workbench/+page.svelte
@@ -16,7 +16,12 @@
 
 <!-- `extras` non si passa di proposito: erano i badge differiti del layout, e qui dentro
      non ci sono. Servivano solo come sovrascrittura anticipata — `overview` porta già
-     ognuno di quei numeri, quindi il workbench è identico, appena meno impaziente. -->
+     ognuno di quei numeri, quindi il workbench è identico, appena meno impaziente.
+
+     Se un giorno questo shimmer non finisce più, il sospettato NON è la promessa: è
+     `HomeWorkbench` che esplode mentre si disegna. Il ramo `:then` muore a metà, `{#await}`
+     resta su quello in attesa e l'errore finisce solo in console — visto una volta, con una
+     variabile rimasta nel markup dopo che la sua dichiarazione era stata tolta. -->
 {#await data.overview}
   <WorkbenchPageShimmer variant="home" />
 {:then overview}


### PR DESCRIPTION
## What?

Four fixes on `/app/[brand]`, and one of them is the reason the page was
unusable:

- **The home draws itself again.** It sat on its loading shimmer forever,
  on every brand, for anyone who opened it.
- **«Overview» leaves the sidebar.** «Home» is the first row again.
- **The MCP guide is fully open and readable**, with its three routes
  numbered instead of three identical grey blocks.
- **The notification count is a circle**, not a 16px number on a coloured
  strip.

One line of housekeeping came with them: the growth checklist printed
`Storico post ({detail})` with the placeholder in plain sight.

## Why?

The shimmer is the one that mattered. The brand home is where every session
starts, and it never finished loading — not slowly, *never*.

## How?

**The streamed overview was the natural suspect and the wrong one.** Measured
before touching anything: the promise resolves in 805 ms, `__data.json`
delivers both chunks, and a `$state` written from its own `.then` inside the
same component updates fine.

What died was the `:then` branch. `HomeWorkbench` threw
`ReferenceError: seoGauge is not defined` while drawing itself; Svelte
discards the half-built branch, leaves the pending one standing, and puts the
error in the console. From the outside that is indistinguishable from data
that never arrives — which is why the first diagnosis went to the promise.

The two pairs of variables (`seoGauge`/`seoGaugeLabel`,
`geoGauge`/`geoGaugeLabel`) were declared next to the three big gauges
(setup, SEO, GEO) and went out with them when that block was replaced by the
todo list. The two `mini-ring`s inside the Web cards stayed in the markup,
CSS and all.

The maths now lives in `src/lib/home-gauges.ts` — pure, beside `home-todos`,
for the same reason: it is the part that can be tested without a browser. The
rule that made the tests worth writing is that **an empty ring is not a
measured zero**: with no analysis the label is a dash, because «0%» reads as
a result.

**Why `npm run check` did not stop this**: it does report it — in the middle
of **349 pre-existing errors**. A gate that always fails stops nothing. Not
fixed here; worth its own pass.

The other three:

- The MCP guide was never collapsed. The home is a flex column and the guide
  did not declare `flex: none`, so the shimmer below squeezed 537px of
  content into 194 — a third of the first command, which reads as a closed
  box. It also gained the hierarchy it was missing: numbered routes, accent
  where it helps reading, a copy button that turns accent once it has copied.
- «Overview» pointed at `/app/<slug>`, which is where «Home» points two rows
  below: the same destination listed twice. The header shell stays — it holds
  the top-bar height and the divider that lines up with the page header.
- `.um-bell-count` had no base rule at all, only three severity backgrounds,
  so the count inherited 16px with no radius and no padding. Now a circle
  that stretches into a pill at two digits.

## Testing?

- `src/lib/home-gauges.test.ts` — 6 tests, written before the module and
  watched fail (`no tests` → module missing), then green. They pin the rule:
  score fills, grade labels, citations before share of voice, a dash when
  nothing was measured, and the fill clamped to 0–100.
- `npx vitest run home-gauges home-todos workbench-paths shortcuts` — 58
  passed.
- `npm run check` — no error in any file this PR touches (only pre-existing
  CSS warnings).
- Browser, signed in, on a real brand: the home loads and renders through to
  the content pipeline, with **no console errors**; the guide shows all three
  routes; the sidebar starts at Home; the bell count is a circle; the
  checklist shows `Storico post (0)` instead of the placeholder.

**Not tested**: the two Web rings themselves. The brand available here is on
the free plan and that section is behind the upgrade wall, so the fix is
covered by the unit tests and by the component no longer throwing — not by
having seen the rings on screen. Worth a look on a paid brand.

## Evidence (screenshots/videos)

Before: the guide cut to a third, a permanent shimmer under it, «Panoramica»
above «Home», the count as a bare number.
After: guide open with routes 1–2–3, the home rendering its setup checklist,
growth data, todos and pipeline; sidebar starting at «Home»; the count in a
circle.

## Anything Else?

- The comment in the workbench page now says where to look if this ever comes
  back: not the promise — the component that draws the `:then`.
- 349 errors in `npm run check` is the reason this class of defect reaches
  production. Cleaning that is its own piece of work, and it is the one thing
  that would have caught this before a browser did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY