### PR TITLE
Block apparel branding violations

### DIFF
--- a/changelog/2026-09-11-apparel-branding-review.md
+++ b/changelog/2026-09-11-apparel-branding-review.md
@@ -1,0 +1,10 @@
+# I marchi sui capi non arrivano più al media né alla pubblicazione
+
+Le istruzioni al generatore non bastavano: un marchio destinato alla ricamatrice
+poteva comparire ricamato su polo, cappelli e altri capi. Il render ora riceve
+una regola esplicita e passa un reviewer visivo prima di restituire un asset.
+Un verdetto mancante o non valido blocca il visual invece di lasciarlo uscire.
+
+La pubblicazione rilegge anche le immagini già presenti o importate. Riceve il
+brief originale per distinguere un logo richiesto sul capo da un marchio estraneo,
+e trattiene il post visivo quando il reviewer non è disponibile.

--- a/src/lib/content/changelog/2026-09-11-apparel-branding-review.ts
+++ b/src/lib/content/changelog/2026-09-11-apparel-branding-review.ts
@@ -1,0 +1,7 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-11',
+  title: 'Unexpected branding on apparel is now blocked',
+  items: ['Generated and scheduled visuals are checked for unrequested logos or labels on garments before they can be used or published.']
+} satisfies ChangelogEntry;

--- a/src/lib/server/content-preview/articles.ts
+++ b/src/lib/server/content-preview/articles.ts
@@ -4,6 +4,9 @@ import { BLOG_IMAGE_MODEL, PRODUCT_REF_IMAGES, aspectRatioFor, brandVisualDirect
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { fetchImagePart } from '$lib/server/brand-context';
 import { structured } from '$lib/server/research';
+import { withBrandContext } from '$lib/server/ai-log';
+import { buildMemoryContext } from '$lib/server/brand-memory';
+import { extractBrandConstraints } from '$lib/server/image-constraint-review';
 
 // Perché le cover del blog restino fedeli a prodotti VERI invece di inventarli.
 async function pickArticleProductRefs(
@@ -65,9 +68,10 @@ export async function generateArticleCover(
     .select('visual_style, ai_context, brand_colors, fonts').eq('brand_id', brand.id).maybeSingle();
   const moodUrls = await loadBrandMoodImageUrls(admin, brand.id).catch((error) => { swallow('load mood image urls', error); return []; });
   const products = await pickArticleProductRefs(admin, brand.id, `${opts.title} ${opts.summary ?? ''}`, 2).catch((error) => { swallow('pick product references', error); return []; });
-  const [moodImages, referenceImages] = await Promise.all([
+  const [moodImages, referenceImages, memory] = await Promise.all([
     loadMoodRefs(moodUrls),
-    loadProductRefs(products.flatMap((p) => p.images).slice(0, PRODUCT_REF_IMAGES))
+    loadProductRefs(products.flatMap((p) => p.images).slice(0, PRODUCT_REF_IMAGES)),
+    buildMemoryContext(admin, brand.id)
   ]);
   const fontNames = (Array.isArray(kit?.fonts) ? (kit!.fonts as AnyRec[]) : []).map((f) => f?.name).filter(Boolean) as string[];
   const productHint = products.length
@@ -75,7 +79,7 @@ export async function generateArticleCover(
     : '';
 
   const prompt = `A striking editorial COVER / hero image for a blog article titled "${opts.title}".${opts.summary ? ` The article is about: ${String(opts.summary).slice(0, 220)}.` : ''}${productHint} Evocative, magazine-quality, a clear focal point with room to breathe. Absolutely NO text, letters, words, captions or logos anywhere in the image.`;
-  const dataUrl = await renderPostImage(prompt, {
+  const dataUrl = await withBrandContext(brand.id, () => renderPostImage(prompt, {
     aspectRatio: '16:9',
     model: BLOG_IMAGE_MODEL,
     visualStyle: (kit?.visual_style as string | undefined) || undefined,
@@ -83,8 +87,9 @@ export async function generateArticleCover(
     brandLook: brandVisualDirective(kit?.brand_colors as string[] | null, fontNames) || undefined,
     moodImages,
     referenceImages,
+    brandRules: extractBrandConstraints(memory) || undefined,
     referenceMode: referenceImages?.length ? 'product' : undefined
-  }).catch((error) => { swallow('render article cover', error); return undefined; });
+  })).catch((error) => { swallow('render article cover', error); return undefined; });
   if (!dataUrl) return null;
   return (await uploadPostImage(admin, brand.id, dataUrl, '16:9')) ?? null;
 }
@@ -104,9 +109,10 @@ export async function editArticleImage(
   const { data: kit } = await admin.from('brand_kit')
     .select('visual_style, ai_context, brand_colors, fonts').eq('brand_id', brand.id).maybeSingle();
   const moodUrls = await loadBrandMoodImageUrls(admin, brand.id).catch((error) => { swallow('load mood image urls', error); return []; });
-  const [moodImages, baseImage] = await Promise.all([
+  const [moodImages, baseImage, memory] = await Promise.all([
     loadMoodRefs(moodUrls),
-    fetchImagePart(opts.baseImageUrl)
+    fetchImagePart(opts.baseImageUrl),
+    buildMemoryContext(admin, brand.id)
   ]);
   if (!baseImage) return null;
 
@@ -117,14 +123,15 @@ User request: ${feedback}
 Absolutely NO text, letters, words, captions or logos anywhere in the image.`;
 
   // Nessun override: `baseImage` seleziona da sé il modello di fedeltà in buildImageRequest.
-  const dataUrl = await renderPostImage(prompt, {
+  const dataUrl = await withBrandContext(brand.id, () => renderPostImage(prompt, {
     aspectRatio: '16:9',
     visualStyle: (kit?.visual_style as string | undefined) || undefined,
     visualPlaybook: extractVisualPlaybook(kit?.ai_context) || undefined,
     brandLook: brandVisualDirective(kit?.brand_colors as string[] | null, fontNames) || undefined,
     moodImages,
+    brandRules: extractBrandConstraints(memory) || undefined,
     baseImage
-  }).catch((error) => { swallow('render edited cover', error); return undefined; });
+  })).catch((error) => { swallow('render edited cover', error); return undefined; });
   if (!dataUrl) return null;
   return (await uploadPostImage(admin, brand.id, dataUrl, '16:9')) ?? null;
 }
@@ -177,7 +184,7 @@ export async function generateArticleImages(
   const { data: kit } = await admin.from('brand_kit')
     .select('visual_style, ai_context, brand_colors, fonts').eq('brand_id', brand.id).maybeSingle();
   const moodUrls = await loadBrandMoodImageUrls(admin, brand.id).catch((error) => { swallow('load mood image urls', error); return []; });
-  const [moodImages] = await Promise.all([loadMoodRefs(moodUrls)]);
+  const [moodImages, memory] = await Promise.all([loadMoodRefs(moodUrls), buildMemoryContext(admin, brand.id)]);
   const fontNames = (Array.isArray(kit?.fonts) ? (kit!.fonts as AnyRec[]) : []).map((f) => f?.name).filter(Boolean) as string[];
   const baseOpts = {
     aspectRatio: '16:9' as const,
@@ -185,7 +192,8 @@ export async function generateArticleImages(
     visualStyle: (kit?.visual_style as string | undefined) || undefined,
     visualPlaybook: extractVisualPlaybook(kit?.ai_context) || undefined,
     brandLook: brandVisualDirective(kit?.brand_colors as string[] | null, fontNames) || undefined,
-    moodImages
+    moodImages,
+    brandRules: extractBrandConstraints(memory) || undefined
   };
 
   const rendered = await Promise.all(
@@ -196,11 +204,11 @@ export async function generateArticleImages(
         ? ` Show the brand's REAL product from the attached reference: ${products.map((p) => p.name).join(', ')}. Keep it pixel-faithful — restyle only scene/lighting.`
         : '';
       const prompt = `An editorial image illustrating the section "${t.heading}" of a blog article titled "${opts.title}".${productHint} Evocative, magazine-quality, a clear focal point. Absolutely NO text, letters, words, captions or logos anywhere in the image.`;
-      const dataUrl = await renderPostImage(prompt, {
+      const dataUrl = await withBrandContext(brand.id, () => renderPostImage(prompt, {
         ...baseOpts,
         referenceImages,
         referenceMode: referenceImages?.length ? 'product' : undefined
-      }).catch((error) => { swallow('render section image', error); return undefined; });
+      })).catch((error) => { swallow('render section image', error); return undefined; });
       if (!dataUrl) return null;
       const url = await uploadPostImage(admin, brand.id, dataUrl, '16:9');
       return url ? { line: t.line, md: `\n![${t.heading}](${url})\n` } : null;

--- a/src/lib/server/content-preview/image-constraint-gate.test.ts
+++ b/src/lib/server/content-preview/image-constraint-gate.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const state = vi.hoisted(() => ({
+  render: vi.fn(),
+  review: vi.fn(),
+  gateCredits: vi.fn()
+}));
+
+vi.mock('$lib/server/ai-log', () => ({
+  getBrandContext: () => 'brand-1',
+  getOrgContext: () => undefined
+}));
+
+vi.mock('$lib/server/credits', () => ({
+  gateCredits: (...args: unknown[]) => state.gateCredits(...args),
+  gateOrgCredits: vi.fn()
+}));
+
+vi.mock('$lib/server/kie-jobs', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('$lib/server/kie-jobs')>()),
+  generateImageOnKie: (...args: unknown[]) => state.render(...args)
+}));
+
+vi.mock('$lib/server/model-routing', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('$lib/server/model-routing')>()),
+  route: () => ({ family: 'nano-banana', endpoint: 'kie', provider: 'kie' })
+}));
+
+vi.mock('$lib/server/image-constraint-review', () => ({
+  APPAREL_BRANDING_DIRECTIVE: 'APPAREL BRANDING',
+  reviewImageConstraints: (...args: unknown[]) => state.review(...args)
+}));
+
+const { renderPostImage } = await import('./images');
+
+beforeEach(() => {
+  state.render.mockReset();
+  state.review.mockReset();
+  state.gateCredits.mockReset();
+  state.render.mockResolvedValue({ dataUrl: 'data:image/png;base64,AAAA' });
+  state.review.mockResolvedValue({ pass: false, issues: ['TAJIMA is embroidered on the polo shirt.'] });
+});
+
+describe('renderPostImage brand constraint gate', () => {
+  it('does not return an image rejected for branding on apparel', async () => {
+    const image = await renderPostImage('A Tajima machine beside a polo shirt.', {
+      brandRules: 'Tajima is allowed only on machines.'
+    });
+
+    expect(image).toBeUndefined();
+    expect(state.render).toHaveBeenCalledTimes(1);
+    expect(state.review).toHaveBeenCalledWith({
+      image: 'data:image/png;base64,AAAA',
+      brief: 'A Tajima machine beside a polo shirt.',
+      brandRules: 'Tajima is allowed only on machines.'
+    });
+  });
+});

--- a/src/lib/server/content-preview/images.ts
+++ b/src/lib/server/content-preview/images.ts
@@ -19,6 +19,8 @@ import { svgToPng } from '$lib/server/brand-analysis';
 import { normalizeContentFormat } from '$lib/content-formats';
 import { firstLogoUrl } from '$lib/brand-fields';
 import { designWallDigestSection } from '$lib/server/wall-digest';
+import { buildMemoryContext } from '$lib/server/brand-memory';
+import { APPAREL_BRANDING_DIRECTIVE, extractBrandConstraints, reviewImageConstraints } from '$lib/server/image-constraint-review';
 
 
 // Image MIME types Gemini ingests directly (SVG is rasterised via svgToPng).
@@ -151,6 +153,7 @@ export type RenderImageOpts = {
   aspectRatio?: AspectRatio;
   model?: string;
   craftFloor?: string;
+  brandRules?: string;
 };
 
 /**
@@ -218,7 +221,8 @@ export function buildImageRequest(imagePrompt: string, opts: RenderImageOpts = {
   const userRefSuffix = opts.userRefImages?.length
     ? '\n\nThe user attached the following image(s) as REFERENCES for this specific edit — use them to guide the change described above: match the look, composition, colours or subject they show, as the feedback implies. Let the user\'s instruction decide exactly what to take from them.'
     : '';
-  const text = `${cleanPrompt}\n\n${ASPECT_LABEL[aspectRatio]}, high quality, social-media ready. No text overlays unless natural.\n\n${HOUSE_LOOK}${opts.craftFloor ?? ''}${styleSuffix}${brandSuffix}${playbookSuffix}${baseSuffix}${logoSuffix}${personSuffix}${refSuffix}${userRefSuffix}${moodSuffix}`;
+  const brandRulesSuffix = opts.brandRules ? `\n\nBRAND APPAREL RULES:\n${opts.brandRules}` : '';
+  const text = `${cleanPrompt}\n\n${ASPECT_LABEL[aspectRatio]}, high quality, social-media ready. No text overlays unless natural.\n\n${HOUSE_LOOK}\n\n${APPAREL_BRANDING_DIRECTIVE}${brandRulesSuffix}${opts.craftFloor ?? ''}${styleSuffix}${brandSuffix}${playbookSuffix}${baseSuffix}${logoSuffix}${personSuffix}${refSuffix}${userRefSuffix}${moodSuffix}`;
   // L'immagine base va per PRIMA: il prompt la chiama "the FIRST attached image". I mood per ultimi.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const parts: any[] = [{ text }, ...(opts.baseImage ? [opts.baseImage] : []), ...(opts.logoImage ? [opts.logoImage] : []), ...(opts.personImages ?? []), ...(opts.referenceImages ?? []), ...(opts.userRefImages ?? []), ...(opts.moodImages ?? [])];
@@ -248,6 +252,23 @@ export async function renderPostImage(
     const { gateCredits, gateOrgCredits } = await import('$lib/server/credits');
     await (gateBrand ? gateCredits(gateBrand) : gateOrgCredits(gateOrg as string));
   }
+
+  const review = async (dataUrl: string): Promise<string | undefined> => {
+    if (!gateBrand) {
+      return dataUrl;
+    }
+    const verdict = await reviewImageConstraints({
+      image: dataUrl,
+      brief: imagePrompt,
+      brandRules: opts.brandRules
+    });
+    if (verdict.pass) {
+      return dataUrl;
+    }
+    console.warn(`[image constraints] rejected render: ${verdict.issues.join('; ')}`);
+    return undefined;
+  };
+
   const req = buildImageRequest(imagePrompt, opts);
   const imageModel = req.model;
   // OpenRouter serve lo STESSO modello Google in una richiesta sincrona: 3,4s di media contro 25,0s
@@ -256,10 +277,11 @@ export async function renderPostImage(
   // Nessun ritentativo qui: un fallimento sincrono torna già diagnosticato, e `generateImageOnOpenrouter`
   // alza l'eccezione invece di restituire un successo vuoto.
   if (route('image').endpoint === 'openrouter') {
-    return await generateImageOnOpenrouter(
+    const dataUrl = await generateImageOnOpenrouter(
       { ...req, model: googleImageModel(req.model, NANO_BANANA_2_LITE) },
       { context: `image:${imageModel}` }
     );
+    return await review(dataUrl);
   }
   // Nano Banana gira su kie: stesso modello, −33%/−40% per immagine (misurato sui crediti
   // addebitati). È l'UNICO punto da cambiare perché ogni render del prodotto passa di qui.
@@ -277,7 +299,9 @@ export async function renderPostImage(
       context: `image:${imageModel}`,
       resumeTaskId
     });
-    if (viaKie.dataUrl) return viaKie.dataUrl;
+    if (viaKie.dataUrl) {
+      return await review(viaKie.dataUrl);
+    }
     resumeTaskId = viaKie.timedOutTaskId;
   }
   throw new Error(
@@ -650,7 +674,7 @@ export async function loadMoodRefs(urls: string[] | undefined): Promise<ImagePar
 
 export type BrandVisualContext = Pick<
   RenderImageOpts,
-  'visualStyle' | 'visualPlaybook' | 'brandLook' | 'logoImage' | 'moodImages'
+  'visualStyle' | 'visualPlaybook' | 'brandLook' | 'logoImage' | 'moodImages' | 'brandRules'
 >;
 
 export async function loadBrandVisualContext(
@@ -667,7 +691,8 @@ export async function loadBrandVisualContext(
     .map((f) => f?.name)
     .filter(Boolean) as string[];
 
-  const [logoImage, moodImages] = await Promise.all([
+  const [memory, logoImage, moodImages] = await Promise.all([
+    buildMemoryContext(supabase, brandId),
     loadBrandLogoImagePart(kit?.logos).catch((error) => {
       swallow('load brand logo part', error);
       return null;
@@ -684,6 +709,7 @@ export async function loadBrandVisualContext(
     visualStyle: (kit?.visual_style as string | null) || undefined,
     visualPlaybook: extractVisualPlaybook(kit?.ai_context) || undefined,
     brandLook: brandVisualDirective(kit?.brand_colors as string[] | null, fonts) || undefined,
+    brandRules: extractBrandConstraints(memory) || undefined,
     logoImage: logoImage ?? undefined,
     moodImages
   };

--- a/src/lib/server/content-preview/weekly-planner-brand-context.test.ts
+++ b/src/lib/server/content-preview/weekly-planner-brand-context.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const state = vi.hoisted(() => ({
+  contexts: [] as string[],
+  render: vi.fn(),
+  upload: vi.fn()
+}));
+
+vi.mock('$lib/server/ai-log', () => ({
+  withBrandContext: <T>(brandId: string, fn: () => T): T => {
+    state.contexts.push(brandId);
+    return fn();
+  }
+}));
+
+vi.mock('$lib/server/brand-memory', () => ({
+  buildMemoryContext: vi.fn(async () => '')
+}));
+
+vi.mock('./images', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./images')>()),
+  renderBrandImage: (...args: unknown[]) => state.render(...args),
+  uploadPostImage: (...args: unknown[]) => state.upload(...args)
+}));
+
+const { renderPreviewImages } = await import('./weekly-planner');
+
+beforeEach(() => {
+  state.contexts = [];
+  state.render.mockReset();
+  state.upload.mockReset();
+  state.render.mockResolvedValue('data:image/png;base64,AAAA');
+  state.upload.mockResolvedValue('https://cdn.example.com/image.png');
+});
+
+describe('renderPreviewImages brand context', () => {
+  it('reviews a brand render inside its brand context', async () => {
+    const supabase = {
+      from: () => ({
+        select: () => ({
+          eq: () => ({ maybeSingle: async () => ({ data: { content_prefs: {} }, error: null }) })
+        })
+      })
+    } as never;
+
+    await renderPreviewImages(
+      {
+        name: 'Severo Ricami',
+        ai_context: '',
+        visual_style: 'editorial photography',
+        brand_colors: [],
+        fonts: [],
+        logos: [],
+        products: []
+      },
+      [{ platform: 'instagram', media: 'image', image_prompt: 'A plain polo shirt.', format: 'single_image' }] as never,
+      { supabase, userId: 'user-1', brandId: 'brand-1', onPost: () => {} }
+    );
+
+    expect(state.contexts).toContain('brand-1');
+  });
+
+  it('reviews onboarding renders without enabling brand media access', async () => {
+    const supabase = {
+      from: () => ({
+        select: () => ({
+          eq: () => ({ maybeSingle: async () => ({ data: { content_prefs: {} }, error: null }) })
+        })
+      })
+    } as never;
+
+    await renderPreviewImages(
+      {
+        name: 'Severo Ricami',
+        ai_context: '',
+        visual_style: 'editorial photography',
+        brand_colors: [],
+        fonts: [],
+        logos: [],
+        products: []
+      },
+      [{ platform: 'instagram', media: 'image', image_prompt: 'A plain polo shirt.', format: 'single_image' }] as never,
+      { supabase, userId: 'user-1', reviewBrandId: 'brand-1', onPost: () => {} } as never
+    );
+
+    expect(state.contexts).toContain('brand-1');
+  });
+});

--- a/src/lib/server/content-preview/weekly-planner.ts
+++ b/src/lib/server/content-preview/weekly-planner.ts
@@ -11,12 +11,15 @@ import { normalizeBeats, type AnyRec, type BrandProfile, type ContentPrefs, type
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { env } from '$env/dynamic/private';
 import { synthesizeVisualStyle } from '$lib/server/brand-context';
+import { buildMemoryContext } from '$lib/server/brand-memory';
+import { withBrandContext } from '$lib/server/ai-log';
 import { route } from '$lib/server/model-routing';
 import { upcomingTimelyHooks } from '$lib/server/thematic-calendar';
 import { normalizeContentFormat } from '$lib/content-formats';
 import { type LadderContext } from '$lib/server/production-ladder';
 import { type Rubric } from '$lib/server/rubrics';
 import { loadKnownSubreddits } from '$lib/server/platform-hygiene';
+import { extractBrandConstraints } from '$lib/server/image-constraint-review';
 
 // Options shared by the planning and rendering halves. Splitting them lets a caller run the cheap
 // text planning in one request and the heavy image rendering in another (see onboarding), so no
@@ -73,6 +76,7 @@ type RenderPreviewOpts = {
   supabase: SupabaseClient;
   userId: string;
   brandId?: string;
+  reviewBrandId?: string;
   // Force one image model for the whole batch, ahead of the brand's own preference. Absent → the
   // brand's Settings choice, and absent that too, buildImageRequest picks as it always has. The
   // guest preview passes the cheapest model here; a UGC cover still overrides everything, because
@@ -391,6 +395,16 @@ export async function renderPreviewImages(
   // settimana, e sette posti da ricordare sono sette posti da dimenticare. Un `imageModel`
   // esplicito (l'anteprima ospite) vince comunque.
   const brandImageModel = opts.imageModel ?? (await brandPreferredImageModel(opts));
+  const reviewBrandId = opts.reviewBrandId ?? opts.brandId;
+  const memory = reviewBrandId ? await buildMemoryContext(opts.supabase, reviewBrandId) : profile.ai_context;
+  const brandRules = extractBrandConstraints(memory) || undefined;
+
+  function renderForBrand<T>(fn: () => T): T {
+    if (reviewBrandId) {
+      return withBrandContext(reviewBrandId, fn);
+    }
+    return fn();
+  }
 
   opts.onProgress?.('generating', `Generating images for ${posts.length} posts…`);
 
@@ -525,6 +539,7 @@ export async function renderPreviewImages(
             visualPlaybook: isUgc ? undefined : visualPlaybook,
             referenceMode,
             brandLook: isUgc ? undefined : brandLook,
+            brandRules,
             // No logo on a candid selfie — it is the single clearest "this is an ad" signal.
             logoImage: isUgc ? undefined : logoImage,
             aspectRatio
@@ -557,7 +572,7 @@ export async function renderPreviewImages(
               })
             : post.image_prompt;
 
-          const dataUrl = await renderBrandImage(framePrompt, renderOpts);
+          const dataUrl = await renderForBrand(() => renderBrandImage(framePrompt, renderOpts));
           const qc = undefined;
           // Expose the verdict so callers can surface it (CLI --verbose).
           if (qc) (post as AnyRec).__qc = qc;
@@ -574,12 +589,14 @@ export async function renderPreviewImages(
               const total = post.image_prompts!.length;
               const rest = await Promise.all(
                 post.image_prompts!.slice(1).map((slidePrompt, idx) =>
-                  renderCarouselSlide(opts.supabase, opts.userId, slidePrompt, idx + 1, total, renderOpts, anchor, {
-                    productName: post.product,
-                    productKind: featured?.kind,
-                    referenceImages,
-                    visualStyle
-                  })
+                  renderForBrand(() =>
+                    renderCarouselSlide(opts.supabase, opts.userId, slidePrompt, idx + 1, total, renderOpts, anchor, {
+                      productName: post.product,
+                      productKind: featured?.kind,
+                      referenceImages,
+                      visualStyle
+                    })
+                  )
                 )
               );
               const urls = [cover, ...rest.filter((u): u is string => !!u)];

--- a/src/lib/server/director.ts
+++ b/src/lib/server/director.ts
@@ -171,6 +171,7 @@ Generated images follow (cover + carousel slides when present). Labels mark POST
             await renderPreviewImages(opts.profile, [post], {
               supabase: opts.supabase,
               userId: opts.userId,
+              brandId: opts.brandId,
               onProgress: () => {},
               onPost: () => {}
             });

--- a/src/lib/server/image-constraint-review.test.ts
+++ b/src/lib/server/image-constraint-review.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  APPAREL_BRANDING_DIRECTIVE,
+  extractBrandConstraints,
+  reviewImageConstraints,
+  type ImageConstraintJudge
+} from './image-constraint-review';
+
+const IMAGE = 'data:image/png;base64,AAAA';
+
+describe('reviewImageConstraints', () => {
+  it('gives saved brand constraints precedence over a requested garment logo', () => {
+    expect(APPAREL_BRANDING_DIRECTIVE).toContain('Brand rules override this exception.');
+  });
+
+  it('uses the saved brand constraints and nothing else from memory', () => {
+    const constraints = extractBrandConstraints(`
+## BRAND MEMORY
+
+### CONSTRAINTS & RULES
+- Tajima is allowed only on embroidery machines, never on garments.
+
+### VOICE & TONE
+- Write in a direct, practical tone.
+`);
+
+    expect(constraints).toBe('Tajima is allowed only on embroidery machines, never on garments.');
+  });
+
+  it('rejects a machine brand embroidered on a garment', async () => {
+    const judge = vi.fn<ImageConstraintJudge>().mockResolvedValue({
+      pass: false,
+      issues: ['TAJIMA is embroidered on the polo shirt.']
+    });
+
+    const review = await reviewImageConstraints(
+      {
+        image: IMAGE,
+        brief: 'A Tajima embroidery machine beside a folded polo shirt.',
+        brandRules: 'Tajima is allowed only on embroidery machines, never on garments.'
+      },
+      { judge }
+    );
+
+    expect(review).toEqual({ pass: false, issues: ['TAJIMA is embroidered on the polo shirt.'] });
+    expect(judge).toHaveBeenCalledWith(
+      expect.objectContaining({
+        instructions: expect.stringContaining('never on a garment, hat, uniform, accessory or textile')
+      })
+    );
+  });
+
+  it('allows a manufacturer mark that appears only on the machine', async () => {
+    const judge = vi.fn<ImageConstraintJudge>().mockResolvedValue({ pass: true, issues: [] });
+
+    const review = await reviewImageConstraints(
+      {
+        image: IMAGE,
+        brief: 'A Tajima embroidery machine stitching a plain polo shirt.'
+      },
+      { judge }
+    );
+
+    expect(review).toEqual({ pass: true, issues: [] });
+    expect(APPAREL_BRANDING_DIRECTIVE).toContain('machine, tool or equipment');
+  });
+});

--- a/src/lib/server/image-constraint-review.ts
+++ b/src/lib/server/image-constraint-review.ts
@@ -1,0 +1,102 @@
+import { llmConfigured, llmImagesFromInline, llmStructured } from '$lib/server/llm';
+
+export const APPAREL_BRANDING_DIRECTIVE = `APPAREL BRANDING — non-negotiable: never add a logo, label, wordmark, readable brand name, patch or embroidered text to a garment, hat, uniform, accessory or textile unless the original brief explicitly requests that exact mark on that wearable item. Brand rules override this exception. A mark that belongs to a machine, tool or equipment may appear only on that machine, tool or equipment, never on a garment, hat, uniform, accessory or textile. Do not invent or move branding between objects.`;
+
+type ImagePart = { inlineData: { mimeType: string; data: string } };
+
+export type ImageConstraintVerdict = {
+  pass: boolean;
+  issues: string[];
+};
+
+export type ImageConstraintJudge = (input: {
+  instructions: string;
+  image: ImagePart;
+}) => Promise<ImageConstraintVerdict>;
+
+type ReviewInput = {
+  image: string;
+  brief: string;
+  brandRules?: string;
+};
+
+const REVIEW_SCHEMA = {
+  type: 'object' as const,
+  properties: {
+    pass: {
+      type: 'boolean' as const,
+      description: 'False when an unrequested logo, wordmark, label, patch or readable brand name appears on wearable apparel.'
+    },
+    issues: {
+      type: 'array' as const,
+      items: { type: 'string' as const },
+      description: 'Short English descriptions of actual constraint violations. Empty when pass is true.'
+    }
+  },
+  required: ['pass', 'issues']
+};
+
+const MAX_REVIEW_ISSUES = 3;
+const BRAND_CONSTRAINTS_SECTION = /(?:^|\n)### CONSTRAINTS & RULES\s*\n([\s\S]*?)(?=\n{2,}### |\n{2,}## |\s*$)/;
+
+export function extractBrandConstraints(context: unknown): string {
+  const section = String(context ?? '').match(BRAND_CONSTRAINTS_SECTION)?.[1] ?? '';
+  return section
+    .split('\n')
+    .map((line) => line.replace(/^[-*]\s*/, '').trim())
+    .filter(Boolean)
+    .join('\n');
+}
+
+function imagePart(dataUrl: string): ImagePart | null {
+  const match = dataUrl.match(/^data:(image\/[a-z0-9.+-]+);base64,([a-z0-9+/=]+)$/i);
+  if (!match) {
+    return null;
+  }
+  return { inlineData: { mimeType: match[1].toLowerCase(), data: match[2] } };
+}
+
+function instructions(input: Pick<ReviewInput, 'brief' | 'brandRules'>): string {
+  const rules = input.brandRules?.trim() ? `\n\nBRAND RULES:\n${input.brandRules.trim()}` : '';
+  return `You review one generated image before it can be used in brand content.
+
+${APPAREL_BRANDING_DIRECTIVE}
+
+Reject if any unrequested brand mark is visible on a wearable item. Do not reject a mark that is visible only on the machine, tool or equipment it belongs to. Treat a logo on apparel as allowed only when the original brief explicitly requests that exact logo on that garment.
+Brand rules override a conflicting original brief.
+
+ORIGINAL BRIEF:
+${input.brief.trim() || '(none)'}${rules}`;
+}
+
+async function judgeWithLlm(input: { instructions: string; image: ImagePart }): Promise<ImageConstraintVerdict> {
+  if (!llmConfigured()) {
+    return { pass: false, issues: ['Image constraint reviewer is unavailable'] };
+  }
+  try {
+    const result = await llmStructured<{ pass?: unknown; issues?: unknown }>({
+      prompt: input.instructions,
+      schema: REVIEW_SCHEMA,
+      images: llmImagesFromInline([input.image]),
+      label: 'image.constraints',
+      reasoningEffort: 'low'
+    });
+    if (typeof result.pass !== 'boolean' || !Array.isArray(result.issues)) {
+      return { pass: false, issues: ['Image constraint reviewer returned an invalid verdict'] };
+    }
+    return { pass: result.pass, issues: result.issues.map(String).filter(Boolean).slice(0, MAX_REVIEW_ISSUES) };
+  } catch {
+    return { pass: false, issues: ['Image constraint reviewer could not verify the image'] };
+  }
+}
+
+export async function reviewImageConstraints(
+  input: ReviewInput,
+  deps: { judge?: ImageConstraintJudge } = {}
+): Promise<ImageConstraintVerdict> {
+  const image = imagePart(input.image);
+  if (!image) {
+    return { pass: false, issues: ['Generated image is not a valid data URL'] };
+  }
+  return await (deps.judge ?? judgeWithLlm)({ instructions: instructions(input), image });
+}

--- a/src/lib/server/onboarding-steps.ts
+++ b/src/lib/server/onboarding-steps.ts
@@ -1011,6 +1011,7 @@ async function processPlanPosts(
   if (Array.isArray(input.people) && input.people.length) profile.people = input.people;
 
   const userId = job.user_id as string;
+  const reviewBrandId = (job.brand_id as string | null) ?? undefined;
   let lastStep = 'start';
 
   try {
@@ -1102,6 +1103,7 @@ async function processPreviewImages(
     await renderPreviewImages(profile, posts, {
       supabase: admin,
       userId,
+      reviewBrandId,
       onProgress: (step, message) => {
         lastStep = step;
         void note(admin, jobId, step, message);

--- a/src/lib/server/prepublish-check.test.ts
+++ b/src/lib/server/prepublish-check.test.ts
@@ -27,6 +27,10 @@ vi.mock('$lib/server/brand-notify', () => ({
   notifyBrandContacts: vi.fn(async () => 0)
 }));
 
+vi.mock('$lib/server/brand-memory', () => ({
+  buildMemoryContext: vi.fn(async () => '')
+}));
+
 const POST = (overrides: Partial<PrepublishPost> = {}): PrepublishPost => ({
   id: 'post-1',
   brand_id: 'brand-1',
@@ -161,12 +165,35 @@ describe('inspectPostForRelease', () => {
     expect(verdict.reason).toBe('Overlay text is garbled');
   });
 
-  it('skips (fail-open) when Gemini is down', async () => {
+  it('gives the reviewer the original image brief for apparel branding checks', async () => {
+    const judge = vi.fn(async (input) => {
+      expect(input.imagePrompt).toBe('A Tajima machine beside a plain polo shirt.');
+      expect(input.brandRules).toBe('Tajima is allowed only on embroidery machines, never on garments.');
+      return { ok: false, reasons: ['TAJIMA is embroidered on the polo shirt.'] };
+    });
+
+    const verdict = await inspectPostForRelease(
+      POST({
+        image_prompt: 'A Tajima machine beside a plain polo shirt.',
+        brand_rules: 'Tajima is allowed only on embroidery machines, never on garments.'
+      }),
+      { probeMedia: async () => ({ ok: true, kind: 'other' }), judge }
+    );
+
+    expect(verdict.decision).toBe('hold');
+    expect(verdict.reason).toBe('TAJIMA is embroidered on the polo shirt.');
+  });
+
+  it('holds a visual post when its reviewer is down', async () => {
     const verdict = await inspectPostForRelease(POST(), {
       probeMedia: async () => ({ ok: true, kind: 'other' }),
       judge: async () => ({ error: 'model_failed' })
     });
-    expect(verdict.decision).toBe('skip');
+    expect(verdict).toEqual({
+      decision: 'hold',
+      reason: 'Image constraint reviewer could not verify the visual',
+      reasons: ['Image constraint reviewer could not verify the visual']
+    });
   });
 });
 

--- a/src/lib/server/prepublish-check.ts
+++ b/src/lib/server/prepublish-check.ts
@@ -16,7 +16,9 @@ import { env as publicEnv } from '$env/dynamic/public';
 import { isImageUrl, isVideoUrl } from '$lib/content-formats';
 import { withBrandContext } from '$lib/server/ai-log';
 import { isUrlSafe } from '$lib/server/brand-analysis';
+import { buildMemoryContext } from '$lib/server/brand-memory';
 import { llmConfigured, llmImagesFromInline, llmStructured } from '$lib/server/llm';
+import { APPAREL_BRANDING_DIRECTIVE, extractBrandConstraints } from '$lib/server/image-constraint-review';
 import {
   prepublishHeldEmailHtml,
   prepublishHeldEmailSubject,
@@ -41,6 +43,8 @@ export type PrepublishPost = {
   platforms?: string[] | null;
   caption: string | null;
   platform_captions?: Record<string, string> | null;
+  image_prompt?: string | null;
+  brand_rules?: string | null;
   media_url: string | null;
   media_urls?: string[] | null;
   content_type?: string | null;
@@ -72,6 +76,8 @@ export type MediaProbe =
 
 export type PrepublishJudge = (input: {
   caption: string;
+  imagePrompt: string;
+  brandRules: string;
   contentType: string;
   imageParts: ImagePart[];
   mediaNotes: string[];
@@ -236,6 +242,8 @@ export async function probeMediaUrl(url: string): Promise<MediaProbe> {
 
 async function geminiJudge(input: {
   caption: string;
+  imagePrompt: string;
+  brandRules: string;
   contentType: string;
   imageParts: ImagePart[];
   mediaNotes: string[];
@@ -251,6 +259,7 @@ Reject ONLY for defects like:
 - obvious generation failure (error screen, "image not available", empty template, lorem ipsum on the image)
 - placeholder or empty caption
 - carousel slide that is blank or clearly unfinished
+- an unrequested logo, label, wordmark, patch or readable brand name on a garment or other wearable item
 
 Approve:
 - any finished post, even if the copy is mediocre or the design is not your taste
@@ -258,9 +267,17 @@ Approve:
 - text or link posts with no image (that is valid — judge caption/URL only)
 - videos whose file is reachable even if you only see a thumbnail or no still
 
+${APPAREL_BRANDING_DIRECTIVE}
+
 content_type: ${input.contentType || 'unknown'}
 CAPTION:
 ${input.caption || '(empty)'}
+
+ORIGINAL IMAGE BRIEF:
+${input.imagePrompt || '(none)'}
+
+BRAND RULES:
+${input.brandRules || '(none)'}
 ${notes}
 
 Return JSON { "ok": boolean, "reasons": string[] }. reasons empty when ok is true. English, one line each.`;
@@ -340,11 +357,16 @@ export async function inspectPostForRelease(
   const judge = deps.judge ?? geminiJudge;
   const judged = await judge({
     caption: String(post.caption ?? ''),
+    imagePrompt: String(post.image_prompt ?? ''),
+    brandRules: String(post.brand_rules ?? ''),
     contentType: String(post.content_type ?? ''),
     imageParts,
     mediaNotes
   });
   if ('error' in judged) {
+    if (requiresVisualMedia(post.content_type)) {
+      return holdVerdict(['Image constraint reviewer could not verify the visual']);
+    }
     console.warn(`[prepublish] skip (infra): ${judged.error} post=${post.id}`);
     return { decision: 'skip', reason: judged.error, reasons: [] };
   }
@@ -486,7 +508,7 @@ export async function runPrepublishTick(
   let q = supabase
     .from('posts')
     .select(
-      'id, brand_id, platform, platforms, caption, platform_captions, media_url, media_urls, content_type, title, link_url, video_thumbnail_url, youtube_thumbnail_url, scheduled_for, prepublish_ok, prepublish_checked_at, status'
+      'id, brand_id, platform, platforms, caption, platform_captions, image_prompt, media_url, media_urls, content_type, title, link_url, video_thumbnail_url, youtube_thumbnail_url, scheduled_for, prepublish_ok, prepublish_checked_at, status'
     )
     .eq('status', 'scheduled')
     .not('scheduled_for', 'is', null)
@@ -517,7 +539,9 @@ export async function runPrepublishTick(
       continue;
     }
     result.checked++;
-    const verdict = await withBrandContext(row.brand_id, () => inspectPostForRelease(row, opts.deps));
+    const memory = await buildMemoryContext(supabase, row.brand_id);
+    const post = { ...row, brand_rules: extractBrandConstraints(memory) };
+    const verdict = await withBrandContext(row.brand_id, () => inspectPostForRelease(post, opts.deps));
     if (verdict.decision === 'hold') {
       try {
         await holdBrokenScheduledPost(supabase, row, verdict.reason);

--- a/src/lib/server/publish.ts
+++ b/src/lib/server/publish.ts
@@ -4,10 +4,12 @@ import { publishPost, getPostStatus, deletePost } from './zernio';
 import { nextOccurrence } from './schedule';
 import { markPageUsed } from './content-library';
 import { withBrandContext } from './ai-log';
+import { buildMemoryContext } from './brand-memory';
 import { platformLimit, platformLabel, captionFor, ensureShortNetworkCuts, mediaUrlsForPublish, VIDEO_ONLY_PLATFORMS, youtubeTitleFrom, type PlatformCaptions } from '$lib/platform-limits';
 import { isVideoUrl } from '$lib/content-formats';
 import { mediaUrlsForCheck, requiresVisualMedia } from './prepublish-check';
 import { recordPostVerdict } from './post-verdict';
+import { extractBrandConstraints } from './image-constraint-review';
 
 const PROVIDER_REFUSAL = 'No social publishing provider is configured on this instance.';
 
@@ -20,6 +22,7 @@ export type ApprovablePost = {
   caption: string | null;
   // Per-platform caption overrides ({"x": ..., "threads": ...}); absent → same caption everywhere.
   platform_captions?: PlatformCaptions;
+  image_prompt?: string | null;
   media_url: string | null;
   // Ordered carousel slide URLs (media_urls column). Optional so legacy selects keep compiling:
   // when absent/empty the publish falls back to the single media_url (first slide only).
@@ -191,9 +194,10 @@ export async function publishApprovedPost(
   // whose migration may be pending, and a failure here must not block ordinary publishing.
   const { data: renderState } = await supabase
     .from('posts')
-    .select('video_render_status, status')
+    .select('video_render_status, status, image_prompt')
     .eq('id', post.id)
     .maybeSingle();
+  post.image_prompt ??= (renderState as { image_prompt?: string | null } | null)?.image_prompt ?? null;
   const wasDraft = (renderState as { status?: string | null } | null)?.status === 'pending_user';
   if ((renderState as { video_render_status?: string | null } | null)?.video_render_status === 'rendering') {
     return {
@@ -293,7 +297,9 @@ export async function publishApprovedPost(
   if (post.prepublish_ok !== true) {
     const { shouldGatePrepublish, inspectPostForRelease } = await import('./prepublish-check');
     if (shouldGatePrepublish(scheduledFor, { now: opts.now })) {
-      const verdict = await withBrandContext(post.brand_id, () => inspectPostForRelease(post));
+      const memory = await buildMemoryContext(supabase, post.brand_id);
+      const reviewPost = { ...post, brand_rules: extractBrandConstraints(memory) };
+      const verdict = await withBrandContext(post.brand_id, () => inspectPostForRelease(reviewPost));
       if (verdict.decision === 'hold') {
         const attention = `Pre-publish hold: ${verdict.reason}`.slice(0, 500);
         await supabase

--- a/src/lib/server/radar.ts
+++ b/src/lib/server/radar.ts
@@ -1024,7 +1024,7 @@ export async function radarProduce(
     brandId: brand.id,
     userId: brand.id
   });
-  await renderPreviewImages(profile, posts, { supabase: admin, userId: brand.id, onProgress: () => {}, onPost: () => {} });
+  await renderPreviewImages(profile, posts, { supabase: admin, userId: brand.id, brandId: brand.id, onProgress: () => {}, onPost: () => {} });
 
   // Skip Director when produce agent already approved (single quality gate).
   const director = isProduceApproved(posts)

--- a/src/routes/api/v1/brands/[slug]/posts/[id]/render/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/posts/[id]/render/+server.ts
@@ -84,6 +84,7 @@ export const POST: RequestHandler = async ({ request, params }) => {
       await renderPreviewImages(profile, [previewPost], {
         supabase,
         userId: brand.id,
+        brandId: brand.id,
         onProgress: () => {},
         onPost: async (p) => {
           if (p.imageUrl) {

--- a/src/routes/api/v1/brands/[slug]/posts/[id]/render/server.test.ts
+++ b/src/routes/api/v1/brands/[slug]/posts/[id]/render/server.test.ts
@@ -114,6 +114,7 @@ describe('POST /api/v1/brands/:slug/posts/:id/render', () => {
     expect(body.url).toBe('https://cdn.test/a.png');
     expect(gateCredits).toHaveBeenCalledWith('brand-1');
     expect(brandContexts).toEqual(['brand-1']);
+    expect(renderPreviewImages.mock.calls[0][2]).toEqual(expect.objectContaining({ brandId: 'brand-1' }));
     expect(kit.tables.get('posts')?.[0].media_url).toBe('https://cdn.test/a.png');
   });
 

--- a/src/routes/api/v1/brands/[slug]/weekly-plan/render/+server.ts
+++ b/src/routes/api/v1/brands/[slug]/weekly-plan/render/+server.ts
@@ -96,6 +96,7 @@ export const POST: RequestHandler = async ({ request, params }) => {
     await renderPreviewImages(profile, previewPosts as any, {
       supabase,
       userId: brand.id,
+      brandId: brand.id,
       onProgress: () => {},
       onPost: async (p: any) => {
         const id = p.__postId;

--- a/src/routes/app/[brand]/onboarding/render-content/+server.ts
+++ b/src/routes/app/[brand]/onboarding/render-content/+server.ts
@@ -72,6 +72,7 @@ export const POST: RequestHandler = async ({ params, locals: { supabase, safeGet
   await renderPreviewImages(profile, previews as unknown as PreviewPost[], {
     supabase,
     userId: user.id,
+    reviewBrandId: brand.id,
     onPost: (post: AnyRec) => {
       if (post.imageUrl) {
         rendered += 1;

--- a/supabase/migrations/0225_prepublish_visual_recheck.sql
+++ b/supabase/migrations/0225_prepublish_visual_recheck.sql
@@ -1,0 +1,29 @@
+create or replace function public.posts_clear_prepublish_on_edit()
+returns trigger
+language plpgsql
+as $$
+begin
+  if
+    new.caption is distinct from old.caption
+    or new.media_url is distinct from old.media_url
+    or new.media_urls is distinct from old.media_urls
+    or new.content_type is distinct from old.content_type
+    or new.title is distinct from old.title
+    or new.link_url is distinct from old.link_url
+    or new.image_prompt is distinct from old.image_prompt
+    or new.video_thumbnail_url is distinct from old.video_thumbnail_url
+    or new.youtube_thumbnail_url is distinct from old.youtube_thumbnail_url
+    or new.platform_captions is distinct from old.platform_captions
+  then
+    new.prepublish_ok := null;
+    new.prepublish_checked_at := null;
+  end if;
+  return new;
+end;
+$$;
+
+update public.posts
+set prepublish_ok = null,
+    prepublish_checked_at = null
+where status = 'scheduled'
+  and coalesce(content_type, '') not in ('text', 'link');


### PR DESCRIPTION
## What
- Reviews generated visuals against saved brand constraints before storage.
- Blocks unexpected branding on apparel while allowing marks on machinery.
- Rechecks imported, edited, and scheduled visuals before publishing.
- Invalidates prior approvals after media or image-brief changes.

## Review
- Standards: no findings.
- Spec: no P1/P2 blockers.

## Tests
- Targeted Vitest suite: 51 passed.
- Schema drift check: passed.
- git diff --check: passed.
- Runtime typecheck: attempted, stopped after more than 3 minutes without output.
- Full suite and live eval: not run.