### PR TITLE
Draw with GPT Image 2.5, at a tenth of the price

### DIFF
--- a/changelog/2026-09-12-openrouter-images-api.md
+++ b/changelog/2026-09-12-openrouter-images-api.md
@@ -1,0 +1,55 @@
+# I GPT Image 2.5 nel catalogo, e come default
+
+## La porta che non avevamo guardato
+
+Per due volte `openai/gpt-image-2.5-*` è sembrato inesistente. Non lo era: le prove erano fatte
+nel posto sbagliato. `GET /api/v1/models` elenca i modelli di CHAT (445, nessun gpt-image), e
+`POST /chat/completions` risponde 404 — ma il 404 lo dice per esteso, e solo se non si manda
+`modalities`, altrimenti il messaggio parla di modalità e non di endpoint:
+
+    openai/gpt-image-2.5-sunburst is an image generation model and cannot be used with the
+    chat/completions endpoint. Use the /api/v1/images endpoint instead.
+
+Il loro catalogo è `GET /api/v1/images/models`: 52 voci, ognuna con i parametri che accetta.
+
+## Cosa è stato misurato, il 2026-09-12, contro l'endpoint vero
+
+|                        | tempo   | costo     |
+|------------------------|---------|-----------|
+| sunburst, da zero      | 15,0s   | $0,0053   |
+| flare, da zero         | 10,5s   | $0,0053   |
+| sunburst, con riferimento | 15,6s | $0,0171   |
+| gemini-3.1-flash-image @openrouter (oggi in produzione) | 13,3s | $0,0748 |
+
+Quattordici volte meno per un'immagine disegnata da zero, quattro per una modificata, a parità di
+tempo. Il render di verifica nell'app: **$0,00635 contro $0,0337** dello stesso prompt sullo stesso
+brand cinque minuti prima.
+
+## Le tre trappole dell'endpoint
+
+1. **`input_references` ha una forma sola**: `[{type:'image_url', image_url:{url}}]`. Le altre
+   quattro provate tornano 400 — tranne `image:`, il nome che verrebbe da OpenAI, che torna **200 e
+   ignora l'immagine**. Chiesto «rendi verde questo limone», è arrivata una limonata inventata da
+   zero. Il costo lo conferma: $0,0060 quando il riferimento cade, $0,017-0,025 quando viene letto.
+   Un successo che ignora metà della richiesta è il guasto peggiore di tutti.
+2. **`aspect_ratio` è un elenco chiuso e 4:5 non c'è.** È il formato di un post Instagram. Si chiede
+   in pixel con `size`, che l'endpoint onora esattamente (1024x1280 chiesto, 1024x1280 tornato, sei
+   volte su sei e anche insieme ai riferimenti) pur non essendo fra i parametri dichiarati. Il nome
+   quando c'è, i pixel quando no: due strade e nessuna terza.
+3. **La risposta è `data[0].b64_json` + `media_type`**, non `choices[].message.images`.
+
+## Cosa è cambiato nel registro
+
+`gpt-image` è la prima famiglia con UN endpoint solo, e il ripiego non poteva più essere per
+endpoint: `HOME` poi kie avrebbe prodotto `gpt-image@kie`, una rotta che nessuno serve e che si
+legge come rispettata mentre atterra altrove. Ora, quando la famiglia scelta non è servibile da
+nessuna parte, si cambia FAMIGLIA: `SLOT_RESERVE` dice quale, per slot, invece di dedurlo.
+
+E il default del modello non è più una costante: `defaultImageModel()` LEGGE la rotta. Erano due
+decisioni separate — la famiglia su cui instradare e l'id da mettere nella richiesta — e il
+trasporto si sceglie sull'id: una rotta `gpt-image@openrouter` con dentro un id Gemini sarebbe
+finita sul trasporto di Gemini. È successo davvero, durante lo sviluppo, e l'ha fatto vedere solo
+`ai_calls`.
+
+Sunburst e non Flare come default: stesso prezzo, 15,0s contro 10,5s, ma è il taglio di precisione
+— e qui dentro le immagini portano testo, che sbagliato si rifà.

--- a/src/lib/content/changelog/2026-09-12-openrouter-images-api.ts
+++ b/src/lib/content/changelog/2026-09-12-openrouter-images-api.ts
@@ -1,0 +1,12 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-12',
+  title: 'New default image model: sharper text, a fraction of the cost',
+  items: [
+    'Images are now drawn by GPT Image 2.5 Sunburst by default, at about a tenth of what the previous model cost per render and in the same time. A post measured on the same prompt went from $0.034 to $0.006.',
+    'GPT Image 2.5 Sunburst and Flare join the model picker for both generating and editing images — Flare is the faster tier at the same price, Sunburst the more precise one.',
+    'Instagram’s 4:5 framing is kept exactly, and reference images — your products, your people, a photo to edit — are carried through as before.',
+    'If OpenRouter is unreachable, images fall back to Nano Banana on kie instead of failing.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -5357,7 +5357,7 @@
         "recommended": "recommended",
         "slots": {
           "imageGenerate": "Image generation",
-          "imageGenerateDesc": "Which model draws a new photo from a prompt. Platform default lets the renderer pick per image. Models outside the Nano Banana family run only on kie and frame Instagram posts at 3:4 instead of 4:5.",
+          "imageGenerateDesc": "Which model draws a new photo from a prompt. The default is GPT Image 2.5 Sunburst, about a tenth of the previous cost at the same speed. Nano Banana, Seedream and Qwen run on kie: slower, and Seedream and Qwen frame Instagram posts at 3:4 instead of 4:5.",
           "imageRefine": "Image refine",
           "imageRefineDesc": "Which model edits a photo that already exists — adding a logo, restyling, changing one detail. Reproducing an image faithfully is a different job from inventing one, and the best family at one is not always the best at the other. Empty follows the generation model.",
           "videoGenerate": "Video generation",

--- a/src/lib/i18n/locales/es.json
+++ b/src/lib/i18n/locales/es.json
@@ -5007,7 +5007,7 @@
         "recommended": "recomendada",
         "slots": {
           "imageGenerate": "Generación de imágenes",
-          "imageGenerateDesc": "Qué modelo dibuja una foto nueva a partir de un prompt. Por defecto el renderizador elige imagen por imagen. Los modelos fuera de la familia Nano Banana solo corren en kie y encuadran los posts de Instagram en 3:4 en lugar de 4:5.",
+          "imageGenerateDesc": "Qué modelo dibuja una foto nueva a partir de un prompt. Por defecto GPT Image 2.5 Sunburst, alrededor de una décima parte del coste anterior al mismo tiempo. Nano Banana, Seedream y Qwen van por kie: más lentos, y Seedream y Qwen encuadran los posts de Instagram en 3:4 en vez de 4:5.",
           "imageRefine": "Edición de imágenes",
           "imageRefineDesc": "Qué modelo edita una foto que ya existe — añadir el logo, cambiar el estilo, corregir un detalle. Reproducir fielmente una imagen es un oficio distinto de inventarla. Vacío: sigue al modelo de generación.",
           "videoGenerate": "Generación de vídeo",

--- a/src/lib/i18n/locales/fr.json
+++ b/src/lib/i18n/locales/fr.json
@@ -5007,7 +5007,7 @@
         "recommended": "recommandé",
         "slots": {
           "imageGenerate": "Génération d’images",
-          "imageGenerateDesc": "Quel modèle dessine une nouvelle photo à partir d’un prompt. Par défaut, le moteur choisit image par image. Les modèles hors de la famille Nano Banana tournent uniquement sur kie et cadrent les posts Instagram en 3:4 au lieu de 4:5.",
+          "imageGenerateDesc": "Quel modèle dessine une nouvelle photo à partir d'un prompt. Par défaut GPT Image 2.5 Sunburst, environ un dixième du coût précédent à vitesse égale. Nano Banana, Seedream et Qwen passent par kie : plus lents, et Seedream et Qwen cadrent les posts Instagram en 3:4 au lieu de 4:5.",
           "imageRefine": "Retouche d’images",
           "imageRefineDesc": "Quel modèle modifie une photo existante — ajouter un logo, changer le style, corriger un détail. Reproduire fidèlement une image est un métier différent d’en inventer une. Vide : suit le modèle de génération.",
           "videoGenerate": "Génération vidéo",

--- a/src/lib/i18n/locales/it.json
+++ b/src/lib/i18n/locales/it.json
@@ -5358,7 +5358,7 @@
         "recommended": "consigliata",
         "slots": {
           "imageGenerate": "Generazione immagini",
-          "imageGenerateDesc": "Quale modello disegna una foto nuova da un prompt. Il default lascia scegliere al renderer immagine per immagine. I modelli fuori dalla famiglia Nano Banana girano solo su kie e inquadrano i post Instagram a 3:4 invece che a 4:5.",
+          "imageGenerateDesc": "Quale modello disegna una foto nuova da un prompt. Il default è GPT Image 2.5 Sunburst, che costa circa un decimo di prima a parità di tempo. Nano Banana, Seedream e Qwen girano su kie: più lenti, e Seedream e Qwen inquadrano i post Instagram a 3:4 invece che a 4:5.",
           "imageRefine": "Modifica immagini",
           "imageRefineDesc": "Quale modello modifica una foto che esiste già — aggiungere il logo, cambiare stile, correggere un dettaglio. Riprodurre fedelmente un’immagine è un mestiere diverso dall’inventarne una, e chi è più bravo in uno non lo è sempre nell’altro. Vuoto segue il modello di generazione.",
           "videoGenerate": "Generazione video",

--- a/src/lib/image-models.test.ts
+++ b/src/lib/image-models.test.ts
@@ -4,7 +4,11 @@ import {
   NANO_BANANA_PRO_MODEL,
   SEEDREAM_5_PRO_MODEL,
   GPT_IMAGE_2_MODEL,
+  GPT_IMAGE_25_SUNBURST_MODEL,
+  GPT_IMAGE_25_FLARE_MODEL,
+  NANO_BANANA_2_MODEL,
   QWEN3_PRO_MODEL,
+  openrouterImagesSize,
   imageModelSpec,
   imageRefineModelFor,
   isKnownImageModelId,
@@ -112,5 +116,62 @@ describe('the refine model', () => {
 
   it('ignores a refine model the catalogue no longer serves', () => {
     expect(imageRefineModelFor({ imageRefineModel: 'seedream-4-legacy' })).toBeUndefined();
+  });
+});
+
+/**
+ * I modelli che vivono SOLO sull'API immagini di OpenRouter.
+ *
+ * Misurato il 2026-09-12 su `GET /api/v1/images/models` e con render veri: `openai/gpt-image-2.5-*`
+ * non esiste su kie né su Google, e il suo endpoint non è `chat/completions` — è `POST /images`,
+ * con `input_references` per le modifiche e `aspect_ratio` da un elenco chiuso che NON contiene
+ * 4:5, cioè il formato di un post Instagram. Quel buco si copre con `size`, che l'endpoint onora
+ * al pixel (1024x1280 chiesto, 1024x1280 tornato) pur non essendo documentato.
+ */
+describe('i modelli dell’API immagini di OpenRouter', () => {
+  it('GPT Image 2.5 Sunburst e Flare sono nel catalogo del brand', () => {
+    expect(isKnownImageModelId(GPT_IMAGE_25_SUNBURST_MODEL)).toBe(true);
+    expect(isKnownImageModelId(GPT_IMAGE_25_FLARE_MODEL)).toBe(true);
+    const ids = IMAGE_MODEL_CHOICES.map((c) => c.id);
+    expect(ids).toContain(GPT_IMAGE_25_SUNBURST_MODEL);
+    expect(ids).toContain(GPT_IMAGE_25_FLARE_MODEL);
+  });
+
+  it('portano l’id con cui OpenRouter li chiama, e gli altri no', () => {
+    expect(imageModelSpec(GPT_IMAGE_25_SUNBURST_MODEL)?.openrouterImages).toBe(
+      'openai/gpt-image-2.5-sunburst'
+    );
+    expect(imageModelSpec(NANO_BANANA_2_MODEL)?.openrouterImages).toBeNull();
+  });
+
+  it('si riconoscono anche dall’id di OpenRouter, non solo dal nostro', () => {
+    expect(imageModelSpec('openai/gpt-image-2.5-flare')?.id).toBe(GPT_IMAGE_25_FLARE_MODEL);
+  });
+
+  it('non esistono su kie né su Google: chi ci finisce lo scopre, non lo indovina', () => {
+    const spec = imageModelSpec(GPT_IMAGE_25_SUNBURST_MODEL)!;
+    expect(spec.google).toBeNull();
+    expect(spec.kie).toBeNull();
+  });
+
+  it('4:5 lo servono, perché è il formato di un post', () => {
+    expect(imageModelSpec(GPT_IMAGE_25_SUNBURST_MODEL)!.aspectRatios).toContain('4:5');
+  });
+});
+
+describe('openrouterImagesSize', () => {
+  it('i rapporti che l’elenco chiuso di OpenRouter ha non passano da size', () => {
+    expect(openrouterImagesSize('1:1')).toBeUndefined();
+    expect(openrouterImagesSize('9:16')).toBeUndefined();
+  });
+
+  it('4:5 e 5:4 non sono in quell’elenco: si chiedono in pixel, o tornerebbe un 400', () => {
+    expect(openrouterImagesSize('4:5')).toBe('1024x1280');
+    expect(openrouterImagesSize('5:4')).toBe('1280x1024');
+  });
+
+  it('un rapporto che non si capisce non inventa una dimensione', () => {
+    expect(openrouterImagesSize(undefined)).toBeUndefined();
+    expect(openrouterImagesSize('banana')).toBeUndefined();
   });
 });

--- a/src/lib/image-models.ts
+++ b/src/lib/image-models.ts
@@ -22,6 +22,8 @@ export const NANO_BANANA_2_MODEL = 'nano-banana-2';
 export const NANO_BANANA_2_LITE_MODEL = 'nano-banana-2-lite';
 export const SEEDREAM_5_PRO_MODEL = 'seedream-5-pro';
 export const GPT_IMAGE_2_MODEL = 'gpt-image-2';
+export const GPT_IMAGE_25_SUNBURST_MODEL = 'gpt-image-2.5-sunburst';
+export const GPT_IMAGE_25_FLARE_MODEL = 'gpt-image-2.5-flare';
 export const QWEN3_PRO_MODEL = 'qwen3-pro';
 
 /** Gli id Gemini che i call site scrivono a mano da prima che questo registro esistesse. */
@@ -32,10 +34,17 @@ export const GEMINI_NANO_BANANA_2_LITE = 'gemini-3.1-flash-lite-image';
 export type ImageModelSpec = {
   id: string;
   label: string;
-  /** L'id su Google, quando lo stesso modello esiste anche lì. null = solo kie. */
+  /** L'id su Google, quando lo stesso modello esiste anche lì. null = non esiste su Google. */
   google: string | null;
-  /** Gli id kie: `text` senza riferimenti, `refs` con. Uguali dove la famiglia non li separa. */
-  kie: { text: string; refs: string };
+  /** Gli id kie: `text` senza riferimenti, `refs` con. Uguali dove la famiglia non li separa.
+   *  null = kie non lo serve, e mandarcelo sarebbe un 400 su ogni immagine del brand. */
+  kie: { text: string; refs: string } | null;
+  /**
+   * L'id sull'API immagini di OpenRouter (`POST /api/v1/images`), che NON è `chat/completions`:
+   * corpo diverso (`prompt`, `input_references`, `aspect_ratio`) e risposta diversa (`b64_json`).
+   * null = quel trasporto non lo serve, e la famiglia passa dalla via Gemini come ha sempre fatto.
+   */
+  openrouterImages: string | null;
   /** Come si chiama il campo dei riferimenti nel payload kie. */
   refField: 'image_input' | 'image_urls' | 'input_urls';
   /** Quanti riferimenti il modello inoltra davvero. */
@@ -63,6 +72,7 @@ const SPECS: ImageModelSpec[] = [
     id: NANO_BANANA_2_LITE_MODEL,
     label: 'Nano Banana 2 Lite',
     google: GEMINI_NANO_BANANA_2_LITE,
+    openrouterImages: null,
     kie: { text: 'nano-banana-2-lite', refs: 'nano-banana-2-lite' },
     refField: 'image_urls',
     maxRefs: 10,
@@ -75,6 +85,7 @@ const SPECS: ImageModelSpec[] = [
     id: NANO_BANANA_2_MODEL,
     label: 'Nano Banana 2',
     google: GEMINI_NANO_BANANA_2,
+    openrouterImages: null,
     kie: { text: 'nano-banana-2', refs: 'nano-banana-2' },
     refField: 'image_input',
     // kie ne documenta 14; 8 è il tetto che il prodotto ha sempre imposto e che i prompt assumono.
@@ -88,6 +99,7 @@ const SPECS: ImageModelSpec[] = [
     id: NANO_BANANA_PRO_MODEL,
     label: 'Nano Banana Pro',
     google: GEMINI_NANO_BANANA_PRO,
+    openrouterImages: null,
     kie: { text: 'nano-banana-pro', refs: 'nano-banana-pro' },
     refField: 'image_input',
     maxRefs: 8,
@@ -100,6 +112,7 @@ const SPECS: ImageModelSpec[] = [
     id: SEEDREAM_5_PRO_MODEL,
     label: 'Seedream 5 Pro',
     google: null,
+    openrouterImages: null,
     kie: { text: 'seedream/5-pro-text-to-image', refs: 'seedream/5-pro-image-to-image' },
     refField: 'image_urls',
     maxRefs: 10,
@@ -112,6 +125,7 @@ const SPECS: ImageModelSpec[] = [
     id: GPT_IMAGE_2_MODEL,
     label: 'GPT Image 2',
     google: null,
+    openrouterImages: null,
     kie: { text: 'gpt-image-2-text-to-image', refs: 'gpt-image-2-image-to-image' },
     refField: 'input_urls',
     maxRefs: 16,
@@ -121,10 +135,53 @@ const SPECS: ImageModelSpec[] = [
     ratios1KOnly: ['4:5', '5:4'],
     outputFormat: null
   },
+  /**
+   * I due GPT Image 2.5. Esistono SOLO sull'API immagini di OpenRouter — non su kie, non su Google
+   * — e sono gli unici del catalogo così. Misurato il 2026-09-12, render veri:
+   *
+   *   generazione   $0,0053   10-15s     contro $0,0748 e 13,3s del Gemini su OpenRouter
+   *   con riferimenti $0,017  15,6s      contro lo stesso $0,0748
+   *
+   * Cioè 14× meno per un'immagine disegnata da zero e 4× meno per una modificata, a parità di
+   * tempo. `sunburst` è il taglio di precisione e `flare` quello di velocità (10,5s contro 15,0s,
+   * stesso prezzo): il default è sunburst perché qui dentro le immagini portano testo, e il testo
+   * sbagliato si rifà.
+   *
+   * `maxRefs: 16` è il tetto che OpenRouter dichiara per `input_references` e che abbiamo visto
+   * accettato. Il 4:5 NON è nel loro elenco di rapporti: si chiede in pixel, vedi
+   * `openrouterImagesSize`.
+   */
+  {
+    id: GPT_IMAGE_25_SUNBURST_MODEL,
+    label: 'GPT Image 2.5 Sunburst',
+    google: null,
+    openrouterImages: 'openai/gpt-image-2.5-sunburst',
+    kie: null,
+    refField: 'input_urls',
+    maxRefs: 16,
+    aspectField: 'aspect_ratio',
+    aspectRatios: ['1:1', '3:2', '2:3', '4:3', '3:4', '4:5', '5:4', '16:9', '9:16', '21:9'],
+    sizeField: null,
+    outputFormat: 'png'
+  },
+  {
+    id: GPT_IMAGE_25_FLARE_MODEL,
+    label: 'GPT Image 2.5 Flare',
+    google: null,
+    openrouterImages: 'openai/gpt-image-2.5-flare',
+    kie: null,
+    refField: 'input_urls',
+    maxRefs: 16,
+    aspectField: 'aspect_ratio',
+    aspectRatios: ['1:1', '3:2', '2:3', '4:3', '3:4', '4:5', '5:4', '16:9', '9:16', '21:9'],
+    sizeField: null,
+    outputFormat: 'png'
+  },
   {
     id: QWEN3_PRO_MODEL,
     label: 'Qwen3 Pro',
     google: null,
+    openrouterImages: null,
     kie: { text: 'qwen3/pro-text-to-image', refs: 'qwen3/pro-image-to-image' },
     refField: 'image_urls',
     maxRefs: 3,
@@ -150,7 +207,9 @@ export function isKnownImageModelId(value: unknown): value is string {
 export function imageModelSpec(value: unknown): ImageModelSpec | undefined {
   const v = String(value ?? '').trim();
   if (!v) return undefined;
-  return SPECS.find((s) => s.id === v || s.google === v || s.kie.text === v || s.kie.refs === v);
+  return SPECS.find(
+    (s) => s.id === v || s.google === v || s.openrouterImages === v || s.kie?.text === v || s.kie?.refs === v
+  );
 }
 
 /**
@@ -205,3 +264,37 @@ export function kieAspectRatio(spec: ImageModelSpec, aspectRatio: string | undef
   return nearestAspectRatio(spec.aspectRatios, String(aspectRatio ?? '').trim() || '1:1', '1:1');
 }
 
+
+/**
+ * I rapporti che l'API immagini di OpenRouter accetta per nome. È un elenco CHIUSO — un valore
+ * fuori da qui torna 400 «Provider rejection», misurato — e 4:5 non c'è.
+ */
+const OPENROUTER_IMAGES_RATIOS = ['1:1', '3:2', '2:3', '4:3', '3:4', '16:9', '9:16', '21:9'];
+
+/**
+ * I rapporti che quell'elenco non ha, chiesti in pixel.
+ *
+ * `size` non è documentato fra i parametri del modello, ma l'endpoint lo onora al pixel: chiesto
+ * 1024x1280, tornato 1024x1280, sei volte su sei e anche insieme ai riferimenti. È l'unico modo di
+ * avere un 4:5, cioè l'inquadratura di ogni post Instagram: senza, ogni post verticale del brand
+ * diventerebbe un 3:4, che è un'altra cosa.
+ *
+ * Undefined per tutto il resto, di proposito: dove il nome basta si usa il nome, che è la strada
+ * documentata e quella che non può sparire.
+ */
+export function openrouterImagesSize(aspectRatio: string | undefined): string | undefined {
+  switch (String(aspectRatio ?? '').trim()) {
+    case '4:5':
+      return '1024x1280';
+    case '5:4':
+      return '1280x1024';
+    default:
+      return undefined;
+  }
+}
+
+/** Il rapporto da mandare per NOME, quando quel nome esiste. Altrimenti decide `openrouterImagesSize`. */
+export function openrouterImagesAspectRatio(aspectRatio: string | undefined): string | undefined {
+  const v = String(aspectRatio ?? '').trim();
+  return OPENROUTER_IMAGES_RATIOS.includes(v) ? v : undefined;
+}

--- a/src/lib/server/content-preview.test.ts
+++ b/src/lib/server/content-preview.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { brandVisualDirective, platformPlaybook, normalizeWeeklyStrategy, attachBrandMoodImages, extractVisualPlaybook, carouselMaxPerBatch, carouselMaxSlides, clampCarousels, resolveSeedWithRubrics, faceBrandMode, scrubPersonAppearance, aspectRatioFor, seedToPost, buildImageRequest, enforceHookComponents, detectSceneCollapse, detectCaptionTells, detectCtaEcho, findJudgeDuplicates, ownerCaptionEditPairs, ownerEditPairsBlock, postQcPayload, sealOnImageText, applySeedFix, BLOG_IMAGE_MODEL, type PostSeed, type PreviewPost } from './content-preview';
+import { defaultImageModel } from './content-preview/default-image-model';
 
 import type { Rubric } from './rubrics';
 
@@ -508,28 +509,31 @@ describe('aspectRatioFor', () => {
 });
 
 describe('buildImageRequest (image model tier)', () => {
-  const LITE = 'gemini-3.1-flash-lite-image';
   const img = { inlineData: { mimeType: 'image/png', data: 'x' } };
+  // Non un id scritto a mano: il default lo decide la famiglia dello slot, e un id copiato qui
+  // dentro sarebbe la seconda voce in capitolo — esattamente cio' che `defaultImageModel` toglie
+  // di mezzo. Il test dice la REGOLA, che non e' cambiata: un ramo solo, per tutti.
+  const DEFAULT = defaultImageModel();
 
-  it('default render model is Nano Banana 2 Lite, also with reproduction refs', () => {
-    expect(buildImageRequest('p', { personImages: [img] }).model).toBe(LITE);
-    expect(buildImageRequest('p', { referenceImages: [img] }).model).toBe(LITE);
-    expect(buildImageRequest('p', { userRefImages: [img] }).model).toBe(LITE);
-    expect(buildImageRequest('p', { baseImage: img }).model).toBe(LITE);
+  it('un default solo, con o senza riferimenti da riprodurre', () => {
+    expect(buildImageRequest('p', { personImages: [img] }).model).toBe(DEFAULT);
+    expect(buildImageRequest('p', { referenceImages: [img] }).model).toBe(DEFAULT);
+    expect(buildImageRequest('p', { userRefImages: [img] }).model).toBe(DEFAULT);
+    expect(buildImageRequest('p', { baseImage: img }).model).toBe(DEFAULT);
   });
 
   // Il nome vecchio di questo test diceva "half-price tier" e asseriva BLOG_IMAGE_MODEL, che e' il
   // modello PIENO: la convinzione era rovesciata, e intanto la maggioranza delle immagini — un
-  // prompt e nessun riferimento — pagava $0,06 a chiamata. Ora Lite vale anche qui.
-  it('senza riferimenti da riprodurre disegna con Lite — mood e logo non contano', () => {
-    expect(buildImageRequest('p', {}).model).toBe(LITE);
-    expect(buildImageRequest('p', { moodImages: [img], logoImage: img }).model).toBe(LITE);
+  // prompt e nessun riferimento — pagava $0,06 a chiamata.
+  it('senza riferimenti da riprodurre usa lo stesso — mood e logo non contano', () => {
+    expect(buildImageRequest('p', {}).model).toBe(DEFAULT);
+    expect(buildImageRequest('p', { moodImages: [img], logoImage: img }).model).toBe(DEFAULT);
   });
 
   it('il blog resta sul modello pieno, perche' + "'" + ' lo chiede esplicitamente', () => {
     // La batch API del blog vuole quel modello e lo passa a mano: cambiare il default non lo
     // tocca, ed e' esattamente cio' che questo cambio NON doveva spostare.
-    expect(BLOG_IMAGE_MODEL).not.toBe(LITE);
+    expect(BLOG_IMAGE_MODEL).not.toBe(DEFAULT);
     expect(buildImageRequest('p', { model: BLOG_IMAGE_MODEL }).model).toBe(BLOG_IMAGE_MODEL);
   });
 

--- a/src/lib/server/content-preview/default-image-model.test.ts
+++ b/src/lib/server/content-preview/default-image-model.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Il modello con cui si disegna quando il brand non ha scelto, e la rotta dello slot, devono dire
+ * la STESSA cosa. Erano due costanti separate: lo slot poteva puntare a una famiglia e il render
+ * partire con l'id di un'altra, e il trasporto si sceglieva sull'id — cioè la rotta si leggeva
+ * come rispettata senza esserlo. Qui il default LEGGE la rotta, così non possono divergere.
+ */
+const M = vi.hoisted(() => ({ env: {} as Record<string, string | undefined> }));
+vi.mock('$env/dynamic/private', () => ({ env: M.env }));
+
+describe('il modello di default delle immagini', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    for (const k of Object.keys(M.env)) delete M.env[k];
+  });
+
+  it('segue la famiglia dello slot: su gpt-image è Sunburst', async () => {
+    M.env.OPENROUTER_API_KEY = 'o';
+    M.env.KIE_API_KEY = 'k';
+    const { defaultImageModel } = await import('./default-image-model');
+    expect(defaultImageModel()).toBe('gpt-image-2.5-sunburst');
+  });
+
+  it('quando la rotta ripiega su kie, il default torna quello di casa', async () => {
+    M.env.KIE_API_KEY = 'k';
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { defaultImageModel } = await import('./default-image-model');
+    expect(defaultImageModel()).toBe('gemini-3.1-flash-lite-image');
+    warn.mockRestore();
+  });
+
+  it('una rotta scelta a mano decide anche il modello', async () => {
+    M.env.OPENROUTER_API_KEY = 'o';
+    M.env.KIE_API_KEY = 'k';
+    M.env.AI_ROUTE_IMAGE = 'nano-banana@openrouter';
+    const { defaultImageModel } = await import('./default-image-model');
+    expect(defaultImageModel()).toBe('gemini-3.1-flash-lite-image');
+  });
+});

--- a/src/lib/server/content-preview/default-image-model.ts
+++ b/src/lib/server/content-preview/default-image-model.ts
@@ -1,0 +1,24 @@
+/**
+ * Il modello con cui si disegna quando il brand non ha scelto.
+ *
+ * Non è una costante: LEGGE la rotta dello slot. Prima erano due decisioni separate — la famiglia
+ * su cui instradare e l'id da mettere nella richiesta — e potevano dire cose diverse. Il trasporto
+ * però si sceglie sull'id, quindi una rotta `gpt-image@openrouter` con un id Gemini dentro sarebbe
+ * finita sul trasporto di Gemini: la rotta si legge come rispettata senza esserlo, che è il guasto
+ * che il registro esiste per impedire.
+ *
+ * Una riga per famiglia, e la riga è l'unica cosa da aggiungere il giorno che ne arriva un'altra.
+ */
+import { GPT_IMAGE_25_SUNBURST_MODEL } from '$lib/image-models';
+import { NANO_BANANA_2_LITE } from '$lib/server/google-models';
+import { route, type ModelFamily } from '$lib/server/model-routing';
+
+const DEFAULT_BY_FAMILY: Partial<Record<ModelFamily, string>> = {
+  // Sunburst e non Flare: stesso prezzo, 15,0s contro 10,5s, ma è il taglio di precisione — e qui
+  // dentro le immagini portano testo, che sbagliato si rifà.
+  'gpt-image': GPT_IMAGE_25_SUNBURST_MODEL
+};
+
+export function defaultImageModel(): string {
+  return DEFAULT_BY_FAMILY[route('image').family] ?? NANO_BANANA_2_LITE;
+}

--- a/src/lib/server/content-preview/images.ts
+++ b/src/lib/server/content-preview/images.ts
@@ -8,7 +8,9 @@ import { fetchImagePart } from '$lib/server/brand-context';
 import { safeFetchBytes } from '$lib/server/tool-guard';
 import { getBrandContext, getOrgContext } from '$lib/server/ai-log';
 import { NANO_BANANA_2_LITE } from '$lib/server/google-models';
-import { GEMINI_NANO_BANANA_2, googleImageModel } from '$lib/image-models';
+import { defaultImageModel } from '$lib/server/content-preview/default-image-model';
+import { generateImageOnOpenrouterImages } from '$lib/server/openrouter-images-api';
+import { GEMINI_NANO_BANANA_2, googleImageModel, imageModelSpec } from '$lib/image-models';
 import { structured } from '$lib/server/research';
 import { signKnowledgePaths } from '$lib/server/media-archive';
 import { generateImageOnKie } from '$lib/server/kie-jobs';
@@ -178,7 +180,9 @@ export function buildImageRequest(imagePrompt: string, opts: RenderImageOpts = {
   const imageModel =
     (opts.baseImage ? opts.refineModel : undefined) ??
     opts.model ??
-    (needsFidelity ? NANO_BANANA_2_LITE : env.IMAGE_MODEL_NO_REF || NANO_BANANA_2_LITE);
+    // Il default non è più una costante: lo decide la famiglia dello slot, così l'id e la rotta
+    // non possono dire cose diverse (vedi `defaultImageModel`).
+    (needsFidelity ? defaultImageModel() : env.IMAGE_MODEL_NO_REF || defaultImageModel());
   // Con foto di persona, il testo sul genere non deve mai scavalcare le foto.
   const cleanPrompt = opts.personImages?.length ? scrubPersonAppearance(imagePrompt) : imagePrompt;
   const styleSuffix = opts.visualStyle ? `\n\nBRAND VISUAL STYLE to match: ${opts.visualStyle}` : '';
@@ -255,6 +259,13 @@ export async function renderPostImage(
   // più per render ($0,0336 contro ~$0,020), quindi è una scelta di latenza, non di risparmio.
   // Nessun ritentativo qui: un fallimento sincrono torna già diagnosticato, e `generateImageOnOpenrouter`
   // alza l'eccezione invece di restituire un successo vuoto.
+  // Tre trasporti, un bivio solo. L'API immagini quando il modello vive LÌ — i GPT Image 2.5 e
+  // nient'altro — e la via Gemini per il resto di OpenRouter. Il ramo si sceglie sul MODELLO e non
+  // sulla rotta, perché è il modello a esistere o non esistere su quell'endpoint: un brand che ha
+  // scelto Nano Banana continua a passare di sotto anche con lo slot su gpt-image.
+  if (route('image').endpoint === 'openrouter' && imageModelSpec(imageModel)?.openrouterImages) {
+    return await generateImageOnOpenrouterImages(req, { context: `image:${imageModel}` });
+  }
   if (route('image').endpoint === 'openrouter') {
     return await generateImageOnOpenrouter(
       { ...req, model: googleImageModel(req.model, NANO_BANANA_2_LITE) },

--- a/src/lib/server/kie-jobs.ts
+++ b/src/lib/server/kie-jobs.ts
@@ -233,7 +233,17 @@ export const KIE_IMAGE_INPUT_MAX = 8;
  */
 export function kieImageModel(model: string | undefined, refCount = 0): string {
   const spec = imageModelSpec(model);
-  if (spec) return refCount > 0 ? spec.kie.refs : spec.kie.text;
+  // Un modello che kie NON serve (i GPT Image 2.5 vivono solo sull'API immagini di OpenRouter)
+  // finisce qui quando OpenRouter è irraggiungibile. Mandarci il suo nome sarebbe un 400 su ogni
+  // immagine del brand: si rende col modello di casa e lo si dice, come fa `googleImageModel`.
+  if (spec && !spec.kie) {
+    console.warn(
+      `[kie-image] ${spec.id} esiste solo sull'API immagini di OpenRouter e questo render sta ` +
+        `andando su kie: uso nano-banana-2. La preferenza del brand non è stata applicata.`
+    );
+    return 'nano-banana-2';
+  }
+  if (spec?.kie) return refCount > 0 ? spec.kie.refs : spec.kie.text;
   // Un id che il catalogo non conosce è un id Gemini di prima del registro: la regola vale ancora.
   if (/pro/i.test(model ?? '')) return 'nano-banana-pro';
   if (/lite/i.test(model ?? '')) return 'nano-banana-2-lite';
@@ -258,7 +268,10 @@ export function buildKieImageInput(opts: {
   resolution?: KieResolution;
   model?: string;
 }): Record<string, unknown> {
-  const spec = imageModelSpec(opts.model) ?? imageModelSpec(NANO_BANANA_2_MODEL)!;
+  // Stessa ragione di `kieImageModel`: su kie un modello senza dialetto kie non ha un payload, e
+  // quello di casa è l'unico che ne ha uno.
+  const asked_spec = imageModelSpec(opts.model);
+  const spec = (asked_spec?.kie ? asked_spec : imageModelSpec(NANO_BANANA_2_MODEL))!;
   const aspect = kieAspectRatio(spec, opts.aspectRatio);
   if (opts.aspectRatio && aspect !== opts.aspectRatio) {
     console.warn(`[kie-image] ${spec.id} non serve aspect_ratio "${opts.aspectRatio}" — uso ${aspect}`);

--- a/src/lib/server/model-routing.test.ts
+++ b/src/lib/server/model-routing.test.ts
@@ -164,10 +164,13 @@ describe('il registro delle rotte', () => {
   });
 
   it('le immagini vanno su openrouter per default, senza nessuna variabile', async () => {
-    // Non e` il prezzo: kie ha il 3,5% di fallimenti e un p95 di 142,9s contro i 3,4s di
-    // OpenRouter. Il default e` la disponibilita`, non il risparmio.
+    // L'endpoint non si e` mai mosso da qui: kie ha il 3,5% di fallimenti e un p95 di 142,9s
+    // contro i 3,4s di OpenRouter, e quella era disponibilita`, non risparmio.
+    //
+    // La FAMIGLIA invece e` cambiata, e quella volta e` il prezzo: $0,0053 contro $0,0748 per
+    // immagine, misurati il 2026-09-12 sull'endpoint vero, a parita` di tempo e di formato.
     const { route } = await import('./model-routing');
-    expect(route('image')).toMatchObject({ family: 'nano-banana', endpoint: 'openrouter' });
+    expect(route('image')).toMatchObject({ family: 'gpt-image', endpoint: 'openrouter' });
   });
 
   it('la voce si sposta col resto, e kie resta il ripiego', async () => {
@@ -400,5 +403,51 @@ describe('restano solo openrouter e kie', () => {
     expect(can('openrouter', 'tts')).toBe(true);
     expect(can('kie', 'tts')).toBe(true);
     expect(missingCapabilities('openrouter')).not.toContain('tts');
+  });
+});
+
+/**
+ * I GPT Image 2.5 vivono su UN endpoint solo — l'API immagini di OpenRouter — e sono i primi del
+ * registro a essere così. Il ripiego per famiglia (`HOME`, poi kie) non può funzionare per loro:
+ * kie non li serve, e una rotta `gpt-image@kie` si leggerebbe come rispettata mentre atterra
+ * altrove, che è il guasto che questo file esiste per impedire. Quando la famiglia scelta non è
+ * servibile da nessuna parte, si cambia FAMIGLIA — e la riserva dello slot è scritta, non dedotta.
+ */
+describe('una famiglia con un endpoint solo', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    for (const k of Object.keys(M.env)) delete M.env[k];
+  });
+
+  it('le immagini le disegna GPT Image 2.5 su openrouter, di default', async () => {
+    setEnv({ KIE_API_KEY: 'k', OPENROUTER_API_KEY: 'o' });
+    const { route } = await import('./model-routing');
+    expect(route('image')).toMatchObject({
+      family: 'gpt-image',
+      endpoint: 'openrouter',
+      provider: 'openrouter'
+    });
+  });
+
+  it('senza openrouter non finisce su una rotta che nessuno serve: torna a nano-banana su kie', async () => {
+    setEnv({ KIE_API_KEY: 'k' });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { route } = await import('./model-routing');
+    expect(route('image')).toMatchObject({
+      family: 'nano-banana',
+      endpoint: 'kie',
+      provider: 'kie'
+    });
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('chiederla su kie a mano non la manda su kie in silenzio', async () => {
+    setEnv({ KIE_API_KEY: 'k', OPENROUTER_API_KEY: 'o', AI_ROUTE_IMAGE: 'gpt-image@kie' });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { route } = await import('./model-routing');
+    expect(route('image').endpoint).toBe('openrouter');
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
   });
 });

--- a/src/lib/server/model-routing.ts
+++ b/src/lib/server/model-routing.ts
@@ -43,6 +43,8 @@ export type ModelFamily =
   | 'grok'
   | 'gpt'
   | 'nano-banana'
+  /** I GPT Image 2.5, che esistono solo sull'API immagini di OpenRouter. */
+  | 'gpt-image'
   | 'gemini-tts'
   | 'grok-imagine'
   | 'seedance'
@@ -126,6 +128,8 @@ const HOME: Record<ModelFamily, Endpoint> = {
   // Come `nano-banana` e `grok-imagine`: openrouter è il DEFAULT dello slot, kie è dove si ripiega.
   'gemini-tts': 'kie',
   'nano-banana': 'kie',
+  // L'unica famiglia senza casa su kie: l'API immagini di OpenRouter è il suo unico posto.
+  'gpt-image': 'openrouter',
   grok: 'kie',
   gpt: 'kie',
   'grok-imagine': 'kie',
@@ -147,6 +151,7 @@ const SERVED_BY: Record<ModelFamily, Endpoint[]> = {
   gemini: ['kie', 'openrouter'],
   'gemini-tts': ['kie', 'openrouter'],
   'nano-banana': ['kie', 'openrouter'],
+  'gpt-image': ['openrouter'],
   grok: ['kie'],
   gpt: ['kie'],
   'grok-imagine': ['kie', 'openrouter'],
@@ -183,8 +188,12 @@ const SLOT_DEFAULT: Record<Slot, Route> = {
   // Il testo su OpenRouter: `structuredGemini` e `groundedGemini` ci passavano gia` da `llm.ts`,
   // e il carico su Google si era fermato da solo il 30 agosto. Qui il default dice la verita`.
   text: r('gemini', 'openrouter'),
-  // Non il prezzo: kie fallisce il 3,5% dei render con un p95 di 142,9s contro i 3,4s di OpenRouter.
-  image: r('nano-banana', 'openrouter'),
+  // Stavolta È il prezzo, e di parecchio. Misurato il 2026-09-12 contro l'endpoint vero:
+  // $0,0053 per un'immagine disegnata da zero e $0,017 per una modificata, contro i $0,0748 medi
+  // del Gemini su OpenRouter negli ultimi 30 giorni — 14× e 4×. Il tempo non peggiora (10-15s
+  // contro 13,3s) e il formato regge, 4:5 compreso, che su questo endpoint va chiesto in pixel.
+  // La riserva resta nano-banana su kie: vedi SLOT_RESERVE.
+  image: r('gpt-image', 'openrouter'),
   // Stessa famiglia Gemini servita da openrouter: le voci sono le stesse (Kore, Puck, Charon,
   // Aoede, Fenrir tutte accettate), quindi per il cliente non cambia nulla. Il costo nemmeno —
   // stesso copione, kie 1,19 crediti = $0,00595 contro $0,005772. Cambia il ripiego, che ora c'e'.
@@ -203,6 +212,22 @@ const SLOT_DEFAULT: Record<Slot, Route> = {
   // `HOME` resta kie ed e` la RISERVA — le due tabelle non devono coincidere, o il ripiego finisce
   // sulla cosa che non funziona.
   video: r('grok-imagine', 'openrouter')
+};
+
+/**
+ * Dove va lo slot quando la famiglia scelta non è servibile da NESSUN endpoint.
+ *
+ * Finché ogni famiglia aveva due endpoint, il ripiego per endpoint bastava: `HOME`, poi kie. Con
+ * `gpt-image`, che vive solo su OpenRouter, quella catena produrrebbe `gpt-image@kie` — una rotta
+ * che nessuno serve e che si leggerebbe come rispettata mentre atterra altrove, cioè il guasto che
+ * questo file esiste per impedire. Qui si cambia FAMIGLIA, e la riserva è scritta invece che
+ * dedotta: quella di casa, su kie, che è dove si va quando OpenRouter non c'è.
+ */
+const SLOT_RESERVE: Record<Slot, Route> = {
+  text: { family: 'gemini', endpoint: 'kie', provider: 'kie' },
+  image: { family: 'nano-banana', endpoint: 'kie', provider: 'kie' },
+  tts: { family: 'gemini-tts', endpoint: 'kie', provider: 'kie' },
+  video: { family: 'grok-imagine', endpoint: 'kie', provider: 'kie' }
 };
 
 function r(family: ModelFamily, endpoint: Endpoint): Route {
@@ -306,11 +331,19 @@ export function route(slot: Slot): Route {
   const why = unroutable(chosen);
   if (!why) return chosen;
   const home = HOME[chosen.family];
-  const fallback = unroutable(r(chosen.family, home)) ? 'kie' : home;
+  if (!unroutable(r(chosen.family, home))) {
+    console.warn(
+      `[AI] ${SLOT_ENV[slot]} chiede ${chosen.family}@${chosen.endpoint}: ${why}. Ripiego su ${home}.`
+    );
+    return r(chosen.family, home);
+  }
+  // Nemmeno la casa della famiglia la serve: si cambia famiglia, non endpoint.
+  const reserve = SLOT_RESERVE[slot];
   console.warn(
-    `[AI] ${SLOT_ENV[slot]} chiede ${chosen.family}@${chosen.endpoint}: ${why}. Ripiego su ${fallback}.`
+    `[AI] ${SLOT_ENV[slot]} chiede ${chosen.family}@${chosen.endpoint}: ${why}, e ${chosen.family} ` +
+      `non ha altro endpoint. Ripiego su ${reserve.family}@${reserve.endpoint}.`
   );
-  return r(chosen.family, fallback);
+  return reserve;
 }
 
 /** True quando quell'endpoint sa fare quella cosa. */

--- a/src/lib/server/openrouter-images-api.test.ts
+++ b/src/lib/server/openrouter-images-api.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * `POST /api/v1/images` è un endpoint diverso da `chat/completions`, non una variante: corpo
+ * diverso (`prompt`, `input_references`, `aspect_ratio`), risposta diversa (`b64_json` +
+ * `media_type`), ed è l'unico posto dove i GPT Image 2.5 esistono.
+ *
+ * Le tre cose che devono reggere, tutte misurate contro l'endpoint vero il 2026-09-12:
+ *  · i riferimenti hanno UNA forma sola — `{type:'image_url', image_url:{url}}`. Le altre quattro
+ *    provate tornano 400, tranne `image:` che torna 200 E IGNORA l'immagine: un limone verde
+ *    inventato da zero invece dello stesso limone colorato. Il silenzio è il guasto peggiore.
+ *  · 4:5 non è fra i rapporti che accettano per nome: va chiesto in pixel, o è un 400.
+ *  · una risposta senza immagine non è un successo.
+ */
+const M = vi.hoisted(() => ({ env: {} as Record<string, string | undefined>, logged: [] as any[] }));
+vi.mock('$env/dynamic/private', () => ({ env: M.env }));
+vi.mock('$lib/server/ai-log', () => ({
+  logAiCall: (e: unknown) => void M.logged.push(e),
+  getBrandContext: () => null
+}));
+
+const REQ = {
+  model: 'gpt-image-2.5-sunburst',
+  contents: [{ parts: [{ text: 'una tazza di ceramica su pietra bagnata' }] }],
+  config: { imageConfig: { aspectRatio: '4:5' } }
+};
+
+const B64 = '/9j/4AAQSkZJRg==';
+
+function reply(body: unknown, status = 200) {
+  return vi.fn(async (_url: string, _init: RequestInit) => new Response(JSON.stringify(body), { status }));
+}
+const sentBody = (f: any) => JSON.parse(String(f.mock.calls[0][1].body));
+const sentUrl = (f: any) => String(f.mock.calls[0][0]);
+const ok = () => ({ data: [{ b64_json: B64, media_type: 'image/png' }], usage: { cost: 0.00527 } });
+
+describe('il render sull’API immagini di OpenRouter', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    for (const k of Object.keys(M.env)) delete M.env[k];
+    M.env.OPENROUTER_API_KEY = 'o';
+    M.logged.length = 0;
+  });
+
+  it('parla con /images e non con chat/completions', async () => {
+    const f = reply(ok());
+    vi.stubGlobal('fetch', f);
+    const { generateImageOnOpenrouterImages } = await import('./openrouter-images-api');
+    await generateImageOnOpenrouterImages(REQ);
+    expect(sentUrl(f)).toMatch(/\/images$/);
+  });
+
+  it('restituisce un data URL col tipo che il provider dichiara', async () => {
+    vi.stubGlobal('fetch', reply(ok()));
+    const { generateImageOnOpenrouterImages } = await import('./openrouter-images-api');
+    expect(await generateImageOnOpenrouterImages(REQ)).toBe(`data:image/png;base64,${B64}`);
+  });
+
+  it('manda l’id con cui OpenRouter chiama quel modello, non il nostro', async () => {
+    const f = reply(ok());
+    vi.stubGlobal('fetch', f);
+    const { generateImageOnOpenrouterImages } = await import('./openrouter-images-api');
+    await generateImageOnOpenrouterImages(REQ);
+    expect(sentBody(f).model).toBe('openai/gpt-image-2.5-sunburst');
+  });
+
+  it('4:5 si chiede in pixel, perché per nome non esiste', async () => {
+    const f = reply(ok());
+    vi.stubGlobal('fetch', f);
+    const { generateImageOnOpenrouterImages } = await import('./openrouter-images-api');
+    await generateImageOnOpenrouterImages(REQ);
+    const body = sentBody(f);
+    expect(body.size).toBe('1024x1280');
+    expect(body.aspect_ratio).toBeUndefined();
+  });
+
+  it('un rapporto che hanno per nome si chiede per nome', async () => {
+    const f = reply(ok());
+    vi.stubGlobal('fetch', f);
+    const { generateImageOnOpenrouterImages } = await import('./openrouter-images-api');
+    await generateImageOnOpenrouterImages({
+      ...REQ,
+      config: { imageConfig: { aspectRatio: '9:16' } }
+    });
+    const body = sentBody(f);
+    expect(body.aspect_ratio).toBe('9:16');
+    expect(body.size).toBeUndefined();
+  });
+
+  it('i riferimenti viaggiano nella forma che l’endpoint accetta davvero', async () => {
+    const f = reply(ok());
+    vi.stubGlobal('fetch', f);
+    const { generateImageOnOpenrouterImages } = await import('./openrouter-images-api');
+    await generateImageOnOpenrouterImages({
+      ...REQ,
+      contents: [
+        {
+          parts: [
+            { text: 'rendi il limone verde' },
+            { inlineData: { mimeType: 'image/png', data: 'AAA' } }
+          ]
+        }
+      ]
+    });
+    const body = sentBody(f);
+    expect(body.prompt).toBe('rendi il limone verde');
+    expect(body.input_references).toEqual([
+      { type: 'image_url', image_url: { url: 'data:image/png;base64,AAA' } }
+    ]);
+  });
+
+  it('una risposta senza immagine non è un successo silenzioso', async () => {
+    vi.stubGlobal('fetch', reply({ data: [] }));
+    const { generateImageOnOpenrouterImages } = await import('./openrouter-images-api');
+    await expect(generateImageOnOpenrouterImages(REQ)).rejects.toThrow(/nessuna immagine/i);
+  });
+
+  it('il costo è quello che fattura la chiamata, e finisce nel registro', async () => {
+    vi.stubGlobal('fetch', reply(ok()));
+    const { generateImageOnOpenrouterImages } = await import('./openrouter-images-api');
+    await generateImageOnOpenrouterImages(REQ);
+    expect(M.logged.at(-1)).toMatchObject({
+      provider: 'openrouter',
+      model: 'openai/gpt-image-2.5-sunburst',
+      ok: true,
+      flatCostUsd: 0.00527
+    });
+  });
+
+  it('un errore del provider è un errore, e lo dice anche al registro', async () => {
+    vi.stubGlobal('fetch', reply({ error: { message: 'Provider rejection' } }, 400));
+    const { generateImageOnOpenrouterImages } = await import('./openrouter-images-api');
+    await expect(generateImageOnOpenrouterImages(REQ)).rejects.toThrow(/Provider rejection/);
+    expect(M.logged.at(-1)).toMatchObject({ ok: false });
+  });
+
+  it('senza chiave non ci prova nemmeno', async () => {
+    delete M.env.OPENROUTER_API_KEY;
+    vi.stubGlobal('fetch', reply(ok()));
+    const { generateImageOnOpenrouterImages } = await import('./openrouter-images-api');
+    await expect(generateImageOnOpenrouterImages(REQ)).rejects.toThrow(/OPENROUTER_API_KEY/);
+  });
+});

--- a/src/lib/server/openrouter-images-api.ts
+++ b/src/lib/server/openrouter-images-api.ts
@@ -1,0 +1,151 @@
+/**
+ * Il render sull'API immagini di OpenRouter — `POST /api/v1/images`, che NON è `chat/completions`.
+ *
+ * Perché una seconda porta e non un parametro: i GPT Image 2.5 esistono SOLO lì. Chiamati su
+ * `chat/completions` rispondono 404 dicendolo per esteso («is an image generation model and cannot
+ * be used with the chat/completions endpoint»), e non compaiono in `/api/v1/models`, che elenca i
+ * modelli di chat. Il loro catalogo è `/api/v1/images/models`, 52 voci con i parametri che ognuna
+ * accetta. Cercarli nel posto sbagliato è il motivo per cui per due volte sono sembrati inesistenti.
+ *
+ * Come `generateImageOnOpenrouter` accanto, si traduce il TRASPORTO e non il contenuto: entra la
+ * stessa `GeminiImageRequest` che `buildImageRequest` assembla per tutti, esce un data URL. Il
+ * prompt messo a punto sul percorso Gemini è lo stesso, e una seconda funzione che lo ricostruisse
+ * divergerebbe al primo ritocco.
+ *
+ * Le tre differenze che contano, tutte MISURATE contro l'endpoint vero il 2026-09-12:
+ *
+ *  1. I riferimenti hanno una forma sola: `input_references: [{type:'image_url', image_url:{url}}]`.
+ *     `{url}`, `{image_url:{url}}`, `{b64_json}` e `{type:'input_image'}` tornano 400. `image:` —
+ *     il nome che verrebbe da OpenAI — torna **200 e ignora l'immagine**: chiesto «rendi verde
+ *     questo limone», è arrivata una limonata inventata da zero. Il costo lo conferma: $0,0060
+ *     quando il riferimento cade, $0,017-0,025 quando viene letto davvero.
+ *  2. `aspect_ratio` è un elenco chiuso e **4:5 non c'è**, cioè il formato di un post Instagram.
+ *     Si chiede in pixel con `size`, che l'endpoint onora esattamente. Vedi `openrouterImagesSize`.
+ *  3. La risposta è `data[0].b64_json` + `media_type`, non `choices[].message.images`.
+ *
+ * PREZZO: da `usage.cost`, la fattura di QUESTA chiamata. Misurato: $0,0053 per un'immagine
+ * disegnata da zero e $0,017 per una modificata, contro i $0,0748 medi del Gemini su OpenRouter.
+ */
+import { env } from '$env/dynamic/private';
+import { logAiCall } from '$lib/server/ai-log';
+import {
+  imageModelSpec,
+  openrouterImagesAspectRatio,
+  openrouterImagesSize
+} from '$lib/image-models';
+import type { GeminiImageRequest } from '$lib/server/kie-jobs';
+
+const OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
+
+type ImagesResponse = {
+  data?: Array<{ b64_json?: string; media_type?: string }>;
+  usage?: { cost?: number };
+  error?: { message?: string };
+};
+
+type Reference = { type: 'image_url'; image_url: { url: string } };
+
+function apiKey(): string | undefined {
+  return env.OPENROUTER_API_KEY?.trim() || env.LLM_API_KEY?.trim() || undefined;
+}
+
+function baseUrl(): string {
+  return (env.LLM_BASE_URL?.trim() || OPENROUTER_BASE_URL).replace(/\/$/, '');
+}
+
+/** Il testo di tutte le parti, nell'ordine in cui il prompt è stato costruito. */
+function promptOf(parts: GeminiImageRequest['contents'][number]['parts']): string {
+  return parts
+    .map((p) => p.text)
+    .filter((t): t is string => !!t)
+    .join('\n\n');
+}
+
+function referencesOf(
+  parts: GeminiImageRequest['contents'][number]['parts'],
+  max: number
+): Reference[] {
+  const refs = parts
+    .filter((p) => p.inlineData)
+    .map((p): Reference => {
+      const { mimeType, data } = p.inlineData!;
+      return { type: 'image_url', image_url: { url: `data:${mimeType};base64,${data}` } };
+    });
+  if (refs.length > max) {
+    console.warn(
+      `[or-images] ${refs.length} riferimenti ma il modello ne inoltra ${max}: ` +
+        `${refs.length - max} scartati. Il tetto va imposto A MONTE, dove si sa che cosa sono.`
+    );
+  }
+  return refs.slice(0, max);
+}
+
+export async function generateImageOnOpenrouterImages(
+  req: GeminiImageRequest,
+  opts: { label?: string; context?: string; signal?: AbortSignal } = {}
+): Promise<string> {
+  const key = apiKey();
+  if (!key) throw new Error('OPENROUTER_API_KEY assente: questo render non ha un trasporto');
+
+  const spec = imageModelSpec(req.model);
+  const model = spec?.openrouterImages;
+  if (!model) {
+    throw new Error(
+      `${req.model} non è servito dall'API immagini di OpenRouter: questa rotta non lo sa disegnare`
+    );
+  }
+
+  const label = opts.label ?? 'renderPostImage';
+  const parts = req.contents?.[0]?.parts ?? [];
+  const aspectRatio = req.config?.imageConfig?.aspectRatio;
+  const references = referencesOf(parts, spec.maxRefs);
+  const t0 = Date.now();
+
+  // Il rapporto per NOME quando quel nome esiste, in pixel quando no: sono le due strade e non c'è
+  // una terza, perché mandare un rapporto fuori elenco è un 400 e non mandarne nessuno è un post
+  // verticale inquadrato quadrato.
+  const byName = openrouterImagesAspectRatio(aspectRatio);
+  const bySize = byName ? undefined : openrouterImagesSize(aspectRatio);
+
+  const body = {
+    model,
+    prompt: promptOf(parts).slice(0, 10_000),
+    ...(byName ? { aspect_ratio: byName } : {}),
+    ...(bySize ? { size: bySize } : {}),
+    ...(references.length ? { input_references: references } : {})
+  };
+
+  const fail = (error: string): never => {
+    logAiCall({ label, provider: 'openrouter', model, ms: Date.now() - t0, ok: false, error, context: opts.context });
+    throw new Error(`OpenRouter images (${model}): ${error}`);
+  };
+
+  let payload: ImagesResponse;
+  try {
+    const res = await fetch(`${baseUrl()}/images`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${key}`, 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+      signal: opts.signal
+    });
+    payload = (await res.json()) as ImagesResponse;
+    if (!res.ok || payload.error) fail(payload.error?.message ?? `HTTP ${res.status}`);
+  } catch (e) {
+    if (e instanceof Error && e.message.startsWith('OpenRouter images (')) throw e;
+    return fail(e instanceof Error ? e.message : 'richiesta fallita');
+  }
+
+  const first = payload.data?.[0];
+  if (!first?.b64_json) fail('nessuna immagine nella risposta');
+
+  logAiCall({
+    label,
+    provider: 'openrouter',
+    model,
+    ms: Date.now() - t0,
+    ok: true,
+    flatCostUsd: payload.usage?.cost,
+    context: opts.context
+  });
+  return `data:${first!.media_type ?? 'image/png'};base64,${first!.b64_json}`;
+}


### PR DESCRIPTION
## What?

`GPT Image 2.5 Sunburst` and `Flare` join the brand's model picker — for
generating **and** editing — and Sunburst becomes the default for image
generation.

Measured, not estimated:

| | time | cost |
|---|---|---|
| Sunburst, from nothing | 15.0s | **$0.0053** |
| Flare, from nothing | 10.5s | $0.0053 |
| Sunburst, with a reference | 15.6s | $0.0171 |
| `gemini-3.1-flash-image` @openrouter — today's default | 13.3s | **$0.0748** |

Fourteen times less for an image drawn from nothing, four times less for one
edited, at the same latency. The verification render inside the app cost
**$0.00635**, where the same prompt on the same brand cost **$0.0337** five
minutes earlier.

## Why?

Because the model exists and the two earlier attempts said it didn't. Both
looked in the wrong place: OpenRouter serves image models from
`/api/v1/images`, and lists them in `/api/v1/images/models` — not in
`/api/v1/models`, which holds 445 chat models and no `gpt-image`. A chat call
404s, and the 404 says so in full only if you *don't* send `modalities`;
otherwise it talks about output modalities and sounds like an unsupported
feature.

Once found, the numbers make the decision: images are the product's largest
per-unit AI cost, and this is the same work for a tenth of it.

## How?

**A second transport, not a parameter.** `openrouter-images-api.ts` speaks
`POST /api/v1/images` and translates the *transport*, not the content — the
same `GeminiImageRequest` that `buildImageRequest` assembles for everyone goes
in, a data URL comes out, exactly like the Gemini transport beside it.

Three things had to be measured rather than assumed, and each is a comment in
the file:

1. **`input_references` has one shape**: `[{type:'image_url', image_url:{url}}]`.
   Four other shapes return 400 — except `image:`, the name OpenAI's own API
   would suggest, which returns **200 and ignores the image**. Asked to turn a
   lemon green it produced a lemonade scene, and the cost gives it away:
   $0.0060 when the reference is dropped, $0.017–0.025 when it is read. A
   success that silently ignores half the request is the worst failure there
   is.
2. **4:5 is not in the aspect-ratio enum**, and 4:5 is an Instagram post. It
   goes through `size`, which the endpoint honours to the pixel (1024x1280
   asked, 1024x1280 returned, six times out of six, references included) even
   though it is not among the declared parameters. Name where the name exists,
   pixels where it doesn't — two paths, no third.
3. The image comes back as `data[0].b64_json` + `media_type`.

**Two registry changes, both forced by a new shape of problem:**

- `gpt-image` is the first family served by a **single** endpoint. The old
  fallback was per endpoint — `HOME`, then kie — which would have produced
  `gpt-image@kie`: a route nobody serves, that reads as honoured while landing
  elsewhere. `SLOT_RESERVE` now names the reserve **family** per slot, so the
  fallback changes family instead of endpoint.
- The default model id is no longer a constant: `defaultImageModel()` reads
  the route. They were two separate decisions — which family to route to, and
  which id to put in the request — and the transport picks on the id. During
  development they disagreed: the slot said `gpt-image`, the request carried a
  Gemini id, the render went down the Gemini path, and **only `ai_calls`
  showed it**. The helper makes that impossible.

**Rejected**: making Flare the default (same price, 4.5s faster, but it is the
speed tier — these images carry text, and wrong text is a re-render); putting
the OpenRouter id in the existing kie-shaped spec fields (the spec would have
lied about a model kie cannot serve).

## Testing?

Red first, watched fail, then green:

- `src/lib/image-models.test.ts` — +5 tests: the two models are in the
  catalogue, carry the OpenRouter id, are recognised *by* it, have no kie and
  no Google id, and serve 4:5. Plus `openrouterImagesSize`: 4:5 and 5:4 in
  pixels, everything else by name, nothing invented for an unknown ratio.
- `src/lib/server/openrouter-images-api.test.ts` — 10 tests: it talks to
  `/images`, sends the OpenRouter id, sends `size` for 4:5 and `aspect_ratio`
  for 9:16, builds references in the only shape that works, refuses a response
  with no image, logs the cost, logs the failure, and refuses without a key.
- `src/lib/server/model-routing.test.ts` — +3: the image slot defaults to
  `gpt-image@openrouter`; without an OpenRouter key it falls back to
  `nano-banana@kie` rather than to a route nobody serves; asking for
  `gpt-image@kie` by hand does not land on kie silently.
- `default-image-model.test.ts` — 3: the default follows the slot's family in
  both directions.
- **Full suite**: 7722 passed. The 16 failures in `src/lib/webmcp.test.ts` are
  pre-existing — a zod `toJSONSchema` error, identical on a clean checkout
  without this branch.

**Browser, on a real brand**: generated a 4:5 image from the media generator
with brand style on. `ai_calls` says `openai/gpt-image-2.5-sunburst`,
`openrouter`, ok, 15.3s, **$0.00635**. The settings picker lists both new
models for generation and for editing.

**Not tested**: a render for a brand that *has* chosen Nano Banana explicitly
(it should keep going down the Gemini path — covered by the dispatch condition
and by unit tests, not by a browser run), and the kie fallback with the
OpenRouter key removed.

## Evidence (screenshots/videos)

- Media generator: the 4:5 mug, brand style on, drawn by Sunburst.
- Settings → Images and video: «GPT Image 2.5 Sunburst» and «GPT Image 2.5
  Flare» in both pickers.
- `ai_calls`: the same prompt at $0.0337 (before) and $0.00635 (after).

## Anything Else?

- The settings copy said that everything outside the Nano Banana family runs
  on kie and frames Instagram posts at 3:4. That is now false for these two —
  corrected in all four catalogues.
- `size` is undocumented. It is measured, and it is the only way to 4:5 on this
  endpoint; if OpenRouter ever drops it, the framing falls back to the nearest
  named ratio rather than breaking. Worth a line in the next sweep of the
  provider's changelog.
- `AI_ROUTE_IMAGE=nano-banana@openrouter` puts everything back the way it was,
  without a deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY