### PR TITLE
Put the mark where Overview used to be

### DIFF
--- a/changelog/2026-09-12-sidebar-logo.md
+++ b/changelog/2026-09-12-sidebar-logo.md
@@ -1,0 +1,13 @@
+# Il marchio in testa alla barra del brand
+
+Togliendo «Panoramica» — che portava a `/app/<slug>`, cioè dove porta «Home» due righe sotto —
+l'header della barra era rimasto vuoto. Teneva ancora il suo lavoro invisibile (l'altezza della top
+bar delle pagine e il filo che ci si allinea), ma da fuori era una fascia di 56px senza niente.
+
+Ci va il marchio, e porta a `/app`. Non è una destinazione inventata per riempire: è l'unico posto
+che da dentro un brand non si raggiungeva più. Ed è la stessa riga che ha già la barra di `/app`
+accanto — stesso `BrandMark`, stessa destinazione, stesso comportamento quando la barra si stringe
+a icone. Due barre della stessa applicazione non devono avere due teste diverse.
+
+Il marchio è allineato con le icone della nav (20px contro 18px: lo scarto è l'inset del disegno
+dentro il suo riquadro), e in modalità icone si centra come loro.

--- a/src/lib/components/DashboardSidebar.svelte
+++ b/src/lib/components/DashboardSidebar.svelte
@@ -3,6 +3,7 @@
   import * as DropdownMenu from '$lib/components/ui/dropdown-menu/index.js';
   import { Badge } from '$lib/components/ui/badge/index.js';
   import { cn } from '$lib/utils.js';
+  import BrandMark from '$lib/components/BrandMark.svelte';
   // Il menu utente è PORTALATO da bits-ui e si smonta alla selezione: per le voci che portano
   // ai settings si chiama l'API del modal invece di affidarsi al click dell'<a>.
   import { locale, _ } from 'svelte-i18n';
@@ -378,12 +379,27 @@
          bordi sono una riga sola che attraversa la finestra invece di due tratti sfalsati.
          Nessun padding orizzontale sul guscio — il filo va da lato a lato; il rientro se lo
          tiene la riga dentro, dove serve a incolonnare l'etichetta con la nav. -->
-    <!-- Resta il guscio, non la voce: «Panoramica» portava a `/app/<slug>`, che e' dove porta
-         «Home» due righe sotto — la stessa destinazione elencata due volte. Quello che l'header
-         faceva oltre a quello serve ancora: tiene l'altezza della top bar delle pagine
-         (`--shell-top-h`) e lo stesso filo, cosi' i due bordi sono una riga sola che attraversa
-         la finestra invece di due tratti sfalsati. -->
-    <Sidebar.Header class="shell-top-header shell-top-divider p-0" />
+    <!-- Al posto di «Panoramica» c'e' il marchio. Quella voce portava a `/app/<slug>`, che e' dove
+         porta «Home» due righe sotto — la stessa destinazione elencata due volte — e lasciava un
+         header vuoto. Il marchio lo riempie e porta ai brand, che e' l'unico posto che da qui non
+         si raggiungeva piu': stessa riga, stesso simbolo e stessa destinazione della barra di
+         `/app` accanto, perche' due barre della stessa applicazione non devono avere due teste
+         diverse.
+
+         L'header resta un header e non la prima voce della lista: tiene l'altezza della top bar
+         delle pagine (`--shell-top-h`) e lo stesso filo, cosi' i due bordi sono una riga sola che
+         attraversa la finestra invece di due tratti sfalsati. -->
+    <Sidebar.Header class="shell-top-header shell-top-divider justify-center p-0">
+      <a
+        href="/app"
+        class="flex w-full items-center px-5 no-underline group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0"
+        style="color: inherit"
+        aria-label={$_('landing.nav.brandAria')}
+        title={$_('landing.nav.brandAria')}
+      >
+        <BrandMark size={mobile ? 32 : 30} />
+      </a>
+    </Sidebar.Header>
   {/if}
 
   <Sidebar.Content class="flex-1 gap-0 overflow-y-auto px-2.5 py-3 group-data-[collapsible=icon]:px-2 group-data-[collapsible=icon]:py-2.5 group-data-[collapsible=icon]:overflow-visible">

--- a/src/lib/content/changelog/2026-09-12-sidebar-logo.ts
+++ b/src/lib/content/changelog/2026-09-12-sidebar-logo.ts
@@ -1,0 +1,9 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-12',
+  title: 'The Anomalia mark is back at the top of the sidebar',
+  items: [
+    'The brand sidebar carries the Anomalia mark again, and it takes you back to your brands — the one place you could no longer reach from inside a brand.'
+  ]
+} satisfies ChangelogEntry;


### PR DESCRIPTION
## What?

The Anomalia mark sits at the top of the brand sidebar, where the «Overview»
row used to be, and links to `/app`.

## Why?

Removing «Overview» (#408 — it pointed at `/app/<slug>`, which is where «Home»
points two rows below) left the header empty. It still held the height of the
page top bar and the rule that lines up with it, but from outside it was 56px
of nothing.

`/app` is not a destination invented to fill the space: it is the one place
you could no longer reach from inside a brand.

## How?

The same row the `/app` sidebar already has: the same `BrandMark`, the same
destination, the same behaviour when the bar collapses to icons. Two sidebars
of the same application should not have two different heads, so this is a copy
of the sibling rather than a second idea.

The mark is aligned with the nav icons — 20px against 18px, the gap being the
drawing's own inset inside its square box — and centres with them in icon mode.

Rejected: adding the «Anomalia» wordmark next to it (the sibling has it, but
there the sidebar belongs to the account; here the name that matters is the
brand's, and it is already at the bottom).

## Testing?

- `npx vitest run workbench-paths shortcuts` — 46 passed (the nav lists are
  untouched, but they are what a sidebar edit can break silently).
- `npm run check` — no error on `DashboardSidebar.svelte`.
- Browser, signed in, real brand: the mark renders in the header above the
  divider, left-aligned with the nav; clicking it goes to `/app`; collapsing
  the sidebar to icons centres it like the rows below.

## Evidence (screenshots/videos)

Sidebar expanded: the mark above the rule, in line with Home · Materiali ·
Strategia. Sidebar collapsed: the mark centred over the icon column.

## Anything Else?

With a single brand, `/app` sends you straight back into that brand — that is
the existing behaviour of the route, and the sibling logo does the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY