### PR TITLE
Give the install instructions a door of their own

### DIFF
--- a/changelog/2026-09-12-sidebar-install.md
+++ b/changelog/2026-09-12-sidebar-install.md
@@ -1,0 +1,18 @@
+# «Installa» in fondo alla barra
+
+Le istruzioni per collegare il proprio agente vivevano in un posto solo: la guida aperta in cima
+alla home del brand. Serviva due volte — il giorno che si comincia, e il giorno che si cambia
+macchina o si aggiunge un secondo agente — ma il secondo giorno nessuno sa più dove cercarla,
+perché la home nel frattempo è diventata altro.
+
+Ora è una riga nel footer della barra, sempre allo stesso posto, sempre visibile: non dipende dal
+piano come «Upgrade», non sparisce quando la barra si stringe a icone (resta la spina), e non
+occupa niente finché non la si cerca.
+
+Apre **lo stesso dialogo della landing** (`ConnectAgentDialog`), non una copia: chi arriva dal sito
+e chi arriva da dentro leggono le stesse istruzioni, e il giorno che cambiano cambiano per
+entrambi. Il dialogo è reso una volta sola, fuori dal ramo mobile/desktop del componente —
+dentro lo snippet sarebbe stato legato a quale dei due è in scena.
+
+Questa riga è anche il primo pezzo della home nuova: la guida in cima alla dashboard può sparire
+adesso che le sue istruzioni hanno una porta propria.

--- a/src/lib/components/DashboardSidebar.svelte
+++ b/src/lib/components/DashboardSidebar.svelte
@@ -4,6 +4,7 @@
   import { Badge } from '$lib/components/ui/badge/index.js';
   import { cn } from '$lib/utils.js';
   import BrandMark from '$lib/components/BrandMark.svelte';
+  import ConnectAgentDialog from '$lib/components/ConnectAgentDialog.svelte';
   // Il menu utente è PORTALATO da bits-ui e si smonta alla selezione: per le voci che portano
   // ai settings si chiama l'API del modal invece di affidarsi al click dell'<a>.
   import { locale, _ } from 'svelte-i18n';
@@ -29,6 +30,7 @@
     Sparkles,
     Plus,
     Bell,
+    Plug2,
   } from '@lucide/svelte';
   import { paletteOpen } from '$lib/shortcuts';
   import {
@@ -176,6 +178,17 @@
   /** Vertical spacing between sidebar nav rows. */
   const navMenuGapClass = $derived(mobile ? 'gap-1.5' : 'gap-2');
   const activateHref = $derived(brandSlug ? `/app/${brandSlug}/activate` : '');
+  /**
+   * Le istruzioni per collegare il proprio agente. Stanno in fondo alla barra e non nella home
+   * perché servono DUE volte: il giorno che si comincia, e il giorno che si cambia macchina o si
+   * aggiunge un secondo agente. Sulla home la guida si legge una volta e poi occupa il primo
+   * terzo della pagina per sempre; qui è una riga, sempre allo stesso posto, e non si vede finché
+   * non la si cerca.
+   *
+   * È lo STESSO dialogo della landing: chi arriva dal sito e chi arriva da dentro leggono le
+   * stesse istruzioni, e quando cambiano cambiano per entrambi.
+   */
+  let installOpen = $state(false);
   const showUpgrade = $derived(!!brandSlug && !isPaidPlan(brandPlan));
   /** Path of in-flight navigation — highlights the destination row immediately. */
   const pendingPath = $derived(navigating.to?.url.pathname ?? null);
@@ -407,6 +420,26 @@
   </Sidebar.Content>
 
   <Sidebar.Footer class="gap-2 border-t border-sidebar-border px-2.5 py-3 group-data-[collapsible=icon]:px-2 group-data-[collapsible=icon]:py-2.5">
+    <button
+      type="button"
+      onclick={() => (installOpen = true)}
+      class={cn(
+        'flex items-center border-0 bg-transparent text-sidebar-foreground/70 transition-colors cursor-pointer touch-manipulation',
+        'hover:bg-black/[0.04] dark:hover:bg-white/[0.06] hover:text-sidebar-foreground',
+        mobile ? 'gap-2 rounded-lg px-2.5 py-2.5' : 'gap-2 rounded-lg px-2.5 py-2',
+        'group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0 group-data-[collapsible=icon]:size-8 group-data-[collapsible=icon]:p-0'
+      )}
+      aria-label={$_('app.nav.install')}
+      title={$_('app.nav.install')}
+    >
+      <Plug2 class={cn('shrink-0', mobile ? 'size-4' : 'size-3.5')} strokeWidth={1.7} />
+      <span
+        class={cn(
+          'font-medium leading-tight group-data-[collapsible=icon]:hidden',
+          mobile ? 'text-[14px]' : 'text-[12.5px]'
+        )}>{$_('app.nav.install')}</span
+      >
+    </button>
     {#if showUpgrade}
       <a
         href={activateHref}
@@ -697,6 +730,8 @@
     <Sidebar.Rail />
   </Sidebar.Root>
 {/if}
+
+<ConnectAgentDialog bind:open={installOpen} />
 
 <style>
   .dashboard-mobile-map {

--- a/src/lib/content/changelog/2026-09-12-sidebar-install.ts
+++ b/src/lib/content/changelog/2026-09-12-sidebar-install.ts
@@ -1,0 +1,9 @@
+import type { ChangelogEntry } from './index';
+
+export default {
+  date: '2026-09-12',
+  title: 'Connecting your AI is one click away, from anywhere',
+  items: [
+    'The sidebar now carries an «Install» row at the bottom, always there: it opens the same instructions for connecting Claude, ChatGPT, Cursor or any other MCP host that the website shows — no more hunting for the guide on the home page.'
+  ]
+} satisfies ChangelogEntry;

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -3904,7 +3904,8 @@
       "radar": "Radar",
       "campaigns": "Campaigns",
       "postsLeft": "{n} posts left this month",
-      "sectionBrand": "Brand"
+      "sectionBrand": "Brand",
+      "install": "Install"
     },
     "hub": {
       "strategy": {

--- a/src/lib/i18n/locales/es.json
+++ b/src/lib/i18n/locales/es.json
@@ -3991,7 +3991,8 @@
       "radar": "Radar",
       "postsLeft": "{n} posts left this month",
       "campaigns": "Campañas",
-      "sectionBrand": "Marca"
+      "sectionBrand": "Marca",
+      "install": "Instalar"
     },
     "strategyTabs": {
       "gtm": "Plan de crecimiento",

--- a/src/lib/i18n/locales/fr.json
+++ b/src/lib/i18n/locales/fr.json
@@ -3991,7 +3991,8 @@
       "radar": "Radar",
       "postsLeft": "{n} posts restants ce mois-ci",
       "campaigns": "Campagnes",
-      "sectionBrand": "Marque"
+      "sectionBrand": "Marque",
+      "install": "Installer"
     },
     "strategyTabs": {
       "gtm": "Plan de croissance",

--- a/src/lib/i18n/locales/it.json
+++ b/src/lib/i18n/locales/it.json
@@ -3905,7 +3905,8 @@
       "radar": "Radar",
       "campaigns": "Campagne",
       "postsLeft": "{n} post rimasti questo mese",
-      "sectionBrand": "Brand"
+      "sectionBrand": "Brand",
+      "install": "Installa"
     },
     "hub": {
       "strategy": {


### PR DESCRIPTION
## What?

An **«Install»** row at the bottom of the brand sidebar, always visible, that
opens the same connect-your-AI dialog the landing page uses.

## Why?

The instructions for connecting an agent lived in one place: the guide opened
at the top of `/app/[brand]`. That covers the first day. It misses the second
one — a new machine, a second agent, a teammate — because by then the home has
filled with other things and nobody knows where the guide went.

It is also the first piece of the new home we agreed on: the guide at the top
of the dashboard can go away now that its instructions have a door of their
own.

## How?

- A row in `Sidebar.Footer`, above «Upgrade». **Not** conditional on the plan
  the way Upgrade is — connecting an agent is not a paid feature — and it
  survives the collapse to icons as the plug glyph, like every other row there.
- It opens **`ConnectAgentDialog`**, the landing's component, not a copy.
  Whoever arrives from the website and whoever arrives from inside the app read
  the same three routes (automatic prompt · per app · CLI), and the day those
  change they change for both.
- The dialog is rendered **once, outside the mobile/desktop branch**. Inside
  the `sidebarBody` snippet it would have been tied to whichever branch is on
  stage; it is `position: fixed`, so it does not care where it sits.
- The label is a new `app.nav.install` key in all four catalogues — «Installa»
  in Italian, «Install» in English. An untranslated English word in an
  otherwise Italian sidebar would be the only one.

Rejected: a nav row in the main list (the list is the brand's places; this is a
utility), and duplicating the dialog's markup into the app (two copies of the
same instructions drift at the first edit).

## Testing?

- `npx vitest run src/lib/i18n` — 23 passed: the new key exists in all four
  catalogues, which is what the parity test is for.
- `npm run check` — no error on `DashboardSidebar.svelte`.
- Browser, signed in, real brand: the row shows as «Installa» with the plug
  icon above Upgrade; collapsed to icons the plug is still there; clicking
  opens the dialog; the «Per app» tab renders the URL, the per-app entries and
  their copy buttons; the × closes it.

## Evidence (screenshots/videos)

Sidebar footer expanded (Installa · Upgrade · user row) and collapsed (the
plug over the sparkle); the dialog open on «Automatico» and on «Per app».

## Anything Else?

The guide still sits at the top of the brand home. Removing it belongs to the
home redesign, not here — this PR only gives its content somewhere else to
live first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzYWEEwsLNS7qgUaAs2uY